### PR TITLE
fix: flaky test `eth_requestAccounts prompts for login when there are no permitted accounts and the wallet is locked`

### DIFF
--- a/test/e2e/json-rpc/eth_requestAccounts.spec.ts
+++ b/test/e2e/json-rpc/eth_requestAccounts.spec.ts
@@ -53,6 +53,9 @@ describe('eth_requestAccounts', function () {
       },
       async ({ driver }: { driver: Driver }) => {
         // eth_requestAccounts
+        await driver.navigate();
+        const loginPage = new LoginPage(driver);
+        await loginPage.checkPageIsLoaded();
         const testDapp = new TestDapp(driver);
         await testDapp.openTestDappPage();
         await testDapp.checkPageIsLoaded();
@@ -81,6 +84,9 @@ describe('eth_requestAccounts', function () {
         title: this.test?.fullTitle(),
       },
       async ({ driver }: { driver: Driver }) => {
+        await driver.navigate();
+        const loginPage = new LoginPage(driver);
+        await loginPage.checkPageIsLoaded();
         const testDapp = new TestDapp(driver);
         await testDapp.openTestDappPage();
         await testDapp.checkPageIsLoaded();
@@ -96,7 +102,6 @@ describe('eth_requestAccounts', function () {
 
         await driver.waitUntilXWindowHandles(3);
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
-        const loginPage = new LoginPage(driver);
         await loginPage.checkPageIsLoaded();
         await loginPage.loginToHomepage();
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

With FixtureBuilderV2 we include a multichain accounts (EVM+nonEVM). When the user approves the dApp connection, the wallet tries to include all available accounts, ie including the Solana one. But the Solana Snap isn't loaded/ready (it's a fixture-only state), so the authorizedScopes validation fails because the Solana account can't be authorized without the Snap being present.
This is a race condition / state mismatch: V2 seeds a Solana account in the fixture, but the Snap that manages it isn't running. When the permission system tries to grant caip25 permissions including that account, it rejects because the account type isn't "supported by the wallet" at that point.

We can go to the login page and ensure the controllers are loaded before going to the test dapp and triggering the permission request.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40957?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that adjust navigation/setup order to reduce a race in e2e initialization; no production code paths are modified.
> 
> **Overview**
> Improves reliability of the `eth_requestAccounts` e2e specs by explicitly navigating to the extension and waiting for the `LoginPage` to load before opening the test dapp in the wallet-locked scenarios.
> 
> This reorders setup so controller/UI initialization happens deterministically before `window.ethereum.request('eth_requestAccounts')` is executed, reducing flakiness around the subsequent login/connect confirmation flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a60ba5bacd84d567ff8d15d6b4254d7047f3406. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->