### PR TITLE
chore: update confirmations codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -151,6 +151,8 @@ app/scripts/lib/transaction                                                     
 ui/pages/confirmations                                                              @MetaMask/confirmations
 ui/components/multichain/pages/send                                                 @MetaMask/confirmations
 ui/pages/confirmations/components/confirm/footer                                    @MetaMask/confirmations
+ui/pages/confirmations/components/confirm/footer/shield-footer-coverage-indicator   @MetaMask/confirmations @MetaMask/web3auth
+ui/pages/confirmations/components/confirm/footer/shield-footer-agreement*           @MetaMask/confirmations @MetaMask/web3auth
 ui/pages/confirmations/components/confirm/info/shield-subscription-approve          @MetaMask/confirmations @MetaMask/web3auth
 ui/pages/confirmations/hooks/alerts/useShieldCoverageAlert.test.ts                  @MetaMask/confirmations @MetaMask/web3auth
 ui/pages/confirmations/hooks/alerts/useShieldCoverageAlert.ts                       @MetaMask/confirmations @MetaMask/web3auth

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -147,12 +147,10 @@ ui/pages/settings/transaction-shield-tab        @MetaMask/web3auth
 app/scripts/controller-init/confirmations                                           @MetaMask/confirmations
 app/scripts/lib/ppom                                                                @MetaMask/confirmations
 app/scripts/lib/signature                                                           @MetaMask/confirmations
-app/scripts/lib/transaction/decode                                                  @MetaMask/confirmations
-app/scripts/lib/transaction/metrics.*                                               @MetaMask/confirmations
-app/scripts/lib/transaction/util.*                                                  @MetaMask/confirmations
+app/scripts/lib/transaction/                                                        @MetaMask/confirmations
 ui/pages/confirmations                                                              @MetaMask/confirmations
 ui/components/multichain/pages/send                                                 @MetaMask/confirmations
-ui/pages/confirmations/components/confirm/footer                                    @MetaMask/confirmations @MetaMask/web3auth
+ui/pages/confirmations/components/confirm/footer                                    @MetaMask/confirmations
 ui/pages/confirmations/components/confirm/info/shield-subscription-approve          @MetaMask/confirmations @MetaMask/web3auth
 ui/pages/confirmations/hooks/alerts/useShieldCoverageAlert.test.ts                  @MetaMask/confirmations @MetaMask/web3auth
 ui/pages/confirmations/hooks/alerts/useShieldCoverageAlert.ts                       @MetaMask/confirmations @MetaMask/web3auth

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -147,7 +147,7 @@ ui/pages/settings/transaction-shield-tab        @MetaMask/web3auth
 app/scripts/controller-init/confirmations                                           @MetaMask/confirmations
 app/scripts/lib/ppom                                                                @MetaMask/confirmations
 app/scripts/lib/signature                                                           @MetaMask/confirmations
-app/scripts/lib/transaction/                                                        @MetaMask/confirmations
+app/scripts/lib/transaction                                                         @MetaMask/confirmations
 ui/pages/confirmations                                                              @MetaMask/confirmations
 ui/components/multichain/pages/send                                                 @MetaMask/confirmations
 ui/pages/confirmations/components/confirm/footer                                    @MetaMask/confirmations


### PR DESCRIPTION
## **Description**

Update confirmations team CODEOWNERS coverage.

- Include entire `app/scripts/lib/transaction` directory as no smart transaction hook there anymore, plus new functionality around delegation and enforced simulations.
- Apply more granular ownership for footer given risk to core confirmation flows.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40599?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

## **Manual testing steps**

## **Screenshots/Recordings**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only adjust `.github/CODEOWNERS`, affecting review/approval routing but not runtime behavior. Low risk, though it can change who is required to approve confirmations/Shield-related PRs.
> 
> **Overview**
> **CODEOWNERS coverage for Confirmations is updated.** The Confirmations team now owns the entire `app/scripts/lib/transaction` directory (replacing several narrower patterns).
> 
> **Footer ownership is made more granular.** `ui/pages/confirmations/components/confirm/footer` is owned by Confirmations, while Shield-specific footer components (`shield-footer-coverage-indicator` and `shield-footer-agreement*`) are explicitly co-owned by Confirmations and Web3Auth.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0510e6638e07b3ae3cd1cee1c3a554cd31b1790c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->