### PR TITLE
chore: add new references to assets selectors

### DIFF
--- a/shared/modules/selectors/assets-migration.ts
+++ b/shared/modules/selectors/assets-migration.ts
@@ -774,9 +774,10 @@ export const getTokenRatesControllerMarketData = createDeepEqualSelector(
 
     return result;
   },
-) as unknown as (state: {
-  metamask: Pick<TokenRatesControllerState, 'marketData'>;
-}) => Record<string, Record<string, MarketDataDetails>>;
+) as unknown as ControllerStateSelector<
+  TokenRatesControllerState,
+  'marketData'
+>;
 
 export const getMultichainAssetsRatesControllerConversionRates =
   createDeepEqualSelector(

--- a/ui/components/multichain/token-list-item/token-list-item.tsx
+++ b/ui/components/multichain/token-list-item/token-list-item.tsx
@@ -152,7 +152,8 @@ export const TokenListItemComponent = ({
   const multiChainMarketData = useSelector(getMarketData);
 
   const tokenPercentageChange = address
-    ? multiChainMarketData?.[chainId]?.[address]?.pricePercentChange1d
+    ? multiChainMarketData?.[chainId as Hex]?.[address as Hex]
+        ?.pricePercentChange1d
     : null;
 
   const tokenTitle = getTokenTitle();
@@ -331,7 +332,7 @@ export const TokenListItemComponent = ({
               <PercentageChange
                 value={
                   isNativeCurrency
-                    ? multiChainMarketData?.[chainId]?.[
+                    ? multiChainMarketData?.[chainId as Hex]?.[
                         getNativeTokenAddress(chainId as Hex)
                       ]?.pricePercentChange1d
                     : tokenPercentageChange

--- a/ui/ducks/bridge/asset-selectors.ts
+++ b/ui/ducks/bridge/asset-selectors.ts
@@ -18,6 +18,12 @@ import {
 } from '@metamask/utils';
 import { ALLOWED_MULTICHAIN_BRIDGE_CHAIN_IDS } from '../../../shared/constants/bridge';
 import { toAssetId } from '../../../shared/lib/asset-utils';
+import {
+  getAccountTrackerControllerAccountsByChainId,
+  getCurrencyRateControllerCurrencyRates,
+  getTokenBalancesControllerTokenBalances,
+  getTokenRatesControllerMarketData,
+} from '../../../shared/modules/selectors/assets-migration';
 import { getMultichainBalances } from '../../selectors/multichain';
 import {
   getAccountAssets,
@@ -25,10 +31,6 @@ import {
   getAssetsRates,
 } from '../../selectors/assets';
 import { getInternalAccountByGroupAndCaip } from '../../selectors/multichain-accounts/account-tree';
-import {
-  getAccountTrackerControllerAccountsByChainId,
-  getTokenBalancesControllerTokenBalances,
-} from '../../../shared/modules/selectors/assets-migration';
 import { type BridgeAppState, getFromChains } from './selectors';
 import { type BridgeToken } from './types';
 import { getMaybeHexChainId, isTronEnergyOrBandwidthResource } from './utils';
@@ -180,8 +182,8 @@ const getEvmAssetsWithBalance = createSelector(
 // Calculates the exchange rate for each asset with a balance
 const getEvmExchangeRates = createSelector(
   [
-    ({ metamask }) => metamask.marketData,
-    ({ metamask }) => metamask.currencyRates,
+    getTokenRatesControllerMarketData,
+    getCurrencyRateControllerCurrencyRates,
     getERC20AssetsWithBalance,
     getNativeAssetsWithBalance,
   ],

--- a/ui/ducks/bridge/selectors.ts
+++ b/ui/ducks/bridge/selectors.ts
@@ -52,6 +52,10 @@ import {
 import { createDeepEqualSelector } from '../../../shared/modules/selectors/util';
 import { CHAIN_IDS, FEATURED_RPCS } from '../../../shared/constants/network';
 import {
+  getCurrencyRateControllerCurrencyRates,
+  getTokenRatesControllerMarketData,
+} from '../../../shared/modules/selectors/assets-migration';
+import {
   getMultichainBalances,
   getMultichainCoinRates,
   getMultichainNetworkConfigurationsByChainId,
@@ -492,8 +496,8 @@ export const getFromTokenConversionRate = createSelector(
     (state: BridgeAppState) => state.bridge.fromTokenExchangeRate,
     getAssetsRates, // non-evm conversion rates multichain equivalent of getMarketData
     getMultichainCoinRates,
-    (state: BridgeAppState) => state.metamask.marketData, // rates for non-native evm tokens
-    (state: BridgeAppState) => state.metamask.currencyRates, // EVM only
+    getTokenRatesControllerMarketData, // rates for non-native evm tokens
+    getCurrencyRateControllerCurrencyRates, // EVM only
   ],
   (
     fromToken,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Adds references to new assets selectors in swaps and ux-extension owned files.

Initially code was present in this PR (https://github.com/MetaMask/metamask-extension/pull/40482), but it got difficult to merge due to approvals needed from multiple codeowners, so the code has been separated in smaller PRs.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40564?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates bridge pricing/selectors to pull `marketData` and `currencyRates` via the assets-migration layer, which could affect displayed conversion rates and sorting if selector outputs differ under the feature flag.
> 
> **Overview**
> Bridge selectors now source EVM token `marketData` and `currencyRates` via the new assets-migration selectors (instead of reading `state.metamask.marketData`/`currencyRates` directly), including the exchange-rate computation in `asset-selectors.ts` and `getFromTokenConversionRate`.
> 
> The assets-migration `getTokenRatesControllerMarketData` selector typing was tightened using a reusable `ControllerStateSelector` type, and `TokenListItem` updated its market-data indexing with explicit `Hex` casts to satisfy type safety when reading 1D percent change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10fb0f00c47fac66cd1aa7f93743b34740f63aa5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->