### PR TITLE
fix: prevent browser font synthesis for MMPoly font weights

### DIFF
--- a/ui/css/utilities/fonts.scss
+++ b/ui/css/utilities/fonts.scss
@@ -81,9 +81,31 @@ $font-path: './fonts';
   font-style: normal;
 }
 
+/* MM Poly */
 @font-face {
   font-family: 'MMPoly';
   src: url('#{$font-path}/MMPoly/MM_Poly-Regular.woff2') format('woff2');
   font-weight: 400;
+  font-style: normal;
+}
+
+// Additional weight declarations to prevent browser font synthesis
+// The DisplayMd typography variant uses font-weight: 700 on small screens and
+// font-weight: 500 on larger screens. Without these declarations, browsers
+// would artificially synthesize bold text, resulting in blurry/muddy rendering.
+// By explicitly mapping weights 500 and 700 to the Regular font file, we ensure
+// consistent rendering quality across all screen sizes.
+// See: https://github.com/MetaMask/metamask-design-system/issues/928
+@font-face {
+  font-family: 'MMPoly';
+  src: url('#{$font-path}/MMPoly/MM_Poly-Regular.woff2') format('woff2');
+  font-weight: 500;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'MMPoly';
+  src: url('#{$font-path}/MMPoly/MM_Poly-Regular.woff2') format('woff2');
+  font-weight: 700;
   font-style: normal;
 }


### PR DESCRIPTION
## **Description**

This PR fixes a font rendering issue where the MMPoly font was being artificially synthesized by browsers, resulting in blurry and muddy text appearance on mobile devices.

The problem occurs because the DisplayMd typography variant applies `font-weight: 700` on small screens (<768px) and `font-weight: 500` on larger screens, but only the Regular (400) weight was loaded for MMPoly. This caused browsers to synthesize the bold text artificially.

The solution adds explicit `@font-face` declarations for weights 500 and 700, both pointing to the Regular font file. This tells browsers to use the exact font file rather than creating synthetic bold rendering.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40349?quickstart=1)

## **Changelog**

CHANGELOG entry: Fixed blurry MMPoly font rendering on mobile devices by preventing browser font synthesis

## **Related issues**

Part of: https://github.com/MetaMask/metamask-design-system/issues/928

## **Manual testing steps**

1. Build the extension with these changes
2. View any page that uses the DisplayMd typography variant with MMPoly font on a mobile viewport (<768px width)
3. Verify that the text appears crisp and clear, not blurry or muddy
4. Compare with uppercase text to ensure rendering quality is maintained

## **Screenshots/Recordings**

### **Before**

Text appeared blurry and muddy due to browser-synthesized bold rendering

https://github.com/user-attachments/assets/41935c6a-3626-4b71-915b-dea08ab32160

### **After**

Text renders clearly using the explicit Regular font file for all weights

https://github.com/user-attachments/assets/5cd5d992-b39d-48d4-ae6b-1c1c5c6a8b5a

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only change that maps additional `MMPoly` weights to an existing font file; low risk aside from potential minor typography/weight appearance differences.
> 
> **Overview**
> Prevents browsers from synthesizing `MMPoly` bold/medium weights (which caused blurry text in responsive typography).
> 
> Adds explicit `@font-face` declarations for `MMPoly` at weights `500` and `700`, both pointing to the existing Regular `.woff2`, with inline documentation referencing the design-system issue.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 184d6ed2b8461d2b5c4cd3867eaa1b72a94e239b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->