### PR TITLE
[Bug]: NFTs in Send flow overlapping

### DIFF
--- a/ui/pages/confirmations/components/UI/asset/asset.test.tsx
+++ b/ui/pages/confirmations/components/UI/asset/asset.test.tsx
@@ -191,6 +191,22 @@ describe('NFTAsset', () => {
     expect(image).toHaveAttribute('src', 'https://example.com/collection.png');
   });
 
+  it('does not render image container when both asset image and collection imageUrl are missing', () => {
+    mockUseNftImageUrl.mockReturnValue('');
+    const assetWithoutAnyImage = {
+      ...mockNFTERC721Asset,
+      image: undefined,
+      collection: {
+        ...mockNFTERC721Asset.collection,
+        imageUrl: undefined,
+      },
+    };
+    const { queryByRole, getByTestId } = render(<Asset asset={assetWithoutAnyImage} />);
+
+    expect(getByTestId('nft-asset')).toBeInTheDocument();
+    expect(queryByRole('img')).not.toBeInTheDocument();
+  });
+
   it('renders account type label when account type is provided', () => {
     const assetWithAccountType = {
       ...mockTokenAsset,

--- a/ui/pages/confirmations/components/UI/asset/asset.tsx
+++ b/ui/pages/confirmations/components/UI/asset/asset.tsx
@@ -66,19 +66,19 @@ const NftAsset = ({ asset, onClick, isSelected }: AssetProps) => {
       paddingLeft={4}
       paddingRight={4}
     >
-      <Box marginRight={4} style={{ minWidth: 32 }}>
-        <BadgeWrapper
-          badge={
-            nftData.chainId ? (
-              <AvatarNetwork
-                size={AvatarNetworkSize.Xs}
-                name={nftData.networkName ?? ''}
-                src={nftData.networkImage}
-              />
-            ) : null
-          }
-        >
-          {image || collection?.imageUrl ? (
+      {image || collection?.imageUrl ? (
+        <Box marginRight={4} style={{ minWidth: 32 }}>
+          <BadgeWrapper
+            badge={
+              nftData.chainId ? (
+                <AvatarNetwork
+                  size={AvatarNetworkSize.Xs}
+                  name={nftData.networkName ?? ''}
+                  src={nftData.networkImage}
+                />
+              ) : null
+            }
+          >
             <Box
               as="img"
               src={nftItemSrc || (collection?.imageUrl as string)}
@@ -90,9 +90,9 @@ const NftAsset = ({ asset, onClick, isSelected }: AssetProps) => {
                 objectFit: 'cover',
               }}
             />
-          ) : null}
-        </BadgeWrapper>
-      </Box>
+          </BadgeWrapper>
+        </Box>
+      ) : null}
       <Box
         display={Display.Flex}
         flexDirection={FlexDirection.Column}


### PR DESCRIPTION
## Summary
Fix NFT overlapping issue in send flow when NFTs have missing images by properly handling the layout when no image is available

## Source
- Work item: bug_9f9cdaa4
- Kind: bug_fix
- Source ref: https://github.com/MetaMask/metamask-extension/issues/40669

## Plan
- Confidence: high
- Modify NftAsset component to conditionally render the image container Box only when an image is available
- When no image is available, don't render the image container Box with marginRight and minWidth to prevent space reservation
- Add appropriate test case to verify the fix works when both asset image and collection imageUrl are missing
- Ensure the layout remains consistent with the fixed ITEM_HEIGHT for virtualization

## Validation

## Review
- Status: approve
- Risk: low
- The fix properly moves the Box container with marginRight and minWidth inside the conditional rendering block
- The BadgeWrapper and its network badge logic are preserved within the conditional structure
- A comprehensive test case was added that verifies the image container is not rendered when both asset.image and collection.imageUrl are missing
- The changes maintain the existing component structure and styling for NFTs that do have images