### PR TITLE
chore: upgrade serialize-javascript resolution to 7.0.3 cp-13.21.0

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -83,3 +83,5 @@ npmPreapprovedPackages:
   - 'extension-port-stream'
   # Temporary bypass for recent minimatch security patch; remove once older than age gate.
   - 'minimatch'
+  # Temporary bypass for serialize-javascript@7.0.3 CVE fix; remove once older than age gate.
+  - 'serialize-javascript'

--- a/lavamoat/webpack/build/policy-override.json
+++ b/lavamoat/webpack/build/policy-override.json
@@ -19,10 +19,8 @@
     },
     "copy-webpack-plugin>serialize-javascript": {
       "globals": {
-        "URL": true
-      },
-      "packages": {
-        "crypto-browserify>randombytes": true
+        "URL": true,
+        "crypto.getRandomValues": true
       }
     },
     "@swc/core": {

--- a/lavamoat/webpack/build/policy.json
+++ b/lavamoat/webpack/build/policy.json
@@ -2786,10 +2786,8 @@
     },
     "copy-webpack-plugin>serialize-javascript": {
       "globals": {
-        "URL": true
-      },
-      "packages": {
-        "crypto-browserify>randombytes": true
+        "URL": true,
+        "crypto.getRandomValues": true
       }
     },
     "mocha>serialize-javascript": {

--- a/lavamoat/webpack/build/policy.json
+++ b/lavamoat/webpack/build/policy.json
@@ -1073,6 +1073,7 @@
         "chokidar>normalize-path": true,
         "schema-utils": true,
         "copy-webpack-plugin>serialize-javascript": true,
+        "mocha>serialize-javascript": true,
         "copy-webpack-plugin>tinyglobby": true
       }
     },
@@ -2499,11 +2500,6 @@
         "string.prototype.matchall>side-channel": true
       }
     },
-    "crypto-browserify>randombytes": {
-      "builtin": {
-        "crypto.randomBytes": true
-      }
-    },
     "mockttp>body-parser>raw-body": {
       "builtin": {
         "async_hooks": true
@@ -2796,6 +2792,12 @@
         "crypto-browserify>randombytes": true
       }
     },
+    "mocha>serialize-javascript": {
+      "globals": {
+        "URL": true,
+        "crypto.getRandomValues": true
+      }
+    },
     "webpack-dev-server>serve-index": {
       "builtin": {
         "fs.readFile": true,
@@ -3059,7 +3061,7 @@
         "@storybook/test-runner>@storybook/core-common>esbuild": true,
         "terser-webpack-plugin>jest-worker": true,
         "schema-utils": true,
-        "copy-webpack-plugin>serialize-javascript": true,
+        "mocha>serialize-javascript": true,
         "terser": true,
         "html-bundler-webpack-plugin>handlebars>uglify-js": true
       }

--- a/package.json
+++ b/package.json
@@ -195,6 +195,7 @@
     "async-done@^1.2.0": "patch:async-done@npm%3A1.3.2#./.yarn/patches/async-done-npm-1.3.2-1f0a4a8997.patch",
     "async-done@^1.2.2": "patch:async-done@npm%3A1.3.2#./.yarn/patches/async-done-npm-1.3.2-1f0a4a8997.patch",
     "fast-json-patch@^3.1.1": "patch:fast-json-patch@npm%3A3.1.1#./.yarn/patches/fast-json-patch-npm-3.1.1-7e8bb70a45.patch",
+    "serialize-javascript": "7.0.3",
     "@types/readable-stream-2@^2.3.15": "npm:@types/readable-stream@^2.3.15",
     "@types/readable-stream-3@^4.0.4": "npm:@types/readable-stream@^4.0.4",
     "readable-stream-2@^2.3.3": "npm:readable-stream@^2.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -39855,21 +39855,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"serialize-javascript@npm:6.0.0":
-  version: 6.0.0
-  resolution: "serialize-javascript@npm:6.0.0"
-  dependencies:
-    randombytes: "npm:^2.1.0"
-  checksum: 10/ed3dabfbb565c48c9eb1ca8fe58f0d256902ab70a8a605be634ddd68388d5f728bb0bd1268e94fab628748ba8ad8392f01b05f3cbe1e4878b5c58c669fd3d1b4
-  languageName: node
-  linkType: hard
-
-"serialize-javascript@npm:^6.0.2":
-  version: 6.0.2
-  resolution: "serialize-javascript@npm:6.0.2"
-  dependencies:
-    randombytes: "npm:^2.1.0"
-  checksum: 10/445a420a6fa2eaee4b70cbd884d538e259ab278200a2ededd73253ada17d5d48e91fb1f4cd224a236ab62ea7ba0a70c6af29fc93b4f3d3078bf7da1c031fde58
+"serialize-javascript@npm:7.0.3":
+  version: 7.0.3
+  resolution: "serialize-javascript@npm:7.0.3"
+  checksum: 10/ce45e28663ee1fa6f32c408c0a563c4a96e872cdc83dc3064c73126f2412048c6c984bfc1160c40188fcfa06cf5e075f5cc2e3261b0384dc8fdef34675c5adef
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

`serialize-javascript` `6.0.2` has a CVE (https://github.com/advisories/GHSA-5c6j-r48x-rmvq). This PR force-upgrades all resolutions to `serialize-javascript@7.0.3`.

This is a transitive dependency update only. The major bump is acceptable here because the breaking change from 6 to 7 was dropping Node 20 support, and this repo is currently on Node `v24.13` via `.nvmrc`.

- Added a root `resolutions` override to force `serialize-javascript` to `7.0.3`
- Added a temporary `.yarnrc.yml` minimal-age-gate bypass for `serialize-javascript` with a removal note
- Regenerated `yarn.lock` so prior `6.0.0`/`6.0.2` entries are replaced by `7.0.3`

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40511?quickstart=1)

## **Changelog**

CHANGELOG entry: null
<!--
## **Related issues**

Fixes:


## **Manual testing steps**

1. Run `yarn install`.
2. Run `yarn dedupe` and verify no additional dedupe changes are required.
3. Run `yarn audit` and verify no audit suggestions are reported.
4. Run `yarn why serialize-javascript` and verify all paths resolve to `7.0.3`.

## **Screenshots/Recordings**


### **Before**


### **After**

-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Forces a major-version upgrade of a widely used transitive dependency and updates LavaMoat webpack policies/globals, which could cause build/test-time compatibility issues despite no runtime feature changes.
> 
> **Overview**
> Upgrades the transitive `serialize-javascript` dependency by adding a root `resolutions` pin to `7.0.3` (addressing the reported CVE) and regenerates `yarn.lock` to remove older `6.x` entries.
> 
> Updates Yarn and LavaMoat configuration to accommodate the new dependency graph: adds a temporary `npmPreapprovedPackages` age-gate bypass for `serialize-javascript`, and adjusts `lavamoat/webpack` policy files to allow `crypto.getRandomValues` and include the new `mocha>serialize-javascript` path (removing the prior `crypto-browserify>randombytes` allowance).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da6e826a2f1e7c842af09a226d63a39aff78a0ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


