### PR TITLE
fix: hide required transactions in activity-v2

### DIFF
--- a/shared/lib/multichain/transformations.ts
+++ b/shared/lib/multichain/transformations.ts
@@ -178,7 +178,13 @@ const INCLUDE_TOKEN_TRANSFERS = false;
 const EXCLUDED_TRANSACTION_TYPES = ['SPAM_TOKEN_TRANSFER'];
 
 // Transform and filter raw API response
-export function selectTransactions(address: string) {
+export function selectTransactions({
+  address,
+  excludeTxHashes,
+}: {
+  address: string;
+  excludeTxHashes?: Set<string>;
+}) {
   const addr = address.toLowerCase();
 
   return (
@@ -192,6 +198,11 @@ export function selectTransactions(address: string) {
         const rawFrom = raw.from?.toLowerCase();
         const rawTo = raw.to?.toLowerCase();
         if (rawFrom !== addr && rawTo !== addr) {
+          return result;
+        }
+
+        // Filter out excluded transaction hashes (e.g. internal prerequisite transactions)
+        if (raw.hash && excludeTxHashes?.has(raw.hash.toLowerCase())) {
           return result;
         }
 

--- a/shared/lib/multichain/transformations.ts
+++ b/shared/lib/multichain/transformations.ts
@@ -180,10 +180,10 @@ const EXCLUDED_TRANSACTION_TYPES = ['SPAM_TOKEN_TRANSFER'];
 // Transform and filter raw API response
 export function selectTransactions({
   address,
-  excludeTxHashes,
+  excludedTxHashes,
 }: {
   address: string;
-  excludeTxHashes?: Set<string>;
+  excludedTxHashes?: Set<string>;
 }) {
   const addr = address.toLowerCase();
 
@@ -202,7 +202,7 @@ export function selectTransactions({
         }
 
         // Filter out excluded transaction hashes (e.g. internal prerequisite transactions)
-        if (raw.hash && excludeTxHashes?.has(raw.hash.toLowerCase())) {
+        if (raw.hash && excludedTxHashes?.has(raw.hash.toLowerCase())) {
           return result;
         }
 

--- a/ui/components/multichain/activity-v2/activity-list.tsx
+++ b/ui/components/multichain/activity-v2/activity-list.tsx
@@ -9,7 +9,6 @@ import { useScrollContainer } from '../../../contexts/scroll-container';
 import { TransactionActivityEmptyState } from '../../app/transaction-activity-empty-state';
 import { PENDING_STATUS_HASH } from '../../../helpers/constants/transactions';
 import { selectLocalTransactions } from '../../../selectors/activity';
-import { selectRequiredTransactionHashes } from '../../../selectors/transactionController';
 import { selectEvmAddress } from '../../../selectors/accounts';
 import { selectCurrentAccountNonEvmTransactions } from '../../../selectors/multichain-transactions';
 import { selectEnabledNetworksAsCaipChainIds } from '../../../selectors/multichain/networks';
@@ -65,9 +64,6 @@ export const ActivityList = () => {
   // Local transactions - may not be in API yet
   const localTransactions = useSelector(selectLocalTransactions);
 
-  // Nested internal transactions that should not be shown in activity
-  const requiredTxHashes = useSelector(selectRequiredTransactionHashes);
-
   // Non-EVM transactions - not in API
   const nonEvmTransactions = useSelector(
     selectCurrentAccountNonEvmTransactions,
@@ -75,7 +71,8 @@ export const ActivityList = () => {
 
   // Merge and flatten for virtualization
   const flattenedItems = useMemo(() => {
-    const evmTransactions = parseApiTransactions(data, requiredTxHashes);
+    const evmTransactions =
+      data?.pages?.flatMap((page) => page.data ?? []) ?? [];
 
     // Filter local transactions by converting hex chainId to CAIP-2
     const filteredLocalTransactions = filterLocalNotInApi(
@@ -99,13 +96,7 @@ export const ActivityList = () => {
     );
 
     return groupAndFlattenMergedTransactions(mergedByTime);
-  }, [
-    data,
-    nonEvmTransactions,
-    localTransactions,
-    enabledNetworks,
-    requiredTxHashes,
-  ]);
+  }, [data, nonEvmTransactions, localTransactions, enabledNetworks]);
 
   const virtualizer = useVirtualizer({
     count: flattenedItems.length,
@@ -258,13 +249,3 @@ export const ActivityList = () => {
   );
 };
 
-function parseApiTransactions(
-  data: ReturnType<typeof useTransactionsQuery>['data'],
-  requiredTxHashes: Set<string>,
-): TransactionViewModel[] {
-  const all = data?.pages?.flatMap((page) => page.data ?? []) ?? [];
-
-  return all.filter(
-    (tx) => !tx.hash || !requiredTxHashes.has(tx.hash.toLowerCase()),
-  );
-}

--- a/ui/components/multichain/activity-v2/activity-list.tsx
+++ b/ui/components/multichain/activity-v2/activity-list.tsx
@@ -9,6 +9,7 @@ import { useScrollContainer } from '../../../contexts/scroll-container';
 import { TransactionActivityEmptyState } from '../../app/transaction-activity-empty-state';
 import { PENDING_STATUS_HASH } from '../../../helpers/constants/transactions';
 import { selectLocalTransactions } from '../../../selectors/activity';
+import { selectRequiredTransactionHashes } from '../../../selectors/transactionController';
 import { selectEvmAddress } from '../../../selectors/accounts';
 import { selectCurrentAccountNonEvmTransactions } from '../../../selectors/multichain-transactions';
 import { selectEnabledNetworksAsCaipChainIds } from '../../../selectors/multichain/networks';
@@ -64,6 +65,9 @@ export const ActivityList = () => {
   // Local transactions - may not be in API yet
   const localTransactions = useSelector(selectLocalTransactions);
 
+  // Nested internal transactions that should not be shown in activity
+  const requiredTxHashes = useSelector(selectRequiredTransactionHashes);
+
   // Non-EVM transactions - not in API
   const nonEvmTransactions = useSelector(
     selectCurrentAccountNonEvmTransactions,
@@ -71,8 +75,7 @@ export const ActivityList = () => {
 
   // Merge and flatten for virtualization
   const flattenedItems = useMemo(() => {
-    const evmTransactions =
-      data?.pages?.flatMap((page) => page.data ?? []) ?? [];
+    const evmTransactions = parseApiTransactions(data, requiredTxHashes);
 
     // Filter local transactions by converting hex chainId to CAIP-2
     const filteredLocalTransactions = filterLocalNotInApi(
@@ -96,7 +99,13 @@ export const ActivityList = () => {
     );
 
     return groupAndFlattenMergedTransactions(mergedByTime);
-  }, [data, nonEvmTransactions, localTransactions, enabledNetworks]);
+  }, [
+    data,
+    nonEvmTransactions,
+    localTransactions,
+    enabledNetworks,
+    requiredTxHashes,
+  ]);
 
   const virtualizer = useVirtualizer({
     count: flattenedItems.length,
@@ -248,3 +257,14 @@ export const ActivityList = () => {
     </Box>
   );
 };
+
+function parseApiTransactions(
+  data: ReturnType<typeof useTransactionsQuery>['data'],
+  requiredTxHashes: Set<string>,
+): TransactionViewModel[] {
+  const all = data?.pages?.flatMap((page) => page.data ?? []) ?? [];
+
+  return all.filter(
+    (tx) => !tx.hash || !requiredTxHashes.has(tx.hash.toLowerCase()),
+  );
+}

--- a/ui/components/multichain/activity-v2/activity-list.tsx
+++ b/ui/components/multichain/activity-v2/activity-list.tsx
@@ -248,4 +248,3 @@ export const ActivityList = () => {
     </Box>
   );
 };
-

--- a/ui/components/multichain/activity-v2/hooks.ts
+++ b/ui/components/multichain/activity-v2/hooks.ts
@@ -15,6 +15,7 @@ import { SET_APPROVAL_FOR_ALL } from '../../../../shared/constants/transaction';
 import { selectEnabledNetworksAsCaipChainIds } from '../../../selectors/multichain/networks';
 import { selectRequiredTransactionHashes } from '../../../selectors/transactionController';
 import { queries } from '../../../helpers/queries';
+import { selectTransactions } from '../../../../shared/lib/multichain/transformations';
 import { calculateFiatFromMarketRates } from './helpers';
 
 function useTransactionParams() {
@@ -46,26 +47,25 @@ export function useTransactionsQuery() {
   const { evmAddress, accountAddresses, networks } = useTransactionParams();
   const internalTxHashes = useSelector(selectRequiredTransactionHashes);
 
+  const selectFn = useMemo(
+    () =>
+      selectTransactions({
+        address: evmAddress,
+        excludedTxHashes: internalTxHashes,
+      }),
+    [evmAddress, internalTxHashes],
+  );
+
   const queryOptions = useMemo(
     () =>
       queries.transactions(
         { accountAddresses, evmAddress, networks },
-        {
-          enabled: Boolean(useExternalServices),
-          keepPreviousData: true,
-        },
-        internalTxHashes,
+        { enabled: Boolean(useExternalServices), keepPreviousData: true },
       ),
-    [
-      evmAddress,
-      accountAddresses,
-      networks,
-      internalTxHashes,
-      useExternalServices,
-    ],
+    [evmAddress, accountAddresses, networks, useExternalServices],
   );
 
-  return useInfiniteQuery(queryOptions);
+  return useInfiniteQuery({ ...queryOptions, select: selectFn });
 }
 
 export function usePrefetchTransactions() {

--- a/ui/components/multichain/activity-v2/hooks.ts
+++ b/ui/components/multichain/activity-v2/hooks.ts
@@ -13,6 +13,7 @@ import { getUseExternalServices } from '../../../selectors';
 import { parseApprovalTransactionData } from '../../../../shared/modules/transaction.utils';
 import { SET_APPROVAL_FOR_ALL } from '../../../../shared/constants/transaction';
 import { selectEnabledNetworksAsCaipChainIds } from '../../../selectors/multichain/networks';
+import { selectRequiredTransactionHashes } from '../../../selectors/transactionController';
 import { queries } from '../../../helpers/queries';
 import { calculateFiatFromMarketRates } from './helpers';
 
@@ -43,14 +44,25 @@ function useTransactionParams() {
 export function useTransactionsQuery() {
   const useExternalServices = useSelector(getUseExternalServices);
   const { evmAddress, accountAddresses, networks } = useTransactionParams();
+  const internalTxHashes = useSelector(selectRequiredTransactionHashes);
 
   const queryOptions = useMemo(
     () =>
       queries.transactions(
         { accountAddresses, evmAddress, networks },
-        { enabled: Boolean(useExternalServices), keepPreviousData: true },
+        {
+          enabled: Boolean(useExternalServices),
+          keepPreviousData: true,
+        },
+        internalTxHashes,
       ),
-    [evmAddress, accountAddresses, networks, useExternalServices],
+    [
+      evmAddress,
+      accountAddresses,
+      networks,
+      internalTxHashes,
+      useExternalServices,
+    ],
   );
 
   return useInfiniteQuery(queryOptions);

--- a/ui/helpers/queries.ts
+++ b/ui/helpers/queries.ts
@@ -23,6 +23,7 @@ export const queries = {
   transactions: (
     params: Params,
     options?: QueryOptions,
+    excludeTxHashes?: Set<string>,
   ): UseInfiniteQueryOptions<
     V4MultiAccountTransactionsResponse,
     unknown,
@@ -51,7 +52,7 @@ export const queries = {
           }) => Promise<V4MultiAccountTransactionsResponse>
         )({ signal });
       },
-      select: selectTransactions(evmAddress),
+      select: selectTransactions({ address: evmAddress, excludeTxHashes }),
       getNextPageParam: ({ pageInfo }) =>
         pageInfo.hasNextPage ? pageInfo.endCursor : undefined,
       staleTime: STALE_TIMES.TRANSACTIONS,

--- a/ui/helpers/queries.ts
+++ b/ui/helpers/queries.ts
@@ -2,7 +2,6 @@ import type { UseInfiniteQueryOptions } from '@tanstack/react-query';
 import type { V4MultiAccountTransactionsResponse } from '@metamask/core-backend';
 import { STALE_TIMES } from '@metamask/core-backend';
 import type { NormalizedV4MultiAccountTransactionsResponse } from '../../shared/lib/multichain/types';
-import { selectTransactions } from '../../shared/lib/multichain/transformations';
 import { apiClient } from './api-client';
 
 type QueryOptions = Partial<
@@ -23,13 +22,12 @@ export const queries = {
   transactions: (
     params: Params,
     options?: QueryOptions,
-    excludeTxHashes?: Set<string>,
   ): UseInfiniteQueryOptions<
     V4MultiAccountTransactionsResponse,
     unknown,
     NormalizedV4MultiAccountTransactionsResponse
   > => {
-    const { accountAddresses, evmAddress, networks } = params;
+    const { accountAddresses, networks } = params;
     const queryParams = { networks, includeTxMetadata: true as const };
 
     const { queryKey } =
@@ -52,7 +50,6 @@ export const queries = {
           }) => Promise<V4MultiAccountTransactionsResponse>
         )({ signal });
       },
-      select: selectTransactions({ address: evmAddress, excludeTxHashes }),
       getNextPageParam: ({ pageInfo }) =>
         pageInfo.hasNextPage ? pageInfo.endCursor : undefined,
       staleTime: STALE_TIMES.TRANSACTIONS,

--- a/ui/selectors/activity.ts
+++ b/ui/selectors/activity.ts
@@ -40,7 +40,7 @@ export const selectLocalTransactions = createSelector(
     transactions,
     selectedAccount,
     smartTransactions,
-    requiredTxHashes,
+    internalTxHashes,
   ): TransactionGroup[] => {
     if (!selectedAccount?.address) {
       return EMPTY_ARRAY as unknown as TransactionGroup[];
@@ -58,7 +58,7 @@ export const selectLocalTransactions = createSelector(
         return false;
       }
 
-      if (tx.hash && requiredTxHashes.has(tx.hash.toLowerCase())) {
+      if (tx.hash && internalTxHashes.has(tx.hash.toLowerCase())) {
         return false;
       }
 

--- a/ui/selectors/activity.ts
+++ b/ui/selectors/activity.ts
@@ -8,10 +8,13 @@ import type { TransactionGroup } from '../../shared/lib/multichain/types';
 import { CHAIN_ID_TO_CURRENCY_SYMBOL_MAP } from '../../shared/constants/network';
 import { NATIVE_TOKEN_ADDRESS } from '../../shared/constants/transaction';
 import {
-  getTransactions,
   groupAndSortTransactionsByNonce,
   smartTransactionsListSelector,
 } from './transactions';
+import {
+  selectOrderedTransactions,
+  selectRequiredTransactionHashes,
+} from './transactionController';
 import { getMarketData, getCurrencyRates } from './selectors';
 import { getSelectedInternalAccount } from './accounts';
 import { EMPTY_ARRAY } from './shared';
@@ -29,10 +32,16 @@ function isFromSelectedAccount(tx: TransactionMeta, selectedAddress: string) {
 }
 
 export const selectLocalTransactions = createSelector(
-  getTransactions,
+  selectOrderedTransactions,
   getSelectedInternalAccount,
   smartTransactionsListSelector,
-  (transactions, selectedAccount, smartTransactions): TransactionGroup[] => {
+  selectRequiredTransactionHashes,
+  (
+    transactions,
+    selectedAccount,
+    smartTransactions,
+    requiredTxHashes,
+  ): TransactionGroup[] => {
     if (!selectedAccount?.address) {
       return EMPTY_ARRAY as unknown as TransactionGroup[];
     }
@@ -46,6 +55,10 @@ export const selectLocalTransactions = createSelector(
       );
 
       if (!passesSenderAndTypeGate) {
+        return false;
+      }
+
+      if (tx.hash && requiredTxHashes.has(tx.hash.toLowerCase())) {
         return false;
       }
 

--- a/ui/selectors/transactionController.test.ts
+++ b/ui/selectors/transactionController.test.ts
@@ -1,0 +1,224 @@
+import type {
+  TransactionControllerState,
+  TransactionMeta,
+} from '@metamask/transaction-controller';
+import { EMPTY_ARRAY } from './shared';
+import {
+  selectTransactions,
+  selectOrderedTransactions,
+  selectRequiredTransactionIds,
+  selectRequiredTransactions,
+  selectRequiredTransactionHashes,
+} from './transactionController';
+
+type TransactionState = {
+  metamask: TransactionControllerState;
+};
+
+function makeTx(
+  overrides: Partial<TransactionMeta> & { id: string; time: number },
+): TransactionMeta {
+  return overrides as unknown as TransactionMeta;
+}
+
+function createMockState(transactions: TransactionMeta[]): TransactionState {
+  return {
+    metamask: { transactions } as unknown as TransactionControllerState,
+  };
+}
+
+describe('transactionController selectors', () => {
+  // Reset reselect memoization between tests
+  beforeEach(() => {
+    selectOrderedTransactions.clearCache();
+    selectRequiredTransactionIds.clearCache();
+    selectRequiredTransactions.clearCache();
+    selectRequiredTransactionHashes.clearCache();
+  });
+
+  describe('selectTransactions', () => {
+    it('returns transactions array from state', () => {
+      const tx = makeTx({ id: 'tx-1', time: 1 });
+      const state = createMockState([tx]);
+
+      expect(selectTransactions(state)).toStrictEqual([tx]);
+    });
+
+    it('returns EMPTY_ARRAY when transactions is undefined', () => {
+      const state = {
+        metamask: {} as unknown as TransactionControllerState,
+      };
+
+      expect(selectTransactions(state)).toBe(EMPTY_ARRAY);
+    });
+
+    it('returns EMPTY_ARRAY when metamask is undefined', () => {
+      const state = { metamask: undefined } as unknown as TransactionState;
+
+      expect(selectTransactions(state)).toBe(EMPTY_ARRAY);
+    });
+  });
+
+  describe('selectOrderedTransactions', () => {
+    it('sorts transactions by time ascending', () => {
+      const tx1 = makeTx({ id: 'a', time: 300 });
+      const tx2 = makeTx({ id: 'b', time: 100 });
+      const tx3 = makeTx({ id: 'c', time: 200 });
+      const state = createMockState([tx1, tx2, tx3]);
+
+      const result = selectOrderedTransactions(state);
+
+      expect(result.map((tx) => tx.id)).toStrictEqual(['b', 'c', 'a']);
+    });
+
+    it('returns a sorted copy without mutating the original', () => {
+      const tx1 = makeTx({ id: 'a', time: 200 });
+      const tx2 = makeTx({ id: 'b', time: 100 });
+      const original = [tx1, tx2];
+      const state = createMockState(original);
+
+      const result = selectOrderedTransactions(state);
+
+      expect(result).not.toBe(original);
+      expect(original.map((tx) => tx.id)).toStrictEqual(['a', 'b']);
+    });
+
+    it('handles empty array', () => {
+      const state = createMockState([]);
+
+      expect(selectOrderedTransactions(state)).toStrictEqual([]);
+    });
+  });
+
+  describe('selectRequiredTransactionIds', () => {
+    it('collects all requiredTransactionIds into a Set', () => {
+      const tx = makeTx({
+        id: 'parent',
+        time: 1,
+        requiredTransactionIds: ['req-1', 'req-2'],
+      });
+      const state = createMockState([tx]);
+
+      const result = selectRequiredTransactionIds(state);
+
+      expect(result).toStrictEqual(new Set(['req-1', 'req-2']));
+    });
+
+    it('returns empty Set when no transactions have requiredTransactionIds', () => {
+      const tx = makeTx({ id: 'tx-1', time: 1 });
+      const state = createMockState([tx]);
+
+      const result = selectRequiredTransactionIds(state);
+
+      expect(result).toStrictEqual(new Set());
+    });
+
+    it('ignores transactions without requiredTransactionIds field', () => {
+      const tx1 = makeTx({
+        id: 'parent',
+        time: 1,
+        requiredTransactionIds: ['req-1'],
+      });
+      const tx2 = makeTx({ id: 'normal', time: 2 });
+      const state = createMockState([tx1, tx2]);
+
+      const result = selectRequiredTransactionIds(state);
+
+      expect(result).toStrictEqual(new Set(['req-1']));
+    });
+
+    it('deduplicates IDs across transactions', () => {
+      const tx1 = makeTx({
+        id: 'parent-1',
+        time: 1,
+        requiredTransactionIds: ['req-1', 'req-2'],
+      });
+      const tx2 = makeTx({
+        id: 'parent-2',
+        time: 2,
+        requiredTransactionIds: ['req-2', 'req-3'],
+      });
+      const state = createMockState([tx1, tx2]);
+
+      const result = selectRequiredTransactionIds(state);
+
+      expect(result).toStrictEqual(new Set(['req-1', 'req-2', 'req-3']));
+    });
+  });
+
+  describe('selectRequiredTransactions', () => {
+    it('returns only transactions whose id is in the required set', () => {
+      const parentTx = makeTx({
+        id: 'parent',
+        time: 3,
+        requiredTransactionIds: ['req-1', 'req-2'],
+      });
+      const reqTx1 = makeTx({ id: 'req-1', time: 1, hash: '0xApproval' });
+      const reqTx2 = makeTx({ id: 'req-2', time: 2, hash: '0xBridge' });
+      const normalTx = makeTx({ id: 'normal', time: 4, hash: '0xNormal' });
+      const state = createMockState([parentTx, reqTx1, reqTx2, normalTx]);
+
+      const result = selectRequiredTransactions(state);
+
+      expect(result.map((tx) => tx.id)).toStrictEqual(['req-1', 'req-2']);
+    });
+
+    it('returns empty array when no transactions match', () => {
+      const tx = makeTx({ id: 'normal', time: 1, hash: '0xNormal' });
+      const state = createMockState([tx]);
+
+      const result = selectRequiredTransactions(state);
+
+      expect(result).toStrictEqual([]);
+    });
+  });
+
+  describe('selectRequiredTransactionHashes', () => {
+    it('returns lowercased hashes of required transactions', () => {
+      const parentTx = makeTx({
+        id: 'parent',
+        time: 3,
+        requiredTransactionIds: ['req-1', 'req-2'],
+      });
+      const reqTx1 = makeTx({ id: 'req-1', time: 1, hash: '0xApproval' });
+      const reqTx2 = makeTx({ id: 'req-2', time: 2, hash: '0xBRIDGE' });
+      const state = createMockState([parentTx, reqTx1, reqTx2]);
+
+      const result = selectRequiredTransactionHashes(state);
+
+      expect(result).toStrictEqual(new Set(['0xapproval', '0xbridge']));
+    });
+
+    it('excludes required transactions without a hash', () => {
+      const parentTx = makeTx({
+        id: 'parent',
+        time: 2,
+        requiredTransactionIds: ['req-1', 'req-2'],
+      });
+      const reqTx1 = makeTx({ id: 'req-1', time: 1, hash: '0xABC' });
+      const reqTxNoHash = makeTx({ id: 'req-2', time: 3 });
+      const state = createMockState([parentTx, reqTx1, reqTxNoHash]);
+
+      const result = selectRequiredTransactionHashes(state);
+
+      expect(result).toStrictEqual(new Set(['0xabc']));
+    });
+
+    it('returns empty Set when no required transactions exist', () => {
+      const normalTx = makeTx({ id: 'normal', time: 1, hash: '0xNormal' });
+      const state = createMockState([normalTx]);
+
+      const result = selectRequiredTransactionHashes(state);
+
+      expect(result).toStrictEqual(new Set());
+    });
+
+    it('returns empty Set for empty state', () => {
+      const state = createMockState([]);
+
+      const result = selectRequiredTransactionHashes(state);
+
+      expect(result).toStrictEqual(new Set());
+    });
+  });
+});

--- a/ui/selectors/transactionController.ts
+++ b/ui/selectors/transactionController.ts
@@ -1,0 +1,42 @@
+import { createSelector } from 'reselect';
+import type {
+  TransactionControllerState,
+  TransactionMeta,
+} from '@metamask/transaction-controller';
+import { EMPTY_ARRAY } from './shared';
+
+type TransactionState = {
+  metamask: TransactionControllerState;
+};
+
+export const selectTransactions = (
+  state: TransactionState,
+): TransactionMeta[] => state.metamask?.transactions ?? EMPTY_ARRAY;
+
+export const selectOrderedTransactions = createSelector(
+  selectTransactions,
+  (transactions) => [...transactions].sort((a, b) => a.time - b.time), // Ascending
+);
+
+export const selectRequiredTransactionIds = createSelector(
+  selectTransactions,
+  (transactions) =>
+    new Set(transactions.flatMap((tx) => tx.requiredTransactionIds ?? [])),
+);
+
+export const selectRequiredTransactions = createSelector(
+  selectTransactions,
+  selectRequiredTransactionIds,
+  (transactions, requiredIds) =>
+    transactions.filter((tx) => requiredIds.has(tx.id)),
+);
+
+export const selectRequiredTransactionHashes = createSelector(
+  selectRequiredTransactions,
+  (transactions) =>
+    new Set(
+      transactions
+        .map((tx) => tx.hash?.toLowerCase())
+        .filter(Boolean) as string[],
+    ),
+);


### PR DESCRIPTION
## **Description**

Hide prerequisite / required transactions (e.g. approvals, Relay deposits) in activity-v2 so users only see the top-level transaction they initiated.

Specifically:

- Identify transactions as "required" when another local transaction references them via `requiredTransactionIds`, and filters them out by matching their on-chain hash.
- Apply filtering to both local transactions (via `selectLocalTransactions`) and API results (via `excludeTxHashes` in `selectTransactions`).
- Introduce new `transactionController.ts` selector file to begin replacing legacy `transactions.js`.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40355?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes transaction selection/filtering for both local and API-backed activity lists; incorrect required-hash detection could hide legitimate transactions from the UI.
> 
> **Overview**
> Filters prerequisite/"required" transactions out of Activity v2 so users primarily see the top-level transaction they initiated.
> 
> Adds a new `ui/selectors/transactionController.ts` selector suite (with tests) to derive `requiredTransactionIds` and their on-chain hashes, then uses those hashes to exclude required transactions from `selectLocalTransactions` and from the multichain API normalization via an extended `selectTransactions({ excludedTxHashes })`.
> 
> Moves the React Query `select` transform wiring for transactions from `queries.transactions` into the Activity v2 hook so it can be parameterized with the dynamically-derived excluded hash set.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f91205ae113de943279e8174786d09df5620784. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->