### PR TITLE
ci: Crowdin workflow update

### DIFF
--- a/.github/workflows/crowdin-download-translations.yml
+++ b/.github/workflows/crowdin-download-translations.yml
@@ -1,0 +1,37 @@
+name: Crowdin Download Approved Translations
+
+on:
+  schedule:
+    - cron: '0 */12 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  download-translations:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.METAMASKBOT_CROWDIN_TOKEN }}
+
+      - name: Crowdin download approved translations
+        uses: crowdin/github-action@a3160b9e5a9e00739392c23da5e580c6cabe526d
+        with:
+          upload_sources: false
+          upload_translations: false
+          download_translations: true
+          export_only_approved: true
+          pull_request_title: 'chore: New Crowdin Translations by GitHub Action'
+          github_user_name: metamaskbot
+          github_user_email: metamaskbot@users.noreply.github.com
+        env:
+          GITHUB_ACTOR: metamaskbot
+          GITHUB_TOKEN: ${{ secrets.METAMASKBOT_CROWDIN_TOKEN }}
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/.github/workflows/crowdin-download-translations.yml
+++ b/.github/workflows/crowdin-download-translations.yml
@@ -5,14 +5,10 @@ on:
     - cron: '0 */12 * * *'
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   download-translations:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 3
 
     steps:
       - name: Checkout

--- a/.github/workflows/crowdin-upload-sources.yml
+++ b/.github/workflows/crowdin-upload-sources.yml
@@ -4,9 +4,7 @@ on:
   push:
     branches:
       - main
-  schedule:
-    - cron: '0 */12 * * *'
-
+      
 jobs:
   synchronize-with-crowdin:
     runs-on: ubuntu-latest
@@ -18,11 +16,12 @@ jobs:
           # Use PAT to ensure that the commit later can trigger status check workflows
           token: ${{ secrets.METAMASKBOT_CROWDIN_TOKEN }}
 
-      - name: crowdin action
+      - name: crowdin upload sources
         uses: crowdin/github-action@a3160b9e5a9e00739392c23da5e580c6cabe526d
         with:
+          upload_sources: true
           upload_translations: false
-          download_translations: true
+          download_translations: false
           pull_request_title: 'chore: New Crowdin Translations by GitHub Action'
           github_user_name: metamaskbot
           github_user_email: metamaskbot@users.noreply.github.com

--- a/.github/workflows/crowdin-upload-sources.yml
+++ b/.github/workflows/crowdin-upload-sources.yml
@@ -1,14 +1,14 @@
-name: Crowdin Action
+name: Crowdin Upload Sources
 
 on:
   push:
     branches:
       - main
-      
+
 jobs:
-  synchronize-with-crowdin:
+  upload-sources:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 3
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change? As discussed in [this Slack thread](https://consensys.slack.com/archives/C06GX49NHTP/p1772825371809799), this PR includes updates to our crowdin workflow files. Previously, we had one workflow file that was responsible for both the upload of new source content and the download of approved translations. The problem with this workflow is that the translation PRs were notoriously hard to merge because the CI process would restart (and approvals would reset) every time a new commit was pushed to the PR.
2. What is the improvement/solution? By implementing an upload workflow and a download workflow, we separate these actions to reduce noise when we are trying to merge the translation PR to main. The upload workflow will continue as it has been, with new and changed strings being pushed to Crowdin every time a PR is merged to main. Now, the download translations action will run every 12 hours. This means we should be able to pull down approved translations, approve the PR, confirm it passes CI checks, and merge it within 12 hours, without having to re-request approvals multiple times. 
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40778?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes CI automation that publishes to Crowdin and opens translation PRs; misconfiguration could stop source sync or scheduled downloads.
> 
> **Overview**
> Separates Crowdin automation into two workflows: a `Crowdin Upload Sources` job that runs on `main` pushes and only uploads sources, and a new scheduled/manual `Crowdin Download Approved Translations` job that only downloads *approved* translations and opens the usual PR.
> 
> Also reduces workflow timeouts to 3 minutes and removes the previous scheduled run from the upload workflow to avoid retriggering/approval resets on translation PRs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d92fa1eb877fd9db35d5fa39736eedb25418d1e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->