### PR TITLE
fix: Add onboarding completion waiting mechanism for services and controllers

### DIFF
--- a/app/scripts/controller-init/multichain/multichain-account-service-init.test.ts
+++ b/app/scripts/controller-init/multichain/multichain-account-service-init.test.ts
@@ -92,6 +92,7 @@ describe('MultichainAccountServiceInit', () => {
         providers: expect.any(Array),
         providerConfigs: expect.any(Object),
         config: expect.any(Object),
+        ensureOnboardingComplete: requestMock.ensureOnboardingComplete,
       });
     });
 

--- a/app/scripts/controller-init/multichain/multichain-account-service-init.ts
+++ b/app/scripts/controller-init/multichain/multichain-account-service-init.ts
@@ -20,13 +20,14 @@ import { trace } from '../../../../shared/lib/trace';
  * @param request - The request object.
  * @param request.controllerMessenger - The messenger to use for the controller.
  * @param request.initMessenger - The messenger to use for initialization.
+ * @param request.ensureOnboardingComplete - Ensure onboarding is complete before initializing.
  * @returns The initialized service.
  */
 export const MultichainAccountServiceInit: ControllerInitFunction<
   MultichainAccountService,
   MultichainAccountServiceMessenger,
   MultichainAccountServiceInitMessenger
-> = ({ controllerMessenger, initMessenger }) => {
+> = ({ controllerMessenger, initMessenger, ensureOnboardingComplete }) => {
   const snapAccountProviderConfig = {
     // READ THIS CAREFULLY:
     // We are using 1 to prevent any concurrent `keyring_createAccount` requests. This ensures
@@ -63,6 +64,7 @@ export const MultichainAccountServiceInit: ControllerInitFunction<
       // @ts-expect-error Controller uses string for names rather than enum
       trace,
     },
+    ensureOnboardingComplete,
   });
 
   const preferencesState = initMessenger.call('PreferencesController:getState');

--- a/app/scripts/controller-init/test/utils.ts
+++ b/app/scripts/controller-init/test/utils.ts
@@ -17,6 +17,7 @@ export function buildControllerInitRequestMock(): jest.Mocked<
 > {
   return {
     currentMigrationVersion: 0,
+    ensureOnboardingComplete: jest.fn().mockResolvedValue(undefined),
     // @ts-expect-error: Partial mock.
     extension: {},
     platform: new ExtensionPlatform(),

--- a/app/scripts/controller-init/types.ts
+++ b/app/scripts/controller-init/types.ts
@@ -86,6 +86,11 @@ export type ControllerInitRequest<
   encryptor: Encryptor;
 
   /**
+   * Returns a promise that resolves when onboarding has been completed.
+   */
+  ensureOnboardingComplete: () => Promise<void>;
+
+  /**
    * The extension browser API.
    */
   extension: Browser;

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -178,7 +178,10 @@ import { isEqualCaseInsensitive } from '../../shared/lib/string-utils';
 import { parseStandardTokenTransactionData } from '../../shared/lib/transaction.utils';
 import { STATIC_MAINNET_TOKEN_LIST } from '../../shared/constants/tokens';
 import { START_UI_SYNC } from '../../shared/constants/ui-initialization';
-import { getTokenValueParam } from '../../shared/lib/metamask-controller-utils';
+import {
+  createEnsureOnboardingCompleteCallback,
+  getTokenValueParam,
+} from '../../shared/lib/metamask-controller-utils';
 import { isManifestV3 } from '../../shared/lib/mv3.utils';
 import { convertNetworkId } from '../../shared/lib/network.utils';
 import { getIsSmartTransaction } from '../../shared/lib/selectors';
@@ -9079,10 +9082,15 @@ export default class MetamaskController extends EventEmitter {
     return isDisabled;
   }
 
+  #createEnsureOnboardingCompleteCallback() {
+    return createEnsureOnboardingCompleteCallback(this.controllerMessenger);
+  }
+
   #initControllers({ existingControllers, initFunctions, initState }) {
     const initRequest = {
       currentMigrationVersion: this.opts.currentMigrationVersion,
       encryptor: this.opts.encryptor,
+      ensureOnboardingComplete: this.#createEnsureOnboardingCompleteCallback(),
       extension: this.extension,
       platform: this.platform,
       getCronjobControllerStorageManager: () =>

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -72,6 +72,7 @@ import {
   DefiReferralPartner,
 } from '../../shared/constants/defi-referrals';
 import { getEnabledAdvancedPermissions } from '../../shared/lib/environment';
+import * as metamaskControllerUtils from '../../shared/lib/metamask-controller-utils';
 import { ReferralStatus } from './controllers/preferences-controller';
 import { METAMASK_COOKIE_HANDLER } from './constants/stream';
 import {
@@ -485,6 +486,34 @@ describe('MetaMaskController', () => {
       expect(METAMASK_HOTLIST_DIFF_URL).toStrictEqual(
         'https://phishing-detection.api.cx.metamask.io/v2/diffsSince',
       );
+    });
+  });
+
+  describe('createEnsureOnboardingCompleteCallback (integration)', () => {
+    it('controller uses shared createEnsureOnboardingCompleteCallback when building initRequest', () => {
+      const createEnsureOnboardingCompleteCallbackSpy = jest.spyOn(
+        metamaskControllerUtils,
+        'createEnsureOnboardingCompleteCallback',
+      );
+      const controllerMessenger = new Messenger({
+        namespace: MOCK_ANY_NAMESPACE,
+      });
+
+      const _controller = new MetaMaskController({
+        initLangCode: 'en_US',
+        browser: browserPolyfillMock,
+        infuraProjectId: 'foo',
+        platform: { _showNotification: jest.fn() },
+        cronjobControllerStorageManager:
+          createMockCronjobControllerStorageManager(),
+        controllerMessenger,
+      });
+      expect(_controller).toBeDefined();
+
+      expect(createEnsureOnboardingCompleteCallbackSpy).toHaveBeenCalledWith(
+        controllerMessenger,
+      );
+      createEnsureOnboardingCompleteCallbackSpy.mockRestore();
     });
   });
 

--- a/shared/lib/metamask-controller-utils.js
+++ b/shared/lib/metamask-controller-utils.js
@@ -1,8 +1,0 @@
-import { TransactionType } from '@metamask/transaction-controller';
-
-export function getTokenValueParam(tokenData = {}) {
-  if (tokenData?.name === TransactionType.tokenMethodIncreaseAllowance) {
-    return tokenData?.args?.increment?.toString();
-  }
-  return tokenData?.args?._value?.toString();
-}

--- a/shared/lib/metamask-controller-utils.test.ts
+++ b/shared/lib/metamask-controller-utils.test.ts
@@ -1,0 +1,134 @@
+import {
+  MOCK_ANY_NAMESPACE,
+  Messenger,
+  MockAnyNamespace,
+} from '@metamask/messenger';
+
+import { type OnboardingControllerState } from '../types/onboarding';
+import { createEnsureOnboardingCompleteCallback } from './metamask-controller-utils';
+
+/** Action/event types so the test messenger accepts OnboardingController actions and events. */
+type TestOnboardingAction = {
+  type: 'OnboardingController:getState';
+  handler: () => OnboardingControllerState;
+};
+type TestOnboardingEvent = {
+  type: 'OnboardingController:stateChange';
+  payload: [OnboardingControllerState];
+};
+
+function createTestMessenger(): Messenger<
+  MockAnyNamespace,
+  TestOnboardingAction,
+  TestOnboardingEvent
+> {
+  return new Messenger<
+    MockAnyNamespace,
+    TestOnboardingAction,
+    TestOnboardingEvent
+  >({ namespace: MOCK_ANY_NAMESPACE });
+}
+
+const COMPLETED_ONBOARDING_STATE: OnboardingControllerState = {
+  seedPhraseBackedUp: null,
+  firstTimeFlowType: null,
+  completedOnboarding: true,
+};
+
+describe('createEnsureOnboardingCompleteCallback', () => {
+  it('returns a function that resolves immediately when onboarding is already complete', async () => {
+    const controllerMessenger = createTestMessenger();
+    controllerMessenger.registerActionHandler(
+      'OnboardingController:getState',
+      jest.fn().mockReturnValue({ completedOnboarding: true }),
+    );
+
+    const ensureOnboardingComplete =
+      createEnsureOnboardingCompleteCallback(controllerMessenger);
+    const result = await ensureOnboardingComplete();
+
+    expect(result).toBeUndefined();
+  });
+
+  it('returns a function that resolves when onboarding completes (stateChange)', async () => {
+    const controllerMessenger = createTestMessenger();
+    controllerMessenger.registerActionHandler(
+      'OnboardingController:getState',
+      jest.fn().mockReturnValue({ completedOnboarding: false }),
+    );
+    const subscribeSpy = jest.fn();
+    const unsubscribeSpy = jest.fn();
+    jest
+      .spyOn(controllerMessenger, 'subscribe')
+      .mockImplementation(((
+        topic: string,
+        listener: (state: OnboardingControllerState) => void,
+      ) =>
+        subscribeSpy(topic, listener)) as typeof controllerMessenger.subscribe);
+    jest
+      .spyOn(controllerMessenger, 'unsubscribe')
+      .mockImplementation(((
+        topic: string,
+        listener: (state: OnboardingControllerState) => void,
+      ) =>
+        unsubscribeSpy(
+          topic,
+          listener,
+        )) as typeof controllerMessenger.unsubscribe);
+
+    const ensureOnboardingComplete =
+      createEnsureOnboardingCompleteCallback(controllerMessenger);
+    const promise = ensureOnboardingComplete();
+
+    expect(subscribeSpy).toHaveBeenCalledWith(
+      'OnboardingController:stateChange',
+      expect.any(Function),
+    );
+
+    const listener = subscribeSpy.mock.calls[0][1] as (
+      state: OnboardingControllerState,
+    ) => void;
+    listener(COMPLETED_ONBOARDING_STATE);
+
+    await promise;
+    expect(unsubscribeSpy).toHaveBeenCalledWith(
+      'OnboardingController:stateChange',
+      listener,
+    );
+  });
+
+  it('uses a single subscription for multiple concurrent callers', async () => {
+    const controllerMessenger = createTestMessenger();
+    controllerMessenger.registerActionHandler(
+      'OnboardingController:getState',
+      jest.fn().mockReturnValue({ completedOnboarding: false }),
+    );
+    const subscribeSpy = jest.fn();
+    jest
+      .spyOn(controllerMessenger, 'subscribe')
+      .mockImplementation(((
+        topic: string,
+        listener: (state: OnboardingControllerState) => void,
+      ) =>
+        subscribeSpy(topic, listener)) as typeof controllerMessenger.subscribe);
+    jest
+      .spyOn(controllerMessenger, 'unsubscribe')
+      .mockImplementation(() => undefined);
+
+    const ensureOnboardingComplete =
+      createEnsureOnboardingCompleteCallback(controllerMessenger);
+
+    const promise1 = ensureOnboardingComplete();
+    const promise2 = ensureOnboardingComplete();
+    const promise3 = ensureOnboardingComplete();
+
+    expect(subscribeSpy).toHaveBeenCalledTimes(1);
+
+    const listener = subscribeSpy.mock.calls[0][1] as (
+      state: OnboardingControllerState,
+    ) => void;
+    listener(COMPLETED_ONBOARDING_STATE);
+
+    await Promise.all([promise1, promise2, promise3]);
+  });
+});

--- a/shared/lib/metamask-controller-utils.ts
+++ b/shared/lib/metamask-controller-utils.ts
@@ -1,0 +1,76 @@
+import { createDeferredPromise } from '@metamask/utils';
+import { TransactionType } from '@metamask/transaction-controller';
+import type { OnboardingControllerState } from '../types/onboarding';
+
+/**
+ * Minimal messenger shape needed for ensureOnboardingComplete.
+ * Satisfied by getRootMessenger() and any init messenger that includes onboarding.
+ */
+export type MessengerWithOnboardingState = {
+  call(action: 'OnboardingController:getState'): OnboardingControllerState;
+  subscribe(
+    topic: 'OnboardingController:stateChange',
+    listener: (state: OnboardingControllerState) => void,
+  ): void;
+  unsubscribe(
+    topic: 'OnboardingController:stateChange',
+    listener: (state: OnboardingControllerState) => void,
+  ): void;
+};
+
+/**
+ * Creates a shared ensureOnboardingComplete function that resolves when
+ * onboarding is complete. Uses a single subscription so multiple callers
+ * do not register duplicate listeners.
+ *
+ * @param controllerMessenger - The controller messenger to call/subscribe (e.g. from getRootMessenger()).
+ * @returns Function that resolves when onboarding has been completed.
+ */
+export function createEnsureOnboardingCompleteCallback(
+  controllerMessenger: MessengerWithOnboardingState,
+): () => Promise<void> {
+  const resolvers: (() => void)[] = [];
+  let listener: ((state: OnboardingControllerState) => void) | null = null;
+
+  return function ensureOnboardingComplete(): Promise<void> {
+    const state = controllerMessenger.call('OnboardingController:getState');
+    if (state.completedOnboarding) {
+      return Promise.resolve();
+    }
+    const { promise, resolve } = createDeferredPromise<void>();
+    resolvers.push(resolve);
+    if (listener === null) {
+      const stateListener = (newState: OnboardingControllerState) => {
+        if (newState.completedOnboarding) {
+          controllerMessenger.unsubscribe(
+            'OnboardingController:stateChange',
+            stateListener,
+          );
+          listener = null;
+          resolvers.forEach((r) => r());
+          resolvers.length = 0;
+        }
+      };
+      listener = stateListener;
+      controllerMessenger.subscribe(
+        'OnboardingController:stateChange',
+        stateListener,
+      );
+    }
+    return promise;
+  };
+}
+
+type TokenDataParam = {
+  name?: string;
+  args?: { increment?: unknown; _value?: unknown };
+};
+
+export function getTokenValueParam(
+  tokenData: TokenDataParam = {},
+): string | undefined {
+  if (tokenData?.name === TransactionType.tokenMethodIncreaseAllowance) {
+    return tokenData?.args?.increment?.toString();
+  }
+  return tokenData?.args?._value?.toString();
+}

--- a/shared/types/onboarding.ts
+++ b/shared/types/onboarding.ts
@@ -1,0 +1,11 @@
+import { FirstTimeFlowType } from '../constants/onboarding';
+
+/**
+ * State shape for the OnboardingController.
+ */
+export type OnboardingControllerState = {
+  seedPhraseBackedUp: boolean | null;
+  firstTimeFlowType: FirstTimeFlowType | null;
+  completedOnboarding: boolean;
+  onboardingTabs?: Record<string, string>;
+};


### PR DESCRIPTION
## **Description**
This PR adds onboarding completion mechanism for controllers and services. 
Controller or a service can use this to wait for the onboarding process to be completed before taking certain steps.

Related Core PR: https://github.com/MetaMask/core/pull/8124

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40707?quickstart=1)

## **Changelog**
<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**
Fixes: https://github.com/MetaMask/metamask-extension/issues/40114

## **Manual testing steps**
1. Open MetaMask.
2. Open background console.
3. Reset the wallet.
4. Re-create the wallet.
5. Observe the console/log output during login. Make sure there is no `` error anymore.

## **Screenshots/Recordings**

### **Before**
No UI changes.

### **After**
No UI changes.

## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches controller initialization wiring and adds a new async onboarding gate used by `MultichainAccountService`, which could affect startup timing/order if the messenger events differ from expectations. Changes are localized but run on every boot.
> 
> **Overview**
> Introduces a shared `createEnsureOnboardingCompleteCallback` helper (with new `OnboardingControllerState` type) that returns a promise resolving once `completedOnboarding` becomes true, using a single shared `stateChange` subscription for concurrent callers.
> 
> Threads a new `ensureOnboardingComplete` function through `ControllerInitRequest`, constructs it in `MetaMaskController` during `#initControllers`, and passes it into `MultichainAccountService` during init; updates mocks and adds unit/integration tests to cover this wiring and the callback behavior.
> 
> Migrates `getTokenValueParam` from `shared/lib/metamask-controller-utils.js` to TypeScript alongside the new onboarding helper.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71cc4ad2d70e455d7ddf4a2b0921dd0ff8c06902. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->