### PR TITLE
chore: refactor settings v2 select items to use <Link /> component

### DIFF
--- a/ui/pages/settings-v2/assets-tab/__snapshots__/assets-tab.test.tsx.snap
+++ b/ui/pages/settings-v2/assets-tab/__snapshots__/assets-tab.test.tsx.snap
@@ -21,12 +21,12 @@ exports[`Assets Tab snapshot matches snapshot 1`] = `
         >
           USD
         </p>
-        <button
-          aria-label="Select Local currency"
-          class="inline-flex items-center justify-center p-0 h-6 w-6 rounded-lg bg-transparent hover:bg-hover active:bg-pressed text-icon-alternative"
+        <a
+          class="flex ml-1"
+          href="/settings-v2/assets/currency"
         >
           <svg
-            class="inline-block w-5 h-5 text-inherit"
+            class="inline-block w-4 h-4 text-icon-alternative"
             fill="currentColor"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -35,7 +35,7 @@ exports[`Assets Tab snapshot matches snapshot 1`] = `
               d="m8.887 22-1.775-1.775L15.337 12 7.112 3.775 8.887 2l10 10z"
             />
           </svg>
-        </button>
+        </a>
       </div>
     </div>
     <div

--- a/ui/pages/settings-v2/assets-tab/local-currency-item.test.tsx
+++ b/ui/pages/settings-v2/assets-tab/local-currency-item.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
@@ -8,12 +8,6 @@ import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate
 import { setBackgroundConnection } from '../../../store/background-connection';
 import { CURRENCY_ROUTE } from '../../../helpers/constants/routes';
 import { LocalCurrencyItem } from './local-currency-item';
-
-const mockNavigate = jest.fn();
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useNavigate: () => mockNavigate,
-}));
 
 const backgroundConnectionMock = new Proxy(
   {},
@@ -42,19 +36,17 @@ describe('LocalCurrencyItem', () => {
     expect(screen.getByText('USD')).toBeInTheDocument();
   });
 
-  it('renders navigation button', () => {
+  it('renders navigation link', () => {
     renderWithProvider(<LocalCurrencyItem />, mockStore);
 
-    const button = screen.getByRole('button');
-    expect(button).toBeInTheDocument();
+    const link = screen.getByRole('link');
+    expect(link).toBeInTheDocument();
   });
 
-  it('navigates to currency page when clicked', () => {
+  it('links to currency page', () => {
     renderWithProvider(<LocalCurrencyItem />, mockStore);
 
-    const button = screen.getByRole('button');
-    fireEvent.click(button);
-
-    expect(mockNavigate).toHaveBeenCalledWith(CURRENCY_ROUTE);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', CURRENCY_ROUTE);
   });
 });

--- a/ui/pages/settings-v2/assets-tab/local-currency-item.tsx
+++ b/ui/pages/settings-v2/assets-tab/local-currency-item.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { useNavigate } from 'react-router-dom';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { getCurrentCurrency } from '../../../ducks/metamask/metamask';
 import { CURRENCY_ROUTE } from '../../../helpers/constants/routes';
@@ -8,18 +7,13 @@ import { SettingsSelectItem } from '../shared';
 
 export const LocalCurrencyItem = () => {
   const t = useI18nContext();
-  const navigate = useNavigate();
   const currentCurrency = useSelector(getCurrentCurrency);
-
-  const handleCurrencyPress = () => {
-    navigate(CURRENCY_ROUTE);
-  };
 
   return (
     <SettingsSelectItem
       label={t('localCurrency')}
+      to={CURRENCY_ROUTE}
       value={currentCurrency.toUpperCase()}
-      onPress={handleCurrencyPress}
     />
   );
 };

--- a/ui/pages/settings-v2/preferences-and-display-tab/__snapshots__/preferences-and-display-tab.test.tsx.snap
+++ b/ui/pages/settings-v2/preferences-and-display-tab/__snapshots__/preferences-and-display-tab.test.tsx.snap
@@ -21,12 +21,12 @@ exports[`PreferencesAndDisplayTab snapshot matches snapshot 1`] = `
         >
           System
         </p>
-        <button
-          aria-label="Select Theme"
-          class="inline-flex items-center justify-center p-0 h-6 w-6 rounded-lg bg-transparent hover:bg-hover active:bg-pressed text-icon-alternative"
+        <a
+          class="flex ml-1"
+          href="/settings-v2/preferences-and-display/theme"
         >
           <svg
-            class="inline-block w-5 h-5 text-inherit"
+            class="inline-block w-4 h-4 text-icon-alternative"
             fill="currentColor"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -35,7 +35,7 @@ exports[`PreferencesAndDisplayTab snapshot matches snapshot 1`] = `
               d="m8.887 22-1.775-1.775L15.337 12 7.112 3.775 8.887 2l10 10z"
             />
           </svg>
-        </button>
+        </a>
       </div>
     </div>
     <div
@@ -49,12 +49,12 @@ exports[`PreferencesAndDisplayTab snapshot matches snapshot 1`] = `
       <div
         class="flex flex-row gap-1 items-center"
       >
-        <button
-          aria-label="Select Language"
-          class="inline-flex items-center justify-center p-0 h-6 w-6 rounded-lg bg-transparent hover:bg-hover active:bg-pressed text-icon-alternative"
+        <a
+          class="flex ml-1"
+          href="/settings-v2/preferences-and-display/language"
         >
           <svg
-            class="inline-block w-5 h-5 text-inherit"
+            class="inline-block w-4 h-4 text-icon-alternative"
             fill="currentColor"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -63,7 +63,7 @@ exports[`PreferencesAndDisplayTab snapshot matches snapshot 1`] = `
               d="m8.887 22-1.775-1.775L15.337 12 7.112 3.775 8.887 2l10 10z"
             />
           </svg>
-        </button>
+        </a>
       </div>
     </div>
     <div
@@ -96,12 +96,12 @@ exports[`PreferencesAndDisplayTab snapshot matches snapshot 1`] = `
             Polycons
           </p>
         </div>
-        <button
-          aria-label="Select Account icon"
-          class="inline-flex items-center justify-center p-0 h-6 w-6 rounded-lg bg-transparent hover:bg-hover active:bg-pressed text-icon-alternative"
+        <a
+          class="flex ml-1"
+          href="/settings-v2/preferences-and-display/account-identicon"
         >
           <svg
-            class="inline-block w-5 h-5 text-inherit"
+            class="inline-block w-4 h-4 text-icon-alternative"
             fill="currentColor"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -110,7 +110,7 @@ exports[`PreferencesAndDisplayTab snapshot matches snapshot 1`] = `
               d="m8.887 22-1.775-1.775L15.337 12 7.112 3.775 8.887 2l10 10z"
             />
           </svg>
-        </button>
+        </a>
       </div>
     </div>
     <div

--- a/ui/pages/settings-v2/preferences-and-display-tab/account-identicon-item.test.tsx
+++ b/ui/pages/settings-v2/preferences-and-display-tab/account-identicon-item.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
@@ -9,12 +9,6 @@ import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate
 import { setBackgroundConnection } from '../../../store/background-connection';
 import { ACCOUNT_IDENTICON_ROUTE } from '../../../helpers/constants/routes';
 import { AccountIdenticonItem } from './account-identicon-item';
-
-const mockNavigate = jest.fn();
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useNavigate: () => mockNavigate,
-}));
 
 const backgroundConnectionMock = new Proxy(
   {},
@@ -53,19 +47,17 @@ describe('AccountIdenticonItem', () => {
     expect(screen.getByText(messages.maskicons.message)).toBeInTheDocument();
   });
 
-  it('renders navigation button', () => {
+  it('renders navigation link', () => {
     renderWithProvider(<AccountIdenticonItem />, mockStore);
 
-    const button = screen.getByRole('button');
-    expect(button).toBeInTheDocument();
+    const link = screen.getByRole('link');
+    expect(link).toBeInTheDocument();
   });
 
-  it('navigates to account identicon page when clicked', () => {
+  it('links to account identicon page', () => {
     renderWithProvider(<AccountIdenticonItem />, mockStore);
 
-    const button = screen.getByRole('button');
-    fireEvent.click(button);
-
-    expect(mockNavigate).toHaveBeenCalledWith(ACCOUNT_IDENTICON_ROUTE);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', ACCOUNT_IDENTICON_ROUTE);
   });
 });

--- a/ui/pages/settings-v2/preferences-and-display-tab/account-identicon-item.tsx
+++ b/ui/pages/settings-v2/preferences-and-display-tab/account-identicon-item.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { useNavigate } from 'react-router-dom';
 import {
   AvatarAccount,
   AvatarAccountVariant,
@@ -22,13 +21,8 @@ import { AVATAR_LABEL_MAP } from './account-identicon-utils';
 
 export const AccountIdenticonItem = () => {
   const t = useI18nContext();
-  const navigate = useNavigate();
   const { avatarType } = useSelector(getPreferences);
   const selectedAccount = useSelector(getSelectedInternalAccount);
-
-  const handlePress = () => {
-    navigate(ACCOUNT_IDENTICON_ROUTE);
-  };
 
   const currentVariant: AvatarAccountVariant =
     avatarType ?? AvatarAccountVariant.Maskicon;
@@ -37,6 +31,7 @@ export const AccountIdenticonItem = () => {
   return (
     <SettingsSelectItem
       label={t('accountIdenticon')}
+      to={ACCOUNT_IDENTICON_ROUTE}
       value={
         <Box
           flexDirection={BoxFlexDirection.Row}
@@ -57,7 +52,6 @@ export const AccountIdenticonItem = () => {
           </Text>
         </Box>
       }
-      onPress={handlePress}
     />
   );
 };

--- a/ui/pages/settings-v2/privacy-tab/__snapshots__/privacy-tab.test.tsx.snap
+++ b/ui/pages/settings-v2/privacy-tab/__snapshots__/privacy-tab.test.tsx.snap
@@ -81,12 +81,11 @@ exports[`PrivacyTab snapshot matches snapshot 1`] = `
         >
           Third-party APIs
         </p>
-        <button
-          aria-label="Select Third-party APIs"
-          class="inline-flex items-center justify-center p-0 h-6 w-6 rounded-lg bg-transparent hover:bg-hover active:bg-pressed text-icon-alternative"
+        <a
+          href="/settings-v2/privacy/third-party-apis"
         >
           <svg
-            class="inline-block w-5 h-5 text-inherit"
+            class="inline-block w-4 h-4 text-icon-alternative"
             fill="currentColor"
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
@@ -95,7 +94,7 @@ exports[`PrivacyTab snapshot matches snapshot 1`] = `
               d="m8.887 22-1.775-1.775L15.337 12 7.112 3.775 8.887 2l10 10z"
             />
           </svg>
-        </button>
+        </a>
       </div>
       <p
         class="text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default"

--- a/ui/pages/settings-v2/privacy-tab/third-party-apis-item.test.tsx
+++ b/ui/pages/settings-v2/privacy-tab/third-party-apis-item.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
@@ -8,20 +8,9 @@ import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate
 import { THIRD_PARTY_APIS_ROUTE } from '../../../helpers/constants/routes';
 import { ThirdPartyApisItem } from './third-party-apis-item';
 
-const mockNavigate = jest.fn();
-
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useNavigate: () => mockNavigate,
-}));
-
 const createMockStore = () => configureMockStore([thunk])(mockState);
 
 describe('ThirdPartyApisItem', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   it('renders title', () => {
     const mockStore = createMockStore();
     renderWithProvider(<ThirdPartyApisItem />, mockStore);
@@ -40,25 +29,19 @@ describe('ThirdPartyApisItem', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders navigation button with correct aria-label', () => {
+  it('renders navigation link', () => {
     const mockStore = createMockStore();
     renderWithProvider(<ThirdPartyApisItem />, mockStore);
 
-    const button = screen.getByRole('button', {
-      name: `${messages.select.message} ${messages.thirdPartyApis.message}`,
-    });
-    expect(button).toBeInTheDocument();
+    const link = screen.getByRole('link');
+    expect(link).toBeInTheDocument();
   });
 
-  it('navigates to third-party APIs route when button is clicked', () => {
+  it('links to third-party APIs route', () => {
     const mockStore = createMockStore();
     renderWithProvider(<ThirdPartyApisItem />, mockStore);
 
-    const button = screen.getByRole('button', {
-      name: `${messages.select.message} ${messages.thirdPartyApis.message}`,
-    });
-    fireEvent.click(button);
-
-    expect(mockNavigate).toHaveBeenCalledWith(THIRD_PARTY_APIS_ROUTE);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', THIRD_PARTY_APIS_ROUTE);
   });
 });

--- a/ui/pages/settings-v2/privacy-tab/third-party-apis-item.tsx
+++ b/ui/pages/settings-v2/privacy-tab/third-party-apis-item.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import {
   Box,
   Text,
@@ -9,20 +9,15 @@ import {
   BoxJustifyContent,
   BoxAlignItems,
   FontWeight,
-  ButtonIcon,
+  Icon,
   IconName,
-  ButtonIconSize,
+  IconSize,
 } from '@metamask/design-system-react';
 import { THIRD_PARTY_APIS_ROUTE } from '../../../helpers/constants/routes';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 
 export const ThirdPartyApisItem = () => {
-  const navigate = useNavigate();
   const t = useI18nContext();
-
-  const handlePress = () => {
-    navigate(THIRD_PARTY_APIS_ROUTE);
-  };
 
   return (
     <Box flexDirection={BoxFlexDirection.Column} paddingVertical={3} gap={1}>
@@ -34,13 +29,13 @@ export const ThirdPartyApisItem = () => {
         <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
           {t('thirdPartyApis')}
         </Text>
-        <ButtonIcon
-          iconName={IconName.ArrowRight}
-          size={ButtonIconSize.Sm}
-          className="text-icon-alternative"
-          onClick={handlePress}
-          ariaLabel={`${t('select')} ${t('thirdPartyApis')}`}
-        />
+        <Link to={THIRD_PARTY_APIS_ROUTE}>
+          <Icon
+            name={IconName.ArrowRight}
+            size={IconSize.Sm}
+            className="text-icon-alternative"
+          />
+        </Link>
       </Box>
       <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
         {t('thirdPartyApisDescription')}

--- a/ui/pages/settings-v2/shared/create-select-item.test.tsx
+++ b/ui/pages/settings-v2/shared/create-select-item.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
@@ -7,13 +7,6 @@ import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import type { MetaMaskReduxState } from '../../../store/store';
 import { createSelectItem, SelectItemConfig } from './create-select-item';
-
-const mockNavigate = jest.fn();
-
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useNavigate: () => mockNavigate,
-}));
 
 const createMockStore = (overrides = {}) =>
   configureMockStore([thunk])({
@@ -36,10 +29,6 @@ const testConfig: SelectItemConfig = {
 const TestSelectItem = createSelectItem(testConfig);
 
 describe('createSelectItem', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   it('renders label from translation key', () => {
     const mockStore = createMockStore();
     renderWithProvider(<TestSelectItem />, mockStore);
@@ -54,13 +43,12 @@ describe('createSelectItem', () => {
     expect(screen.getByText('my-value')).toBeInTheDocument();
   });
 
-  it('navigates to route on press', () => {
+  it('renders a link to the route', () => {
     const mockStore = createMockStore();
     renderWithProvider(<TestSelectItem />, mockStore);
 
-    fireEvent.click(screen.getByRole('button'));
-
-    expect(mockNavigate).toHaveBeenCalledWith('/test-route');
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '/test-route');
   });
 
   it('applies formatValue when provided', () => {

--- a/ui/pages/settings-v2/shared/create-select-item.tsx
+++ b/ui/pages/settings-v2/shared/create-select-item.tsx
@@ -1,6 +1,5 @@
 import React, { type ReactNode } from 'react';
 import { useSelector } from 'react-redux';
-import { useNavigate } from 'react-router-dom';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import type { MetaMaskReduxState } from '../../../store/store';
 import { SettingsSelectItem } from './settings-select-item';
@@ -23,22 +22,17 @@ export type SelectItemConfig = {
 export const createSelectItem = (config: SelectItemConfig): React.FC => {
   const SelectItem = () => {
     const t = useI18nContext();
-    const navigate = useNavigate();
     const value = useSelector(config.valueSelector);
 
     const displayValue = config.formatValue
       ? config.formatValue(value, t)
       : value;
 
-    const handlePress = () => {
-      navigate(config.route);
-    };
-
     return (
       <SettingsSelectItem
         label={t(config.titleKey)}
         value={displayValue}
-        onPress={handlePress}
+        to={config.route}
       />
     );
   };

--- a/ui/pages/settings-v2/shared/settings-select-item.tsx
+++ b/ui/pages/settings-v2/shared/settings-select-item.tsx
@@ -1,4 +1,5 @@
 import React, { type ReactNode } from 'react';
+import { Link } from 'react-router-dom';
 import {
   Box,
   Text,
@@ -8,25 +9,24 @@ import {
   BoxJustifyContent,
   BoxAlignItems,
   IconName,
-  ButtonIcon,
-  ButtonIconSize,
+  Icon,
+  IconSize,
   TextColor,
 } from '@metamask/design-system-react';
-import { useI18nContext } from '../../../hooks/useI18nContext';
 
 type SettingsSelectItemProps = {
   label: string;
   /** Text value to display, or a ReactNode for custom content (e.g., icon + text) */
   value: string | ReactNode;
-  onPress: () => void;
+  /** Route to navigate to when the item is selected */
+  to: string;
 };
 
 export const SettingsSelectItem = ({
   label,
   value,
-  onPress,
+  to,
 }: SettingsSelectItemProps) => {
-  const t = useI18nContext();
   return (
     <Box
       flexDirection={BoxFlexDirection.Row}
@@ -53,13 +53,13 @@ export const SettingsSelectItem = ({
         ) : (
           value
         )}
-        <ButtonIcon
-          iconName={IconName.ArrowRight}
-          size={ButtonIconSize.Sm}
-          className="text-icon-alternative"
-          onClick={onPress}
-          ariaLabel={`${t('select')} ${label}`}
-        />
+        <Link to={to} className="flex ml-1">
+          <Icon
+            name={IconName.ArrowRight}
+            size={IconSize.Sm}
+            className="text-icon-alternative"
+          />
+        </Link>
       </Box>
     </Box>
   );


### PR DESCRIPTION
## **Description**

Instead of using a ButtonIcon for select items, this refactor wraps the icon in a `<Link />` component to make the component more semantically meaningful as clicking this icon only navigates to a new page.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

No change to current experience

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to Settings V2 navigation affordances; main behavior change is switching from `onClick`/`useNavigate` buttons to declarative links, which could affect accessibility/ARIA and routing in a few settings rows.
> 
> **Overview**
> Refactors Settings V2 “select” rows to be declarative links: `SettingsSelectItem` now takes a `to` prop and renders a `react-router-dom` `Link` with an `Icon` arrow, removing the `onPress` callback pattern.
> 
> Updates affected items (`LocalCurrencyItem`, `AccountIdenticonItem`, `ThirdPartyApisItem`, and `createSelectItem`) plus associated unit tests and snapshots to assert `link` rendering and correct `href`/`to` targets (including minor icon sizing/class changes reflected in snapshots).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c9db5ab4458ec1ecaea8e4e96f2a0b134eea514. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->