### PR TITLE
chore: add script to collect automation tests stats

### DIFF
--- a/.github/scripts/collect-qa-stats.mjs
+++ b/.github/scripts/collect-qa-stats.mjs
@@ -37,9 +37,7 @@ import { join } from 'path';
 
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 const GITHUB_REPOSITORY = process.env.GITHUB_REPOSITORY ?? 'MetaMask/metamask-extension';
-const WORKFLOW_RUN_ID = process.env.WORKFLOW_RUN_ID;
-
-
+const WORKFLOW_RUN_ID = "23010648370";
 
 
 if (!GITHUB_TOKEN) throw new Error('Missing required GITHUB_TOKEN env var');
@@ -191,28 +189,32 @@ function getStringAttribute(tag, name) {
  * Parses JUnit XML and returns { total, perFile } where perFile maps
  * test file path to executed test count.
  *
- * Each <testsuite> in jest-junit output corresponds to one test file,
- * and its `name` attribute is the file path (relative to the root).
+ * Relies on jest-junit's `addFileAttribute: 'true'` option, which adds a
+ * `file` attribute to each <testcase> element with the absolute path to the
+ * test file. Skipped tests are identified by a <skipped> child element and
+ * excluded from the count.
  *
  * @param {string} rawXml
  * @returns {{ total: number, perFile: Record<string, number> }}
  */
 function parseJUnitXml(rawXml) {
-  const suiteTags = rawXml.match(/<testsuite\b[^>]*>/g) ?? [];
+  // Match each <testcase> — either self-closing or with a body
+  const testcasePattern = /<testcase\b([^>]*)(?:\/>|>([\s\S]*?)<\/testcase>)/g;
   const perFile = {};
   let total = 0;
 
-  for (const tag of suiteTags) {
-    const tests = getNumericAttribute(tag, 'tests');
-    const skipped = getNumericAttribute(tag, 'skipped');
-    const executed = Math.max(0, tests - skipped);
-    if (executed === 0) continue;
+  for (const match of rawXml.matchAll(testcasePattern)) {
+    const attrs = match[1];
+    const body = match[2] ?? '';
 
-    total += executed;
-    const filePath = getStringAttribute(tag, 'file') || getStringAttribute(tag, 'name');
-    if (filePath) {
-      perFile[filePath] = (perFile[filePath] ?? 0) + executed;
-    }
+    // Exclude skipped tests (<skipped/> or <skipped ...> child element)
+    if (body.includes('<skipped')) continue;
+
+    const filePath = getStringAttribute(attrs, 'file');
+    if (!filePath) continue;
+
+    total++;
+    perFile[filePath] = (perFile[filePath] ?? 0) + 1;
   }
 
   return { total, perFile };

--- a/.github/scripts/collect-qa-stats.mjs
+++ b/.github/scripts/collect-qa-stats.mjs
@@ -1,0 +1,348 @@
+#!/usr/bin/env node
+/**
+ *
+ * Collects QA metrics from the latest successful Main CI run on `main` and
+ * writes qa-stats.json in key: value format.
+ * Metrics that could not be collected (missing artifacts, tests did not run)
+ * are omitted from the output — they will never appear as zero.
+ *
+ * Required env vars:
+ *   GITHUB_TOKEN      — GitHub Actions token for API access
+ *   GITHUB_REPOSITORY — Repository in "owner/repo" format (set automatically in Actions)
+ *
+ * How to add a new metric:
+ *   1. Add a collector function that returns a plain object
+ *   2. Register it in the collectors array in main()
+ *
+ * The only rule: never rename existing keys. The DB key is (project, run_id, namespace, metric_key).
+ * Renaming a key in the JSON creates a new series in the DB while the old name stops getting new data,
+ * which breaks the Grafana time series continuity. Adding and removing keys is fine.
+ *
+ * Example output:
+ *   {
+ *     "unit": {
+ *       "tests_count": 41957,
+ *       "controllers_tests_count": 3200,
+ *       "ui_app_tests_count": 5100,
+ *       "ducks_tests_count": 1500,
+ *       "selectors_tests_count": 900,
+ *       "other_tests_count": 26357
+ *     }
+ *   }
+ */
+
+import { writeFile, mkdir, readFile } from 'fs/promises';
+import { execSync } from 'child_process';
+import { join } from 'path';
+
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+const GITHUB_REPOSITORY = process.env.GITHUB_REPOSITORY ?? 'MetaMask/metamask-extension';
+const WORKFLOW_RUN_ID = process.env.WORKFLOW_RUN_ID;
+
+
+
+
+if (!GITHUB_TOKEN) throw new Error('Missing required GITHUB_TOKEN env var');
+
+// ---------------------------------------------------------------------------
+// GitHub API helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetches the ID of the latest successful "Main" workflow run on `main`.
+ *
+ * @returns {Promise<string>}
+ */
+async function getLatestMainRunId() {
+  const url = `https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/main.yml/runs?branch=main&status=success&per_page=1`;
+  const res = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${GITHUB_TOKEN}`,
+      Accept: 'application/vnd.github+json',
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to fetch Main workflow runs: ${res.status} ${res.statusText}`);
+  }
+
+  const data = await res.json();
+  const run = data.workflow_runs?.[0];
+  if (!run) {
+    throw new Error('No successful Main workflow runs found on main');
+  }
+
+  console.log(`[run] Using Main run #${run.run_number} (id=${run.id}, ${run.created_at})`);
+  return String(run.id);
+}
+
+let _runId = null;
+
+async function getRunId() {
+  if (!_runId) {
+    _runId = await getLatestMainRunId();
+  }
+  return _runId;
+}
+
+let _artifactList = null;
+
+/**
+ * Fetches (and caches) the list of artifact names for the discovered CI run.
+ *
+ * @returns {Promise<Array>}
+ */
+async function getArtifactList() {
+  if (_artifactList) return _artifactList;
+
+  const runId = await getRunId();
+  const artifacts = [];
+  let page = 1;
+
+  while (true) {
+    // const url = `https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${runId}/artifacts?per_page=100&page=${page}`;
+    const url = `https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${WORKFLOW_RUN_ID}/artifacts?per_page=100&page=${page}`;
+    const res = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${GITHUB_TOKEN}`,
+        Accept: 'application/vnd.github+json',
+      },
+    });
+
+    if (!res.ok) {
+      throw new Error(`Failed to list artifacts (page ${page}): ${res.status} ${res.statusText}`);
+    }
+
+    const data = await res.json();
+    artifacts.push(...data.artifacts);
+
+    if (data.artifacts.length < 100) break;
+    page++;
+  }
+
+  _artifactList = artifacts;
+  return _artifactList;
+}
+
+/**
+ * Downloads a named artifact from the discovered CI run, extracts it into a
+ * local directory named after the artifact, and returns that directory path.
+ *
+ * @param {string} artifactName
+ * @returns {Promise<string>} Path to the directory containing the extracted files
+ */
+async function downloadArtifact(artifactName) {
+  const artifacts = await getArtifactList();
+  const artifact = artifacts.find((a) => a.name === artifactName);
+  const runId = await getRunId();
+
+  if (!artifact) {
+    throw new Error(
+      `Artifact "${artifactName}" not found in run ${runId}`,
+    );
+  }
+
+  // GitHub redirects to a pre-signed S3 URL. Follow manually so the
+  // Authorization header is not forwarded to S3.
+  const redirectRes = await fetch(artifact.archive_download_url, {
+    headers: {
+      Authorization: `Bearer ${GITHUB_TOKEN}`,
+      Accept: 'application/vnd.github+json',
+    },
+    redirect: 'manual',
+  });
+
+  const downloadUrl = redirectRes.headers.get('location');
+  if (!downloadUrl) {
+    throw new Error(`No redirect URL returned for artifact "${artifactName}"`);
+  }
+
+  const zipRes = await fetch(downloadUrl);
+  if (!zipRes.ok) {
+    throw new Error(
+      `Failed to download artifact "${artifactName}": ${zipRes.status} ${zipRes.statusText}`,
+    );
+  }
+
+  const destDir = `./${artifactName}`;
+  await mkdir(destDir, { recursive: true });
+  const zipPath = join(destDir, `${artifactName}.zip`);
+  await writeFile(zipPath, Buffer.from(await zipRes.arrayBuffer()));
+  execSync(`unzip -q "${zipPath}" -d "${destDir}"`);
+
+  return destDir;
+}
+
+// ---------------------------------------------------------------------------
+// JUnit XML helpers
+// ---------------------------------------------------------------------------
+
+function getNumericAttribute(tag, name) {
+  const match = tag.match(new RegExp(`${name}="(\\d+)"`));
+  return match ? Number(match[1]) : 0;
+}
+
+function getStringAttribute(tag, name) {
+  const match = tag.match(new RegExp(`${name}="([^"]+)"`));
+  return match ? match[1] : '';
+}
+
+/**
+ * Parses JUnit XML and returns { total, perFile } where perFile maps
+ * test file path to executed test count.
+ *
+ * Each <testsuite> in jest-junit output corresponds to one test file,
+ * and its `name` attribute is the file path (relative to the root).
+ *
+ * @param {string} rawXml
+ * @returns {{ total: number, perFile: Record<string, number> }}
+ */
+function parseJUnitXml(rawXml) {
+  const suiteTags = rawXml.match(/<testsuite\b[^>]*>/g) ?? [];
+  const perFile = {};
+  let total = 0;
+
+  for (const tag of suiteTags) {
+    const tests = getNumericAttribute(tag, 'tests');
+    const skipped = getNumericAttribute(tag, 'skipped');
+    const executed = Math.max(0, tests - skipped);
+    if (executed === 0) continue;
+
+    total += executed;
+    const filePath = getStringAttribute(tag, 'file') || getStringAttribute(tag, 'name');
+    if (filePath) {
+      perFile[filePath] = (perFile[filePath] ?? 0) + executed;
+    }
+  }
+
+  return { total, perFile };
+}
+
+// ---------------------------------------------------------------------------
+// Feature folder mapping — extension directory structure
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps a test file path to a feature category for MetaMask Extension.
+ *
+ * Rules (first match wins):
+ *   ui/components/<group>/   → <group>         (e.g. multichain, app, component_library)
+ *   ui/<folder>/             → <folder>         (e.g. ducks, hooks, selectors, pages)
+ *   app/scripts/<folder>/    → <folder>         (e.g. controllers, lib, migrations)
+ *   app/<folder>/            → <folder>         (e.g. offscreen)
+ *   shared/<folder>/         → shared_<folder>  (e.g. shared_lib, shared_constants)
+ *   Anything else            → other
+ *
+ * @param {string} testFilePath
+ * @returns {string}
+ */
+function getFeatureFolder(testFilePath) {
+  const normalize = (s) => s.toLowerCase().replace(/-/g, '_');
+  const p = testFilePath.replace(/\\/g, '/');
+
+  // ui/components/<group>/ → <group> (e.g. multichain, app, component_library)
+  const uiComponentsMatch = p.match(/\bui\/components\/([^/]+)/);
+  if (uiComponentsMatch) return normalize(uiComponentsMatch[1]);
+
+  // ui/<folder>/ → <folder> (e.g. ducks, hooks, selectors, pages)
+  const uiMatch = p.match(/\bui\/([^/]+)/);
+  if (uiMatch) return normalize(uiMatch[1]);
+
+  // app/scripts/<folder>/ → <folder> (e.g. controllers, lib, migrations)
+  const appScriptsMatch = p.match(/\bapp\/scripts\/([^/]+)/);
+  if (appScriptsMatch) return normalize(appScriptsMatch[1]);
+
+  // app/<folder>/ → <folder> (e.g. offscreen)
+  const appMatch = p.match(/\bapp\/([^/]+)/);
+  if (appMatch) return normalize(appMatch[1]);
+
+  // shared/<folder>/ → shared_<folder>
+  const sharedMatch = p.match(/\bshared\/([^/]+)/);
+  if (sharedMatch) return `shared_${normalize(sharedMatch[1])}`;
+
+  return 'other';
+}
+
+// ---------------------------------------------------------------------------
+// Collectors
+// ---------------------------------------------------------------------------
+
+/**
+ * Downloads all unit-test-results-* shard artifacts (JUnit XML), parses them,
+ * and returns test counts grouped by feature folder.
+ *
+ * Folders whose total count is below minFolderCount are merged into `other`
+ * to reduce noise.
+ *
+ * @param {number} [minFolderCount=200]
+ * @returns {Promise<Record<string, number>>}
+ */
+async function collectUnitTestCount(minFolderCount = 200) {
+  console.log('[unit] collecting per-suite counts from shard artifacts...');
+
+  const artifacts = await getArtifactList();
+  const shardArtifacts = artifacts.filter((a) => /^unit-test-results-\d+$/.test(a.name));
+  console.log(`[unit] found ${shardArtifacts.length} shard artifact(s)`);
+
+  if (shardArtifacts.length === 0) return {};
+
+  const folderCounts = {};
+  let total = 0;
+
+  for (const artifact of shardArtifacts) {
+    const destDir = await downloadArtifact(artifact.name);
+    const raw = await readFile(join(destDir, 'junit.xml'), 'utf8');
+    const { total: shardTotal, perFile } = parseJUnitXml(raw);
+    total += shardTotal;
+
+    for (const [filePath, count] of Object.entries(perFile)) {
+      const folder = getFeatureFolder(filePath);
+      folderCounts[folder] = (folderCounts[folder] ?? 0) + count;
+    }
+  }
+
+  console.log(`[unit] total: ${total}`);
+
+  const result = { tests_count: total };
+  for (const [folder, count] of Object.entries(folderCounts)) {
+    if (minFolderCount > 0 && count < minFolderCount) {
+      result.other_tests_count = (result.other_tests_count ?? 0) + count;
+    } else {
+      result[`${folder}_tests_count`] = count;
+    }
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const stats = {};
+
+  const collectors = [
+    { namespace: 'unit', collect: collectUnitTestCount },
+  ];
+
+  for (const { namespace, collect } of collectors) {
+    try {
+      const nested = await collect();
+      if (Object.keys(nested).length === 0) continue;
+      stats[namespace] = nested;
+    } catch (err) {
+      // namespace will not be present in the output if the collector fails
+      console.error(`[${namespace}] collector failed, skipping:`, err.message);
+    }
+  }
+
+  const outputPath = './qa-stats.json';
+  await writeFile(outputPath, JSON.stringify(stats, null, 2), 'utf8');
+  console.log(`✅ QA stats written to ${outputPath}:`, stats);
+}
+
+main().catch((err) => {
+  console.error('\n❌ Unexpected error:', err);
+  process.exit(1);
+});

--- a/.github/scripts/collect-qa-stats.mjs
+++ b/.github/scripts/collect-qa-stats.mjs
@@ -37,7 +37,7 @@ import { join } from 'path';
 
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 const GITHUB_REPOSITORY = process.env.GITHUB_REPOSITORY ?? 'MetaMask/metamask-extension';
-const WORKFLOW_RUN_ID = "23010648370";
+const WORKFLOW_RUN_ID = "23014510046";
 
 
 if (!GITHUB_TOKEN) throw new Error('Missing required GITHUB_TOKEN env var');
@@ -318,6 +318,66 @@ async function collectUnitTestCount(minFolderCount = 200) {
 }
 
 // ---------------------------------------------------------------------------
+// Integration test helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps an integration test file path to a feature category.
+ *
+ * Extracts the top-level subdirectory under test/integration/:
+ *   test/integration/confirmations/... → confirmations
+ *   test/integration/swaps/...         → swaps
+ *   Anything else                      → other
+ *
+ * @param {string} testFilePath
+ * @returns {string}
+ */
+function getIntegrationFeatureFolder(testFilePath) {
+  const normalize = (s) => s.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+  const p = testFilePath.replace(/\\/g, '/');
+
+  const match = p.match(/\btest\/integration\/([^/]+)/);
+  return match ? normalize(match[1]) : 'other';
+}
+
+/**
+ * Downloads the integration-test-results artifact (single, no sharding),
+ * parses the JUnit XML, and returns test counts grouped by feature folder.
+ *
+ * @returns {Promise<Record<string, number>>}
+ */
+async function collectIntegrationTestCount() {
+  console.log('[integration] collecting per-suite counts from artifact...');
+
+  const artifacts = await getArtifactList();
+  const artifact = artifacts.find((a) => a.name === 'integration-test-results');
+
+  if (!artifact) {
+    console.log('[integration] artifact not found — integration tests did not run, skipping');
+    return {};
+  }
+
+  const destDir = await downloadArtifact(artifact.name);
+  const raw = await readFile(join(destDir, 'junit.xml'), 'utf8');
+  const { total, perFile } = parseJUnitXml(raw);
+
+  console.log(`[integration] total: ${total}`);
+
+  const folderCounts = {};
+  for (const [filePath, count] of Object.entries(perFile)) {
+    const folder = getIntegrationFeatureFolder(filePath);
+    folderCounts[folder] = (folderCounts[folder] ?? 0) + count;
+  }
+
+  const result = { tests_count: total };
+  for (const [folder, count] of Object.entries(folderCounts)) {
+    result[`${folder}_tests_count`] = count;
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
@@ -326,6 +386,7 @@ async function main() {
 
   const collectors = [
     { namespace: 'unit', collect: collectUnitTestCount },
+    { namespace: 'integration', collect: collectIntegrationTestCount },
   ];
 
   for (const { namespace, collect } of collectors) {

--- a/.github/scripts/collect-qa-stats.mjs
+++ b/.github/scripts/collect-qa-stats.mjs
@@ -1,10 +1,9 @@
 #!/usr/bin/env node
 /**
  *
- * Collects QA metrics from the latest successful Main CI run on `main` and
- * writes qa-stats.json in key: value format.
+ * Collects QA metrics into a qa-stats.json file, key: value format.
  * Metrics that could not be collected (missing artifacts, tests did not run)
- * are omitted from the output — they will never appear as zero.
+ * are omitted from the output, i.e., they will not appear in the output file.
  *
  * Required env vars:
  *   GITHUB_TOKEN      — GitHub Actions token for API access
@@ -18,9 +17,13 @@
  * Renaming a key in the JSON creates a new series in the DB while the old name stops getting new data,
  * which breaks the Grafana time series continuity. Adding and removing keys is fine.
  *
+ * Artifact names used below are coupled to `name:` fields in main.yml and run-tests.yml —
+ * renaming either side silently drops that metric from the output.
+ *
  * Naming convention:
  *   - CI-executed (from JUnit XML artifacts): _run suffix     → tests actually ran in CI
  *   - Static source analysis (from code):     _defined suffix → tests defined in the codebase
+ *   - total_tests_skipped is static-analysis derived (it.skip / test.skip / describe.skip)
  *
  * Example output:
  *   {
@@ -34,6 +37,29 @@
  *       "selectors_tests_run": 900,
  *       "other_tests_run": 26357
  *     },
+ *     "integration": {
+ *       "total_tests_run": 540,
+ *       "total_tests_skipped": 2,
+ *       "total_tests_defined": 510,
+ *       "accounts_tests_run": 90,
+ *       "other_tests_run": 450
+ *     },
+ *     "e2e": {
+ *       "total_tests_run": 1200,
+ *       "total_tests_skipped": 5,
+ *       "total_tests_defined": 1100,
+ *       "confirmations_tests_run": 300,
+ *       "send_tests_run": 120,
+ *       "other_tests_run": 780
+ *     },
+ *     "e2e_flask": {
+ *       "total_tests_run": 200,
+ *       "total_tests_skipped": 0,
+ *       "total_tests_defined": 180,
+ *       "snaps_tests_run": 80,
+ *       "accounts_tests_run": 60,
+ *       "other_tests_run": 60
+ *     },
  *     "benchmark": {
  *       "total_tests_defined": 8,
  *       "startup_tests_defined": 2,
@@ -43,20 +69,39 @@
  *   }
  */
 
-import { writeFile, mkdir, readFile, readdir } from 'fs/promises';
+import { readFile, writeFile, mkdir, readdir } from 'fs/promises';
 import { execSync } from 'child_process';
 import { join } from 'path';
 
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
-const GITHUB_REPOSITORY = process.env.GITHUB_REPOSITORY ?? 'MetaMask/metamask-extension';
-const WORKFLOW_RUN_ID = "23014510046";
-
+const GITHUB_REPOSITORY =
+  process.env.GITHUB_REPOSITORY ?? 'MetaMask/metamask-extension';
 
 if (!GITHUB_TOKEN) throw new Error('Missing required GITHUB_TOKEN env var');
 
 // ---------------------------------------------------------------------------
+// Static-scan targets
+// Update these if the repository directory structure or file-naming conventions
+// change — the collectors below rely on them for skip/defined counts.
+// ---------------------------------------------------------------------------
+const SCAN_UNIT_DIRS = ['ui', 'app', 'shared'];
+const SCAN_INTEGRATION_DIR = 'test/integration';
+const SCAN_E2E_DIRS = ['test/e2e/tests', 'test/e2e/accounts', 'test/e2e/snaps'];
+const SCAN_E2E_FLASK_DIRS = [
+  'test/e2e/flask',
+  'test/e2e/accounts',
+  'test/e2e/snaps',
+];
+
+const PATTERN_UNIT_TEST_FILE = /\.test\.(ts|tsx|js|jsx)$/;
+const PATTERN_E2E_SPEC_FILE = /\.spec\.(ts|js)$/;
+
+// ---------------------------------------------------------------------------
 // GitHub API helpers
 // ---------------------------------------------------------------------------
+
+let _runId = null;
+let _artifactList = null;
 
 /**
  * Fetches the ID of the latest successful "Main" workflow run on `main`.
@@ -73,7 +118,9 @@ async function getLatestMainRunId() {
   });
 
   if (!res.ok) {
-    throw new Error(`Failed to fetch Main workflow runs: ${res.status} ${res.statusText}`);
+    throw new Error(
+      `Failed to fetch Main workflow runs: ${res.status} ${res.statusText}`,
+    );
   }
 
   const data = await res.json();
@@ -82,23 +129,21 @@ async function getLatestMainRunId() {
     throw new Error('No successful Main workflow runs found on main');
   }
 
-  console.log(`[run] Using Main run #${run.run_number} (id=${run.id}, ${run.created_at})`);
+  console.log(
+    `[run] Using latest successful Main run #${run.run_number} (id=${run.id}, ${run.created_at})`,
+  );
   return String(run.id);
 }
 
-let _runId = null;
-
 async function getRunId() {
-  if (!_runId) {
-    _runId = await getLatestMainRunId();
-  }
+  if (_runId) return _runId;
+  _runId = await getLatestMainRunId();
   return _runId;
 }
 
-let _artifactList = null;
-
 /**
- * Fetches (and caches) the list of artifact names for the discovered CI run.
+ * Fetches (and caches) the list of artifacts for the discovered CI run.
+ * First call fetches and stores, every subsequent call returns the cached value.
  *
  * @returns {Promise<Array>}
  */
@@ -110,8 +155,7 @@ async function getArtifactList() {
   let page = 1;
 
   while (true) {
-    // const url = `https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${runId}/artifacts?per_page=100&page=${page}`;
-    const url = `https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${WORKFLOW_RUN_ID}/artifacts?per_page=100&page=${page}`;
+    const url = `https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${runId}/artifacts?per_page=100&page=${page}`;
     const res = await fetch(url, {
       headers: {
         Authorization: `Bearer ${GITHUB_TOKEN}`,
@@ -120,7 +164,9 @@ async function getArtifactList() {
     });
 
     if (!res.ok) {
-      throw new Error(`Failed to list artifacts (page ${page}): ${res.status} ${res.statusText}`);
+      throw new Error(
+        `Failed to list artifacts (page ${page}): ${res.status} ${res.statusText}`,
+      );
     }
 
     const data = await res.json();
@@ -210,20 +256,15 @@ function getStringAttribute(tag, name) {
  * @returns {{ total: number, perFile: Record<string, number> }}
  */
 function parseJUnitXml(rawXml) {
-  // Match each <testcase> — either self-closing or with a body
   const testcasePattern = /<testcase\b([^>]*)(?:\/>|>([\s\S]*?)<\/testcase>)/g;
   const perFile = {};
   let total = 0;
-  let skipped = 0;
 
   for (const match of rawXml.matchAll(testcasePattern)) {
     const attrs = match[1];
     const body = match[2] ?? '';
 
-    if (body.includes('<skipped')) {
-      skipped++;
-      continue;
-    }
+    if (body.includes('<skipped')) continue;
 
     const filePath = getStringAttribute(attrs, 'file');
     if (!filePath) continue;
@@ -232,7 +273,134 @@ function parseJUnitXml(rawXml) {
     perFile[filePath] = (perFile[filePath] ?? 0) + 1;
   }
 
-  return { total, skipped, perFile };
+  return { total, perFile };
+}
+
+// ---------------------------------------------------------------------------
+// Static analysis helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Recursively collects file paths under `dir` that satisfy `predicate(filename)`.
+ *
+ * @param {string} dir
+ * @param {(name: string) => boolean} predicate
+ * @returns {Promise<string[]>}
+ */
+async function walkFiles(dir, predicate) {
+  const results = [];
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return results; // directory does not exist — skip silently
+  }
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...(await walkFiles(fullPath, predicate)));
+    } else if (entry.isFile() && predicate(entry.name)) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
+/**
+ * Counts all individual test definitions in a source string — both active and
+ * skipped. Matches it(, it.skip(, it.each(, test(, test.skip(, test.each(, etc.
+ *
+ * Parameterized tests (it.each) are counted as one definition each, even
+ * though they expand into multiple cases at runtime — so total_tests_defined
+ * may be lower than total_tests_run.
+ *
+ * @param {string} source
+ * @returns {number}
+ */
+function countDefinedTests(source) {
+  return (
+    source.match(/\b(?:it|test)(?:\.(?:each|skip|only|concurrent))?\s*\(/g) ??
+    []
+  ).length;
+}
+
+/**
+ * Counts the number of individual test cases that are skipped in a source string.
+ *
+ * Two categories:
+ *   1. Explicit: `it.skip()` / `test.skip()` outside any `describe.skip` block.
+ *   2. Implicit: every `it()` / `test()` call (including `.skip` variants) inside
+ *      a `describe.skip` block, because the whole block is skipped by the runner.
+ *
+ * `describe.skip` blocks are extracted via brace matching so their contents are
+ * not double-counted against the explicit-skip pass.
+ *
+ * @param {string} source
+ * @returns {number}
+ */
+function countSkips(source) {
+  // Find all describe.skip blocks using brace matching.
+  const describeBlocks = [];
+  const re = /\bdescribe\.skip\s*\(/g;
+  let m;
+  while ((m = re.exec(source)) !== null) {
+    const braceStart = source.indexOf('{', m.index + m[0].length);
+    if (braceStart === -1) continue;
+    let depth = 1,
+      pos = braceStart + 1;
+    while (pos < source.length && depth > 0) {
+      if (source[pos] === '{') depth++;
+      else if (source[pos] === '}') depth--;
+      pos++;
+    }
+    describeBlocks.push({
+      start: m.index,
+      end: pos,
+      content: source.slice(braceStart + 1, pos - 1),
+    });
+  }
+
+  // Strip describe.skip regions from source (reverse order to preserve indices).
+  let outside = source;
+  for (let i = describeBlocks.length - 1; i >= 0; i--) {
+    outside =
+      outside.slice(0, describeBlocks[i].start) +
+      outside.slice(describeBlocks[i].end);
+  }
+
+  // Part 1: it.skip / test.skip outside describe.skip blocks.
+  const explicit = (outside.match(/\b(?:it|test)\.skip\s*\(/g) ?? []).length;
+
+  // Part 2: all it() / test() (including .skip) inside describe.skip blocks.
+  const implicit = describeBlocks.reduce(
+    (sum, { content }) =>
+      sum + (content.match(/\b(?:it|test)(?:\.skip)?\s*\(/g) ?? []).length,
+    0,
+  );
+
+  return explicit + implicit;
+}
+
+/**
+ * Scans one or more directories for test files matching `filePattern` and
+ * returns aggregate defined + skipped counts in a single filesystem pass.
+ *
+ * @param {string[]} dirs - Directories to scan
+ * @param {RegExp} filePattern - Filename pattern to include
+ * @returns {Promise<{ defined: number, skipped: number }>}
+ */
+async function scanTestFiles(dirs, filePattern) {
+  let defined = 0,
+    skipped = 0;
+  for (const dir of dirs) {
+    const files = await walkFiles(dir, (name) => filePattern.test(name));
+    for (const f of files) {
+      const source = await readFile(f, 'utf8');
+      defined += countDefinedTests(source);
+      skipped += countSkips(source);
+    }
+  }
+  return { defined, skipped };
 }
 
 // ---------------------------------------------------------------------------
@@ -240,7 +408,7 @@ function parseJUnitXml(rawXml) {
 // ---------------------------------------------------------------------------
 
 /**
- * Maps a test file path to a feature category for MetaMask Extension.
+ * Maps a unit/integration test file path to a feature category.
  *
  * Rules (first match wins):
  *   ui/components/<group>/   → <group>         (e.g. multichain, app, component_library)
@@ -257,86 +425,60 @@ function getFeatureFolder(testFilePath) {
   const normalize = (s) => s.toLowerCase().replace(/-/g, '_');
   const p = testFilePath.replace(/\\/g, '/');
 
-  // ui/components/<group>/ → <group> (e.g. multichain, app, component_library)
   const uiComponentsMatch = p.match(/\bui\/components\/([^/]+)/);
   if (uiComponentsMatch) return normalize(uiComponentsMatch[1]);
 
-  // ui/<folder>/ → <folder> (e.g. ducks, hooks, selectors, pages)
   const uiMatch = p.match(/\bui\/([^/]+)/);
   if (uiMatch) return normalize(uiMatch[1]);
 
-  // app/scripts/<folder>/ → <folder> (e.g. controllers, lib, migrations)
   const appScriptsMatch = p.match(/\bapp\/scripts\/([^/]+)/);
   if (appScriptsMatch) return normalize(appScriptsMatch[1]);
 
-  // app/<folder>/ → <folder> (e.g. offscreen)
   const appMatch = p.match(/\bapp\/([^/]+)/);
   if (appMatch) return normalize(appMatch[1]);
 
-  // shared/<folder>/ → shared_<folder>
   const sharedMatch = p.match(/\bshared\/([^/]+)/);
   if (sharedMatch) return `shared_${normalize(sharedMatch[1])}`;
 
   return 'other';
 }
 
-// ---------------------------------------------------------------------------
-// Static test definition counter
-// ---------------------------------------------------------------------------
-
 /**
- * Recursively walks a directory tree, yielding file paths.
+ * Maps an integration test file path to a feature category.
  *
- * @param {string} dir
- * @param {string[]} [exclude] - Path substrings to skip
- * @returns {AsyncGenerator<string>}
+ * @param {string} testFilePath
+ * @returns {string}
  */
-async function* walkDir(dir, exclude = []) {
-  let entries;
-  try {
-    entries = await readdir(dir, { withFileTypes: true });
-  } catch {
-    return; // directory does not exist — skip silently
-  }
-  for (const entry of entries) {
-    const fullPath = join(dir, entry.name);
-    if (exclude.some((ex) => fullPath.replace(/\\/g, '/').includes(ex))) continue;
-    if (entry.isDirectory()) {
-      yield* walkDir(fullPath, exclude);
-    } else {
-      yield fullPath;
-    }
-  }
+function getIntegrationFeatureFolder(testFilePath) {
+  const normalize = (s) => s.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+  const p = testFilePath.replace(/\\/g, '/');
+  const match = p.match(/\btest\/integration\/([^/]+)/);
+  return match ? normalize(match[1]) : 'other';
 }
 
 /**
- * Counts test definitions (it/test call sites) across source directories.
+ * Maps an E2E test file path to a feature category.
  *
- * Scans *.test.{ts,tsx,js,jsx} files and counts occurrences of:
- *   it(, test(, it.each(, test.each(, it.skip(, test.skip(, it.only(, test.only(
+ * Rules (first match wins):
+ *   test/e2e/tests/<feature>/  →  <feature>
+ *   test/e2e/flask/<feature>/  →  <feature>
+ *   test/e2e/<folder>/         →  <folder>  (e.g. accounts, snaps)
+ *   Anything else              →  other
  *
- * Parameterized tests (it.each) are counted as one definition each, even
- * though they expand into multiple cases at runtime — so total_tests_defined
- * may be lower than total_tests_run.
- *
- * @param {string[]} rootDirs - Directories to scan
- * @param {string[]} [excludePaths] - Path substrings to exclude
- * @returns {Promise<number>}
+ * @param {string} filePath
+ * @returns {string}
  */
-async function countDefinedTests(rootDirs, excludePaths = []) {
-  const testFileRe = /\.test\.(ts|tsx|js|jsx)$/;
-  // Matches: it(  test(  it.each(  test.skip(  it.only(  etc.
-  const testCallRe = /\b(?:it|test)(?:\.(?:each|skip|only|concurrent))?\s*\(/g;
-  let count = 0;
-  for (const dir of rootDirs) {
-    for await (const filePath of walkDir(dir, excludePaths)) {
-      if (!testFileRe.test(filePath)) continue;
-      const content = await readFile(filePath, 'utf8');
-      const matches = content.match(testCallRe);
-      if (matches) count += matches.length;
-    }
-  }
-  return count;
+function getE2eFeatureFolder(filePath) {
+  const normalize = (s) => s.toLowerCase().replace(/-/g, '_');
+  const p = filePath.replace(/\\/g, '/');
+
+  const m = p.match(/\btest\/e2e\/(?:tests|flask)\/([^/]+)/);
+  if (m) return normalize(m[1]);
+
+  const m2 = p.match(/\btest\/e2e\/([^/]+)/);
+  if (m2) return normalize(m2[1]);
+
+  return 'other';
 }
 
 // ---------------------------------------------------------------------------
@@ -347,7 +489,7 @@ async function countDefinedTests(rootDirs, excludePaths = []) {
  * Downloads all unit-test-results-* shard artifacts (JUnit XML), parses them,
  * and returns test counts grouped by feature folder.
  *
- * Also counts test definitions via static source analysis.
+ * Also counts test definitions and skipped tests via static source analysis.
  *
  * Folders whose total count is below minFolderCount are merged into `other`
  * to reduce noise.
@@ -359,21 +501,21 @@ async function collectUnitTestCount(minFolderCount = 200) {
   console.log('[unit] collecting per-suite counts from shard artifacts...');
 
   const artifacts = await getArtifactList();
-  const shardArtifacts = artifacts.filter((a) => /^unit-test-results-\d+$/.test(a.name));
+  const shardArtifacts = artifacts.filter((a) =>
+    /^unit-test-results-\d+$/.test(a.name),
+  );
   console.log(`[unit] found ${shardArtifacts.length} shard artifact(s)`);
 
   if (shardArtifacts.length === 0) return {};
 
   const folderCounts = {};
   let total = 0;
-  let skipped = 0;
 
   for (const artifact of shardArtifacts) {
     const destDir = await downloadArtifact(artifact.name);
     const raw = await readFile(join(destDir, 'junit.xml'), 'utf8');
-    const { total: shardTotal, skipped: shardSkipped, perFile } = parseJUnitXml(raw);
+    const { total: shardTotal, perFile } = parseJUnitXml(raw);
     total += shardTotal;
-    skipped += shardSkipped;
 
     for (const [filePath, count] of Object.entries(perFile)) {
       const folder = getFeatureFolder(filePath);
@@ -381,16 +523,19 @@ async function collectUnitTestCount(minFolderCount = 200) {
     }
   }
 
-  console.log(`[unit] total: ${total}, skipped: ${skipped}`);
+  console.log(`[unit] total: ${total}`);
 
-  // Static count: scan unit test source files (excludes e2e and integration)
-  const defined = await countDefinedTests(
-    ['ui', 'app', 'shared'],
-    ['node_modules'],
+  const { defined, skipped } = await scanTestFiles(
+    SCAN_UNIT_DIRS,
+    PATTERN_UNIT_TEST_FILE,
   );
-  console.log(`[unit] defined: ${defined}`);
+  console.log(`[unit] defined: ${defined}, skipped (static): ${skipped}`);
 
-  const result = { total_tests_run: total, total_tests_skipped: skipped, total_tests_defined: defined };
+  const result = {
+    total_tests_run: total,
+    total_tests_skipped: skipped,
+    total_tests_defined: defined,
+  };
   for (const [folder, count] of Object.entries(folderCounts)) {
     if (minFolderCount > 0 && count < minFolderCount) {
       result.other_tests_run = (result.other_tests_run ?? 0) + count;
@@ -402,34 +547,11 @@ async function collectUnitTestCount(minFolderCount = 200) {
   return result;
 }
 
-// ---------------------------------------------------------------------------
-// Integration test helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Maps an integration test file path to a feature category.
- *
- * Extracts the top-level subdirectory under test/integration/:
- *   test/integration/confirmations/... → confirmations
- *   test/integration/swaps/...         → swaps
- *   Anything else                      → other
- *
- * @param {string} testFilePath
- * @returns {string}
- */
-function getIntegrationFeatureFolder(testFilePath) {
-  const normalize = (s) => s.toLowerCase().replace(/[^a-z0-9]+/g, '_');
-  const p = testFilePath.replace(/\\/g, '/');
-
-  const match = p.match(/\btest\/integration\/([^/]+)/);
-  return match ? normalize(match[1]) : 'other';
-}
-
 /**
  * Downloads the integration-test-results artifact (single, no sharding),
  * parses the JUnit XML, and returns test counts grouped by feature folder.
  *
- * Also counts test definitions via static source analysis.
+ * Also counts test definitions and skipped tests via static source analysis.
  *
  * @returns {Promise<Record<string, number>>}
  */
@@ -440,15 +562,17 @@ async function collectIntegrationTestCount() {
   const artifact = artifacts.find((a) => a.name === 'integration-test-results');
 
   if (!artifact) {
-    console.log('[integration] artifact not found — integration tests did not run, skipping');
+    console.log(
+      '[integration] artifact not found — integration tests did not run, skipping',
+    );
     return {};
   }
 
   const destDir = await downloadArtifact(artifact.name);
   const raw = await readFile(join(destDir, 'junit.xml'), 'utf8');
-  const { total, skipped, perFile } = parseJUnitXml(raw);
+  const { total, perFile } = parseJUnitXml(raw);
 
-  console.log(`[integration] total: ${total}, skipped: ${skipped}`);
+  console.log(`[integration] total: ${total}`);
 
   const folderCounts = {};
   for (const [filePath, count] of Object.entries(perFile)) {
@@ -456,16 +580,137 @@ async function collectIntegrationTestCount() {
     folderCounts[folder] = (folderCounts[folder] ?? 0) + count;
   }
 
-  // Static count: scan integration test source files
-  const defined = await countDefinedTests(['test/integration'], ['node_modules']);
-  console.log(`[integration] defined: ${defined}`);
+  const { defined, skipped } = await scanTestFiles(
+    [SCAN_INTEGRATION_DIR],
+    PATTERN_UNIT_TEST_FILE,
+  );
+  console.log(
+    `[integration] defined: ${defined}, skipped (static): ${skipped}`,
+  );
 
-  const result = { total_tests_run: total, total_tests_skipped: skipped, total_tests_defined: defined };
+  const result = {
+    total_tests_run: total,
+    total_tests_skipped: skipped,
+    total_tests_defined: defined,
+  };
   for (const [folder, count] of Object.entries(folderCounts)) {
     result[`${folder}_tests_run`] = count;
   }
 
   return result;
+}
+
+// ---------------------------------------------------------------------------
+// E2E test collector
+// ---------------------------------------------------------------------------
+
+/** Cached parsed content of test-runs-chrome.json, shared across collectors. */
+let _e2eReportCache = null;
+
+/**
+ * Downloads the test-e2e-chrome-report artifact (once, cached) and returns
+ * the parsed TestRun[] array from test-runs-chrome.json.
+ *
+ * @returns {Promise<Array>}
+ */
+async function getE2eReport() {
+  if (_e2eReportCache) return _e2eReportCache;
+
+  const artifactName = 'test-e2e-chrome-report';
+  console.log(`[e2e] downloading ${artifactName}...`);
+  const destDir = await downloadArtifact(artifactName);
+
+  // The artifact ZIP contains test-runs-chrome.json at its root.
+  // Fall back to the full path in case the upload preserves directory structure.
+  let raw;
+  try {
+    raw = await readFile(join(destDir, 'test-runs-chrome.json'), 'utf8');
+  } catch {
+    raw = await readFile(
+      join(destDir, 'test', 'test-results', 'test-runs-chrome.json'),
+      'utf8',
+    );
+  }
+
+  _e2eReportCache = JSON.parse(raw);
+  return _e2eReportCache;
+}
+
+/**
+ * Shared E2E collector logic. Parses test-runs-chrome.json, filters to a
+ * specific job name, aggregates test counts, and runs a static scan for
+ * total_tests_defined and total_tests_skipped.
+ *
+ * @param {string} jobName - Value of TestRun.name to filter on
+ * @param {string[]} staticDirs - Directories to scan for static test definitions
+ * @returns {Promise<Record<string, number>>}
+ */
+async function collectE2eFromReport(jobName, staticDirs) {
+  const testRuns = await getE2eReport();
+
+  const matchingRuns = testRuns.filter((run) => run.name === jobName);
+  if (matchingRuns.length === 0) {
+    console.log(`[e2e] no runs found for job "${jobName}", skipping`);
+    return {};
+  }
+
+  let total = 0;
+  const folderCounts = {};
+
+  for (const run of matchingRuns) {
+    for (const file of run.testFiles ?? []) {
+      total += file.tests ?? 0;
+
+      const folder = getE2eFeatureFolder(file.path ?? '');
+      folderCounts[folder] = (folderCounts[folder] ?? 0) + (file.tests ?? 0);
+    }
+  }
+
+  console.log(`[e2e/${jobName}] total: ${total}`);
+
+  const { defined, skipped } = await scanTestFiles(
+    staticDirs,
+    PATTERN_E2E_SPEC_FILE,
+  );
+  console.log(
+    `[e2e/${jobName}] defined: ${defined}, skipped (static): ${skipped}`,
+  );
+
+  const result = {
+    total_tests_run: total,
+    total_tests_skipped: skipped,
+    total_tests_defined: defined,
+  };
+  for (const [folder, count] of Object.entries(folderCounts)) {
+    result[`${folder}_tests_run`] = count;
+  }
+
+  return result;
+}
+
+/**
+ * Collects E2E test counts for the standard (non-flask) Chrome build.
+ * Source: test-e2e-chrome-report → job "test-e2e-chrome-browserify"
+ *
+ * @returns {Promise<Record<string, number>>}
+ */
+async function collectE2eTestCount() {
+  console.log('[e2e] collecting counts from test-e2e-chrome-report...');
+  return collectE2eFromReport('test-e2e-chrome-browserify', SCAN_E2E_DIRS);
+}
+
+/**
+ * Collects E2E test counts for the Flask Chrome build.
+ * Source: test-e2e-chrome-report → job "test-e2e-chrome-flask"
+ *
+ * @returns {Promise<Record<string, number>>}
+ */
+async function collectE2eFlaskTestCount() {
+  console.log('[e2e_flask] collecting counts from test-e2e-chrome-report...');
+  return collectE2eFromReport(
+    'test-e2e-chrome-flask',
+    SCAN_E2E_FLASK_DIRS,
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -488,10 +733,10 @@ async function collectBenchmarkScenarioCount() {
   const raw = await readFile(constantsFile, 'utf8');
 
   // Extract all preset string values by their camelCase naming convention.
-  // Presets are defined as string literals under STARTUP_PRESETS, INTERACTION_PRESETS,
-  // and USER_JOURNEY_PRESETS and follow the pattern: startup*, interaction*, userJourney*.
   const presets = new Set();
-  for (const m of raw.matchAll(/'((?:startup|interaction|userJourney)[A-Z][a-zA-Z]*)'/g)) {
+  for (const m of raw.matchAll(
+    /'((?:startup|interaction|userJourney)[A-Z][a-zA-Z]*)'/g,
+  )) {
     presets.add(m[1]);
   }
 
@@ -532,6 +777,8 @@ async function main() {
   const collectors = [
     { namespace: 'unit', collect: collectUnitTestCount },
     { namespace: 'integration', collect: collectIntegrationTestCount },
+    { namespace: 'e2e', collect: collectE2eTestCount },
+    { namespace: 'e2e_flask', collect: collectE2eFlaskTestCount },
     { namespace: 'benchmark', collect: collectBenchmarkScenarioCount },
   ];
 

--- a/.github/scripts/collect-qa-stats.mjs
+++ b/.github/scripts/collect-qa-stats.mjs
@@ -45,20 +45,18 @@
  *       "other_tests_run": 450
  *     },
  *     "e2e": {
- *       "total_tests_run": 1200,
+ *       "total_tests_run": 1400,
  *       "total_tests_skipped": 5,
- *       "total_tests_defined": 1100,
+ *       "total_tests_defined": 1280,
+ *       "main_tests_run": 1200,
+ *       "main_chrome_tests_run": 1200,
+ *       "main_firefox_tests_run": 1185,
+ *       "flask_tests_run": 200,
+ *       "flask_chrome_tests_run": 200,
+ *       "flask_firefox_tests_run": 195,
  *       "confirmations_tests_run": 300,
  *       "send_tests_run": 120,
  *       "other_tests_run": 780
- *     },
- *     "e2e_flask": {
- *       "total_tests_run": 200,
- *       "total_tests_skipped": 0,
- *       "total_tests_defined": 180,
- *       "snaps_tests_run": 80,
- *       "accounts_tests_run": 60,
- *       "other_tests_run": 60
  *     },
  *     "benchmark": {
  *       "total_tests_defined": 8,
@@ -636,81 +634,147 @@ async function getE2eReport() {
   return _e2eReportCache;
 }
 
-/**
- * Shared E2E collector logic. Parses test-runs-chrome.json, filters to a
- * specific job name, aggregates test counts, and runs a static scan for
- * total_tests_defined and total_tests_skipped.
- *
- * @param {string} jobName - Value of TestRun.name to filter on
- * @param {string[]} staticDirs - Directories to scan for static test definitions
- * @returns {Promise<Record<string, number>>}
- */
-async function collectE2eFromReport(jobName, staticDirs) {
-  const testRuns = await getE2eReport();
+/** Cached parsed content of test-runs-firefox.json, shared across collectors. */
+let _e2eFirefoxReportCache = null;
 
-  const matchingRuns = testRuns.filter((run) => run.name === jobName);
-  if (matchingRuns.length === 0) {
-    console.log(`[e2e] no runs found for job "${jobName}", skipping`);
-    return {};
+/**
+ * Downloads the test-e2e-firefox-report artifact (once, cached) and returns
+ * the parsed TestRun[] array from test-runs-firefox.json.
+ *
+ * @returns {Promise<Array>}
+ */
+async function getE2eFirefoxReport() {
+  if (_e2eFirefoxReportCache) return _e2eFirefoxReportCache;
+
+  const artifactName = 'test-e2e-firefox-report';
+  console.log(`[e2e] downloading ${artifactName}...`);
+  const destDir = await downloadArtifact(artifactName);
+
+  let raw;
+  try {
+    raw = await readFile(join(destDir, 'test-runs-firefox.json'), 'utf8');
+  } catch {
+    raw = await readFile(
+      join(destDir, 'test', 'test-results', 'test-runs-firefox.json'),
+      'utf8',
+    );
   }
 
-  let total = 0;
+  _e2eFirefoxReportCache = JSON.parse(raw);
+  return _e2eFirefoxReportCache;
+}
+
+/**
+ * Collects all E2E test counts — both main and flask channels — into a single
+ * namespace. Mirrors the mobile reference pattern where Chrome is the canonical
+ * platform and Firefox is a browser health signal.
+ *
+ * Channel breakdown:
+ *   main  = standard browserify tests (core wallet features, MV3)
+ *   flask = Flask build tests (Snaps, experimental features)
+ *
+ * Browser breakdown (within each channel):
+ *   chrome  = canonical unique count (MV3)
+ *   firefox = health signal — drops if Firefox MV2 infrastructure is broken
+ *
+ * Per-feature keys come from Chrome main only (canonical, like Android in mobile).
+ * Static analysis covers both main + flask directories combined.
+ *
+ * @returns {Promise<Record<string, number>>}
+ */
+async function collectE2eTestCount() {
+  console.log('[e2e] collecting counts from e2e reports...');
+
+  const chromeRuns = await getE2eReport();
+
+  // --- Main channel (Chrome, canonical) ---
+  let mainChromeTotal = 0;
   const folderCounts = {};
 
-  for (const run of matchingRuns) {
+  for (const run of chromeRuns.filter(
+    (r) => r.name === 'test-e2e-chrome-browserify',
+  )) {
     for (const file of run.testFiles ?? []) {
-      total += file.tests ?? 0;
-
+      mainChromeTotal += file.tests ?? 0;
       const folder = getE2eFeatureFolder(file.path ?? '');
       folderCounts[folder] = (folderCounts[folder] ?? 0) + (file.tests ?? 0);
     }
   }
+  console.log(`[e2e/main/chrome] total: ${mainChromeTotal}`);
 
-  console.log(`[e2e/${jobName}] total: ${total}`);
+  // --- Flask channel (Chrome, canonical) ---
+  let flaskChromeTotal = 0;
 
+  for (const run of chromeRuns.filter(
+    (r) => r.name === 'test-e2e-chrome-flask',
+  )) {
+    for (const file of run.testFiles ?? []) {
+      flaskChromeTotal += file.tests ?? 0;
+    }
+  }
+  console.log(`[e2e/flask/chrome] total: ${flaskChromeTotal}`);
+
+  // --- Firefox health signals (both channels) ---
+  let mainFirefoxTotal = 0;
+  let flaskFirefoxTotal = 0;
+  try {
+    const firefoxRuns = await getE2eFirefoxReport();
+
+    for (const run of firefoxRuns.filter(
+      (r) => r.name === 'test-e2e-firefox-browserify',
+    )) {
+      for (const file of run.testFiles ?? []) {
+        mainFirefoxTotal += file.tests ?? 0;
+      }
+    }
+    console.log(`[e2e/main/firefox] total: ${mainFirefoxTotal}`);
+
+    for (const run of firefoxRuns.filter(
+      (r) => r.name === 'test-e2e-firefox-flask',
+    )) {
+      for (const file of run.testFiles ?? []) {
+        flaskFirefoxTotal += file.tests ?? 0;
+      }
+    }
+    console.log(`[e2e/flask/firefox] total: ${flaskFirefoxTotal}`);
+  } catch (err) {
+    console.warn(`[e2e] firefox report not available, skipping: ${err.message}`);
+  }
+
+  // --- Static analysis across both main and flask dirs ---
+  const allE2eDirs = [...new Set([...SCAN_E2E_DIRS, ...SCAN_E2E_FLASK_DIRS])];
   const { defined, skipped } = await scanTestFiles(
-    staticDirs,
+    allE2eDirs,
     PATTERN_E2E_SPEC_FILE,
   );
-  console.log(
-    `[e2e/${jobName}] defined: ${defined}, skipped (static): ${skipped}`,
-  );
+  console.log(`[e2e] defined: ${defined}, skipped (static): ${skipped}`);
 
   const result = {
-    total_tests_run: total,
+    total_tests_run: mainChromeTotal + flaskChromeTotal,
     total_tests_skipped: skipped,
     total_tests_defined: defined,
   };
+
+  // Main channel counts (omit if main tests did not run)
+  if (mainChromeTotal > 0 || mainFirefoxTotal > 0) {
+    result.main_tests_run = mainChromeTotal;
+    result.main_chrome_tests_run = mainChromeTotal;
+    if (mainFirefoxTotal > 0) result.main_firefox_tests_run = mainFirefoxTotal;
+  }
+
+  // Flask channel counts (omit if flask tests did not run)
+  if (flaskChromeTotal > 0 || flaskFirefoxTotal > 0) {
+    result.flask_tests_run = flaskChromeTotal;
+    result.flask_chrome_tests_run = flaskChromeTotal;
+    if (flaskFirefoxTotal > 0) result.flask_firefox_tests_run = flaskFirefoxTotal;
+  }
+
+  // Per-feature breakdown from Chrome main only (canonical, like Android in mobile)
   for (const [folder, count] of Object.entries(folderCounts)) {
     result[`${folder}_tests_run`] = count;
   }
 
   return result;
-}
-
-/**
- * Collects E2E test counts for the standard (non-flask) Chrome build.
- * Source: test-e2e-chrome-report → job "test-e2e-chrome-browserify"
- *
- * @returns {Promise<Record<string, number>>}
- */
-async function collectE2eTestCount() {
-  console.log('[e2e] collecting counts from test-e2e-chrome-report...');
-  return collectE2eFromReport('test-e2e-chrome-browserify', SCAN_E2E_DIRS);
-}
-
-/**
- * Collects E2E test counts for the Flask Chrome build.
- * Source: test-e2e-chrome-report → job "test-e2e-chrome-flask"
- *
- * @returns {Promise<Record<string, number>>}
- */
-async function collectE2eFlaskTestCount() {
-  console.log('[e2e_flask] collecting counts from test-e2e-chrome-report...');
-  return collectE2eFromReport(
-    'test-e2e-chrome-flask',
-    SCAN_E2E_FLASK_DIRS,
-  );
 }
 
 // ---------------------------------------------------------------------------
@@ -778,7 +842,6 @@ async function main() {
     { namespace: 'unit', collect: collectUnitTestCount },
     { namespace: 'integration', collect: collectIntegrationTestCount },
     { namespace: 'e2e', collect: collectE2eTestCount },
-    { namespace: 'e2e_flask', collect: collectE2eFlaskTestCount },
     { namespace: 'benchmark', collect: collectBenchmarkScenarioCount },
   ];
 

--- a/.github/scripts/collect-qa-stats.mjs
+++ b/.github/scripts/collect-qa-stats.mjs
@@ -18,20 +18,32 @@
  * Renaming a key in the JSON creates a new series in the DB while the old name stops getting new data,
  * which breaks the Grafana time series continuity. Adding and removing keys is fine.
  *
+ * Naming convention:
+ *   - CI-executed (from JUnit XML artifacts): _run suffix     → tests actually ran in CI
+ *   - Static source analysis (from code):     _defined suffix → tests defined in the codebase
+ *
  * Example output:
  *   {
  *     "unit": {
- *       "tests_count": 41957,
- *       "controllers_tests_count": 3200,
- *       "ui_app_tests_count": 5100,
- *       "ducks_tests_count": 1500,
- *       "selectors_tests_count": 900,
- *       "other_tests_count": 26357
+ *       "total_tests_run": 41957,
+ *       "total_tests_skipped": 120,
+ *       "total_tests_defined": 39500,
+ *       "controllers_tests_run": 3200,
+ *       "ui_app_tests_run": 5100,
+ *       "ducks_tests_run": 1500,
+ *       "selectors_tests_run": 900,
+ *       "other_tests_run": 26357
+ *     },
+ *     "benchmark": {
+ *       "total_tests_defined": 8,
+ *       "startup_tests_defined": 2,
+ *       "interaction_tests_defined": 1,
+ *       "user_journey_tests_defined": 5
  *     }
  *   }
  */
 
-import { writeFile, mkdir, readFile } from 'fs/promises';
+import { writeFile, mkdir, readFile, readdir } from 'fs/promises';
 import { execSync } from 'child_process';
 import { join } from 'path';
 
@@ -202,13 +214,16 @@ function parseJUnitXml(rawXml) {
   const testcasePattern = /<testcase\b([^>]*)(?:\/>|>([\s\S]*?)<\/testcase>)/g;
   const perFile = {};
   let total = 0;
+  let skipped = 0;
 
   for (const match of rawXml.matchAll(testcasePattern)) {
     const attrs = match[1];
     const body = match[2] ?? '';
 
-    // Exclude skipped tests (<skipped/> or <skipped ...> child element)
-    if (body.includes('<skipped')) continue;
+    if (body.includes('<skipped')) {
+      skipped++;
+      continue;
+    }
 
     const filePath = getStringAttribute(attrs, 'file');
     if (!filePath) continue;
@@ -217,7 +232,7 @@ function parseJUnitXml(rawXml) {
     perFile[filePath] = (perFile[filePath] ?? 0) + 1;
   }
 
-  return { total, perFile };
+  return { total, skipped, perFile };
 }
 
 // ---------------------------------------------------------------------------
@@ -266,12 +281,73 @@ function getFeatureFolder(testFilePath) {
 }
 
 // ---------------------------------------------------------------------------
+// Static test definition counter
+// ---------------------------------------------------------------------------
+
+/**
+ * Recursively walks a directory tree, yielding file paths.
+ *
+ * @param {string} dir
+ * @param {string[]} [exclude] - Path substrings to skip
+ * @returns {AsyncGenerator<string>}
+ */
+async function* walkDir(dir, exclude = []) {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return; // directory does not exist — skip silently
+  }
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (exclude.some((ex) => fullPath.replace(/\\/g, '/').includes(ex))) continue;
+    if (entry.isDirectory()) {
+      yield* walkDir(fullPath, exclude);
+    } else {
+      yield fullPath;
+    }
+  }
+}
+
+/**
+ * Counts test definitions (it/test call sites) across source directories.
+ *
+ * Scans *.test.{ts,tsx,js,jsx} files and counts occurrences of:
+ *   it(, test(, it.each(, test.each(, it.skip(, test.skip(, it.only(, test.only(
+ *
+ * Parameterized tests (it.each) are counted as one definition each, even
+ * though they expand into multiple cases at runtime — so total_tests_defined
+ * may be lower than total_tests_run.
+ *
+ * @param {string[]} rootDirs - Directories to scan
+ * @param {string[]} [excludePaths] - Path substrings to exclude
+ * @returns {Promise<number>}
+ */
+async function countDefinedTests(rootDirs, excludePaths = []) {
+  const testFileRe = /\.test\.(ts|tsx|js|jsx)$/;
+  // Matches: it(  test(  it.each(  test.skip(  it.only(  etc.
+  const testCallRe = /\b(?:it|test)(?:\.(?:each|skip|only|concurrent))?\s*\(/g;
+  let count = 0;
+  for (const dir of rootDirs) {
+    for await (const filePath of walkDir(dir, excludePaths)) {
+      if (!testFileRe.test(filePath)) continue;
+      const content = await readFile(filePath, 'utf8');
+      const matches = content.match(testCallRe);
+      if (matches) count += matches.length;
+    }
+  }
+  return count;
+}
+
+// ---------------------------------------------------------------------------
 // Collectors
 // ---------------------------------------------------------------------------
 
 /**
  * Downloads all unit-test-results-* shard artifacts (JUnit XML), parses them,
  * and returns test counts grouped by feature folder.
+ *
+ * Also counts test definitions via static source analysis.
  *
  * Folders whose total count is below minFolderCount are merged into `other`
  * to reduce noise.
@@ -290,12 +366,14 @@ async function collectUnitTestCount(minFolderCount = 200) {
 
   const folderCounts = {};
   let total = 0;
+  let skipped = 0;
 
   for (const artifact of shardArtifacts) {
     const destDir = await downloadArtifact(artifact.name);
     const raw = await readFile(join(destDir, 'junit.xml'), 'utf8');
-    const { total: shardTotal, perFile } = parseJUnitXml(raw);
+    const { total: shardTotal, skipped: shardSkipped, perFile } = parseJUnitXml(raw);
     total += shardTotal;
+    skipped += shardSkipped;
 
     for (const [filePath, count] of Object.entries(perFile)) {
       const folder = getFeatureFolder(filePath);
@@ -303,14 +381,21 @@ async function collectUnitTestCount(minFolderCount = 200) {
     }
   }
 
-  console.log(`[unit] total: ${total}`);
+  console.log(`[unit] total: ${total}, skipped: ${skipped}`);
 
-  const result = { tests_count: total };
+  // Static count: scan unit test source files (excludes e2e and integration)
+  const defined = await countDefinedTests(
+    ['ui', 'app', 'shared'],
+    ['node_modules'],
+  );
+  console.log(`[unit] defined: ${defined}`);
+
+  const result = { total_tests_run: total, total_tests_skipped: skipped, total_tests_defined: defined };
   for (const [folder, count] of Object.entries(folderCounts)) {
     if (minFolderCount > 0 && count < minFolderCount) {
-      result.other_tests_count = (result.other_tests_count ?? 0) + count;
+      result.other_tests_run = (result.other_tests_run ?? 0) + count;
     } else {
-      result[`${folder}_tests_count`] = count;
+      result[`${folder}_tests_run`] = count;
     }
   }
 
@@ -344,6 +429,8 @@ function getIntegrationFeatureFolder(testFilePath) {
  * Downloads the integration-test-results artifact (single, no sharding),
  * parses the JUnit XML, and returns test counts grouped by feature folder.
  *
+ * Also counts test definitions via static source analysis.
+ *
  * @returns {Promise<Record<string, number>>}
  */
 async function collectIntegrationTestCount() {
@@ -359,9 +446,9 @@ async function collectIntegrationTestCount() {
 
   const destDir = await downloadArtifact(artifact.name);
   const raw = await readFile(join(destDir, 'junit.xml'), 'utf8');
-  const { total, perFile } = parseJUnitXml(raw);
+  const { total, skipped, perFile } = parseJUnitXml(raw);
 
-  console.log(`[integration] total: ${total}`);
+  console.log(`[integration] total: ${total}, skipped: ${skipped}`);
 
   const folderCounts = {};
   for (const [filePath, count] of Object.entries(perFile)) {
@@ -369,9 +456,67 @@ async function collectIntegrationTestCount() {
     folderCounts[folder] = (folderCounts[folder] ?? 0) + count;
   }
 
-  const result = { tests_count: total };
+  // Static count: scan integration test source files
+  const defined = await countDefinedTests(['test/integration'], ['node_modules']);
+  console.log(`[integration] defined: ${defined}`);
+
+  const result = { total_tests_run: total, total_tests_skipped: skipped, total_tests_defined: defined };
   for (const [folder, count] of Object.entries(folderCounts)) {
-    result[`${folder}_tests_count`] = count;
+    result[`${folder}_tests_run`] = count;
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark scenario counter
+// ---------------------------------------------------------------------------
+
+/**
+ * Counts benchmark presets defined in test/e2e/benchmarks/utils/constants.ts.
+ *
+ * Each preset (e.g. startupStandardHome, userJourneyAssets) is one benchmark
+ * test. Presets are categorized by their camelCase prefix and reported as
+ * {category}_tests_defined keys (static source analysis, no artifact downloads).
+ *
+ * @returns {Promise<Record<string, number>>}
+ */
+async function collectBenchmarkScenarioCount() {
+  const constantsFile = 'test/e2e/benchmarks/utils/constants.ts';
+  console.log(`[benchmark] reading preset definitions from ${constantsFile}...`);
+
+  const raw = await readFile(constantsFile, 'utf8');
+
+  // Extract all preset string values by their camelCase naming convention.
+  // Presets are defined as string literals under STARTUP_PRESETS, INTERACTION_PRESETS,
+  // and USER_JOURNEY_PRESETS and follow the pattern: startup*, interaction*, userJourney*.
+  const presets = new Set();
+  for (const m of raw.matchAll(/'((?:startup|interaction|userJourney)[A-Z][a-zA-Z]*)'/g)) {
+    presets.add(m[1]);
+  }
+
+  const categoryCounts = {};
+  for (const preset of presets) {
+    let category;
+    if (preset.startsWith('startup')) {
+      category = 'startup';
+    } else if (preset.startsWith('interaction')) {
+      category = 'interaction';
+    } else if (preset.startsWith('userJourney')) {
+      category = 'user_journey';
+    } else {
+      category = 'other';
+    }
+    categoryCounts[category] = (categoryCounts[category] ?? 0) + 1;
+    console.log(`[benchmark] ${preset} → ${category}`);
+  }
+
+  const total = presets.size;
+  console.log(`[benchmark] total: ${total} unique presets`);
+
+  const result = { total_tests_defined: total };
+  for (const [category, count] of Object.entries(categoryCounts)) {
+    result[`${category}_tests_defined`] = count;
   }
 
   return result;
@@ -387,6 +532,7 @@ async function main() {
   const collectors = [
     { namespace: 'unit', collect: collectUnitTestCount },
     { namespace: 'integration', collect: collectIntegrationTestCount },
+    { namespace: 'benchmark', collect: collectBenchmarkScenarioCount },
   ];
 
   for (const { namespace, collect } of collectors) {

--- a/.github/scripts/collect-qa-stats.ts
+++ b/.github/scripts/collect-qa-stats.ts
@@ -1,6 +1,4 @@
-#!/usr/bin/env node
 /**
- *
  * Collects QA metrics into a qa-stats.json file, key: value format.
  * Metrics that could not be collected (missing artifacts, tests did not run)
  * are omitted from the output, i.e., they will not appear in the output file.
@@ -68,14 +66,67 @@
  */
 
 import { readFile, writeFile, mkdir, readdir } from 'fs/promises';
+import type { Dirent } from 'fs';
 import { execSync } from 'child_process';
 import { join } from 'path';
 
-const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type GitHubArtifact = {
+  id: number;
+  name: string;
+  archive_download_url: string;
+};
+
+type GitHubWorkflowRun = {
+  id: number;
+  run_number: number;
+  created_at: string;
+};
+
+type JUnitParseResult = {
+  total: number;
+  perFile: Record<string, number>;
+};
+
+type ScanResult = {
+  defined: number;
+  skipped: number;
+};
+
+type DescribeBlock = {
+  start: number;
+  end: number;
+  content: string;
+};
+
+type TestFile = {
+  path?: string;
+  tests?: number;
+};
+
+type TestRun = {
+  name: string;
+  testFiles?: TestFile[];
+};
+
+type Collector = {
+  namespace: string;
+  collect: () => Promise<Record<string, number>>;
+};
+
+// ---------------------------------------------------------------------------
+// Environment
+// ---------------------------------------------------------------------------
+
+const rawToken = process.env.GITHUB_TOKEN;
+if (!rawToken) throw new Error('Missing required GITHUB_TOKEN env var');
+const GITHUB_TOKEN: string = rawToken;
+
 const GITHUB_REPOSITORY =
   process.env.GITHUB_REPOSITORY ?? 'MetaMask/metamask-extension';
-
-if (!GITHUB_TOKEN) throw new Error('Missing required GITHUB_TOKEN env var');
 
 // ---------------------------------------------------------------------------
 // Static-scan targets
@@ -91,22 +142,20 @@ const SCAN_E2E_FLASK_DIRS = [
   'test/e2e/snaps',
 ];
 
-const PATTERN_UNIT_TEST_FILE = /\.test\.(ts|tsx|js|jsx)$/;
-const PATTERN_E2E_SPEC_FILE = /\.spec\.(ts|js)$/;
+const PATTERN_UNIT_TEST_FILE = /\.test\.(ts|tsx|js|jsx)$/u;
+const PATTERN_E2E_SPEC_FILE = /\.spec\.(ts|js)$/u;
 
 // ---------------------------------------------------------------------------
 // GitHub API helpers
 // ---------------------------------------------------------------------------
 
-let _runId = null;
-let _artifactList = null;
+let _runId: string | null = null;
+let _artifactList: GitHubArtifact[] | null = null;
 
 /**
  * Fetches the ID of the latest successful "Main" workflow run on `main`.
- *
- * @returns {Promise<string>}
  */
-async function getLatestMainRunId() {
+async function getLatestMainRunId(): Promise<string> {
   const url = `https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/workflows/main.yml/runs?branch=main&status=success&per_page=1`;
   const res = await fetch(url, {
     headers: {
@@ -121,7 +170,9 @@ async function getLatestMainRunId() {
     );
   }
 
-  const data = await res.json();
+  const data = (await res.json()) as {
+    workflow_runs?: GitHubWorkflowRun[];
+  };
   const run = data.workflow_runs?.[0];
   if (!run) {
     throw new Error('No successful Main workflow runs found on main');
@@ -133,7 +184,7 @@ async function getLatestMainRunId() {
   return String(run.id);
 }
 
-async function getRunId() {
+async function getRunId(): Promise<string> {
   if (_runId) return _runId;
   _runId = await getLatestMainRunId();
   return _runId;
@@ -142,17 +193,15 @@ async function getRunId() {
 /**
  * Fetches (and caches) the list of artifacts for the discovered CI run.
  * First call fetches and stores, every subsequent call returns the cached value.
- *
- * @returns {Promise<Array>}
  */
-async function getArtifactList() {
+async function getArtifactList(): Promise<GitHubArtifact[]> {
   if (_artifactList) return _artifactList;
 
   const runId = await getRunId();
-  const artifacts = [];
+  const artifacts: GitHubArtifact[] = [];
   let page = 1;
 
-  while (true) {
+  for (;;) {
     const url = `https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${runId}/artifacts?per_page=100&page=${page}`;
     const res = await fetch(url, {
       headers: {
@@ -167,7 +216,7 @@ async function getArtifactList() {
       );
     }
 
-    const data = await res.json();
+    const data = (await res.json()) as { artifacts: GitHubArtifact[] };
     artifacts.push(...data.artifacts);
 
     if (data.artifacts.length < 100) break;
@@ -182,18 +231,16 @@ async function getArtifactList() {
  * Downloads a named artifact from the discovered CI run, extracts it into a
  * local directory named after the artifact, and returns that directory path.
  *
- * @param {string} artifactName
- * @returns {Promise<string>} Path to the directory containing the extracted files
+ * @param artifactName - The name of the artifact to download.
+ * @returns Path to the directory containing the extracted files.
  */
-async function downloadArtifact(artifactName) {
+async function downloadArtifact(artifactName: string): Promise<string> {
   const artifacts = await getArtifactList();
   const artifact = artifacts.find((a) => a.name === artifactName);
   const runId = await getRunId();
 
   if (!artifact) {
-    throw new Error(
-      `Artifact "${artifactName}" not found in run ${runId}`,
-    );
+    throw new Error(`Artifact "${artifactName}" not found in run ${runId}`);
   }
 
   // GitHub redirects to a pre-signed S3 URL. Follow manually so the
@@ -231,31 +278,26 @@ async function downloadArtifact(artifactName) {
 // JUnit XML helpers
 // ---------------------------------------------------------------------------
 
-function getNumericAttribute(tag, name) {
-  const match = tag.match(new RegExp(`${name}="(\\d+)"`));
-  return match ? Number(match[1]) : 0;
-}
-
-function getStringAttribute(tag, name) {
-  const match = tag.match(new RegExp(`${name}="([^"]+)"`));
+function getStringAttribute(tag: string, name: string): string {
+  const match = tag.match(new RegExp(`${name}="([^"]+)"`, 'u'));
   return match ? match[1] : '';
 }
 
 /**
- * Parses JUnit XML and returns { total, perFile } where perFile maps
+ * Parses JUnit XML and returns `{ total, perFile }` where `perFile` maps
  * test file path to executed test count.
  *
  * Relies on jest-junit's `addFileAttribute: 'true'` option, which adds a
- * `file` attribute to each <testcase> element with the absolute path to the
- * test file. Skipped tests are identified by a <skipped> child element and
+ * `file` attribute to each `<testcase>` element with the absolute path to the
+ * test file. Skipped tests are identified by a `<skipped>` child element and
  * excluded from the count.
  *
- * @param {string} rawXml
- * @returns {{ total: number, perFile: Record<string, number> }}
+ * @param rawXml - Raw JUnit XML string.
  */
-function parseJUnitXml(rawXml) {
-  const testcasePattern = /<testcase\b([^>]*)(?:\/>|>([\s\S]*?)<\/testcase>)/g;
-  const perFile = {};
+function parseJUnitXml(rawXml: string): JUnitParseResult {
+  const testcasePattern =
+    /<testcase\b([^>]*)(?:\/>|>([\s\S]*?)<\/testcase>)/gu;
+  const perFile: Record<string, number> = {};
   let total = 0;
 
   for (const match of rawXml.matchAll(testcasePattern)) {
@@ -281,13 +323,15 @@ function parseJUnitXml(rawXml) {
 /**
  * Recursively collects file paths under `dir` that satisfy `predicate(filename)`.
  *
- * @param {string} dir
- * @param {(name: string) => boolean} predicate
- * @returns {Promise<string[]>}
+ * @param dir - Directory to walk.
+ * @param predicate - Returns true for filenames to include.
  */
-async function walkFiles(dir, predicate) {
-  const results = [];
-  let entries;
+async function walkFiles(
+  dir: string,
+  predicate: (name: string) => boolean,
+): Promise<string[]> {
+  const results: string[] = [];
+  let entries: Dirent[];
   try {
     entries = await readdir(dir, { withFileTypes: true });
   } catch {
@@ -306,19 +350,20 @@ async function walkFiles(dir, predicate) {
 
 /**
  * Counts all individual test definitions in a source string — both active and
- * skipped. Matches it(, it.skip(, it.each(, test(, test.skip(, test.each(, etc.
+ * skipped. Matches `it(`, `it.skip(`, `it.each(`, `test(`, `test.skip(`,
+ * `test.each(`, etc.
  *
- * Parameterized tests (it.each) are counted as one definition each, even
- * though they expand into multiple cases at runtime — so total_tests_defined
- * may be lower than total_tests_run.
+ * Parameterized tests (`it.each`) are counted as one definition each, even
+ * though they expand into multiple cases at runtime — so `total_tests_defined`
+ * may be lower than `total_tests_run`.
  *
- * @param {string} source
- * @returns {number}
+ * @param source - Source file content.
  */
-function countDefinedTests(source) {
+function countDefinedTests(source: string): number {
   return (
-    source.match(/\b(?:it|test)(?:\.(?:each|skip|only|concurrent))?\s*\(/g) ??
-    []
+    source.match(
+      /\b(?:it|test)(?:\.(?:each|skip|only|concurrent))?\s*\(/gu,
+    ) ?? []
   ).length;
 }
 
@@ -333,14 +378,13 @@ function countDefinedTests(source) {
  * `describe.skip` blocks are extracted via brace matching so their contents are
  * not double-counted against the explicit-skip pass.
  *
- * @param {string} source
- * @returns {number}
+ * @param source - Source file content.
  */
-function countSkips(source) {
+function countSkips(source: string): number {
   // Find all describe.skip blocks using brace matching.
-  const describeBlocks = [];
-  const re = /\bdescribe\.skip\s*\(/g;
-  let m;
+  const describeBlocks: DescribeBlock[] = [];
+  const re = /\bdescribe\.skip\s*\(/gu;
+  let m: RegExpExecArray | null;
   while ((m = re.exec(source)) !== null) {
     const braceStart = source.indexOf('{', m.index + m[0].length);
     if (braceStart === -1) continue;
@@ -367,12 +411,12 @@ function countSkips(source) {
   }
 
   // Part 1: it.skip / test.skip outside describe.skip blocks.
-  const explicit = (outside.match(/\b(?:it|test)\.skip\s*\(/g) ?? []).length;
+  const explicit = (outside.match(/\b(?:it|test)\.skip\s*\(/gu) ?? []).length;
 
   // Part 2: all it() / test() (including .skip) inside describe.skip blocks.
   const implicit = describeBlocks.reduce(
     (sum, { content }) =>
-      sum + (content.match(/\b(?:it|test)(?:\.skip)?\s*\(/g) ?? []).length,
+      sum + (content.match(/\b(?:it|test)(?:\.skip)?\s*\(/gu) ?? []).length,
     0,
   );
 
@@ -383,11 +427,13 @@ function countSkips(source) {
  * Scans one or more directories for test files matching `filePattern` and
  * returns aggregate defined + skipped counts in a single filesystem pass.
  *
- * @param {string[]} dirs - Directories to scan
- * @param {RegExp} filePattern - Filename pattern to include
- * @returns {Promise<{ defined: number, skipped: number }>}
+ * @param dirs - Directories to scan.
+ * @param filePattern - Filename pattern to include.
  */
-async function scanTestFiles(dirs, filePattern) {
+async function scanTestFiles(
+  dirs: string[],
+  filePattern: RegExp,
+): Promise<ScanResult> {
   let defined = 0,
     skipped = 0;
   for (const dir of dirs) {
@@ -409,33 +455,32 @@ async function scanTestFiles(dirs, filePattern) {
  * Maps a unit/integration test file path to a feature category.
  *
  * Rules (first match wins):
- *   ui/components/<group>/   → <group>         (e.g. multichain, app, component_library)
- *   ui/<folder>/             → <folder>         (e.g. ducks, hooks, selectors, pages)
- *   app/scripts/<folder>/    → <folder>         (e.g. controllers, lib, migrations)
- *   app/<folder>/            → <folder>         (e.g. offscreen)
- *   shared/<folder>/         → shared_<folder>  (e.g. shared_lib, shared_constants)
- *   Anything else            → other
+ *   `ui/components/<group>/`  → `<group>`          (e.g. multichain, app, component_library)
+ *   `ui/<folder>/`            → `<folder>`          (e.g. ducks, hooks, selectors, pages)
+ *   `app/scripts/<folder>/`   → `<folder>`          (e.g. controllers, lib, migrations)
+ *   `app/<folder>/`           → `<folder>`          (e.g. offscreen)
+ *   `shared/<folder>/`        → `shared_<folder>`   (e.g. shared_lib, shared_constants)
+ *   Anything else             → `other`
  *
- * @param {string} testFilePath
- * @returns {string}
+ * @param testFilePath - Absolute or relative test file path.
  */
-function getFeatureFolder(testFilePath) {
-  const normalize = (s) => s.toLowerCase().replace(/-/g, '_');
-  const p = testFilePath.replace(/\\/g, '/');
+function getFeatureFolder(testFilePath: string): string {
+  const normalize = (s: string) => s.toLowerCase().replace(/-/gu, '_');
+  const p = testFilePath.replace(/\\/gu, '/');
 
-  const uiComponentsMatch = p.match(/\bui\/components\/([^/]+)/);
+  const uiComponentsMatch = p.match(/\bui\/components\/([^/]+)/u);
   if (uiComponentsMatch) return normalize(uiComponentsMatch[1]);
 
-  const uiMatch = p.match(/\bui\/([^/]+)/);
+  const uiMatch = p.match(/\bui\/([^/]+)/u);
   if (uiMatch) return normalize(uiMatch[1]);
 
-  const appScriptsMatch = p.match(/\bapp\/scripts\/([^/]+)/);
+  const appScriptsMatch = p.match(/\bapp\/scripts\/([^/]+)/u);
   if (appScriptsMatch) return normalize(appScriptsMatch[1]);
 
-  const appMatch = p.match(/\bapp\/([^/]+)/);
+  const appMatch = p.match(/\bapp\/([^/]+)/u);
   if (appMatch) return normalize(appMatch[1]);
 
-  const sharedMatch = p.match(/\bshared\/([^/]+)/);
+  const sharedMatch = p.match(/\bshared\/([^/]+)/u);
   if (sharedMatch) return `shared_${normalize(sharedMatch[1])}`;
 
   return 'other';
@@ -444,13 +489,13 @@ function getFeatureFolder(testFilePath) {
 /**
  * Maps an integration test file path to a feature category.
  *
- * @param {string} testFilePath
- * @returns {string}
+ * @param testFilePath - Absolute or relative test file path.
  */
-function getIntegrationFeatureFolder(testFilePath) {
-  const normalize = (s) => s.toLowerCase().replace(/[^a-z0-9]+/g, '_');
-  const p = testFilePath.replace(/\\/g, '/');
-  const match = p.match(/\btest\/integration\/([^/]+)/);
+function getIntegrationFeatureFolder(testFilePath: string): string {
+  const normalize = (s: string) =>
+    s.toLowerCase().replace(/[^a-z0-9]+/gu, '_');
+  const p = testFilePath.replace(/\\/gu, '/');
+  const match = p.match(/\btest\/integration\/([^/]+)/u);
   return match ? normalize(match[1]) : 'other';
 }
 
@@ -458,22 +503,21 @@ function getIntegrationFeatureFolder(testFilePath) {
  * Maps an E2E test file path to a feature category.
  *
  * Rules (first match wins):
- *   test/e2e/tests/<feature>/  →  <feature>
- *   test/e2e/flask/<feature>/  →  <feature>
- *   test/e2e/<folder>/         →  <folder>  (e.g. accounts, snaps)
- *   Anything else              →  other
+ *   `test/e2e/tests/<feature>/`  →  `<feature>`
+ *   `test/e2e/flask/<feature>/`  →  `<feature>`
+ *   `test/e2e/<folder>/`         →  `<folder>`  (e.g. accounts, snaps)
+ *   Anything else                →  `other`
  *
- * @param {string} filePath
- * @returns {string}
+ * @param filePath - Absolute or relative test file path.
  */
-function getE2eFeatureFolder(filePath) {
-  const normalize = (s) => s.toLowerCase().replace(/-/g, '_');
-  const p = filePath.replace(/\\/g, '/');
+function getE2eFeatureFolder(filePath: string): string {
+  const normalize = (s: string) => s.toLowerCase().replace(/-/gu, '_');
+  const p = filePath.replace(/\\/gu, '/');
 
-  const m = p.match(/\btest\/e2e\/(?:tests|flask)\/([^/]+)/);
+  const m = p.match(/\btest\/e2e\/(?:tests|flask)\/([^/]+)/u);
   if (m) return normalize(m[1]);
 
-  const m2 = p.match(/\btest\/e2e\/([^/]+)/);
+  const m2 = p.match(/\btest\/e2e\/([^/]+)/u);
   if (m2) return normalize(m2[1]);
 
   return 'other';
@@ -484,29 +528,30 @@ function getE2eFeatureFolder(filePath) {
 // ---------------------------------------------------------------------------
 
 /**
- * Downloads all unit-test-results-* shard artifacts (JUnit XML), parses them,
+ * Downloads all `unit-test-results-*` shard artifacts (JUnit XML), parses them,
  * and returns test counts grouped by feature folder.
  *
  * Also counts test definitions and skipped tests via static source analysis.
  *
- * Folders whose total count is below minFolderCount are merged into `other`
+ * Folders whose total count is below `minFolderCount` are merged into `other`
  * to reduce noise.
  *
- * @param {number} [minFolderCount=200]
- * @returns {Promise<Record<string, number>>}
+ * @param minFolderCount - Folders below this threshold are folded into `other`.
  */
-async function collectUnitTestCount(minFolderCount = 200) {
+async function collectUnitTestCount(
+  minFolderCount = 200,
+): Promise<Record<string, number>> {
   console.log('[unit] collecting per-suite counts from shard artifacts...');
 
   const artifacts = await getArtifactList();
   const shardArtifacts = artifacts.filter((a) =>
-    /^unit-test-results-\d+$/.test(a.name),
+    /^unit-test-results-\d+$/u.test(a.name),
   );
   console.log(`[unit] found ${shardArtifacts.length} shard artifact(s)`);
 
   if (shardArtifacts.length === 0) return {};
 
-  const folderCounts = {};
+  const folderCounts: Record<string, number> = {};
   let total = 0;
 
   for (const artifact of shardArtifacts) {
@@ -529,7 +574,7 @@ async function collectUnitTestCount(minFolderCount = 200) {
   );
   console.log(`[unit] defined: ${defined}, skipped (static): ${skipped}`);
 
-  const result = {
+  const result: Record<string, number> = {
     total_tests_run: total,
     total_tests_skipped: skipped,
     total_tests_defined: defined,
@@ -546,14 +591,12 @@ async function collectUnitTestCount(minFolderCount = 200) {
 }
 
 /**
- * Downloads the integration-test-results artifact (single, no sharding),
+ * Downloads the `integration-test-results` artifact (single, no sharding),
  * parses the JUnit XML, and returns test counts grouped by feature folder.
  *
  * Also counts test definitions and skipped tests via static source analysis.
- *
- * @returns {Promise<Record<string, number>>}
  */
-async function collectIntegrationTestCount() {
+async function collectIntegrationTestCount(): Promise<Record<string, number>> {
   console.log('[integration] collecting per-suite counts from artifact...');
 
   const artifacts = await getArtifactList();
@@ -572,7 +615,7 @@ async function collectIntegrationTestCount() {
 
   console.log(`[integration] total: ${total}`);
 
-  const folderCounts = {};
+  const folderCounts: Record<string, number> = {};
   for (const [filePath, count] of Object.entries(perFile)) {
     const folder = getIntegrationFeatureFolder(filePath);
     folderCounts[folder] = (folderCounts[folder] ?? 0) + count;
@@ -586,7 +629,7 @@ async function collectIntegrationTestCount() {
     `[integration] defined: ${defined}, skipped (static): ${skipped}`,
   );
 
-  const result = {
+  const result: Record<string, number> = {
     total_tests_run: total,
     total_tests_skipped: skipped,
     total_tests_defined: defined,
@@ -603,15 +646,13 @@ async function collectIntegrationTestCount() {
 // ---------------------------------------------------------------------------
 
 /** Cached parsed content of test-runs-chrome.json, shared across collectors. */
-let _e2eReportCache = null;
+let _e2eReportCache: TestRun[] | null = null;
 
 /**
- * Downloads the test-e2e-chrome-report artifact (once, cached) and returns
- * the parsed TestRun[] array from test-runs-chrome.json.
- *
- * @returns {Promise<Array>}
+ * Downloads the `test-e2e-chrome-report` artifact (once, cached) and returns
+ * the parsed `TestRun[]` array from `test-runs-chrome.json`.
  */
-async function getE2eReport() {
+async function getE2eReport(): Promise<TestRun[]> {
   if (_e2eReportCache) return _e2eReportCache;
 
   const artifactName = 'test-e2e-chrome-report';
@@ -620,7 +661,7 @@ async function getE2eReport() {
 
   // The artifact ZIP contains test-runs-chrome.json at its root.
   // Fall back to the full path in case the upload preserves directory structure.
-  let raw;
+  let raw: string;
   try {
     raw = await readFile(join(destDir, 'test-runs-chrome.json'), 'utf8');
   } catch {
@@ -630,27 +671,25 @@ async function getE2eReport() {
     );
   }
 
-  _e2eReportCache = JSON.parse(raw);
+  _e2eReportCache = JSON.parse(raw) as TestRun[];
   return _e2eReportCache;
 }
 
 /** Cached parsed content of test-runs-firefox.json, shared across collectors. */
-let _e2eFirefoxReportCache = null;
+let _e2eFirefoxReportCache: TestRun[] | null = null;
 
 /**
- * Downloads the test-e2e-firefox-report artifact (once, cached) and returns
- * the parsed TestRun[] array from test-runs-firefox.json.
- *
- * @returns {Promise<Array>}
+ * Downloads the `test-e2e-firefox-report` artifact (once, cached) and returns
+ * the parsed `TestRun[]` array from `test-runs-firefox.json`.
  */
-async function getE2eFirefoxReport() {
+async function getE2eFirefoxReport(): Promise<TestRun[]> {
   if (_e2eFirefoxReportCache) return _e2eFirefoxReportCache;
 
   const artifactName = 'test-e2e-firefox-report';
   console.log(`[e2e] downloading ${artifactName}...`);
   const destDir = await downloadArtifact(artifactName);
 
-  let raw;
+  let raw: string;
   try {
     raw = await readFile(join(destDir, 'test-runs-firefox.json'), 'utf8');
   } catch {
@@ -660,7 +699,7 @@ async function getE2eFirefoxReport() {
     );
   }
 
-  _e2eFirefoxReportCache = JSON.parse(raw);
+  _e2eFirefoxReportCache = JSON.parse(raw) as TestRun[];
   return _e2eFirefoxReportCache;
 }
 
@@ -679,17 +718,15 @@ async function getE2eFirefoxReport() {
  *
  * Per-feature keys come from Chrome main only (canonical, like Android in mobile).
  * Static analysis covers both main + flask directories combined.
- *
- * @returns {Promise<Record<string, number>>}
  */
-async function collectE2eTestCount() {
+async function collectE2eTestCount(): Promise<Record<string, number>> {
   console.log('[e2e] collecting counts from e2e reports...');
 
   const chromeRuns = await getE2eReport();
 
   // --- Main channel (Chrome, canonical) ---
   let mainChromeTotal = 0;
-  const folderCounts = {};
+  const folderCounts: Record<string, number> = {};
 
   for (const run of chromeRuns.filter(
     (r) => r.name === 'test-e2e-chrome-browserify',
@@ -738,7 +775,8 @@ async function collectE2eTestCount() {
     }
     console.log(`[e2e/flask/firefox] total: ${flaskFirefoxTotal}`);
   } catch (err) {
-    console.warn(`[e2e] firefox report not available, skipping: ${err.message}`);
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(`[e2e] firefox report not available, skipping: ${message}`);
   }
 
   // --- Static analysis across both main and flask dirs ---
@@ -749,7 +787,7 @@ async function collectE2eTestCount() {
   );
   console.log(`[e2e] defined: ${defined}, skipped (static): ${skipped}`);
 
-  const result = {
+  const result: Record<string, number> = {
     total_tests_run: mainChromeTotal + flaskChromeTotal,
     total_tests_skipped: skipped,
     total_tests_defined: defined,
@@ -766,7 +804,8 @@ async function collectE2eTestCount() {
   if (flaskChromeTotal > 0 || flaskFirefoxTotal > 0) {
     result.flask_tests_run = flaskChromeTotal;
     result.flask_chrome_tests_run = flaskChromeTotal;
-    if (flaskFirefoxTotal > 0) result.flask_firefox_tests_run = flaskFirefoxTotal;
+    if (flaskFirefoxTotal > 0)
+      result.flask_firefox_tests_run = flaskFirefoxTotal;
   }
 
   // Per-feature breakdown from Chrome main only (canonical, like Android in mobile)
@@ -782,31 +821,31 @@ async function collectE2eTestCount() {
 // ---------------------------------------------------------------------------
 
 /**
- * Counts benchmark presets defined in test/e2e/benchmarks/utils/constants.ts.
+ * Counts benchmark presets defined in `test/e2e/benchmarks/utils/constants.ts`.
  *
- * Each preset (e.g. startupStandardHome, userJourneyAssets) is one benchmark
+ * Each preset (e.g. `startupStandardHome`, `userJourneyAssets`) is one benchmark
  * test. Presets are categorized by their camelCase prefix and reported as
- * {category}_tests_defined keys (static source analysis, no artifact downloads).
- *
- * @returns {Promise<Record<string, number>>}
+ * `{category}_tests_defined` keys (static source analysis, no artifact downloads).
  */
-async function collectBenchmarkScenarioCount() {
+async function collectBenchmarkScenarioCount(): Promise<
+  Record<string, number>
+> {
   const constantsFile = 'test/e2e/benchmarks/utils/constants.ts';
   console.log(`[benchmark] reading preset definitions from ${constantsFile}...`);
 
   const raw = await readFile(constantsFile, 'utf8');
 
   // Extract all preset string values by their camelCase naming convention.
-  const presets = new Set();
+  const presets = new Set<string>();
   for (const m of raw.matchAll(
-    /'((?:startup|interaction|userJourney)[A-Z][a-zA-Z]*)'/g,
+    /'((?:startup|interaction|userJourney)[A-Z][a-zA-Z]*)'/gu,
   )) {
     presets.add(m[1]);
   }
 
-  const categoryCounts = {};
+  const categoryCounts: Record<string, number> = {};
   for (const preset of presets) {
-    let category;
+    let category: string;
     if (preset.startsWith('startup')) {
       category = 'startup';
     } else if (preset.startsWith('interaction')) {
@@ -823,7 +862,7 @@ async function collectBenchmarkScenarioCount() {
   const total = presets.size;
   console.log(`[benchmark] total: ${total} unique presets`);
 
-  const result = { total_tests_defined: total };
+  const result: Record<string, number> = { total_tests_defined: total };
   for (const [category, count] of Object.entries(categoryCounts)) {
     result[`${category}_tests_defined`] = count;
   }
@@ -835,10 +874,10 @@ async function collectBenchmarkScenarioCount() {
 // Main
 // ---------------------------------------------------------------------------
 
-async function main() {
-  const stats = {};
+async function main(): Promise<void> {
+  const stats: Record<string, Record<string, number>> = {};
 
-  const collectors = [
+  const collectors: Collector[] = [
     { namespace: 'unit', collect: collectUnitTestCount },
     { namespace: 'integration', collect: collectIntegrationTestCount },
     { namespace: 'e2e', collect: collectE2eTestCount },
@@ -851,8 +890,8 @@ async function main() {
       if (Object.keys(nested).length === 0) continue;
       stats[namespace] = nested;
     } catch (err) {
-      // namespace will not be present in the output if the collector fails
-      console.error(`[${namespace}] collector failed, skipping:`, err.message);
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`[${namespace}] collector failed, skipping:`, message);
     }
   }
 

--- a/.github/scripts/collect-qa-stats.ts
+++ b/.github/scripts/collect-qa-stats.ts
@@ -37,12 +37,7 @@
  *       "main_tests_run": 1200,
  *       "main_chrome_tests_run": 1200,
  *       "main_firefox_tests_run": 1185,
- *       "flask_tests_run": 200,
- *       "flask_chrome_tests_run": 200,
- *       "flask_firefox_tests_run": 195,
- *       "confirmations_tests_run": 300,
- *       "send_tests_run": 120,
- *       "other_tests_run": 780
+ *       "flask_tests_run": 200
  *     }
  *   }
  */

--- a/.github/scripts/collect-qa-stats.ts
+++ b/.github/scripts/collect-qa-stats.ts
@@ -120,7 +120,7 @@ const GITHUB_REPOSITORY =
 // Update these if the repository directory structure or file-naming conventions
 // change — the collectors below rely on them for skip/defined counts.
 // ---------------------------------------------------------------------------
-const SCAN_UNIT_DIRS = ['ui', 'app', 'shared'];
+const SCAN_UNIT_DIRS = ['ui', 'app', 'shared', 'development', 'test/unit-global'];
 const SCAN_INTEGRATION_DIR = 'test/integration';
 const SCAN_E2E_DIRS = ['test/e2e/tests', 'test/e2e/accounts', 'test/e2e/snaps'];
 const SCAN_E2E_FLASK_DIRS = [
@@ -267,10 +267,23 @@ async function downloadArtifact(artifactName: string): Promise<string> {
     );
   }
 
+  const arrayBuffer = await zipRes.arrayBuffer();
+
+  // Verify the response is a ZIP file by checking magic bytes (PK signature).
+  // This catches cases where the server returns an unexpected content type
+  // (e.g. an HTML error page) before writing anything to disk.
+  const magic = new Uint8Array(arrayBuffer, 0, 2);
+  if (magic[0] !== 0x50 || magic[1] !== 0x4b) {
+    throw new Error(
+      `Downloaded artifact "${artifactName}" is not a valid ZIP file (unexpected magic bytes)`,
+    );
+  }
+
   const destDir = join('temp', artifactName);
   await mkdir(destDir, { recursive: true });
   const zipPath = join(destDir, `${artifactName}.zip`);
-  await writeFile(zipPath, Buffer.from(await zipRes.arrayBuffer()));
+  // Source URL host is validated above before this write.
+  await writeFile(zipPath, Buffer.from(arrayBuffer));
   execFileSync('unzip', ['-qo', zipPath, '-d', destDir]);
 
   return destDir;
@@ -280,9 +293,18 @@ async function downloadArtifact(artifactName: string): Promise<string> {
 // JUnit XML helpers
 // ---------------------------------------------------------------------------
 
+function decodeXmlEntities(s: string): string {
+  return s
+    .replace(/&amp;/gu, '&')
+    .replace(/&lt;/gu, '<')
+    .replace(/&gt;/gu, '>')
+    .replace(/&quot;/gu, '"')
+    .replace(/&apos;/gu, "'");
+}
+
 function getStringAttribute(tag: string, name: string): string {
   const match = tag.match(new RegExp(`${name}="([^"]+)"`, 'u'));
-  return match ? match[1] : '';
+  return match ? decodeXmlEntities(match[1]) : '';
 }
 
 /**

--- a/.github/scripts/collect-qa-stats.ts
+++ b/.github/scripts/collect-qa-stats.ts
@@ -58,7 +58,7 @@
 
 import { readFile, writeFile, mkdir, readdir } from 'fs/promises';
 import type { Dirent } from 'fs';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { join } from 'path';
 
 // ---------------------------------------------------------------------------
@@ -85,7 +85,6 @@ type JUnitParseResult = {
 
 type ScanResult = {
   defined: number;
-  skipped: number;
 };
 
 type DescribeBlock = {
@@ -262,7 +261,7 @@ async function downloadArtifact(artifactName: string): Promise<string> {
   await mkdir(destDir, { recursive: true });
   const zipPath = join(destDir, `${artifactName}.zip`);
   await writeFile(zipPath, Buffer.from(await zipRes.arrayBuffer()));
-  execSync(`unzip -qo "${zipPath}" -d "${destDir}"`);
+  execFileSync('unzip', ['-qo', zipPath, '-d', destDir]);
 
   return destDir;
 }
@@ -410,10 +409,13 @@ function countSkips(source: string): number {
   // Part 1: it.skip / test.skip outside describe.skip blocks.
   const explicit = (outside.match(/\b(?:it|test)\.skip\s*\(/gu) ?? []).length;
 
-  // Part 2: all it() / test() (including .skip) inside describe.skip blocks.
+  // Part 2: all it() / test() (including all modifiers) inside describe.skip blocks.
   const implicit = describeBlocks.reduce(
     (sum, { content }) =>
-      sum + (content.match(/\b(?:it|test)(?:\.skip)?\s*\(/gu) ?? []).length,
+      sum +
+      (content.match(
+        /\b(?:it|test)(?:\.(?:each|skip|only|concurrent))?\s*\(/gu,
+      ) ?? []).length,
     0,
   );
 
@@ -431,17 +433,15 @@ async function scanTestFiles(
   dirs: string[],
   filePattern: RegExp,
 ): Promise<ScanResult> {
-  let defined = 0,
-    skipped = 0;
+  let defined = 0;
   for (const dir of dirs) {
     const files = await walkFiles(dir, (name) => filePattern.test(name));
     for (const f of files) {
       const source = await readFile(f, 'utf8');
       defined += countDefinedTests(source);
-      skipped += countSkips(source);
     }
   }
-  return { defined, skipped };
+  return { defined };
 }
 
 // ---------------------------------------------------------------------------
@@ -511,10 +511,13 @@ function getE2eFeatureFolder(filePath: string): string {
   const normalize = (s: string) => s.toLowerCase().replace(/-/gu, '_');
   const p = filePath.replace(/\\/gu, '/');
 
-  const m = p.match(/\btest\/e2e\/(?:tests|flask)\/([^/]+)/u);
+  // Require a trailing slash so only subdirectory names are captured.
+  // Files placed directly under test/e2e/tests/ or test/e2e/flask/ (with no
+  // subdirectory) would otherwise produce keys containing ".spec.ts".
+  const m = p.match(/\btest\/e2e\/(?:tests|flask)\/([^/]+)\//u);
   if (m) return normalize(m[1]);
 
-  const m2 = p.match(/\btest\/e2e\/([^/]+)/u);
+  const m2 = p.match(/\btest\/e2e\/([^/]+)\//u);
   if (m2) return normalize(m2[1]);
 
   return 'other';
@@ -536,7 +539,7 @@ function getE2eFeatureFolder(filePath: string): string {
  * @param minFolderCount - Folders below this threshold are folded into `other`.
  */
 async function collectUnitTestCount(
-  minFolderCount = 200,
+  minFolderCount = 100,
 ): Promise<Record<string, number>> {
   console.log('[unit] collecting per-suite counts from shard artifacts...');
 
@@ -582,7 +585,8 @@ async function collectUnitTestCount(
     if (minFolderCount > 0 && count < minFolderCount) {
       result.other_tests_run = (result.other_tests_run ?? 0) + count;
     } else {
-      result[`${folder}_tests_run`] = count;
+      result[`${folder}_tests_run`] =
+        (result[`${folder}_tests_run`] ?? 0) + count;
     }
   }
 
@@ -854,9 +858,18 @@ async function collectE2eTestCount(): Promise<Record<string, number>> {
       result.flask_firefox_tests_run = flaskFirefoxTotal;
   }
 
-  // Per-feature breakdown from Chrome main only (canonical, like Android in mobile)
+  // Per-feature breakdown from Chrome main only (canonical, like Android in mobile).
+  // Guard against feature directory names that collide with aggregate keys.
+  const reservedKeys = new Set(Object.keys(result));
   for (const [folder, count] of Object.entries(folderCounts)) {
-    result[`${folder}_tests_run`] = count;
+    const key = `${folder}_tests_run`;
+    if (reservedKeys.has(key)) {
+      console.warn(
+        `[e2e] skipping per-feature key "${key}" — conflicts with aggregate metric`,
+      );
+      continue;
+    }
+    result[key] = count;
   }
 
   return result;

--- a/.github/scripts/collect-qa-stats.ts
+++ b/.github/scripts/collect-qa-stats.ts
@@ -6,25 +6,22 @@
  * Required env vars:
  *   GITHUB_TOKEN      — GitHub Actions token for API access
  *   GITHUB_REPOSITORY — Repository in "owner/repo" format (set automatically in Actions)
- *   RUN_ID_TO_TEST    — Run ID to test (optional, defaults to latest main run)
+ *   RUN_ID_TO_COLLECT — (optional, for local testing)
  *
- * Naming convention:
- *   - CI-executed (from JUnit XML artifacts): _run suffix     → tests actually ran in CI
- *   - Static source analysis (from code):     _defined suffix → tests defined in the codebase
- *   - total_tests_skipped is artifact-derived for unit, integration, and e2e
- *     (counts <skipped> elements in JUnit XML / skipped field in e2e JSON report)
+ * How to add a new metrics:
+ *   1. Add a collector function that returns any of the following:
+ *      {
+ *        "key1": number,
+ *        "key2": "string",
+ *        "key3": "[\"string1\", \"string2\", ...]" },
+ *      }
+ *   2. Register it as a new namespace in the collectors array in main()
  *
  * Example output:
  *   {
  *     "unit": {
  *       "total_tests_run": 41957,
  *       "total_tests_skipped": 120,
- *       "total_tests_defined": 39500,
- *       "controllers_tests_run": 3200,
- *       "ui_app_tests_run": 5100,
- *       "ducks_tests_run": 1500,
- *       "selectors_tests_run": 900,
- *       "other_tests_run": 26357
  *     },
  *     "integration": {
  *       "total_tests_run": 540,
@@ -46,12 +43,6 @@
  *       "confirmations_tests_run": 300,
  *       "send_tests_run": 120,
  *       "other_tests_run": 780
- *     },
- *     "benchmark": {
- *       "total_tests_defined": 8,
- *       "startup_tests_defined": 2,
- *       "interaction_tests_defined": 1,
- *       "user_journey_tests_defined": 5
  *     }
  *   }
  */
@@ -101,7 +92,7 @@ type TestRun = {
 
 type Collector = {
   namespace: string;
-  collect: () => Promise<Record<string, number>>;
+  collect: () => Promise<Record<string, number | string>>;
 };
 
 // ---------------------------------------------------------------------------
@@ -168,7 +159,7 @@ async function getLatestMainRunId(): Promise<string> {
 
 async function getRunId(): Promise<string> {
   if (_runId) return _runId;
-  _runId = process.env.RUN_ID_TO_TEST ?? (await getLatestMainRunId());
+  _runId = process.env.RUN_ID_TO_COLLECT ?? (await getLatestMainRunId());
   return _runId;
 }
 
@@ -504,8 +495,6 @@ function getE2eFeatureFolder(filePath: string): string {
  * Downloads all `unit-test-results-*` shard artifacts (JUnit XML), parses them,
  * and returns test counts grouped by feature folder.
  *
- * Also counts test definitions and skipped tests via static source analysis.
- *
  * Folders whose total count is below `minFolderCount` are merged into `other`
  * to reduce noise.
  *
@@ -729,18 +718,8 @@ async function getE2eSkippedFromXml(): Promise<number> {
 
 /**
  * Collects all E2E test counts — both main and flask channels — into a single
- * namespace. Mirrors the mobile reference pattern where Chrome is the canonical
- * platform and Firefox is a browser health signal.
+ * namespace. Chrome is the canonical platform as reference for CI runs.
  *
- * Channel breakdown:
- *   main  = standard browserify tests (core wallet features, MV3)
- *   flask = Flask build tests (Snaps, experimental features)
- *
- * Browser breakdown (within each channel):
- *   chrome  = canonical unique count (MV3)
- *   firefox = health signal — drops if Firefox MV2 infrastructure is broken
- *
- * Per-feature keys come from Chrome main only (canonical, like Android in mobile).
  * Static analysis covers both main + flask directories combined.
  */
 async function collectE2eTestCount(): Promise<Record<string, number>> {
@@ -775,6 +754,21 @@ async function collectE2eTestCount(): Promise<Record<string, number>> {
     }
   }
   console.log(`[e2e/flask/chrome] total: ${flaskChromeTotal}`);
+
+  // Warn if the Chrome report contains run names we don't recognise — this
+  // would indicate a new CI job category whose tests are not counted in
+  // total_tests_run and should be added to the collector.
+  const knownChromeRunNames = new Set([
+    'test-e2e-chrome-browserify',
+    'test-e2e-chrome-flask',
+  ]);
+  for (const name of new Set(chromeRuns.map((r) => r.name))) {
+    if (!knownChromeRunNames.has(name)) {
+      console.warn(
+        `[e2e] unrecognized Chrome run "${name}" — not counted in total_tests_run; update collector if intentional`,
+      );
+    }
+  }
 
   // --- Firefox health signals (both channels) ---
   let mainFirefoxTotal = 0;
@@ -907,7 +901,7 @@ async function collectBenchmarkScenarioCount(): Promise<
 // ---------------------------------------------------------------------------
 
 async function main(): Promise<void> {
-  const stats: Record<string, Record<string, number>> = {};
+  const stats: Record<string, Record<string, number | string>> = {};
 
   const collectors: Collector[] = [
     { namespace: 'unit', collect: collectUnitTestCount },

--- a/.github/scripts/collect-qa-stats.ts
+++ b/.github/scripts/collect-qa-stats.ts
@@ -6,22 +6,13 @@
  * Required env vars:
  *   GITHUB_TOKEN      — GitHub Actions token for API access
  *   GITHUB_REPOSITORY — Repository in "owner/repo" format (set automatically in Actions)
- *
- * How to add a new metric:
- *   1. Add a collector function that returns a plain object
- *   2. Register it in the collectors array in main()
- *
- * The only rule: never rename existing keys. The DB key is (project, run_id, namespace, metric_key).
- * Renaming a key in the JSON creates a new series in the DB while the old name stops getting new data,
- * which breaks the Grafana time series continuity. Adding and removing keys is fine.
- *
- * Artifact names used below are coupled to `name:` fields in main.yml and run-tests.yml —
- * renaming either side silently drops that metric from the output.
+ *   RUN_ID_TO_TEST    — Run ID to test (optional, defaults to latest main run)
  *
  * Naming convention:
  *   - CI-executed (from JUnit XML artifacts): _run suffix     → tests actually ran in CI
  *   - Static source analysis (from code):     _defined suffix → tests defined in the codebase
- *   - total_tests_skipped is static-analysis derived (it.skip / test.skip / describe.skip)
+ *   - total_tests_skipped is artifact-derived for unit, integration, and e2e
+ *     (counts <skipped> elements in JUnit XML / skipped field in e2e JSON report)
  *
  * Example output:
  *   {
@@ -88,6 +79,7 @@ type GitHubWorkflowRun = {
 
 type JUnitParseResult = {
   total: number;
+  skipped: number;
   perFile: Record<string, number>;
 };
 
@@ -105,6 +97,7 @@ type DescribeBlock = {
 type TestFile = {
   path?: string;
   tests?: number;
+  skipped?: number;
 };
 
 type TestRun = {
@@ -186,7 +179,7 @@ async function getLatestMainRunId(): Promise<string> {
 
 async function getRunId(): Promise<string> {
   if (_runId) return _runId;
-  _runId = await getLatestMainRunId();
+  _runId = process.env.RUN_ID_TO_TEST ?? (await getLatestMainRunId());
   return _runId;
 }
 
@@ -269,7 +262,7 @@ async function downloadArtifact(artifactName: string): Promise<string> {
   await mkdir(destDir, { recursive: true });
   const zipPath = join(destDir, `${artifactName}.zip`);
   await writeFile(zipPath, Buffer.from(await zipRes.arrayBuffer()));
-  execSync(`unzip -q "${zipPath}" -d "${destDir}"`);
+  execSync(`unzip -qo "${zipPath}" -d "${destDir}"`);
 
   return destDir;
 }
@@ -299,12 +292,16 @@ function parseJUnitXml(rawXml: string): JUnitParseResult {
     /<testcase\b([^>]*)(?:\/>|>([\s\S]*?)<\/testcase>)/gu;
   const perFile: Record<string, number> = {};
   let total = 0;
+  let skipped = 0;
 
   for (const match of rawXml.matchAll(testcasePattern)) {
     const attrs = match[1];
     const body = match[2] ?? '';
 
-    if (body.includes('<skipped')) continue;
+    if (body.includes('<skipped')) {
+      skipped++;
+      continue;
+    }
 
     const filePath = getStringAttribute(attrs, 'file');
     if (!filePath) continue;
@@ -313,7 +310,7 @@ function parseJUnitXml(rawXml: string): JUnitParseResult {
     perFile[filePath] = (perFile[filePath] ?? 0) + 1;
   }
 
-  return { total, perFile };
+  return { total, skipped, perFile };
 }
 
 // ---------------------------------------------------------------------------
@@ -553,12 +550,14 @@ async function collectUnitTestCount(
 
   const folderCounts: Record<string, number> = {};
   let total = 0;
+  let totalSkipped = 0;
 
   for (const artifact of shardArtifacts) {
     const destDir = await downloadArtifact(artifact.name);
     const raw = await readFile(join(destDir, 'junit.xml'), 'utf8');
-    const { total: shardTotal, perFile } = parseJUnitXml(raw);
+    const { total: shardTotal, skipped: shardSkipped, perFile } = parseJUnitXml(raw);
     total += shardTotal;
+    totalSkipped += shardSkipped;
 
     for (const [filePath, count] of Object.entries(perFile)) {
       const folder = getFeatureFolder(filePath);
@@ -566,17 +565,17 @@ async function collectUnitTestCount(
     }
   }
 
-  console.log(`[unit] total: ${total}`);
+  console.log(`[unit] total: ${total}, skipped (artifact): ${totalSkipped}`);
 
-  const { defined, skipped } = await scanTestFiles(
+  const { defined } = await scanTestFiles(
     SCAN_UNIT_DIRS,
     PATTERN_UNIT_TEST_FILE,
   );
-  console.log(`[unit] defined: ${defined}, skipped (static): ${skipped}`);
+  console.log(`[unit] defined: ${defined}`);
 
   const result: Record<string, number> = {
     total_tests_run: total,
-    total_tests_skipped: skipped,
+    total_tests_skipped: totalSkipped,
     total_tests_defined: defined,
   };
   for (const [folder, count] of Object.entries(folderCounts)) {
@@ -611,9 +610,9 @@ async function collectIntegrationTestCount(): Promise<Record<string, number>> {
 
   const destDir = await downloadArtifact(artifact.name);
   const raw = await readFile(join(destDir, 'junit.xml'), 'utf8');
-  const { total, perFile } = parseJUnitXml(raw);
+  const { total, skipped, perFile } = parseJUnitXml(raw);
 
-  console.log(`[integration] total: ${total}`);
+  console.log(`[integration] total: ${total}, skipped (artifact): ${skipped}`);
 
   const folderCounts: Record<string, number> = {};
   for (const [filePath, count] of Object.entries(perFile)) {
@@ -621,13 +620,11 @@ async function collectIntegrationTestCount(): Promise<Record<string, number>> {
     folderCounts[folder] = (folderCounts[folder] ?? 0) + count;
   }
 
-  const { defined, skipped } = await scanTestFiles(
+  const { defined } = await scanTestFiles(
     [SCAN_INTEGRATION_DIR],
     PATTERN_UNIT_TEST_FILE,
   );
-  console.log(
-    `[integration] defined: ${defined}, skipped (static): ${skipped}`,
-  );
+  console.log(`[integration] defined: ${defined}`);
 
   const result: Record<string, number> = {
     total_tests_run: total,
@@ -701,6 +698,56 @@ async function getE2eFirefoxReport(): Promise<TestRun[]> {
 
   _e2eFirefoxReportCache = JSON.parse(raw) as TestRun[];
   return _e2eFirefoxReportCache;
+}
+
+/**
+ * Reads the `skipped` attribute from the root `<testsuites>` element of a
+ * `mocha-junit-reporter` XML file.
+ *
+ * Unlike Jest's JUnit output (which marks skipped tests as `<testcase>`
+ * elements with a `<skipped/>` child), `mocha-junit-reporter` records the
+ * total skipped count as an attribute on the `<testsuites>` root element and
+ * omits skipped tests from the `<testcase>` list entirely.
+ *
+ * @param rawXml - Raw JUnit XML string produced by mocha-junit-reporter.
+ */
+function parseMochaSkipped(rawXml: string): number {
+  const match = rawXml.match(/<testsuites\b[^>]*\bskipped="(\d+)"/u);
+  return match ? Number(match[1]) : 0;
+}
+
+/**
+ * Downloads the raw `test-e2e-chrome-browserify` and `test-e2e-chrome-flask`
+ * shard artifacts, reads the `skipped` attribute from each JUnit XML file's
+ * `<testsuites>` root element, and returns the total skipped count.
+ *
+ * Uses `parseMochaSkipped` rather than `parseJUnitXml` because
+ * `mocha-junit-reporter` does not emit `<skipped/>` child elements.
+ */
+async function getE2eSkippedFromXml(): Promise<number> {
+  const artifacts = await getArtifactList();
+  const shardArtifacts = artifacts.filter(
+    (a) =>
+      a.name.startsWith('test-e2e-chrome-browserify') ||
+      a.name.startsWith('test-e2e-chrome-flask'),
+  );
+
+  console.log(
+    `[e2e] found ${shardArtifacts.length} chrome shard artifact(s) for skipped count`,
+  );
+
+  let totalSkipped = 0;
+  for (const artifact of shardArtifacts) {
+    const destDir = await downloadArtifact(artifact.name);
+    const xmlFiles = await walkFiles(destDir, (name) => name.endsWith('.xml'));
+    for (const xmlFile of xmlFiles) {
+      const raw = await readFile(xmlFile, 'utf8');
+      totalSkipped += parseMochaSkipped(raw);
+    }
+  }
+
+  console.log(`[e2e] skipped (artifact XML): ${totalSkipped}`);
+  return totalSkipped;
 }
 
 /**
@@ -779,17 +826,16 @@ async function collectE2eTestCount(): Promise<Record<string, number>> {
     console.warn(`[e2e] firefox report not available, skipping: ${message}`);
   }
 
-  // --- Static analysis across both main and flask dirs ---
+  // --- Static analysis across both main and flask dirs (for defined count only) ---
   const allE2eDirs = [...new Set([...SCAN_E2E_DIRS, ...SCAN_E2E_FLASK_DIRS])];
-  const { defined, skipped } = await scanTestFiles(
-    allE2eDirs,
-    PATTERN_E2E_SPEC_FILE,
-  );
-  console.log(`[e2e] defined: ${defined}, skipped (static): ${skipped}`);
+  const { defined } = await scanTestFiles(allE2eDirs, PATTERN_E2E_SPEC_FILE);
+  console.log(`[e2e] defined: ${defined}`);
+
+  const totalSkipped = await getE2eSkippedFromXml();
 
   const result: Record<string, number> = {
     total_tests_run: mainChromeTotal + flaskChromeTotal,
-    total_tests_skipped: skipped,
+    total_tests_skipped: totalSkipped,
     total_tests_defined: defined,
   };
 

--- a/.github/scripts/collect-qa-stats.ts
+++ b/.github/scripts/collect-qa-stats.ts
@@ -465,19 +465,22 @@ function getFeatureFolder(testFilePath: string): string {
   const normalize = (s: string) => s.toLowerCase().replace(/-/gu, '_');
   const p = testFilePath.replace(/\\/gu, '/');
 
-  const uiComponentsMatch = p.match(/\bui\/components\/([^/]+)/u);
+  // Trailing slash ensures we capture subdirectory names only.
+  // Files placed directly under a scanned root (e.g. app/scripts/foo.test.ts)
+  // would otherwise produce keys containing the filename and extension.
+  const uiComponentsMatch = p.match(/\bui\/components\/([^/]+)\//u);
   if (uiComponentsMatch) return normalize(uiComponentsMatch[1]);
 
-  const uiMatch = p.match(/\bui\/([^/]+)/u);
+  const uiMatch = p.match(/\bui\/([^/]+)\//u);
   if (uiMatch) return normalize(uiMatch[1]);
 
-  const appScriptsMatch = p.match(/\bapp\/scripts\/([^/]+)/u);
+  const appScriptsMatch = p.match(/\bapp\/scripts\/([^/]+)\//u);
   if (appScriptsMatch) return normalize(appScriptsMatch[1]);
 
-  const appMatch = p.match(/\bapp\/([^/]+)/u);
+  const appMatch = p.match(/\bapp\/([^/]+)\//u);
   if (appMatch) return normalize(appMatch[1]);
 
-  const sharedMatch = p.match(/\bshared\/([^/]+)/u);
+  const sharedMatch = p.match(/\bshared\/([^/]+)\//u);
   if (sharedMatch) return `shared_${normalize(sharedMatch[1])}`;
 
   return 'other';

--- a/.github/scripts/collect-qa-stats.ts
+++ b/.github/scripts/collect-qa-stats.ts
@@ -272,7 +272,7 @@ async function downloadArtifact(artifactName: string): Promise<string> {
     );
   }
 
-  const destDir = `./${artifactName}`;
+  const destDir = join('temp', artifactName);
   await mkdir(destDir, { recursive: true });
   const zipPath = join(destDir, `${artifactName}.zip`);
   await writeFile(zipPath, Buffer.from(await zipRes.arrayBuffer()));

--- a/.github/scripts/collect-qa-stats.ts
+++ b/.github/scripts/collect-qa-stats.ts
@@ -465,7 +465,7 @@ function getIntegrationFeatureFolder(testFilePath: string): string {
   const normalize = (s: string) =>
     s.toLowerCase().replace(/[^a-z0-9]+/gu, '_');
   const p = testFilePath.replace(/\\/gu, '/');
-  const match = p.match(/\btest\/integration\/([^/]+)/u);
+  const match = p.match(/\btest\/integration\/([^/]+)\//u);
   return match ? normalize(match[1]) : 'other';
 }
 

--- a/.github/scripts/collect-qa-stats.ts
+++ b/.github/scripts/collect-qa-stats.ts
@@ -250,6 +250,21 @@ async function downloadArtifact(artifactName: string): Promise<string> {
     throw new Error(`No redirect URL returned for artifact "${artifactName}"`);
   }
 
+  // Validate the redirect target is a trusted GitHub/AWS host before writing
+  // the response to disk. This guards against a malicious Location header
+  // pointing to an attacker-controlled server.
+  const downloadHost = new URL(downloadUrl).hostname;
+  if (
+    !downloadHost.endsWith('.amazonaws.com') &&
+    !downloadHost.endsWith('.blob.core.windows.net') &&
+    !downloadHost.endsWith('.github.com') &&
+    downloadHost !== 'github.com'
+  ) {
+    throw new Error(
+      `Untrusted redirect host "${downloadHost}" for artifact "${artifactName}"`,
+    );
+  }
+
   const zipRes = await fetch(downloadUrl);
   if (!zipRes.ok) {
     throw new Error(

--- a/.github/scripts/collect-qa-stats.ts
+++ b/.github/scripts/collect-qa-stats.ts
@@ -13,7 +13,7 @@
  *      {
  *        "key1": number,
  *        "key2": "string",
- *        "key3": "[\"string1\", \"string2\", ...]" },
+ *        "key3": "[\"string1\", \"string2\", ...]",
  *      }
  *   2. Register it as a new namespace in the collectors array in main()
  *
@@ -683,9 +683,9 @@ function parseMochaSkipped(rawXml: string): number {
 }
 
 /**
- * Downloads the raw `test-e2e-chrome-browserify` and `test-e2e-chrome-flask`
- * shard artifacts, reads the `skipped` attribute from each JUnit XML file's
- * `<testsuites>` root element, and returns the total skipped count.
+ * Downloads all Chrome E2E shard artifacts except the explicit browserify run,
+ * reads the `skipped` attribute from each JUnit XML file's `<testsuites>` root
+ * element, and returns the total skipped count.
  *
  * Uses `parseMochaSkipped` rather than `parseJUnitXml` because
  * `mocha-junit-reporter` does not emit `<skipped/>` child elements.
@@ -694,8 +694,9 @@ async function getE2eSkippedFromXml(): Promise<number> {
   const artifacts = await getArtifactList();
   const shardArtifacts = artifacts.filter(
     (a) =>
-      a.name.startsWith('test-e2e-chrome-browserify') ||
-      a.name.startsWith('test-e2e-chrome-flask'),
+      a.name.startsWith('test-e2e-chrome-') &&
+      !a.name.startsWith('test-e2e-chrome-browserify') &&
+      a.name !== 'test-e2e-chrome-report',
   );
 
   console.log(
@@ -727,12 +728,19 @@ async function collectE2eTestCount(): Promise<Record<string, number>> {
 
   const chromeRuns = await getE2eReport();
 
+  // Explicitly excluded run: the browserify build is superseded by webpack.
+  // All other Chrome runs (webpack, flask, rpc, dist, multiple-providers, etc.)
+  // contribute to the totals.
+  const EXCLUDED_CHROME_RUN = 'test-e2e-chrome-browserify';
+
   // --- Main channel (Chrome, canonical) ---
+  // Counts every Chrome run except the explicit browserify job and flask
+  // (flask is tracked separately below).
   let mainChromeTotal = 0;
   const folderCounts: Record<string, number> = {};
 
   for (const run of chromeRuns.filter(
-    (r) => r.name === 'test-e2e-chrome-browserify',
+    (r) => r.name !== EXCLUDED_CHROME_RUN && r.name !== 'test-e2e-chrome-flask',
   )) {
     for (const file of run.testFiles ?? []) {
       const ran = (file.tests ?? 0) - (file.skipped ?? 0);
@@ -754,21 +762,6 @@ async function collectE2eTestCount(): Promise<Record<string, number>> {
     }
   }
   console.log(`[e2e/flask/chrome] total: ${flaskChromeTotal}`);
-
-  // Warn if the Chrome report contains run names we don't recognise — this
-  // would indicate a new CI job category whose tests are not counted in
-  // total_tests_run and should be added to the collector.
-  const knownChromeRunNames = new Set([
-    'test-e2e-chrome-browserify',
-    'test-e2e-chrome-flask',
-  ]);
-  for (const name of new Set(chromeRuns.map((r) => r.name))) {
-    if (!knownChromeRunNames.has(name)) {
-      console.warn(
-        `[e2e] unrecognized Chrome run "${name}" — not counted in total_tests_run; update collector if intentional`,
-      );
-    }
-  }
 
   // --- Firefox health signals (both channels) ---
   let mainFirefoxTotal = 0;

--- a/.github/scripts/collect-qa-stats.ts
+++ b/.github/scripts/collect-qa-stats.ts
@@ -87,11 +87,6 @@ type ScanResult = {
   defined: number;
 };
 
-type DescribeBlock = {
-  start: number;
-  end: number;
-  content: string;
-};
 
 type TestFile = {
   path?: string;
@@ -317,10 +312,11 @@ function parseJUnitXml(rawXml: string): JUnitParseResult {
       continue;
     }
 
+    total++;
+
     const filePath = getStringAttribute(attrs, 'file');
     if (!filePath) continue;
 
-    total++;
     perFile[filePath] = (perFile[filePath] ?? 0) + 1;
   }
 
@@ -378,64 +374,6 @@ function countDefinedTests(source: string): number {
   ).length;
 }
 
-/**
- * Counts the number of individual test cases that are skipped in a source string.
- *
- * Two categories:
- *   1. Explicit: `it.skip()` / `test.skip()` outside any `describe.skip` block.
- *   2. Implicit: every `it()` / `test()` call (including `.skip` variants) inside
- *      a `describe.skip` block, because the whole block is skipped by the runner.
- *
- * `describe.skip` blocks are extracted via brace matching so their contents are
- * not double-counted against the explicit-skip pass.
- *
- * @param source - Source file content.
- */
-function countSkips(source: string): number {
-  // Find all describe.skip blocks using brace matching.
-  const describeBlocks: DescribeBlock[] = [];
-  const re = /\bdescribe\.skip\s*\(/gu;
-  let m: RegExpExecArray | null;
-  while ((m = re.exec(source)) !== null) {
-    const braceStart = source.indexOf('{', m.index + m[0].length);
-    if (braceStart === -1) continue;
-    let depth = 1,
-      pos = braceStart + 1;
-    while (pos < source.length && depth > 0) {
-      if (source[pos] === '{') depth++;
-      else if (source[pos] === '}') depth--;
-      pos++;
-    }
-    describeBlocks.push({
-      start: m.index,
-      end: pos,
-      content: source.slice(braceStart + 1, pos - 1),
-    });
-  }
-
-  // Strip describe.skip regions from source (reverse order to preserve indices).
-  let outside = source;
-  for (let i = describeBlocks.length - 1; i >= 0; i--) {
-    outside =
-      outside.slice(0, describeBlocks[i].start) +
-      outside.slice(describeBlocks[i].end);
-  }
-
-  // Part 1: it.skip / test.skip outside describe.skip blocks.
-  const explicit = (outside.match(/\b(?:it|test)\.skip\s*\(/gu) ?? []).length;
-
-  // Part 2: all it() / test() (including all modifiers) inside describe.skip blocks.
-  const implicit = describeBlocks.reduce(
-    (sum, { content }) =>
-      sum +
-      (content.match(
-        /\b(?:it|test)(?:\.(?:each|skip|only|concurrent))?\s*\(/gu,
-      ) ?? []).length,
-    0,
-  );
-
-  return explicit + implicit;
-}
 
 /**
  * Scans one or more directories for test files matching `filePattern` and
@@ -801,9 +739,10 @@ async function collectE2eTestCount(): Promise<Record<string, number>> {
     (r) => r.name === 'test-e2e-chrome-browserify',
   )) {
     for (const file of run.testFiles ?? []) {
-      mainChromeTotal += file.tests ?? 0;
+      const ran = (file.tests ?? 0) - (file.skipped ?? 0);
+      mainChromeTotal += ran;
       const folder = getE2eFeatureFolder(file.path ?? '');
-      folderCounts[folder] = (folderCounts[folder] ?? 0) + (file.tests ?? 0);
+      folderCounts[folder] = (folderCounts[folder] ?? 0) + ran;
     }
   }
   console.log(`[e2e/main/chrome] total: ${mainChromeTotal}`);
@@ -815,7 +754,7 @@ async function collectE2eTestCount(): Promise<Record<string, number>> {
     (r) => r.name === 'test-e2e-chrome-flask',
   )) {
     for (const file of run.testFiles ?? []) {
-      flaskChromeTotal += file.tests ?? 0;
+      flaskChromeTotal += (file.tests ?? 0) - (file.skipped ?? 0);
     }
   }
   console.log(`[e2e/flask/chrome] total: ${flaskChromeTotal}`);
@@ -830,7 +769,7 @@ async function collectE2eTestCount(): Promise<Record<string, number>> {
       (r) => r.name === 'test-e2e-firefox-browserify',
     )) {
       for (const file of run.testFiles ?? []) {
-        mainFirefoxTotal += file.tests ?? 0;
+        mainFirefoxTotal += (file.tests ?? 0) - (file.skipped ?? 0);
       }
     }
     console.log(`[e2e/main/firefox] total: ${mainFirefoxTotal}`);
@@ -839,7 +778,7 @@ async function collectE2eTestCount(): Promise<Record<string, number>> {
       (r) => r.name === 'test-e2e-firefox-flask',
     )) {
       for (const file of run.testFiles ?? []) {
-        flaskFirefoxTotal += file.tests ?? 0;
+        flaskFirefoxTotal += (file.tests ?? 0) - (file.skipped ?? 0);
       }
     }
     console.log(`[e2e/flask/firefox] total: ${flaskFirefoxTotal}`);

--- a/.github/scripts/collect-qa-stats.ts
+++ b/.github/scripts/collect-qa-stats.ts
@@ -122,12 +122,7 @@ const GITHUB_REPOSITORY =
 // ---------------------------------------------------------------------------
 const SCAN_UNIT_DIRS = ['ui', 'app', 'shared', 'development', 'test/unit-global'];
 const SCAN_INTEGRATION_DIR = 'test/integration';
-const SCAN_E2E_DIRS = ['test/e2e/tests', 'test/e2e/accounts', 'test/e2e/snaps'];
-const SCAN_E2E_FLASK_DIRS = [
-  'test/e2e/flask',
-  'test/e2e/accounts',
-  'test/e2e/snaps',
-];
+const SCAN_E2E_DIR = 'test/e2e';
 
 const PATTERN_UNIT_TEST_FILE = /\.test\.(ts|tsx|js|jsx)$/u;
 const PATTERN_E2E_SPEC_FILE = /\.spec\.(ts|js)$/u;
@@ -295,11 +290,11 @@ async function downloadArtifact(artifactName: string): Promise<string> {
 
 function decodeXmlEntities(s: string): string {
   return s
-    .replace(/&amp;/gu, '&')
     .replace(/&lt;/gu, '<')
     .replace(/&gt;/gu, '>')
     .replace(/&quot;/gu, '"')
-    .replace(/&apos;/gu, "'");
+    .replace(/&apos;/gu, "'")
+    .replace(/&amp;/gu, '&');
 }
 
 function getStringAttribute(tag: string, name: string): string {
@@ -809,9 +804,8 @@ async function collectE2eTestCount(): Promise<Record<string, number>> {
     console.warn(`[e2e] firefox report not available, skipping: ${message}`);
   }
 
-  // --- Static analysis across both main and flask dirs (for defined count only) ---
-  const allE2eDirs = [...new Set([...SCAN_E2E_DIRS, ...SCAN_E2E_FLASK_DIRS])];
-  const { defined } = await scanTestFiles(allE2eDirs, PATTERN_E2E_SPEC_FILE);
+  // --- Static analysis across all of test/e2e/ (for defined count only) ---
+  const { defined } = await scanTestFiles([SCAN_E2E_DIR], PATTERN_E2E_SPEC_FILE);
   console.log(`[e2e] defined: ${defined}`);
 
   const totalSkipped = await getE2eSkippedFromXml();

--- a/.github/workflows/qa-stats.yml
+++ b/.github/workflows/qa-stats.yml
@@ -1,0 +1,31 @@
+name: QA Stats
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+    - cron: '0 15 * * *'
+
+jobs:
+  collect-qa-stats:
+    name: Collect QA Stats
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+
+      - name: Collect QA stats
+        run: node .github/scripts/collect-qa-stats.mjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+
+      - name: Upload QA stats artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: qa-stats
+          path: ./qa-stats.json
+          if-no-files-found: error

--- a/.github/workflows/qa-stats.yml
+++ b/.github/workflows/qa-stats.yml
@@ -2,8 +2,7 @@ name: QA Stats
 
 on:
   schedule:
-    - cron: '0 3 * * *'
-    - cron: '0 15 * * *'
+    - cron: '0 4 * * *'
 
 jobs:
   collect-qa-stats:

--- a/.github/workflows/qa-stats.yml
+++ b/.github/workflows/qa-stats.yml
@@ -4,17 +4,21 @@ on:
   schedule:
     - cron: '0 4 * * *'
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   collect-qa-stats:
     name: Collect QA Stats
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-node@v6
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
-          node-version-file: .nvmrc
+          is-high-risk-environment: false
+          skip-allow-scripts: true
 
       - name: Collect QA stats
         run: node .github/scripts/collect-qa-stats.mjs

--- a/.github/workflows/qa-stats.yml
+++ b/.github/workflows/qa-stats.yml
@@ -21,7 +21,7 @@ jobs:
           skip-allow-scripts: true
 
       - name: Collect QA stats
-        run: node .github/scripts/collect-qa-stats.mjs
+        run: yarn tsx .github/scripts/collect-qa-stats.ts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/qa-stats.yml
+++ b/.github/workflows/qa-stats.yml
@@ -2,7 +2,7 @@ name: QA Stats
 
 on:
   schedule:
-    - cron: '0 4 * * *'
+    - cron: '0 11 * * *'
 
 permissions:
   contents: read

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -36,6 +36,11 @@ jobs:
           name: coverage-unit-${{matrix.shard}}
           path: coverage/unit/coverage-unit-${{matrix.shard}}.json
 
+      - uses: actions/upload-artifact@v6
+        with:
+          name: unit-test-results-${{matrix.shard}}
+          path: test/test-results/junit.xml
+
   test-webpack:
     name: Webpack tests
     runs-on: ubuntu-latest

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -85,6 +85,11 @@ jobs:
           name: coverage-integration
           path: coverage/integration/coverage-integration.json
 
+      - uses: actions/upload-artifact@v6
+        with:
+          name: integration-test-results
+          path: test/test-results/integration/junit.xml
+
   report-coverage:
     name: Report coverage
     if: ${{ github.event_name != 'merge_group' }} # Skip this job for the Merge Queue

--- a/jest.config.js
+++ b/jest.config.js
@@ -41,6 +41,7 @@ module.exports = {
       {
         outputDirectory: 'test/test-results/',
         outputName: 'junit.xml',
+        addFileAttribute: 'true',
       },
     ],
   ],

--- a/jest.integration.config.js
+++ b/jest.integration.config.js
@@ -34,6 +34,7 @@ module.exports = {
       {
         outputDirectory: 'test/test-results/integration',
         outputName: 'junit.xml',
+        addFileAttribute: 'true',
       },
     ],
   ],


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Adds a scheduled QA metrics pipeline to emit automated tests metrics. Example:

```
QA stats written to ./qa-stats.json: {
  unit: {
    total_tests_run: 17737,
    total_tests_skipped: 4,
    total_tests_defined: 14668,
    component_library_tests_run: 480,
    pages_tests_run: 4044,
    store_tests_run: 202,
    hooks_tests_run: 1191,
    lib_tests_run: 1882,
    app_tests_run: 1778,
    contexts_tests_run: 424,
    shared_lib_tests_run: 1401,
    other_tests_run: 819,
    selectors_tests_run: 807,
    multichain_tests_run: 539,
    helpers_tests_run: 480,
    multichain_accounts_tests_run: 343,
    controller_init_tests_run: 522,
    migrations_tests_run: 1407,
    controllers_tests_run: 763,
    ui_tests_run: 223,
    ducks_tests_run: 432
  },
  integration: {
    total_tests_run: 89,
    total_tests_skipped: 1,
    total_tests_defined: 90,
    confirmations_tests_run: 73,
    defi_tests_run: 3,
    notifications_amp_auth_tests_run: 8,
    onboarding_tests_run: 2,
    nfts_tests_run: 3
  },
  e2e: {
    total_tests_run: 804,
    total_tests_skipped: 99,
    total_tests_defined: 792,
    main_tests_run: 702,
    main_chrome_tests_run: 702,
    main_firefox_tests_run: 687,
    flask_tests_run: 102,
    flask_chrome_tests_run: 102,
    flask_firefox_tests_run: 102,
    snaps_tests_run: 47,
    account_activity_tests_run: 3,
    account_tests_run: 18,
    bridge_tests_run: 13,
    btc_tests_run: 5,
    carousel_tests_run: 2,
    confirmations_tests_run: 68,
    connections_tests_run: 10,
    critical_errors_tests_run: 3,
    dapp_interactions_tests_run: 10,
    deep_link_tests_run: 25,
    hardware_wallets_tests_run: 31,
    identity_tests_run: 10,
    metrics_tests_run: 65,
    multichain_accounts_tests_run: 20,
    multichain_tests_run: 7,
    network_tests_run: 44,
    notifications_tests_run: 2,
    onboarding_tests_run: 14,
    petnames_tests_run: 5,
    phishing_controller_tests_run: 20,
    port_stream_chunking_tests_run: 1,
    portfolio_tests_run: 1,
    ppom_tests_run: 7,
    privacy_mode_tests_run: 2,
    privacy_tests_run: 17,
    profile_metrics_tests_run: 5,
    remote_feature_flag_tests_run: 3,
    request_queuing_tests_run: 23,
    reset_wallet_tests_run: 2,
    responsive_ui_tests_run: 3,
    seedless_onboarding_tests_run: 2,
    send_tests_run: 32,
    settings_tests_run: 43,
    shield_tests_run: 24,
    simulation_details_tests_run: 8,
    smart_transactions_tests_run: 4,
    solana_tests_run: 18,
    state_persistence_tests_run: 2,
    survey_tests_run: 1,
    swaps_tests_run: 7,
    synchronous_injection_tests_run: 1,
    tokens_tests_run: 31,
    transaction_tests_run: 22,
    tron_tests_run: 5,
    update_modal_tests_run: 7,
    vault_corruption_tests_run: 7
  },
  benchmark: {
    total_tests_defined: 8,
    startup_tests_defined: 2,
    interaction_tests_defined: 1,
    user_journey_tests_defined: 5
  }
}
```

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40851?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

- revisit jobs and artefacts manually ✅
- check new metrics output ✅

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new scheduled GitHub Actions workflow and a large artifact-downloading script that runs in CI with `GITHUB_TOKEN` and executes `unzip`, so failures or unexpected artifact/redirect handling could break automation or pose minor supply-chain risk.
> 
> **Overview**
> Adds a scheduled `QA Stats` GitHub Actions workflow that runs daily, downloads artifacts from the latest successful `main.yml` run, and uploads a generated `qa-stats.json` artifact.
> 
> Introduces `.github/scripts/collect-qa-stats.ts` to compute unit/integration/E2E/benchmark metrics by parsing JUnit XML and E2E JSON reports, plus static scanning to count test definitions and group results by feature folder.
> 
> Updates unit and integration Jest configs to emit JUnit `<testcase file=...>` attributes (`addFileAttribute`) and updates `run-tests.yml` to upload JUnit artifacts (`unit-test-results-*`, `integration-test-results`) needed by the stats collector.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 910407eccd6757bec93f134dc79247d4a765ec7b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->