### PR TITLE
chore: Teach Cursor about more unit testing rules

### DIFF
--- a/.cursor/rules/unit-testing-guidelines/RULE.md
+++ b/.cursor/rules/unit-testing-guidelines/RULE.md
@@ -115,6 +115,35 @@ it('returns the block number', () => {});
   - Methods starting with `_` (informal private convention)
   - Methods with `private` keyword in TypeScript
   - Functions/methods tagged with `@private` JSDoc
+- **NEVER name a `describe` block after private code** — doing so exposes implementation details in test descriptions and signals the test is structured around internals rather than behaviour
+- If a private function is only reachable through a public function, its tests belong nested inside that public function's `describe` block, using "when..." scenarios to describe the different paths
+
+Example:
+
+```typescript
+// Given this module with one exported function and private helpers:
+//   export function processOrder(order) { ... }  // calls validateOrder(), applyDiscount()
+
+❌ WRONG: separate describe blocks for private helpers
+describe('validateOrder', () => {          // ← private, should not appear
+  it('throws when amount is negative', () => { ... });
+});
+
+describe('applyDiscount', () => {          // ← private, should not appear
+  it('applies 10% for premium users', () => { ... });
+});
+
+✅ CORRECT: all behaviour tested through the public entry point
+describe('processOrder', () => {
+  describe('when the order amount is negative', () => {
+    it('throws a validation error', () => { ... });
+  });
+
+  describe('when the user is a premium member', () => {
+    it('applies a 10% discount', () => { ... });
+  });
+});
+```
 
 #### Test Phase Organization
 
@@ -438,6 +467,61 @@ it('has initial balance', () => {
 });
 ```
 
+#### Prefer Inline Setup Over `beforeEach` Variables
+
+- **PREFER declaring variables inside each test** rather than in outer scope and initialising them in `beforeEach`
+- Shared `beforeEach` variables make it harder to understand what a test depends on — the reader must scroll up to find the setup
+- Use factory functions to reduce repetition without sacrificing locality
+- Reserve `beforeEach` for truly global side effects (e.g. `jest.useFakeTimers()`, `jest.clearAllMocks()`, starting/stopping a server)
+
+Example:
+
+```typescript
+❌ WRONG: variables declared outside tests, initialised in beforeEach
+describe('TokensController', () => {
+  let controller: TokensController;
+  let messenger: Messenger;
+
+  beforeEach(() => {
+    messenger = buildMessenger();
+    controller = new TokensController({ messenger });
+  });
+
+  it('adds a token', () => {
+    controller.addToken({ address: '0x123', symbol: 'DAI', decimals: 18 });
+    expect(controller.state.tokens).toHaveLength(1);
+  });
+
+  it('removes a token', () => {
+    controller.addToken({ address: '0x123', symbol: 'DAI', decimals: 18 });
+    controller.removeToken('0x123');
+    expect(controller.state.tokens).toHaveLength(0);
+  });
+});
+
+✅ CORRECT: each test creates its own instances via factory functions
+function buildController() {
+  const messenger = buildMessenger();
+  const controller = new TokensController({ messenger });
+  return { controller, messenger };
+}
+
+describe('TokensController', () => {
+  it('adds a token', () => {
+    const { controller } = buildController();
+    controller.addToken({ address: '0x123', symbol: 'DAI', decimals: 18 });
+    expect(controller.state.tokens).toHaveLength(1);
+  });
+
+  it('removes a token', () => {
+    const { controller } = buildController();
+    controller.addToken({ address: '0x123', symbol: 'DAI', decimals: 18 });
+    controller.removeToken('0x123');
+    expect(controller.state.tokens).toHaveLength(0);
+  });
+});
+```
+
 ### Controller-Specific Testing Patterns
 
 Reference: [MetaMask Controller Guidelines](https://github.com/MetaMask/core/blob/main/docs/controller-guidelines.md)
@@ -720,6 +804,7 @@ Before submitting tests, ensure:
 - [ ] Test descriptions use present tense without "should"
 - [ ] Tests are focused on single behaviors
 - [ ] Private code is tested through public interface
+- [ ] No `describe` block is named after private/non-exported code
 - [ ] Test phases (Arrange, Act, Assert) are clear
 
 ### Mocking and Data
@@ -730,6 +815,7 @@ Before submitting tests, ensure:
 - [ ] Factory functions used for complex test objects
 - [ ] No shared mutable state across tests
 - [ ] Fresh mock data created per test
+- [ ] Variables declared inside each test (not in outer scope via `beforeEach`)
 
 ### Async Testing
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

When working on a previous PR that involved writing tests, I noticed a couple of things missing from the existing Cursor rules:

- When organizing tests, only reference the public API in test descriptions, particularly when indirectly exercising private code.
- Even when using factory functions to encapsulate setup code, don't share variables across tests using `beforeEach` blocks, but set those variables inside tests themselves.

Both of these are compatible with the unit testing guidelines but were perhaps not highlighted in these agent rules as well as they could have been.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40688?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

(Came out of a previous PR)

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates Cursor unit testing guidance; no runtime code paths are affected.
> 
> **Overview**
> Tightens `.cursor/rules/unit-testing-guidelines/RULE.md` to discourage organizing tests around private/non-exported helpers by **forbidding `describe` blocks named after private code** and showing how to structure scenarios under the public entry point.
> 
> Adds guidance to **prefer inline per-test setup** (via factory helpers) over sharing controller/test variables initialized in `beforeEach`, and updates the testing checklist to reflect both new rules.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f9fa134aaa63adb716046cc0c3ad2d713d7e484. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->