### PR TITLE
feat: add AsterDEX to defi referral program

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -738,6 +738,10 @@
   "assetsDescription": {
     "message": "Autodetect tokens in your wallet, display NFTs, and get batched account balance updates"
   },
+  "asterdexReferralSubtitle": {
+    "message": "Get 4% back on trades with a MetaMask referral code.",
+    "description": "The subtitle of the AsterDEX referral confirmation screen"
+  },
   "attemptToCancelSwapForFree": {
     "message": "Attempt to cancel swap for free"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -738,6 +738,10 @@
   "assetsDescription": {
     "message": "Autodetect tokens in your wallet, display NFTs, and get batched account balance updates"
   },
+  "asterdexReferralSubtitle": {
+    "message": "Get 4% back on trades with a MetaMask referral code.",
+    "description": "The subtitle of the AsterDEX referral confirmation screen"
+  },
   "attemptToCancelSwapForFree": {
     "message": "Attempt to cancel swap for free"
   },

--- a/app/scripts/controllers/preferences-controller.test.ts
+++ b/app/scripts/controllers/preferences-controller.test.ts
@@ -995,6 +995,7 @@ describe('preferences controller', () => {
             "useSidePanelAsDefault": false,
           },
           "referrals": {
+            "asterdex": {},
             "gmx": {},
             "hyperliquid": {},
           },
@@ -1081,6 +1082,7 @@ describe('preferences controller', () => {
             "useSidePanelAsDefault": false,
           },
           "referrals": {
+            "asterdex": {},
             "gmx": {},
             "hyperliquid": {},
           },
@@ -1167,6 +1169,7 @@ describe('preferences controller', () => {
             "useSidePanelAsDefault": false,
           },
           "referrals": {
+            "asterdex": {},
             "gmx": {},
             "hyperliquid": {},
           },
@@ -1305,6 +1308,7 @@ describe('preferences controller', () => {
                 [testAccount2]: ReferralStatus.Declined,
               },
               [DefiReferralPartner.GMX]: {},
+              [DefiReferralPartner.AsterDEX]: {},
             },
           },
         });
@@ -1328,6 +1332,7 @@ describe('preferences controller', () => {
                 [testAccount1]: ReferralStatus.Declined,
               },
               [DefiReferralPartner.GMX]: {},
+              [DefiReferralPartner.AsterDEX]: {},
             },
           },
         });
@@ -1368,6 +1373,7 @@ describe('preferences controller', () => {
                 [existingAccount]: ReferralStatus.Declined,
               },
               [DefiReferralPartner.GMX]: {},
+              [DefiReferralPartner.AsterDEX]: {},
             },
           },
         });
@@ -1390,6 +1396,7 @@ describe('preferences controller', () => {
                 [existingAccount]: ReferralStatus.Approved,
               },
               [DefiReferralPartner.GMX]: {},
+              [DefiReferralPartner.AsterDEX]: {},
             },
           },
         });
@@ -1410,6 +1417,9 @@ describe('preferences controller', () => {
         ).toStrictEqual({});
         expect(
           controller.state.referrals[DefiReferralPartner.GMX],
+        ).toStrictEqual({});
+        expect(
+          controller.state.referrals[DefiReferralPartner.AsterDEX],
         ).toStrictEqual({});
       });
 

--- a/app/scripts/controllers/preferences-controller.ts
+++ b/app/scripts/controllers/preferences-controller.ts
@@ -254,6 +254,7 @@ export const getDefaultPreferencesControllerState =
     useTransactionSimulations: true,
     watchEthereumAccountEnabled: false,
     referrals: {
+      [DefiReferralPartner.AsterDEX]: {},
       [DefiReferralPartner.GMX]: {},
       [DefiReferralPartner.Hyperliquid]: {},
     },

--- a/app/scripts/lib/createDefiReferralMiddleware.test.ts
+++ b/app/scripts/lib/createDefiReferralMiddleware.test.ts
@@ -5,6 +5,7 @@ import {
   DEFI_REFERRAL_PARTNERS,
   DefiReferralPartner,
 } from '../../../shared/constants/defi-referrals';
+import { SECOND } from '../../../shared/constants/time';
 import type { ExtendedJSONRPCRequest } from './createDefiReferralMiddleware';
 
 const mockLogError = jest.fn();
@@ -304,6 +305,31 @@ describe('createDefiReferralMiddleware', () => {
       );
 
       expect(mockHandleReferral).not.toHaveBeenCalled();
+    });
+
+    it('does not trigger when eth_signTypedData_v4 is after the wait window', async () => {
+      jest.useFakeTimers();
+
+      await runMiddleware(
+        createMockRequest(
+          TEST_PARTNER_2_STEP_ORIGIN,
+          'wallet_requestPermissions',
+        ),
+        createWalletRequestPermissionsResponse(TEST_PARTNER_2_STEP_ORIGIN),
+      );
+      expect(mockHandleReferral).not.toHaveBeenCalled();
+
+      // Advance past WAIT_AFTER_FIRST_REQUEST_MS so the interval prunes the entry
+      jest.advanceTimersByTime(SECOND * 10 + 1);
+
+      await runMiddleware(
+        createMockRequest(TEST_PARTNER_2_STEP_ORIGIN, 'eth_signTypedData_v4'),
+        signTypedDataV4Response,
+      );
+
+      expect(mockHandleReferral).not.toHaveBeenCalled();
+
+      jest.useRealTimers();
     });
   });
 });

--- a/app/scripts/lib/createDefiReferralMiddleware.test.ts
+++ b/app/scripts/lib/createDefiReferralMiddleware.test.ts
@@ -1,25 +1,24 @@
 import { PendingJsonRpcResponse } from '@metamask/utils';
 import { ValidPermission, type Caveat } from '@metamask/permission-controller';
 import type { Json } from '@metamask/utils';
-import log from 'loglevel';
 import {
   DEFI_REFERRAL_PARTNERS,
   DefiReferralPartner,
 } from '../../../shared/constants/defi-referrals';
-import {
-  createDefiReferralMiddleware,
-  ReferralTriggerType,
-  type ExtendedJSONRPCRequest,
-} from './createDefiReferralMiddleware';
+import type { ExtendedJSONRPCRequest } from './createDefiReferralMiddleware';
 
-jest.mock('loglevel', () => ({
-  error: jest.fn(),
-}));
+const mockLogError = jest.fn();
+jest.mock('loglevel', () => ({ error: mockLogError }));
 
-// Use any partner for tests - the specific partner doesn't matter
+let createDefiReferralMiddleware: typeof import('./createDefiReferralMiddleware').createDefiReferralMiddleware;
+let ReferralTriggerType: typeof import('./createDefiReferralMiddleware').ReferralTriggerType;
+
 const TEST_PARTNER = DEFI_REFERRAL_PARTNERS[DefiReferralPartner.Hyperliquid];
 const TEST_PARTNER_ORIGIN = TEST_PARTNER.origin;
 const NON_PARTNER_ORIGIN = 'https://example.com';
+const TEST_PARTNER_2_STEP =
+  DEFI_REFERRAL_PARTNERS[DefiReferralPartner.AsterDEX];
+const TEST_PARTNER_2_STEP_ORIGIN = TEST_PARTNER_2_STEP.origin;
 
 const createMockRequest = (
   origin: string,
@@ -58,14 +57,29 @@ const createEthRequestAccountsResponse = (
   result: accounts,
 });
 
+const signTypedDataV4Response: PendingJsonRpcResponse<string> = {
+  id: 1,
+  jsonrpc: '2.0',
+  result: '0xabcd1234',
+};
+
 describe('createDefiReferralMiddleware', () => {
   let mockHandleReferral: jest.Mock;
   let mockNext: jest.Mock;
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    // Dynamic import so each test gets a fresh map (pending reset in afterEach)
+    // eslint-disable-next-line import/extensions
+    const module = await import('./createDefiReferralMiddleware.ts');
+    createDefiReferralMiddleware = module.createDefiReferralMiddleware;
+    ReferralTriggerType = module.ReferralTriggerType;
     jest.clearAllMocks();
     mockHandleReferral = jest.fn().mockResolvedValue(undefined);
     mockNext = jest.fn((cb) => cb?.());
+  });
+
+  afterEach(() => {
+    jest.resetModules(); // Reset the ./createDefiReferralMiddleware.ts import
   });
 
   const runMiddleware = (
@@ -85,60 +99,62 @@ describe('createDefiReferralMiddleware', () => {
     });
   };
 
-  describe('wallet_requestPermissions requests', () => {
-    it('triggers referral when eth_accounts permission is granted', async () => {
-      await runMiddleware(
-        createMockRequest(TEST_PARTNER_ORIGIN),
-        createWalletRequestPermissionsResponse(TEST_PARTNER_ORIGIN),
-      );
+  describe('Partners with single-step `permissions` connection flow', () => {
+    describe('wallet_requestPermissions requests', () => {
+      it('triggers referral when eth_accounts permission is granted', async () => {
+        await runMiddleware(
+          createMockRequest(TEST_PARTNER_ORIGIN),
+          createWalletRequestPermissionsResponse(TEST_PARTNER_ORIGIN),
+        );
 
-      expect(mockNext).toHaveBeenCalledTimes(1);
-      expect(mockHandleReferral).toHaveBeenCalledTimes(1);
-      expect(mockHandleReferral).toHaveBeenCalledWith(
-        TEST_PARTNER,
-        123,
-        ReferralTriggerType.NewConnection,
-      );
+        expect(mockNext).toHaveBeenCalledTimes(1);
+        expect(mockHandleReferral).toHaveBeenCalledTimes(1);
+        expect(mockHandleReferral).toHaveBeenCalledWith(
+          TEST_PARTNER,
+          123,
+          ReferralTriggerType.NewConnection,
+        );
+      });
+
+      it('does not trigger referral when eth_accounts permission is not in result', async () => {
+        await runMiddleware(
+          createMockRequest(TEST_PARTNER_ORIGIN),
+          createWalletRequestPermissionsResponse(
+            TEST_PARTNER_ORIGIN,
+            'other_permission',
+          ),
+        );
+
+        expect(mockNext).toHaveBeenCalledTimes(1);
+        expect(mockHandleReferral).not.toHaveBeenCalled();
+      });
     });
 
-    it('does not trigger referral when eth_accounts permission is not in result', async () => {
-      await runMiddleware(
-        createMockRequest(TEST_PARTNER_ORIGIN),
-        createWalletRequestPermissionsResponse(
-          TEST_PARTNER_ORIGIN,
-          'other_permission',
-        ),
-      );
+    describe('eth_requestAccounts requests', () => {
+      it('triggers referral when accounts are returned', async () => {
+        await runMiddleware(
+          createMockRequest(TEST_PARTNER_ORIGIN, 'eth_requestAccounts'),
+          createEthRequestAccountsResponse(),
+        );
 
-      expect(mockNext).toHaveBeenCalledTimes(1);
-      expect(mockHandleReferral).not.toHaveBeenCalled();
-    });
-  });
+        expect(mockNext).toHaveBeenCalledTimes(1);
+        expect(mockHandleReferral).toHaveBeenCalledTimes(1);
+        expect(mockHandleReferral).toHaveBeenCalledWith(
+          TEST_PARTNER,
+          123,
+          ReferralTriggerType.NewConnection,
+        );
+      });
 
-  describe('eth_requestAccounts requests', () => {
-    it('triggers referral when accounts are returned', async () => {
-      await runMiddleware(
-        createMockRequest(TEST_PARTNER_ORIGIN, 'eth_requestAccounts'),
-        createEthRequestAccountsResponse(),
-      );
+      it('does not trigger referral when result is empty', async () => {
+        await runMiddleware(
+          createMockRequest(TEST_PARTNER_ORIGIN, 'eth_requestAccounts'),
+          createEthRequestAccountsResponse([]),
+        );
 
-      expect(mockNext).toHaveBeenCalledTimes(1);
-      expect(mockHandleReferral).toHaveBeenCalledTimes(1);
-      expect(mockHandleReferral).toHaveBeenCalledWith(
-        TEST_PARTNER,
-        123,
-        ReferralTriggerType.NewConnection,
-      );
-    });
-
-    it('does not trigger referral when result is empty', async () => {
-      await runMiddleware(
-        createMockRequest(TEST_PARTNER_ORIGIN, 'eth_requestAccounts'),
-        createEthRequestAccountsResponse([]),
-      );
-
-      expect(mockNext).toHaveBeenCalledTimes(1);
-      expect(mockHandleReferral).not.toHaveBeenCalled();
+        expect(mockNext).toHaveBeenCalledTimes(1);
+        expect(mockHandleReferral).not.toHaveBeenCalled();
+      });
     });
   });
 
@@ -212,11 +228,82 @@ describe('createDefiReferralMiddleware', () => {
 
       expect(mockNext).toHaveBeenCalledTimes(1);
       expect(mockHandleReferral).toHaveBeenCalledTimes(1);
-      expect(log.error).toHaveBeenCalledTimes(1);
-      expect(log.error).toHaveBeenCalledWith(
+      expect(mockLogError).toHaveBeenCalledTimes(1);
+      expect(mockLogError).toHaveBeenCalledWith(
         `Failed to handle ${TEST_PARTNER.name} referral after permissions grant: `,
         error,
       );
+    });
+  });
+
+  describe('Partners with two-step `permissions_then_signature` connection flow', () => {
+    it('does not trigger on permissions alone', async () => {
+      await runMiddleware(
+        createMockRequest(
+          TEST_PARTNER_2_STEP_ORIGIN,
+          'wallet_requestPermissions',
+        ),
+        createWalletRequestPermissionsResponse(TEST_PARTNER_2_STEP_ORIGIN),
+      );
+
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockHandleReferral).not.toHaveBeenCalled();
+    });
+
+    it('triggers after permissions then eth_signTypedData_v4 success', async () => {
+      await runMiddleware(
+        createMockRequest(
+          TEST_PARTNER_2_STEP_ORIGIN,
+          'wallet_requestPermissions',
+        ),
+        createWalletRequestPermissionsResponse(TEST_PARTNER_2_STEP_ORIGIN),
+      );
+      expect(mockHandleReferral).not.toHaveBeenCalled();
+
+      await runMiddleware(
+        createMockRequest(TEST_PARTNER_2_STEP_ORIGIN, 'eth_signTypedData_v4'),
+        signTypedDataV4Response,
+      );
+
+      expect(mockHandleReferral).toHaveBeenCalledTimes(1);
+      expect(mockHandleReferral).toHaveBeenCalledWith(
+        TEST_PARTNER_2_STEP,
+        123,
+        ReferralTriggerType.NewConnection,
+      );
+    });
+
+    it('does not trigger when eth_signTypedData_v4 has no prior permissions', async () => {
+      await runMiddleware(
+        createMockRequest(
+          TEST_PARTNER_2_STEP_ORIGIN,
+          'eth_signTypedData_v4',
+          123,
+        ),
+        signTypedDataV4Response,
+      );
+
+      expect(mockHandleReferral).not.toHaveBeenCalled();
+    });
+
+    it('does not trigger when eth_signTypedData_v4 result is not a string', async () => {
+      await runMiddleware(
+        createMockRequest(
+          TEST_PARTNER_2_STEP_ORIGIN,
+          'wallet_requestPermissions',
+        ),
+        createWalletRequestPermissionsResponse(TEST_PARTNER_2_STEP_ORIGIN),
+      );
+      await runMiddleware(
+        createMockRequest(
+          TEST_PARTNER_2_STEP_ORIGIN,
+          'eth_signTypedData_v4',
+          123,
+        ),
+        { id: 1, jsonrpc: '2.0', result: null },
+      );
+
+      expect(mockHandleReferral).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/scripts/lib/createDefiReferralMiddleware.ts
+++ b/app/scripts/lib/createDefiReferralMiddleware.ts
@@ -8,8 +8,10 @@ import type {
   PendingJsonRpcResponse,
 } from '@metamask/utils';
 import log from 'loglevel';
+import { SECOND } from '../../../shared/constants/time';
 import {
   getPartnerByOrigin,
+  ConnectionFlow,
   type DefiReferralPartnerConfig,
 } from '../../../shared/constants/defi-referrals';
 
@@ -17,6 +19,9 @@ export type ExtendedJSONRPCRequest = JsonRpcRequest & {
   origin: string;
   tabId: number;
 };
+
+/** How long to wait for the second request to succeed */
+const WAIT_AFTER_FIRST_REQUEST_MS = SECOND * 10;
 
 /**
  * Trigger types for referral flows
@@ -35,12 +40,64 @@ function isExtendedJSONRPCRequest(
   );
 }
 
+const isWalletRequestPermissions = (method: string): boolean =>
+  method === 'wallet_requestPermissions';
+
+const isEthRequestAccounts = (method: string): boolean =>
+  method === 'eth_requestAccounts';
+
+const isEthSignTypedDataV4 = (method: string): boolean =>
+  method === 'eth_signTypedData_v4';
+
+const requiresSignature = (flow: ConnectionFlow) =>
+  flow === 'permissions_then_signature';
+
+let pendingSignatureMap: Map<string, number> | null = null;
+
 /**
- * Creates middleware that monitors permission requests for DeFi referral partners.
- * When a permission is granted to a supported partner, it triggers the referral flow.
+ * Creates a map of "origin:tabId" with timestamps. Callers add entries when
+ * permissions are granted for a referral partner with a two-step connection flow.
+ * A timer prunes entries older than WAIT_AFTER_FIRST_REQUEST_MS; when the map becomes
+ * empty, the interval is cleared and the module-level reference set to null.
+ */
+function makePendingSignatureMap(): Map<string, number> {
+  const map = new Map<string, number>();
+
+  const intervalId = setInterval(() => {
+    const cutoff = Date.now() - WAIT_AFTER_FIRST_REQUEST_MS;
+    for (const [key, timestamp] of map.entries()) {
+      if (timestamp <= cutoff) {
+        map.delete(key);
+      }
+    }
+    if (map.size === 0) {
+      clearInterval(intervalId);
+      map.clear();
+      pendingSignatureMap = null;
+    }
+  }, WAIT_AFTER_FIRST_REQUEST_MS);
+
+  return map;
+}
+
+function getPendingSignatureMap(): Map<string, number> {
+  pendingSignatureMap ??= makePendingSignatureMap();
+  return pendingSignatureMap;
+}
+
+/**
+ * Middleware that runs after each JSON-RPC request and may trigger the DeFi referral
+ * flow when the origin matches a configured partner.
  *
- * @param handleDefiReferral - Function to handle the referral flow for a partner
- * @returns Middleware function
+ * Single-step partners (connectionFlow 'permissions') trigger as soon as permissions
+ * are granted (wallet_requestPermissions or eth_requestAccounts).
+ *
+ * Two-step partners (connectionFlow 'permissions_then_signature'): record the grant
+ * when permissions succeed; trigger only when a subsequent eth_signTypedData_v4 for the
+ * same origin/tab succeeds. Entries expire after WAIT_AFTER_FIRST_REQUEST_MS.
+ *
+ * @param handleDefiReferral - Function to handle the referral flow for a partner.
+ * @returns Async JSON-RPC middleware.
  */
 export function createDefiReferralMiddleware(
   handleDefiReferral: (
@@ -68,44 +125,65 @@ export function createDefiReferralMiddleware(
         return;
       }
 
-      const isWalletRequestPermissions =
-        req.method === 'wallet_requestPermissions';
-      const isEthRequestAccounts = req.method === 'eth_requestAccounts';
+      const key = `${req.origin}:${req.tabId}`;
 
-      // Only continue if the request is a relevant connection request
-      if (!isWalletRequestPermissions && !isEthRequestAccounts) {
+      if (
+        isWalletRequestPermissions(req.method) ||
+        isEthRequestAccounts(req.method)
+      ) {
+        let arePermissionsGranted = false;
+        if (Array.isArray(res.result) && res.result.length > 0) {
+          if (isWalletRequestPermissions(req.method)) {
+            // wallet_requestPermissions returns permission objects with parentCapability key
+            const permissions = res.result as { parentCapability?: string }[];
+            arePermissionsGranted = permissions.some(
+              (permission) => permission?.parentCapability === 'eth_accounts',
+            );
+          } else {
+            // eth_requestAccounts returns an array of address strings
+            arePermissionsGranted = res.result.every(
+              (address) => typeof address === 'string',
+            );
+          }
+        }
+
+        if (arePermissionsGranted) {
+          if (requiresSignature(partner.connectionFlow)) {
+            getPendingSignatureMap().set(key, Date.now());
+          } else {
+            handleDefiReferral(
+              partner,
+              req.tabId,
+              ReferralTriggerType.NewConnection,
+            ).catch((error) => {
+              log.error(
+                `Failed to handle ${partner.name} referral after permissions grant: `,
+                error,
+              );
+            });
+          }
+        }
         return;
       }
 
-      let arePermissionsGranted = false;
-      if (Array.isArray(res.result) && res.result.length > 0) {
-        if (isWalletRequestPermissions) {
-          // wallet_requestPermissions returns permission objects with parentCapability key
-          const permissions = res.result as {
-            parentCapability?: string;
-          }[];
-          arePermissionsGranted = permissions.some(
-            (permission) => permission?.parentCapability === 'eth_accounts',
-          );
-        } else if (isEthRequestAccounts) {
-          // eth_requestAccounts returns an array of address strings
-          arePermissionsGranted = res.result.every(
-            (address) => typeof address === 'string',
-          );
+      if (
+        requiresSignature(partner.connectionFlow) &&
+        isEthSignTypedDataV4(req.method) &&
+        typeof res.result === 'string'
+      ) {
+        if (pendingSignatureMap?.has(key)) {
+          pendingSignatureMap.delete(key);
+          handleDefiReferral(
+            partner,
+            req.tabId,
+            ReferralTriggerType.NewConnection,
+          ).catch((error) => {
+            log.error(
+              `Failed to handle ${partner.name} referral after signature grant: `,
+              error,
+            );
+          });
         }
-      }
-
-      if (arePermissionsGranted) {
-        handleDefiReferral(
-          partner,
-          req.tabId,
-          ReferralTriggerType.NewConnection,
-        ).catch((error) => {
-          log.error(
-            `Failed to handle ${partner.name} referral after permissions grant: `,
-            error,
-          );
-        });
       }
     },
   );

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -5877,9 +5877,18 @@ export default class MetamaskController extends EventEmitter {
   async _updateDefiReferralUrl(partner, tabId) {
     try {
       const { url } = await browser.tabs.get(tabId);
-      const { search } = new URL(url || '');
-      const newUrl = `${partner.referralUrl}${search}`;
-      await browser.tabs.update(tabId, { url: newUrl });
+      const currentUrl = new URL(url || '');
+      const referralUrl = new URL(partner.referralUrl);
+
+      // Preserve (or update) existing params and add referral params
+      const mergedParams = new URLSearchParams(currentUrl.search);
+      for (const [key, value] of referralUrl.searchParams) {
+        mergedParams.set(key, value);
+      }
+
+      // Apply merged params to the referral URL
+      referralUrl.search = mergedParams.toString();
+      await browser.tabs.update(tabId, { url: referralUrl.toString() });
     } catch (error) {
       log.error(
         `Failed to update URL to ${partner.name} referral page: `,

--- a/shared/constants/defi-referrals.ts
+++ b/shared/constants/defi-referrals.ts
@@ -4,6 +4,7 @@
 export enum DefiReferralPartner {
   Hyperliquid = 'hyperliquid',
   GMX = 'gmx',
+  AsterDEX = 'asterdex',
 }
 
 /**
@@ -46,6 +47,15 @@ export const DEFI_REFERRAL_PARTNERS: Record<
     referralUrl: 'https://app.gmx.io/#/referrals/?ref=MMREFCSI2',
     learnMoreUrl: 'https://docs.gmx.io/docs/referrals/',
     approvalType: 'gmx_referral_consent',
+  },
+  [DefiReferralPartner.AsterDEX]: {
+    id: DefiReferralPartner.AsterDEX,
+    name: 'AsterDEX',
+    origin: 'https://www.asterdex.com',
+    referralUrl: '',
+    learnMoreUrl:
+      'https://docs.asterdex.com/product/aster-perpetuals/referral-program',
+    approvalType: 'asterdex_referral_consent',
   },
 };
 

--- a/shared/constants/defi-referrals.ts
+++ b/shared/constants/defi-referrals.ts
@@ -64,7 +64,7 @@ export const DEFI_REFERRAL_PARTNERS: Record<
     name: 'AsterDEX',
     origin: 'https://www.asterdex.com',
     referralUrl:
-      'https://www.asterdex.com/en/trade/pro/futures/BTCUSDT?ref=Ff4dF9', // TODO
+      'https://www.asterdex.com/en/trade/pro/futures/BTCUSDT?ref=82636D',
     learnMoreUrl:
       'https://docs.asterdex.com/product/aster-perpetuals/referral-program',
     approvalType: 'asterdex_referral_consent',

--- a/shared/constants/defi-referrals.ts
+++ b/shared/constants/defi-referrals.ts
@@ -8,6 +8,13 @@ export enum DefiReferralPartner {
 }
 
 /**
+ * The type of connection flow prior to showing the referral screen
+ * - permissions: show referral when permissions succeed (e.g. wallet_requestPermissions).
+ * - permissions_then_signature: show referral after permissions and signature succeed.
+ */
+export type ConnectionFlow = 'permissions' | 'permissions_then_signature';
+
+/**
  * Configuration for a Defi referral partner
  */
 export type DefiReferralPartnerConfig = {
@@ -23,6 +30,8 @@ export type DefiReferralPartnerConfig = {
   learnMoreUrl: string;
   /** Approval type string for ApprovalController */
   approvalType: string;
+  /** Connection flow prior to showing the referral screen */
+  connectionFlow: ConnectionFlow;
 };
 
 /**
@@ -39,6 +48,7 @@ export const DEFI_REFERRAL_PARTNERS: Record<
     referralUrl: 'https://app.hyperliquid.xyz/join/MMREFCSI',
     learnMoreUrl: 'https://hyperliquid.gitbook.io/hyperliquid-docs/referrals',
     approvalType: 'hyperliquid_referral_consent',
+    connectionFlow: 'permissions',
   },
   [DefiReferralPartner.GMX]: {
     id: DefiReferralPartner.GMX,
@@ -47,15 +57,18 @@ export const DEFI_REFERRAL_PARTNERS: Record<
     referralUrl: 'https://app.gmx.io/#/referrals/?ref=MMREFCSI2',
     learnMoreUrl: 'https://docs.gmx.io/docs/referrals/',
     approvalType: 'gmx_referral_consent',
+    connectionFlow: 'permissions',
   },
   [DefiReferralPartner.AsterDEX]: {
     id: DefiReferralPartner.AsterDEX,
     name: 'AsterDEX',
     origin: 'https://www.asterdex.com',
-    referralUrl: '',
+    referralUrl:
+      'https://www.asterdex.com/en/trade/pro/futures/BTCUSDT?ref=Ff4dF9', // TODO
     learnMoreUrl:
       'https://docs.asterdex.com/product/aster-perpetuals/referral-program',
     approvalType: 'asterdex_referral_consent',
+    connectionFlow: 'permissions_then_signature',
   },
 };
 

--- a/test/e2e/fixtures/default-fixture.json
+++ b/test/e2e/fixtures/default-fixture.json
@@ -938,6 +938,7 @@
         "useSidePanelAsDefault": true
       },
       "referrals": {
+        "asterdex": {},
         "gmx": {},
         "hyperliquid": {}
       },

--- a/test/e2e/fixtures/onboarding-fixture.json
+++ b/test/e2e/fixtures/onboarding-fixture.json
@@ -1941,6 +1941,7 @@
         "useSidePanelAsDefault": false
       },
       "referrals": {
+        "asterdex": {},
         "gmx": {},
         "hyperliquid": {}
       },

--- a/test/e2e/tests/settings/state-logs.json
+++ b/test/e2e/tests/settings/state-logs.json
@@ -896,6 +896,7 @@
     "recoveryPhraseReminderHasBeenShown": "boolean",
     "recoveryPhraseReminderLastShown": "number",
     "referrals": {
+      "asterdex": {},
       "gmx": {},
       "hyperliquid": {}
     },

--- a/ui/pages/confirmations/confirmation/stories/defi-referral-consent.stories.tsx
+++ b/ui/pages/confirmations/confirmation/stories/defi-referral-consent.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   HYPERLIQUID_APPROVAL_TYPE,
   GMX_APPROVAL_TYPE,
+  ASTERDEX_APPROVAL_TYPE,
 } from '../../../../../shared/constants/app';
 import {
   DEFI_REFERRAL_PARTNERS,
@@ -12,6 +13,7 @@ import { PendingApproval } from './util';
 
 const HYPERLIQUID_CONFIG = DEFI_REFERRAL_PARTNERS[DefiReferralPartner.Hyperliquid];
 const GMX_CONFIG = DEFI_REFERRAL_PARTNERS[DefiReferralPartner.GMX];
+const ASTERDEX_CONFIG = DEFI_REFERRAL_PARTNERS[DefiReferralPartner.AsterDEX];
 
 const STATE_MOCK_DEFAULT = {
   metamask: {
@@ -19,6 +21,7 @@ const STATE_MOCK_DEFAULT = {
       referrals: {
         [DefiReferralPartner.Hyperliquid]: {},
         [DefiReferralPartner.GMX]: {},
+        [DefiReferralPartner.AsterDEX]: {},
       },
     },
   },
@@ -80,3 +83,22 @@ export const GMXStory = (args: { selectedAddress: string }) => {
 };
 
 GMXStory.storyName = 'GMX';
+
+export const AsterdexStory = (args: { selectedAddress: string }) => {
+  return (
+    <PendingApproval
+      type={ASTERDEX_APPROVAL_TYPE}
+      requestData={{
+        selectedAddress: args.selectedAddress,
+        partnerId: ASTERDEX_CONFIG.id,
+        partnerName: ASTERDEX_CONFIG.name,
+        learnMoreUrl: ASTERDEX_CONFIG.learnMoreUrl,
+      }}
+      state={STATE_MOCK_DEFAULT}
+    >
+      <ConfirmationPage />
+    </PendingApproval>
+  );
+};
+
+AsterdexStory.storyName = 'Asterdex';

--- a/ui/pages/core/defi-referral-consent/defi-referral-consent.tsx
+++ b/ui/pages/core/defi-referral-consent/defi-referral-consent.tsx
@@ -82,6 +82,7 @@ export const DefiReferralConsent: React.FC<DefiReferralConsentProps> = ({
   // This is here to stop yarn verify-locales from removing these strings
   t('hyperliquidReferralSubtitle');
   t('gmxReferralSubtitle');
+  t('asterdexReferralSubtitle');
 
   return (
     <Box


### PR DESCRIPTION
## **Description**

Adds AsterDEX to the DeFi referral program with a **two-step connection flow**: the referral is shown only after both (1) `wallet_requestPermissions` succeed and (2) a successful `eth_signTypedData_v4` for the same origin/tab. Other partners (Hyperliquid, GMX) keep the existing single-step behavior (trigger on permissions only).

- **Config (`shared/constants/defi-referrals.ts`):** Introduces `ConnectionFlow` (`'permissions'` | `'permissions_then_signature'`) and `connectionFlow` on partner config; adds AsterDEX with `connectionFlow: 'permissions_then_signature'`.
- **Middleware (`app/scripts/lib/createDefiReferralMiddleware.ts`):** For two-step partners, records a permissions grant in a `pendingSignatureMap` (keyed by `origin:tabId`) and triggers the referral only when a matching `eth_signTypedData_v4` succeeds within 10 seconds; map entries are pruned by a timer and the interval is cleared when empty. This means that users have 10 seconds on AsterDEX to approve the signature request before the map entry gets pruned. The idea is that this prevents users inadvertently seeing the referral approval screen if they sign any `eth_signTypedData_v4` requests that haven't occurred directly after the connection permissions step. The referral screen should only show after the 2-step connection flow.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces.new/MetaMask/metamask-extension/pull/40563?quickstart=1)

## **Changelog**

CHANGELOG entry: Added AsterDEX to the DeFi referral program

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CEUX-745

## **Manual testing steps**

2. Open AsterDEX; connect wallet (permissions then sign typed data). Confirm the referral consent is shown only after both steps succeed.
3. Open Hyperliquid or GMX and connect. Confirm the referral still triggers on permissions alone.
4. For AsterDEX, confirm that only approving the permissions step does not trigger the referral.

## **Screenshots/Recordings**

### **Before**

### **After**

https://github.com/user-attachments/assets/ea308bc1-86a5-4af4-85c7-ba86232ffb6f




## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: changes referral-triggering middleware logic by adding stateful, time-windowed tracking across JSON-RPC calls, which could affect when/if referral prompts appear for partner origins.
> 
> **Overview**
> Adds **AsterDEX** as a new DeFi referral partner, including new locale copy and wiring it into default `referrals` state, e2e fixtures, and Storybook consent stories.
> 
> Extends partner config with a `connectionFlow` (`permissions` vs `permissions_then_signature`) and updates `createDefiReferralMiddleware` to support a **two-step trigger**: for two-step partners it records a successful permissions grant and only fires the referral after a matching `eth_signTypedData_v4` succeeds within a short window.
> 
> Updates `_updateDefiReferralUrl` to merge existing tab query params into the partner’s referral URL (preserving both existing and referral parameters) instead of appending the current search string verbatim.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed72866870658626b932eed6d8038c5e00e50d4e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->