### PR TITLE
chore: update state logs error toast title and description

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -8141,7 +8141,7 @@
     "message": "How to recover your Secret Recovery Phrase"
   },
   "stateLogError": {
-    "message": "Error in retrieving state logs."
+    "message": "Error in retrieving state logs, please try again later."
   },
   "stateLogFileName": {
     "message": "MetaMask state logs"
@@ -8985,6 +8985,9 @@
   "unableToConnectTo": {
     "message": "Unable to connect to $1.",
     "description": "Message shown when network connection fails. $1 is the network name."
+  },
+  "unableToDownload": {
+    "message": "Unable to download"
   },
   "unapproved": {
     "message": "Unapproved"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -8141,7 +8141,7 @@
     "message": "How to recover your Secret Recovery Phrase"
   },
   "stateLogError": {
-    "message": "Error in retrieving state logs."
+    "message": "Error in retrieving state logs, please try again later."
   },
   "stateLogFileName": {
     "message": "MetaMask state logs"
@@ -8985,6 +8985,9 @@
   "unableToConnectTo": {
     "message": "Unable to connect to $1.",
     "description": "Message shown when network connection fails. $1 is the network name."
+  },
+  "unableToDownload": {
+    "message": "Unable to download"
   },
   "unapproved": {
     "message": "Unapproved"

--- a/ui/pages/settings-v2/privacy-tab/download-state-logs-item.tsx
+++ b/ui/pages/settings-v2/privacy-tab/download-state-logs-item.tsx
@@ -34,9 +34,10 @@ export const DownloadStateLogsItem = () => {
         <ToastContainer>
           <Toast
             startAdornment={
-              <Icon name={IconName.Danger} color={IconColor.ErrorDefault} />
+              <Icon name={IconName.Warning} color={IconColor.WarningDefault} />
             }
-            text={t('stateLogError')}
+            text={t('unableToDownload')}
+            description={t('stateLogError')}
             onClose={() => setShowErrorToast(false)}
             borderRadius={BorderRadius.LG}
             textClassName="text-base"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Updates Settings V2 State logs toast to latest design:

<img width="466" height="821" alt="image" src="https://github.com/user-attachments/assets/9481edef-7d64-40f2-b80a-29e47e8efcd2" />


## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/i18n tweak: adjusts toast icon and strings shown when state log download fails, with no logic or data handling changes.
> 
> **Overview**
> Updates the Settings v2 state logs download failure toast to match the latest design by switching to a warning icon and splitting the messaging into a new title (`unableToDownload`) plus a more descriptive `stateLogError` message.
> 
> Adds the `unableToDownload` i18n key and updates the `stateLogError` copy in both `en` and `en_GB` locales.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b5b0a7e30787020536ef1b98281e050a3a4f8ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->