### PR TITLE
fix: [Bug]: Shield - Too much friction for non-covered transactions, at the level of Malicious transactions

### DIFF
--- a/ui/pages/confirmations/hooks/alerts/useShieldCoverageAlert.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/useShieldCoverageAlert.test.ts
@@ -166,6 +166,70 @@ describe('useShieldCoverageAlert', () => {
     expect(alert.isOpenModalOnClick).toBe(true);
   });
 
+  it('returns danger alert for unknown status with malicious reason code', () => {
+    const state = getStateWithCoverage('unknown', 'E003'); // Malicious blockaid result
+
+    const { result } = renderHookWithConfirmContextProvider(
+      () => useShieldCoverageAlert(),
+      state,
+    );
+
+    expect(result.current).toHaveLength(1);
+    const alert = result.current[0];
+    expect(alert.severity).toBe(Severity.Danger);
+    expect(alert.inlineAlertText).toBe(tEn('shieldNotCovered'));
+    expect(alert.inlineAlertTextBackgroundColor).toBe('error-muted');
+    expect(alert.iconColor).toBe('error-default');
+  });
+
+  it('returns warning alert for unknown status with benign non-coverage reason code', () => {
+    const state = getStateWithCoverage('unknown', 'E400'); // Transaction type not supported
+
+    const { result } = renderHookWithConfirmContextProvider(
+      () => useShieldCoverageAlert(),
+      state,
+    );
+
+    expect(result.current).toHaveLength(1);
+    const alert = result.current[0];
+    expect(alert.severity).toBe(Severity.Warning);
+    expect(alert.inlineAlertText).toBe(tEn('shieldNotCovered'));
+    expect(alert.inlineAlertTextBackgroundColor).toBe('warning-muted');
+    expect(alert.iconColor).toBe('warning-default');
+  });
+
+  it('returns danger alert for unknown status with risky domain reason code', () => {
+    const state = getStateWithCoverage('unknown', 'E102'); // Risky domain
+
+    const { result } = renderHookWithConfirmContextProvider(
+      () => useShieldCoverageAlert(),
+      state,
+    );
+
+    expect(result.current).toHaveLength(1);
+    const alert = result.current[0];
+    expect(alert.severity).toBe(Severity.Danger);
+    expect(alert.inlineAlertText).toBe(tEn('shieldNotCovered'));
+    expect(alert.inlineAlertTextBackgroundColor).toBe('error-muted');
+    expect(alert.iconColor).toBe('error-default');
+  });
+
+  it('returns warning alert for unknown status with local setup reason code', () => {
+    const state = getStateWithCoverage('unknown', 'E104'); // Local setup
+
+    const { result } = renderHookWithConfirmContextProvider(
+      () => useShieldCoverageAlert(),
+      state,
+    );
+
+    expect(result.current).toHaveLength(1);
+    const alert = result.current[0];
+    expect(alert.severity).toBe(Severity.Warning);
+    expect(alert.inlineAlertText).toBe(tEn('shieldNotCovered'));
+    expect(alert.inlineAlertTextBackgroundColor).toBe('warning-muted');
+    expect(alert.iconColor).toBe('warning-default');
+  });
+
   it('updates transaction event fragment with covered status', () => {
     const state = getStateWithCoverage('covered', 'E104', true, 150);
     renderHookWithConfirmContextProvider(() => useShieldCoverageAlert(), state);

--- a/ui/pages/confirmations/hooks/alerts/useShieldCoverageAlert.ts
+++ b/ui/pages/confirmations/hooks/alerts/useShieldCoverageAlert.ts
@@ -28,6 +28,26 @@ import { ShieldCoverageAlertMessage } from './transactions/ShieldCoverageAlertMe
 
 const N_A = 'N/A';
 
+const isMaliciousReasonCode = (reasonCode: string | undefined): boolean => {
+  if (!reasonCode) {
+    return false;
+  }
+  // Malicious or risky reason codes that indicate potential threats
+  const maliciousCodes = [
+    'E003', // Malicious blockaid result
+    'E005', // Malicious sentinel result
+    'E101', // Malicious domain
+    'E102', // Risky domain
+    'E301', // Receiver contract malicious
+    'E302', // Receiver contract risky
+    'E500', // Method params contract malicious
+    'E600', // Malicious token contract
+    'E601', // Risky token contract
+    'E800', // malicious token receiver contract in swap
+  ];
+  return maliciousCodes.includes(reasonCode);
+};
+
 const getModalBodyStr = (reasonCode: string | undefined) => {
   // grouping codes with a fallthrough pattern is not allowed by the linter
   let modalBodyStr: string;
@@ -287,6 +307,18 @@ export function useShieldCoverageAlert(): Alert[] {
           severity = Severity.Danger;
           inlineAlertTextBackgroundColor = BackgroundColor.errorMuted;
           iconColor = IconColor.errorDefault;
+          break;
+        case 'unknown':
+          // Differentiate between malicious and benign non-covered transactions
+          if (isMaliciousReasonCode(reasonCode)) {
+            severity = Severity.Danger;
+            inlineAlertTextBackgroundColor = BackgroundColor.errorMuted;
+            iconColor = IconColor.errorDefault;
+          } else {
+            severity = Severity.Warning;
+            inlineAlertTextBackgroundColor = BackgroundColor.warningMuted;
+            iconColor = IconColor.warningDefault;
+          }
           break;
         default:
       }


### PR DESCRIPTION
## **Description**

Reduce friction for non-covered Shield transactions by creating separate severity levels for benign vs malicious transactions

### Changes

- Modify getModalBodyStr function to categorize reason codes into malicious vs non-coverage types
- Create separate severity handling in useShieldCoverageAlert for 'unknown' status based on reason code category
- Add new severity level (Warning) for benign non-covered transactions vs Danger for malicious transactions
- Preserve existing malicious transaction handling with red background and Severity.Danger
- Update visual styling for non-covered benign transactions to use less alarming colors

## **Changelog**

CHANGELOG entry: Fixed Reduce friction for non-covered Shield transactions by creating separate severity levels for benign vs malicious transactions

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/38861

## **Manual testing steps**

1. [visual] Verify Shield service availability for testing: failed
2. [visual] Verify transaction confirmation flow works without Shield: passed
3. [visual] Proof and layout evidence: failed
4. [visual] Target state evidence: failed

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

> Browser validation was blocked by Shield service connectivity issues. Successfully launched MetaMask, navigated to transaction confirmation screen, but could not trigger Shield coverage alerts due to service unavailability. Target browser state was not reached: Shield service connection failed during setup. Could not establish Shield subscription needed to trigger coverage alerts with different severity levels. The 'Choose your plan' screen showed 'Couldn't connect to Transaction Shield' error. Visual validation did not include a passing visual check with both focused proof and layout context for the changed UI.

**[visual] Verify Shield service availability for testing**: Shield setup failed with connection error, preventing access to coverage alert functionality

**[visual] Verify transaction confirmation flow works without Shield**: Successfully created and reached transaction confirmation screen for ETH send transaction

<details><summary>Agent metadata</summary>

- Work item: `work_53017498`
- Kind: `bug_fix`
- Confidence: high
- Review status: approve
- Risk: low

</details>

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.