### PR TITLE
fix: flaky test `Confirmation Signature - NFT Permit initiates and confirms and emits the correct events`

### DIFF
--- a/test/e2e/page-objects/pages/confirmations/accountDetailsModal.ts
+++ b/test/e2e/page-objects/pages/confirmations/accountDetailsModal.ts
@@ -40,7 +40,9 @@ class AccountDetailsModal extends Confirmation {
   }
 
   async clickAccountDetailsModalCloseButton() {
-    await this.driver.clickElement(this.accountDetailsModalCloseButton);
+    await this.driver.clickElementAndWaitToDisappear(
+      this.accountDetailsModalCloseButton,
+    );
   }
 
   async assertHeaderInfoBalance(balance: string) {

--- a/test/e2e/page-objects/pages/confirmations/confirmation.ts
+++ b/test/e2e/page-objects/pages/confirmations/confirmation.ts
@@ -1,15 +1,21 @@
-import { Key } from 'selenium-webdriver';
 import { Driver } from '../../../webdriver/driver';
 import { RawLocator } from '../../common';
 
 class Confirmation {
   protected driver: Driver;
 
-  private confirmationHeadingTitle: RawLocator;
+  private accountAddressDetails: RawLocator = {
+    tag: 'p',
+    text: 'Account address',
+  };
 
-  private footerCancelButton: RawLocator;
+  private confirmationHeadingTitle: RawLocator = {
+    text: 'Confirmation Dialog',
+  };
 
-  private footerConfirmButton: RawLocator;
+  private footerCancelButton = '[data-testid="confirm-footer-cancel-button"]';
+
+  private footerConfirmButton = '[data-testid="confirm-footer-button"]';
 
   private formComboFieldInputSelector = '.form-combo-field input';
 
@@ -21,40 +27,30 @@ class Confirmation {
 
   private formComboFieldSelector = '.form-combo-field';
 
-  private headerAccountDetailsButton: RawLocator;
+  private headerAccountDetailsButton =
+    '[data-testid="header-info__account-details-button"]';
 
   private inlineAlertButton = '[data-testid="inline-alert"]';
 
   private nameSelector = '.name';
 
-  private navigationTitle: RawLocator;
+  private navigationTitle = '[data-testid="confirm-page-nav-position"]';
 
-  private nextPageButton: RawLocator;
+  private nextPageButton = '[data-testid="confirm-nav__next-confirmation"]';
 
-  private previousPageButton: RawLocator;
+  private previousPageButton =
+    '[data-testid="confirm-nav__previous-confirmation"]';
 
-  private rejectAllButton: RawLocator;
+  private rejectAllButton = '[data-testid="confirm-nav__reject-all"]';
 
   private saveButtonSelector = { text: 'Save', tag: 'button' };
 
-  private scrollToBottomButton: RawLocator;
+  private scrollToBottomButton = '.confirm-scroll-to-bottom__button';
 
   private sectionCollapseButton = '[data-testid="sectionCollapseButton"]';
 
   constructor(driver: Driver) {
     this.driver = driver;
-
-    this.confirmationHeadingTitle = { text: 'Confirmation Dialog' };
-    this.footerCancelButton = '[data-testid="confirm-footer-cancel-button"]';
-    this.footerConfirmButton = '[data-testid="confirm-footer-button"]';
-    this.headerAccountDetailsButton =
-      '[data-testid="header-info__account-details-button"]';
-    this.navigationTitle = '[data-testid="confirm-page-nav-position"]';
-    this.nextPageButton = '[data-testid="confirm-nav__next-confirmation"]';
-    this.previousPageButton =
-      '[data-testid="confirm-nav__previous-confirmation"]';
-    this.rejectAllButton = '[data-testid="confirm-nav__reject-all"]';
-    this.scrollToBottomButton = '.confirm-scroll-to-bottom__button';
   }
 
   async checkPageIsLoaded(): Promise<void> {
@@ -82,10 +78,8 @@ class Confirmation {
   }
 
   async clickHeaderAccountDetailsButton() {
-    const accountDetailsButton = await this.driver.findElement(
-      this.headerAccountDetailsButton,
-    );
-    await accountDetailsButton.sendKeys(Key.RETURN);
+    await this.driver.clickElement(this.headerAccountDetailsButton);
+    await this.driver.waitForSelector(this.accountAddressDetails);
   }
 
   async clickFooterCancelButton() {

--- a/test/e2e/page-objects/pages/confirmations/confirmation.ts
+++ b/test/e2e/page-objects/pages/confirmations/confirmation.ts
@@ -1,3 +1,4 @@
+import { Key } from 'selenium-webdriver';
 import { Driver } from '../../../webdriver/driver';
 import { RawLocator } from '../../common';
 
@@ -78,7 +79,10 @@ class Confirmation {
   }
 
   async clickHeaderAccountDetailsButton() {
-    await this.driver.clickElement(this.headerAccountDetailsButton);
+    const accountDetailsButton = await this.driver.findElement(
+      this.headerAccountDetailsButton,
+    );
+    await accountDetailsButton.sendKeys(Key.RETURN);
     await this.driver.waitForSelector(this.accountAddressDetails);
   }
 

--- a/test/e2e/tests/confirmations/signatures/nft-permit.spec.ts
+++ b/test/e2e/tests/confirmations/signatures/nft-permit.spec.ts
@@ -51,6 +51,7 @@ describe('Confirmation Signature - NFT Permit', function (this: Suite) {
         await assertInfoValues(driver);
         await confirmation.clickScrollToBottomButton();
         await confirmation.clickFooterConfirmButtonAndAndWaitForWindowToClose();
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
 
         await assertAccountDetailsMetrics(
           driver,

--- a/test/e2e/tests/confirmations/signatures/nft-permit.spec.ts
+++ b/test/e2e/tests/confirmations/signatures/nft-permit.spec.ts
@@ -5,7 +5,6 @@ import { Driver } from '../../../webdriver/driver';
 import {
   mockSignatureApprovedWithDecoding,
   mockSignatureRejectedWithDecoding,
-  scrollAndConfirmAndAssertConfirm,
   withSignatureFixtures,
 } from '../helpers';
 import { TestSuiteArguments } from '../transactions/shared';
@@ -38,12 +37,11 @@ describe('Confirmation Signature - NFT Permit', function (this: Suite) {
 
         await loginWithBalanceValidation(driver);
         await testDapp.openTestDappAndTriggerDeploy();
-        await driver.delay(1000);
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
-        await scrollAndConfirmAndAssertConfirm(driver);
+        await confirmation.clickScrollToBottomButton();
+        await confirmation.clickFooterConfirmButtonAndAndWaitForWindowToClose();
 
         await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
-        await driver.delay(1000);
         await testDapp.triggerSignature(SignatureType.NFTPermit);
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
@@ -51,8 +49,8 @@ describe('Confirmation Signature - NFT Permit', function (this: Suite) {
         await accountDetailsModal.clickAccountDetailsModalCloseButton();
 
         await assertInfoValues(driver);
-        await scrollAndConfirmAndAssertConfirm(driver);
-        await driver.delay(1000);
+        await confirmation.clickScrollToBottomButton();
+        await confirmation.clickFooterConfirmButtonAndAndWaitForWindowToClose();
 
         await assertAccountDetailsMetrics(
           driver,
@@ -90,12 +88,11 @@ describe('Confirmation Signature - NFT Permit', function (this: Suite) {
 
         await loginWithBalanceValidation(driver);
         await testDapp.openTestDappAndTriggerDeploy();
-        await driver.delay(1000);
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
-        await driver.clickElement('[data-testid="confirm-footer-button"]');
+        await confirmation.clickScrollToBottomButton();
+        await confirmation.clickFooterConfirmButtonAndAndWaitForWindowToClose();
 
         await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
-        await driver.delay(1000);
         await testDapp.triggerSignature(SignatureType.NFTPermit);
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
@@ -139,8 +136,6 @@ async function assertInfoValues(driver: Driver) {
 
 async function assertVerifiedResults(driver: Driver, publicAddress: string) {
   const testDapp = new TestDapp(driver);
-  await driver.waitUntilXWindowHandles(2);
-  await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
 
   await testDapp.checkSuccessSign721Permit(publicAddress);
   await testDapp.verifySign721PermitResult(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Intermittent failure due to the account detail modal not closing:

ElementClickInterceptedError: element click intercepted: Element <button class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-f...

We now wait until the modal is open (element rendered) before closing it

<img width="400" height="515" alt="image" src="https://github.com/user-attachments/assets/afd98129-7dd8-4b99-824c-65122088ab21" />

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40664?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to E2E test/page-object synchronization (waiting for modal/window transitions), with no production logic impact; risk is mainly around selector/timing assumptions affecting test stability.
> 
> **Overview**
> Stabilizes the flaky NFT Permit confirmation E2E flow by replacing fixed delays and the `scrollAndConfirmAndAssertConfirm` helper with explicit, reusable waits for UI transitions (scroll-to-bottom then confirm and *wait for the dialog window to close*).
> 
> Improves confirmation page objects by waiting for the Account Details section to render after opening it, and by closing the Account Details modal via `clickElementAndWaitToDisappear` to avoid click interception from overlapping elements.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c640b2ba02f4cb3fe48e4825b6c2c3d378847b1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->