### PR TITLE
fix: flaky test `Dapp interactions should connect a second Dapp despite MetaMask being locked`

### DIFF
--- a/test/e2e/page-objects/pages/confirmations/connect-account-confirmation.ts
+++ b/test/e2e/page-objects/pages/confirmations/connect-account-confirmation.ts
@@ -35,6 +35,13 @@ class ConnectAccountConfirmation {
 
   private readonly editPermissionsButton = '[data-testid="edit"]';
 
+  private readonly originHeader = (origin: string) => {
+    return {
+      tag: 'h2',
+      text: origin,
+    };
+  };
+
   private readonly permissionsTab = {
     testId: 'permissions-tab',
   };
@@ -43,11 +50,14 @@ class ConnectAccountConfirmation {
     this.driver = driver;
   }
 
-  async checkPageIsLoaded(): Promise<void> {
+  async checkPageIsLoaded({
+    origin = '127.0.0.1',
+  }: { origin?: string } = {}): Promise<void> {
     try {
       await this.driver.waitForMultipleSelectors([
         this.connectAccountConfirmationTitle,
         this.connectAccountConfirmationButton,
+        this.originHeader(origin),
       ]);
     } catch (e) {
       console.log(

--- a/test/e2e/tests/dapp-interactions/dapp-interactions.spec.ts
+++ b/test/e2e/tests/dapp-interactions/dapp-interactions.spec.ts
@@ -81,6 +81,7 @@ describe('Dapp interactions', function () {
           driver,
         );
         await connectAccountConfirmation.checkPageIsLoaded();
+        await driver.delay(5000);
         await connectAccountConfirmation.confirmConnect();
         await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
         await testDapp.checkConnectedAccounts(DEFAULT_FIXTURE_ACCOUNT);

--- a/test/e2e/tests/dapp-interactions/dapp-interactions.spec.ts
+++ b/test/e2e/tests/dapp-interactions/dapp-interactions.spec.ts
@@ -81,7 +81,6 @@ describe('Dapp interactions', function () {
           driver,
         );
         await connectAccountConfirmation.checkPageIsLoaded();
-        await driver.delay(5000);
         await connectAccountConfirmation.confirmConnect();
         await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
         await testDapp.checkConnectedAccounts(DEFAULT_FIXTURE_ACCOUNT);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Wait until the Connect page renders the origin., before clicking Connect.


<img width="400" height="621" alt="image" src="https://github.com/user-attachments/assets/6e1ea8e9-34bf-4e10-ad80-ae0c7a4061c7" />


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40627?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to E2E page-object selectors/signature, though it may surface new test failures if the expected origin text differs from the default.
> 
> **Overview**
> Improves E2E stability for the Connect Account confirmation dialog by adding an `origin` header selector and requiring it during `checkPageIsLoaded`.
> 
> `checkPageIsLoaded` now accepts an optional `{ origin }` (defaulting to `127.0.0.1`) so tests can wait for the correct requesting-site header before proceeding.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45fedaf11e80b738c7293b7c18f04314b2212f04. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->