### PR TITLE
fix: flaky test `Address Book Sends to an address book entry on a different network`

### DIFF
--- a/test/e2e/tests/settings/address-book.spec.ts
+++ b/test/e2e/tests/settings/address-book.spec.ts
@@ -2,20 +2,17 @@ import { Suite } from 'mocha';
 import { Mockttp } from 'mockttp';
 import { withFixtures } from '../../helpers';
 import { shortenAddress } from '../../../../ui/helpers/utils/util';
-import FixtureBuilder from '../../fixtures/fixture-builder';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import ActivityListPage from '../../page-objects/pages/home/activity-list';
 import ContactsPage from '../../page-objects/pages/settings/contacts-settings';
 import HeaderNavbar from '../../page-objects/pages/header-navbar';
 import SettingsPage from '../../page-objects/pages/settings/settings-page';
 import TransactionConfirmation from '../../page-objects/pages/confirmations/transaction-confirmation';
-import {
-  loginWithBalanceValidation,
-  loginWithoutBalanceValidation,
-} from '../../page-objects/flows/login.flow';
+import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow';
 import NetworkManager from '../../page-objects/pages/network-manager';
 import { TOKENS_API_MOCK_RESULT } from '../../../data/mock-data';
 import { createInternalTransaction } from '../../page-objects/flows/transaction';
+import { NETWORK_CLIENT_ID } from '../../constants';
 
 async function mockTokenList(mockServer: Mockttp) {
   return await mockServer
@@ -73,8 +70,8 @@ describe('Address Book', function (this: Suite) {
   it('Sends to an address book entry on a different network', async function () {
     await withFixtures(
       {
-        fixtures: new FixtureBuilder()
-          .withNetworkControllerOnMainnet()
+        fixtures: new FixtureBuilderV2()
+          .withSelectedNetwork(NETWORK_CLIENT_ID.LINEA_MAINNET)
           .withAddressBookController({
             addressBook: {
               '0x539': {
@@ -90,7 +87,6 @@ describe('Address Book', function (this: Suite) {
           })
           .withEnabledNetworks({
             eip155: {
-              '0x539': true,
               '0xe708': true,
             },
           })
@@ -99,10 +95,10 @@ describe('Address Book', function (this: Suite) {
         title: this.test?.fullTitle(),
       },
       async ({ driver }) => {
-        await loginWithoutBalanceValidation(driver);
-        const networkSelector = new NetworkManager(driver);
-        await networkSelector.selectNetworkByChainId('0xe708');
+        // Start on Linea
+        await loginWithBalanceValidation(driver);
 
+        // Send transaction on Localhost
         await createInternalTransaction({
           driver,
           chainId: '0x539',
@@ -112,6 +108,12 @@ describe('Address Book', function (this: Suite) {
         });
 
         await new TransactionConfirmation(driver).clickFooterConfirmButton();
+
+        // Select Linea to check the Activity list
+        const networkSelector = new NetworkManager(driver);
+        await networkSelector.openNetworkManager();
+        await networkSelector.selectTab('Custom');
+        await networkSelector.selectNetworkByName('Localhost 8545');
 
         const activityList = new ActivityListPage(driver);
         await activityList.checkConfirmedTxNumberDisplayedInActivity(1);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The test is flaky as sometimes the balance is not loaded when we reach the confirmation screen and get input validation error for the amount
<img width="1152" height="836" alt="image" src="https://github.com/user-attachments/assets/3b2ddc02-07ce-4d69-817d-02652f514643" />



[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40665?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to E2E test setup and navigation, with no production code paths affected; main risk is altering assumptions about default network selection in the test.
> 
> **Overview**
> Fixes flakiness in `address-book.spec.ts` for the *send to address book entry on a different network* scenario by switching to `FixtureBuilderV2` with an explicit starting network (`NETWORK_CLIENT_ID.LINEA_MAINNET`) and using `loginWithBalanceValidation` to wait for balances to load.
> 
> Updates the test flow to drive network selection via the network manager UI (selecting `Localhost 8545`) before asserting the Activity list, and removes unused imports/fixture setup tied to the previous approach.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 145f10d6d6242d075313ee7d83b2b45b64b34570. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->