### PR TITLE
chore: filter out Tron staking special assets

### DIFF
--- a/shared/constants/multichain/assets.ts
+++ b/shared/constants/multichain/assets.ts
@@ -58,26 +58,29 @@ export const MULTICHAIN_NETWORK_TO_ASSET_TYPES: Record<
 } as const;
 
 /**
- * Tron resource types that should be filtered out from asset selectors.
- * These are virtual resources used for Tron network operations, not actual tokens.
+ * CAIP asset type portions (namespace:reference) for Tron special assets
+ * that should be filtered out from user-facing asset selectors.
+ * These are virtual resources and staking state assets passed from the Tron Snap
+ * to the extension for informational purposes, not actual tradeable tokens.
  */
-export const TRON_RESOURCE = {
-  ENERGY: 'energy',
-  BANDWIDTH: 'bandwidth',
-  MAX_ENERGY: 'max-energy',
-  MAX_BANDWIDTH: 'max-bandwidth',
-  STRX_ENERGY: 'strx-energy',
-  STRX_BANDWIDTH: 'strx-bandwidth',
+export const TRON_SPECIAL_ASSET_CAIP_TYPES = {
+  ENERGY: 'slip44:energy',
+  BANDWIDTH: 'slip44:bandwidth',
+  MAXIMUM_ENERGY: 'slip44:maximum-energy',
+  MAXIMUM_BANDWIDTH: 'slip44:maximum-bandwidth',
+  STAKED_FOR_ENERGY: 'slip44:195-staked-for-energy',
+  STAKED_FOR_BANDWIDTH: 'slip44:195-staked-for-bandwidth',
+  READY_FOR_WITHDRAWAL: 'slip44:195-ready-for-withdrawal',
+  STAKING_REWARDS: 'slip44:195-staking-rewards',
+  IN_LOCK_PERIOD: 'slip44:195-in-lock-period',
 } as const;
 
-export type TronResourceSymbol =
-  (typeof TRON_RESOURCE)[keyof typeof TRON_RESOURCE];
+export type TronSpecialAssetCaipType =
+  (typeof TRON_SPECIAL_ASSET_CAIP_TYPES)[keyof typeof TRON_SPECIAL_ASSET_CAIP_TYPES];
 
-export const TRON_RESOURCE_SYMBOLS = Object.values(
-  TRON_RESOURCE,
-) as readonly TronResourceSymbol[];
-
-export const TRON_RESOURCE_SYMBOLS_SET: ReadonlySet<TronResourceSymbol> =
-  new Set(TRON_RESOURCE_SYMBOLS);
+export const TRON_SPECIAL_ASSET_CAIP_TYPES_SET: ReadonlySet<TronSpecialAssetCaipType> =
+  new Set(
+    Object.values(TRON_SPECIAL_ASSET_CAIP_TYPES) as TronSpecialAssetCaipType[],
+  );
 
 export const SLIP44_ASSET_NAMESPACE = 'slip44';

--- a/shared/lib/asset-utils.test.ts
+++ b/shared/lib/asset-utils.test.ts
@@ -10,11 +10,16 @@ import { MultichainNetwork } from '@metamask/multichain-transactions-controller'
 import { getNativeAssetForChainId } from '@metamask/bridge-controller';
 import { MultichainNetworks } from '../constants/multichain/networks';
 import {
+  TRON_SPECIAL_ASSET_CAIP_TYPES,
+  TronSpecialAssetCaipType,
+} from '../constants/multichain/assets';
+import {
   getAssetImageUrl,
   fetchAssetMetadata,
   toAssetId,
   fetchAssetMetadataForAssetIds,
   isEvmChainId,
+  isTronSpecialAsset,
 } from './asset-utils';
 
 jest.mock('@metamask/multichain-network-controller');
@@ -496,6 +501,76 @@ describe('asset-utils', () => {
       expect(isEvmChainId('1439' as Hex)).toBe(true); // Decimal string
       expect(isEvmChainId('0x59f' as Hex)).toBe(true); // Hex format
       expect(isEvmChainId('eip155:1439' as CaipChainId)).toBe(true); // CAIP format
+    });
+  });
+
+  describe('isTronSpecialAsset', () => {
+    const tronMainnet = MultichainNetworks.TRON;
+    const tronNile = MultichainNetworks.TRON_NILE;
+    const tronShasta = MultichainNetworks.TRON_SHASTA;
+
+    (
+      Object.entries(TRON_SPECIAL_ASSET_CAIP_TYPES) as [
+        string,
+        TronSpecialAssetCaipType,
+      ][]
+    ).forEach(([key, assetType]) => {
+      it(`returns true for ${key} on Tron mainnet`, () => {
+        expect(
+          isTronSpecialAsset(`${tronMainnet}/${assetType}` as CaipAssetType),
+        ).toBe(true);
+      });
+    });
+
+    it('returns true for special assets on Tron Nile testnet', () => {
+      expect(
+        isTronSpecialAsset(
+          `${tronNile}/${TRON_SPECIAL_ASSET_CAIP_TYPES.ENERGY}` as CaipAssetType,
+        ),
+      ).toBe(true);
+    });
+
+    it('returns true for special assets on Tron Shasta testnet', () => {
+      expect(
+        isTronSpecialAsset(
+          `${tronShasta}/${TRON_SPECIAL_ASSET_CAIP_TYPES.BANDWIDTH}` as CaipAssetType,
+        ),
+      ).toBe(true);
+    });
+
+    it('returns false for native TRX (slip44:195)', () => {
+      expect(
+        isTronSpecialAsset(`${tronMainnet}/slip44:195` as CaipAssetType),
+      ).toBe(false);
+    });
+
+    it('returns false for a normal Tron TRC20 token', () => {
+      expect(
+        isTronSpecialAsset(
+          `${tronMainnet}/trc20:TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t` as CaipAssetType,
+        ),
+      ).toBe(false);
+    });
+
+    it('returns false for non-Tron CAIP IDs', () => {
+      expect(isTronSpecialAsset('eip155:1/erc20:0x123' as CaipAssetType)).toBe(
+        false,
+      );
+      expect(
+        isTronSpecialAsset(
+          'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501' as CaipAssetType,
+        ),
+      ).toBe(false);
+    });
+
+    it('returns false for undefined', () => {
+      expect(isTronSpecialAsset(undefined)).toBe(false);
+    });
+
+    it('returns false for non-CAIP strings', () => {
+      expect(isTronSpecialAsset('0xabc123')).toBe(false);
+      expect(isTronSpecialAsset('')).toBe(false);
+      expect(isTronSpecialAsset('not-a-caip-id')).toBe(false);
     });
   });
 });

--- a/shared/lib/asset-utils.ts
+++ b/shared/lib/asset-utils.ts
@@ -19,13 +19,13 @@ import {
   isNativeAddress,
   isNonEvmChainId,
 } from '@metamask/bridge-controller';
-import { Asset } from '@metamask/assets-controllers';
+
 import getFetchWithTimeout from '../modules/fetch-with-timeout';
 import { decimalToPrefixedHex } from '../modules/conversion.utils';
 import { MultichainNetworks } from '../constants/multichain/networks';
 import {
-  TRON_RESOURCE_SYMBOLS_SET,
-  TronResourceSymbol,
+  TRON_SPECIAL_ASSET_CAIP_TYPES_SET,
+  type TronSpecialAssetCaipType,
 } from '../constants/multichain/assets';
 import { TEN_SECONDS_IN_MILLISECONDS } from './transactions-controller-utils';
 
@@ -262,22 +262,26 @@ export const isEvmChainId = (chainId: CaipChainId | Hex) => {
 };
 
 /**
- * Checks if the given assetId is a Tron resource
+ * Checks if the given CAIP asset ID represents a Tron special asset
+ * (resources, staking state, etc.) that should be filtered out from
+ * user-facing asset lists.
  *
- * @param asset - The assetId to check.
- * @returns `true` if the assetId is a Tron resource, `false` otherwise.
+ * @param assetId - The CAIP asset ID to check.
+ * @returns `true` if the asset is a Tron special asset, `false` otherwise.
  */
-export const isTronResource = (asset: Asset): boolean => {
-  if (!isCaipAssetType(asset.assetId)) {
+export const isTronSpecialAsset = (
+  assetId: CaipAssetType | string | undefined,
+): boolean => {
+  if (!assetId || !isCaipAssetType(assetId)) {
     return false;
   }
-  const { chain } = parseCaipAssetType(asset.assetId);
+  const { chain, assetNamespace, assetReference } = parseCaipAssetType(assetId);
 
   if (chain.namespace !== KnownCaipNamespace.Tron) {
     return false;
   }
 
-  return TRON_RESOURCE_SYMBOLS_SET.has(
-    asset.symbol?.toLowerCase() as TronResourceSymbol,
+  return TRON_SPECIAL_ASSET_CAIP_TYPES_SET.has(
+    `${assetNamespace}:${assetReference}` as TronSpecialAssetCaipType,
   );
 };

--- a/ui/components/app/assets/token-list/token-list.tsx
+++ b/ui/components/app/assets/token-list/token-list.tsx
@@ -29,7 +29,7 @@ import { MetaMetricsContext } from '../../../../contexts/metametrics';
 import { SafeChain } from '../../../../pages/settings/networks-tab/networks-form/use-safe-chains';
 import {
   isEvmChainId,
-  isTronResource,
+  isTronSpecialAsset,
 } from '../../../../../shared/lib/asset-utils';
 import { sortAssetsWithPriority } from '../util/sortAssetsWithPriority';
 import { VirtualizedList } from '../../../ui/virtualized-list/virtualized-list';
@@ -69,7 +69,7 @@ function TokenList({ onTokenClick, safeChains }: TokenListProps) {
 
         // Mapping necessary to comply with the type. Fields will be overriden with useTokenDisplayInfo
         return assets.filter((asset) => {
-          if (isTronResource(asset)) {
+          if (isTronSpecialAsset(asset.assetId)) {
             return false;
           }
           if (shouldHideZeroBalanceTokens && asset.balance === '0') {

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
@@ -56,10 +56,7 @@ import { NETWORK_TO_SHORT_NETWORK_NAME_MAP } from '../../../../../shared/constan
 import { useAsyncResult } from '../../../../hooks/useAsync';
 import { fetchTopAssetsList } from '../../../../pages/swaps/swaps.util';
 import { useMultichainSelector } from '../../../../hooks/useMultichainSelector';
-import {
-  getNativeTokenName,
-  isTronEnergyOrBandwidthResource,
-} from '../../../../ducks/bridge/utils';
+import { getNativeTokenName } from '../../../../ducks/bridge/utils';
 import {
   getMultichainConversionRate,
   getMultichainCurrencyImage,
@@ -73,7 +70,10 @@ import {
 } from '../../../../selectors/multichain';
 import { MultichainNetworks } from '../../../../../shared/constants/multichain/networks';
 import { Numeric } from '../../../../../shared/modules/Numeric';
-import { isEvmChainId } from '../../../../../shared/lib/asset-utils';
+import {
+  isEvmChainId,
+  isTronSpecialAsset,
+} from '../../../../../shared/lib/asset-utils';
 
 import { useAssetMetadata } from './hooks/useAssetMetadata';
 import type { ERC20Asset, NativeAsset, AssetWithDisplayData } from './types';
@@ -286,8 +286,8 @@ export function AssetPickerModal({
     > {
       // Yield multichain tokens with balances
       for (const token of multichainTokensWithBalance) {
-        // Filter out Tron Energy and Bandwidth resources (including MAX-BANDWIDTH, sTRX-BANDWIDTH, sTRX-ENERGY)
-        if (isTronEnergyOrBandwidthResource(token.chainId, token.symbol)) {
+        // Filter out Tron special assets (resources, staking state, etc.)
+        if (isTronSpecialAsset(token.assetId)) {
           continue;
         }
         if (shouldAddToken(token.symbol, token.address, token.chainId)) {
@@ -338,10 +338,6 @@ export function AssetPickerModal({
       }
 
       for (const token of allDetectedTokens) {
-        // Filter out Tron Energy and Bandwidth resources (including MAX-BANDWIDTH, sTRX-BANDWIDTH, sTRX-ENERGY)
-        if (isTronEnergyOrBandwidthResource(currentChainId, token.symbol)) {
-          continue;
-        }
         if (shouldAddToken(token.symbol, token.address, currentChainId)) {
           yield { ...token, chainId: currentChainId };
         }

--- a/ui/ducks/bridge/asset-selectors.ts
+++ b/ui/ducks/bridge/asset-selectors.ts
@@ -17,7 +17,7 @@ import {
   parseCaipAssetType,
 } from '@metamask/utils';
 import { ALLOWED_MULTICHAIN_BRIDGE_CHAIN_IDS } from '../../../shared/constants/bridge';
-import { toAssetId } from '../../../shared/lib/asset-utils';
+import { isTronSpecialAsset, toAssetId } from '../../../shared/lib/asset-utils';
 import {
   getAccountTrackerControllerAccountsByChainId,
   getCurrencyRateControllerCurrencyRates,
@@ -33,7 +33,7 @@ import {
 import { getInternalAccountByGroupAndCaip } from '../../selectors/multichain-accounts/account-tree';
 import { type BridgeAppState, getFromChains } from './selectors';
 import { type BridgeToken } from './types';
-import { getMaybeHexChainId, isTronEnergyOrBandwidthResource } from './utils';
+import { getMaybeHexChainId } from './utils';
 
 const createSelector = untypedCreateSelector.withTypes<BridgeAppState>();
 
@@ -336,11 +336,8 @@ const getBridgeAssetsForAccountGroupId = createSelector(
     }));
 
     const nonEvmAssetsWithFiatBalances = nonEvmAssetsWithBalance
-      // Filter out Tron Energy and Bandwidth resources
-      .filter(
-        ({ chainId, symbol }: BridgeToken) =>
-          !isTronEnergyOrBandwidthResource(chainId, symbol),
-      )
+      // Filter out Tron special assets (resources, staking state, etc.)
+      .filter((token: BridgeToken) => !isTronSpecialAsset(token.assetId))
       .map((asset) => ({
         ...asset,
         tokenFiatAmount: new BigNumber(asset.balance ?? '0')

--- a/ui/ducks/bridge/utils.ts
+++ b/ui/ducks/bridge/utils.ts
@@ -7,7 +7,6 @@ import {
 import { BigNumber } from 'bignumber.js';
 import type { ContractMarketData } from '@metamask/assets-controllers';
 import {
-  ChainId,
   BridgeClientId,
   getNativeAssetForChainId,
   isNonEvmChainId,
@@ -18,10 +17,6 @@ import { handleFetch } from '@metamask/controller-utils';
 import { Numeric } from '../../../shared/modules/Numeric';
 import { BRIDGE_CHAINID_COMMON_TOKEN_PAIR } from '../../../shared/constants/bridge';
 import { getAssetImageUrl } from '../../../shared/lib/asset-utils';
-import {
-  TRON_RESOURCE_SYMBOLS_SET,
-  type TronResourceSymbol,
-} from '../../../shared/constants/multichain/assets';
 import type { TokenPayload, BridgeToken } from './types';
 
 // Re-export isNonEvmChainId from bridge-controller for backward compatibility
@@ -29,23 +24,6 @@ export { isNonEvmChainId as isNonEvmChain } from '@metamask/bridge-controller';
 
 // Re-export isTronChainId from confirmations utils for consistency
 export { isTronChainId } from '../../pages/confirmations/utils/network';
-
-/**
- * Checks if a token is a Tron Energy or Bandwidth resource (not tradeable assets)
- *
- * @param chainId - The chain ID to check
- * @param symbol - The token symbol to check
- * @returns true if the token is a Tron Energy/Bandwidth resource
- */
-export const isTronEnergyOrBandwidthResource = (
-  chainId: ChainId | Hex | CaipChainId | string | undefined,
-  symbol: string | undefined,
-): boolean => {
-  return (
-    Boolean(chainId?.toString()?.includes('tron:')) &&
-    TRON_RESOURCE_SYMBOLS_SET.has(symbol?.toLowerCase() as TronResourceSymbol)
-  );
-};
 
 /**
  *

--- a/ui/hooks/bridge/useTokensWithFiltering.ts
+++ b/ui/hooks/bridge/useTokensWithFiltering.ts
@@ -1,7 +1,11 @@
 import { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { ChainId } from '@metamask/controller-utils';
-import { type CaipChainId, type Hex } from '@metamask/utils';
+import {
+  type CaipAssetType,
+  type CaipChainId,
+  type Hex,
+} from '@metamask/utils';
 import {
   isSolanaChainId,
   isBitcoinChainId,
@@ -35,21 +39,22 @@ import type {
   ERC20Asset,
   NativeAsset,
 } from '../../components/multichain/asset-picker-amount/asset-picker-modal/types';
-import { getAssetImageUrl, toAssetId } from '../../../shared/lib/asset-utils';
+import { getNativeAssetForChainIdSafe } from '../../ducks/bridge/utils';
+import { getBearerToken } from '../../store/actions';
 import { MULTICHAIN_TOKEN_IMAGE_MAP } from '../../../shared/constants/multichain/networks';
 import {
-  isTronEnergyOrBandwidthResource,
-  getNativeAssetForChainIdSafe,
-} from '../../ducks/bridge/utils';
-import { getBearerToken } from '../../store/actions';
+  getAssetImageUrl,
+  isTronSpecialAsset,
+  toAssetId,
+} from '../../../shared/lib/asset-utils';
 
 // This transforms the token object from the bridge-api into the format expected by the AssetPicker
 const buildTokenData = (
   chainId: ChainId | Hex | CaipChainId,
   token?: BridgeAsset | TokenListToken,
 ):
-  | AssetWithDisplayData<NativeAsset>
-  | AssetWithDisplayData<ERC20Asset>
+  | (AssetWithDisplayData<NativeAsset> & { assetId: CaipAssetType | string })
+  | (AssetWithDisplayData<ERC20Asset> & { assetId: CaipAssetType | string })
   | undefined => {
   if (!chainId || !token) {
     return undefined;
@@ -86,7 +91,9 @@ const buildTokenData = (
       // Only unimported native assets are processed here so hardcode balance to 0
       balance: '0',
       string: '0',
-    } as AssetWithDisplayData<NativeAsset>;
+    } as AssetWithDisplayData<NativeAsset> & {
+      assetId: CaipAssetType | string;
+    };
   }
 
   return {
@@ -96,7 +103,7 @@ const buildTokenData = (
     // Only tokens with 0 balance are processed here so hardcode empty string
     balance: '',
     string: undefined,
-  };
+  } as AssetWithDisplayData<ERC20Asset> & { assetId: CaipAssetType | string };
 };
 
 type FilterPredicate = (
@@ -265,9 +272,8 @@ export const useTokensWithFiltering = (
 
         // Yield multichain tokens with balances and are not blocked
         for (const token of multichainTokensWithBalance) {
-          // Filter out Tron Energy and Bandwidth resources (including MAX-BANDWIDTH, sTRX-BANDWIDTH, sTRX-ENERGY)
-          // as they are not tradeable assets
-          if (isTronEnergyOrBandwidthResource(token.chainId, token.symbol)) {
+          // Filter out Tron special assets (resources, staking state, etc.)
+          if (isTronSpecialAsset(token.assetId)) {
             continue;
           }
           if (shouldAddToken(token.symbol, token.address, token.chainId)) {
@@ -338,11 +344,10 @@ export const useTokensWithFiltering = (
             tokenList?.[token_.address] ??
             tokenList?.[token_.address.toLowerCase()];
           const token = buildTokenData(chainId, matchedToken);
-          // Filter out Tron Energy and Bandwidth resources (including MAX-BANDWIDTH, sTRX-BANDWIDTH, sTRX-ENERGY)
-          // as they are not tradeable assets
+          // Filter out Tron special assets (resources, staking state, etc.)
           if (
             token &&
-            !isTronEnergyOrBandwidthResource(chainId, token.symbol) &&
+            !isTronSpecialAsset(token.assetId) &&
             shouldAddToken(token.symbol, token.address ?? undefined, chainId)
           ) {
             yield token;
@@ -354,12 +359,11 @@ export const useTokensWithFiltering = (
         // eslint-disable-next-line @typescript-eslint/naming-convention
         for (const token_ of Object.values(tokenList)) {
           const token = buildTokenData(chainId, token_);
-          // Filter out Tron Energy and Bandwidth resources (including MAX-BANDWIDTH, sTRX-BANDWIDTH, sTRX-ENERGY)
-          // as they are not tradeable assets
+          // Filter out Tron special assets (resources, staking state, etc.)
           if (
             token &&
             token.symbol.indexOf('$') === -1 &&
-            !isTronEnergyOrBandwidthResource(chainId, token.symbol) &&
+            !isTronSpecialAsset(token.assetId) &&
             shouldAddToken(token.symbol, token.address ?? undefined, chainId)
           ) {
             yield token;

--- a/ui/hooks/useMultichainBalances.test.ts
+++ b/ui/hooks/useMultichainBalances.test.ts
@@ -1,5 +1,11 @@
+import { TrxScope, TrxAccountType } from '@metamask/keyring-api';
+import { KeyringTypes } from '@metamask/keyring-controller';
+import type { CaipAssetType } from '@metamask/utils';
 import { createBridgeMockStore } from '../../test/data/bridge/mock-bridge-store';
 import { renderHookWithProvider } from '../../test/lib/render-helpers-navigate';
+import { MultichainNetworks } from '../../shared/constants/multichain/networks';
+import { TRON_SPECIAL_ASSET_CAIP_TYPES } from '../../shared/constants/multichain/assets';
+import { KeyringType } from '../../shared/constants/keyring';
 import { useMultichainBalances } from './useMultichainBalances';
 
 describe('useMultichainBalances', () => {
@@ -268,5 +274,187 @@ describe('useMultichainBalances', () => {
         "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp": 212.89214978478,
       }
     `);
+  });
+
+  describe('Tron special asset filtering', () => {
+    const MOCK_TRON_ACCOUNT = {
+      type: TrxAccountType.Eoa,
+      id: 'tron-account-multichain-balances',
+      address: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t',
+      options: {
+        scope: TrxScope.Mainnet,
+        entropy: {
+          type: 'mnemonic',
+          id: '01K2FF18CTTXJYD34R78X4N1N1',
+          groupIndex: 0,
+        },
+      },
+      scopes: [TrxScope.Mainnet],
+      methods: ['tron_signTransaction'],
+      metadata: {
+        name: 'Tron Account',
+        keyring: { type: KeyringTypes.snap },
+        snap: {
+          id: 'npm:@metamask/tron-wallet-snap',
+          name: 'Tron',
+          enabled: true,
+        },
+      },
+    };
+
+    const tronChainId = MultichainNetworks.TRON;
+    const tronNativeAssetId = `${tronChainId}/slip44:195`;
+    const tronEnergyAssetId = `${tronChainId}/${TRON_SPECIAL_ASSET_CAIP_TYPES.ENERGY}`;
+    const tronBandwidthAssetId = `${tronChainId}/${TRON_SPECIAL_ASSET_CAIP_TYPES.BANDWIDTH}`;
+    const tronStakedForEnergyAssetId = `${tronChainId}/${TRON_SPECIAL_ASSET_CAIP_TYPES.STAKED_FOR_ENERGY}`;
+    const tronInLockPeriodAssetId = `${tronChainId}/${TRON_SPECIAL_ASSET_CAIP_TYPES.IN_LOCK_PERIOD}`;
+
+    const createTronMockStore = () => {
+      const mockStore = createBridgeMockStore({
+        metamaskStateOverrides: {
+          internalAccounts: {
+            accounts: {
+              [MOCK_TRON_ACCOUNT.id]: MOCK_TRON_ACCOUNT,
+            },
+          },
+          balances: {
+            [MOCK_TRON_ACCOUNT.id]: {
+              [tronNativeAssetId]: { amount: '100', unit: 'TRX' },
+              [tronEnergyAssetId]: { amount: '500', unit: 'energy' },
+              [tronBandwidthAssetId]: { amount: '300', unit: 'bandwidth' },
+              [tronStakedForEnergyAssetId]: {
+                amount: '50',
+                unit: '195-staked-for-energy',
+              },
+              [tronInLockPeriodAssetId]: {
+                amount: '10',
+                unit: '195-in-lock-period',
+              },
+            },
+          },
+          conversionRates: {
+            [tronNativeAssetId]: {
+              currency: 'swift:0/iso4217:USD',
+              rate: '0.25',
+              conversionTime: Date.now(),
+              expirationTime: Date.now() + 60000,
+            },
+          },
+        },
+      });
+
+      // Inject Tron account into account group (createBridgeMockStore hardcodes the group)
+      const groupId = 'entropy:01K2FF18CTTXJYD34R78X4N1N1/0';
+      mockStore.metamask.accountTree.wallets[
+        'entropy:01K2FF18CTTXJYD34R78X4N1N1'
+      ].groups[groupId].accounts.push(MOCK_TRON_ACCOUNT.id);
+
+      mockStore.metamask.accountsAssets[MOCK_TRON_ACCOUNT.id] = [
+        tronNativeAssetId as CaipAssetType,
+        tronEnergyAssetId as CaipAssetType,
+        tronBandwidthAssetId as CaipAssetType,
+        tronStakedForEnergyAssetId as CaipAssetType,
+        tronInLockPeriodAssetId as CaipAssetType,
+      ];
+
+      Object.assign(mockStore.metamask.assetsMetadata, {
+        [tronNativeAssetId]: {
+          symbol: 'TRX',
+          name: 'Tron',
+          fungible: true,
+          units: [{ decimals: 6, symbol: 'TRX', name: 'Tron' }],
+        },
+        [tronEnergyAssetId]: {
+          symbol: 'energy',
+          name: 'Energy',
+          fungible: true,
+          units: [{ decimals: 0, symbol: 'energy', name: 'Energy' }],
+        },
+        [tronBandwidthAssetId]: {
+          symbol: 'bandwidth',
+          name: 'Bandwidth',
+          fungible: true,
+          units: [{ decimals: 0, symbol: 'bandwidth', name: 'Bandwidth' }],
+        },
+        [tronStakedForEnergyAssetId]: {
+          symbol: '195-staked-for-energy',
+          name: 'Staked for Energy',
+          fungible: true,
+          units: [
+            {
+              decimals: 6,
+              symbol: '195-staked-for-energy',
+              name: 'Staked for Energy',
+            },
+          ],
+        },
+        [tronInLockPeriodAssetId]: {
+          symbol: '195-in-lock-period',
+          name: 'In Lock Period',
+          fungible: true,
+          units: [
+            {
+              decimals: 6,
+              symbol: '195-in-lock-period',
+              name: 'In Lock Period',
+            },
+          ],
+        },
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (mockStore.metamask as any).keyrings.push({
+        type: KeyringType.snap,
+        accounts: [MOCK_TRON_ACCOUNT.address],
+        metadata: { id: 'tron-keyring', name: '' },
+      });
+
+      return mockStore;
+    };
+
+    it('should exclude Tron special assets from assetsWithBalance', () => {
+      const mockStore = createTronMockStore();
+      const { result } = renderHookWithProvider(
+        () => useMultichainBalances(),
+        mockStore,
+      );
+
+      const tronAssets = result.current.assetsWithBalance.filter(
+        (asset: { chainId: string }) => asset.chainId === tronChainId,
+      );
+
+      expect(tronAssets).toHaveLength(1);
+      expect(tronAssets[0].symbol).toBe('TRX');
+      expect(tronAssets[0].assetId).toBe(tronNativeAssetId);
+
+      const specialAssetSymbols = [
+        'energy',
+        'bandwidth',
+        '195-staked-for-energy',
+        '195-in-lock-period',
+      ];
+      const hasSpecialAssets = result.current.assetsWithBalance.some(
+        (asset: { symbol: string }) =>
+          specialAssetSymbols.includes(asset.symbol),
+      );
+      expect(hasSpecialAssets).toBe(false);
+    });
+
+    it('should exclude Tron special assets from balanceByChainId totals', () => {
+      const mockStore = createTronMockStore();
+      const { result } = renderHookWithProvider(
+        () => useMultichainBalances(),
+        mockStore,
+      );
+
+      // Only the native TRX should contribute to the Tron chain balance.
+      // Without special assets, the total should equal just the TRX fiat value.
+      const tronBalance = result.current.balanceByChainId[tronChainId];
+      expect(tronBalance).toBeDefined();
+
+      // Verify special assets (energy=500, bandwidth=300, staked=50, lock=10)
+      // are NOT included in the total. If they were, the total would be much higher.
+      expect(tronBalance).toBeLessThan(200);
+    });
   });
 });

--- a/ui/hooks/useMultichainBalances.ts
+++ b/ui/hooks/useMultichainBalances.ts
@@ -9,11 +9,8 @@ import { SolScope, BtcScope, TrxScope } from '@metamask/keyring-api';
 import { type InternalAccount } from '@metamask/keyring-internal-api';
 import { BigNumber } from 'bignumber.js';
 import { AssetType } from '../../shared/constants/transaction';
-import {
-  SLIP44_ASSET_NAMESPACE,
-  TRON_RESOURCE_SYMBOLS_SET,
-  type TronResourceSymbol,
-} from '../../shared/constants/multichain/assets';
+import { SLIP44_ASSET_NAMESPACE } from '../../shared/constants/multichain/assets';
+import { isTronSpecialAsset } from '../../shared/lib/asset-utils';
 import {
   getAccountAssets,
   getAssetsMetadata,
@@ -153,16 +150,17 @@ export const useMultichainBalances = (
     tronAccount?.type,
   );
 
+  // Filter out Tron special assets (resources, staking state, etc.) once
+  const filteredTronBalances = useMemo(
+    () =>
+      tronBalancesWithFiat.filter(
+        (token) => !isTronSpecialAsset(token.assetId),
+      ),
+    [tronBalancesWithFiat],
+  );
+
   // return TokenWithFiat sorted by fiat balance amount
   const assetsWithBalance = useMemo(() => {
-    // Filter out Tron energy/bandwidth resources before combining
-    const filteredTronBalances = tronBalancesWithFiat.filter(
-      (token) =>
-        !TRON_RESOURCE_SYMBOLS_SET.has(
-          token.symbol.toLowerCase() as TronResourceSymbol,
-        ),
-    );
-
     return [
       ...evmBalancesWithFiatByChainId,
       ...solanaBalancesWithFiat,
@@ -178,19 +176,11 @@ export const useMultichainBalances = (
     evmBalancesWithFiatByChainId,
     solanaBalancesWithFiat,
     bitcoinBalancesWithFiat,
-    tronBalancesWithFiat,
+    filteredTronBalances,
   ]);
 
   // return total fiat balances by chainId/caipChainId
   const balanceByChainId = useMemo(() => {
-    // Filter out Tron energy/bandwidth resources
-    const filteredTronBalances = tronBalancesWithFiat.filter(
-      (token) =>
-        !TRON_RESOURCE_SYMBOLS_SET.has(
-          token.symbol.toLowerCase() as TronResourceSymbol,
-        ),
-    );
-
     return [
       ...evmBalancesWithFiatByChainId,
       ...solanaBalancesWithFiat,
@@ -208,7 +198,7 @@ export const useMultichainBalances = (
     evmBalancesWithFiatByChainId,
     solanaBalancesWithFiat,
     bitcoinBalancesWithFiat,
-    tronBalancesWithFiat,
+    filteredTronBalances,
   ]);
 
   return { assetsWithBalance, balanceByChainId };

--- a/ui/pages/asset/hooks/useTronResources.test.ts
+++ b/ui/pages/asset/hooks/useTronResources.test.ts
@@ -4,7 +4,7 @@ import { CaipAssetId } from '@metamask/keyring-api';
 import { Asset } from '@metamask/assets-controllers';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { MultichainNetworks } from '../../../../shared/constants/multichain/networks';
-import { TRON_RESOURCE } from '../../../../shared/constants/multichain/assets';
+import { TRON_SPECIAL_ASSET_CAIP_TYPES } from '../../../../shared/constants/multichain/assets';
 import * as assetsSelectors from '../../../selectors/assets';
 import * as multichainSelectors from '../../../selectors/multichain';
 import { useTronResources } from './useTronResources';
@@ -12,7 +12,7 @@ import { useTronResources } from './useTronResources';
 // Mock the selectors
 jest.mock('../../../selectors/assets', () => ({
   ...jest.requireActual('../../../selectors/assets'),
-  getAssetsBySelectedAccountGroupWithTronResources: jest.fn(),
+  getAssetsBySelectedAccountGroupWithTronSpecialAssets: jest.fn(),
 }));
 
 jest.mock('../../../selectors/multichain', () => ({
@@ -40,7 +40,7 @@ describe('useTronResources', () => {
 
   const chainId = MultichainNetworks.TRON;
 
-  const createTronResourceAsset = (
+  const createTronSpecialAsset = (
     symbol: string,
     assetId: CaipAssetId,
   ): Asset =>
@@ -53,40 +53,52 @@ describe('useTronResources', () => {
       isNative: false,
     }) as Asset;
 
+  const mockSelector = (
+    assets: Record<string, Asset[]>,
+    balances: Record<string, Record<string, { amount: string; unit: string }>>,
+  ) => {
+    (
+      assetsSelectors.getAssetsBySelectedAccountGroupWithTronSpecialAssets as unknown as jest.Mock
+    ).mockReturnValue(assets);
+
+    (multichainSelectors.getMultichainBalances as jest.Mock).mockReturnValue(
+      balances,
+    );
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   describe('when account and chainId are provided', () => {
     it('returns energy and bandwidth resources with correct percentages', () => {
-      const energyAssetId = `${chainId}/resource:energy` as CaipAssetId;
-      const maxEnergyAssetId = `${chainId}/resource:max-energy` as CaipAssetId;
-      const bandwidthAssetId = `${chainId}/resource:bandwidth` as CaipAssetId;
+      const energyAssetId =
+        `${chainId}/${TRON_SPECIAL_ASSET_CAIP_TYPES.ENERGY}` as CaipAssetId;
+      const maxEnergyAssetId =
+        `${chainId}/${TRON_SPECIAL_ASSET_CAIP_TYPES.MAXIMUM_ENERGY}` as CaipAssetId;
+      const bandwidthAssetId =
+        `${chainId}/${TRON_SPECIAL_ASSET_CAIP_TYPES.BANDWIDTH}` as CaipAssetId;
       const maxBandwidthAssetId =
-        `${chainId}/resource:max-bandwidth` as CaipAssetId;
+        `${chainId}/${TRON_SPECIAL_ASSET_CAIP_TYPES.MAXIMUM_BANDWIDTH}` as CaipAssetId;
 
-      (
-        assetsSelectors.getAssetsBySelectedAccountGroupWithTronResources as unknown as jest.Mock
-      ).mockReturnValue({
-        [chainId]: [
-          createTronResourceAsset(TRON_RESOURCE.ENERGY, energyAssetId),
-          createTronResourceAsset(TRON_RESOURCE.MAX_ENERGY, maxEnergyAssetId),
-          createTronResourceAsset(TRON_RESOURCE.BANDWIDTH, bandwidthAssetId),
-          createTronResourceAsset(
-            TRON_RESOURCE.MAX_BANDWIDTH,
-            maxBandwidthAssetId,
-          ),
-        ],
-      });
-
-      (multichainSelectors.getMultichainBalances as jest.Mock).mockReturnValue({
-        [mockAccount.id]: {
-          [energyAssetId]: { amount: '500', unit: 'energy' },
-          [maxEnergyAssetId]: { amount: '1000', unit: 'energy' },
-          [bandwidthAssetId]: { amount: '300', unit: 'bandwidth' },
-          [maxBandwidthAssetId]: { amount: '600', unit: 'bandwidth' },
+      mockSelector(
+        {
+          [chainId]: [
+            createTronSpecialAsset('energy', energyAssetId),
+            createTronSpecialAsset('maximum-energy', maxEnergyAssetId),
+            createTronSpecialAsset('bandwidth', bandwidthAssetId),
+            createTronSpecialAsset('maximum-bandwidth', maxBandwidthAssetId),
+          ],
         },
-      });
+        {
+          [mockAccount.id]: {
+            [energyAssetId]: { amount: '500', unit: 'energy' },
+            [maxEnergyAssetId]: { amount: '1000', unit: 'energy' },
+            [bandwidthAssetId]: { amount: '300', unit: 'bandwidth' },
+            [maxBandwidthAssetId]: { amount: '600', unit: 'bandwidth' },
+          },
+        },
+      );
 
       const { result } = renderHook(() =>
         useTronResources(mockAccount, chainId),
@@ -108,21 +120,20 @@ describe('useTronResources', () => {
     });
 
     it('returns zero values with max of 0 when no balances exist', () => {
-      const energyAssetId = `${chainId}/resource:energy` as CaipAssetId;
-      const bandwidthAssetId = `${chainId}/resource:bandwidth` as CaipAssetId;
+      const energyAssetId =
+        `${chainId}/${TRON_SPECIAL_ASSET_CAIP_TYPES.ENERGY}` as CaipAssetId;
+      const bandwidthAssetId =
+        `${chainId}/${TRON_SPECIAL_ASSET_CAIP_TYPES.BANDWIDTH}` as CaipAssetId;
 
-      (
-        assetsSelectors.getAssetsBySelectedAccountGroupWithTronResources as unknown as jest.Mock
-      ).mockReturnValue({
-        [chainId]: [
-          createTronResourceAsset(TRON_RESOURCE.ENERGY, energyAssetId),
-          createTronResourceAsset(TRON_RESOURCE.BANDWIDTH, bandwidthAssetId),
-        ],
-      });
-
-      (multichainSelectors.getMultichainBalances as jest.Mock).mockReturnValue({
-        [mockAccount.id]: {},
-      });
+      mockSelector(
+        {
+          [chainId]: [
+            createTronSpecialAsset('energy', energyAssetId),
+            createTronSpecialAsset('bandwidth', bandwidthAssetId),
+          ],
+        },
+        { [mockAccount.id]: {} },
+      );
 
       const { result } = renderHook(() =>
         useTronResources(mockAccount, chainId),
@@ -144,24 +155,25 @@ describe('useTronResources', () => {
     });
 
     it('handles only current values without max values', () => {
-      const energyAssetId = `${chainId}/resource:energy` as CaipAssetId;
-      const bandwidthAssetId = `${chainId}/resource:bandwidth` as CaipAssetId;
+      const energyAssetId =
+        `${chainId}/${TRON_SPECIAL_ASSET_CAIP_TYPES.ENERGY}` as CaipAssetId;
+      const bandwidthAssetId =
+        `${chainId}/${TRON_SPECIAL_ASSET_CAIP_TYPES.BANDWIDTH}` as CaipAssetId;
 
-      (
-        assetsSelectors.getAssetsBySelectedAccountGroupWithTronResources as unknown as jest.Mock
-      ).mockReturnValue({
-        [chainId]: [
-          createTronResourceAsset(TRON_RESOURCE.ENERGY, energyAssetId),
-          createTronResourceAsset(TRON_RESOURCE.BANDWIDTH, bandwidthAssetId),
-        ],
-      });
-
-      (multichainSelectors.getMultichainBalances as jest.Mock).mockReturnValue({
-        [mockAccount.id]: {
-          [energyAssetId]: { amount: '250', unit: 'energy' },
-          [bandwidthAssetId]: { amount: '150', unit: 'bandwidth' },
+      mockSelector(
+        {
+          [chainId]: [
+            createTronSpecialAsset('energy', energyAssetId),
+            createTronSpecialAsset('bandwidth', bandwidthAssetId),
+          ],
         },
-      });
+        {
+          [mockAccount.id]: {
+            [energyAssetId]: { amount: '250', unit: 'energy' },
+            [bandwidthAssetId]: { amount: '150', unit: 'bandwidth' },
+          },
+        },
+      );
 
       const { result } = renderHook(() =>
         useTronResources(mockAccount, chainId),
@@ -170,7 +182,7 @@ describe('useTronResources', () => {
       expect(result.current.energy).toEqual({
         type: 'energy',
         current: 250,
-        max: 0, // Actual max is 0 when not provided
+        max: 0,
         percentage: 25000, // 250 / 1 * 100 (divisor is Math.max(1, 0) = 1)
       });
 
@@ -183,28 +195,25 @@ describe('useTronResources', () => {
     });
 
     it('handles only max values without current values', () => {
-      const maxEnergyAssetId = `${chainId}/resource:max-energy` as CaipAssetId;
+      const maxEnergyAssetId =
+        `${chainId}/${TRON_SPECIAL_ASSET_CAIP_TYPES.MAXIMUM_ENERGY}` as CaipAssetId;
       const maxBandwidthAssetId =
-        `${chainId}/resource:max-bandwidth` as CaipAssetId;
+        `${chainId}/${TRON_SPECIAL_ASSET_CAIP_TYPES.MAXIMUM_BANDWIDTH}` as CaipAssetId;
 
-      (
-        assetsSelectors.getAssetsBySelectedAccountGroupWithTronResources as unknown as jest.Mock
-      ).mockReturnValue({
-        [chainId]: [
-          createTronResourceAsset(TRON_RESOURCE.MAX_ENERGY, maxEnergyAssetId),
-          createTronResourceAsset(
-            TRON_RESOURCE.MAX_BANDWIDTH,
-            maxBandwidthAssetId,
-          ),
-        ],
-      });
-
-      (multichainSelectors.getMultichainBalances as jest.Mock).mockReturnValue({
-        [mockAccount.id]: {
-          [maxEnergyAssetId]: { amount: '2000', unit: 'energy' },
-          [maxBandwidthAssetId]: { amount: '1500', unit: 'bandwidth' },
+      mockSelector(
+        {
+          [chainId]: [
+            createTronSpecialAsset('maximum-energy', maxEnergyAssetId),
+            createTronSpecialAsset('maximum-bandwidth', maxBandwidthAssetId),
+          ],
         },
-      });
+        {
+          [mockAccount.id]: {
+            [maxEnergyAssetId]: { amount: '2000', unit: 'energy' },
+            [maxBandwidthAssetId]: { amount: '1500', unit: 'bandwidth' },
+          },
+        },
+      );
 
       const { result } = renderHook(() =>
         useTronResources(mockAccount, chainId),
@@ -225,39 +234,38 @@ describe('useTronResources', () => {
       });
     });
 
-    it('filters out non-Tron resource assets', () => {
-      const energyAssetId = `${chainId}/resource:energy` as CaipAssetId;
+    it('filters out non-special Tron assets', () => {
+      const energyAssetId =
+        `${chainId}/${TRON_SPECIAL_ASSET_CAIP_TYPES.ENERGY}` as CaipAssetId;
       const tokenAssetId =
-        `${chainId}/token:TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t` as CaipAssetId;
+        `${chainId}/trc20:TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t` as CaipAssetId;
 
-      (
-        assetsSelectors.getAssetsBySelectedAccountGroupWithTronResources as unknown as jest.Mock
-      ).mockReturnValue({
-        [chainId]: [
-          createTronResourceAsset(TRON_RESOURCE.ENERGY, energyAssetId),
-          {
-            assetId: tokenAssetId,
-            symbol: 'USDT',
-            name: 'Tether USD',
-            decimals: 6,
-            image: '',
-            isNative: false,
-          } as Asset,
-        ],
-      });
-
-      (multichainSelectors.getMultichainBalances as jest.Mock).mockReturnValue({
-        [mockAccount.id]: {
-          [energyAssetId]: { amount: '100', unit: 'energy' },
-          [tokenAssetId]: { amount: '1000', unit: 'USDT' },
+      mockSelector(
+        {
+          [chainId]: [
+            createTronSpecialAsset('energy', energyAssetId),
+            {
+              assetId: tokenAssetId,
+              symbol: 'USDT',
+              name: 'Tether USD',
+              decimals: 6,
+              image: '',
+              isNative: false,
+            } as Asset,
+          ],
         },
-      });
+        {
+          [mockAccount.id]: {
+            [energyAssetId]: { amount: '100', unit: 'energy' },
+            [tokenAssetId]: { amount: '1000', unit: 'USDT' },
+          },
+        },
+      );
 
       const { result } = renderHook(() =>
         useTronResources(mockAccount, chainId),
       );
 
-      // Should only process the energy resource, not the USDT token
       expect(result.current.energy).toEqual({
         type: 'energy',
         current: 100,
@@ -265,7 +273,59 @@ describe('useTronResources', () => {
         percentage: 10000,
       });
 
-      // Bandwidth should be zero since no bandwidth assets exist
+      expect(result.current.bandwidth).toEqual({
+        type: 'bandwidth',
+        current: 0,
+        max: 0,
+        percentage: 0,
+      });
+    });
+
+    it('ignores staking state assets when computing resources', () => {
+      const energyAssetId =
+        `${chainId}/${TRON_SPECIAL_ASSET_CAIP_TYPES.ENERGY}` as CaipAssetId;
+      const readyForWithdrawalId =
+        `${chainId}/${TRON_SPECIAL_ASSET_CAIP_TYPES.READY_FOR_WITHDRAWAL}` as CaipAssetId;
+      const stakingRewardsId =
+        `${chainId}/${TRON_SPECIAL_ASSET_CAIP_TYPES.STAKING_REWARDS}` as CaipAssetId;
+      const inLockPeriodId =
+        `${chainId}/${TRON_SPECIAL_ASSET_CAIP_TYPES.IN_LOCK_PERIOD}` as CaipAssetId;
+
+      mockSelector(
+        {
+          [chainId]: [
+            createTronSpecialAsset('energy', energyAssetId),
+            createTronSpecialAsset(
+              '195-ready-for-withdrawal',
+              readyForWithdrawalId,
+            ),
+            createTronSpecialAsset('195-staking-rewards', stakingRewardsId),
+            createTronSpecialAsset('195-in-lock-period', inLockPeriodId),
+          ],
+        },
+        {
+          [mockAccount.id]: {
+            [energyAssetId]: { amount: '500', unit: 'energy' },
+            [readyForWithdrawalId]: { amount: '100', unit: 'TRX' },
+            [stakingRewardsId]: { amount: '50', unit: 'TRX' },
+            [inLockPeriodId]: { amount: '200', unit: 'TRX' },
+          },
+        },
+      );
+
+      const { result } = renderHook(() =>
+        useTronResources(mockAccount, chainId),
+      );
+
+      // Staking state assets are included in the special assets filter
+      // but should not affect energy/bandwidth output
+      expect(result.current.energy).toEqual({
+        type: 'energy',
+        current: 500,
+        max: 0,
+        percentage: 50000,
+      });
+
       expect(result.current.bandwidth).toEqual({
         type: 'bandwidth',
         current: 0,
@@ -275,15 +335,7 @@ describe('useTronResources', () => {
     });
 
     it('handles empty assets array', () => {
-      (
-        assetsSelectors.getAssetsBySelectedAccountGroupWithTronResources as unknown as jest.Mock
-      ).mockReturnValue({
-        [chainId]: [],
-      });
-
-      (multichainSelectors.getMultichainBalances as jest.Mock).mockReturnValue({
-        [mockAccount.id]: {},
-      });
+      mockSelector({ [chainId]: [] }, { [mockAccount.id]: {} });
 
       const { result } = renderHook(() =>
         useTronResources(mockAccount, chainId),
@@ -305,13 +357,7 @@ describe('useTronResources', () => {
     });
 
     it('handles chainId with no assets', () => {
-      (
-        assetsSelectors.getAssetsBySelectedAccountGroupWithTronResources as unknown as jest.Mock
-      ).mockReturnValue({});
-
-      (multichainSelectors.getMultichainBalances as jest.Mock).mockReturnValue({
-        [mockAccount.id]: {},
-      });
+      mockSelector({}, { [mockAccount.id]: {} });
 
       const { result } = renderHook(() =>
         useTronResources(mockAccount, chainId),
@@ -333,34 +379,33 @@ describe('useTronResources', () => {
     });
 
     it('calculates percentage correctly with full resources', () => {
-      const energyAssetId = `${chainId}/resource:energy` as CaipAssetId;
-      const maxEnergyAssetId = `${chainId}/resource:max-energy` as CaipAssetId;
-      const bandwidthAssetId = `${chainId}/resource:bandwidth` as CaipAssetId;
+      const energyAssetId =
+        `${chainId}/${TRON_SPECIAL_ASSET_CAIP_TYPES.ENERGY}` as CaipAssetId;
+      const maxEnergyAssetId =
+        `${chainId}/${TRON_SPECIAL_ASSET_CAIP_TYPES.MAXIMUM_ENERGY}` as CaipAssetId;
+      const bandwidthAssetId =
+        `${chainId}/${TRON_SPECIAL_ASSET_CAIP_TYPES.BANDWIDTH}` as CaipAssetId;
       const maxBandwidthAssetId =
-        `${chainId}/resource:max-bandwidth` as CaipAssetId;
+        `${chainId}/${TRON_SPECIAL_ASSET_CAIP_TYPES.MAXIMUM_BANDWIDTH}` as CaipAssetId;
 
-      (
-        assetsSelectors.getAssetsBySelectedAccountGroupWithTronResources as unknown as jest.Mock
-      ).mockReturnValue({
-        [chainId]: [
-          createTronResourceAsset(TRON_RESOURCE.ENERGY, energyAssetId),
-          createTronResourceAsset(TRON_RESOURCE.MAX_ENERGY, maxEnergyAssetId),
-          createTronResourceAsset(TRON_RESOURCE.BANDWIDTH, bandwidthAssetId),
-          createTronResourceAsset(
-            TRON_RESOURCE.MAX_BANDWIDTH,
-            maxBandwidthAssetId,
-          ),
-        ],
-      });
-
-      (multichainSelectors.getMultichainBalances as jest.Mock).mockReturnValue({
-        [mockAccount.id]: {
-          [energyAssetId]: { amount: '1000', unit: 'energy' },
-          [maxEnergyAssetId]: { amount: '1000', unit: 'energy' },
-          [bandwidthAssetId]: { amount: '800', unit: 'bandwidth' },
-          [maxBandwidthAssetId]: { amount: '800', unit: 'bandwidth' },
+      mockSelector(
+        {
+          [chainId]: [
+            createTronSpecialAsset('energy', energyAssetId),
+            createTronSpecialAsset('maximum-energy', maxEnergyAssetId),
+            createTronSpecialAsset('bandwidth', bandwidthAssetId),
+            createTronSpecialAsset('maximum-bandwidth', maxBandwidthAssetId),
+          ],
         },
-      });
+        {
+          [mockAccount.id]: {
+            [energyAssetId]: { amount: '1000', unit: 'energy' },
+            [maxEnergyAssetId]: { amount: '1000', unit: 'energy' },
+            [bandwidthAssetId]: { amount: '800', unit: 'bandwidth' },
+            [maxBandwidthAssetId]: { amount: '800', unit: 'bandwidth' },
+          },
+        },
+      );
 
       const { result } = renderHook(() =>
         useTronResources(mockAccount, chainId),
@@ -373,13 +418,7 @@ describe('useTronResources', () => {
 
   describe('when account is undefined', () => {
     it('returns default values', () => {
-      (
-        assetsSelectors.getAssetsBySelectedAccountGroupWithTronResources as unknown as jest.Mock
-      ).mockReturnValue({});
-
-      (multichainSelectors.getMultichainBalances as jest.Mock).mockReturnValue(
-        {},
-      );
+      mockSelector({}, {});
 
       const { result } = renderHook(() => useTronResources(undefined, chainId));
 
@@ -401,13 +440,7 @@ describe('useTronResources', () => {
 
   describe('when chainId is empty', () => {
     it('returns default values', () => {
-      (
-        assetsSelectors.getAssetsBySelectedAccountGroupWithTronResources as unknown as jest.Mock
-      ).mockReturnValue({});
-
-      (multichainSelectors.getMultichainBalances as jest.Mock).mockReturnValue({
-        [mockAccount.id]: {},
-      });
+      mockSelector({}, { [mockAccount.id]: {} });
 
       const { result } = renderHook(() => useTronResources(mockAccount, ''));
 
@@ -429,19 +462,18 @@ describe('useTronResources', () => {
 
   describe('when account balances are undefined', () => {
     it('returns default values', () => {
-      const energyAssetId = `${chainId}/resource:energy` as CaipAssetId;
-      const bandwidthAssetId = `${chainId}/resource:bandwidth` as CaipAssetId;
+      const energyAssetId =
+        `${chainId}/${TRON_SPECIAL_ASSET_CAIP_TYPES.ENERGY}` as CaipAssetId;
+      const bandwidthAssetId =
+        `${chainId}/${TRON_SPECIAL_ASSET_CAIP_TYPES.BANDWIDTH}` as CaipAssetId;
 
-      (
-        assetsSelectors.getAssetsBySelectedAccountGroupWithTronResources as unknown as jest.Mock
-      ).mockReturnValue({
-        [chainId]: [
-          createTronResourceAsset(TRON_RESOURCE.ENERGY, energyAssetId),
-          createTronResourceAsset(TRON_RESOURCE.BANDWIDTH, bandwidthAssetId),
-        ],
-      });
-
-      (multichainSelectors.getMultichainBalances as jest.Mock).mockReturnValue(
+      mockSelector(
+        {
+          [chainId]: [
+            createTronSpecialAsset('energy', energyAssetId),
+            createTronSpecialAsset('bandwidth', bandwidthAssetId),
+          ],
+        },
         {},
       );
 
@@ -467,21 +499,19 @@ describe('useTronResources', () => {
 
   describe('when balance amount is invalid', () => {
     it('handles NaN values gracefully', () => {
-      const energyAssetId = `${chainId}/resource:energy` as CaipAssetId;
+      const energyAssetId =
+        `${chainId}/${TRON_SPECIAL_ASSET_CAIP_TYPES.ENERGY}` as CaipAssetId;
 
-      (
-        assetsSelectors.getAssetsBySelectedAccountGroupWithTronResources as unknown as jest.Mock
-      ).mockReturnValue({
-        [chainId]: [
-          createTronResourceAsset(TRON_RESOURCE.ENERGY, energyAssetId),
-        ],
-      });
-
-      (multichainSelectors.getMultichainBalances as jest.Mock).mockReturnValue({
-        [mockAccount.id]: {
-          [energyAssetId]: { amount: 'invalid', unit: 'energy' },
+      mockSelector(
+        {
+          [chainId]: [createTronSpecialAsset('energy', energyAssetId)],
         },
-      });
+        {
+          [mockAccount.id]: {
+            [energyAssetId]: { amount: 'invalid', unit: 'energy' },
+          },
+        },
+      );
 
       const { result } = renderHook(() =>
         useTronResources(mockAccount, chainId),

--- a/ui/pages/asset/hooks/useTronResources.ts
+++ b/ui/pages/asset/hooks/useTronResources.ts
@@ -2,16 +2,33 @@ import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { CaipAssetId } from '@metamask/keyring-api';
-import { isTronResource } from '../../../../shared/lib/asset-utils';
-import { getAssetsBySelectedAccountGroupWithTronResources } from '../../../selectors/assets';
+import { isCaipAssetType, parseCaipAssetType } from '@metamask/utils';
+import { isTronSpecialAsset } from '../../../../shared/lib/asset-utils';
+import { getAssetsBySelectedAccountGroupWithTronSpecialAssets } from '../../../selectors/assets';
 import { getMultichainBalances } from '../../../selectors/multichain';
-import { TRON_RESOURCE } from '../../../../shared/constants/multichain/assets';
+import { TRON_SPECIAL_ASSET_CAIP_TYPES } from '../../../../shared/constants/multichain/assets';
+
+const TronResourceType = {
+  ENERGY: 'energy',
+  BANDWIDTH: 'bandwidth',
+} as const;
+
+type TronResourceType =
+  (typeof TronResourceType)[keyof typeof TronResourceType];
 
 export type TronResource = {
-  type: 'energy' | 'bandwidth';
+  type: TronResourceType;
   current: number;
   max: number;
   percentage: number;
+};
+
+const getAssetCaipType = (assetId: string): string | undefined => {
+  if (!isCaipAssetType(assetId)) {
+    return undefined;
+  }
+  const { assetNamespace, assetReference } = parseCaipAssetType(assetId);
+  return `${assetNamespace}:${assetReference}`;
 };
 
 /**
@@ -29,16 +46,21 @@ export const useTronResources = (
   bandwidth: TronResource;
 } => {
   const accountGroupAssets = useSelector(
-    getAssetsBySelectedAccountGroupWithTronResources,
+    getAssetsBySelectedAccountGroupWithTronSpecialAssets,
   );
   const multichainBalances = useSelector(getMultichainBalances);
 
   return useMemo(() => {
     if (!account || !chainId) {
       return {
-        energy: { type: 'energy' as const, current: 0, max: 0, percentage: 0 },
+        energy: {
+          type: TronResourceType.ENERGY,
+          current: 0,
+          max: 0,
+          percentage: 0,
+        },
         bandwidth: {
-          type: 'bandwidth' as const,
+          type: TronResourceType.BANDWIDTH,
           current: 0,
           max: 0,
           percentage: 0,
@@ -48,62 +70,52 @@ export const useTronResources = (
 
     const assets = accountGroupAssets[chainId] || [];
     const balances = multichainBalances?.[account.id];
-    const tronResources = assets.filter((asset) => isTronResource(asset));
+    const tronSpecialAssets = assets.filter((asset) =>
+      isTronSpecialAsset(asset.assetId),
+    );
 
-    // Build resource data from assets
-    const resourceData: {
-      energy: { current: number; max: number };
-      bandwidth: { current: number; max: number };
-    } = {
-      energy: { current: 0, max: 0 },
-      bandwidth: { current: 0, max: 0 },
+    const findByCaipType = (caipType: string) =>
+      tronSpecialAssets.find(
+        (asset) => getAssetCaipType(asset.assetId) === caipType,
+      );
+
+    const getBalance = (asset: (typeof tronSpecialAssets)[0] | undefined) =>
+      asset
+        ? parseFloat(balances?.[asset.assetId as CaipAssetId]?.amount || '0')
+        : 0;
+
+    const energyData = {
+      current: getBalance(findByCaipType(TRON_SPECIAL_ASSET_CAIP_TYPES.ENERGY)),
+      max: getBalance(
+        findByCaipType(TRON_SPECIAL_ASSET_CAIP_TYPES.MAXIMUM_ENERGY),
+      ),
     };
 
-    Object.keys(resourceData).forEach((resourceType) => {
-      const resource = tronResources.find(
-        // eslint-disable-next-line @typescript-eslint/no-shadow
-        (resource) => resource.symbol?.toLowerCase() === resourceType,
-      );
-      const max = tronResources.find(
-        // eslint-disable-next-line @typescript-eslint/no-shadow
-        (resource) => resource.symbol?.toLowerCase() === `max-${resourceType}`,
-      );
+    const bandwidthData = {
+      current: getBalance(
+        findByCaipType(TRON_SPECIAL_ASSET_CAIP_TYPES.BANDWIDTH),
+      ),
+      max: getBalance(
+        findByCaipType(TRON_SPECIAL_ASSET_CAIP_TYPES.MAXIMUM_BANDWIDTH),
+      ),
+    };
 
-      resourceData[resourceType as keyof typeof resourceData] = {
-        current: resource
-          ? parseFloat(
-              balances?.[resource.assetId as CaipAssetId]?.amount || '0',
-            )
-          : 0,
-        max: max
-          ? parseFloat(balances?.[max.assetId as CaipAssetId]?.amount || '0')
-          : 0,
-      };
-    });
-
-    // Create resource objects with calculated percentages
-    // Always create resources even if values are 0 (accounts get free bandwidth)
     const createResource = (
-      type: 'energy' | 'bandwidth',
+      type: TronResourceType,
       data: { current: number; max: number },
     ): TronResource => {
-      // Use max of 1 only for percentage calculation to avoid division by zero
       const divisor = Math.max(1, data.max);
-
       return {
         type,
         current: data.current,
-        max: data.max, // Keep actual max for display (can be 0)
+        max: data.max,
         percentage: (data.current / divisor) * 100,
       };
     };
 
     return {
-      energy: createResource(TRON_RESOURCE.ENERGY, resourceData.energy),
-      bandwidth: createResource(
-        TRON_RESOURCE.BANDWIDTH,
-        resourceData.bandwidth,
-      ),
+      energy: createResource(TronResourceType.ENERGY, energyData),
+      bandwidth: createResource(TronResourceType.BANDWIDTH, bandwidthData),
     };
   }, [account, chainId, accountGroupAssets, multichainBalances]);
 };

--- a/ui/selectors/assets.test.ts
+++ b/ui/selectors/assets.test.ts
@@ -37,8 +37,8 @@ import {
   getAssetsBySelectedAccountGroup,
   getAsset,
   getAllIgnoredAssets,
-  getAssetsBySelectedAccountGroupWithTronResources,
   selectAggregatedBalanceForSelectedAccount,
+  getAssetsBySelectedAccountGroupWithTronSpecialAssets,
 } from './assets';
 
 /**
@@ -1566,10 +1566,10 @@ describe('getAssetsBySelectedAccountGroup', () => {
   });
 });
 
-describe('getAssetsBySelectedAccountGroupWithTronResources', () => {
+describe('getAssetsBySelectedAccountGroupWithTronSpecialAssets', () => {
   beforeEach(() => {
-    getAssetsBySelectedAccountGroupWithTronResources.clearCache();
-    getAssetsBySelectedAccountGroupWithTronResources.memoizedResultFunc.clearCache();
+    getAssetsBySelectedAccountGroupWithTronSpecialAssets.clearCache();
+    getAssetsBySelectedAccountGroupWithTronSpecialAssets.memoizedResultFunc.clearCache();
   });
 
   const mockState = {
@@ -1592,12 +1592,13 @@ describe('getAssetsBySelectedAccountGroupWithTronResources', () => {
     },
   };
 
-  it('calls selector with option to not filter tron resources', () => {
+  it('calls selector with option to not filter tron special assets', () => {
     const selectorMock = jest
       .mocked(selectAssetsBySelectedAccountGroup)
       .mockReturnValue({});
 
-    const result = getAssetsBySelectedAccountGroupWithTronResources(mockState);
+    const result =
+      getAssetsBySelectedAccountGroupWithTronSpecialAssets(mockState);
 
     expect(selectorMock).toHaveBeenCalledWith(mockState.metamask, {
       filterTronStakedTokens: false,

--- a/ui/selectors/assets.ts
+++ b/ui/selectors/assets.ts
@@ -1464,7 +1464,7 @@ export const selectAccountSupportsEnabledNetworks = createSelector(
   },
 );
 
-export const getAssetsBySelectedAccountGroupWithTronResources =
+export const getAssetsBySelectedAccountGroupWithTronSpecialAssets =
   createDeepEqualSelector(
     getStateForAssetSelector,
     (assetListState: AssetListState) =>


### PR DESCRIPTION
## **Description**

As part of Tron's staking experience improvements we will be sending more special assets from the Snap to the Extension. These special assets are not tradeable tokens and should be filtered out from selectors like we already do for Staked TRX for example.

This PR:
- Adds the new special assets that should be ignored by the selectors
- Renames the variables that deal with this logic to be more inclusive of assets that are not resources (only Energy and Bandwidth are resources)

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40540?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Closes: [NEB-582](https://consensyssoftware.atlassian.net/browse/NEB-582), [NEB-584](https://consensyssoftware.atlassian.net/browse/NEB-584), [NEB-586](https://consensyssoftware.atlassian.net/browse/NEB-586)

## **Manual testing steps**

All existing Tron functionality should remain unchanged

## **Screenshots/Recordings**

As you can see, the new assets being loaded from the preview build of https://github.com/MetaMask/snap-tron-wallet/pull/226 are not being shown here.

### **Before**

n/a

### **After**

https://github.com/user-attachments/assets/1b4f445f-ab72-486e-a8b5-e177a33b5d8f

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[NEB-582]: https://consensyssoftware.atlassian.net/browse/NEB-582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NEB-584]: https://consensyssoftware.atlassian.net/browse/NEB-584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NEB-586]: https://consensyssoftware.atlassian.net/browse/NEB-586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes token/balance filtering across several UI and bridge selectors based on CAIP parsing; misclassification could hide legitimate Tron assets or affect displayed totals, though covered by new/updated tests.
> 
> **Overview**
> Adds a CAIP-based definition of **Tron “special assets”** (resources plus new staking-state pseudo-assets) via `TRON_SPECIAL_ASSET_CAIP_TYPES` and a new `isTronSpecialAsset()` helper.
> 
> Updates token lists, bridge asset selectors, and `useMultichainBalances` to filter these special assets by `assetId` so they don’t appear in user-facing pickers/lists or contribute to fiat totals, and renames the Tron-assets selector to `getAssetsBySelectedAccountGroupWithTronSpecialAssets`.
> 
> Refreshes Tron resource handling in `useTronResources` to identify energy/bandwidth via CAIP types (ignoring other staking-state assets) and expands unit tests to cover the new filtering behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03583ad8f89112f00d51ece8efb34a5bf1bb9167. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->