### PR TITLE
fix:  cp-13.23.0 hide alert in metamask pay if zero amount

### DIFF
--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.test.ts
@@ -10,15 +10,23 @@ import { genUnapprovedContractInteractionConfirmation } from '../../../../../../
 import { renderHookWithConfirmContextProvider } from '../../../../../../test/lib/confirmations/render-helpers';
 import { useIsGaslessSupported } from '../../gas/useIsGaslessSupported';
 import { useTransactionPayHasSourceAmount } from '../../pay/useTransactionPayHasSourceAmount';
+import { useTransactionPayRequiredTokens } from '../../pay/useTransactionPayData';
+import { useTransactionPayToken } from '../../pay/useTransactionPayToken';
 import { useInsufficientBalanceAlerts } from './useInsufficientBalanceAlerts';
 
 jest.mock('../../gas/useIsGaslessSupported');
 jest.mock('../../pay/useTransactionPayHasSourceAmount');
+jest.mock('../../pay/useTransactionPayData');
+jest.mock('../../pay/useTransactionPayToken');
 
 const useIsGaslessSupportedMock = jest.mocked(useIsGaslessSupported);
 const useTransactionPayHasSourceAmountMock = jest.mocked(
   useTransactionPayHasSourceAmount,
 );
+const useTransactionPayRequiredTokensMock = jest.mocked(
+  useTransactionPayRequiredTokens,
+);
+const useTransactionPayTokenMock = jest.mocked(useTransactionPayToken);
 
 const TRANSACTION_ID_MOCK = '123-456';
 const TRANSACTION_ID_MOCK_2 = '456-789';
@@ -115,6 +123,11 @@ describe('useInsufficientBalanceAlerts', () => {
       pending: false,
     });
     useTransactionPayHasSourceAmountMock.mockReturnValue(false);
+    useTransactionPayRequiredTokensMock.mockReturnValue([]);
+    useTransactionPayTokenMock.mockReturnValue({
+      payToken: undefined,
+      setPayToken: jest.fn(),
+    });
   });
 
   it('returns no alerts if no confirmation', () => {
@@ -185,6 +198,22 @@ describe('useInsufficientBalanceAlerts', () => {
     });
 
     expect(alerts).toEqual(ALERT);
+  });
+
+  it('returns no alerts when pay is active but no required tokens yet', () => {
+    useTransactionPayTokenMock.mockReturnValue({
+      payToken: { address: '0xabc', chainId: '0x1' } as never,
+      setPayToken: jest.fn(),
+    });
+    useTransactionPayRequiredTokensMock.mockReturnValue([]);
+
+    const alerts = runHook({
+      balance: 7,
+      currentConfirmation: TRANSACTION_MOCK,
+      transaction: TRANSACTION_MOCK,
+    });
+
+    expect(alerts).toEqual([]);
   });
 
   it('returns no alerts if no transaction matching confirmation', () => {

--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.test.ts
@@ -10,7 +10,10 @@ import { genUnapprovedContractInteractionConfirmation } from '../../../../../../
 import { renderHookWithConfirmContextProvider } from '../../../../../../test/lib/confirmations/render-helpers';
 import { useIsGaslessSupported } from '../../gas/useIsGaslessSupported';
 import { useTransactionPayHasSourceAmount } from '../../pay/useTransactionPayHasSourceAmount';
-import { useTransactionPayRequiredTokens } from '../../pay/useTransactionPayData';
+import {
+  useTransactionPayPrimaryRequiredToken,
+  useTransactionPayRequiredTokens,
+} from '../../pay/useTransactionPayData';
 import { useTransactionPayToken } from '../../pay/useTransactionPayToken';
 import { useInsufficientBalanceAlerts } from './useInsufficientBalanceAlerts';
 
@@ -22,6 +25,9 @@ jest.mock('../../pay/useTransactionPayToken');
 const useIsGaslessSupportedMock = jest.mocked(useIsGaslessSupported);
 const useTransactionPayHasSourceAmountMock = jest.mocked(
   useTransactionPayHasSourceAmount,
+);
+const useTransactionPayPrimaryRequiredTokenMock = jest.mocked(
+  useTransactionPayPrimaryRequiredToken,
 );
 const useTransactionPayRequiredTokensMock = jest.mocked(
   useTransactionPayRequiredTokens,
@@ -200,12 +206,14 @@ describe('useInsufficientBalanceAlerts', () => {
     expect(alerts).toEqual(ALERT);
   });
 
-  it('returns no alerts when pay is active but no required tokens yet', () => {
+  it('returns no alerts when pay is active but required token amount is zero', () => {
     useTransactionPayTokenMock.mockReturnValue({
       payToken: { address: '0xabc', chainId: '0x1' } as never,
       setPayToken: jest.fn(),
     });
-    useTransactionPayRequiredTokensMock.mockReturnValue([]);
+    useTransactionPayPrimaryRequiredTokenMock.mockReturnValue({
+      amountRaw: '0',
+    } as never);
 
     const alerts = runHook({
       balance: 7,

--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.ts
@@ -15,7 +15,7 @@ import { useConfirmContext } from '../../../context/confirm';
 import { useIsGaslessSupported } from '../../gas/useIsGaslessSupported';
 import { useHasInsufficientBalance } from '../../useHasInsufficientBalance';
 import { useTransactionPayHasSourceAmount } from '../../pay/useTransactionPayHasSourceAmount';
-import { useTransactionPayRequiredTokens } from '../../pay/useTransactionPayData';
+import { useTransactionPayPrimaryRequiredToken } from '../../pay/useTransactionPayData';
 import { useTransactionPayToken } from '../../pay/useTransactionPayToken';
 
 export function useInsufficientBalanceAlerts({
@@ -37,8 +37,10 @@ export function useInsufficientBalanceAlerts({
 
   const isUsingPay = useTransactionPayHasSourceAmount();
   const { payToken } = useTransactionPayToken();
-  const requiredTokens = useTransactionPayRequiredTokens();
-  const isPayPendingInput = Boolean(payToken) && requiredTokens.length === 0;
+  const primaryRequiredToken = useTransactionPayPrimaryRequiredToken();
+
+  const isPayPendingInput =
+    Boolean(payToken) && primaryRequiredToken?.amountRaw === '0';
 
   const isGasFeeTokensEmpty = gasFeeTokens?.length === 0;
 

--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.ts
@@ -15,6 +15,8 @@ import { useConfirmContext } from '../../../context/confirm';
 import { useIsGaslessSupported } from '../../gas/useIsGaslessSupported';
 import { useHasInsufficientBalance } from '../../useHasInsufficientBalance';
 import { useTransactionPayHasSourceAmount } from '../../pay/useTransactionPayHasSourceAmount';
+import { useTransactionPayRequiredTokens } from '../../pay/useTransactionPayData';
+import { useTransactionPayToken } from '../../pay/useTransactionPayToken';
 
 export function useInsufficientBalanceAlerts({
   ignoreGasFeeToken,
@@ -34,6 +36,9 @@ export function useInsufficientBalanceAlerts({
   } = useIsGaslessSupported();
 
   const isUsingPay = useTransactionPayHasSourceAmount();
+  const { payToken } = useTransactionPayToken();
+  const requiredTokens = useTransactionPayRequiredTokens();
+  const isPayPendingInput = Boolean(payToken) && requiredTokens.length === 0;
 
   const isGasFeeTokensEmpty = gasFeeTokens?.length === 0;
 
@@ -62,6 +67,7 @@ export function useInsufficientBalanceAlerts({
   const showAlert =
     hasInsufficientBalance &&
     !isUsingPay &&
+    !isPayPendingInput &&
     isSimulationComplete &&
     hasNoGasFeeTokenSelected &&
     shouldCheckGaslessConditions &&

--- a/ui/pages/confirmations/hooks/pay/useTransactionPayData.test.tsx
+++ b/ui/pages/confirmations/hooks/pay/useTransactionPayData.test.tsx
@@ -14,6 +14,7 @@ import { ConfirmContext } from '../../context/confirm';
 import {
   useIsTransactionPayLoading,
   useTransactionPayIsMaxAmount,
+  useTransactionPayPrimaryRequiredToken,
   useTransactionPayQuotes,
   useTransactionPayRequiredTokens,
   useTransactionPaySourceAmounts,
@@ -28,6 +29,12 @@ const QUOTE_MOCK = {
 
 const REQUIRED_TOKEN_MOCK = {
   address: '0x123',
+  skipIfBalance: false,
+} as unknown as TransactionPayRequiredToken;
+
+const GAS_TOKEN_MOCK = {
+  address: '0x456',
+  skipIfBalance: true,
 } as unknown as TransactionPayRequiredToken;
 
 const SOURCE_AMOUNT_MOCK = {} as TransactionPaySourceAmount;
@@ -123,6 +130,82 @@ describe('useTransactionPayData', () => {
         wrapper: createWrapper(),
       });
       expect(result.current).toBe(true);
+    });
+  });
+
+  describe('useTransactionPayPrimaryRequiredToken', () => {
+    it('returns the first required token without skipIfBalance', () => {
+      const { result } = renderHook(
+        () => useTransactionPayPrimaryRequiredToken(),
+        { wrapper: createWrapper() },
+      );
+      expect(result.current).toStrictEqual(REQUIRED_TOKEN_MOCK);
+    });
+
+    it('skips tokens with skipIfBalance', () => {
+      const store = mockStore({
+        metamask: {
+          transactionData: {
+            [TRANSACTION_ID_MOCK]: {
+              ...STATE_MOCK.metamask.transactionData[TRANSACTION_ID_MOCK],
+              tokens: [GAS_TOKEN_MOCK, REQUIRED_TOKEN_MOCK],
+            },
+          },
+        },
+      });
+
+      const confirmContextValue = {
+        currentConfirmation: { id: TRANSACTION_ID_MOCK },
+        isScrollToBottomCompleted: true,
+        setIsScrollToBottomCompleted: jest.fn(),
+      };
+
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <Provider store={store}>
+          <ConfirmContext.Provider value={confirmContextValue as never}>
+            {children}
+          </ConfirmContext.Provider>
+        </Provider>
+      );
+
+      const { result } = renderHook(
+        () => useTransactionPayPrimaryRequiredToken(),
+        { wrapper },
+      );
+      expect(result.current).toStrictEqual(REQUIRED_TOKEN_MOCK);
+    });
+
+    it('returns undefined when all tokens have skipIfBalance', () => {
+      const store = mockStore({
+        metamask: {
+          transactionData: {
+            [TRANSACTION_ID_MOCK]: {
+              ...STATE_MOCK.metamask.transactionData[TRANSACTION_ID_MOCK],
+              tokens: [GAS_TOKEN_MOCK],
+            },
+          },
+        },
+      });
+
+      const confirmContextValue = {
+        currentConfirmation: { id: TRANSACTION_ID_MOCK },
+        isScrollToBottomCompleted: true,
+        setIsScrollToBottomCompleted: jest.fn(),
+      };
+
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <Provider store={store}>
+          <ConfirmContext.Provider value={confirmContextValue as never}>
+            {children}
+          </ConfirmContext.Provider>
+        </Provider>
+      );
+
+      const { result } = renderHook(
+        () => useTransactionPayPrimaryRequiredToken(),
+        { wrapper },
+      );
+      expect(result.current).toBeUndefined();
     });
   });
 });

--- a/ui/pages/confirmations/hooks/pay/useTransactionPayData.test.tsx
+++ b/ui/pages/confirmations/hooks/pay/useTransactionPayData.test.tsx
@@ -60,8 +60,25 @@ const STATE_MOCK = {
   },
 };
 
-function createWrapper() {
-  const store = mockStore(STATE_MOCK);
+function createWrapper(
+  stateOverrides?: Partial<
+    (typeof STATE_MOCK)['metamask']['transactionData'][typeof TRANSACTION_ID_MOCK]
+  >,
+) {
+  const state = stateOverrides
+    ? {
+        metamask: {
+          transactionData: {
+            [TRANSACTION_ID_MOCK]: {
+              ...STATE_MOCK.metamask.transactionData[TRANSACTION_ID_MOCK],
+              ...stateOverrides,
+            },
+          },
+        },
+      }
+    : STATE_MOCK;
+
+  const store = mockStore(state);
 
   const confirmContextValue = {
     currentConfirmation: { id: TRANSACTION_ID_MOCK },
@@ -143,67 +160,21 @@ describe('useTransactionPayData', () => {
     });
 
     it('skips tokens with skipIfBalance', () => {
-      const store = mockStore({
-        metamask: {
-          transactionData: {
-            [TRANSACTION_ID_MOCK]: {
-              ...STATE_MOCK.metamask.transactionData[TRANSACTION_ID_MOCK],
-              tokens: [GAS_TOKEN_MOCK, REQUIRED_TOKEN_MOCK],
-            },
-          },
-        },
-      });
-
-      const confirmContextValue = {
-        currentConfirmation: { id: TRANSACTION_ID_MOCK },
-        isScrollToBottomCompleted: true,
-        setIsScrollToBottomCompleted: jest.fn(),
-      };
-
-      const wrapper = ({ children }: { children: React.ReactNode }) => (
-        <Provider store={store}>
-          <ConfirmContext.Provider value={confirmContextValue as never}>
-            {children}
-          </ConfirmContext.Provider>
-        </Provider>
-      );
-
       const { result } = renderHook(
         () => useTransactionPayPrimaryRequiredToken(),
-        { wrapper },
+        {
+          wrapper: createWrapper({
+            tokens: [GAS_TOKEN_MOCK, REQUIRED_TOKEN_MOCK],
+          }),
+        },
       );
       expect(result.current).toStrictEqual(REQUIRED_TOKEN_MOCK);
     });
 
     it('returns undefined when all tokens have skipIfBalance', () => {
-      const store = mockStore({
-        metamask: {
-          transactionData: {
-            [TRANSACTION_ID_MOCK]: {
-              ...STATE_MOCK.metamask.transactionData[TRANSACTION_ID_MOCK],
-              tokens: [GAS_TOKEN_MOCK],
-            },
-          },
-        },
-      });
-
-      const confirmContextValue = {
-        currentConfirmation: { id: TRANSACTION_ID_MOCK },
-        isScrollToBottomCompleted: true,
-        setIsScrollToBottomCompleted: jest.fn(),
-      };
-
-      const wrapper = ({ children }: { children: React.ReactNode }) => (
-        <Provider store={store}>
-          <ConfirmContext.Provider value={confirmContextValue as never}>
-            {children}
-          </ConfirmContext.Provider>
-        </Provider>
-      );
-
       const { result } = renderHook(
         () => useTransactionPayPrimaryRequiredToken(),
-        { wrapper },
+        { wrapper: createWrapper({ tokens: [GAS_TOKEN_MOCK] }) },
       );
       expect(result.current).toBeUndefined();
     });

--- a/ui/pages/confirmations/hooks/pay/useTransactionPayData.ts
+++ b/ui/pages/confirmations/hooks/pay/useTransactionPayData.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import type { TransactionMeta } from '@metamask/transaction-controller';
 import {
@@ -35,6 +36,15 @@ export function useTransactionPayTotals() {
 
 export function useTransactionPayIsMaxAmount() {
   return useTransactionPayData(selectTransactionPayIsMaxAmountByTransactionId);
+}
+
+export function useTransactionPayPrimaryRequiredToken() {
+  const requiredTokens = useTransactionPayRequiredTokens();
+
+  return useMemo(
+    () => requiredTokens?.find((t) => !t.skipIfBalance),
+    [requiredTokens],
+  );
 }
 
 function useTransactionPayData<ReturnType>(

--- a/ui/pages/confirmations/hooks/pay/useTransactionPayMetrics.ts
+++ b/ui/pages/confirmations/hooks/pay/useTransactionPayMetrics.ts
@@ -13,8 +13,8 @@ import { hasTransactionType } from '../../utils/transaction-pay';
 import { updateEventFragment } from '../../../../store/actions';
 import { useTransactionPayToken } from './useTransactionPayToken';
 import {
+  useTransactionPayPrimaryRequiredToken,
   useTransactionPayQuotes,
-  useTransactionPayRequiredTokens,
   useTransactionPayTotals,
 } from './useTransactionPayData';
 import { useTransactionPayAvailableTokens } from './useTransactionPayAvailableTokens';
@@ -23,7 +23,7 @@ export function useTransactionPayMetrics() {
   const { currentConfirmation: transactionMeta } =
     useConfirmContext<TransactionMeta>();
   const { payToken } = useTransactionPayToken();
-  const requiredTokens = useTransactionPayRequiredTokens();
+  const primaryRequiredToken = useTransactionPayPrimaryRequiredToken();
   const automaticPayToken = useRef<TransactionPaymentToken>();
   const quotes = useTransactionPayQuotes();
   const totals = useTransactionPayTotals();
@@ -36,7 +36,6 @@ export function useTransactionPayMetrics() {
 
   const transactionId = transactionMeta?.id ?? '';
   const { chainId } = transactionMeta ?? {};
-  const primaryRequiredToken = requiredTokens.find((t) => !t.skipIfBalance);
   const sendingValue = Number(primaryRequiredToken?.amountHuman ?? '0');
 
   if (!automaticPayToken.current && payToken) {

--- a/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
+++ b/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
@@ -57,6 +57,13 @@ function runHook({
       >,
     );
   jest
+    .mocked(useTransactionPayDataModule.useTransactionPayPrimaryRequiredToken)
+    .mockReturnValue(
+      requiredTokens.find((t) => !t.skipIfBalance) as unknown as ReturnType<
+        typeof useTransactionPayDataModule.useTransactionPayPrimaryRequiredToken
+      >,
+    );
+  jest
     .mocked(useTransactionPayTokenModule.useTransactionPayToken)
     .mockReturnValue({
       payToken: {

--- a/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmount.ts
+++ b/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmount.ts
@@ -9,7 +9,7 @@ import { useConfirmContext } from '../../context/confirm';
 import { useTransactionPayToken } from '../pay/useTransactionPayToken';
 import {
   useTransactionPayIsMaxAmount,
-  useTransactionPayRequiredTokens,
+  useTransactionPayPrimaryRequiredToken,
 } from '../pay/useTransactionPayData';
 import { getTokenAddress } from '../../utils/transaction-pay';
 import { useUpdateTokenAmount } from './useUpdateTokenAmount';
@@ -24,16 +24,6 @@ export function useTransactionCustomAmount({
   const [isInputChanged, setInputChanged] = useState(false);
   const [hasInput, setHasInput] = useState(false);
   const [amountHumanDebounced, setAmountHumanDebounced] = useState('0');
-  const requiredTokens = useTransactionPayRequiredTokens();
-  const primaryRequiredToken = useMemo(
-    () => requiredTokens?.find((t) => !t.skipIfBalance),
-    [requiredTokens],
-  );
-  const [amountFiatState, setAmountFiat] = useState(
-    new BigNumber(primaryRequiredToken?.amountUsd ?? '0')
-      .round(2, BigNumber.ROUND_HALF_UP)
-      .toString(10),
-  );
 
   const { currentConfirmation: transactionMeta } =
     useConfirmContext<TransactionMeta>();
@@ -65,6 +55,14 @@ export function useTransactionCustomAmount({
     debounceRef.current = debouncedFn;
     return debouncedFn;
   }, [disableUpdate, updateTokenAmountCallback]);
+
+  const primaryRequiredToken = useTransactionPayPrimaryRequiredToken();
+
+  const [amountFiatState, setAmountFiat] = useState(
+    new BigNumber(primaryRequiredToken?.amountUsd ?? '0')
+      .round(2, BigNumber.ROUND_HALF_UP)
+      .toString(10),
+  );
 
   const amountFiat = useMemo(() => {
     const targetAmountUsd = primaryRequiredToken?.amountUsd;

--- a/ui/pages/confirmations/hooks/transactions/useUpdateTokenAmount.test.ts
+++ b/ui/pages/confirmations/hooks/transactions/useUpdateTokenAmount.test.ts
@@ -79,6 +79,13 @@ function runHook({
         typeof useTransactionPayDataModule.useTransactionPayRequiredTokens
       >,
     );
+  jest
+    .mocked(useTransactionPayDataModule.useTransactionPayPrimaryRequiredToken)
+    .mockReturnValue(
+      requiredTokens.find((t) => !t.skipIfBalance) as unknown as ReturnType<
+        typeof useTransactionPayDataModule.useTransactionPayPrimaryRequiredToken
+      >,
+    );
 
   const state = getMockConfirmStateForTransaction(transactionMeta);
 

--- a/ui/pages/confirmations/hooks/transactions/useUpdateTokenAmount.ts
+++ b/ui/pages/confirmations/hooks/transactions/useUpdateTokenAmount.ts
@@ -9,7 +9,7 @@ import { parseStandardTokenTransactionData } from '../../../../../shared/lib/tra
 import { getTokenTransferData } from '../../utils/transaction-pay';
 import { updateEditableParams } from '../../../../store/actions';
 import { updateAtomicBatchData } from '../../../../store/controller-actions/transaction-controller';
-import { useTransactionPayRequiredTokens } from '../pay/useTransactionPayData';
+import { useTransactionPayPrimaryRequiredToken } from '../pay/useTransactionPayData';
 
 const ERC20_ABI = ['function transfer(address to, uint256 amount)'];
 let erc20Interface: Interface | null = null;
@@ -48,12 +48,7 @@ export function useUpdateTokenAmount() {
     [transactionMeta],
   );
 
-  const requiredTokens = useTransactionPayRequiredTokens();
-
-  const primaryRequiredToken = useMemo(
-    () => requiredTokens?.find((t) => !t.skipIfBalance),
-    [requiredTokens],
-  );
+  const primaryRequiredToken = useTransactionPayPrimaryRequiredToken();
 
   const decimals = primaryRequiredToken?.decimals ?? 18;
 


### PR DESCRIPTION
## **Description**

Suppress insufficient balance alerts in the confirmation UI when MetaMask Pay is active but the user has not yet entered an input amount.

Also extracts a reusable `useTransactionPayPrimaryRequiredToken` hook.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40949?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI logic change that only affects when the insufficient-balance alert is shown during MetaMask Pay flows, plus a small hook refactor reused across a few confirmation hooks.
> 
> **Overview**
> Suppresses the **insufficient balance** alert in confirmations when *MetaMask Pay* is selected but the primary required token amount is still `0` (i.e., user hasn’t entered an amount yet).
> 
> Extracts a reusable `useTransactionPayPrimaryRequiredToken` hook (first required token where `skipIfBalance` is false) and updates Pay-related hooks/tests (`useTransactionPayMetrics`, `useTransactionCustomAmount`, `useUpdateTokenAmount`) to use it.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b8bf756360ea14e48c9d9c7b891590e013d24c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->