### PR TITLE
fix: test `Dapp interactions should connect a second Dapp despite MetaMask being locked`

### DIFF
--- a/test/e2e/page-objects/pages/confirmations/connect-account-confirmation.ts
+++ b/test/e2e/page-objects/pages/confirmations/connect-account-confirmation.ts
@@ -52,12 +52,14 @@ class ConnectAccountConfirmation {
 
   async checkPageIsLoaded({
     origin = '127.0.0.1',
-  }: { origin?: string } = {}): Promise<void> {
+    account = 'Account 1',
+  }: { origin?: string; account?: string } = {}): Promise<void> {
     try {
       await this.driver.waitForMultipleSelectors([
         this.connectAccountConfirmationTitle,
         this.connectAccountConfirmationButton,
         this.originHeader(origin),
+        this.accountListItem(account),
       ]);
     } catch (e) {
       console.log(

--- a/test/e2e/page-objects/pages/confirmations/connect-account-confirmation.ts
+++ b/test/e2e/page-objects/pages/confirmations/connect-account-confirmation.ts
@@ -46,27 +46,18 @@ class ConnectAccountConfirmation {
     testId: 'permissions-tab',
   };
 
-  private readonly walletItem = (walletNumber: string) => {
-    return {
-      tag: 'p',
-      text: walletNumber,
-    };
-  };
-
   constructor(driver: Driver) {
     this.driver = driver;
   }
 
   async checkPageIsLoaded({
     origin = '127.0.0.1',
-    walletItem = 'Wallet 1',
-  }: { origin?: string; walletItem?: string } = {}): Promise<void> {
+  }: { origin?: string } = {}): Promise<void> {
     try {
       await this.driver.waitForMultipleSelectors([
         this.connectAccountConfirmationTitle,
         this.connectAccountConfirmationButton,
         this.originHeader(origin),
-        this.walletItem(walletItem),
       ]);
     } catch (e) {
       console.log(

--- a/test/e2e/page-objects/pages/confirmations/connect-account-confirmation.ts
+++ b/test/e2e/page-objects/pages/confirmations/connect-account-confirmation.ts
@@ -46,20 +46,27 @@ class ConnectAccountConfirmation {
     testId: 'permissions-tab',
   };
 
+  private readonly walletItem = (walletNumber: string) => {
+    return {
+      tag: 'p',
+      text: walletNumber,
+    };
+  };
+
   constructor(driver: Driver) {
     this.driver = driver;
   }
 
   async checkPageIsLoaded({
     origin = '127.0.0.1',
-    account = 'Account 1',
-  }: { origin?: string; account?: string } = {}): Promise<void> {
+    walletItem = 'Wallet 1',
+  }: { origin?: string; walletItem?: string } = {}): Promise<void> {
     try {
       await this.driver.waitForMultipleSelectors([
         this.connectAccountConfirmationTitle,
         this.connectAccountConfirmationButton,
         this.originHeader(origin),
-        this.accountListItem(account),
+        this.walletItem(walletItem),
       ]);
     } catch (e) {
       console.log(

--- a/test/e2e/tests/dapp-interactions/dapp-interactions.spec.ts
+++ b/test/e2e/tests/dapp-interactions/dapp-interactions.spec.ts
@@ -84,6 +84,11 @@ describe('Dapp interactions', function () {
         await connectAccountConfirmation.checkForAccountsInPermissionList([
           'Account 1',
         ]);
+
+        // TODO: investigate what is not yet ready in the background
+        // that causes the account not being connected if we don't wait some seconds
+        await driver.delay(5000);
+
         await connectAccountConfirmation.confirmConnect();
         await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
         await testDapp.checkConnectedAccounts(DEFAULT_FIXTURE_ACCOUNT);

--- a/test/e2e/tests/dapp-interactions/dapp-interactions.spec.ts
+++ b/test/e2e/tests/dapp-interactions/dapp-interactions.spec.ts
@@ -54,7 +54,7 @@ describe('Dapp interactions', function () {
     );
   });
 
-  it('should connect a second Dapp despite MetaMask being locked', async function () {
+  it('TEST should connect a second Dapp despite MetaMask being locked', async function () {
     await withFixtures(
       {
         dappOptions: { numberOfTestDapps: 2 },

--- a/test/e2e/tests/dapp-interactions/dapp-interactions.spec.ts
+++ b/test/e2e/tests/dapp-interactions/dapp-interactions.spec.ts
@@ -1,3 +1,4 @@
+import { MockedEndpoint, Mockttp } from 'mockttp';
 import {
   DAPP_ONE_ADDRESS,
   DAPP_ONE_URL,
@@ -13,7 +14,31 @@ import Homepage from '../../page-objects/pages/home/homepage';
 import LoginPage from '../../page-objects/pages/login-page';
 import PermissionListPage from '../../page-objects/pages/permission/permission-list-page';
 import TestDapp from '../../page-objects/pages/test-dapp';
+import { Driver } from '../../webdriver/driver';
 import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow';
+
+async function mockUserStorageEndpoints(
+  mockServer: Mockttp,
+): Promise<MockedEndpoint[]> {
+  return [
+    await mockServer
+      .forGet(
+        'https://user-storage.api.cx.metamask.io/api/v1/userstorage/multichain_accounts_groups/acdd8a187028a7b031aac2df10d822bc971b239ae184bc362ee1e47e4998c8ad',
+      )
+      .thenCallback(() => ({
+        statusCode: 200,
+        json: null,
+      })),
+    await mockServer
+      .forGet(
+        'https://user-storage.api.cx.metamask.io/api/v1/userstorage/addressBook',
+      )
+      .thenCallback(() => ({
+        statusCode: 200,
+        json: null,
+      })),
+  ];
+}
 
 describe('Dapp interactions', function () {
   it('should trigger the add chain confirmation despite MetaMask being locked', async function () {
@@ -61,9 +86,16 @@ describe('Dapp interactions', function () {
         fixtures: new FixtureBuilderV2()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
+        testSpecificMock: mockUserStorageEndpoints,
         title: this.test?.fullTitle(),
       },
-      async ({ driver }) => {
+      async ({
+        driver,
+        mockedEndpoint: mockedEndpoints,
+      }: {
+        driver: Driver;
+        mockedEndpoint: MockedEndpoint[];
+      }) => {
         await driver.navigate();
         const loginPage = new LoginPage(driver);
         await loginPage.checkPageIsLoaded();
@@ -85,9 +117,13 @@ describe('Dapp interactions', function () {
           'Account 1',
         ]);
 
-        // TODO: investigate what is not yet ready in the background
-        // that causes the account not being connected if we don't wait some seconds
-        await driver.delay(5000);
+        // Wait for the user-storage requests to complete before proceeding
+        for (const endpoint of mockedEndpoints) {
+          await driver.wait(async () => {
+            const isPending = await endpoint.isPending();
+            return isPending === false;
+          }, driver.timeout);
+        }
 
         await connectAccountConfirmation.confirmConnect();
         await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);

--- a/test/e2e/tests/dapp-interactions/dapp-interactions.spec.ts
+++ b/test/e2e/tests/dapp-interactions/dapp-interactions.spec.ts
@@ -17,25 +17,15 @@ import TestDapp from '../../page-objects/pages/test-dapp';
 import { Driver } from '../../webdriver/driver';
 import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow';
 
-async function mockUserStorageEndpoints(
+async function mockNotificationsEndpoint(
   mockServer: Mockttp,
 ): Promise<MockedEndpoint[]> {
   return [
     await mockServer
-      .forGet(
-        'https://user-storage.api.cx.metamask.io/api/v1/userstorage/multichain_accounts_groups/acdd8a187028a7b031aac2df10d822bc971b239ae184bc362ee1e47e4998c8ad',
-      )
+      .forPost('https://notification.api.cx.metamask.io/api/v3/notifications')
       .thenCallback(() => ({
         statusCode: 200,
-        json: null,
-      })),
-    await mockServer
-      .forGet(
-        'https://user-storage.api.cx.metamask.io/api/v1/userstorage/addressBook',
-      )
-      .thenCallback(() => ({
-        statusCode: 200,
-        json: null,
+        json: [],
       })),
   ];
 }
@@ -86,7 +76,7 @@ describe('Dapp interactions', function () {
         fixtures: new FixtureBuilderV2()
           .withPermissionControllerConnectedToTestDapp()
           .build(),
-        testSpecificMock: mockUserStorageEndpoints,
+        testSpecificMock: mockNotificationsEndpoint,
         title: this.test?.fullTitle(),
       },
       async ({
@@ -117,13 +107,12 @@ describe('Dapp interactions', function () {
           'Account 1',
         ]);
 
-        // Wait for the user-storage requests to complete before proceeding
-        for (const endpoint of mockedEndpoints) {
-          await driver.wait(async () => {
-            const isPending = await endpoint.isPending();
-            return isPending === false;
-          }, driver.timeout);
-        }
+        // Wait until last request happens in the connect screen to ensure is ready
+        const [notificationsEndpoint] = mockedEndpoints;
+        await driver.wait(async () => {
+          const isPending = await notificationsEndpoint.isPending();
+          return isPending === false;
+        }, driver.timeout);
 
         await connectAccountConfirmation.confirmConnect();
         await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);

--- a/test/e2e/tests/dapp-interactions/dapp-interactions.spec.ts
+++ b/test/e2e/tests/dapp-interactions/dapp-interactions.spec.ts
@@ -54,7 +54,7 @@ describe('Dapp interactions', function () {
     );
   });
 
-  it('TEST should connect a second Dapp despite MetaMask being locked', async function () {
+  it('should connect a second Dapp despite MetaMask being locked', async function () {
     await withFixtures(
       {
         dappOptions: { numberOfTestDapps: 2 },
@@ -81,6 +81,9 @@ describe('Dapp interactions', function () {
           driver,
         );
         await connectAccountConfirmation.checkPageIsLoaded();
+        await connectAccountConfirmation.checkForAccountsInPermissionList([
+          'Account 1',
+        ]);
         await connectAccountConfirmation.confirmConnect();
         await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
         await testDapp.checkConnectedAccounts(DEFAULT_FIXTURE_ACCOUNT);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This spec is flaky as after confirming a dapp connection, we are still not connected to the dapp.
This was attempted to fix on the UI side: https://github.com/MetaMask/metamask-extension/pull/40627 ensuring the connect screen was ready before proceeding, but the issue seems to be on the  background processes/reqs side -- something hasn't finished so the connect action never takes place.

This spec triggers the connect action with the wallet locked, so once the popup is open, we see the login screen, then unlock it and then we land into the Connect screen (instead of the home screen, where we usually validate the balance before proceeding).

Once there, several requests happen in the background.
I've added a check to validate the last API request happens before proceeding with the next action. I'm unsure which request/process is needed to finish (we do wait for controllers), this could be investigated further.
For now waiting for the last API request to happen seems to fix the issue.


https://github.com/user-attachments/assets/69955bd6-3c93-49bc-9265-70b7b365885d



[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40666?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. ci should pass --> note the e2e quality gate is triggered bc the spec file is edited, so it is already run several times

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
