### PR TITLE
feat: Support messenger subscriptions from the UI

### DIFF
--- a/app/scripts/lib/MessengerSubscriptions.test.ts
+++ b/app/scripts/lib/MessengerSubscriptions.test.ts
@@ -1,0 +1,102 @@
+import {
+  Messenger,
+  MOCK_ANY_NAMESPACE,
+  NamespacedName,
+} from '@metamask/messenger';
+import { Transform } from 'readable-stream';
+import { JsonRpcNotification } from '@metamask/utils';
+import { MessengerSubscriptions } from './MessengerSubscriptions';
+
+function setup() {
+  const messenger = new Messenger({ namespace: MOCK_ANY_NAMESPACE });
+  const stream = new Transform({
+    objectMode: true,
+    transform(_chunk: JsonRpcNotification, _, callback) {
+      callback();
+    },
+  });
+  const subscriptions = new MessengerSubscriptions(messenger, stream);
+
+  return { messenger, stream, subscriptions };
+}
+
+const MOCK_STATE_CHANGE = {
+  event: 'ExampleController:stateChange' as NamespacedName,
+  params: [{ foo: 'bar' }, []],
+};
+
+describe('MessengerSubscriptions', () => {
+  it('sends JSON-RPC notifications for subscribed events', () => {
+    const { messenger, stream, subscriptions } = setup();
+    const subscribeSpy = jest.spyOn(messenger, 'subscribe');
+    const writeSpy = jest.spyOn(stream, 'write');
+
+    const { event, params } = MOCK_STATE_CHANGE;
+
+    subscriptions.subscribe(event);
+
+    expect(subscribeSpy).toHaveBeenCalledWith(event, expect.any(Function));
+
+    messenger.publish(event, ...params);
+
+    expect(writeSpy).toHaveBeenCalledWith({
+      jsonrpc: '2.0',
+      method: 'messengerSubscription',
+      params: [event, [{ foo: 'bar' }, []]],
+    });
+  });
+
+  it('stops sending notifications for a given event when all subscriptions are removed', () => {
+    const { messenger, stream, subscriptions } = setup();
+    const subscribeSpy = jest.spyOn(messenger, 'subscribe');
+    const unsubscribeSpy = jest.spyOn(messenger, 'unsubscribe');
+    const writeSpy = jest.spyOn(stream, 'write');
+
+    const { event, params } = MOCK_STATE_CHANGE;
+
+    subscriptions.subscribe(event);
+    subscriptions.subscribe(event);
+
+    messenger.publish(event, ...params);
+
+    subscriptions.unsubscribe(event);
+    subscriptions.unsubscribe(event);
+
+    messenger.publish(event, ...params);
+
+    expect(writeSpy).toHaveBeenCalledTimes(1);
+    expect(subscribeSpy).toHaveBeenCalledTimes(1);
+    expect(unsubscribeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('unsubscribes from all events when cleared', () => {
+    const { messenger, stream, subscriptions } = setup();
+    const subscribeSpy = jest.spyOn(messenger, 'subscribe');
+    const unsubscribeSpy = jest.spyOn(messenger, 'unsubscribe');
+    const writeSpy = jest.spyOn(stream, 'write');
+
+    const { event, params } = MOCK_STATE_CHANGE;
+
+    subscriptions.subscribe(event);
+    subscriptions.subscribe(event);
+    subscriptions.subscribe('AccountsController:stateChange');
+    subscriptions.subscribe('SnapController:stateChange');
+
+    subscriptions.clear();
+
+    messenger.publish(event, ...params);
+
+    expect(subscribeSpy).toHaveBeenCalledTimes(3);
+    expect(unsubscribeSpy).toHaveBeenCalledTimes(3);
+    expect(writeSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it('throws when attempting to unsubscribe without existing subscription', () => {
+    const { subscriptions } = setup();
+    const { event } = MOCK_STATE_CHANGE;
+
+    expect(() => subscriptions.unsubscribe(event)).toThrow(
+      'No active subscriptions found for: "ExampleController:stateChange".',
+    );
+  });
+});

--- a/app/scripts/lib/MessengerSubscriptions.test.ts
+++ b/app/scripts/lib/MessengerSubscriptions.test.ts
@@ -6,6 +6,7 @@ import {
 import { Transform } from 'readable-stream';
 import { JsonRpcNotification } from '@metamask/utils';
 import { ControllerStateChangeEvent } from '@metamask/base-controller';
+import { MESSENGER_SUBSCRIPTION_NOTIFICATION } from '../../../shared/constants/messages';
 import { MessengerSubscriptions } from './MessengerSubscriptions';
 
 const MOCK_STATE_CHANGE = {
@@ -52,7 +53,7 @@ describe('MessengerSubscriptions', () => {
 
     expect(writeSpy).toHaveBeenCalledWith({
       jsonrpc: '2.0',
-      method: 'messengerSubscription',
+      method: MESSENGER_SUBSCRIPTION_NOTIFICATION,
       params: [event, [{ foo: 'bar' }, []]],
     });
   });

--- a/app/scripts/lib/MessengerSubscriptions.test.ts
+++ b/app/scripts/lib/MessengerSubscriptions.test.ts
@@ -1,14 +1,30 @@
 import {
   Messenger,
   MOCK_ANY_NAMESPACE,
-  NamespacedName,
+  MockAnyNamespace,
 } from '@metamask/messenger';
 import { Transform } from 'readable-stream';
 import { JsonRpcNotification } from '@metamask/utils';
+import { ControllerStateChangeEvent } from '@metamask/base-controller';
 import { MessengerSubscriptions } from './MessengerSubscriptions';
 
+const MOCK_STATE_CHANGE = {
+  event: 'ExampleController:stateChange' as const,
+  state: { foo: 'bar' },
+  patches: [],
+};
+
+type ExampleControllerStateChangeEvent = ControllerStateChangeEvent<
+  'ExampleController',
+  { foo: string }
+>;
+
 function setup() {
-  const messenger = new Messenger({ namespace: MOCK_ANY_NAMESPACE });
+  const messenger = new Messenger<
+    MockAnyNamespace,
+    never,
+    ExampleControllerStateChangeEvent
+  >({ namespace: MOCK_ANY_NAMESPACE });
   const stream = new Transform({
     objectMode: true,
     transform(_chunk: JsonRpcNotification, _, callback) {
@@ -20,24 +36,19 @@ function setup() {
   return { messenger, stream, subscriptions };
 }
 
-const MOCK_STATE_CHANGE = {
-  event: 'ExampleController:stateChange' as NamespacedName,
-  params: [{ foo: 'bar' }, []],
-};
-
 describe('MessengerSubscriptions', () => {
   it('sends JSON-RPC notifications for subscribed events', () => {
     const { messenger, stream, subscriptions } = setup();
     const subscribeSpy = jest.spyOn(messenger, 'subscribe');
     const writeSpy = jest.spyOn(stream, 'write');
 
-    const { event, params } = MOCK_STATE_CHANGE;
+    const { event, state, patches } = MOCK_STATE_CHANGE;
 
     subscriptions.subscribe(event);
 
     expect(subscribeSpy).toHaveBeenCalledWith(event, expect.any(Function));
 
-    messenger.publish(event, ...params);
+    messenger.publish(event, state, patches);
 
     expect(writeSpy).toHaveBeenCalledWith({
       jsonrpc: '2.0',
@@ -52,17 +63,17 @@ describe('MessengerSubscriptions', () => {
     const unsubscribeSpy = jest.spyOn(messenger, 'unsubscribe');
     const writeSpy = jest.spyOn(stream, 'write');
 
-    const { event, params } = MOCK_STATE_CHANGE;
+    const { event, state, patches } = MOCK_STATE_CHANGE;
 
     subscriptions.subscribe(event);
     subscriptions.subscribe(event);
 
-    messenger.publish(event, ...params);
+    messenger.publish(event, state, patches);
 
     subscriptions.unsubscribe(event);
     subscriptions.unsubscribe(event);
 
-    messenger.publish(event, ...params);
+    messenger.publish(event, state, patches);
 
     expect(writeSpy).toHaveBeenCalledTimes(1);
     expect(subscribeSpy).toHaveBeenCalledTimes(1);
@@ -75,7 +86,7 @@ describe('MessengerSubscriptions', () => {
     const unsubscribeSpy = jest.spyOn(messenger, 'unsubscribe');
     const writeSpy = jest.spyOn(stream, 'write');
 
-    const { event, params } = MOCK_STATE_CHANGE;
+    const { event, state, patches } = MOCK_STATE_CHANGE;
 
     subscriptions.subscribe(event);
     subscriptions.subscribe(event);
@@ -84,7 +95,7 @@ describe('MessengerSubscriptions', () => {
 
     subscriptions.clear();
 
-    messenger.publish(event, ...params);
+    messenger.publish(event, state, patches);
 
     expect(subscribeSpy).toHaveBeenCalledTimes(3);
     expect(unsubscribeSpy).toHaveBeenCalledTimes(3);

--- a/app/scripts/lib/MessengerSubscriptions.ts
+++ b/app/scripts/lib/MessengerSubscriptions.ts
@@ -4,11 +4,11 @@ import { BaseControllerMessenger } from '../controller-init/types';
 import { isStreamWritable } from './stream-utils';
 
 export class MessengerSubscriptions {
-  #messenger: BaseControllerMessenger;
+  readonly #messenger: BaseControllerMessenger;
 
-  #stream: Duplex;
+  readonly #stream: Duplex;
 
-  #subscriptions = new Map<
+  readonly #subscriptions = new Map<
     NamespacedName,
     { listener: (...payload: unknown[]) => void; count: number }
   >();

--- a/app/scripts/lib/MessengerSubscriptions.ts
+++ b/app/scripts/lib/MessengerSubscriptions.ts
@@ -1,6 +1,7 @@
 import { Duplex } from 'readable-stream';
 import { NamespacedName } from '@metamask/messenger';
 import { BaseControllerMessenger } from '../controller-init/types';
+import { MESSENGER_SUBSCRIPTION_NOTIFICATION } from '../../../shared/constants/messages';
 import { isStreamWritable } from './stream-utils';
 
 export class MessengerSubscriptions {
@@ -39,7 +40,7 @@ export class MessengerSubscriptions {
 
       this.#stream.write({
         jsonrpc: '2.0',
-        method: 'messengerSubscription',
+        method: MESSENGER_SUBSCRIPTION_NOTIFICATION,
         params: [event, payload],
       });
     };

--- a/app/scripts/lib/MessengerSubscriptions.ts
+++ b/app/scripts/lib/MessengerSubscriptions.ts
@@ -1,0 +1,83 @@
+import { Duplex } from 'readable-stream';
+import { NamespacedName } from '@metamask/messenger';
+import { BaseControllerMessenger } from '../controller-init/types';
+import { isStreamWritable } from './stream-utils';
+
+export class MessengerSubscriptions {
+  #messenger: BaseControllerMessenger;
+
+  #stream: Duplex;
+
+  #subscriptions = new Map<
+    NamespacedName,
+    { listener: (...payload: unknown[]) => void; count: number }
+  >();
+
+  constructor(messenger: BaseControllerMessenger, stream: Duplex) {
+    this.#messenger = messenger;
+    this.#stream = stream;
+  }
+
+  /**
+   * Subscribe to a given messenger event, letting emitted events be sent to the UI process as JSON-RPC notifications.
+   *
+   * If an existing subscription already exists, the number of active listeners for the subscription is increased.
+   *
+   * @param event - The name of the event.
+   */
+  subscribe(event: NamespacedName): void {
+    const subscription = this.#subscriptions.get(event);
+    if (subscription) {
+      subscription.count += 1;
+      return;
+    }
+
+    const listener = (...payload: unknown[]) => {
+      if (!isStreamWritable(this.#stream)) {
+        return;
+      }
+
+      this.#stream.write({
+        jsonrpc: '2.0',
+        method: 'messengerSubscription',
+        params: [event, payload],
+      });
+    };
+
+    this.#subscriptions.set(event, { listener, count: 1 });
+
+    this.#messenger.subscribe(event, listener);
+  }
+
+  /**
+   * Unsubscribe from a given event, if no listeners remain, the subscription is fully removed.
+   *
+   * @param event - The name of the event.
+   */
+  unsubscribe(event: NamespacedName): void {
+    const subscription = this.#subscriptions.get(event);
+
+    if (!subscription) {
+      throw new Error(`No active subscriptions found for: "${event}".`);
+    }
+
+    if (subscription.count > 1) {
+      subscription.count -= 1;
+      return;
+    }
+
+    this.#messenger.unsubscribe(event, subscription.listener);
+    this.#subscriptions.delete(event);
+  }
+
+  /**
+   * Clear all active subscriptions and unregister listeners from the messenger.
+   */
+  clear(): void {
+    this.#subscriptions.forEach((subscription, event) => {
+      this.#messenger.unsubscribe(event, subscription.listener);
+    });
+
+    this.#subscriptions.clear();
+  }
+}

--- a/app/scripts/lib/metaRPCClientFactory.ts
+++ b/app/scripts/lib/metaRPCClientFactory.ts
@@ -7,6 +7,7 @@ import {
   JsonRpcNotification,
   isObject,
   hasProperty,
+  JsonRpcParams,
 } from '@metamask/utils';
 import { JsonRpcError } from '@metamask/rpc-errors';
 import getNextId from '../../../shared/modules/random-id';
@@ -188,8 +189,21 @@ export class MetaRPCClient<Api extends FunctionRegistry<Api>> {
    *
    * @param handler - The handler to call when a notification is received.
    */
-  onNotification = (handler: (data: JsonRpcNotification) => void) => {
+  onNotification = <Params extends JsonRpcParams>(
+    handler: (data: JsonRpcNotification<Params>) => void,
+  ) => {
     this.#notificationChannel.addListener('notification', handler);
+  };
+
+  /**
+   * Remove a listener for JSON-RPC notifications.
+   *
+   * @param handler - The handler to remove.
+   */
+  removeOnNotification = <Params extends JsonRpcParams>(
+    handler: (data: JsonRpcNotification<Params>) => void,
+  ) => {
+    this.#notificationChannel.removeListener('notification', handler);
   };
 
   /**

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -6561,7 +6561,7 @@ export default class MetamaskController extends EventEmitter {
       messengerUnsubscribe: messengerSubscriptions.unsubscribe.bind(
         messengerSubscriptions,
       ),
-      messengerCall: (method, params) =>
+      messengerCall: (method, params = []) =>
         this.controllerMessenger.call(method, ...params),
     };
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -423,6 +423,7 @@ import {
 } from './controller-init/claims';
 import { ProfileMetricsControllerInit } from './controller-init/profile-metrics-controller-init';
 import { ProfileMetricsServiceInit } from './controller-init/profile-metrics-service-init';
+import { MessengerSubscriptions } from './lib/MessengerSubscriptions';
 
 export const METAMASK_CONTROLLER_EVENTS = {
   // Fired after state changes that impact the extension badge (unapproved msg count)
@@ -6541,6 +6542,11 @@ export default class MetamaskController extends EventEmitter {
       });
     };
 
+    const messengerSubscriptions = new MessengerSubscriptions(
+      this.controllerMessenger,
+      outStream,
+    );
+
     const api = {
       ...this.getApi(),
       ...this.controllerApi,
@@ -6549,6 +6555,14 @@ export default class MetamaskController extends EventEmitter {
         handleUpdate();
       },
       getStatePatches: () => patchStore.flushPendingPatches(),
+      messengerSubscribe: messengerSubscriptions.subscribe.bind(
+        messengerSubscriptions,
+      ),
+      messengerUnsubscribe: messengerSubscriptions.unsubscribe.bind(
+        messengerSubscriptions,
+      ),
+      messengerCall: (method, params) =>
+        this.controllerMessenger.call(method, ...params),
     };
 
     this.on('update', handleUpdate);
@@ -6593,6 +6607,7 @@ export default class MetamaskController extends EventEmitter {
         outStream.mmFinished = true;
         this.removeListener('update', handleUpdate);
         patchStore.destroy();
+        messengerSubscriptions.clear();
       }
     };
 

--- a/shared/constants/messages.ts
+++ b/shared/constants/messages.ts
@@ -4,3 +4,5 @@
 export const EXTENSION_MESSAGES = {
   READY: 'METAMASK_EXTENSION_READY',
 } as const;
+
+export const MESSENGER_SUBSCRIPTION_NOTIFICATION = 'messengerSubscription';

--- a/ui/index.js
+++ b/ui/index.js
@@ -44,7 +44,10 @@ import {
 } from './ducks/metamask/metamask';
 import Root from './pages';
 import txHelper from './helpers/utils/tx-helper';
-import { setBackgroundConnection, MESSENGER_SUBSCRIPTION_NOTIFICATION } from './store/background-connection';
+import {
+  setBackgroundConnection,
+  MESSENGER_SUBSCRIPTION_NOTIFICATION,
+} from './store/background-connection';
 import { getStartupTraceTags } from './helpers/utils/tags';
 import { SEEDLESS_PASSWORD_OUTDATED_CHECK_INTERVAL_MS } from './constants';
 

--- a/ui/index.js
+++ b/ui/index.js
@@ -44,7 +44,7 @@ import {
 } from './ducks/metamask/metamask';
 import Root from './pages';
 import txHelper from './helpers/utils/tx-helper';
-import { setBackgroundConnection } from './store/background-connection';
+import { setBackgroundConnection, MESSENGER_SUBSCRIPTION_NOTIFICATION } from './store/background-connection';
 import { getStartupTraceTags } from './helpers/utils/tags';
 import { SEEDLESS_PASSWORD_OUTDATED_CHECK_INTERVAL_MS } from './constants';
 
@@ -79,7 +79,7 @@ export const connectToBackground = (
       store.dispatch(actions.updateMetamaskState(data.params[0]));
     } else if (method === START_UI_SYNC) {
       await handleStartUISync(data.params[0]);
-    } else if (method !== 'messengerSubscription') {
+    } else if (method !== MESSENGER_SUBSCRIPTION_NOTIFICATION) {
       throw new Error(
         `Internal JSON-RPC Notification Not Handled:\n\n ${JSON.stringify(
           data,

--- a/ui/index.js
+++ b/ui/index.js
@@ -26,6 +26,7 @@ import { switchDirection } from '../shared/lib/switch-direction';
 import { setupLocale } from '../shared/lib/error-utils';
 import { trace, TraceName } from '../shared/lib/trace';
 import { getCurrentChainId } from '../shared/modules/selectors/networks';
+import { MESSENGER_SUBSCRIPTION_NOTIFICATION } from '../shared/constants/messages';
 import * as actions from './store/actions';
 import configureStore from './store/store';
 import {
@@ -44,10 +45,7 @@ import {
 } from './ducks/metamask/metamask';
 import Root from './pages';
 import txHelper from './helpers/utils/tx-helper';
-import {
-  setBackgroundConnection,
-  MESSENGER_SUBSCRIPTION_NOTIFICATION,
-} from './store/background-connection';
+import { setBackgroundConnection } from './store/background-connection';
 import { getStartupTraceTags } from './helpers/utils/tags';
 import { SEEDLESS_PASSWORD_OUTDATED_CHECK_INTERVAL_MS } from './constants';
 

--- a/ui/index.js
+++ b/ui/index.js
@@ -79,7 +79,7 @@ export const connectToBackground = (
       store.dispatch(actions.updateMetamaskState(data.params[0]));
     } else if (method === START_UI_SYNC) {
       await handleStartUISync(data.params[0]);
-    } else {
+    } else if (method !== 'messengerSubscription') {
       throw new Error(
         `Internal JSON-RPC Notification Not Handled:\n\n ${JSON.stringify(
           data,

--- a/ui/store/background-connection.test.ts
+++ b/ui/store/background-connection.test.ts
@@ -1,0 +1,122 @@
+import {
+  createDeferredPromise,
+  Json,
+  JsonRpcNotification,
+} from '@metamask/utils';
+import {
+  MESSENGER_SUBSCRIPTION_NOTIFICATION,
+  setBackgroundConnection,
+  subscribeToMessengerEvent,
+} from './background-connection';
+
+type NotificationListener = (data: JsonRpcNotification) => void;
+
+function setup() {
+  const notificationListeners = new Set<NotificationListener>();
+
+  const onNotification = jest
+    .fn()
+    .mockImplementation((listener: NotificationListener) => {
+      notificationListeners.add(listener);
+    });
+
+  const removeOnNotification = jest
+    .fn()
+    .mockImplementation((listener: NotificationListener) => {
+      notificationListeners.delete(listener);
+    });
+
+  const submitNotification = (notification: JsonRpcNotification) => {
+    notificationListeners.forEach((listener) => listener(notification));
+  };
+
+  const messengerSubscribe = jest.fn();
+
+  const messengerUnsubscribe = jest.fn();
+
+  // @ts-expect-error Partial mock.
+  setBackgroundConnection({
+    onNotification,
+    removeOnNotification,
+    messengerSubscribe,
+    messengerUnsubscribe,
+  });
+
+  return {
+    submitNotification,
+    onNotification,
+    removeOnNotification,
+    messengerSubscribe,
+    messengerUnsubscribe,
+  };
+}
+
+const event = 'ExampleController:stateChange';
+
+describe('subscribeToMessengerEvent', () => {
+  it('invokes callback when JSON-RPC notifications are received', async () => {
+    const { submitNotification, messengerSubscribe } = setup();
+
+    const { promise, resolve } = createDeferredPromise<Json>();
+
+    await subscribeToMessengerEvent<[Json]>(event, ([state]) => resolve(state));
+
+    expect(messengerSubscribe).toHaveBeenCalledWith(event);
+
+    submitNotification({
+      jsonrpc: '2.0',
+      method: MESSENGER_SUBSCRIPTION_NOTIFICATION,
+      params: [event, [{ foo: 'bar' }, []]],
+    });
+
+    const result = await promise;
+
+    expect(result).toStrictEqual({ foo: 'bar' });
+  });
+
+  it('unsubscribes when the cleanup function is called', async () => {
+    const {
+      submitNotification,
+      messengerSubscribe,
+      messengerUnsubscribe,
+      onNotification,
+      removeOnNotification,
+    } = setup();
+
+    const listener = jest.fn();
+
+    const unsubscribe = await subscribeToMessengerEvent(event, listener);
+
+    expect(messengerSubscribe).toHaveBeenCalledWith(event);
+    expect(onNotification).toHaveBeenCalledWith(expect.any(Function));
+
+    await unsubscribe();
+
+    submitNotification({
+      jsonrpc: '2.0',
+      method: MESSENGER_SUBSCRIPTION_NOTIFICATION,
+      params: [event, [{ foo: 'bar' }, []]],
+    });
+
+    expect(listener).not.toHaveBeenCalled();
+
+    expect(messengerUnsubscribe).toHaveBeenCalledWith(event);
+    expect(removeOnNotification).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it('ignores other JSON-RPC notifications', async () => {
+    const { submitNotification } = setup();
+
+    const listener = jest.fn();
+
+    await subscribeToMessengerEvent(event, listener);
+
+    submitNotification({
+      jsonrpc: '2.0',
+      method: 'foo',
+      params: [],
+    });
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/ui/store/background-connection.test.ts
+++ b/ui/store/background-connection.test.ts
@@ -3,8 +3,8 @@ import {
   Json,
   JsonRpcNotification,
 } from '@metamask/utils';
+import { MESSENGER_SUBSCRIPTION_NOTIFICATION } from '../../shared/constants/messages';
 import {
-  MESSENGER_SUBSCRIPTION_NOTIFICATION,
   setBackgroundConnection,
   subscribeToMessengerEvent,
 } from './background-connection';

--- a/ui/store/background-connection.ts
+++ b/ui/store/background-connection.ts
@@ -64,6 +64,8 @@ export async function subscribeToMessengerEvent<Data extends Json>(
   event: NamespacedName,
   callback: (data: Data) => void,
 ): Promise<() => Promise<void>> {
+  await submitRequestToBackground('messengerSubscribe', [event]);
+
   const listener = (notification: JsonRpcNotification<[string, Data]>) => {
     if (
       notification.method === MESSENGER_SUBSCRIPTION_NOTIFICATION &&
@@ -72,8 +74,6 @@ export async function subscribeToMessengerEvent<Data extends Json>(
       callback(notification.params[1]);
     }
   };
-
-  await submitRequestToBackground('messengerSubscribe', [event]);
 
   background.onNotification(listener);
 

--- a/ui/store/background-connection.ts
+++ b/ui/store/background-connection.ts
@@ -1,3 +1,5 @@
+import { NamespacedName } from '@metamask/messenger';
+import { Json, JsonRpcNotification } from '@metamask/utils';
 // eslint-disable-next-line import/no-restricted-paths
 import { type MetaRpcClientFactory } from '../../app/scripts/lib/metaRPCClientFactory';
 
@@ -47,4 +49,36 @@ export async function setBackgroundConnection(
   backgroundConnection: BackgroundRpcClient,
 ) {
   background = backgroundConnection;
+}
+
+export const MESSENGER_SUBSCRIPTION_NOTIFICATION = 'messengerSubscription';
+
+/**
+ * Subscribe to a given messenger event emitted by the background.
+ *
+ * @param event - The event name.
+ * @param callback - The callback to invoke when the event is emitted.
+ * @returns A cleanup function that can be invoked to unsubscribe.
+ */
+export async function subscribeToMessengerEvent<Data extends Json>(
+  event: NamespacedName,
+  callback: (data: Data) => void,
+): Promise<() => Promise<void>> {
+  const listener = (notification: JsonRpcNotification<[string, Data]>) => {
+    if (
+      notification.method === MESSENGER_SUBSCRIPTION_NOTIFICATION &&
+      notification.params?.[0] === event
+    ) {
+      callback(notification.params[1]);
+    }
+  };
+
+  await submitRequestToBackground('messengerSubscribe', [event]);
+
+  background.onNotification(listener);
+
+  return () => {
+    background.removeOnNotification(listener);
+    return submitRequestToBackground('messengerUnsubscribe', [event]);
+  };
 }

--- a/ui/store/background-connection.ts
+++ b/ui/store/background-connection.ts
@@ -2,6 +2,7 @@ import { NamespacedName } from '@metamask/messenger';
 import { Json, JsonRpcNotification } from '@metamask/utils';
 // eslint-disable-next-line import/no-restricted-paths
 import { type MetaRpcClientFactory } from '../../app/scripts/lib/metaRPCClientFactory';
+import { MESSENGER_SUBSCRIPTION_NOTIFICATION } from '../../shared/constants/messages';
 
 // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -50,8 +51,6 @@ export async function setBackgroundConnection(
 ) {
   background = backgroundConnection;
 }
-
-export const MESSENGER_SUBSCRIPTION_NOTIFICATION = 'messengerSubscription';
 
 /**
  * Subscribe to a given messenger event emitted by the background.


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Add support for subscribing to messenger events in the UI process across the process boundary. This PR introduces a `MessengerSubscriptions` class that manages event subscriptions for a UI process and is cleared when the UI process terminates. The class can be accessed via the background API methods `messengerSubscribe` and `messengerUnsubscribe`.

The first subscription for each event triggers an actual messenger subscription, any following subscribe or unsubscribe calls increment or decrement the number of active listeners. When a subscription is active, JSON-RPC notifications are written to the controller stream with the method name `messengerSubscription`. A utility function `subscribeToMessengerEvent` was introduced to manage subscribing to and reading the JSON-RPC notifications on the UI side, in the same way that `submitRequestToBackground` deals with JSON-RPC requests.

A few minor tweaks to `metaRPCClientFactory` were required as well to improve typing and allow unregistering listeners for notifications. Additionally, this PR adds a `messengerCall` method to the background API that lets the UI invoke `this.controllerMessenger.call` which will eventually let us remove hardcoding the background API.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40663?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

https://consensyssoftware.atlassian.net/browse/WPC-512

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new background↔UI notification channel and new RPC methods on the controller connection; mistakes could cause missed/extra events or leaked subscriptions across UI lifecycle.
> 
> **Overview**
> Enables the UI process to subscribe to background `controllerMessenger` events and receive them as JSON-RPC notifications (`messengerSubscription`) over the existing controller stream.
> 
> The background now exposes `messengerSubscribe`/`messengerUnsubscribe` (with ref-counting and cleanup on stream end via `MessengerSubscriptions`) plus `messengerCall`, while the UI adds `subscribeToMessengerEvent` and updates notification handling to ignore these new subscription notifications. Tests cover both the subscription manager and the UI helper, and `metaRPCClientFactory` adds `removeOnNotification` and improves notification typing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9aa125096f7c852c871bd758db63f6f8c49a9ed0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->