### PR TITLE
fix: use mouse-move click for three-dot menu to avoid notification badge overlap

### DIFF
--- a/test/e2e/page-objects/pages/header-navbar.ts
+++ b/test/e2e/page-objects/pages/header-navbar.ts
@@ -76,7 +76,7 @@ class HeaderNavbar {
   }
 
   async lockMetaMask(): Promise<void> {
-    await this.openThreeDotMenu();
+    await this.mouseClickOnThreeDotMenu();
     await this.driver.clickElement(this.lockMetaMaskButton);
     await this.driver.waitForSelector('[data-testid="unlock-password"]');
   }
@@ -88,20 +88,20 @@ class HeaderNavbar {
 
   async openAccountDetailsModalDetailsTab(): Promise<void> {
     console.log('Open account details modal');
-    await this.openThreeDotMenu();
+    await this.mouseClickOnThreeDotMenu();
     await this.driver.clickElement(this.openAccountDetailsButton);
     await this.driver.clickElementSafe(this.accountDetailsTab);
   }
 
   async openAccountDetailsModal(): Promise<void> {
     console.log('Open account details modal');
-    await this.openThreeDotMenu();
+    await this.mouseClickOnThreeDotMenu();
     await this.driver.clickElement(this.openAccountDetailsButton);
   }
 
   async openGlobalNetworksMenu(): Promise<void> {
     console.log('Open global menu');
-    await this.openThreeDotMenu();
+    await this.mouseClickOnThreeDotMenu();
     await this.driver.clickElement(this.globalNetworksMenu);
   }
 
@@ -116,7 +116,7 @@ class HeaderNavbar {
 
   async mouseClickOnThreeDotMenu(): Promise<void> {
     console.log('Clicking three dot menu using mouse move');
-    await this.driver.clickElementUsingMouseMove(this.threeDotMenuButton);
+    await this.driver.clickElementWithJs(this.threeDotMenuButton);
     await this.driver.waitForElementToStopMoving(this.drawerBackButton);
   }
 
@@ -137,7 +137,7 @@ class HeaderNavbar {
     skipSitesNavigation?: boolean;
   }): Promise<void> {
     console.log('Open permissions page in header navbar');
-    await this.openThreeDotMenu();
+    await this.mouseClickOnThreeDotMenu();
     await this.driver.clickElement(this.allPermissionsButton);
 
     // Check if we landed on Gator Permissions Page (intermediate page for Flask builds)
@@ -157,19 +157,19 @@ class HeaderNavbar {
 
   async openSnapListPage(): Promise<void> {
     console.log('Open account snap page');
-    await this.openThreeDotMenu();
+    await this.mouseClickOnThreeDotMenu();
     await this.driver.clickElement(this.accountSnapButton);
   }
 
   async openSettingsPage(): Promise<void> {
     console.log('Open settings page');
-    await this.openThreeDotMenu();
+    await this.mouseClickOnThreeDotMenu();
     await this.driver.clickElement(this.settingsButton);
   }
 
   async enableNotifications(): Promise<void> {
     console.log('Enabling notifications for the first time');
-    await this.openThreeDotMenu();
+    await this.mouseClickOnThreeDotMenu();
     await this.driver.clickElement(this.notificationsButton);
     await this.driver.clickElement(this.firstTimeTurnOnNotificationsButton);
   }

--- a/test/e2e/snaps/test-snap-get-locale.spec.js
+++ b/test/e2e/snaps/test-snap-get-locale.spec.js
@@ -107,7 +107,7 @@ describe('Test Snap Get Locale', function () {
         );
 
         // click on the global action menu
-        await driver.clickElement(
+        await driver.clickElementWithJs(
           '[data-testid="account-options-menu-button"]',
         );
 
@@ -139,7 +139,7 @@ describe('Test Snap Get Locale', function () {
           '.settings-page__header__title-container__close-button',
         );
         // click on the global action menu
-        await driver.clickElement(
+        await driver.clickElementWithJs(
           '[data-testid="account-options-menu-button"]',
         );
 

--- a/test/e2e/snaps/test-snap-management.spec.js
+++ b/test/e2e/snaps/test-snap-management.spec.js
@@ -68,7 +68,7 @@ describe('Test Snap Management', function () {
         );
 
         // click on the global action menu
-        await driver.clickElement(
+        await driver.clickElementWithJs(
           '[data-testid="account-options-menu-button"]',
         );
 
@@ -121,7 +121,7 @@ describe('Test Snap Management', function () {
         // we click on the notification icon on top of the account menu button
         // because the notification overlays the icon and this can cause ElementClickInterceptedError
 
-        await driver.clickElement(
+        await driver.clickElementWithJs(
           '[data-testid="account-options-menu-button"]',
         );
 

--- a/test/e2e/snaps/test-snap-metrics.spec.js
+++ b/test/e2e/snaps/test-snap-metrics.spec.js
@@ -557,7 +557,7 @@ describe('Test Snap Metrics', function () {
         await driver.waitForSelector(
           '[data-testid="account-options-menu-button"]',
         );
-        await driver.clickElement(
+        await driver.clickElementWithJs(
           '[data-testid="account-options-menu-button"]',
         );
 

--- a/test/e2e/snaps/test-snap-revoke-perm.spec.js
+++ b/test/e2e/snaps/test-snap-revoke-perm.spec.js
@@ -135,7 +135,7 @@ describe('Test Snap revoke permission', function () {
         await driver.delay(1000);
 
         // click on the global action menu
-        await driver.clickElement(
+        await driver.clickElementWithJs(
           '[data-testid="account-options-menu-button"]',
         );
 

--- a/test/e2e/tests/metrics/marketing-cookieid.spec.ts
+++ b/test/e2e/tests/metrics/marketing-cookieid.spec.ts
@@ -76,7 +76,7 @@ describe('Marketing cookieId', function (this: Suite) {
 
         const homePage = new HomePage(driver);
         await homePage.checkPageIsLoaded();
-        await homePage.headerNavbar.openThreeDotMenu();
+        await homePage.headerNavbar.mouseClickOnThreeDotMenu();
         const events = await getEventPayloads(
           driver,
           mockedEndpoints as MockedEndpoint[],
@@ -122,7 +122,7 @@ describe('Marketing cookieId', function (this: Suite) {
 
         const homePage = new HomePage(driver);
         await homePage.checkPageIsLoaded();
-        await homePage.headerNavbar.openThreeDotMenu();
+        await homePage.headerNavbar.mouseClickOnThreeDotMenu();
         const events = await getEventPayloads(
           driver,
           mockedEndpoints as MockedEndpoint[],
@@ -163,7 +163,7 @@ describe('Marketing cookieId', function (this: Suite) {
 
         const homePage = new HomePage(driver);
         await homePage.checkPageIsLoaded();
-        await homePage.headerNavbar.openThreeDotMenu();
+        await homePage.headerNavbar.mouseClickOnThreeDotMenu();
         const events = await getEventPayloads(
           driver,
           mockedEndpoints as MockedEndpoint[],

--- a/test/e2e/tests/ppom/ppom-toggle-settings.spec.js
+++ b/test/e2e/tests/ppom/ppom-toggle-settings.spec.js
@@ -21,7 +21,7 @@ describe('PPOM Settings', function () {
       async ({ driver }) => {
         await loginWithBalanceValidation(driver);
 
-        await driver.clickElement(
+        await driver.clickElementWithJs(
           '[data-testid="account-options-menu-button"]',
         );
 

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -885,6 +885,12 @@ class Driver {
       .perform();
   }
 
+  async clickElementWithJs(rawLocator) {
+    const element = await this.findClickableElement(rawLocator);
+    await this.scrollToElement(element);
+    await this.driver.executeScript('arguments[0].click()', element);
+  }
+
   /**
    * Simulates a click at the given x and y coordinates.
    *


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40517?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are confined to E2E test utilities and test code; the main risk is that JS-driven clicks could mask real UI clickability issues or change test behavior in edge cases.
> 
> **Overview**
> Improves E2E test stability when opening the header three-dot/account-options menu by routing more flows through `HeaderNavbar.mouseClickOnThreeDotMenu()` and updating several snap/metrics/PPOM tests to use `driver.clickElementWithJs()` instead of a standard Selenium click.
> 
> Adds `Driver.clickElementWithJs()` (DOM `arguments[0].click()` after ensuring the element is clickable/in view) to bypass `ElementClickInterceptedError` scenarios caused by overlaying UI (e.g., notification badge) during menu interactions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c744f78ad894ff6b8f3ec093b864a31e535b5fa0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->