### PR TITLE
Cursor wrong pr

### DIFF
--- a/test/e2e/page-objects/pages/dialog/snap-install.ts
+++ b/test/e2e/page-objects/pages/dialog/snap-install.ts
@@ -90,7 +90,9 @@ class SnapInstall {
     console.log(
       'Clicking on the scroll button and then clicking the confirm button',
     );
-    await this.driver.waitForSelector(this.addToMetaMaskHeader);
+    await this.driver.waitForSelector(this.addToMetaMaskHeader, {
+      timeout: 20000,
+    });
     await this.driver.clickElementSafe(this.snapInstallScrollArea);
     await this.driver.clickElement(this.confirmButton);
   }

--- a/test/e2e/page-objects/pages/snap-simple-keyring-page.ts
+++ b/test/e2e/page-objects/pages/snap-simple-keyring-page.ts
@@ -289,9 +289,8 @@ class SnapSimpleKeyringPage {
     await this.driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
     await this.driver.clickElement(this.confirmConnectionButton);
 
-    // set a bigger timeout to wait for element as a temporary fix to reduce flakiness
     await this.driver.waitForSelector(this.addtoMetamaskMessage, {
-      timeout: 15000,
+      timeout: 20000,
     });
     await this.driver.clickElementSafe(this.snapInstallScrollButton, 200);
     await this.driver.waitForSelector(this.confirmAddtoMetamask);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Increase "Add to MetaMask" dialog timeout to fix flaky E2E tests.

The "Add to MetaMask" dialog was timing out in CI environments, causing several E2E tests to fail. The previous 10s/15s timeouts were insufficient, so they have been increased to 20s.

[Slack Thread](https://consensys.slack.com/archives/CTQAGKY5V/p1773303654984329?thread_ts=1773303654.984329&cid=CTQAGKY5V)

<div><a href="https://cursor.com/agents/bc-84bfab75-d431-5203-a084-6bb6dc2be15c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-84bfab75-d431-5203-a084-6bb6dc2be15c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->