### PR TITLE
refactor: remove build-main code fences

### DIFF
--- a/app/scripts/controllers/app-state-controller.ts
+++ b/app/scripts/controllers/app-state-controller.ts
@@ -30,9 +30,7 @@ import { ProfileMetricsControllerSkipInitialDelayAction } from '@metamask/profil
 import { MINUTE } from '../../../shared/constants/time';
 import { AUTO_LOCK_TIMEOUT_ALARM } from '../../../shared/constants/alarms';
 import { isManifestV3 } from '../../../shared/modules/mv3.utils';
-// TODO: Remove restricted import
-// eslint-disable-next-line import/no-restricted-paths
-import { isBeta } from '../../../ui/helpers/utils/build-types';
+import { isBeta } from '../../../shared/lib/build-types';
 import {
   ENVIRONMENT_TYPE_BACKGROUND,
   POLLING_TOKEN_ENVIRONMENT_TYPES,

--- a/app/scripts/controllers/metametrics-controller.ts
+++ b/app/scripts/controllers/metametrics-controller.ts
@@ -80,15 +80,12 @@ import {
   type EndTraceRequest,
   type TraceCallback,
 } from '../../../shared/lib/trace';
-
-///: BEGIN:ONLY_INCLUDE_IF(build-main)
 import { ENVIRONMENT } from '../../../development/build/constants';
-///: END:ONLY_INCLUDE_IF
-
 import { KeyringType } from '../../../shared/constants/keyring';
 import type { captureException } from '../../../shared/lib/sentry';
 import type { FlattenedBackgroundStateProxy } from '../../../shared/types';
 import { getTokensControllerAllTokens } from '../../../shared/modules/selectors/assets-migration';
+import { isMain } from '../../../shared/lib/build-types';
 import type {
   PreferencesControllerGetStateAction,
   PreferencesControllerStateChangeEvent,
@@ -946,15 +943,14 @@ export default class MetaMetricsController extends BaseController<
       this.setMarketingCampaignCookieId(null);
     }
 
-    ///: BEGIN:ONLY_INCLUDE_IF(build-main)
     if (
+      isMain() &&
       this.#environment !== ENVIRONMENT.DEVELOPMENT &&
       metaMetricsId !== null &&
       participateInMetaMetrics !== null
     ) {
       this.updateExtensionUninstallUrl(participateInMetaMetrics, metaMetricsId);
     }
-    ///: END:ONLY_INCLUDE_IF
 
     return metaMetricsId;
   }

--- a/builds.yml
+++ b/builds.yml
@@ -16,7 +16,6 @@ buildTypes:
   main:
     id: 10
     features:
-      - build-main
       - keyring-snaps
       - multi-srp
       - bitcoin
@@ -80,7 +79,6 @@ buildTypes:
     id: 12
     features:
       - build-experimental
-      - build-main
       - keyring-snaps
       - multi-srp
       - bitcoin
@@ -149,7 +147,6 @@ features:
   # Build Type code extensions. Things like different support links, warning pages, banners
   ###
 
-  build-main:
   build-beta:
     assets:
       # Assets that will be copied

--- a/development/build/transforms/remove-fenced-code.test.js
+++ b/development/build/transforms/remove-fenced-code.test.js
@@ -14,8 +14,8 @@ jest.mock('./utils', () => ({
   getESLintInstance: jest.fn(),
 }));
 
-const FEATURE_A = 'build-main';
-const FEATURE_B = 'build-flask';
+const FEATURE_A = 'build-xx1';
+const FEATURE_B = 'build-xx2';
 
 const getMinimalFencedCode = (params = FEATURE_B) =>
   `///: BEGIN:ONLY_INCLUDE_IF(${params})

--- a/development/ts-migration-dashboard/files-to-convert.json
+++ b/development/ts-migration-dashboard/files-to-convert.json
@@ -1008,7 +1008,6 @@
   "ui/helpers/higher-order-components/with-modal-props/index.js",
   "ui/helpers/higher-order-components/with-modal-props/with-modal-props.js",
   "ui/helpers/higher-order-components/with-modal-props/with-modal-props.test.js",
-  "ui/helpers/utils/build-types.js",
   "ui/helpers/utils/common.util.js",
   "ui/helpers/utils/common.util.test.js",
   "ui/helpers/utils/confirm-tx.util.js",

--- a/shared/lib/build-types.ts
+++ b/shared/lib/build-types.ts
@@ -20,9 +20,9 @@ export function getFoxMeshJson() {
   // This cannot say `isFlask()` because the swc compiler will not inline that
   if (process.env.METAMASK_BUILD_TYPE === 'flask') {
     // eslint-disable-next-line import/no-restricted-paths,@typescript-eslint/no-require-imports
-    return require('../../../app/build-types/flask/images/flask-mascot.json');
+    return require('../../app/build-types/flask/images/flask-mascot.json');
   }
 
   // eslint-disable-next-line import/no-restricted-paths,@typescript-eslint/no-require-imports
-  return require('../../../app/build-types/main/fox.json');
+  return require('../../app/build-types/main/fox.json');
 }

--- a/ui/components/multichain/account-overview/common.ts
+++ b/ui/components/multichain/account-overview/common.ts
@@ -1,6 +1,4 @@
 export type AccountOverviewCommonProps = {
   setBasicFunctionalityModalOpen: () => void;
-  ///: BEGIN:ONLY_INCLUDE_IF(build-main)
   onSupportLinkClick: () => void;
-  ///: END:ONLY_INCLUDE_IF
 };

--- a/ui/components/multichain/global-menu-drawer/useGlobalMenuSections.tsx
+++ b/ui/components/multichain/global-menu-drawer/useGlobalMenuSections.tsx
@@ -80,7 +80,7 @@ import {
 import { useSubscriptionMetrics } from '../../../hooks/shield/metrics/useSubscriptionMetrics';
 import { getPortfolioUrl } from '../../../helpers/utils/portfolio';
 import type { GlobalMenuSection } from '../global-menu/global-menu-list.types';
-import { isBeta, isFlask } from '../../../helpers/utils/build-types';
+import { isBeta, isFlask } from '../../../../shared/lib/build-types';
 
 const METRICS_LOCATION = 'Global Menu';
 

--- a/ui/components/ui/mascot/mascot.component.js
+++ b/ui/components/ui/mascot/mascot.component.js
@@ -2,8 +2,7 @@ import PropTypes from 'prop-types';
 import React, { createRef, Component } from 'react';
 import MetaMaskLogo from '@metamask/logo';
 import { debounce } from 'lodash';
-
-import { getFoxMeshJson } from '../../../helpers/utils/build-types';
+import { getFoxMeshJson } from '../../../../shared/lib/build-types';
 
 const directionTargetGenerator = ({ top, left, height, width }) => {
   const horizontalMiddle = left + width / 2;

--- a/ui/pages/home/beta-and-flask-home-footer.component.tsx
+++ b/ui/pages/home/beta-and-flask-home-footer.component.tsx
@@ -6,7 +6,7 @@ import {
 } from '../../../shared/constants/metametrics';
 import { MetaMetricsContext } from '../../contexts/metametrics';
 import { SUPPORT_LINK } from '../../helpers/constants/common';
-import { isFlask } from '../../helpers/utils/build-types';
+import { isFlask } from '../../../shared/lib/build-types';
 import { useI18nContext } from '../../hooks/useI18nContext';
 
 export default function BetaAndFlaskHomeFooter() {

--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -4,9 +4,7 @@ import { Navigate } from 'react-router-dom';
 import { Text, TextVariant, TextColor } from '@metamask/design-system-react';
 import { COHORT_NAMES } from '@metamask/subscription-controller';
 import {
-  ///: BEGIN:ONLY_INCLUDE_IF(build-main)
   MetaMetricsContextProp,
-  ///: END:ONLY_INCLUDE_IF
   MetaMetricsEventCategory,
   MetaMetricsEventName,
 } from '../../../shared/constants/metametrics';
@@ -22,7 +20,6 @@ import ConnectedAccounts from '../connected-accounts';
 import { isMv3ButOffscreenDocIsMissing } from '../../../shared/modules/mv3.utils';
 import ActionableMessage from '../../components/ui/actionable-message/actionable-message';
 import { ScrollContainer } from '../../contexts/scroll-container';
-
 import {
   FontWeight,
   Display,
@@ -55,17 +52,13 @@ import {
 } from '../../helpers/constants/routes';
 import ZENDESK_URLS from '../../helpers/constants/zendesk-url';
 import { METAMETRICS_SETTINGS_LINK } from '../../helpers/constants/common';
-import {
-  ///: BEGIN:ONLY_INCLUDE_IF(build-main)
-  SUPPORT_LINK,
-  ///: END:ONLY_INCLUDE_IF
-} from '../../../shared/lib/ui-utils';
+import { SUPPORT_LINK } from '../../../shared/lib/ui-utils';
 import { AccountOverview } from '../../components/multichain';
 import PasswordOutdatedModal from '../../components/app/password-outdated-modal';
 import ShieldEntryModal from '../../components/app/shield-entry-modal';
 import RewardsOnboardingModal from '../../components/app/rewards/onboarding/OnboardingModal';
 import { Pna25Modal } from '../../components/app/modals/pna25-modal';
-import { isBeta, isFlask } from '../../helpers/utils/build-types';
+import { isBeta, isFlask, isMain } from '../../../shared/lib/build-types';
 import BetaAndFlaskHomeFooter from './beta-and-flask-home-footer.component';
 import { HomeDeepLinkActions } from './HomeDeepLinkActions';
 
@@ -289,22 +282,22 @@ export default class Home extends PureComponent {
     });
   };
 
-  ///: BEGIN:ONLY_INCLUDE_IF(build-main)
   onSupportLinkClick = () => {
-    this.context.trackEvent(
-      {
-        category: MetaMetricsEventCategory.Home,
-        event: MetaMetricsEventName.SupportLinkClicked,
-        properties: {
-          url: SUPPORT_LINK,
+    if (isMain()) {
+      this.context.trackEvent(
+        {
+          category: MetaMetricsEventCategory.Home,
+          event: MetaMetricsEventName.SupportLinkClicked,
+          properties: {
+            url: SUPPORT_LINK,
+          },
         },
-      },
-      {
-        contextPropsIntoEventProperties: [MetaMetricsContextProp.PageTitle],
-      },
-    );
+        {
+          contextPropsIntoEventProperties: [MetaMetricsContextProp.PageTitle],
+        },
+      );
+    }
   };
-  ///: END:ONLY_INCLUDE_IF
 
   onOutdatedBrowserWarningClose = () => {
     const { setOutdatedBrowserWarningLastShown } = this.props;
@@ -882,9 +875,7 @@ export default class Home extends PureComponent {
             : null}
           <div className="home__main-view">
             <AccountOverview
-              ///: BEGIN:ONLY_INCLUDE_IF(build-main)
               onSupportLinkClick={this.onSupportLinkClick}
-              ///: END:ONLY_INCLUDE_IF
               useExternalServices={useExternalServices}
               setBasicFunctionalityModalOpen={setBasicFunctionalityModalOpen}
             />

--- a/ui/pages/onboarding-flow/onboarding-flow-switch/onboarding-flow-switch.tsx
+++ b/ui/pages/onboarding-flow/onboarding-flow-switch/onboarding-flow-switch.tsx
@@ -32,7 +32,7 @@ import {
   isExperimental,
   isFlask,
   isMain,
-} from '../../../helpers/utils/build-types';
+} from '../../../../shared/lib/build-types';
 
 // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
 // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/ui/pages/settings/info-tab/info-tab.tsx
+++ b/ui/pages/settings/info-tab/info-tab.tsx
@@ -20,7 +20,7 @@ import { Tag } from '../../../components/component-library';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 import { SUPPORT_LINK } from '../../../helpers/constants/common';
-import { isBeta } from '../../../helpers/utils/build-types';
+import { isBeta } from '../../../../shared/lib/build-types';
 import {
   getNumberOfSettingRoutesInTab,
   handleSettingsRefs,

--- a/ui/pages/settings/security-tab/change-password/change-password.tsx
+++ b/ui/pages/settings/security-tab/change-password/change-password.tsx
@@ -21,7 +21,7 @@ import {
   TextColor,
   TextVariant,
 } from '../../../../helpers/constants/design-system';
-import { isBeta, isFlask } from '../../../../helpers/utils/build-types';
+import { isBeta, isFlask } from '../../../../../shared/lib/build-types';
 import Mascot from '../../../../components/ui/mascot';
 import Spinner from '../../../../components/ui/spinner';
 import { useI18nContext } from '../../../../hooks/useI18nContext';

--- a/ui/pages/swaps/awaiting-swap/awaiting-swap.js
+++ b/ui/pages/swaps/awaiting-swap/awaiting-swap.js
@@ -52,7 +52,7 @@ import {
 import { CHAINID_DEFAULT_BLOCK_EXPLORER_URL_MAP } from '../../../../shared/constants/common';
 import { isSwapsDefaultTokenSymbol } from '../../../../shared/modules/swaps.utils';
 import PulseLoader from '../../../components/ui/pulse-loader';
-import { isFlask, isBeta } from '../../../helpers/utils/build-types';
+import { isFlask, isBeta } from '../../../../shared/lib/build-types';
 
 import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
 import { stopPollingForQuotes } from '../../../store/actions';

--- a/ui/pages/swaps/loading-swaps-quotes/loading-swaps-quotes.js
+++ b/ui/pages/swaps/loading-swaps-quotes/loading-swaps-quotes.js
@@ -34,7 +34,7 @@ import {
   JustifyContent,
   TextTransform,
 } from '../../../helpers/constants/design-system';
-import { isFlask, isBeta } from '../../../helpers/utils/build-types';
+import { isFlask, isBeta } from '../../../../shared/lib/build-types';
 import BackgroundAnimation from './background-animation';
 
 export default function LoadingSwapsQuotes({

--- a/ui/pages/swaps/mascot-background-animation/mascot-background-animation.js
+++ b/ui/pages/swaps/mascot-background-animation/mascot-background-animation.js
@@ -4,7 +4,7 @@ import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 
 import Mascot from '../../../components/ui/mascot';
-import { isFlask, isBeta } from '../../../helpers/utils/build-types';
+import { isFlask, isBeta } from '../../../../shared/lib/build-types';
 
 export default function MascotBackgroundAnimation({ height, width }) {
   const animationEventEmitter = useRef(new EventEmitter());

--- a/ui/pages/unlock-page/unlock-page.component.tsx
+++ b/ui/pages/unlock-page/unlock-page.component.tsx
@@ -45,7 +45,7 @@ import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
 } from '../../../shared/constants/metametrics';
-import { isFlask, isBeta } from '../../helpers/utils/build-types';
+import { isFlask, isBeta } from '../../../shared/lib/build-types';
 import { SUPPORT_LINK } from '../../../shared/lib/ui-utils';
 import { TraceName, TraceOperation } from '../../../shared/lib/trace';
 import { FirstTimeFlowType } from '../../../shared/constants/onboarding';


### PR DESCRIPTION
## **Description**

Also moved build-types.ts to `shared/lib` to start tackling some of the `import/no-restricted-paths` problems (some related ones still exist)

## **Changelog**

CHANGELOG entry: null

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes build-time feature gating to runtime `isMain()` checks and updates build-type configuration/import paths, which could alter what code ships or when MetaMetrics/support-link tracking runs across build flavors.
> 
> **Overview**
> Removes the `build-main` feature from `builds.yml` and replaces `ONLY_INCLUDE_IF(build-main)` fenced code with runtime checks (notably `isMain()`) in places like `MetaMetricsController` uninstall-URL updates and Home support-link tracking.
> 
> Centralizes build-type utilities by shifting UI/background imports to `shared/lib/build-types` (and fixes `getFoxMeshJson` require paths), and makes previously main-only props (e.g., `onSupportLinkClick` in `AccountOverview`) always present while keeping main-only metrics behavior via `isMain()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4cf6c057407fc804595b2cf2d3fa11229c1d1c69. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->