### PR TITLE
fix(webpack): preserve null values in safeVariables

### DIFF
--- a/development/webpack/test/config.test.ts
+++ b/development/webpack/test/config.test.ts
@@ -129,6 +129,31 @@ describe('./utils/config.ts', () => {
       assert.strictEqual(variables.get('TESTING_EMPTY_STRING'), null);
     });
 
+    it('includes null values and omits undefined values in safeVariables', () => {
+      const buildTypes = loadBuildTypesConfig();
+      const { args } = parseArgv(['--mode', 'production'], buildTypes);
+
+      mockRc({
+        TESTING_NULL: 'null',
+        TESTING_EMPTY_STRING: '',
+      });
+
+      const { variables, safeVariables } = config.getVariables(
+        args,
+        buildTypes,
+      );
+
+      assert.strictEqual(variables.get('TESTING_NULL'), null);
+      assert.strictEqual(variables.get('TESTING_EMPTY_STRING'), null);
+      assert.strictEqual(variables.get('DEBUG'), undefined);
+      assert.strictEqual(safeVariables.TESTING_NULL, 'null');
+      assert.strictEqual(safeVariables.TESTING_EMPTY_STRING, 'null');
+      assert.strictEqual(
+        Object.prototype.hasOwnProperty.call(safeVariables, 'DEBUG'),
+        false,
+      );
+    });
+
     it('should return buildEnvVarDeclarations with keys from activeBuild.env and buildConfig.env', () => {
       mockRc();
       const buildTypes = loadBuildTypesConfig();

--- a/development/webpack/utils/config.ts
+++ b/development/webpack/utils/config.ts
@@ -166,8 +166,11 @@ export function getVariables(
   // values be JSON stringified, as it JSON.parses them internally.
   const safeVariables: Record<string, string> = {};
   variables.forEach((value, key) => {
-    if (value === null || value === undefined) return;
-    safeVariables[key] = JSON.stringify(value);
+    // this intentionally allows `null`, but omits `undefined`
+    // as this is what the old build system did.
+    if (typeof value !== 'undefined') {
+      safeVariables[key] = JSON.stringify(value);
+    }
   });
 
   // special location for the PPOM_URI, as we don't want to copy the wasm file

--- a/lavamoat/webpack/mv2/beta/policy.json
+++ b/lavamoat/webpack/mv2/beta/policy.json
@@ -2168,8 +2168,7 @@
     },
     "@metamask/snaps-sdk": {
       "globals": {
-        "URL": true,
-        "fetch": true
+        "URL": true
       },
       "packages": {
         "@metamask/rpc-errors": true,

--- a/lavamoat/webpack/mv2/experimental/policy.json
+++ b/lavamoat/webpack/mv2/experimental/policy.json
@@ -2168,8 +2168,7 @@
     },
     "@metamask/snaps-sdk": {
       "globals": {
-        "URL": true,
-        "fetch": true
+        "URL": true
       },
       "packages": {
         "@metamask/rpc-errors": true,

--- a/lavamoat/webpack/mv2/flask/policy.json
+++ b/lavamoat/webpack/mv2/flask/policy.json
@@ -2168,8 +2168,7 @@
     },
     "@metamask/snaps-sdk": {
       "globals": {
-        "URL": true,
-        "fetch": true
+        "URL": true
       },
       "packages": {
         "@metamask/rpc-errors": true,

--- a/lavamoat/webpack/mv2/main/policy.json
+++ b/lavamoat/webpack/mv2/main/policy.json
@@ -2168,8 +2168,7 @@
     },
     "@metamask/snaps-sdk": {
       "globals": {
-        "URL": true,
-        "fetch": true
+        "URL": true
       },
       "packages": {
         "@metamask/rpc-errors": true,


### PR DESCRIPTION
## **Description**

This PR updates webpack variable serialization behavior so `safeVariables` preserves `null` values and omits only `undefined`, matching legacy build behavior.

It also adds an explicit unit test that verifies this behavior in `development/webpack/test/config.test.ts`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/7099

## **Manual testing steps**

1. build using `yarn webpack --minify`
2. search the output files for `WITH_STATE` (an env variable that defaults to `null`.
3. Make sure `WITH_STATE` is ONLY in the .map files, not in source code.

<!--
## **Screenshots/Recordings**

### **Before**

[screenshots/recordings]

### **After**

[screenshots/recordings]
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how webpack serializes env variables into `safeVariables`, which can affect build-time constant injection and output behavior. Updating LavaMoat policies (removing `fetch` from `@metamask/snaps-sdk` globals) could break builds or runtime if that global was still required.
> 
> **Overview**
> Restores legacy webpack env serialization by **including `null` values** in `safeVariables` while still **omitting `undefined`**, so `null` becomes an explicit JSON string (`"null"`) during SWC define-time substitution.
> 
> Adds a unit test asserting the new `safeVariables` behavior for `null` vs `undefined`, and tightens LavaMoat MV2 policies by removing the `fetch` global allowance from `@metamask/snaps-sdk` across build variants.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e795630c7b962b0b8da0361654f043088a540d31. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->