### PR TITLE
chore: Make `extension-platform` CODEOWNER of MetaRPC files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -168,6 +168,8 @@ ui/components/ui/nft-collection-image                 @MetaMask/metamask-assets
 
 # Extension Platform
 .yarnrc.yml                                           @MetaMask/extension-platform
+app/scripts/lib/createMetaRPCHandler.js               @MetaMask/extension-platform
+app/scripts/lib/metaRPCClientFactory.ts               @MetaMask/extension-platform
 
 # Smart Transactions
 app/scripts/controller-init/smart-transactions    @MetaMask/transactions
@@ -203,10 +205,8 @@ test/e2e/flask/multichain-api                                         @MetaMask/
 app/scripts/lib/createRPCMethodTrackingMiddleware.js                  @MetaMask/wallet-integrations
 app/scripts/lib/createMetamaskMiddleware.ts                           @MetaMask/wallet-integrations
 app/scripts/lib/createOnboardingMiddleware.js                         @MetaMask/wallet-integrations
-app/scripts/lib/createMetaRPCHandler.js                               @MetaMask/wallet-integrations
 app/scripts/lib/createEvmMethodsToNonEvmAccountReqFilterMiddleware.ts @MetaMask/wallet-integrations
 app/scripts/lib/createDefiReferralMiddleware.ts                @MetaMask/wallet-integrations
-app/scripts/lib/metaRPCClientFactory.ts                               @MetaMask/wallet-integrations
 app/scripts/lib/middleware/                                           @MetaMask/wallet-integrations
 app/scripts/lib/createOriginThrottlingMiddleware.ts                   @MetaMask/wallet-integrations
 app/scripts/lib/createMainFrameOriginMiddleware.ts                    @MetaMask/wallet-integrations


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Modify `CODEOWNERS` to make `extension-platform` the owners of the MetaRPC files, these do not affect wallet API and are instead for internal extension plumbing, thus they should be owned by Extension Platform.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40705?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CODEOWNERS-only change that shifts review responsibility for `createMetaRPCHandler.js` and `metaRPCClientFactory.ts`; no runtime or build behavior is affected.
> 
> **Overview**
> Updates `.github/CODEOWNERS` to move ownership of the MetaRPC plumbing files (`app/scripts/lib/createMetaRPCHandler.js` and `app/scripts/lib/metaRPCClientFactory.ts`) from **Wallet Integrations** to **Extension Platform**, ensuring reviews route to the team responsible for internal extension infrastructure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c560b9738ac4607c4aa4506830e6ff1b8557bab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->