### PR TITLE
fix: flaky test `Segment User Traits sends identify event when user opts in both metrics and data in privacy settings after opting out during onboarding`

### DIFF
--- a/test/e2e/tests/metrics/segment-user-traits.spec.ts
+++ b/test/e2e/tests/metrics/segment-user-traits.spec.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'assert';
-import { Mockttp } from 'mockttp';
+import { Mockttp, MockedEndpoint } from 'mockttp';
 import { getEventPayloads, withFixtures } from '../../helpers';
 import FixtureBuilder from '../../fixtures/fixture-builder';
 import {
@@ -11,13 +11,49 @@ import HeaderNavbar from '../../page-objects/pages/header-navbar';
 import SettingsPage from '../../page-objects/pages/settings/settings-page';
 import PrivacySettings from '../../page-objects/pages/settings/privacy-settings';
 
-function mergeTraits(
-  events: { traits: Record<string, unknown> }[],
-): Record<string, unknown> {
+type IdentifyEvent = { traits: Record<string, unknown> };
+
+function mergeTraits(events: IdentifyEvent[]): Record<string, unknown> {
   return events.reduce(
     (acc, event) => ({ ...acc, ...event.traits }),
     {} as Record<string, unknown>,
   );
+}
+
+/**
+ * Poll getEventPayloads until the merged traits satisfy every key/value in `expected`.
+ * Throws TimeoutError if the traits don't converge within the timeout window.
+ *
+ * @param driver - The WebDriver instance.
+ * @param driver.wait - Polls a condition function until it returns true or the timeout expires.
+ * @param mockedEndpoints - The mockttp mocked endpoints to retrieve seen requests from.
+ * @param expected - Key/value pairs that the merged traits must satisfy.
+ * @param timeout - Maximum time in ms to wait for the traits to converge (default 30 000).
+ */
+async function waitForExpectedTraits(
+  driver: {
+    wait: (condition: () => Promise<boolean>, timeout: number) => Promise<void>;
+  },
+  mockedEndpoints: MockedEndpoint[],
+  expected: Record<string, unknown>,
+  timeout = 30_000,
+): Promise<Record<string, unknown>> {
+  let events: IdentifyEvent[] = [];
+  await driver.wait(async () => {
+    try {
+      events = await getEventPayloads(driver, mockedEndpoints, false);
+    } catch {
+      return false;
+    }
+    if (events.length === 0) {
+      return false;
+    }
+    const traits = mergeTraits(events);
+    return Object.entries(expected).every(
+      ([key, value]) => traits[key] === value,
+    );
+  }, timeout);
+  return mergeTraits(events);
 }
 
 async function mockSegment(mockServer: Mockttp) {
@@ -54,10 +90,12 @@ describe('Segment User Traits', function () {
           participateInMetaMetrics: true,
           dataCollectionForMarketing: true,
         });
-        const events = await getEventPayloads(driver, mockedEndpoints);
-        const mergedTraits = mergeTraits(events);
-        assert.deepStrictEqual(mergedTraits.is_metrics_opted_in, true);
-        assert.deepStrictEqual(mergedTraits.has_marketing_consent, true);
+        await waitForExpectedTraits(driver, mockedEndpoints, {
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          is_metrics_opted_in: true,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          has_marketing_consent: true,
+        });
       },
     );
   });
@@ -79,10 +117,12 @@ describe('Segment User Traits', function () {
           participateInMetaMetrics: true,
           dataCollectionForMarketing: false,
         });
-        const events = await getEventPayloads(driver, mockedEndpoints);
-        const mergedTraits = mergeTraits(events);
-        assert.deepStrictEqual(mergedTraits.is_metrics_opted_in, true);
-        assert.deepStrictEqual(mergedTraits.has_marketing_consent, false);
+        await waitForExpectedTraits(driver, mockedEndpoints, {
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          is_metrics_opted_in: true,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          has_marketing_consent: false,
+        });
       },
     );
   });
@@ -122,12 +162,11 @@ describe('Segment User Traits', function () {
         testSpecificMock: mockSegment,
       },
       async ({ driver, mockedEndpoint: mockedEndpoints }) => {
-        let events = [];
         await completeCreateNewWalletOnboardingFlow({
           driver,
           participateInMetaMetrics: false,
         });
-        events = await getEventPayloads(driver, mockedEndpoints);
+        const events = await getEventPayloads(driver, mockedEndpoints);
         assert.equal(events.length, 0);
         await new HeaderNavbar(driver).openSettingsPage();
         const settingsPage = new SettingsPage(driver);
@@ -137,10 +176,12 @@ describe('Segment User Traits', function () {
         const privacySettings = new PrivacySettings(driver);
         await privacySettings.checkPageIsLoaded();
         await privacySettings.toggleParticipateInMetaMetrics();
-        events = await getEventPayloads(driver, mockedEndpoints);
-        const mergedTraits = mergeTraits(events);
-        assert.deepStrictEqual(mergedTraits.is_metrics_opted_in, true);
-        assert.deepStrictEqual(mergedTraits.has_marketing_consent, false);
+        await waitForExpectedTraits(driver, mockedEndpoints, {
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          is_metrics_opted_in: true,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          has_marketing_consent: false,
+        });
       },
     );
   });
@@ -157,12 +198,11 @@ describe('Segment User Traits', function () {
         testSpecificMock: mockSegment,
       },
       async ({ driver, mockedEndpoint: mockedEndpoints }) => {
-        let events = [];
         await completeCreateNewWalletOnboardingFlow({
           driver,
           participateInMetaMetrics: false,
         });
-        events = await getEventPayloads(driver, mockedEndpoints);
+        const events = await getEventPayloads(driver, mockedEndpoints);
         assert.equal(events.length, 0);
         await new HeaderNavbar(driver).openSettingsPage();
         const settingsPage = new SettingsPage(driver);
@@ -171,30 +211,14 @@ describe('Segment User Traits', function () {
 
         const privacySettings = new PrivacySettings(driver);
         await privacySettings.checkPageIsLoaded();
-        // Toggle participate in meta metrics first, then toggle data collection for marketing
-        // Data Collection toggle is disabled if participate in meta metrics is off
         await privacySettings.toggleParticipateInMetaMetrics();
         await privacySettings.toggleDataCollectionForMarketing();
-        // maxWait on sendUpdate debounce may split the two toggles into
-        // separate identify events. Poll until the expected traits arrive.
-        await driver.wait(async () => {
-          try {
-            events = await getEventPayloads(driver, mockedEndpoints, false);
-          } catch {
-            return false;
-          }
-          if (events.length === 0) {
-            return false;
-          }
-          const traits = mergeTraits(events);
-          return (
-            traits.is_metrics_opted_in === true &&
-            traits.has_marketing_consent === true
-          );
-        }, 30_000);
-        const traits = mergeTraits(events);
-        assert.deepStrictEqual(traits.is_metrics_opted_in, true);
-        assert.deepStrictEqual(traits.has_marketing_consent, true);
+        await waitForExpectedTraits(driver, mockedEndpoints, {
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          is_metrics_opted_in: true,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          has_marketing_consent: true,
+        });
       },
     );
   });

--- a/test/e2e/tests/metrics/segment-user-traits.spec.ts
+++ b/test/e2e/tests/metrics/segment-user-traits.spec.ts
@@ -196,27 +196,31 @@ describe('Segment User Traits', function () {
         await privacySettings.toggleDataCollectionForMarketing();
         // maxWait on sendUpdate debounce may split the two toggles into
         // separate identify events. Poll until the expected traits arrive.
-        await driver.wait(async () => {
-          try {
-            events = await getEventPayloads(driver, mockedEndpoints, false);
-          } catch {
-            return false;
-          }
-          if (events.length === 0) {
-            return false;
-          }
-          const allTraits = events.reduce(
-            (
-              acc: Record<string, unknown>,
-              event: { traits: Record<string, unknown> },
-            ) => ({ ...acc, ...event.traits }),
-            {} as Record<string, unknown>,
-          );
-          return (
-            allTraits.is_metrics_opted_in === true &&
-            allTraits.has_marketing_consent === true
-          );
-        }, 30_000);
+        await driver.waitUntil(
+          async () => {
+            try {
+              events = await getEventPayloads(driver, mockedEndpoints, false);
+            } catch {
+              return false;
+            }
+            console.log('identify events:', JSON.stringify(events));
+            if (events.length === 0) {
+              return false;
+            }
+            const allTraits = events.reduce(
+              (
+                acc: Record<string, unknown>,
+                event: { traits: Record<string, unknown> },
+              ) => ({ ...acc, ...event.traits }),
+              {} as Record<string, unknown>,
+            );
+            return (
+              allTraits.is_metrics_opted_in === true &&
+              allTraits.has_marketing_consent === true
+            );
+          },
+          { timeout: 30_000, interval: 2_000 },
+        );
         const allTraits = events.reduce(
           (
             acc: Record<string, unknown>,

--- a/test/e2e/tests/metrics/segment-user-traits.spec.ts
+++ b/test/e2e/tests/metrics/segment-user-traits.spec.ts
@@ -28,7 +28,7 @@ function mergeTraits(events: IdentifyEvent[]): Record<string, unknown> {
  * @param driver.wait - Polls a condition function until it returns true or the timeout expires.
  * @param mockedEndpoints - The mockttp mocked endpoints to retrieve seen requests from.
  * @param expected - Key/value pairs that the merged traits must satisfy.
- * @param timeout - Maximum time in ms to wait for the traits to converge (default 30 000).
+ * @param timeout - Maximum time in ms to wait for the traits to converge.
  */
 async function waitForExpectedTraits(
   driver: {

--- a/test/e2e/tests/metrics/segment-user-traits.spec.ts
+++ b/test/e2e/tests/metrics/segment-user-traits.spec.ts
@@ -44,10 +44,39 @@ describe('Segment User Traits', function () {
           participateInMetaMetrics: true,
           dataCollectionForMarketing: true,
         });
-        const events = await getEventPayloads(driver, mockedEndpoints);
-        assert.equal(events.length, 1);
-        assert.deepStrictEqual(events[0].traits.is_metrics_opted_in, true);
-        assert.deepStrictEqual(events[0].traits.has_marketing_consent, true);
+        // Enabling metrics and marketing consent may produce separate identify events due to debounce timing.
+        // Poll until both traits are present across the accumulated events.
+        let events: { traits: Record<string, unknown> }[] = [];
+        await driver.wait(async () => {
+          try {
+            events = await getEventPayloads(driver, mockedEndpoints, false);
+          } catch {
+            return false;
+          }
+          if (events.length === 0) {
+            return false;
+          }
+          const allTraits = events.reduce(
+            (
+              acc: Record<string, unknown>,
+              event: { traits: Record<string, unknown> },
+            ) => ({ ...acc, ...event.traits }),
+            {} as Record<string, unknown>,
+          );
+          return (
+            allTraits.is_metrics_opted_in === true &&
+            allTraits.has_marketing_consent === true
+          );
+        }, 15_000);
+        const allTraits = events.reduce(
+          (
+            acc: Record<string, unknown>,
+            event: { traits: Record<string, unknown> },
+          ) => ({ ...acc, ...event.traits }),
+          {} as Record<string, unknown>,
+        );
+        assert.deepStrictEqual(allTraits.is_metrics_opted_in, true);
+        assert.deepStrictEqual(allTraits.has_marketing_consent, true);
       },
     );
   });

--- a/test/e2e/tests/metrics/segment-user-traits.spec.ts
+++ b/test/e2e/tests/metrics/segment-user-traits.spec.ts
@@ -18,6 +18,7 @@ async function mockSegment(mockServer: Mockttp) {
       .withJsonBodyIncluding({
         batch: [{ type: 'identify' }],
       })
+      .always()
       .thenCallback(() => {
         return {
           statusCode: 200,
@@ -44,39 +45,10 @@ describe('Segment User Traits', function () {
           participateInMetaMetrics: true,
           dataCollectionForMarketing: true,
         });
-        // Enabling metrics and marketing consent may produce separate identify events due to debounce timing.
-        // Poll until both traits are present across the accumulated events.
-        let events: { traits: Record<string, unknown> }[] = [];
-        await driver.wait(async () => {
-          try {
-            events = await getEventPayloads(driver, mockedEndpoints, false);
-          } catch {
-            return false;
-          }
-          if (events.length === 0) {
-            return false;
-          }
-          const allTraits = events.reduce(
-            (
-              acc: Record<string, unknown>,
-              event: { traits: Record<string, unknown> },
-            ) => ({ ...acc, ...event.traits }),
-            {} as Record<string, unknown>,
-          );
-          return (
-            allTraits.is_metrics_opted_in === true &&
-            allTraits.has_marketing_consent === true
-          );
-        }, 15_000);
-        const allTraits = events.reduce(
-          (
-            acc: Record<string, unknown>,
-            event: { traits: Record<string, unknown> },
-          ) => ({ ...acc, ...event.traits }),
-          {} as Record<string, unknown>,
-        );
-        assert.deepStrictEqual(allTraits.is_metrics_opted_in, true);
-        assert.deepStrictEqual(allTraits.has_marketing_consent, true);
+        const events = await getEventPayloads(driver, mockedEndpoints);
+        assert.equal(events.length, 1);
+        assert.deepStrictEqual(events[0].traits.is_metrics_opted_in, true);
+        assert.deepStrictEqual(events[0].traits.has_marketing_consent, true);
       },
     );
   });
@@ -196,31 +168,27 @@ describe('Segment User Traits', function () {
         await privacySettings.toggleDataCollectionForMarketing();
         // maxWait on sendUpdate debounce may split the two toggles into
         // separate identify events. Poll until the expected traits arrive.
-        await driver.waitUntil(
-          async () => {
-            try {
-              events = await getEventPayloads(driver, mockedEndpoints, false);
-            } catch {
-              return false;
-            }
-            console.log('identify events:', JSON.stringify(events));
-            if (events.length === 0) {
-              return false;
-            }
-            const allTraits = events.reduce(
-              (
-                acc: Record<string, unknown>,
-                event: { traits: Record<string, unknown> },
-              ) => ({ ...acc, ...event.traits }),
-              {} as Record<string, unknown>,
-            );
-            return (
-              allTraits.is_metrics_opted_in === true &&
-              allTraits.has_marketing_consent === true
-            );
-          },
-          { timeout: 30_000, interval: 2_000 },
-        );
+        await driver.wait(async () => {
+          try {
+            events = await getEventPayloads(driver, mockedEndpoints, false);
+          } catch {
+            return false;
+          }
+          if (events.length === 0) {
+            return false;
+          }
+          const allTraits = events.reduce(
+            (
+              acc: Record<string, unknown>,
+              event: { traits: Record<string, unknown> },
+            ) => ({ ...acc, ...event.traits }),
+            {} as Record<string, unknown>,
+          );
+          return (
+            allTraits.is_metrics_opted_in === true &&
+            allTraits.has_marketing_consent === true
+          );
+        }, 30_000);
         const allTraits = events.reduce(
           (
             acc: Record<string, unknown>,

--- a/test/e2e/tests/metrics/segment-user-traits.spec.ts
+++ b/test/e2e/tests/metrics/segment-user-traits.spec.ts
@@ -11,6 +11,15 @@ import HeaderNavbar from '../../page-objects/pages/header-navbar';
 import SettingsPage from '../../page-objects/pages/settings/settings-page';
 import PrivacySettings from '../../page-objects/pages/settings/privacy-settings';
 
+function mergeTraits(
+  events: { traits: Record<string, unknown> }[],
+): Record<string, unknown> {
+  return events.reduce(
+    (acc, event) => ({ ...acc, ...event.traits }),
+    {} as Record<string, unknown>,
+  );
+}
+
 async function mockSegment(mockServer: Mockttp) {
   return [
     await mockServer
@@ -46,9 +55,9 @@ describe('Segment User Traits', function () {
           dataCollectionForMarketing: true,
         });
         const events = await getEventPayloads(driver, mockedEndpoints);
-        assert.equal(events.length, 1);
-        assert.deepStrictEqual(events[0].traits.is_metrics_opted_in, true);
-        assert.deepStrictEqual(events[0].traits.has_marketing_consent, true);
+        const mergedTraits = mergeTraits(events);
+        assert.deepStrictEqual(mergedTraits.is_metrics_opted_in, true);
+        assert.deepStrictEqual(mergedTraits.has_marketing_consent, true);
       },
     );
   });
@@ -71,9 +80,9 @@ describe('Segment User Traits', function () {
           dataCollectionForMarketing: false,
         });
         const events = await getEventPayloads(driver, mockedEndpoints);
-        assert.equal(events.length, 1);
-        assert.deepStrictEqual(events[0].traits.is_metrics_opted_in, true);
-        assert.deepStrictEqual(events[0].traits.has_marketing_consent, false);
+        const mergedTraits = mergeTraits(events);
+        assert.deepStrictEqual(mergedTraits.is_metrics_opted_in, true);
+        assert.deepStrictEqual(mergedTraits.has_marketing_consent, false);
       },
     );
   });
@@ -129,9 +138,9 @@ describe('Segment User Traits', function () {
         await privacySettings.checkPageIsLoaded();
         await privacySettings.toggleParticipateInMetaMetrics();
         events = await getEventPayloads(driver, mockedEndpoints);
-        assert.equal(events.length, 1);
-        assert.deepStrictEqual(events[0].traits.is_metrics_opted_in, true);
-        assert.deepStrictEqual(events[0].traits.has_marketing_consent, false);
+        const mergedTraits = mergeTraits(events);
+        assert.deepStrictEqual(mergedTraits.is_metrics_opted_in, true);
+        assert.deepStrictEqual(mergedTraits.has_marketing_consent, false);
       },
     );
   });
@@ -177,27 +186,15 @@ describe('Segment User Traits', function () {
           if (events.length === 0) {
             return false;
           }
-          const allTraits = events.reduce(
-            (
-              acc: Record<string, unknown>,
-              event: { traits: Record<string, unknown> },
-            ) => ({ ...acc, ...event.traits }),
-            {} as Record<string, unknown>,
-          );
+          const traits = mergeTraits(events);
           return (
-            allTraits.is_metrics_opted_in === true &&
-            allTraits.has_marketing_consent === true
+            traits.is_metrics_opted_in === true &&
+            traits.has_marketing_consent === true
           );
         }, 30_000);
-        const allTraits = events.reduce(
-          (
-            acc: Record<string, unknown>,
-            event: { traits: Record<string, unknown> },
-          ) => ({ ...acc, ...event.traits }),
-          {} as Record<string, unknown>,
-        );
-        assert.deepStrictEqual(allTraits.is_metrics_opted_in, true);
-        assert.deepStrictEqual(allTraits.has_marketing_consent, true);
+        const traits = mergeTraits(events);
+        assert.deepStrictEqual(traits.is_metrics_opted_in, true);
+        assert.deepStrictEqual(traits.has_marketing_consent, true);
       },
     );
   });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This PR was merged recently which has been the culprit of the flakiness:  https://github.com/MetaMask/metamask-extension/pull/40331/changes 
The maxWait: SECOND debounce on sendUpdate can split state changes into multiple identify events. 
With .always() the mock now correctly captures all identify events (no matter if 1 or 2, if those are split). This means events.length can be 2 instead of 1, so we omit that strict check. Instead we check for the traits, like it was done, and use mergeTraits in all specs for a safe assert


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40948?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to e2e test code and only affect how Segment identify requests are mocked and asserted, though the new polling/trait-merging logic could mask unexpected extra events if assertions are too loose.
> 
> **Overview**
> **Fixes flaky Segment metrics e2e assertions** by allowing the Segment mock to match repeatedly (`.always()`) and by replacing single-request/`events.length === 1` expectations with polling for the expected trait values.
> 
> Adds `mergeTraits` and a shared `waitForExpectedTraits` helper to merge traits across multiple identify events (e.g., when toggles produce split updates) and updates the affected specs to assert on the merged traits instead of individual event counts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 198e4cf7f823865404334f95530bc37534e5e7f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->