### PR TITLE
fix: migration 196 remove exception missing nativeAssetIdentifiers

### DIFF
--- a/app/scripts/migrations/196.test.ts
+++ b/app/scripts/migrations/196.test.ts
@@ -16,7 +16,7 @@ describe(`migration #${VERSION}`, () => {
     global.sentry = undefined;
   });
 
-  it('DOES NOT modify the controller + exception if NetworkEnablementController is missing', async () => {
+  it('DOES NOT modify the controller (with no exception thrown) if NetworkEnablementController is missing', async () => {
     const oldStorage = {
       meta: { version: OLD_VERSION },
       data: {
@@ -34,9 +34,7 @@ describe(`migration #${VERSION}`, () => {
       OtherRandomController: {},
     });
     expect(changedControllers).toStrictEqual(new Set([]));
-    expect(mockedCaptureException).toHaveBeenCalledWith(
-      new Error(`Migration ${VERSION}: NetworkEnablementController not found.`),
-    );
+    expect(mockedCaptureException).not.toHaveBeenCalled();
   });
 
   it('DOES NOT modify the controller + exception if NetworkEnablementController has changed type', async () => {
@@ -72,7 +70,7 @@ describe(`migration #${VERSION}`, () => {
     );
   });
 
-  it('DOES NOT modify the controller + exception if NetworkEnablementController.nativeAssetIdentifiers is missing', async () => {
+  it('DOES NOT modify the controller (with no exception thrown) if NetworkEnablementController.nativeAssetIdentifiers is missing', async () => {
     const oldStorage = {
       meta: { version: OLD_VERSION },
       data: {
@@ -94,11 +92,7 @@ describe(`migration #${VERSION}`, () => {
       },
     });
     expect(changedControllers).toStrictEqual(new Set([]));
-    expect(mockedCaptureException).toHaveBeenCalledWith(
-      new Error(
-        `Migration ${VERSION}: NetworkEnablementController missing property nativeAssetIdentifiers.`,
-      ),
-    );
+    expect(mockedCaptureException).not.toHaveBeenCalled();
   });
 
   it('DOES NOT modify the controller + exception if NetworkEnablementController.nativeAssetIdentifiers has changed type', async () => {

--- a/app/scripts/migrations/196_utils.ts
+++ b/app/scripts/migrations/196_utils.ts
@@ -27,9 +27,6 @@ export const checkNetworkEnablementState = (
   const networkEnablementState = state.NetworkEnablementController;
 
   if (!hasProperty(state, 'NetworkEnablementController')) {
-    captureException(
-      new Error(`Migration ${version}: NetworkEnablementController not found.`),
-    );
     return false;
   }
 
@@ -43,11 +40,6 @@ export const checkNetworkEnablementState = (
   }
 
   if (!hasProperty(networkEnablementState, 'nativeAssetIdentifiers')) {
-    captureException(
-      new Error(
-        `Migration ${version}: NetworkEnablementController missing property nativeAssetIdentifiers.`,
-      ),
-    );
     return false;
   }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40764?quickstart=1)

The PR fixes two cases that we treated as exception (expected to never happen) but are not: 
- Absence of the `nativeAssetIdentifiers` : This field was created recently (1-2 months ago) but I thought it would be initialized to an empty object for new users, but I didn't realize migrations actually run before controller init.
- Absence of the `NetworkEnablementController`  : That one confused me even more because I thought that a controller should always be assumed to be present. The NetworkEnablementController (as opposed to NetworkController) is fairly recent (7 months) and my understanding is that the message is triggered by old users.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: remove thrown exceptions in migration 196 when `NetworkEnablementController` is absent or `NetworkEnablementController.nativeAssetIdentifiers` is missing.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/40788

## **Manual testing steps**

1. Go to this page...
2.
3.

(if we want to test it since it is a log message thing)
- Reset data.
- Find a version of the Extension prior the creation of NetworkEnablementController and install it.
- Update to latest.
- Check if the error message will appears in the logs.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only reduce Sentry noise by no longer capturing exceptions for optional/missing migration state, without altering the actual migration transformation logic.
> 
> **Overview**
> Migration `196` no longer calls `captureException` when `NetworkEnablementController` is absent or when `NetworkEnablementController.nativeAssetIdentifiers` is missing; it now silently no-ops in these cases while still reporting type mismatches.
> 
> Tests for migration `196` are updated to assert that no exception is captured for these missing-state scenarios.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4edc86cd9f876b6e0620dd4a0b0c123197e77ee1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->