### PR TITLE
fix: MMQA-1546 address PR review comments for perps e2e POM files

### DIFF
--- a/test/e2e/page-objects/pages/perps/perps-home-page.ts
+++ b/test/e2e/page-objects/pages/perps/perps-home-page.ts
@@ -19,10 +19,6 @@ export class PerpsHomePage extends PerpsPositionsBase {
     testId: 'perps-home-back-button',
   };
 
-  private readonly perpsTabView = {
-    testId: 'perps-tab-view',
-  };
-
   private readonly perpsHomeSearchButton = {
     testId: 'perps-home-search-button',
   };
@@ -33,6 +29,10 @@ export class PerpsHomePage extends PerpsPositionsBase {
 
   private readonly perpsRecentActivitySeeAll = {
     testId: 'perps-recent-activity-see-all',
+  };
+
+  private readonly perpsTabView = {
+    testId: 'perps-tab-view',
   };
 
   private readonly perpsTutorialContinueButton = {

--- a/test/e2e/page-objects/pages/perps/perps-home-page.ts
+++ b/test/e2e/page-objects/pages/perps/perps-home-page.ts
@@ -1,5 +1,5 @@
-import { Driver } from '../../../webdriver/driver';
-import { PERPS_TAB_HASH } from '../../../tests/perps/helpers';
+import { PERPS_HOME_ROUTE } from '../../../tests/perps/helpers';
+import { PerpsPositionsBase } from './perps-positions-base';
 
 /**
  * Page object for the Perps tab (wallet home with perps tab selected).
@@ -7,8 +7,12 @@ import { PERPS_TAB_HASH } from '../../../tests/perps/helpers';
  *
  * @see ui/components/app/perps/perps-tab-view.tsx
  */
-export class PerpsHomePage {
-  private readonly driver: Driver;
+export class PerpsHomePage extends PerpsPositionsBase {
+  private readonly addFundsButton =
+    '[data-testid="perps-balance-actions-add-funds-empty"], [data-testid="perps-balance-actions-add-funds"]';
+
+  private readonly balanceSection =
+    '[data-testid="perps-balance-actions"], [data-testid="perps-balance-actions-empty"]';
 
   private readonly perpsHomeBackButton = {
     testId: 'perps-home-back-button',
@@ -22,14 +26,39 @@ export class PerpsHomePage {
     testId: 'perps-explore-markets-row',
   };
 
-  private readonly perpsPositionsSection = {
-    testId: 'perps-positions-section',
+  private readonly perpsHomeSearchButton = {
+    testId: 'perps-home-search-button',
+  };
+
+  private readonly perpsLearnBasics = { testId: 'perps-learn-basics' };
+
+  private readonly perpsRecentActivity = { testId: 'perps-recent-activity' };
+
+  private readonly perpsRecentActivitySeeAll = {
+    testId: 'perps-recent-activity-see-all',
+  };
+
+  private readonly perpsTutorialContinueButton = {
+    testId: 'perps-tutorial-continue-button',
+  };
+
+  private readonly perpsTutorialLetsGoButton = {
+    testId: 'perps-tutorial-lets-go-button',
+  };
+
+  private readonly perpsTutorialModal = { testId: 'perps-tutorial-modal' };
+
+  private readonly perpsWithdrawButton = {
+    testId: 'perps-balance-actions-withdraw',
   };
 
   private readonly positionCardsSelector = '[data-testid^="position-card-"]';
 
-  constructor(driver: Driver) {
-    this.driver = driver;
+  /**
+   * Checks that the Perps Home page back button is visible.
+   */
+  async checkBackButtonIsVisible(): Promise<void> {
+    await this.driver.waitForSelector(this.perpsHomeBackButton);
   }
 
   /**
@@ -40,41 +69,89 @@ export class PerpsHomePage {
   }
 
   /**
-   * Navigates to the wallet home with Perps tab selected and waits for the tab view to load.
+   * Checks that the Perps Home page search button is visible.
+   */
+  async checkSearchButtonIsVisible(): Promise<void> {
+    await this.driver.waitForSelector(this.perpsHomeSearchButton);
+  }
+
+  /**
+   * Clicks the Add funds button (visible in empty state or when balance exists).
+   */
+  async clickAddFunds(): Promise<void> {
+    await this.driver.waitForSelector(this.addFundsButton);
+    const addFundsElement = await this.driver.findElement(this.addFundsButton);
+    await this.driver.scrollToElement(addFundsElement);
+    await this.driver.clickElement(this.addFundsButton);
+  }
+
+  /**
+   * Clicks the "Learn the basics of perps" row (opens the tutorial modal).
+   */
+  async clickLearnBasics(): Promise<void> {
+    await this.driver.clickElement(this.perpsLearnBasics);
+  }
+
+  /**
+   * Clicks the "See All" link in the Recent Activity section (navigates to Perps Activity).
+   * Requires positions so Recent Activity section is visible.
+   */
+  async clickRecentActivitySeeAll(): Promise<void> {
+    await this.driver.clickElement(this.perpsRecentActivitySeeAll);
+  }
+
+  /**
+   * Clicks the search button in the header (navigates to Market List).
+   */
+  async clickSearchButton(): Promise<void> {
+    await this.driver.clickElement(this.perpsHomeSearchButton);
+  }
+
+  /**
+   * Clicks the Withdraw button (visible when account has balance).
+   */
+  async clickWithdraw(): Promise<void> {
+    await this.driver.clickElement(this.perpsWithdrawButton);
+  }
+
+  /**
+   * Waits for the tutorial modal and goes through all steps (Continue x5, then Let's go).
+   * clickElement uses findClickableElement and waits for the button to be visible and enabled.
+   */
+  async goThroughTutorialModal(): Promise<void> {
+    await this.driver.waitForSelector(this.perpsTutorialModal);
+    for (let i = 0; i < 5; i++) {
+      await this.driver.clickElement(this.perpsTutorialContinueButton);
+    }
+    await this.driver.clickElement(this.perpsTutorialLetsGoButton);
+  }
+
+  /**
+   * Navigates to the Perps Home route and waits for the page to load.
+   * Uses window.location.hash for SPA navigation without a full page reload.
    */
   async navigateToPerpsHome(): Promise<void> {
     await this.driver.executeScript(
-      `window.location.hash = '${PERPS_TAB_HASH}';`,
+      `window.location.hash = '${PERPS_HOME_ROUTE}';`,
     );
     await this.checkPageIsLoaded();
   }
 
   /**
-   * Checks that the Perps Home page back button is visible.
+   * Waits for the balance section to be visible (empty or with balance).
+   *
+   * @param timeout - Optional timeout in ms for the selector wait.
    */
-  async checkBackButtonIsVisible(): Promise<void> {
-    await this.driver.waitForSelector(this.perpsHomeBackButton);
-  }
-
-  /**
-   * Checks that the Explore markets row is visible (entry point to market list).
-   */
-  async checkSearchButtonIsVisible(): Promise<void> {
-    await this.driver.waitForSelector(this.perpsExploreMarketsRow);
-  }
-
-  /**
-   * Waits for the positions section to be visible (mock positions loaded).
-   */
-  async waitForPositionsSection(): Promise<void> {
-    await this.driver.waitForSelector(this.perpsPositionsSection);
+  async waitForBalanceSection(timeout?: number): Promise<void> {
+    await this.driver.waitForSelector(this.balanceSection, { timeout });
   }
 
   /**
    * Waits up to `timeout` ms for the number of position cards to equal `expectedCount`,
    * to avoid flakiness when the UI is still updating.
+   *
    * @param expectedCount - Expected number of position cards.
-   * @param timeout - Max wait time in ms (default 10000).
+   * @param timeout - Max wait time in ms (default 10 000).
    */
   async waitForPositionCardsCount(
     expectedCount: number,
@@ -97,102 +174,9 @@ export class PerpsHomePage {
   }
 
   /**
-   * Waits for a position card for the given symbol to be visible.
-   * @param symbol
-   */
-  async waitForPositionCard(symbol: string): Promise<void> {
-    await this.driver.waitForSelector({
-      testId: `position-card-${symbol}`,
-    });
-  }
-
-  /**
-   * Waits for the balance dropdown to be visible.
-   * @param timeout - Optional timeout in ms for the selector wait.
-   */
-  async waitForBalanceSection(timeout?: number): Promise<void> {
-    await this.driver.waitForSelector(
-      '[data-testid="perps-balance-dropdown"]',
-      { timeout },
-    );
-  }
-
-  /**
-   * Clicks the Add funds button (opens balance dropdown first, then clicks Add funds).
-   */
-  async clickAddFunds(): Promise<void> {
-    await this.driver.waitForSelector(
-      '[data-testid="perps-balance-dropdown-balance"]',
-    );
-    await this.driver.clickElement({
-      testId: 'perps-balance-dropdown-balance',
-    });
-    await this.driver.clickElement({
-      testId: 'perps-balance-dropdown-add-funds',
-    });
-  }
-
-  /**
-   * Clicks the Withdraw button (opens balance dropdown first, then clicks Withdraw).
-   */
-  async clickWithdraw(): Promise<void> {
-    await this.driver.waitForSelector(
-      '[data-testid="perps-balance-dropdown-balance"]',
-    );
-    await this.driver.clickElement({
-      testId: 'perps-balance-dropdown-balance',
-    });
-    await this.driver.clickElement({
-      testId: 'perps-balance-dropdown-withdraw',
-    });
-  }
-
-  /**
-   * Clicks the "See All" link in the Recent Activity section (navigates to Perps Activity).
-   * Requires positions so Recent Activity section is visible.
-   */
-  async clickRecentActivitySeeAll(): Promise<void> {
-    await this.driver.clickElement({
-      testId: 'perps-recent-activity-see-all',
-    });
-  }
-
-  /**
-   * Clicks the Explore markets row (navigates to Market List).
-   */
-  async clickSearchButton(): Promise<void> {
-    await this.driver.clickElement(this.perpsExploreMarketsRow);
-  }
-
-  /**
-   * Clicks the "Learn the basics of perps" row (opens the tutorial modal).
-   */
-  async clickLearnBasics(): Promise<void> {
-    await this.driver.clickElement({ testId: 'perps-learn-basics' });
-  }
-
-  /**
-   * Waits for the tutorial modal and goes through all steps (Continue x5, then Let's go).
-   * clickElement uses findClickableElement and waits for the button to be visible and enabled.
-   */
-  async goThroughTutorialModal(): Promise<void> {
-    await this.driver.waitForSelector({ testId: 'perps-tutorial-modal' });
-    for (let i = 0; i < 5; i++) {
-      await this.driver.clickElement({
-        testId: 'perps-tutorial-continue-button',
-      });
-    }
-    await this.driver.clickElement({
-      testId: 'perps-tutorial-lets-go-button',
-    });
-  }
-
-  /**
    * Waits for the Recent Activity section to be visible (when user has positions).
    */
   async waitForRecentActivitySection(): Promise<void> {
-    await this.driver.waitForSelector({
-      testId: 'perps-recent-activity',
-    });
+    await this.driver.waitForSelector(this.perpsRecentActivity);
   }
 }

--- a/test/e2e/page-objects/pages/perps/perps-home-page.ts
+++ b/test/e2e/page-objects/pages/perps/perps-home-page.ts
@@ -2,8 +2,9 @@ import { PERPS_HOME_ROUTE } from '../../../tests/perps/helpers';
 import { PerpsPositionsBase } from './perps-positions-base';
 
 /**
- * Page object for the Perps tab (wallet home with perps tab selected).
- * Content merged from former PerpsHomePage into PerpsTabView.
+ * Page object for the Perps Home view (balance, positions, explore markets, tutorial).
+ * Use this when the user is already on the Perps tab and you interact with the tab content.
+ * For opening the Perps tab from account overview, use PerpsTabPage first (e.g. openPerpsTab), then use this page.
  *
  * @see ui/components/app/perps/perps-tab-view.tsx
  */
@@ -128,7 +129,8 @@ export class PerpsHomePage extends PerpsPositionsBase {
 
   /**
    * Navigates to the Perps Home route and waits for the page to load.
-   * Uses window.location.hash for SPA navigation without a full page reload.
+   * Uses window.location.hash so the SPA router switches view without a full page reload,
+   * which keeps the extension context and avoids re-injecting the extension.
    */
   async navigateToPerpsHome(): Promise<void> {
     await this.driver.executeScript(
@@ -163,14 +165,6 @@ export class PerpsHomePage extends PerpsPositionsBase {
       );
       return elements.length === expectedCount;
     }, timeout);
-  }
-
-  /**
-   * Returns the number of position cards currently displayed.
-   */
-  async getPositionCardsCount(): Promise<number> {
-    const elements = await this.driver.findElements(this.positionCardsSelector);
-    return elements.length;
   }
 
   /**

--- a/test/e2e/page-objects/pages/perps/perps-home-page.ts
+++ b/test/e2e/page-objects/pages/perps/perps-home-page.ts
@@ -60,9 +60,14 @@ export class PerpsHomePage extends PerpsPositionsBase {
 
   /**
    * Waits for the Perps tab view to be loaded and visible.
+   * Uses multiple selectors for robustness (convention).
    */
   async checkPageIsLoaded(): Promise<void> {
-    await this.driver.waitForSelector(this.perpsTabView);
+    await this.driver.waitForMultipleSelectors([
+      this.perpsHomeBackButton,
+      this.perpsHomeSearchButton,
+      this.perpsTabView,
+    ]);
   }
 
   /**
@@ -76,9 +81,6 @@ export class PerpsHomePage extends PerpsPositionsBase {
    * Clicks the Add funds button (visible in empty state or when balance exists).
    */
   async clickAddFunds(): Promise<void> {
-    await this.driver.waitForSelector(this.addFundsButton);
-    const addFundsElement = await this.driver.findElement(this.addFundsButton);
-    await this.driver.scrollToElement(addFundsElement);
     await this.driver.clickElement(this.addFundsButton);
   }
 
@@ -120,13 +122,17 @@ export class PerpsHomePage extends PerpsPositionsBase {
     for (let i = 0; i < 5; i++) {
       await this.driver.clickElement(this.perpsTutorialContinueButton);
     }
-    await this.driver.clickElement(this.perpsTutorialLetsGoButton);
+    await this.driver.clickElementAndWaitToDisappear(
+      this.perpsTutorialLetsGoButton,
+    );
   }
 
   /**
    * Navigates to the Perps Home route and waits for the page to load.
    * Uses window.location.hash so the SPA router switches view without a full page reload,
    * which keeps the extension context and avoids re-injecting the extension.
+   * In the UI, users reach this screen by opening the Perps tab from the account overview;
+   * this method is a test shortcut to land directly on Perps Home.
    */
   async navigateToPerpsHome(): Promise<void> {
     await this.driver.executeScript(
@@ -137,16 +143,13 @@ export class PerpsHomePage extends PerpsPositionsBase {
 
   /**
    * Waits for the balance section to be visible (empty or with balance).
-   *
-   * @param timeout - Optional timeout in ms for the selector wait.
    */
-  async waitForBalanceSection(timeout?: number): Promise<void> {
-    await this.driver.waitForSelector(this.balanceSection, { timeout });
+  async waitForBalanceSection(): Promise<void> {
+    await this.driver.waitForSelector(this.balanceSection);
   }
 
   /**
-   * Waits up to `timeout` ms for the number of position cards to equal `expectedCount`,
-   * to avoid flakiness when the UI is still updating.
+   * Waits until the number of position cards equals `expectedCount` (uses waitUntil to avoid race conditions).
    *
    * @param expectedCount - Expected number of position cards.
    * @param timeout - Max wait time in ms (default 10 000).
@@ -155,12 +158,15 @@ export class PerpsHomePage extends PerpsPositionsBase {
     expectedCount: number,
     timeout = 10000,
   ): Promise<void> {
-    await this.driver.wait(async () => {
-      const elements = await this.driver.findElements(
-        this.positionCardsSelector,
-      );
-      return elements.length === expectedCount;
-    }, timeout);
+    await this.driver.waitUntil(
+      async () => {
+        const elements = await this.driver.findElements(
+          this.positionCardsSelector,
+        );
+        return elements.length === expectedCount;
+      },
+      { timeout, interval: 500 },
+    );
   }
 
   /**

--- a/test/e2e/page-objects/pages/perps/perps-home-page.ts
+++ b/test/e2e/page-objects/pages/perps/perps-home-page.ts
@@ -23,10 +23,6 @@ export class PerpsHomePage extends PerpsPositionsBase {
     testId: 'perps-tab-view',
   };
 
-  private readonly perpsExploreMarketsRow = {
-    testId: 'perps-explore-markets-row',
-  };
-
   private readonly perpsHomeSearchButton = {
     testId: 'perps-home-search-button',
   };

--- a/test/e2e/page-objects/pages/perps/perps-home-page.ts
+++ b/test/e2e/page-objects/pages/perps/perps-home-page.ts
@@ -8,6 +8,10 @@ import { PerpsPositionsBase } from './perps-positions-base';
  * @see ui/components/app/perps/perps-tab-view.tsx
  */
 export class PerpsHomePage extends PerpsPositionsBase {
+  private readonly accountOverviewPerpsTab = {
+    testId: 'account-overview__perps-tab',
+  };
+
   private readonly addFundsButton = {
     testId: 'perps-balance-dropdown-add-funds',
   };
@@ -16,8 +20,16 @@ export class PerpsHomePage extends PerpsPositionsBase {
     testId: 'perps-balance-dropdown-balance',
   };
 
-  private readonly balanceSection = {
+  private readonly balanceDropdownWithdraw = {
+    testId: 'perps-balance-dropdown-withdraw',
+  };
+
+  private readonly perpsBalanceDropdown = {
     testId: 'perps-balance-dropdown',
+  };
+
+  private readonly perpsExploreMarketsRow = {
+    testId: 'perps-explore-markets-row',
   };
 
   private readonly perpsLearnBasics = { testId: 'perps-learn-basics' };
@@ -28,16 +40,8 @@ export class PerpsHomePage extends PerpsPositionsBase {
     testId: 'perps-recent-activity-see-all',
   };
 
-  private readonly perpsExploreMarketsRow = {
-    testId: 'perps-explore-markets-row',
-  };
-
   private readonly perpsTabView = {
     testId: 'perps-tab-view',
-  };
-
-  private readonly perpsBalanceDropdown = {
-    testId: 'perps-balance-dropdown',
   };
 
   private readonly perpsTutorialContinueButton = {
@@ -50,15 +54,7 @@ export class PerpsHomePage extends PerpsPositionsBase {
 
   private readonly perpsTutorialModal = { testId: 'perps-tutorial-modal' };
 
-  private readonly balanceDropdownWithdraw = {
-    testId: 'perps-balance-dropdown-withdraw',
-  };
-
   private readonly positionCardsSelector = '[data-testid^="position-card-"]';
-
-  private readonly accountOverviewPerpsTab = {
-    testId: 'account-overview__perps-tab',
-  };
 
   /**
    * Waits for the Perps Home view to be loaded and visible.
@@ -81,6 +77,13 @@ export class PerpsHomePage extends PerpsPositionsBase {
   }
 
   /**
+   * Clicks the "Explore markets" row (navigates to Perps Market List).
+   */
+  async clickExploreMarketsRow(): Promise<void> {
+    await this.driver.clickElement(this.perpsExploreMarketsRow);
+  }
+
+  /**
    * Clicks the "Learn the basics of perps" row (opens the tutorial modal).
    */
   async clickLearnBasics(): Promise<void> {
@@ -93,13 +96,6 @@ export class PerpsHomePage extends PerpsPositionsBase {
    */
   async clickRecentActivitySeeAll(): Promise<void> {
     await this.driver.clickElement(this.perpsRecentActivitySeeAll);
-  }
-
-  /**
-   * Clicks the "Explore markets" row (navigates to Perps Market List).
-   */
-  async clickExploreMarketsRow(): Promise<void> {
-    await this.driver.clickElement(this.perpsExploreMarketsRow);
   }
 
   /**
@@ -140,7 +136,7 @@ export class PerpsHomePage extends PerpsPositionsBase {
    * Waits for the balance section to be visible (empty or with balance).
    */
   async waitForBalanceSection(): Promise<void> {
-    await this.driver.waitForSelector(this.balanceSection);
+    await this.driver.waitForSelector(this.perpsBalanceDropdown);
   }
 
   /**

--- a/test/e2e/page-objects/pages/perps/perps-home-page.ts
+++ b/test/e2e/page-objects/pages/perps/perps-home-page.ts
@@ -8,22 +8,16 @@ import { PerpsPositionsBase } from './perps-positions-base';
  * @see ui/components/app/perps/perps-tab-view.tsx
  */
 export class PerpsHomePage extends PerpsPositionsBase {
-  private readonly addFundsButton =
-    '[data-testid="perps-balance-dropdown-add-funds"], [data-testid="perps-balance-actions-add-funds-empty"], [data-testid="perps-balance-actions-add-funds"]';
+  private readonly addFundsButton = {
+    testId: 'perps-balance-dropdown-add-funds',
+  };
 
   private readonly balanceDropdownBalanceRow = {
     testId: 'perps-balance-dropdown-balance',
   };
 
-  private readonly balanceSection =
-    '[data-testid="perps-balance-dropdown"], [data-testid="perps-balance-actions"], [data-testid="perps-balance-actions-empty"]';
-
-  private readonly perpsHomeBackButton = {
-    testId: 'perps-home-back-button',
-  };
-
-  private readonly perpsHomeSearchButton = {
-    testId: 'perps-home-search-button',
+  private readonly balanceSection = {
+    testId: 'perps-balance-dropdown',
   };
 
   private readonly perpsLearnBasics = { testId: 'perps-learn-basics' };
@@ -32,6 +26,10 @@ export class PerpsHomePage extends PerpsPositionsBase {
 
   private readonly perpsRecentActivitySeeAll = {
     testId: 'perps-recent-activity-see-all',
+  };
+
+  private readonly perpsExploreMarketsRow = {
+    testId: 'perps-explore-markets-row',
   };
 
   private readonly perpsTabView = {
@@ -52,10 +50,6 @@ export class PerpsHomePage extends PerpsPositionsBase {
 
   private readonly perpsTutorialModal = { testId: 'perps-tutorial-modal' };
 
-  private readonly perpsWithdrawButton = {
-    testId: 'perps-balance-actions-withdraw',
-  };
-
   private readonly balanceDropdownWithdraw = {
     testId: 'perps-balance-dropdown-withdraw',
   };
@@ -67,28 +61,14 @@ export class PerpsHomePage extends PerpsPositionsBase {
   };
 
   /**
-   * Checks that the Perps Home page back button is visible.
-   */
-  async checkBackButtonIsVisible(): Promise<void> {
-    await this.driver.waitForSelector(this.perpsHomeBackButton);
-  }
-
-  /**
    * Waits for the Perps Home view to be loaded and visible.
-   * The main Perps tab shows PerpsTabView (balance dropdown, positions, explore) with no back/search header.
+   * The main Perps tab shows PerpsTabView (balance dropdown, positions, explore).
    */
   async checkPageIsLoaded(): Promise<void> {
     await this.driver.waitForMultipleSelectors([
       this.perpsTabView,
       this.perpsBalanceDropdown,
     ]);
-  }
-
-  /**
-   * Checks that the Perps Home page search button is visible.
-   */
-  async checkSearchButtonIsVisible(): Promise<void> {
-    await this.driver.waitForSelector(this.perpsHomeSearchButton);
   }
 
   /**
@@ -116,10 +96,10 @@ export class PerpsHomePage extends PerpsPositionsBase {
   }
 
   /**
-   * Clicks the search button in the header (navigates to Market List).
+   * Clicks the "Explore markets" row (navigates to Perps Market List).
    */
-  async clickSearchButton(): Promise<void> {
-    await this.driver.clickElement(this.perpsHomeSearchButton);
+  async clickExploreMarketsRow(): Promise<void> {
+    await this.driver.clickElement(this.perpsExploreMarketsRow);
   }
 
   /**

--- a/test/e2e/page-objects/pages/perps/perps-home-page.ts
+++ b/test/e2e/page-objects/pages/perps/perps-home-page.ts
@@ -1,4 +1,3 @@
-import { PERPS_HOME_ROUTE } from '../../../tests/perps/helpers';
 import { PerpsPositionsBase } from './perps-positions-base';
 
 /**
@@ -10,10 +9,14 @@ import { PerpsPositionsBase } from './perps-positions-base';
  */
 export class PerpsHomePage extends PerpsPositionsBase {
   private readonly addFundsButton =
-    '[data-testid="perps-balance-actions-add-funds-empty"], [data-testid="perps-balance-actions-add-funds"]';
+    '[data-testid="perps-balance-dropdown-add-funds"], [data-testid="perps-balance-actions-add-funds-empty"], [data-testid="perps-balance-actions-add-funds"]';
+
+  private readonly balanceDropdownBalanceRow = {
+    testId: 'perps-balance-dropdown-balance',
+  };
 
   private readonly balanceSection =
-    '[data-testid="perps-balance-actions"], [data-testid="perps-balance-actions-empty"]';
+    '[data-testid="perps-balance-dropdown"], [data-testid="perps-balance-actions"], [data-testid="perps-balance-actions-empty"]';
 
   private readonly perpsHomeBackButton = {
     testId: 'perps-home-back-button',
@@ -35,6 +38,10 @@ export class PerpsHomePage extends PerpsPositionsBase {
     testId: 'perps-tab-view',
   };
 
+  private readonly perpsBalanceDropdown = {
+    testId: 'perps-balance-dropdown',
+  };
+
   private readonly perpsTutorialContinueButton = {
     testId: 'perps-tutorial-continue-button',
   };
@@ -49,7 +56,15 @@ export class PerpsHomePage extends PerpsPositionsBase {
     testId: 'perps-balance-actions-withdraw',
   };
 
+  private readonly balanceDropdownWithdraw = {
+    testId: 'perps-balance-dropdown-withdraw',
+  };
+
   private readonly positionCardsSelector = '[data-testid^="position-card-"]';
+
+  private readonly accountOverviewPerpsTab = {
+    testId: 'account-overview__perps-tab',
+  };
 
   /**
    * Checks that the Perps Home page back button is visible.
@@ -59,14 +74,13 @@ export class PerpsHomePage extends PerpsPositionsBase {
   }
 
   /**
-   * Waits for the Perps tab view to be loaded and visible.
-   * Uses multiple selectors for robustness (convention).
+   * Waits for the Perps Home view to be loaded and visible.
+   * The main Perps tab shows PerpsTabView (balance dropdown, positions, explore) with no back/search header.
    */
   async checkPageIsLoaded(): Promise<void> {
     await this.driver.waitForMultipleSelectors([
-      this.perpsHomeBackButton,
-      this.perpsHomeSearchButton,
       this.perpsTabView,
+      this.perpsBalanceDropdown,
     ]);
   }
 
@@ -78,9 +92,11 @@ export class PerpsHomePage extends PerpsPositionsBase {
   }
 
   /**
-   * Clicks the Add funds button (visible in empty state or when balance exists).
+   * Clicks the Add funds button. On Perps Home the balance is in a dropdown:
+   * opens the dropdown first, then clicks Add funds.
    */
   async clickAddFunds(): Promise<void> {
+    await this.driver.clickElement(this.balanceDropdownBalanceRow);
     await this.driver.clickElement(this.addFundsButton);
   }
 
@@ -107,10 +123,12 @@ export class PerpsHomePage extends PerpsPositionsBase {
   }
 
   /**
-   * Clicks the Withdraw button (visible when account has balance).
+   * Clicks the Withdraw button. On Perps Home the balance is in a dropdown:
+   * opens the dropdown first, then clicks Withdraw.
    */
   async clickWithdraw(): Promise<void> {
-    await this.driver.clickElement(this.perpsWithdrawButton);
+    await this.driver.clickElement(this.balanceDropdownBalanceRow);
+    await this.driver.clickElement(this.balanceDropdownWithdraw);
   }
 
   /**
@@ -128,16 +146,13 @@ export class PerpsHomePage extends PerpsPositionsBase {
   }
 
   /**
-   * Navigates to the Perps Home route and waits for the page to load.
-   * Uses window.location.hash so the SPA router switches view without a full page reload,
-   * which keeps the extension context and avoids re-injecting the extension.
-   * In the UI, users reach this screen by opening the Perps tab from the account overview;
-   * this method is a test shortcut to land directly on Perps Home.
+   * Navigates to Perps Home by clicking the Perps tab on the account overview.
+   * Requires the account overview to be visible (e.g. after login or driver.navigate()).
+   * Waits for the Perps tab to be present, clicks it, then waits for the Perps Home view to load.
    */
   async navigateToPerpsHome(): Promise<void> {
-    await this.driver.executeScript(
-      `window.location.hash = '${PERPS_HOME_ROUTE}';`,
-    );
+    await this.driver.waitForSelector(this.accountOverviewPerpsTab);
+    await this.driver.clickElement(this.accountOverviewPerpsTab);
     await this.checkPageIsLoaded();
   }
 

--- a/test/e2e/page-objects/pages/perps/perps-home-page.ts
+++ b/test/e2e/page-objects/pages/perps/perps-home-page.ts
@@ -8,10 +8,6 @@ import { PerpsPositionsBase } from './perps-positions-base';
  * @see ui/components/app/perps/perps-tab-view.tsx
  */
 export class PerpsHomePage extends PerpsPositionsBase {
-  private readonly accountOverviewPerpsTab = {
-    testId: 'account-overview__perps-tab',
-  };
-
   private readonly addFundsButton = {
     testId: 'perps-balance-dropdown-add-funds',
   };

--- a/test/e2e/page-objects/pages/perps/perps-market-detail-page.ts
+++ b/test/e2e/page-objects/pages/perps/perps-market-detail-page.ts
@@ -116,10 +116,11 @@ export class PerpsMarketDetailPage {
 
   /**
    * Navigates to the market detail page for the given symbol.
-   * Uses window.location.hash for SPA navigation without a full page reload.
+   * Uses window.location.hash so the SPA router switches view without a full page reload,
+   * which keeps the extension context and avoids re-injecting the extension.
    * Use a symbol with no existing position (e.g. AVAX) to see Long/Short buttons.
    *
-   * @param symbol
+   * @param symbol - Market symbol (e.g. 'AVAX', 'ETH').
    */
   async navigateToMarket(symbol: string): Promise<void> {
     const encoded = encodeURIComponent(symbol);
@@ -155,16 +156,9 @@ export class PerpsMarketDetailPage {
   }
 
   /**
-   * Waits for the submit button to be present (order form visible).
-   */
-  async waitForSubmitButton(): Promise<void> {
-    await this.driver.waitForSelector(this.submitOrderButton);
-  }
-
-  /**
    * Waits for the Long/Short trade buttons (visible when user has no position in this market).
    *
-   * @param timeout
+   * @param timeout - Optional timeout in ms.
    */
   async waitForTradeCtaButtons(timeout?: number): Promise<void> {
     await this.driver.waitForSelector(this.tradeCtaButtons, { timeout });

--- a/test/e2e/page-objects/pages/perps/perps-market-detail-page.ts
+++ b/test/e2e/page-objects/pages/perps/perps-market-detail-page.ts
@@ -20,11 +20,13 @@ export class PerpsMarketDetailPage {
 
   private readonly marketDetailPage = { testId: 'perps-market-detail-page' };
 
+  private readonly marketDetailBackButton = {
+    testId: 'perps-market-detail-back-button',
+  };
+
   private readonly modifyCtaButton = { testId: 'perps-modify-cta-button' };
 
   private readonly orderEntry = { testId: 'order-entry' };
-
-  private readonly percentPreset25 = { testId: 'percent-preset-25' };
 
   private readonly positionCtaButtons = {
     testId: 'perps-position-cta-buttons',
@@ -43,31 +45,25 @@ export class PerpsMarketDetailPage {
   /**
    * Asserts that the Close button is visible.
    * Requires an open position in this market.
-   *
-   * @param timeout
    */
-  async checkCloseButtonVisible(timeout?: number): Promise<void> {
-    await this.driver.waitForSelector(this.closeCtaButton, { timeout });
+  async checkCloseButtonVisible(): Promise<void> {
+    await this.driver.waitForSelector(this.closeCtaButton);
   }
 
   /**
    * Asserts that the Modify button is visible.
    * Requires an open position in this market.
-   *
-   * @param timeout
    */
-  async checkModifyButtonVisible(timeout?: number): Promise<void> {
-    await this.driver.waitForSelector(this.modifyCtaButton, { timeout });
+  async checkModifyButtonVisible(): Promise<void> {
+    await this.driver.waitForSelector(this.modifyCtaButton);
   }
 
   /**
    * Asserts that the position CTA buttons (Modify/Close) are visible.
    * Call after placing an order to verify the position was opened.
-   *
-   * @param timeout
    */
-  async checkPositionCtaButtonsVisible(timeout?: number): Promise<void> {
-    await this.waitForPositionCtaButtons(timeout);
+  async checkPositionCtaButtonsVisible(): Promise<void> {
+    await this.waitForPositionCtaButtons();
   }
 
   /**
@@ -78,10 +74,14 @@ export class PerpsMarketDetailPage {
   }
 
   /**
-   * Clicks the 25% balance preset to set order amount.
+   * Clicks a balance preset button by percentage (e.g. 25, 50, 75, 100).
+   *
+   * @param percentage - The preset percentage (e.g. 25 for 25%).
    */
-  async clickPercentPreset25(): Promise<void> {
-    await this.driver.clickElement(this.percentPreset25);
+  async clickPercentPreset(percentage: number): Promise<void> {
+    await this.driver.clickElement({
+      testId: `percent-preset-${percentage}`,
+    });
   }
 
   /**
@@ -92,11 +92,16 @@ export class PerpsMarketDetailPage {
   }
 
   /**
-   * Clicks the Submit order button.
-   * clickElement uses findClickableElement and waits for the button to be visible and enabled.
+   * Clicks the Submit order button and waits for it to disappear (e.g. modal closes).
+   * Optional custom timeout for slow environments.
+   *
+   * @param timeout - Optional wait timeout in ms (default 3000).
    */
-  async clickSubmitOrder(): Promise<void> {
-    await this.driver.clickElement(this.submitOrderButton);
+  async clickSubmitOrder(timeout = 3000): Promise<void> {
+    await this.driver.clickElementAndWaitToDisappear(
+      this.submitOrderButton,
+      timeout,
+    );
   }
 
   /**
@@ -127,7 +132,7 @@ export class PerpsMarketDetailPage {
     await this.driver.executeScript(
       `window.location.hash = '${PERPS_MARKET_DETAIL_ROUTE}/${encoded}';`,
     );
-    await this.waitForPageLoaded();
+    await this.checkPageIsLoaded();
   }
 
   /**
@@ -139,28 +144,28 @@ export class PerpsMarketDetailPage {
 
   /**
    * Waits for the market detail page to be loaded.
+   * Uses multiple selectors for robustness (convention).
    */
-  async waitForPageLoaded(): Promise<void> {
-    await this.driver.waitForSelector(this.marketDetailPage);
+  async checkPageIsLoaded(): Promise<void> {
+    await this.driver.waitForMultipleSelectors([
+      this.marketDetailBackButton,
+      this.marketDetailPage,
+    ]);
   }
 
   /**
    * Waits for the Modify/Close buttons (visible when user has an open position in this market).
    * Use after placing an order to confirm the position was opened and the stream updated.
    * Fails the test if the buttons do not appear within the timeout.
-   *
-   * @param timeout
    */
-  async waitForPositionCtaButtons(timeout?: number): Promise<void> {
-    await this.driver.waitForSelector(this.positionCtaButtons, { timeout });
+  async waitForPositionCtaButtons(): Promise<void> {
+    await this.driver.waitForSelector(this.positionCtaButtons);
   }
 
   /**
    * Waits for the Long/Short trade buttons (visible when user has no position in this market).
-   *
-   * @param timeout - Optional timeout in ms.
    */
-  async waitForTradeCtaButtons(timeout?: number): Promise<void> {
-    await this.driver.waitForSelector(this.tradeCtaButtons, { timeout });
+  async waitForTradeCtaButtons(): Promise<void> {
+    await this.driver.waitForSelector(this.tradeCtaButtons);
   }
 }

--- a/test/e2e/page-objects/pages/perps/perps-market-detail-page.ts
+++ b/test/e2e/page-objects/pages/perps/perps-market-detail-page.ts
@@ -9,104 +9,65 @@ import { PERPS_MARKET_DETAIL_ROUTE } from '../../../tests/perps/helpers';
 export class PerpsMarketDetailPage {
   private readonly driver: Driver;
 
+  private readonly amountInputField = { testId: 'amount-input-field' };
+
+  private readonly amountInputFieldInput =
+    '[data-testid="amount-input-field"] input';
+
+  private readonly closeCtaButton = { testId: 'perps-close-cta-button' };
+
+  private readonly longCtaButton = { testId: 'perps-long-cta-button' };
+
   private readonly marketDetailPage = { testId: 'perps-market-detail-page' };
 
-  private readonly tradeCtaButtons = { testId: 'perps-trade-cta-buttons' };
+  private readonly modifyCtaButton = { testId: 'perps-modify-cta-button' };
+
+  private readonly orderEntry = { testId: 'order-entry' };
+
+  private readonly percentPreset25 = { testId: 'percent-preset-25' };
 
   private readonly positionCtaButtons = {
     testId: 'perps-position-cta-buttons',
   };
 
-  private readonly longCtaButton = { testId: 'perps-long-cta-button' };
-
   private readonly shortCtaButton = { testId: 'perps-short-cta-button' };
 
   private readonly submitOrderButton = { testId: 'submit-order-button' };
 
-  private readonly orderEntry = { testId: 'order-entry' };
-
-  /** Container for amount (testId is on TextField wrapper). */
-  private readonly amountInputField = { testId: 'amount-input-field' };
-
-  /** Actual input element to fill (inside the TextField wrapper). */
-  private readonly amountInputFieldInput =
-    '[data-testid="amount-input-field"] input';
-
-  private readonly percentPreset25 = { testId: 'percent-preset-25' };
+  private readonly tradeCtaButtons = { testId: 'perps-trade-cta-buttons' };
 
   constructor(driver: Driver) {
     this.driver = driver;
   }
 
   /**
-   * Navigates to the market detail page for the given symbol.
-   * Use a symbol with no existing position (e.g. AVAX) to see Long/Short buttons.
-   * @param symbol
-   */
-  async navigateToMarket(symbol: string): Promise<void> {
-    const encoded = encodeURIComponent(symbol);
-    await this.driver.executeScript(
-      `window.location.hash = '${PERPS_MARKET_DETAIL_ROUTE}/${encoded}';`,
-    );
-    await this.waitForPageLoaded();
-  }
-
-  /**
-   * Waits for the market detail page to be loaded.
-   */
-  async waitForPageLoaded(): Promise<void> {
-    await this.driver.waitForSelector(this.marketDetailPage);
-  }
-
-  /**
-   * Waits for the Long/Short trade buttons (visible when user has no position in this market).
+   * Asserts that the Close button is visible.
+   * Requires an open position in this market.
+   *
    * @param timeout
    */
-  async waitForTradeCtaButtons(timeout?: number): Promise<void> {
-    await this.driver.waitForSelector(this.tradeCtaButtons, { timeout });
+  async checkCloseButtonVisible(timeout?: number): Promise<void> {
+    await this.driver.waitForSelector(this.closeCtaButton, { timeout });
   }
 
   /**
-   * Waits for the Modify/Close buttons (visible when user has an open position in this market).
-   * Use after placing an order to confirm the position was opened and the stream updated.
-   * Fails the test if the buttons do not appear within the timeout.
+   * Asserts that the Modify button is visible.
+   * Requires an open position in this market.
+   *
    * @param timeout
    */
-  async waitForPositionCtaButtons(timeout?: number): Promise<void> {
-    await this.driver.waitForSelector(this.positionCtaButtons, { timeout });
+  async checkModifyButtonVisible(timeout?: number): Promise<void> {
+    await this.driver.waitForSelector(this.modifyCtaButton, { timeout });
   }
 
   /**
    * Asserts that the position CTA buttons (Modify/Close) are visible.
    * Call after placing an order to verify the position was opened.
+   *
    * @param timeout
    */
   async checkPositionCtaButtonsVisible(timeout?: number): Promise<void> {
     await this.waitForPositionCtaButtons(timeout);
-  }
-
-  /**
-   * Asserts that the Modify button is visible (same as Close: only checks the button).
-   * Requires an open position in this market.
-   * @param timeout
-   */
-  async checkModifyButtonVisible(timeout?: number): Promise<void> {
-    await this.driver.waitForSelector(
-      { testId: 'perps-modify-cta-button' },
-      { timeout },
-    );
-  }
-
-  /**
-   * Asserts that the Close button is visible (only checks the button).
-   * Requires an open position in this market.
-   * @param timeout
-   */
-  async checkCloseButtonVisible(timeout?: number): Promise<void> {
-    await this.driver.waitForSelector(
-      { testId: 'perps-close-cta-button' },
-      { timeout },
-    );
   }
 
   /**
@@ -117,20 +78,6 @@ export class PerpsMarketDetailPage {
   }
 
   /**
-   * Clicks the Short button to open the order entry for a new short position.
-   */
-  async clickShort(): Promise<void> {
-    await this.driver.clickElement(this.shortCtaButton);
-  }
-
-  /**
-   * Waits for the order entry form to be visible.
-   */
-  async waitForOrderEntry(): Promise<void> {
-    await this.driver.waitForSelector(this.orderEntry);
-  }
-
-  /**
    * Clicks the 25% balance preset to set order amount.
    */
   async clickPercentPreset25(): Promise<void> {
@@ -138,8 +85,24 @@ export class PerpsMarketDetailPage {
   }
 
   /**
+   * Clicks the Short button to open the order entry for a new short position.
+   */
+  async clickShort(): Promise<void> {
+    await this.driver.clickElement(this.shortCtaButton);
+  }
+
+  /**
+   * Clicks the Submit order button.
+   * clickElement uses findClickableElement and waits for the button to be visible and enabled.
+   */
+  async clickSubmitOrder(): Promise<void> {
+    await this.driver.clickElement(this.submitOrderButton);
+  }
+
+  /**
    * Types an amount in the amount input (USD).
    * Targets the actual input inside the amount field so fill works.
+   *
    * @param amount
    */
   async fillAmount(amount: string): Promise<void> {
@@ -152,11 +115,43 @@ export class PerpsMarketDetailPage {
   }
 
   /**
-   * Clicks the Submit order button.
-   * clickElement uses findClickableElement and waits for the button to be visible and enabled.
+   * Navigates to the market detail page for the given symbol.
+   * Uses window.location.hash for SPA navigation without a full page reload.
+   * Use a symbol with no existing position (e.g. AVAX) to see Long/Short buttons.
+   *
+   * @param symbol
    */
-  async clickSubmitOrder(): Promise<void> {
-    await this.driver.clickElement(this.submitOrderButton);
+  async navigateToMarket(symbol: string): Promise<void> {
+    const encoded = encodeURIComponent(symbol);
+    await this.driver.executeScript(
+      `window.location.hash = '${PERPS_MARKET_DETAIL_ROUTE}/${encoded}';`,
+    );
+    await this.waitForPageLoaded();
+  }
+
+  /**
+   * Waits for the order entry form to be visible.
+   */
+  async waitForOrderEntry(): Promise<void> {
+    await this.driver.waitForSelector(this.orderEntry);
+  }
+
+  /**
+   * Waits for the market detail page to be loaded.
+   */
+  async waitForPageLoaded(): Promise<void> {
+    await this.driver.waitForSelector(this.marketDetailPage);
+  }
+
+  /**
+   * Waits for the Modify/Close buttons (visible when user has an open position in this market).
+   * Use after placing an order to confirm the position was opened and the stream updated.
+   * Fails the test if the buttons do not appear within the timeout.
+   *
+   * @param timeout
+   */
+  async waitForPositionCtaButtons(timeout?: number): Promise<void> {
+    await this.driver.waitForSelector(this.positionCtaButtons, { timeout });
   }
 
   /**
@@ -167,27 +162,11 @@ export class PerpsMarketDetailPage {
   }
 
   /**
-   * Waits for the submit button to be enabled (form valid and ready to submit).
-   * Use after filling amount to avoid clicking while the button is still disabled.
+   * Waits for the Long/Short trade buttons (visible when user has no position in this market).
+   *
    * @param timeout
    */
-  async waitForSubmitButtonEnabled(timeout?: number): Promise<void> {
-    await this.driver.waitForSelector(this.submitOrderButton, {
-      state: 'enabled',
-      timeout,
-    });
-  }
-
-  /**
-   * Waits for the order form to close after submit (submit button removed from DOM).
-   * The UI switches to detail view when the position appears in the stream or after a fallback timeout.
-   * Use after clickSubmitOrder() to know when submission finished and we left the order view.
-   * @param timeout
-   */
-  async waitForOrderFormClosed(timeout?: number): Promise<void> {
-    await this.driver.waitForSelector(this.submitOrderButton, {
-      state: 'detached',
-      timeout,
-    });
+  async waitForTradeCtaButtons(timeout?: number): Promise<void> {
+    await this.driver.waitForSelector(this.tradeCtaButtons, { timeout });
   }
 }

--- a/test/e2e/page-objects/pages/perps/perps-market-detail-page.ts
+++ b/test/e2e/page-objects/pages/perps/perps-market-detail-page.ts
@@ -1,5 +1,4 @@
 import { Driver } from '../../../webdriver/driver';
-import { PERPS_MARKET_DETAIL_ROUTE } from '../../../tests/perps/helpers';
 
 /**
  * Page object for the Perps Market Detail page (single market, order entry).
@@ -120,18 +119,16 @@ export class PerpsMarketDetailPage {
   }
 
   /**
-   * Navigates to the market detail page for the given symbol.
-   * Uses window.location.hash so the SPA router switches view without a full page reload,
-   * which keeps the extension context and avoids re-injecting the extension.
+   * Navigates to the market detail page by clicking the market row in the Market List.
+   * Requires the Perps Market List to be visible (e.g. after navigateToMarketList()).
    * Use a symbol with no existing position (e.g. AVAX) to see Long/Short buttons.
    *
-   * @param symbol - Market symbol (e.g. 'AVAX', 'ETH').
+   * @param symbol - Market symbol (e.g. 'AVAX', 'ETH'). Colons are replaced with dashes to match the UI testid.
    */
   async navigateToMarket(symbol: string): Promise<void> {
-    const encoded = encodeURIComponent(symbol);
-    await this.driver.executeScript(
-      `window.location.hash = '${PERPS_MARKET_DETAIL_ROUTE}/${encoded}';`,
-    );
+    const marketRowTestId = `market-row-${symbol.replaceAll(':', '-')}`;
+    await this.driver.waitForSelector({ testId: marketRowTestId });
+    await this.driver.clickElement({ testId: marketRowTestId });
     await this.checkPageIsLoaded();
   }
 

--- a/test/e2e/page-objects/pages/perps/perps-market-list-page.ts
+++ b/test/e2e/page-objects/pages/perps/perps-market-list-page.ts
@@ -15,7 +15,8 @@ export class PerpsMarketListPage {
 
   private readonly marketListView = { testId: 'market-list-view' };
 
-  private readonly searchInput = { testId: 'search-input' };
+  /** CSS selector for the search input; driver.fill() expects a string locator. */
+  private readonly searchInput = '[data-testid="search-input"]';
 
   private readonly sortDropdownButton = { testId: 'sort-dropdown-button' };
 

--- a/test/e2e/page-objects/pages/perps/perps-market-list-page.ts
+++ b/test/e2e/page-objects/pages/perps/perps-market-list-page.ts
@@ -9,13 +9,13 @@ import { PERPS_MARKET_LIST_ROUTE } from '../../../tests/perps/helpers';
 export class PerpsMarketListPage {
   private readonly driver: Driver;
 
-  private readonly marketListView = { testId: 'market-list-view' };
+  private readonly filterSelectButton = { testId: 'filter-select-button' };
 
   private readonly filterSortRow = { testId: 'market-list-filter-sort-row' };
 
-  private readonly searchInput = '[data-testid="search-input"]';
+  private readonly marketListView = { testId: 'market-list-view' };
 
-  private readonly filterSelectButton = { testId: 'filter-select-button' };
+  private readonly searchInput = { testId: 'search-input' };
 
   private readonly sortDropdownButton = { testId: 'sort-dropdown-button' };
 
@@ -24,7 +24,18 @@ export class PerpsMarketListPage {
   }
 
   /**
+   * Fills the search input with the given query.
+   *
+   * @param query
+   */
+  async fillSearch(query: string): Promise<void> {
+    await this.driver.waitForSelector(this.searchInput);
+    await this.driver.fill(this.searchInput, query);
+  }
+
+  /**
    * Navigates to the Perps Market List route and waits for the page to load.
+   * Uses window.location.hash for SPA navigation without a full page reload.
    */
   async navigateToMarketList(): Promise<void> {
     await this.driver.executeScript(
@@ -34,31 +45,9 @@ export class PerpsMarketListPage {
   }
 
   /**
-   * Waits for the market list view to be visible.
-   */
-  async waitForPageLoaded(): Promise<void> {
-    await this.driver.waitForSelector(this.marketListView);
-  }
-
-  /**
-   * Waits for the filter/sort row to be visible (hidden when search has text).
-   */
-  async waitForFilterSortRow(): Promise<void> {
-    await this.driver.waitForSelector(this.filterSortRow);
-  }
-
-  /**
-   * Fills the search input with the given query.
-   * @param query
-   */
-  async fillSearch(query: string): Promise<void> {
-    await this.driver.waitForSelector(this.searchInput);
-    await this.driver.fill(this.searchInput, query);
-  }
-
-  /**
    * Selects a filter by type (e.g. 'crypto', 'all').
    * Opens the filter dropdown and clicks the option.
+   *
    * @param optionId - 'all' | 'crypto' | 'stocks' | 'commodities' | 'forex' | 'new'
    */
   async selectFilter(optionId: string): Promise<void> {
@@ -90,5 +79,19 @@ export class PerpsMarketListPage {
     await this.driver.clickElement({
       testId: 'sort-dropdown-option-volumeLow',
     });
+  }
+
+  /**
+   * Waits for the filter/sort row to be visible (hidden when search has text).
+   */
+  async waitForFilterSortRow(): Promise<void> {
+    await this.driver.waitForSelector(this.filterSortRow);
+  }
+
+  /**
+   * Waits for the market list view to be visible.
+   */
+  async waitForPageLoaded(): Promise<void> {
+    await this.driver.waitForSelector(this.marketListView);
   }
 }

--- a/test/e2e/page-objects/pages/perps/perps-market-list-page.ts
+++ b/test/e2e/page-objects/pages/perps/perps-market-list-page.ts
@@ -19,6 +19,14 @@ export class PerpsMarketListPage {
 
   private readonly sortDropdownButton = { testId: 'sort-dropdown-button' };
 
+  private readonly sortOptionVolumeHigh = {
+    testId: 'sort-dropdown-option-volumeHigh',
+  };
+
+  private readonly sortOptionVolumeLow = {
+    testId: 'sort-dropdown-option-volumeLow',
+  };
+
   constructor(driver: Driver) {
     this.driver = driver;
   }
@@ -35,7 +43,8 @@ export class PerpsMarketListPage {
 
   /**
    * Navigates to the Perps Market List route and waits for the page to load.
-   * Uses window.location.hash for SPA navigation without a full page reload.
+   * Uses window.location.hash so the SPA router switches view without a full page reload,
+   * which keeps the extension context and avoids re-injecting the extension.
    */
   async navigateToMarketList(): Promise<void> {
     await this.driver.executeScript(
@@ -53,9 +62,7 @@ export class PerpsMarketListPage {
   async selectFilter(optionId: string): Promise<void> {
     await this.driver.waitForSelector(this.filterSelectButton);
     await this.driver.clickElement(this.filterSelectButton);
-    await this.driver.clickElement({
-      testId: `filter-select-option-${optionId}`,
-    });
+    await this.driver.clickElement({ testId: `filter-select-option-${optionId}` });
   }
 
   /**
@@ -65,9 +72,7 @@ export class PerpsMarketListPage {
   async selectSortByVolumeHigh(): Promise<void> {
     await this.driver.waitForSelector(this.sortDropdownButton);
     await this.driver.clickElement(this.sortDropdownButton);
-    await this.driver.clickElement({
-      testId: 'sort-dropdown-option-volumeHigh',
-    });
+    await this.driver.clickElement(this.sortOptionVolumeHigh);
   }
 
   /**
@@ -76,9 +81,7 @@ export class PerpsMarketListPage {
   async selectSortByVolumeLow(): Promise<void> {
     await this.driver.waitForSelector(this.sortDropdownButton);
     await this.driver.clickElement(this.sortDropdownButton);
-    await this.driver.clickElement({
-      testId: 'sort-dropdown-option-volumeLow',
-    });
+    await this.driver.clickElement(this.sortOptionVolumeLow);
   }
 
   /**

--- a/test/e2e/page-objects/pages/perps/perps-market-list-page.ts
+++ b/test/e2e/page-objects/pages/perps/perps-market-list-page.ts
@@ -28,6 +28,11 @@ export class PerpsMarketListPage {
     testId: 'sort-dropdown-option-volumeLow',
   };
 
+  /** Returns the selector for a filter dropdown option (e.g. 'all', 'crypto'). */
+  private getFilterOptionSelector(optionId: string): { testId: string } {
+    return { testId: `filter-select-option-${optionId}` };
+  }
+
   constructor(driver: Driver) {
     this.driver = driver;
   }
@@ -63,7 +68,7 @@ export class PerpsMarketListPage {
   async selectFilter(optionId: string): Promise<void> {
     await this.driver.waitForSelector(this.filterSelectButton);
     await this.driver.clickElement(this.filterSelectButton);
-    await this.driver.clickElement({ testId: `filter-select-option-${optionId}` });
+    await this.driver.clickElement(this.getFilterOptionSelector(optionId));
   }
 
   /**

--- a/test/e2e/page-objects/pages/perps/perps-market-list-page.ts
+++ b/test/e2e/page-objects/pages/perps/perps-market-list-page.ts
@@ -28,7 +28,11 @@ export class PerpsMarketListPage {
     testId: 'sort-dropdown-option-volumeLow',
   };
 
-  /** Returns the selector for a filter dropdown option (e.g. 'all', 'crypto'). */
+  /**
+   * Returns the selector for a filter dropdown option (e.g. 'all', 'crypto').
+   *
+   * @param optionId - The filter option id (e.g. 'all', 'crypto').
+   */
   private getFilterOptionSelector(optionId: string): { testId: string } {
     return { testId: `filter-select-option-${optionId}` };
   }

--- a/test/e2e/page-objects/pages/perps/perps-market-list-page.ts
+++ b/test/e2e/page-objects/pages/perps/perps-market-list-page.ts
@@ -60,7 +60,7 @@ export class PerpsMarketListPage {
     await this.driver.executeScript(
       `window.location.hash = '${PERPS_MARKET_LIST_ROUTE}';`,
     );
-    await this.waitForPageLoaded();
+    await this.checkPageIsLoaded();
   }
 
   /**
@@ -103,8 +103,12 @@ export class PerpsMarketListPage {
 
   /**
    * Waits for the market list view to be visible.
+   * Uses multiple selectors for robustness (convention).
    */
-  async waitForPageLoaded(): Promise<void> {
-    await this.driver.waitForSelector(this.marketListView);
+  async checkPageIsLoaded(): Promise<void> {
+    await this.driver.waitForMultipleSelectors([
+      this.filterSortRow,
+      this.marketListView,
+    ]);
   }
 }

--- a/test/e2e/page-objects/pages/perps/perps-market-list-page.ts
+++ b/test/e2e/page-objects/pages/perps/perps-market-list-page.ts
@@ -1,5 +1,4 @@
 import { Driver } from '../../../webdriver/driver';
-import { PERPS_MARKET_LIST_ROUTE } from '../../../tests/perps/helpers';
 
 /**
  * Page object for the Perps Market List (search / explore crypto).
@@ -8,6 +7,14 @@ import { PERPS_MARKET_LIST_ROUTE } from '../../../tests/perps/helpers';
  */
 export class PerpsMarketListPage {
   private readonly driver: Driver;
+
+  private readonly exploreMarketsRow = {
+    testId: 'perps-explore-markets-row',
+  };
+
+  /** Toast close button; dismissing it avoids ElementClickInterceptedError when it overlaps the explore row. */
+  private readonly toastCloseButton =
+    '.toasts-container__banner-base button[aria-label="Close"]';
 
   private readonly filterSelectButton = { testId: 'filter-select-button' };
 
@@ -52,14 +59,16 @@ export class PerpsMarketListPage {
   }
 
   /**
-   * Navigates to the Perps Market List route and waits for the page to load.
-   * Uses window.location.hash so the SPA router switches view without a full page reload,
-   * which keeps the extension context and avoids re-injecting the extension.
+   * Navigates to the Perps Market List by clicking the "Explore markets" row.
+   * Requires the Perps Home view to be visible (e.g. after navigateToPerpsHome()).
+   * Dismisses any visible toast first so it does not intercept the click; then uses
+   * clickElementUsingMouseMove for the row to avoid ElementClickInterceptedError.
    */
   async navigateToMarketList(): Promise<void> {
-    await this.driver.executeScript(
-      `window.location.hash = '${PERPS_MARKET_LIST_ROUTE}';`,
-    );
+    await this.driver.waitForSelector(this.exploreMarketsRow);
+    await this.driver.clickElementSafe(this.toastCloseButton, 1500);
+    await this.driver.delay(300);
+    await this.driver.clickElementUsingMouseMove(this.exploreMarketsRow);
     await this.checkPageIsLoaded();
   }
 

--- a/test/e2e/page-objects/pages/perps/perps-market-list-page.ts
+++ b/test/e2e/page-objects/pages/perps/perps-market-list-page.ts
@@ -67,7 +67,6 @@ export class PerpsMarketListPage {
   async navigateToMarketList(): Promise<void> {
     await this.driver.waitForSelector(this.exploreMarketsRow);
     await this.driver.clickElementSafe(this.toastCloseButton, 1500);
-    await this.driver.delay(300);
     await this.driver.clickElementUsingMouseMove(this.exploreMarketsRow);
     await this.checkPageIsLoaded();
   }

--- a/test/e2e/page-objects/pages/perps/perps-positions-base.ts
+++ b/test/e2e/page-objects/pages/perps/perps-positions-base.ts
@@ -1,0 +1,35 @@
+import { Driver } from '../../../webdriver/driver';
+
+/**
+ * Base class with shared position-related selectors and methods
+ * used by both PerpsTabPage and PerpsHomePage.
+ */
+export class PerpsPositionsBase {
+  protected readonly driver: Driver;
+
+  private readonly perpsPositionsSection = {
+    testId: 'perps-positions-section',
+  };
+
+  constructor(driver: Driver) {
+    this.driver = driver;
+  }
+
+  /**
+   * Waits for a position card for the given symbol to be visible.
+   *
+   * @param symbol - The trading pair symbol (e.g. 'ETH', 'BTC').
+   */
+  async waitForPositionCard(symbol: string): Promise<void> {
+    await this.driver.waitForSelector({
+      testId: `position-card-${symbol}`,
+    });
+  }
+
+  /**
+   * Waits for the positions section to be visible (mock positions loaded).
+   */
+  async waitForPositionsSection(): Promise<void> {
+    await this.driver.waitForSelector(this.perpsPositionsSection);
+  }
+}

--- a/test/e2e/page-objects/pages/perps/perps-positions-base.ts
+++ b/test/e2e/page-objects/pages/perps/perps-positions-base.ts
@@ -7,6 +7,10 @@ import { Driver } from '../../../webdriver/driver';
 export class PerpsPositionsBase {
   protected readonly driver: Driver;
 
+  protected readonly accountOverviewPerpsTab = {
+    testId: 'account-overview__perps-tab',
+  };
+
   private readonly perpsPositionsSection = {
     testId: 'perps-positions-section',
   };

--- a/test/e2e/page-objects/pages/perps/perps-tab-page.ts
+++ b/test/e2e/page-objects/pages/perps/perps-tab-page.ts
@@ -2,8 +2,8 @@ import { PERPS_TAB_HASH } from '../../../tests/perps/helpers';
 import { PerpsPositionsBase } from './perps-positions-base';
 
 /**
- * Page object for the Perps tab on the account overview (home).
- * Covers the tab that shows positions and orders from the mock PerpsStreamManager.
+ * Page object for the Perps tab on the account overview (wallet home).
+ * Use this to open the Perps tab from the account overview; then use PerpsHomePage to interact with the tab content (balance, positions, explore, etc.).
  *
  * @see ui/components/app/perps/perps-tab-view.tsx
  */
@@ -14,7 +14,8 @@ export class PerpsTabPage extends PerpsPositionsBase {
 
   /**
    * Opens the Perps tab by setting the window hash to the perps tab query.
-   * Uses window.location.hash for SPA navigation without a full page reload.
+   * Uses window.location.hash so the SPA router switches tab without a full page reload,
+   * which keeps the extension context and avoids re-injecting the extension.
    */
   async openPerpsTab(): Promise<void> {
     await this.driver.executeScript(

--- a/test/e2e/page-objects/pages/perps/perps-tab-page.ts
+++ b/test/e2e/page-objects/pages/perps/perps-tab-page.ts
@@ -1,5 +1,5 @@
-import { Driver } from '../../../webdriver/driver';
 import { PERPS_TAB_HASH } from '../../../tests/perps/helpers';
+import { PerpsPositionsBase } from './perps-positions-base';
 
 /**
  * Page object for the Perps tab on the account overview (home).
@@ -7,32 +7,14 @@ import { PERPS_TAB_HASH } from '../../../tests/perps/helpers';
  *
  * @see ui/components/app/perps/perps-tab-view.tsx
  */
-export class PerpsTabPage {
-  private readonly driver: Driver;
-
+export class PerpsTabPage extends PerpsPositionsBase {
   private readonly accountOverviewAssetTab = {
     testId: 'account-overview__asset-tab',
   };
 
-  private readonly perpsPositionsSection = {
-    testId: 'perps-positions-section',
-  };
-
-  private readonly positionCardsSelector = '[data-testid^="position-card-"]';
-
-  constructor(driver: Driver) {
-    this.driver = driver;
-  }
-
-  /**
-   * Waits for the account overview to be loaded (tabs visible).
-   */
-  async waitForAccountOverviewLoaded(): Promise<void> {
-    await this.driver.waitForSelector(this.accountOverviewAssetTab);
-  }
-
   /**
    * Opens the Perps tab by setting the window hash to the perps tab query.
+   * Uses window.location.hash for SPA navigation without a full page reload.
    */
   async openPerpsTab(): Promise<void> {
     await this.driver.executeScript(
@@ -41,27 +23,9 @@ export class PerpsTabPage {
   }
 
   /**
-   * Waits for the positions section to be visible (mock positions loaded).
+   * Waits for the account overview to be loaded (tabs visible).
    */
-  async waitForPositionsSection(): Promise<void> {
-    await this.driver.waitForSelector(this.perpsPositionsSection);
-  }
-
-  /**
-   * Returns the number of position cards currently displayed.
-   */
-  async getPositionCardsCount(): Promise<number> {
-    const elements = await this.driver.findElements(this.positionCardsSelector);
-    return elements.length;
-  }
-
-  /**
-   * Waits for a position card for the given symbol to be visible.
-   * @param symbol
-   */
-  async waitForPositionCard(symbol: string): Promise<void> {
-    await this.driver.waitForSelector({
-      testId: `position-card-${symbol}`,
-    });
+  async waitForAccountOverviewLoaded(): Promise<void> {
+    await this.driver.waitForSelector(this.accountOverviewAssetTab);
   }
 }

--- a/test/e2e/page-objects/pages/perps/perps-tab-page.ts
+++ b/test/e2e/page-objects/pages/perps/perps-tab-page.ts
@@ -1,4 +1,3 @@
-import { PERPS_TAB_HASH } from '../../../tests/perps/helpers';
 import { PerpsPositionsBase } from './perps-positions-base';
 
 /**
@@ -12,15 +11,17 @@ export class PerpsTabPage extends PerpsPositionsBase {
     testId: 'account-overview__asset-tab',
   };
 
+  private readonly accountOverviewPerpsTab = {
+    testId: 'account-overview__perps-tab',
+  };
+
   /**
-   * Opens the Perps tab by setting the window hash to the perps tab query.
-   * Uses window.location.hash so the SPA router switches tab without a full page reload,
-   * which keeps the extension context and avoids re-injecting the extension.
+   * Opens the Perps tab by clicking the Perps tab on the account overview.
+   * Requires the account overview to be loaded (e.g. after login or driver.navigate()).
    */
   async openPerpsTab(): Promise<void> {
-    await this.driver.executeScript(
-      `window.location.hash = '${PERPS_TAB_HASH}';`,
-    );
+    await this.waitForAccountOverviewLoaded();
+    await this.driver.clickElement(this.accountOverviewPerpsTab);
   }
 
   /**

--- a/test/e2e/page-objects/pages/perps/perps-tab-page.ts
+++ b/test/e2e/page-objects/pages/perps/perps-tab-page.ts
@@ -11,10 +11,6 @@ export class PerpsTabPage extends PerpsPositionsBase {
     testId: 'account-overview__asset-tab',
   };
 
-  private readonly accountOverviewPerpsTab = {
-    testId: 'account-overview__perps-tab',
-  };
-
   /**
    * Opens the Perps tab by clicking the Perps tab on the account overview.
    * Requires the account overview to be loaded (e.g. after login or driver.navigate()).

--- a/test/e2e/tests/perps/helpers.ts
+++ b/test/e2e/tests/perps/helpers.ts
@@ -31,9 +31,9 @@ export const PERPS_MARKET_LIST_ROUTE = '#/perps/market-list';
 
 /**
  * Default withFixtures config for Perps tests (feature flag enabled).
- * Implemented in fixtures/perps-fixture-config.ts; re-exported here for backward compatibility.
+ * Implemented in perps-fixture-config.ts in this directory; re-exported here for convenience.
  *
  * @param title - The test title (e.g. this.test?.fullTitle()) for debugging.
  * @returns Partial withFixtures config to spread into withFixtures().
  */
-export { getPerpsConfig as getConfig } from '../../fixtures/perps-fixture-config';
+export { getPerpsConfig as getConfig } from './perps-fixture-config';

--- a/test/e2e/tests/perps/helpers.ts
+++ b/test/e2e/tests/perps/helpers.ts
@@ -17,6 +17,9 @@
 /** Hash to show the Perps tab on the account overview (home). Tab is controlled by search param. */
 export const PERPS_TAB_HASH = '#/?tab=perps';
 
+/** Perps Home page route. */
+export const PERPS_HOME_ROUTE = '#/perps/home';
+
 /** Base route for Perps market detail. Append encoded symbol, e.g. PERPS_MARKET_DETAIL_ROUTE + '/AVAX' */
 export const PERPS_MARKET_DETAIL_ROUTE = '#/perps/market';
 

--- a/test/e2e/tests/perps/helpers.ts
+++ b/test/e2e/tests/perps/helpers.ts
@@ -14,15 +14,6 @@
  * @see {@link https://github.com/MetaMask/metamask-extension} for more info
  */
 
-/** Base route for Perps market detail. Append encoded symbol, e.g. PERPS_MARKET_DETAIL_ROUTE + '/AVAX' */
-export const PERPS_MARKET_DETAIL_ROUTE = '#/perps/market';
-
-/** Perps Activity page (full history). */
-export const PERPS_ACTIVITY_ROUTE = '#/perps/activity';
-
-/** Perps Market List (search / explore). */
-export const PERPS_MARKET_LIST_ROUTE = '#/perps/market-list';
-
 /**
  * Default withFixtures config for Perps tests (feature flag enabled).
  * Implemented in perps-fixture-config.ts in this directory; re-exported here for convenience.

--- a/test/e2e/tests/perps/helpers.ts
+++ b/test/e2e/tests/perps/helpers.ts
@@ -14,12 +14,6 @@
  * @see {@link https://github.com/MetaMask/metamask-extension} for more info
  */
 
-/** Hash to show the Perps tab on the account overview (home). Tab is controlled by search param. */
-export const PERPS_TAB_HASH = '#/?tab=perps';
-
-/** Perps Home page route. */
-export const PERPS_HOME_ROUTE = '#/perps/home';
-
 /** Base route for Perps market detail. Append encoded symbol, e.g. PERPS_MARKET_DETAIL_ROUTE + '/AVAX' */
 export const PERPS_MARKET_DETAIL_ROUTE = '#/perps/market';
 

--- a/test/e2e/tests/perps/mocks/websocketDefaultMocks.ts
+++ b/test/e2e/tests/perps/mocks/websocketDefaultMocks.ts
@@ -25,7 +25,9 @@ export type WebSocketMessageMock = {
 
 /**
  * Returns the response payload, evaluating getters at send time so timestamps are fresh.
- * @param mock
+ *
+ * @param mock - The WebSocket message mock (response may be a function).
+ * @returns The response object to send back.
  */
 export function getResponsePayload(mock: WebSocketMessageMock): object {
   return typeof mock.response === 'function' ? mock.response() : mock.response;

--- a/test/e2e/tests/perps/mocks/websocketDefaultMocks.ts
+++ b/test/e2e/tests/perps/mocks/websocketDefaultMocks.ts
@@ -12,23 +12,9 @@
  * @see Hyperliquid API docs for message formats
  */
 
-export type WebSocketMessageMock = {
-  /** String(s) that the message should include to trigger this mock */
-  messageIncludes: string | string[];
-  /** The JSON response to send back, or a getter called at send time (e.g. for fresh timestamps) */
-  response: object | (() => object);
-  /** Delay before sending the response (in milliseconds) */
-  delay?: number;
-  /** Custom log message for this mock */
-  logMessage?: string;
-};
+import type { WebSocketMessageMock } from '../../../websocket/types';
 
-/**
- * Returns the response payload, evaluating getters at send time so timestamps are fresh.
- *
- * @param mock - The WebSocket message mock (response may be a function).
- * @returns The response object to send back.
- */
+export type { WebSocketMessageMock } from '../../../websocket/types';
 export function getResponsePayload(mock: WebSocketMessageMock): object {
   return typeof mock.response === 'function' ? mock.response() : mock.response;
 }

--- a/test/e2e/tests/perps/mocks/websocketDefaultMocks.ts
+++ b/test/e2e/tests/perps/mocks/websocketDefaultMocks.ts
@@ -14,7 +14,6 @@
 
 import type { WebSocketMessageMock } from '../../../websocket/types';
 
-export type { WebSocketMessageMock } from '../../../websocket/types';
 export function getResponsePayload(mock: WebSocketMessageMock): object {
   return typeof mock.response === 'function' ? mock.response() : mock.response;
 }

--- a/test/e2e/tests/perps/perps-fixture-config.ts
+++ b/test/e2e/tests/perps/perps-fixture-config.ts
@@ -1,4 +1,4 @@
-import FixtureBuilderV2 from './fixture-builder-v2';
+import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 
 /**
  * Default withFixtures config for Perps E2E tests (feature flag enabled).

--- a/test/e2e/tests/perps/perps-home.spec.ts
+++ b/test/e2e/tests/perps/perps-home.spec.ts
@@ -113,7 +113,7 @@ describe('Perps', function (this: Suite) {
         await perpsHomePage.clickSearchButton();
 
         const marketListPage = new PerpsMarketListPage(driver);
-        await marketListPage.waitForPageLoaded();
+        await marketListPage.checkPageIsLoaded();
         await marketListPage.waitForFilterSortRow();
         await marketListPage.selectFilter('crypto');
         await marketListPage.selectSortByVolumeHigh();

--- a/test/e2e/tests/perps/perps-home.spec.ts
+++ b/test/e2e/tests/perps/perps-home.spec.ts
@@ -49,6 +49,9 @@ describe('Perps', function (this: Suite) {
         await perpsHomePage.navigateToPerpsHome();
         await perpsHomePage.waitForPositionsSection();
 
+        const marketListPage = new PerpsMarketListPage(driver);
+        await marketListPage.navigateToMarketList();
+
         const marketDetailPage = new PerpsMarketDetailPage(driver);
         await marketDetailPage.navigateToMarket('AVAX');
         await marketDetailPage.waitForTradeCtaButtons();
@@ -110,10 +113,9 @@ describe('Perps', function (this: Suite) {
         const perpsHomePage = new PerpsHomePage(driver);
         await perpsHomePage.navigateToPerpsHome();
         await perpsHomePage.waitForBalanceSection();
-        await perpsHomePage.clickSearchButton();
 
         const marketListPage = new PerpsMarketListPage(driver);
-        await marketListPage.checkPageIsLoaded();
+        await marketListPage.navigateToMarketList();
         await marketListPage.waitForFilterSortRow();
         await marketListPage.selectFilter('crypto');
         await marketListPage.selectSortByVolumeHigh();
@@ -152,6 +154,9 @@ describe('Perps', function (this: Suite) {
         const perpsHomePage = new PerpsHomePage(driver);
         await perpsHomePage.navigateToPerpsHome();
         await perpsHomePage.waitForPositionsSection();
+
+        const marketListPage = new PerpsMarketListPage(driver);
+        await marketListPage.navigateToMarketList();
 
         const marketDetailPage = new PerpsMarketDetailPage(driver);
         await marketDetailPage.navigateToMarket('ETH');

--- a/test/e2e/tests/perps/web-socket-connection.spec.ts
+++ b/test/e2e/tests/perps/web-socket-connection.spec.ts
@@ -1,11 +1,11 @@
 import { Suite } from 'mocha';
 import { Driver } from '../../webdriver/driver';
+import { WEBSOCKET_SERVICES } from '../../websocket/constants';
 import WebSocketRegistry from '../../websocket/registry';
 import { withFixtures } from '../../helpers';
 import { loginWithoutBalanceValidation } from '../../page-objects/flows/login.flow';
 import { PerpsHomePage } from '../../page-objects/pages/perps/perps-home-page';
 import { getConfig } from './helpers';
-import { WEBSOCKET_SERVICES } from '../../websocket/constants';
 
 async function waitForWebsocketConnections(
   driver: Driver,
@@ -20,7 +20,21 @@ async function waitForWebsocketConnections(
   }, 10000);
 }
 
-describe('Perps Web Socket', function (this: Suite) {
+/**
+ * Perps Web Socket E2E tests — SKIPPED until real PerpsController is integrated.
+ *
+ * Reasons:
+ * - The extension currently uses MockPerpsController (see test/e2e/tests/perps/helpers.ts
+ * and ui/providers/perps/getPerpsController.mock.ts). The mock only logs subscription
+ * calls and does not open real WebSocket connections.
+ * - These tests expect the Perps view to open a connection to wss://api.hyperliquid.xyz/ws,
+ * which mock-e2e.js forwards to ws://localhost:8090. The mock server never receives
+ * a connection because no code path opens that WebSocket while MockPerpsController is in use.
+ * - To enable: integrate the real PerpsController that connects to Hyperliquid's WebSocket API,
+ * then remove the skip below. The perps mock server and forward are already set up.
+ */
+// eslint-disable-next-line mocha/no-skipped-tests -- Skipped until real PerpsController opens WebSocket; see comment above.
+describe.skip('Perps Web Socket', function (this: Suite) {
   this.timeout(120000);
 
   it('a websocket connection is open when Perps view is open', async function () {

--- a/test/e2e/tests/perps/web-socket-connection.spec.ts
+++ b/test/e2e/tests/perps/web-socket-connection.spec.ts
@@ -1,0 +1,99 @@
+import { Suite } from 'mocha';
+import { Driver } from '../../webdriver/driver';
+import WebSocketRegistry from '../../websocket/registry';
+import { withFixtures } from '../../helpers';
+import { loginWithoutBalanceValidation } from '../../page-objects/flows/login.flow';
+import { PerpsHomePage } from '../../page-objects/pages/perps/perps-home-page';
+import { getConfig } from './helpers';
+import { WEBSOCKET_SERVICES } from '../../websocket/constants';
+
+async function waitForWebsocketConnections(
+  driver: Driver,
+  expectedCount: number,
+) {
+  let connectionCount;
+  await driver.wait(async () => {
+    connectionCount = WebSocketRegistry.getServer(
+      WEBSOCKET_SERVICES.perps,
+    ).getWebsocketConnectionCount();
+    return connectionCount === expectedCount;
+  }, 10000);
+}
+
+describe('Perps Web Socket', function (this: Suite) {
+  this.timeout(120000);
+
+  it('a websocket connection is open when Perps view is open', async function () {
+    await withFixtures(
+      {
+        ...getConfig(this.test?.fullTitle()),
+      },
+      async ({ driver }: { driver: Driver }) => {
+        await loginWithoutBalanceValidation(driver);
+
+        const perpsHomePage = new PerpsHomePage(driver);
+        await perpsHomePage.navigateToPerpsHome();
+        await perpsHomePage.waitForBalanceSection();
+
+        await waitForWebsocketConnections(driver, 1);
+      },
+    );
+  });
+
+  it('the websocket connection is maintained for a grace period when MetaMask window is closed', async function () {
+    await withFixtures(
+      {
+        ...getConfig(this.test?.fullTitle()),
+      },
+      async ({ driver }: { driver: Driver }) => {
+        await loginWithoutBalanceValidation(driver);
+
+        const perpsHomePage = new PerpsHomePage(driver);
+        await perpsHomePage.navigateToPerpsHome();
+        await perpsHomePage.waitForBalanceSection();
+
+        await waitForWebsocketConnections(driver, 1);
+
+        await driver.openNewPage('about:blank');
+
+        await driver.switchToWindowWithTitle('MetaMask');
+        await driver.closeWindow();
+
+        await waitForWebsocketConnections(driver, 1);
+      },
+    );
+  });
+
+  it('websocket connection is shared between multiple MetaMask windows', async function () {
+    await withFixtures(
+      {
+        ...getConfig(this.test?.fullTitle()),
+      },
+      async ({ driver }: { driver: Driver }) => {
+        await loginWithoutBalanceValidation(driver);
+
+        const perpsHomePage = new PerpsHomePage(driver);
+        await perpsHomePage.navigateToPerpsHome();
+        await perpsHomePage.waitForBalanceSection();
+
+        await waitForWebsocketConnections(driver, 1);
+
+        await driver.openNewPage('about:blank');
+
+        await driver.openNewPage(`${driver.extensionUrl}/home.html`);
+
+        await waitForWebsocketConnections(driver, 1);
+
+        await driver.switchToWindowWithTitle('MetaMask');
+        await driver.closeWindow();
+
+        await waitForWebsocketConnections(driver, 1);
+
+        await driver.switchToWindowWithTitle('MetaMask');
+        await driver.closeWindow();
+
+        await waitForWebsocketConnections(driver, 1);
+      },
+    );
+  });
+});

--- a/test/e2e/tests/perps/web-socket-connection.spec.ts
+++ b/test/e2e/tests/perps/web-socket-connection.spec.ts
@@ -3,21 +3,23 @@ import { Driver } from '../../webdriver/driver';
 import { WEBSOCKET_SERVICES } from '../../websocket/constants';
 import WebSocketRegistry from '../../websocket/registry';
 import { withFixtures } from '../../helpers';
-import { loginWithoutBalanceValidation } from '../../page-objects/flows/login.flow';
+import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow';
 import { PerpsHomePage } from '../../page-objects/pages/perps/perps-home-page';
 import { getConfig } from './helpers';
 
-async function waitForWebsocketConnections(
+async function waitForPerpsWebsocketConnections(
   driver: Driver,
   expectedCount: number,
 ) {
-  let connectionCount;
-  await driver.wait(async () => {
-    connectionCount = WebSocketRegistry.getServer(
-      WEBSOCKET_SERVICES.perps,
-    ).getWebsocketConnectionCount();
-    return connectionCount === expectedCount;
-  }, 10000);
+  await driver.waitUntil(
+    async () => {
+      const connectionCount = WebSocketRegistry.getServer(
+        WEBSOCKET_SERVICES.perps,
+      ).getWebsocketConnectionCount();
+      return connectionCount === expectedCount;
+    },
+    { timeout: 10000, interval: 500 },
+  );
 }
 
 /**
@@ -43,13 +45,13 @@ describe.skip('Perps Web Socket', function (this: Suite) {
         ...getConfig(this.test?.fullTitle()),
       },
       async ({ driver }: { driver: Driver }) => {
-        await loginWithoutBalanceValidation(driver);
+        await loginWithBalanceValidation(driver);
 
         const perpsHomePage = new PerpsHomePage(driver);
         await perpsHomePage.navigateToPerpsHome();
         await perpsHomePage.waitForBalanceSection();
 
-        await waitForWebsocketConnections(driver, 1);
+        await waitForPerpsWebsocketConnections(driver, 1);
       },
     );
   });
@@ -60,20 +62,20 @@ describe.skip('Perps Web Socket', function (this: Suite) {
         ...getConfig(this.test?.fullTitle()),
       },
       async ({ driver }: { driver: Driver }) => {
-        await loginWithoutBalanceValidation(driver);
+        await loginWithBalanceValidation(driver);
 
         const perpsHomePage = new PerpsHomePage(driver);
         await perpsHomePage.navigateToPerpsHome();
         await perpsHomePage.waitForBalanceSection();
 
-        await waitForWebsocketConnections(driver, 1);
+        await waitForPerpsWebsocketConnections(driver, 1);
 
         await driver.openNewPage('about:blank');
 
         await driver.switchToWindowWithTitle('MetaMask');
         await driver.closeWindow();
 
-        await waitForWebsocketConnections(driver, 1);
+        await waitForPerpsWebsocketConnections(driver, 1);
       },
     );
   });
@@ -84,29 +86,29 @@ describe.skip('Perps Web Socket', function (this: Suite) {
         ...getConfig(this.test?.fullTitle()),
       },
       async ({ driver }: { driver: Driver }) => {
-        await loginWithoutBalanceValidation(driver);
+        await loginWithBalanceValidation(driver);
 
         const perpsHomePage = new PerpsHomePage(driver);
         await perpsHomePage.navigateToPerpsHome();
         await perpsHomePage.waitForBalanceSection();
 
-        await waitForWebsocketConnections(driver, 1);
+        await waitForPerpsWebsocketConnections(driver, 1);
 
         await driver.openNewPage('about:blank');
 
         await driver.openNewPage(`${driver.extensionUrl}/home.html`);
 
-        await waitForWebsocketConnections(driver, 1);
+        await waitForPerpsWebsocketConnections(driver, 1);
 
         await driver.switchToWindowWithTitle('MetaMask');
         await driver.closeWindow();
 
-        await waitForWebsocketConnections(driver, 1);
+        await waitForPerpsWebsocketConnections(driver, 1);
 
         await driver.switchToWindowWithTitle('MetaMask');
         await driver.closeWindow();
 
-        await waitForWebsocketConnections(driver, 1);
+        await waitForPerpsWebsocketConnections(driver, 1);
       },
     );
   });

--- a/test/e2e/tests/solana/mocks/websocketDefaultMocks.ts
+++ b/test/e2e/tests/solana/mocks/websocketDefaultMocks.ts
@@ -4,8 +4,6 @@
 
 import type { WebSocketMessageMock } from '../../../websocket/types';
 
-export type { WebSocketMessageMock } from '../../../websocket/types';
-
 export const DEFAULT_SOLANA_WS_MOCKS: WebSocketMessageMock[] = [
   {
     messageIncludes: 'signatureSubscribe',

--- a/test/e2e/tests/solana/mocks/websocketDefaultMocks.ts
+++ b/test/e2e/tests/solana/mocks/websocketDefaultMocks.ts
@@ -1,20 +1,10 @@
 /**
  * Configuration for a WebSocket message mock
  */
-export type WebSocketMessageMock = {
-  /** String(s) that the message should include to trigger this mock */
-  messageIncludes: string | string[];
-  /** The JSON response to send back */
-  response: object;
-  /** Delay before sending the response (in milliseconds) */
-  delay?: number;
-  /** Optional follow-up response sent after the initial response */
-  followUpResponse?: object;
-  /** Delay before sending the follow-up response (in milliseconds) */
-  followUpDelay?: number;
-  /** Custom log message for this mock */
-  logMessage?: string;
-};
+
+import type { WebSocketMessageMock } from '../../../websocket/types';
+
+export type { WebSocketMessageMock } from '../../../websocket/types';
 
 export const DEFAULT_SOLANA_WS_MOCKS: WebSocketMessageMock[] = [
   {

--- a/test/e2e/websocket/account-activity-mocks.ts
+++ b/test/e2e/websocket/account-activity-mocks.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/no-shadow
 import { WebSocket } from 'ws';
-import type { WebSocketMessageMock } from '../tests/solana/mocks/websocketDefaultMocks';
+import type { WebSocketMessageMock } from './types';
 import type { WebSocketServiceConfig } from './registry';
 import type LocalWebSocketServer from './server';
 import { WEBSOCKET_SERVICES } from './constants';
@@ -251,7 +251,11 @@ async function setupAccountActivityWebsocketMocks(
 
           const delay = mock.delay ?? 500;
           setTimeout(() => {
-            socket.send(JSON.stringify(mock.response));
+            const payload =
+              typeof mock.response === 'function'
+                ? mock.response()
+                : mock.response;
+            socket.send(JSON.stringify(payload));
             console.log(
               `[AccountActivity Mock] Fallback mock sent for: ${includes.join(' + ')}`,
             );

--- a/test/e2e/websocket/perps-mocks.ts
+++ b/test/e2e/websocket/perps-mocks.ts
@@ -4,7 +4,7 @@ import {
   DEFAULT_HYPERLIQUID_WS_MOCKS,
   getResponsePayload,
 } from '../tests/perps/mocks/websocketDefaultMocks';
-import type { WebSocketMessageMock } from '../tests/solana/mocks/websocketDefaultMocks';
+import type { WebSocketMessageMock } from './types';
 import type { WebSocketServiceConfig } from './registry';
 import type LocalWebSocketServer from './server';
 import { WEBSOCKET_SERVICES } from './constants';

--- a/test/e2e/websocket/registry.ts
+++ b/test/e2e/websocket/registry.ts
@@ -1,4 +1,4 @@
-import type { WebSocketMessageMock } from '../tests/solana/mocks/websocketDefaultMocks';
+import type { WebSocketMessageMock } from './types';
 import LocalWebSocketServer from './server';
 
 /**

--- a/test/e2e/websocket/solana-mocks.ts
+++ b/test/e2e/websocket/solana-mocks.ts
@@ -1,9 +1,9 @@
 // eslint-disable-next-line @typescript-eslint/no-shadow
 import { WebSocket } from 'ws';
 import {
-  WebSocketMessageMock,
   DEFAULT_SOLANA_WS_MOCKS,
 } from '../tests/solana/mocks/websocketDefaultMocks';
+import type { WebSocketMessageMock } from './types';
 import type { WebSocketServiceConfig } from './registry';
 import type LocalWebSocketServer from './server';
 import { WEBSOCKET_SERVICES } from './constants';
@@ -59,10 +59,14 @@ async function setupSolanaWebsocketMocks(
 
           const delay = mock.delay || 500;
           setTimeout(() => {
+            const rawResponse =
+              typeof mock.response === 'function'
+                ? mock.response()
+                : mock.response;
             const response =
               requestId === null
-                ? mock.response
-                : { ...mock.response, id: requestId };
+                ? rawResponse
+                : { ...rawResponse, id: requestId };
             socket.send(JSON.stringify(response));
             console.log(
               `[Solana] Simulated message sent to the client for: ${includes.join(' + ')}`,

--- a/test/e2e/websocket/solana-mocks.ts
+++ b/test/e2e/websocket/solana-mocks.ts
@@ -1,8 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/no-shadow
 import { WebSocket } from 'ws';
-import {
-  DEFAULT_SOLANA_WS_MOCKS,
-} from '../tests/solana/mocks/websocketDefaultMocks';
+import { DEFAULT_SOLANA_WS_MOCKS } from '../tests/solana/mocks/websocketDefaultMocks';
 import type { WebSocketMessageMock } from './types';
 import type { WebSocketServiceConfig } from './registry';
 import type LocalWebSocketServer from './server';

--- a/test/e2e/websocket/types.ts
+++ b/test/e2e/websocket/types.ts
@@ -1,0 +1,19 @@
+/**
+ * Generic WebSocket message mock type used by the registry and all service mocks.
+ * Each service (Solana, Perps, Account Activity) defines its own default mocks;
+ * this type describes the shape required by the setup functions.
+ */
+export type WebSocketMessageMock = {
+  /** String(s) that the message should include to trigger this mock */
+  messageIncludes: string | string[];
+  /** The JSON response to send back, or a getter called at send time (e.g. for fresh timestamps) */
+  response: object | (() => object);
+  /** Delay before sending the response (in milliseconds) */
+  delay?: number;
+  /** Custom log message for this mock */
+  logMessage?: string;
+  /** Optional follow-up response sent after the initial response (e.g. Solana signatureNotification) */
+  followUpResponse?: object;
+  /** Delay before sending the follow-up response (in milliseconds) */
+  followUpDelay?: number;
+};


### PR DESCRIPTION
- Replace hardcoded inline CSS selectors with named class properties using testId objects where possible
- Extract shared position-related selectors and methods into PerpsPositionsBase to reduce duplication between PerpsTabPage and PerpsHomePage
- Remove unused methods: waitForSubmitButtonEnabled, waitForOrderFormClosed (not used, untestable until consumed)
- Remove flaky getPositionCardsCount pattern from both PerpsHomePage and PerpsTabPage
- Extract inline selector literals (tutorial buttons, recent activity, balance actions, modify/close buttons) to named class properties
- Order selectors and methods alphabetically in all POM files
- Add JSDoc explaining window.location.hash SPA navigation approach
- Convert searchInput from raw CSS to testId object format

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40661?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to E2E test page objects and websocket mock utilities, but navigation/click behavior was adjusted to reduce flakiness and could affect existing perps specs.
> 
> **Overview**
> Refactors Perps E2E page objects to remove hash-based SPA navigation and centralize shared position helpers in a new `PerpsPositionsBase`, with `PerpsTabPage`/`PerpsHomePage` now navigating via tab clicks and using `waitForMultipleSelectors`/`waitUntil` for more robust waits.
> 
> Updates market list/detail flows to navigate by clicking UI rows (including toast dismissal and safer mouse-move clicks), adds/renames small helper actions (e.g. generic percent preset click, submit waits for disappearance), and adjusts perps specs to follow the new navigation sequence.
> 
> Unifies WebSocket mock typing via a new shared `test/e2e/websocket/types.ts` (supporting function responses) and updates Solana/Perps/AccountActivity mock senders accordingly; also adds a new skipped `web-socket-connection.spec.ts` for future PerpsController integration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55995135a0e8fe69f11d1a3e4b0b3c947badd615. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->