### PR TITLE
fix(zero-warnings): eliminate every react/no-unused-prop-types and storybook/no-redundant-story-name

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -389,7 +389,7 @@ module.exports = {
       plugins: ['react', 'react-compiler'],
       rules: {
         'react-compiler/react-compiler': 'error',
-        'react/no-unused-prop-types': 'warn',
+        'react/no-unused-prop-types': 'error',
         'react/no-unused-state': 'warn',
         'react/jsx-boolean-value': 'off',
         'react/jsx-curly-brace-presence': 'off',
@@ -623,6 +623,7 @@ module.exports = {
         ],
         // Static hex values are only discouraged in application code, using them in stories is OK.
         '@metamask/design-tokens/color-no-hex': 'off',
+        'storybook/no-redundant-story-name': 'error',
       },
     },
     /**

--- a/ui/components/app/wallet-overview/coin-buttons.tsx
+++ b/ui/components/app/wallet-overview/coin-buttons.tsx
@@ -85,10 +85,8 @@ type CoinButtonsProps = {
   isSwapsChain: boolean;
   isSigningEnabled: boolean;
   /** @deprecated use bridge chain constants instead*/
-  isBridgeChain: boolean;
   isBuyableChain: boolean;
   classPrefix?: string;
-  iconButtonClassName?: string;
   /** When true, disables the send button for non-EVM chains (used on asset page) */
   disableSendForNonEvm?: boolean;
 };

--- a/ui/components/app/wallet-overview/coin-buttons.tsx
+++ b/ui/components/app/wallet-overview/coin-buttons.tsx
@@ -84,7 +84,6 @@ type CoinButtonsProps = {
   trackingLocation: string;
   isSwapsChain: boolean;
   isSigningEnabled: boolean;
-  /** @deprecated use bridge chain constants instead*/
   isBuyableChain: boolean;
   classPrefix?: string;
   /** When true, disables the send button for non-EVM chains (used on asset page) */

--- a/ui/components/multichain-accounts/permissions/permission-review-page/multichain-review-permissions-page.tsx
+++ b/ui/components/multichain-accounts/permissions/permission-review-page/multichain-review-permissions-page.tsx
@@ -382,8 +382,6 @@ export const MultichainReviewPermissions = () => {
 
           {showDisconnectAllModal ? (
             <DisconnectAllModal
-              type={DisconnectType.Account}
-              hostname={activeTabOrigin}
               onClose={() => setShowDisconnectAllModal(false)}
               onClick={() => {
                 setShowDisconnectAllModal(false);

--- a/ui/components/multichain-accounts/permissions/permission-review-page/multichain-review-permissions-page.tsx
+++ b/ui/components/multichain-accounts/permissions/permission-review-page/multichain-review-permissions-page.tsx
@@ -45,10 +45,7 @@ import { NoConnectionContent } from '../../../multichain/pages/connections/compo
 import { Content, Footer, Page } from '../../../multichain/pages/page';
 import { SubjectsType } from '../../../multichain/pages/connections/components/connections.types';
 import { CONNECT_ROUTE } from '../../../../helpers/constants/routes';
-import {
-  DisconnectAllModal,
-  DisconnectType,
-} from '../../../multichain/disconnect-all-modal/disconnect-all-modal';
+import { DisconnectAllModal } from '../../../multichain/disconnect-all-modal/disconnect-all-modal';
 import { DisconnectPermissionsModal } from '../../../multichain/disconnect-permissions-modal/disconnect-permissions-modal';
 import { PermissionsHeader } from '../../../multichain/permissions-header/permissions-header';
 import { EvmAndMultichainNetworkConfigurationsWithCaipChainId } from '../../../../selectors/selectors.types';

--- a/ui/components/multichain/disconnect-all-modal/disconnect-all-modal.stories.tsx
+++ b/ui/components/multichain/disconnect-all-modal/disconnect-all-modal.stories.tsx
@@ -1,19 +1,14 @@
 import React from 'react';
 import { DisconnectAllModal } from '.';
-import { DisconnectType } from './disconnect-all-modal';
 
 export default {
   title: 'Components/Multichain/DisconnectAllModal',
   component: DisconnectAllModal,
   argTypes: {
-    type: { control: 'string' },
-    hostname: { control: 'string' },
     onClose: { action: 'onClose' },
-    onClick: { action: 'onClose' },
+    onClick: { action: 'onClick' },
   },
   args: {
-    type: DisconnectType.Account,
-    hostname: 'app.metamask.io',
     onClick: () => undefined,
     onClose: () => undefined,
   },

--- a/ui/components/multichain/disconnect-all-modal/disconnect-all-modal.test.tsx
+++ b/ui/components/multichain/disconnect-all-modal/disconnect-all-modal.test.tsx
@@ -1,15 +1,12 @@
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 
-import { DisconnectType } from './disconnect-all-modal';
 import { DisconnectAllModal } from '.';
 
 describe('DisconnectAllModal', () => {
   const onClick = jest.fn();
 
   const args = {
-    type: DisconnectType.Account,
-    hostname: 'app.metamask.io',
     onClose: jest.fn(),
     onClick,
   };

--- a/ui/components/multichain/disconnect-all-modal/disconnect-all-modal.tsx
+++ b/ui/components/multichain/disconnect-all-modal/disconnect-all-modal.tsx
@@ -22,8 +22,6 @@ export const DisconnectAllModal = ({
   onClick,
   onClose,
 }: {
-  type: DisconnectType;
-  hostname: string;
   onClick: () => void;
   onClose: () => void;
 }) => {

--- a/ui/components/multichain/disconnect-all-modal/disconnect-all-modal.tsx
+++ b/ui/components/multichain/disconnect-all-modal/disconnect-all-modal.tsx
@@ -12,12 +12,6 @@ import {
 } from '../../component-library';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 
-// Maps to localizations for title and text
-export enum DisconnectType {
-  Account = 'disconnectAllAccountsText',
-  Snap = 'disconnectAllSnapsText',
-}
-
 export const DisconnectAllModal = ({
   onClick,
   onClose,

--- a/ui/components/multichain/pages/permissions-page/connection-list-item.stories.js
+++ b/ui/components/multichain/pages/permissions-page/connection-list-item.stories.js
@@ -63,7 +63,6 @@ const Template = (args) => (
 );
 
 export const Default = Template.bind({});
-Default.storyName = 'Default';
 
 export const Chaos = Template.bind({});
 Chaos.args = {

--- a/ui/components/multichain/pages/review-permissions-page/review-permissions-page.tsx
+++ b/ui/components/multichain/pages/review-permissions-page/review-permissions-page.tsx
@@ -49,10 +49,7 @@ import { NoConnectionContent } from '../connections/components/no-connection';
 import { Content, Footer, Page } from '../page';
 import { SubjectsType } from '../connections/components/connections.types';
 import { CONNECT_ROUTE } from '../../../../helpers/constants/routes';
-import {
-  DisconnectAllModal,
-  DisconnectType,
-} from '../../disconnect-all-modal/disconnect-all-modal';
+import { DisconnectAllModal } from '../../disconnect-all-modal/disconnect-all-modal';
 import { PermissionsHeader } from '../../permissions-header/permissions-header';
 import {
   EvmAndMultichainNetworkConfigurationsWithCaipChainId,

--- a/ui/components/multichain/pages/review-permissions-page/review-permissions-page.tsx
+++ b/ui/components/multichain/pages/review-permissions-page/review-permissions-page.tsx
@@ -233,8 +233,6 @@ export const ReviewPermissions = () => {
           )}
           {showDisconnectAllModal ? (
             <DisconnectAllModal
-              type={DisconnectType.Account}
-              hostname={activeTabOrigin}
               onClose={() => setShowDisconnectAllModal(false)}
               onClick={() => {
                 trace({ name: TraceName.DisconnectAllModal });

--- a/ui/pages/confirmations/confirmation/templates/remove-snap-account.js
+++ b/ui/pages/confirmations/confirmation/templates/remove-snap-account.js
@@ -33,7 +33,6 @@ function getValues(pendingApproval, t, actions, _navigate, _data, contexts) {
         key: 'remove-snap-account',
         props: {
           snapId,
-          snapName,
           publicAddress,
           onCancel,
         },

--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -92,6 +92,8 @@ export default class Home extends PureComponent {
   static propTypes = {
     navigate: PropTypes.func,
     forgottenPassword: PropTypes.bool,
+    isNotification: PropTypes.bool,
+    hasApprovalFlows: PropTypes.bool,
     setConnectedStatusPopoverHasBeenShown: PropTypes.func,
     shouldShowSeedPhraseReminder: PropTypes.bool.isRequired,
     isPopup: PropTypes.bool,
@@ -104,8 +106,6 @@ export default class Home extends PureComponent {
     showMultiRpcModal: PropTypes.bool.isRequired,
     showUpdateModal: PropTypes.bool.isRequired,
     newNetworkAddedConfigurationId: PropTypes.string,
-    // This prop is used in the `shouldCloseNotificationPopup` function
-    // eslint-disable-next-line react/no-unused-prop-types
     totalUnapprovedCount: PropTypes.number.isRequired,
     participateInMetaMetrics: PropTypes.bool.isRequired,
     setDataCollectionForMarketing: PropTypes.func.isRequired,
@@ -123,11 +123,7 @@ export default class Home extends PureComponent {
     setOutdatedBrowserWarningLastShown: PropTypes.func.isRequired,
     newNetworkAddedName: PropTypes.string,
     editedNetwork: PropTypes.object,
-    // This prop is used in the `shouldCloseNotificationPopup` function
-    // eslint-disable-next-line react/no-unused-prop-types
     isSigningQRHardwareTransaction: PropTypes.bool,
-    // This prop is used in the `shouldCloseNotificationPopup` function
-    // eslint-disable-next-line react/no-unused-prop-types
     isHardwareWalletErrorModalVisible: PropTypes.bool,
     newNftAddedMessage: PropTypes.string,
     setNewNftAddedMessage: PropTypes.func.isRequired,
@@ -174,8 +170,23 @@ export default class Home extends PureComponent {
   constructor(props) {
     super(props);
 
-    const { attemptCloseNotificationPopup } = this.props;
-    if (shouldCloseNotificationPopup(props)) {
+    const {
+      attemptCloseNotificationPopup,
+      isNotification,
+      totalUnapprovedCount,
+      hasApprovalFlows,
+      isSigningQRHardwareTransaction,
+      isHardwareWalletErrorModalVisible,
+    } = this.props;
+    if (
+      shouldCloseNotificationPopup({
+        isNotification,
+        totalUnapprovedCount,
+        hasApprovalFlows,
+        isSigningQRHardwareTransaction,
+        isHardwareWalletErrorModalVisible,
+      })
+    ) {
       this.state.notificationClosing = true;
       attemptCloseNotificationPopup();
     }
@@ -234,8 +245,20 @@ export default class Home extends PureComponent {
     }
   }
 
-  static getDerivedStateFromProps(props) {
-    const shouldClose = shouldCloseNotificationPopup(props);
+  static getDerivedStateFromProps({
+    isNotification,
+    totalUnapprovedCount,
+    hasApprovalFlows,
+    isSigningQRHardwareTransaction,
+    isHardwareWalletErrorModalVisible,
+  }) {
+    const shouldClose = shouldCloseNotificationPopup({
+      isNotification,
+      totalUnapprovedCount,
+      hasApprovalFlows,
+      isSigningQRHardwareTransaction,
+      isHardwareWalletErrorModalVisible,
+    });
     if (shouldClose) {
       return { notificationClosing: true };
     }

--- a/ui/pages/notifications/notifications-list.tsx
+++ b/ui/pages/notifications/notifications-list.tsx
@@ -20,9 +20,15 @@ import { NotificationsListReadAllButton } from './notifications-list-read-all-bu
 export type NotificationsListProps = {
   activeTab: TAB_KEYS;
   notifications: INotification[];
+  notificationsCount: number;
   isLoading: boolean;
   isError: boolean;
 };
+
+type NotificationsListStatesProps = Omit<
+  NotificationsListProps,
+  'notificationsCount'
+>;
 
 // NOTE - Tab filters could change once we support more notifications.
 // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
@@ -84,7 +90,7 @@ const NotificationsListStates = ({
   notifications,
   isLoading,
   isError,
-}: NotificationsListProps) => {
+}: NotificationsListStatesProps) => {
   const isMetamaskNotificationsEnabled = useSelector(
     selectIsMetamaskNotificationsEnabled,
   );

--- a/ui/pages/notifications/notifications-list.tsx
+++ b/ui/pages/notifications/notifications-list.tsx
@@ -22,7 +22,6 @@ export type NotificationsListProps = {
   notifications: INotification[];
   isLoading: boolean;
   isError: boolean;
-  notificationsCount: number;
 };
 
 // NOTE - Tab filters could change once we support more notifications.

--- a/ui/pages/remove-snap-account/remove-snap-account.stories.tsx
+++ b/ui/pages/remove-snap-account/remove-snap-account.stories.tsx
@@ -15,7 +15,6 @@ export default {
 export const DefaultStory = () => (
   <RemoveSnapAccount
     snapId="npm:@metamask/test-snap-bip44"
-    snapName="BIP-44"
     publicAddress="0xde939393DDe455081fFb3Dfd027E189919F04BD0"
     onCancel={() => {}}
   />

--- a/ui/pages/remove-snap-account/remove-snap-account.test.tsx
+++ b/ui/pages/remove-snap-account/remove-snap-account.test.tsx
@@ -8,7 +8,6 @@ import RemoveSnapAccount from './remove-snap-account';
 
 const defaultProps = {
   snapId: 'npm:@mock-snap',
-  snapName: 'mock-name',
   publicAddress: '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
   onCancel: () => jest.fn(),
 };

--- a/ui/pages/remove-snap-account/remove-snap-account.tsx
+++ b/ui/pages/remove-snap-account/remove-snap-account.tsx
@@ -25,7 +25,6 @@ import { SnapAccountCard } from './snap-account-card';
 
 export type RemoveSnapAccountProps = {
   snapId: string;
-  snapName: string;
   publicAddress: string;
   onCancel: () => void;
 };


### PR DESCRIPTION
## **Description**

I have been doing most of these `fix(zero-warnings)` PRs with Copilot, but this one was just faster to do by hand.

I have eliminated every `react/no-unused-prop-types` and `storybook/no-redundant-story-name`, then tightened their rules into errors.

`ui/pages/home/home.component.js` had special treatment to remove the 3 instances of `// eslint-disable-next-line react/no-unused-prop-types`

## **Changelog**

CHANGELOG entry: null

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**
[skip-e2e]-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily lint/config and type/prop cleanup; minimal runtime impact aside from small refactors to `Home` notification-close logic and `DisconnectAllModal` props that could break missed call sites.
> 
> **Overview**
> Tightens linting by promoting `react/no-unused-prop-types` (TS React override) and `storybook/no-redundant-story-name` to **errors**, and removes the remaining violations across UI code and stories.
> 
> Simplifies a few component APIs/usages to eliminate unused props: `DisconnectAllModal` no longer accepts `type`/`hostname`, `RemoveSnapAccount` no longer takes `snapName`, and `CoinButtons` drops unused prop definitions. `Home` refactors `shouldCloseNotificationPopup` callers to pass only the needed props (removing inline eslint disables), and `NotificationsList` narrows props passed to its internal state renderer.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65e892b35b9069e6a843e2eb964d887e81625955. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->