### PR TITLE
ci: retry if there's a retry-ci label

### DIFF
--- a/.github/workflows/main-retry.yml
+++ b/.github/workflows/main-retry.yml
@@ -21,14 +21,11 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       RUN_ID: ${{ inputs.run-id }}
       PR_NUMBER: ${{ inputs.pr-number }}
+      REPO: ${{ github.repository }}
     permissions:
       actions: write
       pull-requests: read
     steps:
-      # Must checkout in order to use `gh` commands
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
       - name: Retry
         run: |
           # Wait 10 seconds to ensure that the workflow run has fully completed and is in a state where it can be rerun
@@ -36,10 +33,10 @@ jobs:
 
           # If the PR still has a retry-ci label, do not retry to avoid a possible infinite loop.
           # The label should have been removed by the workflow that triggered this one.
-          CURRENT_LABELS=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name' | tr '\n' ',')
+          CURRENT_LABELS=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels --jq '.labels[].name' | tr '\n' ',')
           if [[ "${CURRENT_LABELS}" == *"retry-ci"* ]]; then
             echo "PR still has a 'retry-ci' label. Exiting to avoid a possible infinite loop."
             exit 1
           fi
 
-          gh run rerun "$RUN_ID" --failed
+          gh run rerun "$RUN_ID" --failed --repo "$REPO"

--- a/.github/workflows/main-retry.yml
+++ b/.github/workflows/main-retry.yml
@@ -1,0 +1,45 @@
+name: Main retry
+
+on:
+  workflow_dispatch:
+    inputs:
+      run-id:
+        required: true
+        type: number
+        description: The run-id to rerun
+      pr-number:
+        required: true
+        type: number
+        description: The PR number associated with the run-id to rerun
+
+jobs:
+  main-retry:
+    name: Main retry
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    env:
+      GH_TOKEN: ${{ github.token }}
+      RUN_ID: ${{ inputs.run-id }}
+      PR_NUMBER: ${{ inputs.pr-number }}
+    permissions:
+      actions: write
+      pull-requests: read
+    steps:
+      # Must checkout in order to use `gh` commands
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Retry
+        run: |
+          # Wait 10 seconds to ensure that the workflow run has fully completed and is in a state where it can be rerun
+          sleep 10
+
+          # If the PR still has a retry-ci label, do not retry to avoid a possible infinite loop.
+          # The label should have been removed by the workflow that triggered this one.
+          CURRENT_LABELS=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name' | tr '\n' ',')
+          if [[ "${CURRENT_LABELS}" == *"retry-ci"* ]]; then
+            echo "PR still has a 'retry-ci' label. Exiting to avoid a possible infinite loop."
+            exit 1
+          fi
+
+          gh run rerun "$RUN_ID" --failed

--- a/.github/workflows/main-retry.yml
+++ b/.github/workflows/main-retry.yml
@@ -28,8 +28,14 @@ jobs:
     steps:
       - name: Retry
         run: |
-          # Wait 10 seconds to ensure that the workflow run has fully completed and is in a state where it can be rerun
-          sleep 10
+          # Check the status of the workflow run to ensure it has completed before attempting to rerun.
+          # If this keeps going too long, it will hit the timeout-minutes and stop.
+          WORKFLOW_STATUS=$(gh run view "$RUN_ID" --repo "$REPO" --json status  --jq '.status')
+          while [[ "$WORKFLOW_STATUS" != "completed" ]]; do
+            sleep 3
+            echo "Workflow run status is '$WORKFLOW_STATUS'. Waiting for it to be 'completed' before rerunning."
+            WORKFLOW_STATUS=$(gh run view "$RUN_ID" --repo "$REPO" --json status  --jq '.status')
+          done
 
           # If the PR still has a retry-ci label, do not retry to avoid a possible infinite loop.
           # The label should have been removed by the workflow that triggered this one.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,7 @@ env:
   # For a `pull_request` event, the head commit hash is `github.event.pull_request.head.sha`.
   # For a `push` event, the head commit hash is `github.sha`.
   HEAD_COMMIT_HASH: ${{ github.event.pull_request.head.sha || github.sha }}
+  RUN_ID: ${{ github.run_id }}
 
 permissions:
   contents: write # required for releases
@@ -375,7 +376,7 @@ jobs:
         with:
           aws-region: ${{ vars.AWS_REGION }}
           role-to-assume: ${{ vars.AWS_IAM_ROLE }}
-          s3-bucket: ${{ vars.AWS_S3_BUCKET }}/${{ github.event.repository.name }}/${{ github.run_id }}/bundle-size
+          s3-bucket: ${{ vars.AWS_S3_BUCKET }}/${{ github.event.repository.name }}/${{ env.RUN_ID }}/bundle-size
           path: test-artifacts/chrome
 
   page-load-benchmark:
@@ -479,7 +480,7 @@ jobs:
         with:
           aws-region: ${{ vars.AWS_REGION }}
           role-to-assume: ${{ vars.AWS_IAM_ROLE }}
-          s3-bucket: ${{ vars.AWS_S3_BUCKET }}/${{ github.event.repository.name }}/${{ github.run_id }}/source-map-explorer
+          s3-bucket: ${{ vars.AWS_S3_BUCKET }}/${{ github.event.repository.name }}/${{ env.RUN_ID }}/source-map-explorer
           path: build-artifacts/source-map-explorer
 
   build-lavamoat-viz:
@@ -557,7 +558,7 @@ jobs:
         with:
           aws-region: ${{ vars.AWS_REGION }}
           role-to-assume: ${{ vars.AWS_IAM_ROLE }}
-          s3-bucket: ${{ vars.AWS_S3_BUCKET }}/${{ github.event.repository.name }}/${{ github.run_id }}/lavamoat-viz
+          s3-bucket: ${{ vars.AWS_S3_BUCKET }}/${{ github.event.repository.name }}/${{ env.RUN_ID }}/lavamoat-viz
           path: build-artifacts/build-viz
 
   publish-prerelease:
@@ -627,7 +628,6 @@ jobs:
       - name: Trigger regression validation in external repo
         env:
           DISPATCH_TOKEN: ${{ secrets.METAMASK_REGRESSION_TRIGGER_TEST }}
-          RUN_ID: ${{ github.run_id }}
         run: |
           # Extract version from branch name (e.g., release/12.5.0 -> 12.5.0)
           # Use BRANCH env var which correctly handles both push and pull_request events
@@ -707,7 +707,6 @@ jobs:
         env:
           NEEDS_JSON: ${{ toJson(needs) }} # This is required for the the job_result lookup and the job_id loop
           BUILDS_FROM_RUN: ${{ needs.get-requirements.outputs.builds-from-run }}
-          RUN_ID: ${{ github.run_id }}
         run: |
           # Function to ensure a job's result is either 'success' or 'skipped'
           requireJobSuccessOrSkipped() {
@@ -759,3 +758,40 @@ jobs:
       - all-jobs-pass
     uses: ./.github/workflows/publish-release.yml
     secrets: inherit
+
+  check-retry-ci:
+    name: Check for retry-ci label and retry
+    if: ${{ !cancelled() && needs.all-jobs-pass.result == 'failure' && github.event_name == 'pull_request' && !(github.event.pull_request.head.repo.fork || github.event.repository.fork) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    needs:
+      - all-jobs-pass
+      - publish-prerelease
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    permissions:
+      actions: write
+      pull-requests: write
+    steps:
+      # Must checkout in order to use `gh` commands
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Check if this PR has a retry-ci label
+        run: |
+          # We cannot use github.event.pull_request.labels here, because it will be stale on a re-run
+          CURRENT_LABELS=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name' | tr '\n' ',')
+
+          if [[ "${CURRENT_LABELS}" == *"retry-ci"* ]]; then
+            echo "This PR has a retry-ci label, removing the label..."
+            gh pr edit "$PR_NUMBER" --remove-label "retry-ci"
+
+            echo "Retrying failed jobs..."
+
+            # We cannot use `gh run rerun` here, because this workflow is still running,
+            # so we must run main-retry.yml, which in turn runs `gh run rerun`
+            gh workflow run main-retry.yml -f run-id="$RUN_ID" -f pr-number="$PR_NUMBER"
+          else
+            echo "This PR does not have a retry-ci label, not retrying."
+          fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -761,7 +761,13 @@ jobs:
 
   check-retry-ci:
     name: Check for retry-ci label and retry
-    if: ${{ !cancelled() && needs.all-jobs-pass.result == 'failure' && github.event_name == 'pull_request' && !(github.event.pull_request.head.repo.fork || github.event.repository.fork) }}
+    if: >-
+      ${{
+        !cancelled() &&
+        needs.all-jobs-pass.result == 'failure' &&
+        github.event_name == 'pull_request' &&
+        !(github.event.pull_request.head.repo.fork || github.event.repository.fork)
+      }}
     runs-on: ubuntu-latest
     timeout-minutes: 2
     needs:
@@ -770,28 +776,25 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
+      REPO: ${{ github.repository }}
     permissions:
       actions: write
       pull-requests: write
     steps:
-      # Must checkout in order to use `gh` commands
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
       - name: Check if this PR has a retry-ci label
         run: |
           # We cannot use github.event.pull_request.labels here, because it will be stale on a re-run
-          CURRENT_LABELS=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name' | tr '\n' ',')
+          CURRENT_LABELS=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels --jq '.labels[].name' | tr '\n' ',')
 
           if [[ "${CURRENT_LABELS}" == *"retry-ci"* ]]; then
             echo "This PR has a retry-ci label, removing the label..."
-            gh pr edit "$PR_NUMBER" --remove-label "retry-ci"
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "retry-ci"
 
             echo "Retrying failed jobs..."
 
             # We cannot use `gh run rerun` here, because this workflow is still running,
             # so we must run main-retry.yml, which in turn runs `gh run rerun`
-            gh workflow run main-retry.yml -f run-id="$RUN_ID" -f pr-number="$PR_NUMBER"
+            gh workflow run main-retry.yml --repo "$REPO" -f run-id="$RUN_ID" -f pr-number="$PR_NUMBER"
           else
             echo "This PR does not have a retry-ci label, not retrying."
           fi


### PR DESCRIPTION
## **Description**

Major developer UX improvement -- put a `retry-ci` label on a PR if you see it's already flaked and you want it to "Re-run failed jobs" when it's done.  Removes the label to prevent infinite loops.

**_Note:_** This will not work as-is on this PR, because the new workflow `main-retry.yml` has to already exist on branch `main` in order to run anything.  But I have tested it by renaming other existing workflows, and it works.
```
HTTP 404: workflow main-retry.yml not found on the default branch (https://api.github.com/repos/MetaMask/metamask-extension/actions/workflows/main-retry.yml)
```

## **Changelog**

CHANGELOG entry: null

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**
[skip-e2e]-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GitHub Actions control flow to programmatically remove PR labels and rerun workflow jobs, which could cause unexpected rerun loops or permission issues if misconfigured.
> 
> **Overview**
> Adds a manual `main-retry.yml` workflow that waits for a specified run to finish, verifies the PR no longer has the `retry-ci` label, and then reruns only failed jobs via `gh run rerun`.
> 
> Updates `main.yml` to expose `RUN_ID` in `env`, use it consistently in S3 upload paths, and introduces a `check-retry-ci` job that (on failed PR runs for non-forks) checks for the `retry-ci` label, removes it, and triggers `main-retry.yml` to rerun failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f2ffb3ae529294cf153e1828abb131193fbf21a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->