### PR TITLE
chore: remove stale npm audit ignore advisories

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -26,27 +26,9 @@ npmAuditIgnoreAdvisories:
   # We are ignoring this on April 24, 2025 to unblock CI, we will follow with a proper fix or confirmation this does not affect our users
   - 1104001
 
-  # Issue: `glob` vulnerability, already fixed in the version we're using (v10.5.0) but the
-  # advisory range hasn't been updated yet.
-  # URL: https://github.com/advisories/GHSA-5j98-mcp5-4vw2
-  - 1109809
-
-  # Issue: `body-parser` denial of service vulnerability
-  # Seemingly only impacts v2.2.0, but we're on v1. The advisory range is overly wide.
-  # The attack vector also does not apply to how we use the package.
-  # URL: https://github.com/advisories/GHSA-wqch-xfxh-vrr4
-  - 1110857
-
-  # Issue: ajv has ReDoS when using `$data` option
-  # A lot of our linting tooling relies on old versions of ajv, which proves hard to deal with
-  # For now, we are ignoring this to unblock CI
-  # URL: https://github.com/advisories/GHSA-2g4f-4pwh-qvx6
-  - 1113214
-
   # Issue: minimatch has a ReDoS via repeated wildcards with non-matching literal in pattern
   # Only affects dev/build-time dependencies (eslint-plugin-n, glob) — not shipped to users.
   # URL: https://github.com/advisories/GHSA-3ppc-4f35-3m26
-  - 1113371
   - 1113459
 
   ### Package Deprecations:
@@ -74,9 +56,6 @@ npmAuditIgnoreAdvisories:
   # Deprecated package still used by older versions of our packages, to be eliminated soon as we
   # update.
   - '@metamask/error-reporting-service (deprecation)'
-
-  # A deprecated v10.x version is used in a few different places, most notably Storybook.
-  - 'glob (deprecation)'
 
   # Deprecated transitive dependency of better-sqlite3. No maintained alternative available yet.
   - 'prebuild-install (deprecation)'


### PR DESCRIPTION
## **Description**

This PR removes stale `npmAuditIgnoreAdvisories` entries from `.yarnrc.yml`.

What changed:
- Removed advisory IDs that are no longer reported by current audit output:
  - `1109809` (`glob`)
  - `1110857` (`body-parser`)
- Removed stale deprecation ignore:
  - `'glob (deprecation)'`

Why:
- These ignores are no longer needed for the current dependency graph.
- Removing stale entries keeps audit suppressions minimal and improves signal quality.

## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

<!--
## **Manual testing steps**

1. Run `yarn audit`.
2. Confirm there are no audit suggestions.
-->

<!--
## **Screenshots/Recordings**

### **Before**

[screenshots/recordings]

### **After**

[screenshots/recordings]
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only cleanup that narrows audit/deprecation suppressions and doesn’t change runtime code paths.
> 
> **Overview**
> Removes several stale entries from `.yarnrc.yml` so `yarn audit`/deprecation suppressions only include currently-reported issues.
> 
> Specifically drops the ignored advisories for `glob`, `body-parser`, and `ajv`, and removes the `glob (deprecation)` suppression, leaving the remaining audit/deprecation allowlist intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27dab4b837a2d0b409074544c377b6f1a5a2bb40. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->