### PR TITLE
fix: limit smart account nav to entropy and simple accounts

### DIFF
--- a/shared/constants/keyring.ts
+++ b/shared/constants/keyring.ts
@@ -29,6 +29,10 @@ export const KeyringType = {
   ...SnapKeyringType,
 };
 
+/**
+ * Keyring types that support EIP-7702 (Setup Smart Account).
+ * Only HD (entropy) and simple (private key) accounts support this; hardware and snap do not.
+ */
 export const KEYRING_TYPES_SUPPORTING_7702 = [
   KeyringTypes.hd,
   KeyringTypes.simple,

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -3059,6 +3059,7 @@
       "warn: ⚠️ React Router Future Flag": 2
     },
     "ui/pages/multichain-accounts/smart-account-page/smart-account-page.test.tsx": {
+      "MetaMask: Background connection not initialized": 2,
       "React: Act warnings (component updates not wrapped)": 2,
       "Reselect: Identity function warnings": 1,
       "Reselect: Input stability warnings": 1,

--- a/ui/pages/multichain-accounts/multichain-account-details-page/multichain-account-details-page.test.tsx
+++ b/ui/pages/multichain-accounts/multichain-account-details-page/multichain-account-details-page.test.tsx
@@ -147,6 +147,18 @@ describe('MultichainAccountDetailsPage', () => {
     expect(screen.getByText(/remove account/iu)).toBeInTheDocument();
   });
 
+  it('does not render Setup Smart Account row for hardware wallet (Ledger) account', () => {
+    mockUseParams.mockReturnValue({
+      id: 'keyring:Ledger Hardware/0xc42edfcc21ed14dda456aa0756c153f7985d8813',
+    });
+
+    renderComponent();
+
+    expect(
+      screen.queryByTestId(accountDetailsRowSmartAccountTestId),
+    ).not.toBeInTheDocument();
+  });
+
   it('opens account rename modal when account name action button is clicked', () => {
     renderComponent();
 

--- a/ui/pages/multichain-accounts/multichain-account-details-page/multichain-account-details-page.tsx
+++ b/ui/pages/multichain-accounts/multichain-account-details-page/multichain-account-details-page.tsx
@@ -6,6 +6,7 @@ import classnames from 'clsx';
 import { AvatarAccountSize } from '@metamask/design-system-react';
 
 import { KeyringTypes } from '@metamask/keyring-controller';
+import { KEYRING_TYPES_SUPPORTING_7702 } from '../../../../shared/constants/keyring';
 import {
   Box,
   ButtonIcon,
@@ -95,6 +96,11 @@ export const MultichainAccountDetailsPage = () => {
     (account) => account.metadata.keyring.type === KeyringTypes.simple,
   );
   const shouldShowBackupReminder = isSRPBackedUp === false;
+
+  const evmKeyringType = evmInternalAccount?.metadata?.keyring?.type;
+  const isEip7702SupportedKeyring =
+    evmKeyringType &&
+    KEYRING_TYPES_SUPPORTING_7702.includes(evmKeyringType as KeyringTypes);
 
   const handleAddressesClick = () => {
     trace({
@@ -233,21 +239,23 @@ export const MultichainAccountDetailsPage = () => {
               }
             />
           )}
-          <AccountDetailsRow
-            label={t('smartAccountLabel')}
-            value={t('setUp')}
-            onClick={handleSmartAccountClick}
-            endAccessory={
-              <ButtonIcon
-                iconName={IconName.ArrowRight}
-                color={IconColor.iconAlternative}
-                size={ButtonIconSize.Sm}
-                ariaLabel={t('smartAccountLabel')}
-                marginLeft={2}
-                data-testid="smart-account-action"
-              />
-            }
-          />
+          {isEip7702SupportedKeyring && (
+            <AccountDetailsRow
+              label={t('smartAccountLabel')}
+              value={t('setUp')}
+              onClick={handleSmartAccountClick}
+              endAccessory={
+                <ButtonIcon
+                  iconName={IconName.ArrowRight}
+                  color={IconColor.iconAlternative}
+                  size={ButtonIconSize.Sm}
+                  ariaLabel={t('smartAccountLabel')}
+                  marginLeft={2}
+                  data-testid="smart-account-action"
+                />
+              }
+            />
+          )}
         </Box>
         <Box className="multichain-account-details-page__section">
           <AccountDetailsRow

--- a/ui/pages/multichain-accounts/smart-account-page/smart-account-page.test.tsx
+++ b/ui/pages/multichain-accounts/smart-account-page/smart-account-page.test.tsx
@@ -8,7 +8,8 @@ import { SmartAccountPage } from './smart-account-page';
 const mockNavigate = jest.fn();
 const mockUseParams = jest.fn();
 
-const MOCK_ADDRESS = '0x1234567890abcdef1234567890abcdef12345678';
+// Use an address from mock-state that has HD Key Tree keyring (EIP-7702 supported)
+const MOCK_ADDRESS = '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -54,5 +55,23 @@ describe('SmartAccountPage', () => {
     fireEvent.click(backButton);
 
     expect(mockNavigate).toHaveBeenCalledWith(-1);
+  });
+
+  it('redirects to previous route when account does not support EIP-7702 (e.g. hardware wallet)', () => {
+    const ledgerAccountAddress = '0xc42edfcc21ed14dda456aa0756c153f7985d8813';
+    mockUseParams.mockReturnValue({
+      address: encodeURIComponent(ledgerAccountAddress),
+    });
+
+    const store = configureStore({
+      metamask: {
+        ...mockState.metamask,
+      },
+    });
+
+    renderWithProvider(<SmartAccountPage />, store);
+
+    expect(mockNavigate).toHaveBeenCalledWith(-1);
+    expect(screen.queryByText(/Smart account/u)).not.toBeInTheDocument();
   });
 });

--- a/ui/pages/multichain-accounts/smart-account-page/smart-account-page.tsx
+++ b/ui/pages/multichain-accounts/smart-account-page/smart-account-page.tsx
@@ -1,5 +1,7 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import { KeyringTypes } from '@metamask/keyring-controller';
 import {
   Box,
   BoxFlexDirection,
@@ -16,6 +18,8 @@ import { TextVariant } from '../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { SmartContractAccountToggleSection } from '../../../components/multichain-accounts/smart-contract-account-toggle-section';
 import { PREVIOUS_ROUTE } from '../../../helpers/constants/routes';
+import { KEYRING_TYPES_SUPPORTING_7702 } from '../../../../shared/constants/keyring';
+import { getInternalAccountByAddress } from '../../../selectors';
 
 export const SmartAccountPage = () => {
   const t = useI18nContext();
@@ -23,8 +27,27 @@ export const SmartAccountPage = () => {
   const { address } = useParams<{ address: string }>();
 
   const decodedAddress = address ? decodeURIComponent(address) : null;
+  const account = useSelector((state) =>
+    decodedAddress ? getInternalAccountByAddress(state, decodedAddress) : null,
+  );
+  const keyringType = account?.metadata?.keyring?.type;
+  const isEip7702SupportedKeyring =
+    keyringType &&
+    KEYRING_TYPES_SUPPORTING_7702.includes(keyringType as KeyringTypes);
+
+  useEffect(() => {
+    // This is added to prevent users from accessing the smart account page
+    // by directly accessing the URL if the account does not support EIP-7702.
+    if (decodedAddress && !isEip7702SupportedKeyring) {
+      navigate(PREVIOUS_ROUTE);
+    }
+  }, [decodedAddress, isEip7702SupportedKeyring, navigate]);
 
   if (!decodedAddress) {
+    return null;
+  }
+
+  if (!isEip7702SupportedKeyring) {
     return null;
   }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Update navigation condition to only allow "Entropy" and "Simple" accounts to access the Smart Account page.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40487?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: limit smart account navigation to entropy and simple accounts

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/40276
Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1501

## **Manual testing steps**

1. Import a Ledger Account (or any hardware wallet account)
2. Click Account details
3. There should not be a option to navigate to the Smart Account page

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

Check https://github.com/MetaMask/metamask-extension/issues/40276

### **After**

https://github.com/user-attachments/assets/ac4afdab-4fde-4144-8c45-e254b0c27e08

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes route/UI gating for the Smart Account flow based on keyring type; a mismatch in keyring metadata or selectors could incorrectly hide/deny access for some accounts.
> 
> **Overview**
> Limits *Smart Account (EIP-7702) setup* to supported keyrings only by introducing `KEYRING_TYPES_SUPPORTING_7702` (`hd`, `simple`) and using it to gate the **“Setup Smart Account”** row on `MultichainAccountDetailsPage`.
> 
> Adds a guard in `SmartAccountPage` to redirect back (and render nothing) when the selected account’s keyring type does not support EIP-7702, preventing direct URL access for hardware/snap accounts; updates/extends unit tests and adjusts the Jest console baseline accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 170440b47a29ff80eab643dfa6d97d63020e4b52. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->