### PR TITLE
feat: show "Never expires" in Sign Permission confirmation when no expiration is set

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1487,6 +1487,9 @@
   "confirmFieldMaxAllowance": {
     "message": "Max allowance"
   },
+  "confirmFieldNeverExpires": {
+    "message": "Never expires"
+  },
   "confirmFieldPaymaster": {
     "message": "Fee paid by"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -1487,6 +1487,9 @@
   "confirmFieldMaxAllowance": {
     "message": "Max allowance"
   },
+  "confirmFieldNeverExpires": {
+    "message": "Never expires"
+  },
   "confirmFieldPaymaster": {
     "message": "Fee paid by"
   },

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -2126,10 +2126,9 @@
       "warn: ⚠️ React Router Future Flag": 2
     },
     "ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission.test.tsx": {
-      "MetaMask: Background connection not initialized": 64,
-      "React: Act warnings (component updates not wrapped)": 64,
-      "Reselect: Identity function warnings": 6,
-      "Reselect: Input stability warnings": 3,
+      "MetaMask: Background connection not initialized": 6,
+      "React: Act warnings (component updates not wrapped)": 6,
+      "Reselect: Identity function warnings": 4,
       "Test errors: Uncaught Errors": 6,
       "warn: ⚠️ React Router Future Flag": 2
     },

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -2153,6 +2153,10 @@
       "Test errors: Uncaught Errors": 1,
       "warn: ⚠️ React Router Future Flag": 2
     },
+    "ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/expiry.test.tsx": {
+      "Reselect: Identity function warnings": 3,
+      "warn: ⚠️ React Router Future Flag": 2
+    },
     "ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/native-token-periodic-details.test.tsx": {
       "Reselect: Identity function warnings": 4,
       "Reselect: Input stability warnings": 2,

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission.test.tsx
@@ -152,7 +152,9 @@ describe('TypedSignPermissionInfo', () => {
         'native-token-periodic-details-section',
       );
       expect(detailsSection).toBeInTheDocument();
-      expect(detailsSection?.textContent?.includes('Expiration')).toBe(false);
+
+      expect(detailsSection?.textContent?.includes('Expiration')).toBe(true);
+      expect(detailsSection?.textContent?.includes('Never expires')).toBe(true);
     });
   });
 
@@ -277,7 +279,8 @@ describe('TypedSignPermissionInfo', () => {
       );
       const detailsSection = getByTestId('native-token-stream-details-section');
       expect(detailsSection).toBeInTheDocument();
-      expect(detailsSection?.textContent?.includes('Expiration')).toBe(false);
+      expect(detailsSection?.textContent?.includes('Expiration')).toBe(true);
+      expect(detailsSection?.textContent?.includes('Never expires')).toBe(true);
     });
   });
 
@@ -353,7 +356,8 @@ describe('TypedSignPermissionInfo', () => {
         'erc20-token-periodic-details-section',
       );
       expect(detailsSection).toBeInTheDocument();
-      expect(detailsSection?.textContent?.includes('Expiration')).toBe(false);
+      expect(detailsSection?.textContent?.includes('Expiration')).toBe(true);
+      expect(detailsSection?.textContent?.includes('Never expires')).toBe(true);
     });
   });
 
@@ -476,7 +480,8 @@ describe('TypedSignPermissionInfo', () => {
       );
       const detailsSection = getByTestId('erc20-token-stream-details-section');
       expect(detailsSection).toBeInTheDocument();
-      expect(detailsSection?.textContent?.includes('Expiration')).toBe(false);
+      expect(detailsSection?.textContent?.includes('Expiration')).toBe(true);
+      expect(detailsSection?.textContent?.includes('Never expires')).toBe(true);
     });
   });
 });

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/erc20-token-periodic-details.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/erc20-token-periodic-details.test.tsx
@@ -102,7 +102,8 @@ describe('Erc20TokenPeriodicDetails', () => {
 
       expect(detailsSection).toBeInTheDocument();
 
-      expect(detailsSection?.textContent?.includes('Expiration')).toBe(false);
+      expect(detailsSection?.textContent?.includes('Expiration')).toBe(true);
+      expect(detailsSection?.textContent?.includes('Never expires')).toBe(true);
     });
 
     it('displays the allowance once token decimals are resolved', async () => {

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/erc20-token-periodic-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/erc20-token-periodic-details.tsx
@@ -14,6 +14,7 @@ import { useI18nContext } from '../../../../../../../hooks/useI18nContext';
 import { formatPeriodDuration } from './typed-sign-permission-util';
 import { TokenAmountRow } from './token-amount-row';
 import { DateAndTimeRow } from './date-and-time-row';
+import { Expiry } from './expiry';
 
 /**
  * Component for displaying ERC20 token periodic permission details.
@@ -69,18 +70,7 @@ export const Erc20TokenPeriodicDetails: React.FC<{
         label={t('confirmFieldStartDate')}
       />
 
-      {expiry ? (
-        <DateAndTimeRow
-          timestamp={expiry}
-          label={t('confirmFieldExpiration')}
-        />
-      ) : (
-        <ConfirmInfoRow label={t('confirmFieldExpiration')}>
-          <Text variant={TextVariant.BodyMd}>
-            {t('confirmFieldNeverExpires')}
-          </Text>
-        </ConfirmInfoRow>
-      )}
+      <Expiry expiry={expiry} />
     </ConfirmInfoSection>
   );
 };

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/erc20-token-periodic-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/erc20-token-periodic-details.tsx
@@ -69,11 +69,17 @@ export const Erc20TokenPeriodicDetails: React.FC<{
         label={t('confirmFieldStartDate')}
       />
 
-      {expiry && (
+      {expiry ? (
         <DateAndTimeRow
           timestamp={expiry}
           label={t('confirmFieldExpiration')}
         />
+      ) : (
+        <ConfirmInfoRow label={t('confirmFieldExpiration')}>
+          <Text variant={TextVariant.BodyMd}>
+            {t('confirmFieldNeverExpires')}
+          </Text>
+        </ConfirmInfoRow>
       )}
     </ConfirmInfoSection>
   );

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/erc20-token-revocation-details.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/erc20-token-revocation-details.test.tsx
@@ -34,10 +34,11 @@ describe('Erc20TokenRevocationDetails', () => {
       expect(detailsSection?.textContent?.includes('Expiration')).toBe(true);
     });
 
-    it('does not render details section when expiry is null', () => {
-      expect(() => renderAndGetDetailsSection(null)).toThrow(
-        'Unable to find an element',
-      );
+    it('renders with "Never expires" when expiry is null', () => {
+      const detailsSection = renderAndGetDetailsSection(null);
+      expect(detailsSection).toBeInTheDocument();
+      expect(detailsSection?.textContent?.includes('Expiration')).toBe(true);
+      expect(detailsSection?.textContent?.includes('Never expires')).toBe(true);
     });
   });
 });

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/erc20-token-revocation-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/erc20-token-revocation-details.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 
+import { Text, TextVariant } from '@metamask/design-system-react';
 import { ConfirmInfoSection } from '../../../../../../../components/app/confirm/info/row/section';
+import { ConfirmInfoRow } from '../../../../../../../components/app/confirm/info/row';
 import { useI18nContext } from '../../../../../../../hooks/useI18nContext';
 import { DateAndTimeRow } from './date-and-time-row';
 
@@ -17,13 +19,20 @@ export const Erc20TokenRevocationDetails: React.FC<{
 }> = ({ expiry }) => {
   const t = useI18nContext();
 
-  if (expiry === null) {
-    return null;
-  }
-
   return (
     <ConfirmInfoSection data-testid="erc20-token-revocation-details-section">
-      <DateAndTimeRow timestamp={expiry} label={t('confirmFieldExpiration')} />
+      {expiry ? (
+        <DateAndTimeRow
+          timestamp={expiry}
+          label={t('confirmFieldExpiration')}
+        />
+      ) : (
+        <ConfirmInfoRow label={t('confirmFieldExpiration')}>
+          <Text variant={TextVariant.BodyMd}>
+            {t('confirmFieldNeverExpires')}
+          </Text>
+        </ConfirmInfoRow>
+      )}
     </ConfirmInfoSection>
   );
 };

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/erc20-token-revocation-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/erc20-token-revocation-details.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 
-import { Text, TextVariant } from '@metamask/design-system-react';
 import { ConfirmInfoSection } from '../../../../../../../components/app/confirm/info/row/section';
-import { ConfirmInfoRow } from '../../../../../../../components/app/confirm/info/row';
-import { useI18nContext } from '../../../../../../../hooks/useI18nContext';
-import { DateAndTimeRow } from './date-and-time-row';
+import { Expiry } from './expiry';
 
 /**
  * Displays details for the ERC20 token revocation permission.
@@ -17,22 +14,9 @@ import { DateAndTimeRow } from './date-and-time-row';
 export const Erc20TokenRevocationDetails: React.FC<{
   expiry: number | null;
 }> = ({ expiry }) => {
-  const t = useI18nContext();
-
   return (
     <ConfirmInfoSection data-testid="erc20-token-revocation-details-section">
-      {expiry ? (
-        <DateAndTimeRow
-          timestamp={expiry}
-          label={t('confirmFieldExpiration')}
-        />
-      ) : (
-        <ConfirmInfoRow label={t('confirmFieldExpiration')}>
-          <Text variant={TextVariant.BodyMd}>
-            {t('confirmFieldNeverExpires')}
-          </Text>
-        </ConfirmInfoRow>
-      )}
+      <Expiry expiry={expiry} />
     </ConfirmInfoSection>
   );
 };

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/erc20-token-stream-details.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/erc20-token-stream-details.test.tsx
@@ -119,7 +119,8 @@ describe('Erc20TokenStreamDetails', () => {
         expiry: null,
       });
       expect(detailsSection).toBeInTheDocument();
-      expect(detailsSection?.textContent?.includes('Expiration')).toBe(false);
+      expect(detailsSection?.textContent?.includes('Expiration')).toBe(true);
+      expect(detailsSection?.textContent?.includes('Never expires')).toBe(true);
     });
 
     it('displays the allowance once token decimals are resolved', async () => {

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/erc20-token-stream-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/erc20-token-stream-details.tsx
@@ -3,8 +3,12 @@ import React from 'react';
 
 import { BigNumber } from 'bignumber.js';
 import { Hex } from '@metamask/utils';
+import { Text, TextVariant } from '@metamask/design-system-react';
 import { ConfirmInfoSection } from '../../../../../../../components/app/confirm/info/row/section';
-import { ConfirmInfoRowDivider } from '../../../../../../../components/app/confirm/info/row';
+import {
+  ConfirmInfoRow,
+  ConfirmInfoRowDivider,
+} from '../../../../../../../components/app/confirm/info/row';
 import { DAY } from '../../../../../../../../shared/constants/time';
 import { fetchErc20Decimals } from '../../../../../utils/token';
 import { useAsyncResult } from '../../../../../../../hooks/useAsync';
@@ -75,11 +79,17 @@ export const Erc20TokenStreamDetails: React.FC<{
           timestamp={startTime}
           label={t('confirmFieldStartDate')}
         />
-        {expiry && (
+        {expiry ? (
           <DateAndTimeRow
             timestamp={expiry}
             label={t('confirmFieldExpiration')}
           />
+        ) : (
+          <ConfirmInfoRow label={t('confirmFieldExpiration')}>
+            <Text variant={TextVariant.BodyMd}>
+              {t('confirmFieldNeverExpires')}
+            </Text>
+          </ConfirmInfoRow>
         )}
       </ConfirmInfoSection>
 

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/erc20-token-stream-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/erc20-token-stream-details.tsx
@@ -3,18 +3,15 @@ import React from 'react';
 
 import { BigNumber } from 'bignumber.js';
 import { Hex } from '@metamask/utils';
-import { Text, TextVariant } from '@metamask/design-system-react';
 import { ConfirmInfoSection } from '../../../../../../../components/app/confirm/info/row/section';
-import {
-  ConfirmInfoRow,
-  ConfirmInfoRowDivider,
-} from '../../../../../../../components/app/confirm/info/row';
+import { ConfirmInfoRowDivider } from '../../../../../../../components/app/confirm/info/row';
 import { DAY } from '../../../../../../../../shared/constants/time';
 import { fetchErc20Decimals } from '../../../../../utils/token';
 import { useAsyncResult } from '../../../../../../../hooks/useAsync';
 import { useI18nContext } from '../../../../../../../hooks/useI18nContext';
 import { TokenAmountRow } from './token-amount-row';
 import { DateAndTimeRow } from './date-and-time-row';
+import { Expiry } from './expiry';
 
 /**
  * Component for displaying ERC20 token stream permission details.
@@ -79,18 +76,7 @@ export const Erc20TokenStreamDetails: React.FC<{
           timestamp={startTime}
           label={t('confirmFieldStartDate')}
         />
-        {expiry ? (
-          <DateAndTimeRow
-            timestamp={expiry}
-            label={t('confirmFieldExpiration')}
-          />
-        ) : (
-          <ConfirmInfoRow label={t('confirmFieldExpiration')}>
-            <Text variant={TextVariant.BodyMd}>
-              {t('confirmFieldNeverExpires')}
-            </Text>
-          </ConfirmInfoRow>
-        )}
+        <Expiry expiry={expiry} />
       </ConfirmInfoSection>
 
       <ConfirmInfoSection data-testid="erc20-token-stream-stream-rate-section">

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/expiry.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/expiry.test.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import configureMockStore from 'redux-mock-store';
+
+import { renderWithConfirmContextProvider } from '../../../../../../../../test/lib/confirmations/render-helpers';
+import { getMockTypedSignPermissionConfirmState } from '../../../../../../../../test/data/confirmations/helper';
+import { Expiry } from './expiry';
+
+describe('Expiry', () => {
+  const getMockStore = () => {
+    const state = getMockTypedSignPermissionConfirmState();
+    return configureMockStore([])(state);
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('with expiry timestamp', () => {
+    it('renders DateAndTimeRow with the expiry timestamp', () => {
+      const expiry = 1234567890 + 86400; // 1 day later
+      const { container } = renderWithConfirmContextProvider(
+        <Expiry expiry={expiry} />,
+        getMockStore(),
+      );
+
+      expect(container).toBeInTheDocument();
+      expect(container.textContent).toContain('Expiration');
+      // DateAndTimeRow should format the date
+      expect(container.textContent).not.toContain('Never expires');
+    });
+
+    it('displays formatted date for valid timestamp', () => {
+      const expiry = 1609459200; // Jan 1, 2021 00:00:00 UTC
+      const { container } = renderWithConfirmContextProvider(
+        <Expiry expiry={expiry} />,
+        getMockStore(),
+      );
+
+      expect(container).toBeInTheDocument();
+      expect(container.textContent).toContain('Expiration');
+      expect(container.textContent).toContain('01 January 2021');
+    });
+  });
+
+  describe('without expiry (null)', () => {
+    it('renders "Never expires" message', () => {
+      const { container } = renderWithConfirmContextProvider(
+        <Expiry expiry={null} />,
+        getMockStore(),
+      );
+
+      expect(container).toBeInTheDocument();
+      expect(container.textContent).toContain('Expiration');
+      expect(container.textContent).toContain('Never expires');
+    });
+
+    it('uses ConfirmInfoRow instead of DateAndTimeRow', () => {
+      const { container } = renderWithConfirmContextProvider(
+        <Expiry expiry={null} />,
+        getMockStore(),
+      );
+
+      expect(container).toBeInTheDocument();
+      // Should not contain date formatting
+      expect(container.textContent).not.toMatch(/\d{2}\s+\w+\s+\d{4}/u);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles zero timestamp as truthy (displays as date)', () => {
+      const { container } = renderWithConfirmContextProvider(
+        <Expiry expiry={0} />,
+        getMockStore(),
+      );
+
+      expect(container).toBeInTheDocument();
+      // Zero is falsy in JavaScript, so should show "Never expires"
+      expect(container.textContent).toContain('Never expires');
+    });
+
+    it('handles very large timestamps', () => {
+      const expiry = 9999999999; // Far future timestamp
+      const { container } = renderWithConfirmContextProvider(
+        <Expiry expiry={expiry} />,
+        getMockStore(),
+      );
+
+      expect(container).toBeInTheDocument();
+      expect(container.textContent).toContain('Expiration');
+      expect(container.textContent).not.toContain('Never expires');
+    });
+  });
+});

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/expiry.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/expiry.test.tsx
@@ -61,8 +61,7 @@ describe('Expiry', () => {
       );
 
       expect(container).toBeInTheDocument();
-      // Should not contain date formatting
-      expect(container.textContent).not.toMatch(/\d{2}\s+\w+\s+\d{4}/u);
+      expect(container.textContent).toContain('Never expires');
     });
   });
 

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/expiry.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/expiry.test.tsx
@@ -6,8 +6,27 @@ import { getMockTypedSignPermissionConfirmState } from '../../../../../../../../
 import { Expiry } from './expiry';
 
 describe('Expiry', () => {
+  const mockDecodedPermission = {
+    expiry: 1234567890 + 86400,
+    origin: 'https://metamask.github.io',
+    permission: {
+      type: 'erc20-token-stream',
+      isAdjustmentAllowed: false,
+      data: {
+        tokenAddress: '0xA0b86a33E6441b8c4C8C0E4A8e4A8e4A8e4A8e4A',
+        initialAmount: '0x1234',
+        maxAmount: '0x5678',
+        amountPerSecond: '0x9abc',
+        startTime: 1234567890,
+      },
+      justification: 'Test justification',
+    },
+    chainId: '0x1',
+    to: '0xCdD6132d1a6efA06bce1A89b0fEa6b08304A3829',
+  } as const;
+
   const getMockStore = () => {
-    const state = getMockTypedSignPermissionConfirmState();
+    const state = getMockTypedSignPermissionConfirmState(mockDecodedPermission);
     return configureMockStore([])(state);
   };
 
@@ -17,7 +36,7 @@ describe('Expiry', () => {
 
   describe('with expiry timestamp', () => {
     it('renders DateAndTimeRow with the expiry timestamp', () => {
-      const expiry = 1234567890 + 86400; // 1 day later
+      const expiry = 1234567890 + 86400;
       const { container } = renderWithConfirmContextProvider(
         <Expiry expiry={expiry} />,
         getMockStore(),
@@ -25,12 +44,11 @@ describe('Expiry', () => {
 
       expect(container).toBeInTheDocument();
       expect(container.textContent).toContain('Expiration');
-      // DateAndTimeRow should format the date
       expect(container.textContent).not.toContain('Never expires');
     });
 
     it('displays formatted date for valid timestamp', () => {
-      const expiry = 1609459200; // Jan 1, 2021 00:00:00 UTC
+      const expiry = 1609459200;
       const { container } = renderWithConfirmContextProvider(
         <Expiry expiry={expiry} />,
         getMockStore(),
@@ -53,32 +71,21 @@ describe('Expiry', () => {
       expect(container.textContent).toContain('Expiration');
       expect(container.textContent).toContain('Never expires');
     });
-
-    it('uses ConfirmInfoRow instead of DateAndTimeRow', () => {
-      const { container } = renderWithConfirmContextProvider(
-        <Expiry expiry={null} />,
-        getMockStore(),
-      );
-
-      expect(container).toBeInTheDocument();
-      expect(container.textContent).toContain('Never expires');
-    });
   });
 
   describe('edge cases', () => {
-    it('handles zero timestamp as truthy (displays as date)', () => {
+    it('handles zero timestamp', () => {
       const { container } = renderWithConfirmContextProvider(
         <Expiry expiry={0} />,
         getMockStore(),
       );
 
       expect(container).toBeInTheDocument();
-      // Zero is falsy in JavaScript, so should show "Never expires"
       expect(container.textContent).toContain('Never expires');
     });
 
     it('handles very large timestamps', () => {
-      const expiry = 9999999999; // Far future timestamp
+      const expiry = 9999999999;
       const { container } = renderWithConfirmContextProvider(
         <Expiry expiry={expiry} />,
         getMockStore(),

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/expiry.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/expiry.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+import { Text, TextVariant } from '@metamask/design-system-react';
+import { ConfirmInfoRow } from '../../../../../../../components/app/confirm/info/row';
+import { useI18nContext } from '../../../../../../../hooks/useI18nContext';
+import { DateAndTimeRow } from './date-and-time-row';
+
+/**
+ * Component for displaying the expiration date or "Never expires" message.
+ * Shows the formatted date if an expiry timestamp is provided, otherwise displays "Never expires".
+ *
+ * @param props - The component props
+ * @param props.expiry - The expiration timestamp in seconds (null if no expiry)
+ * @returns JSX element containing the expiration information
+ */
+export const Expiry: React.FC<{
+  expiry: number | null;
+}> = ({ expiry }) => {
+  const t = useI18nContext();
+
+  if (expiry) {
+    return (
+      <DateAndTimeRow timestamp={expiry} label={t('confirmFieldExpiration')} />
+    );
+  }
+
+  return (
+    <ConfirmInfoRow label={t('confirmFieldExpiration')}>
+      <Text variant={TextVariant.BodyMd}>{t('confirmFieldNeverExpires')}</Text>
+    </ConfirmInfoRow>
+  );
+};

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/native-token-periodic-details.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/native-token-periodic-details.test.tsx
@@ -74,7 +74,8 @@ describe('NativeTokenPeriodicDetails', () => {
       });
 
       expect(detailsSection).toBeInTheDocument();
-      expect(detailsSection?.textContent?.includes('Expiration')).toBe(false);
+      expect(detailsSection?.textContent?.includes('Expiration')).toBe(true);
+      expect(detailsSection?.textContent?.includes('Never expires')).toBe(true);
     });
   });
 
@@ -272,13 +273,14 @@ describe('NativeTokenPeriodicDetails', () => {
       expect(detailsSection?.textContent?.includes('Expiration')).toBe(true);
     });
 
-    it('does not render expiry when null', () => {
+    it('renders "Never expires" when expiry is null', () => {
       const detailsSection = renderAndGetDetailsSection({
         ...defaultProps,
         expiry: null,
       });
       expect(detailsSection).toBeInTheDocument();
-      expect(detailsSection?.textContent?.includes('Expiration')).toBe(false);
+      expect(detailsSection?.textContent?.includes('Expiration')).toBe(true);
+      expect(detailsSection?.textContent?.includes('Never expires')).toBe(true);
     });
   });
 });

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/native-token-periodic-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/native-token-periodic-details.tsx
@@ -18,6 +18,7 @@ import { useI18nContext } from '../../../../../../../hooks/useI18nContext';
 import { formatPeriodDuration } from './typed-sign-permission-util';
 import { DateAndTimeRow } from './date-and-time-row';
 import { NativeAmountRow } from './native-amount-row';
+import { Expiry } from './expiry';
 
 /**
  * Component for displaying native token periodic permission details.
@@ -73,18 +74,7 @@ export const NativeTokenPeriodicDetails: React.FC<{
         label={t('confirmFieldStartDate')}
       />
 
-      {expiry ? (
-        <DateAndTimeRow
-          timestamp={expiry}
-          label={t('confirmFieldExpiration')}
-        />
-      ) : (
-        <ConfirmInfoRow label={t('confirmFieldExpiration')}>
-          <Text variant={TextVariant.BodyMd}>
-            {t('confirmFieldNeverExpires')}
-          </Text>
-        </ConfirmInfoRow>
-      )}
+      <Expiry expiry={expiry} />
     </ConfirmInfoSection>
   );
 };

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/native-token-periodic-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/native-token-periodic-details.tsx
@@ -73,11 +73,17 @@ export const NativeTokenPeriodicDetails: React.FC<{
         label={t('confirmFieldStartDate')}
       />
 
-      {expiry && (
+      {expiry ? (
         <DateAndTimeRow
           timestamp={expiry}
           label={t('confirmFieldExpiration')}
         />
+      ) : (
+        <ConfirmInfoRow label={t('confirmFieldExpiration')}>
+          <Text variant={TextVariant.BodyMd}>
+            {t('confirmFieldNeverExpires')}
+          </Text>
+        </ConfirmInfoRow>
       )}
     </ConfirmInfoSection>
   );

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/native-token-stream-details.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/native-token-stream-details.test.tsx
@@ -103,7 +103,8 @@ describe('NativeTokenStreamDetails', () => {
         expiry: null,
       });
       expect(detailsSection).toBeInTheDocument();
-      expect(detailsSection?.textContent?.includes('Expiration')).toBe(false);
+      expect(detailsSection?.textContent?.includes('Expiration')).toBe(true);
+      expect(detailsSection?.textContent?.includes('Never expires')).toBe(true);
     });
   });
 

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/native-token-stream-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/native-token-stream-details.tsx
@@ -4,13 +4,9 @@ import type { Hex } from '@metamask/utils';
 import React from 'react';
 import { useSelector } from 'react-redux';
 
-import { Text, TextVariant } from '@metamask/design-system-react';
 import { DAY } from '../../../../../../../../shared/constants/time';
 import { ConfirmInfoSection } from '../../../../../../../components/app/confirm/info/row/section';
-import {
-  ConfirmInfoRow,
-  ConfirmInfoRowDivider,
-} from '../../../../../../../components/app/confirm/info/row';
+import { ConfirmInfoRowDivider } from '../../../../../../../components/app/confirm/info/row';
 import {
   getNativeTokenInfo,
   MetaMaskReduxState,
@@ -19,6 +15,7 @@ import { CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP } from '../../../../../../../../share
 import { useI18nContext } from '../../../../../../../hooks/useI18nContext';
 import { NativeAmountRow } from './native-amount-row';
 import { DateAndTimeRow } from './date-and-time-row';
+import { Expiry } from './expiry';
 
 /**
  * Component for displaying native token stream permission details.
@@ -82,18 +79,7 @@ export const NativeTokenStreamDetails: React.FC<{
           timestamp={startTime}
           label={t('confirmFieldStartDate')}
         />
-        {expiry ? (
-          <DateAndTimeRow
-            timestamp={expiry}
-            label={t('confirmFieldExpiration')}
-          />
-        ) : (
-          <ConfirmInfoRow label={t('confirmFieldExpiration')}>
-            <Text variant={TextVariant.BodyMd}>
-              {t('confirmFieldNeverExpires')}
-            </Text>
-          </ConfirmInfoRow>
-        )}
+        <Expiry expiry={expiry} />
       </ConfirmInfoSection>
 
       <ConfirmInfoSection data-testid="native-token-stream-stream-rate-section">

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/native-token-stream-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/native-token-stream-details.tsx
@@ -4,9 +4,13 @@ import type { Hex } from '@metamask/utils';
 import React from 'react';
 import { useSelector } from 'react-redux';
 
+import { Text, TextVariant } from '@metamask/design-system-react';
 import { DAY } from '../../../../../../../../shared/constants/time';
 import { ConfirmInfoSection } from '../../../../../../../components/app/confirm/info/row/section';
-import { ConfirmInfoRowDivider } from '../../../../../../../components/app/confirm/info/row';
+import {
+  ConfirmInfoRow,
+  ConfirmInfoRowDivider,
+} from '../../../../../../../components/app/confirm/info/row';
 import {
   getNativeTokenInfo,
   MetaMaskReduxState,
@@ -78,11 +82,17 @@ export const NativeTokenStreamDetails: React.FC<{
           timestamp={startTime}
           label={t('confirmFieldStartDate')}
         />
-        {expiry && (
+        {expiry ? (
           <DateAndTimeRow
             timestamp={expiry}
             label={t('confirmFieldExpiration')}
           />
+        ) : (
+          <ConfirmInfoRow label={t('confirmFieldExpiration')}>
+            <Text variant={TextVariant.BodyMd}>
+              {t('confirmFieldNeverExpires')}
+            </Text>
+          </ConfirmInfoRow>
         )}
       </ConfirmInfoSection>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Always display the expiration row in EIP-7715 permission confirmations, showing 'Never expires' when no specific expiry is set, to improve user clarity.

CHANGELOG entry: When no expiry is specified for an EIP-7715 `wallet_requestExecutionPermissions` permission, show "Never expires"

---
[Slack Thread](https://consensys.slack.com/archives/C089Z7KQPS9/p1773021558212009?thread_ts=1773021558.212009&cid=C089Z7KQPS9)

<p><a href="https://cursor.com/agents/bc-75fdafd6-8e52-5173-8ea1-17ef82b2fbb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75fdafd6-8e52-5173-8ea1-17ef82b2fbb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->