### PR TITLE
chore: tighten benchmark thresholds based on Sentry data

### DIFF
--- a/test/e2e/benchmarks/flows/README.md
+++ b/test/e2e/benchmarks/flows/README.md
@@ -77,21 +77,28 @@ await timer.measure(async () => {
 });
 ```
 
-**Threshold Validation:**
+**Threshold Validation (mandatory):**
 
-Thresholds are configured separately in `test/e2e/benchmarks/utils/constants.ts` for statistical validation after multiple iterations. Each timer can have P75 and P95 thresholds with warn/fail levels:
+Every benchmark **must** have a threshold entry in `THRESHOLD_REGISTRY` inside `test/e2e/benchmarks/utils/constants.ts`. Thresholds are validated after collecting statistics from all iterations.
+
+To add thresholds for a new benchmark:
+
+1. Define a constant named after the file in UPPER_SNAKE_CASE (e.g. `my-benchmark.ts` -> `MY_BENCHMARK`)
+2. Add it to the `THRESHOLD_REGISTRY` entries
 
 ```typescript
-export const MY_BENCHMARK_THRESHOLDS: ThresholdConfig = {
+const MY_BENCHMARK: ThresholdConfig = {
   myTimerId: {
-    p75: { warn: 1000, fail: 1500 }, // 75th percentile thresholds (ms)
-    p95: { warn: 2000, fail: 3000 }, // 95th percentile thresholds (ms)
-    ciMultiplier: DEFAULT_CI_MULTIPLIER, // 1.5x multiplier for CI environments
+    p75: { warn: 1000, fail: 1500 },
+    p95: { warn: 2000, fail: 3000 },
+    ciMultiplier: DEFAULT_CI_MULTIPLIER,
   },
 };
+
+// Then add MY_BENCHMARK to the THRESHOLD_REGISTRY entries
 ```
 
-Thresholds are validated by the benchmark runner after collecting statistics from all iterations. This approach is more reliable than per-run validation for performance testing.
+The constant name is auto-converted to the file name (`MY_BENCHMARK` -> `my-benchmark`).
 
 ### 3. Add to a preset (optional)
 

--- a/test/e2e/benchmarks/run-benchmark.ts
+++ b/test/e2e/benchmarks/run-benchmark.ts
@@ -111,9 +111,14 @@ async function runBenchmarkFile(
 
   const { run: runFn } = benchmark;
   const thresholdConfig = THRESHOLD_REGISTRY[fileName];
+  if (!thresholdConfig) {
+    throw new Error(
+      `No threshold config for "${fileName}". Add an entry to THRESHOLD_REGISTRY in constants.ts.`,
+    );
+  }
 
   let result: BenchmarkResults;
-  let violations: ThresholdViolation[] = [];
+  let violations: ThresholdViolation[];
 
   if (supportsIterations(filePath) && options.iterations > 0) {
     const testTitle = benchmark.testTitle || fileName;
@@ -144,10 +149,7 @@ async function runBenchmarkFile(
     );
   } else {
     result = (await runFn(options)) as BenchmarkResults;
-
-    if (thresholdConfig) {
-      violations = validateResultThresholds(result, thresholdConfig).violations;
-    }
+    violations = validateResultThresholds(result, thresholdConfig).violations;
   }
 
   logThresholdResult(violations);

--- a/test/e2e/benchmarks/run-benchmark.ts
+++ b/test/e2e/benchmarks/run-benchmark.ts
@@ -14,64 +14,18 @@ import {
   getFirstParentDirectoryThatExists,
   isWritable,
 } from '../../helpers/file';
-import { runBenchmarkWithIterations } from './utils';
+import { runBenchmarkWithIterations, convertSummaryToResults } from './utils';
 import {
   THRESHOLD_REGISTRY,
   STARTUP_PRESETS,
   INTERACTION_PRESETS,
   USER_JOURNEY_PRESETS,
 } from './utils/constants';
-import type {
-  BenchmarkResults,
-  BenchmarkSummary,
-  BenchmarkType,
-  Persona,
-  StatisticalResult,
-} from './utils/types';
-
-/**
- * Convert BenchmarkSummary (from runBenchmarkWithIterations) to BenchmarkResults format
- * for consistent output with send-to-sentry.ts
- *
- * @param summary
- * @param testTitle
- * @param persona
- * @param benchmarkType
- */
-function convertSummaryToResults(
-  summary: BenchmarkSummary,
-  testTitle: string,
-  persona: Persona = 'standard',
-  benchmarkType?: BenchmarkType,
-): BenchmarkResults {
-  const mean: StatisticalResult = {};
-  const min: StatisticalResult = {};
-  const max: StatisticalResult = {};
-  const stdDev: StatisticalResult = {};
-  const p75: StatisticalResult = {};
-  const p95: StatisticalResult = {};
-
-  for (const timer of summary.timers) {
-    mean[timer.id] = timer.mean;
-    min[timer.id] = timer.min;
-    max[timer.id] = timer.max;
-    stdDev[timer.id] = timer.stdDev;
-    p75[timer.id] = timer.p75;
-    p95[timer.id] = timer.p95;
-  }
-
-  return {
-    testTitle,
-    persona,
-    benchmarkType,
-    mean,
-    min,
-    max,
-    stdDev,
-    p75,
-    p95,
-  };
-}
+import {
+  validateResultThresholds,
+  logThresholdResult,
+} from './utils/statistics';
+import type { BenchmarkResults, ThresholdViolation } from './utils/types';
 
 /**
  * Startup benchmarks handle their own iteration internally (browserLoads x pageLoads).
@@ -156,8 +110,11 @@ async function runBenchmarkFile(
   }
 
   const { run: runFn } = benchmark;
+  const thresholdConfig = THRESHOLD_REGISTRY[fileName];
 
-  // For benchmarks that support iterations, use runBenchmarkWithIterations to run multiple times
+  let result: BenchmarkResults;
+  let violations: ThresholdViolation[] = [];
+
   if (supportsIterations(filePath) && options.iterations > 0) {
     const testTitle = benchmark.testTitle || fileName;
     const { persona } = benchmark;
@@ -171,35 +128,31 @@ async function runBenchmarkFile(
       runFn,
       options.iterations,
       options.retries,
-      THRESHOLD_REGISTRY[fileName],
+      thresholdConfig,
     );
 
     console.log(
       `Completed: ${summary.successfulRuns}/${summary.iterations} successful runs`,
     );
 
-    if (summary.thresholdViolations.length > 0) {
-      console.log('\n⚠️  Threshold Violations:');
-      summary.thresholdViolations.forEach((v) => {
-        const icon = v.severity === 'fail' ? '❌' : '⚠️';
-        console.log(
-          `  ${icon} ${v.metricId} (${v.percentile}): ${v.value.toFixed(2)}ms > ${v.threshold}ms`,
-        );
-      });
-    } else {
-      console.log('✅ All thresholds passed');
-    }
-
-    return convertSummaryToResults(
+    violations = summary.thresholdViolations;
+    result = convertSummaryToResults(
       summary,
       testTitle,
       persona,
       summary.benchmarkType,
     );
+  } else {
+    result = (await runFn(options)) as BenchmarkResults;
+
+    if (thresholdConfig) {
+      violations = validateResultThresholds(result, thresholdConfig).violations;
+    }
   }
 
-  // For other benchmarks (page-load), run once with options
-  return runFn(options);
+  logThresholdResult(violations);
+
+  return result;
 }
 
 /**

--- a/test/e2e/benchmarks/run-benchmark.ts
+++ b/test/e2e/benchmarks/run-benchmark.ts
@@ -16,13 +16,7 @@ import {
 } from '../../helpers/file';
 import { runBenchmarkWithIterations } from './utils';
 import {
-  ONBOARDING_IMPORT_THRESHOLDS,
-  ONBOARDING_NEW_WALLET_THRESHOLDS,
-  IMPORT_SRP_HOME_THRESHOLDS,
-  SWAP_THRESHOLDS,
-  SEND_TRANSACTIONS_THRESHOLDS,
-  ASSET_DETAILS_THRESHOLDS,
-  SOLANA_ASSET_DETAILS_THRESHOLDS,
+  THRESHOLD_REGISTRY,
   STARTUP_PRESETS,
   INTERACTION_PRESETS,
   USER_JOURNEY_PRESETS,
@@ -33,7 +27,6 @@ import type {
   BenchmarkType,
   Persona,
   StatisticalResult,
-  ThresholdConfig,
 } from './utils/types';
 
 /**
@@ -81,29 +74,12 @@ function convertSummaryToResults(
 }
 
 /**
- * Check if a benchmark file supports iterations (performance or user-actions)
- *
+ * Startup benchmarks handle their own iteration internally (browserLoads x pageLoads).
+ * All other benchmarks need external iteration + aggregation via runBenchmarkWithIterations.
  * @param filePath
  */
 function supportsIterations(filePath: string): boolean {
-  return (
-    filePath.includes('/user-journey/') || filePath.includes('/interaction/')
-  );
-}
-
-function getThresholdConfig(filePath: string): ThresholdConfig | undefined {
-  const fileName = path.basename(filePath, path.extname(filePath));
-  const thresholdMap: Record<string, ThresholdConfig> = {
-    'onboarding-import-wallet': ONBOARDING_IMPORT_THRESHOLDS,
-    'onboarding-new-wallet': ONBOARDING_NEW_WALLET_THRESHOLDS,
-    'import-srp-home': IMPORT_SRP_HOME_THRESHOLDS,
-    swap: SWAP_THRESHOLDS,
-    'send-transactions': SEND_TRANSACTIONS_THRESHOLDS,
-    'asset-details': ASSET_DETAILS_THRESHOLDS,
-    'solana-asset-details': SOLANA_ASSET_DETAILS_THRESHOLDS,
-  };
-
-  return thresholdMap[fileName];
+  return !filePath.includes('/startup/');
 }
 
 const BENCHMARK_DIR = 'test/e2e/benchmarks/flows';
@@ -195,15 +171,14 @@ async function runBenchmarkFile(
       runFn,
       options.iterations,
       options.retries,
-      getThresholdConfig(filePath),
+      THRESHOLD_REGISTRY[fileName],
     );
 
     console.log(
       `Completed: ${summary.successfulRuns}/${summary.iterations} successful runs`,
     );
 
-    // Log threshold violations if any
-    if (summary.thresholdViolations && summary.thresholdViolations.length > 0) {
+    if (summary.thresholdViolations.length > 0) {
       console.log('\n⚠️  Threshold Violations:');
       summary.thresholdViolations.forEach((v) => {
         const icon = v.severity === 'fail' ? '❌' : '⚠️';
@@ -211,7 +186,7 @@ async function runBenchmarkFile(
           `  ${icon} ${v.metricId} (${v.percentile}): ${v.value.toFixed(2)}ms > ${v.threshold}ms`,
         );
       });
-    } else if (summary.thresholdsPassed !== undefined) {
+    } else {
       console.log('✅ All thresholds passed');
     }
 

--- a/test/e2e/benchmarks/utils/constants.ts
+++ b/test/e2e/benchmarks/utils/constants.ts
@@ -66,10 +66,7 @@ export const WITH_STATE_POWER_USER = {
  */
 export const DEFAULT_CI_MULTIPLIER = 1.5;
 
-/**
- * Onboarding import wallet thresholds.
- */
-export const ONBOARDING_IMPORT_THRESHOLDS: ThresholdConfig = {
+const ONBOARDING_IMPORT_WALLET: ThresholdConfig = {
   importWalletToSocialScreen: {
     p75: { warn: 1800, fail: 2400 },
     p95: { warn: 2800, fail: 3500 },
@@ -96,8 +93,8 @@ export const ONBOARDING_IMPORT_THRESHOLDS: ThresholdConfig = {
     ciMultiplier: DEFAULT_CI_MULTIPLIER,
   },
   doneButtonToHomeScreen: {
-    p75: { warn: 13500, fail: 17500 },
-    p95: { warn: 21000, fail: 26000 },
+    p75: { warn: 10500, fail: 14000 },
+    p95: { warn: 16000, fail: 21000 },
     ciMultiplier: DEFAULT_CI_MULTIPLIER,
   },
   openAccountMenuToAccountListLoaded: {
@@ -107,10 +104,7 @@ export const ONBOARDING_IMPORT_THRESHOLDS: ThresholdConfig = {
   },
 };
 
-/**
- * Onboarding new wallet thresholds.
- */
-export const ONBOARDING_NEW_WALLET_THRESHOLDS: ThresholdConfig = {
+const ONBOARDING_NEW_WALLET: ThresholdConfig = {
   createWalletToSocialScreen: {
     p75: { warn: 1800, fail: 2400 },
     p95: { warn: 2800, fail: 3500 },
@@ -137,19 +131,16 @@ export const ONBOARDING_NEW_WALLET_THRESHOLDS: ThresholdConfig = {
     ciMultiplier: DEFAULT_CI_MULTIPLIER,
   },
   doneButtonToAssetList: {
-    p75: { warn: 13500, fail: 17500 },
-    p95: { warn: 21000, fail: 26000 },
+    p75: { warn: 10500, fail: 14000 },
+    p95: { warn: 16000, fail: 21000 },
     ciMultiplier: DEFAULT_CI_MULTIPLIER,
   },
 };
 
-/**
- * Import SRP from home thresholds.
- */
-export const IMPORT_SRP_HOME_THRESHOLDS: ThresholdConfig = {
+const IMPORT_SRP_HOME: ThresholdConfig = {
   loginToHomeScreen: {
-    p75: { warn: 9000, fail: 11500 },
-    p95: { warn: 14000, fail: 17500 },
+    p75: { warn: 5000, fail: 7000 },
+    p95: { warn: 8000, fail: 10500 },
     ciMultiplier: DEFAULT_CI_MULTIPLIER,
   },
   openAccountMenuAfterLogin: {
@@ -158,67 +149,150 @@ export const IMPORT_SRP_HOME_THRESHOLDS: ThresholdConfig = {
     ciMultiplier: DEFAULT_CI_MULTIPLIER,
   },
   homeAfterImportWithNewWallet: {
-    p75: { warn: 27000, fail: 35000 },
-    p95: { warn: 42000, fail: 52000 },
+    p75: { warn: 20000, fail: 27000 },
+    p95: { warn: 32000, fail: 40000 },
     ciMultiplier: DEFAULT_CI_MULTIPLIER,
   },
 };
 
-/**
- * Swap flow thresholds.
- */
-export const SWAP_THRESHOLDS: ThresholdConfig = {
+const SWAP: ThresholdConfig = {
   openSwapPageFromHome: {
-    p75: { warn: 4500, fail: 5800 },
-    p95: { warn: 7000, fail: 8700 },
+    p75: { warn: 3000, fail: 4500 },
+    p95: { warn: 5000, fail: 7000 },
     ciMultiplier: DEFAULT_CI_MULTIPLIER,
   },
   fetchAndDisplaySwapQuotes: {
-    p75: { warn: 9000, fail: 11500 },
-    p95: { warn: 14000, fail: 17500 },
+    p75: { warn: 1200, fail: 2000 },
+    p95: { warn: 2000, fail: 3500 },
     ciMultiplier: DEFAULT_CI_MULTIPLIER,
   },
 };
 
-/**
- * Send transactions thresholds.
- */
-export const SEND_TRANSACTIONS_THRESHOLDS: ThresholdConfig = {
+const SEND_TRANSACTIONS: ThresholdConfig = {
   openSendPageFromHome: {
-    p75: { warn: 2700, fail: 3500 },
-    p95: { warn: 4200, fail: 5200 },
+    p75: { warn: 1800, fail: 2700 },
+    p95: { warn: 3000, fail: 4000 },
     ciMultiplier: DEFAULT_CI_MULTIPLIER,
   },
   selectTokenToSendFormLoaded: {
-    p75: { warn: 6000, fail: 7500 },
-    p95: { warn: 8000, fail: 10000 },
+    p75: { warn: 4000, fail: 5500 },
+    p95: { warn: 6000, fail: 8000 },
     ciMultiplier: DEFAULT_CI_MULTIPLIER,
   },
   reviewTransactionToConfirmationPage: {
-    p75: { warn: 4500, fail: 5800 },
-    p95: { warn: 7000, fail: 8700 },
+    p75: { warn: 3000, fail: 4500 },
+    p95: { warn: 5000, fail: 7000 },
     ciMultiplier: DEFAULT_CI_MULTIPLIER,
   },
 };
 
-/**
- * Asset details thresholds (power user).
- */
-export const ASSET_DETAILS_THRESHOLDS: ThresholdConfig = {
+const ASSET_DETAILS: ThresholdConfig = {
   assetClickToPriceChart: {
-    p75: { warn: 8000, fail: 12000 },
-    p95: { warn: 12000, fail: 15000 },
+    p75: { warn: 500, fail: 1500 },
+    p95: { warn: 1500, fail: 3000 },
     ciMultiplier: DEFAULT_CI_MULTIPLIER,
   },
 };
 
-/**
- * Solana asset details thresholds (power user).
- */
-export const SOLANA_ASSET_DETAILS_THRESHOLDS: ThresholdConfig = {
+const SOLANA_ASSET_DETAILS: ThresholdConfig = {
   assetClickToPriceChart: {
-    p75: { warn: 5500, fail: 8000 },
-    p95: { warn: 8000, fail: 10000 },
+    p75: { warn: 500, fail: 1500 },
+    p95: { warn: 1500, fail: 3000 },
     ciMultiplier: DEFAULT_CI_MULTIPLIER,
   },
 };
+
+const STANDARD_HOME: ThresholdConfig = {
+  uiStartup: {
+    p75: { warn: 2000, fail: 2500 },
+    p95: { warn: 2500, fail: 3200 },
+    ciMultiplier: DEFAULT_CI_MULTIPLIER,
+  },
+  load: {
+    p75: { warn: 1600, fail: 2200 },
+    p95: { warn: 2200, fail: 2800 },
+    ciMultiplier: DEFAULT_CI_MULTIPLIER,
+  },
+  loadScripts: {
+    p75: { warn: 1400, fail: 1800 },
+    p95: { warn: 1800, fail: 2400 },
+    ciMultiplier: DEFAULT_CI_MULTIPLIER,
+  },
+};
+
+const POWER_USER_HOME: ThresholdConfig = {
+  uiStartup: {
+    p75: { warn: 3000, fail: 4000 },
+    p95: { warn: 4000, fail: 5500 },
+    ciMultiplier: DEFAULT_CI_MULTIPLIER,
+  },
+  load: {
+    p75: { warn: 2500, fail: 3500 },
+    p95: { warn: 3500, fail: 4500 },
+    ciMultiplier: DEFAULT_CI_MULTIPLIER,
+  },
+  loadScripts: {
+    p75: { warn: 2000, fail: 2800 },
+    p95: { warn: 2800, fail: 3800 },
+    ciMultiplier: DEFAULT_CI_MULTIPLIER,
+  },
+};
+
+// Threshold keys must match timer IDs emitted by the benchmark flows (snake_case).
+/* eslint-disable @typescript-eslint/naming-convention */
+const LOAD_NEW_ACCOUNT: ThresholdConfig = {
+  load_new_account: {
+    p75: { warn: 800, fail: 1200 },
+    p95: { warn: 1200, fail: 1800 },
+    ciMultiplier: DEFAULT_CI_MULTIPLIER,
+  },
+};
+
+const CONFIRM_TX: ThresholdConfig = {
+  confirm_tx: {
+    p75: { warn: 7000, fail: 9000 },
+    p95: { warn: 9000, fail: 12000 },
+    ciMultiplier: 1.3,
+  },
+};
+
+const BRIDGE_USER_ACTIONS: ThresholdConfig = {
+  bridge_load_page: {
+    p75: { warn: 500, fail: 800 },
+    p95: { warn: 800, fail: 1200 },
+    ciMultiplier: DEFAULT_CI_MULTIPLIER,
+  },
+  bridge_load_asset_picker: {
+    p75: { warn: 500, fail: 800 },
+    p95: { warn: 800, fail: 1200 },
+    ciMultiplier: DEFAULT_CI_MULTIPLIER,
+  },
+  bridge_search_token: {
+    p75: { warn: 1200, fail: 1800 },
+    p95: { warn: 1800, fail: 2500 },
+    ciMultiplier: DEFAULT_CI_MULTIPLIER,
+  },
+};
+/* eslint-enable @typescript-eslint/naming-convention */
+
+/**
+ * Registry keyed by benchmark file name (kebab-case), auto-converted from
+ * UPPER_SNAKE_CASE, e.g. ONBOARDING_IMPORT_WALLET -> onboarding-import-wallet.
+ */
+export const THRESHOLD_REGISTRY: Record<string, ThresholdConfig> =
+  Object.fromEntries(
+    Object.entries({
+      ONBOARDING_IMPORT_WALLET,
+      ONBOARDING_NEW_WALLET,
+      IMPORT_SRP_HOME,
+      SWAP,
+      SEND_TRANSACTIONS,
+      ASSET_DETAILS,
+      SOLANA_ASSET_DETAILS,
+      STANDARD_HOME,
+      POWER_USER_HOME,
+      LOAD_NEW_ACCOUNT,
+      CONFIRM_TX,
+      BRIDGE_USER_ACTIONS,
+    }).map(([key, config]) => [key.toLowerCase().replace(/_/gu, '-'), config]),
+  );

--- a/test/e2e/benchmarks/utils/runner.ts
+++ b/test/e2e/benchmarks/utils/runner.ts
@@ -25,6 +25,7 @@ import type {
   BenchmarkType,
   Metrics,
   Persona,
+  StatisticalResult,
   ThresholdConfig,
   TimerResult,
   TimerStatistics,
@@ -175,6 +176,50 @@ export async function runBenchmarkWithIterations(
     thresholdViolations: thresholdResult.violations,
     thresholdsPassed: thresholdResult.passed,
     benchmarkType,
+  };
+}
+
+/**
+ * Convert BenchmarkSummary (from runBenchmarkWithIterations) to BenchmarkResults format
+ * for consistent output with send-to-sentry.ts
+ *
+ * @param summary
+ * @param testTitle
+ * @param persona
+ * @param benchmarkType
+ */
+export function convertSummaryToResults(
+  summary: BenchmarkSummary,
+  testTitle: string,
+  persona: Persona = 'standard',
+  benchmarkType?: BenchmarkType,
+): BenchmarkResults {
+  const mean: StatisticalResult = {};
+  const min: StatisticalResult = {};
+  const max: StatisticalResult = {};
+  const stdDev: StatisticalResult = {};
+  const p75: StatisticalResult = {};
+  const p95: StatisticalResult = {};
+
+  for (const timer of summary.timers) {
+    mean[timer.id] = timer.mean;
+    min[timer.id] = timer.min;
+    max[timer.id] = timer.max;
+    stdDev[timer.id] = timer.stdDev;
+    p75[timer.id] = timer.p75;
+    p95[timer.id] = timer.p95;
+  }
+
+  return {
+    testTitle,
+    persona,
+    benchmarkType,
+    mean,
+    min,
+    max,
+    stdDev,
+    p75,
+    p95,
   };
 }
 

--- a/test/e2e/benchmarks/utils/runner.ts
+++ b/test/e2e/benchmarks/utils/runner.ts
@@ -71,7 +71,7 @@ export async function runBenchmarkWithIterations(
   benchmarkFn: BenchmarkFunction,
   iterations: number,
   retries: number,
-  thresholdConfig?: ThresholdConfig,
+  thresholdConfig: ThresholdConfig,
 ): Promise<BenchmarkSummary> {
   const allResults: BenchmarkRunResult[] = [];
   let successfulRuns = 0;
@@ -157,10 +157,7 @@ export async function runBenchmarkWithIterations(
     MAX_EXCLUSION_RATE,
   );
 
-  // Validate thresholds if configured
-  const thresholdResult = thresholdConfig
-    ? validateThresholds(timerStats, thresholdConfig)
-    : undefined;
+  const thresholdResult = validateThresholds(timerStats, thresholdConfig);
 
   // Extract benchmarkType from the first result (same across all iterations)
   const benchmarkType = allResults.find((r) => r.benchmarkType)?.benchmarkType;
@@ -175,10 +172,8 @@ export async function runBenchmarkWithIterations(
     excludedDueToQuality,
     exclusionRatePassed: overallExclusionCheck.passed,
     exclusionRate: overallExclusionCheck.rate,
-    ...(thresholdResult && {
-      thresholdViolations: thresholdResult.violations,
-      thresholdsPassed: thresholdResult.passed,
-    }),
+    thresholdViolations: thresholdResult.violations,
+    thresholdsPassed: thresholdResult.passed,
     benchmarkType,
   };
 }

--- a/test/e2e/benchmarks/utils/statistics.ts
+++ b/test/e2e/benchmarks/utils/statistics.ts
@@ -9,6 +9,7 @@
  */
 
 import type {
+  BenchmarkResults,
   PercentileThreshold,
   StatisticalResult,
   ThresholdConfig,
@@ -528,16 +529,67 @@ export const validateThresholds = (
 };
 
 /**
- * Format threshold violations into human-readable messages
+ * Validate a BenchmarkResults object against configured thresholds.
+ * Used by startup benchmarks which produce BenchmarkResults directly
+ * rather than TimerStatistics[].
  *
- * @param violations - Array of threshold violations
+ * @param results - Benchmark results containing p75/p95 maps
+ * @param thresholdConfig - Threshold configuration for metrics
+ * @returns Object containing violations array and whether all thresholds passed
  */
-export const formatThresholdViolations = (
-  violations: ThresholdViolation[],
-): string[] => {
-  return violations.map((v) => {
-    const severityPrefix = v.severity === 'fail' ? '❌ FAIL' : '⚠️ WARN';
-    const percentileLabel = v.percentile.toUpperCase();
-    return `${severityPrefix}: ${v.metricId} ${percentileLabel} (${v.value.toFixed(2)}ms) exceeds threshold (${v.threshold.toFixed(2)}ms)`;
-  });
+export const validateResultThresholds = (
+  results: BenchmarkResults,
+  thresholdConfig: ThresholdConfig,
+): { violations: ThresholdViolation[]; passed: boolean } => {
+  const violations: ThresholdViolation[] = [];
+
+  for (const [metricId, thresholds] of Object.entries(thresholdConfig)) {
+    if (thresholds.p75 && results.p75[metricId] !== undefined) {
+      const violation = validatePercentile(
+        metricId,
+        'p75',
+        results.p75[metricId],
+        thresholds.p75,
+        thresholds.ciMultiplier,
+      );
+      if (violation) {
+        violations.push(violation);
+      }
+    }
+
+    if (thresholds.p95 && results.p95[metricId] !== undefined) {
+      const violation = validatePercentile(
+        metricId,
+        'p95',
+        results.p95[metricId],
+        thresholds.p95,
+        thresholds.ciMultiplier,
+      );
+      if (violation) {
+        violations.push(violation);
+      }
+    }
+  }
+
+  const passed = !violations.some((v) => v.severity === 'fail');
+  return { violations, passed };
 };
+
+/**
+ * Log threshold validation results to the console.
+ *
+ * @param violations - Array of threshold violations (empty = all passed)
+ */
+export function logThresholdResult(violations: ThresholdViolation[]): void {
+  if (violations.length > 0) {
+    console.log('\n⚠️  Threshold Violations:');
+    violations.forEach((v) => {
+      const icon = v.severity === 'fail' ? '❌' : '⚠️';
+      console.log(
+        `  ${icon} ${v.metricId} (${v.percentile}): ${v.value.toFixed(2)}ms > ${v.threshold}ms`,
+      );
+    });
+  } else {
+    console.log('✅ All thresholds passed');
+  }
+}

--- a/test/e2e/benchmarks/utils/types.ts
+++ b/test/e2e/benchmarks/utils/types.ts
@@ -137,10 +137,8 @@ export type BenchmarkSummary = {
   exclusionRatePassed: boolean;
   /** Percentage of runs that were excluded (0-1) */
   exclusionRate: number;
-  /** List of threshold violations (if any thresholds configured) */
-  thresholdViolations?: ThresholdViolation[];
-  /** Whether all thresholds passed (no 'fail' violations) */
-  thresholdsPassed?: boolean;
+  thresholdViolations: ThresholdViolation[];
+  thresholdsPassed: boolean;
   /** Benchmark type extracted from the first successful run */
   benchmarkType?: BenchmarkType;
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Tighten benchmark performance thresholds based on observed [Sentry dashboard data (14D)](https://metamask.sentry.io/dashboard/231432/?project=4510302346608640&statsPeriod=14d) and add thresholds for all remaining benchmark flows.

Many existing thresholds had excessive headroom, e.g. `fetchAndDisplaySwapQuotes` had 18x headroom and `assetClickToPriceChart` had 133x compared to actual p75 values. Thresholds are now set to ~2-3x observed p75 (before the 1.5x CI multiplier) so regressions are caught earlier.

This PR also makes thresholds mandatory for every benchmark. All threshold configs are consolidated into a single `THRESHOLD_REGISTRY` that auto-maps constant names to file names, replacing the manual lookup that was easy to forget when adding new benchmarks.

### Key changes
**Tightened thresholds (user-journey benchmarks):**

| Metric | Old p75 warn | New p75 warn | Observed p75 |
|--------|-------------|-------------|-------------|
| `doneButtonToHomeScreen` | 13,500ms | 10,500ms | ~8,000ms |
| `doneButtonToAssetList` | 13,500ms | 10,500ms | ~8,000ms |
| `loginToHomeScreen` | 9,000ms | 5,000ms | ~1,840ms |
| `homeAfterImportWithNewWallet` | 27,000ms | 20,000ms | — |
| `fetchAndDisplaySwapQuotes` | 9,000ms | 1,200ms | ~508ms |
| `openSwapPageFromHome` | 4,500ms | 3,000ms | — |
| `openSendPageFromHome` | 2,700ms | 1,800ms | ~900ms |
| `selectTokenToSendFormLoaded` | 6,000ms | 4,000ms | — |
| `reviewTransactionToConfirmationPage` | 4,500ms | 3,000ms | — |
| `assetClickToPriceChart` (EVM) | 8,000ms | 500ms | ~60ms |
| `assetClickToPriceChart` (Solana) | 5,500ms | 500ms | ~60ms |

**New thresholds (startup benchmarks):**

| Benchmark | Metric | p75 warn | p95 warn |
|-----------|--------|----------|----------|
| `standard-home` | `uiStartup` | 2,000ms | 2,500ms |
| `standard-home` | `load` | 1,600ms | 2,200ms |
| `standard-home` | `loadScripts` | 1,400ms | 1,800ms |
| `power-user-home` | `uiStartup` | 3,000ms | 4,000ms |
| `power-user-home` | `load` | 2,500ms | 3,500ms |
| `power-user-home` | `loadScripts` | 2,000ms | 2,800ms |

**New thresholds (interaction benchmarks):**

| Benchmark | Metric | p75 warn | p95 warn |
|-----------|--------|----------|----------|
| `load-new-account` | `load_new_account` | 800ms | 1,200ms |
| `confirm-tx` | `confirm_tx` | 7,000ms | 9,000ms |
| `bridge-user-actions` | `bridge_load_page` | 500ms | 800ms |
| `bridge-user-actions` | `bridge_load_asset_picker` | 500ms | 800ms |
| `bridge-user-actions` | `bridge_search_token` | 1,200ms | 1,800ms |


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40628?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes benchmark runner behavior to require thresholds for every flow and tightens many threshold values, which may increase CI benchmark failures or block new benchmarks if registry entries are missing.
> 
> **Overview**
> **Benchmarks now require explicit threshold configuration.** The runner pulls thresholds from a new `THRESHOLD_REGISTRY` and throws if a benchmark file has no entry, with README guidance updated to make this mandatory.
> 
> **Threshold validation is unified and always logged.** Iterated benchmarks validate aggregated `TimerStatistics`, while startup benchmarks (which return `BenchmarkResults` directly) now validate via `validateResultThresholds`, with shared logging moved into `logThresholdResult` and `convertSummaryToResults` relocated into the benchmark utils.
> 
> **Threshold values were tightened and expanded.** Multiple existing user-journey thresholds were reduced, and new threshold configs were added for remaining startup and interaction benchmark flows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 991272fd49d28376d8a7684bd16deb10561ac617. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->