### PR TITLE
chore: move claim CTA to cover token PCT change

### DIFF
--- a/ui/components/app/assets/token-cell/token-cell.tsx
+++ b/ui/components/app/assets/token-cell/token-cell.tsx
@@ -110,8 +110,7 @@ export default function TokenCell({
             privacyMode={privacyMode}
           />
         }
-        footerLeftDisplay={<TokenCellPercentChange token={displayToken} />}
-        footerRightDisplay={
+        footerLeftDisplay={
           hasClaimableReward ? (
             <ClaimBonusBadge
               tokenAddress={token.address as string}
@@ -120,11 +119,14 @@ export default function TokenCell({
               refetchRewards={refetchMerklRewards}
             />
           ) : (
-            <TokenCellPrimaryDisplay
-              token={displayToken}
-              privacyMode={privacyMode}
-            />
+            <TokenCellPercentChange token={displayToken} />
           )
+        }
+        footerRightDisplay={
+          <TokenCellPrimaryDisplay
+            token={displayToken}
+            privacyMode={privacyMode}
+          />
         }
       />
       {isEvm && showScamWarningModal && (


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40535?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Moved the Claim Bonus CTA to cover token percent change, rather than token quantity

## **Related issues**

Fixes: [MUSD-299](https://consensyssoftware.atlassian.net/browse/MUSD-299)

## **Manual testing steps**
1. Enabled the `earnMerklCampaignClaiming` feature flag
2. Navigate to an account with rewards to claim
3. Observe that claim CTA is correctly positioned and still functions as expected.


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="627" height="241" alt="Screenshot 2026-03-02 at 15 47 33" src="https://github.com/user-attachments/assets/901f5f25-3c09-49fa-9778-954ffad2e559" />


### **After**
<img width="603" height="221" alt="image" src="https://github.com/user-attachments/assets/64c72b52-9510-47c1-a0e9-c6c737b00ca6" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[MUSD-299]: https://consensyssoftware.atlassian.net/browse/MUSD-299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only layout change that reorders footer content in `TokenCell`; main risk is unintended visual regression or misalignment in asset lists.
> 
> **Overview**
> Moves the Merkl `ClaimBonusBadge` in `TokenCell` to render in `footerLeftDisplay`, **replacing the percent-change display when rewards are claimable**, and always shows the token’s primary amount in `footerRightDisplay`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3cd526bcafd7769cd3dc6f0de609878665ae7f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->