### PR TITLE
chore: resolve audit of minimatch with ID: 1113459 cp-13.20.0

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -47,6 +47,7 @@ npmAuditIgnoreAdvisories:
   # Only affects dev/build-time dependencies (eslint-plugin-n, glob) — not shipped to users.
   # URL: https://github.com/advisories/GHSA-3ppc-4f35-3m26
   - 1113371
+  - 1113459
 
   ### Package Deprecations:
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

A new npm audit advisory (ID: `1113459`) was flagged for `minimatch`, reporting a ReDoS vulnerability via repeated wildcards with a non-matching literal in the pattern.

This advisory only affects dev/build-time dependencies like `eslint-plugin-n` and `glob`, and is **not shipped to users**. The dependency can't be easily upgraded because it's deeply embedded across linting and build tooling.

This PR adds advisory `1113459` to the existing `npmAuditIgnoreAdvisories` list in `.yarnrc.yml`, alongside the previously ignored `1113371` for the same underlying `minimatch` ReDoS issue ([GHSA-3ppc-4f35-3m26](https://github.com/advisories/GHSA-3ppc-4f35-3m26)).

I looked into bumping the package directly, but the vulnerable `minimatch@3.1.2` is pulled in by 22 transitive dependents, including `eslint`, `@eslint/eslintrc`, `eslint-plugin-n`, `eslint-plugin-import`, `eslint-plugin-react`, and `depcheck`. All of them pin to the `^3.x` range, and forcing a resolution to v5+ would risk breaking ESLint internals due to API differences. That's a lot of effort and risk for a vulnerability that only affects dev tooling.

<img width="1267" height="773" alt="Screenshot 2026-02-25 at 01 35 17" src="https://github.com/user-attachments/assets/d6d10b29-6304-477f-8b85-a86be6aac985" />

## Next steps
Some upstream packages have already moved off `minimatch@3.x` in their latest releases (e.g. `eslint@10.x` now uses `^10.2.1`, `eslint-plugin-n@17.x` has dropped it entirely, and `@eslint/config-array@0.23.x` uses `^10.2.1`). However, this project is still on older versions (`eslint@8.x/9.x`, `eslint-plugin-n@15.x/16.x`), and other packages like `eslint-plugin-import` and `eslint-plugin-react` haven't updated yet on their end.

As the project upgrades its ESLint tooling, the number of `minimatch@3.x` dependents will shrink. Once nothing pulls it in anymore, both `1113371` and `1113459` can be removed from the ignore list in `.yarnrc.yml`.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40387?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only change that adjusts audit ignore metadata; it doesn’t alter runtime code or shipped dependencies.
> 
> **Overview**
> Updates `.yarnrc.yml` to ignore a newly flagged npm audit advisory (`1113459`) for the `minimatch` ReDoS issue, alongside the existing ignore (`1113371`), to keep CI unblocked while the dependency remains pinned via dev/build tooling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f62cbbef796864287c9a1564b88906d08d080007. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->