### PR TITLE
refactor(ci): dynamic matrix for E2E shards

### DIFF
--- a/.github/workflows/e2e-chrome.yml
+++ b/.github/workflows/e2e-chrome.yml
@@ -10,6 +10,10 @@ on:
         required: true
         type: string
         description: The run ID to get builds from
+      use-matrix:
+        required: true
+        type: string
+        description: The matrix for the E2E jobs
     secrets:
       PR_COMMENT_TOKEN:
         required: false
@@ -23,9 +27,7 @@ jobs:
       INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
     strategy:
       fail-fast: ${{ github.event_name == 'merge_group' }}
-      matrix:
-        index:
-          [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
+      matrix: ${{ fromJson(inputs.use-matrix)['test-e2e-chrome-browserify'] }}
     with:
       test-suite-name: test-e2e-chrome-browserify
       build-artifact: build-test-browserify
@@ -42,9 +44,7 @@ jobs:
       INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
     strategy:
       fail-fast: ${{ github.event_name == 'merge_group' }}
-      matrix:
-        index:
-          [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
+      matrix: ${{ fromJson(inputs.use-matrix)['test-e2e-chrome-webpack'] }}
     with:
       test-suite-name: test-e2e-chrome-webpack
       build-artifact: build-test-webpack
@@ -76,8 +76,7 @@ jobs:
     uses: ./.github/workflows/run-e2e.yml
     strategy:
       fail-fast: ${{ github.event_name == 'merge_group' }}
-      matrix:
-        index: [0, 1, 2, 3, 4]
+      matrix: ${{ fromJson(inputs.use-matrix)['test-e2e-chrome-flask'] }}
     with:
       test-suite-name: test-e2e-chrome-flask
       build-artifact: build-test-flask-browserify

--- a/.github/workflows/e2e-firefox.yml
+++ b/.github/workflows/e2e-firefox.yml
@@ -10,6 +10,10 @@ on:
         required: true
         type: string
         description: The run ID to get builds from
+      use-matrix:
+        required: true
+        type: string
+        description: The matrix for the E2E jobs
     secrets:
       INFURA_PROJECT_ID:
         required: false
@@ -21,9 +25,7 @@ jobs:
       INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
     strategy:
       fail-fast: ${{ github.event_name == 'merge_group' }}
-      matrix:
-        index:
-          [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
+      matrix: ${{ fromJson(inputs.use-matrix)['test-e2e-firefox-browserify'] }}
     with:
       test-suite-name: test-e2e-firefox-browserify
       build-artifact: build-test-mv2-browserify
@@ -40,9 +42,7 @@ jobs:
       INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
     strategy:
       fail-fast: ${{ github.event_name == 'merge_group' }}
-      matrix:
-        index:
-          [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
+      matrix: ${{ fromJson(inputs.use-matrix)['test-e2e-firefox-webpack'] }}
     with:
       test-suite-name: test-e2e-firefox-webpack
       build-artifact: build-test-mv2-webpack
@@ -56,8 +56,7 @@ jobs:
     uses: ./.github/workflows/run-e2e.yml
     strategy:
       fail-fast: ${{ github.event_name == 'merge_group' }}
-      matrix:
-        index: [0, 1, 2, 3, 4]
+      matrix: ${{ fromJson(inputs.use-matrix)['test-e2e-firefox-flask'] }}
     with:
       test-suite-name: test-e2e-firefox-flask
       build-artifact: build-test-flask-mv2-browserify

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -415,6 +415,7 @@ jobs:
     if: ${{ !cancelled() && needs.get-requirements.outputs.needs-e2e == 'true' && !contains(needs.*.result, 'failure') }}
     with:
       builds-from-run: ${{ needs.get-requirements.outputs.builds-from-run }}
+      use-matrix: ${{ needs.prep-e2e.outputs.use-matrix }}
     secrets: inherit
 
   e2e-firefox:
@@ -430,6 +431,7 @@ jobs:
     if: ${{ !cancelled() && needs.get-requirements.outputs.needs-e2e == 'true' && !contains(needs.*.result, 'failure') }}
     with:
       builds-from-run: ${{ needs.get-requirements.outputs.builds-from-run }}
+      use-matrix: ${{ needs.prep-e2e.outputs.use-matrix }}
     secrets:
       INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
 

--- a/.github/workflows/prep-e2e.yml
+++ b/.github/workflows/prep-e2e.yml
@@ -2,6 +2,10 @@ name: Prep E2E
 
 on:
   workflow_call:
+    outputs:
+      use-matrix:
+        description: The matrix for the E2E jobs
+        value: ${{ jobs.prep-e2e.outputs.use-matrix }}
 
 jobs:
   prep-e2e:
@@ -13,6 +17,8 @@ jobs:
       REPOSITORY: ${{ github.event.repository.name }}
       WORKFLOW_ID: main.yml
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+    outputs:
+      use-matrix: ${{ steps.set-use-matrix.outputs.use-matrix }}
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v1
@@ -67,3 +73,24 @@ jobs:
         with:
           name: test-runs-for-splitting
           path: test/test-results/test-runs-*.json
+
+      - name: Set use matrix
+        id: set-use-matrix
+        run: |
+          # Configure suite shard counts here (suite name -> shard count)
+          SUITE_SHARD_COUNTS=$(jq -cn '{
+            "test-e2e-chrome-browserify": 20,
+            "test-e2e-chrome-webpack": 20,
+            "test-e2e-chrome-flask": 5,
+            "test-e2e-firefox-browserify": 20,
+            "test-e2e-firefox-webpack": 20,
+            "test-e2e-firefox-flask": 5
+          }')
+
+          # Expand counts into the job matrix shape expected by downstream workflows
+          MATRIX_JSON=$(jq -cn --argjson counts "$SUITE_SHARD_COUNTS" '
+            reduce ($counts | to_entries[]) as $entry
+              ({}; . + { ($entry.key): { index: [range(0; $entry.value)] } })
+          ')
+
+          echo "use-matrix=${MATRIX_JSON}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## **Description**

**This should be a pure refactor, no changes to any behavior anywhere.**

The goal is to take the E2E shard matrices from being defined like
```
[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
```

to being defined centrally in `.github/workflows/prep-e2e.yml` as
```
SUITE_SHARD_COUNTS=$(jq -cn '{
  "test-e2e-chrome-browserify": 20,
  "test-e2e-chrome-webpack": 20,
  "test-e2e-chrome-flask": 5,
  "test-e2e-firefox-browserify": 20,
  "test-e2e-firefox-webpack": 20,
  "test-e2e-firefox-flask": 5
}')
```

Why do we want this?  Because it will enable the following kinds of things in the future:
- Run just the right number of shards so that it will finish in 10 minutes
- If current usage is light, run in turbo mode with more shards
- If current usage is heavy, give higher priority to `cp-` and release PRs
- Give lower priority to things that are lower down in the Merge Queue list

## **Changelog**

CHANGELOG entry: null

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI-only refactor, but it changes how E2E job matrices are constructed and passed between workflows, which can inadvertently alter shard counts or break workflow execution if the JSON/output wiring is wrong.
> 
> **Overview**
> Centralizes E2E sharding configuration by generating a JSON matrix in `prep-e2e.yml` and exposing it as a workflow output.
> 
> `e2e-chrome.yml` and `e2e-firefox.yml` now accept a `use-matrix` input and use `fromJson(...)` to drive their per-suite shard `strategy.matrix`, with `main.yml` wiring the `prep-e2e` output into both E2E workflow calls.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d5f502ef0997b2f5883289b2aa8d82ed6063025. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->