### PR TITLE
feat: enable swaps a/b test

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ To learn how to develop MetaMask-compatible applications, visit our [Developer D
 
 - [How to add custom build to Chrome](./add-to-chrome.md)
 - [How to add custom build to Firefox](./add-to-firefox.md)
+- [A/B testing guide](./ab-testing.md)
 - [Publishing Guide](./publishing.md)
 - [How to add a feature behind a secret feature flag](./secret-preferences.md)
 - [Developing on MetaMask](../development/README.md)

--- a/docs/ab-testing.md
+++ b/docs/ab-testing.md
@@ -1,0 +1,304 @@
+# A/B Testing Framework
+
+Generic A/B testing guidance for the MetaMask extension.
+
+## Current Analytics Standard
+
+Use these two mechanisms together:
+
+1. Automatic exposure event: `Experiment Viewed`
+2. Business event context: `active_ab_tests`
+
+`ab_tests` is legacy and should not be used for new extension instrumentation.
+
+## References
+
+- [Remote feature flags contributor docs](https://github.com/MetaMask/contributor-docs/blob/main/docs/remote-feature-flags.md)
+- `test/e2e/feature-flags/feature-flag-registry.ts`
+- `test/e2e/tests/remote-feature-flag/remote-feature-flag.spec.ts`
+
+---
+
+## How Variant Assignment Works
+
+The extension receives remote feature flags through
+`@metamask/remote-feature-flag-controller`, which fetches flags from the
+client-config API.
+
+For A/B tests, the controller does client-side bucketing from a JSON array value:
+
+1. The remote flag returns an array where each item has `scope.value` from `0` to `1`.
+2. The controller hashes `sha256(metaMetricsId + flagName)` to produce a deterministic threshold.
+3. The controller selects the first array item where `userThreshold <= scope.value`.
+4. The selected assignment is stored in `metamask.remoteFeatureFlags` as `{ name, value }`.
+
+Example remote flag value:
+
+```json
+[
+  {
+    "name": "control",
+    "scope": { "type": "threshold", "value": 0.5 }
+  },
+  {
+    "name": "treatment",
+    "scope": { "type": "threshold", "value": 1.0 }
+  }
+]
+```
+
+`useABTest` reads the processed assignment's `name` field and maps it to your
+locally defined `variants` object.
+
+If the user does not have a valid assignment yet, the flag is missing, the
+value is invalid, or the controller did not produce a `{ name, value }`
+assignment, the hook falls back to `control` and reports `isActive: false`.
+
+---
+
+## `useABTest` Hook
+
+```typescript
+const quickAmountsTest = useABTest(
+  'swapsSWAPS4135AbtestNumpadQuickAmounts',
+  {
+    control: { buttons: [25, 50, 75, 'MAX'] },
+    treatment: { buttons: [50, 75, 90, 'MAX'] },
+  },
+  {
+    experimentName: 'Swaps Quick Amounts',
+    variationNames: {
+      control: 'Control',
+      treatment: 'Larger Presets',
+    },
+  },
+);
+```
+
+API:
+
+```typescript
+function useABTest<T extends { control: unknown } & Record<string, unknown>>(
+  flagKey: string,
+  variants: T,
+  exposureMetadata?: {
+    experimentName?: string;
+    variationNames?: Partial<Record<Extract<keyof T, string>, string>>;
+  },
+): {
+  variant: T[keyof T];
+  variantName: string;
+  isActive: boolean;
+};
+```
+
+Behavior:
+
+- Fallback is always `control`.
+- `isActive` is `true` only when the remote assignment matches a defined variant.
+- The hook supports both processed controller objects like `{ name, value }` and
+  legacy string values for backward compatibility.
+- When active, the hook emits `Experiment Viewed` once per
+  `experiment_id + variation_id` pair per extension session.
+
+---
+
+## Automatic Exposure Event
+
+`useABTest` automatically emits this event for active assignments:
+
+- `event`: `Experiment Viewed`
+- `category`: `Analytics`
+- required properties:
+  - `experiment_id`
+  - `variation_id`
+- optional properties:
+  - `experiment_name`
+  - `variation_name`
+
+You should not manually fire duplicate exposure events for experiments that use
+`useABTest`.
+
+---
+
+## Business Event Instrumentation
+
+For page views, clicks, submits, conversions, and any other business events,
+attach active experiment assignments with `active_ab_tests`.
+
+Shape:
+
+```typescript
+type ActiveABTest = Array<{ key: string; value: string }>;
+```
+
+Single test example:
+
+```typescript
+const quickAmountsTest = useABTest('swapsSWAPS4135AbtestNumpadQuickAmounts', {
+  control: { buttons: [25, 50, 75, 'MAX'] },
+  treatment: { buttons: [50, 75, 90, 'MAX'] },
+});
+
+const activeABTests = quickAmountsTest.isActive
+  ? [
+      {
+        key: 'swapsSWAPS4135AbtestNumpadQuickAmounts',
+        value: quickAmountsTest.variantName,
+      },
+    ]
+  : undefined;
+
+trackEvent({
+  event: MetaMetricsEventName.TransactionSubmitted,
+  category: MetaMetricsEventCategory.Swaps,
+  properties: {
+    ...(activeABTests && { active_ab_tests: activeABTests }),
+  },
+});
+```
+
+Multiple concurrent tests:
+
+```typescript
+const buttonColorTest = useABTest('swapsSWAPS4135AbtestButtonColor', {
+  control: { color: 'green' },
+  treatment: { color: 'blue' },
+});
+
+const ctaTextTest = useABTest('swapsSWAPS4135AbtestCtaText', {
+  control: { text: 'Get Started' },
+  urgent: { text: 'Start Now' },
+});
+
+const activeABTests = [
+  ...(buttonColorTest.isActive
+    ? [
+        {
+          key: 'swapsSWAPS4135AbtestButtonColor',
+          value: buttonColorTest.variantName,
+        },
+      ]
+    : []),
+  ...(ctaTextTest.isActive
+    ? [
+        {
+          key: 'swapsSWAPS4135AbtestCtaText',
+          value: ctaTextTest.variantName,
+        },
+      ]
+    : []),
+];
+
+trackEvent({
+  event: MetaMetricsEventName.TransactionSubmitted,
+  category: MetaMetricsEventCategory.Swaps,
+  properties: {
+    ...(activeABTests.length > 0 && { active_ab_tests: activeABTests }),
+  },
+});
+```
+
+Do not emit per-test nested properties under `ab_tests`.
+
+---
+
+## Local Development Overrides
+
+To force a specific variant locally, override the processed assignment in
+`.manifest-overrides.json`:
+
+```json
+{
+  "_flags": {
+    "remoteFeatureFlags": {
+      "swapsSWAPS4135AbtestNumpadQuickAmounts": {
+        "name": "treatment",
+        "value": {
+          "buttons": [50, 75, 90, "MAX"]
+        }
+      }
+    }
+  }
+}
+```
+
+This mirrors the post-bucketing shape returned by
+`RemoteFeatureFlagController`, which makes local overrides deterministic.
+
+---
+
+## E2E Test Setup
+
+Every new remote A/B test flag should be registered in
+`test/e2e/feature-flags/feature-flag-registry.ts` with its production default.
+
+For A/B tests, store the exact remote JSON value in the registry, including the
+threshold array, so the E2E mock remains production-accurate.
+
+Use test-specific overrides when you need deterministic assignments in a single
+test:
+
+- `manifestFlags: { remoteFeatureFlags: { flagName: { name, value } } }`
+- `FixtureBuilder.withRemoteFeatureFlags({ flagName: { name, value } })`
+
+---
+
+## Naming Convention
+
+Use the same experiment key format as mobile:
+
+`{teamName}{ticketId}Abtest{TestName}`
+
+Example:
+
+`swapsSWAPS4135AbtestNumpadQuickAmounts`
+
+Recommended pattern:
+
+- `teamName`: lower camel team token, for example `swaps`
+- `ticketId`: uppercase project key plus number, for example `SWAPS4135`
+- literal `Abtest`
+- semantic PascalCase test name
+
+---
+
+## Implementation Checklist
+
+- [ ] Remote flag created with threshold-array JSON value
+- [ ] `useABTest` added in the feature component
+- [ ] `Experiment Viewed` fires for active assignments
+- [ ] Business events include `active_ab_tests`
+- [ ] E2E feature flag registry updated with production default
+- [ ] Local override path documented for QA if needed
+
+---
+
+## FAQ
+
+**Q: What is the fallback variant?**  
+`control`.
+
+**Q: When is `isActive` false?**  
+When the hook is using the fallback because the assignment is missing, invalid,
+or unresolved.
+
+**Q: Do I manually emit `Experiment Viewed`?**  
+No, not when using `useABTest`.
+
+**Q: Should I send both `ab_tests` and `active_ab_tests`?**  
+No. Use `active_ab_tests`.
+
+**Q: What if basic functionality or metrics are unavailable?**  
+If the extension does not have a usable experiment assignment, `useABTest`
+falls back to `control` and does not emit an exposure event.
+
+---
+
+## Related Files
+
+- `ui/hooks/useABTest.ts`
+- `ui/hooks/useABTest.test.ts`
+- `shared/constants/metametrics.ts`
+- `ui/selectors/remote-feature-flags.ts`
+- `test/e2e/feature-flags/feature-flag-registry.ts`

--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -770,6 +770,7 @@ export enum MetaMetricsEventName {
   ActivityDetailsOpened = 'Activity Details Opened',
   ActivityDetailsClosed = 'Activity Details Closed',
   AnalyticsPreferenceSelected = 'Analytics Preference Selected',
+  ExperimentViewed = 'Experiment Viewed',
   AppInstalled = 'App Installed',
   AppOpened = 'App Opened',
   AppUnlocked = 'App Unlocked',
@@ -1106,6 +1107,7 @@ export enum MetaMetricsEventAccountImportType {
 
 export enum MetaMetricsEventCategory {
   Accounts = 'Accounts',
+  Analytics = 'Analytics',
   App = 'App',
   Auth = 'Auth',
   Background = 'Background',

--- a/ui/hooks/useABTest.test.ts
+++ b/ui/hooks/useABTest.test.ts
@@ -1,0 +1,348 @@
+import React from 'react';
+import { act, renderHook } from '@testing-library/react-hooks';
+import { useSelector } from 'react-redux';
+
+import { MetaMetricsContext } from '../contexts/metametrics';
+import {
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
+} from '../../shared/constants/metametrics';
+import type { ABTestExposureMetadata } from './useABTest';
+import { clearABTestExposureTrackingForTest, useABTest } from './useABTest';
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn(),
+}));
+
+jest.mock('../selectors/remote-feature-flags', () => ({
+  getRemoteFeatureFlags: jest.fn(),
+}));
+
+const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
+const mockTrackEvent = jest.fn().mockResolvedValue(undefined);
+
+const mockMetaMetricsContext = {
+  trackEvent: mockTrackEvent,
+  bufferedTrace: jest.fn().mockResolvedValue(undefined),
+  bufferedEndTrace: jest.fn(),
+  onboardingParentContext: { current: null },
+};
+
+const wrapper = ({ children }: { children: React.ReactNode }) =>
+  React.createElement(
+    MetaMetricsContext.Provider,
+    { value: mockMetaMetricsContext },
+    children,
+  );
+
+const buttonColorVariants = {
+  control: { long: 'green', short: 'red' },
+  monochrome: { long: 'white', short: 'white' },
+} as const;
+
+const experimentVariants = {
+  control: { buttons: [25, 50, 75, 'MAX'] },
+  treatment: { buttons: [50, 75, 90, 'MAX'] },
+} as const;
+
+const inactiveAssignmentFixtures: [string, Record<string, unknown>][] = [
+  ['missing flag', {}],
+  ['unknown assignment', { buttonColorTest: { name: 'unknown' } }],
+  [
+    'unprocessed threshold array',
+    {
+      buttonColorTest: [
+        {
+          name: 'control',
+          scope: { type: 'threshold', value: 0.5 },
+        },
+        {
+          name: 'monochrome',
+          scope: { type: 'threshold', value: 1 },
+        },
+      ],
+    },
+  ],
+  ['empty string', { buttonColorTest: '' }],
+];
+
+const renderABTestHook = <
+  TVariants extends { control: unknown } & Record<string, unknown>,
+>(
+  flagKey: string,
+  variants: TVariants,
+  exposureMetadata?: ABTestExposureMetadata<TVariants>,
+) =>
+  renderHook(() => useABTest(flagKey, variants, exposureMetadata), {
+    wrapper,
+  });
+
+const setRemoteFeatureFlags = (flags: unknown) => {
+  mockUseSelector.mockReturnValue(flags as never);
+};
+
+async function flushPromises() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe('useABTest', () => {
+  beforeEach(() => {
+    mockUseSelector.mockReset();
+    mockTrackEvent.mockReset();
+    mockTrackEvent.mockResolvedValue(undefined);
+    clearABTestExposureTrackingForTest();
+    setRemoteFeatureFlags({});
+  });
+
+  describe('variant assignment', () => {
+    it('returns the assigned variant for controller object assignments', () => {
+      setRemoteFeatureFlags({
+        buttonColorTest: { name: 'monochrome', value: { ignored: true } },
+      });
+
+      const { result } = renderABTestHook(
+        'buttonColorTest',
+        buttonColorVariants,
+      );
+
+      expect(result.current.variant).toEqual({
+        long: 'white',
+        short: 'white',
+      });
+      expect(result.current.variantName).toBe('monochrome');
+      expect(result.current.isActive).toBe(true);
+    });
+
+    it('returns the assigned variant for legacy string assignments', () => {
+      setRemoteFeatureFlags({
+        buttonColorTest: 'monochrome',
+      });
+
+      const { result } = renderABTestHook(
+        'buttonColorTest',
+        buttonColorVariants,
+      );
+
+      expect(result.current.variant).toEqual({
+        long: 'white',
+        short: 'white',
+      });
+      expect(result.current.variantName).toBe('monochrome');
+      expect(result.current.isActive).toBe(true);
+    });
+
+    inactiveAssignmentFixtures.forEach(([description, flags]) => {
+      it(`falls back to control for ${description}`, () => {
+        setRemoteFeatureFlags(flags);
+
+        const { result } = renderABTestHook(
+          'buttonColorTest',
+          buttonColorVariants,
+        );
+
+        expect(result.current.variant).toEqual({
+          long: 'green',
+          short: 'red',
+        });
+        expect(result.current.variantName).toBe('control');
+        expect(result.current.isActive).toBe(false);
+      });
+    });
+
+    it('uses the control variant even when it is not the first key', () => {
+      setRemoteFeatureFlags({});
+
+      const { result } = renderABTestHook('buttonColorTest', {
+        treatment: { color: 'blue' },
+        control: { color: 'green' },
+      });
+
+      expect(result.current.variant).toEqual({ color: 'green' });
+      expect(result.current.variantName).toBe('control');
+      expect(result.current.isActive).toBe(false);
+    });
+  });
+
+  describe('experiment exposure tracking', () => {
+    it('emits Experiment Viewed with required and optional metadata', () => {
+      const flagKey = 'swapsSWAPS4135AbtestNumpadQuickAmounts';
+      setRemoteFeatureFlags({
+        [flagKey]: { name: 'treatment' },
+      });
+
+      renderABTestHook(flagKey, experimentVariants, {
+        experimentName: 'Swaps Quick Amounts',
+        variationNames: {
+          control: 'Control',
+          treatment: 'Larger Presets',
+        },
+      });
+
+      expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+      expect(mockTrackEvent).toHaveBeenCalledWith({
+        event: MetaMetricsEventName.ExperimentViewed,
+        category: MetaMetricsEventCategory.Analytics,
+        properties: {
+          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          experiment_id: flagKey,
+          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          variation_id: 'treatment',
+          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          experiment_name: 'Swaps Quick Amounts',
+          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          variation_name: 'Larger Presets',
+        },
+      });
+    });
+
+    it('does not emit an exposure event for inactive assignments', () => {
+      setRemoteFeatureFlags({
+        swapsSWAPS4135AbtestNumpadQuickAmounts: { name: 'unknown' },
+      });
+
+      renderABTestHook(
+        'swapsSWAPS4135AbtestNumpadQuickAmounts',
+        experimentVariants,
+      );
+
+      expect(mockTrackEvent).not.toHaveBeenCalled();
+    });
+
+    it('emits once per experiment and variation after a successful track', async () => {
+      const flagKey = 'swapsSWAPS4135AbtestNumpadQuickAmounts';
+      setRemoteFeatureFlags({
+        [flagKey]: { name: 'control' },
+      });
+
+      renderABTestHook(flagKey, experimentVariants);
+      await flushPromises();
+
+      renderABTestHook(flagKey, experimentVariants);
+
+      expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+    });
+
+    it('emits a new exposure event when the assigned variation changes', () => {
+      const flagKey = 'swapsSWAPS4135AbtestNumpadQuickAmounts';
+      let flags = {
+        [flagKey]: { name: 'control' },
+      };
+
+      mockUseSelector.mockImplementation(() => flags as never);
+
+      const { rerender } = renderABTestHook(flagKey, experimentVariants);
+
+      expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+
+      flags = {
+        [flagKey]: { name: 'treatment' },
+      };
+
+      rerender();
+
+      expect(mockTrackEvent).toHaveBeenCalledTimes(2);
+      expect(mockTrackEvent.mock.calls[1][0]).toEqual({
+        event: MetaMetricsEventName.ExperimentViewed,
+        category: MetaMetricsEventCategory.Analytics,
+        properties: {
+          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          experiment_id: flagKey,
+          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          variation_id: 'treatment',
+        },
+      });
+    });
+
+    it('does not emit duplicate exposures while the first emit is in flight', async () => {
+      const flagKey = 'swapsSWAPS4135AbtestNumpadQuickAmounts';
+      let resolveTrackingPromise: (() => void) | undefined;
+
+      mockTrackEvent.mockReturnValue(
+        new Promise<void>((resolve) => {
+          resolveTrackingPromise = resolve;
+        }),
+      );
+      setRemoteFeatureFlags({
+        [flagKey]: { name: 'control' },
+      });
+
+      renderABTestHook(flagKey, experimentVariants);
+      renderABTestHook(flagKey, experimentVariants);
+
+      expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+
+      resolveTrackingPromise?.();
+      await flushPromises();
+
+      renderABTestHook(flagKey, experimentVariants);
+
+      expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries exposure tracking after a failed emit', async () => {
+      const flagKey = 'swapsSWAPS4135AbtestNumpadQuickAmounts';
+
+      mockTrackEvent
+        .mockRejectedValueOnce(new Error('track failed'))
+        .mockResolvedValue(undefined);
+      setRemoteFeatureFlags({
+        [flagKey]: { name: 'control' },
+      });
+
+      renderABTestHook(flagKey, experimentVariants);
+      expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+
+      await flushPromises();
+
+      renderABTestHook(flagKey, experimentVariants);
+
+      expect(mockTrackEvent).toHaveBeenCalledTimes(2);
+    });
+
+    it('evicts the oldest tracked assignment when the cache reaches capacity', async () => {
+      const unmountHooks: (() => void)[] = [];
+      const flagKeys = Array.from(
+        { length: 501 },
+        (_, index) => `swapsSWAPS4135AbtestCapacity${index}`,
+      );
+
+      for (const flagKey of flagKeys) {
+        setRemoteFeatureFlags({
+          [flagKey]: { name: 'control' },
+        });
+
+        const { unmount } = renderABTestHook(flagKey, {
+          control: { enabled: true },
+        });
+
+        unmountHooks.push(unmount);
+      }
+
+      expect(mockTrackEvent).toHaveBeenCalledTimes(501);
+
+      await flushPromises();
+
+      setRemoteFeatureFlags({
+        [flagKeys[0]]: { name: 'control' },
+      });
+
+      renderABTestHook(flagKeys[0], {
+        control: { enabled: true },
+      });
+
+      expect(mockTrackEvent).toHaveBeenCalledTimes(502);
+
+      unmountHooks.forEach((unmount) => unmount());
+    });
+  });
+});

--- a/ui/hooks/useABTest.ts
+++ b/ui/hooks/useABTest.ts
@@ -1,0 +1,204 @@
+import { useContext, useEffect } from 'react';
+import { useSelector } from 'react-redux';
+
+import {
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
+} from '../../shared/constants/metametrics';
+import { MetaMetricsContext } from '../contexts/metametrics';
+import { getRemoteFeatureFlags } from '../selectors/remote-feature-flags';
+
+/**
+ * Type constraint for variants object. Every A/B test must define a `control`
+ * variant so the hook can provide a stable fallback when assignment is missing
+ * or invalid.
+ */
+export type ABTestVariants = { control: unknown } & Record<string, unknown>;
+
+/**
+ * Optional metadata for automatic experiment exposure tracking.
+ */
+export type ABTestExposureMetadata<TVariants extends ABTestVariants> = {
+  /** Human-readable experiment name. */
+  experimentName?: string;
+  /** Optional map from variant IDs to human-readable display names. */
+  variationNames?: Partial<Record<Extract<keyof TVariants, string>, string>>;
+};
+
+/**
+ * Return type for the `useABTest` hook.
+ */
+export type UseABTestResult<TVariants extends ABTestVariants> = {
+  /** The locally defined payload for the assigned variant. */
+  variant: TVariants[keyof TVariants];
+  /** The assigned variant name, or `control` when falling back. */
+  variantName: string;
+  /** Whether the experiment has an active assignment. */
+  isActive: boolean;
+};
+
+const trackedExposureAssignments = new Set<string>();
+const inFlightExposureAssignments = new Map<string, Promise<void>>();
+const MAX_TRACKED_EXPOSURE_ASSIGNMENTS = 500;
+
+const getExposureCacheKey = (experimentId: string, variationId: string) =>
+  `${experimentId}::${variationId}`;
+
+const hasTrackedExposureAssignment = (assignmentKey: string) =>
+  trackedExposureAssignments.has(assignmentKey) ||
+  inFlightExposureAssignments.has(assignmentKey);
+
+const rememberExposureAssignment = (assignmentKey: string) => {
+  if (trackedExposureAssignments.has(assignmentKey)) {
+    return;
+  }
+
+  if (trackedExposureAssignments.size >= MAX_TRACKED_EXPOSURE_ASSIGNMENTS) {
+    const oldestAssignment = trackedExposureAssignments.values().next().value;
+
+    if (oldestAssignment) {
+      trackedExposureAssignments.delete(oldestAssignment);
+    }
+  }
+
+  trackedExposureAssignments.add(assignmentKey);
+};
+
+const getAssignedVariantName = (flagData: unknown): string | undefined => {
+  if (typeof flagData === 'string') {
+    return flagData;
+  }
+
+  const namedFlagData = flagData as { name?: unknown } | null;
+
+  if (
+    typeof flagData === 'object' &&
+    flagData !== null &&
+    'name' in flagData &&
+    typeof namedFlagData?.name === 'string'
+  ) {
+    return namedFlagData.name;
+  }
+
+  return undefined;
+};
+
+/**
+ * Test-only helper for clearing the module-level exposure cache.
+ */
+export function clearABTestExposureTrackingForTest(): void {
+  trackedExposureAssignments.clear();
+  inFlightExposureAssignments.clear();
+}
+
+/**
+ * Generic hook for remote-config backed A/B tests in the extension.
+ *
+ * The extension receives remote feature flags through
+ * `RemoteFeatureFlagController`. When an experiment flag resolves to a
+ * processed assignment object like `{ name, value }`, this hook maps the
+ * assigned `name` to the locally-defined `variants` object.
+ *
+ * When the assignment is missing, invalid, or not yet bucketed, the hook falls
+ * back to the `control` variant and reports `isActive: false`.
+ *
+ * When an active assignment is present, the hook automatically emits a single
+ * `Experiment Viewed` event once per `experiment_id + variation_id` pair per
+ * extension session.
+ *
+ * @param flagKey - Remote feature flag key, e.g. `swapsSWAPS4135AbtestButtonColor`
+ * @param variants - Local mapping of variant IDs to render-time data.
+ * @param exposureMetadata - Optional metadata for experiment exposure events.
+ * @returns The assigned variant payload, variant name, and active state.
+ */
+export function useABTest<TVariants extends ABTestVariants>(
+  flagKey: string,
+  variants: TVariants,
+  exposureMetadata?: ABTestExposureMetadata<TVariants>,
+): UseABTestResult<TVariants> {
+  const { trackEvent } = useContext(MetaMetricsContext);
+  const flags = useSelector(getRemoteFeatureFlags);
+  const flagData = flags?.[flagKey];
+  const assignedVariantName = getAssignedVariantName(flagData);
+
+  const hasVariant = (key: string) =>
+    Object.prototype.hasOwnProperty.call(variants, key);
+
+  const variantName =
+    assignedVariantName && hasVariant(assignedVariantName)
+      ? assignedVariantName
+      : 'control';
+  const isActive = Boolean(
+    assignedVariantName && hasVariant(assignedVariantName),
+  );
+  const variationDisplayName =
+    exposureMetadata?.variationNames?.[
+      variantName as Extract<keyof TVariants, string>
+    ];
+
+  useEffect(() => {
+    if (!isActive) {
+      return;
+    }
+
+    const variationId = String(variantName);
+    const assignmentKey = getExposureCacheKey(flagKey, variationId);
+
+    if (hasTrackedExposureAssignment(assignmentKey)) {
+      return;
+    }
+
+    let trackingPromise: Promise<void>;
+
+    try {
+      trackingPromise = trackEvent({
+        event: MetaMetricsEventName.ExperimentViewed,
+        category: MetaMetricsEventCategory.Analytics,
+        properties: {
+          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          experiment_id: flagKey,
+          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          variation_id: variationId,
+          ...(exposureMetadata?.experimentName && {
+            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            experiment_name: exposureMetadata.experimentName,
+          }),
+          ...(variationDisplayName && {
+            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            variation_name: variationDisplayName,
+          }),
+        },
+      });
+    } catch {
+      return;
+    }
+
+    const trackedPromise = trackingPromise
+      .then(() => {
+        rememberExposureAssignment(assignmentKey);
+      })
+      .catch(() => undefined)
+      .finally(() => {
+        inFlightExposureAssignments.delete(assignmentKey);
+      });
+
+    inFlightExposureAssignments.set(assignmentKey, trackedPromise);
+  }, [
+    exposureMetadata?.experimentName,
+    flagKey,
+    isActive,
+    trackEvent,
+    variantName,
+    variationDisplayName,
+  ]);
+
+  return {
+    variant: variants[variantName as keyof TVariants],
+    variantName: String(variantName),
+    isActive,
+  };
+}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR enables A/B testing infrastructure in the extension by adding a generic experiment hook, automatic exposure tracking, and standardized analytics/documentation.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40732?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: null

## **Manual testing steps**

1. Not currently a user facing change. Sets the stage for future AB test runs, when the first experiment is ran is when testing steps will be provided.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new analytics event/category and automatic exposure tracking logic, which could affect MetaMetrics data quality if misused or if deduping/caching behaves unexpectedly. Changes are additive and covered by unit tests, reducing functional risk to the extension UI.
> 
> **Overview**
> Adds a generic `useABTest` hook for remote-feature-flag-backed experiments, including a `control` fallback, support for both `{ name, value }` and legacy string assignments, and automatic one-per-session exposure tracking via the new `Experiment Viewed` MetaMetrics event.
> 
> Extends MetaMetrics constants with `MetaMetricsEventName.ExperimentViewed` and `MetaMetricsEventCategory.Analytics`, adds comprehensive unit tests for variant selection and exposure deduping/retry behavior, and documents the standard A/B testing/analytics approach in new `docs/ab-testing.md` (linked from `docs/README.md`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit edb589d4f83e7b1bc1f997766b3d4af9a7a33727. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->