### PR TITLE
docs: update feature flag registry documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,55 +194,20 @@ Feature flags used in tests fall into two categories: remote flags (runtime valu
 
 Remote flags are provided at runtime and should usually follow production defaults from the [Feature Flag Registry](./test/e2e/feature-flags/feature-flag-registry.ts). You do not need a custom build just to change a remote flag value for a test.
 
-Use one of these test-time overrides (choose whichever fits your scenario):
+Use one of these test-time overrides:
 
-- **Manifest override in `withFixtures`** — applies the override at the extension manifest level. Best for simple, test-wide flag overrides that don't depend on other fixture state:
-  ```javascript
-  await withFixtures(
-    {
-      manifestFlags: {
-        remoteFeatureFlags: { myRemoteFlag: true },
-      },
-    },
-    async () => {
-      /* ... */
-    },
-  );
-  ```
-- **Fixture state override via `FixtureBuilder`** — merges values directly into `RemoteFeatureFlagController` state. Best when you need the flag change to interact with other fixture state or when you're already customizing fixtures. Note: `withRemoteFeatureFlags` is only available on the legacy `FixtureBuilder`; use this builder when you need this method, even for new tests:
-  ```javascript
-  new FixtureBuilder().withRemoteFeatureFlags({ myRemoteFlag: true }).build();
-  ```
+- **`manifestFlags` in `withFixtures`** — best for simple, test-wide flag overrides that don't depend on other fixture state.
+- **`FixtureBuilder.withRemoteFeatureFlags()`** — best when you need the flag change to interact with other fixture state. Note: this method is only available on the legacy `FixtureBuilder`; use this builder when you need it, even for new tests.
 
-Then run tests as usual, for example:
-`yarn test:e2e:single test/e2e/tests/account-menu/account-details.spec.js --browser=chrome`
+For code examples and detailed guidelines, see [Feature flags in E2E tests](https://github.com/MetaMask/contributor-docs/blob/main/docs/testing/e2e-testing.md#feature-flags-in-e2e-tests) in contributor-docs.
 
 ##### Build-time feature flags (compile-time)
 
-Build-time flags are set before running tests and require creating a test build with the flag enabled.
-
-- **Via local `.metamaskrc`:**
-  1. Copy `.metamaskrc.dist` to `.metamaskrc` if needed.
-  2. Set your build-time flag in `.metamaskrc`.
-  3. Create a test build with `yarn build:test`.
-
-- **Via command line (single build):**
-  Enable the flag when starting the build command, for example:
-  `MULTICHAIN=1 yarn build:test`
-  or
-  `MULTICHAIN=1 yarn start:test`
-
-After building, run your E2E tests normally. This ensures tests run against the intended build configuration.
+Build-time flags are set before running tests and require creating a test build with the flag enabled. Set the flag either in your local `.metamaskrc` file or as an environment variable prefix (e.g. `MULTICHAIN=1 yarn build:test`), then follow the steps in [Preparing a Test Build](#preparing-a-test-build) to create and run the build.
 
 #### Feature Flag Registry
 
-The [Feature Flag Registry](./test/e2e/feature-flags/feature-flag-registry.ts) is the central source of truth for all remote feature flags used in MetaMask Extension. It ensures E2E tests run against production-accurate flag configurations by default, and provides CI enforcement so every flag reference in the codebase is tracked.
-
-##### How it works
-
-In production, MetaMask fetches remote feature flags from the [client-config API](https://client-config.api.cx.metamask.io/v1/flags?client=extension&distribution=main&environment=prod) at runtime. During E2E tests, the global mock server (`test/e2e/mock-e2e.js`) reads from the registry instead of calling the real API. Each registry entry stores the flag's production default value, so tests reflect real-world behavior unless a specific test explicitly overrides a flag.
-
-A GitHub Actions CI check ([`.github/workflows/check-feature-flag-registry.yml`](./.github/workflows/check-feature-flag-registry.yml)) runs on every PR. It scans changed files for remote feature flag references (dot access, bracket access, destructuring) and verifies each one exists in the registry. If an unregistered flag is detected, the check fails and posts a comment on the PR explaining what to fix.
+The [Feature Flag Registry](./test/e2e/feature-flags/feature-flag-registry.ts) is the central source of truth for all remote feature flags used in MetaMask Extension E2E tests. A [CI check](./.github/workflows/check-feature-flag-registry.yml) runs on every PR to verify that every remote flag reference in changed files exists in the registry. For background on how remote feature flags work in MetaMask, see the [Remote Feature Flags](https://github.com/MetaMask/contributor-docs/blob/main/docs/remote-feature-flags.md) contributor doc.
 
 ##### Registry entry format
 
@@ -266,7 +231,9 @@ myNewFlag: {
 | `productionDefault` | Any valid JSON value (`Json` type — boolean, number, string, null, object, or array)    |
 | `status`            | `FeatureFlagStatus.Active` or `FeatureFlagStatus.Deprecated`                            |
 
-##### Adding a new remote feature flag
+##### Add a flag to the registry
+
+For the full process of creating a remote feature flag (LaunchDarkly setup, code integration), see the [Remote Feature Flags](https://github.com/MetaMask/contributor-docs/blob/main/docs/remote-feature-flags.md) contributor doc. Once the flag exists, register it for E2E tests:
 
 1. Look up the flag's current production value from the [client-config API](https://client-config.api.cx.metamask.io/v1/flags?client=extension&distribution=main&environment=prod). If the flag is not yet in production, set `inProd: false` and `productionDefault` to the intended default.
 2. Add an entry to `test/e2e/feature-flags/feature-flag-registry.ts` in alphabetical order.
@@ -276,20 +243,9 @@ myNewFlag: {
 
 To test behavior with a flag value different from the production default, see the override examples in [Remote feature flags (runtime)](#remote-feature-flags-runtime) above.
 
-##### Helper functions
+The registry module also exports helper functions for use in tests and tooling (e.g. `getProductionRemoteFlagApiResponse()`, `getProductionRemoteFlagDefaults()`). See the JSDoc in [feature-flag-registry.ts](./test/e2e/feature-flags/feature-flag-registry.ts) for details.
 
-The registry module exports several utilities for use in tests and tooling:
-
-| Function                               | Description                                                                              |
-| -------------------------------------- | ---------------------------------------------------------------------------------------- |
-| `getProductionRemoteFlagApiResponse()` | Returns flags in the raw API format (array of single-key objects), used by `mock-e2e.js` |
-| `getProductionRemoteFlagDefaults()`    | Returns a flat `{ flagName: value }` map, useful for assertions and `FixtureBuilder`     |
-| `getRegistryEntry(name)`               | Looks up a single flag's metadata                                                        |
-| `getRegisteredFlagNames()`             | Returns all registered flag names                                                        |
-| `getRegistryEntriesByStatus(status)`   | Filters entries by `Active` or `Deprecated` status                                       |
-| `getDeprecatedFlags()`                 | Returns entries marked as `Deprecated` (candidates for removal)                          |
-
-##### Removing a flag
+##### Remove a flag
 
 When a remote feature flag is fully rolled out or no longer needed:
 

--- a/README.md
+++ b/README.md
@@ -199,6 +199,86 @@ Once you've created a test build with the desired feature flag enabled, proceed 
 
 This approach ensures that your e2e tests accurately reflect the user experience for the upcoming GA features.
 
+#### Feature Flag Registry
+
+The [Feature Flag Registry](./test/e2e/feature-flags/feature-flag-registry.ts) is the central source of truth for all remote feature flags used in MetaMask Extension. It ensures E2E tests run against production-accurate flag configurations by default, and provides CI enforcement so every flag reference in the codebase is tracked.
+
+##### How it works
+
+In production, MetaMask fetches remote feature flags from the [client-config API](https://client-config.api.cx.metamask.io/v1/flags?client=extension&distribution=main&environment=prod) at runtime. During E2E tests, the global mock server (`test/e2e/mock-e2e.js`) reads from the registry instead of calling the real API. Each registry entry stores the flag's production default value, so tests reflect real-world behavior unless a specific test explicitly overrides a flag.
+
+A GitHub Actions CI check ([`.github/workflows/check-feature-flag-registry.yml`](./.github/workflows/check-feature-flag-registry.yml)) runs on every PR. It scans changed files for remote feature flag references (dot access, bracket access, destructuring) and verifies each one exists in the registry. If an unregistered flag is detected, the check fails and posts a comment on the PR explaining what to fix.
+
+##### Registry entry format
+
+Each entry in `test/e2e/feature-flags/feature-flag-registry.ts` has the following shape:
+
+```typescript
+myNewFlag: {
+  name: 'myNewFlag',
+  type: FeatureFlagType.Remote,
+  inProd: true,
+  productionDefault: false,
+  status: FeatureFlagStatus.Active,
+},
+```
+
+| Field | Description |
+| ---- | ---- |
+| `name` | Must match the object key exactly |
+| `type` | `FeatureFlagType.Remote` (fetched at runtime) or `FeatureFlagType.Build` (compile-time) |
+| `inProd` | Whether the flag currently exists in the production client-config API |
+| `productionDefault` | The value returned by the production API (boolean, string, object, or array) |
+| `status` | `FeatureFlagStatus.Active` or `FeatureFlagStatus.Deprecated` |
+
+##### Adding a new remote feature flag
+
+1. Look up the flag's current production value from the [client-config API](https://client-config.api.cx.metamask.io/v1/flags?client=extension&distribution=main&environment=prod). If the flag is not yet in production, set `inProd: false` and `productionDefault` to the intended default.
+2. Add an entry to `test/e2e/feature-flags/feature-flag-registry.ts` in alphabetical order.
+3. If you access the flag via a constant (e.g. `remoteFeatureFlags[MY_CONSTANT]`), also add the constant mapping to [`.github/scripts/known-feature-flag-constants.ts`](./.github/scripts/known-feature-flag-constants.ts) so the CI check can resolve it.
+
+##### Overriding flags in E2E tests
+
+To test behavior with a flag value different from the production default, use one of these approaches:
+
+- **Runtime override via manifest flags:**
+  ```javascript
+  await withFixtures(
+    {
+      manifestFlags: {
+        remoteFeatureFlags: { myNewFlag: true },
+      },
+    },
+    async ({ driver }) => { /* ... */ },
+  );
+  ```
+
+- **Fixture state override via FixtureBuilder:**
+  ```javascript
+  new FixtureBuilder().withRemoteFeatureFlags({ myNewFlag: true }).build();
+  ```
+
+##### Helper functions
+
+The registry module exports several utilities for use in tests and tooling:
+
+| Function | Description |
+| ---- | ---- |
+| `getProductionRemoteFlagApiResponse()` | Returns flags in the raw API format (array of single-key objects), used by `mock-e2e.js` |
+| `getProductionRemoteFlagDefaults()` | Returns a flat `{ flagName: value }` map, useful for assertions and `FixtureBuilder` |
+| `getRegistryEntry(name)` | Looks up a single flag's metadata |
+| `getRegisteredFlagNames()` | Returns all registered flag names |
+| `getRegistryEntriesByStatus(status)` | Filters entries by `Active` or `Deprecated` status |
+| `getDeprecatedFlags()` | Returns entries marked as `Deprecated` (candidates for removal) |
+
+##### Removing a flag
+
+When a remote feature flag is fully rolled out or no longer needed:
+
+1. Remove all references to the flag from application code (`app/`, `ui/`, `shared/`).
+2. Either remove the entry from the registry, or change its `status` to `FeatureFlagStatus.Deprecated` if you want to track it temporarily.
+3. The CI check will post a warning on PRs that remove the last codebase reference to a registered flag, reminding you to clean up the registry.
+
 #### Running E2E performance benchmarks
 
 E2E performance benchmarks measure flow timings (onboarding, send, swap, asset details, etc.) and can be run locally or in CI. Use `yarn test:e2e:benchmark` with `--preset <name>` or a file path. See [test/e2e/benchmarks/flows/README.md](test/e2e/benchmarks/flows/README.md) for presets and options.

--- a/README.md
+++ b/README.md
@@ -194,9 +194,9 @@ Feature flags used in tests fall into two categories: remote flags (runtime valu
 
 Remote flags are provided at runtime and should usually follow production defaults from the [Feature Flag Registry](./test/e2e/feature-flags/feature-flag-registry.ts). You do not need a custom build just to change a remote flag value for a test.
 
-Use one of these test-time overrides:
+Use one of these test-time overrides (choose whichever fits your scenario):
 
-- **Manifest override in `withFixtures`:**
+- **Manifest override in `withFixtures`** — applies the override at the extension manifest level. Best for simple, test-wide flag overrides that don't depend on other fixture state:
   ```javascript
   await withFixtures(
     {
@@ -209,7 +209,7 @@ Use one of these test-time overrides:
     },
   );
   ```
-- **Fixture state override via `FixtureBuilder`:**
+- **Fixture state override via `FixtureBuilder`** — merges values directly into `RemoteFeatureFlagController` state. Best when you need the flag change to interact with other fixture state or when you're already customizing fixtures. Note: `withRemoteFeatureFlags` is only available on the legacy `FixtureBuilder`; use this builder when you need this method, even for new tests:
   ```javascript
   new FixtureBuilder().withRemoteFeatureFlags({ myRemoteFlag: true }).build();
   ```
@@ -263,7 +263,7 @@ myNewFlag: {
 | `name`              | Must match the object key exactly                                                       |
 | `type`              | `FeatureFlagType.Remote` (fetched at runtime) or `FeatureFlagType.Build` (compile-time) |
 | `inProd`            | Whether the flag currently exists in the production client-config API                   |
-| `productionDefault` | The value returned by the production API (boolean, string, object, or array)            |
+| `productionDefault` | Any valid JSON value (`Json` type — boolean, number, string, null, object, or array)    |
 | `status`            | `FeatureFlagStatus.Active` or `FeatureFlagStatus.Deprecated`                            |
 
 ##### Adding a new remote feature flag

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ For the full process of creating a remote feature flag (LaunchDarkly setup, code
 2. Add an entry to `test/e2e/feature-flags/feature-flag-registry.ts` in alphabetical order.
 3. If you access the flag via a constant (e.g. `remoteFeatureFlags[MY_CONSTANT]`), also add the constant mapping to [`.github/scripts/known-feature-flag-constants.ts`](./.github/scripts/known-feature-flag-constants.ts) so the CI check can resolve it.
 
-##### Overriding flags in E2E tests
+##### Override flags in E2E tests
 
 To test behavior with a flag value different from the production default, see the override examples in [Remote feature flags (runtime)](#remote-feature-flags-runtime) above.
 

--- a/README.md
+++ b/README.md
@@ -223,13 +223,13 @@ myNewFlag: {
 },
 ```
 
-| Field | Description |
-| ---- | ---- |
-| `name` | Must match the object key exactly |
-| `type` | `FeatureFlagType.Remote` (fetched at runtime) or `FeatureFlagType.Build` (compile-time) |
-| `inProd` | Whether the flag currently exists in the production client-config API |
-| `productionDefault` | The value returned by the production API (boolean, string, object, or array) |
-| `status` | `FeatureFlagStatus.Active` or `FeatureFlagStatus.Deprecated` |
+| Field               | Description                                                                             |
+| ------------------- | --------------------------------------------------------------------------------------- |
+| `name`              | Must match the object key exactly                                                       |
+| `type`              | `FeatureFlagType.Remote` (fetched at runtime) or `FeatureFlagType.Build` (compile-time) |
+| `inProd`            | Whether the flag currently exists in the production client-config API                   |
+| `productionDefault` | The value returned by the production API (boolean, string, object, or array)            |
+| `status`            | `FeatureFlagStatus.Active` or `FeatureFlagStatus.Deprecated`                            |
 
 ##### Adding a new remote feature flag
 
@@ -242,6 +242,7 @@ myNewFlag: {
 To test behavior with a flag value different from the production default, use one of these approaches:
 
 - **Runtime override via manifest flags:**
+
   ```javascript
   await withFixtures(
     {
@@ -249,7 +250,9 @@ To test behavior with a flag value different from the production default, use on
         remoteFeatureFlags: { myNewFlag: true },
       },
     },
-    async ({ driver }) => { /* ... */ },
+    async ({ driver }) => {
+      /* ... */
+    },
   );
   ```
 
@@ -262,14 +265,14 @@ To test behavior with a flag value different from the production default, use on
 
 The registry module exports several utilities for use in tests and tooling:
 
-| Function | Description |
-| ---- | ---- |
+| Function                               | Description                                                                              |
+| -------------------------------------- | ---------------------------------------------------------------------------------------- |
 | `getProductionRemoteFlagApiResponse()` | Returns flags in the raw API format (array of single-key objects), used by `mock-e2e.js` |
-| `getProductionRemoteFlagDefaults()` | Returns a flat `{ flagName: value }` map, useful for assertions and `FixtureBuilder` |
-| `getRegistryEntry(name)` | Looks up a single flag's metadata |
-| `getRegisteredFlagNames()` | Returns all registered flag names |
-| `getRegistryEntriesByStatus(status)` | Filters entries by `Active` or `Deprecated` status |
-| `getDeprecatedFlags()` | Returns entries marked as `Deprecated` (candidates for removal) |
+| `getProductionRemoteFlagDefaults()`    | Returns a flat `{ flagName: value }` map, useful for assertions and `FixtureBuilder`     |
+| `getRegistryEntry(name)`               | Looks up a single flag's metadata                                                        |
+| `getRegisteredFlagNames()`             | Returns all registered flag names                                                        |
+| `getRegistryEntriesByStatus(status)`   | Filters entries by `Active` or `Deprecated` status                                       |
+| `getDeprecatedFlags()`                 | Returns entries marked as `Deprecated` (candidates for removal)                          |
 
 ##### Removing a flag
 

--- a/README.md
+++ b/README.md
@@ -186,18 +186,53 @@ Single e2e tests can be run with `yarn test:e2e:single test/e2e/tests/TEST_NAME.
 For example, to run the `account-details` tests using Chrome, with debug logging and with the browser set to remain open upon failure, you would use:
 `yarn test:e2e:single test/e2e/tests/account-menu/account-details.spec.js --browser=chrome --leave-running`
 
-#### Running e2e tests against specific feature flag
+#### Running E2E tests with feature flags
 
-While developing new features, we often use feature flags. As we prepare to make these features generally available (GA), we remove the feature flags. Existing feature flags are listed in the `.metamaskrc.dist` file. To execute e2e tests with a particular feature flag enabled, it's necessary to first generate a test build with that feature flag activated. There are two ways to achieve this:
+Feature flags used in tests fall into two categories: remote flags (runtime values fetched from client-config) and build-time flags (compile-time values set during the build). Use the workflow that matches the flag type.
 
-- To enable a feature flag in your local configuration, you should first ensure you have a `.metamaskrc` file copied from `.metamaskrc.dist`. Then, within your local `.metamaskrc` file, you can set the desired feature flag to true. Following this, a test build with the feature flag enabled can be created by executing `yarn build:test`.
+##### Remote feature flags (runtime)
 
-- Alternatively, for enabling a feature flag directly during the test build creation, you can pass the parameter as true via the command line. For instance, activating the MULTICHAIN feature flag can be done by running `MULTICHAIN=1 yarn build:test` or `MULTICHAIN=1 yarn start:test` . This method allows for quick adjustments to feature flags without altering the `.metamaskrc` file.
+Remote flags are provided at runtime and should usually follow production defaults from the [Feature Flag Registry](./test/e2e/feature-flags/feature-flag-registry.ts). You do not need a custom build just to change a remote flag value for a test.
 
-Once you've created a test build with the desired feature flag enabled, proceed to run your tests as usual. Your tests will now run against the version of the extension with the specific feature flag activated. For example:
+Use one of these test-time overrides:
+
+- **Manifest override in `withFixtures`:**
+  ```javascript
+  await withFixtures(
+    {
+      manifestFlags: {
+        remoteFeatureFlags: { myRemoteFlag: true },
+      },
+    },
+    async () => {
+      /* ... */
+    },
+  );
+  ```
+- **Fixture state override via `FixtureBuilder`:**
+  ```javascript
+  new FixtureBuilder().withRemoteFeatureFlags({ myRemoteFlag: true }).build();
+  ```
+
+Then run tests as usual, for example:
 `yarn test:e2e:single test/e2e/tests/account-menu/account-details.spec.js --browser=chrome`
 
-This approach ensures that your e2e tests accurately reflect the user experience for the upcoming GA features.
+##### Build-time feature flags (compile-time)
+
+Build-time flags are set before running tests and require creating a test build with the flag enabled.
+
+- **Via local `.metamaskrc`:**
+  1. Copy `.metamaskrc.dist` to `.metamaskrc` if needed.
+  2. Set your build-time flag in `.metamaskrc`.
+  3. Create a test build with `yarn build:test`.
+
+- **Via command line (single build):**
+  Enable the flag when starting the build command, for example:
+  `MULTICHAIN=1 yarn build:test`
+  or
+  `MULTICHAIN=1 yarn start:test`
+
+After building, run your E2E tests normally. This ensures tests run against the intended build configuration.
 
 #### Feature Flag Registry
 
@@ -239,27 +274,7 @@ myNewFlag: {
 
 ##### Overriding flags in E2E tests
 
-To test behavior with a flag value different from the production default, use one of these approaches:
-
-- **Runtime override via manifest flags:**
-
-  ```javascript
-  await withFixtures(
-    {
-      manifestFlags: {
-        remoteFeatureFlags: { myNewFlag: true },
-      },
-    },
-    async ({ driver }) => {
-      /* ... */
-    },
-  );
-  ```
-
-- **Fixture state override via FixtureBuilder:**
-  ```javascript
-  new FixtureBuilder().withRemoteFeatureFlags({ myNewFlag: true }).build();
-  ```
+To test behavior with a flag value different from the production default, see the override examples in [Remote feature flags (runtime)](#remote-feature-flags-runtime) above.
 
 ##### Helper functions
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Add a new Feature Flag Registry section to `README.md` to document how remote flags are managed for E2E tests.
Explain the full workflow: production source-of-truth, E2E mock behavior, CI enforcement via `check-feature-flag-registry`, and registry entry format.
Document contributor guidance for adding, overriding, and removing feature flags, including helper utilities and constant mapping requirements.

The feature flag registry and CI check were added to keep flag usage production-accurate and prevent untracked flag references. This documentation makes the workflow discoverable and reduces onboarding/friction for contributors updating or introducing flags.


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40554?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: [MMQA-1481](https://consensyssoftware.atlassian.net/browse/MMQA-1481?atlOrigin=eyJpIjoiNTUwZmIzOGU4Nzg1NDI4N2E2ZDI0OTE3OGEyOGNmMGEiLCJwIjoiaiJ9)

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[MMQA-1481]: https://consensyssoftware.atlassian.net/browse/MMQA-1481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes with no runtime behavior modifications.
> 
> **Overview**
> Updates `README.md` E2E guidance to clearly separate **remote (runtime)** vs **build-time (compile-time)** feature flags and points to the recommended test-time override mechanisms (`manifestFlags` in `withFixtures`, legacy `FixtureBuilder.withRemoteFeatureFlags()`).
> 
> Adds a new **Feature Flag Registry** section documenting `test/e2e/feature-flags/feature-flag-registry.ts` as the source of truth for remote flags in E2E, how the `check-feature-flag-registry` CI job enforces registry coverage, and contributor steps to add/override/remove flags (including constant mapping in `.github/scripts/known-feature-flag-constants.ts`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 11635604cb642b70024a274d0ec4a82902b4b1b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->