### PR TITLE
fix: flaky test `Send Tron it should be possible to send TRX`

### DIFF
--- a/test/e2e/tests/send/send-solana.spec.ts
+++ b/test/e2e/tests/send/send-solana.spec.ts
@@ -23,6 +23,9 @@ describe('Send Solana', function () {
         await loginWithBalanceValidation(driver);
         const homePage = new HomePage(driver);
         await homePage.waitForNonEvmAccountsLoaded();
+
+        // Switch to Solana via the UI. Enabling it through fixtures causes a redirect
+        // back to the default network because the snap is not yet initialized
         await switchToNetworkFromNetworkSelect(driver, 'Popular', 'Solana');
         const sendPage = new SendPage(driver);
         const nonEvmHomepage = new NonEvmHomepage(driver);

--- a/test/e2e/tests/send/send-solana.spec.ts
+++ b/test/e2e/tests/send/send-solana.spec.ts
@@ -1,4 +1,3 @@
-import HomePage from '../../page-objects/pages/home/homepage';
 import NonEvmHomepage from '../../page-objects/pages/home/non-evm-homepage';
 import SendPage from '../../page-objects/pages/send/send-page';
 import SnapTransactionConfirmation from '../../page-objects/pages/confirmations/snap-transaction-confirmation';
@@ -21,8 +20,6 @@ describe('Send Solana', function () {
       },
       async ({ driver }) => {
         await loginWithBalanceValidation(driver);
-        const homePage = new HomePage(driver);
-        await homePage.waitForNonEvmAccountsLoaded();
 
         // Switch to Solana via the UI. Enabling it through fixtures causes a redirect
         // back to the default network because the snap is not yet initialized

--- a/test/e2e/tests/send/send-solana.spec.ts
+++ b/test/e2e/tests/send/send-solana.spec.ts
@@ -1,3 +1,4 @@
+import HomePage from '../../page-objects/pages/home/homepage';
 import NonEvmHomepage from '../../page-objects/pages/home/non-evm-homepage';
 import SendPage from '../../page-objects/pages/send/send-page';
 import SnapTransactionConfirmation from '../../page-objects/pages/confirmations/snap-transaction-confirmation';
@@ -20,9 +21,12 @@ describe('Send Solana', function () {
       },
       async ({ driver }) => {
         await loginWithBalanceValidation(driver);
+        const homePage = new HomePage(driver);
+        await homePage.waitForNonEvmAccountsLoaded();
         await switchToNetworkFromNetworkSelect(driver, 'Popular', 'Solana');
         const sendPage = new SendPage(driver);
         const nonEvmHomepage = new NonEvmHomepage(driver);
+        await nonEvmHomepage.checkExpectedTokenBalanceIsDisplayed('50', 'SOL');
         const snapTransactionConfirmation = new SnapTransactionConfirmation(
           driver,
         );

--- a/test/e2e/tests/send/send-tron.spec.ts
+++ b/test/e2e/tests/send/send-tron.spec.ts
@@ -2,7 +2,6 @@ import { withFixtures } from '../../helpers';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { Driver } from '../../webdriver/driver';
 import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow';
-import HomePage from '../../page-objects/pages/home/homepage';
 import NonEvmHomepage from '../../page-objects/pages/home/non-evm-homepage';
 import SendPage from '../../page-objects/pages/send/send-page';
 import SnapTransactionConfirmation from '../../page-objects/pages/confirmations/snap-transaction-confirmation';
@@ -23,8 +22,6 @@ describe('Send Tron', function () {
       },
       async ({ driver }: { driver: Driver }) => {
         await loginWithBalanceValidation(driver);
-        const homePage = new HomePage(driver);
-        await homePage.waitForNonEvmAccountsLoaded();
 
         // Switch to Tron via the UI. Enabling it through fixtures causes a redirect
         // back to the default network because the snap is not yet initialized

--- a/test/e2e/tests/send/send-tron.spec.ts
+++ b/test/e2e/tests/send/send-tron.spec.ts
@@ -1,7 +1,8 @@
 import { withFixtures } from '../../helpers';
-import FixtureBuilder from '../../fixtures/fixture-builder';
+import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { Driver } from '../../webdriver/driver';
 import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow';
+import HomePage from '../../page-objects/pages/home/homepage';
 import NonEvmHomepage from '../../page-objects/pages/home/non-evm-homepage';
 import SendPage from '../../page-objects/pages/send/send-page';
 import SnapTransactionConfirmation from '../../page-objects/pages/confirmations/snap-transaction-confirmation';
@@ -16,7 +17,7 @@ describe('Send Tron', function () {
   it('it should be possible to send TRX', async function () {
     await withFixtures(
       {
-        fixtures: new FixtureBuilder().build(),
+        fixtures: new FixtureBuilderV2().build(),
         title: this.test?.fullTitle(),
         testSpecificMock: mockTronApis,
         manifestFlags: {
@@ -27,6 +28,8 @@ describe('Send Tron', function () {
       },
       async ({ driver }: { driver: Driver }) => {
         await loginWithBalanceValidation(driver);
+        const homePage = new HomePage(driver);
+        await homePage.waitForNonEvmAccountsLoaded();
 
         // Switch to Tron network
         const networkManager = new NetworkManager(driver);
@@ -35,6 +38,10 @@ describe('Send Tron', function () {
         await networkManager.selectNetworkByNameWithWait('Tron');
 
         const nonEvmHomepage = new NonEvmHomepage(driver);
+        await nonEvmHomepage.checkExpectedTokenBalanceIsDisplayed(
+          '6.072',
+          'TRX',
+        );
         const snapTransactionConfirmation = new SnapTransactionConfirmation(
           driver,
         );

--- a/test/e2e/tests/send/send-tron.spec.ts
+++ b/test/e2e/tests/send/send-tron.spec.ts
@@ -20,18 +20,14 @@ describe('Send Tron', function () {
         fixtures: new FixtureBuilderV2().build(),
         title: this.test?.fullTitle(),
         testSpecificMock: mockTronApis,
-        manifestFlags: {
-          remoteFeatureFlags: {
-            tronAccounts: { enabled: true, minimumVersion: '13.6.0' },
-          },
-        },
       },
       async ({ driver }: { driver: Driver }) => {
         await loginWithBalanceValidation(driver);
         const homePage = new HomePage(driver);
         await homePage.waitForNonEvmAccountsLoaded();
 
-        // Switch to Tron network
+        // Switch to Tron via the UI. Enabling it through fixtures causes a redirect
+        // back to the default network because the snap is not yet initialized
         const networkManager = new NetworkManager(driver);
         await networkManager.openNetworkManager();
         await networkManager.selectTab('Popular');


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
We should wait for the balance for non-EVM account to be loaded before proceeding with the Send flow

<img width="1050" height="812" alt="image" src="https://github.com/user-attachments/assets/28fa7753-a48b-47b6-a897-fb8dc0ecddcb" />


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40756?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to E2E test setup/ordering and add additional UI waits to avoid race conditions when non-EVM snaps initialize and balances load.
> 
> **Overview**
> Improves reliability of the Solana and Tron send E2E specs by **switching networks via the UI** (instead of enabling via fixtures/flags) to avoid redirects during snap initialization.
> 
> Adds an explicit wait for the **expected non-EVM token balance** (e.g., `50 SOL`, `6.072 TRX`) to be displayed before proceeding with the send flow, reducing race-condition flakiness.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0aed52abd438b7e3e5079c7ccc5e7056cd72757e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->