### PR TITLE
fix: webpack sourcemap validation platform

### DIFF
--- a/development/webpack/sourcemap-validator.ts
+++ b/development/webpack/sourcemap-validator.ts
@@ -21,7 +21,7 @@ import type {
 import { SourceMapConsumer } from 'source-map';
 import { codeFrameColumns } from '@babel/code-frame';
 
-const PLATFORM = 'chrome';
+const PLATFORMS = ['chrome', 'firefox'] as const;
 const SOURCEMAPS_DIRNAME = 'sourcemaps';
 const CONTENTSCRIPT_RELATIVE_PATH = 'scripts/contentscript.js';
 const CONTENTSCRIPT_SOURCEMAP_REFERENCE =
@@ -42,6 +42,7 @@ export type SourceMapValidatorOptions = {
 
 type DiscoverWebpackBundlesOptions = {
   mapLocation: MapLocation;
+  platform: string;
 };
 
 /**
@@ -116,25 +117,25 @@ export type FilePair = {
 
 /**
  * Detects where webpack output stores source maps by checking whether
- * dist/chrome/scripts/contentscript.js ends with a sourceMappingURL reference.
+ * scripts/contentscript.js ends with a sourceMappingURL reference.
  *
- * If the reference is present, maps are expected as sibling files in dist/chrome.
+ * If the reference is present, maps are expected as sibling files.
  * Otherwise maps are expected under dist/sourcemaps.
  *
- * @param chromeDir - Absolute path to dist/chrome.
+ * @param platformDir - Absolute path to the platform build directory (e.g. dist/chrome or dist/firefox).
  * @returns The detected map location.
  * @throws If contentscript.js cannot be read.
  */
 export async function detectMapLocationFromContentscript(
-  chromeDir: string,
+  platformDir: string,
 ): Promise<MapLocation> {
-  const contentScriptPath = join(chromeDir, CONTENTSCRIPT_RELATIVE_PATH);
+  const contentScriptPath = join(platformDir, CONTENTSCRIPT_RELATIVE_PATH);
   let contentscriptSource: string;
   try {
     contentscriptSource = await readFile(contentScriptPath, 'utf8');
   } catch {
     throw new Error(
-      `SourcemapValidator (webpack) - failed to read "${CONTENTSCRIPT_RELATIVE_PATH}" from dist/chrome. Cannot auto-detect source map location.`,
+      `SourcemapValidator (webpack) - failed to read "${CONTENTSCRIPT_RELATIVE_PATH}" from ${platformDir}. Cannot auto-detect source map location.`,
     );
   }
 
@@ -155,48 +156,56 @@ export async function detectMapLocationFromContentscript(
 export async function main(
   options: SourceMapValidatorOptions = {},
 ): Promise<void> {
-  const chromeDir = join(process.cwd(), 'dist', PLATFORM);
-  let chromeDirExists = false;
-  try {
-    const st = await stat(chromeDir);
-    chromeDirExists = st.isDirectory();
-  } catch {
-    // ENOENT or other; treat as missing
+  const distDir = join(process.cwd(), 'dist');
+  const availablePlatforms: string[] = [];
+
+  for (const platform of PLATFORMS) {
+    try {
+      const st = await stat(join(distDir, platform));
+      if (st.isDirectory()) {
+        availablePlatforms.push(platform);
+      }
+    } catch {
+      // ENOENT or other; treat as missing
+    }
   }
 
-  if (!chromeDirExists) {
+  if (availablePlatforms.length === 0) {
     console.error(
-      `SourcemapValidator (webpack) - dist/chrome/ does not exist or is not a directory. Run a webpack build first (e.g. yarn webpack). Exiting with code 1.`,
+      `SourcemapValidator (webpack) - no platform directories (${PLATFORMS.join(', ')}) found in dist/. Run a webpack build first (e.g. yarn webpack). Exiting with code 1.`,
     );
     process.exit(1);
-    return;
   }
+
+  // Sourcemaps in dist/sourcemaps/ are shared across platforms, so we only
+  // need to validate against one platform's bundles.
+  const platform = availablePlatforms[0];
+  const platformDir = join(distDir, platform);
+  console.log(`SourcemapValidator (webpack) - using platform: ${platform}`);
 
   let mapLocation: MapLocation;
   if (options.mapLocation === undefined) {
     try {
-      mapLocation = await detectMapLocationFromContentscript(chromeDir);
+      mapLocation = await detectMapLocationFromContentscript(platformDir);
       console.log(
         `SourcemapValidator (webpack) - auto-detected map location "${mapLocation}" from "${CONTENTSCRIPT_RELATIVE_PATH}".`,
       );
     } catch (error) {
       console.error(error);
       process.exit(1);
-      return;
     }
   } else {
     mapLocation = options.mapLocation;
   }
 
-  const pairs = await discoverWebpackBundles({ mapLocation });
+  const pairs = await discoverWebpackBundles({ mapLocation, platform });
   if (pairs.length === 0) {
     const searchedLocation =
-      mapLocation === 'sibling' ? 'dist/chrome/' : 'dist/sourcemaps/';
+      mapLocation === 'sibling' ? `dist/${platform}/` : 'dist/sourcemaps/';
     console.error(
-      `SourcemapValidator (webpack) - no .js+.map pairs found using map location "${mapLocation}" (${searchedLocation}). Run a webpack build first and ensure bundles and their .map files are present. Exiting with code 1.`,
+      `SourcemapValidator (webpack) - no .js+.map pairs found for ${platform} using map location "${mapLocation}" (${searchedLocation}). Run a webpack build first and ensure bundles and their .map files are present. Exiting with code 1.`,
     );
     process.exit(1);
-    return;
   }
 
   console.log(
@@ -214,7 +223,6 @@ export async function main(
       'SourcemapValidator (webpack) - one or more bundles failed validation. Exiting with code 1.',
     );
     process.exit(1);
-    return;
   }
 
   console.log(
@@ -223,20 +231,21 @@ export async function main(
 }
 
 /**
- * Recursively finds all .js files in dist/chrome that have a .map file in the
+ * Recursively finds all .js files in the platform directory that have a .map file in the
  * configured location.
  * Skips directories whose names start with '_' or equal 'vendor'.
  *
  * @param options - Source map discovery options.
  * @param options.mapLocation - Where map files are expected for each bundle.
- * @returns Sorted array of { jsPath, mapPath, label } for each bundle (label is path relative to dist/chrome).
+ * @param options.platform - The platform directory name (e.g. 'chrome' or 'firefox').
+ * @returns Sorted array of { jsPath, mapPath, label } for each bundle.
  */
 export async function discoverWebpackBundles(
   options: DiscoverWebpackBundlesOptions,
 ): Promise<FilePair[]> {
-  const { mapLocation } = options;
+  const { mapLocation, platform } = options;
   const distDir = join(process.cwd(), 'dist');
-  const chromeDir = join(distDir, PLATFORM);
+  const platformDir = join(distDir, platform);
   const sourcemapsDir = join(distDir, SOURCEMAPS_DIRNAME);
   const pairs: FilePair[] = [];
 
@@ -257,7 +266,7 @@ export async function discoverWebpackBundles(
     for (const e of entries) {
       const full = join(dir, e.name);
       if (e.isFile() && e.name.endsWith('.js') && !e.name.endsWith('.min.js')) {
-        const relativeBundlePath = toPosixPath(relative(chromeDir, full));
+        const relativeBundlePath = toPosixPath(relative(platformDir, full));
         const mapPath =
           mapLocation === 'sourcemaps'
             ? join(sourcemapsDir, `${relativeBundlePath}.map`)
@@ -283,7 +292,7 @@ export async function discoverWebpackBundles(
     }
   }
 
-  await scanDir(chromeDir);
+  await scanDir(platformDir);
   return pairs.sort((a, b) => a.jsPath.localeCompare(b.jsPath));
 }
 

--- a/development/webpack/sourcemap-validator.ts
+++ b/development/webpack/sourcemap-validator.ts
@@ -175,6 +175,7 @@ export async function main(
       `SourcemapValidator (webpack) - no platform directories (${PLATFORMS.join(', ')}) found in dist/. Run a webpack build first (e.g. yarn webpack). Exiting with code 1.`,
     );
     process.exit(1);
+    return;
   }
 
   // Sourcemaps in dist/sourcemaps/ are shared across platforms, so we only
@@ -193,6 +194,7 @@ export async function main(
     } catch (error) {
       console.error(error);
       process.exit(1);
+      return;
     }
   } else {
     mapLocation = options.mapLocation;
@@ -206,6 +208,7 @@ export async function main(
       `SourcemapValidator (webpack) - no .js+.map pairs found for ${platform} using map location "${mapLocation}" (${searchedLocation}). Run a webpack build first and ensure bundles and their .map files are present. Exiting with code 1.`,
     );
     process.exit(1);
+    return;
   }
 
   console.log(
@@ -223,6 +226,7 @@ export async function main(
       'SourcemapValidator (webpack) - one or more bundles failed validation. Exiting with code 1.',
     );
     process.exit(1);
+    return;
   }
 
   console.log(

--- a/development/webpack/test/sourcemap-validator.test.ts
+++ b/development/webpack/test/sourcemap-validator.test.ts
@@ -213,13 +213,13 @@ describe('sourcemap-validator', () => {
     // includes 'background'), ui.def456.js+.map ('ui'), scripts/contentscript.js+.map ('contentscript').
     it('returns empty array when dist/chrome does not exist', async () => {
       mock.method(process, 'cwd', () => EMPTY_FIXTURE, { times: Infinity });
-      const pairs = await discoverWebpackBundles({ mapLocation: 'sibling' });
+      const pairs = await discoverWebpackBundles({ mapLocation: 'sibling', platform: 'chrome' });
       assert.strictEqual(pairs.length, 0);
     });
 
     it('finds .js files that have a .map sibling', async () => {
       mock.method(process, 'cwd', () => DIST_FIXTURE, { times: Infinity });
-      const pairs = await discoverWebpackBundles({ mapLocation: 'sibling' });
+      const pairs = await discoverWebpackBundles({ mapLocation: 'sibling', platform: 'chrome' });
       assert.ok(pairs.length >= 2);
       assert.ok(pairs.some((p) => p.label.includes('background')));
       assert.ok(pairs.some((p) => p.label.includes('ui')));
@@ -230,7 +230,7 @@ describe('sourcemap-validator', () => {
 
     it('scans subdirectories (e.g. scripts/)', async () => {
       mock.method(process, 'cwd', () => DIST_FIXTURE, { times: Infinity });
-      const pairs = await discoverWebpackBundles({ mapLocation: 'sibling' });
+      const pairs = await discoverWebpackBundles({ mapLocation: 'sibling', platform: 'chrome' });
       assert.ok(pairs.some((p) => p.label.includes('contentscript')));
     });
 
@@ -261,11 +261,13 @@ describe('sourcemap-validator', () => {
         mock.method(process, 'cwd', () => fixtureDir, { times: Infinity });
         const siblingPairs = await discoverWebpackBundles({
           mapLocation: 'sibling',
+          platform: 'chrome',
         });
         assert.strictEqual(siblingPairs.length, 0);
 
         const pairs = await discoverWebpackBundles({
           mapLocation: 'sourcemaps',
+          platform: 'chrome',
         });
         assert.strictEqual(pairs.length, 1);
         assert.strictEqual(pairs[0].label, 'scripts/contentscript.js');
@@ -280,7 +282,7 @@ describe('sourcemap-validator', () => {
 
     it('does not include sibling maps when map location is sourcemaps', async () => {
       mock.method(process, 'cwd', () => DIST_FIXTURE, { times: Infinity });
-      const pairs = await discoverWebpackBundles({ mapLocation: 'sourcemaps' });
+      const pairs = await discoverWebpackBundles({ mapLocation: 'sourcemaps', platform: 'chrome' });
       assert.strictEqual(pairs.length, 0);
     });
   });

--- a/development/webpack/test/sourcemap-validator.test.ts
+++ b/development/webpack/test/sourcemap-validator.test.ts
@@ -213,13 +213,19 @@ describe('sourcemap-validator', () => {
     // includes 'background'), ui.def456.js+.map ('ui'), scripts/contentscript.js+.map ('contentscript').
     it('returns empty array when dist/chrome does not exist', async () => {
       mock.method(process, 'cwd', () => EMPTY_FIXTURE, { times: Infinity });
-      const pairs = await discoverWebpackBundles({ mapLocation: 'sibling', platform: 'chrome' });
+      const pairs = await discoverWebpackBundles({
+        mapLocation: 'sibling',
+        platform: 'chrome',
+      });
       assert.strictEqual(pairs.length, 0);
     });
 
     it('finds .js files that have a .map sibling', async () => {
       mock.method(process, 'cwd', () => DIST_FIXTURE, { times: Infinity });
-      const pairs = await discoverWebpackBundles({ mapLocation: 'sibling', platform: 'chrome' });
+      const pairs = await discoverWebpackBundles({
+        mapLocation: 'sibling',
+        platform: 'chrome',
+      });
       assert.ok(pairs.length >= 2);
       assert.ok(pairs.some((p) => p.label.includes('background')));
       assert.ok(pairs.some((p) => p.label.includes('ui')));
@@ -230,7 +236,10 @@ describe('sourcemap-validator', () => {
 
     it('scans subdirectories (e.g. scripts/)', async () => {
       mock.method(process, 'cwd', () => DIST_FIXTURE, { times: Infinity });
-      const pairs = await discoverWebpackBundles({ mapLocation: 'sibling', platform: 'chrome' });
+      const pairs = await discoverWebpackBundles({
+        mapLocation: 'sibling',
+        platform: 'chrome',
+      });
       assert.ok(pairs.some((p) => p.label.includes('contentscript')));
     });
 
@@ -282,7 +291,10 @@ describe('sourcemap-validator', () => {
 
     it('does not include sibling maps when map location is sourcemaps', async () => {
       mock.method(process, 'cwd', () => DIST_FIXTURE, { times: Infinity });
-      const pairs = await discoverWebpackBundles({ mapLocation: 'sourcemaps', platform: 'chrome' });
+      const pairs = await discoverWebpackBundles({
+        mapLocation: 'sourcemaps',
+        platform: 'chrome',
+      });
       assert.strictEqual(pairs.length, 0);
     });
   });

--- a/development/webpack/test/sourcemap-validator.test.ts
+++ b/development/webpack/test/sourcemap-validator.test.ts
@@ -205,6 +205,60 @@ describe('sourcemap-validator', () => {
         await rm(fixtureDir, { recursive: true, force: true });
       }
     });
+
+    it('works with a firefox platform directory', async () => {
+      const fixtureDir = await mkdtemp(
+        join(tmpdir(), 'sourcemap-validator-detect-firefox-'),
+      );
+
+      try {
+        const firefoxScriptsDir = join(
+          fixtureDir,
+          'dist',
+          'firefox',
+          'scripts',
+        );
+        await mkdir(firefoxScriptsDir, { recursive: true });
+        await writeFile(
+          join(firefoxScriptsDir, 'contentscript.js'),
+          [
+            '(function(){',
+            '  throw new Error("x");',
+            '})();',
+            '//# sourceMappingURL=contentscript.js.map',
+          ].join('\n'),
+        );
+
+        const mapLocation = await detectMapLocationFromContentscript(
+          join(fixtureDir, 'dist', 'firefox'),
+        );
+        assert.strictEqual(mapLocation, 'sibling');
+      } finally {
+        await rm(fixtureDir, { recursive: true, force: true });
+      }
+    });
+
+    it('includes the platform directory path in the error message', async () => {
+      const fixtureDir = await mkdtemp(
+        join(tmpdir(), 'sourcemap-validator-detect-errmsg-'),
+      );
+      const firefoxDir = join(fixtureDir, 'dist', 'firefox');
+
+      try {
+        await assert.rejects(
+          () => detectMapLocationFromContentscript(firefoxDir),
+          (err: Error) => {
+            assert.ok(
+              err.message.includes(firefoxDir),
+              `error message should include platform dir "${firefoxDir}", got: ${err.message}`,
+            );
+            return true;
+          },
+        );
+      } finally {
+        await rm(fixtureDir, { recursive: true, force: true });
+      }
+    });
   });
 
   describe('discoverWebpackBundles', () => {
@@ -296,6 +350,76 @@ describe('sourcemap-validator', () => {
         platform: 'chrome',
       });
       assert.strictEqual(pairs.length, 0);
+    });
+
+    it('discovers bundles under dist/firefox when platform is firefox', async () => {
+      const fixtureDir = await mkdtemp(
+        join(tmpdir(), 'sourcemap-validator-firefox-discover-'),
+      );
+      try {
+        const firefoxDir = join(fixtureDir, 'dist', 'firefox');
+        await mkdir(firefoxDir, { recursive: true });
+        await writeFile(
+          join(firefoxDir, 'background.js'),
+          'throw new Error("x");',
+        );
+        await writeFile(join(firefoxDir, 'background.js.map'), '{}');
+
+        mock.method(process, 'cwd', () => fixtureDir, { times: Infinity });
+        const pairs = await discoverWebpackBundles({
+          mapLocation: 'sibling',
+          platform: 'firefox',
+        });
+        assert.strictEqual(pairs.length, 1);
+        assert.strictEqual(pairs[0].label, 'background.js');
+      } finally {
+        await rm(fixtureDir, { recursive: true, force: true });
+      }
+    });
+
+    it('finds maps under dist/sourcemaps for firefox platform', async () => {
+      const fixtureDir = await mkdtemp(
+        join(tmpdir(), 'sourcemap-validator-firefox-sourcemaps-'),
+      );
+      try {
+        const firefoxScriptsDir = join(
+          fixtureDir,
+          'dist',
+          'firefox',
+          'scripts',
+        );
+        const sourcemapsScriptsDir = join(
+          fixtureDir,
+          'dist',
+          'sourcemaps',
+          'scripts',
+        );
+        await mkdir(firefoxScriptsDir, { recursive: true });
+        await mkdir(sourcemapsScriptsDir, { recursive: true });
+
+        await writeFile(
+          join(firefoxScriptsDir, 'contentscript.js'),
+          'throw new Error("x");',
+        );
+        await writeFile(
+          join(sourcemapsScriptsDir, 'contentscript.js.map'),
+          '{}',
+        );
+
+        mock.method(process, 'cwd', () => fixtureDir, { times: Infinity });
+        const pairs = await discoverWebpackBundles({
+          mapLocation: 'sourcemaps',
+          platform: 'firefox',
+        });
+        assert.strictEqual(pairs.length, 1);
+        assert.strictEqual(pairs[0].label, 'scripts/contentscript.js');
+        assert.strictEqual(
+          pairs[0].mapPath,
+          join(sourcemapsScriptsDir, 'contentscript.js.map'),
+        );
+      } finally {
+        await rm(fixtureDir, { recursive: true, force: true });
+      }
     });
   });
 
@@ -682,14 +806,66 @@ describe('sourcemap-validator', () => {
       }
     });
 
-    it('exits with 1 when dist/chrome does not exist', async () => {
+    it('exits with 1 when no platform directories exist', async () => {
       mock.method(process, 'cwd', () => EMPTY_FIXTURE, { times: Infinity });
       const exitMock = mock.method(process, 'exit', noop as () => never);
-      mock.method(console, 'error', noop);
+      const errors: string[] = [];
+      mock.method(console, 'error', (...args: unknown[]) => {
+        errors.push(args.map((a) => String(a)).join(' '));
+      });
       mock.method(console, 'log', noop);
       await main({ mapLocation: 'sibling' });
       assert.strictEqual(exitMock.mock.calls.length, 1);
       assert.strictEqual(exitMock.mock.calls[0].arguments[0], 1);
+      assert.ok(
+        errors.some((e) => e.includes('chrome') && e.includes('firefox')),
+        'error message should mention both platforms',
+      );
+    });
+
+    it('falls back to firefox when only dist/firefox exists', async () => {
+      mainTestDir = await mkdtemp(
+        join(tmpdir(), 'sourcemap-validator-firefox-only-'),
+      );
+      const firefoxDir = join(mainTestDir, 'dist', 'firefox');
+      await mkdir(firefoxDir, { recursive: true });
+      const exitMock = mock.method(process, 'exit', noop as () => never);
+      const logs: string[] = [];
+      mock.method(console, 'log', (...args: unknown[]) => {
+        logs.push(args.map((a) => String(a)).join(' '));
+      });
+      mock.method(console, 'error', noop);
+      mock.method(console, 'warn', noop);
+      mock.method(process, 'cwd', () => mainTestDir, { times: Infinity });
+      await main({ mapLocation: 'sibling' });
+      assert.ok(
+        logs.some((l) => l.includes('using platform: firefox')),
+        'should log that firefox platform is being used',
+      );
+      // exits with 1 because no .js+.map pairs (empty dir), but it did pick firefox
+      assert.strictEqual(exitMock.mock.calls.length, 1);
+    });
+
+    it('prefers chrome when both chrome and firefox exist', async () => {
+      mainTestDir = await mkdtemp(
+        join(tmpdir(), 'sourcemap-validator-both-platforms-'),
+      );
+      await mkdir(join(mainTestDir, 'dist', 'chrome'), { recursive: true });
+      await mkdir(join(mainTestDir, 'dist', 'firefox'), { recursive: true });
+      const exitMock = mock.method(process, 'exit', noop as () => never);
+      const logs: string[] = [];
+      mock.method(console, 'log', (...args: unknown[]) => {
+        logs.push(args.map((a) => String(a)).join(' '));
+      });
+      mock.method(console, 'error', noop);
+      mock.method(console, 'warn', noop);
+      mock.method(process, 'cwd', () => mainTestDir, { times: Infinity });
+      await main({ mapLocation: 'sibling' });
+      assert.ok(
+        logs.some((l) => l.includes('using platform: chrome')),
+        'should prefer chrome (first in PLATFORMS array)',
+      );
+      assert.strictEqual(exitMock.mock.calls.length, 1);
     });
 
     it('exits with 1 when dist/chrome exists but has no .js+.map pairs', async () => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40865?quickstart=1)

This PR fixes an issue with validating webpack firefox sourcemaps. The sourcemap validation script had the chrome path hardcoded.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/7124

## **Manual testing steps**

1. run `yarn webpack --mode production --browser firefox -v 2` to generate a firefox only webpack build
2. run `yarn validate-source-maps:webpack` to validate sourcemaps for the build
3. Webpack sourcemap validation should work for webpack firefox builds

## **Screenshots/Recordings**

Not applicable

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: build-time validation script is updated to support multiple dist platforms with expanded tests; no runtime or security-sensitive logic changes.
> 
> **Overview**
> Updates the webpack sourcemap validation script to be **platform-aware** instead of hardcoding `dist/chrome`, selecting the first available platform from `dist/chrome` or `dist/firefox` and reflecting the chosen platform in logs/errors.
> 
> Extends bundle discovery to accept an explicit `platform` and adds/updates tests to cover firefox support, platform selection preference (chrome over firefox), and improved error messaging when no platform directories exist.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8771bc46c3862de4f0c67afb735a2be0e0c5db53. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->