### PR TITLE
fix: gas fee estimates now use the tx chain

### DIFF
--- a/ui/pages/confirmations/hooks/useHasInsufficientBalance.test.ts
+++ b/ui/pages/confirmations/hooks/useHasInsufficientBalance.test.ts
@@ -4,6 +4,10 @@ import {
   TransactionType,
 } from '@metamask/transaction-controller';
 import { ApprovalType, toHex } from '@metamask/controller-utils';
+import { NetworkStatus } from '@metamask/network-controller';
+import { CHAIN_IDS } from '../../../../shared/constants/network';
+import { GasEstimateTypes } from '../../../../shared/constants/gas';
+import { mockNetworkState } from '../../../../test/stub/networks';
 import { renderHookWithConfirmContextProvider } from '../../../../test/lib/confirmations/render-helpers';
 import { getMockConfirmState } from '../../../../test/data/confirmations/helper';
 import { genUnapprovedContractInteractionConfirmation } from '../../../../test/data/confirmations/contract-interaction';
@@ -29,14 +33,17 @@ function buildState({
   transaction = TRANSACTION_MOCK,
   selectedNetworkClientId,
   chainId,
+  metamaskOverrides = {},
 }: {
   balance?: number;
   currentConfirmation?: Partial<TransactionMeta>;
   transaction?: Partial<TransactionMeta>;
   selectedNetworkClientId?: string;
   chainId?: string;
+  metamaskOverrides?: Record<string, unknown>;
 } = {}) {
   const accountAddress = transaction?.txParams?.from as string;
+  const txChainId = chainId ?? transaction?.chainId ?? '0x5';
 
   let pendingApprovals = {};
   if (currentConfirmation) {
@@ -53,11 +60,12 @@ function buildState({
       selectedNetworkClientId: selectedNetworkClientId ?? 'goerli',
       pendingApprovals,
       accountsByChainId: {
-        [chainId ?? '0x5']: {
+        [txChainId]: {
           [accountAddress]: { balance: toHex(balance ?? 0) },
         },
       },
       transactions: transaction ? [transaction] : [],
+      ...metamaskOverrides,
     },
   });
 }
@@ -116,5 +124,75 @@ describe('useHasInsufficientBalance', () => {
   it('returns 0x0 if balance missing', () => {
     const result = runHook({ balance: undefined });
     expect(result.hasInsufficientBalance).toBe(true);
+  });
+
+  it('returns false when transaction chain differs from selected chain but balance is sufficient for transaction chain fee', () => {
+    const networkState = mockNetworkState(
+      {
+        chainId: CHAIN_IDS.MAINNET,
+        metadata: {
+          EIPS: { 1559: true },
+          status: NetworkStatus.Available,
+        },
+      },
+      {
+        chainId: CHAIN_IDS.BASE,
+        metadata: {
+          EIPS: { 1559: true },
+          status: NetworkStatus.Available,
+        },
+      },
+    );
+    const transactionOnBase = {
+      ...TRANSACTION_MOCK,
+      chainId: CHAIN_IDS.BASE,
+      txParams: {
+        ...TRANSACTION_MOCK.txParams,
+        value: '0x0',
+        gas: '0x5208',
+      },
+    };
+    const baseChainGasLow = {
+      estimatedBaseFee: '1',
+      high: {
+        suggestedMaxFeePerGas: '2',
+        suggestedMaxPriorityFeePerGas: '1',
+      },
+      medium: {
+        suggestedMaxFeePerGas: '2',
+        suggestedMaxPriorityFeePerGas: '1',
+      },
+      low: {
+        suggestedMaxFeePerGas: '1',
+        suggestedMaxPriorityFeePerGas: '1',
+      },
+    };
+    const result = runHook({
+      transaction: transactionOnBase as Partial<TransactionMeta>,
+      currentConfirmation: transactionOnBase as Partial<TransactionMeta>,
+      chainId: CHAIN_IDS.BASE,
+      balance: 1e18,
+      selectedNetworkClientId: networkState.selectedNetworkClientId,
+      metamaskOverrides: {
+        ...networkState,
+        gasFeeEstimates: {
+          estimatedBaseFee: '100',
+          medium: {
+            suggestedMaxFeePerGas: '150',
+            suggestedMaxPriorityFeePerGas: '8',
+          },
+        },
+        gasEstimateType: GasEstimateTypes.feeMarket,
+        gasFeeEstimatesByChainId: {
+          [CHAIN_IDS.BASE]: {
+            gasFeeEstimates: baseChainGasLow,
+            gasEstimateType: GasEstimateTypes.feeMarket,
+          },
+        },
+        currencyRates: { ETH: { conversionRate: 1 } },
+        currentCurrency: 'usd',
+      },
+    });
+    expect(result.hasInsufficientBalance).toBe(false);
   });
 });

--- a/ui/selectors/confirm-transaction.js
+++ b/ui/selectors/confirm-transaction.js
@@ -116,19 +116,45 @@ export const transactionFeeSelector = function (state, txData) {
     ? networkClientIdsByChainId?.[transactionChainId]
     : undefined;
 
-  const gasFeeEstimates = (
+  let gasFeeEstimates = (
     transactionChainId && transactionNetworkClientId
       ? getGasFeeEstimatesByChainId(state, transactionChainId)
       : getGasFeeEstimates(state)
   ) || {};
-  const gasEstimateType =
+  let gasEstimateType =
     transactionChainId && transactionNetworkClientId
       ? getGasEstimateTypeByChainId(state, transactionChainId)
       : getGasEstimateType(state);
-  const networkAndAccountSupportsEIP1559 =
+  let networkAndAccountSupportsEIP1559 =
     transactionNetworkClientId !== undefined
       ? checkNetworkAndAccountSupports1559(state, transactionNetworkClientId)
       : checkNetworkAndAccountSupports1559(state);
+
+  // When using transaction chain, fall back to selected chain if estimates are missing
+  // (e.g. gasFeeEstimatesByChainId has no entry for the transaction's chain)
+  let useTransactionChainGas = Boolean(
+    transactionChainId && transactionNetworkClientId,
+  );
+  if (useTransactionChainGas) {
+    const hasEIP1559Estimates =
+      !networkAndAccountSupportsEIP1559 ||
+      (gasFeeEstimates.estimatedBaseFee != null &&
+        (gasFeeEstimates[txData.userFeeLevel]?.suggestedMaxFeePerGas != null ||
+          gasFeeEstimates.gasPrice != null));
+    const hasLegacyEstimates =
+      networkAndAccountSupportsEIP1559 ||
+      gasEstimateType === GasEstimateTypes.feeMarket ||
+      gasEstimateType === GasEstimateTypes.none ||
+      gasFeeEstimates.gasPrice != null;
+    if (!hasEIP1559Estimates || !hasLegacyEstimates) {
+      gasFeeEstimates = getGasFeeEstimates(state) || {};
+      gasEstimateType = getGasEstimateType(state);
+      networkAndAccountSupportsEIP1559 = checkNetworkAndAccountSupports1559(
+        state,
+      );
+      useTransactionChainGas = false;
+    }
+  }
 
   const gasEstimationObject = {
     gasLimit: txData.txParams?.gas ?? '0x0',
@@ -175,7 +201,7 @@ export const transactionFeeSelector = function (state, txData) {
       case GasEstimateTypes.legacy:
         gasEstimationObject.gasPrice =
           txData.txParams?.gasPrice ??
-          (transactionChainId
+          (useTransactionChainGas && transactionChainId
             ? getAveragePriceEstimateInHexWEIByChainId(
                 state,
                 transactionChainId,

--- a/ui/selectors/confirm-transaction.js
+++ b/ui/selectors/confirm-transaction.js
@@ -116,19 +116,18 @@ export const transactionFeeSelector = function (state, txData) {
     ? networkClientIdsByChainId?.[transactionChainId]
     : undefined;
 
-  let gasFeeEstimates = (
-    transactionChainId && transactionNetworkClientId
+  let gasFeeEstimates =
+    (transactionChainId && transactionNetworkClientId
       ? getGasFeeEstimatesByChainId(state, transactionChainId)
-      : getGasFeeEstimates(state)
-  ) || {};
+      : getGasFeeEstimates(state)) || {};
   let gasEstimateType =
     transactionChainId && transactionNetworkClientId
       ? getGasEstimateTypeByChainId(state, transactionChainId)
       : getGasEstimateType(state);
   let networkAndAccountSupportsEIP1559 =
-    transactionNetworkClientId !== undefined
-      ? checkNetworkAndAccountSupports1559(state, transactionNetworkClientId)
-      : checkNetworkAndAccountSupports1559(state);
+    transactionNetworkClientId === undefined
+      ? checkNetworkAndAccountSupports1559(state)
+      : checkNetworkAndAccountSupports1559(state, transactionNetworkClientId);
 
   // When using transaction chain, fall back to selected chain if estimates are missing
   // (e.g. gasFeeEstimatesByChainId has no entry for the transaction's chain)
@@ -136,22 +135,26 @@ export const transactionFeeSelector = function (state, txData) {
     transactionChainId && transactionNetworkClientId,
   );
   if (useTransactionChainGas) {
+    const suggestedMaxFee =
+      gasFeeEstimates[txData.userFeeLevel]?.suggestedMaxFeePerGas;
     const hasEIP1559Estimates =
       !networkAndAccountSupportsEIP1559 ||
-      (gasFeeEstimates.estimatedBaseFee != null &&
-        (gasFeeEstimates[txData.userFeeLevel]?.suggestedMaxFeePerGas != null ||
-          gasFeeEstimates.gasPrice != null));
+      (gasFeeEstimates.estimatedBaseFee !== undefined &&
+        gasFeeEstimates.estimatedBaseFee !== null &&
+        ((suggestedMaxFee !== undefined && suggestedMaxFee !== null) ||
+          (gasFeeEstimates.gasPrice !== undefined &&
+            gasFeeEstimates.gasPrice !== null)));
     const hasLegacyEstimates =
       networkAndAccountSupportsEIP1559 ||
       gasEstimateType === GasEstimateTypes.feeMarket ||
       gasEstimateType === GasEstimateTypes.none ||
-      gasFeeEstimates.gasPrice != null;
+      (gasFeeEstimates.gasPrice !== undefined &&
+        gasFeeEstimates.gasPrice !== null);
     if (!hasEIP1559Estimates || !hasLegacyEstimates) {
       gasFeeEstimates = getGasFeeEstimates(state) || {};
       gasEstimateType = getGasEstimateType(state);
-      networkAndAccountSupportsEIP1559 = checkNetworkAndAccountSupports1559(
-        state,
-      );
+      networkAndAccountSupportsEIP1559 =
+        checkNetworkAndAccountSupports1559(state);
       useTransactionChainGas = false;
     }
   }

--- a/ui/selectors/confirm-transaction.js
+++ b/ui/selectors/confirm-transaction.js
@@ -12,7 +12,9 @@ import {
 } from '../../shared/lib/selectors/assets-migration';
 import {
   getGasEstimateType,
+  getGasEstimateTypeByChainId,
   getGasFeeEstimates,
+  getGasFeeEstimatesByChainId,
   getNativeCurrency,
 } from '../ducks/metamask/metamask';
 import {
@@ -29,10 +31,14 @@ import {
   sumHexes,
 } from '../../shared/lib/conversion.utils';
 import { getProviderConfig } from '../../shared/lib/selectors/networks';
-import { getAveragePriceEstimateInHexWEI } from './custom-gas';
+import {
+  getAveragePriceEstimateInHexWEI,
+  getAveragePriceEstimateInHexWEIByChainId,
+} from './custom-gas';
 import {
   checkNetworkAndAccountSupports1559,
   getMetaMaskAccounts,
+  getNetworkConfigurationIdByChainId,
 } from './selectors';
 import {
   getUnapprovedTransactions,
@@ -101,10 +107,28 @@ export const transactionFeeSelector = function (state, txData) {
   const currentCurrency = currentCurrencySelector(state);
   const conversionRate = conversionRateSelector(state);
   const nativeCurrency = getNativeCurrency(state);
-  const gasFeeEstimates = getGasFeeEstimates(state) || {};
-  const gasEstimateType = getGasEstimateType(state);
+
+  // Use transaction's chain for gas and 1559 when available (fixes insufficient balance
+  // when a different chain is selected in the UI)
+  const transactionChainId = txData?.chainId;
+  const networkClientIdsByChainId = getNetworkConfigurationIdByChainId(state);
+  const transactionNetworkClientId = transactionChainId
+    ? networkClientIdsByChainId?.[transactionChainId]
+    : undefined;
+
+  const gasFeeEstimates = (
+    transactionChainId && transactionNetworkClientId
+      ? getGasFeeEstimatesByChainId(state, transactionChainId)
+      : getGasFeeEstimates(state)
+  ) || {};
+  const gasEstimateType =
+    transactionChainId && transactionNetworkClientId
+      ? getGasEstimateTypeByChainId(state, transactionChainId)
+      : getGasEstimateType(state);
   const networkAndAccountSupportsEIP1559 =
-    checkNetworkAndAccountSupports1559(state);
+    transactionNetworkClientId !== undefined
+      ? checkNetworkAndAccountSupports1559(state, transactionNetworkClientId)
+      : checkNetworkAndAccountSupports1559(state);
 
   const gasEstimationObject = {
     gasLimit: txData.txParams?.gas ?? '0x0',
@@ -150,7 +174,13 @@ export const transactionFeeSelector = function (state, txData) {
         break;
       case GasEstimateTypes.legacy:
         gasEstimationObject.gasPrice =
-          txData.txParams?.gasPrice ?? getAveragePriceEstimateInHexWEI(state);
+          txData.txParams?.gasPrice ??
+          (transactionChainId
+            ? getAveragePriceEstimateInHexWEIByChainId(
+                state,
+                transactionChainId,
+              )
+            : getAveragePriceEstimateInHexWEI(state));
         break;
       default:
         break;

--- a/ui/selectors/confirm-transaction.test.js
+++ b/ui/selectors/confirm-transaction.test.js
@@ -2,10 +2,13 @@ import {
   TransactionStatus,
   TransactionType,
 } from '@metamask/transaction-controller';
+import { NetworkStatus } from '@metamask/network-controller';
 import { CHAIN_IDS } from '../../shared/constants/network';
+import { GasEstimateTypes } from '../../shared/constants/gas';
 import { mockNetworkState } from '../../test/stub/networks';
 import {
   conversionRateSelector,
+  transactionFeeSelector,
   unconfirmedTransactionsHashSelector,
 } from './confirm-transaction';
 
@@ -68,6 +71,111 @@ describe('Confirm Transaction Selector', () => {
         3: state.metamask.transactions[2],
         4: state.metamask.transactions[3],
       });
+    });
+  });
+
+  describe('transactionFeeSelector', () => {
+    const baseTxData = {
+      txParams: { gas: '0x5208', value: '0x0' },
+      userFeeLevel: 'medium',
+    };
+
+    it('uses transaction chain gas when txData.chainId is set and chain has networkClientId', () => {
+      const networkState = mockNetworkState(
+        {
+          chainId: CHAIN_IDS.MAINNET,
+          metadata: { EIPS: { 1559: true }, status: NetworkStatus.Available },
+        },
+        {
+          chainId: CHAIN_IDS.BASE,
+          metadata: { EIPS: { 1559: true }, status: NetworkStatus.Available },
+        },
+      );
+      const selectedChainGasHigh = {
+        estimatedBaseFee: '100',
+        high: {
+          suggestedMaxFeePerGas: '200',
+          suggestedMaxPriorityFeePerGas: '10',
+        },
+        medium: {
+          suggestedMaxFeePerGas: '150',
+          suggestedMaxPriorityFeePerGas: '8',
+        },
+        low: {
+          suggestedMaxFeePerGas: '120',
+          suggestedMaxPriorityFeePerGas: '5',
+        },
+      };
+      const transactionChainGasLow = {
+        estimatedBaseFee: '1',
+        high: {
+          suggestedMaxFeePerGas: '2',
+          suggestedMaxPriorityFeePerGas: '1',
+        },
+        medium: {
+          suggestedMaxFeePerGas: '2',
+          suggestedMaxPriorityFeePerGas: '1',
+        },
+        low: {
+          suggestedMaxFeePerGas: '1',
+          suggestedMaxPriorityFeePerGas: '1',
+        },
+      };
+      const state = {
+        metamask: {
+          ...networkState,
+          gasFeeEstimates: selectedChainGasHigh,
+          gasEstimateType: GasEstimateTypes.feeMarket,
+          gasFeeEstimatesByChainId: {
+            [CHAIN_IDS.BASE]: {
+              gasFeeEstimates: transactionChainGasLow,
+              gasEstimateType: GasEstimateTypes.feeMarket,
+            },
+          },
+          currencyRates: { ETH: { conversionRate: 1 } },
+          currentCurrency: 'usd',
+        },
+      };
+
+      const feeWithTransactionChain = transactionFeeSelector(state, {
+        ...baseTxData,
+        chainId: CHAIN_IDS.BASE,
+      });
+      const feeWithSelectedChainOnly = transactionFeeSelector(state, {
+        ...baseTxData,
+        chainId: undefined,
+      });
+
+      expect(
+        BigInt(feeWithTransactionChain.hexMaximumTransactionFee),
+      ).toBeLessThan(BigInt(feeWithSelectedChainOnly.hexMaximumTransactionFee));
+    });
+
+    it('uses selected chain gas when txData has no chainId', () => {
+      const networkState = mockNetworkState({
+        chainId: CHAIN_IDS.MAINNET,
+        metadata: { EIPS: { 1559: true }, status: NetworkStatus.Available },
+      });
+      const gasEstimates = {
+        estimatedBaseFee: '50',
+        medium: {
+          suggestedMaxFeePerGas: '100',
+          suggestedMaxPriorityFeePerGas: '5',
+        },
+      };
+      const state = {
+        metamask: {
+          ...networkState,
+          gasFeeEstimates: gasEstimates,
+          gasEstimateType: GasEstimateTypes.feeMarket,
+          currencyRates: { ETH: { conversionRate: 1 } },
+          currentCurrency: 'usd',
+        },
+      };
+
+      const result = transactionFeeSelector(state, baseTxData);
+      expect(result.hexMaximumTransactionFee).toBeDefined();
+      expect(result.hexMinimumTransactionFee).toBeDefined();
     });
   });
 });

--- a/ui/selectors/custom-gas.js
+++ b/ui/selectors/custom-gas.js
@@ -8,7 +8,9 @@ import { formatETHFee } from '../helpers/utils/formatters';
 import { GasEstimateTypes as GAS_FEE_CONTROLLER_ESTIMATE_TYPES } from '../../shared/constants/gas';
 import {
   getGasEstimateType,
+  getGasEstimateTypeByChainId,
   getGasFeeEstimates,
+  getGasFeeEstimatesByChainId,
   isEIP1559Network,
 } from '../ducks/metamask/metamask';
 import { calcGasTotal } from '../../shared/lib/transactions-controller-utils';
@@ -32,6 +34,26 @@ export function getAveragePriceEstimateInHexWEI(state) {
   const averagePriceEstimate = getAverageEstimate(state);
 
   return getGasPriceInHexWei(averagePriceEstimate);
+}
+
+/**
+ * Get average gas price estimate in hex wei for a specific chain.
+ * Used when computing transaction fees for a transaction's chain (e.g. confirmation screen).
+ *
+ * @param {object} state - Redux state
+ * @param {string} chainId - Hex chain ID
+ * @returns {string} Average price in hex wei, or '0x0' if no legacy estimate for chain
+ */
+export function getAveragePriceEstimateInHexWEIByChainId(state, chainId) {
+  const gasFeeEstimates = getGasFeeEstimatesByChainId(state, chainId);
+  const gasEstimateType = getGasEstimateTypeByChainId(state, chainId);
+
+  const averagePriceEstimate =
+    gasEstimateType === GAS_FEE_CONTROLLER_ESTIMATE_TYPES.legacy
+      ? gasFeeEstimates?.medium
+      : null;
+
+  return getGasPriceInHexWei(averagePriceEstimate || '0');
 }
 
 export function getFastPriceEstimateInHexWEI(state) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes a gas fee estimate of a transaction using the selected network in the home page instead of the one associated to the current transaction.

One of the consequences of this was gasless was enabled by default in some cases when the user had enough native gas funds.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40951?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix gas fee estimate used on wrong network

## **Related issues**

Fixes:

## **Manual testing steps**

1. Select a network (ex: Polygon) in the home page
2. Click on Send
3. Select a token from another network (ex: Base)
4. If you have enough native gas token, MetaMask shouldn't default to gasless by selecting an ERC-20 as the gas fee token.

To properly test this, first reproduce the issue with extension <= 13.22.0, then install the extension with the fix and check the native gas token is now selected by default.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/2bc273f6-d0f3-4d68-ae96-ef23c0805445



### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/f268ac95-7453-4bcb-a32b-44b0d6765ebc




## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
