### PR TITLE
refactor: use accountGroupId query parameter instead of URL segment

### DIFF
--- a/ui/components/app/wallet-overview/coin-buttons.tsx
+++ b/ui/components/app/wallet-overview/coin-buttons.tsx
@@ -332,7 +332,7 @@ const CoinButtons = ({
     if (selectedAccountGroup) {
       // Navigate to the multichain address list page with receive source
       navigate(
-        `${MULTICHAIN_ACCOUNT_ADDRESS_LIST_PAGE_ROUTE}/${encodeURIComponent(selectedAccountGroup)}?${AddressListQueryParams.Source}=${AddressListSource.Receive}`,
+        `${MULTICHAIN_ACCOUNT_ADDRESS_LIST_PAGE_ROUTE}?accountGroupId=${encodeURIComponent(selectedAccountGroup)}&${AddressListQueryParams.Source}=${AddressListSource.Receive}`,
       );
     } else {
       // Show the traditional receive modal

--- a/ui/components/app/wallet-overview/coin-overview.tsx
+++ b/ui/components/app/wallet-overview/coin-overview.tsx
@@ -255,7 +255,7 @@ export const CoinOverview = ({
     if (selectedAccountGroup) {
       // Navigate to the multichain address list page with receive source
       navigate(
-        `${MULTICHAIN_ACCOUNT_ADDRESS_LIST_PAGE_ROUTE}/${encodeURIComponent(selectedAccountGroup)}?${AddressListQueryParams.Source}=${AddressListSource.Receive}`,
+        `${MULTICHAIN_ACCOUNT_ADDRESS_LIST_PAGE_ROUTE}?accountGroupId=${encodeURIComponent(selectedAccountGroup)}&${AddressListQueryParams.Source}=${AddressListSource.Receive}`,
       );
     }
   }, [selectedAccountGroup, navigate, trackEvent, chainId]);

--- a/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
+++ b/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
@@ -114,7 +114,7 @@ export const MultichainAccountMenu = ({
         name: TraceName.ShowAccountAddressList,
         op: TraceOperation.AccountUi,
       });
-      const multichainAccountAddressesPageRoute = `${MULTICHAIN_ACCOUNT_ADDRESS_LIST_PAGE_ROUTE}/${encodeURIComponent(accountGroupId)}`;
+      const multichainAccountAddressesPageRoute = `${MULTICHAIN_ACCOUNT_ADDRESS_LIST_PAGE_ROUTE}?accountGroupId=${encodeURIComponent(accountGroupId)}`;
       navigate(multichainAccountAddressesPageRoute);
     };
 

--- a/ui/components/multichain-accounts/multichain-address-rows-hovered-list/multichain-hovered-address-rows-hovered-list.test.tsx
+++ b/ui/components/multichain-accounts/multichain-address-rows-hovered-list/multichain-hovered-address-rows-hovered-list.test.tsx
@@ -731,7 +731,7 @@ describe('MultichainHoveredAddressRowsList', () => {
       fireEvent.click(viewAllButton);
 
       expect(mockUseNavigate).toHaveBeenCalledWith(
-        `${MULTICHAIN_ACCOUNT_ADDRESS_LIST_PAGE_ROUTE}/${encodeURIComponent(GROUP_ID_MOCK)}`,
+        `${MULTICHAIN_ACCOUNT_ADDRESS_LIST_PAGE_ROUTE}?accountGroupId=${encodeURIComponent(GROUP_ID_MOCK)}`,
       );
     });
 
@@ -772,7 +772,7 @@ describe('MultichainHoveredAddressRowsList', () => {
       fireEvent.click(viewAllButton);
 
       expect(mockUseNavigate).toHaveBeenCalledWith(
-        `${MULTICHAIN_ACCOUNT_ADDRESS_LIST_PAGE_ROUTE}/${encodeURIComponent(SPECIAL_GROUP_ID)}`,
+        `${MULTICHAIN_ACCOUNT_ADDRESS_LIST_PAGE_ROUTE}?accountGroupId=${encodeURIComponent(SPECIAL_GROUP_ID)}`,
       );
     });
 
@@ -796,7 +796,7 @@ describe('MultichainHoveredAddressRowsList', () => {
 
       expect(mockOnViewAllClick).toHaveBeenCalledTimes(1);
       expect(mockUseNavigate).toHaveBeenCalledWith(
-        `${MULTICHAIN_ACCOUNT_ADDRESS_LIST_PAGE_ROUTE}/${encodeURIComponent(GROUP_ID_MOCK)}`,
+        `${MULTICHAIN_ACCOUNT_ADDRESS_LIST_PAGE_ROUTE}?accountGroupId=${encodeURIComponent(GROUP_ID_MOCK)}`,
       );
     });
 

--- a/ui/components/multichain-accounts/multichain-address-rows-hovered-list/multichain-hovered-address-rows-hovered-list.tsx
+++ b/ui/components/multichain-accounts/multichain-address-rows-hovered-list/multichain-hovered-address-rows-hovered-list.tsx
@@ -322,7 +322,7 @@ export const MultichainHoveredAddressRowsList = ({
       e.stopPropagation();
       onViewAllClick?.();
       navigate(
-        `${MULTICHAIN_ACCOUNT_ADDRESS_LIST_PAGE_ROUTE}/${encodeURIComponent(groupId)}`,
+        `${MULTICHAIN_ACCOUNT_ADDRESS_LIST_PAGE_ROUTE}?accountGroupId=${encodeURIComponent(groupId)}`,
       );
     },
     [groupId, navigate, onViewAllClick],

--- a/ui/pages/multichain-accounts/multichain-account-address-list-page/multichain-account-address-list-page.stories.tsx
+++ b/ui/pages/multichain-accounts/multichain-account-address-list-page/multichain-account-address-list-page.stories.tsx
@@ -39,11 +39,11 @@ export const Default: Story = {
   ],
   parameters: {
     initialEntries: [
-      `/multichain-account-address-list/${encodeURIComponent(
+      `/multichain-account-address-list?accountGroupId=${encodeURIComponent(
         MOCK_GROUP_ID,
-      )}?source=receive`,
+      )}&source=receive`,
     ],
-    path: '/multichain-account-address-list/:accountGroupId',
+    path: '/multichain-account-address-list',
     backgrounds: {
       default: 'light',
     },

--- a/ui/pages/multichain-accounts/multichain-account-address-list-page/multichain-account-address-list-page.test.tsx
+++ b/ui/pages/multichain-accounts/multichain-account-address-list-page/multichain-account-address-list-page.test.tsx
@@ -24,13 +24,11 @@ const MOCK_GROUP_ID = 'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0' as AccountGroupId;
 const MOCK_GROUP_NAME = 'Account 1';
 
 const mockUseNavigate = jest.fn();
-const mockUseParams = jest.fn();
 const mockUseLocation = jest.fn();
 jest.mock('react-router-dom', () => {
   return {
     ...jest.requireActual('react-router-dom'),
     useNavigate: () => mockUseNavigate,
-    useParams: () => mockUseParams(),
     useLocation: () => mockUseLocation(),
   };
 });
@@ -42,8 +40,8 @@ describe('MultichainAccountAddressListPage', () => {
   });
 
   it('renders the page with correct components', () => {
-    mockUseParams.mockReturnValue({
-      accountGroupId: MOCK_GROUP_ID,
+    mockUseLocation.mockReturnValue({
+      search: `?accountGroupId=${encodeURIComponent(MOCK_GROUP_ID)}`,
     });
 
     const store = configureStore({
@@ -70,8 +68,8 @@ describe('MultichainAccountAddressListPage', () => {
   });
 
   it('navigates back when back button is clicked', () => {
-    mockUseParams.mockReturnValue({
-      accountGroupId: MOCK_GROUP_ID,
+    mockUseLocation.mockReturnValue({
+      search: `?accountGroupId=${encodeURIComponent(MOCK_GROUP_ID)}`,
     });
 
     const store = configureStore({
@@ -89,8 +87,8 @@ describe('MultichainAccountAddressListPage', () => {
   });
 
   it('displays fallback text when account group does not exist', () => {
-    mockUseParams.mockReturnValue({
-      accountGroupId: 'non-existent-group',
+    mockUseLocation.mockReturnValue({
+      search: `?accountGroupId=${encodeURIComponent('non-existent-group')}`,
     });
 
     const store = configureStore({
@@ -109,10 +107,8 @@ describe('MultichainAccountAddressListPage', () => {
   });
 
   it('decodes and renders account group with encoded ID', () => {
-    const encodedGroupId = encodeURIComponent(MOCK_GROUP_ID);
-
-    mockUseParams.mockReturnValue({
-      accountGroupId: encodedGroupId,
+    mockUseLocation.mockReturnValue({
+      search: `?accountGroupId=${encodeURIComponent(MOCK_GROUP_ID)}`,
     });
 
     const store = configureStore({
@@ -133,9 +129,8 @@ describe('MultichainAccountAddressListPage', () => {
   });
 
   it('shows receiving address title in receive mode', () => {
-    mockUseLocation.mockReturnValue({ search: '?source=receive' });
-    mockUseParams.mockReturnValue({
-      accountGroupId: MOCK_GROUP_ID,
+    mockUseLocation.mockReturnValue({
+      search: `?accountGroupId=${encodeURIComponent(MOCK_GROUP_ID)}&source=receive`,
     });
 
     const store = configureStore({
@@ -156,9 +151,8 @@ describe('MultichainAccountAddressListPage', () => {
   });
 
   it('renders correctly with multiple accounts in group', () => {
-    // The mock state already has two accounts in the group
-    mockUseParams.mockReturnValue({
-      accountGroupId: MOCK_GROUP_ID,
+    mockUseLocation.mockReturnValue({
+      search: `?accountGroupId=${encodeURIComponent(MOCK_GROUP_ID)}`,
     });
 
     const store = configureStore({
@@ -181,10 +175,9 @@ describe('MultichainAccountAddressListPage', () => {
   it('decodes and renders account group with special characters in ID', () => {
     const specialGroupId =
       'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0' as AccountGroupId;
-    const encodedSpecialGroupId = encodeURIComponent(specialGroupId);
 
-    mockUseParams.mockReturnValue({
-      accountGroupId: encodedSpecialGroupId,
+    mockUseLocation.mockReturnValue({
+      search: `?accountGroupId=${encodeURIComponent(specialGroupId)}`,
     });
 
     const store = configureStore({
@@ -202,9 +195,8 @@ describe('MultichainAccountAddressListPage', () => {
   });
 
   it('renders with different query parameters correctly', () => {
-    mockUseLocation.mockReturnValue({ search: '?source=other' });
-    mockUseParams.mockReturnValue({
-      accountGroupId: MOCK_GROUP_ID,
+    mockUseLocation.mockReturnValue({
+      search: `?accountGroupId=${encodeURIComponent(MOCK_GROUP_ID)}&source=other`,
     });
 
     const store = configureStore({
@@ -227,8 +219,8 @@ describe('MultichainAccountAddressListPage', () => {
   });
 
   it('displays fallback text when account group ID is null', () => {
-    mockUseParams.mockReturnValue({
-      accountGroupId: null,
+    mockUseLocation.mockReturnValue({
+      search: '',
     });
 
     const store = configureStore({
@@ -243,9 +235,9 @@ describe('MultichainAccountAddressListPage', () => {
     expect(screen.getByText('Account / Addresses')).toBeInTheDocument();
   });
 
-  it('displays fallback text when account group ID is undefined', () => {
-    mockUseParams.mockReturnValue({
-      accountGroupId: undefined,
+  it('displays fallback text when account group ID is missing', () => {
+    mockUseLocation.mockReturnValue({
+      search: '?other=param',
     });
 
     const store = configureStore({
@@ -262,8 +254,8 @@ describe('MultichainAccountAddressListPage', () => {
 
   describe('tracing', () => {
     it('ends ShowAccountAddressList trace on mount', () => {
-      mockUseParams.mockReturnValue({
-        accountGroupId: MOCK_GROUP_ID,
+      mockUseLocation.mockReturnValue({
+        search: `?accountGroupId=${encodeURIComponent(MOCK_GROUP_ID)}`,
       });
 
       const store = configureStore(mockState);

--- a/ui/pages/multichain-accounts/multichain-account-address-list-page/multichain-account-address-list-page.tsx
+++ b/ui/pages/multichain-accounts/multichain-account-address-list-page/multichain-account-address-list-page.tsx
@@ -1,6 +1,10 @@
 import React, { useState, useCallback, useEffect } from 'react';
 
-import { useNavigate, useLocation, useParams } from 'react-router-dom';
+import {
+  useNavigate,
+  useLocation,
+  type Location as RouterLocation,
+} from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { CaipChainId } from '@metamask/utils';
 import {
@@ -29,28 +33,20 @@ import {
 } from './multichain-account-address-list-page.types';
 
 type MultichainAccountAddressListPageProps = {
-  params?: { accountGroupId: string };
-  location?: {
-    pathname: string;
-    search: string;
-    hash: string;
-    state: unknown;
-    key: string;
-  };
+  location?: RouterLocation;
 };
 
 export const MultichainAccountAddressListPage = ({
-  params: propsParams,
   location: propsLocation,
 }: MultichainAccountAddressListPageProps = {}) => {
   const t = useI18nContext();
   const navigate = useNavigate();
   const hookLocation = useLocation();
-  const hookParams = useParams<{ accountGroupId: string }>();
 
   const location = propsLocation || hookLocation;
-  const { accountGroupId } = propsParams || hookParams;
 
+  const searchParams = new URLSearchParams(location.search);
+  const accountGroupId = searchParams.get('accountGroupId');
   const decodedAccountGroupId = accountGroupId
     ? (decodeURIComponent(accountGroupId) as AccountGroupId)
     : null;
@@ -61,7 +57,6 @@ export const MultichainAccountAddressListPage = ({
       : null,
   );
 
-  const searchParams = new URLSearchParams(location.search);
   const isReceiveMode =
     searchParams.get(AddressListQueryParams.Source) ===
     AddressListSource.Receive;

--- a/ui/pages/multichain-accounts/multichain-account-details-page/multichain-account-details-page.tsx
+++ b/ui/pages/multichain-accounts/multichain-account-details-page/multichain-account-details-page.tsx
@@ -106,13 +106,13 @@ export const MultichainAccountDetailsPage = () => {
       op: TraceOperation.AccountUi,
     });
     navigate(
-      `${MULTICHAIN_ACCOUNT_ADDRESS_LIST_PAGE_ROUTE}/${encodeURIComponent(accountGroupId)}`,
+      `${MULTICHAIN_ACCOUNT_ADDRESS_LIST_PAGE_ROUTE}?accountGroupId=${encodeURIComponent(accountGroupId)}`,
     );
   };
 
   const handlePrivateKeysClick = () => {
     navigate(
-      `${MULTICHAIN_ACCOUNT_PRIVATE_KEY_LIST_PAGE_ROUTE}/${encodeURIComponent(accountGroupId)}`,
+      `${MULTICHAIN_ACCOUNT_PRIVATE_KEY_LIST_PAGE_ROUTE}?accountGroupId=${encodeURIComponent(accountGroupId)}`,
     );
   };
 

--- a/ui/pages/multichain-accounts/multichain-account-private-key-list-page/multichain-account-private-key-list-page.test.tsx
+++ b/ui/pages/multichain-accounts/multichain-account-private-key-list-page/multichain-account-private-key-list-page.test.tsx
@@ -7,7 +7,7 @@ import configureStore from '../../../store/store';
 import { MultichainAccountPrivateKeyListPage } from './multichain-account-private-key-list-page';
 
 const mockNavigate = jest.fn();
-const mockUseParams = jest.fn();
+const mockUseLocation = jest.fn();
 const backButtonTestId = 'multichain-account-address-list-page-back-button';
 
 // Use actual group IDs from mock-state.json
@@ -16,7 +16,7 @@ const MOCK_GROUP_ID = 'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0' as AccountGroupId;
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useNavigate: () => mockNavigate,
-  useParams: () => mockUseParams(),
+  useLocation: () => mockUseLocation(),
 }));
 
 describe('MultichainAccountAddressListPage', () => {
@@ -25,8 +25,8 @@ describe('MultichainAccountAddressListPage', () => {
   });
 
   it('handles back button click', () => {
-    mockUseParams.mockReturnValue({
-      accountGroupId: MOCK_GROUP_ID,
+    mockUseLocation.mockReturnValue({
+      search: `?accountGroupId=${encodeURIComponent(MOCK_GROUP_ID)}`,
     });
 
     const store = configureStore({
@@ -44,8 +44,8 @@ describe('MultichainAccountAddressListPage', () => {
   });
 
   it('displays the proper account group name', () => {
-    mockUseParams.mockReturnValue({
-      accountGroupId: MOCK_GROUP_ID,
+    mockUseLocation.mockReturnValue({
+      search: `?accountGroupId=${encodeURIComponent(MOCK_GROUP_ID)}`,
     });
     const store = configureStore({
       metamask: {
@@ -57,8 +57,8 @@ describe('MultichainAccountAddressListPage', () => {
   });
 
   it('renders fallback account name when no account is found', () => {
-    mockUseParams.mockReturnValue({
-      accountGroupId: 'invalid-group-id',
+    mockUseLocation.mockReturnValue({
+      search: `?accountGroupId=${encodeURIComponent('invalid-group-id')}`,
     });
     const store = configureStore({
       metamask: {
@@ -71,8 +71,8 @@ describe('MultichainAccountAddressListPage', () => {
   });
 
   it('renders warning banner', () => {
-    mockUseParams.mockReturnValue({
-      accountGroupId: MOCK_GROUP_ID,
+    mockUseLocation.mockReturnValue({
+      search: `?accountGroupId=${encodeURIComponent(MOCK_GROUP_ID)}`,
     });
     const store = configureStore({
       metamask: {

--- a/ui/pages/multichain-accounts/multichain-account-private-key-list-page/multichain-account-private-key-list-page.tsx
+++ b/ui/pages/multichain-accounts/multichain-account-private-key-list-page/multichain-account-private-key-list-page.tsx
@@ -1,6 +1,10 @@
 import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import { useNavigate, useParams } from 'react-router-dom';
+import {
+  useNavigate,
+  useLocation,
+  type Location as RouterLocation,
+} from 'react-router-dom';
 import {
   Box,
   BoxFlexDirection,
@@ -31,17 +35,19 @@ import ZENDESK_URLS from '../../../helpers/constants/zendesk-url';
 import { PREVIOUS_ROUTE } from '../../../helpers/constants/routes';
 
 type MultichainAccountPrivateKeyListPageProps = {
-  params?: { accountGroupId: string };
+  location?: RouterLocation;
 };
 
 export const MultichainAccountPrivateKeyListPage = ({
-  params: propsParams,
+  location: propsLocation,
 }: MultichainAccountPrivateKeyListPageProps = {}) => {
   const t = useI18nContext();
   const navigate = useNavigate();
-  const hookParams = useParams<{ accountGroupId: string }>();
+  const hookLocation = useLocation();
 
-  const { accountGroupId } = propsParams || hookParams;
+  const location = propsLocation || hookLocation;
+  const searchParams = new URLSearchParams(location.search);
+  const accountGroupId = searchParams.get('accountGroupId');
 
   const decodedAccountGroupId: AccountGroupId | null = accountGroupId
     ? (decodeURIComponent(accountGroupId) as AccountGroupId)

--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -828,14 +828,14 @@ export default function Routes() {
         basicFunctionalityRequired: false,
       }),
       createRouteWithLayout({
-        path: `${MULTICHAIN_ACCOUNT_ADDRESS_LIST_PAGE_ROUTE}/:accountGroupId`,
+        path: MULTICHAIN_ACCOUNT_ADDRESS_LIST_PAGE_ROUTE,
         component: MultichainAccountAddressListPage,
         layout: RootLayout,
         authenticated: true,
         basicFunctionalityRequired: false,
       }),
       createRouteWithLayout({
-        path: `${MULTICHAIN_ACCOUNT_PRIVATE_KEY_LIST_PAGE_ROUTE}/:accountGroupId`,
+        path: MULTICHAIN_ACCOUNT_PRIVATE_KEY_LIST_PAGE_ROUTE,
         component: MultichainAccountPrivateKeyListPage,
         layout: RootLayout,
         authenticated: true,


### PR DESCRIPTION
## **Description**

Replace :accountGroupId route parameter with ?accountGroupId= query parameter for multichain account address list and private key list pages.

- Remove /:accountGroupId from route paths in routes.component.tsx
- Update all navigation calls to pass accountGroupId as a query param
- Update consuming pages to read accountGroupId from URLSearchParams
- Update tests and storybook to match new query param pattern

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: refactor: use accountGroupId query parameter 

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes route definitions and navigation for multichain address/private-key list pages, which can break deep links, bookmarks, or any remaining callers still using the old `/:accountGroupId` paths. Logic changes are straightforward but touch multiple entry points and tests.
> 
> **Overview**
> **Switches multichain address list + private key list routing from path params to query params.** The routes in `routes.component.tsx` no longer include `/:accountGroupId`, and all navigations to these pages now build URLs like `.../multichain-account-address-list?accountGroupId=...` (including receive flows, account menus, hovered “View all”, and account details links).
> 
> **Updates page parameter parsing and test/story fixtures accordingly.** `MultichainAccountAddressListPage` and `MultichainAccountPrivateKeyListPage` now read `accountGroupId` via `URLSearchParams` (optionally via injected `location`), and associated unit tests + Storybook initial entries were updated to match the new query-string format and missing-param fallback behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f872be5e9cad5f18fe31362bc49f5618b8c7377. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->