### PR TITLE
fix: [Bug]: NFTs in Send flow overlapping

### DIFF
--- a/ui/pages/confirmations/components/UI/asset/asset.test.tsx
+++ b/ui/pages/confirmations/components/UI/asset/asset.test.tsx
@@ -200,4 +200,36 @@ describe('NFTAsset', () => {
 
     expect(getByText('Native SegWit')).toBeInTheDocument();
   });
+
+  it('renders fallback placeholder when NFT has no image or collection imageUrl', () => {
+    mockUseNftImageUrl.mockReturnValue('');
+    const assetWithoutImages = {
+      ...mockNFTERC721Asset,
+      image: undefined,
+      collection: {
+        name: 'Test Collection',
+        imageUrl: undefined,
+      },
+    };
+    const { getByText } = render(<Asset asset={assetWithoutImages} />);
+
+    // Should render the first letter of collection name as fallback
+    expect(getByText('T')).toBeInTheDocument();
+  });
+
+  it('renders question mark fallback when NFT has no image and no collection name', () => {
+    mockUseNftImageUrl.mockReturnValue('');
+    const assetWithoutImagesOrName = {
+      ...mockNFTERC721Asset,
+      image: undefined,
+      collection: {
+        name: undefined,
+        imageUrl: undefined,
+      },
+    };
+    const { getByText } = render(<Asset asset={assetWithoutImagesOrName} />);
+
+    // Should render '?' as fallback
+    expect(getByText('?')).toBeInTheDocument();
+  });
 });

--- a/ui/pages/confirmations/components/UI/asset/asset.tsx
+++ b/ui/pages/confirmations/components/UI/asset/asset.tsx
@@ -15,6 +15,7 @@ import {
   BackgroundColor,
   Display,
   FlexDirection,
+  JustifyContent,
   TextColor,
   TextVariant,
 } from '../../../../../helpers/constants/design-system';
@@ -90,7 +91,26 @@ const NftAsset = ({ asset, onClick, isSelected }: AssetProps) => {
                 objectFit: 'cover',
               }}
             />
-          ) : null}
+          ) : (
+            <Box
+              display={Display.Flex}
+              alignItems={AlignItems.center}
+              justifyContent={JustifyContent.center}
+              backgroundColor={BackgroundColor.backgroundAlternative}
+              style={{
+                width: 32,
+                height: 32,
+                borderRadius: 8,
+              }}
+            >
+              <Text
+                variant={TextVariant.bodySmMedium}
+                color={TextColor.textAlternative}
+              >
+                {collection?.name ? collection.name.charAt(0).toUpperCase() : '?'}
+              </Text>
+            </Box>
+          )}
         </BadgeWrapper>
       </Box>
       <Box


### PR DESCRIPTION
## **Description**

NFTs in send flow are overlapping when image is missing due to inconsistent layout height

### Changes

- Modify NftAsset component to always render a 32x32 element, either the actual image or a fallback placeholder
- Add fallback logic similar to AvatarToken that shows collection name initial or '?' when no image is available
- Ensure the fallback maintains the same 32x32 dimensions and border-radius styling as the image
- Preserve existing network badge functionality

## **Changelog**

CHANGELOG entry: Fixed NFTs in send flow are overlapping when image is missing due to inconsistent layout height

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/40669

## **Manual testing steps**

1. [visual] MetaMask extension launches and unlocks successfully: passed
2. [visual] NFT import functionality works with deployed contracts: passed
3. [visual] NFT fallback placeholder renders correctly in send flow: passed
4. [visual] NFT asset is interactive and selectable in send flow: passed

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

> Successfully validated the NFT overlapping fix in the send flow. The fallback placeholder system is working correctly, displaying a '?' character for NFTs without collection names and maintaining consistent 32x32px dimensions. The network badge functionality is preserved and the NFT is properly selectable in the send interface.

**[visual] MetaMask extension launches and unlocks successfully**: Extension opened on unlock screen, successfully unlocked with default password, and navigated to home screen showing 25 ETH balance

**[visual] NFT import functionality works with deployed contracts**: Successfully deployed NFT contracts, imported NFT with address 0x581c3c1a2a4ebde2a0df29b5cf4c116e42945947 and token ID 1, NFT appears in the NFTs tab

**[visual] NFT fallback placeholder renders correctly in send flow**: NFT asset displays in send flow with '?' fallback character for missing collection name, maintaining 32x32px dimensions with proper styling and network badge functionality. The element shows 'testId: nft-asset' with text '?L' indicating successful fallback implementation.

**[visual] NFT asset is interactive and selectable in send flow**: Successfully clicked on NFT asset in send flow, confirming the element is properly interactive and maintains functionality with the fallback placeholder implementation

<details><summary>Agent metadata</summary>

- Work item: `work_28bfdc89`
- Kind: `bug_fix`
- Confidence: high
- Review status: approve
- Risk: low

### Review findings

- Added proper fallback logic that renders collection name initial or '?' when no image is available
- Fallback maintains exact 32x32px dimensions with consistent styling (borderRadius: 8px, backgroundColor: backgroundAlternative)
- Two comprehensive test cases added covering both collection name fallback and question mark fallback scenarios
- Visual validation confirms NFT assets maintain consistent height in send flow with no overlapping
- Network badge functionality preserved as evidenced in validation screenshots

</details>

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.