### PR TITLE
feat: implement geoblocking on musd reward claiming

### DIFF
--- a/privacy-snapshot.json
+++ b/privacy-snapshot.json
@@ -87,6 +87,7 @@
   "on-ramp.api.cx.metamask.io",
   "on-ramp-content.api.cx.metamask.io",
   "on-ramp-content.uat-api.cx.metamask.io",
+  "on-ramp.api.cx.metamask.io",
   "optimism-mainnet.infura.io",
   "phishing-detection.api.cx.metamask.io",
   "polygon-mainnet.infura.io",

--- a/privacy-snapshot.json
+++ b/privacy-snapshot.json
@@ -87,7 +87,6 @@
   "on-ramp.api.cx.metamask.io",
   "on-ramp-content.api.cx.metamask.io",
   "on-ramp-content.uat-api.cx.metamask.io",
-  "on-ramp.api.cx.metamask.io",
   "optimism-mainnet.infura.io",
   "phishing-detection.api.cx.metamask.io",
   "polygon-mainnet.infura.io",

--- a/test/integration/defi/defi-positions.test.tsx
+++ b/test/integration/defi/defi-positions.test.tsx
@@ -24,6 +24,19 @@ jest.mock('../../../ui/store/background-connection', () => ({
   submitRequestToBackground: jest.fn(),
 }));
 
+jest.mock('../../../ui/hooks/musd/useMusdGeoBlocking', () => ({
+  ...jest.requireActual('../../../ui/hooks/musd/useMusdGeoBlocking'),
+  useMusdGeoBlocking: () => ({
+    isBlocked: false,
+    userCountry: 'US',
+    isLoading: false,
+    error: null,
+    blockedRegions: [],
+    blockedMessage: null,
+    refreshGeolocation: jest.fn(),
+  }),
+}));
+
 const mockedBackgroundConnection = jest.mocked(backgroundConnection);
 
 const backgroundConnectionMocked = {

--- a/ui/components/app/musd/hooks/useMerklClaim.test.ts
+++ b/ui/components/app/musd/hooks/useMerklClaim.test.ts
@@ -27,7 +27,18 @@ jest.mock('../../../../store/actions', () => ({
 
 jest.mock('../merkl-client');
 
+jest.mock('../../../../hooks/musd/useMusdGeoBlocking', () => ({
+  useMusdGeoBlocking: jest.fn(() => ({
+    isBlocked: false,
+    userCountry: 'US',
+    isLoading: false,
+  })),
+}));
+
 const { useSelector } = jest.requireMock('react-redux');
+const { useMusdGeoBlocking } = jest.requireMock(
+  '../../../../hooks/musd/useMusdGeoBlocking',
+);
 
 const MOCK_ADDRESS = '0x1234567890abcdef1234567890abcdef12345678';
 const MOCK_TOKEN_ADDRESS = '0xacA92E438df0B2401fF60dA7E4337B687a2435DA';
@@ -66,6 +77,12 @@ describe('useMerklClaim', () => {
     (merklClient.fetchMerklRewardsForAsset as jest.Mock).mockResolvedValue(
       mockRewardData,
     );
+
+    useMusdGeoBlocking.mockReturnValue({
+      isBlocked: false,
+      userCountry: 'US',
+      isLoading: false,
+    });
   });
 
   it('initializes with correct default state', () => {
@@ -209,6 +226,28 @@ describe('useMerklClaim', () => {
 
     expect(abortSpy).toHaveBeenCalled();
     abortSpy.mockRestore();
+  });
+
+  it('does not dispatch transaction when user is geoblocked', async () => {
+    useMusdGeoBlocking.mockReturnValue({
+      isBlocked: true,
+      userCountry: 'GB',
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() =>
+      useMerklClaim({
+        tokenAddress: MOCK_TOKEN_ADDRESS,
+        chainId: '0x1' as `0x${string}`,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.claimRewards();
+    });
+
+    expect(merklClient.fetchMerklRewardsForAsset).not.toHaveBeenCalled();
+    expect(mockAddTransaction).not.toHaveBeenCalled();
   });
 
   it('uses correct network client for Linea', async () => {

--- a/ui/components/app/musd/hooks/useMerklClaim.test.ts
+++ b/ui/components/app/musd/hooks/useMerklClaim.test.ts
@@ -66,6 +66,10 @@ const mockRewardData = {
 };
 
 describe('useMerklClaim', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   beforeEach(() => {
     jest.clearAllMocks();
 
@@ -225,7 +229,6 @@ describe('useMerklClaim', () => {
     });
 
     expect(abortSpy).toHaveBeenCalled();
-    abortSpy.mockRestore();
   });
 
   it('does not dispatch transaction when user is geoblocked', async () => {

--- a/ui/components/app/musd/hooks/useMerklClaim.ts
+++ b/ui/components/app/musd/hooks/useMerklClaim.ts
@@ -5,6 +5,7 @@ import type { Hex } from '@metamask/utils';
 import { TransactionType } from '@metamask/transaction-controller';
 import { Interface } from '@ethersproject/abi';
 import { getSelectedInternalAccount } from '../../../../selectors/accounts';
+import { useMusdGeoBlocking } from '../../../../hooks/musd/useMusdGeoBlocking';
 import {
   addTransaction,
   findNetworkClientIdByChainId,
@@ -41,6 +42,7 @@ export const useMerklClaim = ({
   const abortControllerRef = useRef<AbortController | null>(null);
   const navigate = useNavigate();
   const location = useLocation();
+  const { isBlocked: isGeoBlocked } = useMusdGeoBlocking();
 
   const selectedAccount = useSelector(getSelectedInternalAccount);
   const selectedAddress = selectedAccount?.address;
@@ -56,6 +58,10 @@ export const useMerklClaim = ({
   );
 
   const claimRewards = useCallback(async () => {
+    if (isGeoBlocked) {
+      return;
+    }
+
     if (!selectedAddress) {
       const errorMessage = 'No account selected';
       setError(errorMessage);
@@ -132,6 +138,7 @@ export const useMerklClaim = ({
       setIsClaiming(false);
     }
   }, [
+    isGeoBlocked,
     selectedAddress,
     tokenAddress,
     chainId,

--- a/ui/components/app/musd/hooks/useMerklRewards.test.ts
+++ b/ui/components/app/musd/hooks/useMerklRewards.test.ts
@@ -105,10 +105,19 @@ describe('useMerklRewards', () => {
       typeof merklClient.getClaimedAmountFromContract
     >;
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   beforeEach(() => {
     jest.clearAllMocks();
     setupSelectorMock();
     mockGetClaimedAmountFromContract.mockResolvedValue(null);
+    useMusdGeoBlocking.mockReturnValue({
+      isBlocked: false,
+      userCountry: 'US',
+      isLoading: false,
+    });
   });
 
   it('returns false for ineligible token', () => {
@@ -299,7 +308,6 @@ describe('useMerklRewards', () => {
 
     expect(consoleSpy).toHaveBeenCalled();
     expect(result.current.hasClaimableReward).toBe(false);
-    consoleSpy.mockRestore();
   });
 
   it('aborts fetch on unmount', () => {
@@ -317,7 +325,6 @@ describe('useMerklRewards', () => {
     unmount();
 
     expect(abortSpy).toHaveBeenCalled();
-    abortSpy.mockRestore();
   });
 
   it('returns false for sub-cent unclaimed amounts', async () => {
@@ -405,13 +412,6 @@ describe('useMerklRewards', () => {
 
     expect(result.current.hasClaimableReward).toBe(false);
     expect(mockFetchMerklRewardsForAsset).not.toHaveBeenCalled();
-
-    // Reset for other tests
-    useMusdGeoBlocking.mockReturnValue({
-      isBlocked: false,
-      userCountry: 'US',
-      isLoading: false,
-    });
   });
 
   it('falls back to API claimed value when getClaimedAmountFromContract returns null', async () => {

--- a/ui/components/app/musd/hooks/useMerklRewards.test.ts
+++ b/ui/components/app/musd/hooks/useMerklRewards.test.ts
@@ -18,7 +18,18 @@ jest.mock('..', () => ({
   useOnMerklClaimConfirmed: jest.fn(),
 }));
 
+jest.mock('../../../../hooks/musd/useMusdGeoBlocking', () => ({
+  useMusdGeoBlocking: jest.fn(() => ({
+    isBlocked: false,
+    userCountry: 'US',
+    isLoading: false,
+  })),
+}));
+
 const { useSelector } = jest.requireMock('react-redux');
+const { useMusdGeoBlocking } = jest.requireMock(
+  '../../../../hooks/musd/useMusdGeoBlocking',
+);
 
 const MOCK_ADDRESS = '0x1234567890abcdef1234567890abcdef12345678';
 
@@ -371,6 +382,36 @@ describe('useMerklRewards', () => {
     });
 
     expect(result.current.hasClaimableReward).toBe(true);
+  });
+
+  it('returns false and skips API call when user is geoblocked', async () => {
+    useMusdGeoBlocking.mockReturnValue({
+      isBlocked: true,
+      userCountry: 'GB',
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() =>
+      useMerklRewards({
+        tokenAddress: MUSD_TOKEN_ADDRESS,
+        chainId: '0x1' as `0x${string}`,
+        showMerklBadge: true,
+      }),
+    );
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(result.current.hasClaimableReward).toBe(false);
+    expect(mockFetchMerklRewardsForAsset).not.toHaveBeenCalled();
+
+    // Reset for other tests
+    useMusdGeoBlocking.mockReturnValue({
+      isBlocked: false,
+      userCountry: 'US',
+      isLoading: false,
+    });
   });
 
   it('falls back to API claimed value when getClaimedAmountFromContract returns null', async () => {

--- a/ui/components/app/musd/hooks/useMerklRewards.ts
+++ b/ui/components/app/musd/hooks/useMerklRewards.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import type { Hex } from '@metamask/utils';
 import { getSelectedInternalAccount } from '../../../../selectors/accounts';
+import { useMusdGeoBlocking } from '../../../../hooks/musd/useMusdGeoBlocking';
 import { ELIGIBLE_TOKENS } from '../constants';
 import {
   fetchMerklRewardsForAsset,
@@ -64,6 +65,7 @@ export const useMerklRewards = ({
   showMerklBadge,
 }: UseMerklRewardsOptions): UseMerklRewardsReturn => {
   const merklRewardsEnabled = useSelector(getMerklRewardsEnabled);
+  const { isBlocked: isGeoBlocked } = useMusdGeoBlocking();
 
   const [hasClaimableReward, setHasClaimableReward] = useState(false);
 
@@ -74,8 +76,9 @@ export const useMerklRewards = ({
     () =>
       showMerklBadge &&
       merklRewardsEnabled &&
+      !isGeoBlocked &&
       isEligibleForMerklRewards(chainId, tokenAddress),
-    [showMerklBadge, merklRewardsEnabled, chainId, tokenAddress],
+    [showMerklBadge, merklRewardsEnabled, isGeoBlocked, chainId, tokenAddress],
   );
 
   const fetchClaimableRewards = useCallback(

--- a/ui/pages/asset/components/asset-page.test.tsx
+++ b/ui/pages/asset/components/asset-page.test.tsx
@@ -20,6 +20,19 @@ import {
 import useMultiPolling from '../../../hooks/useMultiPolling';
 import AssetPage from './asset-page';
 
+jest.mock('../../../hooks/musd/useMusdGeoBlocking', () => ({
+  ...jest.requireActual('../../../hooks/musd/useMusdGeoBlocking'),
+  useMusdGeoBlocking: () => ({
+    isBlocked: false,
+    userCountry: 'US',
+    isLoading: false,
+    error: null,
+    blockedRegions: [],
+    blockedMessage: null,
+    refreshGeolocation: jest.fn(),
+  }),
+}));
+
 jest.mock('../../../store/actions', () => ({
   ...jest.requireActual('../../../store/actions'),
   tokenBalancesStartPolling: jest.fn().mockResolvedValue('pollingToken'),

--- a/ui/pages/defi/components/defi-details-list.test.tsx
+++ b/ui/pages/defi/components/defi-details-list.test.tsx
@@ -10,6 +10,19 @@ const mockUseParams = jest
   .fn()
   .mockReturnValue({ chainId: CHAIN_IDS.MAINNET, protocolId: 'aave' });
 
+jest.mock('../../../../ui/hooks/musd/useMusdGeoBlocking', () => ({
+  ...jest.requireActual('../../../../ui/hooks/musd/useMusdGeoBlocking'),
+  useMusdGeoBlocking: () => ({
+    isBlocked: false,
+    userCountry: 'US',
+    isLoading: false,
+    error: null,
+    blockedRegions: [],
+    blockedMessage: null,
+    refreshGeolocation: jest.fn(),
+  }),
+}));
+
 const mockUseNavigate = jest.fn();
 jest.mock('react-router-dom', () => {
   return {

--- a/ui/pages/defi/components/defi-details-page.test.tsx
+++ b/ui/pages/defi/components/defi-details-page.test.tsx
@@ -9,6 +9,19 @@ import DeFiPage from './defi-details-page';
 
 const selectedAddress = '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc';
 
+jest.mock('../../../../ui/hooks/musd/useMusdGeoBlocking', () => ({
+  ...jest.requireActual('../../../../ui/hooks/musd/useMusdGeoBlocking'),
+  useMusdGeoBlocking: () => ({
+    isBlocked: false,
+    userCountry: 'US',
+    isLoading: false,
+    error: null,
+    blockedRegions: [],
+    blockedMessage: null,
+    refreshGeolocation: jest.fn(),
+  }),
+}));
+
 describe('DeFiDetailsPage', () => {
   const mockStore = {
     ...mockState,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR uses the geoblocking logic from the MUSD conversion flow to also prevent claiming MUSD rewards in geoblocked regions
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40634?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Prevent MUSD reward claiming in Geoblocked regions.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Enable the `earnMerklCampaignClaiming` feature flag
2. Login to an account with rewards to claim from a blocked region (e.g. UK)
3. Verify that claim button is now shown.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds geo-blocking checks that short-circuit reward fetching and transaction creation; risk is moderate because it changes who can see/claim rewards and could inadvertently block eligible users if the geo check misbehaves.
> 
> **Overview**
> Extends existing mUSD geo-blocking to Merkl rewards by **skipping reward lookups and claim transaction creation** when `useMusdGeoBlocking` reports the user is blocked.
> 
> Updates unit/integration tests to mock `useMusdGeoBlocking` consistently and adds coverage ensuring geoblocked users neither call the Merkl API nor dispatch claim transactions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a384f166c4c16dba45031242dd46021a983bae33. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->