### PR TITLE
bump: @metamask/tron-wallet-snap to `1.22.1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -391,7 +391,7 @@
     "@metamask/subscription-controller": "^6.0.0",
     "@metamask/transaction-controller": "^62.19.0",
     "@metamask/transaction-pay-controller": "^12.2.0",
-    "@metamask/tron-wallet-snap": "^1.21.1",
+    "@metamask/tron-wallet-snap": "1.22.1",
     "@metamask/user-operation-controller": "^40.0.0",
     "@metamask/utils": "^11.10.0",
     "@ngraveio/bc-ur": "^1.1.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8180,10 +8180,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/tron-wallet-snap@npm:^1.21.1":
-  version: 1.21.1
-  resolution: "@metamask/tron-wallet-snap@npm:1.21.1"
-  checksum: 10/02b479ad79758dc7ddafd694f4d54ed1e928d98740fc89e489b951f0029a02aeab1f8b5a565139a2ce17c52fd1c109007ebbe27938ff7b92c539e62b35ec838d
+"@metamask/tron-wallet-snap@npm:1.22.1":
+  version: 1.22.1
+  resolution: "@metamask/tron-wallet-snap@npm:1.22.1"
+  checksum: 10/035e044a023f887377da09e0431749aced5700903bb492191631f7f9f5b2ac1f81240885e795755dd48fb603ec6034063424ef734a8ebe4ded820b31049c4877
   languageName: node
   linkType: hard
 
@@ -33025,7 +33025,7 @@ __metadata:
     "@metamask/test-snaps": "npm:^3.4.0"
     "@metamask/transaction-controller": "npm:^62.19.0"
     "@metamask/transaction-pay-controller": "npm:^12.2.0"
-    "@metamask/tron-wallet-snap": "npm:^1.21.1"
+    "@metamask/tron-wallet-snap": "npm:1.22.1"
     "@metamask/user-operation-controller": "npm:^40.0.0"
     "@metamask/utils": "npm:^11.10.0"
     "@ngraveio/bc-ur": "npm:^1.1.13"


### PR DESCRIPTION
## **Description**

Bump Tron snap package version to version `1.22.1`

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40574?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [NEB-555](https://consensyssoftware.atlassian.net/browse/NEB-555?atlOrigin=eyJpIjoiNzhjMzBjODdkYjQyNGQyYzg0MTYwNWZhYTBjNThhODUiLCJwIjoiaiJ9)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

n/a

### **After**

n/a

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[NEB-555]: https://consensyssoftware.atlassian.net/browse/NEB-555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency bump limited to the Tron snap package; main risk is behavioral changes introduced by the updated external package version.
> 
> **Overview**
> Updates the `@metamask/tron-wallet-snap` dependency from `^1.21.1` to **pinned** version `1.22.1`.
> 
> Refreshes `yarn.lock` to reflect the new resolved version and checksum, and updates the workspace dependency reference to `npm:1.22.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5eda39a513613fa837f2a7795878cd58180e5cbe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->