### PR TITLE
fix: inconsistent decimals between all and selected network

### DIFF
--- a/ui/components/app/multichain-transaction-details-modal/multichain-transaction-details-modal.tsx
+++ b/ui/components/app/multichain-transaction-details-modal/multichain-transaction-details-modal.tsx
@@ -43,11 +43,7 @@ import {
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 import { ConfirmInfoRowDivider as Divider } from '../confirm/info/row';
 import { getURLHostName, shortenAddress } from '../../../helpers/utils/util';
-import {
-  getAccountName,
-  getSelectedAccount,
-  getSelectedMultichainNetworkConfiguration,
-} from '../../../selectors';
+import { getAccountName, getSelectedAccount } from '../../../selectors';
 import {
   KEYRING_TRANSACTION_STATUS_KEY,
   useMultichainTransactionDisplay,
@@ -78,7 +74,6 @@ export function MultichainTransactionDetailsModal({
   const t = useI18nContext();
   const { trackEvent } = useContext(MetaMetricsContext);
   const userAddress = useSelector(getSelectedAccount)?.address;
-  const networkConfig = useSelector(getSelectedMultichainNetworkConfiguration);
   const {
     from,
     to,
@@ -90,7 +85,7 @@ export function MultichainTransactionDetailsModal({
     type,
     timestamp,
     id,
-  } = useMultichainTransactionDisplay(transaction, networkConfig);
+  } = useMultichainTransactionDisplay(transaction);
 
   const internalAccounts = useSelector(getInternalAccounts);
   const internalAccountsById = useSelector(getInternalAccountsObject);

--- a/ui/components/multichain/activity-v2/non-evm-activity-list-item.tsx
+++ b/ui/components/multichain/activity-v2/non-evm-activity-list-item.tsx
@@ -13,7 +13,6 @@ import TransactionIcon from '../../app/transaction-icon/transaction-icon';
 import TransactionStatusLabel from '../../app/transaction-status-label/transaction-status-label';
 import { formatTimestamp } from '../../app/multichain-transaction-details-modal/helpers';
 import { ActivityListItem as LegacyActivityListItem } from '../activity-list-item';
-import { getSelectedMultichainNetworkConfiguration } from '../../../selectors/multichain/networks';
 import { ChainBadge } from '../../app/chain-badge/chain-badge';
 import { selectBridgeHistoryForAccountGroup } from '../../../ducks/bridge-status/selectors';
 import LegacyMultichainBridgeListItem from '../../app/multichain-bridge-transaction-list-item/multichain-bridge-transaction-list-item';
@@ -26,11 +25,10 @@ type Props = {
 // Wrapper around TransactionListItem for non-EVM transactions
 // until we properly map values to the new ActivityListItem
 export const NonEvmActivityListItem = ({ transaction, onClick }: Props) => {
-  const networkConfig = useSelector(getSelectedMultichainNetworkConfiguration);
   const bridgeHistoryItems = useSelector(selectBridgeHistoryForAccountGroup);
   const matchedBridgeHistoryItem = bridgeHistoryItems[transaction.id];
   const { from, to, type, timestamp, isRedeposit, title } =
-    useMultichainTransactionDisplay(transaction, networkConfig);
+    useMultichainTransactionDisplay(transaction);
   const statusKey = KEYRING_TRANSACTION_STATUS_KEY[transaction.status];
 
   if (

--- a/ui/hooks/useMultichainTransactionDisplay.ts
+++ b/ui/hooks/useMultichainTransactionDisplay.ts
@@ -6,7 +6,6 @@ import {
 import { TransactionStatus } from '@metamask/transaction-controller';
 import { MULTICHAIN_NETWORK_DECIMAL_PLACES } from '@metamask/multichain-network-controller';
 import { useSelector } from 'react-redux';
-import type { CaipChainId } from '@metamask/utils';
 import { formatWithThreshold } from '../components/app/assets/util/formatWithThreshold';
 import { getIntlLocale } from '../ducks/locale/locale';
 import { TransactionGroupStatus } from '../../shared/constants/transaction';
@@ -37,13 +36,9 @@ type AggregatedMovement = {
   amount: number;
 };
 
-export function useMultichainTransactionDisplay(
-  transaction: Transaction,
-  networkConfig: { chainId: CaipChainId },
-) {
+export function useMultichainTransactionDisplay(transaction: Transaction) {
   const locale = useSelector(getIntlLocale);
-  const { chainId } = networkConfig;
-  const decimalPlaces = MULTICHAIN_NETWORK_DECIMAL_PLACES[chainId];
+  const decimalPlaces = MULTICHAIN_NETWORK_DECIMAL_PLACES[transaction.chain];
   const t = useI18nContext();
 
   const from = aggregateAmount(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fix the inconsistent decimal handling of non EVM transactions when choosing between All Networks and the selected network

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40341?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: inconsistent decimals between and and selected network

## **Related issues**

Fixes: #40242 

## **Manual testing steps**

1. Select Solana network
2. Send amount with several decimals, in Solana network and confirm
3. Go to Activity
4. See tx with decimals
5. Select All popular network
6. See tx decimals are different

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to transaction amount formatting and a hook signature; main risk is display regressions for chains where `transaction.chain` doesn’t map to `MULTICHAIN_NETWORK_DECIMAL_PLACES`.
> 
> **Overview**
> Fixes inconsistent decimal formatting for non-EVM/multichain transactions by making `useMultichainTransactionDisplay` derive `decimalPlaces` from `transaction.chain` instead of the currently selected network.
> 
> Updates call sites (e.g., `MultichainTransactionDetailsModal` and `NonEvmActivityListItem`) to stop selecting/passing `getSelectedMultichainNetworkConfiguration`, simplifying the API and ensuring amounts render consistently when switching between *All Networks* and a specific network.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b70bf1c891477120066d122c652f47659a9502c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->