### PR TITLE
fix: set all environments to use the same FF mocks cp-13.20.0

### DIFF
--- a/test/e2e/mock-e2e.js
+++ b/test/e2e/mock-e2e.js
@@ -187,27 +187,12 @@ async function setupMocking(
   // Mocks below this line can be overridden by test-specific mocks
 
   // remote feature flags — production-accurate defaults from the registry
+  // FF will apply to all environments: rc, prod and dev
   await server
     .forGet('https://client-config.api.cx.metamask.io/v1/flags')
     .withQuery({
       client: 'extension',
       distribution: 'main',
-      environment: 'dev',
-    })
-    .thenCallback(() => {
-      return {
-        ok: true,
-        statusCode: 200,
-        json: getProductionRemoteFlagApiResponse(),
-      };
-    });
-
-  await server
-    .forGet('https://client-config.api.cx.metamask.io/v1/flags')
-    .withQuery({
-      client: 'extension',
-      distribution: 'main',
-      environment: 'rc',
     })
     .thenCallback(() => {
       return {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40445?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[skip-e2e]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the E2E mock for `client-config` feature flags to no longer key off the `environment` query param, which could affect how broadly the mock matches and potentially alter E2E behavior across runs. Scope is limited to test infrastructure, not production code.
> 
> **Overview**
> Updates the global E2E network mock (`test/e2e/mock-e2e.js`) so the `GET https://client-config.api.cx.metamask.io/v1/flags` stub is **no longer duplicated per `environment` (e.g., `dev`/`rc`)** and instead returns the same production-default flag payload regardless of environment.
> 
> This makes feature-flag mocking consistent across environments while still allowing test-specific mocks to override the default.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a5f46e8204ca38a70d1931dff6cdcfa2014b79e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->