### PR TITLE
feat: improve appearance of musd claim summary

### DIFF
--- a/ui/pages/confirmations/components/activity/transaction-details-account-row/transaction-details-account-row.test.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-account-row/transaction-details-account-row.test.tsx
@@ -61,4 +61,34 @@ describe('TransactionDetailsAccountRow', () => {
     const { getByText } = render();
     expect(getByText(messages.account.message)).toBeInTheDocument();
   });
+
+  it('renders nothing when account name and from address are both unavailable', () => {
+    const transactionMetaWithoutFrom = {
+      ...mockTransactionMeta,
+      txParams: {
+        ...mockTransactionMeta.txParams,
+        from: undefined,
+      },
+    };
+
+    const stateWithNoMatchingAccount = {
+      metamask: {
+        internalAccounts: {
+          accounts: {},
+          selectedAccount: 'account-1',
+        },
+      },
+    };
+
+    const { container } = renderWithProvider(
+      <TransactionDetailsProvider
+        transactionMeta={transactionMetaWithoutFrom as never}
+      >
+        <TransactionDetailsAccountRow />
+      </TransactionDetailsProvider>,
+      mockStore(stateWithNoMatchingAccount),
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
 });

--- a/ui/pages/confirmations/components/activity/transaction-details-account-row/transaction-details-account-row.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-account-row/transaction-details-account-row.tsx
@@ -1,12 +1,17 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { Text } from '../../../../../components/component-library';
+import { Text, Box } from '../../../../../components/component-library';
 import {
+  AlignItems,
+  Display,
+  FlexDirection,
   TextColor,
   TextVariant,
 } from '../../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { getAccountName, getInternalAccounts } from '../../../../../selectors';
+import { shortenAddress } from '../../../../../helpers/utils/util';
+import { PreferredAvatar } from '../../../../../components/app/preferred-avatar/preferred-avatar';
 import { TransactionDetailsRow } from '../transaction-details-row';
 import { useTransactionDetails } from '../transaction-details-context';
 
@@ -21,15 +26,24 @@ export function TransactionDetailsAccountRow() {
   } = transactionMeta;
 
   const accountName = getAccountName(internalAccounts, from);
+  const displayName = accountName || shortenAddress(from);
 
   return (
     <TransactionDetailsRow
       label={t('account')}
       data-testid="transaction-details-account-row"
     >
-      <Text variant={TextVariant.bodyMd} color={TextColor.textAlternative}>
-        {accountName ?? from}
-      </Text>
+      <Box
+        display={Display.Flex}
+        flexDirection={FlexDirection.Row}
+        alignItems={AlignItems.center}
+        gap={2}
+      >
+        <PreferredAvatar address={from} />
+        <Text variant={TextVariant.bodyMd} color={TextColor.textAlternative}>
+          {displayName}
+        </Text>
+      </Box>
     </TransactionDetailsRow>
   );
 }

--- a/ui/pages/confirmations/components/activity/transaction-details-account-row/transaction-details-account-row.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-account-row/transaction-details-account-row.tsx
@@ -1,17 +1,12 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { Text, Box } from '../../../../../components/component-library';
+import { Text } from '../../../../../components/component-library';
 import {
-  AlignItems,
-  Display,
-  FlexDirection,
   TextColor,
   TextVariant,
 } from '../../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { getAccountName, getInternalAccounts } from '../../../../../selectors';
-import { shortenAddress } from '../../../../../helpers/utils/util';
-import { PreferredAvatar } from '../../../../../components/app/preferred-avatar/preferred-avatar';
 import { TransactionDetailsRow } from '../transaction-details-row';
 import { useTransactionDetails } from '../transaction-details-context';
 
@@ -26,24 +21,21 @@ export function TransactionDetailsAccountRow() {
   } = transactionMeta;
 
   const accountName = getAccountName(internalAccounts, from);
-  const displayName = accountName || shortenAddress(from);
+
+  const displayName = accountName ?? from;
+
+  if (!displayName) {
+    return null;
+  }
 
   return (
     <TransactionDetailsRow
       label={t('account')}
       data-testid="transaction-details-account-row"
     >
-      <Box
-        display={Display.Flex}
-        flexDirection={FlexDirection.Row}
-        alignItems={AlignItems.center}
-        gap={2}
-      >
-        <PreferredAvatar address={from} />
-        <Text variant={TextVariant.bodyMd} color={TextColor.textAlternative}>
-          {displayName}
-        </Text>
-      </Box>
+      <Text variant={TextVariant.bodyMd} color={TextColor.textAlternative}>
+        {displayName}
+      </Text>
     </TransactionDetailsRow>
   );
 }

--- a/ui/pages/confirmations/components/activity/transaction-details-network-fee-row/transaction-details-network-fee-row.test.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-network-fee-row/transaction-details-network-fee-row.test.tsx
@@ -42,16 +42,16 @@ function render(networkFeeFiat?: string) {
 }
 
 describe('TransactionDetailsNetworkFeeRow', () => {
-  it('renders with correct test id', () => {
-    const { getByTestId } = render();
+  it('renders nothing when networkFeeFiat is not provided', () => {
+    const { container } = render();
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders with correct test id when networkFeeFiat is provided', () => {
+    const { getByTestId } = render('5.25');
     expect(
       getByTestId('transaction-details-network-fee-row'),
     ).toBeInTheDocument();
-  });
-
-  it('renders dash when networkFeeFiat is not provided', () => {
-    const { getByText } = render();
-    expect(getByText('-')).toBeInTheDocument();
   });
 
   it('renders formatted fee when networkFeeFiat is provided', () => {

--- a/ui/pages/confirmations/components/activity/transaction-details-network-fee-row/transaction-details-network-fee-row.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-network-fee-row/transaction-details-network-fee-row.tsx
@@ -22,12 +22,16 @@ export function TransactionDetailsNetworkFeeRow() {
     return fiatFormatter(Number(payNetworkFeeFiat));
   }, [fiatFormatter, payNetworkFeeFiat]);
 
+  if (!payNetworkFeeFiat) {
+    return null;
+  }
+
   return (
     <TransactionDetailsRow
       label={t('networkFee')}
       data-testid="transaction-details-network-fee-row"
     >
-      <Text variant={TextVariant.bodyMd}>{networkFeeFormatted ?? '-'}</Text>
+      <Text variant={TextVariant.bodyMd}>{networkFeeFormatted}</Text>
     </TransactionDetailsRow>
   );
 }

--- a/ui/pages/confirmations/components/activity/transaction-details-total-row/transaction-details-total-row.test.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-total-row/transaction-details-total-row.test.tsx
@@ -42,14 +42,14 @@ function render(totalFiat?: string) {
 }
 
 describe('TransactionDetailsTotalRow', () => {
-  it('renders with correct test id', () => {
-    const { getByTestId } = render();
-    expect(getByTestId('transaction-details-total-row')).toBeInTheDocument();
+  it('renders nothing when totalFiat is not provided', () => {
+    const { container } = render();
+    expect(container.firstChild).toBeNull();
   });
 
-  it('renders dash when totalFiat is not provided', () => {
-    const { getByText } = render();
-    expect(getByText('-')).toBeInTheDocument();
+  it('renders with correct test id when totalFiat is provided', () => {
+    const { getByTestId } = render('150.75');
+    expect(getByTestId('transaction-details-total-row')).toBeInTheDocument();
   });
 
   it('renders formatted total when totalFiat is provided', () => {

--- a/ui/pages/confirmations/components/activity/transaction-details-total-row/transaction-details-total-row.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-total-row/transaction-details-total-row.tsx
@@ -22,12 +22,16 @@ export function TransactionDetailsTotalRow() {
     return fiatFormatter(Number(payTotal));
   }, [fiatFormatter, payTotal]);
 
+  if (!payTotal) {
+    return null;
+  }
+
   return (
     <TransactionDetailsRow
       label={t('total')}
       data-testid="transaction-details-total-row"
     >
-      <Text variant={TextVariant.bodyMd}>{totalFormatted ?? '-'}</Text>
+      <Text variant={TextVariant.bodyMd}>{totalFormatted}</Text>
     </TransactionDetailsRow>
   );
 }

--- a/ui/pages/confirmations/components/activity/transaction-details/transaction-details.test.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details/transaction-details.test.tsx
@@ -128,16 +128,18 @@ describe('TransactionDetails', () => {
     expect(getByTestId('transaction-details-account-row')).toBeInTheDocument();
   });
 
-  it('renders network fee row', () => {
-    const { getByTestId } = render();
+  it('does not render network fee row without metamaskPay', () => {
+    const { queryByTestId } = render();
     expect(
-      getByTestId('transaction-details-network-fee-row'),
-    ).toBeInTheDocument();
+      queryByTestId('transaction-details-network-fee-row'),
+    ).not.toBeInTheDocument();
   });
 
-  it('renders total row', () => {
-    const { getByTestId } = render();
-    expect(getByTestId('transaction-details-total-row')).toBeInTheDocument();
+  it('does not render total row without metamaskPay', () => {
+    const { queryByTestId } = render();
+    expect(
+      queryByTestId('transaction-details-total-row'),
+    ).not.toBeInTheDocument();
   });
 
   it('renders summary section', () => {

--- a/ui/pages/confirmations/components/activity/transaction-details/transaction-details.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details/transaction-details.tsx
@@ -14,9 +14,13 @@ import { TransactionDetailsNetworkFeeRow } from '../transaction-details-network-
 import { TransactionDetailsBridgeFeeRow } from '../transaction-details-bridge-fee-row';
 import { TransactionDetailsTotalRow } from '../transaction-details-total-row';
 import { TransactionDetailsSummary } from '../transaction-details-summary';
+import { useTransactionDetails } from '../transaction-details-context';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export function TransactionDetails() {
+  const { transactionMeta } = useTransactionDetails();
+  const hasPaymentDetails = Boolean(transactionMeta.metamaskPay);
+
   return (
     <Box
       display={Display.Flex}
@@ -39,20 +43,24 @@ export function TransactionDetails() {
         <TransactionDetailsAccountRow />
       </Box>
 
-      <ConfirmInfoRowDivider />
+      {hasPaymentDetails && (
+        <>
+          <ConfirmInfoRowDivider />
 
-      <Box
-        display={Display.Flex}
-        flexDirection={FlexDirection.Column}
-        gap={3}
-        paddingTop={2}
-        paddingBottom={2}
-      >
-        <TransactionDetailsPaidWithRow />
-        <TransactionDetailsNetworkFeeRow />
-        <TransactionDetailsBridgeFeeRow />
-        <TransactionDetailsTotalRow />
-      </Box>
+          <Box
+            display={Display.Flex}
+            flexDirection={FlexDirection.Column}
+            gap={3}
+            paddingTop={2}
+            paddingBottom={2}
+          >
+            <TransactionDetailsPaidWithRow />
+            <TransactionDetailsNetworkFeeRow />
+            <TransactionDetailsBridgeFeeRow />
+            <TransactionDetailsTotalRow />
+          </Box>
+        </>
+      )}
 
       <ConfirmInfoRowDivider />
 


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Updates the transaction summary from musd claims to remove unused rows, and to include an account
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40839?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to the transactions view, check out a Bonus claim - verify that the design no longer include empty rows. 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
<img width="421" height="451" alt="image" src="https://github.com/user-attachments/assets/ac122f78-b7ae-4647-bbcf-5b4ef783bf93" />

### **After**

<!-- [screenshots/recordings] -->

<img width="396" height="321" alt="image" src="https://github.com/user-attachments/assets/7231b7e0-9e48-4f46-b982-45da6e2c3ef9" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI change that only affects conditional rendering of transaction detail rows when MetaMask Pay/tx fields are missing; no changes to transaction logic or data handling.
> 
> **Overview**
> Improves the transaction details summary by **removing empty/placeholder rows**.
> 
> The Account row now renders only when an account name or `from` address is available. The Network Fee and Total rows (and their surrounding section/divider) now **render only when `transactionMeta.metamaskPay` provides the corresponding fiat values**, instead of showing `-` placeholders.
> 
> Tests were updated to assert non-rendering behavior when the required fields are absent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 471b266ff4ad0b6a76b83849f120781ef92600d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->