### PR TITLE
fix: prevent re-sync account removal dialogs cp-13.21.0

### DIFF
--- a/.yarn/patches/@metamask-multichain-account-service-npm-7.0.0-52b2fa1b5d.patch
+++ b/.yarn/patches/@metamask-multichain-account-service-npm-7.0.0-52b2fa1b5d.patch
@@ -1,0 +1,31 @@
+diff --git a/dist/providers/SnapAccountProvider.cjs b/dist/providers/SnapAccountProvider.cjs
+index 796cff7ff4a15d2a685c896509d9b1af891123d2..c99cede4e1b5e1836c670fe3fb900628df2c8968 100644
+--- a/dist/providers/SnapAccountProvider.cjs
++++ b/dist/providers/SnapAccountProvider.cjs
+@@ -80,24 +80,8 @@ class SnapAccountProvider extends BaseBip44AccountProvider_1.BaseBip44AccountPro
+             // NOTE: This should never happen, but if it does, we recover by deleting the
+             // extra accounts from the Snap to bring it back in sync with MetaMask.
+             if (localSnapAccounts.length < snapAccounts.size) {
+-                // Build a set of local account IDs for quick lookup
+-                const localAccountIds = new Set(localSnapAccounts.map((account) => account.id));
+-                // Find and delete accounts that exist in Snap but not in MetaMask
+-                await Promise.all([...snapAccounts].map(async (snapAccountId) => {
+-                    try {
+-                        if (!localAccountIds.has(snapAccountId)) {
+-                            // This account exists in the Snap but not in MetaMask, delete it from
+-                            // the Snap.
+-                            await __classPrivateFieldGet(this, _SnapAccountProvider_client, "f").deleteAccount(snapAccountId);
+-                            // Update the local Set so subsequent checks use the correct size
+-                            snapAccounts.delete(snapAccountId);
+-                        }
+-                    }
+-                    catch (error) {
+-                        const sentryError = (0, utils_1.createSentryError)(`Unable to delete de-synced Snap account: ${this.snapId}`, error, { provider: this.getName(), snapAccountId });
+-                        this.messenger.captureException?.(sentryError);
+-                    }
+-                }));
++                console.warn(`Snap "${this.snapId}" has de-synced accounts, Snap has more accounts than MetaMask! (${localSnapAccounts.length} < ${snapAccounts.size})`);
++                return;
+             }
+             // We want this part to be fast, so we only check for sizes, but we might need
+             // to make a real "diff" between the 2 states to not miss any de-sync.

--- a/package.json
+++ b/package.json
@@ -259,7 +259,8 @@
     "@metamask/snaps-controllers": "^18.0.1",
     "@metamask/assets-controllers@npm:^99.2.0": "patch:@metamask/assets-controllers@npm%3A100.0.2#~/.yarn/patches/@metamask-assets-controllers-npm-100.0.2-e49991eaf1.patch",
     "@metamask/assets-controllers@npm:^99.4.0": "patch:@metamask/assets-controllers@npm%3A100.0.2#~/.yarn/patches/@metamask-assets-controllers-npm-100.0.2-e49991eaf1.patch",
-    "@metamask/assets-controllers@npm:^93.0.0": "patch:@metamask/assets-controllers@npm%3A100.0.2#~/.yarn/patches/@metamask-assets-controllers-npm-100.0.2-e49991eaf1.patch"
+    "@metamask/assets-controllers@npm:^93.0.0": "patch:@metamask/assets-controllers@npm%3A100.0.2#~/.yarn/patches/@metamask-assets-controllers-npm-100.0.2-e49991eaf1.patch",
+    "@metamask/multichain-account-service@npm:^7.0.0": "patch:@metamask/multichain-account-service@npm%3A7.0.0#~/.yarn/patches/@metamask-multichain-account-service-npm-7.0.0-52b2fa1b5d.patch"
   },
   "dependencies": {
     "@babel/runtime": "patch:@babel/runtime@npm%3A7.26.10#~/.yarn/patches/@babel-runtime-npm-7.26.10-fe8c62510a.patch",
@@ -348,7 +349,7 @@
     "@metamask/message-signing-snap": "1.1.4",
     "@metamask/messenger": "^0.3.0",
     "@metamask/metamask-eth-abis": "^3.1.1",
-    "@metamask/multichain-account-service": "^7.0.0",
+    "@metamask/multichain-account-service": "patch:@metamask/multichain-account-service@npm%3A7.0.0#~/.yarn/patches/@metamask-multichain-account-service-npm-7.0.0-52b2fa1b5d.patch",
     "@metamask/multichain-api-client": "^0.10.1",
     "@metamask/multichain-api-middleware": "^1.2.5",
     "@metamask/multichain-network-controller": "^3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6960,7 +6960,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/multichain-account-service@npm:^7.0.0":
+"@metamask/multichain-account-service@npm:7.0.0":
   version: 7.0.0
   resolution: "@metamask/multichain-account-service@npm:7.0.0"
   dependencies:
@@ -6987,6 +6987,36 @@ __metadata:
     "@metamask/providers": ^22.0.0
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
   checksum: 10/eacb3680db8078f051f98703d54e4249a4c3088c124e336e1461313681a209ff1d21c278c64f104ee45faec57d14f64657c59725678350e571535e09d854d11a
+  languageName: node
+  linkType: hard
+
+"@metamask/multichain-account-service@patch:@metamask/multichain-account-service@npm%3A7.0.0#~/.yarn/patches/@metamask-multichain-account-service-npm-7.0.0-52b2fa1b5d.patch":
+  version: 7.0.0
+  resolution: "@metamask/multichain-account-service@patch:@metamask/multichain-account-service@npm%3A7.0.0#~/.yarn/patches/@metamask-multichain-account-service-npm-7.0.0-52b2fa1b5d.patch::version=7.0.0&hash=fd52db"
+  dependencies:
+    "@ethereumjs/util": "npm:^9.1.0"
+    "@metamask/accounts-controller": "npm:^36.0.0"
+    "@metamask/base-controller": "npm:^9.0.0"
+    "@metamask/eth-snap-keyring": "npm:^19.0.0"
+    "@metamask/key-tree": "npm:^10.1.1"
+    "@metamask/keyring-api": "npm:^21.5.0"
+    "@metamask/keyring-controller": "npm:^25.1.0"
+    "@metamask/keyring-internal-api": "npm:^10.0.0"
+    "@metamask/keyring-snap-client": "npm:^8.2.0"
+    "@metamask/keyring-utils": "npm:^3.1.0"
+    "@metamask/messenger": "npm:^0.3.0"
+    "@metamask/snaps-controllers": "npm:^17.2.0"
+    "@metamask/snaps-sdk": "npm:^10.3.0"
+    "@metamask/snaps-utils": "npm:^11.7.0"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/utils": "npm:^11.9.0"
+    async-mutex: "npm:^0.5.0"
+    lodash: "npm:^4.17.21"
+  peerDependencies:
+    "@metamask/account-api": ^1.0.0
+    "@metamask/providers": ^22.0.0
+    webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
+  checksum: 10/dbab33bc4428be639a140a88d2429952442882cb5a972d074030e169f958fe56c1e605f18c47e87c873e120d3688c17c89d7371790a4743bcda0a874d23d5f22
   languageName: node
   linkType: hard
 
@@ -32971,7 +33001,7 @@ __metadata:
     "@metamask/message-signing-snap": "npm:1.1.4"
     "@metamask/messenger": "npm:^0.3.0"
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
-    "@metamask/multichain-account-service": "npm:^7.0.0"
+    "@metamask/multichain-account-service": "patch:@metamask/multichain-account-service@npm%3A7.0.0#~/.yarn/patches/@metamask-multichain-account-service-npm-7.0.0-52b2fa1b5d.patch"
     "@metamask/multichain-api-client": "npm:^0.10.1"
     "@metamask/multichain-api-middleware": "npm:^1.2.5"
     "@metamask/multichain-network-controller": "npm:^3.0.3"


### PR DESCRIPTION
## **Description**

Prevent auto-removal of de-synced Snap accounts.

This feature has been introduced to keep Snaps and the client in-sync, but the dialogs are a side-effects of this.

There is not clear root-cause of why the de-sync happened in the first place, but we have strong suspicions that some Snap accounts can have duplicated addresses (race-condition), in which case, the account removal might not target the proper duplicated account.

Duplicated accounts might have the same addresses, but not the same IDs, and since we're removing "by address", there's not guarantee we're going to to delete the right account.

For now, we skip the re-sync entirely has there is not undesired side-effects of having more Snap accounts than the client.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40575?quickstart=1)

## **Changelog**

CHANGELOG entry: Fixed automatic account removal dialogs, no accounts will be deleted automatically.

## **Related issues**

- https://github.com/MetaMask/metamask-extension/pull/40572 (hotfix for the 13.20.1)

## **Manual testing steps**

Difficult to replicate. See the recordings.

## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/f55bee4a-9a70-463f-8868-3c018f50262f

### **After**

https://github.com/user-attachments/assets/56a64bbc-bf6b-4b73-a05d-e14a414705aa

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes account sync behavior in `@metamask/multichain-account-service` to no longer delete Snap accounts automatically when a de-sync is detected, which could affect account state consistency but avoids unintended removals.
> 
> **Overview**
> Prevents automatic removal of Snap accounts during account re-sync when the Snap reports more accounts than the local client.
> 
> This applies a Yarn patch to `@metamask/multichain-account-service@7.0.0` that replaces the previous delete-and-report flow with a `console.warn` and early return, and wires the patched package via `package.json` resolutions and `yarn.lock`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73970e9c755b2c7c5a9f610a1a09869505b86d0d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->