### PR TITLE
fix: maintain activity tab scroll position

### DIFF
--- a/ui/components/multichain/activity-v2/activity-list.tsx
+++ b/ui/components/multichain/activity-v2/activity-list.tsx
@@ -16,6 +16,7 @@ import { useEarliestNonceByChain } from '../../../hooks/useEarliestNonceByChain'
 import type { TransactionViewModel } from '../../../../shared/lib/multichain/types';
 import { formatDateWithYearContext } from '../../../helpers/utils/util';
 import AssetListControlBar from '../../app/assets/asset-list/asset-list-control-bar';
+import { noAdjustmentsScroll } from '../../ui/virtualized-list/virtualized-list';
 import {
   mergeAllTransactionsByTime,
   groupAndFlattenMergedTransactions,
@@ -143,6 +144,8 @@ export const ActivityList = ({ filter }: Props) => {
     },
     overscan: 5,
     scrollMargin,
+    initialOffset: scrollContainerRef?.current?.scrollTop,
+    scrollToFn: noAdjustmentsScroll,
   });
 
   const virtualItems = virtualizer.getVirtualItems();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Maintain scroll position when navigating to the Activity tab

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40681?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: maintain activity tab scroll position

## **Related issues**

Fixes:

## **Manual testing steps**

1. Scroll down the Tokens list
2. Switch to the Activity tab

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk UI change that tweaks `@tanstack/react-virtual` options; main risk is minor scrolling/virtualization regressions (e.g., unexpected jump or offset) in the Activity tab.
> 
> **Overview**
> Preserves the Activity tab’s scroll position by initializing the `useVirtualizer` offset from the current scroll container `scrollTop`.
> 
> Updates the virtualizer to use the shared `noAdjustmentsScroll` `scrollToFn`, aligning scroll behavior with other virtualized lists and preventing unwanted scroll adjustments on navigation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7ceae854006802e15d6862f70ce7c41918f5925. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->