### PR TITLE
fix: remove unnecessary snap actions from permission controller messenger

### DIFF
--- a/app/scripts/controller-init/messengers/permission-controller-messenger.ts
+++ b/app/scripts/controller-init/messengers/permission-controller-messenger.ts
@@ -9,8 +9,6 @@ import type {
 import type { GetSubjectMetadata } from '@metamask/permission-controller';
 import { AccountsControllerListAccountsAction } from '@metamask/accounts-controller';
 import {
-  GetPermittedSnaps,
-  InstallSnaps,
   MultichainRouterGetSupportedAccountsAction,
   MultichainRouterIsSupportedScopeAction,
 } from '@metamask/snaps-controllers';
@@ -22,9 +20,7 @@ type AllowedActions =
   | HasApprovalRequest
   | AcceptRequest
   | RejectRequest
-  | GetSubjectMetadata
-  | GetPermittedSnaps
-  | InstallSnaps;
+  | GetSubjectMetadata;
 
 export type PermissionControllerMessenger = ReturnType<
   typeof getPermissionControllerMessenger
@@ -56,8 +52,6 @@ export function getPermissionControllerMessenger(
       'ApprovalController:hasRequest',
       'ApprovalController:acceptRequest',
       'ApprovalController:rejectRequest',
-      'SnapController:getPermitted',
-      'SnapController:install',
       'SubjectMetadataController:getSubjectMetadata',
     ],
   });

--- a/app/scripts/controller-init/permission-controller-init.ts
+++ b/app/scripts/controller-init/permission-controller-init.ts
@@ -38,8 +38,6 @@ export const PermissionControllerInit: ControllerInitFunction<
 
   const controller = new PermissionController({
     state: persistedState.PermissionController,
-    // @ts-expect-error: The permission controller needs certain actions that
-    // are not declared in the messenger's type.
     messenger: controllerMessenger,
     caveatSpecifications: getCaveatSpecifications({
       listAccounts: initMessenger.call.bind(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The `PermissionControllerMessenger` includes `GetPermittedSnaps` and `InstallSnaps` in its `AllowedActions`, and delegates `SnapController:getPermitted` and `SnapController:install` actions. These actions are not part of the `PermissionController`'s expected messenger type, causing a type mismatch that required a `@ts-expect-error` directive introduced in #36076.

This PR removes those unnecessary actions from the messenger, which eliminates the `@ts-expect-error` on the `messenger` property in `permission-controller-init.ts`. These actions are only used by the `SideEffectMessenger` in snap permission specifications, not by the `PermissionController` itself.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40862?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: `@ts-expect-error` introduced in #36076

## **Manual testing steps**

1. Build the extension
2. Verify snap permissions still work correctly (install snaps, check permitted snaps)
3. Verify no TypeScript errors related to permission controller messenger

## **Screenshots/Recordings**

### **Before**

<!-- N/A - type-only change -->

### **After**

<!-- N/A - type-only change -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.