### PR TITLE
test: fix flaky WeakRefObjectMap unit test

### DIFF
--- a/app/scripts/lib/WeakRefObjectMap.test.ts
+++ b/app/scripts/lib/WeakRefObjectMap.test.ts
@@ -27,17 +27,20 @@ function hasInternalEntry(map: WeakRefObjectMap<TestRecord>, key: string) {
   ).map.has(key);
 }
 
-async function collectWithRetries(
+async function collectWithinTimeout(
   weakRef: WeakRef<object>,
-  retries = 100,
+  timeoutMs = 15_000,
 ): Promise<boolean> {
-  for (let i = 0; i < retries; i++) {
+  const deadline = Date.now() + timeoutMs;
+
+  do {
     global.gc?.();
     await new Promise((resolve) => setImmediate(resolve));
     if (weakRef.deref() === undefined) {
       return true;
     }
-  }
+  } while (Date.now() < deadline);
+
   return false;
 }
 
@@ -113,7 +116,7 @@ describe('WeakRefObjectMap', () => {
       const weakRef = new WeakRef(staleTarget);
       staleTarget = null;
 
-      const collected = await collectWithRetries(weakRef);
+      const collected = await collectWithinTimeout(weakRef);
       if (!collected) {
         // Keep this test resilient in runtimes where collection is delayed.
         expect(map.has('stale')).toBe(true);
@@ -338,7 +341,7 @@ describe('WeakRefObjectMap with garbage collection', () => {
       const weakRef = new WeakRef(staleTarget);
       staleTarget = null;
 
-      const collected = await collectWithRetries(weakRef);
+      const collected = await collectWithinTimeout(weakRef);
       if (!collected) {
         expect(gcMap.size).toBe(2);
         return;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

fixes flaky test introduced by https://github.com/MetaMask/metamask-extension/pull/40467

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40676?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null
<!--
## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**


### **Before**


### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that adjusts garbage-collection polling logic; no production code paths are affected.
> 
> **Overview**
> Updates `WeakRefObjectMap` GC-dependent unit tests to wait for collection *within a time deadline* (`collectWithinTimeout`) instead of using a fixed retry count. Call sites are updated accordingly, improving resilience in environments where garbage collection timing is inconsistent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dcddf5aee8df1e7e1313ed79b2e4324fa6a2e5ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->