### PR TITLE
fix: network change alert incorrectly shown for all send transactions

### DIFF
--- a/ui/pages/confirmations/hooks/alerts/useNetworkAndOriginSwitchingAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/useNetworkAndOriginSwitchingAlerts.ts
@@ -38,7 +38,7 @@ export const useNetworkAndOriginSwitchingAlerts = (): Alert[] => {
     (async () => {
       const lastConfirmation = await getLastInteractedConfirmationInfo();
 
-      if (!isMounted) {
+      if (!isMounted || !currentConfirmation) {
         return;
       }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fix - Network and origin change alert is show for all send confirmations.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/40655

## **Manual testing steps**

1. Start send flow
2. On confirmation page check that network change alert is not visible

## **Screenshots/Recordings**
<img width="806" height="738" alt="Screenshot 2026-03-10 at 5 28 24 PM" src="https://github.com/user-attachments/assets/58643d1d-8704-4671-ba5e-473d1d58003d" />

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small conditional guard in a UI hook that only changes when last-confirmation state is updated and when alerts can trigger.
> 
> **Overview**
> Fixes false *network/origin switching* alerts by ensuring `useNetworkAndOriginSwitchingAlerts` bails out when `currentConfirmation` is not available (in addition to the existing unmount guard).
> 
> This prevents persisting/updating last-interacted confirmation info during transient states where the confirmation context is empty, avoiding alerts being shown for unrelated send confirmations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f51c58834f8811a6cab76f45ec161bbd7d04256. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->