### PR TITLE
fix: Advanced Permissions granted on previous installs do not show immediately in Dapp Connections

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -806,6 +806,10 @@ export default class MetamaskController extends EventEmitter {
     // This captures the version and date when MetaMask was first installed.
     this.appMetadataController.maybeRecordFirstTimeInfo(version);
 
+    this.gatorPermissionsController.initialize().catch((_error) => {
+      // no need to do anything, sync will retry, either next time the controller is initialized, or the next time the user visits permissions page.
+    });
+
     this.provider =
       this.networkController.getProviderAndBlockTracker().provider;
     this.blockTracker =

--- a/test/e2e/fixtures/default-fixture.json
+++ b/test/e2e/fixtures/default-fixture.json
@@ -816,7 +816,15 @@
     },
     "PermissionController": {},
     "PermissionLogController": {
-      "permissionHistory": {}
+      "permissionHistory": {
+        "npm:@metamask/gator-permissions-snap": {
+          "eth_accounts": {
+            "accounts": {
+              "0x5cfe73b6021e818b776b421b1c4db2474086a7e1": 1773959045299
+            }
+          }
+        }
+      }
     },
     "PhishingController": {
       "addressScanCache": {},


### PR DESCRIPTION
## **Description**

When a user grants an Advanced Permission to a dapp, the details are stored offline. If the user then installs a fresh instance of MetaMask, the permissions don't sync immediately and show as "No permissions" while a syncronisation process happens.

This change triggers syncronisation when the controller is instantiated _only the first time_. After a successfuly syncronisation happens, future syncronisations will only trigger when the user navigates to the All Permissions page (or makes changes to granted permissions.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40469?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Advanced Permissions granted on previous installs now show in Dapp Connections


## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
