### PR TITLE
fix: cp-13.23.0 allow claiming musd bonus in full-screen

### DIFF
--- a/ui/hooks/musd/index.ts
+++ b/ui/hooks/musd/index.ts
@@ -53,3 +53,5 @@ export {
 } from './useCustomAmount';
 
 export { useCanBuyMusd, type UseCanBuyMusdResult } from './useCanBuyMusd';
+
+export { isMerklClaimTransaction } from './useMerklClaimStatus';

--- a/ui/hooks/musd/useMerklClaimStatus.ts
+++ b/ui/hooks/musd/useMerklClaimStatus.ts
@@ -27,7 +27,7 @@ const IN_FLIGHT_STATUSES: string[] = [
  * @param tx - The transaction metadata
  * @returns Whether the transaction is a Merkl claim
  */
-const isMerklClaimTransaction = (tx: TransactionMeta): boolean =>
+export const isMerklClaimTransaction = (tx: TransactionMeta): boolean =>
   tx.txParams?.to?.toLowerCase() === MERKL_DISTRIBUTOR_ADDRESS.toLowerCase();
 
 export type MerklClaimToastState = 'in-progress' | 'success' | 'failed' | null;

--- a/ui/pages/routes/confirmation-handler.tsx
+++ b/ui/pages/routes/confirmation-handler.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useSelector } from 'react-redux';
+import { type TransactionMeta } from '@metamask/transaction-controller';
 
 import {
   PREPARE_SWAP_ROUTE,
@@ -21,15 +22,16 @@ import {
   ENVIRONMENT_TYPE_FULLSCREEN,
   ENVIRONMENT_TYPE_NOTIFICATION,
   ENVIRONMENT_TYPE_POPUP,
-  ORIGIN_METAMASK,
   SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES,
 } from '../../../shared/constants/app';
 import {
+  getTransactions,
   selectHasApprovalFlows,
   selectHasBridgeQuotes,
   selectPendingApprovalsForNavigation,
 } from '../../selectors';
 import { useModalState } from '../../hooks/useModalState';
+import { isMerklClaimTransaction } from '../../hooks/musd';
 
 const EXEMPTED_ROUTES = [
   CROSS_CHAIN_SWAP_ROUTE,
@@ -68,6 +70,12 @@ export const ConfirmationHandler = () => {
   const stayOnHomePage = Boolean(location.state?.stayOnHomePage);
 
   const canRedirect = !isNotification && !stayOnHomePage;
+  const transactions = useSelector(getTransactions) as TransactionMeta[];
+
+  const merklClaims = useMemo(
+    () => transactions.filter(isMerklClaimTransaction),
+    [transactions],
+  );
 
   // Ported from home.component - checkStatusAndNavigate()
   const checkStatusAndNavigate = useCallback(() => {
@@ -109,15 +117,15 @@ export const ConfirmationHandler = () => {
 
   const hasSwapRelatedNavigation = hasBridgeQuotes;
 
-  const hasInternalOriginApprovals = pendingApprovals.some(
-    (approval) => approval.origin === ORIGIN_METAMASK,
+  const isMerklTransaction = pendingApprovals.some((approval) =>
+    merklClaims.some((mc) => mc.id === approval.requestData.txId),
   );
 
   const isFullscreenExemption =
     isFullscreen &&
     !hasAllowedPopupRedirectApprovals &&
     !hasSwapRelatedNavigation &&
-    !hasInternalOriginApprovals;
+    !isMerklTransaction;
 
   // Ported from home.component - componentDidUpdate()
   useEffect(() => {

--- a/ui/pages/routes/confirmation-handler.tsx
+++ b/ui/pages/routes/confirmation-handler.tsx
@@ -21,6 +21,7 @@ import {
   ENVIRONMENT_TYPE_FULLSCREEN,
   ENVIRONMENT_TYPE_NOTIFICATION,
   ENVIRONMENT_TYPE_POPUP,
+  ORIGIN_METAMASK,
   SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES,
 } from '../../../shared/constants/app';
 import {
@@ -108,10 +109,15 @@ export const ConfirmationHandler = () => {
 
   const hasSwapRelatedNavigation = hasBridgeQuotes;
 
+  const hasInternalOriginApprovals = pendingApprovals.some(
+    (approval) => approval.origin === ORIGIN_METAMASK,
+  );
+
   const isFullscreenExemption =
     isFullscreen &&
     !hasAllowedPopupRedirectApprovals &&
-    !hasSwapRelatedNavigation;
+    !hasSwapRelatedNavigation &&
+    !hasInternalOriginApprovals;
 
   // Ported from home.component - componentDidUpdate()
   useEffect(() => {

--- a/ui/pages/routes/routes.component.test.js
+++ b/ui/pages/routes/routes.component.test.js
@@ -138,6 +138,7 @@ jest.mock('../../hooks/musd', () => ({
   BuyGetMusdCtaVariant: { BUY: 'buy', GET: 'get' },
   isTokenInWildcardList: jest.fn().mockReturnValue(false),
   checkTokenAllowed: jest.fn().mockReturnValue(false),
+  isMerklClaimTransaction: jest.fn().mockReturnValue(false),
 }));
 
 jest.mock('../../hooks/useMultiPolling', () => ({


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The claim modal was previously not opening in full screen views. This PR ensures that it will be opened in full screen view.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40708?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug that prevented claiming MUSD bonuses in full screen mode

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-467

## **Manual testing steps**

1. Enable the earnMerklCampaignClaiming flag
2. Navigate to an account with a musd bonsu to claim
3. Enter fullscreen
4. Confirm that it is possible to open the claim modal and claim the bonus.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
<img width="1281" height="1367" alt="image" src="https://github.com/user-attachments/assets/0b7824dd-1c33-48ae-94f1-5b1541103738" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches global confirmation/navigation logic to special-case Merkl claim transactions, which could affect redirect behavior for fullscreen users if the tx/approval matching is wrong.
> 
> **Overview**
> Fixes fullscreen navigation so **Merkl (MUSD bonus) claim** confirmations aren’t blocked by the fullscreen redirect exemption.
> 
> This exports `isMerklClaimTransaction` from the MUSD hooks and uses it in `confirmation-handler.tsx` to detect pending Merkl claim approvals (via `getTransactions` + `approval.requestData.txId`) and disable the fullscreen exemption for those flows. Tests update the MUSD hook mock to include `isMerklClaimTransaction`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18fa5e24098d5700de9cb757d2b5229a10f80269. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->