### PR TITLE
fix: non-evm send details account name

### DIFF
--- a/ui/components/app/multichain-transaction-details-modal/multichain-transaction-details-modal.tsx
+++ b/ui/components/app/multichain-transaction-details-modal/multichain-transaction-details-modal.tsx
@@ -43,7 +43,11 @@ import {
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 import { ConfirmInfoRowDivider as Divider } from '../confirm/info/row';
 import { getURLHostName, shortenAddress } from '../../../helpers/utils/util';
-import { getAccountName, getSelectedAccount } from '../../../selectors';
+import {
+  getAccountName,
+  getIsMultichainAccountsState2Enabled,
+  getSelectedAccount,
+} from '../../../selectors';
 import {
   KEYRING_TRANSACTION_STATUS_KEY,
   useMultichainTransactionDisplay,
@@ -53,6 +57,8 @@ import {
   getInternalAccountsObject,
   isNonEvmAccount,
 } from '../../../selectors/accounts';
+import { getAccountGroupsByAddress } from '../../../selectors/multichain-accounts/account-tree';
+import type { MultichainAccountsState } from '../../../selectors/multichain-accounts/account-tree.types';
 import {
   formatTimestamp,
   getTransactionUrl,
@@ -93,6 +99,33 @@ export function MultichainTransactionDetailsModal({
   const nonEvmSenderAddress = isNonEvmAccount(txInternalAccount)
     ? txInternalAccount?.address
     : undefined;
+  const isMultichainAccountsState2Enabled = useSelector(
+    getIsMultichainAccountsState2Enabled,
+  );
+
+  const fromAddress =
+    type === TransactionType.Send
+      ? nonEvmSenderAddress || userAddress
+      : from?.address;
+  const toAddress = to?.address;
+  const relevantAddresses = [fromAddress, toAddress].filter(
+    (addr): addr is string => Boolean(addr),
+  );
+
+  const accountGroups = useSelector((state: MultichainAccountsState) =>
+    isMultichainAccountsState2Enabled && relevantAddresses.length > 0
+      ? getAccountGroupsByAddress(state, relevantAddresses)
+      : [],
+  );
+
+  const getAccountGroupName = (address: string): string | undefined => {
+    const group = accountGroups.find((g) =>
+      g.accounts.some(
+        (a) => a.address?.toLowerCase() === address.toLowerCase(),
+      ),
+    );
+    return group?.metadata?.name ?? undefined;
+  };
 
   const getStatusColor = (txStatus: string) => {
     switch (txStatus?.toLowerCase()) {
@@ -112,7 +145,11 @@ export function MultichainTransactionDetailsModal({
     if (!address) {
       return null;
     }
-    const accountName = getAccountName(internalAccounts, address);
+    const groupName = isMultichainAccountsState2Enabled
+      ? getAccountGroupName(address)
+      : undefined;
+    const accountName =
+      groupName || getAccountName(internalAccounts, address);
     const displayName = accountName || shortenAddress(address);
 
     return (

--- a/ui/pages/confirmations/components/activity/transaction-details-account-row/transaction-details-account-row.test.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-account-row/transaction-details-account-row.test.tsx
@@ -34,6 +34,11 @@ const mockState = {
       },
       selectedAccount: 'account-1',
     },
+    accountTree: {
+      selectedAccountGroup: 'entropy:test-wallet/0',
+      wallets: {},
+    },
+    remoteFeatureFlags: {},
   },
 };
 

--- a/ui/pages/confirmations/components/activity/transaction-details-account-row/transaction-details-account-row.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-account-row/transaction-details-account-row.tsx
@@ -6,7 +6,15 @@ import {
   TextVariant,
 } from '../../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
-import { getAccountName, getInternalAccounts } from '../../../../../selectors';
+import {
+  getAccountName,
+  getInternalAccounts,
+  getIsMultichainAccountsState2Enabled,
+} from '../../../../../selectors';
+import type { MultichainAccountsState } from '../../../../../selectors/multichain-accounts/account-tree.types';
+import {
+  selectAccountGroupNameByInternalAccount,
+} from '../../../selectors/accounts';
 import { TransactionDetailsRow } from '../transaction-details-row';
 import { useTransactionDetails } from '../transaction-details-context';
 
@@ -15,12 +23,21 @@ export function TransactionDetailsAccountRow() {
   const t = useI18nContext();
   const { transactionMeta } = useTransactionDetails();
   const internalAccounts = useSelector(getInternalAccounts);
+  const isMultichainAccountsState2Enabled = useSelector(
+    getIsMultichainAccountsState2Enabled,
+  );
 
   const {
     txParams: { from },
   } = transactionMeta;
 
-  const accountName = getAccountName(internalAccounts, from);
+  const accountGroupName = useSelector((state: MultichainAccountsState) =>
+    selectAccountGroupNameByInternalAccount(state, from),
+  );
+  const internalAccountName = getAccountName(internalAccounts, from);
+  const accountName = isMultichainAccountsState2Enabled
+    ? accountGroupName ?? internalAccountName
+    : internalAccountName;
 
   return (
     <TransactionDetailsRow


### PR DESCRIPTION
Fixes non-EVM transaction details displaying "Snap Account X" instead of user-facing account group names.

The `getAccountName()` function was returning internal snap account names for non-EVM accounts. This PR updates `multichain-transaction-details-modal.tsx` and `transaction-details-account-row.tsx` to prioritize account group names when the `enableMultichainAccountsState2` feature flag is enabled, mirroring the logic in `useConfirmationRecipientInfo.ts`.

---
<p><a href="https://cursor.com/agents/bc-885ec3a8-faa9-441a-a78f-ab13095b3b29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-885ec3a8-faa9-441a-a78f-ab13095b3b29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

