### PR TITLE
fix: disable closing price impact modal while submitting a trade

### DIFF
--- a/ui/pages/bridge/hooks/useSubmitBridgeTransaction.ts
+++ b/ui/pages/bridge/hooks/useSubmitBridgeTransaction.ts
@@ -156,8 +156,6 @@ export default function useSubmitBridgeTransaction() {
         navigateToBridgePage();
         return;
       }
-      navigateToActivityPage();
-      return;
     } finally {
       setIsSubmitting(false);
     }

--- a/ui/pages/bridge/prepare/bridge-price-impact-modal.test.tsx
+++ b/ui/pages/bridge/prepare/bridge-price-impact-modal.test.tsx
@@ -88,7 +88,7 @@ describe('BridgePriceImpactModal', () => {
           getByRole('button', { name: messages.proceed.message }),
         );
       });
-      expect(mockOnClose).toHaveBeenCalledTimes(1);
+      expect(mockOnClose).toHaveBeenCalledTimes(0);
       expect(mockSubmitBridgeTransaction).toHaveBeenCalledTimes(1);
     });
 

--- a/ui/pages/bridge/prepare/bridge-price-impact-modal.tsx
+++ b/ui/pages/bridge/prepare/bridge-price-impact-modal.tsx
@@ -65,7 +65,7 @@ export const BridgePriceImpactWarningModal = ({
     return true;
   }, [variant, isPriceImpactError, isPriceImpactWarning]);
 
-  const shouldAllowClose = !(isSubmitting && variant === 'submit-cta');
+  const shouldAllowClose = variant !== 'submit-cta';
 
   return (
     <Modal
@@ -80,7 +80,7 @@ export const BridgePriceImpactWarningModal = ({
         <ModalHeader
           onClose={onClose}
           closeButtonProps={{
-            disabled: isSubmitting && variant === 'submit-cta',
+            disabled: isSubmitting && !shouldAllowClose,
           }}
         >
           <Column alignItems={AlignItems.center} gap={2}>
@@ -123,7 +123,6 @@ export const BridgePriceImpactWarningModal = ({
                   if (activeQuote) {
                     await submitBridgeTransaction(activeQuote);
                   }
-                  onClose();
                 }}
               >
                 {t('proceed')}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Fixes a bug in which the priceImpact modal automatically closes after tx submission, which allows re-submitting the same trade. This change disables closing the modal when the modal overlay is clicked and also removes `onClose` call after the transaction is submitted

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40811?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: disable closing price impact modal while submitting a trade

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-4256

## **Manual testing steps**

1. Get a swap quote with high price impact (small amount of ETH to MUSD usually has a PancakeSwap route)
2. Submit the trade
3. Try to close the modal while submission is in progress
4. After submission, the wallet should navigate to the activity log

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the bridge submission UX/control flow by keeping the price impact modal open and adjusting post-submit navigation, which could affect error handling and prevent/allow unintended resubmissions.
> 
> **Overview**
> Prevents the `BridgePriceImpactWarningModal` (submit CTA variant) from being dismissed via outside click/escape during submission and removes the automatic `onClose()` after clicking **Proceed**, keeping the modal open until explicitly cancelled.
> 
> Adjusts bridge submission error handling in `useSubmitBridgeTransaction` by no longer immediately navigating to the Activity page from the catch block (only hardware-wallet rejections redirect back to the bridge page), and updates the modal test expectations accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d434b80474323714352f5d99d87baeee1874808d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->