### PR TITLE
fix: don’t show MUSD claim cta when geoblocked

### DIFF
--- a/ui/components/app/musd/hooks/useMerklRewards.test.ts
+++ b/ui/components/app/musd/hooks/useMerklRewards.test.ts
@@ -448,6 +448,61 @@ describe('useMerklRewards', () => {
     expect(mockFetchMerklRewardsForAsset).not.toHaveBeenCalled();
   });
 
+  it('returns false when geoblocking resolves after query returns claimable reward', async () => {
+    // Simulate: geo check still loading, so isBlocked starts as false
+    useMusdGeoBlocking.mockReturnValue({
+      isBlocked: false,
+      userCountry: null,
+      isLoading: true,
+    });
+
+    mockFetchMerklRewardsForAsset.mockResolvedValueOnce({
+      token: {
+        address: MUSD_TOKEN_ADDRESS,
+        chainId: 59144,
+        symbol: 'MUSD',
+        decimals: 6,
+        price: 1.0,
+      },
+      pending: '0',
+      proofs: [],
+      amount: '10500000',
+      claimed: '0',
+      recipient: MOCK_ADDRESS,
+    });
+    mockGetClaimedAmountFromContract.mockResolvedValueOnce(null);
+
+    const hookArgs = {
+      tokenAddress: MUSD_TOKEN_ADDRESS,
+      chainId: '0x1' as `0x${string}`,
+      showMerklBadge: true,
+    };
+
+    const { result, rerender, waitForNextUpdate } = renderHook(
+      () => useMerklRewards(hookArgs),
+      { wrapper: createWrapper() },
+    );
+
+    await act(async () => {
+      await waitForNextUpdate();
+    });
+
+    // Query resolved with claimable reward, but geo still loading
+    // isEligible gates the return value so it should still be false
+    // because showMerklBadge && merklRewardsEnabled && !isGeoBlocked && isEligibleToken
+    // During loading isGeoBlocked=false, so query runs and caches true.
+    // Now simulate geo check completing with blocked result:
+    useMusdGeoBlocking.mockReturnValue({
+      isBlocked: true,
+      userCountry: 'GB',
+      isLoading: false,
+    });
+
+    rerender();
+
+    expect(result.current.hasClaimableReward).toBe(false);
+  });
+
   it('falls back to API claimed value when getClaimedAmountFromContract returns null', async () => {
     mockGetClaimedAmountFromContract.mockResolvedValueOnce(null);
 

--- a/ui/components/app/musd/hooks/useMerklRewards.ts
+++ b/ui/components/app/musd/hooks/useMerklRewards.ts
@@ -132,7 +132,7 @@ export const useMerklRewards = ({
   }, [refetchQuery]);
 
   return {
-    hasClaimableReward,
+    hasClaimableReward: isEligible && hasClaimableReward,
     refetch,
   };
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
In the process of merging multiple PRs on thursday, we seem to have clobbered the functionality to hide the claim bonus CTA in a geoblocked region. This PR re-adds that.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40924?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

## **Manual testing steps**

1. Go to token list for an account with bonus to claim in a geoblocked region
2. No CTA should be shown

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches geoblocking/eligibility gating for the Merkl rewards CTA, which is compliance-sensitive, but the change is small and localized to a single hook plus a targeted test.
> 
> **Overview**
> Ensures the mUSD Merkl rewards hook never reports `hasClaimableReward` for geoblocked users by gating the returned value on `isEligible` (not just the query `enabled` flag), preventing cached query results from resurfacing the claim CTA after geoblocking resolves.
> 
> Adds a regression test covering the race where the rewards query returns a claimable result while geo status is still loading and later flips to blocked.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 608518f3dcbaf0b29c283dde6dce13d28443560e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->