### PR TITLE
BigInt migration strategy

### DIFF
--- a/ui/helpers/utils/util.js
+++ b/ui/helpers/utils/util.js
@@ -1,7 +1,6 @@
 import punycode from 'punycode/punycode';
 import abi from 'human-standard-token-abi';
 import BigNumber from 'bignumber.js';
-import BN from 'bn.js';
 import { DateTime } from 'luxon';
 import {
   getFormattedIpfsUrl,
@@ -242,13 +241,16 @@ export function isOriginContractAddress(to, sendTokenAddress) {
   return to.toLowerCase() === sendTokenAddress.toLowerCase();
 }
 
-// Takes wei Hex, returns wei BN, even if input is null
+// Takes wei Hex, returns wei bigint, even if input is null
 export function numericBalance(balance) {
   if (!balance) {
-    return new BN(0, 16);
+    return 0n;
   }
   const stripped = stripHexPrefix(balance);
-  return new BN(stripped, 16);
+  if (!stripped) {
+    return 0n;
+  }
+  return BigInt(`0x${stripped}`);
 }
 
 // Takes  hex, returns [beforeDecimal, afterDecimal]

--- a/ui/pages/confirmations/components/confirm/info/utils.ts
+++ b/ui/pages/confirmations/components/confirm/info/utils.ts
@@ -1,7 +1,6 @@
 import { TransactionMeta } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 import { remove0x } from '@metamask/utils';
-import { BN } from 'bn.js';
 import { TransactionDescription } from '@ethersproject/abi';
 import {
   BackgroundColor,
@@ -41,24 +40,35 @@ export const getAmountColors = (credit?: boolean, debit?: boolean) => {
  * If the original value is zero and the new value is not, returns 100.
  */
 export function getPercentageChange(
-  originalValue: InstanceType<typeof BN>,
-  newValue: InstanceType<typeof BN>,
+  originalValue: bigint,
+  newValue: bigint,
 ): number {
-  const precisionFactor = new BN(10).pow(new BN(18));
-  const originalValuePrecision = originalValue.mul(precisionFactor);
-  const newValuePrecision = newValue.mul(precisionFactor);
+  const difference = newValue - originalValue;
 
-  const difference = newValuePrecision.sub(originalValuePrecision);
-
-  if (difference.isZero()) {
+  if (difference === 0n) {
     return 0;
   }
 
-  if (originalValuePrecision.isZero() && !newValuePrecision.isZero()) {
+  if (originalValue === 0n && newValue !== 0n) {
     return 100;
   }
 
-  return difference.muln(100).div(originalValuePrecision).abs().toNumber();
+  const absoluteDifference = difference < 0n ? -difference : difference;
+  const absoluteOriginalValue =
+    originalValue < 0n ? -originalValue : originalValue;
+
+  return Number((absoluteDifference * 100n) / absoluteOriginalValue);
+}
+
+function hexToBigInt(value: Hex): bigint {
+  const normalizedValue = value.toLowerCase();
+  if (normalizedValue.startsWith('-0x')) {
+    return -BigInt(`0x${remove0x(normalizedValue.slice(1))}`);
+  }
+  if (normalizedValue.startsWith('0x')) {
+    return BigInt(normalizedValue);
+  }
+  return BigInt(`0x${remove0x(normalizedValue)}`);
 }
 
 /**
@@ -74,15 +84,15 @@ function percentageChangeWithinThreshold(
   newValue: Hex,
   newNegative?: boolean,
 ): boolean {
-  const originalValueBN = new BN(remove0x(originalValue), 'hex');
-  let newValueBN = new BN(remove0x(newValue), 'hex');
+  const originalValueBigInt = hexToBigInt(originalValue);
+  let newValueBigInt = hexToBigInt(newValue);
 
   if (newNegative) {
-    newValueBN = newValueBN.neg();
+    newValueBigInt = -newValueBigInt;
   }
 
   return (
-    getPercentageChange(originalValueBN, newValueBN) <=
+    getPercentageChange(originalValueBigInt, newValueBigInt) <=
     VALUE_COMPARISON_PERCENT_THRESHOLD
   );
 }

--- a/ui/pages/confirmations/hooks/send/useAmountValidation.ts
+++ b/ui/pages/confirmations/hooks/send/useAmountValidation.ts
@@ -107,11 +107,16 @@ export function validateERC1155Balance(
     return undefined;
   }
 
-  if (asset?.balance && value) {
-    const valueInt = parseInt(value, 10);
-    const balanceInt = parseInt(asset.balance.toString(), 10);
-    if (valueInt > balanceInt) {
-      return t('insufficientFundsSend');
+  if (asset?.balance !== undefined && value) {
+    try {
+      const valueInt = BigInt(value);
+      const balanceInt = BigInt(asset.balance.toString());
+
+      if (valueInt > balanceInt) {
+        return t('insufficientFundsSend');
+      }
+    } catch {
+      return t('invalidValue');
     }
   }
 

--- a/ui/pages/confirmations/hooks/send/useERC1155BalanceChecker.ts
+++ b/ui/pages/confirmations/hooks/send/useERC1155BalanceChecker.ts
@@ -6,30 +6,8 @@ import {
 } from '../../../../store/actions';
 import { Asset, AssetStandard } from '../../types/send';
 
-const BN_WORD_SIZE_IN_BITS = 26n;
 const MAX_SAFE_INTEGER_BIGINT = BigInt(Number.MAX_SAFE_INTEGER);
 const MIN_SAFE_INTEGER_BIGINT = BigInt(Number.MIN_SAFE_INTEGER);
-
-type BalanceWithWords = {
-  words?: unknown;
-};
-
-const wordsToBigInt = (words: unknown): bigint => {
-  if (!Array.isArray(words)) {
-    return 0n;
-  }
-
-  return words.reduce((value, word, index) => {
-    if (typeof word !== 'number' || !Number.isFinite(word) || word < 0) {
-      return value;
-    }
-
-    const normalizedWord = BigInt(Math.trunc(word));
-    const bitOffset = BigInt(index) * BN_WORD_SIZE_IN_BITS;
-
-    return value + normalizedWord * 2n ** bitOffset;
-  }, 0n);
-};
 
 const parseHexLikeStringToBigInt = (balance: string): bigint => {
   const normalizedBalance = balance.trim();
@@ -49,21 +27,12 @@ const parseHexLikeStringToBigInt = (balance: string): bigint => {
   return BigInt(`0x${normalizedBalance}`);
 };
 
-const getBalanceValue = (
-  balance: string | BalanceWithWords,
-): number | string => {
+const getBalanceValue = (balance: string): number | string => {
   let parsedBalance = 0n;
-
-  if (typeof balance === 'string') {
-    try {
-      parsedBalance = parseHexLikeStringToBigInt(balance);
-    } catch {
-      parsedBalance = 0n;
-    }
-  } else if (balance && typeof balance === 'object' && 'words' in balance) {
-    // Reconstruct from BN internal structure (Firefox case)
-    // BN stores value in `words` array as base-2^26 limbs.
-    parsedBalance = wordsToBigInt(balance.words);
+  try {
+    parsedBalance = parseHexLikeStringToBigInt(balance);
+  } catch {
+    parsedBalance = 0n;
   }
 
   if (
@@ -96,9 +65,7 @@ export const useERC1155BalanceChecker = () => {
 
       return {
         nft,
-        balance: getBalanceValue(
-          balance as unknown as string | BalanceWithWords,
-        ),
+        balance: getBalanceValue(balance),
       };
     } catch (error) {
       console.error('Error fetching ERC1155 balance:', error);

--- a/ui/pages/confirmations/hooks/send/useERC1155BalanceChecker.ts
+++ b/ui/pages/confirmations/hooks/send/useERC1155BalanceChecker.ts
@@ -1,5 +1,4 @@
 import { useCallback } from 'react';
-import BN from 'bn.js';
 
 import {
   findNetworkClientIdByChainId,
@@ -7,18 +6,74 @@ import {
 } from '../../../../store/actions';
 import { Asset, AssetStandard } from '../../types/send';
 
-const getBalanceValue = (balance: string | { words: string }) => {
-  let balanceStr: string;
+const BN_WORD_SIZE_IN_BITS = 26n;
+const MAX_SAFE_INTEGER_BIGINT = BigInt(Number.MAX_SAFE_INTEGER);
+const MIN_SAFE_INTEGER_BIGINT = BigInt(Number.MIN_SAFE_INTEGER);
+
+type BalanceWithWords = {
+  words?: unknown;
+};
+
+const wordsToBigInt = (words: unknown): bigint => {
+  if (!Array.isArray(words)) {
+    return 0n;
+  }
+
+  return words.reduce((value, word, index) => {
+    if (typeof word !== 'number' || !Number.isFinite(word) || word < 0) {
+      return value;
+    }
+
+    const normalizedWord = BigInt(Math.trunc(word));
+    const bitOffset = BigInt(index) * BN_WORD_SIZE_IN_BITS;
+
+    return value + normalizedWord * 2n ** bitOffset;
+  }, 0n);
+};
+
+const parseHexLikeStringToBigInt = (balance: string): bigint => {
+  const normalizedBalance = balance.trim();
+
+  if (!normalizedBalance) {
+    return 0n;
+  }
+
+  if (
+    normalizedBalance.startsWith('0x') ||
+    normalizedBalance.startsWith('-0x')
+  ) {
+    return BigInt(normalizedBalance);
+  }
+
+  // Keep existing behavior: plain strings are interpreted as hexadecimal.
+  return BigInt(`0x${normalizedBalance}`);
+};
+
+const getBalanceValue = (
+  balance: string | BalanceWithWords,
+): number | string => {
+  let parsedBalance = 0n;
+
   if (typeof balance === 'string') {
-    balanceStr = parseInt(balance, 16).toString();
+    try {
+      parsedBalance = parseHexLikeStringToBigInt(balance);
+    } catch {
+      parsedBalance = 0n;
+    }
   } else if (balance && typeof balance === 'object' && 'words' in balance) {
     // Reconstruct from BN internal structure (Firefox case)
-    // BN stores value in `words` array as base-2^26 limbs
-    balanceStr = new BN(balance.words, 'le').toString(10);
-  } else {
-    balanceStr = '0';
+    // BN stores value in `words` array as base-2^26 limbs.
+    parsedBalance = wordsToBigInt(balance.words);
   }
-  return parseInt(balanceStr, 10);
+
+  if (
+    parsedBalance >= MIN_SAFE_INTEGER_BIGINT &&
+    parsedBalance <= MAX_SAFE_INTEGER_BIGINT
+  ) {
+    return Number(parsedBalance);
+  }
+
+  return parsedBalance.toString(10);
 };
 
 export const useERC1155BalanceChecker = () => {
@@ -39,7 +94,12 @@ export const useERC1155BalanceChecker = () => {
         networkClientId,
       );
 
-      return { nft, balance: getBalanceValue(balance) };
+      return {
+        nft,
+        balance: getBalanceValue(
+          balance as unknown as string | BalanceWithWords,
+        ),
+      };
     } catch (error) {
       console.error('Error fetching ERC1155 balance:', error);
       return null;


### PR DESCRIPTION
Migrate several UI and utility modules (`util.js`, `confirm/info/utils.ts`, `useAmountValidation.ts`, `useERC1155BalanceChecker.ts`) to use native `BigInt` for numeric operations, removing `bn.js` dependencies as part of the phased migration.

---
<p><a href="https://cursor.com/agents/bc-134cac00-2c67-4e6c-be3a-5e262fe29c26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-134cac00-2c67-4e6c-be3a-5e262fe29c26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

