### PR TITLE
fix: nft image `startsWith` error

### DIFF
--- a/ui/components/app/assets/nfts/nft-details/nft-details.tsx
+++ b/ui/components/app/assets/nfts/nft-details/nft-details.tsx
@@ -148,7 +148,8 @@ export function NftDetailsComponent({
   const nftImageAlt = getNftImageAlt(nft);
   const image = getNftImage(_image);
   const nftSrcUrl = imageOriginal ?? image ?? imageFromTokenURI;
-  const isIpfsURL = nftSrcUrl?.startsWith('ipfs:');
+  const isIpfsURL =
+    typeof nftSrcUrl === 'string' && nftSrcUrl.startsWith('ipfs:');
 
   const isImageHosted =
     // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880

--- a/ui/hooks/useFetchNftDetailsFromTokenURI.ts
+++ b/ui/hooks/useFetchNftDetailsFromTokenURI.ts
@@ -24,8 +24,12 @@ const useFetchNftDetailsFromTokenURI = (
 
         // Try parsing JSON
         const data = JSON.parse(rawData);
-        setImage(data.image);
-        setName(data.name);
+        if (typeof data.image === 'string') {
+          setImage(data.image);
+        }
+        if (typeof data.name === 'string') {
+          setName(data.name);
+        }
       } catch {
         // ignore
       }

--- a/ui/hooks/useFetchNftdetailsFromTokenURI.test.ts
+++ b/ui/hooks/useFetchNftdetailsFromTokenURI.test.ts
@@ -85,4 +85,28 @@ describe('useFetchNftDetailsFromTokenURI', () => {
       name: '',
     });
   });
+
+  it('should not set image or name when they are not strings in the response', async () => {
+    const mockData = {
+      name: { nested: 'object' },
+      description: 'This is a collection of Rock NFTs.',
+      image: ['array', 'of', 'images'],
+    };
+
+    const mockFetch = jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve(JSON.stringify(mockData)),
+    } as Response);
+
+    const result = renderHook(() =>
+      useFetchNftDetailsFromTokenURI('https://test.com'),
+    );
+
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+
+    expect(result.result.current).toEqual({
+      image: '',
+      name: '',
+    });
+  });
 });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes `TypeError: Pe.startsWith is not a function` when loading NFT images by ensuring `nftSrcUrl` is a string.

The error occurred because `nftSrcUrl` could be a non-string value (e.g., an object or number) if the NFT metadata from the token URI contained a non-string `image` field. The optional chaining (`?.`) only guards against `null`/`undefined`, not against calling `.startsWith()` on a defined non-string value. This PR adds explicit type checks to prevent this.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40413?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: nft image `startsWith` error

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/40412 https://consensyssoftware.atlassian.net/browse/ASSETS-2793

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots. 

---
<p><a href="https://cursor.com/agents/bc-75ec73d1-183a-405c-8673-6effe38a71d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75ec73d1-183a-405c-8673-6effe38a71d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive type-guard changes plus a unit test; behavior only changes for malformed/unsupported tokenURI metadata.
> 
> **Overview**
> Prevents a runtime crash in NFT details rendering by only calling `startsWith('ipfs:')` when the computed `nftSrcUrl` is actually a string.
> 
> Hardens `useFetchNftDetailsFromTokenURI` to only populate `image`/`name` when the tokenURI JSON fields are strings, and adds a test case covering non-string metadata responses.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7e5afdbb5c98f21e975db6e6e40f0b16e316803. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->