### PR TITLE
refactor(development): extract shared segment mock utilities and make server composable

### DIFF
--- a/development/README.md
+++ b/development/README.md
@@ -25,6 +25,45 @@ Events triggered whilst using the extension will be logged to the console of the
 
 More information on the API and its usage can be found [here](./mock-segment.js#L28).
 
+### Collecting and Querying Events with the Mock Segment Collector
+
+If you need to query or analyse events after they are fired (e.g., to feed them to
+an AI agent for validation, or to assert on event counts in a scripted flow), use
+the [Mock Segment Collector](./mock-segment-collector.js) instead. It stores every
+event in memory and exposes a REST API to retrieve them:
+
+- Add/replace the `SEGMENT_HOST` and `SEGMENT_WRITE_KEY` variables in `.metamaskrc`
+  ```
+  SEGMENT_HOST='http://localhost:9090'
+  SEGMENT_WRITE_KEY='FAKE'
+  ```
+- Build the project to the `./dist/` folder with `yarn dist`
+- Run the collector from the command line
+  ```
+  node development/mock-segment-collector.js
+  ```
+- Query collected events via the REST API
+
+  ```bash
+  # All events
+  curl http://localhost:9090/events
+
+  # Filter by event name
+  curl http://localhost:9090/events?event=Transaction+Submitted
+
+  # Filter by Segment type (track, page, identify)
+  curl http://localhost:9090/events?type=track
+
+  # Compact summary (event counts grouped by name)
+  curl http://localhost:9090/events/summary
+
+  # Clear all stored events
+  curl -X DELETE http://localhost:9090/events
+  ```
+
+The full REST API reference is documented in the
+[source file header](./mock-segment-collector.js#L3).
+
 ### Debugging in Segment
 
 To debug in a production Segment environment:

--- a/development/lib/create-segment-server.js
+++ b/development/lib/create-segment-server.js
@@ -1,4 +1,5 @@
 const http = require('http');
+const { setCorsHeaders } = require('./segment-utils');
 
 /**
  * This is the default error handler to be used by this mock segment server.
@@ -24,17 +25,39 @@ function defaultOnError(error) {
 
 /**
  * Creates a HTTP server that acts as a fake version of the Segment API.
- * The bevahiour is rudimentary at the moment - it returns HTTP 200 in response
- * to every request. The only function this serves is to spy on requests sent to
- * this server, and to parse the request payloads as Segment batch events.
+ * Returns HTTP 200 to every request, parses batch payloads, and forwards
+ * the extracted events to `onRequest`.
  *
- * @param {MockSegmentRequestHandler} onRequest - A callback for each request the server receives.
- * @param {(error: Error) => void} [onError] - A callback for server error events
+ * @param {MockSegmentRequestHandler} onRequest - Called for each request
+ *   that is not handled by `options.onBeforeRequest`.
+ * @param {(error: Error) => void} [onError] - Server error callback.
+ * @param {object} [options]
+ * @param {(request: IncomingMessage, response: ServerResponse, url: URL) => boolean} [options.onBeforeRequest]
+ *   - Optional hook invoked before body parsing. Return `true` to indicate the
+ *   request was handled (the default batch logic will be skipped).
  */
-function createSegmentServer(onRequest, onError = defaultOnError) {
-  const server = http.createServer(async (request, response) => {
-    const chunks = [];
+function createSegmentServer(
+  onRequest,
+  onError = defaultOnError,
+  options = {},
+) {
+  const { onBeforeRequest } = options;
 
+  const server = http.createServer(async (request, response) => {
+    if (request.method === 'OPTIONS') {
+      setCorsHeaders(response);
+      response.statusCode = 200;
+      response.end();
+      return;
+    }
+
+    const url = new URL(request.url, `http://${request.headers.host}`);
+
+    if (onBeforeRequest && onBeforeRequest(request, response, url)) {
+      return;
+    }
+
+    const chunks = [];
     request.on('data', (chunk) => {
       chunks.push(chunk);
     });
@@ -45,21 +68,15 @@ function createSegmentServer(onRequest, onError = defaultOnError) {
       });
     });
 
-    // respond to preflight request
-    if (request.method === 'OPTIONS') {
-      response.setHeader('Access-Control-Allow-Origin', '*');
-      response.setHeader('Access-Control-Allow-Methods', '*');
-      response.setHeader('Access-Control-Allow-Headers', '*');
-      response.statusCode = 200;
-      response.end();
-      return;
-    }
-
     let metricEvents = [];
     if (chunks.length) {
-      const body = Buffer.concat(chunks).toString();
-      const segmentPayload = JSON.parse(body);
-      metricEvents = segmentPayload.batch;
+      try {
+        const body = Buffer.concat(chunks).toString();
+        const segmentPayload = JSON.parse(body);
+        metricEvents = segmentPayload.batch || [];
+      } catch (_) {
+        // Malformed or non-JSON payload — treat as zero events
+      }
     }
 
     onRequest(request, response, metricEvents);

--- a/development/lib/create-segment-server.test.js
+++ b/development/lib/create-segment-server.test.js
@@ -1,0 +1,219 @@
+const http = require('http');
+const { createSegmentServer } = require('./create-segment-server');
+
+function getAvailablePort() {
+  return new Promise((resolve) => {
+    const tmp = http.createServer();
+    tmp.listen(0, 'localhost', () => {
+      const { port } = tmp.address();
+      tmp.close(() => resolve(port));
+    });
+  });
+}
+
+function request(port, { method = 'GET', path = '/', body } = {}) {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { hostname: 'localhost', port, path, method },
+      (res) => {
+        const chunks = [];
+        res.on('data', (chunk) => chunks.push(chunk));
+        res.on('end', () => {
+          resolve({
+            statusCode: res.statusCode,
+            headers: res.headers,
+            body: Buffer.concat(chunks).toString(),
+          });
+        });
+      },
+    );
+    req.on('error', reject);
+    if (body) {
+      req.write(typeof body === 'string' ? body : JSON.stringify(body));
+    }
+    req.end();
+  });
+}
+
+describe('createSegmentServer', () => {
+  let server;
+  let port;
+
+  afterEach(async () => {
+    if (server) {
+      await server.stop();
+      server = null;
+    }
+  });
+
+  describe('OPTIONS requests', () => {
+    it('responds with 200 and CORS headers', async () => {
+      const onRequest = jest.fn();
+      port = await getAvailablePort();
+      server = createSegmentServer(onRequest);
+      await server.start(port);
+
+      const res = await request(port, { method: 'OPTIONS' });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.headers['access-control-allow-origin']).toBe('*');
+      expect(res.headers['access-control-allow-headers']).toBe('*');
+      expect(onRequest).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('batch requests', () => {
+    it('parses a valid JSON batch body and forwards events to onRequest', async () => {
+      const onRequest = jest.fn((_req, res) => {
+        res.statusCode = 200;
+        res.end();
+      });
+      port = await getAvailablePort();
+      server = createSegmentServer(onRequest);
+      await server.start(port);
+
+      const batch = [
+        { type: 'track', event: 'Test' },
+        { type: 'page', name: 'Home' },
+      ];
+
+      await request(port, {
+        method: 'POST',
+        path: '/v1/batch',
+        body: { batch },
+      });
+
+      expect(onRequest).toHaveBeenCalledTimes(1);
+      const events = onRequest.mock.calls[0][2];
+      expect(events).toStrictEqual(batch);
+    });
+
+    it('treats malformed JSON as zero events', async () => {
+      const onRequest = jest.fn((_req, res) => {
+        res.statusCode = 200;
+        res.end();
+      });
+      port = await getAvailablePort();
+      server = createSegmentServer(onRequest);
+      await server.start(port);
+
+      await request(port, {
+        method: 'POST',
+        path: '/v1/batch',
+        body: '{not valid json',
+      });
+
+      expect(onRequest).toHaveBeenCalledTimes(1);
+      const events = onRequest.mock.calls[0][2];
+      expect(events).toStrictEqual([]);
+    });
+
+    it('treats an empty body as zero events', async () => {
+      const onRequest = jest.fn((_req, res) => {
+        res.statusCode = 200;
+        res.end();
+      });
+      port = await getAvailablePort();
+      server = createSegmentServer(onRequest);
+      await server.start(port);
+
+      await request(port, { method: 'POST', path: '/v1/batch' });
+
+      expect(onRequest).toHaveBeenCalledTimes(1);
+      const events = onRequest.mock.calls[0][2];
+      expect(events).toStrictEqual([]);
+    });
+
+    it('defaults batch to empty array when payload has no batch field', async () => {
+      const onRequest = jest.fn((_req, res) => {
+        res.statusCode = 200;
+        res.end();
+      });
+      port = await getAvailablePort();
+      server = createSegmentServer(onRequest);
+      await server.start(port);
+
+      await request(port, {
+        method: 'POST',
+        path: '/v1/batch',
+        body: { other: 'data' },
+      });
+
+      expect(onRequest).toHaveBeenCalledTimes(1);
+      const events = onRequest.mock.calls[0][2];
+      expect(events).toStrictEqual([]);
+    });
+  });
+
+  describe('onBeforeRequest hook', () => {
+    it('skips batch logic when onBeforeRequest returns true', async () => {
+      const onRequest = jest.fn();
+      const onBeforeRequest = jest.fn((_req, res) => {
+        res.statusCode = 200;
+        res.end('intercepted');
+        return true;
+      });
+
+      port = await getAvailablePort();
+      server = createSegmentServer(onRequest, undefined, { onBeforeRequest });
+      await server.start(port);
+
+      const res = await request(port, {
+        method: 'GET',
+        path: '/custom-route',
+      });
+
+      expect(res.body).toBe('intercepted');
+      expect(onBeforeRequest).toHaveBeenCalledTimes(1);
+      expect(onRequest).not.toHaveBeenCalled();
+    });
+
+    it('falls through to batch logic when onBeforeRequest returns false', async () => {
+      const onRequest = jest.fn((_req, res) => {
+        res.statusCode = 200;
+        res.end();
+      });
+      const onBeforeRequest = jest.fn(() => false);
+
+      port = await getAvailablePort();
+      server = createSegmentServer(onRequest, undefined, { onBeforeRequest });
+      await server.start(port);
+
+      await request(port, { method: 'POST', path: '/v1/batch' });
+
+      expect(onBeforeRequest).toHaveBeenCalledTimes(1);
+      expect(onRequest).toHaveBeenCalledTimes(1);
+    });
+
+    it('passes the parsed URL to onBeforeRequest', async () => {
+      const onRequest = jest.fn((_req, res) => {
+        res.statusCode = 200;
+        res.end();
+      });
+      const onBeforeRequest = jest.fn(() => false);
+
+      port = await getAvailablePort();
+      server = createSegmentServer(onRequest, undefined, { onBeforeRequest });
+      await server.start(port);
+
+      await request(port, { method: 'GET', path: '/events?type=track' });
+
+      const url = onBeforeRequest.mock.calls[0][2];
+      expect(url).toBeInstanceOf(URL);
+      expect(url.pathname).toBe('/events');
+      expect(url.searchParams.get('type')).toBe('track');
+    });
+  });
+
+  describe('server lifecycle', () => {
+    it('starts and stops without errors', async () => {
+      const onRequest = jest.fn();
+      port = await getAvailablePort();
+      server = createSegmentServer(onRequest);
+
+      await server.start(port);
+      await server.stop();
+      server = null;
+    });
+  });
+});

--- a/development/lib/segment-utils.js
+++ b/development/lib/segment-utils.js
@@ -1,0 +1,108 @@
+/**
+ * Set permissive CORS headers on a response.
+ *
+ * @param {import('http').ServerResponse} response
+ */
+function setCorsHeaders(response) {
+  response.setHeader('Access-Control-Allow-Origin', '*');
+  response.setHeader(
+    'Access-Control-Allow-Methods',
+    'GET, POST, DELETE, OPTIONS',
+  );
+  response.setHeader('Access-Control-Allow-Headers', '*');
+}
+
+/**
+ * Send a JSON response with CORS headers.
+ *
+ * @param {import('http').ServerResponse} response
+ * @param {number} statusCode
+ * @param {unknown} body - JSON-serialisable value
+ */
+function jsonResponse(response, statusCode, body) {
+  setCorsHeaders(response);
+  response.setHeader('Content-Type', 'application/json');
+  response.statusCode = statusCode;
+  response.end(JSON.stringify(body, null, 2));
+}
+
+/**
+ * Human-readable label for a Segment event type.
+ *
+ * @param {object} event - Segment event
+ * @returns {string}
+ */
+function getTypeLabel(event) {
+  switch (event.type) {
+    case 'track':
+      return 'Track';
+    case 'page':
+      return 'Page';
+    case 'identify':
+      return 'Identify';
+    default:
+      return 'Unknown';
+  }
+}
+
+/**
+ * Event name (track/page) or user/anonymous ID (identify).
+ *
+ * @param {object} event - Segment event
+ * @returns {string}
+ */
+function getNameOrId(event) {
+  switch (event.type) {
+    case 'track':
+      return event.event || '(no name)';
+    case 'page':
+      return event.name || '(no name)';
+    case 'identify':
+      return event.userId || event.anonymousId || '(no id)';
+    default:
+      return `[Unrecognized event type: ${event.type}]`;
+  }
+}
+
+/**
+ * Return the properties (or traits for identify events) attached to an event.
+ *
+ * @param {object} event - Segment event
+ * @returns {object | undefined}
+ */
+function getEventProperties(event) {
+  return event.type === 'identify' ? event.traits : event.properties;
+}
+
+/**
+ * Log a Segment event to the console.
+ *
+ * @param {string} prefix - Log line prefix, e.g. "[mock-segment]"
+ * @param {object} event  - Segment event
+ */
+function logSegmentEvent(prefix, event) {
+  const properties = getEventProperties(event);
+  const hasProperties =
+    properties &&
+    typeof properties === 'object' &&
+    Object.keys(properties).length > 0;
+  const label = getTypeLabel(event);
+  const nameOrId = getNameOrId(event);
+
+  if (hasProperties) {
+    console.log(
+      `${prefix} ${label}: ${nameOrId}\n${JSON.stringify(properties, null, 2)}`,
+    );
+  } else {
+    console.log(`${prefix} ${label}: ${nameOrId}`);
+  }
+}
+
+module.exports = {
+  setCorsHeaders,
+  jsonResponse,
+  getTypeLabel,
+  getNameOrId,
+  getEventProperties,
+  logSegmentEvent,
+};

--- a/development/lib/segment-utils.test.js
+++ b/development/lib/segment-utils.test.js
@@ -1,0 +1,249 @@
+const {
+  setCorsHeaders,
+  jsonResponse,
+  getTypeLabel,
+  getNameOrId,
+  getEventProperties,
+  logSegmentEvent,
+} = require('./segment-utils');
+
+function createMockResponse() {
+  const headers = {};
+  return {
+    headers,
+    statusCode: 0,
+    setHeader: jest.fn((key, value) => {
+      headers[key] = value;
+    }),
+    end: jest.fn(),
+  };
+}
+
+describe('segment-utils', () => {
+  describe('setCorsHeaders', () => {
+    it('sets Access-Control-Allow-Origin to wildcard', () => {
+      const response = createMockResponse();
+
+      setCorsHeaders(response);
+
+      expect(response.setHeader).toHaveBeenCalledWith(
+        'Access-Control-Allow-Origin',
+        '*',
+      );
+    });
+
+    it('sets Access-Control-Allow-Methods to GET, POST, DELETE, OPTIONS', () => {
+      const response = createMockResponse();
+
+      setCorsHeaders(response);
+
+      expect(response.setHeader).toHaveBeenCalledWith(
+        'Access-Control-Allow-Methods',
+        'GET, POST, DELETE, OPTIONS',
+      );
+    });
+
+    it('sets Access-Control-Allow-Headers to wildcard', () => {
+      const response = createMockResponse();
+
+      setCorsHeaders(response);
+
+      expect(response.setHeader).toHaveBeenCalledWith(
+        'Access-Control-Allow-Headers',
+        '*',
+      );
+    });
+  });
+
+  describe('jsonResponse', () => {
+    it('sets CORS headers on the response', () => {
+      const response = createMockResponse();
+
+      jsonResponse(response, 200, { ok: true });
+
+      expect(response.setHeader).toHaveBeenCalledWith(
+        'Access-Control-Allow-Origin',
+        '*',
+      );
+    });
+
+    it('sets Content-Type to application/json', () => {
+      const response = createMockResponse();
+
+      jsonResponse(response, 200, { ok: true });
+
+      expect(response.setHeader).toHaveBeenCalledWith(
+        'Content-Type',
+        'application/json',
+      );
+    });
+
+    it('sets the given status code', () => {
+      const response = createMockResponse();
+
+      jsonResponse(response, 404, { error: 'not found' });
+
+      expect(response.statusCode).toBe(404);
+    });
+
+    it('writes the JSON-stringified body to the response', () => {
+      const response = createMockResponse();
+      const body = { total: 3, items: [1, 2, 3] };
+
+      jsonResponse(response, 200, body);
+
+      expect(response.end).toHaveBeenCalledWith(JSON.stringify(body, null, 2));
+    });
+  });
+
+  describe('getTypeLabel', () => {
+    it('returns "Track" for track events', () => {
+      expect(getTypeLabel({ type: 'track' })).toBe('Track');
+    });
+
+    it('returns "Page" for page events', () => {
+      expect(getTypeLabel({ type: 'page' })).toBe('Page');
+    });
+
+    it('returns "Identify" for identify events', () => {
+      expect(getTypeLabel({ type: 'identify' })).toBe('Identify');
+    });
+
+    it('returns "Unknown" for unrecognized event types', () => {
+      expect(getTypeLabel({ type: 'foobar' })).toBe('Unknown');
+    });
+
+    it('returns "Unknown" when type is undefined', () => {
+      expect(getTypeLabel({})).toBe('Unknown');
+    });
+  });
+
+  describe('getNameOrId', () => {
+    it('returns the event name for track events', () => {
+      expect(getNameOrId({ type: 'track', event: 'Button Clicked' })).toBe(
+        'Button Clicked',
+      );
+    });
+
+    it('returns "(no name)" for track events without an event name', () => {
+      expect(getNameOrId({ type: 'track' })).toBe('(no name)');
+    });
+
+    it('returns the page name for page events', () => {
+      expect(getNameOrId({ type: 'page', name: 'Home' })).toBe('Home');
+    });
+
+    it('returns "(no name)" for page events without a name', () => {
+      expect(getNameOrId({ type: 'page' })).toBe('(no name)');
+    });
+
+    it('returns the userId for identify events', () => {
+      expect(getNameOrId({ type: 'identify', userId: 'user-1' })).toBe(
+        'user-1',
+      );
+    });
+
+    it('falls back to anonymousId for identify events without userId', () => {
+      expect(getNameOrId({ type: 'identify', anonymousId: 'anon-42' })).toBe(
+        'anon-42',
+      );
+    });
+
+    it('returns "(no id)" for identify events without userId or anonymousId', () => {
+      expect(getNameOrId({ type: 'identify' })).toBe('(no id)');
+    });
+
+    it('returns an unrecognized-type message for unknown types', () => {
+      expect(getNameOrId({ type: 'alias' })).toBe(
+        '[Unrecognized event type: alias]',
+      );
+    });
+  });
+
+  describe('getEventProperties', () => {
+    it('returns traits for identify events', () => {
+      const traits = { email: 'a@b.com' };
+      expect(getEventProperties({ type: 'identify', traits })).toBe(traits);
+    });
+
+    it('returns properties for track events', () => {
+      const properties = { category: 'Nav' };
+      expect(getEventProperties({ type: 'track', properties })).toBe(
+        properties,
+      );
+    });
+
+    it('returns properties for page events', () => {
+      const properties = { url: '/home' };
+      expect(getEventProperties({ type: 'page', properties })).toBe(properties);
+    });
+
+    it('returns undefined when no properties or traits exist', () => {
+      expect(getEventProperties({ type: 'track' })).toBeUndefined();
+    });
+  });
+
+  describe('logSegmentEvent', () => {
+    let consoleSpy;
+
+    beforeEach(() => {
+      consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+    });
+
+    afterEach(() => {
+      consoleSpy.mockRestore();
+    });
+
+    it('logs type and name for events without properties', () => {
+      logSegmentEvent('[test]', { type: 'track', event: 'Click' });
+
+      expect(consoleSpy).toHaveBeenCalledWith('[test] Track: Click');
+    });
+
+    it('logs type, name, and formatted properties for events with properties', () => {
+      const properties = { category: 'Nav' };
+      logSegmentEvent('[test]', {
+        type: 'track',
+        event: 'Click',
+        properties,
+      });
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        `[test] Track: Click\n${JSON.stringify(properties, null, 2)}`,
+      );
+    });
+
+    it('logs traits for identify events with traits', () => {
+      const traits = { plan: 'pro' };
+      logSegmentEvent('[test]', {
+        type: 'identify',
+        userId: 'u1',
+        traits,
+      });
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        `[test] Identify: u1\n${JSON.stringify(traits, null, 2)}`,
+      );
+    });
+
+    it('does not include properties block when properties is an empty object', () => {
+      logSegmentEvent('[test]', {
+        type: 'track',
+        event: 'Empty',
+        properties: {},
+      });
+
+      expect(consoleSpy).toHaveBeenCalledWith('[test] Track: Empty');
+    });
+
+    it('does not include properties block when properties is null', () => {
+      logSegmentEvent('[test]', {
+        type: 'track',
+        event: 'Null',
+        properties: null,
+      });
+
+      expect(consoleSpy).toHaveBeenCalledWith('[test] Track: Null');
+    });
+  });
+});

--- a/development/mock-segment-collector.js
+++ b/development/mock-segment-collector.js
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+
+/**
+ * Enhanced Mock Segment API with event collection and REST query capabilities.
+ *
+ * This extends the basic mock-segment.js by storing all received events in
+ * memory and exposing REST endpoints to query, filter, and clear them.
+ *
+ * Intended for validating that the extension fires the correct Segment
+ * analytics events during manual or automated UI flows (e.g., via the
+ * MetaMask MCP visual testing tools).
+ *
+ * ## Setup
+ *
+ * 1. Set these values in `.metamaskrc`:
+ *      SEGMENT_HOST='http://localhost:9090'
+ *      SEGMENT_WRITE_KEY='FAKE'
+ *
+ * 2. Build the extension:
+ *      yarn build:test
+ *
+ * 3. Start this collector:
+ *      node development/mock-segment-collector.js
+ *
+ * 4. Load the extension and opt into MetaMetrics (Settings > Security &
+ *    Privacy > Participate in MetaMetrics).
+ *
+ * 5. Perform UI flows (send, swap, sign, etc.).
+ *
+ * 6. Query collected events:
+ *      curl http://localhost:9090/events                              # all events
+ *      curl http://localhost:9090/events?event=Transaction+Submitted  # filter by event name
+ *      curl http://localhost:9090/events?type=track                   # filter by type
+ *      curl http://localhost:9090/events?category=Transactions        # filter by properties.category
+ *      curl -X DELETE http://localhost:9090/events                    # clear all events
+ *
+ * ## REST API
+ *
+ * ### GET /events
+ *   Returns JSON array of all collected events.
+ *   Optional query parameters (combinable):
+ *     - event    : Filter by event name (e.g., "Transaction Submitted")
+ *     - type     : Filter by Segment type ("track", "page", "identify")
+ *     - category : Filter by properties.category
+ *
+ *   Response shape:
+ *   [
+ *     {
+ *       "receivedAt": "2026-03-03T10:00:00.000Z",
+ *       "type": "track",
+ *       "event": "Transaction Submitted",
+ *       "properties": { ... },
+ *       "userId": "...",
+ *       "anonymousId": "...",
+ *       ...
+ *     }
+ *   ]
+ *
+ * ### GET /events/summary
+ *   Returns a compact summary: event counts grouped by name.
+ *   Response shape:
+ *   {
+ *     "total": 12,
+ *     "byEvent": {
+ *       "Transaction Submitted": 2,
+ *       "Transaction Finalized": 2,
+ *       ...
+ *     }
+ *   }
+ *
+ * ### DELETE /events
+ *   Clears all stored events. Returns { "cleared": <count> }.
+ *
+ * ### POST /v1/batch
+ *   Standard Segment batch endpoint. Events are stored and logged.
+ *   Always returns HTTP 200 (so the extension keeps sending).
+ *
+ * All other requests return HTTP 200 with an empty body.
+ */
+
+const { createSegmentServer } = require('./lib/create-segment-server');
+const {
+  setCorsHeaders,
+  jsonResponse,
+  logSegmentEvent,
+} = require('./lib/segment-utils');
+const { parsePort } = require('./lib/parse-port');
+
+const DEFAULT_PORT = 9090;
+const PREFIX = '[segment-collector]';
+
+/** @type {Array<object>} */
+const events = [];
+
+const FILTER_PREDICATES = {
+  event: (e, value) => e.event === value,
+  type: (e, value) => e.type === value,
+  category: (e, value) => e.properties?.category === value,
+};
+
+// ── Route handlers ─────────────────────────────────────────────────────────
+
+function handleGetEvents(url, response) {
+  const params = url.searchParams;
+  let filtered = events;
+
+  for (const [param, predicate] of Object.entries(FILTER_PREDICATES)) {
+    const value = params.get(param);
+    if (value) {
+      filtered = filtered.filter((e) => predicate(e, value));
+    }
+  }
+
+  jsonResponse(response, 200, filtered);
+}
+
+function handleGetSummary(_url, response) {
+  const byEvent = {};
+  for (const event of events) {
+    const name = event.event || event.type || 'unknown';
+    byEvent[name] = (byEvent[name] || 0) + 1;
+  }
+
+  jsonResponse(response, 200, { total: events.length, byEvent });
+}
+
+function handleDeleteEvents(response) {
+  const count = events.length;
+  events.length = 0;
+  console.log(`${PREFIX} Cleared ${count} event(s)`);
+  jsonResponse(response, 200, { cleared: count });
+}
+
+// ── Server hooks ───────────────────────────────────────────────────────────
+
+function onBeforeRequest(request, response, url) {
+  const { pathname } = url;
+
+  if (request.method === 'GET' && pathname === '/events/summary') {
+    handleGetSummary(url, response);
+    return true;
+  }
+
+  if (request.method === 'GET' && pathname === '/events') {
+    handleGetEvents(url, response);
+    return true;
+  }
+
+  if (request.method === 'DELETE' && pathname === '/events') {
+    handleDeleteEvents(response);
+    return true;
+  }
+
+  return false;
+}
+
+function onBatchRequest(_request, response, batchEvents) {
+  const timestamp = new Date().toISOString();
+
+  for (const event of batchEvents) {
+    events.push({ receivedAt: timestamp, ...event });
+    logSegmentEvent(PREFIX, event);
+  }
+
+  if (batchEvents.length > 0) {
+    console.log(
+      `${PREFIX} Stored ${batchEvents.length} event(s) — total: ${events.length}`,
+    );
+  }
+
+  setCorsHeaders(response);
+  response.statusCode = 200;
+  response.end();
+}
+
+function onError(error) {
+  console.error(`${PREFIX} Server error:`, error);
+  process.exit(1);
+}
+
+// ── Main ───────────────────────────────────────────────────────────────────
+
+async function main() {
+  const args = process.argv.slice(2);
+  let port = process.env.PORT || DEFAULT_PORT;
+
+  while (args.length) {
+    if (/^(--port|-p)$/u.test(args[0])) {
+      if (args[1] === undefined) {
+        throw new Error('Missing port argument');
+      }
+      port = parsePort(args[1]);
+      args.splice(0, 2);
+    } else {
+      args.shift();
+    }
+  }
+
+  const server = createSegmentServer(onBatchRequest, onError, {
+    onBeforeRequest,
+  });
+
+  await server.start(port);
+
+  console.log(`${PREFIX} Listening on port ${port}`);
+
+  const shutdown = () => {
+    console.log(
+      `\n${PREFIX} Shutting down (${events.length} events collected)`,
+    );
+    server.stop();
+    process.exit(0);
+  };
+
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/development/mock-segment-collector.js
+++ b/development/mock-segment-collector.js
@@ -216,7 +216,20 @@ async function main() {
   process.on('SIGTERM', shutdown);
 }
 
-main().catch((error) => {
-  console.error(error);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  events,
+  FILTER_PREDICATES,
+  handleGetEvents,
+  handleGetSummary,
+  handleDeleteEvents,
+  onBeforeRequest,
+  onBatchRequest,
+  main,
+};

--- a/development/mock-segment-collector.test.js
+++ b/development/mock-segment-collector.test.js
@@ -1,0 +1,308 @@
+const {
+  events,
+  FILTER_PREDICATES,
+  handleGetEvents,
+  handleGetSummary,
+  handleDeleteEvents,
+  onBeforeRequest,
+  onBatchRequest,
+} = require('./mock-segment-collector');
+
+function createMockResponse() {
+  const headers = {};
+  return {
+    headers,
+    statusCode: 0,
+    setHeader: jest.fn((key, value) => {
+      headers[key] = value;
+    }),
+    end: jest.fn(),
+  };
+}
+
+function createMockUrl(path, params = {}) {
+  const url = new URL(path, 'http://localhost:9090');
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return url;
+}
+
+function seedEvents(items) {
+  events.length = 0;
+  events.push(...items);
+}
+
+describe('mock-segment-collector', () => {
+  afterEach(() => {
+    events.length = 0;
+  });
+
+  describe('FILTER_PREDICATES', () => {
+    it('filters by event name', () => {
+      const ev = { event: 'Transaction Submitted' };
+      expect(FILTER_PREDICATES.event(ev, 'Transaction Submitted')).toBe(true);
+      expect(FILTER_PREDICATES.event(ev, 'Other')).toBe(false);
+    });
+
+    it('filters by type', () => {
+      const ev = { type: 'track' };
+      expect(FILTER_PREDICATES.type(ev, 'track')).toBe(true);
+      expect(FILTER_PREDICATES.type(ev, 'page')).toBe(false);
+    });
+
+    it('filters by properties.category', () => {
+      const ev = { properties: { category: 'Transactions' } };
+      expect(FILTER_PREDICATES.category(ev, 'Transactions')).toBe(true);
+      expect(FILTER_PREDICATES.category(ev, 'Other')).toBe(false);
+    });
+
+    it('returns false for category filter when properties is undefined', () => {
+      expect(FILTER_PREDICATES.category({}, 'Transactions')).toBe(false);
+    });
+  });
+
+  describe('handleGetEvents', () => {
+    it('returns all events when no filters are provided', () => {
+      seedEvents([
+        { type: 'track', event: 'A' },
+        { type: 'page', name: 'B' },
+      ]);
+      const response = createMockResponse();
+
+      handleGetEvents(createMockUrl('/events'), response);
+
+      const body = JSON.parse(response.end.mock.calls[0][0]);
+      expect(body).toHaveLength(2);
+    });
+
+    it('filters events by event name', () => {
+      seedEvents([
+        { type: 'track', event: 'Click' },
+        { type: 'track', event: 'Submit' },
+      ]);
+      const response = createMockResponse();
+
+      handleGetEvents(createMockUrl('/events', { event: 'Click' }), response);
+
+      const body = JSON.parse(response.end.mock.calls[0][0]);
+      expect(body).toHaveLength(1);
+      expect(body[0].event).toBe('Click');
+    });
+
+    it('filters events by type', () => {
+      seedEvents([
+        { type: 'track', event: 'A' },
+        { type: 'page', name: 'Home' },
+        { type: 'track', event: 'B' },
+      ]);
+      const response = createMockResponse();
+
+      handleGetEvents(createMockUrl('/events', { type: 'page' }), response);
+
+      const body = JSON.parse(response.end.mock.calls[0][0]);
+      expect(body).toHaveLength(1);
+      expect(body[0].type).toBe('page');
+    });
+
+    it('filters events by category', () => {
+      seedEvents([
+        { type: 'track', event: 'A', properties: { category: 'Nav' } },
+        { type: 'track', event: 'B', properties: { category: 'Tx' } },
+      ]);
+      const response = createMockResponse();
+
+      handleGetEvents(createMockUrl('/events', { category: 'Tx' }), response);
+
+      const body = JSON.parse(response.end.mock.calls[0][0]);
+      expect(body).toHaveLength(1);
+      expect(body[0].event).toBe('B');
+    });
+
+    it('combines multiple filters', () => {
+      seedEvents([
+        { type: 'track', event: 'A', properties: { category: 'Nav' } },
+        { type: 'track', event: 'B', properties: { category: 'Nav' } },
+        { type: 'page', event: 'A', properties: { category: 'Nav' } },
+      ]);
+      const response = createMockResponse();
+
+      handleGetEvents(
+        createMockUrl('/events', { type: 'track', category: 'Nav' }),
+        response,
+      );
+
+      const body = JSON.parse(response.end.mock.calls[0][0]);
+      expect(body).toHaveLength(2);
+    });
+
+    it('returns an empty array when no events match', () => {
+      seedEvents([{ type: 'track', event: 'A' }]);
+      const response = createMockResponse();
+
+      handleGetEvents(
+        createMockUrl('/events', { event: 'NonExistent' }),
+        response,
+      );
+
+      const body = JSON.parse(response.end.mock.calls[0][0]);
+      expect(body).toStrictEqual([]);
+    });
+  });
+
+  describe('handleGetSummary', () => {
+    it('returns total count and events grouped by name', () => {
+      seedEvents([
+        { event: 'Click', type: 'track' },
+        { event: 'Click', type: 'track' },
+        { event: 'Submit', type: 'track' },
+      ]);
+      const response = createMockResponse();
+
+      handleGetSummary(createMockUrl('/events/summary'), response);
+
+      const body = JSON.parse(response.end.mock.calls[0][0]);
+      expect(body.total).toBe(3);
+      expect(body.byEvent).toStrictEqual({ Click: 2, Submit: 1 });
+    });
+
+    it('falls back to type or "unknown" when event name is missing', () => {
+      seedEvents([{ type: 'page' }, {}]);
+      const response = createMockResponse();
+
+      handleGetSummary(createMockUrl('/events/summary'), response);
+
+      const body = JSON.parse(response.end.mock.calls[0][0]);
+      expect(body.total).toBe(2);
+      expect(body.byEvent).toStrictEqual({ page: 1, unknown: 1 });
+    });
+
+    it('returns zero total when no events exist', () => {
+      const response = createMockResponse();
+
+      handleGetSummary(createMockUrl('/events/summary'), response);
+
+      const body = JSON.parse(response.end.mock.calls[0][0]);
+      expect(body).toStrictEqual({ total: 0, byEvent: {} });
+    });
+  });
+
+  describe('handleDeleteEvents', () => {
+    it('clears all stored events and returns the count', () => {
+      jest.spyOn(console, 'log').mockImplementation();
+      seedEvents([{ type: 'track' }, { type: 'page' }]);
+      const response = createMockResponse();
+
+      handleDeleteEvents(response);
+
+      const body = JSON.parse(response.end.mock.calls[0][0]);
+      expect(body).toStrictEqual({ cleared: 2 });
+      expect(events).toHaveLength(0);
+      console.log.mockRestore();
+    });
+  });
+
+  describe('onBeforeRequest', () => {
+    it('routes GET /events/summary and returns true', () => {
+      const response = createMockResponse();
+      const url = createMockUrl('/events/summary');
+
+      const handled = onBeforeRequest({ method: 'GET' }, response, url);
+
+      expect(handled).toBe(true);
+    });
+
+    it('routes GET /events and returns true', () => {
+      const response = createMockResponse();
+      const url = createMockUrl('/events');
+
+      const handled = onBeforeRequest({ method: 'GET' }, response, url);
+
+      expect(handled).toBe(true);
+    });
+
+    it('routes DELETE /events and returns true', () => {
+      jest.spyOn(console, 'log').mockImplementation();
+      const response = createMockResponse();
+      const url = createMockUrl('/events');
+
+      const handled = onBeforeRequest({ method: 'DELETE' }, response, url);
+
+      expect(handled).toBe(true);
+      console.log.mockRestore();
+    });
+
+    it('returns false for unmatched routes', () => {
+      const response = createMockResponse();
+      const url = createMockUrl('/v1/batch');
+
+      const handled = onBeforeRequest({ method: 'POST' }, response, url);
+
+      expect(handled).toBe(false);
+    });
+
+    it('returns false for GET on an unknown path', () => {
+      const response = createMockResponse();
+      const url = createMockUrl('/unknown');
+
+      const handled = onBeforeRequest({ method: 'GET' }, response, url);
+
+      expect(handled).toBe(false);
+    });
+  });
+
+  describe('onBatchRequest', () => {
+    it('stores received events with a receivedAt timestamp', () => {
+      jest.spyOn(console, 'log').mockImplementation();
+      const response = createMockResponse();
+      const batchEvents = [
+        { type: 'track', event: 'Click' },
+        { type: 'page', name: 'Home' },
+      ];
+
+      onBatchRequest({}, response, batchEvents);
+
+      expect(events).toHaveLength(2);
+      expect(events[0]).toMatchObject({ type: 'track', event: 'Click' });
+      expect(events[0].receivedAt).toBeDefined();
+      expect(events[1]).toMatchObject({ type: 'page', name: 'Home' });
+      console.log.mockRestore();
+    });
+
+    it('responds with 200 and CORS headers', () => {
+      jest.spyOn(console, 'log').mockImplementation();
+      const response = createMockResponse();
+
+      onBatchRequest({}, response, [{ type: 'track', event: 'A' }]);
+
+      expect(response.statusCode).toBe(200);
+      expect(response.headers['Access-Control-Allow-Origin']).toBe('*');
+      expect(response.end).toHaveBeenCalled();
+      console.log.mockRestore();
+    });
+
+    it('does not log a storage summary when batch is empty', () => {
+      const logSpy = jest.spyOn(console, 'log').mockImplementation();
+      const response = createMockResponse();
+
+      onBatchRequest({}, response, []);
+
+      const storedCalls = logSpy.mock.calls.filter(
+        (call) => typeof call[0] === 'string' && call[0].includes('Stored'),
+      );
+      expect(storedCalls).toHaveLength(0);
+      logSpy.mockRestore();
+    });
+
+    it('accumulates events across multiple calls', () => {
+      jest.spyOn(console, 'log').mockImplementation();
+      const response = createMockResponse();
+
+      onBatchRequest({}, response, [{ type: 'track', event: 'A' }]);
+      onBatchRequest({}, response, [{ type: 'track', event: 'B' }]);
+
+      expect(events).toHaveLength(2);
+      console.log.mockRestore();
+    });
+  });
+});

--- a/development/mock-segment.js
+++ b/development/mock-segment.js
@@ -1,60 +1,13 @@
 #!/usr/bin/env node
 const { createSegmentServer } = require('./lib/create-segment-server');
+const { logSegmentEvent } = require('./lib/segment-utils');
 const { parsePort } = require('./lib/parse-port');
 
 const DEFAULT_PORT = 9090;
-const prefix = '[mock-segment]';
+const PREFIX = '[mock-segment]';
 
 function onRequest(_request, response, events) {
-  const getTypeLabel = (e) => {
-    switch (e.type) {
-      case 'track':
-        return 'Track';
-      case 'page':
-        return 'Page';
-      case 'identify':
-        return 'Identify';
-      default:
-        return 'Unknown';
-    }
-  };
-  const getNameOrId = (e) => {
-    switch (e.type) {
-      case 'track':
-        return e.event || '(no name)';
-      case 'page':
-        return e.name || '(no name)';
-      case 'identify':
-        return e.userId || e.anonymousId || '(no id)';
-      default:
-        return `[Unrecognized event type: ${e.type}]`;
-    }
-  };
-
-  events.forEach((event) => {
-    const properties =
-      event && event.type === 'identify'
-        ? event.traits
-        : event && event.properties;
-    const hasProperties =
-      properties &&
-      typeof properties === 'object' &&
-      Object.keys(properties).length > 0;
-    const label = getTypeLabel(event);
-    const nameOrId = getNameOrId(event);
-    if (hasProperties) {
-      console.log(
-        `${prefix}: ${label} event received: ${nameOrId}\n${JSON.stringify(
-          properties,
-          null,
-          2,
-        )}`,
-      );
-    } else {
-      console.log(`${prefix}: ${label} event received: ${nameOrId}`);
-    }
-  });
-
+  events.forEach((event) => logSegmentEvent(PREFIX, event));
   response.statusCode = 200;
   response.end();
 }
@@ -85,7 +38,7 @@ function onError(error) {
 const main = async () => {
   const args = process.argv.slice(2);
 
-  let port = process.env.port || DEFAULT_PORT;
+  let port = process.env.PORT || DEFAULT_PORT;
 
   while (args.length) {
     if (/^(--port|-p)$/u.test(args[0])) {
@@ -100,7 +53,7 @@ const main = async () => {
   const server = createSegmentServer(onRequest, onError);
 
   await server.start(port);
-  console.log(`${prefix}: Listening on port ${port}`);
+  console.log(`${PREFIX}: Listening on port ${port}`);
 };
 
 main().catch(onError);


### PR DESCRIPTION
## **Description**

The existing `mock-segment.js` only logs events to the console, making it impossible to programmatically query or validate which Segment analytics events the extension fires during a UI flow.

This PR adds a **mock Segment collector** (`development/mock-segment-collector.js`) that stores every received event in memory and exposes REST endpoints to query, filter, and clear them. This enables scripted validation of analytics events — for example, by an AI agent (via MCP visual testing tools) or any HTTP client after a manual flow.

To avoid duplicating HTTP/CORS/body-parsing logic, shared utilities are extracted into `development/lib/segment-utils.js` and `createSegmentServer` gains an `onBeforeRequest` hook so consumers can handle custom routes before batch processing.

**Changes at a glance:**

- **New** `development/mock-segment-collector.js` — stores events, exposes `GET /events`, `GET /events/summary`, `DELETE /events`
- **New** `development/lib/segment-utils.js` — shared helpers (`logSegmentEvent`, `setCorsHeaders`, `jsonResponse`, etc.)
- **Refactored** `development/lib/create-segment-server.js` — `onBeforeRequest` hook, early OPTIONS handling, try/catch on JSON.parse
- **Simplified** `development/mock-segment.js` — uses shared utilities; fixes `process.env.port` → `process.env.PORT` casing bug
- **Updated** `development/README.md` — documents the collector REST API

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40747?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

<!--
No related issues.
-->

## **Manual testing steps**

1. Set `SEGMENT_HOST='http://localhost:9090'` and `SEGMENT_WRITE_KEY='FAKE'` in `.metamaskrc`
2. Build the extension: `yarn build:test`
3. Start the simple mock: `node development/mock-segment.js` — verify events log to console when using the extension
4. Stop the simple mock and start the collector: `node development/mock-segment-collector.js`
5. Perform a UI flow (e.g. send transaction) then query events:
   - `curl http://localhost:9090/events` — returns all collected events as JSON
   - `curl http://localhost:9090/events/summary` — returns event count summary
   - `curl http://localhost:9090/events?event=Transaction+Submitted` — filters by event name
   - `curl -X DELETE http://localhost:9090/events` — clears all stored events

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to development-only Segment mock tooling, adding tests and more robust request handling without affecting production code paths.
> 
> **Overview**
> Adds a new `mock-segment-collector.js` dev tool that **stores incoming Segment batch events in memory** and exposes a small REST API (`GET /events`, `GET /events/summary`, `DELETE /events`) for querying/filtering and clearing collected analytics.
> 
> Refactors the mock server to be more composable and resilient: `createSegmentServer` now supports an `onBeforeRequest` hook for custom routes, centralizes CORS handling for `OPTIONS`, and safely treats malformed/non-JSON bodies as zero events. Extracts shared helpers into `segment-utils.js` (CORS + JSON responses + consistent event logging), updates `mock-segment.js` to use them and fixes `PORT` env var casing, and documents the collector usage in `development/README.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit acd919922dfbecd6af14f598315998c5809e33b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->