### PR TITLE
chore: update default address styles

### DIFF
--- a/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.tsx
+++ b/ui/components/multichain-accounts/multichain-account-cell/multichain-account-cell.tsx
@@ -119,12 +119,14 @@ const AccountCellDefaultAddress = ({
       aria-label={t('copyAddressShort')}
     >
       <Text
-        variant={TextVariant.BodyXs}
+        variant={TextVariant.BodySm}
         color={
           addressCopied ? TextColor.SuccessDefault : TextColor.TextAlternative
         }
       >
-        {shortenAddress(normalizeSafeAddress(defaultAddress))}
+        {addressCopied
+          ? t('addressCopied')
+          : shortenAddress(normalizeSafeAddress(defaultAddress))}
       </Text>
       <Icon
         name={addressCopied ? IconName.CopySuccess : IconName.Copy}

--- a/ui/components/multichain-accounts/multichain-account-network-group-with-default-address/multichain-account-network-group-with-default-address.tsx
+++ b/ui/components/multichain-accounts/multichain-account-network-group-with-default-address/multichain-account-network-group-with-default-address.tsx
@@ -13,6 +13,7 @@ import {
   Text,
   TextVariant,
   TextColor,
+  FontWeight,
 } from '@metamask/design-system-react';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { shortenAddress } from '../../../helpers/utils/util';
@@ -78,7 +79,8 @@ export const MultichainAccountNetworkGroupWithDefaultAddress = ({
         limit={MAX_NETWORK_AVATARS}
       />
       <Text
-        variant={TextVariant.BodyXs}
+        variant={TextVariant.BodySm}
+        fontWeight={FontWeight.Medium}
         color={
           addressCopied ? TextColor.SuccessDefault : TextColor.TextAlternative
         }

--- a/ui/components/multichain-accounts/multichain-address-rows-hovered-list/multichain-hovered-address-rows-hovered-list.tsx
+++ b/ui/components/multichain-accounts/multichain-address-rows-hovered-list/multichain-hovered-address-rows-hovered-list.tsx
@@ -134,7 +134,7 @@ export const MultichainHoveredAddressRowsList = ({
 
     const rect = referenceElement.getBoundingClientRect();
     const viewportHeight = window.innerHeight;
-    const popoverEstimatedHeight = 400; // Based on the maxHeight set on the popover
+    const popoverEstimatedHeight = 275; // Based on the maxHeight set on the popover
     const spaceBelow = viewportHeight - rect.bottom;
 
     // If there's not enough space below, use TopStart
@@ -329,7 +329,7 @@ export const MultichainHoveredAddressRowsList = ({
         paddingTop={1}
         style={{
           zIndex: 99999,
-          maxHeight: '400px',
+          maxHeight: '275px',
           minWidth: '340px',
         }}
       >


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- Tiny styling tweaks to Default Address feature
- Update to dynamic popover position on hovered account network group component to reflect the height of the popover more accurately

Figma here: https://www.figma.com/design/IVt20ztP5OpMtBpIzGX0Q4/Adding-default-address-toggle-for-home-address-and-account-list?node-id=230-34467&m=dev

## **Changelog**

CHANGELOG entry: Small styling tweaks to default address feature

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CEUX-935

## **Manual testing steps**

Verify the following changes:

1. Changing the text to from body/sm/regular to body/sm/medium (image 1)
2. Changing the text size on the account picker from body/xs/regular to body/sm/regular (image 2). 
3. Changing it to "Address copied" too on the account picker view (image 3)
4. Dynamic popover position for hovered account network group is similar to before but stays at bottom for smaller screen sizes than previously (see screenshot section)

<img width="845" height="402" alt="image" src="https://github.com/user-attachments/assets/fc6140ce-48c4-497d-89e2-e02ce43339ff" />

<img width="614" height="533" alt="image" src="https://github.com/user-attachments/assets/c3490c1e-2319-41f8-ac19-68e3a19ff98c" />

<img width="656" height="496" alt="image" src="https://github.com/user-attachments/assets/7e1b4256-7232-4a64-a455-175c18de1bf6" />


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

Popover position pops to the top on small screen heights when there is still plenty of space to render beneath:
<img width="627" height="432" alt="image" src="https://github.com/user-attachments/assets/606f24e2-0b3a-4ce4-b14c-cddcfb7042d1" />


### **After**

Popover stays at bottom for smaller screen heights than before:
<img width="415" height="430" alt="image" src="https://github.com/user-attachments/assets/350bfb3b-dc79-49ae-a2bf-06a70da1fb7a" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only tweaks: changes text styling/copy feedback and adjusts a popover height/position heuristic; no sensitive logic or data flows are modified.
> 
> **Overview**
> Improves the multichain account picker/default-address UI by bumping address text to `BodySm`, using medium weight in the default-address network group, and showing the localized `addressCopied` label in the account cell after copying (instead of continuing to show the shortened address).
> 
> Adjusts the hovered address rows popover sizing assumptions by reducing `maxHeight` (and its matching estimated height used for top/bottom positioning) from `400px` to `275px`, so the popover more accurately stays below the trigger when there’s sufficient viewport space.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5bd0574e35bf0f8699c35fa39693e6ff87cbff2f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->