### PR TITLE
fix(webpack): block lavamoat in watch mode

### DIFF
--- a/development/webpack/test/cli.test.ts
+++ b/development/webpack/test/cli.test.ts
@@ -91,7 +91,7 @@ describe('./utils/cli.ts', () => {
   });
 
   // TODO: Remove this temporary block and tests once LavaMoat supports watch
-  // mode. Tracking issue: https://github.com/MetaMask/MetaMask-planning/issues/7075
+  // mode. Tracking issue: https://github.com/MetaMask/metamask-extension/issues/40677
   describe('temporary: block lavamoat and watch mode options', () => {
     it('exits when watch and lavamoat are both enabled', () => {
       const exit = mock.method(process, 'exit', noop as () => never);

--- a/development/webpack/test/cli.test.ts
+++ b/development/webpack/test/cli.test.ts
@@ -1,10 +1,14 @@
-import { describe, it, afterEach } from 'node:test';
+import { describe, it, afterEach, mock } from 'node:test';
 import assert from 'node:assert';
 import { loadBuildTypesConfig } from '../../lib/build-type';
 import { getDryRunMessage, parseArgv } from '../utils/cli';
-import { Browsers } from '../utils/helpers';
+import { Browsers, noop } from '../utils/helpers';
 
 describe('./utils/cli.ts', () => {
+  afterEach(() => {
+    mock.restoreAll();
+  });
+
   const defaultArgs = {
     mode: 'development',
     env: 'development',
@@ -84,6 +88,42 @@ describe('./utils/cli.ts', () => {
   it('should return all browsers when `--browser all` is specified', () => {
     const { args } = parseArgv(['--browser', 'all'], loadBuildTypesConfig());
     assert.deepStrictEqual(args.browser, Browsers);
+  });
+
+  // TODO: Remove this temporary block and tests once LavaMoat supports watch
+  // mode. Tracking issue: https://github.com/MetaMask/MetaMask-planning/issues/7075
+  describe('temporary: block lavamoat and watch mode options', () => {
+    it('exits when watch and lavamoat are both enabled', () => {
+      const exit = mock.method(process, 'exit', noop as () => never);
+      const error = mock.method(console, 'error', noop);
+
+      parseArgv(['--watch', '--lavamoat'], loadBuildTypesConfig());
+
+      assert.strictEqual(exit.mock.calls.length, 1);
+      assert.strictEqual(exit.mock.calls[0].arguments[0], 1);
+      assert.ok(
+        error.mock.calls.some((call) =>
+          String(call.arguments[0]).includes(
+            'LavaMoat does not currently support watch mode.',
+          ),
+        ),
+      );
+    });
+
+    it('explains how to disable lavamoat in production mode', () => {
+      const exit = mock.method(process, 'exit', noop as () => never);
+      const error = mock.method(console, 'error', noop);
+
+      parseArgv(['--mode', 'production', '--watch'], loadBuildTypesConfig());
+
+      assert.strictEqual(exit.mock.calls.length, 1);
+      assert.strictEqual(exit.mock.calls[0].arguments[0], 1);
+      assert.ok(
+        error.mock.calls.some((call) =>
+          String(call.arguments[0]).includes('`--no-lavamoat`'),
+        ),
+      );
+    });
   });
 
   describe('build environment defaulting', () => {

--- a/development/webpack/utils/cli.ts
+++ b/development/webpack/utils/cli.ts
@@ -240,6 +240,23 @@ function getCli<T extends YargsOptionsMap = Options>(options: T, name: string) {
       'Options:': toOrange('Options:'),
       'Examples:': toOrange('Examples:'),
     })
+    .check((args) => {
+      // TODO: LavaMoat doesn't support watch mode yet, so disallow this
+      // combination until that support is implemented.
+      // Tracking issue: https://github.com/MetaMask/MetaMask-planning/issues/7075
+      if (args.watch === true && args.lavamoat === true) {
+        const message =
+          'LavaMoat does not currently support watch mode. See https://github.com/MetaMask/MetaMask-planning/issues/7075 for details.';
+        if (args.mode === 'production') {
+          throw new Error(
+            `${message} LavaMoat is enabled automatically when mode is "production"; you can disable it with \`--no-lavamoat\`.`,
+          );
+        } else {
+          throw new Error(message);
+        }
+      }
+      return true;
+    })
     .options(options);
   return cli;
 }

--- a/development/webpack/utils/cli.ts
+++ b/development/webpack/utils/cli.ts
@@ -243,10 +243,10 @@ function getCli<T extends YargsOptionsMap = Options>(options: T, name: string) {
     .check((args) => {
       // TODO: LavaMoat doesn't support watch mode yet, so disallow this
       // combination until that support is implemented.
-      // Tracking issue: https://github.com/MetaMask/MetaMask-planning/issues/7075
+      // Tracking issue: https://github.com/MetaMask/metamask-extension/issues/40677
       if (args.watch === true && args.lavamoat === true) {
         const message =
-          'LavaMoat does not currently support watch mode. See https://github.com/MetaMask/MetaMask-planning/issues/7075 for details.';
+          'LavaMoat does not currently support watch mode. See https://github.com/MetaMask/metamask-extension/issues/40677 for details.';
         if (args.mode === 'production') {
           throw new Error(
             `${message} LavaMoat is enabled automatically when mode is "production"; you can disable it with \`--no-lavamoat\`.`,


### PR DESCRIPTION
## **Description**

This PR blocks unsupported webpack CLI usage where `watch` and `lavamoat` are enabled at the same time.

Changes included:
- Added a `yargs` `.check()` guard in the webpack CLI parser to fail when both options resolve to `true`.
- Added a clear error message with a production-specific hint to use `--no-lavamoat`.
- Added/organized unit tests under a temporary block with a TODO linked to the tracking issue.

Tracking issue: https://github.com/MetaMask/MetaMask-planning/issues/7075

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40546?quickstart=1)

## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Run `yarn tsx --test development/webpack/test/cli.test.ts` and verify all tests pass.
2. Run `yarn webpack --watch --lavamoat` and verify it exits with the LavaMoat/watch-mode error.
3. Run `yarn webpack --mode production --watch` and verify the error message includes the `--no-lavamoat` guidance.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

<!--
## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build-tooling change that only rejects an unsupported flag combination; main impact is potentially breaking any scripts that currently rely on `--watch` with implicit/explicit `--lavamoat`.
> 
> **Overview**
> Adds a `yargs` validation check in the webpack CLI (`development/webpack/utils/cli.ts`) to **disallow `--watch` when `lavamoat` resolves to `true`**, since LavaMoat doesn’t support watch mode; production mode errors additionally point users to `--no-lavamoat`.
> 
> Updates `cli.test.ts` to cover the new failure behavior by mocking `process.exit`/`console.error`, and restores mocks after each test.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8cb6f02d56b2e76702a6f7f3ea96a4d56c80814d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->