### PR TITLE
test(webpack): isolate config env in tests cp-13.23.0

### DIFF
--- a/development/webpack/test/config.test.ts
+++ b/development/webpack/test/config.test.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
-import { describe, it, afterEach, mock } from 'node:test';
+import process from 'node:process';
+import { describe, it, afterEach, beforeEach, mock } from 'node:test';
 import assert from 'node:assert';
 import { resolve } from 'node:path';
 import { version } from '../../../package.json';
@@ -13,6 +14,7 @@ describe('./utils/config.ts', () => {
   // system, so we don't check for everything, just that the interface is
   // behaving
   describe('variables', () => {
+    const originalEnv = { ...process.env };
     const originalReadFileSync = fs.readFileSync;
     function mockRc(
       env: Record<string, string> = {},
@@ -36,7 +38,14 @@ describe('./utils/config.ts', () => {
         return originalReadFileSync(path, options);
       });
     }
-    afterEach(() => mock.restoreAll());
+    beforeEach(() => {
+      process.env = {};
+    });
+
+    afterEach(() => {
+      process.env = { ...originalEnv };
+      mock.restoreAll();
+    });
 
     it('should return valid build variables for the default build', () => {
       const buildTypes = loadBuildTypesConfig();


### PR DESCRIPTION
## **Description**

The webpack `config.getVariables` tests were reading inherited `process.env` values, so the `includes null values and omits undefined values in safeVariables` assertion could pass or fail depending on the shell environment.

This change clears `process.env` before each test case and restores the original environment afterward. That keeps the tests deterministic while preserving the runtime behavior of `config.getVariables`.

You can test this by running `GITHUB_HEAD_REF=release/1.2.3 yarn test:unit:webpack:coverage` on `main`, where it will fail, and on this branch, where it won't.

## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**
Fixes:
-->

## **Manual testing steps**

1. Run `yarn lint:changed:fix`.
2. Run `yarn tsx --test development/webpack/test/config.test.ts`.
3. Run `ALLOW_LOCAL_SNAPS=false TESTING_NULL=from-env DEBUG=1 yarn tsx --test development/webpack/test/config.test.ts`.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that resets/restores `process.env` to prevent flaky assertions dependent on the developer/CI shell environment.
> 
> **Overview**
> Prevents webpack `config.getVariables` unit tests from accidentally inheriting ambient `process.env` values.
> 
> The test suite now clears `process.env` in `beforeEach` and restores the original environment in `afterEach` (alongside `mock.restoreAll()`), making the `safeVariables` expectations deterministic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1d7c72d42bbe40a57615e3acde3671f30332d60. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->