### PR TITLE
fix: updated utils to handle corrupted account state

### DIFF
--- a/ui/components/app/contact-list/utils.ts
+++ b/ui/components/app/contact-list/utils.ts
@@ -1,15 +1,20 @@
 import { AddressBookEntry } from '@metamask/address-book-controller';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 
+const getAccountName = (account: InternalAccount): string =>
+  account?.metadata?.name ?? '';
+
 export const buildDuplicateContactMap = (
   addressBook: AddressBookEntry[],
   internalAccounts: InternalAccount[],
 ) => {
   const contactMap = new Map<string, string[]>(
-    internalAccounts.map((account) => [
-      account.metadata.name.trim().toLowerCase(),
-      [`account-id-${account.id}`],
-    ]),
+    internalAccounts
+      .filter((account) => getAccountName(account))
+      .map((account) => [
+        getAccountName(account).trim().toLowerCase(),
+        [`account-id-${account.id}`],
+      ]),
   );
 
   addressBook.forEach((entry) => {
@@ -34,9 +39,10 @@ export const hasDuplicateContacts = (
     new Set(addressBook.map(({ name }) => name.toLowerCase().trim())),
   );
 
-  const hasAccountNameCollision = internalAccounts.some((account) =>
-    uniqueContactNames.includes(account.metadata.name.toLowerCase().trim()),
-  );
+  const hasAccountNameCollision = internalAccounts.some((account) => {
+    const name = getAccountName(account);
+    return name && uniqueContactNames.includes(name.toLowerCase().trim());
+  });
 
   return (
     uniqueContactNames.length !== addressBook.length || hasAccountNameCollision
@@ -52,10 +58,10 @@ export const isDuplicateContact = (
     ({ name }) => name.toLowerCase().trim() === newName.toLowerCase().trim(),
   );
 
-  const nameExistsInAccountList = internalAccounts.some(
-    ({ metadata }) =>
-      metadata.name.toLowerCase().trim() === newName.toLowerCase().trim(),
-  );
+  const nameExistsInAccountList = internalAccounts.some((account) => {
+    const name = getAccountName(account);
+    return name && name.toLowerCase().trim() === newName.toLowerCase().trim();
+  });
 
   return nameExistsInAddressBook || nameExistsInAccountList;
 };

--- a/ui/pages/contacts/contacts-list-page.test.tsx
+++ b/ui/pages/contacts/contacts-list-page.test.tsx
@@ -88,6 +88,32 @@ describe('ContactsListPage', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/');
   });
 
+  it('renders without crashing when an account has missing metadata', () => {
+    const stateWithBrokenAccount = {
+      ...mockState,
+      metamask: {
+        ...mockState.metamask,
+        internalAccounts: {
+          ...mockState.metamask.internalAccounts,
+          accounts: {
+            ...mockState.metamask.internalAccounts.accounts,
+            'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee': {
+              id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+              address: '0x1234567890abcdef1234567890abcdef12345678',
+              options: {},
+              methods: [],
+              scopes: ['eip155:0'],
+              type: 'eip155:eoa',
+            },
+          },
+        },
+      },
+    };
+    const { getByTestId } = renderPage(stateWithBrokenAccount);
+    expect(getByTestId('contacts-page')).toBeInTheDocument();
+    expect(getByTestId('contact-list-item')).toBeInTheDocument();
+  });
+
   describe('chain-aware navigation', () => {
     it('includes the correct chainId for contacts on different chains', () => {
       const multiChainState = {


### PR DESCRIPTION
## **Description**

The contacts list page (ContactsListPage) and the add/edit contact forms crash when an internal account has corrupted state — specifically when account.metadata or account.metadata.name is undefined. This can happen due to state corruption or migration edge cases.

This PR adds defensive handling in the contact list utility functions (buildDuplicateContactMap, hasDuplicateContacts, isDuplicateContact) via a getAccountName helper that safely accesses account?.metadata?.name, falling back to an empty string. Accounts with missing names are filtered out of duplicate detection rather than causing a runtime crash.

A component-level test is added to ContactsListPage to verify the page renders without crashing when an account has missing metadata

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a crash on the contacts page when an internal account had corrupted or missing metadata.

## **Related issues**

Fixes: #39699

## **Manual testing steps**

1. Open MetaMask and navigate to the Contacts page via the global menu
2. Verify the contacts page loads and existing contacts are displayed
3. Add a new contact and verify it saves successfully

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds defensive null/undefined handling around `InternalAccount.metadata.name` in duplicate-contact utilities and a regression test to prevent crashes from corrupted account state.
> 
> **Overview**
> Prevents the Contacts UI from crashing when an `InternalAccount` is missing `metadata`/`metadata.name` by introducing a safe `getAccountName` helper and skipping unnamed accounts in duplicate-name detection (`buildDuplicateContactMap`, `hasDuplicateContacts`, `isDuplicateContact`).
> 
> Adds a `ContactsListPage` test that renders the page with a deliberately malformed internal account to verify the page still loads and shows contacts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e43dc250525d8341813e56c4e666be0c7e29ba2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->