### PR TITLE
fix: updated styles for backup and sync page

### DIFF
--- a/ui/components/app/identity/backup-and-sync-features-toggles/backup-and-sync-features-toggles.tsx
+++ b/ui/components/app/identity/backup-and-sync-features-toggles/backup-and-sync-features-toggles.tsx
@@ -132,8 +132,6 @@ const FeatureToggle = ({
             value={isFeatureEnabled}
             disabled={!isBackupAndSyncEnabled}
             onToggle={handleToggleFeature}
-            offLabel={t('off')}
-            onLabel={t('on')}
             dataTestId={section.toggleButtonTestId}
           />
         </div>

--- a/ui/components/app/identity/backup-and-sync-toggle/backup-and-sync-toggle.tsx
+++ b/ui/components/app/identity/backup-and-sync-toggle/backup-and-sync-toggle.tsx
@@ -199,7 +199,7 @@ export const BackupAndSyncToggle = () => {
         display={Display.Flex}
         justifyContent={JustifyContent.spaceBetween}
         alignItems={AlignItems.flexStart}
-        marginBottom={4}
+        marginBottom={1}
       >
         <Text variant={TextVariant.bodyMdMedium}>
           {t('backupAndSyncEnable')}
@@ -217,8 +217,6 @@ export const BackupAndSyncToggle = () => {
             <ToggleButton
               value={isBackupAndSyncEnabled}
               onToggle={handleBackupAndSyncToggleSetValue}
-              offLabel={t('off')}
-              onLabel={t('on')}
               dataTestId={backupAndSyncToggleTestIds.toggleButton}
             />
           </div>

--- a/ui/pages/settings/backup-and-sync-tab/backup-and-sync-tab.tsx
+++ b/ui/pages/settings/backup-and-sync-tab/backup-and-sync-tab.tsx
@@ -39,12 +39,16 @@ const BackupAndSyncTab = () => {
       paddingLeft={4}
     >
       <BackupAndSyncToggle />
-      <Box
-        borderColor={BoxBorderColor.BorderMuted}
-        borderWidth={1}
-        className="w-full h-px border-b-0"
-      />
-      {isBackupAndSyncEnabled && <BackupAndSyncFeaturesToggles />}
+      {isBackupAndSyncEnabled && (
+        <>
+          <Box
+            borderColor={BoxBorderColor.BorderMuted}
+            borderWidth={1}
+            className="w-full h-px border-b-0"
+          />
+          <BackupAndSyncFeaturesToggles />
+        </>
+      )}
     </Box>
   );
 };


### PR DESCRIPTION
This PR is to update styling in backup and sync settings page

1. Updated the Backup and Sync tab so the divider is only rendered when the toggle is on. 
2. Removed offLabel={t('off')} and onLabel={t('on')} from ToggleButton
3. Updated the space between the title & description to 4px

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Run extension and go to backup and sync page in settings.
2. Check the UI match with the [Figma](https://www.figma.com/design/AF8hdmRBQaqqUSWM9tSe1q/Settings-Redesign?node-id=7650-35335&m=dev)

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

![Screenshot 2026-02-25 at 2 10 30 PM](https://github.com/user-attachments/assets/076ef6dc-80d2-4717-8fc2-951a4eeee3a7)

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure UI/styling tweaks (conditional rendering and spacing/labels) with no changes to backup/sync business logic or data handling.
> 
> **Overview**
> Updates the Backup & Sync settings UI to better match design specs: the divider and `BackupAndSyncFeaturesToggles` section are now only rendered when Backup & Sync is enabled.
> 
> Removes `on/off` labels from the `ToggleButton` instances on this page and tightens spacing under the main header by reducing the title/toggle row `marginBottom` from `4` to `1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94278c15b112add8ab6c6be0a2d4a6f46f34545f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->