### PR TITLE
feat: add Settings V2 download state logs

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2419,6 +2419,9 @@
   "downArrow": {
     "message": "down arrow"
   },
+  "download": {
+    "message": "Download"
+  },
   "downloadAppDescription": {
     "message": "Bring MetaMask with you everywhere you go. Turn on Face ID so you always have access, even if you forget your password."
   },
@@ -8154,6 +8157,9 @@
   },
   "stateLogsDescription": {
     "message": "State logs contain your public account addresses and sent transactions."
+  },
+  "stateLogsModalDescription": {
+    "message": "State logs can help us debug issues you might encounter. Only send it to MetaMask for support, because state logs contain your public account address and transactions."
   },
   "status": {
     "message": "Status"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -2419,6 +2419,9 @@
   "downArrow": {
     "message": "down arrow"
   },
+  "download": {
+    "message": "Download"
+  },
   "downloadAppDescription": {
     "message": "Bring MetaMask with you everywhere you go. Turn on Face ID so you always have access, even if you forget your password."
   },
@@ -8154,6 +8157,9 @@
   },
   "stateLogsDescription": {
     "message": "State logs contain your public account addresses and sent transactions."
+  },
+  "stateLogsModalDescription": {
+    "message": "State logs can help us debug issues you might encounter. Only send it to MetaMask for support, because state logs contain your public account address and transactions."
   },
   "status": {
     "message": "Status"

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -2880,6 +2880,9 @@
       "React: componentWill* lifecycle deprecations": 1,
       "warn: ⚠️ React Router Future Flag": 2
     },
+    "ui/pages/settings-v2/privacy-tab/download-state-logs-item.test.tsx": {
+      "warn: ⚠️ React Router Future Flag": 2
+    },
     "ui/pages/settings-v2/privacy-tab/metametrics-item.test.tsx": {
       "React: componentWill* lifecycle deprecations": 1,
       "warn: ⚠️ React Router Future Flag": 2

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -302,6 +302,10 @@ export declare global {
 
   var stateHooks: StateHooks;
 
+  var logStateString: (
+    callback: (err: Error | null, result: string) => void,
+  ) => void;
+
   var browser: Browser;
 
   var INFURA_PROJECT_ID: string | undefined;

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -302,9 +302,7 @@ export declare global {
 
   var stateHooks: StateHooks;
 
-  var logStateString: (
-    callback: (err: Error | null, result: string) => void,
-  ) => void;
+  var logStateString: () => Promise<string>;
 
   var browser: Browser;
 

--- a/ui/index.js
+++ b/ui/index.js
@@ -406,20 +406,17 @@ function setupStateHooks(store) {
   };
 }
 
-window.logStateString = async function (cb) {
+/**
+ * Returns the extension state as a formatted JSON string for debugging.
+ * Includes app state, logs, and platform info.
+ *
+ * @returns {Promise<string>} The state as a JSON string
+ */
+window.logStateString = async function () {
   const state = await window.stateHooks.getCleanAppState();
-  const logs = window.stateHooks.getLogs();
-  browser.runtime
-    .getPlatformInfo()
-    .then((platform) => {
-      state.platform = platform;
-      state.logs = logs;
-      const stateString = JSON.stringify(state, null, 2);
-      cb(null, stateString);
-    })
-    .catch((err) => {
-      cb(err);
-    });
+  state.logs = window.stateHooks.getLogs();
+  state.platform = await browser.runtime.getPlatformInfo();
+  return JSON.stringify(state, null, 2);
 };
 
 window.logState = function (toClipboard) {

--- a/ui/index.js
+++ b/ui/index.js
@@ -419,15 +419,16 @@ window.logStateString = async function () {
   return JSON.stringify(state, null, 2);
 };
 
-window.logState = function (toClipboard) {
-  return window.logStateString((err, result) => {
-    if (err) {
-      console.error(err.message);
-    } else if (toClipboard) {
+window.logState = async function (toClipboard) {
+  try {
+    const result = await window.logStateString();
+    if (toClipboard) {
       copyToClipboard(result, COPY_OPTIONS);
       console.log('State log copied');
     } else {
       console.log(result);
     }
-  });
+  } catch (err) {
+    console.error(err.message);
+  }
 };

--- a/ui/pages/settings-v2/privacy-tab/__snapshots__/privacy-tab.test.tsx.snap
+++ b/ui/pages/settings-v2/privacy-tab/__snapshots__/privacy-tab.test.tsx.snap
@@ -314,6 +314,20 @@ exports[`PrivacyTab snapshot matches snapshot 1`] = `
         We'll use MetaMetrics to learn how you interact with our marketing communications. We may share relevant news (like product features and other materials).
       </p>
     </div>
+    <div
+      class="bg-muted my-2 h-px w-full"
+    />
+    <button
+      class="inline-flex items-center justify-center rounded-xl font-medium min-w-20 overflow-hidden relative h-12 transition-all duration-100 ease-linear active:scale-[0.97] active:ease-[cubic-bezier(0.3,0.8,0.3,1)] bg-icon-default hover:bg-icon-default-hover active:bg-icon-default-pressed focus-visible:ring-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-default text-text-default !bg-transparent p-0 text-left"
+      data-testid="download-state-logs-button"
+      role="button"
+    >
+      <span
+        class="text-inherit text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default"
+      >
+        Download state logs
+      </span>
+    </button>
   </div>
 </div>
 `;

--- a/ui/pages/settings-v2/privacy-tab/download-state-logs-item.test.tsx
+++ b/ui/pages/settings-v2/privacy-tab/download-state-logs-item.test.tsx
@@ -15,21 +15,20 @@ jest.mock('../../../helpers/utils/export-utils', () => ({
 
 const mockExportAsFile = exportUtils.exportAsFile as jest.Mock;
 
-type LogStateCallback = (err: Error | null, result?: string) => void;
-
 describe('DownloadStateLogsItem', () => {
   const mockStore = configureMockStore([thunk])(mockState);
-  let mockLogStateString: jest.Mock<void, [LogStateCallback]>;
+  let mockLogStateString: jest.Mock<Promise<string>>;
 
   beforeEach(() => {
     jest.clearAllMocks();
     mockLogStateString = jest.fn();
-    globalThis.logStateString = mockLogStateString as unknown as typeof globalThis.logStateString;
+    window.logStateString =
+      mockLogStateString as unknown as typeof window.logStateString;
   });
 
   afterEach(() => {
     // @ts-expect-error - resetting mock
-    delete globalThis.logStateString;
+    delete window.logStateString;
   });
 
   it('renders the button with correct text', () => {
@@ -56,9 +55,7 @@ describe('DownloadStateLogsItem', () => {
   });
 
   it('calls logStateString and exportAsFile on download', async () => {
-    mockLogStateString.mockImplementation((callback) => {
-      callback(null, '{"state": "data"}');
-    });
+    mockLogStateString.mockResolvedValue('{"state": "data"}');
     mockExportAsFile.mockResolvedValue(undefined);
 
     renderWithProvider(<DownloadStateLogsItem />, mockStore);
@@ -83,10 +80,8 @@ describe('DownloadStateLogsItem', () => {
     });
   });
 
-  it('shows error toast when logStateString returns error', async () => {
-    mockLogStateString.mockImplementation((callback) => {
-      callback(new Error('Failed to get state'));
-    });
+  it('shows error toast when logStateString rejects', async () => {
+    mockLogStateString.mockRejectedValue(new Error('Failed to get state'));
 
     renderWithProvider(<DownloadStateLogsItem />, mockStore);
 
@@ -111,9 +106,7 @@ describe('DownloadStateLogsItem', () => {
   });
 
   it('shows error toast when exportAsFile throws', async () => {
-    mockLogStateString.mockImplementation((callback) => {
-      callback(null, '{"state": "data"}');
-    });
+    mockLogStateString.mockResolvedValue('{"state": "data"}');
     mockExportAsFile.mockRejectedValue(new Error('Export failed'));
 
     renderWithProvider(<DownloadStateLogsItem />, mockStore);

--- a/ui/pages/settings-v2/privacy-tab/download-state-logs-item.test.tsx
+++ b/ui/pages/settings-v2/privacy-tab/download-state-logs-item.test.tsx
@@ -24,11 +24,12 @@ describe('DownloadStateLogsItem', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockLogStateString = jest.fn();
-    (globalThis as Record<string, unknown>).logStateString = mockLogStateString;
+    globalThis.logStateString = mockLogStateString as unknown as typeof globalThis.logStateString;
   });
 
   afterEach(() => {
-    delete (globalThis as Record<string, unknown>).logStateString;
+    // @ts-expect-error - resetting mock
+    delete globalThis.logStateString;
   });
 
   it('renders the button with correct text', () => {
@@ -37,7 +38,9 @@ describe('DownloadStateLogsItem', () => {
     expect(
       screen.getByTestId('download-state-logs-button'),
     ).toBeInTheDocument();
-    expect(screen.getByText(messages.downloadStateLogs.message)).toBeInTheDocument();
+    expect(
+      screen.getByText(messages.downloadStateLogs.message),
+    ).toBeInTheDocument();
   });
 
   it('opens modal when button is clicked', async () => {

--- a/ui/pages/settings-v2/privacy-tab/download-state-logs-item.test.tsx
+++ b/ui/pages/settings-v2/privacy-tab/download-state-logs-item.test.tsx
@@ -37,7 +37,7 @@ describe('DownloadStateLogsItem', () => {
     expect(
       screen.getByTestId('download-state-logs-button'),
     ).toBeInTheDocument();
-    expect(screen.getByText(messages.stateLogs.message)).toBeInTheDocument();
+    expect(screen.getByText(messages.downloadStateLogs.message)).toBeInTheDocument();
   });
 
   it('opens modal when button is clicked', async () => {

--- a/ui/pages/settings-v2/privacy-tab/download-state-logs-item.test.tsx
+++ b/ui/pages/settings-v2/privacy-tab/download-state-logs-item.test.tsx
@@ -1,0 +1,134 @@
+import { fireEvent, screen, waitFor, act } from '@testing-library/react';
+import React from 'react';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import mockState from '../../../../test/data/mock-state.json';
+import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
+import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
+import * as exportUtils from '../../../helpers/utils/export-utils';
+import { DownloadStateLogsItem } from './download-state-logs-item';
+
+jest.mock('../../../helpers/utils/export-utils', () => ({
+  ...jest.requireActual('../../../helpers/utils/export-utils'),
+  exportAsFile: jest.fn(),
+}));
+
+const mockExportAsFile = exportUtils.exportAsFile as jest.Mock;
+
+type LogStateCallback = (err: Error | null, result?: string) => void;
+
+describe('DownloadStateLogsItem', () => {
+  const mockStore = configureMockStore([thunk])(mockState);
+  let mockLogStateString: jest.Mock<void, [LogStateCallback]>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLogStateString = jest.fn();
+    (globalThis as Record<string, unknown>).logStateString = mockLogStateString;
+  });
+
+  afterEach(() => {
+    delete (globalThis as Record<string, unknown>).logStateString;
+  });
+
+  it('renders the button with correct text', () => {
+    renderWithProvider(<DownloadStateLogsItem />, mockStore);
+
+    expect(
+      screen.getByTestId('download-state-logs-button'),
+    ).toBeInTheDocument();
+    expect(screen.getByText(messages.stateLogs.message)).toBeInTheDocument();
+  });
+
+  it('opens modal when button is clicked', async () => {
+    renderWithProvider(<DownloadStateLogsItem />, mockStore);
+
+    fireEvent.click(screen.getByTestId('download-state-logs-button'));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(messages.stateLogsModalDescription.message),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('calls logStateString and exportAsFile on download', async () => {
+    mockLogStateString.mockImplementation((callback) => {
+      callback(null, '{"state": "data"}');
+    });
+    mockExportAsFile.mockResolvedValue(undefined);
+
+    renderWithProvider(<DownloadStateLogsItem />, mockStore);
+
+    fireEvent.click(screen.getByTestId('download-state-logs-button'));
+
+    await waitFor(() => {
+      expect(screen.getByText(messages.download.message)).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText(messages.download.message));
+    });
+
+    expect(mockLogStateString).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(mockExportAsFile).toHaveBeenCalledWith(
+        `${messages.stateLogFileName.message}.json`,
+        '{"state": "data"}',
+        exportUtils.ExportableContentType.JSON,
+      );
+    });
+  });
+
+  it('shows error toast when logStateString returns error', async () => {
+    mockLogStateString.mockImplementation((callback) => {
+      callback(new Error('Failed to get state'));
+    });
+
+    renderWithProvider(<DownloadStateLogsItem />, mockStore);
+
+    fireEvent.click(screen.getByTestId('download-state-logs-button'));
+
+    await waitFor(() => {
+      expect(screen.getByText(messages.download.message)).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText(messages.download.message));
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('download-state-logs-error-toast'),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(messages.stateLogError.message),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('shows error toast when exportAsFile throws', async () => {
+    mockLogStateString.mockImplementation((callback) => {
+      callback(null, '{"state": "data"}');
+    });
+    mockExportAsFile.mockRejectedValue(new Error('Export failed'));
+
+    renderWithProvider(<DownloadStateLogsItem />, mockStore);
+
+    fireEvent.click(screen.getByTestId('download-state-logs-button'));
+
+    await waitFor(() => {
+      expect(screen.getByText(messages.download.message)).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText(messages.download.message));
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('download-state-logs-error-toast'),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/ui/pages/settings-v2/privacy-tab/download-state-logs-item.test.tsx
+++ b/ui/pages/settings-v2/privacy-tab/download-state-logs-item.test.tsx
@@ -13,6 +13,11 @@ jest.mock('../../../helpers/utils/export-utils', () => ({
   exportAsFile: jest.fn(),
 }));
 
+jest.mock('../../../../shared/lib/sentry', () => ({
+  ...jest.requireActual('../../../../shared/lib/sentry'),
+  captureException: jest.fn(),
+}));
+
 const mockExportAsFile = exportUtils.exportAsFile as jest.Mock;
 
 describe('DownloadStateLogsItem', () => {

--- a/ui/pages/settings-v2/privacy-tab/download-state-logs-item.tsx
+++ b/ui/pages/settings-v2/privacy-tab/download-state-logs-item.tsx
@@ -1,0 +1,49 @@
+import React, { useState } from 'react';
+import {
+  Button,
+  Icon,
+  IconColor,
+  IconName,
+} from '@metamask/design-system-react';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import { Toast, ToastContainer } from '../../../components/multichain/toast';
+import { BorderRadius } from '../../../helpers/constants/design-system';
+import DownloadStateLogsModal from './download-state-logs-modal';
+
+export const DownloadStateLogsItem = () => {
+  const t = useI18nContext();
+  const [showModal, setShowModal] = useState(false);
+  const [showErrorToast, setShowErrorToast] = useState(false);
+
+  return (
+    <>
+      <Button
+        data-testid="download-state-logs-button"
+        onClick={() => setShowModal(true)}
+        className="text-text-default !bg-transparent p-0 text-left"
+      >
+        {t('downloadStateLogs')}
+      </Button>
+      {showModal && (
+        <DownloadStateLogsModal
+          onClose={() => setShowModal(false)}
+          onError={() => setShowErrorToast(true)}
+        />
+      )}
+      {showErrorToast && (
+        <ToastContainer>
+          <Toast
+            startAdornment={
+              <Icon name={IconName.Danger} color={IconColor.ErrorDefault} />
+            }
+            text={t('stateLogError')}
+            onClose={() => setShowErrorToast(false)}
+            borderRadius={BorderRadius.LG}
+            textClassName="text-base"
+            dataTestId="download-state-logs-error-toast"
+          />
+        </ToastContainer>
+      )}
+    </>
+  );
+};

--- a/ui/pages/settings-v2/privacy-tab/download-state-logs-modal.tsx
+++ b/ui/pages/settings-v2/privacy-tab/download-state-logs-modal.tsx
@@ -40,13 +40,7 @@ export default function DownloadStateLogsModal({
   const t = useI18nContext();
 
   const handleDownload = () => {
-    (
-      globalThis as unknown as {
-        logStateString: (
-          cb: (err: Error | null, result: string) => void,
-        ) => void;
-      }
-    ).logStateString(async (err: Error | null, result: string) => {
+    globalThis.logStateString(async (err, result) => {
       if (err) {
         onError();
       } else {
@@ -90,7 +84,7 @@ export default function DownloadStateLogsModal({
         </Box>
         <ModalFooter>
           <Button
-            data-testid="download-state-logs-button"
+            data-testid="download-state-logs-modal-button"
             className="w-full"
             variant={ButtonVariant.Primary}
             onClick={handleDownload}

--- a/ui/pages/settings-v2/privacy-tab/download-state-logs-modal.tsx
+++ b/ui/pages/settings-v2/privacy-tab/download-state-logs-modal.tsx
@@ -27,6 +27,7 @@ import {
   exportAsFile,
   ExportableContentType,
 } from '../../../helpers/utils/export-utils';
+import { captureException } from '../../../../shared/lib/sentry';
 
 type DownloadStateLogsModalProps = {
   onClose: () => void;
@@ -47,7 +48,8 @@ export default function DownloadStateLogsModal({
         stateString,
         ExportableContentType.JSON,
       );
-    } catch {
+    } catch (error) {
+      captureException(error);
       onError();
     }
     onClose();

--- a/ui/pages/settings-v2/privacy-tab/download-state-logs-modal.tsx
+++ b/ui/pages/settings-v2/privacy-tab/download-state-logs-modal.tsx
@@ -39,22 +39,17 @@ export default function DownloadStateLogsModal({
 }: Readonly<DownloadStateLogsModalProps>) {
   const t = useI18nContext();
 
-  const handleDownload = () => {
-    globalThis.logStateString(async (err, result) => {
-      if (err) {
-        onError();
-      } else {
-        try {
-          await exportAsFile(
-            `${t('stateLogFileName')}.json`,
-            result,
-            ExportableContentType.JSON,
-          );
-        } catch {
-          onError();
-        }
-      }
-    });
+  const handleDownload = async () => {
+    try {
+      const stateString = await window.logStateString();
+      await exportAsFile(
+        `${t('stateLogFileName')}.json`,
+        stateString,
+        ExportableContentType.JSON,
+      );
+    } catch {
+      onError();
+    }
     onClose();
   };
 

--- a/ui/pages/settings-v2/privacy-tab/download-state-logs-modal.tsx
+++ b/ui/pages/settings-v2/privacy-tab/download-state-logs-modal.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import {
+  Box,
+  BoxFlexDirection,
+  BoxAlignItems,
+  BoxJustifyContent,
+  Button,
+  ButtonVariant,
+  Text,
+  TextVariant,
+  TextColor,
+} from '@metamask/design-system-react';
+import {
+  Modal,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+} from '../../../components/component-library';
+import {
+  AlignItems,
+  Display,
+  FlexDirection,
+} from '../../../helpers/constants/design-system';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import {
+  exportAsFile,
+  ExportableContentType,
+} from '../../../helpers/utils/export-utils';
+
+type DownloadStateLogsModalProps = {
+  onClose: () => void;
+  onError: () => void;
+};
+
+export default function DownloadStateLogsModal({
+  onClose,
+  onError,
+}: Readonly<DownloadStateLogsModalProps>) {
+  const t = useI18nContext();
+
+  const handleDownload = () => {
+    (
+      globalThis as unknown as {
+        logStateString: (
+          cb: (err: Error | null, result: string) => void,
+        ) => void;
+      }
+    ).logStateString(async (err: Error | null, result: string) => {
+      if (err) {
+        onError();
+      } else {
+        try {
+          await exportAsFile(
+            `${t('stateLogFileName')}.json`,
+            result,
+            ExportableContentType.JSON,
+          );
+        } catch {
+          onError();
+        }
+      }
+    });
+    onClose();
+  };
+
+  return (
+    <Modal isOpen onClose={onClose}>
+      <ModalOverlay />
+      <ModalContent
+        alignItems={AlignItems.center}
+        modalDialogProps={{
+          display: Display.Flex,
+          flexDirection: FlexDirection.Column,
+        }}
+      >
+        <ModalHeader onClose={onClose}>
+          <Box
+            flexDirection={BoxFlexDirection.Column}
+            alignItems={BoxAlignItems.Center}
+            justifyContent={BoxJustifyContent.Center}
+          >
+            <Text variant={TextVariant.HeadingSm}>{t('stateLogs')}</Text>
+          </Box>
+        </ModalHeader>
+        <Box marginHorizontal={4} marginBottom={3}>
+          <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
+            {t('stateLogsModalDescription')}
+          </Text>
+        </Box>
+        <ModalFooter>
+          <Button
+            data-testid="download-state-logs-button"
+            className="w-full"
+            variant={ButtonVariant.Primary}
+            onClick={handleDownload}
+          >
+            {t('download')}
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/ui/pages/settings-v2/privacy-tab/privacy-tab.tsx
+++ b/ui/pages/settings-v2/privacy-tab/privacy-tab.tsx
@@ -11,6 +11,7 @@ import { ThirdPartyApisItem } from './third-party-apis-item';
 import { BasicFunctionalityToggleItem } from './basic-functionality-item';
 import { MetametricsToggleItem } from './metametrics-item';
 import { DataCollectionToggleItem } from './data-collection-item';
+import { DownloadStateLogsItem } from './download-state-logs-item';
 
 const BatchAccountBalanceRequestsToggleItem = createToggleItem({
   name: 'BatchAccountBalanceRequestsToggleItem',
@@ -47,6 +48,11 @@ const PRIVACY_SETTING_ITEMS: SettingItemConfig[] = [
     hasDividerBefore: true,
   },
   { id: 'data-collection', component: DataCollectionToggleItem },
+  {
+    id: 'download-state-logs',
+    component: DownloadStateLogsItem,
+    hasDividerBefore: true,
+  },
 ];
 
 const PrivacyTab = () => <SettingsTab items={PRIVACY_SETTING_ITEMS} />;

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.js
@@ -139,22 +139,17 @@ export default class AdvancedTab extends PureComponent {
             <Button
               variant={ButtonVariant.Secondary}
               data-testid="advanced-setting-state-logs-button"
-              onClick={() => {
-                window.logStateString(async (err, result) => {
-                  if (err) {
-                    displayErrorInSettings(t('stateLogError'));
-                  } else {
-                    try {
-                      await exportAsFile(
-                        `${t('stateLogFileName')}.json`,
-                        result,
-                        ExportableContentType.JSON,
-                      );
-                    } catch (error) {
-                      displayErrorInSettings(error.message);
-                    }
-                  }
-                });
+              onClick={async () => {
+                try {
+                  const result = await window.logStateString();
+                  await exportAsFile(
+                    `${t('stateLogFileName')}.json`,
+                    result,
+                    ExportableContentType.JSON,
+                  );
+                } catch (error) {
+                  displayErrorInSettings(error.message || t('stateLogError'));
+                }
               }}
             >
               {t('downloadStateLogs')}

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.test.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.test.js
@@ -205,10 +205,7 @@ describe('AdvancedTab Component', () => {
     });
 
     it('should call exportAsFile when the toggle button is clicked', async () => {
-      // Mock successful state log retrieval
-      mockLogStateString.mockImplementation((callback) => {
-        callback(null, '{"state": "data"}');
-      });
+      mockLogStateString.mockResolvedValue('{"state": "data"}');
       const { queryByTestId } = renderWithProvider(<AdvancedTab />, mockStore);
       const stateLogButton = queryByTestId(
         'advanced-setting-state-logs-button',

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.test.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.test.js
@@ -216,10 +216,7 @@ describe('AdvancedTab Component', () => {
       });
     });
     it('should call displayErrorInSettings when the state file download fails', async () => {
-      // Mock failed state log retrieval
-      mockLogStateString.mockImplementation((callback) => {
-        callback(new Error('state file error'), null);
-      });
+      mockLogStateString.mockRejectedValue(new Error('state file error'));
       const { queryByTestId } = renderWithProvider(<AdvancedTab />, mockStore);
       const stateLogButton = queryByTestId(
         'advanced-setting-state-logs-button',


### PR DESCRIPTION
## **Description**

Adds the 'Download state logs' item to Settings V2 -> Privacy. Functionality is the same but now the button opens a modal first which contains more information. If there is an error, instead of showing it as a string on the top of Privacy tab, it shows in a persistent toast.

Updates the global `logStateString` function too which was a bit outdated and adds a type.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CEUX-911

## **Manual testing steps**

1. Uncomment the object under `Uncomment to view Settings V2 in Hamburger Menu`
2. Go to Settings v2 -> Privacy -> State logs
3. Check the modal appears, the logs are downloaded correctly
4. Manually check if the request fails the toast shows

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="415" height="824" alt="image" src="https://github.com/user-attachments/assets/79d73d3f-842e-4610-a3e1-2721a9ea5829" />

<img width="408" height="825" alt="image" src="https://github.com/user-attachments/assets/4ef5d240-a9fa-445e-b6bf-a8477d658920" />

<img width="409" height="823" alt="image" src="https://github.com/user-attachments/assets/e5d6c524-29b7-49db-85c2-510c47e33be4" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new Settings V2 download flow and changes the global `window.logStateString` API from callback-based to Promise-based, which could break any callers not updated. The downloaded file contains sensitive-ish state/log data, so regressions could affect support/debug workflows and user expectations.
> 
> **Overview**
> Adds a **Settings V2 → Privacy** entry to download state logs, using a new modal that explains what the logs contain and a persistent toast for failures.
> 
> Refactors the global `window.logStateString`/`window.logState` helpers to be **Promise-based** and returns the formatted state JSON directly (with platform + logs), and updates the existing Settings (Advanced) state-log download button and tests to use the new async API.
> 
> Updates i18n strings (`download`, `stateLogsModalDescription`) and adds coverage/snapshots for the new Settings V2 item.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34d463990d3f76794052e8bbd6b9b5783afb86b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->