### PR TITLE
fix: error handling for Ledger hardware wallet errors

### DIFF
--- a/app/scripts/lib/offscreen-bridge/ledger-offscreen-bridge.ts
+++ b/app/scripts/lib/offscreen-bridge/ledger-offscreen-bridge.ts
@@ -6,11 +6,20 @@ import {
   AppConfigurationResponse,
 } from '@metamask/eth-ledger-bridge-keyring';
 import { TransportStatusError } from '@ledgerhq/errors';
+import { LEDGER_ERROR_MAPPINGS } from '@metamask/hw-wallet-sdk';
 import {
   LedgerAction,
   OffscreenCommunicationEvents,
   OffscreenCommunicationTarget,
 } from '../../../../shared/constants/offscreen-communication';
+
+/**
+ * Convert a Ledger status code (number) to the hex key used in LEDGER_ERROR_MAPPINGS (e.g. 27267 -> "0x6a83").
+ * @param statusCode - Error status code.
+ */
+function statusCodeToHexKey(statusCode: number): string {
+  return `0x${statusCode.toString(16).padStart(4, '0')}`.toLowerCase();
+}
 
 const MESSAGE_TIMEOUT = 4000;
 
@@ -175,12 +184,20 @@ export class LedgerOffscreenBridge
               typeof error.statusCode === 'number' &&
               error.statusCode > 0
             ) {
-              // This is TransportStatusError, convert the SerializedLedgerError to a TransportStatusError
-              // TransportStatusError will regenerate the error message based on the statusCode
-              const transportStatusError = new TransportStatusError(
-                error.statusCode,
-              );
-              reject(transportStatusError);
+              const hexKey = statusCodeToHexKey(error.statusCode);
+              const mapping = LEDGER_ERROR_MAPPINGS[
+                hexKey as keyof typeof LEDGER_ERROR_MAPPINGS
+              ] as { userMessage?: string } | undefined;
+              if (mapping?.userMessage) {
+                reject(new Error(mapping.userMessage));
+              } else {
+                // This is TransportStatusError, convert the SerializedLedgerError to a TransportStatusError
+                // TransportStatusError will regenerate the error message based on the statusCode
+                const transportStatusError = new TransportStatusError(
+                  error.statusCode,
+                );
+                reject(transportStatusError);
+              }
             } else if (error?.message) {
               // Regenerate the error based on the SerializedLedgerError
               const newError = new Error(error.message, {

--- a/app/scripts/lib/offscreen-bridge/ledger-offscreen-bridge.ts
+++ b/app/scripts/lib/offscreen-bridge/ledger-offscreen-bridge.ts
@@ -6,17 +6,11 @@ import {
   AppConfigurationResponse,
 } from '@metamask/eth-ledger-bridge-keyring';
 import { TransportStatusError } from '@ledgerhq/errors';
-import { ErrorCode } from '@metamask/hw-wallet-sdk';
 import {
   LedgerAction,
   OffscreenCommunicationEvents,
   OffscreenCommunicationTarget,
 } from '../../../../shared/constants/offscreen-communication';
-import {
-  toHardwareWalletError,
-  HardwareWalletType,
-  // eslint-disable-next-line import/no-restricted-paths
-} from '../../../../ui/contexts/hardware-wallets';
 
 const MESSAGE_TIMEOUT = 4000;
 
@@ -181,16 +175,12 @@ export class LedgerOffscreenBridge
               typeof error.statusCode === 'number' &&
               error.statusCode > 0
             ) {
-              const transportError = new TransportStatusError(error.statusCode);
-              const hwError = toHardwareWalletError(
-                transportError,
-                HardwareWalletType.Ledger,
+              // This is TransportStatusError, convert the SerializedLedgerError to a TransportStatusError
+              // TransportStatusError will regenerate the error message based on the statusCode
+              const transportStatusError = new TransportStatusError(
+                error.statusCode,
               );
-              if (hwError.code === ErrorCode.Unknown) {
-                reject(transportError);
-              } else {
-                reject(new Error(hwError.userMessage));
-              }
+              reject(transportStatusError);
             } else if (error?.message) {
               // Regenerate the error based on the SerializedLedgerError
               const newError = new Error(error.message, {

--- a/app/scripts/lib/offscreen-bridge/ledger-offscreen-bridge.ts
+++ b/app/scripts/lib/offscreen-bridge/ledger-offscreen-bridge.ts
@@ -6,20 +6,17 @@ import {
   AppConfigurationResponse,
 } from '@metamask/eth-ledger-bridge-keyring';
 import { TransportStatusError } from '@ledgerhq/errors';
-import { LEDGER_ERROR_MAPPINGS } from '@metamask/hw-wallet-sdk';
+import { ErrorCode } from '@metamask/hw-wallet-sdk';
 import {
   LedgerAction,
   OffscreenCommunicationEvents,
   OffscreenCommunicationTarget,
 } from '../../../../shared/constants/offscreen-communication';
-
-/**
- * Convert a Ledger status code (number) to the hex key used in LEDGER_ERROR_MAPPINGS (e.g. 27267 -> "0x6a83").
- * @param statusCode - Error status code.
- */
-function statusCodeToHexKey(statusCode: number): string {
-  return `0x${statusCode.toString(16).padStart(4, '0')}`.toLowerCase();
-}
+import {
+  toHardwareWalletError,
+  HardwareWalletType,
+  // eslint-disable-next-line import/no-restricted-paths
+} from '../../../../ui/contexts/hardware-wallets';
 
 const MESSAGE_TIMEOUT = 4000;
 
@@ -184,19 +181,15 @@ export class LedgerOffscreenBridge
               typeof error.statusCode === 'number' &&
               error.statusCode > 0
             ) {
-              const hexKey = statusCodeToHexKey(error.statusCode);
-              const mapping = LEDGER_ERROR_MAPPINGS[
-                hexKey as keyof typeof LEDGER_ERROR_MAPPINGS
-              ] as { userMessage?: string } | undefined;
-              if (mapping?.userMessage) {
-                reject(new Error(mapping.userMessage));
+              const transportError = new TransportStatusError(error.statusCode);
+              const hwError = toHardwareWalletError(
+                transportError,
+                HardwareWalletType.Ledger,
+              );
+              if (hwError.code === ErrorCode.Unknown) {
+                reject(transportError);
               } else {
-                // This is TransportStatusError, convert the SerializedLedgerError to a TransportStatusError
-                // TransportStatusError will regenerate the error message based on the statusCode
-                const transportStatusError = new TransportStatusError(
-                  error.statusCode,
-                );
-                reject(transportStatusError);
+                reject(new Error(hwError.userMessage));
               }
             } else if (error?.message) {
               // Regenerate the error based on the SerializedLedgerError

--- a/ui/pages/create-account/connect-hardware/index.js
+++ b/ui/pages/create-account/connect-hardware/index.js
@@ -266,7 +266,10 @@ class ConnectHardwareForm extends Component {
           });
         } else if (ledgerErrorCode) {
           this.setState({
-            error: `${errorMessage} - ${getErrorMessage(ledgerErrorCode)}`,
+            error: `${errorMessage} - ${getErrorMessage(
+              ledgerErrorCode,
+              this.context.t,
+            )}`,
           });
         } else if (
           errorMessage

--- a/ui/pages/create-account/connect-hardware/index.js
+++ b/ui/pages/create-account/connect-hardware/index.js
@@ -5,6 +5,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
+import { ErrorCode } from '@metamask/hw-wallet-sdk';
 import * as actions from '../../../store/actions';
 import { getCurrentChainId } from '../../../../shared/modules/selectors/networks';
 import {
@@ -45,6 +46,10 @@ import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
+import {
+  toHardwareWalletError,
+  HardwareWalletType,
+} from '../../../contexts/hardware-wallets';
 import AccountList from './account-list';
 import SelectHardware from './select-hardware';
 import { capitalizeStr } from './utils';
@@ -246,6 +251,20 @@ class ConnectHardwareForm extends Component {
       })
       .catch((e) => {
         const errorMessage = typeof e === 'string' ? e : e.message;
+
+        // Use shared Ledger error mapping (hw-wallet-sdk) when connecting to Ledger
+        if (device === HardwareDeviceNames.ledger) {
+          const hwError = toHardwareWalletError(e, HardwareWalletType.Ledger);
+
+          if (
+            hwError.code !== ErrorCode.Unknown &&
+            hwError.code !== ErrorCode.ConnectionClosed
+          ) {
+            this.setState({ error: hwError.userMessage });
+            return;
+          }
+        }
+
         const ledgerErrorCode = Object.keys(LEDGER_ERRORS_CODES).find(
           (errorCode) => errorMessage.includes(errorCode),
         );

--- a/ui/pages/create-account/connect-hardware/index.test.tsx
+++ b/ui/pages/create-account/connect-hardware/index.test.tsx
@@ -352,5 +352,44 @@ describe('ConnectHardwareForm', () => {
 
       await expect(mockConnectHardware()).rejects.toThrow('Test Error');
     });
+
+    describe('Ledger error handling (toHardwareWalletError)', () => {
+      it('displays SDK userMessage when Ledger error has a mapped status code (e.g. 0x6a83 wrong app)', async () => {
+        mockConnectHardware.mockRejectedValue(
+          new Error('Ledger device: UNKNOWN_ERROR (0x6a83)'),
+        );
+
+        const { getByText, getByLabelText } = renderWithProvider(
+          <ConnectHardwareForm {...mockProps} />,
+          mockStore,
+        );
+
+        fireEvent.click(getByLabelText(messages.ledger.message));
+        fireEvent.click(getByText(messages.continue.message));
+
+        await waitFor(() => {
+          expect(
+            getByText('Ethereum app is closed. Please open it to continue.'),
+          ).toBeInTheDocument();
+        });
+      });
+
+      it('displays original error message when Ledger error maps to Unknown or ConnectionClosed (e.g. no app open)', async () => {
+        const appClosedMessage = 'Ledger: App closed or connection issue';
+        mockConnectHardware.mockRejectedValue(new Error(appClosedMessage));
+
+        const { getByText, getByLabelText } = renderWithProvider(
+          <ConnectHardwareForm {...mockProps} />,
+          mockStore,
+        );
+
+        fireEvent.click(getByLabelText(messages.ledger.message));
+        fireEvent.click(getByText(messages.continue.message));
+
+        await waitFor(() => {
+          expect(getByText(appClosedMessage)).toBeInTheDocument();
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
## **Description**
This PR adds fix for error handling and message display for Ledger hardware wallets.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40597?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fix error message displayed for Ledger hardware wallets

## **Related issues**
Fixes: https://github.com/MetaMask/metamask-extension/issues/39726

## **Manual testing steps**
1. Go to MetaMask extension account list and start process for adding hardware wallet.
2. Choose Ledger.
3. On Ledger, open apps that are not supported (e.g. Solana, BTC) or close all apps.
4. Click continue and allow Ledger device to connect to the web browser.
5. Observe error message displayed at the top of the MetaMask extension page.
6. Make sure that there are no "UNKNOWN ERRORS".
7. Make sure that Ethereum app is working as expected.

## **Screenshots/Recordings**

### **Before**
<img width="574" height="252" alt="image" src="https://github.com/user-attachments/assets/65e24c54-4c65-4acb-8954-9da0d435726d" />
<img width="2076" height="1538" alt="image" src="https://github.com/user-attachments/assets/6cee871d-6edc-4297-ae3a-10150e93412f" />


### **After**

***Testing with multiple apps or when all are closed***
Test device used: Ledger Flex
Browser: Chrome
Running local extension build from `main`

<img width="761" height="887" alt="Screenshot 2026-03-04 at 13 05 28" src="https://github.com/user-attachments/assets/a16a6da0-532a-4117-aa78-a9173b1da77c" />

## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI behavior change limited to Ledger connect error messaging; main risk is misclassification of certain errors leading to different user-facing messages.
> 
> **Overview**
> Improves Ledger hardware-wallet connection error display by first mapping thrown errors through shared `hw-wallet-sdk` logic (`toHardwareWalletError`) and showing the SDK-provided `userMessage` for recognized Ledger status codes (excluding `Unknown`/`ConnectionClosed`).
> 
> Keeps the existing fallback error parsing for U2F/timeout/legacy Ledger error codes, but updates `LEDGER_ERRORS_CODES` messages to be localized via `t`.
> 
> Adds tests covering the new Ledger mapping behavior (mapped status code shows SDK message; unmapped/connection-closed cases fall back to the original error message).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b646dc93fe24b1483ec17ddedd203ffa093e325a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->