### PR TITLE
feat: add delete metametrics data item in Settings V2

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2263,8 +2263,12 @@
     "message": "This will delete historical MetaMetrics data associated with your use on this device. Your wallet and accounts will remain exactly as they are now after this data has been deleted. This process may take up to 30 days. View our $1.",
     "description": "$1 will have text saying Privacy Policy "
   },
+  "deleteMetaMetricsDataDescriptionV2": {
+    "message": "This will delete historical MetaMetrics data associated with your wallet. MetaMetrics includes anonymized usage and diagnostic data. Your wallet and accounts will remain the same. This process may take up to 30 days. View our $1.",
+    "description": "$1 will have text saying Privacy Policy "
+  },
   "deleteMetaMetricsDataErrorDesc": {
-    "message": "This request can't be completed right now due to an analytics system server issue, please try again later"
+    "message": "This request can't be completed right now due to an analytics system server issue, please try again later."
   },
   "deleteMetaMetricsDataErrorTitle": {
     "message": "We are unable to delete this data right now"
@@ -2276,8 +2280,11 @@
     "message": "Delete MetaMetrics data?"
   },
   "deleteMetaMetricsDataRequestedDescription": {
-    "message": "You initiated this action on $1. This process can take up to 30 days. View the $2",
+    "message": "You initiated this action on $1. This process can take up to 30 days. View the $2.",
     "description": "$1 will be the date on which teh deletion is requested and $2 will have text saying Privacy Policy "
+  },
+  "deleteMetaMetricsDataToast": {
+    "message": "Data will be deleted within 30 days"
   },
   "deleteNetworkIntro": {
     "message": "If you delete this network, you will need to add it again to view your assets in this network"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2273,6 +2273,9 @@
   "deleteMetaMetricsDataErrorTitle": {
     "message": "We are unable to delete this data right now"
   },
+  "deleteMetaMetricsDataErrorToast": {
+    "message": "Unable to delete"
+  },
   "deleteMetaMetricsDataModalDesc": {
     "message": "We are about to remove all your MetaMetrics data. Are you sure?"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2283,7 +2283,7 @@
     "message": "Delete MetaMetrics data?"
   },
   "deleteMetaMetricsDataRequestedDescription": {
-    "message": "You initiated this action on $1. This process can take up to 30 days. View the $2.",
+    "message": "You initiated deletion on $1. This process can take up to 30 days. View the $2.",
     "description": "$1 will be the date on which teh deletion is requested and $2 will have text saying Privacy Policy "
   },
   "deleteMetaMetricsDataToast": {

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -2263,8 +2263,12 @@
     "message": "This will delete historical MetaMetrics data associated with your use on this device. Your wallet and accounts will remain exactly as they are now after this data has been deleted. This process may take up to 30 days. View our $1.",
     "description": "$1 will have text saying Privacy Policy "
   },
+  "deleteMetaMetricsDataDescriptionV2": {
+    "message": "This will delete historical MetaMetrics data associated with your wallet. MetaMetrics includes anonymized usage and diagnostic data. Your wallet and accounts will remain the same. This process may take up to 30 days. View our $1.",
+    "description": "$1 will have text saying Privacy Policy "
+  },
   "deleteMetaMetricsDataErrorDesc": {
-    "message": "This request can't be completed right now due to an analytics system server issue, please try again later"
+    "message": "This request can't be completed right now due to an analytics system server issue, please try again later."
   },
   "deleteMetaMetricsDataErrorTitle": {
     "message": "We are unable to delete this data right now"
@@ -2276,8 +2280,11 @@
     "message": "Delete MetaMetrics data?"
   },
   "deleteMetaMetricsDataRequestedDescription": {
-    "message": "You initiated this action on $1. This process can take up to 30 days. View the $2",
+    "message": "You initiated this action on $1. This process can take up to 30 days. View the $2.",
     "description": "$1 will be the date on which teh deletion is requested and $2 will have text saying Privacy Policy "
+  },
+  "deleteMetaMetricsDataToast": {
+    "message": "Data will be deleted within 30 days"
   },
   "deleteNetworkIntro": {
     "message": "If you delete this network, you will need to add it again to view your assets in this network"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -2273,6 +2273,9 @@
   "deleteMetaMetricsDataErrorTitle": {
     "message": "We are unable to delete this data right now"
   },
+  "deleteMetaMetricsDataErrorToast": {
+    "message": "Unable to delete"
+  },
   "deleteMetaMetricsDataModalDesc": {
     "message": "We are about to remove all your MetaMetrics data. Are you sure?"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -2283,7 +2283,7 @@
     "message": "Delete MetaMetrics data?"
   },
   "deleteMetaMetricsDataRequestedDescription": {
-    "message": "You initiated this action on $1. This process can take up to 30 days. View the $2.",
+    "message": "You initiated deletion on $1. This process can take up to 30 days. View the $2.",
     "description": "$1 will be the date on which teh deletion is requested and $2 will have text saying Privacy Policy "
   },
   "deleteMetaMetricsDataToast": {

--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -1259,6 +1259,12 @@ export enum DeleteRegulationStatus {
   Unknown = 'UNKNOWN',
 }
 
+export const DATA_DELETION_IN_PROGRESS_STATUSES: DeleteRegulationStatus[] = [
+  DeleteRegulationStatus.Initialized,
+  DeleteRegulationStatus.Running,
+  DeleteRegulationStatus.Finished,
+];
+
 export enum MetaMetricsEventTransactionEstimateType {
   DappProposed = 'dapp_proposed',
   DefaultEstimate = 'default_estimate',

--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -1259,7 +1259,7 @@ export enum DeleteRegulationStatus {
   Unknown = 'UNKNOWN',
 }
 
-export const DATA_DELETION_IN_PROGRESS_STATUSES: DeleteRegulationStatus[] = [
+export const DATA_DELETION_REQUESTED_STATUSES: DeleteRegulationStatus[] = [
   DeleteRegulationStatus.Initialized,
   DeleteRegulationStatus.Running,
   DeleteRegulationStatus.Finished,

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -2890,6 +2890,9 @@
       "React: componentWill* lifecycle deprecations": 1,
       "warn: ⚠️ React Router Future Flag": 2
     },
+    "ui/pages/settings-v2/privacy-tab/delete-metametrics-data-item.test.tsx": {
+      "warn: ⚠️ React Router Future Flag": 2
+    },
     "ui/pages/settings-v2/privacy-tab/download-state-logs-item.test.tsx": {
       "warn: ⚠️ React Router Future Flag": 2
     },

--- a/ui/components/app/data-deletion-error-modal/data-deletion-error-modal.tsx
+++ b/ui/components/app/data-deletion-error-modal/data-deletion-error-modal.tsx
@@ -28,14 +28,24 @@ import {
 } from '../../component-library';
 import { hideDataDeletionErrorModal } from '../../../ducks/app/app';
 
+type DataDeletionErrorModalProps = {
+  onClose?: () => void;
+};
+
 // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
 // eslint-disable-next-line @typescript-eslint/naming-convention
-export default function DataDeletionErrorModal() {
+export default function DataDeletionErrorModal({
+  onClose,
+}: DataDeletionErrorModalProps) {
   const t = useI18nContext();
   const dispatch = useDispatch();
 
   function closeModal() {
-    dispatch(hideDataDeletionErrorModal());
+    if (onClose) {
+      onClose();
+    } else {
+      dispatch(hideDataDeletionErrorModal());
+    }
   }
 
   return (

--- a/ui/components/app/data-deletion-error-modal/data-deletion-error-modal.tsx
+++ b/ui/components/app/data-deletion-error-modal/data-deletion-error-modal.tsx
@@ -28,24 +28,14 @@ import {
 } from '../../component-library';
 import { hideDataDeletionErrorModal } from '../../../ducks/app/app';
 
-type DataDeletionErrorModalProps = {
-  onClose?: () => void;
-};
-
 // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
 // eslint-disable-next-line @typescript-eslint/naming-convention
-export default function DataDeletionErrorModal({
-  onClose,
-}: DataDeletionErrorModalProps) {
+export default function DataDeletionErrorModal() {
   const t = useI18nContext();
   const dispatch = useDispatch();
 
   function closeModal() {
-    if (onClose) {
-      onClose();
-    } else {
-      dispatch(hideDataDeletionErrorModal());
-    }
+    dispatch(hideDataDeletionErrorModal());
   }
 
   return (

--- a/ui/pages/settings-v2/privacy-tab/__snapshots__/privacy-tab.test.tsx.snap
+++ b/ui/pages/settings-v2/privacy-tab/__snapshots__/privacy-tab.test.tsx.snap
@@ -55,8 +55,8 @@ exports[`PrivacyTab snapshot matches snapshot 1`] = `
         class="text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default"
       >
         <span>
-
-          Includes basic features like token details and gas settings. Keep this feature on for the best experience.  Read our
+           
+          Includes basic features like token details and gas settings. Keep this feature on for the best experience.  Read our 
           <a
             class="inline-flex items-center justify-center font-medium min-w-20 overflow-hidden relative duration-100 ease-linear active:ease-[cubic-bezier(0.3,0.8,0.3,1)] h-auto rounded-none bg-transparent px-0 transform-none transition-none active:scale-100 text-primary-default hover:bg-hover hover:text-primary-default-hover hover:underline hover:decoration-primary-default-hover hover:decoration-2 hover:underline-offset-4 active:bg-pressed active:text-primary-default-pressed active:decoration-primary-default-pressed"
             href="https://consensys.io/privacy-policy/"
@@ -66,7 +66,7 @@ exports[`PrivacyTab snapshot matches snapshot 1`] = `
             Privacy Policy
           </a>
            to learn more.
-
+           
         </span>
       </div>
     </div>
@@ -324,6 +324,20 @@ exports[`PrivacyTab snapshot matches snapshot 1`] = `
         class="text-inherit text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default"
       >
         Delete MetaMetrics data
+      </span>
+    </button>
+    <div
+      class="bg-muted my-2 h-px w-full"
+    />
+    <button
+      class="inline-flex items-center justify-center rounded-xl font-medium min-w-20 overflow-hidden relative h-12 transition-all duration-100 ease-linear active:scale-[0.97] active:ease-[cubic-bezier(0.3,0.8,0.3,1)] bg-icon-default hover:bg-icon-default-hover active:bg-icon-default-pressed focus-visible:ring-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-default text-text-default !bg-transparent p-0 text-left"
+      data-testid="download-state-logs-button"
+      role="button"
+    >
+      <span
+        class="text-inherit text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default"
+      >
+        Download state logs
       </span>
     </button>
   </div>

--- a/ui/pages/settings-v2/privacy-tab/__snapshots__/privacy-tab.test.tsx.snap
+++ b/ui/pages/settings-v2/privacy-tab/__snapshots__/privacy-tab.test.tsx.snap
@@ -55,18 +55,18 @@ exports[`PrivacyTab snapshot matches snapshot 1`] = `
         class="text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default"
       >
         <span>
-           
-          Includes basic features like token details and gas settings. Keep this feature on for the best experience.  Read our 
+
+          Includes basic features like token details and gas settings. Keep this feature on for the best experience.  Read our
           <a
             class="inline-flex items-center justify-center font-medium min-w-20 overflow-hidden relative duration-100 ease-linear active:ease-[cubic-bezier(0.3,0.8,0.3,1)] h-auto rounded-none bg-transparent px-0 transform-none transition-none active:scale-100 text-primary-default hover:bg-hover hover:text-primary-default-hover hover:underline hover:decoration-primary-default-hover hover:decoration-2 hover:underline-offset-4 active:bg-pressed active:text-primary-default-pressed active:decoration-primary-default-pressed"
-            href="https://consensys.io/privacy-policy"
+            href="https://consensys.io/privacy-policy/"
             rel="noopener noreferrer"
             target="_blank"
           >
             Privacy Policy
           </a>
            to learn more.
-           
+
         </span>
       </div>
     </div>
@@ -314,18 +314,16 @@ exports[`PrivacyTab snapshot matches snapshot 1`] = `
         We'll use MetaMetrics to learn how you interact with our marketing communications. We may share relevant news (like product features and other materials).
       </p>
     </div>
-    <div
-      class="bg-muted my-2 h-px w-full"
-    />
     <button
-      class="inline-flex items-center justify-center rounded-xl font-medium min-w-20 overflow-hidden relative h-12 transition-all duration-100 ease-linear active:scale-[0.97] active:ease-[cubic-bezier(0.3,0.8,0.3,1)] bg-icon-default hover:bg-icon-default-hover active:bg-icon-default-pressed focus-visible:ring-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-default text-text-default !bg-transparent p-0 text-left"
-      data-testid="download-state-logs-button"
+      class="inline-flex items-center justify-center rounded-xl font-medium min-w-20 overflow-hidden relative h-12 transition-all duration-100 ease-linear active:scale-[0.97] active:ease-[cubic-bezier(0.3,0.8,0.3,1)] bg-icon-default hover:bg-icon-default-hover active:bg-icon-default-pressed focus-visible:ring-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-default text-error-default !bg-transparent p-0 text-left"
+      data-testid="delete-metametrics-button"
+      disabled=""
       role="button"
     >
       <span
         class="text-inherit text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default"
       >
-        Download state logs
+        Delete MetaMetrics data
       </span>
     </button>
   </div>

--- a/ui/pages/settings-v2/privacy-tab/basic-functionality-item.test.tsx
+++ b/ui/pages/settings-v2/privacy-tab/basic-functionality-item.test.tsx
@@ -6,6 +6,7 @@ import mockState from '../../../../test/data/mock-state.json';
 import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import { setBackgroundConnection } from '../../../store/background-connection';
+import { CONSENSYS_PRIVACY_LINK } from '../../../../shared/lib/ui-utils';
 import { BasicFunctionalityToggleItem } from './basic-functionality-item';
 
 const mockToggleExternalServices = jest.fn();
@@ -55,7 +56,7 @@ describe('BasicFunctionalityToggleItem', () => {
       name: messages.privacyMsg.message,
     });
     expect(link).toBeInTheDocument();
-    expect(link).toHaveAttribute('href', 'https://consensys.io/privacy-policy');
+    expect(link).toHaveAttribute('href', CONSENSYS_PRIVACY_LINK);
   });
 
   it('renders toggle in enabled state when useExternalServices is true', () => {

--- a/ui/pages/settings-v2/privacy-tab/basic-functionality-item.tsx
+++ b/ui/pages/settings-v2/privacy-tab/basic-functionality-item.tsx
@@ -1,6 +1,5 @@
 import React, { useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { TextButton } from '@metamask/design-system-react';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { getUseExternalServices } from '../../../selectors';
 import { toggleExternalServices } from '../../../store/actions';
@@ -11,6 +10,7 @@ import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
+import { PrivacyPolicyLink } from '../shared';
 
 export const BasicFunctionalityToggleItem = () => {
   const t = useI18nContext();
@@ -41,15 +41,7 @@ export const BasicFunctionalityToggleItem = () => {
   };
 
   const description = t('basicConfigurationDescriptionV2', [
-    <TextButton asChild key="privacy-link">
-      <a
-        href="https://consensys.io/privacy-policy"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        {t('privacyMsg')}
-      </a>
-    </TextButton>,
+    <PrivacyPolicyLink key="basic-functionality-privacy-link" />,
   ]);
 
   return (

--- a/ui/pages/settings-v2/privacy-tab/delete-metametrics-data-item.test.tsx
+++ b/ui/pages/settings-v2/privacy-tab/delete-metametrics-data-item.test.tsx
@@ -1,0 +1,220 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { useSelector } from 'react-redux';
+import configureStore from '../../../store/store';
+import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
+import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
+import { DeleteRegulationStatus } from '../../../../shared/constants/metametrics';
+import {
+  getMetaMetricsDataDeletionTimestamp,
+  getMetaMetricsDataDeletionStatus,
+  getMetaMetricsId,
+  getParticipateInMetaMetrics,
+  getLatestMetricsEventTimestamp,
+} from '../../../selectors';
+import { DeleteMetametricsDataItem } from './delete-metametrics-data-item';
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn(),
+}));
+
+describe('DeleteMetametricsDataItem', () => {
+  const useSelectorMock = useSelector as jest.Mock;
+
+  const mockSelectorsDefault = () => {
+    useSelectorMock.mockImplementation((selector) => {
+      if (selector === getParticipateInMetaMetrics) {
+        return true;
+      }
+      if (selector === getMetaMetricsId) {
+        return 'mock-metametrics-id';
+      }
+      if (selector === getMetaMetricsDataDeletionStatus) {
+        return undefined;
+      }
+      if (selector === getMetaMetricsDataDeletionTimestamp) {
+        return 0;
+      }
+      if (selector === getLatestMetricsEventTimestamp) {
+        return 0;
+      }
+      return undefined;
+    });
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSelectorsDefault();
+  });
+
+  it('renders delete button', () => {
+    const store = configureStore({});
+    renderWithProvider(<DeleteMetametricsDataItem />, store);
+
+    expect(
+      screen.getByTestId('delete-metametrics-button'),
+    ).toBeInTheDocument();
+  });
+
+  it('button is disabled when metametrics is not enabled', () => {
+    useSelectorMock.mockImplementation((selector) => {
+      if (selector === getParticipateInMetaMetrics) {
+        return false;
+      }
+      if (selector === getMetaMetricsId) {
+        return null;
+      }
+      return undefined;
+    });
+
+    const store = configureStore({});
+    renderWithProvider(<DeleteMetametricsDataItem />, store);
+
+    expect(screen.getByTestId('delete-metametrics-button')).toBeDisabled();
+  });
+
+  it('button is disabled when metaMetricsId is null', () => {
+    useSelectorMock.mockImplementation((selector) => {
+      if (selector === getParticipateInMetaMetrics) {
+        return true;
+      }
+      if (selector === getMetaMetricsId) {
+        return null;
+      }
+      return undefined;
+    });
+
+    const store = configureStore({});
+    renderWithProvider(<DeleteMetametricsDataItem />, store);
+
+    expect(screen.getByTestId('delete-metametrics-button')).toBeDisabled();
+  });
+
+  it('button is enabled when metametrics is enabled and has ID', () => {
+    const store = configureStore({});
+    renderWithProvider(<DeleteMetametricsDataItem />, store);
+
+    expect(screen.getByTestId('delete-metametrics-button')).toBeEnabled();
+  });
+
+  it('opens delete modal when button is clicked', async () => {
+    const store = configureStore({});
+    renderWithProvider(<DeleteMetametricsDataItem />, store);
+
+    fireEvent.click(screen.getByTestId('delete-metametrics-button'));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(messages.deleteMetaMetricsDataModalTitle.message),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('opens deletion in progress modal when deletion is already in progress', async () => {
+    const now = Date.now();
+    useSelectorMock.mockImplementation((selector) => {
+      if (selector === getParticipateInMetaMetrics) {
+        return true;
+      }
+      if (selector === getMetaMetricsId) {
+        return 'mock-metametrics-id';
+      }
+      if (selector === getMetaMetricsDataDeletionStatus) {
+        return DeleteRegulationStatus.Running;
+      }
+      if (selector === getMetaMetricsDataDeletionTimestamp) {
+        return now;
+      }
+      if (selector === getLatestMetricsEventTimestamp) {
+        return now - 10000;
+      }
+      return undefined;
+    });
+
+    const store = configureStore({});
+    renderWithProvider(<DeleteMetametricsDataItem />, store);
+
+    fireEvent.click(screen.getByTestId('delete-metametrics-button'));
+
+    await waitFor(() => {
+      const messageStart =
+        messages.deleteMetaMetricsDataRequestedDescription.message.split(
+          '$1',
+        )[0];
+      expect(
+        screen.getByText(new RegExp(messageStart)),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('shows deletion in progress modal for Initialized status', async () => {
+    const now = Date.now();
+    useSelectorMock.mockImplementation((selector) => {
+      if (selector === getParticipateInMetaMetrics) {
+        return true;
+      }
+      if (selector === getMetaMetricsId) {
+        return 'mock-metametrics-id';
+      }
+      if (selector === getMetaMetricsDataDeletionStatus) {
+        return DeleteRegulationStatus.Initialized;
+      }
+      if (selector === getMetaMetricsDataDeletionTimestamp) {
+        return now;
+      }
+      if (selector === getLatestMetricsEventTimestamp) {
+        return now - 10000;
+      }
+      return undefined;
+    });
+
+    const store = configureStore({});
+    renderWithProvider(<DeleteMetametricsDataItem />, store);
+
+    fireEvent.click(screen.getByTestId('delete-metametrics-button'));
+
+    await waitFor(() => {
+      const messageStart =
+        messages.deleteMetaMetricsDataRequestedDescription.message.split(
+          '$1',
+        )[0];
+      expect(
+        screen.getByText(new RegExp(messageStart)),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('opens delete modal when there are new events after deletion finished', async () => {
+    const now = Date.now();
+    useSelectorMock.mockImplementation((selector) => {
+      if (selector === getParticipateInMetaMetrics) {
+        return true;
+      }
+      if (selector === getMetaMetricsId) {
+        return 'mock-metametrics-id';
+      }
+      if (selector === getMetaMetricsDataDeletionStatus) {
+        return DeleteRegulationStatus.Finished;
+      }
+      if (selector === getMetaMetricsDataDeletionTimestamp) {
+        return now - 10000;
+      }
+      if (selector === getLatestMetricsEventTimestamp) {
+        return now;
+      }
+      return undefined;
+    });
+
+    const store = configureStore({});
+    renderWithProvider(<DeleteMetametricsDataItem />, store);
+
+    fireEvent.click(screen.getByTestId('delete-metametrics-button'));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(messages.deleteMetaMetricsDataModalTitle.message),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/ui/pages/settings-v2/privacy-tab/delete-metametrics-data-item.test.tsx
+++ b/ui/pages/settings-v2/privacy-tab/delete-metametrics-data-item.test.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import configureStore from '../../../store/store';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
-import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
 import { DeleteRegulationStatus } from '../../../../shared/constants/metametrics';
 import {
   getMetaMetricsDataDeletionTimestamp,
@@ -52,9 +51,7 @@ describe('DeleteMetametricsDataItem', () => {
     const store = configureStore({});
     renderWithProvider(<DeleteMetametricsDataItem />, store);
 
-    expect(
-      screen.getByTestId('delete-metametrics-button'),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId('delete-metametrics-button')).toBeInTheDocument();
   });
 
   it('button is disabled when metametrics is not enabled', () => {
@@ -106,7 +103,7 @@ describe('DeleteMetametricsDataItem', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText(messages.deleteMetaMetricsDataModalTitle.message),
+        screen.getByTestId('delete-metametrics-modal'),
       ).toBeInTheDocument();
     });
   });
@@ -138,12 +135,8 @@ describe('DeleteMetametricsDataItem', () => {
     fireEvent.click(screen.getByTestId('delete-metametrics-button'));
 
     await waitFor(() => {
-      const messageStart =
-        messages.deleteMetaMetricsDataRequestedDescription.message.split(
-          '$1',
-        )[0];
       expect(
-        screen.getByText(new RegExp(messageStart)),
+        screen.getByTestId('deletion-in-progress-modal'),
       ).toBeInTheDocument();
     });
   });
@@ -175,12 +168,8 @@ describe('DeleteMetametricsDataItem', () => {
     fireEvent.click(screen.getByTestId('delete-metametrics-button'));
 
     await waitFor(() => {
-      const messageStart =
-        messages.deleteMetaMetricsDataRequestedDescription.message.split(
-          '$1',
-        )[0];
       expect(
-        screen.getByText(new RegExp(messageStart)),
+        screen.getByTestId('deletion-in-progress-modal'),
       ).toBeInTheDocument();
     });
   });
@@ -213,7 +202,7 @@ describe('DeleteMetametricsDataItem', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText(messages.deleteMetaMetricsDataModalTitle.message),
+        screen.getByTestId('delete-metametrics-modal'),
       ).toBeInTheDocument();
     });
   });

--- a/ui/pages/settings-v2/privacy-tab/delete-metametrics-data-item.tsx
+++ b/ui/pages/settings-v2/privacy-tab/delete-metametrics-data-item.tsx
@@ -1,0 +1,110 @@
+import React, { useState } from 'react';
+import { useSelector } from 'react-redux';
+import {
+  Button,
+  Icon,
+  IconColor,
+  IconName,
+} from '@metamask/design-system-react';
+import {
+  DeleteRegulationStatus,
+  DATA_DELETION_IN_PROGRESS_STATUSES,
+} from '../../../../shared/constants/metametrics';
+import DataDeletionErrorModal from '../../../components/app/data-deletion-error-modal';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import {
+  getMetaMetricsDataDeletionTimestamp,
+  getMetaMetricsDataDeletionStatus,
+  getMetaMetricsId,
+  getParticipateInMetaMetrics,
+  getLatestMetricsEventTimestamp,
+} from '../../../selectors';
+import { Toast, ToastContainer } from '../../../components/multichain/toast';
+import { BorderRadius } from '../../../helpers/constants/design-system';
+import DeleteMetametricsModal from './delete-metametrics-modal';
+import DeletionInProgressModal from './deletion-in-progress-modal';
+
+export const DeleteMetametricsDataItem = () => {
+  const t = useI18nContext();
+
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [showErrorModal, setShowErrorModal] = useState(false);
+  const [showDeletionInProgressModal, setShowDeletionInProgressModal] =
+    useState(false);
+  const [showDataDeletionSuccessToast, setShowDataDeletionSuccessToast] =
+    useState(false);
+
+  const metaMetricsId = useSelector(getMetaMetricsId);
+  const metaMetricsDataDeletionStatus: DeleteRegulationStatus = useSelector(
+    getMetaMetricsDataDeletionStatus,
+  );
+  const metaMetricsDataDeletionTimestamp = useSelector(
+    getMetaMetricsDataDeletionTimestamp,
+  );
+  const latestMetricsEventTimestamp = useSelector(
+    getLatestMetricsEventTimestamp,
+  );
+  const isMetaMetricsEnabled =
+    useSelector(getParticipateInMetaMetrics) && Boolean(metaMetricsId);
+
+  const hasNoPendingDataToDelete =
+    metaMetricsDataDeletionTimestamp > latestMetricsEventTimestamp;
+
+  const isDataDeletionInProgress =
+    Boolean(metaMetricsId) &&
+    DATA_DELETION_IN_PROGRESS_STATUSES.includes(
+      metaMetricsDataDeletionStatus,
+    ) &&
+    hasNoPendingDataToDelete;
+
+  return (
+    <>
+      <Button
+        data-testid="delete-metametrics-button"
+        onClick={() =>
+          isDataDeletionInProgress
+            ? setShowDeletionInProgressModal(true)
+            : setShowDeleteModal(true)
+        }
+        disabled={!isMetaMetricsEnabled}
+        className="text-error-default !bg-transparent p-0 text-left"
+      >
+        {t('deleteMetaMetricsData')}
+      </Button>
+      {showDeleteModal && (
+        <DeleteMetametricsModal
+          onClose={() => setShowDeleteModal(false)}
+          onSuccess={() => setShowDataDeletionSuccessToast(true)}
+          onError={() => setShowErrorModal(true)}
+        />
+      )}
+      {showDeletionInProgressModal && (
+        <DeletionInProgressModal
+          onClose={() => setShowDeletionInProgressModal(false)}
+        />
+      )}
+      {showErrorModal && (
+        <DataDeletionErrorModal onClose={() => setShowErrorModal(false)} />
+      )}
+      {showDataDeletionSuccessToast && (
+        <ToastContainer>
+          <Toast
+            startAdornment={
+              <Icon
+                name={IconName.CheckBold}
+                color={IconColor.SuccessDefault}
+              />
+            }
+            text={t('deleteMetaMetricsDataToast')}
+            onClose={() => setShowDataDeletionSuccessToast(false)}
+            autoHideTime={2500}
+            onAutoHideToast={() => setShowDataDeletionSuccessToast(false)}
+            borderRadius={BorderRadius.LG}
+            textClassName="text-base"
+            data-testid="delete-metametrics-data-success-toast"
+          />
+        </ToastContainer>
+      )}
+    </>
+  );
+};

--- a/ui/pages/settings-v2/privacy-tab/delete-metametrics-data-item.tsx
+++ b/ui/pages/settings-v2/privacy-tab/delete-metametrics-data-item.tsx
@@ -10,7 +10,6 @@ import {
   DeleteRegulationStatus,
   DATA_DELETION_IN_PROGRESS_STATUSES,
 } from '../../../../shared/constants/metametrics';
-import DataDeletionErrorModal from '../../../components/app/data-deletion-error-modal';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
   getMetaMetricsDataDeletionTimestamp,
@@ -28,8 +27,9 @@ export const DeleteMetametricsDataItem = () => {
   const t = useI18nContext();
 
   const [showDeleteModal, setShowDeleteModal] = useState(false);
-  const [showErrorModal, setShowErrorModal] = useState(false);
   const [showDeletionInProgressModal, setShowDeletionInProgressModal] =
+    useState(false);
+  const [showDataDeletionErrorToast, setshowDataDeletionErrorToast] =
     useState(false);
   const [showDataDeletionSuccessToast, setShowDataDeletionSuccessToast] =
     useState(false);
@@ -75,7 +75,7 @@ export const DeleteMetametricsDataItem = () => {
         <DeleteMetametricsModal
           onClose={() => setShowDeleteModal(false)}
           onSuccess={() => setShowDataDeletionSuccessToast(true)}
-          onError={() => setShowErrorModal(true)}
+          onError={() => setshowDataDeletionErrorToast(true)}
         />
       )}
       {showDeletionInProgressModal && (
@@ -83,8 +83,20 @@ export const DeleteMetametricsDataItem = () => {
           onClose={() => setShowDeletionInProgressModal(false)}
         />
       )}
-      {showErrorModal && (
-        <DataDeletionErrorModal onClose={() => setShowErrorModal(false)} />
+      {showDataDeletionErrorToast && (
+        <ToastContainer>
+          <Toast
+            startAdornment={
+              <Icon name={IconName.Warning} color={IconColor.WarningDefault} />
+            }
+            text={t('deleteMetaMetricsDataErrorToast')}
+            description={t('deleteMetaMetricsDataErrorDesc')}
+            onClose={() => setshowDataDeletionErrorToast(false)}
+            borderRadius={BorderRadius.LG}
+            textClassName="text-base"
+            data-testid="delete-metametrics-data-error-toast"
+          />
+        </ToastContainer>
       )}
       {showDataDeletionSuccessToast && (
         <ToastContainer>

--- a/ui/pages/settings-v2/privacy-tab/delete-metametrics-data-item.tsx
+++ b/ui/pages/settings-v2/privacy-tab/delete-metametrics-data-item.tsx
@@ -29,7 +29,7 @@ export const DeleteMetametricsDataItem = () => {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [showDeletionInProgressModal, setShowDeletionInProgressModal] =
     useState(false);
-  const [showDataDeletionErrorToast, setshowDataDeletionErrorToast] =
+  const [showDataDeletionErrorToast, setShowDataDeletionErrorToast] =
     useState(false);
   const [showDataDeletionSuccessToast, setShowDataDeletionSuccessToast] =
     useState(false);
@@ -73,7 +73,7 @@ export const DeleteMetametricsDataItem = () => {
         <DeleteMetametricsModal
           onClose={() => setShowDeleteModal(false)}
           onSuccess={() => setShowDataDeletionSuccessToast(true)}
-          onError={() => setshowDataDeletionErrorToast(true)}
+          onError={() => setShowDataDeletionErrorToast(true)}
         />
       )}
       {showDeletionInProgressModal && (
@@ -89,7 +89,7 @@ export const DeleteMetametricsDataItem = () => {
             }
             text={t('deleteMetaMetricsDataErrorToast')}
             description={t('deleteMetaMetricsDataErrorDesc')}
-            onClose={() => setshowDataDeletionErrorToast(false)}
+            onClose={() => setShowDataDeletionErrorToast(false)}
             borderRadius={BorderRadius.LG}
             textClassName="text-base"
             data-testid="delete-metametrics-data-error-toast"

--- a/ui/pages/settings-v2/privacy-tab/delete-metametrics-data-item.tsx
+++ b/ui/pages/settings-v2/privacy-tab/delete-metametrics-data-item.tsx
@@ -8,7 +8,7 @@ import {
 } from '@metamask/design-system-react';
 import {
   DeleteRegulationStatus,
-  DATA_DELETION_IN_PROGRESS_STATUSES,
+  DATA_DELETION_REQUESTED_STATUSES,
 } from '../../../../shared/constants/metametrics';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
@@ -52,9 +52,7 @@ export const DeleteMetametricsDataItem = () => {
 
   const isDataDeletionInProgress =
     Boolean(metaMetricsId) &&
-    DATA_DELETION_IN_PROGRESS_STATUSES.includes(
-      metaMetricsDataDeletionStatus,
-    ) &&
+    DATA_DELETION_REQUESTED_STATUSES.includes(metaMetricsDataDeletionStatus) &&
     hasNoPendingDataToDelete;
 
   return (

--- a/ui/pages/settings-v2/privacy-tab/delete-metametrics-modal.tsx
+++ b/ui/pages/settings-v2/privacy-tab/delete-metametrics-modal.tsx
@@ -1,0 +1,139 @@
+import React, { useContext } from 'react';
+import {
+  Box,
+  BoxFlexDirection,
+  BoxAlignItems,
+  BoxJustifyContent,
+  Button,
+  ButtonVariant,
+  Text,
+  TextVariant,
+  TextColor,
+  FontWeight,
+} from '@metamask/design-system-react';
+import {
+  Modal,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+} from '../../../components/component-library';
+import {
+  AlignItems,
+  Display,
+  FlexDirection,
+} from '../../../helpers/constants/design-system';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import { createMetaMetricsDataDeletionTask } from '../../../store/actions';
+import { MetaMetricsContext } from '../../../contexts/metametrics';
+import {
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
+} from '../../../../shared/constants/metametrics';
+import { captureException } from '../../../../shared/lib/sentry';
+import { PrivacyPolicyLink } from '../shared';
+
+type DeleteMetametricsModalProps = {
+  onClose: () => void;
+  onSuccess: () => void;
+  onError: () => void;
+};
+
+export default function DeleteMetametricsModal({
+  onClose,
+  onSuccess,
+  onError,
+}: Readonly<DeleteMetametricsModalProps>) {
+  const t = useI18nContext();
+  const { trackEvent } = useContext(MetaMetricsContext);
+
+  const deleteMetaMetricsData = async () => {
+    try {
+      await createMetaMetricsDataDeletionTask();
+      trackEvent(
+        {
+          category: MetaMetricsEventCategory.Settings,
+          event: MetaMetricsEventName.MetricsDataDeletionRequest,
+        },
+        {
+          excludeMetaMetricsId: true,
+        },
+      );
+      onSuccess();
+    } catch (error) {
+      captureException(error);
+      trackEvent(
+        {
+          category: MetaMetricsEventCategory.Settings,
+          event: MetaMetricsEventName.ErrorOccured,
+        },
+        {
+          excludeMetaMetricsId: true,
+        },
+      );
+      onError();
+    } finally {
+      onClose();
+    }
+  };
+
+  return (
+    <Modal isOpen onClose={onClose}>
+      <ModalOverlay />
+      <ModalContent
+        alignItems={AlignItems.center}
+        modalDialogProps={{
+          display: Display.Flex,
+          flexDirection: FlexDirection.Column,
+        }}
+      >
+        <ModalHeader onClose={onClose}>
+          <Box
+            flexDirection={BoxFlexDirection.Column}
+            alignItems={BoxAlignItems.Center}
+            justifyContent={BoxJustifyContent.Center}
+          >
+            <Text
+              variant={TextVariant.HeadingSm}
+              fontWeight={FontWeight.Medium}
+            >
+              {t('deleteMetaMetricsDataModalTitle')}
+            </Text>
+          </Box>
+        </ModalHeader>
+        <Box
+          marginHorizontal={4}
+          marginBottom={3}
+          flexDirection={BoxFlexDirection.Column}
+          gap={4}
+        >
+          <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
+            {t('deleteMetaMetricsDataDescriptionV2', [
+              <PrivacyPolicyLink key="delete-metametrics-modal-privacy-link" />,
+            ])}
+          </Text>
+        </Box>
+        <ModalFooter>
+          <Box className="flex gap-4">
+            <Button
+              className="flex-1"
+              variant={ButtonVariant.Secondary}
+              onClick={onClose}
+            >
+              {t('cancel')}
+            </Button>
+            <Button
+              data-testid="clear-metametrics-data"
+              className="flex-1"
+              variant={ButtonVariant.Primary}
+              isDanger
+              onClick={deleteMetaMetricsData}
+            >
+              {t('delete')}
+            </Button>
+          </Box>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/ui/pages/settings-v2/privacy-tab/delete-metametrics-modal.tsx
+++ b/ui/pages/settings-v2/privacy-tab/delete-metametrics-modal.tsx
@@ -78,7 +78,7 @@ export default function DeleteMetametricsModal({
   };
 
   return (
-    <Modal isOpen onClose={onClose}>
+    <Modal isOpen onClose={onClose} data-testid="delete-metametrics-modal">
       <ModalOverlay />
       <ModalContent
         alignItems={AlignItems.center}

--- a/ui/pages/settings-v2/privacy-tab/deletion-in-progress-modal.tsx
+++ b/ui/pages/settings-v2/privacy-tab/deletion-in-progress-modal.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import {
+  Box,
+  BoxFlexDirection,
+  BoxAlignItems,
+  BoxJustifyContent,
+  Button,
+  ButtonVariant,
+  Text,
+  TextVariant,
+  TextColor,
+  FontWeight,
+} from '@metamask/design-system-react';
+import {
+  Modal,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+} from '../../../components/component-library';
+import {
+  AlignItems,
+  Display,
+  FlexDirection,
+} from '../../../helpers/constants/design-system';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import { useSelector } from 'react-redux';
+import { getMetaMetricsDataDeletionTimestamp } from '../../../selectors';
+import { formatDate } from '../../../helpers/utils/util';
+import { PrivacyPolicyLink } from '../shared';
+
+type DeletionInProgressModalProps = {
+  onClose: () => void;
+};
+
+export default function DeletionInProgressModal({
+  onClose,
+}: Readonly<DeletionInProgressModalProps>) {
+  const t = useI18nContext();
+  const metaMetricsDataDeletionTimestamp = useSelector(
+    getMetaMetricsDataDeletionTimestamp,
+  );
+  const formatedDate = formatDate(metaMetricsDataDeletionTimestamp, 'd/MM/y');
+
+  return (
+    <Modal isOpen onClose={onClose}>
+      <ModalOverlay />
+      <ModalContent
+        alignItems={AlignItems.center}
+        modalDialogProps={{
+          display: Display.Flex,
+          flexDirection: FlexDirection.Column,
+        }}
+      >
+        <ModalHeader onClose={onClose}>
+          <Box
+            flexDirection={BoxFlexDirection.Column}
+            alignItems={BoxAlignItems.Center}
+            justifyContent={BoxJustifyContent.Center}
+          >
+            <Text
+              variant={TextVariant.HeadingSm}
+              fontWeight={FontWeight.Medium}
+            >
+              {t('deleteMetaMetricsDataModalTitle')}
+            </Text>
+          </Box>
+        </ModalHeader>
+        <Box
+          marginHorizontal={4}
+          marginBottom={3}
+          flexDirection={BoxFlexDirection.Column}
+          gap={4}
+        >
+          <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
+            {t('deleteMetaMetricsDataRequestedDescription', [
+                  formatedDate,
+                  <PrivacyPolicyLink key="deletion-in-progress-modal-privacy-link" />,
+                ])}
+          </Text>
+        </Box>
+        <ModalFooter>
+          <Box className="flex gap-4">
+            <Button
+              className="flex-1"
+              variant={ButtonVariant.Secondary}
+              onClick={onClose}
+            >
+              {t('cancel')}
+            </Button>
+            <Button
+              className="flex-1"
+              variant={ButtonVariant.Primary}
+              isDanger
+              disabled
+            >
+              {t('delete')}
+            </Button>
+          </Box>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/ui/pages/settings-v2/privacy-tab/deletion-in-progress-modal.tsx
+++ b/ui/pages/settings-v2/privacy-tab/deletion-in-progress-modal.tsx
@@ -11,6 +11,7 @@ import {
   TextColor,
   FontWeight,
 } from '@metamask/design-system-react';
+import { useSelector } from 'react-redux';
 import {
   Modal,
   ModalContent,
@@ -24,7 +25,6 @@ import {
   FlexDirection,
 } from '../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../hooks/useI18nContext';
-import { useSelector } from 'react-redux';
 import { getMetaMetricsDataDeletionTimestamp } from '../../../selectors';
 import { formatDate } from '../../../helpers/utils/util';
 import { PrivacyPolicyLink } from '../shared';
@@ -43,7 +43,7 @@ export default function DeletionInProgressModal({
   const formatedDate = formatDate(metaMetricsDataDeletionTimestamp, 'd/MM/y');
 
   return (
-    <Modal isOpen onClose={onClose}>
+    <Modal isOpen onClose={onClose} data-testid="deletion-in-progress-modal">
       <ModalOverlay />
       <ModalContent
         alignItems={AlignItems.center}
@@ -74,9 +74,9 @@ export default function DeletionInProgressModal({
         >
           <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
             {t('deleteMetaMetricsDataRequestedDescription', [
-                  formatedDate,
-                  <PrivacyPolicyLink key="deletion-in-progress-modal-privacy-link" />,
-                ])}
+              formatedDate,
+              <PrivacyPolicyLink key="deletion-in-progress-modal-privacy-link" />,
+            ])}
           </Text>
         </Box>
         <ModalFooter>

--- a/ui/pages/settings-v2/privacy-tab/deletion-in-progress-modal.tsx
+++ b/ui/pages/settings-v2/privacy-tab/deletion-in-progress-modal.tsx
@@ -40,7 +40,10 @@ export default function DeletionInProgressModal({
   const metaMetricsDataDeletionTimestamp = useSelector(
     getMetaMetricsDataDeletionTimestamp,
   );
-  const formatedDate = formatDate(metaMetricsDataDeletionTimestamp, 'd/MM/y');
+  const formatedDate = formatDate(
+    metaMetricsDataDeletionTimestamp,
+    'MMM d, yyyy',
+  );
 
   return (
     <Modal isOpen onClose={onClose} data-testid="deletion-in-progress-modal">

--- a/ui/pages/settings-v2/privacy-tab/privacy-tab.tsx
+++ b/ui/pages/settings-v2/privacy-tab/privacy-tab.tsx
@@ -11,6 +11,7 @@ import { ThirdPartyApisItem } from './third-party-apis-item';
 import { BasicFunctionalityToggleItem } from './basic-functionality-item';
 import { MetametricsToggleItem } from './metametrics-item';
 import { DataCollectionToggleItem } from './data-collection-item';
+import { DeleteMetametricsDataItem } from './delete-metametrics-data-item';
 import { DownloadStateLogsItem } from './download-state-logs-item';
 
 const BatchAccountBalanceRequestsToggleItem = createToggleItem({
@@ -48,6 +49,7 @@ const PRIVACY_SETTING_ITEMS: SettingItemConfig[] = [
     hasDividerBefore: true,
   },
   { id: 'data-collection', component: DataCollectionToggleItem },
+  { id: 'delete-metametrics-data', component: DeleteMetametricsDataItem },
   {
     id: 'download-state-logs',
     component: DownloadStateLogsItem,

--- a/ui/pages/settings-v2/shared/index.ts
+++ b/ui/pages/settings-v2/shared/index.ts
@@ -3,5 +3,6 @@ export type { SelectItemConfig } from './create-select-item';
 export { createToggleItem } from './create-toggle-item';
 export type { ToggleItemConfig } from './create-toggle-item';
 export { Divider } from './divider';
+export { PrivacyPolicyLink } from './privacy-policy-link';
 export { SettingsTab } from './settings-tab';
 export { SettingsSelectItem } from './settings-select-item';

--- a/ui/pages/settings-v2/shared/privacy-policy-link.tsx
+++ b/ui/pages/settings-v2/shared/privacy-policy-link.tsx
@@ -3,15 +3,11 @@ import { TextButton } from '@metamask/design-system-react';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { CONSENSYS_PRIVACY_LINK } from '../../../../shared/lib/ui-utils';
 
-type PrivacyPolicyLinkProps = {
-  key: string;
-};
-
-export const PrivacyPolicyLink = ({ key = 'privacy-policy-link' }: PrivacyPolicyLinkProps) => {
+export const PrivacyPolicyLink = () => {
   const t = useI18nContext();
 
   return (
-    <TextButton asChild key={key}>
+    <TextButton asChild>
       <a
         href={CONSENSYS_PRIVACY_LINK}
         target="_blank"

--- a/ui/pages/settings-v2/shared/privacy-policy-link.tsx
+++ b/ui/pages/settings-v2/shared/privacy-policy-link.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { TextButton } from '@metamask/design-system-react';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import { CONSENSYS_PRIVACY_LINK } from '../../../../shared/lib/ui-utils';
+
+type PrivacyPolicyLinkProps = {
+  key: string;
+};
+
+export const PrivacyPolicyLink = ({ key = 'privacy-policy-link' }: PrivacyPolicyLinkProps) => {
+  const t = useI18nContext();
+
+  return (
+    <TextButton asChild key={key}>
+      <a
+        href={CONSENSYS_PRIVACY_LINK}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {t('privacyMsg')}
+      </a>
+    </TextButton>
+  );
+};

--- a/ui/pages/settings/security-tab/delete-metametrics-data-button/delete-metametrics-data-button.test.tsx
+++ b/ui/pages/settings/security-tab/delete-metametrics-data-button/delete-metametrics-data-button.test.tsx
@@ -170,7 +170,7 @@ describe('DeleteMetaMetricsDataButton', () => {
       container.querySelector('.settings-page__content-description')
         ?.textContent,
     ).toMatchInlineSnapshot(
-      `" You initiated this action on 7/06/2024. This process can take up to 30 days. View the Privacy Policy "`,
+      `" You initiated deletion on 7/06/2024. This process can take up to 30 days. View the Privacy Policy. "`,
     );
   });
 
@@ -203,7 +203,7 @@ describe('DeleteMetaMetricsDataButton', () => {
       container.querySelector('.settings-page__content-description')
         ?.textContent,
     ).toMatchInlineSnapshot(
-      `" You initiated this action on 7/06/2024. This process can take up to 30 days. View the Privacy Policy "`,
+      `" You initiated deletion on 7/06/2024. This process can take up to 30 days. View the Privacy Policy. "`,
     );
   });
 


### PR DESCRIPTION
## **Description**

Adds the "Delete MetaMetrics Data" button to the Settings V2 Privacy tab, allowing users to request deletion of their MetaMetrics data.

- Added `DeleteMetametricsDataItem` component with a styled delete button
- Added `DeleteMetametricsModal` for confirming the deletion request
- Added `DeletionInProgressModal` shown when a deletion is already in progress
- Shows error toast on failure and success toast on successful deletion request
- Button is disabled when MetaMetrics is not enabled
- Proper error handling with Sentry logging

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40849?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [CEUX-911](https://consensyssoftware.atlassian.net/browse/CEUX-911)

## **Manual testing steps**

1. Go to Settings > Privacy (ensure Settings V2 is enabled)
2. Enable MetaMetrics if not already enabled
3. Find the "Delete MetaMetrics data" button (red text, below Data Collection toggle)
4. Click the button to open the confirmation modal
5. Click "Delete" to initiate the deletion request
6. Verify success toast appears
7. Click the button again - verify "Deletion in progress" modal appears
8. (Error case) If deletion fails, verify error toast appears

Note: the request fails locally as the real segment request isn't made. Therefore this can be tested by mocking the data (check screenshots below).

## **Screenshots/Recordings**

### **Before**

### **After**

<img width="515" height="815" alt="image" src="https://github.com/user-attachments/assets/807998c1-969f-4317-897a-5fcf93985e2d" />

<img width="476" height="817" alt="image" src="https://github.com/user-attachments/assets/677f82ea-d6c4-418e-8924-87fbf424fcf2" />

<img width="474" height="817" alt="image" src="https://github.com/user-attachments/assets/fc9c97e0-31ed-4364-8b04-5a3cd365b807" />


<img width="477" height="823" alt="image" src="https://github.com/user-attachments/assets/9af3c4b8-3833-4e95-b79c-ab1cb4b04497" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[CEUX-911]: https://consensyssoftware.atlassian.net/browse/CEUX-911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new UI and state-based logic for requesting MetaMetrics data deletion (including status handling, modals, and toasts), which could affect the user’s privacy workflow if statuses/timestamps are misinterpreted. No wallet/account data paths are modified, but it touches analytics deletion and telemetry event tracking.
> 
> **Overview**
> Adds a **Settings V2 Privacy tab** action to request deletion of MetaMetrics data via a new `DeleteMetametricsDataItem`, including a confirmation modal, an *in-progress* modal when a deletion task is already underway, and success/error toasts.
> 
> Updates localization strings for the new UI and tweaks existing copy/punctuation, introduces `DATA_DELETION_REQUESTED_STATUSES` to centralize which deletion statuses count as “requested,” and standardizes Privacy Policy links via a reusable `PrivacyPolicyLink` (also updating snapshots/tests).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2b45d1fe3ec4118b27b504360e3ce9b13edb8f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->