### PR TITLE
fix: Add `maxWait` to `sendUpdate` debounce to fix UI sync starvation

### DIFF
--- a/app/scripts/controllers/metametrics-controller.ts
+++ b/app/scripts/controllers/metametrics-controller.ts
@@ -1386,10 +1386,6 @@ export default class MetaMetricsController extends BaseController<
   _buildUserTraitsObject(
     metamaskState: MetaMaskState,
   ): Partial<MetaMetricsUserTraits> | null {
-    if (!metamaskState?.preferences) {
-      return null;
-    }
-
     const { traits } = this.state;
     const storageKindTrait = traits[MetaMetricsUserTrait.StorageKind];
 
@@ -1445,7 +1441,7 @@ export default class MetaMetricsController extends BaseController<
       [MetaMetricsUserTrait.TokenDetectionEnabled]:
         metamaskState.useTokenDetection,
       [MetaMetricsUserTrait.ShowNativeTokenAsMainBalance]:
-        metamaskState.preferences.showNativeTokenAsMainBalance,
+        metamaskState.preferences?.showNativeTokenAsMainBalance,
       [MetaMetricsUserTrait.CurrentCurrency]: metamaskState.currentCurrency,
       [MetaMetricsUserTrait.SecurityProviders]:
         metamaskState.securityAlertsEnabled ? ['blockaid'] : [],
@@ -1456,11 +1452,11 @@ export default class MetaMetricsController extends BaseController<
       [MetaMetricsUserTrait.HasMarketingConsent]:
         metamaskState.dataCollectionForMarketing,
       [MetaMetricsUserTrait.TokenSortPreference]:
-        metamaskState.preferences.tokenSortConfig?.key || '',
+        metamaskState.preferences?.tokenSortConfig?.key || '',
       [MetaMetricsUserTrait.PrivacyModeEnabled]:
-        metamaskState.preferences.privacyMode,
+        metamaskState.preferences?.privacyMode,
       [MetaMetricsUserTrait.NetworkFilterPreference]: Object.keys(
-        metamaskState.preferences.tokenNetworkFilter || {},
+        metamaskState.preferences?.tokenNetworkFilter || {},
       ),
       [MetaMetricsUserTrait.ProfileId]: Object.entries(
         metamaskState.srpSessionData || {},

--- a/app/scripts/controllers/metametrics-controller.ts
+++ b/app/scripts/controllers/metametrics-controller.ts
@@ -1386,6 +1386,10 @@ export default class MetaMetricsController extends BaseController<
   _buildUserTraitsObject(
     metamaskState: MetaMaskState,
   ): Partial<MetaMetricsUserTraits> | null {
+    if (!metamaskState?.preferences) {
+      return null;
+    }
+
     const { traits } = this.state;
     const storageKindTrait = traits[MetaMetricsUserTrait.StorageKind];
 

--- a/app/scripts/controllers/metametrics-controller.ts
+++ b/app/scripts/controllers/metametrics-controller.ts
@@ -1441,7 +1441,7 @@ export default class MetaMetricsController extends BaseController<
       [MetaMetricsUserTrait.TokenDetectionEnabled]:
         metamaskState.useTokenDetection,
       [MetaMetricsUserTrait.ShowNativeTokenAsMainBalance]:
-        metamaskState.preferences?.showNativeTokenAsMainBalance,
+        metamaskState.preferences?.showNativeTokenAsMainBalance ?? false,
       [MetaMetricsUserTrait.CurrentCurrency]: metamaskState.currentCurrency,
       [MetaMetricsUserTrait.SecurityProviders]:
         metamaskState.securityAlertsEnabled ? ['blockaid'] : [],
@@ -1454,7 +1454,7 @@ export default class MetaMetricsController extends BaseController<
       [MetaMetricsUserTrait.TokenSortPreference]:
         metamaskState.preferences?.tokenSortConfig?.key || '',
       [MetaMetricsUserTrait.PrivacyModeEnabled]:
-        metamaskState.preferences?.privacyMode,
+        metamaskState.preferences?.privacyMode ?? false,
       [MetaMetricsUserTrait.NetworkFilterPreference]: Object.keys(
         metamaskState.preferences?.tokenNetworkFilter || {},
       ),

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -492,6 +492,7 @@ export default class MetamaskController extends EventEmitter {
     this.sendUpdate = debounce(
       this.privateSendUpdate.bind(this),
       MILLISECOND * 200,
+      { maxWait: MILLISECOND * 1000 }, // Force flush to avoid indefinite sync starvation
     );
     this.opts = opts;
     this.requestSafeReload =

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -492,7 +492,7 @@ export default class MetamaskController extends EventEmitter {
     this.sendUpdate = debounce(
       this.privateSendUpdate.bind(this),
       MILLISECOND * 200,
-      { maxWait: MILLISECOND * 1000 }, // Force flush to avoid indefinite sync starvation
+      { maxWait: SECOND }, // Force flush to avoid indefinite sync starvation
     );
     this.opts = opts;
     this.requestSafeReload =

--- a/test/e2e/tests/metrics/segment-user-traits.spec.ts
+++ b/test/e2e/tests/metrics/segment-user-traits.spec.ts
@@ -165,21 +165,34 @@ describe('Segment User Traits', function () {
         // Data Collection toggle is disabled if participate in meta metrics is off
         await privacySettings.toggleParticipateInMetaMetrics();
         await privacySettings.toggleDataCollectionForMarketing();
-        // Allow debounced state updates to flush (maxWait may cause
-        // intermediate identify events between the two toggles)
-        await driver.delay(2000);
-        events = await getEventPayloads(driver, mockedEndpoints);
-        assert.ok(events.length >= 1);
-        // Aggregate traits across all identify events to handle both
-        // single-event (batched) and multi-event (split) cases
+        // maxWait on sendUpdate debounce may split the two toggles into
+        // separate identify events. Poll until the expected traits arrive.
+        await driver.wait(async () => {
+          events = await getEventPayloads(
+            driver,
+            mockedEndpoints,
+            false,
+          );
+          if (events.length === 0) {
+            return false;
+          }
+          const allTraits = events.reduce(
+            (
+              acc: Record<string, unknown>,
+              event: { traits: Record<string, unknown> },
+            ) => ({ ...acc, ...event.traits }),
+            {} as Record<string, unknown>,
+          );
+          return (
+            allTraits.is_metrics_opted_in === true &&
+            allTraits.has_marketing_consent === true
+          );
+        }, driver.timeout);
         const allTraits = events.reduce(
           (
             acc: Record<string, unknown>,
             event: { traits: Record<string, unknown> },
-          ) => ({
-            ...acc,
-            ...event.traits,
-          }),
+          ) => ({ ...acc, ...event.traits }),
           {} as Record<string, unknown>,
         );
         assert.deepStrictEqual(allTraits.is_metrics_opted_in, true);

--- a/test/e2e/tests/metrics/segment-user-traits.spec.ts
+++ b/test/e2e/tests/metrics/segment-user-traits.spec.ts
@@ -165,10 +165,25 @@ describe('Segment User Traits', function () {
         // Data Collection toggle is disabled if participate in meta metrics is off
         await privacySettings.toggleParticipateInMetaMetrics();
         await privacySettings.toggleDataCollectionForMarketing();
+        // Allow debounced state updates to flush (maxWait may cause
+        // intermediate identify events between the two toggles)
+        await driver.delay(2000);
         events = await getEventPayloads(driver, mockedEndpoints);
-        assert.equal(events.length, 1);
-        assert.deepStrictEqual(events[0].traits.is_metrics_opted_in, true);
-        assert.deepStrictEqual(events[0].traits.has_marketing_consent, true);
+        assert.ok(events.length >= 1);
+        // Aggregate traits across all identify events to handle both
+        // single-event (batched) and multi-event (split) cases
+        const allTraits = events.reduce(
+          (
+            acc: Record<string, unknown>,
+            event: { traits: Record<string, unknown> },
+          ) => ({
+            ...acc,
+            ...event.traits,
+          }),
+          {} as Record<string, unknown>,
+        );
+        assert.deepStrictEqual(allTraits.is_metrics_opted_in, true);
+        assert.deepStrictEqual(allTraits.has_marketing_consent, true);
       },
     );
   });

--- a/test/e2e/tests/metrics/segment-user-traits.spec.ts
+++ b/test/e2e/tests/metrics/segment-user-traits.spec.ts
@@ -168,11 +168,11 @@ describe('Segment User Traits', function () {
         // maxWait on sendUpdate debounce may split the two toggles into
         // separate identify events. Poll until the expected traits arrive.
         await driver.wait(async () => {
-          events = await getEventPayloads(
-            driver,
-            mockedEndpoints,
-            false,
-          );
+          try {
+            events = await getEventPayloads(driver, mockedEndpoints, false);
+          } catch {
+            return false;
+          }
           if (events.length === 0) {
             return false;
           }
@@ -187,7 +187,7 @@ describe('Segment User Traits', function () {
             allTraits.is_metrics_opted_in === true &&
             allTraits.has_marketing_consent === true
           );
-        }, driver.timeout);
+        }, 30_000);
         const allTraits = events.reduce(
           (
             acc: Record<string, unknown>,


### PR DESCRIPTION
## **Description**

Adds `{ maxWait: MILLISECOND * 1000 }` to the `debounce` options for `sendUpdate` in `metamask-controller.js`, forcing a periodic flush even under continuous state updates. This prevents the background-to-UI state sync from being starved indefinitely during heavy operations (e.g. syncing >100 accounts).

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40331?quickstart=1)

## **Changelog**

CHANGELOG entry: Fixed background-to-UI state sync starvation that caused UI to become stuck indefinitely during large account syncs.

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/6777

## **Manual testing steps**

1. Load an SRP with >100 accounts
2. Open the Accounts list
3. Verify accounts populate and the UI does not get stuck in a permanent "syncing" state

## **Screenshots/Recordings**

### **Before**

<!-- N/A - behavioral fix, no visual change -->

### **After**

<!-- N/A - behavioral fix, no visual change -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts background-to-UI state update scheduling; behavioral/timing changes could affect UI freshness and event ordering under heavy state churn. Includes an e2e test change to reduce flakiness, but edge-case timing regressions are still possible.
> 
> **Overview**
> Prevents background-to-UI state sync starvation by adding `maxWait: SECOND` to the `sendUpdate` debounce in `metamask-controller.js`, ensuring state updates flush periodically even during continuous updates.
> 
> Hardens MetaMetrics user-trait generation in `metametrics-controller.ts` by making several `preferences`-derived traits null-safe with defaults, and updates the metrics e2e test to tolerate identify events being split across multiple updates by polling/merging traits before asserting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c512fb67269cfae34c8e991742e491f02eb8ed66. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->