### PR TITLE
chore: Upgrade @metamask/design-tokens from v8.1.1 to v8.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -311,7 +311,7 @@
     "@metamask/delegation-deployments": "^0.15.0",
     "@metamask/design-system-react": "^0.9.0",
     "@metamask/design-system-tailwind-preset": "^0.6.1",
-    "@metamask/design-tokens": "^8.2.1",
+    "@metamask/design-tokens": "^8.2.2",
     "@metamask/eip-5792-middleware": "^2.1.0",
     "@metamask/eip-7702-internal-rpc-middleware": "^0.1.0",
     "@metamask/ens-controller": "^18.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6013,7 +6013,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/design-tokens@npm:^8.2.1":
+"@metamask/design-tokens@npm:^8.2.2":
   version: 8.2.2
   resolution: "@metamask/design-tokens@npm:8.2.2"
   checksum: 10/2ab9e2c148f55874819c550a2e038c050d906709c33315edd200ddaeb7677b5f121f50fa2f43c06ce94b5fc66b59450c81b8927088721d8ad6ee559cf864f442
@@ -32939,7 +32939,7 @@ __metadata:
     "@metamask/delegation-deployments": "npm:^0.15.0"
     "@metamask/design-system-react": "npm:^0.9.0"
     "@metamask/design-system-tailwind-preset": "npm:^0.6.1"
-    "@metamask/design-tokens": "npm:^8.2.1"
+    "@metamask/design-tokens": "npm:^8.2.2"
     "@metamask/eip-5792-middleware": "npm:^2.1.0"
     "@metamask/eip-7702-internal-rpc-middleware": "npm:^0.1.0"
     "@metamask/ens-controller": "npm:^18.0.0"


### PR DESCRIPTION
## **Description**

This PR upgrades the `@metamask/design-tokens` package from version 8.1.1 to 8.2.2. This update includes typography size updates and other design token improvements.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Build the project and verify no build errors occur
2. Check that typography and design tokens are rendering correctly throughout the UI
3. Verify no visual regressions in components that use design tokens

## **Screenshots/Recordings**

N/A - This is a package version update that includes typography size updates.

### **Before**

Version 8.1.1

### **After**

Partial font size changes that will likely go unnoticed. This is primarily a smoke test to confirm Extension runs as expected.

https://github.com/user-attachments/assets/e93f7574-bab0-4441-aa09-d58ebc4ef90f

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency bump limited to design tokens, but it may cause unintended visual/typography regressions where token values changed.
> 
> **Overview**
> Upgrades `@metamask/design-tokens` from `^8.2.1` to `^8.2.2` in `package.json`.
> 
> Updates `yarn.lock` to resolve `@metamask/design-tokens@8.2.2` and align the root dependency list with the new version.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2efd93e869141c66f7bde46ce77f813ae14070e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->