### PR TITLE
test: remove unnecessary dev subscription API mock from E2E

### DIFF
--- a/privacy-snapshot.json
+++ b/privacy-snapshot.json
@@ -116,7 +116,6 @@
   "start.metamask.io",
   "static.cx.metamask.io",
   "subscription.api.cx.metamask.io",
-  "subscription.dev-api.cx.metamask.io",
   "support.metamask-institutional.io",
   "support.metamask.io",
   "swap.api.cx.metamask.io",

--- a/test/e2e/mock-e2e.js
+++ b/test/e2e/mock-e2e.js
@@ -253,38 +253,6 @@ async function setupMocking(
       };
     });
 
-  await server
-    .forGet('https://subscription.dev-api.cx.metamask.io/v1/subscriptions')
-    .thenCallback(() => {
-      return {
-        statusCode: 200,
-        json: {
-          subscriptions: [],
-          trialedProducts: [],
-        },
-      };
-    });
-
-  await server
-    .forGet(
-      'https://subscription.dev-api.cx.metamask.io/v1/subscriptions/eligibility',
-    )
-    .thenCallback(() => {
-      return {
-        statusCode: 200,
-        json: [
-          {
-            canSubscribe: false,
-            canViewEntryModal: false,
-            minBalanceUSD: 1000,
-            product: 'shield',
-            modalType: 'A',
-            cohorts: [],
-          },
-        ],
-      };
-    });
-
   // User Profile Lineage
   await server
     .forGet('https://authentication.api.cx.metamask.io/api/v2/profile/lineage')


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Remove the unnecessary `subscription.dev-api.cx.metamask.io` mock endpoints from the global E2E mock setup (mock-e2e.js).
These dev API mocks were added in [#39910 (Feature Flag Registry)](https://github.com/MetaMask/metamask-extension/pull/39910) as a workaround when tests started failing due to calls to real endpoints. 

Needed investigation based on these comments:
https://github.com/MetaMask/metamask-extension/pull/39910/changes#r2816499042

https://github.com/MetaMask/metamask-extension/pull/39910/changes/BASE..0a1c6e4d69681aa9b964e72e11ed28bb9f3e4b3e#r2816505500


Investigation shows they are not needed because:

- E2E test builds use `METAMASK_BUILD_TYPE=main` (the default), which maps to `SubscriptionEnv.PRD` in `shared/modules/shield/config.ts`
- The `@metamask/subscription-controller `only uses `subscription.dev-api.cx.metamask.io` when `SubscriptionEnv.DEV` is configured, which requires `METAMASK_BUILD_TYPE=dev` — not a standard E2E test scenario
- No source code or test file directly references the dev subscription URL
- All shield, privacy, state-persistence, and benchmark tests pass without the dev mock

The prod subscription mocks (`subscription.api.cx.metamask.io`) remain unchanged.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40430?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: [MMQA-1480](https://consensyssoftware.atlassian.net/browse/MMQA-1480?atlOrigin=eyJpIjoiYWI1YWJiMTViZDlmNDY1MWEwMGY1YTMzMjQzYTM1ZWUiLCJwIjoiaiJ9)

## **Manual testing steps**

1. Run shield E2E tests:

- `yarn test:e2e:single test/e2e/tests/shield/shield-entry-modal.spec.ts --browser=chrome`
- `yarn test:e2e:single test/e2e/tests/shield/shield-plan-subscription.spec.ts --browser=chrome`
- `yarn test:e2e:single test/e2e/tests/shield/shield-subscription-management.spec.ts --browser=chrome`
- `yarn test:e2e:single test/e2e/tests/shield/shield-ruleset-engine.spec.ts --browser=chrome`

2. Run privacy test: `yarn test:e2e:single test/e2e/tests/privacy/basic-functionality.spec.ts --browser=chrome`
3. Run state persistence test: `yarn test:e2e:single test/e2e/tests/state-persistence/state-persistence.spec.ts --browser=chrome`
4. Run startup benchmark: `yarn test:e2e:benchmark test/e2e/benchmarks/flows/startup/standard-home.ts -i 1`
5. All tests should pass without the dev API mock

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[MMQA-1480]: https://consensyssoftware.atlassian.net/browse/MMQA-1480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes unused E2E mocks and a privacy allowlist entry for a dev-only subscriptions endpoint, with no runtime product logic changes.
> 
> **Overview**
> Removes the dev subscriptions endpoint (`subscription.dev-api.cx.metamask.io`) from `privacy-snapshot.json` and deletes the corresponding global E2E network mocks in `test/e2e/mock-e2e.js`.
> 
> E2E tests now only mock the production subscriptions endpoints (`subscription.api.cx.metamask.io`) for subscription polling and eligibility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e798f7eb1d2c978792f4cfbbce556f97e63c3256. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->