### PR TITLE
fix: don't prevent users from removing account that are from account snap accounts

### DIFF
--- a/ui/pages/multichain-accounts/multichain-account-details-page/multichain-account-details-page.test.tsx
+++ b/ui/pages/multichain-accounts/multichain-account-details-page/multichain-account-details-page.test.tsx
@@ -126,16 +126,6 @@ describe('MultichainAccountDetailsPage', () => {
     expect(screen.queryByText(/remove account/iu)).not.toBeInTheDocument();
   });
 
-  it('does not render remove account section for Snap wallet type', () => {
-    mockUseParams.mockReturnValue({
-      id: 'snap:local:snap-id/0xb552685e3d2790efd64a175b00d51f02cdafee5d',
-    });
-
-    renderComponent();
-
-    expect(screen.queryByText(/remove account/iu)).not.toBeInTheDocument();
-  });
-
   it('renders remove account section for Keyring wallet type', () => {
     mockUseParams.mockReturnValue({
       id: 'keyring:Ledger Hardware/0xc42edfcc21ed14dda456aa0756c153f7985d8813',

--- a/ui/pages/multichain-accounts/multichain-account-details-page/multichain-account-details-page.tsx
+++ b/ui/pages/multichain-accounts/multichain-account-details-page/multichain-account-details-page.tsx
@@ -71,8 +71,7 @@ export const MultichainAccountDetailsPage = () => {
   const { keyringId, isSRPBackedUp } = useWalletInfo(walletId);
   const walletRoute = `${MULTICHAIN_WALLET_DETAILS_PAGE_ROUTE}/${encodeURIComponent(walletId)}`;
   const isRemovable =
-    wallet?.type !== AccountWalletType.Entropy &&
-    wallet?.type !== AccountWalletType.Snap;
+    wallet?.type !== AccountWalletType.Entropy;
   const addressCount = useSelector((state) =>
     getNetworkAddressCount(state, accountGroupId),
   );

--- a/ui/pages/multichain-accounts/multichain-account-details-page/multichain-account-details-page.tsx
+++ b/ui/pages/multichain-accounts/multichain-account-details-page/multichain-account-details-page.tsx
@@ -70,7 +70,7 @@ export const MultichainAccountDetailsPage = () => {
   const wallet = useSelector((state) => getWallet(state, walletId));
   const { keyringId, isSRPBackedUp } = useWalletInfo(walletId);
   const walletRoute = `${MULTICHAIN_WALLET_DETAILS_PAGE_ROUTE}/${encodeURIComponent(walletId)}`;
-  const isRemovable = wallet?.type === AccountWalletType.Keyring;
+  const isRemovable = wallet?.type !== AccountWalletType.Entropy;
   const addressCount = useSelector((state) =>
     getNetworkAddressCount(state, accountGroupId),
   );

--- a/ui/pages/multichain-accounts/multichain-account-details-page/multichain-account-details-page.tsx
+++ b/ui/pages/multichain-accounts/multichain-account-details-page/multichain-account-details-page.tsx
@@ -70,8 +70,7 @@ export const MultichainAccountDetailsPage = () => {
   const wallet = useSelector((state) => getWallet(state, walletId));
   const { keyringId, isSRPBackedUp } = useWalletInfo(walletId);
   const walletRoute = `${MULTICHAIN_WALLET_DETAILS_PAGE_ROUTE}/${encodeURIComponent(walletId)}`;
-  const isRemovable =
-    wallet?.type !== AccountWalletType.Entropy;
+  const isRemovable = wallet?.type === AccountWalletType.Keyring;
   const addressCount = useSelector((state) =>
     getNetworkAddressCount(state, accountGroupId),
   );


### PR DESCRIPTION
## **Description**

Institutional snap users need to be able to remove the accounts, so that they can (for example) update their tokens

## **Changelog**

CHANGELOG entry: Allow users to remove snap accounts if they are from a snap account wallet

## **Related issues**

N/A

## **Manual testing steps**

1. Import a Cubist account
2. Visit the account details page
3. Observe that it is now removable

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands when account removal UI is exposed; incorrect wallet-type detection could allow unintended removals or confuse users, though the change is small and localized.
> 
> **Overview**
> Allows the **Remove account** section to appear for Snap wallet types by changing the removability check in `MultichainAccountDetailsPage` to only block Entropy wallets.
> 
> Updates the page test suite by removing the expectation that Snap wallets cannot be removed, keeping coverage for Entropy (not removable) and Keyring (removable).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce49af31a3bfbbf2dc1f7f396bc40f96f5766481. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->