### PR TITLE
fix: flaky test `Account Activity Web Socket a websocket connection is open when MetaMask full view is open`

### DIFF
--- a/test/e2e/tests/account-activity/web-socket-connection.spec.ts
+++ b/test/e2e/tests/account-activity/web-socket-connection.spec.ts
@@ -16,7 +16,7 @@ async function waitForAccountActivityWebsocketConnections(
       WEBSOCKET_SERVICES.accountActivity,
     ).getWebsocketConnectionCount();
     return connectionCount === expectedCount;
-  }, 10000);
+  }, 20000);
 }
 
 describe('Account Activity Web Socket', function (this: Suite) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Increasing timeout for websocket connection as sometimes can take longer than 10s

<img width="884" height="986" alt="image" src="https://github.com/user-attachments/assets/fe6bd9bd-c629-44cc-be66-4b598d413a5a" />


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40623?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts an E2E test wait timeout, with no production code changes. Main impact is slightly longer potential test runtime if the expected websocket state is never reached.
> 
> **Overview**
> Reduces flakiness in `web-socket-connection.spec.ts` by increasing the timeout for `waitForAccountActivityWebsocketConnections` from 10s to 20s when waiting for the expected websocket connection count.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 101d59f890d717d15b4cbe871ed3579ed4f563c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->