### PR TITLE
fix: flaky test `Multichain Aggregated Balances shows correct aggregated balance when "Current Network"`

### DIFF
--- a/test/e2e/page-objects/pages/header-navbar.ts
+++ b/test/e2e/page-objects/pages/header-navbar.ts
@@ -125,9 +125,6 @@ class HeaderNavbar {
           waitAtLeastGuard: regularDelayMs,
         },
       );
-      await this.driver.waitForSelector(this.globalMenuButton, {
-        state: 'enabled',
-      });
       await this.driver.clickElement(this.globalMenuButton);
     }
     await this.driver.waitForElementToStopMoving(this.drawerBackButton);

--- a/test/e2e/page-objects/pages/header-navbar.ts
+++ b/test/e2e/page-objects/pages/header-navbar.ts
@@ -110,25 +110,26 @@ class HeaderNavbar {
     await this.driver.clickElement(this.globalNetworksMenu);
   }
 
-  async openGlobalMenu(): Promise<void> {
+  async openGlobalMenu({
+    withNotificationCounter = false,
+  } = {}): Promise<void> {
     console.log('Open account options menu');
-    // Sometimes the notification counter briefly appears and disappears overlapping the menu icon
-    await this.driver.assertElementNotPresent(
-      this.notificationCounterMenuIcon,
-      {
-        waitAtLeastGuard: regularDelayMs,
-      },
-    );
-    await this.driver.waitForSelector(this.globalMenuButton, {
-      state: 'enabled',
-    });
-    await this.driver.clickElement(this.globalMenuButton);
-    await this.driver.waitForElementToStopMoving(this.drawerBackButton);
-  }
-
-  async mouseClickOnThreeDotMenu(): Promise<void> {
-    console.log('Clicking three dot menu using mouse move');
-    await this.driver.clickElementUsingMouseMove(this.globalMenuButton);
+    if (withNotificationCounter) {
+      // To avoid ElementIntercept error because of the notification overlap
+      await this.driver.clickElementUsingMouseMove(this.globalMenuButton);
+    } else {
+      // Sometimes the notification counter briefly appears and disappears overlapping the menu icon
+      await this.driver.assertElementNotPresent(
+        this.notificationCounterMenuIcon,
+        {
+          waitAtLeastGuard: regularDelayMs,
+        },
+      );
+      await this.driver.waitForSelector(this.globalMenuButton, {
+        state: 'enabled',
+      });
+      await this.driver.clickElement(this.globalMenuButton);
+    }
     await this.driver.waitForElementToStopMoving(this.drawerBackButton);
   }
 
@@ -193,12 +194,12 @@ class HeaderNavbar {
 
   async clickNotificationsOptions(): Promise<void> {
     console.log('Click notifications options');
-    await this.mouseClickOnThreeDotMenu();
+    await this.openGlobalMenu({ withNotificationCounter: true });
     await this.driver.clickElement(this.notificationsButton);
   }
 
   async checkNotificationCountInMenuOption(count: number): Promise<void> {
-    await this.mouseClickOnThreeDotMenu();
+    await this.openGlobalMenu({ withNotificationCounter: true });
     await this.driver.findElement({
       css: this.notificationCountOption,
       text: count.toString(),

--- a/test/e2e/page-objects/pages/header-navbar.ts
+++ b/test/e2e/page-objects/pages/header-navbar.ts
@@ -112,6 +112,13 @@ class HeaderNavbar {
 
   async openGlobalMenu(): Promise<void> {
     console.log('Open account options menu');
+    // Sometimes the notification counter briefly appears and disappears overlapping the menu icon
+    await this.driver.assertElementNotPresent(
+      this.notificationCounterMenuIcon,
+      {
+        waitAtLeastGuard: regularDelayMs,
+      },
+    );
     await this.driver.waitForSelector(this.globalMenuButton, {
       state: 'enabled',
     });
@@ -168,13 +175,6 @@ class HeaderNavbar {
 
   async openSettingsPage(): Promise<void> {
     console.log('Open settings page');
-    // Sometimes the notification counter briefly appears and disappears overlapping the menu icon
-    await this.driver.assertElementNotPresent(
-      this.notificationCounterMenuIcon,
-      {
-        waitAtLeastGuard: regularDelayMs,
-      },
-    );
     await this.openGlobalMenu();
     await this.driver.clickElement(this.settingsButton);
   }

--- a/test/e2e/page-objects/pages/header-navbar.ts
+++ b/test/e2e/page-objects/pages/header-navbar.ts
@@ -5,33 +5,43 @@ import { regularDelayMs } from '../../helpers';
 class HeaderNavbar {
   protected driver: Driver;
 
-  private readonly accountMenuButton = '[data-testid="account-menu-icon"]';
+  private readonly accountDetailsTab = { text: 'Details', tag: 'button' };
 
   private readonly accountListPage = '.account-list-page';
+
+  private readonly accountMenuButton = '[data-testid="account-menu-icon"]';
+
+  private readonly accountSnapButton = { text: 'Snaps', tag: 'div' };
 
   private readonly allPermissionsButton =
     '[data-testid="global-menu-connected-sites"]';
 
+  private readonly connectedSitePopoverNetworkButton =
+    '[data-testid="connected-site-popover-network-button"]';
+
+  private readonly connectionMenu = '[data-testid="connection-menu"]';
+
   private readonly copyAddressButton = '[aria-label="Copy address"]';
 
-  private readonly threeDotMenuButton =
+  private readonly drawerBackButton = '[data-testid="drawer-close-button"]';
+
+  private readonly firstTimeTurnOnNotificationsButton =
+    '[data-testid="turn-on-notifications-button"]';
+
+  private readonly globalMenuButton =
     '[data-testid="account-options-menu-button"]';
 
-  private readonly accountSnapButton = { text: 'Snaps', tag: 'div' };
+  private readonly globalNetworksMenu = '[data-testid="global-menu-networks"]';
 
   private readonly lockMetaMaskButton = '[data-testid="global-menu-lock"]';
 
-  private readonly openAccountDetailsButton =
-    '[data-testid="account-list-menu-details"]';
+  private readonly networkAddressesLink =
+    '[data-testid="networks-subtitle-test-id"]';
 
-  private readonly accountDetailsTab = { text: 'Details', tag: 'button' };
-
-  private readonly settingsButton = '[data-testid="global-menu-settings"]';
+  private readonly networkOption = (networkId: string) =>
+    `[data-testid="${networkId}"]`;
 
   private readonly networkPicker = '.mm-picker-network';
-
-  private readonly notificationsButton =
-    '[data-testid="notifications-menu-item"]';
 
   private readonly notificationCounterMenuIcon = {
     testId: 'notifications-tag-counter__unread-dot',
@@ -40,23 +50,13 @@ class HeaderNavbar {
   private readonly notificationCountOption =
     '[data-testid="global-menu-notification-count"]';
 
-  private readonly firstTimeTurnOnNotificationsButton =
-    '[data-testid="turn-on-notifications-button"]';
+  private readonly notificationsButton =
+    '[data-testid="notifications-menu-item"]';
 
-  private readonly globalNetworksMenu = '[data-testid="global-menu-networks"]';
+  private readonly openAccountDetailsButton =
+    '[data-testid="account-list-menu-details"]';
 
-  private readonly connectionMenu = '[data-testid="connection-menu"]';
-
-  private readonly connectedSitePopoverNetworkButton =
-    '[data-testid="connected-site-popover-network-button"]';
-
-  private readonly networkAddressesLink =
-    '[data-testid="networks-subtitle-test-id"]';
-
-  private readonly networkOption = (networkId: string) =>
-    `[data-testid="${networkId}"]`;
-
-  private readonly drawerBackButton = '[data-testid="drawer-close-button"]';
+  private readonly settingsButton = '[data-testid="global-menu-settings"]';
 
   constructor(driver: Driver) {
     this.driver = driver;
@@ -66,7 +66,7 @@ class HeaderNavbar {
     try {
       await this.driver.waitForMultipleSelectors([
         this.accountMenuButton,
-        this.threeDotMenuButton,
+        this.globalMenuButton,
       ]);
     } catch (e) {
       console.log('Timeout while waiting for header navbar to be loaded', e);
@@ -112,16 +112,16 @@ class HeaderNavbar {
 
   async openGlobalMenu(): Promise<void> {
     console.log('Open account options menu');
-    await this.driver.waitForSelector(this.threeDotMenuButton, {
+    await this.driver.waitForSelector(this.globalMenuButton, {
       state: 'enabled',
     });
-    await this.driver.clickElement(this.threeDotMenuButton);
+    await this.driver.clickElement(this.globalMenuButton);
     await this.driver.waitForElementToStopMoving(this.drawerBackButton);
   }
 
   async mouseClickOnThreeDotMenu(): Promise<void> {
     console.log('Clicking three dot menu using mouse move');
-    await this.driver.clickElementUsingMouseMove(this.threeDotMenuButton);
+    await this.driver.clickElementUsingMouseMove(this.globalMenuButton);
     await this.driver.waitForElementToStopMoving(this.drawerBackButton);
   }
 

--- a/test/e2e/page-objects/pages/header-navbar.ts
+++ b/test/e2e/page-objects/pages/header-navbar.ts
@@ -1,5 +1,6 @@
 import { strict as assert } from 'assert';
 import { Driver } from '../../webdriver/driver';
+import { regularDelayMs } from '../../helpers';
 
 class HeaderNavbar {
   protected driver: Driver;
@@ -31,6 +32,10 @@ class HeaderNavbar {
 
   private readonly notificationsButton =
     '[data-testid="notifications-menu-item"]';
+
+  private readonly notificationCounterMenuIcon = {
+    testId: 'notifications-tag-counter__unread-dot',
+  };
 
   private readonly notificationCountOption =
     '[data-testid="global-menu-notification-count"]';
@@ -76,7 +81,7 @@ class HeaderNavbar {
   }
 
   async lockMetaMask(): Promise<void> {
-    await this.openThreeDotMenu();
+    await this.openGlobalMenu();
     await this.driver.clickElement(this.lockMetaMaskButton);
     await this.driver.waitForSelector('[data-testid="unlock-password"]');
   }
@@ -88,24 +93,24 @@ class HeaderNavbar {
 
   async openAccountDetailsModalDetailsTab(): Promise<void> {
     console.log('Open account details modal');
-    await this.openThreeDotMenu();
+    await this.openGlobalMenu();
     await this.driver.clickElement(this.openAccountDetailsButton);
     await this.driver.clickElementSafe(this.accountDetailsTab);
   }
 
   async openAccountDetailsModal(): Promise<void> {
     console.log('Open account details modal');
-    await this.openThreeDotMenu();
+    await this.openGlobalMenu();
     await this.driver.clickElement(this.openAccountDetailsButton);
   }
 
   async openGlobalNetworksMenu(): Promise<void> {
     console.log('Open global menu');
-    await this.openThreeDotMenu();
+    await this.openGlobalMenu();
     await this.driver.clickElement(this.globalNetworksMenu);
   }
 
-  async openThreeDotMenu(): Promise<void> {
+  async openGlobalMenu(): Promise<void> {
     console.log('Open account options menu');
     await this.driver.waitForSelector(this.threeDotMenuButton, {
       state: 'enabled',
@@ -137,7 +142,7 @@ class HeaderNavbar {
     skipSitesNavigation?: boolean;
   }): Promise<void> {
     console.log('Open permissions page in header navbar');
-    await this.openThreeDotMenu();
+    await this.openGlobalMenu();
     await this.driver.clickElement(this.allPermissionsButton);
 
     // Check if we landed on Gator Permissions Page (intermediate page for Flask builds)
@@ -157,19 +162,26 @@ class HeaderNavbar {
 
   async openSnapListPage(): Promise<void> {
     console.log('Open account snap page');
-    await this.openThreeDotMenu();
+    await this.openGlobalMenu();
     await this.driver.clickElement(this.accountSnapButton);
   }
 
   async openSettingsPage(): Promise<void> {
     console.log('Open settings page');
-    await this.openThreeDotMenu();
+    // Sometimes the notification counter briefly appears and disappears overlapping the menu icon
+    await this.driver.assertElementNotPresent(
+      this.notificationCounterMenuIcon,
+      {
+        waitAtLeastGuard: regularDelayMs,
+      },
+    );
+    await this.openGlobalMenu();
     await this.driver.clickElement(this.settingsButton);
   }
 
   async enableNotifications(): Promise<void> {
     console.log('Enabling notifications for the first time');
-    await this.openThreeDotMenu();
+    await this.openGlobalMenu();
     await this.driver.clickElement(this.notificationsButton);
     await this.driver.clickElement(this.firstTimeTurnOnNotificationsButton);
   }

--- a/test/e2e/tests/metrics/marketing-cookieid.spec.ts
+++ b/test/e2e/tests/metrics/marketing-cookieid.spec.ts
@@ -76,7 +76,7 @@ describe('Marketing cookieId', function (this: Suite) {
 
         const homePage = new HomePage(driver);
         await homePage.checkPageIsLoaded();
-        await homePage.headerNavbar.openThreeDotMenu();
+        await homePage.headerNavbar.openGlobalMenu();
         const events = await getEventPayloads(
           driver,
           mockedEndpoints as MockedEndpoint[],
@@ -122,7 +122,7 @@ describe('Marketing cookieId', function (this: Suite) {
 
         const homePage = new HomePage(driver);
         await homePage.checkPageIsLoaded();
-        await homePage.headerNavbar.openThreeDotMenu();
+        await homePage.headerNavbar.openGlobalMenu();
         const events = await getEventPayloads(
           driver,
           mockedEndpoints as MockedEndpoint[],
@@ -163,7 +163,7 @@ describe('Marketing cookieId', function (this: Suite) {
 
         const homePage = new HomePage(driver);
         await homePage.checkPageIsLoaded();
-        await homePage.headerNavbar.openThreeDotMenu();
+        await homePage.headerNavbar.openGlobalMenu();
         const events = await getEventPayloads(
           driver,
           mockedEndpoints as MockedEndpoint[],

--- a/test/e2e/tests/multichain/aggregated-balances.spec.ts
+++ b/test/e2e/tests/multichain/aggregated-balances.spec.ts
@@ -22,7 +22,7 @@ const NETWORK_NAME_SEPOLIA = 'Sepolia';
 const SEPOLIA_NATIVE_TOKEN = 'SepoliaETH';
 
 describe('Multichain Aggregated Balances', function (this: Suite) {
-  it('TEST shows correct aggregated balance when "Current Network" is selected', async function () {
+  it('shows correct aggregated balance when "Current Network" is selected', async function () {
     const smartContract = SMART_CONTRACTS.NFTS;
     await withFixtures(
       {

--- a/test/e2e/tests/multichain/aggregated-balances.spec.ts
+++ b/test/e2e/tests/multichain/aggregated-balances.spec.ts
@@ -22,7 +22,7 @@ const NETWORK_NAME_SEPOLIA = 'Sepolia';
 const SEPOLIA_NATIVE_TOKEN = 'SepoliaETH';
 
 describe('Multichain Aggregated Balances', function (this: Suite) {
-  it('shows correct aggregated balance when "Current Network" is selected', async function () {
+  it('TEST shows correct aggregated balance when "Current Network" is selected', async function () {
     const smartContract = SMART_CONTRACTS.NFTS;
     await withFixtures(
       {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The spec is flaky as sometimes the notification counter briefly appears and then disappears. This causes that if we happen to click into the main menu, while the notification counter is there, we get the ElementInterceptError.


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40621?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. I triggered the e2e quality gate to ensure the fix was working in ci

## **Screenshots/Recordings**


https://github.com/user-attachments/assets/916ec485-02e9-4507-b0b4-e66c5404ac39



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[skip-e2e]
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to E2E page objects/tests; main risk is breaking other E2E flows if the new `openGlobalMenu` guard/selector mismatches the UI.
> 
> **Overview**
> Reduces E2E flakiness when opening the header account options menu by renaming `openThreeDotMenu` to `openGlobalMenu` and adding a pre-click guard that waits for the transient notification counter dot to disappear before clicking.
> 
> Updates the header navbar page object to use a `globalMenuButton` selector and adjusts dependent tests (e.g., `marketing-cookieid.spec.ts`) to call `openGlobalMenu`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52c23b04cd67c2130acab9c9a1100a7ead93cf74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->