### PR TITLE
fix: Fix NFT missing-image overlap in send flow (#40669)

### DIFF
--- a/ui/pages/confirmations/components/UI/asset/asset.test.tsx
+++ b/ui/pages/confirmations/components/UI/asset/asset.test.tsx
@@ -200,4 +200,61 @@ describe('NFTAsset', () => {
 
     expect(getByText('Native SegWit')).toBeInTheDocument();
   });
+
+  it('shows fallback image when NFT image fails to load', () => {
+    const { getByAltText, getByTestId } = render(
+      <Asset asset={mockNFTERC721Asset} />,
+    );
+
+    const image = getByAltText('Test NFT');
+    fireEvent.error(image);
+
+    expect(getByTestId('nft-default-image')).toBeInTheDocument();
+  });
+
+  it('shows fallback image when NFT has no image and no collection imageUrl', () => {
+    const assetWithNoImages = {
+      ...mockNFTERC721Asset,
+      image: undefined,
+      collection: {
+        ...mockNFTERC721Asset.collection,
+        imageUrl: undefined,
+      },
+    };
+    const { getByTestId } = render(<Asset asset={assetWithNoImages} />);
+
+    expect(getByTestId('nft-default-image')).toBeInTheDocument();
+  });
+
+  it('maintains layout when using fallback image', () => {
+    const assetWithNoImages = {
+      ...mockNFTERC721Asset,
+      image: undefined,
+      collection: {
+        ...mockNFTERC721Asset.collection,
+        imageUrl: undefined,
+      },
+    };
+    const { getByTestId } = render(<Asset asset={assetWithNoImages} />);
+
+    const fallbackImage = getByTestId('nft-default-image');
+    expect(fallbackImage).toHaveClass('nft-asset__default-image');
+  });
+
+  it('shows network badge with fallback image', () => {
+    const assetWithNoImages = {
+      ...mockNFTERC721Asset,
+      image: undefined,
+      collection: {
+        ...mockNFTERC721Asset.collection,
+        imageUrl: undefined,
+      },
+    };
+    const { getByTestId, getByRole } = render(<Asset asset={assetWithNoImages} />);
+
+    expect(getByTestId('nft-default-image')).toBeInTheDocument();
+    expect(
+      getByRole('img', { name: messages.networkNameEthereum.message }),
+    ).toBeInTheDocument();
+  });
 });

--- a/ui/pages/confirmations/components/UI/asset/asset.tsx
+++ b/ui/pages/confirmations/components/UI/asset/asset.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { KeyringAccountType } from '@metamask/keyring-api';
 import { Hex } from '@metamask/utils';
 import {
@@ -28,6 +28,8 @@ import { accountTypeLabel } from '../../../constants/network';
 import { useFormatters } from '../../../../../hooks/useFormatters';
 import { AccountTypeLabel } from '../account-type-label';
 import { getAvatarTokenSrc } from '../../../../../components/app/assets/asset-list/cells/asset-cell-badge';
+import NftDefaultImage from '../../../../../components/app/assets/nfts/nft-default-image/nft-default-image';
+import './index.scss';
 
 type AssetProps = {
   asset: AssetType;
@@ -38,6 +40,7 @@ type AssetProps = {
 const NftAsset = ({ asset, onClick, isSelected }: AssetProps) => {
   const nftData = asset;
   const { collection, name, tokenId, image, standard, balance } = nftData;
+  const [imageError, setImageError] = useState(false);
 
   const nftItemSrc = useNftImageUrl(image as string);
 
@@ -78,11 +81,12 @@ const NftAsset = ({ asset, onClick, isSelected }: AssetProps) => {
             ) : null
           }
         >
-          {image || collection?.imageUrl ? (
+          {(image || collection?.imageUrl) && !imageError ? (
             <Box
               as="img"
               src={nftItemSrc || (collection?.imageUrl as string)}
               alt={name}
+              onError={() => setImageError(true)}
               style={{
                 width: 32,
                 height: 32,
@@ -90,7 +94,12 @@ const NftAsset = ({ asset, onClick, isSelected }: AssetProps) => {
                 objectFit: 'cover',
               }}
             />
-          ) : null}
+          ) : (
+            <NftDefaultImage
+              className="nft-asset__default-image"
+              clickable={false}
+            />
+          )}
         </BadgeWrapper>
       </Box>
       <Box

--- a/ui/pages/confirmations/components/UI/asset/index.scss
+++ b/ui/pages/confirmations/components/UI/asset/index.scss
@@ -6,3 +6,10 @@
     cursor: pointer;
   }
 }
+
+.nft-asset__default-image {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  padding-top: 0 !important;
+}


### PR DESCRIPTION
## **Description**

Fix NFT missing-image overlap in send flow by adding proper fallback image handling

### Changes

- Add onError handler to the img element in NftAsset component to handle broken images
- Implement fallback to NftDefaultImage component when image fails to load
- Add state management for image loading error to trigger fallback display
- Ensure consistent sizing (32x32px) for both successful images and fallback
- Import and integrate NftDefaultImage component similar to nft-item implementation

## **Changelog**

CHANGELOG entry: Fixed Fix NFT missing-image overlap in send flow by adding proper fallback image handling

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/40669

## **Manual testing steps**

1. [visual-setup] yarn build:test: failed

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

> Visual validation setup failed before the MCP browser session could start

<!-- [screenshots/recordings] -->

<details><summary>Agent metadata</summary>

- Work item: `work_788226d2`
- Kind: `bug_fix`
- Confidence: high
- Review status: approve
- Risk: low

</details>

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.