### PR TITLE
fix: [Bug]: Petname address text styling issues in send confirmation from/to section

### DIFF
--- a/ui/components/app/name/index.scss
+++ b/ui/components/app/name/index.scss
@@ -17,6 +17,18 @@
     }
   }
 
+  &__saved {
+    .name__name {
+      color: var(--color-text-default);
+    }
+
+    &.name__clickable:hover {
+      .name__name {
+        color: var(--color-info-default);
+      }
+    }
+  }
+
   &__trust-signal-icon {
     width: 16px;
     height: 16px;

--- a/ui/components/ui/sender-to-recipient/sender-to-recipient.component.js
+++ b/ui/components/ui/sender-to-recipient/sender-to-recipient.component.js
@@ -135,7 +135,6 @@ export default function SenderToRecipient({
       <Arrow variant={variant} />
       {recipientAddress ? (
         <RecipientWithAddress
-          className="justify-end"
           checksummedRecipientAddress={checksummedRecipientAddress}
           chainId={chainId}
         />


### PR DESCRIPTION
## **Description**

Fix petname styling issues in send confirmation from/to section where petnames display with incorrect blue color and centering alignment instead of matching hex address styling

### Changes

- Modify Name component CSS to ensure default state uses default text color for saved petnames
- Adjust sender-to-recipient styling to ensure consistent left-alignment for both hex addresses and petnames
- Update Name component to only apply blue color on hover state, not in default state
- Ensure margin and alignment consistency between petname and hex address displays

## **Changelog**

CHANGELOG entry: Fixed Fix petname styling issues in send confirmation from/to section where petnames display with incorrect blue color and centering alignment instead of matching hex address styling

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/40841

## **Manual testing steps**

1. [visual] Confirmation screen displays hex address with correct styling: passed
2. [visual] Petname styling verification with saved address: failed
3. [visual] Proof and layout evidence: failed
4. [visual] Target state evidence: failed

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

> Browser validation failed to demonstrate the petname styling bug due to inability to create a saved petname through the UI. However, successfully captured the target confirmation screen state showing proper hex address styling that petnames should match after the fix. Target browser state was not reached: Could not create a saved petname through the MetaMask UI during testing session. The address book/contacts functionality was not accessible through the settings menu, and clicking on addresses in the confirmation screen did not provide petname creation options. Without a saved petname, cannot demonstrate the blue color and centering styling bugs described in the issue. Visual validation did not include a passing visual check with both focused proof and layout context for the changed UI.

**[visual] Confirmation screen displays hex address with correct styling**: Hex address 0x5cFE73b6021E818B776b421B1c4Db2474086a7e1 displays in the To section with default black text color and proper left alignment, demonstrating the expected styling that petnames should match after the fix

**[visual] Petname styling verification with saved address**: N/A

<details><summary>Agent metadata</summary>

- Work item: `work_2ccda390`
- Kind: `bug_fix`
- Confidence: high
- Review status: approve
- Risk: low

</details>

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.