### PR TITLE
fix: NFT tab scroll position

### DIFF
--- a/ui/components/app/assets/nfts/nft-grid/nft-grid.tsx
+++ b/ui/components/app/assets/nfts/nft-grid/nft-grid.tsx
@@ -1,19 +1,11 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { toHex } from '@metamask/controller-utils';
-import {
-  AlignItems,
-  Display,
-  JustifyContent,
-} from '../../../../../helpers/constants/design-system';
 import { Box } from '../../../../component-library';
 import { getNftImageAlt, getNftImage } from '../../../../../helpers/utils/nfts';
 import { NftItem } from '../../../../multichain/nft-item';
 import { NFT } from '../../../../multichain/asset-picker-amount/asset-picker-modal/types';
-import {
-  getIpfsGateway,
-  getNftIsStillFetchingIndication,
-} from '../../../../../selectors';
+import { getIpfsGateway } from '../../../../../selectors';
 import useGetAssetImageUrl from '../../../../../hooks/useGetAssetImageUrl';
 import { getImageForChainId } from '../../../../../selectors/multichain';
 import { getNetworkConfigurationsByChainId } from '../../../../../../shared/modules/selectors/networks';
@@ -21,7 +13,6 @@ import useFetchNftDetailsFromTokenURI from '../../../../../hooks/useFetchNftDeta
 // TODO: Remove restricted import
 // eslint-disable-next-line import/no-restricted-paths
 import { isWebUrl } from '../../../../../../app/scripts/lib/util';
-import PulseLoader from '../../../../ui/pulse-loader';
 import {
   VirtualizedList,
   noAdjustmentsScroll,
@@ -100,10 +91,6 @@ export default function NftGrid({
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const nftsStillFetchingIndication = useSelector(
-    getNftIsStillFetchingIndication,
-  );
-
   // Detect container width for virtualization grouping only
   const [itemsPerRow, setItemsPerRow] = useState(3);
 
@@ -129,20 +116,6 @@ export default function NftGrid({
     return () => resizeObserver.disconnect();
   }, []);
 
-  const loadingFooter = nftsStillFetchingIndication ? (
-    <Box
-      className="nfts-tab__fetching"
-      justifyContent={JustifyContent.center}
-      alignItems={AlignItems.center}
-      display={Display.Flex}
-      marginTop={4}
-    >
-      <Box marginTop={4} marginBottom={4}>
-        <PulseLoader />
-      </Box>
-    </Box>
-  ) : null;
-
   // Group NFTs into rows for virtualization
   const nftRows = useMemo(() => {
     const rows: NFT[][] = [];
@@ -160,7 +133,6 @@ export default function NftGrid({
         data={nftRows}
         estimatedItemSize={ESTIMATED_ROW_SIZE}
         scrollToFn={noAdjustmentsScroll}
-        listFooterComponent={loadingFooter}
         keyExtractor={extractRowKey}
         renderItem={({ item, index: rowIndex }) => (
           <Box className={`grid gap-4 pb-4 ${gridClassName}`}>

--- a/ui/components/app/assets/nfts/nft-grid/nft-grid.tsx
+++ b/ui/components/app/assets/nfts/nft-grid/nft-grid.tsx
@@ -22,7 +22,10 @@ import useFetchNftDetailsFromTokenURI from '../../../../../hooks/useFetchNftDeta
 // eslint-disable-next-line import/no-restricted-paths
 import { isWebUrl } from '../../../../../../app/scripts/lib/util';
 import PulseLoader from '../../../../ui/pulse-loader';
-import { VirtualizedList } from '../../../../ui/virtualized-list/virtualized-list';
+import {
+  VirtualizedList,
+  noAdjustmentsScroll,
+} from '../../../../ui/virtualized-list/virtualized-list';
 import NFTGridItemErrorBoundary from './nft-grid-item-error-boundary';
 
 const NFTGridItem = (props: {
@@ -74,6 +77,15 @@ const NFTGridItem = (props: {
 
 // Container width threshold for switching between 3 and 4 columns
 const CONTAINER_WIDTH_THRESHOLD = 640;
+const ESTIMATED_ROW_SIZE = 172;
+
+function extractRowKey(row: NFT[], index: number) {
+  return (
+    row
+      .map((nft) => `${nft.chainId}-${nft.address}-${nft.tokenId}`)
+      .join('|') || String(index)
+  );
+}
 
 // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
 // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -146,8 +158,10 @@ export default function NftGrid({
     <Box ref={containerRef} style={{ margin: 16 }}>
       <VirtualizedList
         data={nftRows}
-        estimatedItemSize={200}
+        estimatedItemSize={ESTIMATED_ROW_SIZE}
+        scrollToFn={noAdjustmentsScroll}
         listFooterComponent={loadingFooter}
+        keyExtractor={extractRowKey}
         renderItem={({ item, index: rowIndex }) => (
           <Box className={`grid gap-4 pb-4 ${gridClassName}`}>
             {item.map((nft, index) => (

--- a/ui/components/app/assets/nfts/nfts-tab/nfts-tab.tsx
+++ b/ui/components/app/assets/nfts/nfts-tab/nfts-tab.tsx
@@ -2,11 +2,6 @@ import React, { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import { toHex } from '@metamask/controller-utils';
-import {
-  AlignItems,
-  Display,
-  JustifyContent,
-} from '../../../../../helpers/constants/design-system';
 import { useNftsCollections } from '../../../../../hooks/useNftsCollections';
 import {
   getIsMainnet,
@@ -23,7 +18,6 @@ import { ASSET_ROUTE } from '../../../../../helpers/constants/routes';
 import NftGrid from '../nft-grid/nft-grid';
 import { sortAssets } from '../../util/sort';
 import AssetListControlBar from '../../asset-list/asset-list-control-bar';
-import PulseLoader from '../../../../ui/pulse-loader';
 import { NftEmptyState } from '../nft-empty-state';
 
 // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
@@ -37,17 +31,17 @@ export default function NftsTab() {
     getNftIsStillFetchingIndication,
   );
 
-  const { nftsLoading, collections } = useNftsCollections();
+  const { collections } = useNftsCollections();
 
   const { currentlyOwnedNfts, previouslyOwnedNfts } = useNfts();
 
   const hasAnyNfts = Object.keys(collections).length > 0;
 
   useEffect(() => {
-    if (!nftsLoading && !nftsStillFetchingIndication) {
+    if (!nftsStillFetchingIndication) {
       endTrace({ name: TraceName.AccountOverviewNftsTab });
     }
-  }, [nftsLoading, nftsStillFetchingIndication]);
+  }, [nftsStillFetchingIndication]);
 
   const handleNftClick = (nft: NFT) => {
     navigate(
@@ -60,22 +54,6 @@ export default function NftsTab() {
     order: 'asc',
     sortCallback: 'alphaNumeric',
   });
-
-  if (!hasAnyNfts && nftsStillFetchingIndication) {
-    return (
-      <Box
-        className="nfts-tab__loading"
-        justifyContent={JustifyContent.center}
-        alignItems={AlignItems.center}
-        display={Display.Flex}
-        marginTop={4}
-        paddingTop={4}
-        paddingBottom={4}
-      >
-        <PulseLoader />
-      </Box>
-    );
-  }
 
   return (
     <>

--- a/ui/components/ui/virtualized-list/virtualized-list.tsx
+++ b/ui/components/ui/virtualized-list/virtualized-list.tsx
@@ -1,6 +1,18 @@
 import React, { type ReactNode } from 'react';
-import { useVirtualizer } from '@tanstack/react-virtual';
+import {
+  useVirtualizer,
+  type VirtualizerOptions,
+} from '@tanstack/react-virtual';
 import { useScrollContainer } from '../../../contexts/scroll-container';
+
+type ScrollToFn = VirtualizerOptions<HTMLDivElement, Element>['scrollToFn'];
+
+export const noAdjustmentsScroll: ScrollToFn = (offset, options, instance) => {
+  instance.scrollElement?.scrollTo?.({
+    top: offset,
+    behavior: options.behavior,
+  });
+};
 
 type Props<TItem> = {
   data: TItem[];
@@ -10,6 +22,7 @@ type Props<TItem> = {
   listFooterComponent?: ReactNode;
   overscan?: number;
   renderItem: (info: { item: TItem; index: number }) => ReactNode;
+  scrollToFn?: ScrollToFn;
 };
 
 export const VirtualizedList = <TItem,>({
@@ -20,6 +33,7 @@ export const VirtualizedList = <TItem,>({
   listFooterComponent,
   overscan = 5,
   renderItem,
+  scrollToFn,
 }: Props<TItem>) => {
   const scrollContainerRef = useScrollContainer();
   const disabled = process.env.IN_TEST;
@@ -33,6 +47,7 @@ export const VirtualizedList = <TItem,>({
       keyExtractor ? keyExtractor(data[index], index) : index,
     overscan,
     initialOffset: scrollContainerRef?.current?.scrollTop,
+    ...(scrollToFn ? { scrollToFn } : {}),
   });
 
   if (data.length === 0) {

--- a/ui/components/ui/virtualized-list/virtualized-list.tsx
+++ b/ui/components/ui/virtualized-list/virtualized-list.tsx
@@ -1,4 +1,4 @@
-import React, { type ReactNode } from 'react';
+import React, { type ReactNode, useEffect } from 'react';
 import {
   useVirtualizer,
   type VirtualizerOptions,
@@ -49,6 +49,12 @@ export const VirtualizedList = <TItem,>({
     initialOffset: scrollContainerRef?.current?.scrollTop,
     ...(scrollToFn ? { scrollToFn } : {}),
   });
+
+  useEffect(() => {
+    if (scrollContainerRef?.current) {
+      virtualizer.measure();
+    }
+  }, [scrollContainerRef, virtualizer]);
 
   if (data.length === 0) {
     return (

--- a/ui/hooks/useNfts.ts
+++ b/ui/hooks/useNfts.ts
@@ -2,31 +2,13 @@ import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { getAllNfts } from '../ducks/metamask/metamask';
 import { getEnabledNetworksByNamespace } from '../selectors/multichain/networks';
-import { getCurrentChainId } from '../../shared/modules/selectors/networks';
 import { NFT } from '../components/multichain/asset-picker-amount/asset-picker-modal/types';
 
-export function useNfts({
-  overridePopularNetworkFilter = false,
-}: {
-  overridePopularNetworkFilter?: boolean;
-} = {}) {
+export function useNfts() {
   const allUserNfts = useSelector(getAllNfts);
-  const chainId = useSelector(getCurrentChainId);
   const enabledNetworksByNamespace = useSelector(getEnabledNetworksByNamespace);
 
   const { currentlyOwnedNfts, previouslyOwnedNfts } = useMemo(() => {
-    if (overridePopularNetworkFilter) {
-      const chainNfts = (allUserNfts?.[chainId] ?? []) as NFT[];
-      return {
-        currentlyOwnedNfts: chainNfts.filter(
-          (nft) => nft?.isCurrentlyOwned !== false,
-        ),
-        previouslyOwnedNfts: chainNfts.filter(
-          (nft) => nft?.isCurrentlyOwned === false,
-        ),
-      };
-    }
-
     const nftsFromEnabledNetworks: Record<string, NFT[]> = {};
     Object.entries(allUserNfts ?? {}).forEach(
       ([networkChainId, networkNfts]) => {
@@ -52,12 +34,7 @@ export function useNfts({
     });
 
     return { currentlyOwnedNfts: current, previouslyOwnedNfts: previous };
-  }, [
-    overridePopularNetworkFilter,
-    allUserNfts,
-    chainId,
-    enabledNetworksByNamespace,
-  ]);
+  }, [allUserNfts, enabledNetworksByNamespace]);
 
   return { currentlyOwnedNfts, previouslyOwnedNfts };
 }

--- a/ui/hooks/useNfts.ts
+++ b/ui/hooks/useNfts.ts
@@ -1,37 +1,33 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import { isEqual } from 'lodash';
-import { getNftContracts, getAllNfts } from '../ducks/metamask/metamask';
-import { getAllChainsToPoll, getSelectedInternalAccount } from '../selectors';
+import { getAllNfts } from '../ducks/metamask/metamask';
 import { getEnabledNetworksByNamespace } from '../selectors/multichain/networks';
 import { getCurrentChainId } from '../../shared/modules/selectors/networks';
 import { NFT } from '../components/multichain/asset-picker-amount/asset-picker-modal/types';
-import { usePrevious } from './usePrevious';
-import { useI18nContext } from './useI18nContext';
 
 export function useNfts({
   overridePopularNetworkFilter = false,
 }: {
   overridePopularNetworkFilter?: boolean;
 } = {}) {
-  const t = useI18nContext();
-
   const allUserNfts = useSelector(getAllNfts);
-
-  const { address: selectedAddress } = useSelector(getSelectedInternalAccount);
   const chainId = useSelector(getCurrentChainId);
-
-  const allChainIds = useSelector(getAllChainsToPoll);
   const enabledNetworksByNamespace = useSelector(getEnabledNetworksByNamespace);
 
-  const nfts = useMemo(() => {
-    // Filter NFTs to only include those from enabled networks
-    const nftsFromEnabledNetworks: Record<string, NFT[]> = {};
-
+  const { currentlyOwnedNfts, previouslyOwnedNfts } = useMemo(() => {
     if (overridePopularNetworkFilter) {
-      return allUserNfts?.[chainId] ?? [];
+      const chainNfts = (allUserNfts?.[chainId] ?? []) as NFT[];
+      return {
+        currentlyOwnedNfts: chainNfts.filter(
+          (nft) => nft?.isCurrentlyOwned !== false,
+        ),
+        previouslyOwnedNfts: chainNfts.filter(
+          (nft) => nft?.isCurrentlyOwned === false,
+        ),
+      };
     }
 
+    const nftsFromEnabledNetworks: Record<string, NFT[]> = {};
     Object.entries(allUserNfts ?? {}).forEach(
       ([networkChainId, networkNfts]) => {
         if (
@@ -43,7 +39,19 @@ export function useNfts({
       },
     );
 
-    return nftsFromEnabledNetworks;
+    const allNfts: NFT[] = Object.values(nftsFromEnabledNetworks).flat();
+    const current: NFT[] = [];
+    const previous: NFT[] = [];
+
+    allNfts.forEach((nft) => {
+      if (nft?.isCurrentlyOwned === false) {
+        previous.push(nft);
+      } else {
+        current.push(nft);
+      }
+    });
+
+    return { currentlyOwnedNfts: current, previouslyOwnedNfts: previous };
   }, [
     overridePopularNetworkFilter,
     allUserNfts,
@@ -51,62 +59,5 @@ export function useNfts({
     enabledNetworksByNamespace,
   ]);
 
-  const nftContracts = useSelector(getNftContracts);
-
-  const previouslyOwnedText = t('nftsPreviouslyOwned');
-  const unknownCollectionText = t('unknownCollection');
-
-  const [currentlyOwnedNfts, setCurrentlyOwnedNfts] = useState<NFT[]>([]);
-  const [previouslyOwnedNfts, setPreviouslyOwnedNfts] = useState<NFT[]>([]);
-  const [loading, setNftsLoading] = useState(true);
-  const prevNfts = usePrevious(nfts);
-  const prevChainId = usePrevious(allChainIds);
-  const prevSelectedAddress = usePrevious(selectedAddress);
-
-  useEffect(() => {
-    const selectNfts = () => {
-      setNftsLoading(true);
-      if (selectedAddress === undefined || allChainIds === undefined) {
-        return;
-      }
-
-      const previousNfts: NFT[] = [];
-      const currentNfts: NFT[] = [];
-
-      const allNfts: NFT[] = Object.values(nfts).flat() as NFT[];
-
-      allNfts.forEach((nft: NFT) => {
-        if (nft?.isCurrentlyOwned === false) {
-          previousNfts.push(nft);
-        } else {
-          currentNfts.push(nft);
-        }
-      });
-      setPreviouslyOwnedNfts(previousNfts);
-      setCurrentlyOwnedNfts(currentNfts);
-      setNftsLoading(false);
-    };
-
-    if (
-      !isEqual(prevNfts, nfts) ||
-      !isEqual(prevSelectedAddress, selectedAddress) ||
-      !isEqual(prevChainId, chainId)
-    ) {
-      selectNfts();
-    }
-  }, [
-    nfts,
-    prevNfts,
-    nftContracts,
-    setNftsLoading,
-    chainId,
-    prevChainId,
-    selectedAddress,
-    prevSelectedAddress,
-    previouslyOwnedText,
-    unknownCollectionText,
-    allChainIds,
-  ]);
-
-  return { loading, currentlyOwnedNfts, previouslyOwnedNfts };
+  return { currentlyOwnedNfts, previouslyOwnedNfts };
 }

--- a/ui/hooks/useNftsCollections.js
+++ b/ui/hooks/useNftsCollections.js
@@ -1,11 +1,9 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import { isEqual } from 'lodash';
 import { getNftContracts, getAllNfts } from '../ducks/metamask/metamask';
 import { getSelectedInternalAccount } from '../selectors';
 import { getEnabledNetworksByNamespace } from '../selectors/multichain/networks';
 import { getNftImage } from '../helpers/utils/nfts';
-import { usePrevious } from './usePrevious';
 import { useI18nContext } from './useI18nContext';
 
 export function useNftsCollections() {
@@ -13,21 +11,23 @@ export function useNftsCollections() {
   const previouslyOwnedText = t('nftsPreviouslyOwned');
   const unknownCollectionText = t('unknownCollection');
 
-  const [collections, setCollections] = useState({});
-  const [previouslyOwnedCollection, setPreviouslyOwnedCollection] = useState({
-    collectionName: previouslyOwnedText,
-    nfts: [],
-  });
   const allUserNfts = useSelector(getAllNfts);
   const enabledNetworksByNamespace = useSelector(getEnabledNetworksByNamespace);
-  const enabledChainIds = Object.keys(enabledNetworksByNamespace);
-
   const { address: selectedAddress } = useSelector(getSelectedInternalAccount);
+  const nftContracts = useSelector(getNftContracts);
 
-  const nfts = useMemo(() => {
-    // Filter NFTs to only include those from enabled networks
+  const { collections, previouslyOwnedCollection } = useMemo(() => {
+    if (selectedAddress === undefined) {
+      return {
+        collections: {},
+        previouslyOwnedCollection: {
+          collectionName: previouslyOwnedText,
+          nfts: [],
+        },
+      };
+    }
+
     const nftsFromEnabledNetworks = {};
-
     Object.entries(allUserNfts ?? {}).forEach(
       ([networkChainId, networkNfts]) => {
         if (
@@ -39,70 +39,42 @@ export function useNftsCollections() {
       },
     );
 
-    return nftsFromEnabledNetworks;
-  }, [allUserNfts, enabledNetworksByNamespace]);
-
-  const [nftsLoading, setNftsLoading] = useState(true);
-  const nftContracts = useSelector(getNftContracts);
-  const prevNfts = usePrevious(nfts);
-  const prevEnabledChainIds = usePrevious(enabledChainIds);
-  const prevSelectedAddress = usePrevious(selectedAddress);
-
-  useEffect(() => {
-    const getCollections = () => {
-      setNftsLoading(true);
-      if (selectedAddress === undefined || enabledChainIds.length === 0) {
-        setNftsLoading(false);
-        return;
-      }
-      const newCollections = {};
-      const newPreviouslyOwnedCollections = {
-        collectionName: previouslyOwnedText,
-        nfts: [],
-      };
-
-      const allNfts = Object.values(nfts).flat();
-
-      allNfts.forEach((nft) => {
-        if (nft?.isCurrentlyOwned === false) {
-          newPreviouslyOwnedCollections.nfts.push(nft);
-        } else if (newCollections[nft.address]) {
-          newCollections[nft.address].nfts.push(nft);
-        } else {
-          const collectionContract = nftContracts.find(
-            ({ address }) => address === nft.address,
-          );
-          newCollections[nft.address] = {
-            collectionName: collectionContract?.name || unknownCollectionText,
-            collectionImage: collectionContract?.logo || getNftImage(nft.image),
-            nfts: [nft],
-          };
-        }
-      });
-      setCollections(newCollections);
-      setPreviouslyOwnedCollection(newPreviouslyOwnedCollections);
-      setNftsLoading(false);
+    const allNfts = Object.values(nftsFromEnabledNetworks).flat();
+    const newCollections = {};
+    const newPreviouslyOwned = {
+      collectionName: previouslyOwnedText,
+      nfts: [],
     };
 
-    if (
-      !isEqual(prevNfts, nfts) ||
-      !isEqual(prevSelectedAddress, selectedAddress) ||
-      !isEqual(prevEnabledChainIds, enabledChainIds)
-    ) {
-      getCollections();
-    }
+    allNfts.forEach((nft) => {
+      if (nft?.isCurrentlyOwned === false) {
+        newPreviouslyOwned.nfts.push(nft);
+      } else if (newCollections[nft.address]) {
+        newCollections[nft.address].nfts.push(nft);
+      } else {
+        const collectionContract = nftContracts.find(
+          ({ address }) => address === nft.address,
+        );
+        newCollections[nft.address] = {
+          collectionName: collectionContract?.name || unknownCollectionText,
+          collectionImage: collectionContract?.logo || getNftImage(nft.image),
+          nfts: [nft],
+        };
+      }
+    });
+
+    return {
+      collections: newCollections,
+      previouslyOwnedCollection: newPreviouslyOwned,
+    };
   }, [
-    nfts,
-    prevNfts,
-    nftContracts,
-    setNftsLoading,
-    enabledChainIds,
-    prevEnabledChainIds,
+    allUserNfts,
+    enabledNetworksByNamespace,
     selectedAddress,
-    prevSelectedAddress,
+    nftContracts,
     previouslyOwnedText,
     unknownCollectionText,
   ]);
 
-  return { nftsLoading, collections, previouslyOwnedCollection };
+  return { collections, previouslyOwnedCollection };
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Switching from Tokens to NFT tab caused the scroll position to jump. Two causes:

1. useNftsCollections and useNfts used useEffect + useState to compute derived state from Redux (an anti-pattern). This delayed NFT data by one render tick, causing NftsTab to render a loading spinner with zero height and causing the scroll container's scrollTop to 0. Refactored both hooks to use useMemo so data is computed synchronously on first render. Also removed dead code several imports in the useEffect dependency arrays were never actually used.

2. The virtualizer default scrollToFn applies measurement adjustments. When estimated size differ from measured size, react-virtual corrects the scroll position. Because the NFT tab has dynamic rows this adjustment can be cause a wrong scroll position. Added a noAdjustmentsScrollToFn option to VirtualizedList.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40643?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: NFT tab scroll position

## **Related issues**

Fixes:

## **Manual testing steps**

1. Use an account with **MANY** NFTs
2. Switch to the NFT tab

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/039d8022-1239-40ac-92d9-5983e645e555



<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared `VirtualizedList` virtualization behavior and refactors NFT data hooks to compute synchronously; mistakes could affect scroll position or rendering in other virtualized lists.
> 
> **Overview**
> Fixes NFT tab scroll jumps when switching tabs by removing one-render-tick delays in NFT-derived data and by disabling react-virtual scroll offset “adjustments”.
> 
> `useNfts` and `useNftsCollections` are refactored from `useEffect`+`useState` to synchronous `useMemo` derivations (and `NftsTab` removes the interim loading spinner/trace dependency). `VirtualizedList` now accepts an optional `scrollToFn` (with new `noAdjustmentsScroll`) and forces a `measure()` when the scroll container is available; `NftGrid` adopts these options, tweaks estimated row sizing, and adds a stable row `keyExtractor`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05676535326ce15022f7a26d610b9e4cc55ee9db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->