### PR TITLE
fix: flaky tests `Check balance For a non 0 balance account - USD balance` and `Check balance Just created Solana account shows 0 USD when native token is not enabled`

### DIFF
--- a/test/e2e/page-objects/pages/home/homepage.ts
+++ b/test/e2e/page-objects/pages/home/homepage.ts
@@ -82,6 +82,8 @@ class HomePage {
 
   protected readonly sendButton: string = '[data-testid="eth-overview-send"]';
 
+  public readonly solanaAccountIcon = 'img[src="./images/solana-logo.svg"]';
+
   protected readonly swapButton: string = '[data-testid="eth-overview-swap"]';
 
   private readonly refreshErc20Tokens = {
@@ -201,6 +203,11 @@ class HomePage {
     } catch (e) {
       console.log('Error waiting for network, DOM, and Redux ready', e);
     }
+  }
+
+  async waitForSolanaAccountLoaded(): Promise<void> {
+    console.log('Waiting for Solana account icon to be visible');
+    await this.driver.waitForSelector(this.solanaAccountIcon);
   }
 
   async checkPageIsNotLoaded(): Promise<void> {

--- a/test/e2e/page-objects/pages/home/homepage.ts
+++ b/test/e2e/page-objects/pages/home/homepage.ts
@@ -82,7 +82,7 @@ class HomePage {
 
   protected readonly sendButton: string = '[data-testid="eth-overview-send"]';
 
-  public readonly solanaAccountIcon = 'img[src="./images/solana-logo.svg"]';
+  private readonly solanaAccountIcon = 'img[src="./images/solana-logo.svg"]';
 
   protected readonly swapButton: string = '[data-testid="eth-overview-swap"]';
 

--- a/test/e2e/page-objects/pages/home/homepage.ts
+++ b/test/e2e/page-objects/pages/home/homepage.ts
@@ -42,6 +42,8 @@ class HomePage {
     css: '.mm-banner-base',
   };
 
+  private readonly bitcoinAccountIcon = 'img[src="./images/bitcoin-logo.svg"]';
+
   protected readonly bridgeButton: string =
     '[data-testid="eth-overview-bridge"]';
 
@@ -205,9 +207,10 @@ class HomePage {
     }
   }
 
-  async waitForSolanaAccountLoaded(): Promise<void> {
-    console.log('Waiting for Solana account icon to be visible');
+  async waitForNonEvmAccountsLoaded(): Promise<void> {
+    console.log('Waiting for Non EVM account icons to be visible');
     await this.driver.waitForSelector(this.solanaAccountIcon);
+    await this.driver.waitForSelector(this.bitcoinAccountIcon);
   }
 
   async checkPageIsNotLoaded(): Promise<void> {

--- a/test/e2e/tests/solana/check-balance.spec.ts
+++ b/test/e2e/tests/solana/check-balance.spec.ts
@@ -18,6 +18,7 @@ describe('Check balance', function (this: Suite) {
       async ({ driver }) => {
         await loginWithBalanceValidation(driver);
         const homePage = new NonEvmHomepage(driver);
+        await homePage.waitForSolanaAccountLoaded();
         await switchToNetworkFromNetworkSelect(driver, 'Popular', 'Solana');
         await homePage.checkPageIsLoaded({ amount: '0 SOL' });
       },
@@ -35,6 +36,7 @@ describe('Check balance', function (this: Suite) {
       async ({ driver }) => {
         await loginWithBalanceValidation(driver, undefined, undefined, '$0.00');
         const homePage = new NonEvmHomepage(driver);
+        await homePage.waitForSolanaAccountLoaded();
         await switchToNetworkFromNetworkSelect(driver, 'Popular', 'Solana');
         await homePage.checkPageIsLoaded({ amount: '$0' });
       },
@@ -52,6 +54,7 @@ describe('Check balance', function (this: Suite) {
       async ({ driver }) => {
         await loginWithBalanceValidation(driver, undefined, undefined, '$0.00');
         const homePage = new NonEvmHomepage(driver);
+        await homePage.waitForSolanaAccountLoaded();
         await switchToNetworkFromNetworkSelect(driver, 'Popular', 'Solana');
         await homePage.checkPageIsLoaded({ amount: '$5,643.50' });
       },
@@ -67,6 +70,7 @@ describe('Check balance', function (this: Suite) {
       async ({ driver }) => {
         await loginWithBalanceValidation(driver);
         const homePage = new NonEvmHomepage(driver);
+        await homePage.waitForSolanaAccountLoaded();
         await switchToNetworkFromNetworkSelect(driver, 'Popular', 'Solana');
         await homePage.checkPageIsLoaded({ amount: '50 SOL' });
       },

--- a/test/e2e/tests/solana/check-balance.spec.ts
+++ b/test/e2e/tests/solana/check-balance.spec.ts
@@ -2,10 +2,7 @@ import { Suite } from 'mocha';
 import NonEvmHomepage from '../../page-objects/pages/home/non-evm-homepage';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { withFixtures } from '../../helpers';
-import {
-  loginWithBalanceValidation,
-  loginWithoutBalanceValidation,
-} from '../../page-objects/flows/login.flow';
+import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow';
 import { switchToNetworkFromNetworkSelect } from '../../page-objects/flows/network.flow';
 import { buildSolanaTestSpecificMock } from './common-solana';
 
@@ -36,14 +33,14 @@ describe('Check balance', function (this: Suite) {
         testSpecificMock: buildSolanaTestSpecificMock({ balance: 0 }),
       },
       async ({ driver }) => {
-        await loginWithoutBalanceValidation(driver);
+        await loginWithBalanceValidation(driver, undefined, undefined, '$0.00');
         const homePage = new NonEvmHomepage(driver);
         await switchToNetworkFromNetworkSelect(driver, 'Popular', 'Solana');
         await homePage.checkPageIsLoaded({ amount: '$0' });
       },
     );
   });
-  it('For a non 0 balance account - USD balance', async function () {
+  it.only('For a non 0 balance account - USD balance', async function () {
     await withFixtures(
       {
         fixtures: new FixtureBuilderV2()
@@ -53,7 +50,7 @@ describe('Check balance', function (this: Suite) {
         testSpecificMock: buildSolanaTestSpecificMock(),
       },
       async ({ driver }) => {
-        await loginWithoutBalanceValidation(driver);
+        await loginWithBalanceValidation(driver, undefined, undefined, '$0.00');
         const homePage = new NonEvmHomepage(driver);
         await switchToNetworkFromNetworkSelect(driver, 'Popular', 'Solana');
         await homePage.checkPageIsLoaded({ amount: '$5,643.50' });

--- a/test/e2e/tests/solana/check-balance.spec.ts
+++ b/test/e2e/tests/solana/check-balance.spec.ts
@@ -40,7 +40,7 @@ describe('Check balance', function (this: Suite) {
       },
     );
   });
-  it.only('For a non 0 balance account - USD balance', async function () {
+  it('For a non 0 balance account - USD balance', async function () {
     await withFixtures(
       {
         fixtures: new FixtureBuilderV2()

--- a/test/e2e/tests/solana/check-balance.spec.ts
+++ b/test/e2e/tests/solana/check-balance.spec.ts
@@ -18,7 +18,7 @@ describe('Check balance', function (this: Suite) {
       async ({ driver }) => {
         await loginWithBalanceValidation(driver);
         const homePage = new NonEvmHomepage(driver);
-        await homePage.waitForSolanaAccountLoaded();
+        await homePage.waitForNonEvmAccountsLoaded();
         await switchToNetworkFromNetworkSelect(driver, 'Popular', 'Solana');
         await homePage.checkPageIsLoaded({ amount: '0 SOL' });
       },
@@ -36,7 +36,7 @@ describe('Check balance', function (this: Suite) {
       async ({ driver }) => {
         await loginWithBalanceValidation(driver, undefined, undefined, '$0.00');
         const homePage = new NonEvmHomepage(driver);
-        await homePage.waitForSolanaAccountLoaded();
+        await homePage.waitForNonEvmAccountsLoaded();
         await switchToNetworkFromNetworkSelect(driver, 'Popular', 'Solana');
         await homePage.checkPageIsLoaded({ amount: '$0' });
       },
@@ -54,7 +54,7 @@ describe('Check balance', function (this: Suite) {
       async ({ driver }) => {
         await loginWithBalanceValidation(driver, undefined, undefined, '$0.00');
         const homePage = new NonEvmHomepage(driver);
-        await homePage.waitForSolanaAccountLoaded();
+        await homePage.waitForNonEvmAccountsLoaded();
         await switchToNetworkFromNetworkSelect(driver, 'Popular', 'Solana');
         await homePage.checkPageIsLoaded({ amount: '$5,643.50' });
       },
@@ -70,7 +70,7 @@ describe('Check balance', function (this: Suite) {
       async ({ driver }) => {
         await loginWithBalanceValidation(driver);
         const homePage = new NonEvmHomepage(driver);
-        await homePage.waitForSolanaAccountLoaded();
+        await homePage.waitForNonEvmAccountsLoaded();
         await switchToNetworkFromNetworkSelect(driver, 'Popular', 'Solana');
         await homePage.checkPageIsLoaded({ amount: '50 SOL' });
       },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

We try to switch to Solana, but nothing happens as the solana account is not yet loaded (see network icons on top left, how Solana is not there yet). Then, trying to switch takes no effect.

<img width="1050" height="812" alt="image" src="https://github.com/user-attachments/assets/c23bfc37-4d5b-4baf-abef-1969ee4f224c" />


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40488?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that add an explicit readiness wait and adjust login balance assertions to reduce Solana e2e flakiness.
> 
> **Overview**
> Reduces Solana e2e test flakiness by waiting for non-EVM accounts to finish loading before attempting a network switch.
> 
> Adds `HomePage.waitForNonEvmAccountsLoaded()` (waits for Solana/Bitcoin account icons), and updates Solana balance tests to call it after login; tests that previously used `loginWithoutBalanceValidation` now use `loginWithBalanceValidation` with an explicit `$0.00` expectation when native token display is disabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b3a3e59cabf9e11a5719b8fe96a9b434e2408d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->