### PR TITLE
feat(llm-workflow): add headless sidepanel mode for MCP extension launcher

### DIFF
--- a/.claude/skills/metamask-visual-testing/SKILL.md
+++ b/.claude/skills/metamask-visual-testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: metamask-visual-testing
-description: Launch and test MetaMask Chrome extension with Playwright. Use for visual validation of UI changes, testing onboarding/unlock flows, and capturing screenshots.
+description: Launch and test MetaMask Chrome extension with Playwright in headless sidepanel mode. Use for visual validation of UI changes, testing onboarding/unlock flows, confirmations, and capturing screenshots.
 compatibility: opencode
 metadata:
   location: test/e2e/playwright/llm-workflow/mcp-server
@@ -43,7 +43,7 @@ The MetaMask MCP server provides tools for browser automation:
 | `mm_cleanup`                | Stop browser and all services                               |
 | `mm_get_state`              | Get current extension state (includes tab info)             |
 | `mm_navigate`               | Navigate to home, settings, notification, or URL            |
-| `mm_wait_for_notification`  | Wait for notification popup and set it as active page       |
+| `mm_wait_for_notification`  | Wait for sidepanel confirmation route and set it as active  |
 | `mm_switch_to_tab`          | Switch active page to a different tab (by role or URL)      |
 | `mm_close_tab`              | Close a tab (notification, dapp, or other)                  |
 | `mm_list_testids`           | List visible data-testid attributes                         |
@@ -202,6 +202,36 @@ mm_set_context {
 mm_launch { "stateMode": "default" }
 ```
 
+## Sidepanel Mode (Default)
+
+The MCP server runs in **headless mode by default**, which means the extension uses Chrome's side panel (`sidepanel.html`) instead of the traditional popup (`notification.html`). This is the default behavior — no configuration is needed.
+
+### Sidepanel vs Popup: Key Differences
+
+| Behavior                         | Sidepanel (headless, default)                                    | Popup (legacy)                                  |
+| -------------------------------- | ---------------------------------------------------------------- | ----------------------------------------------- |
+| **Confirmation UI**              | Renders inside `sidepanel.html`                                  | Opens separate `notification.html` popup window |
+| **After confirming**             | Sidepanel stays open and navigates back to the home page (route) | Popup auto-closes                               |
+| **After rejecting**              | Sidepanel stays open and navigates back to the home page (route) | Popup auto-closes                               |
+| **Page lifecycle**               | Single persistent page, URL hash changes between routes          | New page opens, closes on completion            |
+| **Confirmation route detection** | Checks URL hash against known confirmation route prefixes        | Waits for `notification.html` page event        |
+
+### What This Means for Testing
+
+1. **No tab closing after confirmation**: In sidepanel mode, the confirmation page does not close. After clicking confirm/reject, the sidepanel navigates back to the home route within `sidepanel.html`. You do NOT need to switch tabs after a confirmation — just continue interacting with the sidepanel page.
+
+2. **`mm_wait_for_notification` behavior**: This tool opens or finds the `sidepanel.html` page and waits for a confirmation route to appear in its URL hash (e.g., `#/confirm-transaction/...`). It does NOT wait for a new popup window.
+
+3. **Post-confirmation state**: After a confirmation action, use `mm_describe_screen` to verify the extension returned to the home screen. The sidepanel page remains the active page.
+
+4. **Confirmation routes detected**:
+   - `/connect`
+   - `/confirm-transaction`
+   - `/confirmation`
+   - `/confirm-import-token`
+   - `/confirm-add-suggested-token`
+   - `/confirm-add-suggested-nft`
+
 ## Core Workflow
 
 ### 0. Reuse Existing Knowledge (REQUIRED)
@@ -357,31 +387,32 @@ Options:
 - `selector`: Capture specific element
 - `includeBase64`: Include base64 in response
 
-### 6. Handle Notifications (Dapp flows)
+### 6. Handle Confirmations (Dapp flows)
 
-When a dapp triggers a notification (connect, sign, send), wait for it:
+When a dapp triggers a confirmation (connect, sign, send), wait for it:
 
 ```
 mm_wait_for_notification { "timeoutMs": 10000 }
 ```
 
-This automatically sets the notification as the **active page**, so subsequent `mm_click`, `mm_type`, and `mm_describe_screen` calls operate on the notification popup.
+This opens or finds the `sidepanel.html` page, waits for a confirmation route to appear in the URL hash, and sets it as the **active page**. Subsequent `mm_click`, `mm_type`, and `mm_describe_screen` calls operate on the sidepanel.
 
-**Dapp connection flow example:**
+**Dapp connection flow example (sidepanel mode):**
 
 ```
 mm_navigate { "screen": "url", "url": "https://test-dapp.io" }  → Opens dapp in new tab, sets as active
-mm_click { "testId": "connectButton" }                          → Triggers notification
-mm_wait_for_notification                                        → Active page = notification
-mm_describe_screen                                              → Shows notification elements
-mm_click { "testId": "confirm-btn" }                            → Clicks on notification
+mm_click { "testId": "connectButton" }                          → Triggers confirmation
+mm_wait_for_notification                                        → Active page = sidepanel (on confirmation route)
+mm_describe_screen                                              → Shows confirmation elements
+mm_click { "testId": "confirm-btn" }                            → Confirms action
+mm_describe_screen                                              → Sidepanel navigates back to home page
 mm_switch_to_tab { "role": "dapp" }                             → Switch back to dapp
 mm_describe_screen                                              → Verify connected state
 ```
 
-**Note:** Notification popups typically close automatically after clicking confirm or cancel. After the action, switch to another tab (e.g., `mm_switch_to_tab { "role": "dapp" }`) to continue interacting.
+**Important sidepanel behavior:** After clicking confirm or reject, the sidepanel does **NOT** close. It stays open and navigates back to the home page (route). Use `mm_describe_screen` to verify the sidepanel returned to home, then switch to the dapp tab to continue.
 
-**Tab roles:** `extension` (home), `notification` (popups), `dapp` (external sites), `other`
+**Tab roles:** `extension` (home), `notification` (sidepanel), `dapp` (external sites), `other`
 
 ### 7. Navigate
 
@@ -627,7 +658,7 @@ Error responses:
 
 ## Known Limitations
 
-1. **Headed mode only**: Chrome extensions cannot run headless. Requires display (use XVFB on Linux CI).
+1. **Headless mode (default)**: The extension runs in headless mode using the Chrome side panel (`sidepanel.html`) instead of the popup (`notification.html`). This is the default and does not require a visible display.
 2. **Single session**: Only one browser session at a time. Call `mm_cleanup` before `mm_launch`.
 3. **macOS/Linux**: Port cleanup commands (`lsof`) are Unix-specific.
 

--- a/test/e2e/playwright/llm-workflow/extension-launcher.ts
+++ b/test/e2e/playwright/llm-workflow/extension-launcher.ts
@@ -7,6 +7,14 @@ import {
   waitForExtensionUiReady,
 } from '@metamask/client-mcp-core';
 import type { ExtensionReadinessConfig } from '@metamask/client-mcp-core';
+import {
+  CONNECT_ROUTE,
+  CONFIRM_TRANSACTION_ROUTE,
+  CONFIRMATION_V_NEXT_ROUTE,
+  CONFIRM_IMPORT_TOKEN_ROUTE,
+  CONFIRM_ADD_SUGGESTED_TOKEN_ROUTE,
+  CONFIRM_ADD_SUGGESTED_NFT_ROUTE,
+} from '../../../../ui/helpers/constants/routes';
 import type {
   LauncherLaunchOptions,
   ScreenshotOptions,
@@ -17,6 +25,16 @@ import type {
 
 const DEFAULT_PASSWORD = 'correct horse battery staple';
 const DEFAULT_CHAIN_ID = 1337;
+
+// Routes that indicate a confirmation screen when matched against the sidepanel URL hash.
+const SIDEPANEL_CONFIRMATION_ROUTE_PREFIXES: string[] = [
+  CONNECT_ROUTE,
+  CONFIRM_TRANSACTION_ROUTE,
+  CONFIRMATION_V_NEXT_ROUTE,
+  CONFIRM_IMPORT_TOKEN_ROUTE,
+  CONFIRM_ADD_SUGGESTED_TOKEN_ROUTE,
+  CONFIRM_ADD_SUGGESTED_NFT_ROUTE,
+];
 const METAMASK_EXTENSION_READINESS_CONFIG: ExtensionReadinessConfig = {
   readySelectors: [
     '[data-testid="unlock-password"]',
@@ -32,6 +50,7 @@ const METAMASK_EXTENSION_READINESS_CONFIG: ExtensionReadinessConfig = {
 
 type ResolvedOptions = {
   extensionPath: string;
+  headless: boolean;
   userDataDir: string;
   viewportWidth: number;
   viewportHeight: number;
@@ -81,6 +100,7 @@ export class MetaMaskExtensionLauncher {
     this.options = {
       extensionPath:
         options.extensionPath ?? path.join(process.cwd(), 'dist', 'chrome'),
+      headless: Boolean(options.headless),
       userDataDir: options.userDataDir ?? '',
       viewportWidth: options.viewportWidth ?? 1280,
       viewportHeight: options.viewportHeight ?? 800,
@@ -173,7 +193,8 @@ export class MetaMaskExtensionLauncher {
       );
 
       this.context = await chromium.launchPersistentContext(this.userDataDir, {
-        headless: false,
+        headless: this.options.headless,
+        channel: 'chromium',
         args: launchArgs,
         ignoreHTTPSErrors: Boolean(this.options.proxyServer),
         viewport: {
@@ -380,7 +401,32 @@ export class MetaMaskExtensionLauncher {
       .filter((page) => page.url().startsWith(extensionPrefix));
   }
 
-  async waitForNotificationPage(timeoutMs: number = 10000): Promise<Page> {
+  async waitForNotificationPage(
+    headless: boolean,
+    timeoutMs: number = 10000,
+  ): Promise<Page> {
+    return headless
+      ? this.waitForSidepanelNotificationPage(timeoutMs)
+      : this.waitForPopupNotificationPage(timeoutMs);
+  }
+
+  private async throwNotifcationPageError(
+    timeoutMs: number,
+    notificationUrl: string,
+  ): Promise<never> {
+    const allPages = await this.getAllExtensionPages();
+    const pageUrls = allPages.map((p) => p.url()).join(', ');
+
+    throw new Error(
+      `Notification page did not appear within ${timeoutMs}ms. ` +
+        `Expected URL starting with: ${notificationUrl}. ` +
+        `Current extension pages: [${pageUrls}]`,
+    );
+  }
+
+  private async waitForPopupNotificationPage(
+    timeoutMs: number = 10000,
+  ): Promise<Page> {
     // Notification pages may initially open as about:blank before the extension
     // redirects them. We wait for either an existing notification page or a new
     // page event, handling the about:blank → notification.html transition.
@@ -431,15 +477,51 @@ export class MetaMaskExtensionLauncher {
         return finalCheck;
       }
 
-      const allPages = await this.getAllExtensionPages();
-      const pageUrls = allPages.map((p) => p.url()).join(', ');
-
-      throw new Error(
-        `Notification page did not appear within ${timeoutMs}ms. ` +
-          `Expected URL starting with: ${notificationUrl}. ` +
-          `Current extension pages: [${pageUrls}]`,
-      );
+      return await this.throwNotifcationPageError(timeoutMs, notificationUrl);
     }
+  }
+
+  private async waitForSidepanelNotificationPage(
+    timeoutMs: number = 10000,
+  ): Promise<Page> {
+    this.ensureBrowserContext();
+    const context = this.context as BrowserContext;
+    const sidepanelUrl = `chrome-extension://${this.extensionId as string}/sidepanel.html`;
+
+    let sidepanelPage = context
+      .pages()
+      .find((page) => page.url().startsWith(sidepanelUrl));
+
+    if (!sidepanelPage) {
+      sidepanelPage = await context.newPage();
+      await sidepanelPage.goto(sidepanelUrl);
+      await sidepanelPage.waitForLoadState('domcontentloaded');
+      this.attachConsoleListeners(sidepanelPage);
+    }
+
+    try {
+      await this.waitForSidepanelConfirmation(sidepanelPage, timeoutMs);
+      return sidepanelPage;
+    } catch {
+      return await this.throwNotifcationPageError(timeoutMs, sidepanelUrl);
+    }
+  }
+
+  private async waitForSidepanelConfirmation(
+    sidepanelPage: Page,
+    timeoutMs: number,
+  ): Promise<void> {
+    if (isOnConfirmationRoute(sidepanelPage.url())) {
+      await sidepanelPage.waitForLoadState('domcontentloaded');
+      return;
+    }
+
+    await sidepanelPage.waitForURL(
+      (url) => isOnConfirmationRoute(url.toString()),
+      { timeout: timeoutMs },
+    );
+
+    await sidepanelPage.waitForLoadState('domcontentloaded');
   }
 
   async cleanup(): Promise<void> {
@@ -471,6 +553,17 @@ export async function launchMetaMask(
   const launcher = new MetaMaskExtensionLauncher(options);
   await launcher.launch();
   return launcher;
+}
+
+function isOnConfirmationRoute(url: string): boolean {
+  const hashIndex = url.indexOf('#');
+  if (hashIndex === -1) {
+    return false;
+  }
+  const hashPath = url.substring(hashIndex + 1).split('?')[0];
+  return SIDEPANEL_CONFIRMATION_ROUTE_PREFIXES.some(
+    (prefix) => hashPath === prefix || hashPath.startsWith(`${prefix}/`),
+  );
 }
 
 export { DEFAULT_PASSWORD };

--- a/test/e2e/playwright/llm-workflow/launcher-types.ts
+++ b/test/e2e/playwright/llm-workflow/launcher-types.ts
@@ -27,6 +27,7 @@ export type LaunchOptions = {
   viewportWidth?: number;
   viewportHeight?: number;
   slowMo?: number;
+  headless?: boolean;
   /**
    * Whether to automatically build the extension before launching.
    * This option is handled by the MCP session manager (BuildCapability) and is ignored by the launcher.
@@ -74,6 +75,8 @@ export type ScreenName =
   | 'send'
   | 'swap'
   | 'bridge'
+  | 'connect'
+  | 'confirmation'
   | 'confirm-transaction'
   | 'confirm-signature'
   | 'notification'

--- a/test/e2e/playwright/llm-workflow/launcher/state-inspector.ts
+++ b/test/e2e/playwright/llm-workflow/launcher/state-inspector.ts
@@ -1,6 +1,8 @@
 import type { Page } from '@playwright/test';
 import {
   CONFIRM_TRANSACTION_ROUTE,
+  CONFIRMATION_V_NEXT_ROUTE,
+  CONNECT_ROUTE,
   CROSS_CHAIN_SWAP_ROUTE,
   PREPARE_SWAP_ROUTE,
   SEND_ROUTE,
@@ -98,6 +100,14 @@ export function detectScreenFromUrl(
     {
       matcher: (path) => hasRoutePrefix(path, CONFIRM_TRANSACTION_ROUTE),
       screen: 'confirm-transaction',
+    },
+    {
+      matcher: (path) => hasRoutePrefix(path, CONFIRMATION_V_NEXT_ROUTE),
+      screen: 'confirmation',
+    },
+    {
+      matcher: (path) => hasRoutePrefix(path, CONNECT_ROUTE),
+      screen: 'connect',
     },
     {
       matcher: (path) => hasRoutePrefix(path, SETTINGS_ROUTE),

--- a/test/e2e/playwright/llm-workflow/mcp-server/metamask-provider.ts
+++ b/test/e2e/playwright/llm-workflow/mcp-server/metamask-provider.ts
@@ -39,6 +39,7 @@ import { MetaMaskContractSeedingCapability } from '../capabilities/seeding';
 
 const DEFAULT_ANVIL_PORT = 8545;
 const DEFAULT_FIXTURE_SERVER_PORT = 12345;
+const HEADLESS = true;
 
 export class MetaMaskSessionManager implements ISessionManager {
   private activeSession: {
@@ -289,7 +290,10 @@ export class MetaMaskSessionManager implements ISessionManager {
 
     const extPrefix = `chrome-extension://${extensionId}`;
     if (url.startsWith(extPrefix)) {
-      return url.includes('notification.html') ? 'notification' : 'extension';
+      if (url.includes('notification.html')) {
+        return 'notification';
+      }
+      return 'extension';
     }
     if (url.startsWith('http')) {
       return 'dapp';
@@ -460,6 +464,7 @@ export class MetaMaskSessionManager implements ISessionManager {
       }
 
       const launchOptions: LauncherLaunchOptions = {
+        headless: HEADLESS,
         stateMode,
         slowMo: input.slowMo ?? 0,
         extensionPath,
@@ -653,13 +658,15 @@ export class MetaMaskSessionManager implements ISessionManager {
       throw new Error(ErrorCodes.MM_NO_ACTIVE_SESSION);
     }
 
+    const notificationPath = HEADLESS ? 'sidepanel' : 'notification';
+
     const context = this.getContext();
     const { extensionId } = this.activeSession.state;
-    const notificationUrl = `chrome-extension://${extensionId}/notification.html`;
+    const notificationUrl = `chrome-extension://${extensionId}/${notificationPath}.html`;
 
     const existingNotification = context
       .pages()
-      .find((p) => p.url().includes('notification.html'));
+      .find((p) => p.url().includes(`${notificationPath}.html`));
 
     if (existingNotification) {
       await existingNotification.bringToFront();
@@ -679,10 +686,12 @@ export class MetaMaskSessionManager implements ISessionManager {
     if (!this.activeSession) {
       throw new Error(ErrorCodes.MM_NO_ACTIVE_SESSION);
     }
-    const notificationPage =
-      await this.activeSession.launcher.waitForNotificationPage(timeoutMs);
-    this.setActivePage(notificationPage);
-    return notificationPage;
+    const page = await this.activeSession.launcher.waitForNotificationPage(
+      HEADLESS,
+      timeoutMs,
+    );
+    this.setActivePage(page);
+    return page;
   }
 
   async screenshot(


### PR DESCRIPTION
## **Description**

The MCP extension launcher previously used the popup `notification.html` flow for confirmation UIs, which requires a visible display to work. This changes the default to Chrome's side panel (`sidepanel.html`), enabling true headless browser operation.

In headless mode, the sidepanel persists after confirm/reject actions — navigating back to the home route instead of closing — which changes the interaction model for LLM-driven testing flows.

Key changes:
- Add `headless` launch option and enable it by default in the MCP server
- Implement `waitForSidepanelNotificationPage` using shared route constants to detect confirmation screens inside the sidepanel URL hash
- Add `connect` and `confirmation` screen detection to the state inspector
- Update SKILL.md documentation with sidepanel behavior, route list, and differences from the popup flow

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40730?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Build the extension with `yarn build:test`
2. Start the MCP server and launch a session via `mm_launch`
3. Navigate to a test dapp and trigger a connect or transaction flow
4. Verify `mm_wait_for_notification` resolves with the sidepanel page on a confirmation route
5. Confirm/reject the action and verify the sidepanel navigates back to the home screen instead of closing

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the LLM-workflow Playwright launcher/session manager notification/confirmation page detection and defaults to headless sidepanel navigation, which can break existing e2e automation flows if route matching or tab-role assumptions are wrong.
> 
> **Overview**
> Switches the LLM workflow MCP Playwright launcher to support **headless sidepanel-based confirmations** (using `sidepanel.html`) instead of relying on `notification.html` popups, and wires this on by default in the MCP session manager.
> 
> `mm_wait_for_notification` now resolves by opening/finding the sidepanel and waiting for known confirmation route prefixes in the URL hash; state detection is extended to classify `connect` and `confirmation` screens, and docs are updated to explain the new sidepanel interaction model (persistent page after confirm/reject, updated tab roles/flows).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4911b0882ed477b1e8e35d4b159ac91fcfdeee34. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->