### PR TITLE
Metamask extension issue

### DIFF
--- a/ui/components/app/modals/turn-on-metamask-notifications/turn-on-metamask-notifications.tsx
+++ b/ui/components/app/modals/turn-on-metamask-notifications/turn-on-metamask-notifications.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useContext, useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import { I18nContext } from '../../../../contexts/i18n';
@@ -57,8 +57,13 @@ export default function TurnOnMetamaskNotifications() {
   const [isLoading, setIsLoading] = useState<boolean>(
     isUpdatingMetamaskNotifications,
   );
+  const isLoadingRef = useRef(isUpdatingMetamaskNotifications);
 
   const { enableNotifications, error } = useEnableNotifications();
+
+  useEffect(() => {
+    isLoadingRef.current = isLoading;
+  }, [isLoading]);
 
   const handleTurnOnNotifications = async () => {
     setIsLoading(true);
@@ -78,24 +83,25 @@ export default function TurnOnMetamaskNotifications() {
   };
 
   const handleHideModal = () => {
+    // Read loading state from a ref to avoid scheduling state updates during close.
+    const isCurrentlyLoading = isLoadingRef.current;
+
+    if (!isCurrentlyLoading) {
+      trackEvent({
+        category: MetaMetricsEventCategory.NotificationsActivationFlow,
+        event: MetaMetricsEventName.NotificationsActivated,
+        properties: {
+          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          is_profile_syncing_enabled: isBackupAndSyncEnabled,
+          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          action_type: 'dismissed',
+        },
+      });
+    }
+
     hideModal();
-    setIsLoading((prevLoadingState) => {
-      if (!prevLoadingState) {
-        trackEvent({
-          category: MetaMetricsEventCategory.NotificationsActivationFlow,
-          event: MetaMetricsEventName.NotificationsActivated,
-          properties: {
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            is_profile_syncing_enabled: isBackupAndSyncEnabled,
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            action_type: 'dismissed',
-          },
-        });
-      }
-      return prevLoadingState;
-    });
   };
 
   useEffect(() => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Avoid unmounted state updates in the notifications activation modal to prevent flaky CI failures.

The `TurnOnMetamaskNotifications` modal's `handleHideModal` previously called `setIsLoading` after `hideModal()`, which could race with component unmounting. This intermittently triggered "React: State updates on unmounted components" baseline violations in CI. The fix replaces the state update with a `useRef` to track loading state, ensuring `setState` is not called on an unmounted component while preserving dismissed metrics.

---
[Slack Thread](https://consensys.slack.com/archives/D0A342PL97X/p1772699383673719?thread_ts=1772699383.673719&cid=D0A342PL97X)

<p><a href="https://cursor.com/agents/bc-072bd1e5-3cf2-571f-b972-e0bec8520512"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-072bd1e5-3cf2-571f-b972-e0bec8520512"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->