### PR TITLE
test: migrate `withSelectedNetworkControllerPerDomain` to FixtureBuilderV2

### DIFF
--- a/.cursor/rules/e2e-testing-guidelines/RULE.md
+++ b/.cursor/rules/e2e-testing-guidelines/RULE.md
@@ -82,8 +82,8 @@ For new test code, use `FixtureBuilderV2` by default.
 
 `FixtureBuilderV2` currently supports:
 
-- `withAddressBookController`
 - `withAccountsController`
+- `withAddressBookController`
 - `withAppStateController`
 - `withCurrencyController`
 - `withKeyringController`
@@ -92,6 +92,7 @@ For new test code, use `FixtureBuilderV2` by default.
 - `withOnboardingController`
 - `withPermissionController`
 - `withPreferencesController`
+- `withSelectedNetworkController`
 - `withTransactionController`
 - `withConversionRateDisabled`
 - `withEnabledNetworks`
@@ -100,6 +101,7 @@ For new test code, use `FixtureBuilderV2` by default.
 - `withNetworkControllerTripleNode`
 - `withPermissionControllerConnectedToTestDapp`
 - `withSelectedNetwork`
+- `withSelectedNetworkControllerPerDomain`
 - `withShowNativeTokenAsMainBalanceDisabled`
 - `withShowNativeTokenAsMainBalanceEnabled`
 - `withSmartTransactionsOptedOut`

--- a/test/e2e/constants.ts
+++ b/test/e2e/constants.ts
@@ -13,6 +13,14 @@ export const LOCAL_NODE_MNEMONIC =
 export const LOCALHOST_NETWORK_CLIENT_ID =
   '3a5eb6f2-cb62-428d-897c-b7ded577d7c2';
 
+/** networkClientId for the second local node (0x53a / Localhost 8546). */
+export const SECOND_NODE_NETWORK_CLIENT_ID =
+  '76e9cd59-d8e2-47e7-b369-9c205ccb602c';
+
+/** networkClientId for the third local node (0x3e8 / Localhost 7777). */
+export const THIRD_NODE_NETWORK_CLIENT_ID =
+  'a3460c52-12ee-4267-9be6-1503095a587e';
+
 /**
  * Network client IDs. Each key maps to the `networkClientId` used inside
  * `NetworkController.networkConfigurationsByChainId`.

--- a/test/e2e/fixtures/fixture-builder-v2.ts
+++ b/test/e2e/fixtures/fixture-builder-v2.ts
@@ -189,10 +189,9 @@ class FixtureBuilderV2 {
   withEnabledNetworks(
     data: NetworkEnablementControllerState['enabledNetworkMap'],
   ): this {
-    // Clear existing map first – this is a full replacement, not a merge
     this.fixture.data.NetworkEnablementController.enabledNetworkMap =
-      {} as FixtureType['data']['NetworkEnablementController']['enabledNetworkMap'];
-    return this.withNetworkEnablementController({ enabledNetworkMap: data });
+      data as FixtureType['data']['NetworkEnablementController']['enabledNetworkMap'];
+    return this;
   }
 
   withLedgerAccount(): this {

--- a/test/e2e/fixtures/fixture-builder-v2.ts
+++ b/test/e2e/fixtures/fixture-builder-v2.ts
@@ -4,6 +4,7 @@ import type { AddressBookControllerState } from '@metamask/address-book-controll
 import type { CurrencyRateState } from '@metamask/assets-controllers';
 import type { KeyringControllerState } from '@metamask/keyring-controller';
 import type { NetworkEnablementControllerState } from '@metamask/network-enablement-controller';
+import type { SelectedNetworkControllerState } from '@metamask/selected-network-controller';
 import type {
   PermissionConstraint,
   PermissionControllerState,
@@ -77,6 +78,11 @@ class FixtureBuilderV2 {
                           GENERIC  CONTROLLER METHODS
      ==================================================================
   */
+  withAccountsController(data: Partial<AccountsControllerState>): this {
+    merge(this.fixture.data.AccountsController, data);
+    return this;
+  }
+
   withAddressBookController(data: Partial<AddressBookControllerState>): this {
     if (!this.fixture.data.AddressBookController) {
       (this.fixture.data as Record<string, unknown>).AddressBookController = {
@@ -84,11 +90,6 @@ class FixtureBuilderV2 {
       };
     }
     merge(this.fixture.data.AddressBookController, data);
-    return this;
-  }
-
-  withAccountsController(data: Partial<AccountsControllerState>): this {
-    merge(this.fixture.data.AccountsController, data);
     return this;
   }
 
@@ -135,6 +136,13 @@ class FixtureBuilderV2 {
     },
   ): this {
     merge(this.fixture.data.PreferencesController, data);
+    return this;
+  }
+
+  withSelectedNetworkController(
+    data: Partial<SelectedNetworkControllerState>,
+  ): this {
+    merge(this.fixture.data.SelectedNetworkController, data);
     return this;
   }
 
@@ -312,7 +320,7 @@ class FixtureBuilderV2 {
   }
 
   withPermissionControllerConnectedToTestDapp({
-    account = '',
+    account = DEFAULT_FIXTURE_ACCOUNT_LOWERCASE,
     useLocalhostHostname = false,
     numberOfDapps = 1,
     chainIds = [1337],
@@ -329,9 +337,7 @@ class FixtureBuilderV2 {
       );
     }
 
-    const selectedAccount = account
-      ? account.toLowerCase()
-      : DEFAULT_FIXTURE_ACCOUNT_LOWERCASE;
+    const selectedAccount = account.toLowerCase();
 
     const dappUrls = [
       useLocalhostHostname ? DAPP_URL_LOCALHOST : DAPP_URL,
@@ -393,6 +399,15 @@ class FixtureBuilderV2 {
   ): this {
     return this.withNetworkController({
       selectedNetworkClientId: networkClientId,
+    });
+  }
+
+  withSelectedNetworkControllerPerDomain(): this {
+    return this.withSelectedNetworkController({
+      domains: {
+        [DAPP_URL]: LOCALHOST_NETWORK_CLIENT_ID,
+        [DAPP_ONE_URL]: '76e9cd59-d8e2-47e7-b369-9c205ccb602c',
+      },
     });
   }
 

--- a/test/e2e/fixtures/fixture-builder-v2.ts
+++ b/test/e2e/fixtures/fixture-builder-v2.ts
@@ -37,6 +37,8 @@ import {
   LEDGER_FIXTURE_VAULT,
   LOCALHOST_NETWORK_CLIENT_ID,
   NETWORK_CLIENT_ID,
+  SECOND_NODE_NETWORK_CLIENT_ID,
+  THIRD_NODE_NETWORK_CLIENT_ID,
 } from '../constants';
 import { KNOWN_PUBLIC_KEY_ADDRESSES } from '../../stub/keyring-bridge';
 import defaultFixtureJson from './default-fixture.json';
@@ -269,7 +271,7 @@ class FixtureBuilderV2 {
 
   withNetworkControllerDoubleNode(): this {
     const secondNodeChainId = '0x53a';
-    const secondNodeClientId = '76e9cd59-d8e2-47e7-b369-9c205ccb602c';
+    const secondNodeClientId = SECOND_NODE_NETWORK_CLIENT_ID;
 
     // Enable the new chain in NetworkEnablementController so
     // CAIP-25 connect flow includes it in the permission scopes.
@@ -308,7 +310,7 @@ class FixtureBuilderV2 {
 
   withNetworkControllerTripleNode(): this {
     const thirdNodeChainId = '0x3e8';
-    const thirdNodeClientId = 'a3460c52-12ee-4267-9be6-1503095a587e';
+    const thirdNodeClientId = THIRD_NODE_NETWORK_CLIENT_ID;
 
     // Enable the third chain (see withNetworkControllerDoubleNode for context)
     this.withNetworkEnablementController({
@@ -430,7 +432,7 @@ class FixtureBuilderV2 {
     return this.withSelectedNetworkController({
       domains: {
         [DAPP_URL]: LOCALHOST_NETWORK_CLIENT_ID,
-        [DAPP_ONE_URL]: '76e9cd59-d8e2-47e7-b369-9c205ccb602c',
+        [DAPP_ONE_URL]: SECOND_NODE_NETWORK_CLIENT_ID,
       },
     });
   }

--- a/test/e2e/fixtures/fixture-builder-v2.ts
+++ b/test/e2e/fixtures/fixture-builder-v2.ts
@@ -118,6 +118,13 @@ class FixtureBuilderV2 {
     return this;
   }
 
+  withNetworkEnablementController(
+    data: Partial<NetworkEnablementControllerState>,
+  ): this {
+    merge(this.fixture.data.NetworkEnablementController, data);
+    return this;
+  }
+
   withOnboardingController(data: Partial<OnboardingControllerState>): this {
     merge(this.fixture.data.OnboardingController, data);
     return this;
@@ -180,9 +187,10 @@ class FixtureBuilderV2 {
   withEnabledNetworks(
     data: NetworkEnablementControllerState['enabledNetworkMap'],
   ): this {
+    // Clear existing map first – this is a full replacement, not a merge
     this.fixture.data.NetworkEnablementController.enabledNetworkMap =
-      data as FixtureType['data']['NetworkEnablementController']['enabledNetworkMap'];
-    return this;
+      {} as FixtureType['data']['NetworkEnablementController']['enabledNetworkMap'];
+    return this.withNetworkEnablementController({ enabledNetworkMap: data });
   }
 
   withLedgerAccount(): this {
@@ -263,6 +271,15 @@ class FixtureBuilderV2 {
     const secondNodeChainId = '0x53a';
     const secondNodeClientId = '76e9cd59-d8e2-47e7-b369-9c205ccb602c';
 
+    // Enable the new chain in NetworkEnablementController so
+    // CAIP-25 connect flow includes it in the permission scopes.
+    // (V1 fixtures ran state migrations that auto-enabled new chains)
+    this.withNetworkEnablementController({
+      enabledNetworkMap: {
+        eip155: { [parseInt(secondNodeChainId, 16)]: true },
+      },
+    });
+
     return this.withNetworkController({
       networkConfigurationsByChainId: {
         [secondNodeChainId]: {
@@ -292,6 +309,13 @@ class FixtureBuilderV2 {
   withNetworkControllerTripleNode(): this {
     const thirdNodeChainId = '0x3e8';
     const thirdNodeClientId = 'a3460c52-12ee-4267-9be6-1503095a587e';
+
+    // Enable the third chain (see withNetworkControllerDoubleNode for context)
+    this.withNetworkEnablementController({
+      enabledNetworkMap: {
+        eip155: { [parseInt(thirdNodeChainId, 16)]: true },
+      },
+    });
 
     return this.withNetworkControllerDoubleNode().withNetworkController({
       networkConfigurationsByChainId: {

--- a/test/e2e/fixtures/fixture-builder-v2.ts
+++ b/test/e2e/fixtures/fixture-builder-v2.ts
@@ -273,15 +273,6 @@ class FixtureBuilderV2 {
     const secondNodeChainId = '0x53a';
     const secondNodeClientId = SECOND_NODE_NETWORK_CLIENT_ID;
 
-    // Enable the new chain in NetworkEnablementController so
-    // CAIP-25 connect flow includes it in the permission scopes.
-    // (V1 fixtures ran state migrations that auto-enabled new chains)
-    this.withNetworkEnablementController({
-      enabledNetworkMap: {
-        eip155: { [parseInt(secondNodeChainId, 16)]: true },
-      },
-    });
-
     return this.withNetworkController({
       networkConfigurationsByChainId: {
         [secondNodeChainId]: {
@@ -311,13 +302,6 @@ class FixtureBuilderV2 {
   withNetworkControllerTripleNode(): this {
     const thirdNodeChainId = '0x3e8';
     const thirdNodeClientId = THIRD_NODE_NETWORK_CLIENT_ID;
-
-    // Enable the third chain (see withNetworkControllerDoubleNode for context)
-    this.withNetworkEnablementController({
-      enabledNetworkMap: {
-        eip155: { [parseInt(thirdNodeChainId, 16)]: true },
-      },
-    });
 
     return this.withNetworkControllerDoubleNode().withNetworkController({
       networkConfigurationsByChainId: {

--- a/test/e2e/json-rpc/switchEthereumChain_pendingConfirmation.spec.ts
+++ b/test/e2e/json-rpc/switchEthereumChain_pendingConfirmation.spec.ts
@@ -1,6 +1,6 @@
 import { WINDOW_TITLES } from '../constants';
 import { withFixtures } from '../helpers';
-import FixtureBuilder from '../fixtures/fixture-builder';
+import FixtureBuilderV2 from '../fixtures/fixture-builder-v2';
 import Confirmation from '../page-objects/pages/confirmations/confirmation';
 import NetworkSwitchAlertModal from '../page-objects/pages/dialog/network-switch-alert-modal';
 import ReviewPermissionsConfirmation from '../page-objects/pages/confirmations/review-permissions-confirmation';
@@ -13,9 +13,9 @@ describe('Switch Ethereum Chain for two dapps with pending confirmation in the o
     await withFixtures(
       {
         dappOptions: { numberOfTestDapps: 2 },
-        fixtures: new FixtureBuilder()
+        fixtures: new FixtureBuilderV2()
           .withNetworkControllerDoubleNode()
-          .withPermissionControllerConnectedToTestDappWithChains(['0x539'])
+          .withPermissionControllerConnectedToTestDapp()
           .build(),
         localNodeOptions: [
           {
@@ -91,12 +91,11 @@ describe('Switch Ethereum Chain for two dapps with pending confirmation in the o
     await withFixtures(
       {
         dappOptions: { numberOfTestDapps: 2 },
-        fixtures: new FixtureBuilder()
+        fixtures: new FixtureBuilderV2()
           .withNetworkControllerDoubleNode()
-          .withPermissionControllerConnectedToTestDappWithChains([
-            '0x539',
-            '0x53a',
-          ])
+          .withPermissionControllerConnectedToTestDapp({
+            chainIds: [1337, 1338],
+          })
           .build(),
         localNodeOptions: [
           {

--- a/test/e2e/json-rpc/wallet_addEthereumChain.spec.ts
+++ b/test/e2e/json-rpc/wallet_addEthereumChain.spec.ts
@@ -3,7 +3,6 @@ import {
   CaveatConstraint,
   PermissionConstraint,
 } from '@metamask/permission-controller';
-import FixtureBuilder from '../fixtures/fixture-builder';
 import FixtureBuilderV2 from '../fixtures/fixture-builder-v2';
 import { Driver } from '../webdriver/driver';
 import { WINDOW_TITLES } from '../constants';
@@ -374,12 +373,11 @@ describe('Add Ethereum Chain', function () {
       await withFixtures(
         {
           dappOptions: { numberOfTestDapps: 1 },
-          fixtures: new FixtureBuilder()
+          fixtures: new FixtureBuilderV2()
             .withNetworkControllerDoubleNode()
-            .withPermissionControllerConnectedToTestDappWithChains([
-              '0x539',
-              '0x53a',
-            ])
+            .withPermissionControllerConnectedToTestDapp({
+              chainIds: [1337, 1338],
+            })
             .build(),
           localNodeOptions: [
             {
@@ -453,12 +451,11 @@ describe('Add Ethereum Chain', function () {
       await withFixtures(
         {
           dappOptions: { numberOfTestDapps: 1 },
-          fixtures: new FixtureBuilder()
+          fixtures: new FixtureBuilderV2()
             .withNetworkControllerDoubleNode()
-            .withPermissionControllerConnectedToTestDappWithChains([
-              '0x539',
-              '0x53a',
-            ])
+            .withPermissionControllerConnectedToTestDapp({
+              chainIds: [1337, 1338],
+            })
             .build(),
           localNodeOptions: [
             {
@@ -524,8 +521,8 @@ describe('Add Ethereum Chain', function () {
       await withFixtures(
         {
           dappOptions: { numberOfTestDapps: 1 },
-          fixtures: new FixtureBuilder()
-            .withPermissionControllerConnectedToTestDappWithChains(['0x539'])
+          fixtures: new FixtureBuilderV2()
+            .withPermissionControllerConnectedToTestDapp()
             .build(),
           title: this.test?.fullTitle(),
         },
@@ -587,9 +584,9 @@ describe('Add Ethereum Chain', function () {
       await withFixtures(
         {
           dappOptions: { numberOfTestDapps: 1 },
-          fixtures: new FixtureBuilder()
+          fixtures: new FixtureBuilderV2()
             .withNetworkControllerDoubleNode()
-            .withPermissionControllerConnectedToTestDappWithChains(['0x539'])
+            .withPermissionControllerConnectedToTestDapp()
             .build(),
           localNodeOptions: [
             {

--- a/test/e2e/json-rpc/wallet_getCapabilities.spec.ts
+++ b/test/e2e/json-rpc/wallet_getCapabilities.spec.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from 'assert';
 import { withFixtures } from '../helpers';
-import FixtureBuilder from '../fixtures/fixture-builder';
+import FixtureBuilderV2 from '../fixtures/fixture-builder-v2';
 import TestDapp from '../page-objects/pages/test-dapp';
 import { loginWithBalanceValidation } from '../page-objects/flows/login.flow';
 import { DEFAULT_FIXTURE_ACCOUNT } from '../constants';
@@ -11,8 +11,8 @@ describe('wallet_getCapabilities', function () {
     await withFixtures(
       {
         dappOptions: { numberOfTestDapps: 1 },
-        fixtures: new FixtureBuilder()
-          .withPermissionControllerConnectedToTestDappWithChains(['0x1'])
+        fixtures: new FixtureBuilderV2()
+          .withPermissionControllerConnectedToTestDapp({ chainIds: [1] })
           .build(),
         title: this.test?.fullTitle(),
         testSpecificMock: mockEip7702FeatureFlag,
@@ -42,8 +42,8 @@ describe('wallet_getCapabilities', function () {
     await withFixtures(
       {
         dappOptions: { numberOfTestDapps: 1 },
-        fixtures: new FixtureBuilder()
-          .withPermissionControllerConnectedToTestDappWithChains(['0x539'])
+        fixtures: new FixtureBuilderV2()
+          .withPermissionControllerConnectedToTestDapp()
           .build(),
         title: this.test?.fullTitle(),
         testSpecificMock: mockEip7702FeatureFlag,

--- a/test/e2e/json-rpc/wallet_revokePermissions.spec.ts
+++ b/test/e2e/json-rpc/wallet_revokePermissions.spec.ts
@@ -2,7 +2,7 @@ import { strict as assert } from 'assert';
 import { PermissionConstraint } from '@metamask/permission-controller';
 import { WINDOW_TITLES } from '../constants';
 import { withFixtures } from '../helpers';
-import FixtureBuilder from '../fixtures/fixture-builder';
+import FixtureBuilderV2 from '../fixtures/fixture-builder-v2';
 import TestDapp from '../page-objects/pages/test-dapp';
 import { loginWithBalanceValidation } from '../page-objects/flows/login.flow';
 
@@ -11,8 +11,8 @@ describe('Revoke Dapp Permissions', function () {
     await withFixtures(
       {
         dappOptions: { numberOfTestDapps: 1 },
-        fixtures: new FixtureBuilder()
-          .withPermissionControllerConnectedToTestDappWithChains(['0x539'])
+        fixtures: new FixtureBuilderV2()
+          .withPermissionControllerConnectedToTestDapp()
           .build(),
         title: this.test?.fullTitle(),
       },
@@ -72,8 +72,8 @@ describe('Revoke Dapp Permissions', function () {
     await withFixtures(
       {
         dappOptions: { numberOfTestDapps: 1 },
-        fixtures: new FixtureBuilder()
-          .withPermissionControllerConnectedToTestDappWithChains(['0x539'])
+        fixtures: new FixtureBuilderV2()
+          .withPermissionControllerConnectedToTestDapp()
           .build(),
         title: this.test?.fullTitle(),
       },
@@ -131,8 +131,8 @@ describe('Revoke Dapp Permissions', function () {
     await withFixtures(
       {
         dappOptions: { numberOfTestDapps: 1 },
-        fixtures: new FixtureBuilder()
-          .withPermissionControllerConnectedToTestDappWithChains(['0x539'])
+        fixtures: new FixtureBuilderV2()
+          .withPermissionControllerConnectedToTestDapp()
           .build(),
         title: this.test?.fullTitle(),
       },
@@ -194,8 +194,8 @@ describe('Revoke Dapp Permissions', function () {
       await withFixtures(
         {
           dappOptions: { numberOfTestDapps: 1 },
-          fixtures: new FixtureBuilder()
-            .withPermissionControllerConnectedToTestDappWithChains(['0x539'])
+          fixtures: new FixtureBuilderV2()
+            .withPermissionControllerConnectedToTestDapp()
             .build(),
           title: this.test?.fullTitle(),
         },

--- a/test/e2e/tests/connections/review-switch-permission-page.spec.ts
+++ b/test/e2e/tests/connections/review-switch-permission-page.spec.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'assert';
-import FixtureBuilder from '../../fixtures/fixture-builder';
+import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { DEFAULT_FIXTURE_ACCOUNT, WINDOW_TITLES } from '../../constants';
 import { withFixtures } from '../../helpers';
 import HomePage from '../../page-objects/pages/home/homepage';
@@ -16,7 +16,7 @@ describe('Permissions Page when Dapp Switch to an enabled and non permissioned n
     await withFixtures(
       {
         dappOptions: { numberOfTestDapps: 1 },
-        fixtures: new FixtureBuilder()
+        fixtures: new FixtureBuilderV2()
           .withNetworkControllerDoubleNode()
           .withSelectedNetworkControllerPerDomain()
           .build(),

--- a/test/e2e/tests/network/custom-rpc-history.spec.ts
+++ b/test/e2e/tests/network/custom-rpc-history.spec.ts
@@ -2,6 +2,7 @@ import { Suite } from 'mocha';
 import { NetworkStatus, RpcEndpointType } from '@metamask/network-controller';
 import { withFixtures } from '../../helpers';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
+import { LOCALHOST_NETWORK_CLIENT_ID } from '../../constants';
 import AddEditNetworkModal from '../../page-objects/pages/dialog/add-edit-network';
 import AddNetworkRpcUrlModal from '../../page-objects/pages/dialog/add-network-rpc-url';
 import Homepage from '../../page-objects/pages/home/homepage';
@@ -157,7 +158,7 @@ describe('Custom RPC history', function (this: Suite) {
                 nativeCurrency: 'ETH',
                 rpcEndpoints: [
                   {
-                    networkClientId: 'networkConfigurationId',
+                    networkClientId: LOCALHOST_NETWORK_CLIENT_ID,
                     type: RpcEndpointType.Custom,
                     url: 'http://localhost:8545',
                   },
@@ -215,7 +216,7 @@ describe('Custom RPC history', function (this: Suite) {
                 nativeCurrency: 'ETH',
                 rpcEndpoints: [
                   {
-                    networkClientId: 'networkConfigurationId',
+                    networkClientId: LOCALHOST_NETWORK_CLIENT_ID,
                     type: RpcEndpointType.Custom,
                     url: 'http://localhost:8545',
                   },

--- a/test/e2e/tests/network/custom-rpc-history.spec.ts
+++ b/test/e2e/tests/network/custom-rpc-history.spec.ts
@@ -1,7 +1,6 @@
 import { Suite } from 'mocha';
-import { mockNetworkStateOld } from '../../../stub/networks';
+import { NetworkStatus, RpcEndpointType } from '@metamask/network-controller';
 import { withFixtures } from '../../helpers';
-import FixtureBuilder from '../../fixtures/fixture-builder';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import AddEditNetworkModal from '../../page-objects/pages/dialog/add-edit-network';
 import AddNetworkRpcUrlModal from '../../page-objects/pages/dialog/add-network-rpc-url';
@@ -145,29 +144,41 @@ describe('Custom RPC history', function (this: Suite) {
   });
 
   it('finds all recent RPCs in history', async function () {
-    const networkState = mockNetworkStateOld(
-      {
-        rpcUrl: 'http://127.0.0.1:8545/1',
-        chainId: '0x539',
-        ticker: 'ETH',
-        nickname: 'http://127.0.0.1:8545/1',
-      },
-      {
-        rpcUrl: 'http://127.0.0.1:8545/2',
-        chainId: '0x539',
-        ticker: 'ETH',
-        nickname: 'http://127.0.0.1:8545/2',
-      },
-    );
-    // Use type assertion to make selectedNetworkClientId optional
-    (
-      networkState as { selectedNetworkClientId?: string }
-    ).selectedNetworkClientId = undefined;
-
     await withFixtures(
       {
-        fixtures: new FixtureBuilder()
-          .withNetworkController(networkState)
+        fixtures: new FixtureBuilderV2()
+          .withNetworkController({
+            networkConfigurationsByChainId: {
+              '0x539': {
+                blockExplorerUrls: [],
+                chainId: '0x539',
+                defaultRpcEndpointIndex: 0,
+                name: 'Localhost 8545',
+                nativeCurrency: 'ETH',
+                rpcEndpoints: [
+                  {
+                    networkClientId: 'networkConfigurationId',
+                    type: RpcEndpointType.Custom,
+                    url: 'http://localhost:8545',
+                  },
+                  {
+                    networkClientId: 'rpc-id-1',
+                    type: RpcEndpointType.Custom,
+                    url: 'http://127.0.0.1:8545/1',
+                  },
+                  {
+                    networkClientId: 'rpc-id-2',
+                    type: RpcEndpointType.Custom,
+                    url: 'http://127.0.0.1:8545/2',
+                  },
+                ],
+              },
+            },
+            networksMetadata: {
+              'rpc-id-1': { EIPS: {}, status: NetworkStatus.Available },
+              'rpc-id-2': { EIPS: {}, status: NetworkStatus.Available },
+            },
+          })
           .build(),
         title: this.test?.fullTitle(),
       },
@@ -191,29 +202,50 @@ describe('Custom RPC history', function (this: Suite) {
   });
 
   it('deletes a custom RPC', async function () {
-    const networkState = mockNetworkStateOld(
-      {
-        rpcUrl: 'http://127.0.0.1:8545/1',
-        chainId: '0x539',
-        ticker: 'ETH',
-        nickname: 'http://127.0.0.1:8545/1',
-      },
-      {
-        rpcUrl: 'http://127.0.0.1:8545/2',
-        chainId: '0x540',
-        ticker: 'ETH',
-        nickname: 'http://127.0.0.1:8545/2',
-      },
-    );
-    // Use type assertion to make selectedNetworkClientId optional
-    (
-      networkState as { selectedNetworkClientId?: string }
-    ).selectedNetworkClientId = undefined;
-
     await withFixtures(
       {
-        fixtures: new FixtureBuilder()
-          .withNetworkController(networkState)
+        fixtures: new FixtureBuilderV2()
+          .withNetworkController({
+            networkConfigurationsByChainId: {
+              '0x539': {
+                blockExplorerUrls: [],
+                chainId: '0x539',
+                defaultRpcEndpointIndex: 0,
+                name: 'Localhost 8545',
+                nativeCurrency: 'ETH',
+                rpcEndpoints: [
+                  {
+                    networkClientId: 'networkConfigurationId',
+                    type: RpcEndpointType.Custom,
+                    url: 'http://localhost:8545',
+                  },
+                  {
+                    networkClientId: 'rpc-id-1',
+                    type: RpcEndpointType.Custom,
+                    url: 'http://127.0.0.1:8545/1',
+                  },
+                ],
+              },
+              '0x540': {
+                blockExplorerUrls: [],
+                chainId: '0x540',
+                defaultRpcEndpointIndex: 0,
+                name: 'http://127.0.0.1:8545/2',
+                nativeCurrency: 'ETH',
+                rpcEndpoints: [
+                  {
+                    networkClientId: 'rpc-id-2',
+                    type: RpcEndpointType.Custom,
+                    url: 'http://127.0.0.1:8545/2',
+                  },
+                ],
+              },
+            },
+            networksMetadata: {
+              'rpc-id-1': { EIPS: {}, status: NetworkStatus.Available },
+              'rpc-id-2': { EIPS: {}, status: NetworkStatus.Available },
+            },
+          })
           .build(),
         title: this.test?.fullTitle(),
       },

--- a/test/e2e/tests/network/remove-network.spec.ts
+++ b/test/e2e/tests/network/remove-network.spec.ts
@@ -2,10 +2,7 @@ import { strict as assert } from 'assert';
 import { Suite } from 'mocha';
 import { NetworkStatus, RpcEndpointType } from '@metamask/network-controller';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
-import {
-  SECOND_NODE_NETWORK_CLIENT_ID,
-  WINDOW_TITLES,
-} from '../../constants';
+import { SECOND_NODE_NETWORK_CLIENT_ID, WINDOW_TITLES } from '../../constants';
 import { withFixtures } from '../../helpers';
 import { Driver } from '../../webdriver/driver';
 import AddEditNetworkModal from '../../page-objects/pages/dialog/add-edit-network';

--- a/test/e2e/tests/network/remove-network.spec.ts
+++ b/test/e2e/tests/network/remove-network.spec.ts
@@ -1,9 +1,6 @@
 import { strict as assert } from 'assert';
 import { Suite } from 'mocha';
-import {
-  NetworkStatus,
-  RpcEndpointType,
-} from '@metamask/network-controller';
+import { NetworkStatus, RpcEndpointType } from '@metamask/network-controller';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { WINDOW_TITLES } from '../../constants';
 import { withFixtures } from '../../helpers';
@@ -86,14 +83,12 @@ describe('Remove Network:', function (this: Suite) {
                 nativeCurrency: 'ETH',
                 rpcEndpoints: [
                   {
-                    networkClientId:
-                      '76e9cd59-d8e2-47e7-b369-9c205ccb602c',
+                    networkClientId: '76e9cd59-d8e2-47e7-b369-9c205ccb602c',
                     type: RpcEndpointType.Custom,
                     url: 'http://localhost:8546',
                   },
                   {
-                    networkClientId:
-                      '2ce66016-8aab-47df-b27f-318c80865eb1',
+                    networkClientId: '2ce66016-8aab-47df-b27f-318c80865eb1',
                     type: RpcEndpointType.Custom,
                     url: 'http://127.0.0.1:8546',
                   },

--- a/test/e2e/tests/network/remove-network.spec.ts
+++ b/test/e2e/tests/network/remove-network.spec.ts
@@ -2,7 +2,10 @@ import { strict as assert } from 'assert';
 import { Suite } from 'mocha';
 import { NetworkStatus, RpcEndpointType } from '@metamask/network-controller';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
-import { WINDOW_TITLES } from '../../constants';
+import {
+  SECOND_NODE_NETWORK_CLIENT_ID,
+  WINDOW_TITLES,
+} from '../../constants';
 import { withFixtures } from '../../helpers';
 import { Driver } from '../../webdriver/driver';
 import AddEditNetworkModal from '../../page-objects/pages/dialog/add-edit-network';
@@ -83,7 +86,7 @@ describe('Remove Network:', function (this: Suite) {
                 nativeCurrency: 'ETH',
                 rpcEndpoints: [
                   {
-                    networkClientId: '76e9cd59-d8e2-47e7-b369-9c205ccb602c',
+                    networkClientId: SECOND_NODE_NETWORK_CLIENT_ID,
                     type: RpcEndpointType.Custom,
                     url: 'http://localhost:8546',
                   },
@@ -96,7 +99,7 @@ describe('Remove Network:', function (this: Suite) {
               },
             },
             networksMetadata: {
-              '76e9cd59-d8e2-47e7-b369-9c205ccb602c': {
+              [SECOND_NODE_NETWORK_CLIENT_ID]: {
                 EIPS: {},
                 status: NetworkStatus.Available,
               },

--- a/test/e2e/tests/network/remove-network.spec.ts
+++ b/test/e2e/tests/network/remove-network.spec.ts
@@ -1,6 +1,10 @@
 import { strict as assert } from 'assert';
 import { Suite } from 'mocha';
-import FixtureBuilder from '../../fixtures/fixture-builder';
+import {
+  NetworkStatus,
+  RpcEndpointType,
+} from '@metamask/network-controller';
+import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { WINDOW_TITLES } from '../../constants';
 import { withFixtures } from '../../helpers';
 import { Driver } from '../../webdriver/driver';
@@ -17,33 +21,10 @@ describe('Remove Network:', function (this: Suite) {
     await withFixtures(
       {
         dappOptions: { numberOfTestDapps: 1 },
-        fixtures: new FixtureBuilder()
-          .withPermissionControllerConnectedToTestDappWithChains([
-            '0x539',
-            '0x53a',
-          ])
-          .withNetworkController({
-            providerConfig: {
-              rpcPrefs: { blockExplorerUrl: 'https://etherscan.io/' },
-            },
-            networkConfigurations: {
-              networkConfigurationId: {
-                chainId: '0x539',
-                nickname: 'Localhost 8545',
-                rpcUrl: 'http://localhost:8545',
-                ticker: 'ETH',
-                rpcPrefs: { blockExplorerUrl: 'https://etherscan.io/' },
-              },
-              '2ce66016-8aab-47df-b27f-318c80865eb0': {
-                chainId: '0x53a',
-                id: '2ce66016-8aab-47df-b27f-318c80865eb0',
-                nickname: 'Localhost 8546',
-                rpcPrefs: {},
-                rpcUrl: 'http://localhost:8546',
-                ticker: 'ETH',
-              },
-            },
-            selectedNetworkClientId: 'networkConfigurationId',
+        fixtures: new FixtureBuilderV2()
+          .withNetworkControllerDoubleNode()
+          .withPermissionControllerConnectedToTestDapp({
+            chainIds: [1337, 1338],
           })
           .build(),
         localNodeOptions: [
@@ -94,41 +75,44 @@ describe('Remove Network:', function (this: Suite) {
     await withFixtures(
       {
         dappOptions: { numberOfTestDapps: 1 },
-        fixtures: new FixtureBuilder()
-          .withPermissionControllerConnectedToTestDappWithChains([
-            '0x539',
-            '0x53a',
-          ])
+        fixtures: new FixtureBuilderV2()
           .withNetworkController({
-            providerConfig: {
-              rpcPrefs: { blockExplorerUrl: 'https://etherscan.io/' },
-            },
-            networkConfigurations: {
-              networkConfigurationId: {
-                chainId: '0x539',
-                nickname: 'Localhost 8545',
-                rpcUrl: 'http://localhost:8545',
-                ticker: 'ETH',
-                rpcPrefs: { blockExplorerUrl: 'https://etherscan.io/' },
-              },
-              '2ce66016-8aab-47df-b27f-318c80865eb0': {
+            networkConfigurationsByChainId: {
+              '0x53a': {
+                blockExplorerUrls: [],
                 chainId: '0x53a',
-                id: '2ce66016-8aab-47df-b27f-318c80865eb0',
-                nickname: 'Localhost 8546',
-                rpcPrefs: {},
-                rpcUrl: 'http://localhost:8546',
-                ticker: 'ETH',
+                defaultRpcEndpointIndex: 0,
+                name: 'Localhost 8546',
+                nativeCurrency: 'ETH',
+                rpcEndpoints: [
+                  {
+                    networkClientId:
+                      '76e9cd59-d8e2-47e7-b369-9c205ccb602c',
+                    type: RpcEndpointType.Custom,
+                    url: 'http://localhost:8546',
+                  },
+                  {
+                    networkClientId:
+                      '2ce66016-8aab-47df-b27f-318c80865eb1',
+                    type: RpcEndpointType.Custom,
+                    url: 'http://127.0.0.1:8546',
+                  },
+                ],
+              },
+            },
+            networksMetadata: {
+              '76e9cd59-d8e2-47e7-b369-9c205ccb602c': {
+                EIPS: {},
+                status: NetworkStatus.Available,
               },
               '2ce66016-8aab-47df-b27f-318c80865eb1': {
-                chainId: '0x53a',
-                id: '2ce66016-8aab-47df-b27f-318c80865eb1',
-                nickname: 'Localhost 8546 alternative',
-                rpcPrefs: {},
-                rpcUrl: 'http://127.0.0.1:8546',
-                ticker: 'ETH',
+                EIPS: {},
+                status: NetworkStatus.Available,
               },
             },
-            selectedNetworkClientId: 'networkConfigurationId',
+          })
+          .withPermissionControllerConnectedToTestDapp({
+            chainIds: [1337, 1338],
           })
           .build(),
         localNodeOptions: [

--- a/test/e2e/tests/network/switch-custom-network.spec.ts
+++ b/test/e2e/tests/network/switch-custom-network.spec.ts
@@ -1,6 +1,5 @@
 import { strict as assert } from 'assert';
 import { Suite } from 'mocha';
-import FixtureBuilder from '../../fixtures/fixture-builder';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { WINDOW_TITLES } from '../../constants';
 import { regularDelayMs, withFixtures } from '../../helpers';
@@ -57,12 +56,10 @@ describe('Switch ethereum chain', function (this: Suite) {
     await withFixtures(
       {
         dappOptions: { numberOfTestDapps: 1 },
-        fixtures: new FixtureBuilder()
-          .withPopularNetworks()
-          .withPermissionControllerConnectedToTestDappWithChains([
-            '0x1', // Hex Chain ID for Ethereum
-            '0x89', // Hex Chain ID for Polygon
-          ])
+        fixtures: new FixtureBuilderV2()
+          .withPermissionControllerConnectedToTestDapp({
+            chainIds: [1, 137], // Ethereum and Polygon
+          })
           .build(),
         title: this.test?.fullTitle(),
       },
@@ -106,7 +103,7 @@ describe('Switch ethereum chain', function (this: Suite) {
     await withFixtures(
       {
         dappOptions: { numberOfTestDapps: 1 },
-        fixtures: new FixtureBuilder()
+        fixtures: new FixtureBuilderV2()
           .withPermissionControllerConnectedToTestDapp() // Connected to Localhost
           .build(),
         title: this.test?.fullTitle(),

--- a/test/e2e/tests/request-queuing/chainid-check.spec.ts
+++ b/test/e2e/tests/request-queuing/chainid-check.spec.ts
@@ -1,7 +1,7 @@
 import { strict as assert } from 'assert';
 import { DAPP_URL, WINDOW_TITLES } from '../../constants';
 import { switchToNetworkFromNetworkSelect } from '../../page-objects/flows/network.flow';
-import FixtureBuilder from '../../fixtures/fixture-builder';
+import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { withFixtures, regularDelayMs } from '../../helpers';
 import { PAGES } from '../../webdriver/driver';
 import TestDapp from '../../page-objects/pages/test-dapp';
@@ -17,7 +17,7 @@ describe('Request Queueing chainId proxy sync', function () {
     await withFixtures(
       {
         dappOptions: { numberOfTestDapps: 1 },
-        fixtures: new FixtureBuilder()
+        fixtures: new FixtureBuilderV2()
           .withNetworkControllerDoubleNode()
           .withSelectedNetworkControllerPerDomain()
           .build(),

--- a/test/e2e/tests/request-queuing/dapp1-send-dapp2-signTypedData.spec.ts
+++ b/test/e2e/tests/request-queuing/dapp1-send-dapp2-signTypedData.spec.ts
@@ -17,7 +17,6 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
         dappOptions: { numberOfTestDapps: 2 },
         fixtures: new FixtureBuilderV2()
           .withNetworkControllerTripleNode()
-          .withSelectedNetworkControllerPerDomain()
           .build(),
         localNodeOptions: [
           {

--- a/test/e2e/tests/request-queuing/dapp1-send-dapp2-signTypedData.spec.ts
+++ b/test/e2e/tests/request-queuing/dapp1-send-dapp2-signTypedData.spec.ts
@@ -1,5 +1,5 @@
 import { DAPP_ONE_URL, DAPP_URL, WINDOW_TITLES } from '../../constants';
-import FixtureBuilder from '../../fixtures/fixture-builder';
+import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { withFixtures } from '../../helpers';
 import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow';
 import TestDapp from '../../page-objects/pages/test-dapp';
@@ -15,7 +15,7 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
     await withFixtures(
       {
         dappOptions: { numberOfTestDapps: 2 },
-        fixtures: new FixtureBuilder()
+        fixtures: new FixtureBuilderV2()
           .withNetworkControllerTripleNode()
           .withSelectedNetworkControllerPerDomain()
           .build(),

--- a/test/e2e/tests/request-queuing/dapp1-switch-dapp2-send.spec.ts
+++ b/test/e2e/tests/request-queuing/dapp1-switch-dapp2-send.spec.ts
@@ -1,4 +1,4 @@
-import FixtureBuilder from '../../fixtures/fixture-builder';
+import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { withFixtures } from '../../helpers';
 import { DAPP_ONE_URL, DAPP_URL, WINDOW_TITLES } from '../../constants';
 import ActivityListPage from '../../page-objects/pages/home/activity-list';
@@ -19,7 +19,7 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
     await withFixtures(
       {
         dappOptions: { numberOfTestDapps: 2 },
-        fixtures: new FixtureBuilder()
+        fixtures: new FixtureBuilderV2()
           .withNetworkControllerTripleNode()
           .withSelectedNetworkControllerPerDomain()
           .build(),

--- a/test/e2e/tests/request-queuing/dapp1-switch-dapp2-send.spec.ts
+++ b/test/e2e/tests/request-queuing/dapp1-switch-dapp2-send.spec.ts
@@ -150,7 +150,7 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
     await withFixtures(
       {
         dappOptions: { numberOfTestDapps: 2 },
-        fixtures: new FixtureBuilder()
+        fixtures: new FixtureBuilderV2()
           .withNetworkControllerTripleNode()
           .withEnabledNetworks({
             eip155: {

--- a/test/e2e/tests/request-queuing/multiple-networks-dapps-txs.spec.ts
+++ b/test/e2e/tests/request-queuing/multiple-networks-dapps-txs.spec.ts
@@ -1,7 +1,7 @@
 import { Suite } from 'mocha';
 import { DAPP_ONE_URL, DAPP_URL, WINDOW_TITLES } from '../../constants';
 import { switchToNetworkFromNetworkSelect } from '../../page-objects/flows/network.flow';
-import FixtureBuilder from '../../fixtures/fixture-builder';
+import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { withFixtures } from '../../helpers';
 import ActivityListPage from '../../page-objects/pages/home/activity-list';
 import HomePage from '../../page-objects/pages/home/homepage';
@@ -19,7 +19,7 @@ describe.skip('Request Queuing for Multiple Dapps and Txs on different networks.
     await withFixtures(
       {
         dappOptions: { numberOfTestDapps: 2 },
-        fixtures: new FixtureBuilder()
+        fixtures: new FixtureBuilderV2()
           .withEnabledNetworks({
             eip155: {
               '0x53a': true,

--- a/test/e2e/tests/request-queuing/sendTx-revokePermissions.spec.ts
+++ b/test/e2e/tests/request-queuing/sendTx-revokePermissions.spec.ts
@@ -3,7 +3,7 @@ import TestDapp from '../../page-objects/pages/test-dapp';
 import TransactionConfirmation from '../../page-objects/pages/confirmations/transaction-confirmation';
 import { Driver } from '../../webdriver/driver';
 import { DEFAULT_FIXTURE_ACCOUNT, WINDOW_TITLES } from '../../constants';
-import FixtureBuilder from '../../fixtures/fixture-builder';
+import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { withFixtures } from '../../helpers';
 
 describe('Request Queuing', function () {
@@ -14,7 +14,7 @@ describe('Request Queuing', function () {
     await withFixtures(
       {
         dappOptions: { numberOfTestDapps: 1 },
-        fixtures: new FixtureBuilder()
+        fixtures: new FixtureBuilderV2()
           .withPermissionControllerConnectedToTestDapp()
           .withSelectedNetworkControllerPerDomain()
           .build(),

--- a/test/stub/networks.ts
+++ b/test/stub/networks.ts
@@ -13,8 +13,11 @@ import {
   CHAIN_ID_TO_CURRENCY_SYMBOL_MAP,
 } from '../../shared/constants/network';
 
-// TODO: This is intentionally the old network state, and could be
-// removed if the e2e tests bump `FIXTURE_STATE_METADATA_VERSION` to >= 127
+/**
+ * @deprecated Use `FixtureBuilderV2.withNetworkController()` instead.
+ * This helper produces the legacy flat `networkConfigurations` format (pre-migration 127).
+ * It will be removed once `FixtureBuilder` (legacy) is fully replaced by `FixtureBuilderV2`.
+ */
 export const mockNetworkStateOld = (
   ...networks: {
     id?: string;

--- a/test/stub/networks.ts
+++ b/test/stub/networks.ts
@@ -17,6 +17,7 @@ import {
  * @deprecated Use `FixtureBuilderV2.withNetworkController()` instead.
  * This helper produces the legacy flat `networkConfigurations` format (pre-migration 127).
  * It will be removed once `FixtureBuilder` (legacy) is fully replaced by `FixtureBuilderV2`.
+ * @param networks - The network configurations to mock.
  */
 export const mockNetworkStateOld = (
   ...networks: {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Continue migrating to FixtureBuilderV2. Primarily focused on withSelectedNetworkControllerPerDomain. Follow up PR from https://github.com/MetaMask/metamask-extension/pull/40560



[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40706?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Ci should continue to pass

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="3080" height="1541" alt="image" src="https://github.com/user-attachments/assets/1b2512dd-6707-461e-aabf-6c879bb2252d" />


### **After**

<img width="3080" height="1541" alt="image" src="https://github.com/user-attachments/assets/656784bd-8ea4-4ad2-a1ec-9f0579506b86" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it updates shared E2E fixture-building helpers and rewires many specs to the new network/permission state formats, which could cause test flakiness or incorrect setup if any mapping is off. No production runtime logic is changed.
> 
> **Overview**
> **Continues the E2E `FixtureBuilderV2` migration** by switching a set of JSON-RPC, network, connection, and request-queuing specs from legacy `FixtureBuilder`/legacy helpers to `FixtureBuilderV2`.
> 
> Adds `FixtureBuilderV2` support for `SelectedNetworkController` (including a new `withSelectedNetworkControllerPerDomain()` helper) and introduces shared constants for second/third local node `networkClientId`s, then updates network-state setup in tests to use the post-migration `networkConfigurationsByChainId` shape.
> 
> Separately updates E2E testing guidelines to reflect the newly supported `FixtureBuilderV2` methods, and marks `mockNetworkStateOld` as *deprecated* in favor of `FixtureBuilderV2.withNetworkController()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc088604ef39fd080c96db0e5c4e2c87642e527a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->