### PR TITLE
fix: broken tests due to a time dependent mock cp-13.21.0

### DIFF
--- a/test/e2e/page-objects/pages/header-navbar.ts
+++ b/test/e2e/page-objects/pages/header-navbar.ts
@@ -14,7 +14,7 @@ class HeaderNavbar {
   private readonly copyAddressButton = '[aria-label="Copy address"]';
 
   private readonly threeDotMenuButton =
-    '[data-testid="account-options-menu-button"]';
+    'button[data-testid="account-options-menu-button"]';
 
   private readonly accountSnapButton = { text: 'Snaps', tag: 'div' };
 
@@ -110,7 +110,7 @@ class HeaderNavbar {
     await this.driver.waitForSelector(this.threeDotMenuButton, {
       state: 'enabled',
     });
-    await this.driver.clickElement(this.threeDotMenuButton);
+    await this.driver.clickElementUsingMouseMove(this.threeDotMenuButton);
     await this.driver.waitForElementToStopMoving(this.drawerBackButton);
   }
 

--- a/test/e2e/page-objects/pages/header-navbar.ts
+++ b/test/e2e/page-objects/pages/header-navbar.ts
@@ -14,7 +14,7 @@ class HeaderNavbar {
   private readonly copyAddressButton = '[aria-label="Copy address"]';
 
   private readonly threeDotMenuButton =
-    'button[data-testid="account-options-menu-button"]';
+    '[data-testid="account-options-menu-button"]';
 
   private readonly accountSnapButton = { text: 'Snaps', tag: 'div' };
 

--- a/test/e2e/page-objects/pages/header-navbar.ts
+++ b/test/e2e/page-objects/pages/header-navbar.ts
@@ -110,7 +110,7 @@ class HeaderNavbar {
     await this.driver.waitForSelector(this.threeDotMenuButton, {
       state: 'enabled',
     });
-    await this.driver.clickElementUsingMouseMove(this.threeDotMenuButton);
+    await this.driver.clickElement(this.threeDotMenuButton);
     await this.driver.waitForElementToStopMoving(this.drawerBackButton);
   }
 

--- a/test/e2e/tests/notifications/mocks.ts
+++ b/test/e2e/tests/notifications/mocks.ts
@@ -87,11 +87,11 @@ const mockFeatureAnnouncementResponse = {
   ...getMockFeatureAnnouncementResponse(),
   url: /^https:\/\/cdn\.contentful\.com\/.*$/u,
 };
-const date = new Date();
-date.setMonth(date.getMonth() - 1);
+const FEATURE_ANNOUNCEMENT_EXPIRED_MS = 31 * 24 * 60 * 60 * 1000;
+const date = new Date(Date.now() - FEATURE_ANNOUNCEMENT_EXPIRED_MS);
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (mockFeatureAnnouncementResponse.response as any).items[0].sys.createdAt =
-  date.toString();
+  date.toISOString();
 
 export function getMockWalletNotificationItemId(trigger: TRIGGER_TYPES) {
   return (


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<p><a href="https://cursor.com/agents/bc-0768a871-8c86-57cd-9883-2aee620eba89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0768a871-8c86-57cd-9883-2aee620eba89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts E2E test mocks to avoid time-dependent failures, with no production code changes.
> 
> **Overview**
> Fixes flaky notification E2E tests by making the feature-announcement mock’s `sys.createdAt` explicitly *expired* using a fixed `31`-day offset from `Date.now()`.
> 
> Also switches the mocked timestamp from `date.toString()` to `date.toISOString()` to match expected API formatting more reliably.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c78bba2bfaffe00bcd4681187a076f147b7f7fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->