### PR TITLE
bump: dorny/paths-filter to 4.0.0

### DIFF
--- a/.github/workflows/get-requirements.yml
+++ b/.github/workflows/get-requirements.yml
@@ -90,7 +90,7 @@ jobs:
 
       - id: filter
         if: ${{ steps.check-skip-merge-queue.outputs.up-to-date != 'true' }}
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
+        uses: dorny/paths-filter@9d7afb8d214ad99e78fbd4247752c4caed2b6e4c
         with:
           filters: .github/filter-rules.yml
           list-files: shell


### PR DESCRIPTION
## **Description**

A new version of `dorny/paths-filter` just came out, and the important change is it supports Node 24.

This needs a security audit.

## **Changelog**

CHANGELOG entry: null

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**
[skip-e2e]-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates a third-party GitHub Action used to determine which CI jobs run; if the new version changes filtering behavior, it could incorrectly skip or trigger jobs. Limited scope to CI configuration only.
> 
> **Overview**
> Bumps the `dorny/paths-filter` GitHub Action used by `get-requirements.yml` to a newer pinned commit (v4.0.0) to keep the workflow compatible with newer Node runtimes.
> 
> No other workflow logic or filter configuration is changed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94b21676eaef11c03941db22b3a695d1ed5d8850. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->