### PR TITLE
test: disable `wallet-fixture-validation` spec in the RC and stable branch cp-13.20.0 

### DIFF
--- a/test/e2e/run-all.ts
+++ b/test/e2e/run-all.ts
@@ -22,6 +22,18 @@ const FLASK_ONLY_TESTS: string[] = [];
 // This test should only be run manually or via specific workflow update-onboarding-fixture.yml
 const DIST_EXCLUDED_TESTS: string[] = ['wallet-fixture-export.spec.ts'];
 
+// These tests are excluded on RC branches
+const RC_EXCLUDED_TESTS: string[] = ['wallet-fixture-validation.spec.ts'];
+
+function isReleaseCandidateBranch(): boolean {
+  const branch =
+    process.env.BRANCH ||
+    process.env.GITHUB_HEAD_REF ||
+    process.env.GITHUB_REF_NAME ||
+    '';
+  return /^release\/(\d+)[.](\d+)[.](\d+)$/u.test(branch);
+}
+
 const getTestPathsForTestDir = async (testDir: string): Promise<string[]> => {
   const testFilenames = await fs.promises.readdir(testDir, {
     withFileTypes: true,
@@ -266,6 +278,15 @@ async function main(): Promise<void> {
       ...(await getTestPathsForTestDir(testDir)),
       ...filteredFlaskAndMainTests,
     ];
+  }
+
+  if (isReleaseCandidateBranch()) {
+    console.log('RC branch detected — excluding tests:', RC_EXCLUDED_TESTS);
+    testPaths = testPaths.filter((p) =>
+      RC_EXCLUDED_TESTS.every(
+        (excludedTest) => path.basename(p) !== excludedTest,
+      ),
+    );
   }
 
   const runE2eTestPath = path.join(__dirname, 'run-e2e-test.js');

--- a/test/e2e/run-all.ts
+++ b/test/e2e/run-all.ts
@@ -25,13 +25,24 @@ const DIST_EXCLUDED_TESTS: string[] = ['wallet-fixture-export.spec.ts'];
 // These tests are excluded on RC branches
 const RC_EXCLUDED_TESTS: string[] = ['wallet-fixture-validation.spec.ts'];
 
-function isReleaseCandidateBranch(): boolean {
-  const branch =
+// These tests are excluded on the stable branch
+const STABLE_EXCLUDED_TESTS: string[] = ['wallet-fixture-validation.spec.ts'];
+
+function getBranchName(): string {
+  return (
     process.env.BRANCH ||
     process.env.GITHUB_HEAD_REF ||
     process.env.GITHUB_REF_NAME ||
-    '';
-  return /^release\/(\d+)[.](\d+)[.](\d+)$/u.test(branch);
+    ''
+  );
+}
+
+function isReleaseCandidateBranch(): boolean {
+  return /^release\/(\d+)[.](\d+)[.](\d+)$/u.test(getBranchName());
+}
+
+function isStableBranch(): boolean {
+  return getBranchName() === 'stable';
 }
 
 const getTestPathsForTestDir = async (testDir: string): Promise<string[]> => {
@@ -284,6 +295,18 @@ async function main(): Promise<void> {
     console.log('RC branch detected — excluding tests:', RC_EXCLUDED_TESTS);
     testPaths = testPaths.filter((p) =>
       RC_EXCLUDED_TESTS.every(
+        (excludedTest) => path.basename(p) !== excludedTest,
+      ),
+    );
+  }
+
+  if (isStableBranch()) {
+    console.log(
+      'Stable branch detected — excluding tests:',
+      STABLE_EXCLUDED_TESTS,
+    );
+    testPaths = testPaths.filter((p) =>
+      STABLE_EXCLUDED_TESTS.every(
         (excludedTest) => path.basename(p) !== excludedTest,
       ),
     );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Disable `wallet-fixture-validation` spec in the RC branch. The reason for that is because if we wanted to update the fixture, the script: `@metamaskbot update-e2e-fixture` will fail, because of branch protection in the RC --> we cannot add direct commits, we need to use PRs.
To avoid this inconvenience, I disable the validation there

[Update] Disable also for stable branch

<img width="1818" height="774" alt="image" src="https://github.com/user-attachments/assets/3b0a1b21-a688-4fd3-99f5-3407c5374293" />


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40406?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[skip-e2e]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only alters E2E test selection logic based on branch name, with no production/runtime code impact.
> 
> **Overview**
> Adds branch-aware filtering to the E2E runner (`test/e2e/run-all.ts`) so `wallet-fixture-validation.spec.ts` is automatically excluded when running on *release candidate* (`release/x.y.z`) or `stable` branches.
> 
> Introduces helpers to detect the current branch via CI env vars and logs when these exclusions are applied.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a77c8cb03e38ed254859ff8741b4c0d99ede2c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->