### PR TITLE
chore: replace deprecated identicon

### DIFF
--- a/ui/components/app/account-list-item/__snapshots__/account-list-item-component.test.js.snap
+++ b/ui/components/app/account-list-item/__snapshots__/account-list-item-component.test.js.snap
@@ -7,45 +7,44 @@ exports[`AccountListItem Component render should match snapshot 1`] = `
     data-testid="account-list-item"
   >
     <div
-      class="account-list-item__top-row"
+      class="account-list-item__top-row items-center gap-2"
     >
       <div
-        class=""
+        class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-md h-6 w-6"
       >
         <div
-          class="identicon account-list-item__identicon"
-          style="height: 18px; width: 18px; border-radius: 9px;"
+          class="flex [&>div]:!rounded-none"
         >
           <div
-            style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 18px; height: 18px; display: inline-block; background: rgb(24, 151, 242);"
+            style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 24px; height: 24px; display: inline-block; background: rgb(24, 151, 242);"
           >
             <svg
-              height="18"
-              width="18"
+              height="24"
+              width="24"
               x="0"
               y="0"
             >
               <rect
                 fill="#2362E1"
-                height="18"
-                transform="translate(2.01899822894579 -3.00054972556886) rotate(458.4 9.00000000000000 9.00000000000000)"
-                width="18"
+                height="24"
+                transform="translate(2.69199763859439 -4.00073296742514) rotate(458.4 12.00000000000000 12.00000000000000)"
+                width="24"
                 x="0"
                 y="0"
               />
               <rect
                 fill="#F94301"
-                height="18"
-                transform="translate(-8.64194585042824 4.49569779496123) rotate(268.8 9.00000000000000 9.00000000000000)"
-                width="18"
+                height="24"
+                transform="translate(-11.52259446723766 5.99426372661497) rotate(268.8 12.00000000000000 12.00000000000000)"
+                width="24"
                 x="0"
                 y="0"
               />
               <rect
                 fill="#FA7900"
-                height="18"
-                transform="translate(-5.10539291960705 16.58250893288440) rotate(117.3 9.00000000000000 9.00000000000000)"
-                width="18"
+                height="24"
+                transform="translate(-6.80719055947607 22.11001191051253) rotate(117.3 12.00000000000000 12.00000000000000)"
+                width="24"
                 x="0"
                 y="0"
               />

--- a/ui/components/app/account-list-item/account-list-item.js
+++ b/ui/components/app/account-list-item/account-list-item.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Identicon from '../../ui/identicon';
+import { AvatarBaseSize } from '@metamask/design-system-react';
+import { PreferredAvatar } from '../preferred-avatar';
 import AccountMismatchWarning from '../../ui/account-mismatch-warning/account-mismatch-warning.component';
 // TODO: Remove restricted import
 // eslint-disable-next-line import/no-restricted-paths
@@ -27,12 +28,9 @@ export default function AccountListItem({
       data-testid="account-list-item"
       onClick={() => handleClick?.({ name, address, balance })}
     >
-      <div className="account-list-item__top-row">
-        <Identicon
-          address={address}
-          className="account-list-item__identicon"
-          diameter={18}
-        />
+      <div className="account-list-item__top-row items-center gap-2">
+        <PreferredAvatar address={address} size={AvatarBaseSize.Sm} />
+
         <div className="account-list-item__account-name">{name || address}</div>
         {icon ? (
           <div

--- a/ui/components/app/account-list-item/index.scss
+++ b/ui/components/app/account-list-item/index.scss
@@ -10,8 +10,6 @@
 
   &__account-name {
     @include design-system.Paragraph;
-
-    margin-left: 8px;
   }
 
   &__icon {

--- a/ui/pages/confirm-decrypt-message/__snapshots__/confirm-decrypt-message.component.test.js.snap
+++ b/ui/pages/confirm-decrypt-message/__snapshots__/confirm-decrypt-message.component.test.js.snap
@@ -46,45 +46,44 @@ exports[`ConfirmDecryptMessage Component matches snapshot 1`] = `
               data-testid="account-list-item"
             >
               <div
-                class="account-list-item__top-row"
+                class="account-list-item__top-row items-center gap-2"
               >
                 <div
-                  class=""
+                  class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-md h-6 w-6"
                 >
                   <div
-                    class="identicon account-list-item__identicon"
-                    style="height: 18px; width: 18px; border-radius: 9px;"
+                    class="flex [&>div]:!rounded-none"
                   >
                     <div
-                      style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 18px; height: 18px; display: inline-block; background: rgb(250, 58, 0);"
+                      style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 24px; height: 24px; display: inline-block; background: rgb(250, 58, 0);"
                     >
                       <svg
-                        height="18"
-                        width="18"
+                        height="24"
+                        width="24"
                         x="0"
                         y="0"
                       >
                         <rect
                           fill="#18CDF2"
-                          height="18"
-                          transform="translate(-0.58972134588409 -1.85865978907153) rotate(328.9 9.00000000000000 9.00000000000000)"
-                          width="18"
+                          height="24"
+                          transform="translate(-0.78629512784545 -2.47821305209537) rotate(328.9 12.00000000000000 12.00000000000000)"
+                          width="24"
                           x="0"
                           y="0"
                         />
                         <rect
                           fill="#035E56"
-                          height="18"
-                          transform="translate(-10.29288471121802 5.95825980285859) rotate(176.2 9.00000000000000 9.00000000000000)"
-                          width="18"
+                          height="24"
+                          transform="translate(-13.72384628162403 7.94434640381145) rotate(176.2 12.00000000000000 12.00000000000000)"
+                          width="24"
                           x="0"
                           y="0"
                         />
                         <rect
                           fill="#F26602"
-                          height="18"
-                          transform="translate(9.37566113525096 -7.99039109418586) rotate(468.9 9.00000000000000 9.00000000000000)"
-                          width="18"
+                          height="24"
+                          transform="translate(12.50088151366794 -10.65385479224781) rotate(468.9 12.00000000000000 12.00000000000000)"
+                          width="24"
                           x="0"
                           y="0"
                         />
@@ -238,45 +237,44 @@ exports[`ConfirmDecryptMessage Component shows error on decrypt inline error 1`]
               data-testid="account-list-item"
             >
               <div
-                class="account-list-item__top-row"
+                class="account-list-item__top-row items-center gap-2"
               >
                 <div
-                  class=""
+                  class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-md h-6 w-6"
                 >
                   <div
-                    class="identicon account-list-item__identicon"
-                    style="height: 18px; width: 18px; border-radius: 9px;"
+                    class="flex [&>div]:!rounded-none"
                   >
                     <div
-                      style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 18px; height: 18px; display: inline-block; background: rgb(250, 58, 0);"
+                      style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 24px; height: 24px; display: inline-block; background: rgb(250, 58, 0);"
                     >
                       <svg
-                        height="18"
-                        width="18"
+                        height="24"
+                        width="24"
                         x="0"
                         y="0"
                       >
                         <rect
                           fill="#18CDF2"
-                          height="18"
-                          transform="translate(-0.58972134588409 -1.85865978907153) rotate(328.9 9.00000000000000 9.00000000000000)"
-                          width="18"
+                          height="24"
+                          transform="translate(-0.78629512784545 -2.47821305209537) rotate(328.9 12.00000000000000 12.00000000000000)"
+                          width="24"
                           x="0"
                           y="0"
                         />
                         <rect
                           fill="#035E56"
-                          height="18"
-                          transform="translate(-10.29288471121802 5.95825980285859) rotate(176.2 9.00000000000000 9.00000000000000)"
-                          width="18"
+                          height="24"
+                          transform="translate(-13.72384628162403 7.94434640381145) rotate(176.2 12.00000000000000 12.00000000000000)"
+                          width="24"
                           x="0"
                           y="0"
                         />
                         <rect
                           fill="#F26602"
-                          height="18"
-                          transform="translate(9.37566113525096 -7.99039109418586) rotate(468.9 9.00000000000000 9.00000000000000)"
-                          width="18"
+                          height="24"
+                          transform="translate(12.50088151366794 -10.65385479224781) rotate(468.9 12.00000000000000 12.00000000000000)"
+                          width="24"
                           x="0"
                           y="0"
                         />
@@ -428,45 +426,44 @@ exports[`ConfirmDecryptMessage Component shows the correct message data 1`] = `
               data-testid="account-list-item"
             >
               <div
-                class="account-list-item__top-row"
+                class="account-list-item__top-row items-center gap-2"
               >
                 <div
-                  class=""
+                  class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-md h-6 w-6"
                 >
                   <div
-                    class="identicon account-list-item__identicon"
-                    style="height: 18px; width: 18px; border-radius: 9px;"
+                    class="flex [&>div]:!rounded-none"
                   >
                     <div
-                      style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 18px; height: 18px; display: inline-block; background: rgb(250, 58, 0);"
+                      style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 24px; height: 24px; display: inline-block; background: rgb(250, 58, 0);"
                     >
                       <svg
-                        height="18"
-                        width="18"
+                        height="24"
+                        width="24"
                         x="0"
                         y="0"
                       >
                         <rect
                           fill="#18CDF2"
-                          height="18"
-                          transform="translate(-0.58972134588409 -1.85865978907153) rotate(328.9 9.00000000000000 9.00000000000000)"
-                          width="18"
+                          height="24"
+                          transform="translate(-0.78629512784545 -2.47821305209537) rotate(328.9 12.00000000000000 12.00000000000000)"
+                          width="24"
                           x="0"
                           y="0"
                         />
                         <rect
                           fill="#035E56"
-                          height="18"
-                          transform="translate(-10.29288471121802 5.95825980285859) rotate(176.2 9.00000000000000 9.00000000000000)"
-                          width="18"
+                          height="24"
+                          transform="translate(-13.72384628162403 7.94434640381145) rotate(176.2 12.00000000000000 12.00000000000000)"
+                          width="24"
                           x="0"
                           y="0"
                         />
                         <rect
                           fill="#F26602"
-                          height="18"
-                          transform="translate(9.37566113525096 -7.99039109418586) rotate(468.9 9.00000000000000 9.00000000000000)"
-                          width="18"
+                          height="24"
+                          transform="translate(12.50088151366794 -10.65385479224781) rotate(468.9 12.00000000000000 12.00000000000000)"
+                          width="24"
                           x="0"
                           y="0"
                         />

--- a/ui/pages/confirm-encryption-public-key/__snapshots__/confirm-encryption-public-key.component.test.js.snap
+++ b/ui/pages/confirm-encryption-public-key/__snapshots__/confirm-encryption-public-key.component.test.js.snap
@@ -46,45 +46,44 @@ exports[`ConfirmDecryptMessage Component should match snapshot when preference i
               data-testid="account-list-item"
             >
               <div
-                class="account-list-item__top-row"
+                class="account-list-item__top-row items-center gap-2"
               >
                 <div
-                  class=""
+                  class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-md h-6 w-6"
                 >
                   <div
-                    class="identicon account-list-item__identicon"
-                    style="height: 18px; width: 18px; border-radius: 9px;"
+                    class="flex [&>div]:!rounded-none"
                   >
                     <div
-                      style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 18px; height: 18px; display: inline-block; background: rgb(245, 228, 0);"
+                      style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 24px; height: 24px; display: inline-block; background: rgb(245, 228, 0);"
                     >
                       <svg
-                        height="18"
-                        width="18"
+                        height="24"
+                        width="24"
                         x="0"
                         y="0"
                       >
                         <rect
                           fill="#F2BE02"
-                          height="18"
-                          transform="translate(3.08403288802877 -2.92239018861041) rotate(387.1 9.00000000000000 9.00000000000000)"
-                          width="18"
+                          height="24"
+                          transform="translate(4.11204385070503 -3.89652025148055) rotate(387.1 12.00000000000000 12.00000000000000)"
+                          width="24"
                           x="0"
                           y="0"
                         />
                         <rect
                           fill="#01778E"
-                          height="18"
-                          transform="translate(-1.46556896727428 9.39634101873176) rotate(227.4 9.00000000000000 9.00000000000000)"
-                          width="18"
+                          height="24"
+                          transform="translate(-1.95409195636571 12.52845469164235) rotate(227.4 12.00000000000000 12.00000000000000)"
+                          width="24"
                           x="0"
                           y="0"
                         />
                         <rect
                           fill="#C81435"
-                          height="18"
-                          transform="translate(10.10795109800867 -7.08336509169213) rotate(422.3 9.00000000000000 9.00000000000000)"
-                          width="18"
+                          height="24"
+                          transform="translate(13.47726813067823 -9.44448678892284) rotate(422.3 12.00000000000000 12.00000000000000)"
+                          width="24"
                           x="0"
                           y="0"
                         />


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Replace deprecated (and incorrectly used) Identicon in account-list-item

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40691?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: chore: replace deprecated identicon

## **Related issues**

Fixes:

## **Manual testing steps**

1. Trigger `eth_decrypt`

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="148" height="86" alt="Screenshot 2026-03-06 at 11 19 19 PM" src="https://github.com/user-attachments/assets/d86e204b-b98a-433e-9f01-d4d322a9f8cc" />


<!-- [screenshots/recordings] -->

### **After**
<img width="133" height="73" alt="Screenshot 2026-03-06 at 11 26 00 PM" src="https://github.com/user-attachments/assets/36b8bb65-5a1e-4d9f-9d72-cd2b91f60c77" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that swaps the avatar implementation and adjusts layout spacing; main risk is minor visual regressions in account rows where the new avatar size/markup differs.
> 
> **Overview**
> Updates `AccountListItem` to stop using the deprecated `Identicon` and instead render the design-system-backed `PreferredAvatar` (respecting the user’s avatar type preference), while also tweaking row alignment with `items-center`/`gap-2`.
> 
> Cleans up related styling (removes the old name left-margin) and updates Jest snapshots for `account-list-item`, `confirm-decrypt-message`, and `confirm-encryption-public-key` to reflect the new avatar markup/sizing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99e29144904680b3be4343d5b7f6e8f79abf3e82. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->