### PR TITLE
chore: bump assets controllers to v100.2.0

### DIFF
--- a/app/scripts/controller-init/messengers/account-tracker-controller-messenger.ts
+++ b/app/scripts/controller-init/messengers/account-tracker-controller-messenger.ts
@@ -5,6 +5,10 @@ import {
   NetworkControllerNetworkAddedEvent,
   NetworkControllerNetworkDidChangeEvent,
 } from '@metamask/network-controller';
+import {
+  NetworkEnablementControllerGetStateAction,
+  NetworkEnablementControllerListPopularEvmNetworksAction,
+} from '@metamask/network-enablement-controller';
 import { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
 import {
   AccountsControllerGetSelectedAccountAction,
@@ -32,6 +36,8 @@ type AllowedActions =
   | AccountsControllerListAccountsAction
   | NetworkControllerGetNetworkClientByIdAction
   | NetworkControllerGetStateAction
+  | NetworkEnablementControllerGetStateAction
+  | NetworkEnablementControllerListPopularEvmNetworksAction
   | PreferencesControllerGetStateAction
   | KeyringControllerGetStateAction;
 
@@ -69,6 +75,8 @@ export function getAccountTrackerControllerMessenger(
       'AccountsController:listAccounts',
       'NetworkController:getNetworkClientById',
       'NetworkController:getState',
+      'NetworkEnablementController:getState',
+      'NetworkEnablementController:listPopularEvmNetworks',
       'PreferencesController:getState',
       'KeyringController:getState',
     ],

--- a/package.json
+++ b/package.json
@@ -290,7 +290,7 @@
     "@metamask/announcement-controller": "^8.0.0",
     "@metamask/approval-controller": "^8.0.0",
     "@metamask/assets-controller": "^2.1.0",
-    "@metamask/assets-controllers": "^100.1.0",
+    "@metamask/assets-controllers": "^100.2.0",
     "@metamask/base-controller": "^9.0.0",
     "@metamask/bitcoin-wallet-snap": "^1.10.0",
     "@metamask/bridge-controller": "^67.4.0",

--- a/test/e2e/tests/bridge/bridge-L2-tests.spec.ts
+++ b/test/e2e/tests/bridge/bridge-L2-tests.spec.ts
@@ -10,7 +10,12 @@ describe('Bridge tests', function (this: Suite) {
     await withFixtures(
       getBridgeL2Fixtures(this.test?.fullTitle(), DEFAULT_BRIDGE_FEATURE_FLAGS),
       async ({ driver }) => {
-        await loginWithBalanceValidation(driver, undefined, undefined, '$0');
+        await loginWithBalanceValidation(
+          driver,
+          undefined,
+          undefined,
+          '$225,750.00',
+        );
 
         await bridgeTransaction({
           driver,

--- a/test/e2e/tests/bridge/bridge-positive-cases.spec.ts
+++ b/test/e2e/tests/bridge/bridge-positive-cases.spec.ts
@@ -20,8 +20,13 @@ describe('Bridge tests', function (this: Suite) {
         false,
       ),
       async ({ driver }) => {
-        // We start with a subset of networks (not localhost) so balance is displayed in fiat (and is $0 as it's missing price api mocks)
-        await loginWithBalanceValidation(driver, undefined, undefined, '$0');
+        // the balance has been fixed now , we show native balance when currency controller is set
+        await loginWithBalanceValidation(
+          driver,
+          undefined,
+          undefined,
+          '$225,730.11',
+        );
 
         const homePage = new HomePage(driver);
 
@@ -93,8 +98,12 @@ describe('Bridge tests', function (this: Suite) {
         false,
       ),
       async ({ driver }) => {
-        // We start with a subset of networks (not localhost) so balance is displayed in fiat (and is $0 as it's missing price api mocks)
-        await loginWithBalanceValidation(driver, undefined, undefined, '$0');
+        await loginWithBalanceValidation(
+          driver,
+          undefined,
+          undefined,
+          '$225,730.11',
+        );
         const networkManager = new NetworkManager(driver);
 
         // Navigate to Bridge page
@@ -129,8 +138,12 @@ describe('Bridge tests', function (this: Suite) {
         false,
       ),
       async ({ driver }) => {
-        // We start with a subset of networks (not localhost) so balance is displayed in fiat (and is $0 as it's missing price api mocks)
-        await loginWithBalanceValidation(driver, undefined, undefined, '$0');
+        await loginWithBalanceValidation(
+          driver,
+          undefined,
+          undefined,
+          '$225,730.11',
+        );
 
         const homePage = new HomePage(driver);
         await homePage.checkPageIsLoaded();

--- a/test/e2e/tests/bridge/swap-positive-cases.spec.ts
+++ b/test/e2e/tests/bridge/swap-positive-cases.spec.ts
@@ -19,7 +19,12 @@ describe('Swap tests', function (this: Suite) {
         ),
       },
       async ({ driver, mockedEndpoint: mockedEndpoints }) => {
-        await loginWithBalanceValidation(driver, undefined, undefined, '$0');
+        await loginWithBalanceValidation(
+          driver,
+          undefined,
+          undefined,
+          '$225,730.11',
+        );
 
         const homePage = new HomePage(driver);
         await homePage.checkPageIsLoaded();
@@ -98,7 +103,12 @@ describe('Swap tests', function (this: Suite) {
         true,
       ),
       async ({ driver, mockedEndpoint: mockedEndpoints }) => {
-        await loginWithBalanceValidation(driver, undefined, undefined, '$0');
+        await loginWithBalanceValidation(
+          driver,
+          undefined,
+          undefined,
+          '$225,730.11',
+        );
 
         const homePage = new HomePage(driver);
         await homePage.checkPageIsLoaded();

--- a/test/e2e/tests/solana/check-balance.spec.ts
+++ b/test/e2e/tests/solana/check-balance.spec.ts
@@ -34,7 +34,12 @@ describe('Check balance', function (this: Suite) {
         testSpecificMock: buildSolanaTestSpecificMock({ balance: 0 }),
       },
       async ({ driver }) => {
-        await loginWithBalanceValidation(driver, undefined, undefined, '$0.00');
+        await loginWithBalanceValidation(
+          driver,
+          undefined,
+          undefined,
+          '$42,500.00',
+        );
         const homePage = new NonEvmHomepage(driver);
         await homePage.waitForNonEvmAccountsLoaded();
         await switchToNetworkFromNetworkSelect(driver, 'Popular', 'Solana');
@@ -52,7 +57,12 @@ describe('Check balance', function (this: Suite) {
         testSpecificMock: buildSolanaTestSpecificMock(),
       },
       async ({ driver }) => {
-        await loginWithBalanceValidation(driver, undefined, undefined, '$0.00');
+        await loginWithBalanceValidation(
+          driver,
+          undefined,
+          undefined,
+          '$42,500.00',
+        );
         const homePage = new NonEvmHomepage(driver);
         await homePage.waitForNonEvmAccountsLoaded();
         await switchToNetworkFromNetworkSelect(driver, 'Popular', 'Solana');

--- a/test/e2e/tests/swaps/swap-erc20-with-loaded-state.spec.ts
+++ b/test/e2e/tests/swaps/swap-erc20-with-loaded-state.spec.ts
@@ -41,7 +41,12 @@ describe('Swap', function () {
       await withFixtures(
         getBridgeFixtures(this.test?.fullTitle(), DEFAULT_BRIDGE_FEATURE_FLAGS),
         async ({ driver }) => {
-          await loginWithBalanceValidation(driver, undefined, undefined, '$0');
+          await loginWithBalanceValidation(
+            driver,
+            undefined,
+            undefined,
+            '$225,730.11',
+          );
 
           await bridgeTransaction({
             driver,

--- a/test/e2e/tests/swaps/swap-eth.spec.ts
+++ b/test/e2e/tests/swaps/swap-eth.spec.ts
@@ -15,7 +15,12 @@ describe('Swap Eth for another Token', function () {
         BRIDGE_FEATURE_FLAGS_WITH_SSE_ENABLED,
       ),
       async ({ driver }) => {
-        await loginWithBalanceValidation(driver, undefined, undefined, '$0');
+        await loginWithBalanceValidation(
+          driver,
+          undefined,
+          undefined,
+          '$225,730.11',
+        );
 
         await bridgeTransaction({
           driver,

--- a/test/e2e/tests/swaps/swaps-notifications.spec.ts
+++ b/test/e2e/tests/swaps/swaps-notifications.spec.ts
@@ -59,7 +59,12 @@ describe('Swaps - notifications', function () {
     await withFixtures(
       getBridgeFixturesWithTokenAlertWarning(this.test?.fullTitle()),
       async ({ driver, mockedEndpoint }) => {
-        await loginWithBalanceValidation(driver, undefined, undefined, '$0');
+        await loginWithBalanceValidation(
+          driver,
+          undefined,
+          undefined,
+          '$225,730.11',
+        );
         const homePage = new HomePage(driver);
         await homePage.startSwapFlow();
 
@@ -154,7 +159,12 @@ describe('Swaps - notifications', function () {
         BRIDGE_FEATURE_FLAGS_WITH_SSE_ENABLED,
       ),
       async ({ driver }) => {
-        await loginWithBalanceValidation(driver, undefined, undefined, '$0');
+        await loginWithBalanceValidation(
+          driver,
+          undefined,
+          undefined,
+          '$225,730.11',
+        );
         const homePage = new HomePage(driver);
         await homePage.startSwapFlow();
 

--- a/test/e2e/tests/tokens/import-tokens.spec.ts
+++ b/test/e2e/tests/tokens/import-tokens.spec.ts
@@ -232,7 +232,12 @@ describe('Import flow', function () {
         testSpecificMock: mockTokensAndPrices,
       },
       async ({ driver }) => {
-        await loginWithBalanceValidation(driver, undefined, undefined, '$0.00');
+        await loginWithBalanceValidation(
+          driver,
+          undefined,
+          undefined,
+          '$85,000.00',
+        );
 
         const homePage = new HomePage(driver);
         const assetListPage = new AssetListPage(driver);
@@ -308,7 +313,12 @@ describe('Import flow', function () {
         testSpecificMock: mockTokensAndPrices,
       },
       async ({ driver }) => {
-        await loginWithBalanceValidation(driver, undefined, undefined, '$0.00');
+        await loginWithBalanceValidation(
+          driver,
+          undefined,
+          undefined,
+          '$85,000.00',
+        );
 
         const homePage = new HomePage(driver);
         await homePage.checkPageIsLoaded();

--- a/ui/selectors/assets.test.ts
+++ b/ui/selectors/assets.test.ts
@@ -947,6 +947,8 @@ describe('Aggregated balance adapters/selectors', () => {
     expect(args[6]).toHaveProperty('accountsAssets');
     expect(args[7]).toHaveProperty('allTokens');
     expect(args[8]).toEqual({ currentCurrency: 'usd', currencyRates: {} });
+    // args[9] = enabledNetworkMap, args[10] = networkConfigurationsByChainId
+    expect(args[10]).toBeDefined();
   });
 
   it('memoizes aggregate output for identical state', () => {
@@ -1026,6 +1028,7 @@ describe('Aggregated balance recomputation behavior', () => {
     const accountsAssets = {};
     const assetsMetadata = {};
     const allIgnoredAssets = {};
+    const networkConfigurationsByChainId = {};
 
     const baseState: BalanceCalculationState = {
       metamask: {
@@ -1043,6 +1046,7 @@ describe('Aggregated balance recomputation behavior', () => {
         accountsAssets,
         assetsMetadata,
         allIgnoredAssets,
+        networkConfigurationsByChainId,
       } as unknown as BalanceCalculationState['metamask'],
     };
 
@@ -1065,6 +1069,7 @@ describe('Aggregated balance recomputation behavior', () => {
         accountsAssets,
         assetsMetadata,
         allIgnoredAssets,
+        networkConfigurationsByChainId,
         // unrelated field
         remoteFeatureFlags: { foo: true },
       } as unknown as BalanceCalculationState['metamask'],
@@ -1098,6 +1103,7 @@ describe('Aggregated balance recomputation behavior', () => {
         accountsAssets: {},
         assetsMetadata: {},
         allIgnoredAssets: {},
+        networkConfigurationsByChainId: {},
       } as unknown as BalanceCalculationState['metamask'],
     };
 

--- a/ui/selectors/assets.ts
+++ b/ui/selectors/assets.ts
@@ -55,6 +55,7 @@ import { isEvmChainId } from '../../shared/lib/asset-utils';
 import { isEmptyHexString } from '../../shared/modules/hexstring-utils';
 import { isZeroAmount } from '../helpers/utils/number-utils';
 import {
+  getNetworkConfigurationsByChainId,
   getNonTestNetworks,
   NetworkState,
 } from '../../shared/modules/selectors/networks';
@@ -905,6 +906,7 @@ export const selectBalanceForAllWallets = createSelector(
     selectTokensStateForBalances,
     selectCurrencyRateStateForBalances,
     selectEnabledNetworkMapForBalances,
+    getNetworkConfigurationsByChainId,
   ],
   (
     accountTreeState,
@@ -917,6 +919,7 @@ export const selectBalanceForAllWallets = createSelector(
     tokensState,
     currencyRateState,
     enabledNetworkMap,
+    networkConfigurationsByChainId,
   ) =>
     calculateBalanceForAllWallets(
       // TODO: fix this by ensuring @metamask/assets-controllers has proper types
@@ -930,6 +933,7 @@ export const selectBalanceForAllWallets = createSelector(
       tokensState,
       currencyRateState,
       enabledNetworkMap,
+      networkConfigurationsByChainId,
     ),
 );
 

--- a/ui/selectors/assets.ts
+++ b/ui/selectors/assets.ts
@@ -933,7 +933,7 @@ export const selectBalanceForAllWallets = createSelector(
       tokensState,
       currencyRateState,
       enabledNetworkMap,
-      networkConfigurationsByChainId,
+      networkConfigurationsByChainId ?? {},
     ),
 );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5358,6 +5358,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/account-tree-controller@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "@metamask/account-tree-controller@npm:5.0.0"
+  dependencies:
+    "@metamask/accounts-controller": "npm:^37.0.0"
+    "@metamask/base-controller": "npm:^9.0.0"
+    "@metamask/keyring-controller": "npm:^25.1.0"
+    "@metamask/messenger": "npm:^0.3.0"
+    "@metamask/multichain-account-service": "npm:^7.1.0"
+    "@metamask/profile-sync-controller": "npm:^27.1.0"
+    "@metamask/snaps-controllers": "npm:^17.2.0"
+    "@metamask/snaps-sdk": "npm:^10.3.0"
+    "@metamask/snaps-utils": "npm:^11.7.0"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/utils": "npm:^11.9.0"
+    fast-deep-equal: "npm:^3.1.3"
+    lodash: "npm:^4.17.21"
+  peerDependencies:
+    "@metamask/providers": ^22.0.0
+    webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
+  checksum: 10/7cdc2e79470db56da544704435a22b4f28638f2a27ad7b42aedd898051baa6b7afbf526b4e4df75fdc87078b7e464594aa95e7e478847fd6d9ae1a3476e327cd
+  languageName: node
+  linkType: hard
+
 "@metamask/account-watcher@npm:^4.1.3":
   version: 4.1.3
   resolution: "@metamask/account-watcher@npm:4.1.3"
@@ -5479,9 +5503,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/assets-controllers@npm:^100.0.3, @metamask/assets-controllers@npm:^100.1.0":
-  version: 100.1.0
-  resolution: "@metamask/assets-controllers@npm:100.1.0"
+"@metamask/assets-controllers@npm:^100.0.3, @metamask/assets-controllers@npm:^100.2.0":
+  version: 100.2.0
+  resolution: "@metamask/assets-controllers@npm:100.2.0"
   dependencies:
     "@ethereumjs/util": "npm:^9.1.0"
     "@ethersproject/abi": "npm:^5.7.0"
@@ -5490,32 +5514,32 @@ __metadata:
     "@ethersproject/contracts": "npm:^5.7.0"
     "@ethersproject/providers": "npm:^5.7.0"
     "@metamask/abi-utils": "npm:^2.0.3"
-    "@metamask/account-tree-controller": "npm:^4.1.1"
-    "@metamask/accounts-controller": "npm:^36.0.1"
+    "@metamask/account-tree-controller": "npm:^5.0.0"
+    "@metamask/accounts-controller": "npm:^37.0.0"
     "@metamask/approval-controller": "npm:^8.0.0"
     "@metamask/base-controller": "npm:^9.0.0"
     "@metamask/contract-metadata": "npm:^2.4.0"
     "@metamask/controller-utils": "npm:^11.19.0"
-    "@metamask/core-backend": "npm:^6.0.0"
+    "@metamask/core-backend": "npm:^6.1.0"
     "@metamask/eth-query": "npm:^4.0.0"
     "@metamask/keyring-api": "npm:^21.5.0"
     "@metamask/keyring-controller": "npm:^25.1.0"
     "@metamask/messenger": "npm:^0.3.0"
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
-    "@metamask/multichain-account-service": "npm:^7.0.0"
+    "@metamask/multichain-account-service": "npm:^7.1.0"
     "@metamask/network-controller": "npm:^30.0.0"
     "@metamask/network-enablement-controller": "npm:^4.2.0"
     "@metamask/permission-controller": "npm:^12.2.0"
     "@metamask/phishing-controller": "npm:^16.3.0"
     "@metamask/polling-controller": "npm:^16.0.3"
-    "@metamask/preferences-controller": "npm:^22.1.0"
+    "@metamask/preferences-controller": "npm:^23.0.0"
     "@metamask/profile-sync-controller": "npm:^27.1.0"
     "@metamask/rpc-errors": "npm:^7.0.2"
     "@metamask/snaps-controllers": "npm:^17.2.0"
     "@metamask/snaps-sdk": "npm:^10.3.0"
     "@metamask/snaps-utils": "npm:^11.7.0"
     "@metamask/storage-service": "npm:^1.0.0"
-    "@metamask/transaction-controller": "npm:^62.20.0"
+    "@metamask/transaction-controller": "npm:^62.21.0"
     "@metamask/utils": "npm:^11.9.0"
     "@types/bn.js": "npm:^5.1.5"
     "@types/uuid": "npm:^8.3.0"
@@ -5531,7 +5555,7 @@ __metadata:
   peerDependencies:
     "@metamask/providers": ^22.0.0
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
-  checksum: 10/25a32346b51432bc9d40028719a1b8f0b4a2797458c0fa22f84c1ac3982a4a16e89d7e0b16e1c439377e65621445733b17905b24d4d25c804317b087a19af0ba
+  checksum: 10/701503f96931a250eee75051e0f10915a30c7d24365eceb6199a3f8caa7ebf05bb6e95d4e654d1846e58fee07e339e2dff9a0f15a4907c5d0338dbb494b2b794
   languageName: node
   linkType: hard
 
@@ -5918,19 +5942,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/core-backend@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "@metamask/core-backend@npm:6.0.0"
+"@metamask/core-backend@npm:^6.0.0, @metamask/core-backend@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "@metamask/core-backend@npm:6.1.0"
   dependencies:
-    "@metamask/accounts-controller": "npm:^36.0.0"
-    "@metamask/controller-utils": "npm:^11.18.0"
+    "@metamask/accounts-controller": "npm:^37.0.0"
+    "@metamask/controller-utils": "npm:^11.19.0"
     "@metamask/keyring-controller": "npm:^25.1.0"
     "@metamask/messenger": "npm:^0.3.0"
     "@metamask/profile-sync-controller": "npm:^27.1.0"
     "@metamask/utils": "npm:^11.9.0"
     "@tanstack/query-core": "npm:^5.62.16"
     uuid: "npm:^8.3.2"
-  checksum: 10/b663aa0ce78ffd493f556070906d7f008c0bd97ce613445366340fe61c0db4b85ca5ce7153a21fb4358a1b5fac31973b708ecb1795fa13fb1d827f62718eaca8
+  checksum: 10/9271cb7eea6c8122c505b66ebced1861572bd781f4ed294e4d9dc2d9f7f100412f5c44a8e53f9b6dc02aa2801f64daeb9fcc398d19cdb04222ae121438017686
   languageName: node
   linkType: hard
 
@@ -7005,6 +7029,36 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/multichain-account-service@npm:^7.1.0":
+  version: 7.1.0
+  resolution: "@metamask/multichain-account-service@npm:7.1.0"
+  dependencies:
+    "@ethereumjs/util": "npm:^9.1.0"
+    "@metamask/accounts-controller": "npm:^37.0.0"
+    "@metamask/base-controller": "npm:^9.0.0"
+    "@metamask/eth-snap-keyring": "npm:^19.0.0"
+    "@metamask/key-tree": "npm:^10.1.1"
+    "@metamask/keyring-api": "npm:^21.5.0"
+    "@metamask/keyring-controller": "npm:^25.1.0"
+    "@metamask/keyring-internal-api": "npm:^10.0.0"
+    "@metamask/keyring-snap-client": "npm:^8.2.0"
+    "@metamask/keyring-utils": "npm:^3.1.0"
+    "@metamask/messenger": "npm:^0.3.0"
+    "@metamask/snaps-controllers": "npm:^17.2.0"
+    "@metamask/snaps-sdk": "npm:^10.3.0"
+    "@metamask/snaps-utils": "npm:^11.7.0"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/utils": "npm:^11.9.0"
+    async-mutex: "npm:^0.5.0"
+    lodash: "npm:^4.17.21"
+  peerDependencies:
+    "@metamask/account-api": ^1.0.0
+    "@metamask/providers": ^22.0.0
+    webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
+  checksum: 10/a4264b228be60fe2021a3f6ccfc1eab145c0dd104158a8184278ded2141ca888cf305fd7c4bd1274924a9eb7908b2774852848287bf27d6b972efdd6ba35e11a
+  languageName: node
+  linkType: hard
+
 "@metamask/multichain-account-service@patch:@metamask/multichain-account-service@npm%3A7.0.0#~/.yarn/patches/@metamask-multichain-account-service-npm-7.0.0-52b2fa1b5d.patch":
   version: 7.0.0
   resolution: "@metamask/multichain-account-service@patch:@metamask/multichain-account-service@npm%3A7.0.0#~/.yarn/patches/@metamask-multichain-account-service-npm-7.0.0-52b2fa1b5d.patch::version=7.0.0&hash=fd52db"
@@ -7455,6 +7509,16 @@ __metadata:
     "@metamask/keyring-controller": "npm:^25.1.0"
     "@metamask/messenger": "npm:^0.3.0"
   checksum: 10/bdb6a727cd88313b29b66dfd10308accc8c8bf52830bd7950a5afa7c832554958b94d207ed46ba4b7c8645cd05697e4601ee18194f988416d8dec0bbd2977516
+  languageName: node
+  linkType: hard
+
+"@metamask/preferences-controller@npm:^23.0.0":
+  version: 23.0.0
+  resolution: "@metamask/preferences-controller@npm:23.0.0"
+  dependencies:
+    "@metamask/base-controller": "npm:^9.0.0"
+    "@metamask/messenger": "npm:^0.3.0"
+  checksum: 10/3dd5aa99cf781ffdc364d577536f009eaa0cdb57e8ae85ae6d311b51a358986194d8f745280518f86f1bc4b41094a89162ffad8b6c544178c0d892fe430ebf10
   languageName: node
   linkType: hard
 
@@ -8147,9 +8211,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@npm:^62.12.0, @metamask/transaction-controller@npm:^62.14.0, @metamask/transaction-controller@npm:^62.16.0, @metamask/transaction-controller@npm:^62.17.0, @metamask/transaction-controller@npm:^62.17.1, @metamask/transaction-controller@npm:^62.19.0, @metamask/transaction-controller@npm:^62.20.0":
-  version: 62.20.0
-  resolution: "@metamask/transaction-controller@npm:62.20.0"
+"@metamask/transaction-controller@npm:^62.12.0, @metamask/transaction-controller@npm:^62.14.0, @metamask/transaction-controller@npm:^62.16.0, @metamask/transaction-controller@npm:^62.17.0, @metamask/transaction-controller@npm:^62.17.1, @metamask/transaction-controller@npm:^62.19.0, @metamask/transaction-controller@npm:^62.20.0, @metamask/transaction-controller@npm:^62.21.0":
+  version: 62.21.0
+  resolution: "@metamask/transaction-controller@npm:62.21.0"
   dependencies:
     "@ethereumjs/common": "npm:^4.4.0"
     "@ethereumjs/tx": "npm:^5.4.0"
@@ -8158,11 +8222,11 @@ __metadata:
     "@ethersproject/contracts": "npm:^5.7.0"
     "@ethersproject/providers": "npm:^5.7.0"
     "@ethersproject/wallet": "npm:^5.7.0"
-    "@metamask/accounts-controller": "npm:^36.0.1"
+    "@metamask/accounts-controller": "npm:^37.0.0"
     "@metamask/approval-controller": "npm:^8.0.0"
     "@metamask/base-controller": "npm:^9.0.0"
     "@metamask/controller-utils": "npm:^11.19.0"
-    "@metamask/core-backend": "npm:^6.0.0"
+    "@metamask/core-backend": "npm:^6.1.0"
     "@metamask/eth-query": "npm:^4.0.0"
     "@metamask/gas-fee-controller": "npm:^26.0.3"
     "@metamask/messenger": "npm:^0.3.0"
@@ -8182,7 +8246,7 @@ __metadata:
   peerDependencies:
     "@babel/runtime": ^7.0.0
     "@metamask/eth-block-tracker": ">=9"
-  checksum: 10/5b0f1af0cf484d39ff29c674bdaed864c6301b98f247cd8c647ac7c51838a27d3b4ddea1bf21c5931e0ce5f60db5f0afb38924e746261afcafb12e28a8581cd6
+  checksum: 10/0dfc1853852f780911d14b8b7421cd946c10d8c8d144f19c6b4cd3ad8f8e412f48d8477cc1b4c1df497bab89bf5b9fd671c829fe5cb84397df09241e2b643a06
   languageName: node
   linkType: hard
 
@@ -33102,7 +33166,7 @@ __metadata:
     "@metamask/api-specs": "npm:^0.13.0"
     "@metamask/approval-controller": "npm:^8.0.0"
     "@metamask/assets-controller": "npm:^2.1.0"
-    "@metamask/assets-controllers": "npm:^100.1.0"
+    "@metamask/assets-controllers": "npm:^100.2.0"
     "@metamask/auto-changelog": "npm:^5.3.1"
     "@metamask/base-controller": "npm:^9.0.0"
     "@metamask/bitcoin-wallet-snap": "npm:^1.10.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
bump assets controllers to v100.2.0

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40725?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: bump assets controllers to v100.2.0

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency bump plus changes to balance aggregation inputs can impact wallet balance display and network filtering behavior. Risk is moderated by updated unit/E2E coverage but should be sanity-checked across common network/account states.
> 
> **Overview**
> Updates `@metamask/assets-controllers` to `v100.2.0` (and related transitive deps in `yarn.lock`), and wires in required new inputs for balance aggregation.
> 
> `selectBalanceForAllWallets` now passes `networkConfigurationsByChainId` into `calculateBalanceForAllWallets`, and the Account Tracker controller messenger is expanded to allow `NetworkEnablementController` actions (`getState`, `listPopularEvmNetworks`). E2E balance assertions are updated to reflect the new/fixed initial balance display, and selector unit tests are adjusted for the new balance-calculation argument.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bde4015add9c48d110dd27976ccba2d205753a9c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->