### PR TITLE
feat: add trending deeplink redirecting to home page

### DIFF
--- a/shared/lib/deep-links/routes/index.ts
+++ b/shared/lib/deep-links/routes/index.ts
@@ -13,6 +13,7 @@ import type { Route } from './route';
 import { sell } from './sell';
 import { shield } from './shield';
 import { swap } from './swap';
+import { trending } from './trending';
 
 export type { Route } from './route';
 
@@ -56,3 +57,4 @@ addRoute(predict);
 addRoute(rewards);
 addRoute(shield);
 addRoute(asset);
+addRoute(trending);

--- a/shared/lib/deep-links/routes/trending.ts
+++ b/shared/lib/deep-links/routes/trending.ts
@@ -1,0 +1,9 @@
+import { DEFAULT_ROUTE, Route } from './route';
+
+export const trending = new Route({
+  pathname: '/trending',
+  getTitle: (_: URLSearchParams) => 'deepLink_theHomePage',
+  handler: function handler(_params: URLSearchParams) {
+    return { path: DEFAULT_ROUTE, query: new URLSearchParams() };
+  },
+});


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

`/trending` deeplink is implemented on mobile but leads to a 404 on extension.
This PR adda it on extension and redirects to the home page.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40450?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/GE-132

## **Manual testing steps**

1. Go to 
2. Open the console with F12
3. Type `open("https://link.metamask.io/trending")` in the console
4. It should open the home page

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single new deep-link route that maps `/trending` to the existing default/home destination, with no data handling or auth changes.
> 
> **Overview**
> Adds a new deep-link route, `/trending`, and registers it in the deep-link route map.
> 
> The new route mirrors the home deep link title and resolves by redirecting to `DEFAULT_ROUTE` with no query params, preventing `/trending` from 404ing in the extension.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc595666e7ea277211d6b5fd05f38bdd235dc670. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->