### PR TITLE
fix: non-evm details account display name

### DIFF
--- a/ui/components/app/multichain-transaction-details-modal/multichain-transaction-details-modal.tsx
+++ b/ui/components/app/multichain-transaction-details-modal/multichain-transaction-details-modal.tsx
@@ -43,22 +43,73 @@ import {
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 import { ConfirmInfoRowDivider as Divider } from '../confirm/info/row';
 import { getURLHostName, shortenAddress } from '../../../helpers/utils/util';
-import { getAccountName, getSelectedAccount } from '../../../selectors';
+import { getSelectedAccount } from '../../../selectors';
 import {
   KEYRING_TRANSACTION_STATUS_KEY,
   useMultichainTransactionDisplay,
 } from '../../../hooks/useMultichainTransactionDisplay';
 import {
-  getInternalAccounts,
   getInternalAccountsObject,
   isNonEvmAccount,
 } from '../../../selectors/accounts';
+import { selectAccountGroupNameByAddress } from '../../../selectors/multichain-accounts/account-tree';
 import {
   formatTimestamp,
   getTransactionUrl,
   getAddressUrl,
   shortenTransactionId,
 } from './helpers';
+
+type Props = {
+  label: string;
+  address?: string;
+  chain: string;
+};
+
+const AccountRow = ({ label, address, chain }: Props) => {
+  const displayName = useSelector((state) =>
+    selectAccountGroupNameByAddress(state, address),
+  );
+
+  if (!address) {
+    return null;
+  }
+
+  return (
+    <Box display={Display.Flex} justifyContent={JustifyContent.spaceBetween}>
+      <Text variant={TextVariant.bodyMd} fontWeight={FontWeight.Medium}>
+        {label}
+      </Text>
+      <Box display={Display.Flex} alignItems={AlignItems.center} gap={1}>
+        <ButtonLink
+          size={ButtonLinkSize.Inherit}
+          textProps={{
+            variant: TextVariant.bodyMd,
+            alignItems: AlignItems.flexStart,
+          }}
+          as="a"
+          externalLink
+          href={getAddressUrl(address, chain)}
+        >
+          {displayName || shortenAddress(address)}
+          <Icon
+            marginLeft={2}
+            name={IconName.Export}
+            size={IconSize.Sm}
+            color={IconColor.primaryDefault}
+            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
+            // eslint-disable-next-line @typescript-eslint/no-misused-promises
+            onClick={() =>
+              navigator.clipboard.writeText(
+                getAddressUrl(address as string, chain),
+              )
+            }
+          />
+        </ButtonLink>
+      </Box>
+    </Box>
+  );
+};
 
 export type MultichainTransactionDetailsModalProps = {
   transaction: Transaction;
@@ -87,12 +138,18 @@ export function MultichainTransactionDetailsModal({
     id,
   } = useMultichainTransactionDisplay(transaction);
 
-  const internalAccounts = useSelector(getInternalAccounts);
   const internalAccountsById = useSelector(getInternalAccountsObject);
   const txInternalAccount = internalAccountsById?.[transaction.account];
   const nonEvmSenderAddress = isNonEvmAccount(txInternalAccount)
     ? txInternalAccount?.address
     : undefined;
+
+  // Derive addresses
+  const fromAddress =
+    type === TransactionType.Send
+      ? nonEvmSenderAddress || userAddress
+      : from?.address;
+  const toAddress = to?.address;
 
   const getStatusColor = (txStatus: string) => {
     switch (txStatus?.toLowerCase()) {
@@ -107,49 +164,6 @@ export function MultichainTransactionDetailsModal({
     }
   };
   const statusKey = KEYRING_TRANSACTION_STATUS_KEY[status];
-
-  const accountComponent = (label: string, address?: string) => {
-    if (!address) {
-      return null;
-    }
-    const accountName = getAccountName(internalAccounts, address);
-    const displayName = accountName || shortenAddress(address);
-
-    return (
-      <Box display={Display.Flex} justifyContent={JustifyContent.spaceBetween}>
-        <Text variant={TextVariant.bodyMd} fontWeight={FontWeight.Medium}>
-          {label}
-        </Text>
-        <Box display={Display.Flex} alignItems={AlignItems.center} gap={1}>
-          <ButtonLink
-            size={ButtonLinkSize.Inherit}
-            textProps={{
-              variant: TextVariant.bodyMd,
-              alignItems: AlignItems.flexStart,
-            }}
-            as="a"
-            externalLink
-            href={getAddressUrl(address, chain)}
-          >
-            {displayName}
-            <Icon
-              marginLeft={2}
-              name={IconName.Export}
-              size={IconSize.Sm}
-              color={IconColor.primaryDefault}
-              // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-              // eslint-disable-next-line @typescript-eslint/no-misused-promises
-              onClick={() =>
-                navigator.clipboard.writeText(
-                  getAddressUrl(address as string, chain),
-                )
-              }
-            />
-          </ButtonLink>
-        </Box>
-      </Box>
-    );
-  };
 
   const amountComponent = (
     asset:
@@ -304,16 +318,11 @@ export function MultichainTransactionDetailsModal({
             gap={4}
           >
             {/* From */}
-            {accountComponent(
-              t('from'),
-              type === TransactionType.Send
-                ? nonEvmSenderAddress || userAddress
-                : from?.address,
-            )}
+            <AccountRow label={t('from')} address={fromAddress} chain={chain} />
 
             {/* Amounts per token */}
             <>
-              {accountComponent(t('to'), to?.address)}
+              <AccountRow label={t('to')} address={toAddress} chain={chain} />
               {amountComponent(
                 type === TransactionType.Swap ? from : to,
                 t('amount'),

--- a/ui/selectors/multichain-accounts/account-tree.test.ts
+++ b/ui/selectors/multichain-accounts/account-tree.test.ts
@@ -36,6 +36,7 @@ import {
   getDefaultScopeAndAddressByAccountGroupId,
   getIconSeedAddressesByAccountGroups,
   getNormalizedGroupsMetadata,
+  selectAccountGroupNameByAddress,
 } from './account-tree';
 import { MultichainAccountsState } from './account-tree.types';
 import {
@@ -1582,6 +1583,29 @@ describe('Multichain Accounts Selectors', () => {
       expect(result).toEqual({
         'keyring:some/0x123': '',
       });
+    });
+  });
+
+  describe('selectAccountGroupNameByAddress', () => {
+    it('returns account group name for a valid address', () => {
+      const result = selectAccountGroupNameByAddress(
+        typedMockState,
+        ACCOUNT_1_ADDRESS,
+      );
+      expect(result).toBe('Account 1');
+    });
+
+    it('returns undefined when address is not provided', () => {
+      const result = selectAccountGroupNameByAddress(typedMockState, undefined);
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined when address does not match any account', () => {
+      const result = selectAccountGroupNameByAddress(
+        typedMockState,
+        '0x0000000000000000000000000000000000000000',
+      );
+      expect(result).toBeUndefined();
     });
   });
 });

--- a/ui/selectors/multichain-accounts/account-tree.ts
+++ b/ui/selectors/multichain-accounts/account-tree.ts
@@ -884,6 +884,42 @@ export const getWalletIdsByType = createSelector(
 );
 
 /**
+ * Get the account group display name for a given address.
+ * Returns the account group name (e.g., "Account 3") rather than
+ * the internal account name (e.g., "Snap Account 11").
+ *
+ * @param state - Redux state.
+ * @param address - The address to look up.
+ * @returns The account group name, internal account name, or undefined.
+ */
+export function selectAccountGroupNameByAddress(
+  state: unknown,
+  address?: string,
+) {
+  if (!address) {
+    return undefined;
+  }
+
+  const typedState = state as MultichainAccountsState;
+  const internalAccounts = getInternalAccounts(typedState);
+  const accountGroups = getAllAccountGroups(typedState);
+
+  const internalAccount = internalAccounts.find(
+    (acc) => acc.address.toLowerCase() === address.toLowerCase(),
+  );
+
+  if (!internalAccount) {
+    return undefined;
+  }
+
+  const accountGroup = accountGroups.find((group) =>
+    group.accounts.includes(internalAccount.id),
+  );
+
+  return accountGroup?.metadata.name ?? internalAccount.metadata.name;
+}
+
+/**
  * Get account list statistics (pinned count, hidden count, total accounts).
  * Used for analytics tracking in the account list views.
  *


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Render the account group display name instead of the internal name

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40498?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: non-evm txn details account display name

## **Related issues**

Fixes: #40090 

## **Manual testing steps**

1. Complete a non-EVM send transaction
2. Go to Activity tab
3. Click for details

## **Screenshots/Recordings**

Before: "Snap Account X"
After: _User-defined name_

<img width="754" height="311" alt="image" src="https://github.com/user-attachments/assets/57608341-2e64-4416-94b0-49407daf4345" />


<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/selector change that only affects how account names are resolved/displayed in the transaction details modal; primary risk is incorrect/undefined name lookup for some addresses.
> 
> **Overview**
> Updates the multichain transaction details modal to render From/To rows via a new `AccountRow` component that resolves a user-facing **account group** display name (falling back to `shortenAddress`) rather than showing the internal account name.
> 
> Adds a new selector, `selectAccountGroupNameByAddress`, plus tests, to map an address to its containing account group name (or fall back to the internal account name when no group metadata exists).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dadb13f69489b34a7a87e32a600a86d028204e90. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->