### PR TITLE
feat: Improve account from/to display on confirmation page

### DIFF
--- a/test/e2e/page-objects/pages/confirmations/confirmation.ts
+++ b/test/e2e/page-objects/pages/confirmations/confirmation.ts
@@ -25,6 +25,9 @@ class Confirmation {
 
   private inlineAlertButton = '[data-testid="inline-alert"]';
 
+  private addressDisplaySelector =
+    '[data-testid="recipient-address"] [data-testid="confirm-info-row-display-name"]';
+
   private nameSelector = '.name';
 
   private navigationTitle: RawLocator;
@@ -184,6 +187,13 @@ class Confirmation {
     });
   }
 
+  async checkAddressIsDisplayed(address: string): Promise<void> {
+    await this.driver.findElement({
+      css: '[data-testid="confirm-info-row-display-name"]',
+      text: address,
+    });
+  }
+
   async clickName(value: string): Promise<void> {
     console.log(`Clicking on name: ${value}`);
     await this.driver.clickElement({
@@ -197,16 +207,19 @@ class Confirmation {
     name,
     proposedName,
   }: {
-    value: string;
+    value?: string;
     name?: string;
     proposedName?: string;
   }): Promise<void> {
-    await this.clickName(value);
-    console.log(
-      `Saving name for value: ${value}, name: ${name}, proposedName: ${proposedName}`,
-    );
+    if (value) {
+      await this.driver.clickElement({
+        text: value,
+      });
+    } else {
+      await this.driver.clickElement(this.addressDisplaySelector);
+    }
+    console.log(`Saving name: ${name}, proposedName: ${proposedName}`);
     await this.driver.clickElement(this.formComboFieldSelector);
-
     if (proposedName) {
       await this.driver.clickElement({
         css: this.formComboFieldOptionPrimarySelector,

--- a/test/e2e/page-objects/pages/send/send-token-confirmation-page.ts
+++ b/test/e2e/page-objects/pages/send/send-token-confirmation-page.ts
@@ -136,6 +136,21 @@ class SendTokenConfirmPage {
     );
   }
 
+  async checkRecipientAddressDisplayed(address: string): Promise<void> {
+    console.log(
+      `Checking recipient address ${address} is displayed on confirmation screen`,
+    );
+    await this.driver.wait(async () => {
+      const recipientAddress = await this.driver.findElement(
+        '[data-testid="recipient-address"]',
+      );
+      return (await recipientAddress.getText()).includes(
+        address.substring(0, 6),
+      );
+    }, 10000);
+    console.log(`Recipient address displayed as expected`);
+  }
+
   async checkTransactionAmount(amount: string): Promise<void> {
     console.log(`Checking transaction amount is ${amount}`);
     await this.driver.waitForSelector({

--- a/test/e2e/tests/petnames/petnames-transactions.spec.ts
+++ b/test/e2e/tests/petnames/petnames-transactions.spec.ts
@@ -8,7 +8,7 @@ import { Driver } from '../../webdriver/driver';
 import { createInternalTransaction } from '../../page-objects/flows/transaction';
 
 const ADDRESS_MOCK = '0x0c54fccd2e384b4bb6f2e405bf5cbc15a017aafb';
-const ABBREVIATED_ADDRESS_MOCK = '0x0c54F...7AaFb';
+const ADDRESS_MOCK_RENDERED = '0x0c54FcCd2e384b4BB6f2E405Bf5Cbc15a017AaFb';
 const CUSTOM_NAME_MOCK = 'Custom Name';
 const PROPOSED_NAME_MOCK = 'test4.lens';
 
@@ -30,14 +30,9 @@ describe('Petnames - Transactions', function () {
         await testDapp.openTestDappPage();
         await testDapp.clickSimpleSendButton();
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
-        await confirmation.checkNameIsDisplayed(
-          ABBREVIATED_ADDRESS_MOCK,
-          false,
-        );
 
         // Test custom name.
         await confirmation.saveName({
-          value: ABBREVIATED_ADDRESS_MOCK,
           name: CUSTOM_NAME_MOCK,
         });
         await confirmation.checkPageIsLoaded();
@@ -45,11 +40,10 @@ describe('Petnames - Transactions', function () {
         await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
         await testDapp.clickSimpleSendButton();
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
-        await confirmation.checkNameIsDisplayed(CUSTOM_NAME_MOCK, true);
+        await confirmation.checkAddressIsDisplayed(CUSTOM_NAME_MOCK);
 
         // Test proposed name.
         await confirmation.saveName({
-          value: CUSTOM_NAME_MOCK,
           proposedName: PROPOSED_NAME_MOCK,
         });
         await confirmation.checkPageIsLoaded();
@@ -57,7 +51,7 @@ describe('Petnames - Transactions', function () {
         await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
         await testDapp.clickSimpleSendButton();
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
-        await confirmation.checkNameIsDisplayed(PROPOSED_NAME_MOCK, true);
+        await confirmation.checkAddressIsDisplayed(PROPOSED_NAME_MOCK);
       },
     );
   });
@@ -79,14 +73,10 @@ describe('Petnames - Transactions', function () {
         const confirmation = new Confirmation(driver);
         await loginWithBalanceValidation(driver);
         await createWalletSendTransaction(ADDRESS_MOCK, driver);
-        await confirmation.checkNameIsDisplayed(
-          ABBREVIATED_ADDRESS_MOCK,
-          false,
-        );
+        await confirmation.checkAddressIsDisplayed(ADDRESS_MOCK_RENDERED);
 
         // Test custom name.
         await confirmation.saveName({
-          value: ABBREVIATED_ADDRESS_MOCK,
           name: CUSTOM_NAME_MOCK,
         });
 
@@ -96,11 +86,10 @@ describe('Petnames - Transactions', function () {
           WINDOW_TITLES.ExtensionInFullScreenView,
         );
         await createWalletSendTransaction(ADDRESS_MOCK, driver);
-        await confirmation.checkNameIsDisplayed(CUSTOM_NAME_MOCK, true);
+        await confirmation.checkAddressIsDisplayed(CUSTOM_NAME_MOCK);
 
         // Test proposed name.
         await confirmation.saveName({
-          value: CUSTOM_NAME_MOCK,
           proposedName: PROPOSED_NAME_MOCK,
         });
         await confirmation.checkPageIsLoaded();
@@ -109,7 +98,7 @@ describe('Petnames - Transactions', function () {
           WINDOW_TITLES.ExtensionInFullScreenView,
         );
         await createWalletSendTransaction(ADDRESS_MOCK, driver);
-        await confirmation.checkNameIsDisplayed(PROPOSED_NAME_MOCK, true);
+        await confirmation.checkAddressIsDisplayed(PROPOSED_NAME_MOCK);
       },
     );
   });

--- a/test/e2e/tests/send/send-eth-advanced.spec.ts
+++ b/test/e2e/tests/send/send-eth-advanced.spec.ts
@@ -242,10 +242,11 @@ describe('Send ETH - Advanced', function () {
 
           await sendPage.pressContinueButton();
 
+          await sendTokenConfirmPage.checkPageIsLoaded();
+
           // Verify the recipient address is displayed correctly (should show the actual recipient, not the one in the data)
-          await sendTokenConfirmPage.checkRecipientAddressDisplayedCount(
-            '0xc427D...Acd28',
-            1,
+          await sendTokenConfirmPage.checkRecipientAddressDisplayed(
+            '0xc427D562164062a23a5cFf596A4a3208e72Acd28',
           );
         },
       );

--- a/test/e2e/tests/send/send-hex-address.spec.ts
+++ b/test/e2e/tests/send/send-hex-address.spec.ts
@@ -92,10 +92,7 @@ describe('Send - Hex Address Normalization', function () {
 
           // Verify address on confirmation screen
           const transactionConfirmation = new TransactionConfirmation(driver);
-          await transactionConfirmation.checkNameIsDisplayed(
-            hexAbbreviatedAddress,
-            false,
-          );
+          await transactionConfirmation.checkAddressIsDisplayed('0x2f318C');
         },
       );
     });

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -330,6 +330,9 @@
     "ui/components/app/configure-snap-popup/configure-snap-popup.test.tsx": {
       "warn: ⚠️ React Router Future Flag": 2
     },
+    "ui/components/app/confirm/info/row/address-display.test.tsx": {
+      "warn: ⚠️ React Router Future Flag": 2
+    },
     "ui/components/app/confirm/info/row/address.test.tsx": {
       "MetaMask: Background connection not initialized": 2,
       "React: Act warnings (component updates not wrapped)": 2,

--- a/ui/components/app/confirm/info/row/address-display.test.tsx
+++ b/ui/components/app/confirm/info/row/address-display.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import mockState from '../../../../../../test/data/mock-state.json';
+import { renderWithProvider } from '../../../../../../test/lib/render-helpers-navigate';
+import configureStore from '../../../../../store/store';
+import { TrustSignalDisplayState } from '../../../../../hooks/useTrustSignals';
+import { ConfirmInfoRowAddressDisplay } from './address-display';
+import { TEST_ADDRESS } from './constants';
+
+const defaultProps = {
+  address: TEST_ADDRESS,
+  chainId: '0x1',
+  name: null as string | null,
+  isAccount: false,
+  image: undefined,
+  displayState: TrustSignalDisplayState.Unknown,
+};
+
+const render = (props: Partial<typeof defaultProps> = {}) => {
+  const store = configureStore({
+    metamask: { ...mockState.metamask },
+  });
+
+  return renderWithProvider(
+    <ConfirmInfoRowAddressDisplay {...defaultProps} {...props} />,
+    store,
+  );
+};
+
+describe('ConfirmInfoRowAddressDisplay', () => {
+  it('renders display name element for unknown address', () => {
+    const { getByTestId } = render();
+    expect(getByTestId('confirm-info-row-display-name')).toBeInTheDocument();
+  });
+
+  it('renders account name for known address', () => {
+    const { getByTestId } = render({
+      address: '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
+      name: 'Account 1',
+      isAccount: true,
+      displayState: TrustSignalDisplayState.Recognized,
+    });
+    expect(getByTestId('confirm-info-row-display-name')).toHaveTextContent(
+      'Account 1',
+    );
+  });
+
+  it('renders with clickable class for non-account address', () => {
+    const { getByTestId } = render();
+    expect(getByTestId('confirm-info-row-display-name')).toHaveClass(
+      'confirm-info-row-address-display__clickable',
+    );
+  });
+
+  it('does not render clickable class for account address', () => {
+    const { getByTestId } = render({
+      address: '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
+      name: 'Account 1',
+      isAccount: true,
+      displayState: TrustSignalDisplayState.Recognized,
+    });
+    expect(getByTestId('confirm-info-row-display-name')).not.toHaveClass(
+      'confirm-info-row-address-display__clickable',
+    );
+  });
+
+  it('renders full address when container has sufficient width', () => {
+    jest
+      .spyOn(HTMLElement.prototype, 'clientWidth', 'get')
+      .mockReturnValue(500);
+
+    const { getByTestId } = render();
+    expect(getByTestId('confirm-info-row-display-name').textContent).toContain(
+      '0x5CfE73b6',
+    );
+
+    jest.restoreAllMocks();
+  });
+});

--- a/ui/components/app/confirm/info/row/address-display.tsx
+++ b/ui/components/app/confirm/info/row/address-display.tsx
@@ -2,6 +2,8 @@ import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { NameType } from '@metamask/name-controller';
 import {
   AvatarAccountSize,
+  AvatarToken,
+  AvatarTokenSize,
   Box,
   BoxAlignItems,
   BoxFlexDirection,
@@ -13,7 +15,6 @@ import {
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react';
-import Identicon from '../../../../ui/identicon';
 import { toChecksumHexAddress } from '../../../../../../shared/modules/hexstring-utils';
 import { PreferredAvatar } from '../../../preferred-avatar';
 import NameDetails from '../../../name/name-details/name-details';
@@ -113,7 +114,7 @@ const TrustIcon = ({
       );
     default:
       if (image) {
-        return <Identicon address={address} diameter={16} image={image} />;
+        return <AvatarToken src={image} size={AvatarTokenSize.Xs} />;
       }
       return null;
   }

--- a/ui/components/app/confirm/info/row/address-display.tsx
+++ b/ui/components/app/confirm/info/row/address-display.tsx
@@ -1,0 +1,249 @@
+import React, { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { NameType } from '@metamask/name-controller';
+import {
+  AvatarAccountSize,
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react';
+import Identicon from '../../../../ui/identicon';
+import { toChecksumHexAddress } from '../../../../../../shared/modules/hexstring-utils';
+import { PreferredAvatar } from '../../../preferred-avatar';
+import NameDetails from '../../../name/name-details/name-details';
+import { TrustSignalDisplayState } from '../../../../../hooks/useTrustSignals';
+
+const ELLIPSIS = '\u2026';
+
+function useMiddleTruncation(text: string) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [display, setDisplay] = useState(text);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) {
+      return;
+    }
+
+    const availableWidth = el.clientWidth;
+    const canvas = document.createElement('canvas');
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+      return;
+    }
+
+    const style = getComputedStyle(el);
+    ctx.font = `${style.fontSize} ${style.fontFamily}`;
+
+    if (ctx.measureText(text).width <= availableWidth) {
+      setDisplay(text);
+      return;
+    }
+
+    const ellipsisWidth = ctx.measureText(ELLIPSIS).width;
+    const halfWidth = (availableWidth - ellipsisWidth) / 2;
+
+    let startEnd = 0;
+    let w = 0;
+    for (let i = 0; i < text.length; i++) {
+      w += ctx.measureText(text[i]).width;
+      if (w > halfWidth) {
+        break;
+      }
+      startEnd = i + 1;
+    }
+
+    let tailStart = text.length;
+    w = 0;
+    for (let i = text.length - 1; i >= 0; i--) {
+      w += ctx.measureText(text[i]).width;
+      if (w > halfWidth) {
+        break;
+      }
+      tailStart = i;
+    }
+
+    setDisplay(`${text.slice(0, startEnd)}${ELLIPSIS}${text.slice(tailStart)}`);
+  }, [text]);
+
+  return { containerRef, display };
+}
+
+const TrustIcon = ({
+  displayState,
+  image,
+  address,
+}: {
+  displayState: TrustSignalDisplayState;
+  image?: string;
+  address: string;
+}) => {
+  switch (displayState) {
+    case TrustSignalDisplayState.Malicious:
+      return (
+        <Icon
+          name={IconName.Danger}
+          size={IconSize.Sm}
+          color={IconColor.ErrorDefault}
+          style={{ flexShrink: 0 }}
+        />
+      );
+    case TrustSignalDisplayState.Verified:
+      return (
+        <Icon
+          name={IconName.VerifiedFilled}
+          size={IconSize.Sm}
+          color={IconColor.InfoDefault}
+          style={{ flexShrink: 0 }}
+        />
+      );
+    case TrustSignalDisplayState.Unknown:
+      return (
+        <Icon
+          name={IconName.Question}
+          size={IconSize.Sm}
+          style={{ flexShrink: 0 }}
+        />
+      );
+    default:
+      if (image) {
+        return <Identicon address={address} diameter={16} image={image} />;
+      }
+      return null;
+  }
+};
+
+export type ConfirmInfoRowAddressDisplayProps = {
+  address: string;
+  chainId: string;
+  name: string | null;
+  isAccount: boolean;
+  image?: string;
+  displayState: TrustSignalDisplayState;
+  showAvatar?: boolean;
+};
+
+export const ConfirmInfoRowAddressDisplay = memo(
+  ({
+    address,
+    chainId,
+    name,
+    isAccount,
+    image,
+    displayState,
+    showAvatar = true,
+  }: ConfirmInfoRowAddressDisplayProps) => {
+    const hexAddress = toChecksumHexAddress(address);
+
+    const [modalOpen, setModalOpen] = useState(false);
+
+    const isClickable = !isAccount;
+    const { containerRef, display } = useMiddleTruncation(hexAddress);
+
+    const handleClick = useCallback(() => {
+      if (!isClickable) {
+        return;
+      }
+      setModalOpen(true);
+    }, [isClickable]);
+
+    const handleModalClose = useCallback(() => {
+      setModalOpen(false);
+    }, []);
+
+    return (
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        gap={2}
+      >
+        {modalOpen && (
+          <NameDetails
+            value={hexAddress}
+            type={NameType.ETHEREUM_ADDRESS}
+            variation={chainId}
+            onClose={handleModalClose}
+          />
+        )}
+        <TrustIcon
+          displayState={displayState}
+          image={image}
+          address={hexAddress}
+        />
+        {name && isClickable && (
+          <Text
+            variant={TextVariant.BodyMd}
+            color={TextColor.TextDefault}
+            className="confirm-info-row-address-display__clickable"
+            asChild
+          >
+            <button
+              type="button"
+              style={{ whiteSpace: 'nowrap', flex: 1 }}
+              onClick={handleClick}
+              data-testid="confirm-info-row-display-name"
+            >
+              {name}
+            </button>
+          </Text>
+        )}
+        {name && !isClickable && (
+          <Text
+            variant={TextVariant.BodyMd}
+            color={TextColor.TextDefault}
+            data-testid="confirm-info-row-display-name"
+            style={{ whiteSpace: 'nowrap', flex: 1 }}
+          >
+            {name}
+          </Text>
+        )}
+        {!name && isClickable && (
+          <Text
+            variant={TextVariant.BodyMd}
+            color={TextColor.TextDefault}
+            className="confirm-info-row-address-display__clickable"
+            asChild
+          >
+            <button
+              type="button"
+              ref={containerRef as unknown as React.Ref<HTMLButtonElement>}
+              style={{ flex: 1, whiteSpace: 'nowrap', overflow: 'hidden' }}
+              onClick={handleClick}
+              data-testid="confirm-info-row-display-name"
+            >
+              {display}
+            </button>
+          </Text>
+        )}
+        {!name && !isClickable && (
+          <Text
+            variant={TextVariant.BodyMd}
+            color={TextColor.TextDefault}
+            data-testid="confirm-info-row-display-name"
+            asChild
+          >
+            <span
+              ref={containerRef}
+              style={{ flex: 1, whiteSpace: 'nowrap', overflow: 'hidden' }}
+            >
+              {display}
+            </span>
+          </Text>
+        )}
+        {showAvatar && (
+          <PreferredAvatar
+            address={hexAddress}
+            size={AvatarAccountSize.Sm}
+            style={{ flexShrink: 0 }}
+          />
+        )}
+      </Box>
+    );
+  },
+);

--- a/ui/components/app/confirm/info/row/index.scss
+++ b/ui/components/app/confirm/info/row/index.scss
@@ -15,3 +15,17 @@
   cursor: pointer;
   text-decoration: underline;
 }
+
+.confirm-info-row-address-display__clickable {
+  cursor: pointer;
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  text-align: left;
+
+  &:hover {
+    color: var(--color-info-default);
+  }
+}

--- a/ui/components/app/confirm/info/row/index.ts
+++ b/ui/components/app/confirm/info/row/index.ts
@@ -1,4 +1,5 @@
 export * from './address';
+export * from './address-display';
 export * from './date';
 export * from './divider';
 export * from './row';

--- a/ui/pages/confirmations/components/confirm/info/native-transfer/__snapshots__/native-transfer.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/native-transfer/__snapshots__/native-transfer.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`NativeTransferInfo renders correctly 1`] = `
 <div>
@@ -21,144 +21,197 @@ exports[`NativeTransferInfo renders correctly 1`] = `
     data-testid="confirmation__transaction-flow"
   >
     <div
-      class="mm-box mm-box--padding-bottom-1 mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-space-between mm-box--align-items-center"
+      class="flex flex-col"
     >
       <div
-        class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
-        style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; flex: 1; flex-direction: column;"
+        class="flex flex-row gap-2 items-center"
       >
         <div
-          class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--color-text-alternative"
-          style="flex-shrink: 0; flex-basis: auto; max-width: 100%;"
+          class=""
+          style="flex: 1; min-width: 0;"
         >
           <div
-            class="mm-box mm-box--display-flex mm-box--align-items-center"
-            style="flex-shrink: 0;"
-          >
-            <p
-              class="mm-box mm-text mm-text--body-md-medium mm-box--color-inherit"
-            >
-              From
-            </p>
-          </div>
-        </div>
-        <div
-          class="mm-box mm-box--margin-top-2"
-          data-testid="sender-address"
-        >
-          <div
-            class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--align-items-center"
+            class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
+            style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; flex-direction: column; width: 100%;"
           >
             <div
-              class="mm-box overflow-hidden mm-box--display-flex mm-box--flex-direction-column"
+              class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--color-text-alternative"
+              style="flex-shrink: 0; flex-basis: auto; max-width: 100%;"
             >
               <div
-                class="name name__recognized_unsaved"
+                class="mm-box mm-box--display-flex mm-box--align-items-center"
+                style="flex-shrink: 0;"
               >
-                <div
-                  class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section h-4 w-4 rounded-md"
-                >
-                  <div
-                    class="flex [&>div]:!rounded-none"
-                  >
-                    <div
-                      style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 16px; height: 16px; display: inline-block; background: rgb(250, 58, 0);"
-                    >
-                      <svg
-                        height="16"
-                        width="16"
-                        x="0"
-                        y="0"
-                      >
-                        <rect
-                          fill="#18CDF2"
-                          height="16"
-                          transform="translate(-0.52419675189697 -1.65214203473025) rotate(328.9 8.00000000000000 8.00000000000000)"
-                          width="16"
-                          x="0"
-                          y="0"
-                        />
-                        <rect
-                          fill="#035E56"
-                          height="16"
-                          transform="translate(-9.14923085441602 5.29623093587430) rotate(176.2 8.00000000000000 8.00000000000000)"
-                          width="16"
-                          x="0"
-                          y="0"
-                        />
-                        <rect
-                          fill="#F26602"
-                          height="16"
-                          transform="translate(8.33392100911196 -7.10256986149854) rotate(468.9 8.00000000000000 8.00000000000000)"
-                          width="16"
-                          x="0"
-                          y="0"
-                        />
-                      </svg>
-                    </div>
-                  </div>
-                </div>
                 <p
-                  class="mm-box mm-text name__name mm-text--body-md mm-box--color-text-default"
+                  class="mm-box mm-text mm-text--body-md-medium mm-box--color-inherit"
+                >
+                  From Wallet 1
+                </p>
+              </div>
+            </div>
+            <div
+              class="mt-2 w-full"
+              data-testid="sender-address"
+            >
+              <div
+                class="flex flex-row gap-2 items-center"
+              >
+                <p
+                  class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default"
+                  data-testid="confirm-info-row-display-name"
+                  style="white-space: nowrap; flex: 1;"
                 >
                   Account 1
                 </p>
               </div>
-              <p
-                class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
-                style="text-align: right;"
+            </div>
+          </div>
+        </div>
+        <div
+          class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
+          style="flex-shrink: 0;"
+        >
+          <div
+            class="flex [&>div]:!rounded-none"
+          >
+            <div
+              style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(250, 58, 0);"
+            >
+              <svg
+                height="32"
+                width="32"
+                x="0"
+                y="0"
               >
-                Wallet 1
-              </p>
+                <rect
+                  fill="#18CDF2"
+                  height="32"
+                  transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
+                  width="32"
+                  x="0"
+                  y="0"
+                />
+                <rect
+                  fill="#035E56"
+                  height="32"
+                  transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
+                  width="32"
+                  x="0"
+                  y="0"
+                />
+                <rect
+                  fill="#F26602"
+                  height="32"
+                  transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
+                  width="32"
+                  x="0"
+                  y="0"
+                />
+              </svg>
             </div>
           </div>
         </div>
       </div>
-      <span
-        class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-icon-alternative"
-        style="mask-image: url('./images/icons/arrow-right.svg');"
-      />
       <div
-        class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
-        style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; flex: 1; flex-direction: column; overflow: hidden;"
+        class=""
       >
         <div
-          class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--color-text-alternative"
-          style="flex-shrink: 0; flex-basis: auto; max-width: 100%;"
+          class="flex flex-row gap-2 items-center"
         >
           <div
-            class="mm-box mm-box--display-flex mm-box--align-items-center"
-            style="flex-shrink: 0;"
-          >
-            <p
-              class="mm-box mm-text mm-text--body-md-medium mm-box--color-inherit"
-            >
-              To
-            </p>
-          </div>
-        </div>
-        <div
-          class="mm-box w-full mm-box--margin-top-2"
-          data-testid="recipient-address"
-        >
-          <div
-            class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--align-items-center"
+            class=""
+            style="flex: 1; min-width: 0;"
           >
             <div
-              class="mm-box overflow-hidden mm-box--display-flex mm-box--flex-direction-column"
+              class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
+              style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; flex-direction: column; width: 100%;"
             >
               <div
-                class="name name__clickable name__missing"
+                class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--color-text-alternative"
+                style="flex-shrink: 0; flex-basis: auto; max-width: 100%;"
               >
-                <span
-                  class="mm-box name__icon mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
-                  style="mask-image: url('./images/icons/question.svg');"
-                />
-                <p
-                  class="mm-box mm-text name__value mm-text--body-md mm-box--color-text-default"
+                <div
+                  class="mm-box mm-box--display-flex mm-box--align-items-center"
+                  style="flex-shrink: 0;"
                 >
-                  0x2e0D7...5d09B
-                </p>
+                  <p
+                    class="mm-box mm-text mm-text--body-md-medium mm-box--color-inherit"
+                  >
+                    To
+                  </p>
+                </div>
+              </div>
+              <div
+                class="mt-2 w-full"
+                data-testid="recipient-address"
+              >
+                <div
+                  class="flex flex-row gap-2 items-center"
+                >
+                  <svg
+                    class="inline-block w-4 h-4 text-icon-default"
+                    fill="currentColor"
+                    style="flex-shrink: 0;"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M11.95 18q.525 0 .888-.362c.362-.363.362-.538.362-.888s-.12-.646-.362-.887-.538-.363-.888-.363-.646.12-.887.363-.363.537-.363.887.12.646.363.888.537.362.887.362m-.9-3.85h1.85q0-.825.187-1.3c.187-.475.48-.75 1.063-1.3a7.5 7.5 0 0 0 1.025-1.238q.375-.587.375-1.412 0-1.4-1.025-2.15C13.5 6 13.033 6 12.1 6q-1.424 0-2.313.75-.887.75-1.237 1.8l1.65.65q.124-.45.562-.975C11.2 7.7 11.5 7.7 12.1 7.7q.8 0 1.2.437c.4.437.4.613.4.963q0 .5-.3.938t-.75.812q-1.1.975-1.35 1.475c-.25.5-.25.942-.25 1.825M12 22q-2.075 0-3.9-.787c-1.825-.788-2.275-1.238-3.175-2.138S3.312 17.117 2.787 15.9 2 13.383 2 12s.262-2.683.787-3.9 1.238-2.275 2.138-3.175S6.883 3.312 8.1 2.787 10.617 2 12 2s2.683.262 3.9.787 2.275 1.238 3.175 2.138 1.613 1.958 2.138 3.175S22 10.617 22 12s-.262 2.683-.787 3.9-1.238 2.275-2.138 3.175-1.958 1.613-3.175 2.138S13.383 22 12 22m0-2q3.35 0 5.675-2.325C20 15.35 20 14.233 20 12q0-3.35-2.325-5.675C15.35 4 14.233 4 12 4Q8.65 4 6.325 6.325C4 8.65 4 9.767 4 12q0 3.35 2.325 5.675C8.65 20 9.767 20 12 20"
+                    />
+                  </svg>
+                  <button
+                    class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default confirm-info-row-address-display__clickable"
+                    data-testid="confirm-info-row-display-name"
+                    style="flex: 1; white-space: nowrap; overflow: hidden;"
+                    type="button"
+                  >
+                    …
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
+            style="flex-shrink: 0;"
+          >
+            <div
+              class="flex [&>div]:!rounded-none"
+            >
+              <div
+                style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(24, 100, 242);"
+              >
+                <svg
+                  height="32"
+                  width="32"
+                  x="0"
+                  y="0"
+                >
+                  <rect
+                    fill="#C81420"
+                    height="32"
+                    transform="translate(-5.50523690490468 -5.26512336373754) rotate(385.9 16.00000000000000 16.00000000000000)"
+                    width="32"
+                    x="0"
+                    y="0"
+                  />
+                  <rect
+                    fill="#E9F500"
+                    height="32"
+                    transform="translate(10.67446940672640 12.42992815919339) rotate(184.5 16.00000000000000 16.00000000000000)"
+                    width="32"
+                    x="0"
+                    y="0"
+                  />
+                  <rect
+                    fill="#FAB300"
+                    height="32"
+                    transform="translate(1.81545519923623 -26.03028190637629) rotate(431.3 16.00000000000000 16.00000000000000)"
+                    width="32"
+                    x="0"
+                    y="0"
+                  />
+                </svg>
               </div>
             </div>
           </div>

--- a/ui/pages/confirmations/components/confirm/info/nft-token-transfer/__snapshots__/nft-token-transfer.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/nft-token-transfer/__snapshots__/nft-token-transfer.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`NFTTokenTransferInfo renders correctly 1`] = `
 <div>
@@ -51,144 +51,197 @@ exports[`NFTTokenTransferInfo renders correctly 1`] = `
     data-testid="confirmation__transaction-flow"
   >
     <div
-      class="mm-box mm-box--padding-bottom-1 mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-space-between mm-box--align-items-center"
+      class="flex flex-col"
     >
       <div
-        class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
-        style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; flex: 1; flex-direction: column;"
+        class="flex flex-row gap-2 items-center"
       >
         <div
-          class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--color-text-alternative"
-          style="flex-shrink: 0; flex-basis: auto; max-width: 100%;"
+          class=""
+          style="flex: 1; min-width: 0;"
         >
           <div
-            class="mm-box mm-box--display-flex mm-box--align-items-center"
-            style="flex-shrink: 0;"
-          >
-            <p
-              class="mm-box mm-text mm-text--body-md-medium mm-box--color-inherit"
-            >
-              From
-            </p>
-          </div>
-        </div>
-        <div
-          class="mm-box mm-box--margin-top-2"
-          data-testid="sender-address"
-        >
-          <div
-            class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--align-items-center"
+            class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
+            style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; flex-direction: column; width: 100%;"
           >
             <div
-              class="mm-box overflow-hidden mm-box--display-flex mm-box--flex-direction-column"
+              class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--color-text-alternative"
+              style="flex-shrink: 0; flex-basis: auto; max-width: 100%;"
             >
               <div
-                class="name name__recognized_unsaved"
+                class="mm-box mm-box--display-flex mm-box--align-items-center"
+                style="flex-shrink: 0;"
               >
-                <div
-                  class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section h-4 w-4 rounded-md"
-                >
-                  <div
-                    class="flex [&>div]:!rounded-none"
-                  >
-                    <div
-                      style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 16px; height: 16px; display: inline-block; background: rgb(250, 58, 0);"
-                    >
-                      <svg
-                        height="16"
-                        width="16"
-                        x="0"
-                        y="0"
-                      >
-                        <rect
-                          fill="#18CDF2"
-                          height="16"
-                          transform="translate(-0.52419675189697 -1.65214203473025) rotate(328.9 8.00000000000000 8.00000000000000)"
-                          width="16"
-                          x="0"
-                          y="0"
-                        />
-                        <rect
-                          fill="#035E56"
-                          height="16"
-                          transform="translate(-9.14923085441602 5.29623093587430) rotate(176.2 8.00000000000000 8.00000000000000)"
-                          width="16"
-                          x="0"
-                          y="0"
-                        />
-                        <rect
-                          fill="#F26602"
-                          height="16"
-                          transform="translate(8.33392100911196 -7.10256986149854) rotate(468.9 8.00000000000000 8.00000000000000)"
-                          width="16"
-                          x="0"
-                          y="0"
-                        />
-                      </svg>
-                    </div>
-                  </div>
-                </div>
                 <p
-                  class="mm-box mm-text name__name mm-text--body-md mm-box--color-text-default"
+                  class="mm-box mm-text mm-text--body-md-medium mm-box--color-inherit"
+                >
+                  From Wallet 1
+                </p>
+              </div>
+            </div>
+            <div
+              class="mt-2 w-full"
+              data-testid="sender-address"
+            >
+              <div
+                class="flex flex-row gap-2 items-center"
+              >
+                <p
+                  class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default"
+                  data-testid="confirm-info-row-display-name"
+                  style="white-space: nowrap; flex: 1;"
                 >
                   Account 1
                 </p>
               </div>
-              <p
-                class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
-                style="text-align: right;"
+            </div>
+          </div>
+        </div>
+        <div
+          class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
+          style="flex-shrink: 0;"
+        >
+          <div
+            class="flex [&>div]:!rounded-none"
+          >
+            <div
+              style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(250, 58, 0);"
+            >
+              <svg
+                height="32"
+                width="32"
+                x="0"
+                y="0"
               >
-                Wallet 1
-              </p>
+                <rect
+                  fill="#18CDF2"
+                  height="32"
+                  transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
+                  width="32"
+                  x="0"
+                  y="0"
+                />
+                <rect
+                  fill="#035E56"
+                  height="32"
+                  transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
+                  width="32"
+                  x="0"
+                  y="0"
+                />
+                <rect
+                  fill="#F26602"
+                  height="32"
+                  transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
+                  width="32"
+                  x="0"
+                  y="0"
+                />
+              </svg>
             </div>
           </div>
         </div>
       </div>
-      <span
-        class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-icon-alternative"
-        style="mask-image: url('./images/icons/arrow-right.svg');"
-      />
       <div
-        class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
-        style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; flex: 1; flex-direction: column; overflow: hidden;"
+        class=""
       >
         <div
-          class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--color-text-alternative"
-          style="flex-shrink: 0; flex-basis: auto; max-width: 100%;"
+          class="flex flex-row gap-2 items-center"
         >
           <div
-            class="mm-box mm-box--display-flex mm-box--align-items-center"
-            style="flex-shrink: 0;"
-          >
-            <p
-              class="mm-box mm-text mm-text--body-md-medium mm-box--color-inherit"
-            >
-              To
-            </p>
-          </div>
-        </div>
-        <div
-          class="mm-box w-full mm-box--margin-top-2"
-          data-testid="recipient-address"
-        >
-          <div
-            class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--align-items-center"
+            class=""
+            style="flex: 1; min-width: 0;"
           >
             <div
-              class="mm-box overflow-hidden mm-box--display-flex mm-box--flex-direction-column"
+              class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
+              style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; flex-direction: column; width: 100%;"
             >
               <div
-                class="name name__clickable name__missing"
+                class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--color-text-alternative"
+                style="flex-shrink: 0; flex-basis: auto; max-width: 100%;"
               >
-                <span
-                  class="mm-box name__icon mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
-                  style="mask-image: url('./images/icons/question.svg');"
-                />
-                <p
-                  class="mm-box mm-text name__value mm-text--body-md mm-box--color-text-default"
+                <div
+                  class="mm-box mm-box--display-flex mm-box--align-items-center"
+                  style="flex-shrink: 0;"
                 >
-                  0x2e0D7...5d09B
-                </p>
+                  <p
+                    class="mm-box mm-text mm-text--body-md-medium mm-box--color-inherit"
+                  >
+                    To
+                  </p>
+                </div>
+              </div>
+              <div
+                class="mt-2 w-full"
+                data-testid="recipient-address"
+              >
+                <div
+                  class="flex flex-row gap-2 items-center"
+                >
+                  <svg
+                    class="inline-block w-4 h-4 text-icon-default"
+                    fill="currentColor"
+                    style="flex-shrink: 0;"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M11.95 18q.525 0 .888-.362c.362-.363.362-.538.362-.888s-.12-.646-.362-.887-.538-.363-.888-.363-.646.12-.887.363-.363.537-.363.887.12.646.363.888.537.362.887.362m-.9-3.85h1.85q0-.825.187-1.3c.187-.475.48-.75 1.063-1.3a7.5 7.5 0 0 0 1.025-1.238q.375-.587.375-1.412 0-1.4-1.025-2.15C13.5 6 13.033 6 12.1 6q-1.424 0-2.313.75-.887.75-1.237 1.8l1.65.65q.124-.45.562-.975C11.2 7.7 11.5 7.7 12.1 7.7q.8 0 1.2.437c.4.437.4.613.4.963q0 .5-.3.938t-.75.812q-1.1.975-1.35 1.475c-.25.5-.25.942-.25 1.825M12 22q-2.075 0-3.9-.787c-1.825-.788-2.275-1.238-3.175-2.138S3.312 17.117 2.787 15.9 2 13.383 2 12s.262-2.683.787-3.9 1.238-2.275 2.138-3.175S6.883 3.312 8.1 2.787 10.617 2 12 2s2.683.262 3.9.787 2.275 1.238 3.175 2.138 1.613 1.958 2.138 3.175S22 10.617 22 12s-.262 2.683-.787 3.9-1.238 2.275-2.138 3.175-1.958 1.613-3.175 2.138S13.383 22 12 22m0-2q3.35 0 5.675-2.325C20 15.35 20 14.233 20 12q0-3.35-2.325-5.675C15.35 4 14.233 4 12 4Q8.65 4 6.325 6.325C4 8.65 4 9.767 4 12q0 3.35 2.325 5.675C8.65 20 9.767 20 12 20"
+                    />
+                  </svg>
+                  <button
+                    class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default confirm-info-row-address-display__clickable"
+                    data-testid="confirm-info-row-display-name"
+                    style="flex: 1; white-space: nowrap; overflow: hidden;"
+                    type="button"
+                  >
+                    …
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
+            style="flex-shrink: 0;"
+          >
+            <div
+              class="flex [&>div]:!rounded-none"
+            >
+              <div
+                style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(24, 100, 242);"
+              >
+                <svg
+                  height="32"
+                  width="32"
+                  x="0"
+                  y="0"
+                >
+                  <rect
+                    fill="#C81420"
+                    height="32"
+                    transform="translate(-5.50523690490468 -5.26512336373754) rotate(385.9 16.00000000000000 16.00000000000000)"
+                    width="32"
+                    x="0"
+                    y="0"
+                  />
+                  <rect
+                    fill="#E9F500"
+                    height="32"
+                    transform="translate(10.67446940672640 12.42992815919339) rotate(184.5 16.00000000000000 16.00000000000000)"
+                    width="32"
+                    x="0"
+                    y="0"
+                  />
+                  <rect
+                    fill="#FAB300"
+                    height="32"
+                    transform="translate(1.81545519923623 -26.03028190637629) rotate(431.3 16.00000000000000 16.00000000000000)"
+                    width="32"
+                    x="0"
+                    y="0"
+                  />
+                </svg>
               </div>
             </div>
           </div>

--- a/ui/pages/confirmations/components/confirm/info/token-transfer/__snapshots__/token-transfer.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/token-transfer/__snapshots__/token-transfer.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`TokenTransferInfo renders correctly 1`] = `
 <div>
@@ -32,144 +32,197 @@ exports[`TokenTransferInfo renders correctly 1`] = `
     data-testid="confirmation__transaction-flow"
   >
     <div
-      class="mm-box mm-box--padding-bottom-1 mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-space-between mm-box--align-items-center"
+      class="flex flex-col"
     >
       <div
-        class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
-        style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; flex: 1; flex-direction: column;"
+        class="flex flex-row gap-2 items-center"
       >
         <div
-          class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--color-text-alternative"
-          style="flex-shrink: 0; flex-basis: auto; max-width: 100%;"
+          class=""
+          style="flex: 1; min-width: 0;"
         >
           <div
-            class="mm-box mm-box--display-flex mm-box--align-items-center"
-            style="flex-shrink: 0;"
-          >
-            <p
-              class="mm-box mm-text mm-text--body-md-medium mm-box--color-inherit"
-            >
-              From
-            </p>
-          </div>
-        </div>
-        <div
-          class="mm-box mm-box--margin-top-2"
-          data-testid="sender-address"
-        >
-          <div
-            class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--align-items-center"
+            class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
+            style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; flex-direction: column; width: 100%;"
           >
             <div
-              class="mm-box overflow-hidden mm-box--display-flex mm-box--flex-direction-column"
+              class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--color-text-alternative"
+              style="flex-shrink: 0; flex-basis: auto; max-width: 100%;"
             >
               <div
-                class="name name__recognized_unsaved"
+                class="mm-box mm-box--display-flex mm-box--align-items-center"
+                style="flex-shrink: 0;"
               >
-                <div
-                  class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section h-4 w-4 rounded-md"
-                >
-                  <div
-                    class="flex [&>div]:!rounded-none"
-                  >
-                    <div
-                      style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 16px; height: 16px; display: inline-block; background: rgb(250, 58, 0);"
-                    >
-                      <svg
-                        height="16"
-                        width="16"
-                        x="0"
-                        y="0"
-                      >
-                        <rect
-                          fill="#18CDF2"
-                          height="16"
-                          transform="translate(-0.52419675189697 -1.65214203473025) rotate(328.9 8.00000000000000 8.00000000000000)"
-                          width="16"
-                          x="0"
-                          y="0"
-                        />
-                        <rect
-                          fill="#035E56"
-                          height="16"
-                          transform="translate(-9.14923085441602 5.29623093587430) rotate(176.2 8.00000000000000 8.00000000000000)"
-                          width="16"
-                          x="0"
-                          y="0"
-                        />
-                        <rect
-                          fill="#F26602"
-                          height="16"
-                          transform="translate(8.33392100911196 -7.10256986149854) rotate(468.9 8.00000000000000 8.00000000000000)"
-                          width="16"
-                          x="0"
-                          y="0"
-                        />
-                      </svg>
-                    </div>
-                  </div>
-                </div>
                 <p
-                  class="mm-box mm-text name__name mm-text--body-md mm-box--color-text-default"
+                  class="mm-box mm-text mm-text--body-md-medium mm-box--color-inherit"
+                >
+                  From Wallet 1
+                </p>
+              </div>
+            </div>
+            <div
+              class="mt-2 w-full"
+              data-testid="sender-address"
+            >
+              <div
+                class="flex flex-row gap-2 items-center"
+              >
+                <p
+                  class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default"
+                  data-testid="confirm-info-row-display-name"
+                  style="white-space: nowrap; flex: 1;"
                 >
                   Account 1
                 </p>
               </div>
-              <p
-                class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
-                style="text-align: right;"
+            </div>
+          </div>
+        </div>
+        <div
+          class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
+          style="flex-shrink: 0;"
+        >
+          <div
+            class="flex [&>div]:!rounded-none"
+          >
+            <div
+              style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(250, 58, 0);"
+            >
+              <svg
+                height="32"
+                width="32"
+                x="0"
+                y="0"
               >
-                Wallet 1
-              </p>
+                <rect
+                  fill="#18CDF2"
+                  height="32"
+                  transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
+                  width="32"
+                  x="0"
+                  y="0"
+                />
+                <rect
+                  fill="#035E56"
+                  height="32"
+                  transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
+                  width="32"
+                  x="0"
+                  y="0"
+                />
+                <rect
+                  fill="#F26602"
+                  height="32"
+                  transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
+                  width="32"
+                  x="0"
+                  y="0"
+                />
+              </svg>
             </div>
           </div>
         </div>
       </div>
-      <span
-        class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-icon-alternative"
-        style="mask-image: url('./images/icons/arrow-right.svg');"
-      />
       <div
-        class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
-        style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; flex: 1; flex-direction: column; overflow: hidden;"
+        class=""
       >
         <div
-          class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--color-text-alternative"
-          style="flex-shrink: 0; flex-basis: auto; max-width: 100%;"
+          class="flex flex-row gap-2 items-center"
         >
           <div
-            class="mm-box mm-box--display-flex mm-box--align-items-center"
-            style="flex-shrink: 0;"
-          >
-            <p
-              class="mm-box mm-text mm-text--body-md-medium mm-box--color-inherit"
-            >
-              To
-            </p>
-          </div>
-        </div>
-        <div
-          class="mm-box w-full mm-box--margin-top-2"
-          data-testid="recipient-address"
-        >
-          <div
-            class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--align-items-center"
+            class=""
+            style="flex: 1; min-width: 0;"
           >
             <div
-              class="mm-box overflow-hidden mm-box--display-flex mm-box--flex-direction-column"
+              class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
+              style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; flex-direction: column; width: 100%;"
             >
               <div
-                class="name name__clickable name__missing"
+                class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--color-text-alternative"
+                style="flex-shrink: 0; flex-basis: auto; max-width: 100%;"
               >
-                <span
-                  class="mm-box name__icon mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
-                  style="mask-image: url('./images/icons/question.svg');"
-                />
-                <p
-                  class="mm-box mm-text name__value mm-text--body-md mm-box--color-text-default"
+                <div
+                  class="mm-box mm-box--display-flex mm-box--align-items-center"
+                  style="flex-shrink: 0;"
                 >
-                  0x2e0D7...5d09B
-                </p>
+                  <p
+                    class="mm-box mm-text mm-text--body-md-medium mm-box--color-inherit"
+                  >
+                    To
+                  </p>
+                </div>
+              </div>
+              <div
+                class="mt-2 w-full"
+                data-testid="recipient-address"
+              >
+                <div
+                  class="flex flex-row gap-2 items-center"
+                >
+                  <svg
+                    class="inline-block w-4 h-4 text-icon-default"
+                    fill="currentColor"
+                    style="flex-shrink: 0;"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M11.95 18q.525 0 .888-.362c.362-.363.362-.538.362-.888s-.12-.646-.362-.887-.538-.363-.888-.363-.646.12-.887.363-.363.537-.363.887.12.646.363.888.537.362.887.362m-.9-3.85h1.85q0-.825.187-1.3c.187-.475.48-.75 1.063-1.3a7.5 7.5 0 0 0 1.025-1.238q.375-.587.375-1.412 0-1.4-1.025-2.15C13.5 6 13.033 6 12.1 6q-1.424 0-2.313.75-.887.75-1.237 1.8l1.65.65q.124-.45.562-.975C11.2 7.7 11.5 7.7 12.1 7.7q.8 0 1.2.437c.4.437.4.613.4.963q0 .5-.3.938t-.75.812q-1.1.975-1.35 1.475c-.25.5-.25.942-.25 1.825M12 22q-2.075 0-3.9-.787c-1.825-.788-2.275-1.238-3.175-2.138S3.312 17.117 2.787 15.9 2 13.383 2 12s.262-2.683.787-3.9 1.238-2.275 2.138-3.175S6.883 3.312 8.1 2.787 10.617 2 12 2s2.683.262 3.9.787 2.275 1.238 3.175 2.138 1.613 1.958 2.138 3.175S22 10.617 22 12s-.262 2.683-.787 3.9-1.238 2.275-2.138 3.175-1.958 1.613-3.175 2.138S13.383 22 12 22m0-2q3.35 0 5.675-2.325C20 15.35 20 14.233 20 12q0-3.35-2.325-5.675C15.35 4 14.233 4 12 4Q8.65 4 6.325 6.325C4 8.65 4 9.767 4 12q0 3.35 2.325 5.675C8.65 20 9.767 20 12 20"
+                    />
+                  </svg>
+                  <button
+                    class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default confirm-info-row-address-display__clickable"
+                    data-testid="confirm-info-row-display-name"
+                    style="flex: 1; white-space: nowrap; overflow: hidden;"
+                    type="button"
+                  >
+                    …
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
+            style="flex-shrink: 0;"
+          >
+            <div
+              class="flex [&>div]:!rounded-none"
+            >
+              <div
+                style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(24, 100, 242);"
+              >
+                <svg
+                  height="32"
+                  width="32"
+                  x="0"
+                  y="0"
+                >
+                  <rect
+                    fill="#C81420"
+                    height="32"
+                    transform="translate(-5.50523690490468 -5.26512336373754) rotate(385.9 16.00000000000000 16.00000000000000)"
+                    width="32"
+                    x="0"
+                    y="0"
+                  />
+                  <rect
+                    fill="#E9F500"
+                    height="32"
+                    transform="translate(10.67446940672640 12.42992815919339) rotate(184.5 16.00000000000000 16.00000000000000)"
+                    width="32"
+                    x="0"
+                    y="0"
+                  />
+                  <rect
+                    fill="#FAB300"
+                    height="32"
+                    transform="translate(1.81545519923623 -26.03028190637629) rotate(431.3 16.00000000000000 16.00000000000000)"
+                    width="32"
+                    x="0"
+                    y="0"
+                  />
+                </svg>
               </div>
             </div>
           </div>

--- a/ui/pages/confirmations/components/confirm/info/token-transfer/__snapshots__/transaction-flow-section.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/token-transfer/__snapshots__/transaction-flow-section.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<TransactionFlowSection /> renders correctly 1`] = `
 <div>
@@ -7,144 +7,209 @@ exports[`<TransactionFlowSection /> renders correctly 1`] = `
     data-testid="confirmation__transaction-flow"
   >
     <div
-      class="mm-box mm-box--padding-bottom-1 mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-space-between mm-box--align-items-center"
+      class="flex flex-col"
     >
       <div
-        class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
-        style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; flex: 1; flex-direction: column;"
+        class="flex flex-row gap-2 items-center"
       >
         <div
-          class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--color-text-alternative"
-          style="flex-shrink: 0; flex-basis: auto; max-width: 100%;"
+          class=""
+          style="flex: 1; min-width: 0;"
         >
           <div
-            class="mm-box mm-box--display-flex mm-box--align-items-center"
-            style="flex-shrink: 0;"
+            class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
+            style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; flex-direction: column; width: 100%;"
           >
-            <p
-              class="mm-box mm-text mm-text--body-md-medium mm-box--color-inherit"
+            <div
+              class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--color-text-alternative"
+              style="flex-shrink: 0; flex-basis: auto; max-width: 100%;"
             >
-              From
-            </p>
+              <div
+                class="mm-box mm-box--display-flex mm-box--align-items-center"
+                style="flex-shrink: 0;"
+              >
+                <p
+                  class="mm-box mm-text mm-text--body-md-medium mm-box--color-inherit"
+                >
+                  From
+                </p>
+              </div>
+            </div>
+            <div
+              class="mt-2 w-full"
+              data-testid="sender-address"
+            >
+              <div
+                class="flex flex-row gap-2 items-center"
+              >
+                <svg
+                  class="inline-block w-4 h-4 text-icon-default"
+                  fill="currentColor"
+                  style="flex-shrink: 0;"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M11.95 18q.525 0 .888-.362c.362-.363.362-.538.362-.888s-.12-.646-.362-.887-.538-.363-.888-.363-.646.12-.887.363-.363.537-.363.887.12.646.363.888.537.362.887.362m-.9-3.85h1.85q0-.825.187-1.3c.187-.475.48-.75 1.063-1.3a7.5 7.5 0 0 0 1.025-1.238q.375-.587.375-1.412 0-1.4-1.025-2.15C13.5 6 13.033 6 12.1 6q-1.424 0-2.313.75-.887.75-1.237 1.8l1.65.65q.124-.45.562-.975C11.2 7.7 11.5 7.7 12.1 7.7q.8 0 1.2.437c.4.437.4.613.4.963q0 .5-.3.938t-.75.812q-1.1.975-1.35 1.475c-.25.5-.25.942-.25 1.825M12 22q-2.075 0-3.9-.787c-1.825-.788-2.275-1.238-3.175-2.138S3.312 17.117 2.787 15.9 2 13.383 2 12s.262-2.683.787-3.9 1.238-2.275 2.138-3.175S6.883 3.312 8.1 2.787 10.617 2 12 2s2.683.262 3.9.787 2.275 1.238 3.175 2.138 1.613 1.958 2.138 3.175S22 10.617 22 12s-.262 2.683-.787 3.9-1.238 2.275-2.138 3.175-1.958 1.613-3.175 2.138S13.383 22 12 22m0-2q3.35 0 5.675-2.325C20 15.35 20 14.233 20 12q0-3.35-2.325-5.675C15.35 4 14.233 4 12 4Q8.65 4 6.325 6.325C4 8.65 4 9.767 4 12q0 3.35 2.325 5.675C8.65 20 9.767 20 12 20"
+                  />
+                </svg>
+                <button
+                  class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default confirm-info-row-address-display__clickable"
+                  data-testid="confirm-info-row-display-name"
+                  style="flex: 1; white-space: nowrap; overflow: hidden;"
+                  type="button"
+                >
+                  0x0DCD5D886577d5081B0c52e242Ef29E70Be3E7bc
+                </button>
+              </div>
+            </div>
           </div>
         </div>
         <div
-          class="mm-box mm-box--margin-top-2"
-          data-testid="sender-address"
+          class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
+          style="flex-shrink: 0;"
         >
           <div
-            class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--align-items-center"
+            class="flex [&>div]:!rounded-none"
           >
             <div
-              class="mm-box overflow-hidden mm-box--display-flex mm-box--flex-direction-column"
+              style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(250, 58, 0);"
             >
-              <div
-                class="name name__recognized_unsaved"
+              <svg
+                height="32"
+                width="32"
+                x="0"
+                y="0"
               >
-                <div
-                  class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section h-4 w-4 rounded-md"
-                >
-                  <div
-                    class="flex [&>div]:!rounded-none"
-                  >
-                    <div
-                      style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 16px; height: 16px; display: inline-block; background: rgb(250, 58, 0);"
-                    >
-                      <svg
-                        height="16"
-                        width="16"
-                        x="0"
-                        y="0"
-                      >
-                        <rect
-                          fill="#18CDF2"
-                          height="16"
-                          transform="translate(-0.52419675189697 -1.65214203473025) rotate(328.9 8.00000000000000 8.00000000000000)"
-                          width="16"
-                          x="0"
-                          y="0"
-                        />
-                        <rect
-                          fill="#035E56"
-                          height="16"
-                          transform="translate(-9.14923085441602 5.29623093587430) rotate(176.2 8.00000000000000 8.00000000000000)"
-                          width="16"
-                          x="0"
-                          y="0"
-                        />
-                        <rect
-                          fill="#F26602"
-                          height="16"
-                          transform="translate(8.33392100911196 -7.10256986149854) rotate(468.9 8.00000000000000 8.00000000000000)"
-                          width="16"
-                          x="0"
-                          y="0"
-                        />
-                      </svg>
-                    </div>
-                  </div>
-                </div>
-                <p
-                  class="mm-box mm-text name__name mm-text--body-md mm-box--color-text-default"
-                >
-                  Account 1
-                </p>
-              </div>
-              <p
-                class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
-                style="text-align: right;"
-              >
-                Wallet 1
-              </p>
+                <rect
+                  fill="#18CDF2"
+                  height="32"
+                  transform="translate(-1.04839350379394 -3.30428406946050) rotate(328.9 16.00000000000000 16.00000000000000)"
+                  width="32"
+                  x="0"
+                  y="0"
+                />
+                <rect
+                  fill="#035E56"
+                  height="32"
+                  transform="translate(-18.29846170883204 10.59246187174860) rotate(176.2 16.00000000000000 16.00000000000000)"
+                  width="32"
+                  x="0"
+                  y="0"
+                />
+                <rect
+                  fill="#F26602"
+                  height="32"
+                  transform="translate(16.66784201822392 -14.20513972299708) rotate(468.9 16.00000000000000 16.00000000000000)"
+                  width="32"
+                  x="0"
+                  y="0"
+                />
+              </svg>
             </div>
           </div>
         </div>
       </div>
-      <span
-        class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-icon-alternative"
-        style="mask-image: url('./images/icons/arrow-right.svg');"
-      />
       <div
-        class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
-        style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; flex: 1; flex-direction: column; overflow: hidden;"
+        class=""
       >
         <div
-          class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--color-text-alternative"
-          style="flex-shrink: 0; flex-basis: auto; max-width: 100%;"
+          class="flex flex-row gap-2 items-center"
         >
           <div
-            class="mm-box mm-box--display-flex mm-box--align-items-center"
-            style="flex-shrink: 0;"
-          >
-            <p
-              class="mm-box mm-text mm-text--body-md-medium mm-box--color-inherit"
-            >
-              To
-            </p>
-          </div>
-        </div>
-        <div
-          class="mm-box w-full mm-box--margin-top-2"
-          data-testid="recipient-address"
-        >
-          <div
-            class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--align-items-center"
+            class=""
+            style="flex: 1; min-width: 0;"
           >
             <div
-              class="mm-box overflow-hidden mm-box--display-flex mm-box--flex-direction-column"
+              class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
+              style="overflow-wrap: anywhere; min-height: 24px; position: relative; background: transparent; flex-direction: column; width: 100%;"
             >
               <div
-                class="name name__clickable name__missing"
+                class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--color-text-alternative"
+                style="flex-shrink: 0; flex-basis: auto; max-width: 100%;"
               >
-                <span
-                  class="mm-box name__icon mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
-                  style="mask-image: url('./images/icons/question.svg');"
-                />
-                <p
-                  class="mm-box mm-text name__value mm-text--body-md mm-box--color-text-default"
+                <div
+                  class="mm-box mm-box--display-flex mm-box--align-items-center"
+                  style="flex-shrink: 0;"
                 >
-                  0x6B175...71d0F
-                </p>
+                  <p
+                    class="mm-box mm-text mm-text--body-md-medium mm-box--color-inherit"
+                  >
+                    To
+                  </p>
+                </div>
+              </div>
+              <div
+                class="mt-2 w-full"
+                data-testid="recipient-address"
+              >
+                <div
+                  class="flex flex-row gap-2 items-center"
+                >
+                  <svg
+                    class="inline-block w-4 h-4 text-icon-default"
+                    fill="currentColor"
+                    style="flex-shrink: 0;"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M11.95 18q.525 0 .888-.362c.362-.363.362-.538.362-.888s-.12-.646-.362-.887-.538-.363-.888-.363-.646.12-.887.363-.363.537-.363.887.12.646.363.888.537.362.887.362m-.9-3.85h1.85q0-.825.187-1.3c.187-.475.48-.75 1.063-1.3a7.5 7.5 0 0 0 1.025-1.238q.375-.587.375-1.412 0-1.4-1.025-2.15C13.5 6 13.033 6 12.1 6q-1.424 0-2.313.75-.887.75-1.237 1.8l1.65.65q.124-.45.562-.975C11.2 7.7 11.5 7.7 12.1 7.7q.8 0 1.2.437c.4.437.4.613.4.963q0 .5-.3.938t-.75.812q-1.1.975-1.35 1.475c-.25.5-.25.942-.25 1.825M12 22q-2.075 0-3.9-.787c-1.825-.788-2.275-1.238-3.175-2.138S3.312 17.117 2.787 15.9 2 13.383 2 12s.262-2.683.787-3.9 1.238-2.275 2.138-3.175S6.883 3.312 8.1 2.787 10.617 2 12 2s2.683.262 3.9.787 2.275 1.238 3.175 2.138 1.613 1.958 2.138 3.175S22 10.617 22 12s-.262 2.683-.787 3.9-1.238 2.275-2.138 3.175-1.958 1.613-3.175 2.138S13.383 22 12 22m0-2q3.35 0 5.675-2.325C20 15.35 20 14.233 20 12q0-3.35-2.325-5.675C15.35 4 14.233 4 12 4Q8.65 4 6.325 6.325C4 8.65 4 9.767 4 12q0 3.35 2.325 5.675C8.65 20 9.767 20 12 20"
+                    />
+                  </svg>
+                  <button
+                    class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default confirm-info-row-address-display__clickable"
+                    data-testid="confirm-info-row-display-name"
+                    style="flex: 1; white-space: nowrap; overflow: hidden;"
+                    type="button"
+                  >
+                    0x6B175474E89094C44Da98b954EedeAC495271d0F
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
+            style="flex-shrink: 0;"
+          >
+            <div
+              class="flex [&>div]:!rounded-none"
+            >
+              <div
+                style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 32px; height: 32px; display: inline-block; background: rgb(242, 194, 2);"
+              >
+                <svg
+                  height="32"
+                  width="32"
+                  x="0"
+                  y="0"
+                >
+                  <rect
+                    fill="#C81432"
+                    height="32"
+                    transform="translate(-2.43202780002606 -0.42125256193660) rotate(248.2 16.00000000000000 16.00000000000000)"
+                    width="32"
+                    x="0"
+                    y="0"
+                  />
+                  <rect
+                    fill="#03435E"
+                    height="32"
+                    transform="translate(-16.34812089562976 -6.15118763341713) rotate(327.5 16.00000000000000 16.00000000000000)"
+                    width="32"
+                    x="0"
+                    y="0"
+                  />
+                  <rect
+                    fill="#187AF2"
+                    height="32"
+                    transform="translate(12.00147078810870 21.19028204627600) rotate(156.4 16.00000000000000 16.00000000000000)"
+                    width="32"
+                    x="0"
+                    y="0"
+                  />
+                </svg>
               </div>
             </div>
           </div>

--- a/ui/pages/confirmations/components/confirm/info/token-transfer/transaction-flow-section.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/token-transfer/transaction-flow-section.test.tsx
@@ -2,10 +2,13 @@ import React from 'react';
 import configureMockStore from 'redux-mock-store';
 import { getMockTokenTransferConfirmState } from '../../../../../../../test/data/confirmations/helper';
 import { renderWithConfirmContextProvider } from '../../../../../../../test/lib/confirmations/render-helpers';
+import { useDisplayName } from '../../../../../../hooks/useDisplayName';
+import { TrustSignalDisplayState } from '../../../../../../hooks/useTrustSignals';
 import { useTransferRecipient } from '../hooks/useTransferRecipient';
 import { TransactionFlowSection } from './transaction-flow-section';
 
 jest.mock('../hooks/useTransferRecipient');
+jest.mock('../../../../../../hooks/useDisplayName');
 
 jest.mock(
   '../../../../../../components/app/alert-system/contexts/alertMetricsContext.tsx',
@@ -18,14 +21,22 @@ jest.mock(
   }),
 );
 
+const mockUseDisplayName = jest.mocked(useDisplayName);
+
 describe('<TransactionFlowSection />', () => {
   const useTransferRecipientMock = jest.mocked(useTransferRecipient);
+
+  const RECIPIENT_ADDRESS = '0x6B175474E89094C44Da98b954EedeAC495271d0F';
+
   beforeEach(() => {
     jest.resetAllMocks();
-
-    useTransferRecipientMock.mockReturnValue(
-      '0x6B175474E89094C44Da98b954EedeAC495271d0F',
-    );
+    useTransferRecipientMock.mockReturnValue(RECIPIENT_ADDRESS);
+    mockUseDisplayName.mockReturnValue({
+      name: null,
+      hasPetname: false,
+      isAccount: false,
+      displayState: TrustSignalDisplayState.Unknown,
+    });
   });
 
   it('renders correctly', () => {
@@ -36,5 +47,93 @@ describe('<TransactionFlowSection />', () => {
       mockStore,
     );
     expect(container).toMatchSnapshot();
+  });
+
+  it('renders From and To labels', () => {
+    const state = getMockTokenTransferConfirmState({});
+    const mockStore = configureMockStore([])(state);
+    const { getByText } = renderWithConfirmContextProvider(
+      <TransactionFlowSection />,
+      mockStore,
+    );
+
+    expect(getByText('From')).toBeInTheDocument();
+    expect(getByText('To')).toBeInTheDocument();
+  });
+
+  it('renders sender and recipient address sections', () => {
+    const state = getMockTokenTransferConfirmState({});
+    const mockStore = configureMockStore([])(state);
+    const { getByTestId } = renderWithConfirmContextProvider(
+      <TransactionFlowSection />,
+      mockStore,
+    );
+
+    expect(getByTestId('sender-address')).toBeInTheDocument();
+    expect(getByTestId('recipient-address')).toBeInTheDocument();
+  });
+
+  it('displays the transaction flow section container', () => {
+    const state = getMockTokenTransferConfirmState({});
+    const mockStore = configureMockStore([])(state);
+    const { getByTestId } = renderWithConfirmContextProvider(
+      <TransactionFlowSection />,
+      mockStore,
+    );
+
+    expect(getByTestId('confirmation__transaction-flow')).toBeInTheDocument();
+  });
+
+  it('renders display name elements for sender and recipient', () => {
+    const state = getMockTokenTransferConfirmState({});
+    const mockStore = configureMockStore([])(state);
+    const { getAllByTestId } = renderWithConfirmContextProvider(
+      <TransactionFlowSection />,
+      mockStore,
+    );
+
+    const displayNames = getAllByTestId('confirm-info-row-display-name');
+    expect(displayNames).toHaveLength(2);
+  });
+
+  it('displays wallet name next to labels when subtitle is returned', () => {
+    mockUseDisplayName.mockReturnValue({
+      name: 'Account 1',
+      hasPetname: true,
+      isAccount: true,
+      displayState: TrustSignalDisplayState.Petname,
+      subtitle: 'Wallet 1',
+    });
+
+    const state = getMockTokenTransferConfirmState({});
+    const mockStore = configureMockStore([])(state);
+    const { getByText } = renderWithConfirmContextProvider(
+      <TransactionFlowSection />,
+      mockStore,
+    );
+
+    expect(getByText('From Wallet 1')).toBeInTheDocument();
+    expect(getByText('To Wallet 1')).toBeInTheDocument();
+  });
+
+  it('displays plain labels when subtitle is not returned', () => {
+    mockUseDisplayName.mockReturnValue({
+      name: null,
+      hasPetname: false,
+      isAccount: false,
+      displayState: TrustSignalDisplayState.Unknown,
+      subtitle: undefined,
+    });
+
+    const state = getMockTokenTransferConfirmState({});
+    const mockStore = configureMockStore([])(state);
+    const { getByText, queryByText } = renderWithConfirmContextProvider(
+      <TransactionFlowSection />,
+      mockStore,
+    );
+
+    expect(getByText('From')).toBeInTheDocument();
+    expect(getByText('To')).toBeInTheDocument();
+    expect(queryByText(/Wallet/u)).not.toBeInTheDocument();
   });
 });

--- a/ui/pages/confirmations/components/confirm/info/token-transfer/transaction-flow-section.tsx
+++ b/ui/pages/confirmations/components/confirm/info/token-transfer/transaction-flow-section.tsx
@@ -1,23 +1,20 @@
 import { TransactionMeta } from '@metamask/transaction-controller';
+import { NameType } from '@metamask/name-controller';
+import {
+  AvatarAccountSize,
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+} from '@metamask/design-system-react';
 import React from 'react';
 import { ConfirmInfoSection } from '../../../../../../components/app/confirm/info/row/section';
-import {
-  Box,
-  Icon,
-  IconName,
-  IconSize,
-} from '../../../../../../components/component-library';
-import {
-  AlignItems,
-  Display,
-  FlexDirection,
-  IconColor,
-  JustifyContent,
-} from '../../../../../../helpers/constants/design-system';
-import { ConfirmInfoRowAddress } from '../../../../../../components/app/confirm/info/row';
 import { ConfirmInfoAlertRow } from '../../../../../../components/app/confirm/info/row/alert-row/alert-row';
 import { RowAlertKey } from '../../../../../../components/app/confirm/info/row/constants';
+import { ConfirmInfoRowAddressDisplay } from '../../../../../../components/app/confirm/info/row/address-display';
+import { PreferredAvatar } from '../../../../../../components/app/preferred-avatar';
+import { toChecksumHexAddress } from '../../../../../../../shared/modules/hexstring-utils';
 import { useI18nContext } from '../../../../../../hooks/useI18nContext';
+import { useDisplayName } from '../../../../../../hooks/useDisplayName';
 import { useConfirmContext } from '../../../../context/confirm';
 import { useTransferRecipient } from '../hooks/useTransferRecipient';
 
@@ -28,57 +25,119 @@ export const TransactionFlowSection = () => {
     useConfirmContext<TransactionMeta>();
 
   const recipientAddress = useTransferRecipient();
+
   const { chainId } = transactionMeta;
+  const fromAddress = transactionMeta.txParams.from;
+  const toAddress = recipientAddress ?? '';
+
+  const {
+    name: fromName,
+    isAccount: fromIsAccount,
+    image: fromImage,
+    displayState: fromDisplayState,
+    subtitle: fromWalletName,
+  } = useDisplayName({
+    value: toChecksumHexAddress(fromAddress),
+    type: NameType.ETHEREUM_ADDRESS,
+    preferContractSymbol: true,
+    variation: chainId,
+  });
+
+  const {
+    name: toName,
+    isAccount: toIsAccount,
+    image: toImage,
+    displayState: toDisplayState,
+    subtitle: toWalletName,
+  } = useDisplayName({
+    value: toChecksumHexAddress(toAddress),
+    type: NameType.ETHEREUM_ADDRESS,
+    preferContractSymbol: true,
+    variation: chainId,
+  });
+
+  const fromLabel = fromWalletName
+    ? `${t('from')} ${fromWalletName}`
+    : t('from');
+
+  const toLabel = toWalletName ? `${t('to')} ${toWalletName}` : t('to');
 
   return (
     <ConfirmInfoSection data-testid="confirmation__transaction-flow">
-      <Box
-        display={Display.Flex}
-        flexDirection={FlexDirection.Row}
-        justifyContent={JustifyContent.spaceBetween}
-        alignItems={AlignItems.center}
-        paddingBottom={1}
-      >
-        <ConfirmInfoAlertRow
-          alertKey={RowAlertKey.SigningInWith}
-          label={t('from')}
-          ownerId={transactionMeta.id}
-          style={{
-            flex: 1,
-            flexDirection: FlexDirection.Column,
-          }}
+      <Box flexDirection={BoxFlexDirection.Column}>
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          gap={2}
         >
-          <Box marginTop={2} data-testid="sender-address">
-            <ConfirmInfoRowAddress
-              address={transactionMeta.txParams.from}
-              chainId={chainId}
+          <Box style={{ flex: 1, minWidth: 0 }}>
+            <ConfirmInfoAlertRow
+              alertKey={RowAlertKey.SigningInWith}
+              label={fromLabel}
+              ownerId={transactionMeta.id}
+              style={{ flexDirection: 'column', width: '100%' }}
+            >
+              <Box
+                marginTop={2}
+                data-testid="sender-address"
+                className="w-full"
+              >
+                <ConfirmInfoRowAddressDisplay
+                  address={fromAddress}
+                  chainId={chainId}
+                  name={fromName}
+                  isAccount={fromIsAccount}
+                  image={fromImage}
+                  displayState={fromDisplayState}
+                  showAvatar={false}
+                />
+              </Box>
+            </ConfirmInfoAlertRow>
+          </Box>
+          <PreferredAvatar
+            address={toChecksumHexAddress(fromAddress)}
+            size={AvatarAccountSize.Md}
+            style={{ flexShrink: 0 }}
+          />
+        </Box>
+
+        <Box style={{ borderTop: `1px solid var(--color-border-muted)` }}>
+          <Box
+            flexDirection={BoxFlexDirection.Row}
+            alignItems={BoxAlignItems.Center}
+            gap={2}
+          >
+            <Box style={{ flex: 1, minWidth: 0 }}>
+              <ConfirmInfoAlertRow
+                alertKey={RowAlertKey.InteractingWith}
+                label={toLabel}
+                ownerId={transactionMeta.id}
+                style={{ flexDirection: 'column', width: '100%' }}
+              >
+                <Box
+                  marginTop={2}
+                  data-testid="recipient-address"
+                  className="w-full"
+                >
+                  <ConfirmInfoRowAddressDisplay
+                    address={toAddress}
+                    chainId={chainId}
+                    name={toName}
+                    isAccount={toIsAccount}
+                    image={toImage}
+                    displayState={toDisplayState}
+                    showAvatar={false}
+                  />
+                </Box>
+              </ConfirmInfoAlertRow>
+            </Box>
+            <PreferredAvatar
+              address={toChecksumHexAddress(toAddress)}
+              size={AvatarAccountSize.Md}
+              style={{ flexShrink: 0 }}
             />
           </Box>
-        </ConfirmInfoAlertRow>
-
-        <Icon
-          name={IconName.ArrowRight}
-          size={IconSize.Md}
-          color={IconColor.iconAlternative}
-        />
-
-        <ConfirmInfoAlertRow
-          alertKey={RowAlertKey.InteractingWith}
-          label={t('to')}
-          ownerId={transactionMeta.id}
-          style={{
-            flex: 1,
-            flexDirection: FlexDirection.Column,
-            overflow: 'hidden',
-          }}
-        >
-          <Box marginTop={2} data-testid="recipient-address" className="w-full">
-            <ConfirmInfoRowAddress
-              address={recipientAddress ?? ''}
-              chainId={chainId}
-            />
-          </Box>
-        </ConfirmInfoAlertRow>
+        </Box>
       </Box>
     </ConfirmInfoSection>
   );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Improvements in account from / to section on top of confirmation page.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/7004

## **Manual testing steps**

1. Submit confirmation
2. Check account from / to section

## **Screenshots/Recordings**
<img width="369" height="710" alt="Screenshot 2026-02-18 at 5 12 39 PM" src="https://github.com/user-attachments/assets/f42e962e-dd30-4cce-a251-b096e3f0ae31" />

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches confirmation UI rendering and interaction patterns (clickability/modals/truncation), which can cause subtle regressions in transaction review UX and test flakiness, but does not change transaction signing logic.
> 
> **Overview**
> Updates the confirmation screen’s **From/To transaction flow section** to use `useDisplayName` and a new `ConfirmInfoRowAddressDisplay`, showing trust/identity icons, checksum addresses with responsive middle-truncation, optional wallet subtitles (e.g., “From Wallet 1”), and separate avatars for sender/recipient.
> 
> Adds `ConfirmInfoRowAddressDisplay` (and styles/tests) and updates confirmation snapshots/tests accordingly. E2E page objects/tests are adjusted to interact with the new `data-testid="confirm-info-row-display-name"` element (including clicking the recipient display when saving a petname) and to assert recipient rendering via a more robust address check on the send confirmation page.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 07d0f54f84bc6240f522a65310186dec37f14183. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->