### PR TITLE
fix: cp-13.21.0 hover network addresses divider styles

### DIFF
--- a/ui/components/multichain-accounts/multichain-address-rows-hovered-list/multichain-hovered-address-rows-hovered-list.tsx
+++ b/ui/components/multichain-accounts/multichain-address-rows-hovered-list/multichain-hovered-address-rows-hovered-list.tsx
@@ -107,7 +107,7 @@ const ViewAllButton = ({
     </Button>
   ) : (
     <>
-      <div className="my-1 -mx-4 border-t border-border-muted" />
+      <div className="my-1 -mx-1 border-t border-border-muted" />
       <Button
         size={ButtonSize.Sm}
         variant={ButtonVariant.Tertiary}


### PR DESCRIPTION


## **Description**

Tiny fix to the negative margin on the popover account list to render the divider style correctly. I think this wasn't previously caught because of the way that tailwind ignores styles if they are not already in the build, so during development with hot-reloading the new styles I was adding weren't necessarily getting reflected on the screen.

## **Changelog**

CHANGELOG entry: Fix account list popover divider style

## **Related issues**

Fixes:

## **Manual testing steps**

1. On the home page account hover popover component, check the divider style is full width to the popover container.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="759" height="497" alt="image" src="https://github.com/user-attachments/assets/c9d09b8f-7e71-4626-a868-17689c721921" />


### **After**

<img width="368" height="251" alt="image" src="https://github.com/user-attachments/assets/d2453ae9-8b90-450c-bc53-99e6914d05cd" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, CSS-only change that tweaks a Tailwind margin utility in a hover popover. Main risk is minor visual regression in the `MultichainHoveredAddressRowsList` divider width/alignment.
> 
> **Overview**
> Fixes the divider styling in the multichain account hover popover by adjusting the negative horizontal margin (`-mx-4` → `-mx-1`) for the separator above the tertiary "View All" button when default-address styles are not shown, so the divider renders correctly within the popover.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 085e474afeeddb08e16e50e06dc575ab5717343f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->