### PR TITLE
N+1 API calls

### DIFF
--- a/app/scripts/controller-init/token-list-controller-init.test.ts
+++ b/app/scripts/controller-init/token-list-controller-init.test.ts
@@ -24,8 +24,10 @@ jest.mock('@metamask/assets-controllers', () => {
   return {
     TokenListController: jest.fn().mockImplementation(function (this: {
       initialize: jest.Mock;
+      _executePoll: jest.Mock;
     }) {
       this.initialize = jest.fn().mockResolvedValue(undefined);
+      this._executePoll = jest.fn().mockResolvedValue(undefined);
     }),
   };
 });
@@ -85,6 +87,10 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('TokenListControllerInit', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('initializes the controller', () => {
     const { controller } = TokenListControllerInit(getInitRequestMock());
     expect(controller).toBeInstanceOf(TokenListController);
@@ -99,5 +105,60 @@ describe('TokenListControllerInit', () => {
       state: undefined,
       chainId: '0x1',
     });
+  });
+
+  it('waits for initialize to finish before executing poll', async () => {
+    let resolveInitialize: (() => void) | undefined;
+    const initializePromise = new Promise<void>((resolve) => {
+      resolveInitialize = resolve;
+    });
+    const executePollMock = jest.fn().mockResolvedValue(undefined);
+
+    const controllerMock = jest.mocked(TokenListController);
+    controllerMock.mockImplementationOnce(function (this: {
+      initialize: jest.Mock;
+      _executePoll: jest.Mock;
+    }) {
+      this.initialize = jest.fn().mockReturnValue(initializePromise);
+      this._executePoll = executePollMock;
+      return this as unknown as TokenListController;
+    });
+
+    const { controller } = TokenListControllerInit(getInitRequestMock());
+    const pollPromise = controller._executePoll({ chainId: '0x1' });
+
+    expect(executePollMock).not.toHaveBeenCalled();
+
+    resolveInitialize?.();
+    await pollPromise;
+
+    expect(executePollMock).toHaveBeenCalledWith({ chainId: '0x1' });
+  });
+
+  it('continues polling even if initialize fails', async () => {
+    const initializeError = new Error('initialize failed');
+    const executePollMock = jest.fn().mockResolvedValue(undefined);
+    const consoleErrorMock = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    const controllerMock = jest.mocked(TokenListController);
+    controllerMock.mockImplementationOnce(function (this: {
+      initialize: jest.Mock;
+      _executePoll: jest.Mock;
+    }) {
+      this.initialize = jest.fn().mockRejectedValue(initializeError);
+      this._executePoll = executePollMock;
+      return this as unknown as TokenListController;
+    });
+
+    const { controller } = TokenListControllerInit(getInitRequestMock());
+    await controller._executePoll({ chainId: '0x1' });
+
+    expect(consoleErrorMock).toHaveBeenCalledWith(
+      'TokenListController: Failed to initialize from storage:',
+      initializeError,
+    );
+    expect(executePollMock).toHaveBeenCalledWith({ chainId: '0x1' });
   });
 });

--- a/app/scripts/controller-init/token-list-controller-init.ts
+++ b/app/scripts/controller-init/token-list-controller-init.ts
@@ -19,15 +19,21 @@ export const TokenListControllerInit: ControllerInitFunction<
     chainId: getGlobalChainId(initMessenger),
   });
 
-  // Initialize the controller to load cached token lists from storage.
-  // This is a fire-and-forget operation - if it fails, the controller will
-  // self-heal by fetching token lists on demand when needed.
-  controller.initialize().catch((error: Error) => {
+  // Load cached token lists from storage before the first poll executes.
+  // Polling can begin before `initialize` resolves during app bootstrap, so
+  // we gate `_executePoll` to avoid redundant token API requests.
+  const initializePromise = controller.initialize().catch((error: Error) => {
     console.error(
       'TokenListController: Failed to initialize from storage:',
       error,
     );
   });
+
+  const executePoll = controller._executePoll.bind(controller);
+  controller._executePoll = async (input) => {
+    await initializePromise;
+    return executePoll(input);
+  };
 
   return {
     controller,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Gate token list polling on initialization to fix an N+1 API call issue during app init.

The `TokenListController._executePoll` could run before `initialize()` completed, causing duplicate `/tokens/{chainId}` requests for each enabled chain during app startup. This change ensures polling waits for initialization to complete, preventing early fetches from bypassing cached token lists.

---
<p><a href="https://cursor.com/agents/bc-ad9211b0-a929-42d3-b149-8dc00790c701"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad9211b0-a929-42d3-b149-8dc00790c701"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->