### PR TITLE
fix(zero-warnings): tighten eslint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -397,10 +397,10 @@ module.exports = {
         'react/default-props-match-prop-types': 'warn',
         'react/jsx-no-duplicate-props': 'warn',
         'react/display-name': 'off',
-        'react/no-unescaped-entities': 'warn',
+        'react/no-unescaped-entities': 'error',
         'react/prop-types': 'off',
         'react/no-children-prop': 'off',
-        'react/jsx-key': 'warn', // TODO - increase this into 'error' level
+        'react/jsx-key': 'error',
         'react-hooks/rules-of-hooks': 'error',
         'react-hooks/exhaustive-deps': [
           'warn',


### PR DESCRIPTION
## **Description**

As a result of #40787, #40791, and #40821, we can now tighten two warnings into errors:

```
'react/no-unescaped-entities': 'error',
'react/jsx-key': 'error',
```

## **Changelog**

CHANGELOG entry: null

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**
[skip-e2e]-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low runtime risk, but this can cause CI/build failures by turning previously-allowed `react/no-unescaped-entities` and missing `react/jsx-key` warnings into errors for `ui/**/*.ts(x)` files.
> 
> **Overview**
> Tightens the TypeScript React ESLint override by promoting `react/no-unescaped-entities` and `react/jsx-key` from *warning* to **error**, making these issues fail linting for `ui/**/*.ts` and `ui/**/*.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ceb3d15b93281e79b41b0e3203c1e41351bce483. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->