### PR TITLE
fix: swap activity fee label paid by metamask

### DIFF
--- a/ui/pages/bridge/transaction-details/transaction-details.tsx
+++ b/ui/pages/bridge/transaction-details/transaction-details.tsx
@@ -21,6 +21,7 @@ import {
   Icon,
   IconName,
   IconSize,
+  SuccessPill,
   Text,
 } from '../../../components/component-library';
 import {
@@ -435,19 +436,23 @@ const CrossChainSwapTxDetails = () => {
             <TransactionDetailRow
               title={t('bridgeTxDetailsTotalGasFee')}
               value={
-                <>
-                  {data?.hexGasTotal &&
-                    gasCurrency?.decimals &&
-                    gasCurrency?.symbol &&
-                    formatTokenAmount(
-                      locale,
-                      new Numeric(data.hexGasTotal, 16)
-                        .toBase(10)
-                        .shiftedBy(gasCurrency.decimals ?? 0)
-                        .toString(),
-                      gasCurrency?.symbol,
-                    )}
-                </>
+                data?.isGasFeeSponsored ? (
+                  <SuccessPill label={t('swapGasFeesSponsored')} />
+                ) : (
+                  <>
+                    {data?.hexGasTotal &&
+                      gasCurrency?.decimals &&
+                      gasCurrency?.symbol &&
+                      formatTokenAmount(
+                        locale,
+                        new Numeric(data.hexGasTotal, 16)
+                          .toBase(10)
+                          .shiftedBy(gasCurrency.decimals ?? 0)
+                          .toString(),
+                        gasCurrency?.symbol,
+                      )}
+                  </>
+                )
               }
             />
           </Box>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40757?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: adds "Paid by MetaMask" on Activity "Total gas fee" row when the tx was a gas-sponsored swap.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/40737

## **Manual testing steps**

1. Select Monad or SEI network (or any gas-sponsored network).
2. Select the in-extension Swap feature.
3. Perform any swap - "Paid by MetaMask".
4. Once completed, click on the transaction item in the Activity tab.
5. Observe content of the Transaction Detail view.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

Fee information displayed, empty or 0 "Nonce" row
<img width="200" alt="image" src="https://github.com/user-attachments/assets/5d24cf8e-a8bc-4d0d-9ea0-86673624a07a" />



### **After**

"Paid by MetaMask" tag instead of fee information, no "Nonce" row.
<img width="200" alt="image" src="https://github.com/user-attachments/assets/de6fc1fe-30f0-45b8-929a-67d98780d848" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that conditionally alters the gas fee display based on an existing `isGasFeeSponsored` flag.
> 
> **Overview**
> Updates the Bridge/Swap `Transaction Details` view so the **Total gas fee** row shows a `SuccessPill` ("Paid by MetaMask" via `swapGasFeesSponsored`) when `getTransactionBreakdownData` marks the transaction as gas-fee-sponsored, instead of rendering a numeric fee amount.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8783ae5d5fe29df5031c07f69daf65fde164fd07. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->