### PR TITLE
fix: handle unresolved token metadata for advanced permissions cp-13.23.0

### DIFF
--- a/shared/lib/gator-permissions/gator-permissions-utils.ts
+++ b/shared/lib/gator-permissions/gator-permissions-utils.ts
@@ -407,7 +407,9 @@ export function formatGatorAmountLabel(params: {
         ? `<${formatter.format(threshold)}`
         : formatter.format(numericAmount);
 
-    const note = tokenDecimals ? '' : ' (raw units)';
+    const hasDecimals = typeof tokenDecimals === 'number';
+
+    const note = hasDecimals ? '' : ' (raw units)';
 
     return `${formattedAmount} ${tokenSymbol} ${frequency}${note}`;
   } catch (error) {

--- a/shared/lib/gator-permissions/gator-permissions-utils.ts
+++ b/shared/lib/gator-permissions/gator-permissions-utils.ts
@@ -359,7 +359,7 @@ export function formatGatorAmountLabel(params: {
   amount: string;
   tokenSymbol: string;
   frequency: string;
-  tokenDecimals: number | null;
+  tokenDecimals?: number;
   locale: string;
   threshold?: number;
   numberFormatOptions?: Intl.NumberFormatOptions;

--- a/shared/lib/gator-permissions/gator-permissions-utils.ts
+++ b/shared/lib/gator-permissions/gator-permissions-utils.ts
@@ -16,7 +16,7 @@ import {
 // Token info type used across helpers
 export type GatorTokenInfo = {
   symbol: string;
-  decimals: number | undefined;
+  decimals: number | null;
   name?: string;
   image?: string;
   address?: string;

--- a/shared/lib/gator-permissions/gator-permissions-utils.ts
+++ b/shared/lib/gator-permissions/gator-permissions-utils.ts
@@ -16,7 +16,7 @@ import {
 // Token info type used across helpers
 export type GatorTokenInfo = {
   symbol: string;
-  decimals: number | null;
+  decimals?: number;
   name?: string;
   image?: string;
   address?: string;
@@ -283,7 +283,7 @@ async function fetchGatorErc20TokenInfo(
 
   return {
     symbol: symbol || 'Unknown Token',
-    decimals: decimals ?? 18,
+    decimals,
     name,
     image,
     address,
@@ -359,7 +359,7 @@ export function formatGatorAmountLabel(params: {
   amount: string;
   tokenSymbol: string;
   frequency: string;
-  tokenDecimals: number;
+  tokenDecimals: number | null;
   locale: string;
   threshold?: number;
   numberFormatOptions?: Intl.NumberFormatOptions;
@@ -384,7 +384,8 @@ export function formatGatorAmountLabel(params: {
     if (amount.startsWith('0x')) {
       // For hex amounts, we need to convert from wei to token units
       const weiAmount = BigInt(amount);
-      const divisor = BigInt(10 ** tokenDecimals);
+      // if tokenDecimals is null, we show raw units and add a note `(raw units)`
+      const divisor = BigInt(10 ** (tokenDecimals ?? 0));
 
       // Use BigInt division to avoid precision loss
       const quotient = weiAmount / divisor;
@@ -393,6 +394,7 @@ export function formatGatorAmountLabel(params: {
       // Convert to number only after BigInt division
       numericAmount = Number(quotient) + Number(remainder) / Number(divisor);
     } else {
+      // todo: we shouldn't accept a non-hex value, and we definitely shouldn't be using floating point
       numericAmount = parseFloat(amount);
       if (Number.isNaN(numericAmount)) {
         return 'Permission details unavailable';
@@ -405,7 +407,9 @@ export function formatGatorAmountLabel(params: {
         ? `<${formatter.format(threshold)}`
         : formatter.format(numericAmount);
 
-    return `${formattedAmount} ${tokenSymbol} ${frequency}`;
+    const note = !tokenDecimals ? ' (raw units)' : '';
+
+    return `${formattedAmount} ${tokenSymbol} ${frequency}${note}`;
   } catch (error) {
     return 'Permission details unavailable';
   }

--- a/shared/lib/gator-permissions/gator-permissions-utils.ts
+++ b/shared/lib/gator-permissions/gator-permissions-utils.ts
@@ -407,7 +407,7 @@ export function formatGatorAmountLabel(params: {
         ? `<${formatter.format(threshold)}`
         : formatter.format(numericAmount);
 
-    const note = !tokenDecimals ? ' (raw units)' : '';
+    const note = tokenDecimals ? '' : ' (raw units)';
 
     return `${formattedAmount} ${tokenSymbol} ${frequency}${note}`;
   } catch (error) {

--- a/shared/lib/gator-permissions/gator-permissions-utils.ts
+++ b/shared/lib/gator-permissions/gator-permissions-utils.ts
@@ -16,7 +16,7 @@ import {
 // Token info type used across helpers
 export type GatorTokenInfo = {
   symbol: string;
-  decimals: number;
+  decimals: number | undefined;
   name?: string;
   image?: string;
   address?: string;

--- a/shared/lib/gator-permissions/numbers-utils.test.ts
+++ b/shared/lib/gator-permissions/numbers-utils.test.ts
@@ -1,89 +1,89 @@
-import { getDecimalizedHexValue } from './numbers-utils';
+import { formatDecimalShiftedValue } from './numbers-utils';
 
 describe('numbers-utils', () => {
-  describe('getDecimalizedHexValue', () => {
+  describe('formatDecimalShiftedValue', () => {
     it('should convert hex value with 18 decimals', () => {
       // 1 ETH in wei (1e18) = 0xde0b6b3a7640000
-      expect(getDecimalizedHexValue('0xde0b6b3a7640000', 18)).toBe('1');
+      expect(formatDecimalShiftedValue('0xde0b6b3a7640000', 18)).toBe('1');
 
       // 5000000000000000000 wei (5 ETH)
-      expect(getDecimalizedHexValue('0x4563918244f40000', 18)).toBe('5');
+      expect(formatDecimalShiftedValue('0x4563918244f40000', 18)).toBe('5');
     });
 
     it('should convert hex value with 6 decimals', () => {
       // 1000000 (1 TOKEN with 6 decimals)
-      expect(getDecimalizedHexValue('0xf4240', 6)).toBe('1');
+      expect(formatDecimalShiftedValue('0xf4240', 6)).toBe('1');
 
       // 100000000 (100 TOKEN)
-      expect(getDecimalizedHexValue('0x5f5e100', 6)).toBe('100');
+      expect(formatDecimalShiftedValue('0x5f5e100', 6)).toBe('100');
     });
 
     it('should convert hex value with 8 decimals', () => {
       // 100000000 (1 TOKEN with 8 decimals)
-      expect(getDecimalizedHexValue('0x5f5e100', 8)).toBe('1');
+      expect(formatDecimalShiftedValue('0x5f5e100', 8)).toBe('1');
 
       // 50000000 (0.5 TOKEN)
-      expect(getDecimalizedHexValue('0x2faf080', 8)).toBe('0.5');
+      expect(formatDecimalShiftedValue('0x2faf080', 8)).toBe('0.5');
     });
 
     it('should handle zero value', () => {
-      expect(getDecimalizedHexValue('0x0', 18)).toBe('0');
-      expect(getDecimalizedHexValue('0x0', 6)).toBe('0');
-      expect(getDecimalizedHexValue('0x0', 0)).toBe('0');
+      expect(formatDecimalShiftedValue('0x0', 18)).toBe('0');
+      expect(formatDecimalShiftedValue('0x0', 6)).toBe('0');
+      expect(formatDecimalShiftedValue('0x0', 0)).toBe('0');
     });
 
     it('should handle small fractional amounts', () => {
       // 0.1 ETH = 100000000000000000 wei
-      expect(getDecimalizedHexValue('0x16345785d8a0000', 18)).toBe('0.1');
+      expect(formatDecimalShiftedValue('0x16345785d8a0000', 18)).toBe('0.1');
 
       // 0.01 ETH = 10000000000000000 wei
-      expect(getDecimalizedHexValue('0x2386f26fc10000', 18)).toBe('0.01');
+      expect(formatDecimalShiftedValue('0x2386f26fc10000', 18)).toBe('0.01');
     });
 
     it('should handle large amounts', () => {
       // 1,000,000 ETH in wei
       const largeAmount = '0xd3c21bcecceda1000000';
-      expect(getDecimalizedHexValue(largeAmount, 18)).toBe('1000000');
+      expect(formatDecimalShiftedValue(largeAmount, 18)).toBe('1000000');
     });
 
     it('should handle amounts with many decimal places', () => {
       // 1.123456789 ETH = 1123456789000000000 wei = 0xf9751ff4cd89200
-      expect(getDecimalizedHexValue('0xf9751ff4cd89200', 18)).toBe(
+      expect(formatDecimalShiftedValue('0xf9751ff4cd89200', 18)).toBe(
         '1.123456789',
       );
     });
 
     it('should handle conversion without decimals (no shift)', () => {
-      expect(getDecimalizedHexValue('0x64', 0)).toBe('100');
-      expect(getDecimalizedHexValue('0xff', 0)).toBe('255');
-      expect(getDecimalizedHexValue('0x3e8', 0)).toBe('1000');
+      expect(formatDecimalShiftedValue('0x64', 0)).toBe('100');
+      expect(formatDecimalShiftedValue('0xff', 0)).toBe('255');
+      expect(formatDecimalShiftedValue('0x3e8', 0)).toBe('1000');
     });
 
     it('should maintain precision for very small amounts', () => {
       // 1 wei (smallest unit for 18 decimals)
-      expect(getDecimalizedHexValue('0x1', 18)).toBe('0.000000000000000001');
+      expect(formatDecimalShiftedValue('0x1', 18)).toBe('0.000000000000000001');
 
       // 1 smallest unit for 6 decimals
-      expect(getDecimalizedHexValue('0x1', 6)).toBe('0.000001');
+      expect(formatDecimalShiftedValue('0x1', 6)).toBe('0.000001');
     });
 
     it('should handle edge case of undefined or zero decimals', () => {
-      expect(getDecimalizedHexValue('0x64', 0)).toBe('100');
+      expect(formatDecimalShiftedValue('0x64', 0)).toBe('100');
     });
 
     it('should convert values consistently regardless of hex case', () => {
-      expect(getDecimalizedHexValue('0xFF', 0)).toBe('255');
-      expect(getDecimalizedHexValue('0xff', 0)).toBe('255');
-      expect(getDecimalizedHexValue('0xFf', 0)).toBe('255');
+      expect(formatDecimalShiftedValue('0xFF', 0)).toBe('255');
+      expect(formatDecimalShiftedValue('0xff', 0)).toBe('255');
+      expect(formatDecimalShiftedValue('0xFf', 0)).toBe('255');
     });
 
     it('should return raw units when decimals is undefined', () => {
       // When decimals cannot be resolved, return the raw hex value in decimal
-      expect(getDecimalizedHexValue('0x64', undefined)).toBe('100');
-      expect(getDecimalizedHexValue('0xde0b6b3a7640000', undefined)).toBe(
+      expect(formatDecimalShiftedValue('0x64', undefined)).toBe('100');
+      expect(formatDecimalShiftedValue('0xde0b6b3a7640000', undefined)).toBe(
         '1000000000000000000',
       );
-      expect(getDecimalizedHexValue('0x1', undefined)).toBe('1');
+      expect(formatDecimalShiftedValue('0x1', undefined)).toBe('1');
     });
   });
 });

--- a/shared/lib/gator-permissions/numbers-utils.test.ts
+++ b/shared/lib/gator-permissions/numbers-utils.test.ts
@@ -76,5 +76,14 @@ describe('numbers-utils', () => {
       expect(getDecimalizedHexValue('0xff', 0)).toBe('255');
       expect(getDecimalizedHexValue('0xFf', 0)).toBe('255');
     });
+
+    it('should return raw units when decimals is undefined', () => {
+      // When decimals cannot be resolved, return the raw hex value in decimal
+      expect(getDecimalizedHexValue('0x64', undefined)).toBe('100');
+      expect(getDecimalizedHexValue('0xde0b6b3a7640000', undefined)).toBe(
+        '1000000000000000000',
+      );
+      expect(getDecimalizedHexValue('0x1', undefined)).toBe('1');
+    });
   });
 });

--- a/shared/lib/gator-permissions/numbers-utils.ts
+++ b/shared/lib/gator-permissions/numbers-utils.ts
@@ -19,9 +19,16 @@ export const DEFAULT_TOKEN_AMOUNT_FORMAT_OPTIONS: Intl.NumberFormatOptions = {
  * Converts a hex value to a decimal value
  *
  * @param value - The hex value to convert
- * @param decimals - The number of decimals to shift the value by
- * @returns The decimal value
+ * @param decimals - The number of decimals to shift the value by (undefined if decimals could not be resolved)
+ * @returns The decimal value, or raw units if decimals is undefined
  */
-export function getDecimalizedHexValue(value: Hex, decimals: number): string {
+export function getDecimalizedHexValue(
+  value: Hex,
+  decimals: number | undefined,
+): string {
+  if (decimals === undefined) {
+    // Return raw units when decimals cannot be resolved
+    return new Numeric(value, 16).toBase(10).toString();
+  }
   return new Numeric(value, 16).toBase(10).shiftedBy(decimals).toString();
 }

--- a/shared/lib/gator-permissions/numbers-utils.ts
+++ b/shared/lib/gator-permissions/numbers-utils.ts
@@ -24,7 +24,7 @@ export const DEFAULT_TOKEN_AMOUNT_FORMAT_OPTIONS: Intl.NumberFormatOptions = {
  */
 export function formatDecimalShiftedValue(
   value: Hex,
-  decimals: number | null,
+  decimals?: number,
 ): string {
   const valueDec = new Numeric(value, 16).toBase(10);
   if (!decimals) {

--- a/shared/lib/gator-permissions/numbers-utils.ts
+++ b/shared/lib/gator-permissions/numbers-utils.ts
@@ -28,7 +28,7 @@ export function formatDecimalShiftedValue(
 ): string {
   const valueDec = new Numeric(value, 16).toBase(10);
   if (!decimals) {
-    // Return raw units when decimals cannot be resolved
+    // Return raw units when decimals cannot be resolved, or decimals is zero
     return valueDec.toString();
   }
   return valueDec.shiftedBy(decimals).toString();

--- a/shared/lib/gator-permissions/numbers-utils.ts
+++ b/shared/lib/gator-permissions/numbers-utils.ts
@@ -22,13 +22,14 @@ export const DEFAULT_TOKEN_AMOUNT_FORMAT_OPTIONS: Intl.NumberFormatOptions = {
  * @param decimals - The number of decimals to shift the value by (undefined if decimals could not be resolved)
  * @returns The decimal value, or raw units if decimals is undefined
  */
-export function getDecimalizedHexValue(
+export function formatDecimalShiftedValue(
   value: Hex,
-  decimals: number | undefined,
+  decimals: number | null,
 ): string {
-  if (decimals === undefined) {
+  const valueDec = new Numeric(value, 16).toBase(10);
+  if (!decimals) {
     // Return raw units when decimals cannot be resolved
-    return new Numeric(value, 16).toBase(10).toString();
+    return valueDec.toString();
   }
-  return new Numeric(value, 16).toBase(10).shiftedBy(decimals).toString();
+  return valueDec.shiftedBy(decimals).toString();
 }

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -1863,11 +1863,9 @@
       "warn: ⚠️ React Router Future Flag": 2
     },
     "ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission.test.tsx": {
-      "MetaMask: Background connection not initialized": 6,
       "React: Act warnings (component updates not wrapped)": 6,
       "Reselect: Identity function warnings": 4,
       "Test errors: Uncaught Errors": 6,
-      "Test errors: Uncaught TypeErrors": 6,
       "warn: ⚠️ React Router Future Flag": 2
     },
     "ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/erc20-token-periodic-details.test.tsx": {

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -1867,12 +1867,13 @@
       "React: Act warnings (component updates not wrapped)": 6,
       "Reselect: Identity function warnings": 4,
       "Test errors: Uncaught Errors": 6,
+      "Test errors: Uncaught TypeErrors": 6,
       "warn: ⚠️ React Router Future Flag": 2
     },
     "ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/erc20-token-periodic-details.test.tsx": {
       "React: Act warnings (component updates not wrapped)": 5,
       "Reselect: Identity function warnings": 4,
-      "Test errors: Uncaught Errors": 1,
+      "Test errors: Uncaught Errors": 2,
       "warn: ⚠️ React Router Future Flag": 2
     },
     "ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/erc20-token-revocation-details.test.tsx": {
@@ -1881,7 +1882,7 @@
     },
     "ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/erc20-token-stream-details.test.tsx": {
       "Reselect: Identity function warnings": 4,
-      "Test errors: Uncaught Errors": 1,
+      "Test errors: Uncaught Errors": 2,
       "warn: ⚠️ React Router Future Flag": 2
     },
     "ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/native-token-periodic-details.test.tsx": {

--- a/ui/components/multichain/disconnect-permissions-modal/permission-item.tsx
+++ b/ui/components/multichain/disconnect-permissions-modal/permission-item.tsx
@@ -56,7 +56,7 @@ export const PermissionItem: React.FC<PermissionItemProps> = ({
       amount: string,
       tokenName: string,
       frequency: string,
-      tokenDecimals: number | null,
+      tokenDecimals?: number,
     ) =>
       formatGatorAmountLabel({
         amount,

--- a/ui/components/multichain/disconnect-permissions-modal/permission-item.tsx
+++ b/ui/components/multichain/disconnect-permissions-modal/permission-item.tsx
@@ -56,7 +56,7 @@ export const PermissionItem: React.FC<PermissionItemProps> = ({
       amount: string,
       tokenName: string,
       frequency: string,
-      tokenDecimals: number,
+      tokenDecimals: number | null,
     ) =>
       formatGatorAmountLabel({
         amount,

--- a/ui/components/multichain/pages/gator-permissions/components/review-gator-permission-item.tsx
+++ b/ui/components/multichain/pages/gator-permissions/components/review-gator-permission-item.tsx
@@ -227,7 +227,7 @@ export const ReviewGatorPermissionItem = ({
 
     const { symbol, decimals } = tokenMetadata;
 
-    if (decimals === null) {
+    if (!decimals) {
       return `${formatDecimalShiftedValue(value, decimals)} ${symbol}/sec (raw units)`;
     }
 
@@ -241,7 +241,7 @@ export const ReviewGatorPermissionItem = ({
 
     const { symbol, decimals } = tokenMetadata;
 
-    if (decimals === null) {
+    if (!decimals) {
       return `${formatDecimalShiftedValue(value, decimals)} ${symbol} (raw units)`;
     }
 
@@ -319,10 +319,6 @@ export const ReviewGatorPermissionItem = ({
     (
       permission: NativeTokenPeriodicPermission | Erc20TokenPeriodicPermission,
     ): PermissionDetails => {
-      const { symbol, decimals } = tokenMetadata;
-      const decimalsNotice =
-        decimals === undefined ? ' (raw units - decimals unavailable)' : '';
-
       return {
         amountLabel: {
           translationKey: 'amount',

--- a/ui/components/multichain/pages/gator-permissions/components/review-gator-permission-item.tsx
+++ b/ui/components/multichain/pages/gator-permissions/components/review-gator-permission-item.tsx
@@ -229,11 +229,11 @@ export const ReviewGatorPermissionItem = ({
       const { symbol, decimals } = tokenMetadata;
 
       const formattedValueWithSymbol = `${formatDecimalShiftedValue(value, decimals)} ${symbol}`;
-      if (!decimals) {
-        return `${formattedValueWithSymbol}/sec (raw units)`;
+      if (typeof decimals === 'number') {
+        return `${formattedValueWithSymbol}/sec`;
       }
 
-      return `${formattedValueWithSymbol}/sec`;
+      return `${formattedValueWithSymbol}/sec (raw units)`;
     },
     [tokenMetadata],
   );
@@ -247,11 +247,11 @@ export const ReviewGatorPermissionItem = ({
       const { symbol, decimals } = tokenMetadata;
 
       const formattedValueWithSymbol = `${formatDecimalShiftedValue(value, decimals)} ${symbol}`;
-      if (decimals === undefined) {
-        return `${formattedValueWithSymbol} (raw units)`;
+      if (typeof decimals === 'number') {
+        return `${formattedValueWithSymbol}`;
       }
 
-      return `${formattedValueWithSymbol}`;
+      return `${formattedValueWithSymbol} (raw units)`;
     },
     [tokenMetadata],
   );

--- a/ui/components/multichain/pages/gator-permissions/components/review-gator-permission-item.tsx
+++ b/ui/components/multichain/pages/gator-permissions/components/review-gator-permission-item.tsx
@@ -245,7 +245,7 @@ export const ReviewGatorPermissionItem = ({
 
       const { symbol, decimals } = tokenMetadata;
 
-      if (!decimals) {
+      if (decimals === undefined) {
         return `${formatDecimalShiftedValue(value, decimals)} ${symbol} (raw units)`;
       }
 

--- a/ui/components/multichain/pages/gator-permissions/components/review-gator-permission-item.tsx
+++ b/ui/components/multichain/pages/gator-permissions/components/review-gator-permission-item.tsx
@@ -285,7 +285,9 @@ export const ReviewGatorPermissionItem = ({
         expandedDetails: {
           initialAllowance: {
             translationKey: 'gatorPermissionsInitialAllowance',
-            value: formatValue(permission.data.initialAmount, `0 ${tokenMetadata?.symbol}`),
+            value: formatValue(
+              permission.data.initialAmount, `0 ${tokenMetadata?.symbol}`
+            ),
             testId: 'review-gator-permission-initial-allowance',
           },
           maxAllowance: {

--- a/ui/components/multichain/pages/gator-permissions/components/review-gator-permission-item.tsx
+++ b/ui/components/multichain/pages/gator-permissions/components/review-gator-permission-item.tsx
@@ -34,7 +34,7 @@ import {
   convertTimestampToReadableDate,
   getPeriodFrequencyValueTranslationKey,
   convertAmountPerSecondToAmountPerPeriod,
-  getDecimalizedHexValue,
+  formatDecimalShiftedValue,
   extractExpiryToReadableDate,
   GatorPermissionRule,
 } from '../../../../../../shared/lib/gator-permissions';
@@ -44,6 +44,7 @@ import { getPendingRevocations } from '../../../../../selectors/gator-permission
 import { useGatorPermissionTokenInfo } from '../../../../../hooks/gator-permissions/useGatorPermissionTokenInfo';
 import { CopyIcon } from '../../../../app/confirm/info/row/copy-icon';
 import { Skeleton } from '../../../../component-library/skeleton';
+import { Hex } from '@metamask/utils';
 
 // Shared row style for permission details
 const rowStyle = { flex: '1', alignSelf: 'center' } as const;
@@ -219,6 +220,34 @@ export const ReviewGatorPermissionItem = ({
     [t],
   );
 
+  const formatValueAsRatePerSecond = useCallback((value: Hex | null | undefined) => {
+    if (!value) {
+      return 'Unknown';
+    }
+
+    const { symbol, decimals } = tokenMetadata;
+
+    if (decimals === null) {
+      return `${formatDecimalShiftedValue(value, decimals)} ${symbol}/sec (raw units)`;
+    }
+
+    return `${formatDecimalShiftedValue(value, decimals)} ${symbol}/sec`;
+  }, [tokenMetadata]);
+
+  const formatValue = useCallback((value: Hex | null | undefined) => {
+    if (!value) {
+      return 'Unknown';
+    }
+
+    const { symbol, decimals } = tokenMetadata;
+
+    if (decimals === null) {
+      return `${formatDecimalShiftedValue(value, decimals)} ${symbol} (raw units)`;
+    }
+
+    return `${formatDecimalShiftedValue(value, decimals)} ${symbol}`;
+  }, [tokenMetadata]);
+
   /**
    * Returns the token stream permission details
    *
@@ -229,19 +258,15 @@ export const ReviewGatorPermissionItem = ({
     (
       permission: NativeTokenStreamPermission | Erc20TokenStreamPermission,
     ): PermissionDetails => {
-      const { symbol, decimals } = tokenMetadata;
       const amountPerPeriod = convertAmountPerSecondToAmountPerPeriod(
         permission.data.amountPerSecond,
         'weekly',
       );
 
-      const decimalsNotice =
-        decimals === undefined ? ' (raw units - decimals unavailable)' : '';
-
       return {
         amountLabel: {
           translationKey: 'gatorPermissionsStreamingAmountLabel',
-          value: `${getDecimalizedHexValue(amountPerPeriod, decimals)} ${symbol}${decimalsNotice}`,
+          value: formatValue(amountPerPeriod),
           testId: 'review-gator-permission-amount-label',
         },
         frequencyLabel: {
@@ -252,20 +277,12 @@ export const ReviewGatorPermissionItem = ({
         expandedDetails: {
           initialAllowance: {
             translationKey: 'gatorPermissionsInitialAllowance',
-            value: `${getDecimalizedHexValue(
-              permission.data.initialAmount || '0x0',
-              decimals,
-            )} ${symbol}${decimalsNotice}`,
+            value: formatValue(permission.data.initialAmount),
             testId: 'review-gator-permission-initial-allowance',
           },
           maxAllowance: {
             translationKey: 'gatorPermissionsMaxAllowance',
-            value: permission.data.maxAmount
-              ? `${getDecimalizedHexValue(
-                  permission.data.maxAmount,
-                  decimals,
-                )} ${symbol}${decimalsNotice}`
-              : t('unlimited'),
+            value: formatValue(permission.data.maxAmount),
             testId: 'review-gator-permission-max-allowance',
           },
           startDate: {
@@ -283,10 +300,7 @@ export const ReviewGatorPermissionItem = ({
           },
           streamRate: {
             translationKey: 'gatorPermissionsStreamRate',
-            value: `${getDecimalizedHexValue(
-              permission.data.amountPerSecond,
-              decimals,
-            )} ${symbol}/sec${decimalsNotice}`,
+            value: formatValueAsRatePerSecond(permission.data.amountPerSecond),
             testId: 'review-gator-permission-stream-rate',
           },
         },
@@ -312,10 +326,7 @@ export const ReviewGatorPermissionItem = ({
       return {
         amountLabel: {
           translationKey: 'amount',
-          value: `${getDecimalizedHexValue(
-            permission.data.periodAmount,
-            decimals,
-          )} ${symbol}${decimalsNotice}`,
+          value: formatValue(permission.data.periodAmount),
           testId: 'review-gator-permission-amount-label',
         },
         frequencyLabel: {

--- a/ui/components/multichain/pages/gator-permissions/components/review-gator-permission-item.tsx
+++ b/ui/components/multichain/pages/gator-permissions/components/review-gator-permission-item.tsx
@@ -25,6 +25,7 @@ import {
   NativeTokenStreamPermission,
   PermissionInfoWithMetadata,
 } from '@metamask/gator-permissions-controller';
+import { Hex } from '@metamask/utils';
 import { getImageForChainId } from '../../../../../selectors/multichain';
 import { getURLHost, shortenAddress } from '../../../../../helpers/utils/util';
 import Card from '../../../../ui/card';
@@ -44,7 +45,6 @@ import { getPendingRevocations } from '../../../../../selectors/gator-permission
 import { useGatorPermissionTokenInfo } from '../../../../../hooks/gator-permissions/useGatorPermissionTokenInfo';
 import { CopyIcon } from '../../../../app/confirm/info/row/copy-icon';
 import { Skeleton } from '../../../../component-library/skeleton';
-import { Hex } from '@metamask/utils';
 
 // Shared row style for permission details
 const rowStyle = { flex: '1', alignSelf: 'center' } as const;
@@ -220,33 +220,39 @@ export const ReviewGatorPermissionItem = ({
     [t],
   );
 
-  const formatValueAsRatePerSecond = useCallback((value: Hex | null | undefined) => {
-    if (!value) {
-      return 'Unknown';
-    }
+  const formatValueAsRatePerSecond = useCallback(
+    (value: Hex | null | undefined) => {
+      if (!value) {
+        return 'Unknown';
+      }
 
-    const { symbol, decimals } = tokenMetadata;
+      const { symbol, decimals } = tokenMetadata;
 
-    if (!decimals) {
-      return `${formatDecimalShiftedValue(value, decimals)} ${symbol}/sec (raw units)`;
-    }
+      if (!decimals) {
+        return `${formatDecimalShiftedValue(value, decimals)} ${symbol}/sec (raw units)`;
+      }
 
-    return `${formatDecimalShiftedValue(value, decimals)} ${symbol}/sec`;
-  }, [tokenMetadata]);
+      return `${formatDecimalShiftedValue(value, decimals)} ${symbol}/sec`;
+    },
+    [tokenMetadata],
+  );
 
-  const formatValue = useCallback((value: Hex | null | undefined) => {
-    if (!value) {
-      return 'Unknown';
-    }
+  const formatValue = useCallback(
+    (value: Hex | null | undefined) => {
+      if (!value) {
+        return 'Unknown';
+      }
 
-    const { symbol, decimals } = tokenMetadata;
+      const { symbol, decimals } = tokenMetadata;
 
-    if (!decimals) {
-      return `${formatDecimalShiftedValue(value, decimals)} ${symbol} (raw units)`;
-    }
+      if (!decimals) {
+        return `${formatDecimalShiftedValue(value, decimals)} ${symbol} (raw units)`;
+      }
 
-    return `${formatDecimalShiftedValue(value, decimals)} ${symbol}`;
-  }, [tokenMetadata]);
+      return `${formatDecimalShiftedValue(value, decimals)} ${symbol}`;
+    },
+    [tokenMetadata],
+  );
 
   /**
    * Returns the token stream permission details

--- a/ui/components/multichain/pages/gator-permissions/components/review-gator-permission-item.tsx
+++ b/ui/components/multichain/pages/gator-permissions/components/review-gator-permission-item.tsx
@@ -316,7 +316,14 @@ export const ReviewGatorPermissionItem = ({
         },
       };
     },
-    [t, formatValue, formatValueAsRatePerSecond, getExpirationDate, permissionResponse.rules],
+    [
+      t,
+      formatValue,
+      formatValueAsRatePerSecond,
+      getExpirationDate,
+      permissionResponse.rules,
+      tokenMetadata,
+    ],
   );
 
   /**

--- a/ui/components/multichain/pages/gator-permissions/components/review-gator-permission-item.tsx
+++ b/ui/components/multichain/pages/gator-permissions/components/review-gator-permission-item.tsx
@@ -235,10 +235,13 @@ export const ReviewGatorPermissionItem = ({
         'weekly',
       );
 
+      const decimalsNotice =
+        decimals === undefined ? ' (raw units - decimals unavailable)' : '';
+
       return {
         amountLabel: {
           translationKey: 'gatorPermissionsStreamingAmountLabel',
-          value: `${getDecimalizedHexValue(amountPerPeriod, decimals)} ${symbol}`,
+          value: `${getDecimalizedHexValue(amountPerPeriod, decimals)} ${symbol}${decimalsNotice}`,
           testId: 'review-gator-permission-amount-label',
         },
         frequencyLabel: {
@@ -252,7 +255,7 @@ export const ReviewGatorPermissionItem = ({
             value: `${getDecimalizedHexValue(
               permission.data.initialAmount || '0x0',
               decimals,
-            )} ${symbol}`,
+            )} ${symbol}${decimalsNotice}`,
             testId: 'review-gator-permission-initial-allowance',
           },
           maxAllowance: {
@@ -261,7 +264,7 @@ export const ReviewGatorPermissionItem = ({
               ? `${getDecimalizedHexValue(
                   permission.data.maxAmount,
                   decimals,
-                )} ${symbol}`
+                )} ${symbol}${decimalsNotice}`
               : t('unlimited'),
             testId: 'review-gator-permission-max-allowance',
           },
@@ -283,7 +286,7 @@ export const ReviewGatorPermissionItem = ({
             value: `${getDecimalizedHexValue(
               permission.data.amountPerSecond,
               decimals,
-            )} ${symbol}/sec`,
+            )} ${symbol}/sec${decimalsNotice}`,
             testId: 'review-gator-permission-stream-rate',
           },
         },
@@ -303,13 +306,16 @@ export const ReviewGatorPermissionItem = ({
       permission: NativeTokenPeriodicPermission | Erc20TokenPeriodicPermission,
     ): PermissionDetails => {
       const { symbol, decimals } = tokenMetadata;
+      const decimalsNotice =
+        decimals === undefined ? ' (raw units - decimals unavailable)' : '';
+
       return {
         amountLabel: {
           translationKey: 'amount',
           value: `${getDecimalizedHexValue(
             permission.data.periodAmount,
             decimals,
-          )} ${symbol}`,
+          )} ${symbol}${decimalsNotice}`,
           testId: 'review-gator-permission-amount-label',
         },
         frequencyLabel: {

--- a/ui/components/multichain/pages/gator-permissions/components/review-gator-permission-item.tsx
+++ b/ui/components/multichain/pages/gator-permissions/components/review-gator-permission-item.tsx
@@ -286,7 +286,8 @@ export const ReviewGatorPermissionItem = ({
           initialAllowance: {
             translationKey: 'gatorPermissionsInitialAllowance',
             value: formatValue(
-              permission.data.initialAmount, `0 ${tokenMetadata?.symbol}`
+              permission.data.initialAmount,
+              `0 ${tokenMetadata?.symbol}`
             ),
             testId: 'review-gator-permission-initial-allowance',
           },

--- a/ui/components/multichain/pages/gator-permissions/components/review-gator-permission-item.tsx
+++ b/ui/components/multichain/pages/gator-permissions/components/review-gator-permission-item.tsx
@@ -248,7 +248,7 @@ export const ReviewGatorPermissionItem = ({
 
       const formattedValueWithSymbol = `${formatDecimalShiftedValue(value, decimals)} ${symbol}`;
       if (typeof decimals === 'number') {
-        return `${formattedValueWithSymbol}`;
+        return formattedValueWithSymbol;
       }
 
       return `${formattedValueWithSymbol} (raw units)`;
@@ -316,7 +316,7 @@ export const ReviewGatorPermissionItem = ({
         },
       };
     },
-    [tokenMetadata, t, getExpirationDate, permissionResponse.rules],
+    [t, formatValue, formatValueAsRatePerSecond, getExpirationDate, permissionResponse.rules],
   );
 
   /**
@@ -359,7 +359,7 @@ export const ReviewGatorPermissionItem = ({
         },
       };
     },
-    [tokenMetadata, getExpirationDate, permissionResponse.rules],
+    [formatValue, getExpirationDate, permissionResponse.rules],
   );
 
   /**

--- a/ui/components/multichain/pages/gator-permissions/components/review-gator-permission-item.tsx
+++ b/ui/components/multichain/pages/gator-permissions/components/review-gator-permission-item.tsx
@@ -228,28 +228,30 @@ export const ReviewGatorPermissionItem = ({
 
       const { symbol, decimals } = tokenMetadata;
 
+      const formattedValueWithSymbol = `${formatDecimalShiftedValue(value, decimals)} ${symbol}`;
       if (!decimals) {
-        return `${formatDecimalShiftedValue(value, decimals)} ${symbol}/sec (raw units)`;
+        return `${formattedValueWithSymbol}/sec (raw units)`;
       }
 
-      return `${formatDecimalShiftedValue(value, decimals)} ${symbol}/sec`;
+      return `${formattedValueWithSymbol}/sec`;
     },
     [tokenMetadata],
   );
 
   const formatValue = useCallback(
-    (value: Hex | null | undefined) => {
+    (value: Hex | null | undefined, placeholder: string = 'Unknown') => {
       if (!value) {
-        return 'Unknown';
+        return placeholder;
       }
 
       const { symbol, decimals } = tokenMetadata;
 
+      const formattedValueWithSymbol = `${formatDecimalShiftedValue(value, decimals)} ${symbol}`;
       if (decimals === undefined) {
-        return `${formatDecimalShiftedValue(value, decimals)} ${symbol} (raw units)`;
+        return `${formattedValueWithSymbol} (raw units)`;
       }
 
-      return `${formatDecimalShiftedValue(value, decimals)} ${symbol}`;
+      return `${formattedValueWithSymbol}`;
     },
     [tokenMetadata],
   );
@@ -283,12 +285,12 @@ export const ReviewGatorPermissionItem = ({
         expandedDetails: {
           initialAllowance: {
             translationKey: 'gatorPermissionsInitialAllowance',
-            value: formatValue(permission.data.initialAmount),
+            value: formatValue(permission.data.initialAmount, `0 ${tokenMetadata?.symbol}`),
             testId: 'review-gator-permission-initial-allowance',
           },
           maxAllowance: {
             translationKey: 'gatorPermissionsMaxAllowance',
-            value: formatValue(permission.data.maxAmount),
+            value: formatValue(permission.data.maxAmount, t('unlimited')),
             testId: 'review-gator-permission-max-allowance',
           },
           startDate: {
@@ -298,7 +300,6 @@ export const ReviewGatorPermissionItem = ({
             ),
             testId: 'review-gator-permission-start-date',
           },
-
           expirationDate: {
             translationKey: 'gatorPermissionsExpirationDate',
             value: getExpirationDate(permissionResponse.rules),

--- a/ui/components/multichain/pages/gator-permissions/components/review-gator-permission-item.tsx
+++ b/ui/components/multichain/pages/gator-permissions/components/review-gator-permission-item.tsx
@@ -287,7 +287,7 @@ export const ReviewGatorPermissionItem = ({
             translationKey: 'gatorPermissionsInitialAllowance',
             value: formatValue(
               permission.data.initialAmount,
-              `0 ${tokenMetadata?.symbol}`
+              `0 ${tokenMetadata?.symbol}`,
             ),
             testId: 'review-gator-permission-initial-allowance',
           },

--- a/ui/hooks/gator-permissions/useGatorPermissionTokenInfo.test.tsx
+++ b/ui/hooks/gator-permissions/useGatorPermissionTokenInfo.test.tsx
@@ -385,7 +385,7 @@ describe('useGatorPermissionTokenInfo', () => {
       await waitForNextUpdate();
 
       expect(result.current.tokenInfo?.symbol).toBe('Unknown Token');
-      expect(result.current.tokenInfo?.decimals).toBe(18);
+      expect(result.current.tokenInfo?.decimals).toBe(null);
       expect(result.current.error).toBeInstanceOf(Error);
       expect(result.current.error?.message).toBe('On-chain Error');
     });
@@ -402,7 +402,7 @@ describe('useGatorPermissionTokenInfo', () => {
       expect(result.current.loading).toBe(false);
       expect(result.current.tokenInfo).toMatchObject({
         symbol: 'Unknown Token',
-        decimals: 18,
+        decimals: null,
         chainId: mockChainId,
       });
     });
@@ -417,7 +417,7 @@ describe('useGatorPermissionTokenInfo', () => {
       expect(result.current.loading).toBe(false);
       expect(result.current.tokenInfo).toMatchObject({
         symbol: 'Unknown Token',
-        decimals: 18,
+        decimals: null,
         chainId: '0x0',
       });
     });

--- a/ui/hooks/gator-permissions/useGatorPermissionTokenInfo.test.tsx
+++ b/ui/hooks/gator-permissions/useGatorPermissionTokenInfo.test.tsx
@@ -402,7 +402,6 @@ describe('useGatorPermissionTokenInfo', () => {
       expect(result.current.loading).toBe(false);
       expect(result.current.tokenInfo).toMatchObject({
         symbol: 'Unknown Token',
-        decimals: undefined,
         chainId: mockChainId,
       });
     });
@@ -417,7 +416,6 @@ describe('useGatorPermissionTokenInfo', () => {
       expect(result.current.loading).toBe(false);
       expect(result.current.tokenInfo).toMatchObject({
         symbol: 'Unknown Token',
-        decimals: null,
         chainId: '0x0',
       });
     });

--- a/ui/hooks/gator-permissions/useGatorPermissionTokenInfo.test.tsx
+++ b/ui/hooks/gator-permissions/useGatorPermissionTokenInfo.test.tsx
@@ -385,7 +385,7 @@ describe('useGatorPermissionTokenInfo', () => {
       await waitForNextUpdate();
 
       expect(result.current.tokenInfo?.symbol).toBe('Unknown Token');
-      expect(result.current.tokenInfo?.decimals).toBe(null);
+      expect(result.current.tokenInfo?.decimals).toBeUndefined();
       expect(result.current.error).toBeInstanceOf(Error);
       expect(result.current.error?.message).toBe('On-chain Error');
     });
@@ -402,7 +402,7 @@ describe('useGatorPermissionTokenInfo', () => {
       expect(result.current.loading).toBe(false);
       expect(result.current.tokenInfo).toMatchObject({
         symbol: 'Unknown Token',
-        decimals: null,
+        decimals: undefined,
         chainId: mockChainId,
       });
     });

--- a/ui/hooks/gator-permissions/useGatorPermissionTokenInfo.ts
+++ b/ui/hooks/gator-permissions/useGatorPermissionTokenInfo.ts
@@ -150,7 +150,6 @@ export function useGatorPermissionTokenInfo(
     return {
       tokenInfo: {
         symbol: 'Unknown Token',
-        decimals: null,
         chainId: chainId || '0x0',
       },
       loading: isFetching,

--- a/ui/hooks/gator-permissions/useGatorPermissionTokenInfo.ts
+++ b/ui/hooks/gator-permissions/useGatorPermissionTokenInfo.ts
@@ -91,9 +91,8 @@ export function useGatorPermissionTokenInfo(
   }, [tokenAddress, chainId, erc20TokensByChain, allTokens, isNativeToken]);
 
   // Determine if we should fetch token info
-  const shouldFetch = Boolean(
-    !isNativeToken && !cachedOrImportedTokenInfo && tokenAddress && chainId,
-  );
+  const shouldFetch =
+    Boolean(!isNativeToken && !cachedOrImportedTokenInfo && tokenAddress && chainId);
 
   // Tier 2 & 3: Fetch using API and on-chain fallback if not in cache/imported (only for ERC-20 tokens)
   const asyncResult = useAsyncResult(async () => {
@@ -111,9 +110,10 @@ export function useGatorPermissionTokenInfo(
   }, [shouldFetch, tokenAddress, chainId, allowExternalServices]);
 
   // Extract fetched token info from async result
-  const fetchedTokenInfo =
-    asyncResult.status === 'success' ? asyncResult.value : null;
-  const error = asyncResult.status === 'error' ? asyncResult.error : null;
+  const fetchedTokenInfo = asyncResult.value ?? null;
+
+  const error = asyncResult.error ?? null;
+
   // Only consider it fetching if we actually should fetch
   const isFetching = shouldFetch && asyncResult.pending;
 
@@ -144,11 +144,13 @@ export function useGatorPermissionTokenInfo(
       };
     }
 
+
+    // cannot resolve token info, return some placeholder data
     return {
       tokenInfo: {
         symbol: 'Unknown Token',
-        decimals: error ? undefined : 18,
-        chainId: chainId || ('0x0' as const),
+        decimals: null,
+        chainId: chainId || '0x0',
       },
       loading: isFetching,
     };

--- a/ui/hooks/gator-permissions/useGatorPermissionTokenInfo.ts
+++ b/ui/hooks/gator-permissions/useGatorPermissionTokenInfo.ts
@@ -147,7 +147,7 @@ export function useGatorPermissionTokenInfo(
     return {
       tokenInfo: {
         symbol: 'Unknown Token',
-        decimals: 18,
+        decimals: error ? undefined : 18,
         chainId: chainId || ('0x0' as const),
       },
       loading: isFetching,
@@ -158,6 +158,7 @@ export function useGatorPermissionTokenInfo(
     fetchedTokenInfo,
     chainId,
     isFetching,
+    error,
   ]);
 
   return { ...result, error };

--- a/ui/hooks/gator-permissions/useGatorPermissionTokenInfo.ts
+++ b/ui/hooks/gator-permissions/useGatorPermissionTokenInfo.ts
@@ -92,8 +92,8 @@ export function useGatorPermissionTokenInfo(
 
   // Determine whether we should fetch token info
   const shouldFetch = Boolean(
-      !isNativeToken && !cachedOrImportedTokenInfo && tokenAddress && chainId
-    );
+    !isNativeToken && !cachedOrImportedTokenInfo && tokenAddress && chainId,
+  );
 
   // Tier 2 & 3: Fetch using API and on-chain fallback if not in cache/imported (only for ERC-20 tokens)
   const asyncResult = useAsyncResult(async () => {
@@ -144,7 +144,6 @@ export function useGatorPermissionTokenInfo(
         loading: false,
       };
     }
-
 
     // cannot resolve token info, return some placeholder data
     return {

--- a/ui/hooks/gator-permissions/useGatorPermissionTokenInfo.ts
+++ b/ui/hooks/gator-permissions/useGatorPermissionTokenInfo.ts
@@ -90,9 +90,10 @@ export function useGatorPermissionTokenInfo(
     );
   }, [tokenAddress, chainId, erc20TokensByChain, allTokens, isNativeToken]);
 
-  // Determine if we should fetch token info
-  const shouldFetch =
-    Boolean(!isNativeToken && !cachedOrImportedTokenInfo && tokenAddress && chainId);
+  // Determine whether we should fetch token info
+  const shouldFetch = Boolean(
+      !isNativeToken && !cachedOrImportedTokenInfo && tokenAddress && chainId
+    );
 
   // Tier 2 & 3: Fetch using API and on-chain fallback if not in cache/imported (only for ERC-20 tokens)
   const asyncResult = useAsyncResult(async () => {

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission.test.tsx
@@ -15,6 +15,11 @@ jest.mock(
   }),
 );
 
+jest.mock('../../../../utils/token', () => ({
+  ...jest.requireActual('../../../../utils/token'),
+  fetchErc20DecimalsOrThrow: jest.fn().mockResolvedValue(18),
+}));
+
 describe('TypedSignPermissionInfo', () => {
   describe('permission section fields', () => {
     const permission = {

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/erc20-token-periodic-details.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/erc20-token-periodic-details.test.tsx
@@ -7,6 +7,7 @@ import { renderWithConfirmContextProvider } from '../../../../../../../../test/l
 import * as tokenUtils from '../../../../../utils/token';
 import { Erc20TokenPeriodicDetails } from './erc20-token-periodic-details';
 import { formatPeriodDuration } from './typed-sign-permission-util';
+import { TestErrorBoundary } from './test-error-boundary';
 
 jest.mock('../../../../../utils/token', () => ({
   ...jest.requireActual('../../../../../utils/token'),
@@ -139,15 +140,28 @@ describe('Erc20TokenPeriodicDetails', () => {
         new Error('Unable to resolve token decimals'),
       );
 
-      expect(() =>
-        renderWithConfirmContextProvider(
-          <Erc20TokenPeriodicDetails {...defaultProps} />,
-          getMockStore(),
-        ),
-      ).toThrow();
+      const { getByTestId } = renderWithConfirmContextProvider(
+        <TestErrorBoundary>
+          <Erc20TokenPeriodicDetails {...defaultProps} />
+        </TestErrorBoundary>,
+        getMockStore(),
+      );
+
+      await waitFor(() => {
+        expect(getByTestId('error-boundary')).toBeInTheDocument();
+        expect(getByTestId('error-boundary')).toHaveTextContent(
+          'Unable to resolve token decimals',
+        );
+      });
+
+      (
+        tokenUtils as jest.Mocked<typeof tokenUtils>
+      ).fetchErc20DecimalsOrThrow.mockResolvedValue(2);
     });
   });
 
+  // Tests that intentionally throw may still log "Error: Uncaught [Error ...]";
+  // see console baseline "Test errors: Uncaught Errors" for this file.
   describe('error handling', () => {
     it('throws error when start time is missing', () => {
       const permissionWithoutStartTime = {

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/erc20-token-periodic-details.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/erc20-token-periodic-details.test.tsx
@@ -10,7 +10,7 @@ import { formatPeriodDuration } from './typed-sign-permission-util';
 
 jest.mock('../../../../../utils/token', () => ({
   ...jest.requireActual('../../../../../utils/token'),
-  fetchErc20Decimals: jest.fn().mockResolvedValue(2),
+  fetchErc20DecimalsOrThrow: jest.fn().mockResolvedValue(2),
 }));
 
 // Mock the formatPeriodDuration utility function
@@ -78,7 +78,8 @@ describe('Erc20TokenPeriodicDetails', () => {
 
     await waitFor(() => {
       expect(
-        (tokenUtils as jest.Mocked<typeof tokenUtils>).fetchErc20Decimals,
+        (tokenUtils as jest.Mocked<typeof tokenUtils>)
+          .fetchErc20DecimalsOrThrow,
       ).toHaveBeenCalled();
     });
 
@@ -119,7 +120,7 @@ describe('Erc20TokenPeriodicDetails', () => {
     it('formats the allowance based on the resolved token decimals', async () => {
       (
         tokenUtils as jest.Mocked<typeof tokenUtils>
-      ).fetchErc20Decimals.mockResolvedValue(3);
+      ).fetchErc20DecimalsOrThrow.mockResolvedValue(3);
 
       const detailsSection =
         await renderWithDecimalsAndGetDetailsSection(defaultProps);
@@ -129,6 +130,21 @@ describe('Erc20TokenPeriodicDetails', () => {
       expect(
         detailsSection?.textContent?.includes('4.66'), // 0x1234 / 10^3
       ).toBe(true);
+    });
+
+    it('throws error when decimals cannot be resolved', async () => {
+      (
+        tokenUtils as jest.Mocked<typeof tokenUtils>
+      ).fetchErc20DecimalsOrThrow.mockRejectedValue(
+        new Error('Unable to resolve token decimals'),
+      );
+
+      expect(() =>
+        renderWithConfirmContextProvider(
+          <Erc20TokenPeriodicDetails {...defaultProps} />,
+          getMockStore(),
+        ),
+      ).toThrow();
     });
   });
 

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/erc20-token-periodic-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/erc20-token-periodic-details.tsx
@@ -9,7 +9,7 @@ import {
 } from '../../../../../../../components/app/confirm/info/row';
 import { ConfirmInfoSection } from '../../../../../../../components/app/confirm/info/row/section';
 import { useAsyncResult } from '../../../../../../../hooks/useAsync';
-import { fetchErc20Decimals } from '../../../../../utils/token';
+import { fetchErc20DecimalsOrThrow } from '../../../../../utils/token';
 import { useI18nContext } from '../../../../../../../hooks/useI18nContext';
 import { formatPeriodDuration } from './typed-sign-permission-util';
 import { TokenAmountRow } from './token-amount-row';
@@ -41,8 +41,13 @@ export const Erc20TokenPeriodicDetails: React.FC<{
   const { periodAmount, periodDuration, startTime } = permission.data;
 
   const metadataResult = useAsyncResult(() =>
-    fetchErc20Decimals(permission.data.tokenAddress, chainId),
+    fetchErc20DecimalsOrThrow(permission.data.tokenAddress, chainId),
   );
+
+  // Throw error if decimals cannot be resolved during permission signing
+  if (metadataResult.status === 'error') {
+    throw metadataResult.error;
+  }
 
   const decimals = metadataResult.value;
 

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/erc20-token-stream-details.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/erc20-token-stream-details.test.tsx
@@ -9,7 +9,7 @@ import { Erc20TokenStreamDetails } from './erc20-token-stream-details';
 
 jest.mock('../../../../../utils/token', () => ({
   ...jest.requireActual('../../../../../utils/token'),
-  fetchErc20Decimals: jest.fn().mockResolvedValue(2),
+  fetchErc20DecimalsOrThrow: jest.fn().mockResolvedValue(2),
 }));
 
 describe('Erc20TokenStreamDetails', () => {
@@ -60,7 +60,8 @@ describe('Erc20TokenStreamDetails', () => {
 
     await waitFor(() =>
       expect(
-        (tokenUtils as jest.Mocked<typeof tokenUtils>).fetchErc20Decimals,
+        (tokenUtils as jest.Mocked<typeof tokenUtils>)
+          .fetchErc20DecimalsOrThrow,
       ).toHaveBeenCalled(),
     );
 
@@ -134,7 +135,7 @@ describe('Erc20TokenStreamDetails', () => {
     it('formats the allowance based on the resolved token decimals', async () => {
       (
         tokenUtils as jest.Mocked<typeof tokenUtils>
-      ).fetchErc20Decimals.mockResolvedValue(3);
+      ).fetchErc20DecimalsOrThrow.mockResolvedValue(3);
 
       const { detailsSection } = await renderAndGetSections(defaultProps);
 
@@ -172,6 +173,21 @@ describe('Erc20TokenStreamDetails', () => {
           getMockStore(),
         ),
       ).toThrow('Start time is required');
+    });
+
+    it('throws error when decimals cannot be resolved', async () => {
+      (
+        tokenUtils as jest.Mocked<typeof tokenUtils>
+      ).fetchErc20DecimalsOrThrow.mockRejectedValue(
+        new Error('Unable to resolve token decimals'),
+      );
+
+      expect(() =>
+        renderWithConfirmContextProvider(
+          <Erc20TokenStreamDetails {...defaultProps} />,
+          getMockStore(),
+        ),
+      ).toThrow();
     });
   });
 

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/erc20-token-stream-details.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/erc20-token-stream-details.test.tsx
@@ -6,6 +6,7 @@ import { getMockTypedSignPermissionConfirmState } from '../../../../../../../../
 import { renderWithConfirmContextProvider } from '../../../../../../../../test/lib/confirmations/render-helpers';
 import * as tokenUtils from '../../../../../utils/token';
 import { Erc20TokenStreamDetails } from './erc20-token-stream-details';
+import { TestErrorBoundary } from './test-error-boundary';
 
 jest.mock('../../../../../utils/token', () => ({
   ...jest.requireActual('../../../../../utils/token'),
@@ -154,6 +155,9 @@ describe('Erc20TokenStreamDetails', () => {
     });
   });
 
+  // These tests intentionally throw; React may still log "Error: Uncaught [Error ...]"
+  // before the error boundary catches it, so the console baseline "Test errors: Uncaught Errors"
+  // for this file is expected to include those counts.
   describe('error handling', () => {
     it('throws error when start time is missing', () => {
       const permissionWithoutStartTime = {
@@ -182,18 +186,30 @@ describe('Erc20TokenStreamDetails', () => {
         new Error('Unable to resolve token decimals'),
       );
 
-      expect(() =>
-        renderWithConfirmContextProvider(
-          <Erc20TokenStreamDetails {...defaultProps} />,
-          getMockStore(),
-        ),
-      ).toThrow();
+      const { getByTestId } = renderWithConfirmContextProvider(
+        <TestErrorBoundary>
+          <Erc20TokenStreamDetails {...defaultProps} />
+        </TestErrorBoundary>,
+        getMockStore(),
+      );
+
+      await waitFor(() => {
+        expect(getByTestId('error-boundary')).toBeInTheDocument();
+        expect(getByTestId('error-boundary')).toHaveTextContent(
+          'Unable to resolve token decimals',
+        );
+      });
+
+      // Restore default mock so later tests get resolved decimals
+      (
+        tokenUtils as jest.Mocked<typeof tokenUtils>
+      ).fetchErc20DecimalsOrThrow.mockResolvedValue(2);
     });
   });
 
   describe('edge cases', () => {
     it('handles very large amounts', async () => {
-      const permissionWithLargeAmounts = {
+      const permissionWithLargeAmounts: Erc20TokenStreamPermission = {
         ...mockPermission,
         data: {
           ...mockPermission.data,
@@ -201,7 +217,8 @@ describe('Erc20TokenStreamDetails', () => {
           maxAmount: '0xffffffffffffffffffffffffffffffffffffffff',
           amountPerSecond: '0xffffffffffffffffffffffffffffffffffffffff',
         },
-      } as Erc20TokenStreamPermission;
+      };
+
       const { detailsSection } = await renderAndGetSections({
         ...defaultProps,
         permission: permissionWithLargeAmounts,

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/erc20-token-stream-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/erc20-token-stream-details.tsx
@@ -6,7 +6,7 @@ import { Hex } from '@metamask/utils';
 import { ConfirmInfoSection } from '../../../../../../../components/app/confirm/info/row/section';
 import { ConfirmInfoRowDivider } from '../../../../../../../components/app/confirm/info/row';
 import { DAY } from '../../../../../../../../shared/constants/time';
-import { fetchErc20Decimals } from '../../../../../utils/token';
+import { fetchErc20DecimalsOrThrow } from '../../../../../utils/token';
 import { useAsyncResult } from '../../../../../../../hooks/useAsync';
 import { useI18nContext } from '../../../../../../../hooks/useI18nContext';
 import { TokenAmountRow } from './token-amount-row';
@@ -41,8 +41,13 @@ export const Erc20TokenStreamDetails: React.FC<{
   const amountPerDay = new BigNumber(amountPerSecond).mul(DAY / 1000); // DAY is in milliseconds
 
   const metadataResult = useAsyncResult(() =>
-    fetchErc20Decimals(permission.data.tokenAddress, chainId),
+    fetchErc20DecimalsOrThrow(permission.data.tokenAddress, chainId),
   );
+
+  // Throw error if decimals cannot be resolved during permission signing
+  if (metadataResult.status === 'error') {
+    throw metadataResult.error;
+  }
 
   const decimals = metadataResult.value;
 

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/test-error-boundary.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/test-error-boundary.tsx
@@ -20,11 +20,7 @@ export const TestErrorBoundary = class extends React.Component<
 
   render() {
     if (this.state.error) {
-      return (
-        <div data-testid="error-boundary">
-          {this.state.error.message}
-        </div>
-      );
+      return <div data-testid="error-boundary">{this.state.error.message}</div>;
     }
     return this.props.children;
   }

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/test-error-boundary.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/test-error-boundary.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+/**
+ * Error boundary for tests that need to capture errors thrown from children.
+ * Use when testing components that throw on a subsequent render (e.g. after
+ * useAsyncResult rejects), so the test can assert the error via waitFor instead
+ * of expect().toThrow().
+ *
+ * Renders the caught error message in a div with data-testid="error-boundary".
+ */
+export const TestErrorBoundary = class extends React.Component<
+  { children: React.ReactNode },
+  { error: Error | null }
+> {
+  state = { error: null as Error | null };
+
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div data-testid="error-boundary">
+          {this.state.error.message}
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+};

--- a/ui/pages/confirmations/utils/token.test.ts
+++ b/ui/pages/confirmations/utils/token.test.ts
@@ -73,6 +73,18 @@ describe('fetchErc20DecimalsOrThrow', () => {
     );
   });
 
+  it('should throw an error when token details result is undefined', async () => {
+    (getTokenStandardAndDetailsByChain as jest.Mock).mockResolvedValue(
+      undefined,
+    );
+
+    await expect(
+      fetchErc20DecimalsOrThrow(MOCK_ADDRESS, MOCK_CHAIN_ID),
+    ).rejects.toThrow(
+      `Unable to resolve token decimals for address ${MOCK_ADDRESS} on chain ${MOCK_CHAIN_ID}`,
+    );
+  });
+
   it('should return the decimals for a given token address', async () => {
     (getTokenStandardAndDetailsByChain as jest.Mock).mockResolvedValue({
       decimals: MOCK_DECIMALS,

--- a/ui/pages/confirmations/utils/token.test.ts
+++ b/ui/pages/confirmations/utils/token.test.ts
@@ -7,6 +7,7 @@ import {
   fetchAllErc20Decimals,
   fetchAllTokenDetails,
   fetchErc20Decimals,
+  fetchErc20DecimalsOrThrow,
   getTokenValueFromRecord,
   memoizedGetTokenStandardAndDetailsByChain,
 } from './token';
@@ -54,6 +55,45 @@ describe('fetchErc20Decimals', () => {
 
     await fetchErc20Decimals('0xDifferentAddress');
     expect(getTokenStandardAndDetailsByChain).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('fetchErc20DecimalsOrThrow', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should throw an error if no decimals were found from details', async () => {
+    (getTokenStandardAndDetailsByChain as jest.Mock).mockResolvedValue({});
+
+    await expect(
+      fetchErc20DecimalsOrThrow(MOCK_ADDRESS, MOCK_CHAIN_ID),
+    ).rejects.toThrow(
+      `Unable to resolve token decimals for address ${MOCK_ADDRESS} on chain ${MOCK_CHAIN_ID}`,
+    );
+  });
+
+  it('should return the decimals for a given token address', async () => {
+    (getTokenStandardAndDetailsByChain as jest.Mock).mockResolvedValue({
+      decimals: MOCK_DECIMALS,
+    });
+    const decimals = await fetchErc20DecimalsOrThrow(
+      MOCK_ADDRESS,
+      MOCK_CHAIN_ID,
+    );
+
+    expect(decimals).toBe(MOCK_DECIMALS);
+  });
+
+  it('should throw an error if the network request fails', async () => {
+    const networkError = new Error('Network error');
+    (getTokenStandardAndDetailsByChain as jest.Mock).mockRejectedValue(
+      networkError,
+    );
+
+    await expect(
+      fetchErc20DecimalsOrThrow(MOCK_ADDRESS, MOCK_CHAIN_ID),
+    ).rejects.toThrow('Network error');
   });
 });
 

--- a/ui/pages/confirmations/utils/token.ts
+++ b/ui/pages/confirmations/utils/token.ts
@@ -125,6 +125,36 @@ export const fetchErc20Decimals = async (
 };
 
 /**
+ * Fetches the decimals for the given token address, throwing an error if unable to resolve.
+ * Used during permission signing to ensure accurate token metadata is available.
+ *
+ * @param address - The ethereum token contract address. It is expected to be in hex format.
+ * @param chainId - ChainId on which we need to check token. It is expected to be in hex format.
+ * @throws Error if token decimals cannot be resolved
+ */
+export const fetchErc20DecimalsOrThrow = async (
+  address: Hex | string,
+  chainId?: Hex | string,
+): Promise<number> => {
+  const result = (await getTokenStandardAndDetailsByChain(
+    address,
+    undefined,
+    undefined,
+    chainId,
+  )) as TokenDetailsERC20;
+  const { decimals: decStr } = result;
+  const decimals = parseTokenDetailDecimals(decStr);
+
+  if (decimals === undefined) {
+    throw new Error(
+      `Unable to resolve token decimals for address ${address} on chain ${chainId}`,
+    );
+  }
+
+  return decimals;
+};
+
+/**
  * Fetches the decimals for the given token addresses.
  *
  * @param addresses - The array ofethereum token contract address. Addresses are expected to be in hex format.

--- a/ui/pages/confirmations/utils/token.ts
+++ b/ui/pages/confirmations/utils/token.ts
@@ -141,7 +141,14 @@ export const fetchErc20DecimalsOrThrow = async (
     undefined,
     undefined,
     chainId,
-  )) as TokenDetailsERC20;
+  )) as TokenDetailsERC20 | undefined | null;
+
+  if (!result) {
+    throw new Error(
+      `Unable to resolve token decimals for address ${address} on chain ${chainId}`,
+    );
+  }
+
   const { decimals: decStr } = result;
   const decimals = parseTokenDetailDecimals(decStr);
 

--- a/ui/pages/confirmations/utils/token.ts
+++ b/ui/pages/confirmations/utils/token.ts
@@ -136,12 +136,12 @@ export const fetchErc20DecimalsOrThrow = async (
   address: Hex | string,
   chainId?: Hex | string,
 ): Promise<number> => {
-  const result = (await getTokenStandardAndDetailsByChain(
+  const result = await getTokenStandardAndDetailsByChain(
     address,
     undefined,
     undefined,
     chainId,
-  )) as TokenDetailsERC20 | undefined | null;
+  );
 
   if (!result) {
     throw new Error(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Modify token decimal resolution for EIP-7715 permissions to throw an error during `eth_signTypedData_v4` requests and display raw units with a notice for granted permissions.

When processing a `wallet_requestExecutionPermissions` request, token metadata is retrieved from the chain directly (the user may be granting a permission to a token that was not previously imported into their wallet). If the token metadata is unable to be resolved, we cannot accurately display the terms of the permission, and the user may be misled into granting a larger permission that they intended. Previously a default `decimals: 18` was used.

When displaying a previously granted permission, it's important that we inform the user as best we can, even though the full data may not be available. In this case, if token metadata is unable to be retrieved, we simply show the raw token value with a notice indicating that the decimals was unable to be resolved.

Will now throw if any sign permission request is received where token metadata cannot be resolved - this shouldn't really happen, as the snap will reject the request earlier if metadata is not available.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40652?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Show granted Advanced Permissions values as raw units when token metadata cannot be resolved

## **Related issues**

Fixes:

## **Manual testing steps**

This is difficult to test without code changes, as it's covering an edgecase.

1. Request and grant erc20-token-stream or erc20-token-periodic permission (or have previously done so)
2. Hardcode an address in `useGatorPermissionTokenInfo()` and `fetchErc20DecimalsOrThrow()` that will not resolve an erc20 contract (use random address)
3. View permissions in "All Permissions" section - expect "raw units" to be shown
4. Request erc20-token-stream or erc20-token-periodic permission (with a legitimate erc20 token address)
5. Click "grant" on the permission picker screen
6. Expect error to be thrown on the sign permission screen

## **Screenshots/Recordings**

<img width="487" height="336" alt="image" src="https://github.com/user-attachments/assets/007a023c-abcd-4a70-8102-654609e9dd1e" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes permission signing and display behavior when ERC-20 decimals can’t be resolved, including throwing errors during `eth_signTypedData_v4` flows; this can block signing and impacts user-facing permission details rendering.
> 
> **Overview**
> Stops defaulting unresolved token decimals to `18` for advanced (EIP-7715) permissions and instead treats decimals as optional throughout token metadata.
> 
> For *already-granted permissions*, amount formatting now falls back to displaying **raw units** and appends a `(raw units)` note when decimals are missing (via `formatGatorAmountLabel` and the new `formatDecimalShiftedValue`).
> 
> For *permission signing/confirmation* (`erc20-token-*` typed-sign details), the UI now calls `fetchErc20DecimalsOrThrow` and **throws** if decimals can’t be resolved, with tests updated (including a new `TestErrorBoundary`) and console baseline adjustments for expected uncaught error logs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d70d5aa97fdf49446a422c3a85b011c942cfbca9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->