### PR TITLE
fix: cp-13.23.0 gas station in metamask pay

### DIFF
--- a/app/scripts/controller-init/confirmations/transaction-controller-init.test.ts
+++ b/app/scripts/controller-init/confirmations/transaction-controller-init.test.ts
@@ -1,6 +1,7 @@
 import { NetworkController } from '@metamask/network-controller';
 // Mocha type definitions are conflicting with Jest
 import { it as jestIt } from '@jest/globals';
+import { ORIGIN_METAMASK } from '@metamask/controller-utils';
 import {
   TransactionMeta,
   TransactionType,
@@ -242,22 +243,13 @@ describe('Transaction Controller Init', () => {
     expect(pendingTransactions?.isResubmitEnabled?.()).toBe(false);
   });
 
-  jestIt.each([
-    ['swap', TransactionType.swap, false],
-    ['swapApproval', TransactionType.swapApproval, false],
-    ['bridge', TransactionType.bridge, false],
-    ['bridgeApproval', TransactionType.bridgeApproval, false],
-    ['contractInteraction', TransactionType.contractInteraction, true],
-  ])(
-    'disables automatic gas fee updates for %s transactions',
-    (_label, type, gasFeeUpdateEnabled) => {
-      const isAutomaticGasFeeUpdateEnabled = testConstructorOption(
-        'isAutomaticGasFeeUpdateEnabled',
-      );
-
-      const tx: TransactionMeta = {
+  describe('isAutomaticGasFeeUpdateEnabled', () => {
+    function buildTransactionMeta(
+      overrides: Partial<TransactionMeta> = {},
+    ): TransactionMeta {
+      return {
         id: '1',
-        type,
+        type: TransactionType.contractInteraction,
         chainId: CHAIN_ID_MOCK,
         networkClientId: 'test-network',
         status: TransactionStatus.unapproved,
@@ -265,11 +257,107 @@ describe('Transaction Controller Init', () => {
         txParams: {
           from: '0x0000000000000000000000000000000000000000',
         },
+        ...overrides,
       };
+    }
 
-      expect(isAutomaticGasFeeUpdateEnabled?.(tx)).toBe(gasFeeUpdateEnabled);
-    },
-  );
+    jestIt.each([
+      ['swap', TransactionType.swap, false],
+      ['swapApproval', TransactionType.swapApproval, false],
+      ['bridge', TransactionType.bridge, false],
+      ['bridgeApproval', TransactionType.bridgeApproval, false],
+      ['contractInteraction', TransactionType.contractInteraction, true],
+    ])('returns %s for %s transactions', (_label, type, expected) => {
+      const isAutomaticGasFeeUpdateEnabled = testConstructorOption(
+        'isAutomaticGasFeeUpdateEnabled',
+      );
+
+      expect(
+        isAutomaticGasFeeUpdateEnabled?.(buildTransactionMeta({ type })),
+      ).toBe(expected);
+    });
+
+    it('returns false for relayDeposit transactions', () => {
+      const isAutomaticGasFeeUpdateEnabled = testConstructorOption(
+        'isAutomaticGasFeeUpdateEnabled',
+      );
+
+      expect(
+        isAutomaticGasFeeUpdateEnabled?.(
+          buildTransactionMeta({ type: TransactionType.relayDeposit }),
+        ),
+      ).toBe(false);
+    });
+
+    it('returns false for perpsRelayDeposit transactions', () => {
+      const isAutomaticGasFeeUpdateEnabled = testConstructorOption(
+        'isAutomaticGasFeeUpdateEnabled',
+      );
+
+      expect(
+        isAutomaticGasFeeUpdateEnabled?.(
+          buildTransactionMeta({ type: TransactionType.perpsRelayDeposit }),
+        ),
+      ).toBe(false);
+    });
+
+    it('returns false for predictRelayDeposit transactions', () => {
+      const isAutomaticGasFeeUpdateEnabled = testConstructorOption(
+        'isAutomaticGasFeeUpdateEnabled',
+      );
+
+      expect(
+        isAutomaticGasFeeUpdateEnabled?.(
+          buildTransactionMeta({ type: TransactionType.predictRelayDeposit }),
+        ),
+      ).toBe(false);
+    });
+
+    it('returns false for transactions with nested relayDeposit type', () => {
+      const isAutomaticGasFeeUpdateEnabled = testConstructorOption(
+        'isAutomaticGasFeeUpdateEnabled',
+      );
+
+      expect(
+        isAutomaticGasFeeUpdateEnabled?.(
+          buildTransactionMeta({
+            type: TransactionType.contractInteraction,
+            nestedTransactions: [{ type: TransactionType.relayDeposit }],
+          }),
+        ),
+      ).toBe(false);
+    });
+
+    it('returns false for tokenMethodApprove with ORIGIN_METAMASK', () => {
+      const isAutomaticGasFeeUpdateEnabled = testConstructorOption(
+        'isAutomaticGasFeeUpdateEnabled',
+      );
+
+      expect(
+        isAutomaticGasFeeUpdateEnabled?.(
+          buildTransactionMeta({
+            type: TransactionType.tokenMethodApprove,
+            origin: ORIGIN_METAMASK,
+          }),
+        ),
+      ).toBe(false);
+    });
+
+    it('returns true for tokenMethodApprove with non-MetaMask origin', () => {
+      const isAutomaticGasFeeUpdateEnabled = testConstructorOption(
+        'isAutomaticGasFeeUpdateEnabled',
+      );
+
+      expect(
+        isAutomaticGasFeeUpdateEnabled?.(
+          buildTransactionMeta({
+            type: TransactionType.tokenMethodApprove,
+            origin: 'https://external-dapp.com',
+          }),
+        ),
+      ).toBe(true);
+    });
+  });
 
   describe('publish hook', () => {
     const mockTransactionMeta: TransactionMeta = {

--- a/app/scripts/controller-init/confirmations/transaction-controller-init.test.ts
+++ b/app/scripts/controller-init/confirmations/transaction-controller-init.test.ts
@@ -266,6 +266,9 @@ describe('Transaction Controller Init', () => {
       ['swapApproval', TransactionType.swapApproval, false],
       ['bridge', TransactionType.bridge, false],
       ['bridgeApproval', TransactionType.bridgeApproval, false],
+      ['relayDeposit', TransactionType.relayDeposit, false],
+      ['perpsRelayDeposit', TransactionType.perpsRelayDeposit, false],
+      ['predictRelayDeposit', TransactionType.predictRelayDeposit, false],
       ['contractInteraction', TransactionType.contractInteraction, true],
     ])('returns %s for %s transactions', (_label, type, expected) => {
       const isAutomaticGasFeeUpdateEnabled = testConstructorOption(
@@ -275,42 +278,6 @@ describe('Transaction Controller Init', () => {
       expect(
         isAutomaticGasFeeUpdateEnabled?.(buildTransactionMeta({ type })),
       ).toBe(expected);
-    });
-
-    it('returns false for relayDeposit transactions', () => {
-      const isAutomaticGasFeeUpdateEnabled = testConstructorOption(
-        'isAutomaticGasFeeUpdateEnabled',
-      );
-
-      expect(
-        isAutomaticGasFeeUpdateEnabled?.(
-          buildTransactionMeta({ type: TransactionType.relayDeposit }),
-        ),
-      ).toBe(false);
-    });
-
-    it('returns false for perpsRelayDeposit transactions', () => {
-      const isAutomaticGasFeeUpdateEnabled = testConstructorOption(
-        'isAutomaticGasFeeUpdateEnabled',
-      );
-
-      expect(
-        isAutomaticGasFeeUpdateEnabled?.(
-          buildTransactionMeta({ type: TransactionType.perpsRelayDeposit }),
-        ),
-      ).toBe(false);
-    });
-
-    it('returns false for predictRelayDeposit transactions', () => {
-      const isAutomaticGasFeeUpdateEnabled = testConstructorOption(
-        'isAutomaticGasFeeUpdateEnabled',
-      );
-
-      expect(
-        isAutomaticGasFeeUpdateEnabled?.(
-          buildTransactionMeta({ type: TransactionType.predictRelayDeposit }),
-        ),
-      ).toBe(false);
     });
 
     it('returns false for transactions with nested relayDeposit type', () => {

--- a/app/scripts/controller-init/confirmations/transaction-controller-init.test.ts
+++ b/app/scripts/controller-init/confirmations/transaction-controller-init.test.ts
@@ -22,6 +22,7 @@ import { buildControllerInitRequestMock, CHAIN_ID_MOCK } from '../test/utils';
 import { ControllerInitRequest } from '../types';
 import * as smartTransactionsModule from '../../lib/smart-transaction/smart-transactions';
 import * as sentinelApiModule from '../../lib/transaction/sentinel-api';
+import * as selectorsModule from '../../../../shared/lib/selectors';
 import { Delegation7702PublishHook } from '../../lib/transaction/hooks/delegation-7702-publish';
 import { TransactionControllerInit } from './transaction-controller-init';
 
@@ -30,6 +31,7 @@ jest.mock('@metamask/transaction-pay-controller');
 jest.mock('../../lib/smart-transaction/smart-transactions');
 jest.mock('../../lib/transaction/sentinel-api');
 jest.mock('../../lib/transaction/hooks/delegation-7702-publish');
+jest.mock('../../../../shared/lib/selectors');
 
 /**
  * Build a mock NetworkController.
@@ -322,6 +324,77 @@ describe('Transaction Controller Init', () => {
             origin: 'https://external-dapp.com',
           }),
         ),
+      ).toBe(true);
+    });
+  });
+
+  describe('isEIP7702GasFeeTokensEnabled', () => {
+    const getIsSmartTransactionMock = jest.mocked(
+      selectorsModule.getIsSmartTransaction,
+    );
+
+    const isSendBundleSupportedMock = jest.mocked(
+      sentinelApiModule.isSendBundleSupported,
+    );
+
+    const mockTransactionMeta = {
+      id: '1',
+      status: TransactionStatus.unapproved,
+      chainId: CHAIN_ID_MOCK,
+      networkClientId: 'test-network',
+      time: Date.now(),
+      txParams: {
+        from: '0x0000000000000000000000000000000000000000',
+      },
+    } as TransactionMeta;
+
+    it('returns true when smart transactions disabled and send bundle not supported', async () => {
+      getIsSmartTransactionMock.mockReturnValue(false);
+      isSendBundleSupportedMock.mockResolvedValue(false);
+
+      const optionFn = testConstructorOption('isEIP7702GasFeeTokensEnabled');
+
+      expect(await optionFn?.(mockTransactionMeta)).toBe(true);
+    });
+
+    it('returns false when smart transactions enabled and send bundle supported', async () => {
+      getIsSmartTransactionMock.mockReturnValue(true);
+      isSendBundleSupportedMock.mockResolvedValue(true);
+
+      const optionFn = testConstructorOption('isEIP7702GasFeeTokensEnabled');
+
+      expect(await optionFn?.(mockTransactionMeta)).toBe(false);
+    });
+
+    it('returns true when smart transactions disabled and send bundle supported', async () => {
+      getIsSmartTransactionMock.mockReturnValue(false);
+      isSendBundleSupportedMock.mockResolvedValue(true);
+
+      const optionFn = testConstructorOption('isEIP7702GasFeeTokensEnabled');
+
+      expect(await optionFn?.(mockTransactionMeta)).toBe(true);
+    });
+
+    it('returns true when smart transactions enabled and send bundle not supported', async () => {
+      getIsSmartTransactionMock.mockReturnValue(true);
+      isSendBundleSupportedMock.mockResolvedValue(false);
+
+      const optionFn = testConstructorOption('isEIP7702GasFeeTokensEnabled');
+
+      expect(await optionFn?.(mockTransactionMeta)).toBe(true);
+    });
+
+    it('returns true when isExternalSign is true', async () => {
+      getIsSmartTransactionMock.mockReturnValue(true);
+      isSendBundleSupportedMock.mockResolvedValue(true);
+
+      const optionFn = testConstructorOption('isEIP7702GasFeeTokensEnabled');
+
+      expect(
+        await optionFn?.({
+          ...mockTransactionMeta,
+          isExternalSign: true,
+        }),
       ).toBe(true);
     });
   });

--- a/app/scripts/controller-init/confirmations/transaction-controller-init.ts
+++ b/app/scripts/controller-init/confirmations/transaction-controller-init.ts
@@ -127,7 +127,7 @@ export const TransactionControllerInit: ControllerInitFunction<
     },
     isAutomaticGasFeeUpdateEnabled,
     isEIP7702GasFeeTokensEnabled: async (transactionMeta) => {
-      const { chainId } = transactionMeta;
+      const { chainId, isExternalSign } = transactionMeta;
       const uiState = getUIState(getFlatState());
 
       // @ts-expect-error Smart transaction selector types does not match controller state
@@ -137,8 +137,13 @@ export const TransactionControllerInit: ControllerInitFunction<
 
       // EIP7702 gas fee tokens are enabled when:
       // - Smart transactions are NOT enabled, OR
-      // - Send bundle is NOT supported
-      return !isSmartTransactionEnabled || !isSendBundleSupportedChain;
+      // - Send bundle is NOT supported, OR
+      // - Gas fee token was provided when creating transaction
+      return (
+        !isSmartTransactionEnabled ||
+        !isSendBundleSupportedChain ||
+        Boolean(isExternalSign)
+      );
     },
     isFirstTimeInteractionEnabled: () =>
       preferencesController().state.securityAlertsEnabled,

--- a/app/scripts/controller-init/confirmations/transaction-controller-init.ts
+++ b/app/scripts/controller-init/confirmations/transaction-controller-init.ts
@@ -1,4 +1,5 @@
 import { PRODUCT_TYPES } from '@metamask/subscription-controller';
+import { ORIGIN_METAMASK } from '@metamask/controller-utils';
 import {
   type PublishBatchHookRequest,
   type PublishBatchHookTransaction,
@@ -113,18 +114,7 @@ export const TransactionControllerInit: ControllerInitFunction<
         onboardingController().state.completedOnboarding,
       updateTransactions: true,
     },
-    isAutomaticGasFeeUpdateEnabled: ({ type }) => {
-      // Disables automatic gas fee updates for swap and bridge transactions
-      // which provide their own gas parameters when they are submitted
-      const disabledTypes = [
-        TransactionType.swap,
-        TransactionType.swapApproval,
-        TransactionType.bridge,
-        TransactionType.bridgeApproval,
-      ];
-
-      return !type || !disabledTypes.includes(type);
-    },
+    isAutomaticGasFeeUpdateEnabled,
     isEIP7702GasFeeTokensEnabled: async (transactionMeta) => {
       const { chainId } = transactionMeta;
       const uiState = getUIState(getFlatState());
@@ -462,4 +452,49 @@ export function publishBatchHook({
     featureFlags,
     transactionMeta,
   });
+}
+
+const DISABLED_AUTOMATIC_GAS_FEE_UPDATE_TYPES = [
+  TransactionType.swap,
+  TransactionType.swapApproval,
+  TransactionType.bridge,
+  TransactionType.bridgeApproval,
+];
+
+const RELAY_DEPOSIT_TYPES = [
+  TransactionType.relayDeposit,
+  TransactionType.perpsRelayDeposit,
+  TransactionType.predictRelayDeposit,
+];
+
+function isAutomaticGasFeeUpdateEnabled(transaction: TransactionMeta) {
+  if (hasRelayDepositType(transaction)) {
+    return false;
+  }
+
+  if (
+    transaction.origin === ORIGIN_METAMASK &&
+    transaction.type === TransactionType.tokenMethodApprove
+  ) {
+    return false;
+  }
+
+  return (
+    !transaction.type ||
+    !DISABLED_AUTOMATIC_GAS_FEE_UPDATE_TYPES.includes(transaction.type)
+  );
+}
+
+function hasRelayDepositType(transaction: TransactionMeta) {
+  const { nestedTransactions, type } = transaction;
+
+  if (RELAY_DEPOSIT_TYPES.includes(type as TransactionType)) {
+    return true;
+  }
+
+  return (
+    nestedTransactions?.some((tx) =>
+      RELAY_DEPOSIT_TYPES.includes(tx.type as TransactionType),
+    ) ?? false
+  );
 }

--- a/app/scripts/controller-init/confirmations/transaction-controller-init.ts
+++ b/app/scripts/controller-init/confirmations/transaction-controller-init.ts
@@ -19,6 +19,7 @@ import {
 } from '@metamask/transaction-pay-controller';
 import { Hex } from '@metamask/utils';
 import { trace } from '../../../../shared/lib/trace';
+import { hasTransactionType } from '../../../../shared/lib/transactions.utils';
 import { getIsSmartTransaction } from '../../../../shared/lib/selectors';
 import { getShieldGatewayConfig } from '../../../../shared/lib/shield';
 import { TransactionMetricsRequest } from '../../../../shared/types/metametrics';
@@ -49,6 +50,16 @@ import {
   ControllerInitRequest,
   ControllerInitResult,
 } from '../types';
+
+const DISABLED_AUTOMATIC_GAS_FEE_UPDATE_TYPES = [
+  TransactionType.swap,
+  TransactionType.swapApproval,
+  TransactionType.bridge,
+  TransactionType.bridgeApproval,
+  TransactionType.relayDeposit,
+  TransactionType.perpsRelayDeposit,
+  TransactionType.predictRelayDeposit,
+];
 
 export const TransactionControllerInit: ControllerInitFunction<
   TransactionController,
@@ -454,24 +465,7 @@ export function publishBatchHook({
   });
 }
 
-const DISABLED_AUTOMATIC_GAS_FEE_UPDATE_TYPES = [
-  TransactionType.swap,
-  TransactionType.swapApproval,
-  TransactionType.bridge,
-  TransactionType.bridgeApproval,
-];
-
-const RELAY_DEPOSIT_TYPES = [
-  TransactionType.relayDeposit,
-  TransactionType.perpsRelayDeposit,
-  TransactionType.predictRelayDeposit,
-];
-
 function isAutomaticGasFeeUpdateEnabled(transaction: TransactionMeta) {
-  if (hasRelayDepositType(transaction)) {
-    return false;
-  }
-
   if (
     transaction.origin === ORIGIN_METAMASK &&
     transaction.type === TransactionType.tokenMethodApprove
@@ -479,22 +473,8 @@ function isAutomaticGasFeeUpdateEnabled(transaction: TransactionMeta) {
     return false;
   }
 
-  return (
-    !transaction.type ||
-    !DISABLED_AUTOMATIC_GAS_FEE_UPDATE_TYPES.includes(transaction.type)
-  );
-}
-
-function hasRelayDepositType(transaction: TransactionMeta) {
-  const { nestedTransactions, type } = transaction;
-
-  if (RELAY_DEPOSIT_TYPES.includes(type as TransactionType)) {
-    return true;
-  }
-
-  return (
-    nestedTransactions?.some((tx) =>
-      RELAY_DEPOSIT_TYPES.includes(tx.type as TransactionType),
-    ) ?? false
+  return !hasTransactionType(
+    transaction,
+    DISABLED_AUTOMATIC_GAS_FEE_UPDATE_TYPES,
   );
 }

--- a/shared/lib/transactions.utils.test.ts
+++ b/shared/lib/transactions.utils.test.ts
@@ -1,5 +1,9 @@
-import { NestedTransactionMetadata } from '@metamask/transaction-controller';
-import { isBatchTransaction } from './transactions.utils';
+import {
+  NestedTransactionMetadata,
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
+import { isBatchTransaction, hasTransactionType } from './transactions.utils';
 
 describe('Transactions utils', () => {
   describe('isBatchTransaction', () => {
@@ -14,6 +18,98 @@ describe('Transactions utils', () => {
 
     it('returns false when nestedTransactions is undefined', () => {
       expect(isBatchTransaction(undefined)).toBe(false);
+    });
+  });
+
+  describe('hasTransactionType', () => {
+    it('returns true when transaction type matches', () => {
+      const transactionMeta = {
+        type: TransactionType.simpleSend,
+      } as TransactionMeta;
+
+      expect(
+        hasTransactionType(transactionMeta, [TransactionType.simpleSend]),
+      ).toBe(true);
+    });
+
+    it('returns true when transaction type is in the list', () => {
+      const transactionMeta = {
+        type: TransactionType.tokenMethodTransfer,
+      } as TransactionMeta;
+
+      expect(
+        hasTransactionType(transactionMeta, [
+          TransactionType.simpleSend,
+          TransactionType.tokenMethodTransfer,
+        ]),
+      ).toBe(true);
+    });
+
+    it('returns false when transaction type does not match', () => {
+      const transactionMeta = {
+        type: TransactionType.simpleSend,
+      } as TransactionMeta;
+
+      expect(
+        hasTransactionType(transactionMeta, [
+          TransactionType.tokenMethodTransfer,
+        ]),
+      ).toBe(false);
+    });
+
+    it('returns false when transactionMeta is undefined', () => {
+      expect(hasTransactionType(undefined, [TransactionType.simpleSend])).toBe(
+        false,
+      );
+    });
+
+    it('returns true when nested transaction type matches', () => {
+      const transactionMeta = {
+        type: TransactionType.simpleSend,
+        nestedTransactions: [
+          { type: TransactionType.tokenMethodApprove },
+          { type: TransactionType.tokenMethodTransfer },
+        ],
+      } as unknown as TransactionMeta;
+
+      expect(
+        hasTransactionType(transactionMeta, [
+          TransactionType.tokenMethodApprove,
+        ]),
+      ).toBe(true);
+    });
+
+    it('returns false when neither top-level nor nested types match', () => {
+      const transactionMeta = {
+        type: TransactionType.simpleSend,
+        nestedTransactions: [{ type: TransactionType.tokenMethodTransfer }],
+      } as unknown as TransactionMeta;
+
+      expect(hasTransactionType(transactionMeta, [TransactionType.swap])).toBe(
+        false,
+      );
+    });
+
+    it('returns true for top-level type even with nested transactions', () => {
+      const transactionMeta = {
+        type: TransactionType.swap,
+        nestedTransactions: [{ type: TransactionType.tokenMethodTransfer }],
+      } as unknown as TransactionMeta;
+
+      expect(hasTransactionType(transactionMeta, [TransactionType.swap])).toBe(
+        true,
+      );
+    });
+
+    it('returns false when nestedTransactions is empty', () => {
+      const transactionMeta = {
+        type: TransactionType.simpleSend,
+        nestedTransactions: [],
+      } as unknown as TransactionMeta;
+
+      expect(hasTransactionType(transactionMeta, [TransactionType.swap])).toBe(
+        false,
+      );
     });
   });
 });

--- a/shared/lib/transactions.utils.ts
+++ b/shared/lib/transactions.utils.ts
@@ -1,4 +1,8 @@
-import { NestedTransactionMetadata } from '@metamask/transaction-controller';
+import {
+  NestedTransactionMetadata,
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
 
 /**
  * Determines if a transaction is a batch transaction.
@@ -10,4 +14,28 @@ export function isBatchTransaction(
   nestedTransactions: NestedTransactionMetadata[] | undefined,
 ): boolean {
   return Boolean(nestedTransactions?.length);
+}
+
+/**
+ * Checks if a transaction (including nested transactions) matches any of the given types.
+ *
+ * @param transactionMeta - The transaction metadata to check.
+ * @param types - The transaction types to match against.
+ * @returns Whether the transaction or any nested transaction matches one of the types.
+ */
+export function hasTransactionType(
+  transactionMeta: TransactionMeta | undefined,
+  types: TransactionType[],
+) {
+  const { nestedTransactions, type } = transactionMeta ?? {};
+
+  if (types.includes(type as TransactionType)) {
+    return true;
+  }
+
+  return (
+    nestedTransactions?.some((tx) =>
+      types.includes(tx.type as TransactionType),
+    ) ?? false
+  );
 }

--- a/ui/pages/confirmations/components/activity/transaction-details-summary/transaction-details-summary.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-summary/transaction-details-summary.tsx
@@ -26,7 +26,7 @@ import { selectNetworkConfigurationByChainId } from '../../../../../selectors';
 import { useTokenWithBalance } from '../../../hooks/tokens/useTokenWithBalance';
 import { BlockExplorerLink } from '../block-explorer-link';
 import { TransactionStatusIcon } from '../transaction-status-icon';
-import { hasTransactionType } from '../../../utils/transaction-pay';
+import { hasTransactionType } from '../../../../../../shared/lib/transactions.utils';
 
 type TranslateFunction = (key: string, args?: string[]) => string;
 

--- a/ui/pages/confirmations/components/rows/bridge-time-row/bridge-time-row.tsx
+++ b/ui/pages/confirmations/components/rows/bridge-time-row/bridge-time-row.tsx
@@ -21,7 +21,7 @@ import {
 import { useTransactionPayToken } from '../../../hooks/pay/useTransactionPayToken';
 import { useConfirmContext } from '../../../context/confirm';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
-import { hasTransactionType } from '../../../utils/transaction-pay';
+import { hasTransactionType } from '../../../../../../shared/lib/transactions.utils';
 
 const SAME_CHAIN_DURATION_SECONDS = '< 10';
 

--- a/ui/pages/confirmations/hooks/pay/useTransactionPayMetrics.ts
+++ b/ui/pages/confirmations/hooks/pay/useTransactionPayMetrics.ts
@@ -9,7 +9,7 @@ import { getNativeTokenAddress } from '@metamask/assets-controllers';
 import { BigNumber } from 'bignumber.js';
 import type { TransactionPaymentToken } from '@metamask/transaction-pay-controller';
 import { useConfirmContext } from '../../context/confirm';
-import { hasTransactionType } from '../../utils/transaction-pay';
+import { hasTransactionType } from '../../../../../shared/lib/transactions.utils';
 import { updateEventFragment } from '../../../../store/actions';
 import { useTransactionPayToken } from './useTransactionPayToken';
 import {

--- a/ui/pages/confirmations/utils/transaction-pay.test.ts
+++ b/ui/pages/confirmations/utils/transaction-pay.test.ts
@@ -1,7 +1,4 @@
-import {
-  TransactionMeta,
-  TransactionType,
-} from '@metamask/transaction-controller';
+import { TransactionMeta } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 import type {
   TransactionPayRequiredToken,
@@ -9,7 +6,6 @@ import type {
 } from '@metamask/transaction-pay-controller';
 import { Asset, AssetStandard } from '../types/send';
 import {
-  hasTransactionType,
   getTokenTransferData,
   getTokenAddress,
   getAvailableTokens,
@@ -75,98 +71,6 @@ function createMockRequiredToken(
 }
 
 describe('transaction-pay utils', () => {
-  describe('hasTransactionType', () => {
-    it('returns true when transaction type matches', () => {
-      const transactionMeta = {
-        type: TransactionType.simpleSend,
-      } as TransactionMeta;
-
-      expect(
-        hasTransactionType(transactionMeta, [TransactionType.simpleSend]),
-      ).toBe(true);
-    });
-
-    it('returns true when transaction type is in the list', () => {
-      const transactionMeta = {
-        type: TransactionType.tokenMethodTransfer,
-      } as TransactionMeta;
-
-      expect(
-        hasTransactionType(transactionMeta, [
-          TransactionType.simpleSend,
-          TransactionType.tokenMethodTransfer,
-        ]),
-      ).toBe(true);
-    });
-
-    it('returns false when transaction type does not match', () => {
-      const transactionMeta = {
-        type: TransactionType.simpleSend,
-      } as TransactionMeta;
-
-      expect(
-        hasTransactionType(transactionMeta, [
-          TransactionType.tokenMethodTransfer,
-        ]),
-      ).toBe(false);
-    });
-
-    it('returns false when transactionMeta is undefined', () => {
-      expect(hasTransactionType(undefined, [TransactionType.simpleSend])).toBe(
-        false,
-      );
-    });
-
-    it('returns true when nested transaction type matches', () => {
-      const transactionMeta = {
-        type: TransactionType.simpleSend,
-        nestedTransactions: [
-          { type: TransactionType.tokenMethodApprove },
-          { type: TransactionType.tokenMethodTransfer },
-        ],
-      } as unknown as TransactionMeta;
-
-      expect(
-        hasTransactionType(transactionMeta, [
-          TransactionType.tokenMethodApprove,
-        ]),
-      ).toBe(true);
-    });
-
-    it('returns false when neither top-level nor nested types match', () => {
-      const transactionMeta = {
-        type: TransactionType.simpleSend,
-        nestedTransactions: [{ type: TransactionType.tokenMethodTransfer }],
-      } as unknown as TransactionMeta;
-
-      expect(hasTransactionType(transactionMeta, [TransactionType.swap])).toBe(
-        false,
-      );
-    });
-
-    it('returns true for top-level type even with nested transactions', () => {
-      const transactionMeta = {
-        type: TransactionType.swap,
-        nestedTransactions: [{ type: TransactionType.tokenMethodTransfer }],
-      } as unknown as TransactionMeta;
-
-      expect(hasTransactionType(transactionMeta, [TransactionType.swap])).toBe(
-        true,
-      );
-    });
-
-    it('returns false when nestedTransactions is empty', () => {
-      const transactionMeta = {
-        type: TransactionType.simpleSend,
-        nestedTransactions: [],
-      } as unknown as TransactionMeta;
-
-      expect(hasTransactionType(transactionMeta, [TransactionType.swap])).toBe(
-        false,
-      );
-    });
-  });
-
   describe('getTokenTransferData', () => {
     it('returns token transfer data from txParams when data starts with transfer selector', () => {
       const transactionMeta = {

--- a/ui/pages/confirmations/utils/transaction-pay.test.ts
+++ b/ui/pages/confirmations/utils/transaction-pay.test.ts
@@ -264,13 +264,6 @@ describe('transaction-pay utils', () => {
       expect(result[0].address).toBe(TOKEN_ADDRESS_2_MOCK);
     });
 
-    it('marks token as disabled when no native balance', () => {
-      const tokens = [createMockAsset({ address: TOKEN_ADDRESS_MOCK })];
-
-      const result = getAvailableTokens({ tokens });
-
-      expect(result[0].disabled).toBe(true);
-    });
 
     it('marks token as enabled when native token has balance', () => {
       const tokens = [

--- a/ui/pages/confirmations/utils/transaction-pay.test.ts
+++ b/ui/pages/confirmations/utils/transaction-pay.test.ts
@@ -264,7 +264,6 @@ describe('transaction-pay utils', () => {
       expect(result[0].address).toBe(TOKEN_ADDRESS_2_MOCK);
     });
 
-
     it('marks token as enabled when native token has balance', () => {
       const tokens = [
         createMockAsset({ address: TOKEN_ADDRESS_MOCK }),

--- a/ui/pages/confirmations/utils/transaction-pay.ts
+++ b/ui/pages/confirmations/utils/transaction-pay.ts
@@ -1,7 +1,4 @@
-import {
-  TransactionMeta,
-  TransactionType,
-} from '@metamask/transaction-controller';
+import { TransactionMeta } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 import type {
   TransactionPayRequiredToken,
@@ -12,23 +9,6 @@ import { BigNumber } from 'bignumber.js';
 import { Asset, AssetStandard } from '../types/send';
 
 const FOUR_BYTE_TOKEN_TRANSFER = '0xa9059cbb';
-
-export function hasTransactionType(
-  transactionMeta: TransactionMeta | undefined,
-  types: TransactionType[],
-) {
-  const { nestedTransactions, type } = transactionMeta ?? {};
-
-  if (types.includes(type as TransactionType)) {
-    return true;
-  }
-
-  return (
-    nestedTransactions?.some((tx) =>
-      types.includes(tx.type as TransactionType),
-    ) ?? false
-  );
-}
 
 export function getTokenTransferData(
   transactionMeta: TransactionMeta | undefined,

--- a/ui/pages/confirmations/utils/transaction-pay.ts
+++ b/ui/pages/confirmations/utils/transaction-pay.ts
@@ -107,10 +107,12 @@ export function getAvailableTokens({
           t.chainId === chainId && t.address === getNativeTokenAddress(chainId),
       );
 
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const noNativeBalance =
         !nativeToken || new BigNumber(nativeToken.balance ?? 0).isZero();
 
-      const disabled = noNativeBalance;
+      // Temporary pending gas station feature flag integration.
+      const disabled = false;
 
       const isSelected =
         payToken?.address.toLowerCase() === token.address?.toLowerCase() &&


### PR DESCRIPTION
## **Description**

Resolve unstable gas station support in MetaMask Pay due to automatic gas fee updates on internal deposit transactions, and incorrect gas fee tokens request when STX enabled.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40799?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes transaction fee-update gating and EIP-7702 gas-fee-token enablement logic, which can affect how transactions are priced and submitted across several MetaMask Pay flows.
> 
> **Overview**
> Fixes MetaMask Pay “gas station” instability by tightening when **automatic gas fee updates** run: updates are now disabled for swap/bridge *and* relay-deposit transaction types (including nested relay deposits) and for internal MetaMask-origin `tokenMethodApprove` transactions.
> 
> Adjusts `isEIP7702GasFeeTokensEnabled` so gas-fee tokens remain enabled when a transaction was created with an external gas-fee token (`isExternalSign`), even if smart transactions and send-bundle support are on.
> 
> Consolidates `hasTransactionType` into `shared/lib/transactions.utils` (with new unit tests) and updates confirmation UI code to import it from shared; removes the duplicate implementation from `transaction-pay` utilities. Also temporarily forces `getAvailableTokens` to never mark tokens disabled (pending gas-station feature flag integration), and updates/extends tests accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94cc9d39fabcfea755f2052b51409cd4118ec185. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->