### PR TITLE
fix: Correct name for `useSnapNavigation` return value

### DIFF
--- a/ui/components/app/snaps/snap-ui-link/snap-ui-link.js
+++ b/ui/components/app/snaps/snap-ui-link/snap-ui-link.js
@@ -18,7 +18,7 @@ export const SnapUILink = ({ href, children }) => {
   const [isOpen, setIsOpen] = useState(false);
 
   const isMetaMaskUrl = href.startsWith('metamask:');
-  const { navigate } = useSnapNavigation();
+  const { handleSnapNavigate } = useSnapNavigation();
 
   const { snapId } = useSnapInterfaceContext();
   const hideSnapBranding = useSelector((state) =>
@@ -26,7 +26,7 @@ export const SnapUILink = ({ href, children }) => {
   );
 
   const handleMetaMaskLinkClick = () => {
-    navigate(href);
+    handleSnapNavigate(href);
   };
 
   const handleLinkClick = () => {

--- a/ui/components/app/snaps/snap-ui-markdown/snap-ui-markdown.js
+++ b/ui/components/app/snaps/snap-ui-markdown/snap-ui-markdown.js
@@ -52,7 +52,7 @@ const isMetaMaskUrl = (href) => href.startsWith('metamask:');
 
 export const SnapUIMarkdown = ({ children, markdown }) => {
   const [redirectUrl, setRedirectUrl] = useState(undefined);
-  const { navigate } = useSnapNavigation();
+  const { handleSnapNavigate } = useSnapNavigation();
 
   if (markdown === false) {
     return <Paragraph>{children}</Paragraph>;
@@ -91,7 +91,7 @@ export const SnapUIMarkdown = ({ children, markdown }) => {
                 onClick={(e) => {
                   e.stopPropagation();
                   if (isMetaMaskUrl(href)) {
-                    navigate(href);
+                    handleSnapNavigate(href);
                   } else {
                     handleLinkClick(href);
                   }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes an issue where defining `metamask://` URLs in Snaps would not work because the return value for `useSnapNavigation` was updated without changing all the usages.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40950?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed an issue with Snaps links

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk rename-alignment change limited to Snap UI link handling; main risk is regressions in `metamask:` link click behavior if any callers still expect the old `navigate` return shape.
> 
> **Overview**
> Fixes Snap UI `metamask:` link handling by updating `SnapUILink` and `SnapUIMarkdown` to call `useSnapNavigation()`’s renamed `handleSnapNavigate` function instead of the previously-referenced `navigate`.
> 
> This restores in-app navigation for `metamask:` URLs originating from Snap-rendered links and markdown.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53a71e498b122baea4286d6c1128e135029b20af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->