### PR TITLE
feat: Add total exposure component to stream type Advanced Permissions cp-13.23.0

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1544,6 +1544,9 @@
   "confirmFieldTooltipPaymaster": {
     "message": "The fee for this transaction will be paid by the paymaster smart contract."
   },
+  "confirmFieldTotalExposure": {
+    "message": "Total exposure"
+  },
   "confirmGasFeeTokenBalance": {
     "message": "Bal:"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -1544,6 +1544,9 @@
   "confirmFieldTooltipPaymaster": {
     "message": "The fee for this transaction will be paid by the paymaster smart contract."
   },
+  "confirmFieldTotalExposure": {
+    "message": "Total exposure"
+  },
   "confirmGasFeeTokenBalance": {
     "message": "Bal:"
   },

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -1913,6 +1913,10 @@
       "Reselect: Identity function warnings": 3,
       "warn: ⚠️ React Router Future Flag": 2
     },
+    "ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/total-exposure.test.tsx": {
+      "Reselect: Identity function warnings": 4,
+      "warn: ⚠️ React Router Future Flag": 2
+    },
     "ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-v4-simulation/decoded-simulation/decoded-simulation.test.tsx": {
       "MetaMask: Background connection not initialized": 4,
       "React: Act warnings (component updates not wrapped)": 4,

--- a/ui/pages/confirmations/components/confirm/info/__snapshots__/info.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/__snapshots__/info.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`Info renders info section for approve request 1`] = `
           </p>
           <div>
             <div
-              aria-describedby="tippy-tooltip-18"
+              aria-describedby="tippy-tooltip-19"
               class=""
               data-original-title="Estimated changes are what might happen if you go through with this transaction. This is just a prediction, not a guarantee."
               data-tooltipped=""
@@ -132,7 +132,7 @@ exports[`Info renders info section for approve request 1`] = `
           </p>
           <div>
             <div
-              aria-describedby="tippy-tooltip-14"
+              aria-describedby="tippy-tooltip-15"
               class=""
               data-original-title="This is the address that will be able to withdraw your NFTs."
               data-tooltipped=""
@@ -233,7 +233,7 @@ exports[`Info renders info section for approve request 1`] = `
           </p>
           <div>
             <div
-              aria-describedby="tippy-tooltip-15"
+              aria-describedby="tippy-tooltip-16"
               class=""
               data-original-title="This is the site asking for your confirmation."
               data-tooltipped=""
@@ -279,7 +279,7 @@ exports[`Info renders info section for approve request 1`] = `
           </p>
           <div>
             <div
-              aria-describedby="tippy-tooltip-16"
+              aria-describedby="tippy-tooltip-17"
               class=""
               data-original-title="This is the contract you're interacting with. Protect yourself from scammers by verifying the details."
               data-tooltipped=""
@@ -345,7 +345,7 @@ exports[`Info renders info section for approve request 1`] = `
             </p>
             <div>
               <div
-                aria-describedby="tippy-tooltip-17"
+                aria-describedby="tippy-tooltip-18"
                 class=""
                 data-original-title="Amount paid to process the transaction on network."
                 data-tooltipped=""
@@ -507,7 +507,7 @@ exports[`Info renders info section for contract interaction request 1`] = `
                 </p>
                 <div>
                   <div
-                    aria-describedby="tippy-tooltip-10"
+                    aria-describedby="tippy-tooltip-11"
                     class=""
                     data-original-title="Estimated changes are what might happen if you go through with this transaction. This is just a prediction, not a guarantee."
                     data-tooltipped=""
@@ -592,7 +592,7 @@ exports[`Info renders info section for contract interaction request 1`] = `
           </p>
           <div>
             <div
-              aria-describedby="tippy-tooltip-11"
+              aria-describedby="tippy-tooltip-12"
               class=""
               data-original-title="This is the site asking for your confirmation."
               data-tooltipped=""
@@ -638,7 +638,7 @@ exports[`Info renders info section for contract interaction request 1`] = `
           </p>
           <div>
             <div
-              aria-describedby="tippy-tooltip-12"
+              aria-describedby="tippy-tooltip-13"
               class=""
               data-original-title="This is the contract you're interacting with. Protect yourself from scammers by verifying the details."
               data-tooltipped=""
@@ -704,7 +704,7 @@ exports[`Info renders info section for contract interaction request 1`] = `
             </p>
             <div>
               <div
-                aria-describedby="tippy-tooltip-13"
+                aria-describedby="tippy-tooltip-14"
                 class=""
                 data-original-title="Amount paid to process the transaction on network."
                 data-tooltipped=""
@@ -1001,7 +1001,7 @@ exports[`Info renders info section for setApprovalForAll request 1`] = `
           </p>
           <div>
             <div
-              aria-describedby="tippy-tooltip-19"
+              aria-describedby="tippy-tooltip-20"
               class=""
               data-original-title="Estimated changes are what might happen if you go through with this transaction. This is just a prediction, not a guarantee."
               data-tooltipped=""
@@ -1108,7 +1108,7 @@ exports[`Info renders info section for setApprovalForAll request 1`] = `
           </p>
           <div>
             <div
-              aria-describedby="tippy-tooltip-20"
+              aria-describedby="tippy-tooltip-21"
               class=""
               data-original-title="This is the address that will be able to withdraw your NFTs."
               data-tooltipped=""
@@ -1209,7 +1209,7 @@ exports[`Info renders info section for setApprovalForAll request 1`] = `
           </p>
           <div>
             <div
-              aria-describedby="tippy-tooltip-21"
+              aria-describedby="tippy-tooltip-22"
               class=""
               data-original-title="This is the site asking for your confirmation."
               data-tooltipped=""
@@ -1255,7 +1255,7 @@ exports[`Info renders info section for setApprovalForAll request 1`] = `
           </p>
           <div>
             <div
-              aria-describedby="tippy-tooltip-22"
+              aria-describedby="tippy-tooltip-23"
               class=""
               data-original-title="This is the contract you're interacting with. Protect yourself from scammers by verifying the details."
               data-tooltipped=""
@@ -1321,7 +1321,7 @@ exports[`Info renders info section for setApprovalForAll request 1`] = `
             </p>
             <div>
               <div
-                aria-describedby="tippy-tooltip-23"
+                aria-describedby="tippy-tooltip-24"
                 class=""
                 data-original-title="Amount paid to process the transaction on network."
                 data-tooltipped=""
@@ -2605,6 +2605,67 @@ exports[`Info renders info section for typed sign request with permission 1`] = 
               aria-describedby="tippy-tooltip-9"
               class=""
               data-original-title="0.000000000402624"
+              data-tooltipped=""
+              style="display: inline;"
+              tabindex="0"
+            >
+              <p
+                class="mm-box mm-text mm-text--body-md mm-box--color-inherit"
+                style="white-space: pre-wrap;"
+              >
+                &lt;0.000001
+              </p>
+            </div>
+          </div>
+        </div>
+        <div
+          class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-full h-4 w-4"
+        >
+          <img
+            alt="ETH"
+            class="size-full object-contain"
+            src="./images/eth_logo.svg"
+          />
+        </div>
+        <p
+          class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default"
+        >
+          ETH
+        </p>
+      </div>
+    </div>
+    <div
+      class="mm-box confirm-info-row mm-box--margin-top-2 mm-box--margin-bottom-2 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--flex-direction-row mm-box--flex-wrap-wrap mm-box--justify-content-space-between mm-box--align-items-flex-start mm-box--color-text-default mm-box--rounded-lg"
+      style="overflow-wrap: anywhere; min-height: 24px; position: relative;"
+    >
+      <div
+        class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--color-text-alternative"
+        style="flex-shrink: 0; flex-basis: auto; max-width: 100%;"
+      >
+        <div
+          class="mm-box mm-box--display-flex mm-box--align-items-center"
+          style="flex-shrink: 0;"
+        >
+          <p
+            class="mm-box mm-text mm-text--body-md-medium mm-box--color-inherit"
+          >
+            Total exposure
+          </p>
+        </div>
+      </div>
+      <div
+        class="flex flex-row gap-2 items-center"
+      >
+        <div
+          class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap mm-box--align-items-center mm-box--min-width-0"
+        >
+          <div
+            style="min-width: 0;"
+          >
+            <div
+              aria-describedby="tippy-tooltip-10"
+              class=""
+              data-original-title="0.00000000000000466"
               data-tooltipped=""
               style="display: inline;"
               tabindex="0"

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/erc20-token-stream-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/erc20-token-stream-details.tsx
@@ -12,6 +12,7 @@ import { useI18nContext } from '../../../../../../../hooks/useI18nContext';
 import { TokenAmountRow } from './token-amount-row';
 import { DateAndTimeRow } from './date-and-time-row';
 import { Expiry } from './expiry';
+import { TotalExposure } from './total-exposure';
 
 /**
  * Component for displaying ERC20 token stream permission details.
@@ -93,6 +94,17 @@ export const Erc20TokenStreamDetails: React.FC<{
           decimals={decimals}
           tokenAddress={permission.data.tokenAddress}
           chainId={chainId}
+        />
+        <TotalExposure
+          variant="erc20"
+          initialAmount={initialAmount}
+          maxAmount={maxAmount}
+          amountPerSecond={amountPerSecond}
+          startTime={startTime}
+          expiry={expiry}
+          tokenAddress={permission.data.tokenAddress}
+          chainId={chainId}
+          decimals={decimals}
         />
       </ConfirmInfoSection>
     </>

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/native-token-stream-details.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/native-token-stream-details.test.tsx
@@ -109,6 +109,11 @@ describe('NativeTokenStreamDetails', () => {
   });
 
   describe('data display', () => {
+    it('displays total exposure in stream rate section', () => {
+      const { streamRateSection } = renderAndGetSections(defaultProps);
+      expect(streamRateSection?.textContent).toContain('Total exposure');
+    });
+
     it('displays correct test IDs', () => {
       const { detailsSection, streamRateSection } =
         renderAndGetSections(defaultProps);

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/native-token-stream-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/native-token-stream-details.tsx
@@ -16,6 +16,7 @@ import { useI18nContext } from '../../../../../../../hooks/useI18nContext';
 import { NativeAmountRow } from './native-amount-row';
 import { DateAndTimeRow } from './date-and-time-row';
 import { Expiry } from './expiry';
+import { TotalExposure } from './total-exposure';
 
 /**
  * Component for displaying native token stream permission details.
@@ -93,6 +94,17 @@ export const NativeTokenStreamDetails: React.FC<{
         <NativeAmountRow
           label={t('confirmFieldAvailablePerDay')}
           value={amountPerDay}
+          symbol={symbol}
+          decimals={decimals}
+          imageUrl={tokenImageUrl}
+        />
+        <TotalExposure
+          variant="native"
+          initialAmount={initialAmount ?? undefined}
+          maxAmount={maxAmount ?? undefined}
+          amountPerSecond={amountPerSecond}
+          startTime={startTime}
+          expiry={expiry}
           symbol={symbol}
           decimals={decimals}
           imageUrl={tokenImageUrl}

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/total-exposure.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/total-exposure.test.tsx
@@ -1,0 +1,277 @@
+import React from 'react';
+import configureMockStore from 'redux-mock-store';
+
+import { getMockTypedSignPermissionConfirmState } from '../../../../../../../../test/data/confirmations/helper';
+import { renderWithConfirmContextProvider } from '../../../../../../../../test/lib/confirmations/render-helpers';
+import { computeTotalExposure, TotalExposure } from './total-exposure';
+
+describe('TotalExposure', () => {
+  const mockDecodedPermission = {
+    expiry: 1234567890 + 86400,
+    origin: 'https://metamask.github.io',
+    permission: {
+      type: 'erc20-token-stream',
+      isAdjustmentAllowed: false,
+      data: {
+        tokenAddress: '0xA0b86a33E6441b8c4C8C0E4A8e4A8e4A8e4A8e4A',
+        initialAmount: '0x1234',
+        maxAmount: '0x5678',
+        amountPerSecond: '0x9abc',
+        startTime: 1234567890,
+      },
+      justification: 'Test justification',
+    },
+    chainId: '0x1',
+    to: '0xCdD6132d1a6efA06bce1A89b0fEa6b08304A3829',
+  } as const;
+
+  const getMockStore = () => {
+    const state = getMockTypedSignPermissionConfirmState(mockDecodedPermission);
+    return configureMockStore([])(state);
+  };
+
+  const defaultErc20Props = {
+    variant: 'erc20' as const,
+    initialAmount: '0x1234' as const,
+    maxAmount: '0x5678' as const,
+    amountPerSecond: '0x9abc' as const,
+    startTime: 1234567890,
+    expiry: 1234567890 + 86400,
+    tokenAddress: '0xA0b86a33E6441b8c4C8C0E4A8e4A8e4A8e4A8e4A',
+    chainId: '0x1' as const,
+    decimals: 2,
+  };
+
+  const defaultNativeProps = {
+    variant: 'native' as const,
+    initialAmount: '0x1234' as const,
+    maxAmount: '0x5678' as const,
+    amountPerSecond: '0x9abc' as const,
+    startTime: 1234567890,
+    expiry: 1234567890 + 86400,
+    symbol: 'ETH',
+    decimals: 18,
+    imageUrl: 'https://example.com/eth.png',
+  };
+
+  describe('computeTotalExposure', () => {
+    it('returns min of maxAmount and exposure at expiry when both are set', () => {
+      const result = computeTotalExposure({
+        initialAmount: '0x0',
+        maxAmount: '0x64', // 100
+        amountPerSecond: '0x1', // 1 per second
+        startTime: 1000,
+        expiry: 1050, // 50 seconds
+      });
+      expect(result).not.toBeNull();
+      expect(result?.toNumber()).toBe(50); // 0 + 50*1 = 50, min(100, 50) = 50
+    });
+
+    it('returns maxAmount when exposure at expiry exceeds it', () => {
+      const result = computeTotalExposure({
+        initialAmount: '0x0',
+        maxAmount: '0x32', // 50
+        amountPerSecond: '0x1',
+        startTime: 1000,
+        expiry: 1100, // 100 seconds -> 100 exposure
+      });
+      expect(result).not.toBeNull();
+      expect(result?.toNumber()).toBe(50);
+    });
+
+    it('returns exposure at expiry when only expiry is set', () => {
+      const result = computeTotalExposure({
+        initialAmount: '0x64', // 100
+        maxAmount: undefined,
+        amountPerSecond: '0x1',
+        startTime: 1000,
+        expiry: 1020, // 20 seconds
+      });
+      expect(result).not.toBeNull();
+      expect(result?.toNumber()).toBe(120); // 100 + 20*1
+    });
+
+    it('returns maxAmount when only maxAmount is set', () => {
+      const result = computeTotalExposure({
+        initialAmount: '0x0',
+        maxAmount: '0x64',
+        amountPerSecond: '0x1',
+        startTime: 1000,
+        expiry: null,
+      });
+      expect(result).not.toBeNull();
+      expect(result?.toNumber()).toBe(100);
+    });
+
+    it('returns null (unlimited) when neither maxAmount nor expiry is set', () => {
+      const result = computeTotalExposure({
+        initialAmount: '0x64',
+        maxAmount: undefined,
+        amountPerSecond: '0x1',
+        startTime: 1000,
+        expiry: null,
+      });
+      expect(result).toBeNull();
+    });
+
+    it('returns initial amount only when elapsed seconds is zero or negative', () => {
+      const result = computeTotalExposure({
+        initialAmount: '0x64', // 100
+        maxAmount: undefined,
+        amountPerSecond: '0x1',
+        startTime: 1000,
+        expiry: 1000, // 0 seconds elapsed
+      });
+      expect(result).not.toBeNull();
+      expect(result?.toNumber()).toBe(100);
+    });
+
+    it('handles decimal string amounts', () => {
+      const result = computeTotalExposure({
+        initialAmount: '0',
+        maxAmount: '100',
+        amountPerSecond: '1',
+        startTime: 0,
+        expiry: 10,
+      });
+      expect(result).not.toBeNull();
+      expect(result?.toNumber()).toBe(10);
+    });
+
+    it('parses hex amounts correctly', () => {
+      const result = computeTotalExposure({
+        initialAmount: '0x0',
+        maxAmount: '0x100',
+        amountPerSecond: '0x2',
+        startTime: 0,
+        expiry: 10,
+      });
+      expect(result).not.toBeNull();
+      expect(result?.toNumber()).toBe(20); // 0 + 10*2
+    });
+
+    it('returns null (unlimited) when maxAmount is max uint256', () => {
+      const maxUint256 =
+        '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+      const result = computeTotalExposure({
+        initialAmount: '0x0',
+        maxAmount: maxUint256,
+        amountPerSecond: '0x1',
+        startTime: 1000,
+        expiry: 2000,
+      });
+      expect(result).toBeNull();
+    });
+
+    it('treats undefined initialAmount as zero for exposure at expiry', () => {
+      const result = computeTotalExposure({
+        initialAmount: undefined,
+        maxAmount: undefined,
+        amountPerSecond: '0x1',
+        startTime: 0,
+        expiry: 10, // 10 seconds
+      });
+      expect(result).not.toBeNull();
+      expect(result?.toNumber()).toBe(10); // 0 + 10*1
+    });
+
+    it('returns initial only when elapsed is negative (expiry before startTime)', () => {
+      const result = computeTotalExposure({
+        initialAmount: '0x64', // 100
+        maxAmount: undefined,
+        amountPerSecond: '0x1',
+        startTime: 1000,
+        expiry: 500, // 500 seconds before start
+      });
+      expect(result).not.toBeNull();
+      expect(result?.toNumber()).toBe(100); // streamed = 0 when elapsed <= 0
+    });
+  });
+
+  describe('TotalExposure component (ERC20 variant)', () => {
+    it('renders total exposure label', () => {
+      const { getByText } = renderWithConfirmContextProvider(
+        <TotalExposure {...defaultErc20Props} />,
+        getMockStore(),
+      );
+      expect(getByText('Total exposure')).toBeInTheDocument();
+    });
+
+    it('renders unlimited when totalExposure is null (no max nor expiry)', () => {
+      const { getByText } = renderWithConfirmContextProvider(
+        <TotalExposure
+          {...defaultErc20Props}
+          maxAmount={undefined}
+          expiry={null}
+        />,
+        getMockStore(),
+      );
+      expect(getByText('Unlimited')).toBeInTheDocument();
+    });
+
+    it('renders unlimited when maxAmount is max uint256', () => {
+      const maxUint256 =
+        '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+      const { getByText } = renderWithConfirmContextProvider(
+        <TotalExposure
+          {...defaultErc20Props}
+          maxAmount={maxUint256}
+          expiry={1234567890 + 86400}
+        />,
+        getMockStore(),
+      );
+      expect(getByText('Unlimited')).toBeInTheDocument();
+    });
+
+    it('renders token amount row when totalExposure is computed', () => {
+      const { container } = renderWithConfirmContextProvider(
+        <TotalExposure {...defaultErc20Props} />,
+        getMockStore(),
+      );
+      expect(container).toBeInTheDocument();
+      expect(container.textContent).toContain('Total exposure');
+      expect(container.textContent).not.toContain('Unlimited');
+    });
+  });
+
+  describe('TotalExposure component (native variant)', () => {
+    it('renders total exposure label', () => {
+      const { getByText } = renderWithConfirmContextProvider(
+        <TotalExposure {...defaultNativeProps} />,
+        getMockStore(),
+      );
+      expect(getByText('Total exposure')).toBeInTheDocument();
+    });
+
+    it('renders symbol when totalExposure is computed', () => {
+      const { getByText } = renderWithConfirmContextProvider(
+        <TotalExposure {...defaultNativeProps} />,
+        getMockStore(),
+      );
+      expect(getByText('ETH')).toBeInTheDocument();
+      expect(getByText('Total exposure')).toBeInTheDocument();
+    });
+
+    it('renders unlimited with symbol when totalExposure is null', () => {
+      const { getByText } = renderWithConfirmContextProvider(
+        <TotalExposure
+          {...defaultNativeProps}
+          maxAmount={undefined}
+          expiry={null}
+        />,
+        getMockStore(),
+      );
+      expect(getByText('Unlimited')).toBeInTheDocument();
+      expect(getByText('ETH')).toBeInTheDocument();
+    });
+
+    it('renders without imageUrl when not provided', () => {
+      const { container } = renderWithConfirmContextProvider(
+        <TotalExposure {...defaultNativeProps} imageUrl={undefined} />,
+        getMockStore(),
+      );
+      expect(container).toBeInTheDocument();
+      expect(container.textContent).toContain('Total exposure');
+    });
+  });
+});

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/total-exposure.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/total-exposure.test.tsx
@@ -6,8 +6,9 @@ import { renderWithConfirmContextProvider } from '../../../../../../../../test/l
 import { computeTotalExposure, TotalExposure } from './total-exposure';
 
 describe('TotalExposure', () => {
+  const duration = 86400;
   const mockDecodedPermission = {
-    expiry: 1234567890 + 86400,
+    expiry: 1234567890 + duration,
     origin: 'https://metamask.github.io',
     permission: {
       type: 'erc20-token-stream',
@@ -31,28 +32,28 @@ describe('TotalExposure', () => {
   };
 
   const defaultErc20Props = {
-    variant: 'erc20' as const,
-    initialAmount: '0x1234' as const,
-    maxAmount: '0x5678' as const,
-    amountPerSecond: '0x9abc' as const,
+    variant: 'erc20',
+    initialAmount: '0x1234',
+    maxAmount: '0x5678',
+    amountPerSecond: '0x9abc',
     startTime: 1234567890,
-    expiry: 1234567890 + 86400,
+    expiry: 1234567890 + duration,
     tokenAddress: '0xA0b86a33E6441b8c4C8C0E4A8e4A8e4A8e4A8e4A',
-    chainId: '0x1' as const,
+    chainId: '0x1',
     decimals: 2,
-  };
+  } as const;
 
   const defaultNativeProps = {
-    variant: 'native' as const,
-    initialAmount: '0x1234' as const,
-    maxAmount: '0x5678' as const,
-    amountPerSecond: '0x9abc' as const,
+    variant: 'native',
+    initialAmount: '0x1234',
+    maxAmount: '0x5678',
+    amountPerSecond: '0x9abc',
     startTime: 1234567890,
-    expiry: 1234567890 + 86400,
+    expiry: 1234567890 + duration,
     symbol: 'ETH',
     decimals: 18,
     imageUrl: 'https://example.com/eth.png',
-  };
+  } as const;
 
   describe('computeTotalExposure', () => {
     it('returns min of maxAmount and exposure at expiry when both are set', () => {
@@ -124,18 +125,6 @@ describe('TotalExposure', () => {
       });
       expect(result).not.toBeNull();
       expect(result?.toNumber()).toBe(100);
-    });
-
-    it('handles decimal string amounts', () => {
-      const result = computeTotalExposure({
-        initialAmount: '0',
-        maxAmount: '100',
-        amountPerSecond: '1',
-        startTime: 0,
-        expiry: 10,
-      });
-      expect(result).not.toBeNull();
-      expect(result?.toNumber()).toBe(10);
     });
 
     it('parses hex amounts correctly', () => {
@@ -216,7 +205,7 @@ describe('TotalExposure', () => {
         <TotalExposure
           {...defaultErc20Props}
           maxAmount={maxUint256}
-          expiry={1234567890 + 86400}
+          expiry={1234567890 + duration}
         />,
         getMockStore(),
       );

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/total-exposure.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/total-exposure.test.tsx
@@ -197,7 +197,9 @@ describe('TotalExposure', () => {
         <TotalExposure {...defaultErc20Props} />,
         getMockStore(),
       );
-      expect(getByText(messages.confirmFieldTotalExposure.message)).toBeInTheDocument();
+      expect(
+        getByText(messages.confirmFieldTotalExposure.message),
+      ).toBeInTheDocument();
     });
 
     it('renders unlimited when totalExposure is null (no max nor expiry)', () => {
@@ -232,7 +234,9 @@ describe('TotalExposure', () => {
         getMockStore(),
       );
       expect(container).toBeInTheDocument();
-      expect(container.textContent).toContain(messages.confirmFieldTotalExposure.message);
+      expect(container.textContent).toContain(
+        messages.confirmFieldTotalExposure.message,
+      );
       expect(container.textContent).not.toContain(messages.unlimited.message);
     });
   });
@@ -243,7 +247,9 @@ describe('TotalExposure', () => {
         <TotalExposure {...defaultNativeProps} />,
         getMockStore(),
       );
-      expect(getByText(messages.confirmFieldTotalExposure.message)).toBeInTheDocument();
+      expect(
+        getByText(messages.confirmFieldTotalExposure.message),
+      ).toBeInTheDocument();
     });
 
     it('renders symbol when totalExposure is computed', () => {
@@ -252,7 +258,9 @@ describe('TotalExposure', () => {
         getMockStore(),
       );
       expect(getByText('ETH')).toBeInTheDocument();
-      expect(getByText(messages.confirmFieldTotalExposure.message)).toBeInTheDocument();
+      expect(
+        getByText(messages.confirmFieldTotalExposure.message),
+      ).toBeInTheDocument();
     });
 
     it('renders unlimited with symbol when totalExposure is null', () => {
@@ -274,7 +282,9 @@ describe('TotalExposure', () => {
         getMockStore(),
       );
       expect(container).toBeInTheDocument();
-      expect(container.textContent).toContain(messages.confirmFieldTotalExposure.message);
+      expect(container.textContent).toContain(
+        messages.confirmFieldTotalExposure.message,
+      );
     });
   });
 });

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/total-exposure.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/total-exposure.test.tsx
@@ -3,6 +3,7 @@ import configureMockStore from 'redux-mock-store';
 
 import { getMockTypedSignPermissionConfirmState } from '../../../../../../../../test/data/confirmations/helper';
 import { renderWithConfirmContextProvider } from '../../../../../../../../test/lib/confirmations/render-helpers';
+import { enLocale as messages } from '../../../../../../../../test/lib/i18n-helpers';
 import { computeTotalExposure, TotalExposure } from './total-exposure';
 
 describe('TotalExposure', () => {
@@ -183,7 +184,7 @@ describe('TotalExposure', () => {
         <TotalExposure {...defaultErc20Props} />,
         getMockStore(),
       );
-      expect(getByText('Total exposure')).toBeInTheDocument();
+      expect(getByText(messages.confirmFieldTotalExposure.message)).toBeInTheDocument();
     });
 
     it('renders unlimited when totalExposure is null (no max nor expiry)', () => {
@@ -195,7 +196,7 @@ describe('TotalExposure', () => {
         />,
         getMockStore(),
       );
-      expect(getByText('Unlimited')).toBeInTheDocument();
+      expect(getByText(messages.unlimited.message)).toBeInTheDocument();
     });
 
     it('renders unlimited when maxAmount is max uint256', () => {
@@ -209,7 +210,7 @@ describe('TotalExposure', () => {
         />,
         getMockStore(),
       );
-      expect(getByText('Unlimited')).toBeInTheDocument();
+      expect(getByText(messages.unlimited.message)).toBeInTheDocument();
     });
 
     it('renders token amount row when totalExposure is computed', () => {
@@ -218,8 +219,8 @@ describe('TotalExposure', () => {
         getMockStore(),
       );
       expect(container).toBeInTheDocument();
-      expect(container.textContent).toContain('Total exposure');
-      expect(container.textContent).not.toContain('Unlimited');
+      expect(container.textContent).toContain(messages.confirmFieldTotalExposure.message);
+      expect(container.textContent).not.toContain(messages.unlimited.message);
     });
   });
 
@@ -229,7 +230,7 @@ describe('TotalExposure', () => {
         <TotalExposure {...defaultNativeProps} />,
         getMockStore(),
       );
-      expect(getByText('Total exposure')).toBeInTheDocument();
+      expect(getByText(messages.confirmFieldTotalExposure.message)).toBeInTheDocument();
     });
 
     it('renders symbol when totalExposure is computed', () => {
@@ -238,7 +239,7 @@ describe('TotalExposure', () => {
         getMockStore(),
       );
       expect(getByText('ETH')).toBeInTheDocument();
-      expect(getByText('Total exposure')).toBeInTheDocument();
+      expect(getByText(messages.confirmFieldTotalExposure.message)).toBeInTheDocument();
     });
 
     it('renders unlimited with symbol when totalExposure is null', () => {
@@ -250,7 +251,7 @@ describe('TotalExposure', () => {
         />,
         getMockStore(),
       );
-      expect(getByText('Unlimited')).toBeInTheDocument();
+      expect(getByText(messages.unlimited.message)).toBeInTheDocument();
       expect(getByText('ETH')).toBeInTheDocument();
     });
 
@@ -260,7 +261,7 @@ describe('TotalExposure', () => {
         getMockStore(),
       );
       expect(container).toBeInTheDocument();
-      expect(container.textContent).toContain('Total exposure');
+      expect(container.textContent).toContain(messages.confirmFieldTotalExposure.message);
     });
   });
 });

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/total-exposure.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/total-exposure.test.tsx
@@ -153,6 +153,19 @@ describe('TotalExposure', () => {
       expect(result).toBeNull();
     });
 
+    it('returns null (unlimited) when maxAmount is max uint256 in uppercase hex', () => {
+      const maxUint256Upper =
+        '0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF';
+      const result = computeTotalExposure({
+        initialAmount: '0x0',
+        maxAmount: maxUint256Upper,
+        amountPerSecond: '0x1',
+        startTime: 1000,
+        expiry: 2000,
+      });
+      expect(result).toBeNull();
+    });
+
     it('treats undefined initialAmount as zero for exposure at expiry', () => {
       const result = computeTotalExposure({
         initialAmount: undefined,

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/total-exposure.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/total-exposure.test.tsx
@@ -57,52 +57,64 @@ describe('TotalExposure', () => {
   } as const;
 
   describe('computeTotalExposure', () => {
-    it('returns min of maxAmount and exposure at expiry when both are set', () => {
-      const result = computeTotalExposure({
-        initialAmount: '0x0',
-        maxAmount: '0x64', // 100
-        amountPerSecond: '0x1', // 1 per second
-        startTime: 1000,
-        expiry: 1050, // 50 seconds
-      });
-      expect(result).not.toBeNull();
-      expect(result?.toNumber()).toBe(50); // 0 + 50*1 = 50, min(100, 50) = 50
-    });
-
-    it('returns maxAmount when exposure at expiry exceeds it', () => {
+    it('returns maxAmount when less than accrued exposure', () => {
       const result = computeTotalExposure({
         initialAmount: '0x0',
         maxAmount: '0x32', // 50
         amountPerSecond: '0x1',
         startTime: 1000,
-        expiry: 1100, // 100 seconds -> 100 exposure
+        expiry: 1100, // 100 seconds -> 100 accrued exposure
       });
       expect(result).not.toBeNull();
-      expect(result?.toNumber()).toBe(50);
+      expect(result?.toNumber()).toBe(0x32);
     });
 
-    it('returns exposure at expiry when only expiry is set', () => {
+    it('returns maxAmount when less than initialAmount + accrued exposure', () => {
+      const result = computeTotalExposure({
+        initialAmount: '0x32', // 50
+        maxAmount: '0x64', // 100
+        amountPerSecond: '0x1',
+        startTime: 1000,
+        expiry: 1100, // 100 seconds -> 100 accrued exposure
+      });
+      expect(result).not.toBeNull();
+      expect(result?.toNumber()).toBe(0x64);
+    });
+
+    it('returns initialAmount + accrued exposure when it is less than maxAmount', () => {
+      const result = computeTotalExposure({
+        initialAmount: '0x14', // 20
+        maxAmount: '0x100', // 256
+        amountPerSecond: '0x1',
+        startTime: 1000,
+        expiry: 1100, // 100 seconds -> 100 accrued exposure
+      });
+      expect(result).not.toBeNull();
+      expect(result?.toNumber()).toBe(0x14 + 100);
+    });
+
+    it('returns initialAmount + accrued exposure when no maxAmount is set', () => {
       const result = computeTotalExposure({
         initialAmount: '0x64', // 100
         maxAmount: undefined,
         amountPerSecond: '0x1',
         startTime: 1000,
-        expiry: 1020, // 20 seconds
+        expiry: 1100, // 100 seconds -> 100 accrued exposure
       });
       expect(result).not.toBeNull();
-      expect(result?.toNumber()).toBe(120); // 100 + 20*1
+      expect(result?.toNumber()).toBe(0x64 + 100);
     });
 
-    it('returns maxAmount when only maxAmount is set', () => {
+    it('returns maxAmount when no expiry is set', () => {
       const result = computeTotalExposure({
         initialAmount: '0x0',
-        maxAmount: '0x64',
+        maxAmount: '0x64', // 100
         amountPerSecond: '0x1',
         startTime: 1000,
         expiry: null,
       });
       expect(result).not.toBeNull();
-      expect(result?.toNumber()).toBe(100);
+      expect(result?.toNumber()).toBe(0x64);
     });
 
     it('returns null (unlimited) when neither maxAmount nor expiry is set', () => {
@@ -116,7 +128,7 @@ describe('TotalExposure', () => {
       expect(result).toBeNull();
     });
 
-    it('returns initial amount only when elapsed seconds is zero or negative', () => {
+    it('returns initial amount only when elapsed seconds is zero', () => {
       const result = computeTotalExposure({
         initialAmount: '0x64', // 100
         maxAmount: undefined,
@@ -125,7 +137,7 @@ describe('TotalExposure', () => {
         expiry: 1000, // 0 seconds elapsed
       });
       expect(result).not.toBeNull();
-      expect(result?.toNumber()).toBe(100);
+      expect(result?.toNumber()).toBe(0x64);
     });
 
     it('parses hex amounts correctly', () => {
@@ -137,10 +149,10 @@ describe('TotalExposure', () => {
         expiry: 10,
       });
       expect(result).not.toBeNull();
-      expect(result?.toNumber()).toBe(20); // 0 + 10*2
+      expect(result?.toNumber()).toBe(0x2 * 10);
     });
 
-    it('returns null (unlimited) when maxAmount is max uint256', () => {
+    it('returns null (unlimited) only when maxAmount is max uint256 and expiry is null', () => {
       const maxUint256 =
         '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
       const result = computeTotalExposure({
@@ -148,12 +160,26 @@ describe('TotalExposure', () => {
         maxAmount: maxUint256,
         amountPerSecond: '0x1',
         startTime: 1000,
-        expiry: 2000,
+        expiry: null,
       });
       expect(result).toBeNull();
     });
 
-    it('returns null (unlimited) when maxAmount is max uint256 in uppercase hex', () => {
+    it('returns exposure at expiry (not null) when expiry is set even if maxAmount is max uint256', () => {
+      const maxUint256 =
+        '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+      const result = computeTotalExposure({
+        initialAmount: '0x0',
+        maxAmount: maxUint256,
+        amountPerSecond: '0x1',
+        startTime: 1000,
+        expiry: 1050, // 50 seconds
+      });
+      expect(result).not.toBeNull();
+      expect(result?.toNumber()).toBe(50);
+    });
+
+    it('returns null (unlimited) when maxAmount is max uint256 in uppercase hex and expiry is null', () => {
       const maxUint256Upper =
         '0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF';
       const result = computeTotalExposure({
@@ -161,7 +187,7 @@ describe('TotalExposure', () => {
         maxAmount: maxUint256Upper,
         amountPerSecond: '0x1',
         startTime: 1000,
-        expiry: 2000,
+        expiry: null,
       });
       expect(result).toBeNull();
     });
@@ -175,7 +201,7 @@ describe('TotalExposure', () => {
         expiry: 10, // 10 seconds
       });
       expect(result).not.toBeNull();
-      expect(result?.toNumber()).toBe(10); // 0 + 10*1
+      expect(result?.toNumber()).toBe(10);
     });
 
     it('returns initial only when elapsed is negative (expiry before startTime)', () => {
@@ -187,7 +213,7 @@ describe('TotalExposure', () => {
         expiry: 500, // 500 seconds before start
       });
       expect(result).not.toBeNull();
-      expect(result?.toNumber()).toBe(100); // streamed = 0 when elapsed <= 0
+      expect(result?.toNumber()).toBe(0x64);
     });
   });
 
@@ -214,10 +240,24 @@ describe('TotalExposure', () => {
       expect(getByText(messages.unlimited.message)).toBeInTheDocument();
     });
 
-    it('renders unlimited when maxAmount is max uint256', () => {
+    it('renders unlimited when maxAmount is max uint256 and expiry is null', () => {
       const maxUint256 =
         '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
       const { getByText } = renderWithConfirmContextProvider(
+        <TotalExposure
+          {...defaultErc20Props}
+          maxAmount={maxUint256}
+          expiry={null}
+        />,
+        getMockStore(),
+      );
+      expect(getByText(messages.unlimited.message)).toBeInTheDocument();
+    });
+
+    it('renders token amount (not unlimited) when maxAmount is max uint256 but expiry is set', () => {
+      const maxUint256 =
+        '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+      const { queryByText, container } = renderWithConfirmContextProvider(
         <TotalExposure
           {...defaultErc20Props}
           maxAmount={maxUint256}
@@ -225,7 +265,10 @@ describe('TotalExposure', () => {
         />,
         getMockStore(),
       );
-      expect(getByText(messages.unlimited.message)).toBeInTheDocument();
+      expect(queryByText(messages.unlimited.message)).not.toBeInTheDocument();
+      expect(container.textContent).toContain(
+        messages.confirmFieldTotalExposure.message,
+      );
     });
 
     it('renders token amount row when totalExposure is computed', () => {

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/total-exposure.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/total-exposure.tsx
@@ -1,0 +1,214 @@
+import React from 'react';
+
+import { BigNumber } from 'bignumber.js';
+import { NameType } from '@metamask/name-controller';
+import { Hex } from '@metamask/utils';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  Text,
+} from '@metamask/design-system-react';
+import { ConfirmInfoRow } from '../../../../../../../components/app/confirm/info/row';
+import { useI18nContext } from '../../../../../../../hooks/useI18nContext';
+import Name from '../../../../../../../components/app/name';
+import { NativeAmountRow } from './native-amount-row';
+import { TokenAmountRow } from './token-amount-row';
+
+const MAX_UINT256 =
+  '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+
+/**
+ * Parses an amount string (hex or decimal) to BigNumber.
+ * When value is defined (Hex), returns BigNumber; when value is undefined (or null), returns null.
+ *
+ * @param value - Hex string (0x-prefix) or decimal string; undefined/null treated as absent
+ * @returns BigNumber when value is Hex, or null when value is undefined or null
+ */
+function toAmountBn(value: Hex): BigNumber;
+function toAmountBn(value: Hex | undefined | null): BigNumber | null;
+function toAmountBn(value: Hex | undefined | null): BigNumber | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  return value.startsWith('0x')
+    ? new BigNumber(value, 16)
+    : new BigNumber(value);
+}
+
+/**
+ * Computes total exposure for a stream permission.
+ *
+ * Formula (aligned with gator-permissions-snap deriveExposureForStreamingPermission):
+ * - When expiry is set: exposureAtExpiry = (initialAmount ?? 0) + amountPerSecond * max(0, expiry - startTime)
+ * - When both maxAmount and exposureAtExpiry exist: total = min(maxAmount, exposureAtExpiry)
+ * - Otherwise: total = maxAmount ?? exposureAtExpiry ?? null
+ * - Special case: maxAmount === MAX_UINT256 is treated as unlimited (returns null).
+ *
+ * @param params - Parameters required to compute total exposure (amounts as Hex strings)
+ * @param params.initialAmount
+ * @param params.maxAmount
+ * @param params.amountPerSecond
+ * @param params.startTime
+ * @param params.expiry
+ * @returns BigNumber for the total exposure, or null if unlimited
+ */
+export function computeTotalExposure(params: {
+  initialAmount?: Hex | null | undefined;
+  maxAmount?: Hex | null | undefined;
+  amountPerSecond: Hex;
+  startTime: number;
+  expiry: number | null;
+}): BigNumber | null {
+  const { initialAmount, maxAmount, amountPerSecond, startTime, expiry } =
+    params;
+
+  let exposureAtExpiry: BigNumber | null = null;
+  if (expiry !== null) {
+    const elapsedSeconds = expiry - startTime;
+    const initial = initialAmount
+      ? toAmountBn(initialAmount)
+      : new BigNumber(0);
+    const rateBn = toAmountBn(amountPerSecond);
+    const streamed =
+      elapsedSeconds > 0 && rateBn
+        ? rateBn.times(elapsedSeconds)
+        : new BigNumber(0);
+    exposureAtExpiry = initial.plus(streamed);
+  }
+
+  // max amount is unlimited
+  if (maxAmount === MAX_UINT256) {
+    return null;
+  }
+
+  const maxAmountBn = toAmountBn(maxAmount);
+
+  if (exposureAtExpiry !== null && maxAmountBn !== null) {
+    return BigNumber.min(maxAmountBn, exposureAtExpiry);
+  }
+  return maxAmountBn ?? exposureAtExpiry ?? null;
+}
+
+/** Base stream params required to compute total exposure. Amounts are hex or decimal strings. */
+export type TotalExposureStreamParams = {
+  /** Initial amount (hex or decimal string). */
+  initialAmount?: Hex | null | undefined;
+  /** Max amount cap (hex or decimal string). */
+  maxAmount?: Hex | null | undefined;
+  /** Stream rate per second (hex or decimal string). */
+  amountPerSecond: Hex;
+  /** Stream start time (Unix seconds). */
+  startTime: number;
+  /** Expiry time (Unix seconds), or null if no expiry. */
+  expiry: number | null;
+};
+
+/** Props when displaying total exposure for an ERC20 token. */
+export type TotalExposureErc20Props = TotalExposureStreamParams & {
+  variant: 'erc20';
+  /** Token contract address (for symbol display). */
+  tokenAddress: Hex;
+  /** Chain ID for the token. */
+  chainId: Hex;
+  /** Token decimals (undefined while loading). */
+  decimals: number | undefined;
+};
+
+/** Props when displaying total exposure for a native token. */
+export type TotalExposureNativeProps = TotalExposureStreamParams & {
+  variant: 'native';
+  /** Native token symbol (e.g. ETH). */
+  symbol: string;
+  /** Token decimals. */
+  decimals: number;
+  /** Optional network/token image URL. */
+  imageUrl?: string;
+};
+
+/**
+ * Props for the TotalExposure component.
+ * Use variant 'erc20' for ERC20 streams, 'native' for native token streams.
+ */
+export type TotalExposureProps =
+  | TotalExposureErc20Props
+  | TotalExposureNativeProps;
+
+/**
+ * Component for displaying total exposure for a stream permission.
+ * Shows the computed total (min of max amount and exposure at expiry) when bounded,
+ * or "Unlimited" when neither max amount nor expiry is set.
+ * Supports ERC20 (token address + chainId) and native (symbol + imageUrl) display.
+ *
+ * @param props - The component props (stream params + variant-specific display props)
+ * @returns JSX element containing the total exposure row
+ */
+export const TotalExposure: React.FC<TotalExposureProps> = (props) => {
+  const t = useI18nContext();
+  const { initialAmount, maxAmount, amountPerSecond, startTime, expiry } =
+    props;
+
+  const totalExposure = computeTotalExposure({
+    initialAmount,
+    maxAmount,
+    amountPerSecond,
+    startTime,
+    expiry,
+  });
+
+  if (totalExposure === null) {
+    if (props.variant === 'erc20') {
+      return (
+        <ConfirmInfoRow label={t('confirmFieldTotalExposure')}>
+          <Box
+            flexDirection={BoxFlexDirection.Row}
+            gap={2}
+            alignItems={BoxAlignItems.Center}
+          >
+            {t('unlimited')}
+            <Name
+              value={props.tokenAddress}
+              type={NameType.ETHEREUM_ADDRESS}
+              preferContractSymbol
+              variation={props.chainId}
+            />
+          </Box>
+        </ConfirmInfoRow>
+      );
+    }
+
+    return (
+      <ConfirmInfoRow label={t('confirmFieldTotalExposure')}>
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          gap={2}
+          alignItems={BoxAlignItems.Center}
+        >
+          {t('unlimited')}
+          <Text>{props.symbol}</Text>
+        </Box>
+      </ConfirmInfoRow>
+    );
+  }
+
+  if (props.variant === 'erc20') {
+    return (
+      <TokenAmountRow
+        label={t('confirmFieldTotalExposure')}
+        value={totalExposure}
+        decimals={props.decimals}
+        tokenAddress={props.tokenAddress}
+        chainId={props.chainId}
+      />
+    );
+  }
+  return (
+    <NativeAmountRow
+      label={t('confirmFieldTotalExposure')}
+      value={totalExposure}
+      symbol={props.symbol}
+      decimals={props.decimals}
+      imageUrl={props.imageUrl}
+    />
+  );
+};

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/total-exposure.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/total-exposure.tsx
@@ -52,8 +52,8 @@ function toAmountBn(value: Hex | undefined | null): BigNumber | null {
  * @returns BigNumber for the total exposure, or null if unlimited
  */
 export function computeTotalExposure(params: {
-  initialAmount?: Hex | null | undefined;
-  maxAmount?: Hex | null | undefined;
+  initialAmount?: Hex | null;
+  maxAmount?: Hex | null;
   amountPerSecond: Hex;
   startTime: number;
   expiry: number | null;
@@ -91,9 +91,9 @@ export function computeTotalExposure(params: {
 /** Base stream params required to compute total exposure. Amounts are hex or decimal strings. */
 export type TotalExposureStreamParams = {
   /** Initial amount (hex or decimal string). */
-  initialAmount?: Hex | null | undefined;
+  initialAmount?: Hex | null;
   /** Max amount cap (hex or decimal string). */
-  maxAmount?: Hex | null | undefined;
+  maxAmount?: Hex | null;
   /** Stream rate per second (hex or decimal string). */
   amountPerSecond: Hex;
   /** Stream start time (Unix seconds). */

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/total-exposure.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/total-exposure.tsx
@@ -73,10 +73,7 @@ export function computeTotalExposure(params: {
         ? rateBn.times(elapsedSeconds)
         : new BigNumber(0);
     exposureAtExpiry = initial.plus(streamed);
-  }
-
-  // max amount is unlimited
-  if (maxAmount?.toLowerCase() === MAX_UINT256) {
+  } else if (maxAmount?.toLowerCase() === MAX_UINT256) {
     return null;
   }
 

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/total-exposure.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/total-exposure.tsx
@@ -43,7 +43,7 @@ function toAmountBn(value: Hex | undefined | null): BigNumber | null {
  * - When expiry is set: exposureAtExpiry = (initialAmount ?? 0) + amountPerSecond * max(0, expiry - startTime)
  * - When both maxAmount and exposureAtExpiry exist: total = min(maxAmount, exposureAtExpiry)
  * - Otherwise: total = maxAmount ?? exposureAtExpiry ?? null
- * - Special case: maxAmount === MAX_UINT256 is treated as unlimited (returns null).
+ * - Special case: maxAmount equal to MAX_UINT256 is treated as unlimited (returns null).
  *
  * @param params - Parameters required to compute total exposure (amounts as Hex strings)
  * @param params.initialAmount
@@ -78,7 +78,7 @@ export function computeTotalExposure(params: {
   }
 
   // max amount is unlimited
-  if (maxAmount === MAX_UINT256) {
+  if (maxAmount?.toLowerCase() === MAX_UINT256) {
     return null;
   }
 

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/total-exposure.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/total-exposure.tsx
@@ -19,11 +19,11 @@ const MAX_UINT256 =
   '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
 
 /**
- * Parses an amount string (hex or decimal) to BigNumber.
- * When value is defined (Hex), returns BigNumber; when value is undefined (or null), returns null.
+ * Parses an amount represented as a hex string to BigNumber.
+ * When value is defined, returns BigNumber; when value is undefined (or null), returns null.
  *
- * @param value - Hex string (0x-prefix) or decimal string; undefined/null treated as absent
- * @returns BigNumber when value is Hex, or null when value is undefined or null
+ * @param value - Hex string; undefined/null treated as absent
+ * @returns BigNumber when value is defined, or null when value is undefined or null
  */
 function toAmountBn(value: Hex): BigNumber;
 function toAmountBn(value: Hex | undefined | null): BigNumber | null;
@@ -31,9 +31,7 @@ function toAmountBn(value: Hex | undefined | null): BigNumber | null {
   if (value === undefined || value === null) {
     return null;
   }
-  return value.startsWith('0x')
-    ? new BigNumber(value, 16)
-    : new BigNumber(value);
+  return new BigNumber(value, 16);
 }
 
 /**


### PR DESCRIPTION
## **Description**

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40830?quickstart=1)

Permission signature confirmation now shows total exposure for stream type permission requests. This matches the Permission picker confirmation.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: show "total exposure" for stream type Advanced Permissions

## **Related issues**

Fixes:

## **Manual testing steps**

1. Run the site in https://github.com/MetaMask/snap-7715-permissions/tree/main/packages/site
2. Request erc20-token-stream or native-token-stream permission
3. Note the "total exposure" shown in the permission picker (this value will change depending on parameters)
4. Click "Grant"

Note the "total exposure" shown in the signature confirmation should match that shown in the Permission picker.

## **Screenshots/Recordings**

<img width="525" height="164" alt="image" src="https://github.com/user-attachments/assets/f570a098-4e35-446a-9a4b-21f5728e4a04" />
<img width="520" height="141" alt="image" src="https://github.com/user-attachments/assets/34a79b28-9306-4440-b0ff-784d3c87c468" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new calculation and UI display for stream permission exposure in signature confirmations; risk is mainly incorrect exposure math or formatting misleading users during approval.
> 
> **Overview**
> Signature confirmation UI for `native-token-stream` and `erc20-token-stream` permissions now includes a **Total exposure** row alongside stream-rate details.
> 
> Introduces `TotalExposure` + `computeTotalExposure` to compute exposure at expiry (capped by `maxAmount`, treating max-uint as *Unlimited*), wires it into both stream detail components, adds i18n strings, and updates/extends Jest coverage (new unit tests + snapshot/baseline updates).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d6922c9ea643420f35b1ae426f9e09d5b138bed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->