### PR TITLE
fix: send asset view with zero balance

### DIFF
--- a/ui/pages/confirmations/hooks/send/useSendQueryParams.ts
+++ b/ui/pages/confirmations/hooks/send/useSendQueryParams.ts
@@ -24,7 +24,7 @@ export const useSendQueryParams = () => {
   const navigate = useNavigate();
   const { pathname } = useLocation();
   const [searchParams] = useSearchParams();
-  const { tokens, nfts } = useSendAssets();
+  const { tokens, nfts } = useSendAssets({ includeNoBalance: true });
   const allAssets = useMemo(() => [...tokens, ...nfts], [tokens, nfts]);
 
   const subPath = useMemo(() => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Summary: When a user goes through the "send" flow with an asset they don't have a balance of, the "send" view enters an infinite loading state.

Detail:
In `ui/pages/confirmations/hooks/send/useSendQueryParams.ts` the hook `useSendAssets` was called with implicit `{ includeNoBalance: false }`, which meant that when trying to find the asset metadata, the view was only considering assets for which the user had some balance of. This causes the view to never find the corresponding asset, displaying an infinite loading state and no error.
This fix forces `{ includeNoBalance: true }` - only for `useSendQueryParams` so the asset metadata is always found in the "send" flow.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Fixes https://github.com/MetaMask/metamask-extension/issues/40475

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40537?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: add `{ includeNoBalance: true }` to `useSendQueryParams` to fix an issue where the "send" view was frozen in loading state when user has no balance.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/40475

## **Manual testing steps**

1. Go to your (least) favorite network.
2. Add an asset that you have no balance of (this can be a suppored asset with logo).
3. Click on the asset from the list to have the "asset view" with the detail and the "send" button.
4. Click on "send" from the view of this asset.
5. Before the fix, the view enters an infinite loading state, after the fix the send flow starts normally.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="200" alt="image" src="https://github.com/user-attachments/assets/19f886a8-f801-4e0b-9e6d-f2873fc64155" />


### **After**

<img width="200" alt="image" src="https://github.com/user-attachments/assets/60620cfd-e143-4b14-8b34-b9ad0e45aab4" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized change to the send-flow URL param asset lookup; potential impact is limited to showing additional (zero-balance) assets in this hook’s resolution path.
> 
> **Overview**
> Fixes the send flow getting stuck loading when launched for an asset with a zero balance by having `useSendQueryParams` call `useSendAssets({ includeNoBalance: true })`, ensuring the requested asset metadata can be resolved from query params.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7de30cdba49022d5648b43a5bca4e961742ec0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->