### PR TITLE
fix: [Bug]: NFTs in Send flow overlapping

### DIFF
--- a/ui/pages/confirmations/components/UI/asset/asset.test.tsx
+++ b/ui/pages/confirmations/components/UI/asset/asset.test.tsx
@@ -200,4 +200,19 @@ describe('NFTAsset', () => {
 
     expect(getByText('Native SegWit')).toBeInTheDocument();
   });
+
+  it('renders NftDefaultImage when NFT has no image or collection image', () => {
+    mockUseNftImageUrl.mockReturnValue('');
+    const assetWithoutImages = {
+      ...mockNFTERC721Asset,
+      image: undefined,
+      collection: {
+        ...mockNFTERC721Asset.collection,
+        imageUrl: undefined,
+      },
+    };
+    const { getByTestId } = render(<Asset asset={assetWithoutImages} />);
+
+    expect(getByTestId('nft-default-image')).toBeInTheDocument();
+  });
 });

--- a/ui/pages/confirmations/components/UI/asset/asset.tsx
+++ b/ui/pages/confirmations/components/UI/asset/asset.tsx
@@ -28,6 +28,7 @@ import { accountTypeLabel } from '../../../constants/network';
 import { useFormatters } from '../../../../../hooks/useFormatters';
 import { AccountTypeLabel } from '../account-type-label';
 import { getAvatarTokenSrc } from '../../../../../components/app/assets/asset-list/cells/asset-cell-badge';
+import NftDefaultImage from '../../../../../components/app/assets/nfts/nft-default-image/nft-default-image';
 
 type AssetProps = {
   asset: AssetType;
@@ -90,7 +91,20 @@ const NftAsset = ({ asset, onClick, isSelected }: AssetProps) => {
                 objectFit: 'cover',
               }}
             />
-          ) : null}
+          ) : (
+            <Box
+              style={{
+                width: 32,
+                height: 32,
+                position: 'relative',
+              }}
+            >
+              <NftDefaultImage
+                className="nft-asset__default-image"
+                clickable={false}
+              />
+            </Box>
+          )}
         </BadgeWrapper>
       </Box>
       <Box


### PR DESCRIPTION
## **Description**

Fix NFT overlap in send flow when images are missing

### Changes

- {"file":"ui/pages/confirmations/components/UI/asset/asset.tsx","change":"Import NftDefaultImage component and use it as fallback when NFT has no image or collection image"}
- {"file":"ui/pages/confirmations/components/UI/asset/asset.tsx","change":"Modify the conditional rendering in NftAsset component to always show either the actual image or NftDefaultImage placeholder"}

## **Changelog**

CHANGELOG entry: Fixed Fix NFT overlap in send flow when images are missing

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/40669

## **Manual testing steps**

1. set -o pipefail; source ~/.nvm/nvm.sh && nvm use 2>/dev/null; yarn lint:changed 2>&1 | head -100: passed
2. set -o pipefail; source ~/.nvm/nvm.sh && nvm use 2>/dev/null; node -e "const fs = require('node:fs'); const path = require('node:path'); const { spawnSync } = require('node:child_process'); const changed = (process.env.CHANGED_TS_FILES || '').split(/\s+/).filter(Boolean); if (changed.length === 0) { console.log('No testable files changed'); process.exit(0); } const tests = new Set(); for (const file of changed) { if (/\.(test|spec)\.(ts|tsx|js|jsx|mjs|cjs)$/u.test(file)) { tests.add(file); continue; } const parsed = path.parse(file); for (const ext of ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs']) { for (const suffix of ['.test', '.spec']) { const candidate = path.join(parsed.dir, parsed.name + suffix + ext); if (fs.existsSync(candidate)) tests.add(candidate); } } } const testFiles = [...tests]; if (testFiles.length === 0) { console.log('No related Jest tests found for changed files'); process.exit(0); } const result = spawnSync(process.execPath, ['--expose-gc', './node_modules/jest/bin/jest.js', ...testFiles, '--passWithNoTests', '--watchman=false'], { stdio: 'inherit' }); process.exit(result.status ?? 1);" 2>&1 | tail -50: passed
3. [visual] Browser launch and MetaMask extension initialization: failed
4. [visual] Screenshot evidence: failed
5. [visual] Target state evidence: failed

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

> Browser validation could not be completed due to MCP connection failure Visual validation did not produce any real screenshot artifacts from mm_screenshot. Target browser state was not reached: MCP connection failed - 'Not connected' error prevents browser launch and interaction. Unable to establish MetaMask browser session for visual validation.

**[visual] Browser launch and MetaMask extension initialization**: Could not launch browser due to MCP connection failure

<details><summary>Agent metadata</summary>

- Work item: `work_a4b1603c`
- Kind: `bug_fix`
- Confidence: high
- Review status: approve
- Review type: auto
- Risk: low

### Review findings

- ui/pages/confirmations/components/UI/asset/asset.tsx:97 - Inline styles used instead of CSS classes

</details>

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.