### PR TITLE
fix: trailingComma on JSONC

### DIFF
--- a/.github/filter-rules.yml
+++ b/.github/filter-rules.yml
@@ -32,6 +32,8 @@ config_files: &config_files
   - 'prettier.config.js'
   - 'stylelint.config.js'
   - 'tailwind.config.js'
+  - '.prettierrc*'
+  - '.prettierignore'
   - 'sonar-project.properties'
   - 'codecov.yml'
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -8,7 +8,6 @@ node_modules/**/*
 /changed-files/**/*
 /coverage/**/*
 /development/chromereload.js
-/development/circular-deps.jsonc
 /development/ts-migration-dashboard/filesToConvert.json
 /development/ts-migration-dashboard/build/**
 /dist/**/*

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -5,6 +5,9 @@ singleQuote: true
 trailingComma: all
 plugins: ['prettier-plugin-sort-json']
 overrides:
+  - files: '*.jsonc'
+    options:
+      trailingComma: none
   - files:
       - 'test/e2e/tests/metrics/state-snapshots/*.json'
       - 'test/jest/console-baseline-*.json'


### PR DESCRIPTION
## **Description**

Solves a longstanding papercut where Prettier/VSCode would put trailing commas into `development/circular-deps.jsonc`, and then yellow squigglies would appear.  Also adds Prettier configuration files to the list of files that should not trigger E2E tests.

Documentation says [accepts trailing commas, but they are discouraged and the editor will display a warning](https://code.visualstudio.com/docs/languages/json#_json-with-comments)

The reason I was looking into this is that I was adding a new JSONC file in a different upcoming PR.

## **Changelog**

CHANGELOG entry: null

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**
[skip-e2e]-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only changes to formatting and CI path filters; low blast radius, with minor risk of reformat-only churn in existing `.jsonc` files.
> 
> **Overview**
> Adjusts Prettier settings by adding a `.jsonc` override that sets `trailingComma: none`, preventing editors/Prettier from emitting trailing commas in JSON-with-comments.
> 
> Updates CI path filtering to include `.prettierrc*` and `.prettierignore` as config-file changes, and removes `development/circular-deps.jsonc` from `.prettierignore` so it is formatted consistently.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 737d63e5cb42a4a8fb8636db2ec6bc4a9a662785. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->