### PR TITLE
fix: add mock to launch darkly RC environment, to have the same behaviour as in main cp-13.20.0 

### DIFF
--- a/test/e2e/mock-e2e.js
+++ b/test/e2e/mock-e2e.js
@@ -202,6 +202,21 @@ async function setupMocking(
       };
     });
 
+  await server
+    .forGet('https://client-config.api.cx.metamask.io/v1/flags')
+    .withQuery({
+      client: 'extension',
+      distribution: 'main',
+      environment: 'rc',
+    })
+    .thenCallback(() => {
+      return {
+        ok: true,
+        statusCode: 200,
+        json: getProductionRemoteFlagApiResponse(),
+      };
+    });
+
   // Subscriptions Polling Get Subscriptions
   await server
     .forGet('https://subscription.api.cx.metamask.io/v1/subscriptions')


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Add mock to launch darkly RC environment, to have the same behaviour as in main.

In the RC, we have the rc environment, whereas in main, we have dev environment. This causes different requests to the LaunchDarkly:
https://client-config.api.cx.metamask.io/v1/flags?client=extension&distribution=main&environment=rc
https://client-config.api.cx.metamask.io/v1/flags?client=extension&distribution=main&environment=dev

And we only have a global mock for the dev one.

This difference was highlighted by the @MetaMask/extension-platform , where the RC branch had different fixtures,causing the fixture validation to fail.
Aside from that, we can run into future issues, where specs have different outcomes in main/PRs than in the RC branch, because of that difference.
So we want to add a mock with the exact same response as we have in dev, so we have the exact same behaviour in both branches.


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40390?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Checkout the rc branch release/13.20.0
2. Apply this change in your local branch
3. Grab the chrome dist build from the RC branch https://github.com/MetaMask/metamask-extension/pull/40258#issuecomment-3954969629
4. Paste it into your local dist folder (delete the existing. chrome one)
5. Run yarn test:e2e:single test/e2e/dist/wallet-fixture-validation.spec.ts --leave-running=true --browser=chrome

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

RC branch

<img width="1562" height="1416" alt="image" src="https://github.com/user-attachments/assets/dbac5efb-0ea8-436f-9c70-a29df13c7f65" />

main/PRs branch

<img width="1638" height="1282" alt="image" src="https://github.com/user-attachments/assets/e5cbb7ff-e6c3-4250-af7e-8f76f5cfd841" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that adds an additional network mock; low risk outside of potentially masking environment-specific flag differences in E2E runs.
> 
> **Overview**
> Aligns E2E behavior between `main` and RC builds by mocking the client-config feature flag fetch for the `rc` environment.
> 
> The global E2E mock now intercepts `GET https://client-config.api.cx.metamask.io/v1/flags` with `environment=rc` and returns the same `getProductionRemoteFlagApiResponse()` payload used for `environment=dev`, preventing fixture/flag mismatches across branches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13914292d98ceef4c7d45c2bfb01e9ebff824504. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->