### PR TITLE
feat: Add support for additional icon colors in `SnapUIIcon`

### DIFF
--- a/ui/components/app/snaps/snap-ui-renderer/components/icon.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/icon.ts
@@ -19,6 +19,12 @@ export const icon: UIComponentFactory<IconElement> = ({ element }) => {
         return IconColor.iconMuted;
       case 'primary':
         return IconColor.primaryDefault;
+      case 'error':
+        return IconColor.errorDefault;
+      case 'warning':
+        return IconColor.warningDefault;
+      case 'success':
+        return IconColor.successDefault;
       default:
         return IconColor.iconDefault;
     }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Add mapping for additional icon colors.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40797?quickstart=1)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated UI mapping change that only affects icon color rendering and has no security or data-handling impact.
> 
> **Overview**
> Adds support for additional `SnapUIIcon` color values by mapping `error`, `warning`, and `success` to their corresponding design-system `IconColor` tokens (in addition to existing `muted`/`primary`), while keeping the default color fallback unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28146222d2a502a854dda5ab9ff2375ff814f77c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->