### PR TITLE
fix: flaky test Snap Multi Install test multi install snap

### DIFF
--- a/test/e2e/snaps/test-snap-multi-install.spec.js
+++ b/test/e2e/snaps/test-snap-multi-install.spec.js
@@ -51,6 +51,12 @@ describe('Test Snap Multi Install', function () {
         // switch to metamask extension
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
+        // wait for connection request dialog to load
+        await driver.waitForSelector({
+          text: 'Connection request',
+          tag: 'h3',
+        });
+
         // wait for and click connect
         await driver.waitForSelector({
           text: 'Connect',

--- a/test/e2e/snaps/test-snap-multi-install.spec.js
+++ b/test/e2e/snaps/test-snap-multi-install.spec.js
@@ -67,11 +67,14 @@ describe('Test Snap Multi Install', function () {
           tag: 'button',
         });
 
-        // wait and scroll if necessary
-        await driver.waitForSelector({
-          tag: 'h3',
-          text: 'Add to MetaMask',
-        });
+        // wait for snap binary download and verification to complete, then scroll if necessary
+        await driver.waitForSelector(
+          {
+            tag: 'h3',
+            text: 'Add to MetaMask',
+          },
+          { timeout: 30000 },
+        );
         await driver.clickElementSafe(
           '[data-testid="snap-install-scroll"]',
           3000,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes flaky `Test Snap Multi Install` by waiting for the "Connection request" header before clicking "Connect".

The test was encountering a `TimeoutError` because it could click a disabled "Connect" button during the snap's loading state, preventing the "Add to MetaMask" dialog from appearing. This fix ensures the dialog is in the expected "Connection request" state before proceeding, mirroring a previous fix for similar snap install tests.

---
[Slack Thread](https://consensys.slack.com/archives/CTQAGKY5V/p1773130708494979?thread_ts=1773130708.494979&cid=CTQAGKY5V)

<p><a href="https://cursor.com/agents/bc-1c705902-f0ab-55a9-9f23-034d59bff296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c705902-f0ab-55a9-9f23-034d59bff296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->