### PR TITLE
ci: update action-checkout-and-setup to v3

### DIFF
--- a/.github/workflows/add-release-label.yml
+++ b/.github/workflows/add-release-label.yml
@@ -13,12 +13,11 @@ jobs:
     if: github.event.pull_request.merged == true
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           fetch-depth: 0 # This is needed to checkout all branches
           skip-allow-scripts: true
-          use-yarn-hydrate: true
 
       - name: Get the next semver version
         id: get-next-semver-version

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -18,11 +18,10 @@ jobs:
       BRANCH: ${{ github.head_ref || github.ref_name }}
     steps:
       - name: Checkout and setup high risk environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: true
           skip-allow-scripts: true
-          use-yarn-hydrate: true
 
       - name: Build storybook
         run: yarn storybook:build

--- a/.github/workflows/build-ts-migration-dashboard.yml
+++ b/.github/workflows/build-ts-migration-dashboard.yml
@@ -16,11 +16,10 @@ jobs:
       BRANCH: ${{ github.head_ref || github.ref_name }}
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: true
           skip-allow-scripts: true
-          use-yarn-hydrate: true
 
       - name: Build ts migration dashboard
         run: yarn ts-migration:dashboard:build

--- a/.github/workflows/check-attributions.yml
+++ b/.github/workflows/check-attributions.yml
@@ -11,11 +11,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           skip-allow-scripts: true
-          use-yarn-hydrate: true
 
       - name: Check attributions changes
         run: yarn attributions:check

--- a/.github/workflows/check-pr-labels.yml
+++ b/.github/workflows/check-pr-labels.yml
@@ -23,11 +23,10 @@ jobs:
 
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           skip-allow-scripts: true
-          use-yarn-hydrate: true
 
       - name: Check PR has required labels
         env:

--- a/.github/workflows/check-template-and-add-labels.yml
+++ b/.github/workflows/check-template-and-add-labels.yml
@@ -14,11 +14,10 @@ jobs:
     if: ${{ github.event_name != 'merge_group' }} # Skip this step for merge_group events
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           skip-allow-scripts: true
-          use-yarn-hydrate: true
 
       - name: Check template and add labels
         id: check-template-and-add-labels

--- a/.github/workflows/close-bug-report.yml
+++ b/.github/workflows/close-bug-report.yml
@@ -14,11 +14,10 @@ jobs:
     if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           skip-allow-scripts: true
-          use-yarn-hydrate: true
 
       - name: Close release bug report issue
         env:

--- a/.github/workflows/create-bug-report.yml
+++ b/.github/workflows/create-bug-report.yml
@@ -20,11 +20,10 @@ jobs:
 
       - name: Checkout and setup environment
         if: steps.extract_version.outputs.version
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           skip-allow-scripts: true
-          use-yarn-hydrate: true
 
       - name: Create bug report issue on planning repo
         if: steps.extract_version.outputs.version

--- a/.github/workflows/e2e-chrome.yml
+++ b/.github/workflows/e2e-chrome.yml
@@ -139,11 +139,10 @@ jobs:
       TEST_RUNS_PATH: test/test-results/test-runs-chrome.json
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           skip-allow-scripts: true
-          use-yarn-hydrate: true
 
       - name: Download test results
         uses: actions/download-artifact@v7

--- a/.github/workflows/e2e-firefox.yml
+++ b/.github/workflows/e2e-firefox.yml
@@ -96,11 +96,10 @@ jobs:
       TEST_RUNS_PATH: test/test-results/test-runs-firefox.json
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           skip-allow-scripts: true
-          use-yarn-hydrate: true
 
       - name: Download test results
         uses: actions/download-artifact@v7

--- a/.github/workflows/identify-codeowners.yml
+++ b/.github/workflows/identify-codeowners.yml
@@ -21,11 +21,10 @@ jobs:
     environment: pr-comment
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           skip-allow-scripts: true
-          use-yarn-hydrate: true
 
       - name: Identify codeowners
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,11 +54,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           skip-allow-scripts: true
-          use-yarn-hydrate: true
 
       - name: lint:prettier (for json,md,mdx,yml files)
         run: yarn lint:prettier
@@ -75,16 +74,17 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
+        id: checkout-and-setup
         with:
           is-high-risk-environment: false
           cache-node-modules: true
           skip-allow-scripts: true
-          use-yarn-hydrate: true
 
       # Need to cache `.metamask` folder for the anvil binary
       - name: Cache .metamask folder
-        uses: actions/cache/save@v4
+        if: ${{ steps.checkout-and-setup.outputs.node-modules-cache-hit != 'true' }}
+        uses: actions/cache/save@v5
         with:
           path: .metamask
           key: .metamask-${{ hashFiles('yarn.lock') }}
@@ -106,11 +106,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           skip-allow-scripts: true
-          use-yarn-hydrate: true
 
       - name: Lint
         run: yarn lint
@@ -353,11 +352,10 @@ jobs:
       SELENIUM_BROWSER: chrome
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           skip-allow-scripts: true
-          use-yarn-hydrate: true
 
       - name: Download artifact 'build-dist-browserify'
         uses: actions/download-artifact@v7
@@ -461,11 +459,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           skip-allow-scripts: true
-          use-yarn-hydrate: true
 
       - name: Download artifact 'build-dist-browserify'
         uses: actions/download-artifact@v7
@@ -508,11 +505,10 @@ jobs:
       lavamoat-policy-changed: ${{ steps.lavamoat-policy-changed.outputs.lavamoat-policy-changed }}
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           skip-allow-scripts: true
-          use-yarn-hydrate: true
 
       - name: Download changed-files artifact
         if: ${{ env.BRANCH != 'main' }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -66,11 +66,10 @@ jobs:
       BUILD_STATUS: ${{ needs.build-dist-browserify.result == 'success' && needs.build-dist-mv2-browserify.result == 'success' && needs.build-experimental-browserify.result == 'success' && needs.build-experimental-mv2-browserify.result == 'success' && 'success' || 'failure' }}
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           skip-allow-scripts: true
-          use-yarn-hydrate: true
 
       - name: Post nightly builds notification
         run: yarn tsx .github/scripts/post-nightly-builds.ts

--- a/.github/workflows/page-load-benchmark.yml
+++ b/.github/workflows/page-load-benchmark.yml
@@ -35,11 +35,10 @@ jobs:
       BENCHMARK_PAGE_LOADS: ${{ inputs.page-loads }}
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           skip-allow-scripts: true
-          use-yarn-hydrate: true
 
       - name: Download artifact 'build-test-browserify'
         uses: actions/download-artifact@v7

--- a/.github/workflows/prep-e2e.yml
+++ b/.github/workflows/prep-e2e.yml
@@ -15,11 +15,10 @@ jobs:
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           skip-allow-scripts: true
-          use-yarn-hydrate: true
 
       - name: Get changed files with git diff
         # On branch `stable`, there's no reason to do a diff

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -39,12 +39,11 @@ jobs:
       POST_NEW_BUILDS: ${{ inputs.post-new-builds }}
     steps:
       - name: Checkout and setup high risk environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: true
           skip-allow-scripts: true
           fetch-depth: 0 # This is needed to get merge base to calculate bundle size diff
-          use-yarn-hydrate: true
 
       - name: Find the associated PR
         if: ${{ startsWith(env.BRANCH, 'release/') && (!env.PR_NUMBER || !env.BASE_COMMIT_HASH || !env.HEAD_COMMIT_HASH) }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -64,12 +64,11 @@ jobs:
       VAPID_KEY: ${{ secrets.VAPID_KEY }}
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: true
           skip-allow-scripts: true
           fetch-depth: 0
-          use-yarn-hydrate: true
 
       - name: Download artifact 'build-dist-browserify'
         uses: actions/download-artifact@v7

--- a/.github/workflows/repository-health-checks.yml
+++ b/.github/workflows/repository-health-checks.yml
@@ -13,12 +13,11 @@ jobs:
       BRANCH: ${{ github.head_ref || github.ref_name }}
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           fetch-depth: 0 # This is needed to checkout all branches
           skip-allow-scripts: true
-          use-yarn-hydrate: true
 
       - name: ShellCheck Lint
         if: ${{ !cancelled() }}

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -80,11 +80,10 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           skip-allow-scripts: true
-          use-yarn-hydrate: true
 
       - name: Restore .metamask folder
         id: restore-metamask
@@ -173,11 +172,10 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           skip-allow-scripts: true
-          use-yarn-hydrate: true
 
       - name: Restore .metamask folder
         id: restore-metamask

--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -92,11 +92,10 @@ jobs:
       VAPID_KEY: ${{ secrets.VAPID_KEY }}
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: true
           skip-allow-scripts: true
-          use-yarn-hydrate: true
 
       - name: Run build
         run: ${{ inputs.build-command }}

--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -80,11 +80,10 @@ jobs:
       RUN_ATTEMPT: ${{ github.run_attempt }}
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           skip-allow-scripts: true
-          use-yarn-hydrate: true
 
       - name: Restore .metamask folder
         id: restore-metamask

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,11 +20,10 @@ jobs:
         shard: [1, 2, 3, 4, 5, 6]
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           skip-allow-scripts: true
-          use-yarn-hydrate: true
 
       - name: test:unit:coverage
         run: yarn test:unit:coverage --shard=${{ matrix.shard }}/${{ strategy.job-total }}
@@ -43,11 +42,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           skip-allow-scripts: true
-          use-yarn-hydrate: true
 
       - name: test:unit:webpack:coverage
         run: yarn test:unit:webpack:coverage
@@ -66,11 +64,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           skip-allow-scripts: true
-          use-yarn-hydrate: true
 
       - name: test:integration:coverage
         run: yarn test:integration:coverage
@@ -97,11 +94,10 @@ jobs:
       stored-coverage: ${{ steps.get-stored-coverage.outputs.STORED_COVERAGE }}
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           skip-allow-scripts: true
-          use-yarn-hydrate: true
 
       - name: Download artifacts
         uses: actions/download-artifact@v7

--- a/.github/workflows/test-storybook.yml
+++ b/.github/workflows/test-storybook.yml
@@ -10,11 +10,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           skip-allow-scripts: true
-          use-yarn-hydrate: true
 
       - name: Install Playwright browsers
         run: yarn exec playwright install chromium

--- a/.github/workflows/update-attributions.yml
+++ b/.github/workflows/update-attributions.yml
@@ -62,11 +62,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.issue.number }}
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           skip-allow-scripts: true
-          use-yarn-hydrate: true
       - name: Get commit SHA
         id: commit-sha
         run: echo "COMMIT_SHA=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
@@ -89,11 +88,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.issue.number }}
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           skip-allow-scripts: true
-          use-yarn-hydrate: true
       - name: Generate Attributions
         run: yarn attributions:generate
       - name: Cache attributions file

--- a/.github/workflows/update-e2e-fixtures.yml
+++ b/.github/workflows/update-e2e-fixtures.yml
@@ -68,11 +68,10 @@ jobs:
           PR_NUMBER: ${{ github.event.issue.number }}
 
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           skip-allow-scripts: true
-          use-yarn-hydrate: true
 
       - name: Get commit SHA
         id: commit-sha
@@ -152,11 +151,10 @@ jobs:
           ref: ${{ needs.prepare.outputs.BRANCH }}
 
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           skip-allow-scripts: true
-          use-yarn-hydrate: true
 
       - name: Restore .metamask folder
         id: restore-metamask

--- a/.github/workflows/update-lavamoat-policies.yml
+++ b/.github/workflows/update-lavamoat-policies.yml
@@ -57,12 +57,11 @@ jobs:
 
       - name: Checkout and setup environment
         if: ${{ steps.is-fork.outputs.IS_FORK == 'false' }}
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           cache-node-modules: true
           skip-allow-scripts: true
-          use-yarn-hydrate: true
 
       - name: Get commit SHA
         if: ${{ steps.is-fork.outputs.IS_FORK == 'false' }}
@@ -87,11 +86,10 @@ jobs:
         run: gh pr checkout "${PR_NUMBER}"
 
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           skip-allow-scripts: true
-          use-yarn-hydrate: true
 
       - name: Update LavaMoat build policy
         run: yarn lavamoat:build:auto
@@ -121,11 +119,10 @@ jobs:
         run: gh pr checkout "${PR_NUMBER}"
 
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           skip-allow-scripts: true
-          use-yarn-hydrate: true
 
       - name: Restore build policy
         uses: actions/cache/restore@v5
@@ -161,11 +158,10 @@ jobs:
         run: gh pr checkout "${PR_NUMBER}"
 
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           skip-allow-scripts: true
-          use-yarn-hydrate: true
 
       - name: Update LavaMoat webpack build policy
         run: yarn webpack:tsc && yarn webpack:lavamoat:policy:build
@@ -195,11 +191,10 @@ jobs:
         run: gh pr checkout "${PR_NUMBER}"
 
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           skip-allow-scripts: true
-          use-yarn-hydrate: true
 
       - name: Restore webpack build policy
         uses: actions/cache/restore@v5
@@ -236,11 +231,10 @@ jobs:
         run: gh pr checkout "${PR_NUMBER}"
 
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           skip-allow-scripts: true
-          use-yarn-hydrate: true
 
       - name: Restore webpack build policy
         uses: actions/cache/restore@v5

--- a/.github/workflows/validate-lavamoat-policies.yml
+++ b/.github/workflows/validate-lavamoat-policies.yml
@@ -23,11 +23,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           skip-allow-scripts: true
-          use-yarn-hydrate: true
 
       - name: Validate LavaMoat build policy
         run: yarn lavamoat:build:auto
@@ -45,11 +44,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           skip-allow-scripts: true
-          use-yarn-hydrate: true
 
       - name: Validate LavaMoat webapp policy
         run: yarn lavamoat:webapp:auto
@@ -67,11 +65,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           skip-allow-scripts: true
-          use-yarn-hydrate: true
 
       - name: Validate LavaMoat webpack build policy
         run: yarn webpack:tsc && yarn webpack:lavamoat:policy:build
@@ -89,11 +86,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           skip-allow-scripts: true
-          use-yarn-hydrate: true
 
       - name: Validate LavaMoat webpack MV2 policy
         run: yarn webpack:tsc && yarn webpack:lavamoat:policy:mv2
@@ -111,11 +107,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
           skip-allow-scripts: true
-          use-yarn-hydrate: true
 
       - name: Validate LavaMoat webpack MV3 policy
         run: yarn webpack:tsc && yarn webpack:lavamoat:policy:mv3


### PR DESCRIPTION
## **Description**

`MetaMask/action-checkout-and-setup@v3` contains both a speedup and a security fix.

## **Changelog**

CHANGELOG entry: null

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes; main risk is CI behavior changes (checkout/setup and caching) that could cause unexpected job failures or cache misses, but no product/runtime code is affected.
> 
> **Overview**
> **Updates CI workflow setup to use `MetaMask/action-checkout-and-setup@v3` across the repo**, replacing all `@v1` references.
> 
> In `main.yml`’s dependency prep job, this also wires in the action’s cache output (`id: checkout-and-setup`) to **skip saving the `.metamask` cache when the node-modules cache already hit**, and bumps the cache save action from `actions/cache/save@v4` to `@v5`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b6814abb1e063ac50682297bc7b399a2a5ff09f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->