### PR TITLE
chore: Adjust BannerBase default text variants

### DIFF
--- a/test/e2e/page-objects/pages/bridge/quote-page.ts
+++ b/test/e2e/page-objects/pages/bridge/quote-page.ts
@@ -50,15 +50,10 @@ class BridgeQuotePage {
   private confirmButton =
     '[data-testid="confirm-sign-and-send-transaction-confirm-snap-footer-button"]';
 
-  private noOptionAvailable = {
-    text: `This trade route isn't available right now. Try changing the amount, network, or token and we'll find the best option.`,
-    css: '.mm-text--body-md',
-  };
+  private noOptionAvailable = '[data-testid="bridge-no-options-available"]';
 
-  private moreETHneededForGas = {
-    text: `You don't have enough ETH to pay the gas fee for this bridge. Enter a smaller amount or buy more ETH.`,
-    css: '.mm-text--body-md',
-  };
+  private moreETHneededForGas =
+    '[data-testid="bridge-insufficient-gas-for-quote"]';
 
   private switchTokensButton = '[data-testid="switch-tokens"]';
 

--- a/ui/components/app/alert-system/general-alert/__snapshots__/general-alert.test.tsx.snap
+++ b/ui/components/app/alert-system/general-alert/__snapshots__/general-alert.test.tsx.snap
@@ -13,12 +13,12 @@ exports[`GeneralAlert renders general alert 1`] = `
       class="mm-box mm-box--min-width-0"
     >
       <p
-        class="mm-box mm-text mm-text--body-lg-medium mm-box--color-text-default"
+        class="mm-box mm-text mm-text--body-md-medium mm-box--color-text-default"
       >
         Security Alert
       </p>
       <p
-        class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+        class="mm-box mm-text mm-text--body-sm mm-box--color-text-default"
       >
         This is a security alert
       </p>

--- a/ui/components/component-library/banner-alert/__snapshots__/banner-alert.test.tsx.snap
+++ b/ui/components/component-library/banner-alert/__snapshots__/banner-alert.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`BannerAlert should render BannerAlert element correctly 1`] = `
       class="mm-box mm-box--min-width-0"
     >
       <p
-        class="mm-box mm-text mm-text--body-lg-medium mm-box--color-text-default"
+        class="mm-box mm-text mm-text--body-md-medium mm-box--color-text-default"
       >
         BannerAlert test
       </p>

--- a/ui/components/component-library/banner-base/README.mdx
+++ b/ui/components/component-library/banner-base/README.mdx
@@ -19,7 +19,7 @@ import { BannerBase } from '../banner-base';
 
 ### Title
 
-Use the `title` prop to pass a string that is sentence case no period. Use the `titleProps` prop to pass additional props to the `Text` component.
+Use the `title` prop to pass a string that is sentence case no period. By default, `title` uses `TextVariant.bodyMdMedium`. Use the `titleProps` prop to pass additional props to the `Text` component.
 
 <Canvas>
   <Story id="components-componentlibrary-bannerbase--title" />
@@ -36,6 +36,7 @@ import { BannerBase } from '../../component-library';
 ### Description
 
 The `description` is the content area of the `BannerBase` that must be a string. Description shouldn't repeat title and only 1-3 lines.
+By default, `description` uses `TextVariant.bodySm`. Use `descriptionProps` to customize it.
 
 If content requires more than a string, see `children` prop below.
 

--- a/ui/components/component-library/banner-base/__snapshots__/banner-base.test.tsx.snap
+++ b/ui/components/component-library/banner-base/__snapshots__/banner-base.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`BannerBase should render BannerBase element correctly 1`] = `
       class="mm-box mm-box--min-width-0"
     >
       <p
-        class="mm-box mm-text mm-text--body-lg-medium mm-box--color-text-default"
+        class="mm-box mm-text mm-text--body-md-medium mm-box--color-text-default"
       >
         BannerBase test
       </p>

--- a/ui/components/component-library/banner-base/banner-base.test.tsx
+++ b/ui/components/component-library/banner-base/banner-base.test.tsx
@@ -39,7 +39,9 @@ describe('BannerBase', () => {
       />,
     );
 
-    expect(getByText('BannerBase title test')).toBeDefined();
+    expect(getByText('BannerBase title test')).toHaveClass(
+      'mm-text--body-md-medium',
+    );
     expect(getByTestId('title')).toBeDefined();
   });
 
@@ -50,7 +52,9 @@ describe('BannerBase', () => {
         descriptionProps={{ 'data-testid': 'description' }}
       />,
     );
-    expect(getByText('BannerBase description test')).toBeDefined();
+    expect(getByText('BannerBase description test')).toHaveClass(
+      'mm-text--body-sm',
+    );
     expect(getByTestId('description')).toBeDefined();
   });
 

--- a/ui/components/component-library/banner-base/banner-base.tsx
+++ b/ui/components/component-library/banner-base/banner-base.tsx
@@ -56,11 +56,15 @@ export const BannerBase: BannerBaseComponent = React.forwardRef(
         {/* min-Width: 0 style is used to prevent grid/flex blowout */}
         <Box minWidth={BlockSize.Zero}>
           {title && (
-            <Text variant={TextVariant.bodyLgMedium} {...titleProps}>
+            <Text variant={TextVariant.bodyMdMedium} {...titleProps}>
               {title}
             </Text>
           )}
-          {description && <Text {...descriptionProps}>{description}</Text>}
+          {description && (
+            <Text variant={TextVariant.bodySm} {...descriptionProps}>
+              {description}
+            </Text>
+          )}
           {children && typeof children === 'object' ? (
             children
           ) : (

--- a/ui/components/component-library/banner-tip/__snapshots__/banner-tip.test.tsx.snap
+++ b/ui/components/component-library/banner-tip/__snapshots__/banner-tip.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`BannerTip should render BannerTip element correctly 1`] = `
       class="mm-box mm-box--min-width-0"
     >
       <p
-        class="mm-box mm-text mm-text--body-lg-medium mm-box--color-text-default"
+        class="mm-box mm-text mm-text--body-md-medium mm-box--color-text-default"
       >
         BannerTip test
       </p>

--- a/ui/pages/bridge/prepare/prepare-bridge-page.tsx
+++ b/ui/pages/bridge/prepare/prepare-bridge-page.tsx
@@ -627,6 +627,9 @@ const PrepareBridgePage = ({
               <BannerAlert
                 severity={BannerAlertSeverity.Danger}
                 description={t('noOptionsAvailableMessage')}
+                descriptionProps={{
+                  'data-testid': 'bridge-no-options-available',
+                }}
                 textAlign={TextAlign.Left}
               />
             </Column>
@@ -759,6 +762,9 @@ const PrepareBridgePage = ({
                   : 'bridgeValidationInsufficientGasMessage',
                 [ticker],
               )}
+              descriptionProps={{
+                'data-testid': 'bridge-insufficient-gas-for-quote',
+              }}
               textAlign={TextAlign.Left}
               actionButtonLabel={t('buyMoreAsset', [ticker])}
               actionButtonOnClick={() => openBuyCryptoInPdapp()}

--- a/ui/pages/settings/security-tab/__snapshots__/security-tab.test.js.snap
+++ b/ui/pages/settings/security-tab/__snapshots__/security-tab.test.js.snap
@@ -124,7 +124,7 @@ exports[`Security Tab should match snapshot 1`] = `
               class="mm-box mm-box--min-width-0"
             >
               <p
-                class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+                class="mm-box mm-text mm-text--body-sm mm-box--color-text-default"
               >
                 Secret Recovery Phrase backed up
               </p>


### PR DESCRIPTION
## **Description**

Updated `BannerBase` default typography variants to align with the text variant update, and added explicit unit coverage and docs for those defaults.

- Changed default `title` text variant from `bodyLgMedium` to `bodyMdMedium`.
- Changed default `description` text variant from inherited default (`bodyMd`) to explicit `bodySm`.
- Added unit assertions validating default title/description text classes.
- Updated component README to document default typography and how to override with `titleProps`/`descriptionProps`.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40580?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Run `yarn lint:changed:fix`.
2. Run `yarn test:unit ui/components/component-library/banner-base/banner-base.test.tsx -t "should render BannerBase title|should render BannerBase description" --watchman=false`.
3. In Storybook (`yarn storybook`), open `Components/ComponentLibrary/BannerBase` and confirm title/description typography defaults render as expected, while `titleProps` and `descriptionProps` can still override styles.

## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/755127ff-53a8-4494-9927-9e97292c937b

### **After**

https://github.com/user-attachments/assets/26ddf831-3c55-4e77-8f25-66a0bd8f0a17

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only typography default changes to `BannerBase` that cascade into banner snapshots, plus adding `data-testid` hooks for bridge alert banners used by E2E selectors.
> 
> **Overview**
> Updates `BannerBase` default typography by changing the `title` variant to `bodyMdMedium` and making `description` explicitly use `bodySm`, with accompanying README documentation and unit assertions for these defaults.
> 
> Adjusts dependent banner snapshots (`BannerAlert`, `BannerTip`, `GeneralAlert`, security tab) to reflect the new default text classes. Separately adds `data-testid` values to bridge “no quotes” and “insufficient gas” banner descriptions and updates bridge E2E page-object selectors to rely on those stable test IDs instead of matching copy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ee104f6b1240d4b7b3263998804534f05c0fece. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->