### PR TITLE
refactor: update mmLazy to handle templates

### DIFF
--- a/ui/helpers/utils/mm-lazy.ts
+++ b/ui/helpers/utils/mm-lazy.ts
@@ -1,11 +1,27 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import React from 'react';
 import { getManifestFlags } from '../../../shared/lib/manifestFlags';
 import { endTrace, trace, TraceName } from '../../../shared/lib/trace';
 
-export type DynamicImportType = () => Promise<ModuleWithDefaultType>;
-export type ModuleWithDefaultType = {
-  default: React.ComponentType;
+type DynamicImportType = () => Promise<any>;
+export type ModuleWithDefaultType<
+  Component extends React.ComponentType<any> = React.ComponentType,
+> = {
+  default: Component;
 };
+
+/**
+ * Infers the component type from a dynamic import function.
+ * If the import returns a module with a `default` export that is a ComponentType,
+ * the component type (including its props) is preserved.
+ */
+type InferComponent<ImportFn extends DynamicImportType> =
+  Awaited<ReturnType<ImportFn>> extends {
+    default: infer Comp extends React.ComponentType<any>;
+  }
+    ? Comp
+    : React.ComponentType;
 
 // This only has to happen once per app load, so do it outside a function
 const lazyLoadSubSampleRate = getManifestFlags().sentry?.lazyLoadSubSampleRate;
@@ -17,7 +33,10 @@ const lazyLoadSubSampleRate = getManifestFlags().sentry?.lazyLoadSubSampleRate;
  *
  * @param fn - an import of the form `() => import('AAA')`
  */
-export function mmLazy(fn: DynamicImportType) {
+export function mmLazy<ImportFn extends DynamicImportType>(
+  fn: ImportFn,
+): React.LazyExoticComponent<InferComponent<ImportFn>> {
+  type Component = InferComponent<ImportFn>;
   return React.lazy(async () => {
     // We can't start the trace here because we don't have the componentName yet, so we just hold the startTime
     const startTime = Date.now();
@@ -36,7 +55,7 @@ export function mmLazy(fn: DynamicImportType) {
       endTrace({ name: TraceName.LazyLoadComponent });
     }
 
-    return component;
+    return component as ModuleWithDefaultType<Component>;
   });
 }
 

--- a/ui/pages/onboarding-flow/onboarding-flow.tsx
+++ b/ui/pages/onboarding-flow/onboarding-flow.tsx
@@ -73,7 +73,7 @@ import type { MetaMaskReduxDispatch } from '../../store/store';
 import { useTheme } from '../../hooks/useTheme';
 import { ThemeType } from '../../../shared/constants/preferences';
 import { isFlask } from '../../../shared/lib/build-types';
-import { DynamicImportType, mmLazy } from '../../helpers/utils/mm-lazy';
+import { mmLazy } from '../../helpers/utils/mm-lazy';
 import OnboardingFlowSwitch from './onboarding-flow-switch/onboarding-flow-switch';
 import CreatePassword from './create-password/create-password';
 import ReviewRecoveryPhrase from './recovery-phrase/review-recovery-phrase';
@@ -92,14 +92,10 @@ import OnboardingDownloadApp from './download-app/download-app';
 // Lazy-load ExperimentalArea so the flask/ module is only fetched in Flask builds.
 // This is not just for performance, it is necessary so non-Flask builds don't try
 // to import Flask-only code and fail.
-// TODO: Fix type casting once `mmLazy` is updated to handle component props.
 const ExperimentalArea = mmLazy(
-  (() =>
-    import(
-      // eslint-disable-next-line import/extensions, import/no-useless-path-segments -- these are needed for mmLazy
-      '../../components/app/flask/experimental-area/index.js'
-    )) as unknown as DynamicImportType,
-) as unknown as React.ComponentType<{ redirectTo?: string }>;
+  // eslint-disable-next-line import/extensions, import/no-useless-path-segments -- these are needed for mmLazy
+  () => import('../../components/app/flask/experimental-area/index.js'),
+) as React.ComponentType<{ redirectTo: string }>;
 
 // Helper to convert onboarding paths to relative paths for nested route matching
 const toRelativePath = (path: string) =>

--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -121,7 +121,7 @@ import KeyringSnapRemovalResult from '../../components/app/modals/keyring-snap-r
 import { DeprecatedNetworkModal } from '../settings/deprecated-network-modal/DeprecatedNetworkModal';
 import NetworkConfirmationPopover from '../../components/multichain/network-list-menu/network-confirmation-popover/network-confirmation-popover';
 import { ToastMaster } from '../../components/app/toast-master/toast-master';
-import { type DynamicImportType, mmLazy } from '../../helpers/utils/mm-lazy';
+import { mmLazy } from '../../helpers/utils/mm-lazy';
 import { PerpsControllerProvider } from '../../providers/perps';
 import CrossChainSwapTxDetails from '../bridge/transaction-details/transaction-details';
 import {
@@ -145,213 +145,108 @@ import { getConnectingLabel, setTheme } from './utils';
 import { ConfirmationHandler } from './confirmation-handler';
 import { Modals } from './modals';
 
-// TODO: Fix `as unknown as` casting once `mmLazy` is updated to handle named exports, wrapped components, and other React module types.
-// Casting is preferable over `@ts-expect-error` annotations in this case,
-// because it doesn't suppress competing error messages e.g. "Cannot find module..."
-
 // Begin Lazy Routes
-const OnboardingFlow = mmLazy(
-  (() => import('../onboarding-flow/index.ts')) as unknown as DynamicImportType,
-);
-const Lock = mmLazy(
-  (() => import('../lock/index.ts')) as unknown as DynamicImportType,
-);
-const UnlockPage = mmLazy(
-  (() => import('../unlock-page/index.ts')) as unknown as DynamicImportType,
-);
-const RestoreVaultPage = mmLazy(
-  (() =>
-    import('../keychains/restore-vault.tsx')) as unknown as DynamicImportType,
-);
-const ImportSrpPage = mmLazy(
-  // TODO: This is a named export. Fix incorrect type casting once `mmLazy` is updated to handle non-default export types.
-  (() =>
-    import('../multi-srp/import-srp/index.ts')) as unknown as DynamicImportType,
-);
+const OnboardingFlow = mmLazy(() => import('../onboarding-flow/index.ts'));
+const Lock = mmLazy(() => import('../lock/index.ts'));
+const UnlockPage = mmLazy(() => import('../unlock-page/index.ts'));
+const RestoreVaultPage = mmLazy(() => import('../keychains/restore-vault.tsx'));
+const ImportSrpPage = mmLazy(() => import('../multi-srp/import-srp/index.ts'));
 const RevealSeedConfirmation = mmLazy(
-  (() =>
-    import('../keychains/reveal-seed.tsx')) as unknown as DynamicImportType,
+  () => import('../keychains/reveal-seed.tsx'),
 );
-const Settings = mmLazy(
-  (() => import('../settings/index.js')) as unknown as DynamicImportType,
+const Settings = mmLazy(() => import('../settings/index.js'));
+const NotificationDetails = mmLazy(
+  () => import('../notification-details/index.js'),
 );
+const Notifications = mmLazy(() => import('../notifications/index.js'));
+const SnapList = mmLazy(() => import('../snaps/snaps-list/index.js'));
+const SnapView = mmLazy(() => import('../snaps/snap-view/index.js'));
+const ConfirmEncryptionPublicKey = mmLazy(
+  () => import('../confirm-encryption-public-key/index.js'),
+);
+const ConfirmDecryptMessage = mmLazy(
+  () => import('../confirm-decrypt-message/index.js'),
+);
+const Confirm = mmLazy(() => import('../confirmations/confirm/confirm.tsx'));
+const SendPage = mmLazy(() => import('../confirmations/send/index.ts'));
+const CrossChainSwap = mmLazy(() => import('../bridge/index.tsx'));
+const PermissionsConnect = mmLazy(
+  () => import('../permissions-connect/index.js'),
+);
+const ConfirmAddSuggestedTokenPage = mmLazy(
+  () => import('../confirm-add-suggested-token/index.js'),
+);
+const ConfirmAddSuggestedNftPage = mmLazy(
+  () => import('../confirm-add-suggested-nft/index.js'),
+);
+const ConfirmationPage = mmLazy(
+  () => import('../confirmations/confirmation/index.js'),
+);
+const CreateAccountPage = mmLazy(
+  () => import('../create-account/create-account.component.js'),
+);
+const NftFullImage = mmLazy(
+  () =>
+    import('../../components/app/assets/nfts/nft-details/nft-full-image.tsx'),
+);
+const Asset = mmLazy(() => import('../asset/index.js'));
+const DeFiPage = mmLazy(() => import('../defi/index.ts'));
+const PermissionsPage = mmLazy(
+  () =>
+    import(
+      '../../components/multichain/pages/permissions-page/permissions-page.js'
+    ),
+);
+const GatorPermissionsPage = mmLazy(
+  () =>
+    import(
+      '../../components/multichain/pages/gator-permissions/gator-permissions-page.tsx'
+    ),
+);
+const GatorPermissionsTokenTransferPermissionsPage = mmLazy(
+  () =>
+    import(
+      '../../components/multichain/pages/gator-permissions/token-transfer/token-transfer-page.tsx'
+    ),
+);
+const GatorPermissionsReviewPermissionsPage = mmLazy(
+  () =>
+    import(
+      '../../components/multichain/pages/gator-permissions/review-permissions/review-gator-permissions-page.tsx'
+    ),
+);
+const Home = mmLazy(() => import('../home/index.js'));
+const DeepLink = mmLazy(() => import('../deep-link/deep-link.tsx'));
+const BasicFunctionalityOff = mmLazy(
+  () =>
+    import('../basic-functionality-required/basic-functionality-required.tsx'),
+);
+const MultichainAccountDetailsPage = mmLazy(
+  () =>
+    import('../multichain-accounts/multichain-account-details-page/index.ts'),
+);
+const SmartAccountPage = mmLazy(
+  () => import('../multichain-accounts/smart-account-page/index.ts'),
+);
+const NonEvmBalanceCheck = mmLazy(
+  () => import('../nonevm-balance-check/index.tsx'),
+);
+const ShieldPlan = mmLazy(() => import('../shield-plan/index.ts'));
+const PerpsHomePage = mmLazy(() => import('../perps/perps-home-page.tsx'));
+const PerpsMarketDetailPage = mmLazy(
+  () => import('../perps/perps-market-detail-page.tsx'),
+);
+const MarketListView = mmLazy(() => import('../perps/market-list/index.tsx'));
+const PerpsActivityPage = mmLazy(
+  () => import('../perps/perps-activity-page.tsx'),
+);
+const PerpsOrderEntryPage = mmLazy(
+  () => import('../perps/perps-order-entry-page.tsx'),
+);
+// End Lazy Routes
 
 const NotificationsSettingsRedirect = () => (
   <Navigate to={NOTIFICATIONS_SETTINGS_ROUTE} replace />
-);
-
-const NotificationDetails = mmLazy(
-  (() =>
-    import('../notification-details/index.js')) as unknown as DynamicImportType,
-);
-const Notifications = mmLazy(
-  (() => import('../notifications/index.js')) as unknown as DynamicImportType,
-);
-const SnapList = mmLazy(
-  (() =>
-    import('../snaps/snaps-list/index.js')) as unknown as DynamicImportType,
-);
-const SnapView = mmLazy(
-  (() => import('../snaps/snap-view/index.js')) as unknown as DynamicImportType,
-);
-const ConfirmEncryptionPublicKey = mmLazy(
-  (() =>
-    import(
-      '../confirm-encryption-public-key/index.js'
-    )) as unknown as DynamicImportType,
-);
-const ConfirmDecryptMessage = mmLazy(
-  (() =>
-    import(
-      '../confirm-decrypt-message/index.js'
-    )) as unknown as DynamicImportType,
-);
-const Confirm = mmLazy(
-  (() =>
-    import(
-      '../confirmations/confirm/confirm.tsx'
-    )) as unknown as DynamicImportType,
-);
-const SendPage = mmLazy(
-  // TODO: This is a named export. Fix incorrect type casting once `mmLazy` is updated to handle non-default export types.
-  (() =>
-    import('../confirmations/send/index.ts')) as unknown as DynamicImportType,
-);
-const CrossChainSwap = mmLazy(
-  (() => import('../bridge/index.tsx')) as unknown as DynamicImportType,
-);
-const PermissionsConnect = mmLazy(
-  (() =>
-    import('../permissions-connect/index.js')) as unknown as DynamicImportType,
-);
-const ConfirmAddSuggestedTokenPage = mmLazy(
-  (() =>
-    import(
-      '../confirm-add-suggested-token/index.js'
-    )) as unknown as DynamicImportType,
-);
-const ConfirmAddSuggestedNftPage = mmLazy(
-  (() =>
-    import(
-      '../confirm-add-suggested-nft/index.js'
-    )) as unknown as DynamicImportType,
-);
-const ConfirmationPage = mmLazy(
-  (() =>
-    import(
-      '../confirmations/confirmation/index.js'
-    )) as unknown as DynamicImportType,
-);
-const CreateAccountPage = mmLazy(
-  (() =>
-    import(
-      '../create-account/create-account.component.js'
-    )) as unknown as DynamicImportType,
-);
-const NftFullImage = mmLazy(
-  (() =>
-    import(
-      '../../components/app/assets/nfts/nft-details/nft-full-image.tsx'
-    )) as unknown as DynamicImportType,
-);
-const Asset = mmLazy(
-  (() => import('../asset/index.js')) as unknown as DynamicImportType,
-);
-const DeFiPage = mmLazy(
-  (() => import('../defi/index.ts')) as unknown as DynamicImportType,
-);
-const PermissionsPage = mmLazy(
-  // TODO: This is a named export. Fix incorrect type casting once `mmLazy` is updated to handle non-default export types.
-  (() =>
-    import(
-      '../../components/multichain/pages/permissions-page/permissions-page.js'
-    )) as unknown as DynamicImportType,
-);
-const GatorPermissionsPage = mmLazy(
-  // TODO: This is a named export. Fix incorrect type casting once `mmLazy` is updated to handle non-default export types.
-  (() =>
-    import(
-      '../../components/multichain/pages/gator-permissions/gator-permissions-page.tsx'
-    )) as unknown as DynamicImportType,
-);
-const GatorPermissionsTokenTransferPermissionsPage = mmLazy(
-  // TODO: This is a named export. Fix incorrect type casting once `mmLazy` is updated to handle non-default export types.
-  (() =>
-    import(
-      '../../components/multichain/pages/gator-permissions/token-transfer/token-transfer-page.tsx'
-    )) as unknown as DynamicImportType,
-);
-const GatorPermissionsReviewPermissionsPage = mmLazy(
-  // TODO: This is a named export. Fix incorrect type casting once `mmLazy` is updated to handle non-default export types.
-  (() =>
-    import(
-      '../../components/multichain/pages/gator-permissions/review-permissions/review-gator-permissions-page.tsx'
-    )) as unknown as DynamicImportType,
-);
-
-const Home = mmLazy(
-  (() => import('../home/index.js')) as unknown as DynamicImportType,
-);
-
-const DeepLink = mmLazy(
-  // TODO: This is a named export. Fix incorrect type casting once `mmLazy` is updated to handle non-default export types.
-  (() => import('../deep-link/deep-link.tsx')) as unknown as DynamicImportType,
-);
-
-const BasicFunctionalityOff = mmLazy(
-  (() =>
-    import(
-      '../basic-functionality-required/basic-functionality-required.tsx'
-    )) as unknown as DynamicImportType,
-);
-
-const MultichainAccountDetailsPage = mmLazy(
-  (() =>
-    import(
-      '../multichain-accounts/multichain-account-details-page/index.ts'
-    )) as unknown as DynamicImportType,
-);
-
-const SmartAccountPage = mmLazy(
-  (() =>
-    import(
-      '../multichain-accounts/smart-account-page/index.ts'
-    )) as unknown as DynamicImportType,
-);
-
-const NonEvmBalanceCheck = mmLazy(
-  (() =>
-    import(
-      '../nonevm-balance-check/index.tsx'
-    )) as unknown as DynamicImportType,
-);
-
-const ShieldPlan = mmLazy(
-  (() => import('../shield-plan/index.ts')) as unknown as DynamicImportType,
-);
-const PerpsHomePage = mmLazy(
-  (() =>
-    import('../perps/perps-home-page.tsx')) as unknown as DynamicImportType,
-);
-const PerpsMarketDetailPage = mmLazy(
-  (() =>
-    import(
-      '../perps/perps-market-detail-page.tsx'
-    )) as unknown as DynamicImportType,
-);
-const MarketListView = mmLazy(
-  (() =>
-    import('../perps/market-list/index.tsx')) as unknown as DynamicImportType,
-);
-const PerpsActivityPage = mmLazy(
-  (() =>
-    import('../perps/perps-activity-page.tsx')) as unknown as DynamicImportType,
-);
-const PerpsOrderEntryPage = mmLazy(
-  (() =>
-    import(
-      '../perps/perps-order-entry-page.tsx'
-    )) as unknown as DynamicImportType,
 );
 
 // Perps pages wrapped with PerpsControllerProvider
@@ -384,8 +279,6 @@ const WrappedPerpsOrderEntryPage = () => (
     <PerpsOrderEntryPage />
   </PerpsControllerProvider>
 );
-
-// End Lazy Routes
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export default function Routes() {


### PR DESCRIPTION
## **Description**

90% AI-generated, solves this TODO:
```
// TODO: Fix `as unknown as` casting once `mmLazy` is updated to handle named exports, wrapped components, and other React module types.
// Casting is preferable over `@ts-expect-error` annotations in this case,
// because it doesn't suppress competing error messages e.g. "Cannot find module..."
```

## **Changelog**

CHANGELOG entry: null

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the shared `mmLazy` helper used across many routes; while runtime behavior is intended to be unchanged, type inference changes could surface build/type regressions or subtly alter expected component prop types.
> 
> **Overview**
> **`mmLazy` is now generically typed to preserve component prop types** by inferring the default-exported `React.ComponentType` from the provided dynamic import function, and `ModuleWithDefaultType` was updated accordingly.
> 
> This refactor removes the `DynamicImportType` export and eliminates many `as unknown as DynamicImportType` casts in `routes.component.tsx` and `onboarding-flow.tsx`, simplifying lazy route/component declarations (including the Flask-only `ExperimentalArea` lazy import).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 38de58286b2e3905f724039dbd79415463710489. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->