### PR TITLE
Issue #18714 Replace deprecated constants with enums

### DIFF
--- a/ui/pages/confirmations/confirmation/templates/switch-ethereum-chain.js
+++ b/ui/pages/confirmations/confirmation/templates/switch-ethereum-chain.js
@@ -1,14 +1,14 @@
 import { providerErrors } from '@metamask/rpc-errors';
 import {
   JustifyContent,
-  SEVERITIES,
+  Severity,
   TextColor,
   TypographyVariant,
 } from '../../../../helpers/constants/design-system';
 
 const PENDING_TX_DROP_NOTICE = {
   id: 'PENDING_TX_DROP_NOTICE',
-  severity: SEVERITIES.WARNING,
+  severity: Severity.Warning,
   content: {
     element: 'span',
     children: {


### PR DESCRIPTION
## **Description**

This PR removes the depreccated SEVERITY constant from ui/pages/confirmations/confirmation/templates/switch-ethereum-chain.js

Partial fix for #18714

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40704?quickstart=1)

## **Screenshots/Recordings**

### **Before**

<img width="1920" height="1080" alt="cats-before-crypto" src="https://github.com/user-attachments/assets/ab3a87c4-30a3-4ef7-885d-8d59783c48eb" />

### **After**

<img width="1920" height="1080" alt="cats-after-crypto" src="https://github.com/user-attachments/assets/07e762cf-a4c8-4777-8f9f-f03c34da1d3c" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small constant swap in a confirmation template with no logic or data-flow changes.
> 
> **Overview**
> Updates the switch-network confirmation template to stop importing deprecated `SEVERITIES` and instead use the `Severity` enum (e.g., `Severity.Warning`) for the pending-transaction drop alert.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63e2e29325c2303316ac2fc97b67587b27ae81d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->