### PR TITLE
feat(STX-356): add logic for gasless bridge with EIP-7702

### DIFF
--- a/package.json
+++ b/package.json
@@ -375,7 +375,7 @@
     "@metamask/selected-network-controller": "^25.0.0",
     "@metamask/shield-controller": "^5.0.1",
     "@metamask/signature-controller": "^39.0.2",
-    "@metamask/smart-transactions-controller": "^22.5.0",
+    "@metamask/smart-transactions-controller": "^22.6.0",
     "@metamask/snaps-controllers": "^18.0.1",
     "@metamask/snaps-execution-environments": "^11.0.0",
     "@metamask/snaps-rpc-methods": "^14.3.0",

--- a/shared/modules/selectors/smart-transactions.ts
+++ b/shared/modules/selectors/smart-transactions.ts
@@ -229,12 +229,8 @@ export const getIsSmartTransaction = (
 
 export const getGaslessBridgeWith7702EnabledForChain = (
   state: SmartTransactionsState,
-  chainId?: string,
+  chainId: Hex,
 ): boolean => {
-  const effectiveChainId = (chainId || getCurrentChainId(state)) as Hex;
-  const featureFlags = getSmartTransactionsFeatureFlagsForChain(
-    state,
-    effectiveChainId,
-  );
+  const featureFlags = getSmartTransactionsFeatureFlagsForChain(state, chainId);
   return featureFlags?.gaslessBridgeWith7702Enabled ?? false;
 };

--- a/shared/modules/selectors/smart-transactions.ts
+++ b/shared/modules/selectors/smart-transactions.ts
@@ -226,3 +226,15 @@ export const getIsSmartTransaction = (
     smartTransactionsPreferenceEnabled && smartTransactionsEnabled,
   );
 };
+
+export const getGaslessBridgeWith7702EnabledForChain = (
+  state: SmartTransactionsState,
+  chainId?: string,
+): boolean => {
+  const effectiveChainId = (chainId || getCurrentChainId(state)) as Hex;
+  const featureFlags = getSmartTransactionsFeatureFlagsForChain(
+    state,
+    effectiveChainId,
+  );
+  return featureFlags?.gaslessBridgeWith7702Enabled ?? false;
+};

--- a/ui/pages/bridge/hooks/useGasIncluded7702.test.ts
+++ b/ui/pages/bridge/hooks/useGasIncluded7702.test.ts
@@ -1,9 +1,7 @@
 import { act, waitFor } from '@testing-library/react';
 import { renderHookWithProvider } from '../../../../test/lib/render-helpers-navigate';
-import {
-  getGaslessBridgeWith7702EnabledForChain,
-  getIsSmartTransaction,
-} from '../../../../shared/modules/selectors';
+import { getGaslessBridgeWith7702EnabledForChain } from '../../../../shared/modules/selectors';
+import { getIsStxEnabled } from '../../../ducks/bridge/selectors';
 import { useGasIncluded7702 } from './useGasIncluded7702';
 
 jest.mock('../../../store/actions', () => ({
@@ -15,6 +13,11 @@ jest.mock('../../../store/controller-actions/transaction-controller', () => ({
 }));
 
 jest.mock('../../../../shared/modules/selectors');
+
+jest.mock('../../../ducks/bridge/selectors', () => ({
+  ...jest.requireActual('../../../ducks/bridge/selectors'),
+  getIsStxEnabled: jest.fn(),
+}));
 
 const renderUseGasIncluded7702 = (
   params: Parameters<typeof useGasIncluded7702>[0],
@@ -35,7 +38,7 @@ describe('useGasIncluded7702', () => {
   const mockIsAtomicBatchSupported = jest.requireMock(
     '../../../store/controller-actions/transaction-controller',
   ).isAtomicBatchSupported;
-  const mockGetIsSmartTransaction = jest.mocked(getIsSmartTransaction);
+  const mockGetIsStxEnabled = jest.mocked(getIsStxEnabled);
   const mockGetGaslessBridgeWith7702Enabled = jest.mocked(
     getGaslessBridgeWith7702EnabledForChain,
   );
@@ -43,7 +46,7 @@ describe('useGasIncluded7702', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.spyOn(console, 'error').mockImplementation(() => undefined);
-    mockGetIsSmartTransaction.mockReturnValue(false);
+    mockGetIsStxEnabled.mockReturnValue(false);
     mockGetGaslessBridgeWith7702Enabled.mockReturnValue(false);
   });
 
@@ -52,7 +55,7 @@ describe('useGasIncluded7702', () => {
   });
 
   it('returns false and skips checks when send bundle supported AND Smart Transactions enabled', () => {
-    mockGetIsSmartTransaction.mockReturnValue(true);
+    mockGetIsStxEnabled.mockReturnValue(true);
 
     const { result } = renderUseGasIncluded7702({
       isSwap: true,
@@ -67,7 +70,7 @@ describe('useGasIncluded7702', () => {
   });
 
   it('proceeds with checks when send bundle supported BUT Smart Transactions disabled', async () => {
-    mockGetIsSmartTransaction.mockReturnValue(false);
+    mockGetIsStxEnabled.mockReturnValue(false);
     mockIsRelaySupported.mockResolvedValue(true);
 
     const { result, waitForNextUpdate } = renderUseGasIncluded7702({
@@ -157,7 +160,6 @@ describe('useGasIncluded7702', () => {
     expect(result.current).toBe(false);
     expect(mockIsRelaySupported).not.toHaveBeenCalled();
     expect(mockGetGaslessBridgeWith7702Enabled).not.toHaveBeenCalled();
-    expect(mockGetIsSmartTransaction).not.toHaveBeenCalled();
   });
 
   it('returns false for non-EVM chain IDs and skips relay check', () => {
@@ -184,10 +186,7 @@ describe('useGasIncluded7702', () => {
       expect.anything(),
       '0x1',
     );
-    expect(mockGetIsSmartTransaction).toHaveBeenCalledWith(
-      expect.anything(),
-      '0x1',
-    );
+    expect(mockGetIsStxEnabled).toHaveBeenCalled();
   });
 
   it('returns true when relay is supported', async () => {

--- a/ui/pages/bridge/hooks/useGasIncluded7702.test.ts
+++ b/ui/pages/bridge/hooks/useGasIncluded7702.test.ts
@@ -1,6 +1,9 @@
 import { act, waitFor } from '@testing-library/react';
 import { renderHookWithProvider } from '../../../../test/lib/render-helpers-navigate';
-import { getIsSmartTransaction } from '../../../../shared/modules/selectors';
+import {
+  getGaslessBridgeWith7702EnabledForChain,
+  getIsSmartTransaction,
+} from '../../../../shared/modules/selectors';
 import { useGasIncluded7702 } from './useGasIncluded7702';
 
 jest.mock('../../../store/actions', () => ({
@@ -33,11 +36,15 @@ describe('useGasIncluded7702', () => {
     '../../../store/controller-actions/transaction-controller',
   ).isAtomicBatchSupported;
   const mockGetIsSmartTransaction = jest.mocked(getIsSmartTransaction);
+  const mockGetGaslessBridgeWith7702Enabled = jest.mocked(
+    getGaslessBridgeWith7702EnabledForChain,
+  );
 
   beforeEach(() => {
     jest.clearAllMocks();
     jest.spyOn(console, 'error').mockImplementation(() => undefined);
     mockGetIsSmartTransaction.mockReturnValue(false);
+    mockGetGaslessBridgeWith7702Enabled.mockReturnValue(false);
   });
 
   afterEach(() => {
@@ -79,7 +86,9 @@ describe('useGasIncluded7702', () => {
     expect(result.current).toBe(true);
   });
 
-  it('returns false when isSwap is false', () => {
+  it('returns false when isSwap is false and gaslessBridgeWith7702Enabled is false', () => {
+    mockGetGaslessBridgeWith7702Enabled.mockReturnValue(false);
+
     const { result } = renderUseGasIncluded7702({
       isSwap: false,
       selectedAccount: { address: '0x123' },
@@ -89,6 +98,40 @@ describe('useGasIncluded7702', () => {
 
     expect(result.current).toBe(false);
     expect(mockIsRelaySupported).not.toHaveBeenCalled();
+  });
+
+  it('proceeds with relay check when isSwap is true regardless of gaslessBridgeWith7702Enabled value', async () => {
+    mockGetGaslessBridgeWith7702Enabled.mockReturnValue(true);
+    mockIsRelaySupported.mockResolvedValue(true);
+
+    const { result, waitForNextUpdate } = renderUseGasIncluded7702({
+      isSwap: true,
+      selectedAccount: { address: '0x123' },
+      fromChain: { chainId: '0x1' },
+      isSendBundleSupportedForChain: false,
+    });
+
+    await waitForNextUpdate();
+
+    expect(result.current).toBe(true);
+    expect(mockIsRelaySupported).toHaveBeenCalledWith('0x1');
+  });
+
+  it('returns true when isSwap is false and gaslessBridgeWith7702Enabled is true and relay supported', async () => {
+    mockGetGaslessBridgeWith7702Enabled.mockReturnValue(true);
+    mockIsRelaySupported.mockResolvedValue(true);
+
+    const { result, waitForNextUpdate } = renderUseGasIncluded7702({
+      isSwap: false,
+      selectedAccount: { address: '0x123' },
+      fromChain: { chainId: '0x1' },
+      isSendBundleSupportedForChain: false,
+    });
+
+    await waitForNextUpdate();
+
+    expect(result.current).toBe(true);
+    expect(mockIsRelaySupported).toHaveBeenCalledWith('0x1');
   });
 
   it('returns false when selectedAccount is null', () => {
@@ -103,7 +146,7 @@ describe('useGasIncluded7702', () => {
     expect(mockIsRelaySupported).not.toHaveBeenCalled();
   });
 
-  it('returns false when fromChain is null', () => {
+  it('returns false when fromChain is null and does not call selectors with a chainId', () => {
     const { result } = renderUseGasIncluded7702({
       isSwap: true,
       selectedAccount: { address: '0x123' },
@@ -113,6 +156,38 @@ describe('useGasIncluded7702', () => {
 
     expect(result.current).toBe(false);
     expect(mockIsRelaySupported).not.toHaveBeenCalled();
+    expect(mockGetGaslessBridgeWith7702Enabled).not.toHaveBeenCalled();
+    expect(mockGetIsSmartTransaction).not.toHaveBeenCalled();
+  });
+
+  it('returns false for non-EVM chain IDs and skips relay check', () => {
+    const { result } = renderUseGasIncluded7702({
+      isSwap: true,
+      selectedAccount: { address: '0x123' },
+      fromChain: { chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp' },
+      isSendBundleSupportedForChain: false,
+    });
+
+    expect(result.current).toBe(false);
+    expect(mockIsRelaySupported).not.toHaveBeenCalled();
+  });
+
+  it('passes the correct hex chainId to selectors', () => {
+    renderUseGasIncluded7702({
+      isSwap: true,
+      selectedAccount: { address: '0x123' },
+      fromChain: { chainId: '0x1' },
+      isSendBundleSupportedForChain: false,
+    });
+
+    expect(mockGetGaslessBridgeWith7702Enabled).toHaveBeenCalledWith(
+      expect.anything(),
+      '0x1',
+    );
+    expect(mockGetIsSmartTransaction).toHaveBeenCalledWith(
+      expect.anything(),
+      '0x1',
+    );
   });
 
   it('returns true when relay is supported', async () => {
@@ -179,18 +254,20 @@ describe('useGasIncluded7702', () => {
     );
   });
 
-  it('handles case-insensitive chainId comparison', async () => {
+  it('converts decimal chainId to hex before calling isRelaySupported', async () => {
     mockIsRelaySupported.mockResolvedValue(true);
 
     const { result, waitForNextUpdate } = renderUseGasIncluded7702({
       isSwap: true,
       selectedAccount: { address: '0x123' },
-      fromChain: { chainId: '0x1' },
+      fromChain: { chainId: '10' },
       isSendBundleSupportedForChain: false,
     });
 
     await waitForNextUpdate();
+
     expect(result.current).toBe(true);
+    expect(mockIsRelaySupported).toHaveBeenCalledWith('0xa');
   });
 
   describe('Race condition handling', () => {

--- a/ui/pages/bridge/hooks/useGasIncluded7702.ts
+++ b/ui/pages/bridge/hooks/useGasIncluded7702.ts
@@ -4,7 +4,10 @@ import {
 } from '@metamask/bridge-controller';
 import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { getIsSmartTransaction } from '../../../../shared/modules/selectors';
+import {
+  getGaslessBridgeWith7702EnabledForChain,
+  getIsSmartTransaction,
+} from '../../../../shared/modules/selectors';
 import { isRelaySupported } from '../../../store/actions';
 import { getMaybeHexChainId } from '../../../ducks/bridge/utils';
 
@@ -39,13 +42,24 @@ export function useGasIncluded7702({
   fromChain,
   isSendBundleSupportedForChain,
 }: UseGasIncluded7702Params): boolean {
+  const isGaslessBridgeWith7702Enabled = useSelector((state) =>
+    fromChain?.chainId
+      ? getGaslessBridgeWith7702EnabledForChain(
+          state as never,
+          getMaybeHexChainId(fromChain.chainId) ?? fromChain.chainId,
+        )
+      : false,
+  );
+
   const [isGasIncluded7702Supported, setIsGasIncluded7702Supported] =
     useState(false);
   const isSmartTransaction = useSelector((state) =>
-    getIsSmartTransaction(
-      state as never,
-      getMaybeHexChainId(fromChain?.chainId) ?? fromChain?.chainId,
-    ),
+    fromChain?.chainId
+      ? getIsSmartTransaction(
+          state as never,
+          getMaybeHexChainId(fromChain.chainId) ?? fromChain.chainId,
+        )
+      : false,
   );
 
   useEffect(() => {
@@ -54,7 +68,7 @@ export function useGasIncluded7702({
     const checkGasIncluded7702Support = async () => {
       if (
         (isSendBundleSupportedForChain && isSmartTransaction) ||
-        !isSwap ||
+        (!isSwap && !isGaslessBridgeWith7702Enabled) ||
         !selectedAccount?.address ||
         !fromChain?.chainId
       ) {
@@ -93,6 +107,7 @@ export function useGasIncluded7702({
     fromChain?.chainId,
     isSendBundleSupportedForChain,
     isSmartTransaction,
+    isGaslessBridgeWith7702Enabled,
     isSwap,
     selectedAccount?.address,
   ]);

--- a/ui/pages/bridge/hooks/useGasIncluded7702.ts
+++ b/ui/pages/bridge/hooks/useGasIncluded7702.ts
@@ -6,9 +6,10 @@ import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import {
   getGaslessBridgeWith7702EnabledForChain,
-  getIsSmartTransaction,
+  SmartTransactionsState,
 } from '../../../../shared/modules/selectors';
 import { isRelaySupported } from '../../../store/actions';
+import { getIsStxEnabled } from '../../../ducks/bridge/selectors';
 import { getMaybeHexChainId } from '../../../ducks/bridge/utils';
 
 type Chain = {
@@ -42,25 +43,20 @@ export function useGasIncluded7702({
   fromChain,
   isSendBundleSupportedForChain,
 }: UseGasIncluded7702Params): boolean {
-  const isGaslessBridgeWith7702Enabled = useSelector((state) =>
-    fromChain?.chainId
-      ? getGaslessBridgeWith7702EnabledForChain(
-          state as never,
-          getMaybeHexChainId(fromChain.chainId) ?? fromChain.chainId,
-        )
-      : false,
+  const isGaslessBridgeWith7702Enabled = useSelector(
+    (state: SmartTransactionsState) => {
+      const hexChainId = fromChain?.chainId
+        ? getMaybeHexChainId(fromChain.chainId)
+        : undefined;
+      return hexChainId
+        ? getGaslessBridgeWith7702EnabledForChain(state, hexChainId)
+        : false;
+    },
   );
 
   const [isGasIncluded7702Supported, setIsGasIncluded7702Supported] =
     useState(false);
-  const isSmartTransaction = useSelector((state) =>
-    fromChain?.chainId
-      ? getIsSmartTransaction(
-          state as never,
-          getMaybeHexChainId(fromChain.chainId) ?? fromChain.chainId,
-        )
-      : false,
-  );
+  const isSmartTransaction = useSelector(getIsStxEnabled);
 
   useEffect(() => {
     let isCancelled = false;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8367,9 +8367,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/smart-transactions-controller@npm:^22.5.0":
-  version: 22.5.0
-  resolution: "@metamask/smart-transactions-controller@npm:22.5.0"
+"@metamask/smart-transactions-controller@npm:^22.6.0":
+  version: 22.6.0
+  resolution: "@metamask/smart-transactions-controller@npm:22.6.0"
   dependencies:
     "@babel/runtime": "npm:^7.24.1"
     "@ethereumjs/tx": "npm:^5.2.1"
@@ -8403,7 +8403,7 @@ __metadata:
       optional: true
     "@metamask/gas-fee-controller":
       optional: true
-  checksum: 10/215c5fe21e5e1679e4e0bc247d4ace99d88464ae97fd8c75fcd3bb3dc8420e11752b18a8eddd481591fc97508cfa87e909f7defda6911027c95166e6f69c5ba5
+  checksum: 10/f8fc9b7b63f343d9e806cec8da14f5419af075aac0d751bff727f6c9380ee28710406a4deae7753bf55155cf0469089b6e1058d02f0e47a2bfbfa3128abb7cba
   languageName: node
   linkType: hard
 
@@ -8832,7 +8832,46 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@npm:^62.11.0, @metamask/transaction-controller@npm:^62.12.0, @metamask/transaction-controller@npm:^62.14.0, @metamask/transaction-controller@npm:^62.16.0, @metamask/transaction-controller@npm:^62.17.0, @metamask/transaction-controller@npm:^62.17.1, @metamask/transaction-controller@npm:^62.19.0, @metamask/transaction-controller@npm:^62.4.0, @metamask/transaction-controller@npm:^62.7.0":
+"@metamask/transaction-controller@npm:^62.11.0, @metamask/transaction-controller@npm:^62.12.0, @metamask/transaction-controller@npm:^62.14.0, @metamask/transaction-controller@npm:^62.16.0, @metamask/transaction-controller@npm:^62.17.0, @metamask/transaction-controller@npm:^62.17.1, @metamask/transaction-controller@npm:^62.4.0, @metamask/transaction-controller@npm:^62.7.0":
+  version: 62.17.1
+  resolution: "@metamask/transaction-controller@npm:62.17.1"
+  dependencies:
+    "@ethereumjs/common": "npm:^4.4.0"
+    "@ethereumjs/tx": "npm:^5.4.0"
+    "@ethereumjs/util": "npm:^9.1.0"
+    "@ethersproject/abi": "npm:^5.7.0"
+    "@ethersproject/contracts": "npm:^5.7.0"
+    "@ethersproject/providers": "npm:^5.7.0"
+    "@ethersproject/wallet": "npm:^5.7.0"
+    "@metamask/accounts-controller": "npm:^36.0.1"
+    "@metamask/approval-controller": "npm:^8.0.0"
+    "@metamask/base-controller": "npm:^9.0.0"
+    "@metamask/controller-utils": "npm:^11.19.0"
+    "@metamask/core-backend": "npm:^6.0.0"
+    "@metamask/eth-query": "npm:^4.0.0"
+    "@metamask/gas-fee-controller": "npm:^26.0.3"
+    "@metamask/messenger": "npm:^0.3.0"
+    "@metamask/metamask-eth-abis": "npm:^3.1.1"
+    "@metamask/network-controller": "npm:^30.0.0"
+    "@metamask/nonce-tracker": "npm:^6.0.0"
+    "@metamask/remote-feature-flag-controller": "npm:^4.0.0"
+    "@metamask/rpc-errors": "npm:^7.0.2"
+    "@metamask/utils": "npm:^11.9.0"
+    async-mutex: "npm:^0.5.0"
+    bignumber.js: "npm:^9.1.2"
+    bn.js: "npm:^5.2.1"
+    eth-method-registry: "npm:^4.0.0"
+    fast-json-patch: "npm:^3.1.1"
+    lodash: "npm:^4.17.21"
+    uuid: "npm:^8.3.2"
+  peerDependencies:
+    "@babel/runtime": ^7.0.0
+    "@metamask/eth-block-tracker": ">=9"
+  checksum: 10/b82970496e11c919f2be425ebd0aafcf10f355a8521b2c2d6aa62ab1bd634e8f71187f48e57d40a7c87620a61263fde38e5529d304ec5f144f8000f20b0acd27
+  languageName: node
+  linkType: hard
+
+"@metamask/transaction-controller@npm:^62.19.0":
   version: 62.19.0
   resolution: "@metamask/transaction-controller@npm:62.19.0"
   dependencies:
@@ -33825,7 +33864,7 @@ __metadata:
     "@metamask/selected-network-controller": "npm:^25.0.0"
     "@metamask/shield-controller": "npm:^5.0.1"
     "@metamask/signature-controller": "npm:^39.0.2"
-    "@metamask/smart-transactions-controller": "npm:^22.5.0"
+    "@metamask/smart-transactions-controller": "npm:^22.6.0"
     "@metamask/snap-account-abstraction-keyring-site": "npm:^1.0.0"
     "@metamask/snap-simple-keyring-site": "npm:^2.0.0"
     "@metamask/snaps-controllers": "npm:^18.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8832,46 +8832,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@npm:^62.11.0, @metamask/transaction-controller@npm:^62.12.0, @metamask/transaction-controller@npm:^62.14.0, @metamask/transaction-controller@npm:^62.16.0, @metamask/transaction-controller@npm:^62.17.0, @metamask/transaction-controller@npm:^62.17.1, @metamask/transaction-controller@npm:^62.4.0, @metamask/transaction-controller@npm:^62.7.0":
-  version: 62.17.1
-  resolution: "@metamask/transaction-controller@npm:62.17.1"
-  dependencies:
-    "@ethereumjs/common": "npm:^4.4.0"
-    "@ethereumjs/tx": "npm:^5.4.0"
-    "@ethereumjs/util": "npm:^9.1.0"
-    "@ethersproject/abi": "npm:^5.7.0"
-    "@ethersproject/contracts": "npm:^5.7.0"
-    "@ethersproject/providers": "npm:^5.7.0"
-    "@ethersproject/wallet": "npm:^5.7.0"
-    "@metamask/accounts-controller": "npm:^36.0.1"
-    "@metamask/approval-controller": "npm:^8.0.0"
-    "@metamask/base-controller": "npm:^9.0.0"
-    "@metamask/controller-utils": "npm:^11.19.0"
-    "@metamask/core-backend": "npm:^6.0.0"
-    "@metamask/eth-query": "npm:^4.0.0"
-    "@metamask/gas-fee-controller": "npm:^26.0.3"
-    "@metamask/messenger": "npm:^0.3.0"
-    "@metamask/metamask-eth-abis": "npm:^3.1.1"
-    "@metamask/network-controller": "npm:^30.0.0"
-    "@metamask/nonce-tracker": "npm:^6.0.0"
-    "@metamask/remote-feature-flag-controller": "npm:^4.0.0"
-    "@metamask/rpc-errors": "npm:^7.0.2"
-    "@metamask/utils": "npm:^11.9.0"
-    async-mutex: "npm:^0.5.0"
-    bignumber.js: "npm:^9.1.2"
-    bn.js: "npm:^5.2.1"
-    eth-method-registry: "npm:^4.0.0"
-    fast-json-patch: "npm:^3.1.1"
-    lodash: "npm:^4.17.21"
-    uuid: "npm:^8.3.2"
-  peerDependencies:
-    "@babel/runtime": ^7.0.0
-    "@metamask/eth-block-tracker": ">=9"
-  checksum: 10/b82970496e11c919f2be425ebd0aafcf10f355a8521b2c2d6aa62ab1bd634e8f71187f48e57d40a7c87620a61263fde38e5529d304ec5f144f8000f20b0acd27
-  languageName: node
-  linkType: hard
-
-"@metamask/transaction-controller@npm:^62.19.0":
+"@metamask/transaction-controller@npm:^62.11.0, @metamask/transaction-controller@npm:^62.12.0, @metamask/transaction-controller@npm:^62.14.0, @metamask/transaction-controller@npm:^62.16.0, @metamask/transaction-controller@npm:^62.17.0, @metamask/transaction-controller@npm:^62.17.1, @metamask/transaction-controller@npm:^62.19.0, @metamask/transaction-controller@npm:^62.4.0, @metamask/transaction-controller@npm:^62.7.0":
   version: 62.19.0
   resolution: "@metamask/transaction-controller@npm:62.19.0"
   dependencies:


### PR DESCRIPTION
This PR adds the logic to enable gasless bridge with EIP-7702. The networks where this will be enabled are controlled via a smart transaction team feature flag defined in the remote config API. 

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40354?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: add gasless bridge with EIP-7702

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes feature-gating logic for when gasless relay support checks run during bridging, which can affect transaction routing/UX across chains; mitigated by added unit test coverage and being controlled by remote feature flags.
> 
> **Overview**
> Adds a new Smart Transactions selector, `getGaslessBridgeWith7702EnabledForChain`, exposing a remote-config-driven feature flag to control where gasless bridge with EIP-7702 is enabled.
> 
> Updates `useGasIncluded7702` so gasless 7702 support checks can run for non-swap bridge flows only when this new flag is enabled (while still skipping when send-bundle+STX is active), and switches STX detection to use the bridge selector `getIsStxEnabled`. Tests are expanded to cover the new gating behavior, non-EVM chain IDs, and decimal-to-hex chainId conversion for relay support checks.
> 
> Bumps `@metamask/smart-transactions-controller` to `^22.6.0` (lockfile updated).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a5b87c4b082ff2696935853fc7853d16ea2e443d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->