### PR TITLE
Issue 18714 Replace deprecated constants with enums

### DIFF
--- a/ui/pages/swaps/notification-page/notification-page.js
+++ b/ui/pages/swaps/notification-page/notification-page.js
@@ -6,11 +6,11 @@ import { I18nContext } from '../../../contexts/i18n';
 import { setSwapsErrorKey } from '../../../store/actions';
 import Box from '../../../components/ui/box';
 import {
-  DISPLAY,
+  Display,
   AlignItems,
   TextVariant,
-  FLEX_DIRECTION,
-  TEXT_ALIGN,
+  FlexDirection,
+  TextAlign,
   IconColor,
 } from '../../../helpers/constants/design-system';
 import { Icon, IconName, Text } from '../../../components/component-library';
@@ -38,12 +38,12 @@ export default function NotificationPage({ notificationKey }) {
     <div className="notification-page">
       <Box
         alignItems={AlignItems.center}
-        display={DISPLAY.FLEX}
-        flexDirection={FLEX_DIRECTION.COLUMN}
+        display={Display.Flex}
+        flexDirection={FlexDirection.Column}
         marginTop={10}
         marginLeft={4}
         marginRight={4}
-        textAlign={TEXT_ALIGN.CENTER}
+        textAlign={TextAlign.Center}
         className="notification-page__content"
       >
         <Box marginTop={8} marginBottom={4}>


### PR DESCRIPTION
## **Description**

This PR replaces the use of deprecated Display, FlexDirection and TextAlign constants with enum in pages/swaps/notifcation-page.js file.
Fixes https://github.com/MetaMask/metamask-extension/issues/18714

## **Screenshots/Recordings**

### **Before**

<img width="1920" height="1080" alt="noti-page-initial" src="https://github.com/user-attachments/assets/168dbbcc-0568-4b30-8969-9c0bdbade6ff" />

### **After**

<img width="1920" height="1080" alt="noti-after-page" src="https://github.com/user-attachments/assets/9932b4a9-1e0c-46fb-8a8f-20b05e61af7a" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI refactor that swaps deprecated `DISPLAY`/`FLEX_DIRECTION`/`TEXT_ALIGN` constants for the newer `Display`/`FlexDirection`/`TextAlign` enums, with no intended behavior change.
> 
> **Overview**
> Updates the swaps `NotificationPage` layout props to use the newer design-system enums (`Display.Flex`, `FlexDirection.Column`, `TextAlign.Center`) instead of the deprecated constants.
> 
> This is a mechanical import/usage change intended to keep the page aligned with current design-system APIs without altering UI behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd57c0c90a3b0c6c4e31736970ffb4019059b140. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->