### PR TITLE
fix: flaky test `Segment User Traits sends identify event when user opts in both metrics and data in privacy settings after opting out during onboarding`

### DIFF
--- a/test/e2e/page-objects/pages/settings/privacy-settings.ts
+++ b/test/e2e/page-objects/pages/settings/privacy-settings.ts
@@ -278,7 +278,7 @@ class PrivacySettings {
     console.log(
       'Opt out data collection for marketing on privacy settings page',
     );
-    await this.toggleDataCollectionForMarketing();
+    await this.toggleDataCollectionForMarketing({ targetState: 'off' });
     await this.driver.waitForSelector(this.dataCollectionWarningMessage);
     await this.driver.clickElementAndWaitToDisappear(
       this.dataCollectionWarningAckButton,
@@ -360,18 +360,28 @@ class PrivacySettings {
     await this.driver.clickElement(this.autoDetectToken);
   }
 
-  async toggleParticipateInMetaMetrics(): Promise<void> {
+  async toggleParticipateInMetaMetrics({
+    targetState = 'on',
+  }: { targetState?: 'on' | 'off' } = {}): Promise<void> {
     console.log(
       'Toggle participate in meta metrics in Security and Privacy settings page',
     );
     await this.driver.clickElement(this.participateInMetaMetricsToggle);
+    await this.driver.waitForSelector(
+      `${this.participateInMetaMetricsToggle}.toggle-button--${targetState}`,
+    );
   }
 
-  async toggleDataCollectionForMarketing(): Promise<void> {
+  async toggleDataCollectionForMarketing({
+    targetState = 'on',
+  }: { targetState?: 'on' | 'off' } = {}): Promise<void> {
     console.log(
       'Toggle data collection for marketing in Security and Privacy settings page',
     );
     await this.driver.clickElement(this.dataCollectionForMarketingToggle);
+    await this.driver.waitForSelector(
+      `${this.dataCollectionForMarketingToggle}.toggle-button--${targetState}`,
+    );
   }
 }
 

--- a/test/e2e/tests/metrics/metametrics-persistence.spec.ts
+++ b/test/e2e/tests/metrics/metametrics-persistence.spec.ts
@@ -33,7 +33,9 @@ describe('MetaMetrics ID persistence', function () {
         await settingsPage.goToPrivacySettings();
         const privacySettings = new PrivacySettings(driver);
         await privacySettings.checkPageIsLoaded();
-        await privacySettings.toggleParticipateInMetaMetrics();
+        await privacySettings.toggleParticipateInMetaMetrics({
+          targetState: 'off',
+        });
 
         // wait for state to update
         await driver.delay(500);

--- a/test/e2e/tests/metrics/segment-user-traits.spec.ts
+++ b/test/e2e/tests/metrics/segment-user-traits.spec.ts
@@ -170,6 +170,7 @@ describe('Segment User Traits', function () {
         await driver.wait(async () => {
           try {
             events = await getEventPayloads(driver, mockedEndpoints, false);
+            console.log(events);
           } catch {
             return false;
           }

--- a/test/e2e/tests/metrics/segment-user-traits.spec.ts
+++ b/test/e2e/tests/metrics/segment-user-traits.spec.ts
@@ -170,7 +170,6 @@ describe('Segment User Traits', function () {
         await driver.wait(async () => {
           try {
             events = await getEventPayloads(driver, mockedEndpoints, false);
-            console.log(events);
           } catch {
             return false;
           }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
In this spec we are first enabling metrics and then enabling marketing. There is a race condition where right after enabling metrics, if we enable marketing but the metrics is not yet enabled, then marketing cannot be enabled (as one feature depends on the other).

After clicking the MetaMetrics toggle, the Redux state update and React re-render need to complete before the marketing toggle loses its toggle-button--disabled class and becomes clickable. When the second click fires before the re-render, it hits a disabled toggle and is silently ignored. That's why has_marketing_consent stays false forever and the 30s poll times out.

The fix is to wait for the marketing toggle to become enabled after toggling MetaMetrics


<img width="1152" height="836" alt="image" src="https://github.com/user-attachments/assets/c866cb17-db65-4308-a735-8bbbc0244e0d" />

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40914?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to E2E page objects/tests and only add deterministic waits after toggle clicks to reduce flakiness from UI re-render timing.
> 
> **Overview**
> Improves E2E stability around Privacy Settings consent toggles by making `toggleParticipateInMetaMetrics` and `toggleDataCollectionForMarketing` accept an optional `targetState` and *wait for the toggle’s DOM class to reflect the expected on/off state* after clicking.
> 
> Updates tests and helpers to use `targetState: 'off'` when opting out (e.g., `metametrics-persistence.spec.ts`, `optOutDataCollectionForMarketing`), reducing race conditions where a follow-up click could occur before the UI enables/updates the dependent toggle.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e3ee84b41c7ff00ffa9548991455fb51b76b9cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->