### PR TITLE
refactor: get snapId from query parameter

### DIFF
--- a/ui/components/app/snaps/snap-settings-page/snap-settings-renderer.tsx
+++ b/ui/components/app/snaps/snap-settings-page/snap-settings-renderer.tsx
@@ -1,6 +1,6 @@
-import React, { FunctionComponent, useEffect, useMemo } from 'react';
+import React, { FunctionComponent, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useLocation } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 
 import { deleteInterface } from '../../../../store/actions';
@@ -16,7 +16,6 @@ import { DelineatorType } from '../../../../helpers/constants/snaps';
 import { Copyable } from '../copyable';
 import { SnapUIRenderer } from '../snap-ui-renderer';
 import { useSnapSettings } from '../../../../hooks/snaps/useSnapSettings';
-import { decodeSnapIdFromPathname } from '../../../../helpers/utils/snaps';
 
 type SnapSettingsRendererProps = {
   snapId: string;
@@ -25,11 +24,11 @@ type SnapSettingsRendererProps = {
 export const SnapSettingsRenderer: FunctionComponent<
   SnapSettingsRendererProps
 > = () => {
-  const { pathname } = useLocation();
+  const [searchParams] = useSearchParams();
   const dispatch = useDispatch();
   const t = useI18nContext();
 
-  const snapId = useMemo(() => decodeSnapIdFromPathname(pathname), [pathname]);
+  const snapId = searchParams.get('snapId') ?? '';
 
   const { name: snapName } = useSelector((state) =>
     getSnapMetadata(state, snapId),

--- a/ui/components/app/snaps/snap-settings-page/snap-settings-renderer.tsx
+++ b/ui/components/app/snaps/snap-settings-page/snap-settings-renderer.tsx
@@ -28,7 +28,7 @@ export const SnapSettingsRenderer: FunctionComponent<
   const dispatch = useDispatch();
   const t = useI18nContext();
 
-  const snapId = searchParams.get('snapId') ?? '';
+  const snapId = searchParams.get('snapId');
 
   const { name: snapName } = useSelector((state) =>
     getSnapMetadata(state, snapId),

--- a/ui/components/app/snaps/snap-settings-page/snap-settings-renderer.tsx
+++ b/ui/components/app/snaps/snap-settings-page/snap-settings-renderer.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useSearchParams } from 'react-router-dom';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
@@ -17,13 +17,7 @@ import { Copyable } from '../copyable';
 import { SnapUIRenderer } from '../snap-ui-renderer';
 import { useSnapSettings } from '../../../../hooks/snaps/useSnapSettings';
 
-type SnapSettingsRendererProps = {
-  snapId: string;
-};
-
-export const SnapSettingsRenderer: FunctionComponent<
-  SnapSettingsRendererProps
-> = () => {
+export const SnapSettingsRenderer = () => {
   const [searchParams] = useSearchParams();
   const dispatch = useDispatch();
   const t = useI18nContext();

--- a/ui/components/multichain-accounts/add-wallet-modal/add-wallet-modal.tsx
+++ b/ui/components/multichain-accounts/add-wallet-modal/add-wallet-modal.tsx
@@ -57,6 +57,7 @@ import {
   ACCOUNT_WATCHER_SNAP_ID,
   // eslint-disable-next-line import/no-restricted-paths
 } from '../../../../app/scripts/lib/snap-keyring/account-watcher-snap';
+import { getSnapRoute } from '../../../helpers/utils/util';
 
 export type AddWalletModalProps = Omit<
   ModalProps,
@@ -119,9 +120,7 @@ export const AddWalletModal: React.FC<AddWalletModalProps> = ({
             id: 'institutional-wallet',
             titleKey: 'manageInstitutionalWallets',
             iconName: IconName.Add,
-            route: `/snaps/view/${encodeURIComponent(
-              INSTITUTIONAL_WALLET_SNAP_ID,
-            )}`,
+            route: getSnapRoute(INSTITUTIONAL_WALLET_SNAP_ID),
           },
         ]
       : []),
@@ -208,7 +207,7 @@ export const AddWalletModal: React.FC<AddWalletModalProps> = ({
       },
     });
     onClose();
-    navigate(`/snaps/view/${encodeURIComponent(ACCOUNT_WATCHER_SNAP_ID)}`);
+    navigate(getSnapRoute(ACCOUNT_WATCHER_SNAP_ID));
   }, [trackEvent, onClose, navigate]);
 
   return (

--- a/ui/components/multichain/account-menu/account-menu.tsx
+++ b/ui/components/multichain/account-menu/account-menu.tsx
@@ -68,6 +68,7 @@ import {
   WalletClientType,
 } from '../../../hooks/accounts/useMultichainWalletSnapClient';
 import { endTrace, TraceName } from '../../../../shared/lib/trace';
+import { getSnapRoute } from '../../../helpers/utils/util';
 import { CreateEthAccount } from '../create-eth-account';
 import { CreateSnapAccount } from '../create-snap-account';
 import { CreateAccountSnapOptions } from '../../../../shared/lib/accounts';
@@ -209,7 +210,7 @@ export const AccountMenu = ({
       },
     });
     onClose();
-    navigate(`/snaps/view/${encodeURIComponent(ACCOUNT_WATCHER_SNAP_ID)}`);
+    navigate(getSnapRoute(ACCOUNT_WATCHER_SNAP_ID));
   }, [trackEvent, hdEntropyIndex, onClose, navigate]);
 
   const bitcoinSupportEnabled = useSelector(getIsBitcoinSupportEnabled);
@@ -632,11 +633,7 @@ export const AccountMenu = ({
                   startIconName={IconName.Add}
                   onClick={() => {
                     onClose();
-                    navigate(
-                      `/snaps/view/${encodeURIComponent(
-                        INSTITUTIONAL_WALLET_SNAP_ID,
-                      )}`,
-                    );
+                    navigate(getSnapRoute(INSTITUTIONAL_WALLET_SNAP_ID));
                   }}
                 >
                   {t('manageInstitutionalWallets')}

--- a/ui/helpers/constants/routes.ts
+++ b/ui/helpers/constants/routes.ts
@@ -326,7 +326,7 @@ export const ROUTES = [
     trackInAnalytics: true,
   },
   {
-    path: `${SNAP_SETTINGS_ROUTE}/:snapId`,
+    path: SNAP_SETTINGS_ROUTE,
     label: 'Snap Settings Page',
     trackInAnalytics: true,
   },
@@ -445,7 +445,7 @@ export const ROUTES = [
   },
   { path: SNAPS_ROUTE, label: 'Snaps List Page', trackInAnalytics: true },
   {
-    path: `${SNAPS_VIEW_ROUTE}/:snapId`,
+    path: SNAPS_VIEW_ROUTE,
     label: 'Snap View Page',
     trackInAnalytics: true,
   },

--- a/ui/helpers/utils/snaps.ts
+++ b/ui/helpers/utils/snaps.ts
@@ -1,16 +1,5 @@
 import { isProduction } from '../../../shared/modules/environment';
 
-/**
- * Decode a snap ID fron a pathname.
- *
- * @param pathname - The pathname to decode the snap ID from.
- * @returns The decoded snap ID, or `undefined` if the snap ID could not be decoded.
- */
-export const decodeSnapIdFromPathname = (pathname: string) => {
-  const snapIdURI = pathname?.match(/[^/]+$/u)?.[0];
-  return snapIdURI && decodeURIComponent(snapIdURI);
-};
-
 const IGNORED_EXAMPLE_SNAPS = ['npm:@metamask/preinstalled-example-snap'];
 
 /**

--- a/ui/helpers/utils/util.js
+++ b/ui/helpers/utils/util.js
@@ -751,7 +751,7 @@ export const getSnapName = (snapsMetadata) => {
 };
 
 export const getSnapRoute = (snapId) => {
-  return `${SNAPS_VIEW_ROUTE}/${encodeURIComponent(snapId)}`;
+  return `${SNAPS_VIEW_ROUTE}?snapId=${encodeURIComponent(snapId)}`;
 };
 
 export const getDedupedSnaps = (request, permissions) => {

--- a/ui/hooks/snaps/useSnapSettings.ts
+++ b/ui/hooks/snaps/useSnapSettings.ts
@@ -5,7 +5,7 @@ import {
   handleSnapRequest,
 } from '../../store/actions';
 
-export function useSnapSettings({ snapId }: { snapId?: string }) {
+export function useSnapSettings({ snapId }: { snapId?: string | null }) {
   const dispatch = useDispatch();
   const [loading, setLoading] = useState<boolean>(true);
   const [data, setData] = useState<{ id: string } | undefined>(undefined);

--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -653,7 +653,7 @@ export default function Routes() {
           'basicFunctionalityRequired_openSnapsPage',
       }),
       createRouteWithLayout({
-        path: `${SNAPS_VIEW_ROUTE}/*`,
+        path: SNAPS_VIEW_ROUTE,
         component: SnapView,
         layout: RootLayout,
         authenticated: true,

--- a/ui/pages/settings/settings.component.js
+++ b/ui/pages/settings/settings.component.js
@@ -97,6 +97,7 @@ class SettingsPage extends PureComponent {
     backRoute: PropTypes.string,
     conversionDate: PropTypes.number,
     currentPath: PropTypes.string,
+    currentSnapId: PropTypes.string,
     hasSubscribedToShield: PropTypes.bool,
     isAddressEntryPage: PropTypes.bool,
     isMetaMaskShieldFeatureEnabled: PropTypes.bool,
@@ -390,6 +391,7 @@ class SettingsPage extends PureComponent {
     const {
       navigate,
       currentPath,
+      currentSnapId,
       useExternalServices,
       settingsPageSnaps,
       isMetaMaskShieldFeatureEnabled,
@@ -476,6 +478,17 @@ class SettingsPage extends PureComponent {
           if (key === GENERAL_ROUTE && currentPath === SETTINGS_ROUTE) {
             return true;
           }
+
+          if (
+            currentPath === SNAP_SETTINGS_ROUTE &&
+            key.startsWith(`${SNAP_SETTINGS_ROUTE}?`)
+          ) {
+            const keySnapId = new URLSearchParams(key.split('?')[1]).get(
+              'snapId',
+            );
+            return keySnapId === currentSnapId;
+          }
+
           return matchPath(key, currentPath);
         }}
         onSelect={(key) => {

--- a/ui/pages/settings/settings.component.js
+++ b/ui/pages/settings/settings.component.js
@@ -407,7 +407,7 @@ class SettingsPage extends PureComponent {
             style={{ '--size': '20px' }}
           />
         ),
-        key: `${SNAP_SETTINGS_ROUTE}/${encodeURIComponent(id)}`,
+        key: `${SNAP_SETTINGS_ROUTE}?snapId=${encodeURIComponent(id)}`,
       };
     });
 
@@ -507,7 +507,7 @@ class SettingsPage extends PureComponent {
           element={<InfoTab />}
         />
         <Route
-          path={`${toRelativeRoutePath(SNAP_SETTINGS_ROUTE, SETTINGS_ROUTE)}/:snapId`}
+          path={toRelativeRoutePath(SNAP_SETTINGS_ROUTE, SETTINGS_ROUTE)}
           element={<SnapSettingsRenderer />}
         />
         <Route

--- a/ui/pages/settings/settings.container.js
+++ b/ui/pages/settings/settings.container.js
@@ -200,6 +200,7 @@ const mapStateToProps = (state, ownProps) => {
     backRoute,
     conversionDate,
     currentPath: pathname,
+    currentSnapId: snapIdFromSearch,
     hasSubscribedToShield: getHasSubscribedToShield(state),
     isAddressEntryPage,
     isMetaMaskShieldFeatureEnabled: getIsMetaMaskShieldFeatureEnabled(),

--- a/ui/pages/settings/settings.container.js
+++ b/ui/pages/settings/settings.container.js
@@ -107,9 +107,7 @@ const mapStateToProps = (state, ownProps) => {
   const isAddPopularCustomNetwork = Boolean(
     pathname.match(ADD_POPULAR_CUSTOM_NETWORK),
   );
-  const isSnapSettingsRoute = Boolean(
-    pathname.split('?')[0].match(SNAP_SETTINGS_ROUTE),
-  );
+  const isSnapSettingsRoute = pathname === SNAP_SETTINGS_ROUTE;
   const isShieldClaimNewPage = Boolean(
     pathname.match(TRANSACTION_SHIELD_CLAIM_ROUTES.NEW.FULL),
   );

--- a/ui/pages/settings/settings.container.js
+++ b/ui/pages/settings/settings.container.js
@@ -191,9 +191,10 @@ const mapStateToProps = (state, ownProps) => {
     name: snapNameGetter(snapId),
   }));
 
-  const snapSettingsTitle = isSnapSettingsRoute
-    ? snapNameGetter(snapIdFromSearch)
-    : '';
+  const snapSettingsTitle =
+    isSnapSettingsRoute && snapIdFromSearch
+      ? snapNameGetter(snapIdFromSearch)
+      : '';
 
   return {
     addNewNetwork,

--- a/ui/pages/settings/settings.container.js
+++ b/ui/pages/settings/settings.container.js
@@ -45,7 +45,6 @@ import {
 import { getProviderConfig } from '../../../shared/modules/selectors/networks';
 import { toggleNetworkMenu } from '../../store/actions';
 import { getSnapName } from '../../helpers/utils/util';
-import { decodeSnapIdFromPathname } from '../../helpers/utils/snaps';
 import { getIsSeedlessPasswordOutdated } from '../../ducks/metamask/metamask';
 import { getIsMetaMaskShieldFeatureEnabled } from '../../../shared/modules/environment';
 import { getHasSubscribedToShield } from '../../selectors/subscription/subscription';
@@ -90,6 +89,7 @@ const mapStateToProps = (state, ownProps) => {
   // param to check and show shield entry modal at start
   const shouldShowShieldEntryModal =
     searchParams.get(SHIELD_QUERY_PARAMS.showShieldEntryModal) === 'true';
+  const snapIdFromSearch = searchParams.get('snapId');
 
   const pathNameTail = pathname.match(/[^/]+$/u)?.[0] || '';
   const isAddressEntryPage = pathNameTail.includes('0x');
@@ -107,7 +107,9 @@ const mapStateToProps = (state, ownProps) => {
   const isAddPopularCustomNetwork = Boolean(
     pathname.match(ADD_POPULAR_CUSTOM_NETWORK),
   );
-  const isSnapSettingsRoute = Boolean(pathname.match(SNAP_SETTINGS_ROUTE));
+  const isSnapSettingsRoute = Boolean(
+    pathname.split('?')[0].match(SNAP_SETTINGS_ROUTE),
+  );
   const isShieldClaimNewPage = Boolean(
     pathname.match(TRANSACTION_SHIELD_CLAIM_ROUTES.NEW.FULL),
   );
@@ -190,7 +192,7 @@ const mapStateToProps = (state, ownProps) => {
   }));
 
   const snapSettingsTitle = isSnapSettingsRoute
-    ? snapNameGetter(decodeSnapIdFromPathname(pathname))
+    ? snapNameGetter(snapIdFromSearch)
     : '';
 
   return {

--- a/ui/pages/settings/settings.test.js
+++ b/ui/pages/settings/settings.test.js
@@ -50,10 +50,12 @@ describe('SettingsPage', () => {
   });
 
   it('should render correctly', () => {
+    mockRouterLocation = { pathname: '/settings/snap', search: '' };
+
     const { queryByText } = renderWithProvider(
       <Settings {...props} />,
       mockStore,
-      '/settings',
+      '/settings/snap',
     );
 
     expect(queryByText(messages.settings.message)).toBeInTheDocument();
@@ -67,17 +69,5 @@ describe('SettingsPage', () => {
     );
 
     expect(queryByPlaceholderText(messages.search.message)).toBeInTheDocument();
-  });
-
-  it('falls back to default title when snap settings route has no snapId query', () => {
-    mockRouterLocation = { pathname: '/settings/snap', search: '' };
-
-    const { queryByText } = renderWithProvider(
-      <Settings {...props} />,
-      mockStore,
-      '/settings/snap',
-    );
-
-    expect(queryByText(messages.settings.message)).toBeInTheDocument();
   });
 });

--- a/ui/pages/settings/settings.test.js
+++ b/ui/pages/settings/settings.test.js
@@ -6,11 +6,9 @@ import { enLocale as messages } from '../../../test/lib/i18n-helpers';
 import mockState from '../../../test/data/mock-state.json';
 import Settings from '.';
 
-let mockRouterLocation = { pathname: '/settings', search: '' };
-
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
-  useLocation: () => mockRouterLocation,
+  useLocation: () => ({ pathname: '/settings' }),
   useNavigate: () => jest.fn(),
   useParams: () => ({}),
 }));
@@ -23,7 +21,7 @@ jest.mock(
       <Component
         {...props}
         navigate={jest.fn()}
-        location={mockRouterLocation}
+        location={{ pathname: '/settings' }}
         params={{}}
       />
     );
@@ -44,10 +42,6 @@ describe('SettingsPage', () => {
   };
 
   const mockStore = configureMockStore()(mockState);
-
-  beforeEach(() => {
-    mockRouterLocation = { pathname: '/settings', search: '' };
-  });
 
   it('should render correctly', () => {
     const { queryByText } = renderWithProvider(

--- a/ui/pages/settings/settings.test.js
+++ b/ui/pages/settings/settings.test.js
@@ -50,12 +50,10 @@ describe('SettingsPage', () => {
   });
 
   it('should render correctly', () => {
-    mockRouterLocation = { pathname: '/settings/snap', search: '' };
-
     const { queryByText } = renderWithProvider(
       <Settings {...props} />,
       mockStore,
-      '/settings/snap',
+      '/settings',
     );
 
     expect(queryByText(messages.settings.message)).toBeInTheDocument();

--- a/ui/pages/settings/settings.test.js
+++ b/ui/pages/settings/settings.test.js
@@ -6,9 +6,11 @@ import { enLocale as messages } from '../../../test/lib/i18n-helpers';
 import mockState from '../../../test/data/mock-state.json';
 import Settings from '.';
 
+let mockRouterLocation = { pathname: '/settings', search: '' };
+
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
-  useLocation: () => ({ pathname: '/settings' }),
+  useLocation: () => mockRouterLocation,
   useNavigate: () => jest.fn(),
   useParams: () => ({}),
 }));
@@ -21,7 +23,7 @@ jest.mock(
       <Component
         {...props}
         navigate={jest.fn()}
-        location={{ pathname: '/settings' }}
+        location={mockRouterLocation}
         params={{}}
       />
     );
@@ -43,6 +45,10 @@ describe('SettingsPage', () => {
 
   const mockStore = configureMockStore()(mockState);
 
+  beforeEach(() => {
+    mockRouterLocation = { pathname: '/settings', search: '' };
+  });
+
   it('should render correctly', () => {
     const { queryByText } = renderWithProvider(
       <Settings {...props} />,
@@ -61,5 +67,17 @@ describe('SettingsPage', () => {
     );
 
     expect(queryByPlaceholderText(messages.search.message)).toBeInTheDocument();
+  });
+
+  it('falls back to default title when snap settings route has no snapId query', () => {
+    mockRouterLocation = { pathname: '/settings/snap', search: '' };
+
+    const { queryByText } = renderWithProvider(
+      <Settings {...props} />,
+      mockStore,
+      '/settings/snap',
+    );
+
+    expect(queryByText(messages.settings.message)).toBeInTheDocument();
   });
 });

--- a/ui/pages/snaps/snap-view/snap-view.js
+++ b/ui/pages/snaps/snap-view/snap-view.js
@@ -26,7 +26,7 @@ function SnapView() {
   const [searchParams] = useSearchParams();
 
   // The snap ID is in URI-encoded form in the query parameter.
-  const snapId = searchParams.get('snapId');
+  const snapId = searchParams.get('snapId') ?? '';
   const snaps = useSelector(getSnaps);
   const snap = Object.entries(snaps)
     .map(([_, snapState]) => snapState)

--- a/ui/pages/snaps/snap-view/snap-view.js
+++ b/ui/pages/snaps/snap-view/snap-view.js
@@ -9,7 +9,7 @@ import {
   JustifyContent,
 } from '../../../helpers/constants/design-system';
 import { DEFAULT_ROUTE, SNAPS_ROUTE } from '../../../helpers/constants/routes';
-import { getSnaps, getPermissions } from '../../../selectors';
+import { getPermissions, getSnap } from '../../../selectors';
 import {
   ButtonIcon,
   Box,
@@ -26,11 +26,8 @@ function SnapView() {
   const [searchParams] = useSearchParams();
 
   // The snap ID is in URI-encoded form in the query parameter.
-  const snapId = searchParams.get('snapId') ?? '';
-  const snaps = useSelector(getSnaps);
-  const snap = Object.entries(snaps)
-    .map(([_, snapState]) => snapState)
-    .find((snapState) => snapState.id === snapId);
+  const snapId = searchParams.get('snapId');
+  const snap = useSelector((state) => getSnap(state, snapId));
 
   useEffect(() => {
     if (!snap) {

--- a/ui/pages/snaps/snap-view/snap-view.js
+++ b/ui/pages/snaps/snap-view/snap-view.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { hasProperty } from '@metamask/utils';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import {
   AlignItems,
   BackgroundColor,
@@ -23,11 +23,10 @@ import SnapSettings from './snap-settings';
 
 function SnapView() {
   const navigate = useNavigate();
-  const location = useLocation();
+  const [searchParams] = useSearchParams();
 
-  const { pathname } = location;
-  // The snap ID is in URI-encoded form in the last path segment of the URL.
-  const snapId = decodeURIComponent(pathname.match(/[^/]+$/u)[0]);
+  // The snap ID is in URI-encoded form in the query parameter.
+  const snapId = searchParams.get('snapId');
   const snaps = useSelector(getSnaps);
   const snap = Object.entries(snaps)
     .map(([_, snapState]) => snapState)

--- a/ui/pages/snaps/snap-view/snap-view.test.js
+++ b/ui/pages/snaps/snap-view/snap-view.test.js
@@ -23,12 +23,15 @@ jest.mock('../../../store/actions.ts', () => {
 
 jest.mock('react-router-dom', () => {
   const original = jest.requireActual('react-router-dom');
+  const snapId = 'npm:@metamask/test-snap-bip44';
   return {
     ...original,
+    useSearchParams: jest.fn(() => [
+      new URLSearchParams(`snapId=${encodeURIComponent(snapId)}`),
+    ]),
     useLocation: jest.fn(() => ({
-      pathname: `/snaps/view/${encodeURIComponent(
-        'npm:@metamask/test-snap-bip44',
-      )}`,
+      pathname: `/snaps/view`,
+      search: `?snapId=${encodeURIComponent(snapId)}`,
     })),
   };
 });


### PR DESCRIPTION
## **Description**

Refactors Snap page routing to use [snapId](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) from query params instead of parsing IDs from path segments.

Why
Snap IDs can contain `/` and is not ideal as a URL path segment. Firefox can decode this before react-router has a chance to read it, interpreting it into multiple segments.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: refactor: get snapId from query param

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core routing and navigation for Snap view/settings pages; regressions would manifest as broken deep links or incorrect tab activation if `snapId` is missing/mis-encoded.
> 
> **Overview**
> Refactors Snap routing to pass `snapId` via the `?snapId=` query parameter instead of as a URL path segment, updating route definitions and navigation helpers (`getSnapRoute`).
> 
> Updates Snap view and settings renderers to read `snapId` from `useSearchParams`, removes the pathname-based `decodeSnapIdFromPathname` utility, and adjusts Settings tabs/title logic to keep the correct Snap tab active based on the query param. Includes a small test update for `SnapView` to mock query-parameter routing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 084d27deeb5fc16f7eebd4b6d04c0b6569451149. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->