### PR TITLE
chore: Bump @metamask/gator-permissions-snap from ^1.2.0 to ^1.3.0 cp-13.23.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -333,7 +333,7 @@
     "@metamask/etherscan-link": "^3.0.0",
     "@metamask/gas-fee-controller": "^25.0.0",
     "@metamask/gator-permissions-controller": "^2.1.0",
-    "@metamask/gator-permissions-snap": "^1.2.0",
+    "@metamask/gator-permissions-snap": "^1.3.0",
     "@metamask/hw-wallet-sdk": "^0.5.0",
     "@metamask/institutional-wallet-snap": "1.3.4",
     "@metamask/jazzicon": "patch:@metamask/jazzicon@npm%3A2.0.0#~/.yarn/patches/@metamask-jazzicon-npm-2.0.0-36957be38d.patch",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6908,9 +6908,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/gator-permissions-snap@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "@metamask/gator-permissions-snap@npm:1.2.0"
+"@metamask/gator-permissions-snap@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "@metamask/gator-permissions-snap@npm:1.3.0"
   dependencies:
     "@metamask/abi-utils": "npm:3.0.0"
     "@metamask/delegation-core": "npm:0.3.0"
@@ -6918,7 +6918,7 @@ __metadata:
     "@metamask/snaps-sdk": "npm:10.2.0"
     "@metamask/utils": "npm:11.4.2"
     zod: "npm:3.25.76"
-  checksum: 10/3da76215f5333927af302b8fc9841180c27766889afd6e793b8ef249832b6f14b3ba93ddb469ae638faae0f1a20ccd21bba66e5ac9b1ec51633a946f5c44046f
+  checksum: 10/65b6371ee9858e4299907ad7973f11dd5e4093c8c44a8a007baae22afb6a04007a4e8af8882799954d147bb4cc93006f7b075b8124b6ca585b9d3369721c1ca9
   languageName: node
   linkType: hard
 
@@ -33897,7 +33897,7 @@ __metadata:
     "@metamask/foundryup": "npm:^1.0.1"
     "@metamask/gas-fee-controller": "npm:^25.0.0"
     "@metamask/gator-permissions-controller": "npm:^2.1.0"
-    "@metamask/gator-permissions-snap": "npm:^1.2.0"
+    "@metamask/gator-permissions-snap": "npm:^1.3.0"
     "@metamask/hw-wallet-sdk": "npm:^0.5.0"
     "@metamask/institutional-wallet-snap": "npm:1.3.4"
     "@metamask/jazzicon": "patch:@metamask/jazzicon@npm%3A2.0.0#~/.yarn/patches/@metamask-jazzicon-npm-2.0.0-36957be38d.patch"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Bump @metamask/gator-permissions-snap from ^1.2.0 to ^1.3.0

https://github.com/MetaMask/snap-7715-permissions/releases/tag/v18.0.0

### Changed
- `justification` field may now be longer (up to 300 chars), and will be more prominently displayed in the UI ([#282](https://github.com/MetaMask/snap-7715-permissions/pull/282))

### Fixed
- Improve display of existing permissions before granting a new permission ([#284](https://github.com/MetaMask/snap-7715-permissions/pull/284), [#283](https://github.com/MetaMask/snap-7715-permissions/pull/283))
  - Show all permissions from all chains granted to the requesting origin
  - Group existing permissions by granting account
  - Improved validation and asyncronous loading with caching, and skeleton UI

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40933?quickstart=1)

## **Changelog**

Changes to unreleased feature, and slight change to `justification` field formatting.

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Advanced Permissions `justification` parameter now accepts up to 300 chars, shown more clearly in confirmation.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-only bump; primary risk is behavioral changes inside the updated snap affecting permission flows at runtime.
> 
> **Overview**
> Updates the `@metamask/gator-permissions-snap` dependency from `^1.2.0` to `^1.3.0`, with corresponding `yarn.lock` resolution/checksum changes to pull the new package version.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3a10c9eb6992d3d2a48af68a5961dddeb0018b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->