### PR TITLE
chore: add default address e2e tests

### DIFF
--- a/test/e2e/page-objects/pages/home/homepage.ts
+++ b/test/e2e/page-objects/pages/home/homepage.ts
@@ -106,6 +106,9 @@ class HomePage {
 
   private readonly copyAddressButton = '[data-testid="app-header-copy-button"]';
 
+  private readonly defaultAddressContainer =
+    '[data-testid="default-address-container"]';
+
   private readonly connectionsRemovedModal =
     '[data-testid="connections-removed-modal"]';
 
@@ -574,6 +577,16 @@ class HomePage {
 
   async checkConnectionsRemovedModalIsDisplayed(): Promise<void> {
     await this.driver.waitForSelector(this.connectionsRemovedModal);
+  }
+
+  async checkDefaultAddressIsDisplayed(): Promise<void> {
+    console.log('Check default address is displayed in header on homepage');
+    await this.driver.waitForSelector(this.defaultAddressContainer);
+  }
+
+  async checkDefaultAddressIsNotDisplayed(): Promise<void> {
+    console.log('Check default address is not displayed in header on homepage');
+    await this.driver.assertElementNotPresent(this.defaultAddressContainer);
   }
 
   async checkShieldEntryModalIsDisplayed(): Promise<void> {

--- a/test/e2e/page-objects/pages/settings/general-settings.ts
+++ b/test/e2e/page-objects/pages/settings/general-settings.ts
@@ -34,6 +34,9 @@ class GeneralSettings {
   private readonly toggleNativeTokenAsMainBalance =
     '[id="toggle-show-native-token-as-main-balance"] .toggle-button';
 
+  private readonly showDefaultAddressToggle =
+    '[id="show-default-address"] .toggle-button';
+
   constructor(driver: Driver) {
     this.driver = driver;
   }
@@ -113,6 +116,14 @@ class GeneralSettings {
 
   async toggleShowNativeTokenAsMainBalance(): Promise<void> {
     await this.driver.clickElement(this.toggleNativeTokenAsMainBalance);
+  }
+
+  async toggleShowDefaultAddress(): Promise<void> {
+    await this.driver.clickElement(this.showDefaultAddressToggle);
+  }
+
+  async checkShowDefaultAddressSectionIsDisplayed(): Promise<void> {
+    await this.driver.waitForSelector(this.showDefaultAddressToggle);
   }
 }
 

--- a/test/e2e/tests/settings/show-default-address.spec.ts
+++ b/test/e2e/tests/settings/show-default-address.spec.ts
@@ -1,6 +1,6 @@
 import { Suite } from 'mocha';
 import { withFixtures } from '../../helpers';
-import FixtureBuilder from '../../fixtures/fixture-builder';
+import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import GeneralSettings from '../../page-objects/pages/settings/general-settings';
 import HomePage from '../../page-objects/pages/home/homepage';
 import SettingsPage from '../../page-objects/pages/settings/settings-page';
@@ -10,7 +10,7 @@ describe('Show default address', function (this: Suite) {
   it('displays Show default address section on General settings', async function () {
     await withFixtures(
       {
-        fixtures: new FixtureBuilder().build(),
+        fixtures: new FixtureBuilderV2().build(),
         title: this.test?.fullTitle(),
       },
       async ({ driver }) => {
@@ -29,7 +29,7 @@ describe('Show default address', function (this: Suite) {
   it('does not display default address in header on homepage by default', async function () {
     await withFixtures(
       {
-        fixtures: new FixtureBuilder().build(),
+        fixtures: new FixtureBuilderV2().build(),
         title: this.test?.fullTitle(),
       },
       async ({ driver }) => {
@@ -46,7 +46,7 @@ describe('Show default address', function (this: Suite) {
   it('displays default address in header on homepage when toggle is on', async function () {
     await withFixtures(
       {
-        fixtures: new FixtureBuilder().build(),
+        fixtures: new FixtureBuilderV2().build(),
         title: this.test?.fullTitle(),
       },
       async ({ driver }) => {

--- a/test/e2e/tests/settings/show-default-address.spec.ts
+++ b/test/e2e/tests/settings/show-default-address.spec.ts
@@ -46,8 +46,7 @@ describe('Show default address', function (this: Suite) {
   it('displays default address in header on homepage when toggle is on', async function () {
     await withFixtures(
       {
-        fixtures: new FixtureBuilder()
-          .build(),
+        fixtures: new FixtureBuilder().build(),
         title: this.test?.fullTitle(),
       },
       async ({ driver }) => {

--- a/test/e2e/tests/settings/show-default-address.spec.ts
+++ b/test/e2e/tests/settings/show-default-address.spec.ts
@@ -36,9 +36,7 @@ describe('Show default address', function (this: Suite) {
 
         // Check on home page that default address is not present
         await new HomePage(driver).checkPageIsLoaded();
-        await driver.assertElementNotPresent(
-          '[data-testid="default-address-container"]',
-        );
+        await new HomePage(driver).checkDefaultAddressIsNotDisplayed();
       },
     );
   });
@@ -61,9 +59,7 @@ describe('Show default address', function (this: Suite) {
 
         // Check on home page that default address is present
         await new HomePage(driver).checkPageIsLoaded();
-        await driver.waitForSelector(
-          '[data-testid="default-address-container"]',
-        );
+        await new HomePage(driver).checkDefaultAddressIsDisplayed();
       },
     );
   });

--- a/test/e2e/tests/settings/show-default-address.spec.ts
+++ b/test/e2e/tests/settings/show-default-address.spec.ts
@@ -17,7 +17,8 @@ describe('Show default address', function (this: Suite) {
         await loginWithBalanceValidation(driver);
 
         // Navigate to settings and check "show default address" section is displayed
-        await new HomePage(driver).headerNavbar.openSettingsPage();
+        const homePage = new HomePage(driver);
+        await homePage.headerNavbar.openSettingsPage();
         const generalSettings = new GeneralSettings(driver);
         await generalSettings.checkPageIsLoaded();
         await generalSettings.checkShowDefaultAddressSectionIsDisplayed();
@@ -35,8 +36,9 @@ describe('Show default address', function (this: Suite) {
         await loginWithBalanceValidation(driver);
 
         // Check on home page that default address is not present
-        await new HomePage(driver).checkPageIsLoaded();
-        await new HomePage(driver).checkDefaultAddressIsNotDisplayed();
+        const homePage = new HomePage(driver);
+        await homePage.checkPageIsLoaded();
+        await homePage.checkDefaultAddressIsNotDisplayed();
       },
     );
   });
@@ -51,15 +53,16 @@ describe('Show default address', function (this: Suite) {
         await loginWithBalanceValidation(driver);
 
         // Navigate to settings and toggle on "show default address" feature
-        await new HomePage(driver).headerNavbar.openSettingsPage();
+        const homePage = new HomePage(driver);
+        await homePage.headerNavbar.openSettingsPage();
         const generalSettings = new GeneralSettings(driver);
         await generalSettings.checkPageIsLoaded();
         await generalSettings.toggleShowDefaultAddress();
         await new SettingsPage(driver).closeSettingsPage();
 
         // Check on home page that default address is present
-        await new HomePage(driver).checkPageIsLoaded();
-        await new HomePage(driver).checkDefaultAddressIsDisplayed();
+        await homePage.checkPageIsLoaded();
+        await homePage.checkDefaultAddressIsDisplayed();
       },
     );
   });

--- a/test/e2e/tests/settings/show-default-address.spec.ts
+++ b/test/e2e/tests/settings/show-default-address.spec.ts
@@ -1,0 +1,71 @@
+import { Suite } from 'mocha';
+import { withFixtures } from '../../helpers';
+import FixtureBuilder from '../../fixtures/fixture-builder';
+import GeneralSettings from '../../page-objects/pages/settings/general-settings';
+import HomePage from '../../page-objects/pages/home/homepage';
+import SettingsPage from '../../page-objects/pages/settings/settings-page';
+import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow';
+
+describe('Show default address', function (this: Suite) {
+  it('displays Show default address section on General settings', async function () {
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilder().build(),
+        title: this.test?.fullTitle(),
+      },
+      async ({ driver }) => {
+        await loginWithBalanceValidation(driver);
+
+        // Navigate to settings and check "show default address" section is displayed
+        await new HomePage(driver).headerNavbar.openSettingsPage();
+        const generalSettings = new GeneralSettings(driver);
+        await generalSettings.checkPageIsLoaded();
+        await generalSettings.checkShowDefaultAddressSectionIsDisplayed();
+      },
+    );
+  });
+
+  it('does not display default address in header on homepage by default', async function () {
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilder().build(),
+        title: this.test?.fullTitle(),
+      },
+      async ({ driver }) => {
+        await loginWithBalanceValidation(driver);
+
+        // Check on home page that default address is not present
+        await new HomePage(driver).checkPageIsLoaded();
+        await driver.assertElementNotPresent(
+          '[data-testid="default-address-container"]',
+        );
+      },
+    );
+  });
+
+  it('displays default address in header on homepage when toggle is on', async function () {
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilder()
+          .build(),
+        title: this.test?.fullTitle(),
+      },
+      async ({ driver }) => {
+        await loginWithBalanceValidation(driver);
+
+        // Navigate to settings and toggle on "show default address" feature
+        await new HomePage(driver).headerNavbar.openSettingsPage();
+        const generalSettings = new GeneralSettings(driver);
+        await generalSettings.checkPageIsLoaded();
+        await generalSettings.toggleShowDefaultAddress();
+        await new SettingsPage(driver).closeSettingsPage();
+
+        // Check on home page that default address is present
+        await new HomePage(driver).checkPageIsLoaded();
+        await driver.waitForSelector(
+          '[data-testid="default-address-container"]',
+        );
+      },
+    );
+  });
+});


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds e2e tests for the default address feature. Figma here: https://www.figma.com/design/IVt20ztP5OpMtBpIzGX0Q4/Adding-default-address-toggle-for-home-address-and-account-list?node-id=0-1&p=f&m=dev

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: 

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes (new spec + page-object helpers) with no production logic modifications; risk is limited to potential e2e flakiness due to new selectors.
> 
> **Overview**
> Adds new e2e coverage for the *Show default address* setting, asserting the toggle section exists in General Settings, the default address is hidden on the homepage header by default, and it appears after enabling the toggle.
> 
> Extends e2e page objects with selectors and helpers for the header `default-address-container` element and the General Settings toggle (`#show-default-address`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c34c302b1b38ba5f6fef8064df524462c4b4080d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->