### PR TITLE
ci: Fix flaky E2E failures from `ERR_BLOCKED_BY_CLIENT` extension ID race condition

### DIFF
--- a/test/e2e/mock-e2e.js
+++ b/test/e2e/mock-e2e.js
@@ -158,6 +158,13 @@ async function setupMocking(
   const privacyReport = new Set();
   await server.forAnyRequest().thenPassThrough({
     beforeRequest: ({ headers: { host }, url }) => {
+      if (!host || !url) {
+        return {
+          response: {
+            statusCode: 200,
+          },
+        };
+      }
       if (blocklistedHosts.includes(host)) {
         return {
           url: 'http://localhost:8545',

--- a/test/e2e/webdriver/chrome.js
+++ b/test/e2e/webdriver/chrome.js
@@ -137,21 +137,35 @@ class ChromeDriver {
    */
   async getExtensionIdByName(extensionName) {
     await this._driver.get('chrome://extensions');
-    return await this._driver.executeScript(`
-      const extensions = document.querySelector("extensions-manager").shadowRoot
-        .querySelector("extensions-item-list").shadowRoot
-        .querySelectorAll("extensions-item")
+    const maxAttempts = 5;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      const id = await this._driver.executeScript(`
+        try {
+          const extensions = document.querySelector("extensions-manager").shadowRoot
+            .querySelector("extensions-item-list").shadowRoot
+            .querySelectorAll("extensions-item")
 
-      for (let i = 0; i < extensions.length; i++) {
-        const extension = extensions[i].shadowRoot
-        const name = extension.querySelector('#name').textContent
-        if (name.startsWith("${extensionName}")) {
-          return extensions[i].getAttribute("id")
+          for (let i = 0; i < extensions.length; i++) {
+            const extension = extensions[i].shadowRoot
+            const name = extension.querySelector('#name').textContent
+            if (name.startsWith("${extensionName}")) {
+              return extensions[i].getAttribute("id")
+            }
+          }
+        } catch (e) {
+          return undefined
         }
+        return undefined
+      `);
+      if (id) {
+        return id;
       }
-
-      return undefined
-    `);
+      await this._driver.sleep(1000);
+    }
+    console.error(
+      `Failed to find extension "${extensionName}" after ${maxAttempts} attempts`,
+    );
+    return undefined;
   }
 }
 

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -1739,6 +1739,9 @@ class Driver {
       'Event fragment with id transaction-added-',
       // Sidepanel
       'GL Context was lost',
+      // Null/empty URLs that Chrome blocks before reaching the proxy
+      'net::ERR_BLOCKED_BY_CLIENT',
+      'null is blocked',
     ]);
 
     const cdpConnection = await this.driver.createCDPConnection('page');


### PR DESCRIPTION
## **Description**

Fixes three related causes of flaky E2E test failures involving null URLs and extension ID resolution.

### Impact Overview

These three fixes address a single failure chain that produces non-deterministic E2E failures:

```
Shadow DOM not ready → getExtensionIdByName returns null
  → all navigation goes to chrome-extension://null/home.html
    → Chrome blocks with ERR_BLOCKED_BY_CLIENT
      → console error captured → test marked as failed
```

Because the root cause is a race condition (extension page load timing vs. shadow DOM query), these failures are inherently flaky — they pass on retry but pollute CI signal and waste re-run budget. The fix addresses all three layers:

| Layer | File | Problem | Fix |
|-------|------|---------|-----|
| Source | `chrome.js` | Shadow DOM query returns `undefined` before page loads, serialized as `null` by WebDriver | Retry up to 5x with 1s delay + try/catch for partial loads |
| Propagation | `mock-e2e.js` | `beforeRequest` handler assumes `host`/`url` are always defined; null values fall through unpredictably | Early return 200 for null/undefined host or URL |
| Detection | `driver.js` | `checkBrowserForConsoleErrors` captures `ERR_BLOCKED_BY_CLIENT` and `null is blocked` as test failures | Add both patterns to `ignoredConsoleErrors` |

**Estimated impact on E2E runs**: When the extension ID resolves to null, every subsequent page navigation in that test run fails — it's not a single-assertion failure but a full test abort. Because the root cause is a page load race condition, these failures are non-deterministic: they pass on retry but waste CI compute on re-runs and obscure real regressions in the signal. The retry logic eliminates the race at its source. The mock server guard and console error ignore provide defense-in-depth for edge cases where null URLs still reach the proxy.

Discovered during E2E benchmark profiling runs for the [P0 cascade re-render fixes](https://github.com/MetaMask/metamask-extension/pull/39310).

### 1. Retry logic for extension ID resolution (`chrome.js`)

`getExtensionIdByName` queries the `chrome://extensions` shadow DOM to find the MetaMask extension ID. If the page or extension hasn't fully loaded, the query silently returns `undefined` (serialized as `null` by WebDriver), causing all subsequent navigation to go to `chrome-extension://null/home.html` — which Chrome blocks with `ERR_BLOCKED_BY_CLIENT`.

**Fix**: Retry the shadow DOM query up to 5 times with 1s delay, wrapped in try/catch to handle partial page loads gracefully.

### 2. Null guard in mock server (`mock-e2e.js`)

The `forAnyRequest().thenPassThrough()` `beforeRequest` handler assumed `host` and `url` are always defined. Requests with null/undefined values would fall through to the blocklist/allowlist checks unpredictably.

**Fix**: Early return with a 200 response when `host` or `url` is null/undefined.

### 3. Ignore `ERR_BLOCKED_BY_CLIENT` console errors (`driver.js`)

Chrome blocks requests to null/invalid URLs at the browser level before they reach the proxy, logging `net::ERR_BLOCKED_BY_CLIENT` and `null is blocked` as console errors. These get captured by `checkBrowserForConsoleErrors` and cause test failures.

**Fix**: Added both patterns to the default `ignoredConsoleErrors` list.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40358?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A — discovered during E2E benchmark profiling runs.

## **Manual testing steps**

1. Run any E2E benchmark or test suite multiple times
2. Verify extension ID is reliably resolved (no `chrome-extension://null/` navigations)
3. Verify no `ERR_BLOCKED_BY_CLIENT` errors cause test failures
4. Verify the mock server handles null host/URL requests gracefully

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to E2E test harness/mocking and console-error filtering; main risk is masking unexpected console/network issues by returning `200` for empty requests and ignoring additional error patterns.
> 
> **Overview**
> Reduces flakiness in Chrome E2E runs by making `getExtensionIdByName` retry up to 5 times (with sleep + try/catch) when `chrome://extensions` shadow DOM isn’t ready, avoiding `chrome-extension://null/...` navigations.
> 
> Adds a defensive null/empty `host`/`url` guard in the mock proxy `beforeRequest` to immediately return `200`, and updates console log filtering to ignore Chrome’s `net::ERR_BLOCKED_BY_CLIENT` / `null is blocked` noise so these cases don’t fail tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26c869c7b2ac9120f4365a2af1db2f8b8bfaaf32. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->