### PR TITLE
fix: [Bug]: NFTs in Send flow overlapping

### DIFF
--- a/ui/pages/confirmations/components/UI/asset/asset.test.tsx
+++ b/ui/pages/confirmations/components/UI/asset/asset.test.tsx
@@ -200,4 +200,27 @@ describe('NFTAsset', () => {
 
     expect(getByText('Native SegWit')).toBeInTheDocument();
   });
+
+  it('renders placeholder icon when NFT has no image or collection image', () => {
+    const assetWithoutAnyImage = {
+      ...mockNFTERC721Asset,
+      image: undefined,
+      collection: {
+        ...mockNFTERC721Asset.collection,
+        imageUrl: undefined,
+      },
+    };
+    mockUseNftImageUrl.mockReturnValue('');
+
+    const { getByTestId, queryByAltText } = render(
+      <Asset asset={assetWithoutAnyImage} />,
+    );
+
+    expect(getByTestId('nft-asset')).toBeInTheDocument();
+    expect(queryByAltText('Test NFT')).not.toBeInTheDocument();
+    // Verify placeholder icon is rendered
+    const nftAsset = getByTestId('nft-asset');
+    const iconElement = nftAsset.querySelector('.mm-icon');
+    expect(iconElement).toBeInTheDocument();
+  });
 });

--- a/ui/pages/confirmations/components/UI/asset/asset.tsx
+++ b/ui/pages/confirmations/components/UI/asset/asset.tsx
@@ -9,6 +9,9 @@ import {
   Box,
   Text,
   AvatarTokenSize,
+  Icon,
+  IconName,
+  IconSize,
 } from '../../../../../components/component-library';
 import {
   AlignItems,
@@ -17,6 +20,8 @@ import {
   FlexDirection,
   TextColor,
   TextVariant,
+  JustifyContent,
+  IconColor,
 } from '../../../../../helpers/constants/design-system';
 import {
   type Asset as AssetType,
@@ -90,7 +95,25 @@ const NftAsset = ({ asset, onClick, isSelected }: AssetProps) => {
                 objectFit: 'cover',
               }}
             />
-          ) : null}
+          ) : (
+            <Box
+              display={Display.Flex}
+              alignItems={AlignItems.center}
+              justifyContent={JustifyContent.center}
+              backgroundColor={BackgroundColor.backgroundAlternative}
+              style={{
+                width: 32,
+                height: 32,
+                borderRadius: 8,
+              }}
+            >
+              <Icon
+                name={IconName.Image}
+                size={IconSize.Sm}
+                color={IconColor.iconMuted}
+              />
+            </Box>
+          )}
         </BadgeWrapper>
       </Box>
       <Box


### PR DESCRIPTION
## **Description**

Fix NFT overlap in send flow when images are missing

### Changes

- Add Icon import to the asset component
- Replace null rendering with a placeholder Box containing an Icon when NFT image is missing
- Ensure the placeholder maintains the same dimensions (32x32) as actual images
- Update tests to verify proper placeholder rendering

## **Changelog**

CHANGELOG entry: Fixed Fix NFT overlap in send flow when images are missing

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/40669

## **Manual testing steps**

1. set -o pipefail; source ~/.nvm/nvm.sh && nvm use 2>/dev/null; yarn lint:changed 2>&1 | head -100: passed
2. set -o pipefail; source ~/.nvm/nvm.sh && nvm use 2>/dev/null; node -e "const fs = require('node:fs'); const path = require('node:path'); const { spawnSync } = require('node:child_process'); const changed = (process.env.CHANGED_TS_FILES || '').split(/\s+/).filter(Boolean); if (changed.length === 0) { console.log('No testable files changed'); process.exit(0); } const tests = new Set(); for (const file of changed) { if (/\.(test|spec)\.(ts|tsx|js|jsx|mjs|cjs)$/u.test(file)) { tests.add(file); continue; } const parsed = path.parse(file); for (const ext of ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs']) { for (const suffix of ['.test', '.spec']) { const candidate = path.join(parsed.dir, parsed.name + suffix + ext); if (fs.existsSync(candidate)) tests.add(candidate); } } } const testFiles = [...tests]; if (testFiles.length === 0) { console.log('No related Jest tests found for changed files'); process.exit(0); } const result = spawnSync(process.execPath, ['--expose-gc', './node_modules/jest/bin/jest.js', ...testFiles, '--passWithNoTests', '--watchman=false'], { stdio: 'inherit' }); process.exit(result.status ?? 1);" 2>&1 | tail -50: passed
3. [visual] Browser launch and wallet unlock: passed
4. [visual] NFT tab navigation: passed
5. [visual] Multiple NFTs with missing images in send flow: failed
6. [visual] Proof and layout evidence: failed
7. [visual] Target state evidence: failed

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

> Failed to verify NFT overlap fix - only one NFT visible in send flow instead of multiple NFTs required to demonstrate fix Target browser state was not reached: Only 1 NFT visible in send flow (Test Dapp NFTs #1) instead of multiple NFTs required to verify overlap fix. Cannot verify if placeholder icon prevents overlap without multiple NFTs present Visual validation did not include a passing visual check with both focused proof and layout context for the changed UI.

**[visual] Browser launch and wallet unlock**: Successfully launched browser and unlocked wallet

**[visual] NFT tab navigation**: NFT tab loaded showing NFT collection

**[visual] Multiple NFTs with missing images in send flow**: Only 1 NFT visible in send flow instead of multiple NFTs required to demonstrate the overlap fix

<details><summary>Agent metadata</summary>

- Work item: `work_b57dd6b4`
- Kind: `bug_fix`
- Confidence: high
- Review status: approve
- Review type: manual
- Risk: low

</details>

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.