### PR TITLE
feat: enable metamask pay in dapps via feature flag

### DIFF
--- a/builds.yml
+++ b/builds.yml
@@ -445,5 +445,3 @@ env:
   # Authentication (Backup & Sync, Profile metrics...)
   - FORCE_AUTH_MATCH_BUILD: false
 
-  # Enable MetaMask Pay in dApp transaction confirmations
-  - MM_PAY_DAPPS_ENABLED: false

--- a/builds.yml
+++ b/builds.yml
@@ -444,4 +444,3 @@ env:
 
   # Authentication (Backup & Sync, Profile metrics...)
   - FORCE_AUTH_MATCH_BUILD: false
-

--- a/package.json
+++ b/package.json
@@ -314,7 +314,7 @@
     "@metamask/design-system-react": "^0.9.0",
     "@metamask/design-system-tailwind-preset": "^0.6.1",
     "@metamask/design-tokens": "^8.2.2",
-    "@metamask/eip-5792-middleware": "^2.1.0",
+    "@metamask/eip-5792-middleware": "3.0.0",
     "@metamask/eip-7702-internal-rpc-middleware": "^0.1.0",
     "@metamask/ens-controller": "^18.0.0",
     "@metamask/ens-resolver-snap": "^1.1.0",

--- a/ui/pages/confirmations/components/confirm/info/shared/gas-fees-section/gas-fees-section.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-fees-section/gas-fees-section.test.tsx
@@ -18,6 +18,7 @@ jest.mock('../../../../../../../store/actions', () => ({
 }));
 
 jest.mock('../../../../../hooks/pay/useTransactionPayData', () => ({
+  ...jest.requireActual('../../../../../hooks/pay/useTransactionPayData'),
   useTransactionPaySourceAmounts: jest.fn(),
 }));
 

--- a/ui/pages/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/ui/pages/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -194,7 +194,9 @@ function CenterContainer({
             <PayTokenAmount amountHuman={amountHuman} disabled={!hasTokens} />
           )}
           {children}
-          {disablePay !== true && hasTokens && <PayWithRow />}
+          {disablePay !== true && hasTokens && (
+            <PayWithRow variant={ConfirmInfoRowSize.Small} />
+          )}
         </Box>
       )}
 

--- a/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.stories.tsx
+++ b/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.stories.tsx
@@ -12,6 +12,7 @@ import {
 } from '../../../../../../test/data/confirmations/contract-interaction';
 import { ApprovalType } from '@metamask/controller-utils';
 
+import { ConfirmInfoRowSize } from '../../../../../components/app/confirm/info/row/row';
 import { PayWithRow, PayWithRowSkeleton } from './pay-with-row';
 
 const CHAIN_ID_MOCK = '0x5';
@@ -117,6 +118,11 @@ export default Story;
 export const DefaultStory = () => <PayWithRow />;
 DefaultStory.storyName = 'Default';
 
+export const SmallStory = () => (
+  <PayWithRow variant={ConfirmInfoRowSize.Small} />
+);
+SmallStory.storyName = 'Small';
+
 export const SkeletonStory = () => <PayWithRowSkeleton />;
 SkeletonStory.storyName = 'Skeleton';
 
@@ -130,4 +136,4 @@ export const LoadingStory = () => {
     </Provider>
   );
 };
-LoadingStory.storyName = 'Loading (No Payment Token)';
+LoadingStory.storyName = 'Loading';

--- a/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
+++ b/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
@@ -182,7 +182,7 @@ describe('PayWithRow', () => {
 
     expect(screen.queryByTestId('pay-with-modal')).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByTestId('pay-with-row'));
+    fireEvent.click(screen.getByTestId('pay-with-pill'));
 
     expect(screen.getByTestId('pay-with-modal')).toBeInTheDocument();
   });
@@ -191,7 +191,7 @@ describe('PayWithRow', () => {
     const store = mockStore(getMockState());
     renderWithProvider(<PayWithRow />, store);
 
-    fireEvent.click(screen.getByTestId('pay-with-row'));
+    fireEvent.click(screen.getByTestId('pay-with-pill'));
     expect(screen.getByTestId('pay-with-modal')).toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId('close-modal'));
@@ -233,35 +233,19 @@ describe('PayWithRow', () => {
     const store = mockStore(getMockState());
     renderWithProvider(<PayWithRow />, store);
 
-    fireEvent.click(screen.getByTestId('pay-with-row'));
+    fireEvent.click(screen.getByTestId('pay-with-pill'));
 
     expect(screen.queryByTestId('pay-with-modal')).not.toBeInTheDocument();
   });
 
-  describe('Default variant', () => {
-    it('renders default pill container', () => {
+  describe('Default variant (inline row with pill selector)', () => {
+    it('renders row with symbol in pill', () => {
       const store = mockStore(getMockState());
       renderWithProvider(<PayWithRow />, store);
 
       expect(screen.getByTestId('pay-with-row')).toBeInTheDocument();
-    });
-
-    it('renders balance display', () => {
-      const store = mockStore(getMockState());
-      renderWithProvider(<PayWithRow />, store);
-
-      expect(screen.getByTestId('pay-with-balance')).toHaveTextContent(
-        '$150.00',
-      );
-    });
-
-    it('renders pay with text inside symbol text', () => {
-      const store = mockStore(getMockState());
-      renderWithProvider(<PayWithRow />, store);
-
-      expect(screen.getByTestId('pay-with-symbol')).toHaveTextContent(
-        'Pay with ETH',
-      );
+      expect(screen.getByTestId('pay-with-pill')).toBeInTheDocument();
+      expect(screen.getByTestId('pay-with-symbol')).toHaveTextContent('ETH');
     });
 
     it('shows arrow icon when editable', () => {
@@ -281,18 +265,8 @@ describe('PayWithRow', () => {
     });
   });
 
-  describe('Small variant', () => {
-    it('renders balance display', () => {
-      const store = mockStore(getMockState());
-      renderWithProvider(
-        <PayWithRow variant={ConfirmInfoRowSize.Small} />,
-        store,
-      );
-
-      expect(screen.getByTestId('pay-with-balance')).toBeInTheDocument();
-    });
-
-    it('does not render pill element', () => {
+  describe('Small variant (pill)', () => {
+    it('renders pill container', () => {
       const store = mockStore(getMockState());
       renderWithProvider(
         <PayWithRow variant={ConfirmInfoRowSize.Small} />,
@@ -300,7 +274,52 @@ describe('PayWithRow', () => {
       );
 
       expect(screen.getByTestId('pay-with-row')).toBeInTheDocument();
-      expect(screen.getByTestId('pay-with-symbol')).toHaveTextContent('ETH');
+    });
+
+    it('renders balance display', () => {
+      const store = mockStore(getMockState());
+      renderWithProvider(
+        <PayWithRow variant={ConfirmInfoRowSize.Small} />,
+        store,
+      );
+
+      expect(screen.getByTestId('pay-with-balance')).toHaveTextContent(
+        '$150.00',
+      );
+    });
+
+    it('renders pay with text inside symbol text', () => {
+      const store = mockStore(getMockState());
+      renderWithProvider(
+        <PayWithRow variant={ConfirmInfoRowSize.Small} />,
+        store,
+      );
+
+      expect(screen.getByTestId('pay-with-symbol')).toHaveTextContent(
+        'Pay with ETH',
+      );
+    });
+
+    it('shows arrow icon when editable', () => {
+      const store = mockStore(getMockState());
+      renderWithProvider(
+        <PayWithRow variant={ConfirmInfoRowSize.Small} />,
+        store,
+      );
+
+      expect(screen.getByTestId('pay-with-arrow')).toBeInTheDocument();
+    });
+
+    it('hides arrow icon for hardware account', () => {
+      isHardwareAccountMock.mockReturnValue(true);
+
+      const store = mockStore(getMockState());
+      renderWithProvider(
+        <PayWithRow variant={ConfirmInfoRowSize.Small} />,
+        store,
+      );
+
+      expect(screen.queryByTestId('pay-with-arrow')).not.toBeInTheDocument();
     });
   });
 });

--- a/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.tsx
+++ b/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.tsx
@@ -12,10 +12,9 @@ import {
   Text,
 } from '../../../../../components/component-library';
 import { Skeleton } from '../../../../../components/component-library/skeleton';
-import {
-  ConfirmInfoRow,
-  ConfirmInfoRowSize,
-} from '../../../../../components/app/confirm/info/row/row';
+import { ConfirmInfoRowSize } from '../../../../../components/app/confirm/info/row/row';
+import { ConfirmInfoAlertRow } from '../../../../../components/app/confirm/info/row/alert-row/alert-row';
+import { RowAlertKey } from '../../../../../components/app/confirm/info/row/constants';
 import {
   AlignItems,
   BackgroundColor,
@@ -51,7 +50,7 @@ type PayWithRowContentProps = {
   onOpenModal: () => void;
 };
 
-type PayWithRowSmallProps = PayWithRowContentProps & {
+type PayWithRowPillProps = PayWithRowContentProps & {
   balanceUsdFormatted: string;
 };
 
@@ -142,81 +141,85 @@ export function PayWithRow({
         <PayWithModal isOpen={isModalOpen} onClose={handleCloseModal} />
       )}
       {isSmall ? (
-        <PayWithRowSmall
+        <PayWithRowPill
           {...contentProps}
           balanceUsdFormatted={balanceUsdFormatted}
         />
       ) : (
-        <PayWithRowDefault
+        <PayWithRowInline
           {...contentProps}
-          balanceUsdFormatted={balanceUsdFormatted}
+          ownerId={currentConfirmation?.id ?? ''}
         />
       )}
     </>
   );
 }
 
-function PayWithRowSmall({
+function PayWithRowInline({
   displayToken,
-  balanceUsdFormatted,
   canEdit,
   from,
   onOpenModal,
-}: PayWithRowSmallProps) {
+  ownerId,
+}: PayWithRowContentProps & { ownerId: string }) {
   const t = useI18nContext();
 
   return (
-    <ConfirmInfoRow
+    <ConfirmInfoAlertRow
+      alertKey={RowAlertKey.PayWith}
+      ownerId={ownerId}
       data-testid="pay-with-row"
       label={t('payWith')}
-      rowVariant={ConfirmInfoRowSize.Small}
+      rowVariant={ConfirmInfoRowSize.Default}
     >
       <Box
-        display={Display.Flex}
-        flexDirection={FlexDirection.Row}
-        alignItems={AlignItems.center}
-        gap={2}
+        data-testid="pay-with-pill"
         onClick={canEdit ? onOpenModal : undefined}
-        style={{ cursor: canEdit ? 'pointer' : 'default' }}
+        backgroundColor={
+          canEdit
+            ? BackgroundColor.backgroundMuted
+            : BackgroundColor.transparent
+        }
+        borderRadius={BorderRadius.pill}
+        display={Display.InlineFlex}
+        alignItems={AlignItems.center}
+        gap={1}
+        style={{
+          cursor: canEdit ? 'pointer' : 'default',
+          padding: canEdit ? '4px 8px' : '0px',
+        }}
       >
-        <TokenIcon
-          chainId={displayToken.chainId as `0x${string}`}
-          tokenAddress={displayToken.address as `0x${string}`}
-          size="sm"
-        />
-        <Text
-          variant={TextVariant.bodyMd}
-          color={TextColor.textDefault}
-          data-testid="pay-with-symbol"
+        <Box
+          display={Display.Flex}
+          alignItems={AlignItems.center}
+          marginRight={1}
         >
-          {displayToken.symbol}
-        </Text>
-        <Text
-          variant={TextVariant.bodyMd}
-          color={TextColor.textAlternative}
-          data-testid="pay-with-balance"
-        >
-          {balanceUsdFormatted}
-        </Text>
+          <TokenIcon
+            chainId={displayToken.chainId as `0x${string}`}
+            tokenAddress={displayToken.address as `0x${string}`}
+            size="xs"
+          />
+        </Box>
+        <Text data-testid="pay-with-symbol">{displayToken.symbol}</Text>
         {canEdit && from && (
           <Icon
+            data-testid="pay-with-arrow"
             name={IconName.ArrowDown}
             size={IconSize.Sm}
-            color={IconColor.iconAlternative}
           />
         )}
       </Box>
-    </ConfirmInfoRow>
+    </ConfirmInfoAlertRow>
   );
 }
 
-function PayWithRowDefault({
+function PayWithRowPill({
   displayToken,
   balanceUsdFormatted,
   canEdit,
   from,
   onOpenModal,
-}: PayWithRowContentProps & { balanceUsdFormatted: string }) {
+}: PayWithRowPillProps) {
   const t = useI18nContext();
 
   return (

--- a/ui/pages/confirmations/components/rows/transaction-pay-section/transaction-pay-section.test.tsx
+++ b/ui/pages/confirmations/components/rows/transaction-pay-section/transaction-pay-section.test.tsx
@@ -7,10 +7,12 @@ import {
   useTransactionPayRequiredTokens,
 } from '../../../hooks/pay/useTransactionPayData';
 import { useTransactionPayToken } from '../../../hooks/pay/useTransactionPayToken';
+import { selectIsMetaMaskPayDappsEnabled } from '../../../selectors/feature-flags';
 import { TransactionPaySection } from './transaction-pay-section';
 
 jest.mock('../../../hooks/pay/useTransactionPayData');
 jest.mock('../../../hooks/pay/useTransactionPayToken');
+jest.mock('../../../selectors/feature-flags');
 
 jest.mock('../pay-with-row/pay-with-row', () => ({
   PayWithRow: () => <div data-testid="pay-with-row">PayWithRow</div>,
@@ -48,12 +50,11 @@ describe('TransactionPaySection', () => {
     useIsTransactionPayLoading,
   );
   const useTransactionPayTokenMock = jest.mocked(useTransactionPayToken);
-
-  const originalEnv = process.env;
+  const selectIsMetaMaskPayDappsEnabledMock = jest.mocked(selectIsMetaMaskPayDappsEnabled);
 
   beforeEach(() => {
     jest.resetAllMocks();
-    process.env = { ...originalEnv, MM_PAY_DAPPS_ENABLED: 'true' };
+    selectIsMetaMaskPayDappsEnabledMock.mockReturnValue(true);
 
     useTransactionPayRequiredTokensMock.mockReturnValue([]);
     useIsTransactionPayLoadingMock.mockReturnValue(false);
@@ -64,21 +65,8 @@ describe('TransactionPaySection', () => {
     });
   });
 
-  afterEach(() => {
-    process.env = originalEnv;
-  });
-
-  it('returns null when MM_PAY_DAPPS_ENABLED is not set', () => {
-    process.env = { ...originalEnv };
-    delete process.env.MM_PAY_DAPPS_ENABLED;
-
-    const { container } = render();
-
-    expect(container).toBeEmptyDOMElement();
-  });
-
-  it('returns null when MM_PAY_DAPPS_ENABLED is false', () => {
-    process.env = { ...originalEnv, MM_PAY_DAPPS_ENABLED: 'false' };
+  it('returns null when dappsEnabled feature flag is disabled', () => {
+    selectIsMetaMaskPayDappsEnabledMock.mockReturnValue(false);
 
     const { container } = render();
 

--- a/ui/pages/confirmations/components/rows/transaction-pay-section/transaction-pay-section.test.tsx
+++ b/ui/pages/confirmations/components/rows/transaction-pay-section/transaction-pay-section.test.tsx
@@ -50,7 +50,9 @@ describe('TransactionPaySection', () => {
     useIsTransactionPayLoading,
   );
   const useTransactionPayTokenMock = jest.mocked(useTransactionPayToken);
-  const selectIsMetaMaskPayDappsEnabledMock = jest.mocked(selectIsMetaMaskPayDappsEnabled);
+  const selectIsMetaMaskPayDappsEnabledMock = jest.mocked(
+    selectIsMetaMaskPayDappsEnabled,
+  );
 
   beforeEach(() => {
     jest.resetAllMocks();

--- a/ui/pages/confirmations/components/rows/transaction-pay-section/transaction-pay-section.tsx
+++ b/ui/pages/confirmations/components/rows/transaction-pay-section/transaction-pay-section.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 import { ConfirmInfoSection } from '../../../../../components/app/confirm/info/row/section';
 import {
   useIsTransactionPayLoading,
@@ -9,13 +10,16 @@ import { PayWithRow } from '../pay-with-row/pay-with-row';
 import { BridgeFeeRow } from '../bridge-fee-row/bridge-fee-row';
 import { TotalRow } from '../total-row/total-row';
 import { RequiredTokensRow } from '../required-tokens-row';
+import { selectIsMetaMaskPayDappsEnabled } from '../../../selectors/feature-flags';
 
 export const TransactionPaySection = () => {
   const requiredTokens = useTransactionPayRequiredTokens();
   const isLoading = useIsTransactionPayLoading();
   const { payToken } = useTransactionPayToken();
 
-  if (!process.env.MM_PAY_DAPPS_ENABLED) {
+  const isPayDappsEnabled = useSelector(selectIsMetaMaskPayDappsEnabled);
+
+  if (!isPayDappsEnabled) {
     return null;
   }
 

--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.test.ts
@@ -9,11 +9,16 @@ import { getMockConfirmState } from '../../../../../../test/data/confirmations/h
 import { genUnapprovedContractInteractionConfirmation } from '../../../../../../test/data/confirmations/contract-interaction';
 import { renderHookWithConfirmContextProvider } from '../../../../../../test/lib/confirmations/render-helpers';
 import { useIsGaslessSupported } from '../../gas/useIsGaslessSupported';
+import { useTransactionPayHasSourceAmount } from '../../pay/useTransactionPayHasSourceAmount';
 import { useInsufficientBalanceAlerts } from './useInsufficientBalanceAlerts';
 
 jest.mock('../../gas/useIsGaslessSupported');
+jest.mock('../../pay/useTransactionPayHasSourceAmount');
 
 const useIsGaslessSupportedMock = jest.mocked(useIsGaslessSupported);
+const useTransactionPayHasSourceAmountMock = jest.mocked(
+  useTransactionPayHasSourceAmount,
+);
 
 const TRANSACTION_ID_MOCK = '123-456';
 const TRANSACTION_ID_MOCK_2 = '456-789';
@@ -109,6 +114,7 @@ describe('useInsufficientBalanceAlerts', () => {
       isSupported: false,
       pending: false,
     });
+    useTransactionPayHasSourceAmountMock.mockReturnValue(false);
   });
 
   it('returns no alerts if no confirmation', () => {
@@ -132,6 +138,18 @@ describe('useInsufficientBalanceAlerts', () => {
         ...TRANSACTION_MOCK,
         isGasFeeSponsored: true,
       },
+    });
+
+    expect(alerts).toEqual([]);
+  });
+
+  it('returns no alerts if pay quote is being used', () => {
+    useTransactionPayHasSourceAmountMock.mockReturnValue(true);
+
+    const alerts = runHook({
+      balance: 7,
+      currentConfirmation: TRANSACTION_MOCK,
+      transaction: TRANSACTION_MOCK,
     });
 
     expect(alerts).toEqual([]);

--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.ts
@@ -14,6 +14,7 @@ import { getUseTransactionSimulations } from '../../../../../selectors';
 import { useConfirmContext } from '../../../context/confirm';
 import { useIsGaslessSupported } from '../../gas/useIsGaslessSupported';
 import { useHasInsufficientBalance } from '../../useHasInsufficientBalance';
+import { useTransactionPayHasSourceAmount } from '../../pay/useTransactionPayHasSourceAmount';
 
 export function useInsufficientBalanceAlerts({
   ignoreGasFeeToken,
@@ -31,6 +32,8 @@ export function useInsufficientBalanceAlerts({
     isSupported: isGaslessSupported,
     pending: isGaslessSupportedPending,
   } = useIsGaslessSupported();
+
+  const isUsingPay = useTransactionPayHasSourceAmount();
 
   const isGasFeeTokensEmpty = gasFeeTokens?.length === 0;
 
@@ -58,6 +61,7 @@ export function useInsufficientBalanceAlerts({
 
   const showAlert =
     hasInsufficientBalance &&
+    !isUsingPay &&
     isSimulationComplete &&
     hasNoGasFeeTokenSelected &&
     shouldCheckGaslessConditions &&

--- a/ui/pages/confirmations/hooks/pay/useTransactionPayHasSourceAmount.test.ts
+++ b/ui/pages/confirmations/hooks/pay/useTransactionPayHasSourceAmount.test.ts
@@ -1,0 +1,71 @@
+import { renderHook } from '@testing-library/react-hooks';
+import {
+  useTransactionPaySourceAmounts,
+  useTransactionPayRequiredTokens,
+} from './useTransactionPayData';
+import { useTransactionPayHasSourceAmount } from './useTransactionPayHasSourceAmount';
+
+jest.mock('./useTransactionPayData');
+
+const useTransactionPaySourceAmountsMock = jest.mocked(
+  useTransactionPaySourceAmounts,
+);
+const useTransactionPayRequiredTokensMock = jest.mocked(
+  useTransactionPayRequiredTokens,
+);
+
+describe('useTransactionPayHasSourceAmount', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    useTransactionPaySourceAmountsMock.mockReturnValue(undefined);
+    useTransactionPayRequiredTokensMock.mockReturnValue([]);
+  });
+
+  it('returns false when sourceAmounts is undefined', () => {
+    const { result } = renderHook(() => useTransactionPayHasSourceAmount());
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false when sourceAmounts is empty', () => {
+    useTransactionPaySourceAmountsMock.mockReturnValue([] as never);
+
+    const { result } = renderHook(() => useTransactionPayHasSourceAmount());
+    expect(result.current).toBe(false);
+  });
+
+  it('returns true when sourceAmount matches a required token', () => {
+    useTransactionPaySourceAmountsMock.mockReturnValue([
+      { targetTokenAddress: '0xABC' },
+    ] as never);
+    useTransactionPayRequiredTokensMock.mockReturnValue([
+      { address: '0xabc', skipIfBalance: false },
+    ] as never);
+
+    const { result } = renderHook(() => useTransactionPayHasSourceAmount());
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false when sourceAmount matches a required token with skipIfBalance', () => {
+    useTransactionPaySourceAmountsMock.mockReturnValue([
+      { targetTokenAddress: '0xABC' },
+    ] as never);
+    useTransactionPayRequiredTokensMock.mockReturnValue([
+      { address: '0xabc', skipIfBalance: true },
+    ] as never);
+
+    const { result } = renderHook(() => useTransactionPayHasSourceAmount());
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false when sourceAmount does not match any required token', () => {
+    useTransactionPaySourceAmountsMock.mockReturnValue([
+      { targetTokenAddress: '0xDEF' },
+    ] as never);
+    useTransactionPayRequiredTokensMock.mockReturnValue([
+      { address: '0xabc', skipIfBalance: false },
+    ] as never);
+
+    const { result } = renderHook(() => useTransactionPayHasSourceAmount());
+    expect(result.current).toBe(false);
+  });
+});

--- a/ui/pages/confirmations/hooks/pay/useTransactionPayHasSourceAmount.ts
+++ b/ui/pages/confirmations/hooks/pay/useTransactionPayHasSourceAmount.ts
@@ -1,0 +1,22 @@
+import { useMemo } from 'react';
+import {
+  useTransactionPaySourceAmounts,
+  useTransactionPayRequiredTokens,
+} from './useTransactionPayData';
+
+export function useTransactionPayHasSourceAmount() {
+  const sourceAmounts = useTransactionPaySourceAmounts();
+  const requiredTokens = useTransactionPayRequiredTokens();
+
+  return useMemo(
+    () =>
+      sourceAmounts?.some((a) =>
+        requiredTokens.some(
+          (rt) =>
+            rt.address.toLowerCase() === a.targetTokenAddress.toLowerCase() &&
+            !rt.skipIfBalance,
+        ),
+      ) ?? false,
+    [sourceAmounts, requiredTokens],
+  );
+}

--- a/ui/pages/confirmations/selectors/feature-flags.test.ts
+++ b/ui/pages/confirmations/selectors/feature-flags.test.ts
@@ -1,0 +1,50 @@
+import { selectIsMetaMaskPayDappsEnabled } from './feature-flags';
+
+type MockState = {
+  metamask: {
+    remoteFeatureFlags: Record<string, unknown>;
+  };
+};
+
+const getMockState = (
+  confirmations_pay?: Record<string, unknown>,
+): MockState => ({
+  metamask: {
+    remoteFeatureFlags: {
+      ...(confirmations_pay !== undefined && { confirmations_pay }),
+    },
+  },
+});
+
+describe('Confirmations Pay Feature Flags', () => {
+  describe('selectIsMetaMaskPayDappsEnabled', () => {
+    it('returns true when dappsEnabled is true', () => {
+      const state = getMockState({ dappsEnabled: true });
+      expect(selectIsMetaMaskPayDappsEnabled(state)).toBe(true);
+    });
+
+    it('returns false when dappsEnabled is false', () => {
+      const state = getMockState({ dappsEnabled: false });
+      expect(selectIsMetaMaskPayDappsEnabled(state)).toBe(false);
+    });
+
+    it('defaults to false when confirmations_pay flag is not set', () => {
+      const state = getMockState();
+      expect(selectIsMetaMaskPayDappsEnabled(state)).toBe(false);
+    });
+
+    it('defaults to false when confirmations_pay is an empty object', () => {
+      const state = getMockState({});
+      expect(selectIsMetaMaskPayDappsEnabled(state)).toBe(false);
+    });
+
+    it('defaults to false when remoteFeatureFlags is empty', () => {
+      const state: MockState = {
+        metamask: {
+          remoteFeatureFlags: {},
+        },
+      };
+      expect(selectIsMetaMaskPayDappsEnabled(state)).toBe(false);
+    });
+  });
+});

--- a/ui/pages/confirmations/selectors/feature-flags.test.ts
+++ b/ui/pages/confirmations/selectors/feature-flags.test.ts
@@ -1,44 +1,48 @@
 /* eslint-disable @typescript-eslint/naming-convention, camelcase */
 import { selectIsMetaMaskPayDappsEnabled } from './feature-flags';
 
-type ConfirmationsPayFlag = {
-  dappsEnabled?: boolean;
+type ConfirmationsPayDappsFlag = {
+  enabled?: boolean;
 };
 
 type MockState = {
   metamask: {
     remoteFeatureFlags: {
-      confirmations_pay?: ConfirmationsPayFlag;
+      confirmations_pay_dapps?: ConfirmationsPayDappsFlag;
     };
   };
 };
 
-const getMockState = (confirmations_pay?: ConfirmationsPayFlag): MockState => ({
+const getMockState = (
+  confirmations_pay_dapps?: ConfirmationsPayDappsFlag,
+): MockState => ({
   metamask: {
     remoteFeatureFlags: {
-      ...(confirmations_pay !== undefined && { confirmations_pay }),
+      ...(confirmations_pay_dapps !== undefined && {
+        confirmations_pay_dapps,
+      }),
     },
   },
 });
 
 describe('Confirmations Pay Feature Flags', () => {
   describe('selectIsMetaMaskPayDappsEnabled', () => {
-    it('returns true when dappsEnabled is true', () => {
-      const state = getMockState({ dappsEnabled: true });
+    it('returns true when enabled is true', () => {
+      const state = getMockState({ enabled: true });
       expect(selectIsMetaMaskPayDappsEnabled(state)).toBe(true);
     });
 
-    it('returns false when dappsEnabled is false', () => {
-      const state = getMockState({ dappsEnabled: false });
+    it('returns false when enabled is false', () => {
+      const state = getMockState({ enabled: false });
       expect(selectIsMetaMaskPayDappsEnabled(state)).toBe(false);
     });
 
-    it('defaults to false when confirmations_pay flag is not set', () => {
+    it('defaults to false when confirmations_pay_dapps is not set', () => {
       const state = getMockState();
       expect(selectIsMetaMaskPayDappsEnabled(state)).toBe(false);
     });
 
-    it('defaults to false when confirmations_pay is an empty object', () => {
+    it('defaults to false when confirmations_pay_dapps is an empty object', () => {
       const state = getMockState({});
       expect(selectIsMetaMaskPayDappsEnabled(state)).toBe(false);
     });

--- a/ui/pages/confirmations/selectors/feature-flags.test.ts
+++ b/ui/pages/confirmations/selectors/feature-flags.test.ts
@@ -1,14 +1,19 @@
+/* eslint-disable @typescript-eslint/naming-convention, camelcase */
 import { selectIsMetaMaskPayDappsEnabled } from './feature-flags';
+
+type ConfirmationsPayFlag = {
+  dappsEnabled?: boolean;
+};
 
 type MockState = {
   metamask: {
-    remoteFeatureFlags: Record<string, unknown>;
+    remoteFeatureFlags: {
+      confirmations_pay?: ConfirmationsPayFlag;
+    };
   };
 };
 
-const getMockState = (
-  confirmations_pay?: Record<string, unknown>,
-): MockState => ({
+const getMockState = (confirmations_pay?: ConfirmationsPayFlag): MockState => ({
   metamask: {
     remoteFeatureFlags: {
       ...(confirmations_pay !== undefined && { confirmations_pay }),

--- a/ui/pages/confirmations/selectors/feature-flags.ts
+++ b/ui/pages/confirmations/selectors/feature-flags.ts
@@ -8,6 +8,7 @@ type ConfirmationsPayFeatureFlags = {
 const selectConfirmationsPayFeatureFlags = createSelector(
   getRemoteFeatureFlags,
   (flags) =>
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     (flags as unknown as { confirmations_pay?: ConfirmationsPayFeatureFlags })
       .confirmations_pay,
 );

--- a/ui/pages/confirmations/selectors/feature-flags.ts
+++ b/ui/pages/confirmations/selectors/feature-flags.ts
@@ -1,0 +1,18 @@
+import { createSelector } from 'reselect';
+import { getRemoteFeatureFlags } from '../../../selectors/remote-feature-flags';
+
+type ConfirmationsPayFeatureFlags = {
+  dappsEnabled?: boolean;
+};
+
+const selectConfirmationsPayFeatureFlags = createSelector(
+  getRemoteFeatureFlags,
+  (flags) =>
+    (flags as unknown as { confirmations_pay?: ConfirmationsPayFeatureFlags })
+      .confirmations_pay,
+);
+
+export const selectIsMetaMaskPayDappsEnabled = createSelector(
+  selectConfirmationsPayFeatureFlags,
+  (flags): boolean => flags?.dappsEnabled ?? false,
+);

--- a/ui/pages/confirmations/selectors/feature-flags.ts
+++ b/ui/pages/confirmations/selectors/feature-flags.ts
@@ -1,19 +1,23 @@
 import { createSelector } from 'reselect';
 import { getRemoteFeatureFlags } from '../../../selectors/remote-feature-flags';
 
-type ConfirmationsPayFeatureFlags = {
-  dappsEnabled?: boolean;
+type ConfirmationsPayDappsFlag = {
+  enabled?: boolean;
 };
 
-const selectConfirmationsPayFeatureFlags = createSelector(
+const selectConfirmationsPayDappsFlag = createSelector(
   getRemoteFeatureFlags,
   (flags) =>
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    (flags as unknown as { confirmations_pay?: ConfirmationsPayFeatureFlags })
-      .confirmations_pay,
+    /* eslint-disable @typescript-eslint/naming-convention */
+    (
+      flags as unknown as {
+        confirmations_pay_dapps?: ConfirmationsPayDappsFlag;
+      }
+    ).confirmations_pay_dapps,
+  /* eslint-enable @typescript-eslint/naming-convention */
 );
 
 export const selectIsMetaMaskPayDappsEnabled = createSelector(
-  selectConfirmationsPayFeatureFlags,
-  (flags): boolean => flags?.dappsEnabled ?? false,
+  selectConfirmationsPayDappsFlag,
+  (flag): boolean => flag?.enabled ?? false,
 );

--- a/ui/pages/confirmations/utils/transaction-pay.test.ts
+++ b/ui/pages/confirmations/utils/transaction-pay.test.ts
@@ -264,10 +264,14 @@ describe('transaction-pay utils', () => {
   });
 
   describe('getAvailableTokens', () => {
-    it('filters out non-ERC20 tokens', () => {
+    it('filters out NFT tokens but keeps native and ERC20', () => {
       const tokens = [
-        createMockAsset({ standard: AssetStandard.Native }),
+        createMockAsset({
+          standard: AssetStandard.Native,
+          address: '0xnative',
+        }),
         createMockAsset({ standard: AssetStandard.ERC721 }),
+        createMockAsset({ standard: AssetStandard.ERC1155 }),
         createMockAsset({
           standard: AssetStandard.ERC20,
           address: TOKEN_ADDRESS_MOCK,
@@ -276,8 +280,11 @@ describe('transaction-pay utils', () => {
 
       const result = getAvailableTokens({ tokens });
 
-      expect(result).toHaveLength(1);
-      expect(result[0].address).toBe(TOKEN_ADDRESS_MOCK);
+      expect(result).toHaveLength(2);
+      expect(result.map((t) => t.address)).toStrictEqual([
+        '0xnative',
+        TOKEN_ADDRESS_MOCK,
+      ]);
     });
 
     it('filters out tokens without eip155 account type', () => {

--- a/ui/pages/confirmations/utils/transaction-pay.ts
+++ b/ui/pages/confirmations/utils/transaction-pay.ts
@@ -91,7 +91,8 @@ export function getAvailableTokens({
   return tokens
     .filter((token) => {
       if (
-        token.standard !== AssetStandard.ERC20 ||
+        (token.standard !== AssetStandard.ERC20 &&
+          token.standard !== AssetStandard.Native) ||
         !token.accountType?.includes('eip155')
       ) {
         return false;

--- a/ui/selectors/activity.ts
+++ b/ui/selectors/activity.ts
@@ -49,12 +49,15 @@ export const selectLocalTransactions = createSelector(
     const selectedAddress = selectedAccount.address.toLowerCase();
 
     const filtered = (transactions ?? []).filter((tx) => {
-      const passesSenderAndTypeGate = isFromSelectedAccount(
-        tx,
-        selectedAddress,
-      );
+      const hasNonce = tx.txParams?.nonce !== undefined;
 
-      if (!passesSenderAndTypeGate) {
+      // Ensure any externally signed transactions are always included.
+      // Such as EIP-7702 gas station and MetaMask Pay.
+      if (!hasNonce) {
+        return true;
+      }
+
+      if (!isFromSelectedAccount(tx, selectedAddress)) {
         return false;
       }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6020,17 +6020,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eip-5792-middleware@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "@metamask/eip-5792-middleware@npm:2.1.0"
+"@metamask/eip-5792-middleware@npm:3.0.0":
+  version: 3.0.0
+  resolution: "@metamask/eip-5792-middleware@npm:3.0.0"
   dependencies:
     "@metamask/messenger": "npm:^0.3.0"
     "@metamask/superstruct": "npm:^3.1.0"
-    "@metamask/transaction-controller": "npm:^62.7.0"
-    "@metamask/utils": "npm:^11.8.1"
+    "@metamask/transaction-controller": "npm:^62.19.0"
+    "@metamask/utils": "npm:^11.9.0"
     lodash: "npm:^4.17.21"
     uuid: "npm:^8.3.2"
-  checksum: 10/18080c435b920302146df7694a1ab1f9b1a95ae92737d4601aceb5897b94cf481cc8e13946b54c4a9dd2bc2a67b7139d566f55647a4627b8b64edb732691893e
+  checksum: 10/4f78454c4346434d597d58e66813b2d0a066d71f01346c5fc85490b3d9e1fe0823b009f1f394b0037781deaccbc8203042b698d76fd91e306159f5ae0efbb039
   languageName: node
   linkType: hard
 
@@ -32957,7 +32957,7 @@ __metadata:
     "@metamask/design-system-react": "npm:^0.9.0"
     "@metamask/design-system-tailwind-preset": "npm:^0.6.1"
     "@metamask/design-tokens": "npm:^8.2.2"
-    "@metamask/eip-5792-middleware": "npm:^2.1.0"
+    "@metamask/eip-5792-middleware": "npm:3.0.0"
     "@metamask/eip-7702-internal-rpc-middleware": "npm:^0.1.0"
     "@metamask/ens-controller": "npm:^18.0.0"
     "@metamask/ens-resolver-snap": "npm:^1.1.0"


### PR DESCRIPTION
## **Description**

Replace the `MM_PAY_DAPPS_ENABLED` build-time environment variable with a `enabled` property under the `confirmations_pay_dapps` remote feature flag (defaults to `false`).

- Fix layouts for both variants of `PayWithRow`.
- Ignore insufficient balance alert if using MetaMask Pay.
- Ensure MetaMask Pay transactions visible in new activity list.
- Include native tokens in `PayWithModal`.
- Bump `eip-5792-middleware`.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40514?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

<img width="369" height="104" alt="dApp" src="https://github.com/user-attachments/assets/16f0eaf4-a8e4-4f78-a576-b99108e17a6e" />

<img width="306" height="244" alt="Internal" src="https://github.com/user-attachments/assets/0daa472f-4bd2-499c-8aa6-bb2ce5b7a269" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes feature gating and several confirmation/activity behaviors, which could unintentionally hide/show MetaMask Pay UI or affect which transactions appear in activity. Mostly UI/selector logic with good test coverage, but it touches user-visible transaction lists and alert suppression.
> 
> **Overview**
> MetaMask Pay-in-dapps enablement is switched from a build-time env var (`MM_PAY_DAPPS_ENABLED`) to a remote feature flag (`remoteFeatureFlags.confirmations_pay_dapps.enabled`, defaulting to `false`), and `TransactionPaySection` now renders only when that selector is enabled.
> 
> `PayWithRow` is reworked to support two layouts (default inline row vs small pill), including updated click targets/test IDs and Storybook coverage, and `CustomAmountInfo` now uses the small variant.
> 
> Insufficient-balance alerts are suppressed when a Pay quote is being used (new `useTransactionPayHasSourceAmount` hook), available Pay tokens now include native assets (not just ERC20), and the activity selector always includes externally signed transactions (identified by missing `txParams.nonce`).
> 
> Dependency bump: `@metamask/eip-5792-middleware` is upgraded to `3.0.0` (with updated lockfile).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31f702104df57e8850cfc9485f4ad3e1dc0d35f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->