### PR TITLE
fix: remove headers from bridge e2e mocks

### DIFF
--- a/test/e2e/tests/bridge/bridge-test-utils.ts
+++ b/test/e2e/tests/bridge/bridge-test-utils.ts
@@ -187,31 +187,28 @@ async function mockPortfolioPage(mockServer: Mockttp) {
 }
 
 async function mockGetTxStatus(mockServer: Mockttp) {
-  return await mockServer
-    .forGet(/getTxStatus/u)
-    .withHeaders({ Authorization: 'Bearer MOCK_SRP_IDENTIFIER_1' })
-    .thenCallback(async (req) => {
-      const urlObj = new URL(req.url);
-      const txHash = urlObj.searchParams.get('srcTxHash');
-      const srcChainId = urlObj.searchParams.get('srcChainId');
-      const destChainId = urlObj.searchParams.get('destChainId');
-      return {
-        statusCode: 200,
-        json: {
-          status: 'COMPLETE',
-          isExpectedToken: true,
-          bridge: 'across',
-          srcChain: {
-            chainId: Number(srcChainId),
-            txHash,
-          },
-          destChain: {
-            chainId: Number(destChainId),
-            txHash,
-          },
+  return await mockServer.forGet(/getTxStatus/u).thenCallback(async (req) => {
+    const urlObj = new URL(req.url);
+    const txHash = urlObj.searchParams.get('srcTxHash');
+    const srcChainId = urlObj.searchParams.get('srcChainId');
+    const destChainId = urlObj.searchParams.get('destChainId');
+    return {
+      statusCode: 200,
+      json: {
+        status: 'COMPLETE',
+        isExpectedToken: true,
+        bridge: 'across',
+        srcChain: {
+          chainId: Number(srcChainId),
+          txHash,
         },
-      };
-    });
+        destChain: {
+          chainId: Number(destChainId),
+          txHash,
+        },
+      },
+    };
+  });
 }
 
 async function mockTopAssetsLinea(mockServer: Mockttp) {
@@ -296,29 +293,23 @@ const toBridgeTokenResponse = (
 };
 
 async function mockGetPopularTokens(mockServer: Mockttp) {
-  return await mockServer
-    .forPost(/getTokens\/popular/u)
-    .withHeaders({ Authorization: 'Bearer MOCK_SRP_IDENTIFIER_1' })
-    .thenCallback(() => ({
-      statusCode: 200,
-      json: [
-        MOCK_TOKENS_ETHEREUM.map((token) => toBridgeTokenResponse(1, token)),
-        MOCK_TOKENS_LINEA.map((token) => toBridgeTokenResponse(59144, token)),
-        MOCK_TOKENS_ARBITRUM.map((token) =>
-          toBridgeTokenResponse(42161, token),
-        ),
-        MOCK_GET_TOKEN_ARBITRUM.map((token) =>
-          toBridgeTokenResponse(42161, token),
-        ),
-      ].flat(),
-    }));
+  return await mockServer.forPost(/getTokens\/popular/u).thenCallback(() => ({
+    statusCode: 200,
+    json: [
+      MOCK_TOKENS_ETHEREUM.map((token) => toBridgeTokenResponse(1, token)),
+      MOCK_TOKENS_LINEA.map((token) => toBridgeTokenResponse(59144, token)),
+      MOCK_TOKENS_ARBITRUM.map((token) => toBridgeTokenResponse(42161, token)),
+      MOCK_GET_TOKEN_ARBITRUM.map((token) =>
+        toBridgeTokenResponse(42161, token),
+      ),
+    ].flat(),
+  }));
 }
 
 async function mockSearchTokens(mockServer: Mockttp) {
   return [
     await mockServer
       .forPost(/getTokens\/search/u)
-      .withHeaders({ Authorization: 'Bearer MOCK_SRP_IDENTIFIER_1' })
       .withJsonBodyIncluding({
         chainIds: ['eip155:1'],
       })
@@ -338,7 +329,7 @@ async function mockSearchTokens(mockServer: Mockttp) {
       }),
     await mockServer
       .forPost(/getTokens\/search/u)
-      .withHeaders({ Authorization: 'Bearer MOCK_SRP_IDENTIFIER_1' })
+
       .withJsonBodyIncluding({
         chainIds: ['eip155:59144'],
       })
@@ -358,7 +349,7 @@ async function mockSearchTokens(mockServer: Mockttp) {
       }),
     await mockServer
       .forPost(/getTokens\/search/u)
-      .withHeaders({ Authorization: 'Bearer MOCK_SRP_IDENTIFIER_1' })
+
       .withJsonBodyIncluding({
         chainIds: ['eip155:42161'],
       })
@@ -489,7 +480,7 @@ async function mockSwapETHtoMUSD(mockServer: Mockttp) {
   return await mockServer
     .forGet(/getQuoteStream/u)
     .once()
-    .withHeaders({ Authorization: 'Bearer MOCK_SRP_IDENTIFIER_1' })
+
     .withQuery({
       srcTokenAddress: '0x0000000000000000000000000000000000000000',
       destTokenAddress: '0xacA92E438df0B2401fF60dA7E4337B687a2435DA',
@@ -506,7 +497,7 @@ async function mockUSDCtoDAI(mockServer: Mockttp, sseEnabled?: boolean) {
     return await mockServer
       .forGet(/getQuoteStream/u)
       .once()
-      .withHeaders({ Authorization: 'Bearer MOCK_SRP_IDENTIFIER_1' })
+
       .withQuery({
         srcTokenAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
         destTokenAddress: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
@@ -520,7 +511,7 @@ async function mockUSDCtoDAI(mockServer: Mockttp, sseEnabled?: boolean) {
 
   return await mockServer
     .forGet(/getQuote/u)
-    .withHeaders({ Authorization: 'Bearer MOCK_SRP_IDENTIFIER_1' })
+
     .withQuery({
       srcTokenAddress: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
       destTokenAddress: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
@@ -551,7 +542,7 @@ async function mockGetTxStatusInvalid(
 ) {
   return await mockServer
     .forGet(/getTxStatus/u)
-    .withHeaders({ Authorization: 'Bearer MOCK_SRP_IDENTIFIER_1' })
+
     .thenCallback(() => {
       return {
         statusCode: options.statusCode,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Bridge e2e tests are flaky because the auth header is not always defined on initial page load. This removes the headers from the e2e test mocks

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40613?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: flaky bridge e2e tests

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only adjust e2e `mockttp` request matchers by removing Authorization header requirements, affecting test setup but not production code.
> 
> **Overview**
> Bridge e2e mocks no longer require an `Authorization: Bearer ...` header when matching bridge API requests (e.g., `getTxStatus`, token search/popular endpoints, and quote/quoteStream mocks).
> 
> This makes the mocked endpoints accept requests regardless of auth header presence, reducing brittleness when the bridge client changes how it sets headers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c28e076cc007418873c60e40961148d9db40c623. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->