### PR TITLE
chore: bring back benchmark pipeline in release branch

### DIFF
--- a/.github/workflows/get-requirements.yml
+++ b/.github/workflows/get-requirements.yml
@@ -145,7 +145,7 @@ jobs:
       - name: Compute needs-benchmarks flag
         id: set-needs-benchmarks
         # Do not run benchmarks on a fork
-        if: ${{ env.IS_FORK == 'false' && (env.IS_RUN_EVERYTHING_BRANCH == 'true' || env.EVENT_NAME == 'pull_request') && steps.set-skip-everything.outputs.skip-everything != 'true' }}
+        if: ${{ env.IS_FORK == 'false' && steps.set-skip-everything.outputs.skip-everything != 'true' }}
         run: echo "needs-benchmarks=true" >> "$GITHUB_OUTPUT"
 
       - name: Compute needs-e2e flag

--- a/.github/workflows/get-requirements.yml
+++ b/.github/workflows/get-requirements.yml
@@ -144,8 +144,8 @@ jobs:
       # This is very simple right now, but is built to have future complexity
       - name: Compute needs-benchmarks flag
         id: set-needs-benchmarks
-        # Do not run benchmarks on a fork
-        if: ${{ env.IS_FORK == 'false' && steps.set-skip-everything.outputs.skip-everything != 'true' }}
+        # Do not run benchmarks on a fork or in the merge queue
+        if: ${{ env.IS_FORK == 'false' && env.EVENT_NAME != 'merge_group' && steps.set-skip-everything.outputs.skip-everything != 'true' }}
         run: echo "needs-benchmarks=true" >> "$GITHUB_OUTPUT"
 
       - name: Compute needs-e2e flag


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
[#39197](https://github.com/MetaMask/metamask-extension/pull/39197) introduced a centralized `get-requirements` workflow that decides which CI jobs to run. As part of that change, benchmarks were restricted to only `pull_request` events and the `main`/`stable` branches. This means benchmarks are skipped on release branch pushes, since those are `push` events on branches that aren't `main` or `stable`.

This PR removes that restriction so benchmark tests also run on release branches. Collecting benchmark data from release branches contributes to the performance dashboard and gives us real-server performance signals closer to what ships to users.


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40527?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[skip-e2e]
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk code-wise, but it changes CI behavior by enabling benchmark jobs on more events/branches, which may increase workflow duration and resource usage.
> 
> **Overview**
> Updates `get-requirements.yml` so the `needs-benchmarks` flag is set for any non-fork run that isn’t in the merge queue (and isn’t `skip-everything`), instead of only for `pull_request` events or `main`/`stable`.
> 
> This effectively re-enables benchmark jobs on release-branch `push` workflows while still skipping benchmarks for forks and `merge_group` events.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0176f997cd738ab6df611c6be1f8c635cec3a7d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->