### PR TITLE
chore: upgrade @metamask/design-system-react to 0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -309,7 +309,7 @@
     "@metamask/delegation-controller": "^2.0.1",
     "@metamask/delegation-core": "^0.2.0-rc.1",
     "@metamask/delegation-deployments": "^0.15.0",
-    "@metamask/design-system-react": "0.10.0",
+    "@metamask/design-system-react": "^0.10.0",
     "@metamask/design-system-tailwind-preset": "^0.6.1",
     "@metamask/design-tokens": "^8.2.2",
     "@metamask/eip-5792-middleware": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -309,7 +309,7 @@
     "@metamask/delegation-controller": "^2.0.1",
     "@metamask/delegation-core": "^0.2.0-rc.1",
     "@metamask/delegation-deployments": "^0.15.0",
-    "@metamask/design-system-react": "^0.9.0",
+    "@metamask/design-system-react": "0.10.0",
     "@metamask/design-system-tailwind-preset": "^0.6.1",
     "@metamask/design-tokens": "^8.2.2",
     "@metamask/eip-5792-middleware": "3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5991,7 +5991,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/design-system-react@npm:0.10.0":
+"@metamask/design-system-react@npm:^0.10.0":
   version: 0.10.0
   resolution: "@metamask/design-system-react@npm:0.10.0"
   dependencies:
@@ -32964,7 +32964,7 @@ __metadata:
     "@metamask/delegation-controller": "npm:^2.0.1"
     "@metamask/delegation-core": "npm:^0.2.0-rc.1"
     "@metamask/delegation-deployments": "npm:^0.15.0"
-    "@metamask/design-system-react": "npm:0.10.0"
+    "@metamask/design-system-react": "npm:^0.10.0"
     "@metamask/design-system-tailwind-preset": "npm:^0.6.1"
     "@metamask/design-tokens": "npm:^8.2.2"
     "@metamask/eip-5792-middleware": "npm:3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5991,11 +5991,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/design-system-react@npm:^0.9.0":
-  version: 0.9.0
-  resolution: "@metamask/design-system-react@npm:0.9.0"
+"@metamask/design-system-react@npm:0.10.0":
+  version: 0.10.0
+  resolution: "@metamask/design-system-react@npm:0.10.0"
   dependencies:
-    "@metamask/design-system-shared": "npm:^0.2.0"
+    "@metamask/design-system-shared": "npm:^0.3.0"
     "@metamask/jazzicon": "npm:^2.0.0"
     "@radix-ui/react-slot": "npm:^1.1.0"
     blo: "npm:^2.0.0"
@@ -6006,16 +6006,16 @@ __metadata:
     "@metamask/utils": ^11.10.0
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
-  checksum: 10/344d16745f3924f8a9f10f4293e611238c16fe452eb151117ee6711565e081bc97d9a792047e50903a88a7f0bf1c64bb483bfe791b90fa0a7214646a519d8085
+  checksum: 10/ffe596117c6928959daba460f51ae1747fa854566ce82c0c3ca6398b9dc37035844c33dc23f5212910258386e3277b87789d0722c508873b62746a1137a53994
   languageName: node
   linkType: hard
 
-"@metamask/design-system-shared@npm:^0.2.0":
-  version: 0.2.0
-  resolution: "@metamask/design-system-shared@npm:0.2.0"
+"@metamask/design-system-shared@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@metamask/design-system-shared@npm:0.3.0"
   dependencies:
     "@metamask/utils": "npm:^11.10.0"
-  checksum: 10/8b7436e4c1882495faa1ca402456dfb82247e517c718da0bed0c4daf7ec06ed0e6bfa7fa3c9fa6930b30e4e5f3f8576436f0de27d9a86f97169cab0423285612
+  checksum: 10/2be032b91b10d03ca4e02ba9ff5afc9db763fb865161add83a7e28ef83f165cc3c3edba03f5d600ec95e3014afd0077abcadd75e613792e77c709760813ff749
   languageName: node
   linkType: hard
 
@@ -32964,7 +32964,7 @@ __metadata:
     "@metamask/delegation-controller": "npm:^2.0.1"
     "@metamask/delegation-core": "npm:^0.2.0-rc.1"
     "@metamask/delegation-deployments": "npm:^0.15.0"
-    "@metamask/design-system-react": "npm:^0.9.0"
+    "@metamask/design-system-react": "npm:0.10.0"
     "@metamask/design-system-tailwind-preset": "npm:^0.6.1"
     "@metamask/design-tokens": "npm:^8.2.2"
     "@metamask/eip-5792-middleware": "npm:3.0.0"


### PR DESCRIPTION
## **Description**

Upgrades the extension to the latest `@metamask/design-system-react` release (`^0.10.0`) to stay current with the design-system monorepo release stream.

https://github.com/MetaMask/metamask-design-system/releases

This PR updates only dependency metadata and lockfile resolution:
- `@metamask/design-system-react`: `^0.9.0` -> `^0.10.0`
- Transitive update: `@metamask/design-system-shared`: `^0.2.0` -> `^0.3.0`

No runtime source-code changes are included in this PR.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Run `yarn install`.
2. Run `yarn lint:changed:fix` and confirm no lint errors for changed files.
3. Open `package.json` and `yarn.lock` and verify `@metamask/design-system-react` resolves to `^0.10.0`.

## **Screenshots/Recordings**

### **Before**

N/A (dependency-only change)

### **After**

N/A (dependency-only change)

General smoke test to check extension runs without errors

https://github.com/user-attachments/assets/04e42150-b55c-42b6-a935-0b133e2d3872

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency-only upgrade, but updating the shared design system can subtly change UI rendering/behavior and introduce new peer/transitive constraints at runtime. Risk is limited to build/install and UI regressions since no application code changed.
> 
> **Overview**
> Upgrades `@metamask/design-system-react` from `^0.9.0` to `^0.10.0` in `package.json`.
> 
> Updates `yarn.lock` to resolve `@metamask/design-system-react@0.10.0` and its transitive `@metamask/design-system-shared` dependency from `^0.2.0` to `^0.3.0` (with corresponding lockfile metadata/checksum changes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32943a281115c6fb7da274e9ac460845d17b541c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->