### PR TITLE
fix: only show claim button if there is at least 1 cent of rewards

### DIFF
--- a/ui/components/app/musd/hooks/useMerklRewards.test.ts
+++ b/ui/components/app/musd/hooks/useMerklRewards.test.ts
@@ -309,6 +309,70 @@ describe('useMerklRewards', () => {
     abortSpy.mockRestore();
   });
 
+  it('returns false for sub-cent unclaimed amounts', async () => {
+    mockFetchMerklRewardsForAsset.mockResolvedValueOnce({
+      token: {
+        address: MUSD_TOKEN_ADDRESS,
+        chainId: 59144,
+        symbol: 'MUSD',
+        decimals: 6,
+        price: 1.0,
+      },
+      pending: '0',
+      proofs: [],
+      amount: '5', // 0.000005 MUSD = $0.000005
+      claimed: '0',
+      recipient: MOCK_ADDRESS,
+    });
+    mockGetClaimedAmountFromContract.mockResolvedValueOnce(null);
+
+    const { result } = renderHook(() =>
+      useMerklRewards({
+        tokenAddress: MUSD_TOKEN_ADDRESS,
+        chainId: '0x1' as `0x${string}`,
+        showMerklBadge: true,
+      }),
+    );
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(result.current.hasClaimableReward).toBe(false);
+  });
+
+  it('returns true for exactly 1 cent unclaimed amount', async () => {
+    mockFetchMerklRewardsForAsset.mockResolvedValueOnce({
+      token: {
+        address: MUSD_TOKEN_ADDRESS,
+        chainId: 59144,
+        symbol: 'MUSD',
+        decimals: 6,
+        price: 1.0,
+      },
+      pending: '0',
+      proofs: [],
+      amount: '10000', // 0.01 MUSD = $0.01
+      claimed: '0',
+      recipient: MOCK_ADDRESS,
+    });
+    mockGetClaimedAmountFromContract.mockResolvedValueOnce(null);
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useMerklRewards({
+        tokenAddress: MUSD_TOKEN_ADDRESS,
+        chainId: '0x1' as `0x${string}`,
+        showMerklBadge: true,
+      }),
+    );
+
+    await act(async () => {
+      await waitForNextUpdate();
+    });
+
+    expect(result.current.hasClaimableReward).toBe(true);
+  });
+
   it('falls back to API claimed value when getClaimedAmountFromContract returns null', async () => {
     mockGetClaimedAmountFromContract.mockResolvedValueOnce(null);
 

--- a/ui/components/app/musd/hooks/useMerklRewards.ts
+++ b/ui/components/app/musd/hooks/useMerklRewards.ts
@@ -126,7 +126,9 @@ export const useMerklRewards = ({
           BigInt(matchingReward.amount) - BigInt(claimedAmount);
 
         if (!abortController.signal.aborted) {
-          setHasClaimableReward(unclaimedBaseUnits > 0n);
+          const oneCentInBaseUnits =
+            10n ** BigInt(matchingReward.token.decimals - 2);
+          setHasClaimableReward(unclaimedBaseUnits >= oneCentInBaseUnits);
         }
       } catch (error) {
         if (error instanceof Error && error.name === 'AbortError') {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Updates the useMerklRewards hook to only say that there are claimable rewards, if those rewards are at least $0.01 MUSD. Adds tests for the failure case, and the case where we have exactly 1 cent!

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40444?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: only show claim bonus CTA if there is at least 1 cent to claim

## **Related issues**

Fixes:

## **Manual testing steps**

1. For an account with less than 1 cent of MUSD to claim - verify that claim bonus CTA is not shown
2. For an account with more than 1 cent of MUSD to claim - verify that claim bonuis CTA is shown.


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small UI gating change in `useMerklRewards` plus unit tests; main risk is edge-case handling for unusual token decimals affecting the 1-cent threshold calculation.
> 
> **Overview**
> Updates `useMerklRewards` to only set `hasClaimableReward` when unclaimed rewards are **at least $0.01** (computed as `10^(decimals-2)` base units) instead of any positive amount.
> 
> Adds tests to assert sub-cent unclaimed amounts return false and an exact 1-cent amount returns true.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 37b3a2204b3e3746531b34d3e5d40fed0a680ecf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->