### PR TITLE
chore: Add @MetaMask/delegation as co-owners of permission signature confirmation code

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -153,6 +153,7 @@ app/scripts/lib/transaction                                                     
 ui/pages/confirmations                                                              @MetaMask/confirmations
 ui/components/multichain/pages/send                                                 @MetaMask/confirmations
 ui/pages/confirmations/components/confirm/footer                                    @MetaMask/confirmations
+ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission     @MetaMask/confirmations @MetaMask/delegation
 ui/pages/confirmations/components/confirm/footer/shield-footer-coverage-indicator   @MetaMask/confirmations @MetaMask/web3auth
 ui/pages/confirmations/components/confirm/footer/shield-footer-agreement*           @MetaMask/confirmations @MetaMask/web3auth
 ui/pages/confirmations/components/confirm/info/shield-subscription-approve          @MetaMask/confirmations @MetaMask/web3auth

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -968,11 +968,6 @@
       "React: Act warnings (component updates not wrapped)": 2,
       "Reselect: Identity function warnings": 3
     },
-    "ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission.test.tsx": {
-      "React: Act warnings (component updates not wrapped)": 6,
-      "Reselect: Identity function warnings": 4,
-      "Test errors: Uncaught Errors": 6
-    },
     "ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/erc20-token-periodic-details.test.tsx": {
       "React: Act warnings (component updates not wrapped)": 5,
       "Reselect: Identity function warnings": 4,
@@ -997,6 +992,12 @@
     },
     "ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/total-exposure.test.tsx": {
       "Reselect: Identity function warnings": 4,
+      "warn: ⚠️ React Router Future Flag": 2
+    },
+    "ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/typed-sign-permission.test.tsx": {
+      "React: Act warnings (component updates not wrapped)": 6,
+      "Reselect: Identity function warnings": 4,
+      "Test errors: Uncaught Errors": 6,
       "warn: ⚠️ React Router Future Flag": 2
     },
     "ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-v4-simulation/decoded-simulation/decoded-simulation.test.tsx": {

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/index.ts
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/index.ts
@@ -1,0 +1,1 @@
+export { default } from './typed-sign-permission';

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/typed-sign-permission.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/typed-sign-permission.test.tsx
@@ -1,16 +1,13 @@
 import { DecodedPermission } from '@metamask/gator-permissions-controller';
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
-import { getMockTypedSignPermissionConfirmState } from '../../../../../../../test/data/confirmations/helper';
-import {
-  renderWithConfirmContextProvider,
-  renderWithConfirmContext,
-} from '../../../../../../../test/lib/confirmations/render-helpers';
-import { enLocale as messages } from '../../../../../../../test/lib/i18n-helpers';
+import { getMockTypedSignPermissionConfirmState } from '../../../../../../../../test/data/confirmations/helper';
+import { renderWithConfirmContextProvider, renderWithConfirmContext } from '../../../../../../../../test/lib/confirmations/render-helpers';
+import { enLocale as messages } from '../../../../../../../../test/lib/i18n-helpers';
 import TypedSignPermissionInfo from './typed-sign-permission';
 
 jest.mock(
-  '../../../../../../components/app/alert-system/contexts/alertMetricsContext',
+  '../../../../../../../components/app/alert-system/contexts/alertMetricsContext',
   () => ({
     useAlertMetrics: jest.fn(() => ({
       trackAlertMetrics: jest.fn(),
@@ -18,8 +15,8 @@ jest.mock(
   }),
 );
 
-jest.mock('../../../../utils/token', () => ({
-  ...jest.requireActual('../../../../utils/token'),
+jest.mock('../../../../..//utils/token', () => ({
+  ...jest.requireActual('../../../../../utils/token'),
   fetchErc20DecimalsOrThrow: jest.fn().mockResolvedValue(18),
 }));
 

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/typed-sign-permission.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/typed-sign-permission.test.tsx
@@ -1,8 +1,12 @@
 import { DecodedPermission } from '@metamask/gator-permissions-controller';
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
+
 import { getMockTypedSignPermissionConfirmState } from '../../../../../../../../test/data/confirmations/helper';
-import { renderWithConfirmContextProvider, renderWithConfirmContext } from '../../../../../../../../test/lib/confirmations/render-helpers';
+import {
+  renderWithConfirmContextProvider,
+  renderWithConfirmContext,
+} from '../../../../../../../../test/lib/confirmations/render-helpers';
 import { enLocale as messages } from '../../../../../../../../test/lib/i18n-helpers';
 import TypedSignPermissionInfo from './typed-sign-permission';
 
@@ -15,7 +19,7 @@ jest.mock(
   }),
 );
 
-jest.mock('../../../../..//utils/token', () => ({
+jest.mock('../../../../../utils/token', () => ({
   ...jest.requireActual('../../../../../utils/token'),
   fetchErc20DecimalsOrThrow: jest.fn().mockResolvedValue(18),
 }));

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/typed-sign-permission.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/typed-sign-permission.tsx
@@ -8,23 +8,23 @@ import React from 'react';
 import { isSnapId } from '@metamask/snaps-utils';
 
 import { Text, TextVariant } from '@metamask/design-system-react';
-import { SignatureRequestType } from '../../../../types/confirm';
-import { useConfirmContext } from '../../../../context/confirm';
-import { ConfirmInfoRow } from '../../../../../../components/app/confirm/info/row';
-import { ConfirmInfoRowAddress } from '../../../../../../components/app/confirm/info/row/address';
-import { ConfirmInfoSection } from '../../../../../../components/app/confirm/info/row/section';
-import { ConfirmInfoRowUrl } from '../../../../../../components/app/confirm/info/row/url';
-import { useI18nContext } from '../../../../../../hooks/useI18nContext';
-import { NetworkRow } from '../shared/network-row/network-row';
-import { ConfirmInfoAlertRow } from '../../../../../../components/app/confirm/info/row/alert-row/alert-row';
-import { RowAlertKey } from '../../../../../../components/app/confirm/info/row/constants';
-import { SigningInWithRow } from '../shared/sign-in-with-row/sign-in-with-row';
+import { SignatureRequestType } from '../../../../../types/confirm';
+import { useConfirmContext } from '../../../../../context/confirm';
+import { ConfirmInfoRow } from '../../../../../../../components/app/confirm/info/row';
+import { ConfirmInfoRowAddress } from '../../../../../../../components/app/confirm/info/row/address';
+import { ConfirmInfoSection } from '../../../../../../../components/app/confirm/info/row/section';
+import { ConfirmInfoRowUrl } from '../../../../../../../components/app/confirm/info/row/url';
+import { useI18nContext } from '../../../../../../../hooks/useI18nContext';
+import { NetworkRow } from '../../shared/network-row/network-row';
+import { ConfirmInfoAlertRow } from '../../../../../../../components/app/confirm/info/row/alert-row/alert-row';
+import { RowAlertKey } from '../../../../../../../components/app/confirm/info/row/constants';
+import { SigningInWithRow } from '../../shared/sign-in-with-row/sign-in-with-row';
 
-import { NativeTokenStreamDetails } from './typed-sign-permission/native-token-stream-details';
-import { NativeTokenPeriodicDetails } from './typed-sign-permission/native-token-periodic-details';
-import { Erc20TokenPeriodicDetails } from './typed-sign-permission/erc20-token-periodic-details';
-import { Erc20TokenStreamDetails } from './typed-sign-permission/erc20-token-stream-details';
-import { Erc20TokenRevocationDetails } from './typed-sign-permission/erc20-token-revocation-details';
+import { NativeTokenStreamDetails } from './native-token-stream-details';
+import { NativeTokenPeriodicDetails } from './native-token-periodic-details';
+import { Erc20TokenPeriodicDetails } from './erc20-token-periodic-details';
+import { Erc20TokenStreamDetails } from './erc20-token-stream-details';
+import { Erc20TokenRevocationDetails } from './erc20-token-revocation-details';
 
 /**
  * Main component for displaying typed signature permission information.


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Added @MetaMask/delegation as co-owners of permission signature confirmation code. 

Also, moves `typed-sign-permission.tsx` (and tests) into `typed-sign-permission` directory for increased cohesion.

This code is responsible for rendering EIP-7715 advanced permissions signature confirmations. This functionality is owned by the @MetaMask/delegation team, and the @MetaMask/confirmations team are responsible for the confirmations functionality generally. As such, the two teams are designated as co-owners of this code.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40939?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CODEOWNERS ownership metadata and a folder reorganization of the `typed-sign-permission` confirmation UI/tests with import-path updates, with no functional behavior changes expected.
> 
> **Overview**
> Updates `.github/CODEOWNERS` to add `@MetaMask/delegation` as co-owners for `ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission`.
> 
> Reorganizes the typed-sign permission confirmation component by adding an `index.ts` barrel and relocating `typed-sign-permission` and its unit test into the `typed-sign-permission/` directory, updating relative imports/mocks accordingly and adjusting `test/jest/console-baseline-unit.json` for the new test path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6359f5e03406ec014ba982bc2c4e77e13a3cc53f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->