### PR TITLE
feat: use design-system-react components on shield confirmation screens

### DIFF
--- a/ui/pages/confirmations/components/confirm/footer/shield-footer-agreement.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/shield-footer-agreement.tsx
@@ -1,21 +1,17 @@
 import {
+  Box,
+  BoxFlexDirection,
+  BoxJustifyContent,
+  Text,
+  TextButton,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react';
+import {
   TransactionMeta,
   TransactionType,
 } from '@metamask/transaction-controller';
 import React from 'react';
-import {
-  Box,
-  ButtonLink,
-  ButtonLinkSize,
-  Text,
-} from '../../../../../components/component-library';
-import {
-  Display,
-  FlexDirection,
-  JustifyContent,
-  TextColor,
-  TextVariant,
-} from '../../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { useConfirmContext } from '../../../context/confirm';
 import { SHIELD_TERMS_OF_USE_URL } from '../../../../../../shared/lib/ui-utils';
@@ -30,21 +26,25 @@ const ShieldFooterAgreement = () => {
 
   return (
     <Box
-      display={Display.Flex}
-      flexDirection={FlexDirection.Row}
-      justifyContent={JustifyContent.center}
+      flexDirection={BoxFlexDirection.Row}
+      justifyContent={BoxJustifyContent.Center}
       gap={4}
     >
-      <Text variant={TextVariant.bodySm} color={TextColor.textAlternative}>
+      <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
         {t('shieldFooterAgreement', [
-          <ButtonLink
-            href={SHIELD_TERMS_OF_USE_URL}
-            size={ButtonLinkSize.Inherit}
-            externalLink
+          <TextButton
+            asChild
             key="shield-footer-agreement-button"
+            className="inline font-normal"
           >
-            {t('snapsTermsOfUse')}
-          </ButtonLink>,
+            <a
+              href={SHIELD_TERMS_OF_USE_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {t('snapsTermsOfUse')}
+            </a>
+          </TextButton>,
         ])}
       </Text>
     </Box>

--- a/ui/pages/confirmations/components/confirm/footer/shield-footer-coverage-indicator/shield-footer-coverage-indicator.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/shield-footer-coverage-indicator/shield-footer-coverage-indicator.tsx
@@ -61,7 +61,11 @@ const ShieldFooterCoverageIndicator = () => {
         ownerId={currentConfirmation.id}
         label=""
         labelChildren={
-          <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium} color={TextColor.Inherit}>
+          <Text
+            variant={TextVariant.BodyMd}
+            fontWeight={FontWeight.Medium}
+            color={TextColor.Inherit}
+          >
             {t('transactionShield')}
           </Text>
         }

--- a/ui/pages/confirmations/components/confirm/footer/shield-footer-coverage-indicator/shield-footer-coverage-indicator.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/shield-footer-coverage-indicator/shield-footer-coverage-indicator.tsx
@@ -1,16 +1,17 @@
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  FontWeight,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react';
 import { TransactionMeta } from '@metamask/transaction-controller';
 import React, { useMemo } from 'react';
 import { ConfirmInfoAlertRow } from '../../../../../../components/app/confirm/info/row/alert-row/alert-row';
 import { RowAlertKey } from '../../../../../../components/app/confirm/info/row/constants';
-import { Box, Text } from '../../../../../../components/component-library';
-import {
-  AlignItems,
-  Display,
-  FlexDirection,
-  Severity,
-  TextColor,
-  TextVariant,
-} from '../../../../../../helpers/constants/design-system';
+import { Severity } from '../../../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../../../hooks/useI18nContext';
 import { useConfirmContext } from '../../../../context/confirm';
 import { useEnableShieldCoverageChecks } from '../../../../hooks/transactions/useEnableShieldCoverageChecks';
@@ -40,9 +41,8 @@ const ShieldFooterCoverageIndicator = () => {
 
   return (
     <Box
-      display={Display.Flex}
-      flexDirection={FlexDirection.Row}
-      alignItems={AlignItems.center}
+      flexDirection={BoxFlexDirection.Row}
+      alignItems={BoxAlignItems.Center}
       paddingLeft={4}
       paddingRight={4}
       // box shadow to match the original var(--shadow-size-md) on the footer,
@@ -61,13 +61,13 @@ const ShieldFooterCoverageIndicator = () => {
         ownerId={currentConfirmation.id}
         label=""
         labelChildren={
-          <Text variant={TextVariant.bodyMdMedium} color={TextColor.inherit}>
+          <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium} color={TextColor.Inherit}>
             {t('transactionShield')}
           </Text>
         }
         style={{
           marginBottom: 0,
-          alignItems: AlignItems.center,
+          alignItems: 'center',
           width: '100%',
         }}
         showAlertLoader

--- a/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/subscription-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/subscription-details.tsx
@@ -3,6 +3,10 @@ import {
   BoxAlignItems,
   BoxFlexDirection,
   BoxJustifyContent,
+  FontWeight,
+  Text,
+  TextColor,
+  TextVariant,
 } from '@metamask/design-system-react';
 import React from 'react';
 import {
@@ -10,11 +14,6 @@ import {
   RECURRING_INTERVALS,
 } from '@metamask/subscription-controller';
 import { ConfirmInfoSection } from '../../../../../../components/app/confirm/info/row/section';
-import { Text } from '../../../../../../components/component-library';
-import {
-  TextColor,
-  TextVariant,
-} from '../../../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../../../hooks/useI18nContext';
 import { getProductPrice } from '../../../../../shield-plan/utils';
 import { SUBSCRIPTION_DEFAULT_TRIAL_PERIOD_DAYS } from '../../../../../../../shared/constants/subscriptions';
@@ -54,10 +53,10 @@ export const SubscriptionDetails = ({
           justifyContent={BoxJustifyContent.Center}
           alignItems={BoxAlignItems.Start}
         >
-          <Text variant={TextVariant.bodyMdBold} color={TextColor.textDefault}>
+          <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Bold} color={TextColor.TextDefault}>
             {t('transactionShield')}
           </Text>
-          <Text variant={TextVariant.bodyMd} color={TextColor.textDefault}>
+          <Text variant={TextVariant.BodyMd} color={TextColor.TextDefault}>
             {planDetailsStr}
           </Text>
         </Box>
@@ -73,7 +72,7 @@ export const SubscriptionDetails = ({
               backgroundColor: 'var(--color-primary-muted-hover)',
             }}
           >
-            <Text variant={TextVariant.bodySm} color={TextColor.inherit}>
+            <Text variant={TextVariant.BodySm} color={TextColor.Inherit}>
               {t('freeTrialDays', [
                 productPrice?.trialPeriodDays ??
                   SUBSCRIPTION_DEFAULT_TRIAL_PERIOD_DAYS,

--- a/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/subscription-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shield-subscription-approve/subscription-details.tsx
@@ -53,7 +53,11 @@ export const SubscriptionDetails = ({
           justifyContent={BoxJustifyContent.Center}
           alignItems={BoxAlignItems.Start}
         >
-          <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Bold} color={TextColor.TextDefault}>
+          <Text
+            variant={TextVariant.BodyMd}
+            fontWeight={FontWeight.Bold}
+            color={TextColor.TextDefault}
+          >
             {t('transactionShield')}
           </Text>
           <Text variant={TextVariant.BodyMd} color={TextColor.TextDefault}>

--- a/ui/pages/confirmations/hooks/alerts/transactions/ShieldCoverageAlertMessage.tsx
+++ b/ui/pages/confirmations/hooks/alerts/transactions/ShieldCoverageAlertMessage.tsx
@@ -1,11 +1,12 @@
 'use no memo';
 
 import React from 'react';
-import { ButtonLink, Text } from '../../../../../components/component-library';
 import {
+  Text,
+  TextButton,
   TextColor,
   TextVariant,
-} from '../../../../../helpers/constants/design-system';
+} from '@metamask/design-system-react';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 
 const SHIELD_LEARN_HOW_COVERAGE_WORKS_URL =
@@ -22,21 +23,20 @@ export const ShieldCoverageAlertMessage = ({
 
   return (
     <Text
-      variant={TextVariant.bodyMd}
-      color={TextColor.textDefault}
+      variant={TextVariant.BodyMd}
+      color={TextColor.TextDefault}
       data-testid="alert-modal__selected-alert"
     >
       {t(modalBodyStr, [
-        <ButtonLink
-          href={SHIELD_LEARN_HOW_COVERAGE_WORKS_URL}
-          key="link"
-          target="_blank"
-          rel="noreferrer noopener"
-          color={TextColor.primaryDefault}
-          style={{ verticalAlign: 'baseline' }}
-        >
-          {t('shieldCoverageAlertMessageLearnHowCoverageWorks')}
-        </ButtonLink>,
+        <TextButton asChild key="link" className="inline">
+          <a
+            href={SHIELD_LEARN_HOW_COVERAGE_WORKS_URL}
+            target="_blank"
+            rel="noreferrer noopener"
+          >
+            {t('shieldCoverageAlertMessageLearnHowCoverageWorks')}
+          </a>
+        </TextButton>,
         COVERAGE_AMOUNT,
       ])}
     </Text>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The Shield confirmation UI components currently depend on the internal component-library for foundational primitives (Text, Box, ButtonLink) and on helpers/constants/design-system for enum values (TextVariant, TextColor, Display, FlexDirection, etc.).

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40832?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: use design-system-react components on shield confirmation screens

## **Related issues**

Fixes:

## **Manual testing steps**
**Testing transaction confirmation page**
1. Login to and account with shield subscription
2. Initiate a transaction or signature request to open the confirmation page.
3. Check confirmation indicator at the bottom and the modal when you click it

**Testing Shield subscription confirmation page**
1. Login to an account without shield subscription and has crypto balance
2. Subscribe to shield on settings page
3. Should redirect to shield-plan page
4. Choose crypto as payment and submit
5. Check confirmation page

 
## **Screenshots/Recordings**
_There should be no changes on before/after screens_

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="202" height="59" alt="before-coverage-indicator" src="https://github.com/user-attachments/assets/b042c026-5788-4ecf-9d03-8db75692e53c" />


<img width="505" height="874" alt="before-confirm-screen" src="https://github.com/user-attachments/assets/2d8b55fa-77ca-4a14-8b12-f314e2ee3f16" />


<img width="370" height="294" alt="before-alert" src="https://github.com/user-attachments/assets/0475f720-fbce-4a5f-8d08-92dc10ddbabc" />

<!-- [screenshots/recordings] -->

### **After**
<img width="507" height="875" alt="after-confirm-screen" src="https://github.com/user-attachments/assets/991fe2fc-0f5e-464d-8a33-ac4ab1be7a22" />


<img width="387" height="190" alt="after-coverage-indicator" src="https://github.com/user-attachments/assets/cda0ab1c-ee6a-499d-a4ac-36adbaac19d0" />


<img width="378" height="302" alt="after-alert" src="https://github.com/user-attachments/assets/99406cb0-4126-4efd-8e48-ccf257db7331" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a UI refactor swapping component primitives and style enums, with minimal behavioral change. Risk is limited to potential styling/regression differences in Shield confirmation footers and alert messaging links.
> 
> **Overview**
> Updates Shield confirmation screens to use `@metamask/design-system-react` primitives instead of the internal `component-library` and most `helpers/constants/design-system` enums.
> 
> This refactors footer agreement, coverage indicator, subscription details, and the Shield coverage alert message to the new `Text`/`Box` APIs (new `TextVariant`/`TextColor` values, explicit `FontWeight`) and replaces `ButtonLink` with `TextButton` wrapping an external `<a>` via `asChild`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d519baa2e9637ebbb5b9058344066c0645caa2b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->