### PR TITLE
fix: fixes ledger decline button not clearing

### DIFF
--- a/ui/pages/bridge/prepare/bridge-cta-button.test.tsx
+++ b/ui/pages/bridge/prepare/bridge-cta-button.test.tsx
@@ -5,6 +5,7 @@ import {
   getNativeAssetForChainId,
   formatChainIdToCaip,
 } from '@metamask/bridge-controller';
+import { userEvent } from '@testing-library/user-event';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import configureStore from '../../../store/store';
 import { createBridgeMockStore } from '../../../../test/data/bridge/mock-bridge-store';
@@ -191,6 +192,25 @@ describe('BridgeCTAButton', () => {
 
     expect(getByText(messages.swap.message)).toBeInTheDocument();
     expect(getByRole('button')).not.toBeDisabled();
+  });
+
+  it('clears declined state when fetching new quotes', async () => {
+    const onFetchNewQuotes = jest.fn();
+    const mockStore = createBridgeMockStore({
+      bridgeSliceOverrides: {
+        wasTxDeclined: true,
+      },
+    });
+    const store = configureStore(mockStore);
+    const { getByText } = renderWithProvider(
+      <BridgeCTAButton onFetchNewQuotes={onFetchNewQuotes} />,
+      store,
+    );
+
+    await userEvent.click(getByText(messages.bridgeFetchNewQuotes.message));
+
+    expect(onFetchNewQuotes).toHaveBeenCalledTimes(1);
+    expect(store.getState().bridge.wasTxDeclined).toBe(false);
   });
 
   it('should render hardware wallet connect label with wallet name', () => {

--- a/ui/pages/bridge/prepare/bridge-cta-button.tsx
+++ b/ui/pages/bridge/prepare/bridge-cta-button.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import {
   Button,
   ButtonLink,
@@ -34,6 +34,7 @@ import {
   useHardwareWalletConfig,
   useHardwareWalletState,
 } from '../../../contexts/hardware-wallets';
+import { setWasTxDeclined } from '../../../ducks/bridge/actions';
 
 export const BridgeCTAButton = ({
   onFetchNewQuotes,
@@ -45,6 +46,7 @@ export const BridgeCTAButton = ({
   onOpenRecipientModal?: () => void;
 }) => {
   const t = useI18nContext();
+  const dispatch = useDispatch();
 
   const toToken = useSelector(getToToken);
 
@@ -238,7 +240,12 @@ export const BridgeCTAButton = ({
           as="a"
           variant={TextVariant.bodyMd}
           style={{ whiteSpace: 'nowrap' }}
-          onClick={onFetchNewQuotes}
+          onClick={() => {
+            if (wasTxDeclined) {
+              dispatch(setWasTxDeclined(false));
+            }
+            onFetchNewQuotes();
+          }}
         >
           {t(secondaryButtonLabel)}
         </ButtonLink>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes a bug where the ledger transaction decline label was not clearing when refetching quotes, blocking new quotes from being executed. 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40501?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fixed a bug when cancelling a hardware wallet tx that would cause swaps button to not display

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/40277

## **Manual testing steps**

1. Go to execute a swap with a ledger HW
2. cancel the tx
3. refetch a quote
4. you should be able to swap

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-state fix in the bridge CTA flow; low risk and covered by a new test, though it affects gating of quote refresh/swap eligibility.
> 
> **Overview**
> Fixes a bridge refresh edge case where a previously *declined* hardware-wallet transaction could leave the UI stuck in the declined state.
> 
> `BridgeCTAButton` now clears the `bridge.wasTxDeclined` flag when the user clicks the secondary "fetch new quotes" link, then triggers `onFetchNewQuotes`. Adds a regression test asserting the state reset and callback invocation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d854d907768374efb3467bd3f156ee81dea5f57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->