### PR TITLE
fix: [Bug]: Settings - `Proposed nicknames` appears in settings search, but it's not present in Settings

### DIFF
--- a/ui/helpers/constants/settings.js
+++ b/ui/helpers/constants/settings.js
@@ -16,6 +16,7 @@ import {
   SECURITY_PASSWORD_CHANGE_ROUTE,
   TRANSACTION_SHIELD_ROUTE,
   TRANSACTION_SHIELD_CLAIM_ROUTES,
+  PRIVACY_ROUTE,
 } from './routes';
 
 /**
@@ -330,12 +331,12 @@ const SETTINGS_CONSTANTS = [
     route: `${SECURITY_ROUTE}#network-details-check`,
     icon: 'fa fa-lock',
   },
-  // securityAndPrivacy settingsRefs[16]
+  // privacy settingsRefs[0]
   {
-    tabMessage: (t) => t('securityAndPrivacy'),
+    tabMessage: (t) => t('privacy'),
     sectionMessage: (t) => t('externalNameSourcesSetting'),
     descriptionMessage: (t) => t('externalNameSourcesSettingDescription'),
-    route: `${SECURITY_ROUTE}#proposed-nicknames`,
+    route: `${PRIVACY_ROUTE}#proposed-nicknames`,
     icon: 'fa fa-lock',
   },
   // securityAndPrivacy settingsRefs[17]

--- a/ui/helpers/utils/settings-search.test.js
+++ b/ui/helpers/utils/settings-search.test.js
@@ -146,6 +146,8 @@ const t = (key) => {
       return 'Enable "Add a new Bitcoin account (Beta)"';
     case 'backupAndSync':
       return 'Backup and Sync';
+    case 'privacy':
+      return 'Privacy';
     default:
       return '';
   }
@@ -183,7 +185,11 @@ describe('Settings Search Utils', () => {
     it('returns "Security & privacy" section count', () => {
       expect(
         getNumberOfSettingRoutesInTab(t, t('securityAndPrivacy')),
-      ).toStrictEqual(22);
+      ).toStrictEqual(21);
+    });
+
+    it('returns "Privacy" section count', () => {
+      expect(getNumberOfSettingRoutesInTab(t, t('privacy'))).toStrictEqual(1);
     });
 
     it('returns "Network" section count', () => {


### PR DESCRIPTION
## **Description**

Update settings search configuration to point to correct location for 'Proposed nicknames' feature

### Changes

- {"file":"ui/helpers/constants/settings.js","description":"Update the proposed nicknames search entry to point to the Privacy tab in Settings v2","changes":["Import PRIVACY_ROUTE constant from routes","Update line 338 route from `${SECURITY_ROUTE}#proposed-nicknames` to `${PRIVACY_ROUTE}#proposed-nicknames`","Update tabMessage from 'securityAndPrivacy' to the appropriate Privacy tab message function"]}

## **Changelog**

CHANGELOG entry: Fixed Update settings search configuration to point to correct location for 'Proposed nicknames' feature

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/40656

## **Manual testing steps**

1. bash -c 'set -o pipefail; source ~/.nvm/nvm.sh && nvm use 2>/dev/null; if [ -n "$CHANGED_TS_FILES" ]; then npx tsc --noEmit $CHANGED_TS_FILES 2>&1 | head -50; else echo "No TS files changed, skipping tsc"; fi': passed
2. bash -c 'set -o pipefail; source ~/.nvm/nvm.sh && nvm use 2>/dev/null; yarn lint:changed 2>&1 | head -100': passed
3. bash -c 'set -o pipefail; source ~/.nvm/nvm.sh && nvm use 2>/dev/null; yarn jest --changedSince=HEAD~1 --passWithNoTests 2>&1 | tail -30': passed
4. [visual-setup] yarn build:test: failed

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

> Visual validation setup failed before the MCP browser session could start

<!-- [screenshots/recordings] -->

<details><summary>Agent metadata</summary>

- Work item: `work_d3f6f1cb`
- Kind: `bug_fix`
- Confidence: high
- Review status: approve
- Risk: low

</details>

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.