### PR TITLE
fix: [Bug]: NFTs in Send flow overlapping

### DIFF
--- a/ui/pages/confirmations/components/UI/asset/asset.test.tsx
+++ b/ui/pages/confirmations/components/UI/asset/asset.test.tsx
@@ -200,4 +200,49 @@ describe('NFTAsset', () => {
 
     expect(getByText('Native SegWit')).toBeInTheDocument();
   });
+
+  it('renders placeholder when both image and collection.imageUrl are missing', () => {
+    mockUseNftImageUrl.mockReturnValue('');
+    const assetWithoutImages = {
+      ...mockNFTERC721Asset,
+      image: undefined,
+      collection: {
+        name: 'Test Collection',
+        imageUrl: undefined,
+      },
+    };
+    const { getByTestId } = render(<Asset asset={assetWithoutImages} />);
+
+    const nftAsset = getByTestId('nft-asset');
+    expect(nftAsset).toBeInTheDocument();
+
+    // Verify the placeholder box exists with correct dimensions
+    const placeholder = nftAsset.querySelector('div[style*="width: 32"]');
+    expect(placeholder).toBeInTheDocument();
+    expect(placeholder).toHaveStyle({
+      width: '32px',
+      height: '32px',
+      borderRadius: '8px',
+    });
+  });
+
+  it('maintains consistent layout height with missing images', () => {
+    mockUseNftImageUrl.mockReturnValue('');
+    const assetWithoutImages = {
+      ...mockNFTERC721Asset,
+      image: undefined,
+      collection: {
+        name: 'Test Collection',
+        imageUrl: undefined,
+      },
+    };
+    const { getByTestId } = render(<Asset asset={assetWithoutImages} />);
+
+    const nftAsset = getByTestId('nft-asset');
+    const computedStyle = window.getComputedStyle(nftAsset);
+
+    // Verify consistent padding is applied for virtualized list
+    expect(computedStyle.paddingTop).toBe('12px'); // 3 * 4px base unit
+    expect(computedStyle.paddingBottom).toBe('12px'); // 3 * 4px base unit
+  });
 });

--- a/ui/pages/confirmations/components/UI/asset/asset.tsx
+++ b/ui/pages/confirmations/components/UI/asset/asset.tsx
@@ -90,7 +90,16 @@ const NftAsset = ({ asset, onClick, isSelected }: AssetProps) => {
                 objectFit: 'cover',
               }}
             />
-          ) : null}
+          ) : (
+            <Box
+              style={{
+                width: 32,
+                height: 32,
+                borderRadius: 8,
+                backgroundColor: 'var(--color-background-alternative)',
+              }}
+            />
+          )}
         </BadgeWrapper>
       </Box>
       <Box


### PR DESCRIPTION
## **Description**

NFT rows in the send flow are overlapping when NFT images are missing due to inconsistent layout handling in the Asset component.

### Changes

- Modify the NftAsset component to always render a placeholder container when both image and collection.imageUrl are missing, maintaining consistent spacing and layout
- Add a fallback empty div or placeholder with the same dimensions (32x32px) when no image is available
- Add test cases for NFTs with missing images to ensure proper layout

## **Changelog**

CHANGELOG entry: Fixed NFT rows in the send flow are overlapping when NFT images are missing due to inconsistent layout handling in the Asset component.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/40669

## **Manual testing steps**

1. [visual] MetaMask extension launches and unlocks successfully: passed
2. [visual] NFT import functionality works with test contract: passed
3. [visual] NFT with missing image displays placeholder in send flow: passed
4. [visual] NFT selection works correctly in send flow: passed

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

> Successfully validated the NFT row overlapping fix by testing the send flow with an imported NFT that has missing images. The placeholder image functionality works correctly, maintaining proper layout and spacing.

**[visual] MetaMask extension launches and unlocks successfully**: Extension opened on unlock screen, successfully unlocked with password, navigated to home screen showing 25 ETH balance

**[visual] NFT import functionality works with test contract**: Successfully imported NFT from deployed contract address 0x581c3c1a2a4ebde2a0df29b5cf4c116e42945947 with token ID 1, NFT appears in NFTs tab with default image placeholder

**[visual] NFT with missing image displays placeholder in send flow**: NFT appears in send flow asset list with nft-asset test ID, showing consistent layout with other assets. No overlapping observed, placeholder maintains proper spacing and 32x32px dimensions as intended by the fix.

**[visual] NFT selection works correctly in send flow**: NFT can be successfully selected in the send flow, confirming the placeholder fix maintains functionality while preventing layout issues

<details><summary>Agent metadata</summary>

- Work item: `work_65f011f8`
- Kind: `bug_fix`
- Confidence: high
- Review status: approve
- Risk: low

### Review findings

- Added placeholder Box with proper dimensions (32x32px) when both image and collection.imageUrl are missing
- Placeholder uses appropriate background color (--color-background-alternative) and border radius (8px)
- Two new test cases verify placeholder rendering and layout consistency
- Tests properly mock useNftImageUrl hook and validate DOM structure
- Visual validation confirms no overlapping occurs in send flow with missing NFT images

</details>

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.