### PR TITLE
fix: await click & remove duplicate call in transaction modal test

### DIFF
--- a/ui/pages/bridge/prepare/bridge-transaction-settings-modal.test.tsx
+++ b/ui/pages/bridge/prepare/bridge-transaction-settings-modal.test.tsx
@@ -75,7 +75,7 @@ const interactWithCustomInput = async (
   action?: (input: HTMLElement) => void | Promise<void>,
 ) => {
   await act(async () => {
-    userEvent.click(screen.getByTestId(TX_MODAL.customButton));
+    await userEvent.click(screen.getByTestId(TX_MODAL.customButton));
   });
   await waitForElementById(TX_MODAL.customInput);
   const input = getByTestId(TX_MODAL.customInput);
@@ -318,9 +318,6 @@ describe('BridgeTransactionSettingsModal', () => {
             expect(getByTestId(TX_MODAL.customInput)).toHaveDisplayValue(
               expectedDisplayValue,
             );
-          });
-          await act(async () => {
-            userEvent.click(getByTestId(TX_MODAL.submitButton));
           });
 
           await submitUpdate(getByTestId);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

1. Add await before `userEvent.click()` in `interactWithCustomInput` helper
2. Remove the redundant `userEvent.click()` call before `submitUpdate()`

For 1:
Without await, the click operation may not complete before the test proceeds to waitForElementById, causing a race condition where the custom input element hasn't appeared yet.

For 2:
The test clicks the submit button twice in succession:
 * First via `userEvent.click(getByTestId(TX_MODAL.submitButton))`
 * Then via `submitUpdate(getByTestId)` which also clicks the submit button
 * The first click dispatches the action and closes the modal (`onClose()`), so the second click fails because the button no longer exists in the DOM.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: await click & remove duplicate call in transaction modal test

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that reduce flakiness by awaiting async user interactions and preventing a double-click on the submit button.
> 
> **Overview**
> Stabilizes `BridgeTransactionSettingsModal` tests by **awaiting** the `userEvent.click()` on the Custom slippage option to avoid timing races before the input renders.
> 
> Removes a redundant explicit submit click in the valid-input parameterized tests, relying solely on `submitUpdate()` to perform the submission and modal close.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 523037f6a3ca831794239ed55e00f4985076e36d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->