### PR TITLE
feat: webpack build type assets

### DIFF
--- a/development/webpack/webpack.config.ts
+++ b/development/webpack/webpack.config.ts
@@ -162,6 +162,25 @@ const plugins: WebpackPluginInstance[] = [
       // misc images
       // TODO: fix overlap between this folder and automatically bundled assets
       { from: join(context, 'images'), to: 'images' },
+      // TODO: automatically bundle build-type specific images
+      ...(args.type === 'flask'
+        ? [
+            {
+              from: join(context, 'build-types', 'flask', 'images'),
+              to: 'images',
+              force: true,
+            },
+          ]
+        : []),
+      ...(args.type === 'beta'
+        ? [
+            {
+              from: join(context, 'build-types', 'beta', 'images'),
+              to: 'images',
+              force: true,
+            },
+          ]
+        : []),
       // snaps MV3 needs the offscreen document
       ...(MANIFEST_VERSION === 3
         ? [


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40547?quickstart=1)

This PR adds two entries to the copy plugin to copy build-type specific images to the dist folder when necessary. Later, this will need to be refactored to automatically bundle the icons based on the manifest.json, and to bundle the images from the source code. Today, this would be very difficult because we still use the browserify build system, so we would need to do dirty hacks on the browserify side to allow this behavior. Deprecating browserify first will make implementing webpack automatic bundling a lot easier in the future.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/26260

## **Manual testing steps**

1. run `yarn webpack --type flask`
2. you should see the flask images

## **Screenshots/Recordings**

Not applicable

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
