### PR TITLE
chore: refactor logic and const on ipfs gateway setting

### DIFF
--- a/shared/constants/network.ts
+++ b/shared/constants/network.ts
@@ -1502,6 +1502,7 @@ export const UNSUPPORTED_RPC_METHODS = new Set([
 ]);
 
 export const IPFS_DEFAULT_GATEWAY_URL = 'dweb.link';
+export const IPFS_FORBIDDEN_GATEWAY = 'gateway.ipfs.io';
 
 export const QUICKNODE_ENDPOINT_URLS_BY_INFURA_NETWORK_NAME = {
   'ethereum-mainnet': () => process.env.QUICKNODE_MAINNET_URL,

--- a/ui/pages/onboarding-flow/privacy-settings/privacy-settings.tsx
+++ b/ui/pages/onboarding-flow/privacy-settings/privacy-settings.tsx
@@ -65,6 +65,7 @@ import {
 } from '../../../ducks/app/app';
 import {
   CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP,
+  IPFS_FORBIDDEN_GATEWAY,
   TEST_CHAINS,
 } from '../../../../shared/constants/network';
 import { selectIsBackupAndSyncEnabled } from '../../../selectors/identity/backup-and-sync';
@@ -185,7 +186,7 @@ export default function PrivacySettings() {
     setIPFSURL(url);
     try {
       const { host } = new URL(addUrlProtocolPrefix(url) as string);
-      if (!host || host === 'gateway.ipfs.io') {
+      if (!host || host === IPFS_FORBIDDEN_GATEWAY) {
         throw new Error();
       }
       setIPFSError(null);

--- a/ui/pages/settings-v2/privacy-tab/ipfs-gateway-item.tsx
+++ b/ui/pages/settings-v2/privacy-tab/ipfs-gateway-item.tsx
@@ -9,7 +9,10 @@ import {
   setIsIpfsGatewayEnabled,
 } from '../../../store/actions';
 import type { MetaMaskReduxState } from '../../../store/store';
-import { IPFS_DEFAULT_GATEWAY_URL } from '../../../../shared/constants/network';
+import {
+  IPFS_DEFAULT_GATEWAY_URL,
+  IPFS_FORBIDDEN_GATEWAY,
+} from '../../../../shared/constants/network';
 // eslint-disable-next-line import/no-restricted-paths
 import { addUrlProtocolPrefix } from '../../../../app/scripts/lib/util';
 
@@ -28,35 +31,27 @@ export const IpfsGatewayItem = () => {
   const [ipfsGatewayError, setIpfsGatewayError] = useState('');
 
   const handleIpfsGatewayChange = (url: string) => {
-    let error = '';
+    setIpfsGatewayValue(url);
 
-    if (url.length > 0) {
-      try {
-        const validUrl = addUrlProtocolPrefix(url);
-
-        if (validUrl) {
-          const urlObj = new URL(validUrl);
-
-          // don't allow the use of this gateway
-          if (urlObj.host === 'gateway.ipfs.io') {
-            error = t('forbiddenIpfsGateway');
-          }
-
-          if (error.length === 0) {
-            dispatch(setIpfsGateway(urlObj.host));
-          }
-        } else {
-          error = t('invalidIpfsGateway');
-        }
-      } catch {
-        error = t('invalidIpfsGateway');
-      }
-    } else {
-      error = t('invalidIpfsGateway');
+    if (!url.length) {
+      setIpfsGatewayError(t('invalidIpfsGateway'));
+      return;
     }
 
-    setIpfsGatewayValue(url);
-    setIpfsGatewayError(error);
+    const validUrl = addUrlProtocolPrefix(url);
+    if (!validUrl) {
+      setIpfsGatewayError(t('invalidIpfsGateway'));
+      return;
+    }
+
+    const urlObj = new URL(validUrl);
+    if (urlObj.host === IPFS_FORBIDDEN_GATEWAY) {
+      setIpfsGatewayError(t('forbiddenIpfsGateway'));
+      return;
+    }
+
+    dispatch(setIpfsGateway(urlObj.host));
+    setIpfsGatewayError('');
   };
 
   const handleToggle = (currentValue: boolean) => {

--- a/ui/pages/settings/security-tab/security-tab.component.js
+++ b/ui/pages/settings/security-tab/security-tab.component.js
@@ -14,7 +14,10 @@ import {
   MetaMetricsEventKeyType,
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
-import { IPFS_DEFAULT_GATEWAY_URL } from '../../../../shared/constants/network';
+import {
+  IPFS_DEFAULT_GATEWAY_URL,
+  IPFS_FORBIDDEN_GATEWAY,
+} from '../../../../shared/constants/network';
 import {
   AUTO_DETECT_TOKEN_LEARN_MORE_LINK,
   COINGECKO_LINK,
@@ -664,7 +667,7 @@ export default class SecurityTab extends PureComponent {
           const urlObj = new URL(validUrl);
 
           // don't allow the use of this gateway
-          if (urlObj.host === 'gateway.ipfs.io') {
+          if (urlObj.host === IPFS_FORBIDDEN_GATEWAY) {
             ipfsError = t('forbiddenIpfsGateway');
           }
 


### PR DESCRIPTION
## **Description**

Small refactor on the IPFS setting item on the validation logic and usage of a shared const.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

No change in current behaviour.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes the forbidden IPFS gateway host and streamlines UI-side validation; behavior should be unchanged aside from slightly stricter early-return validation in settings.
> 
> **Overview**
> **Centralizes IPFS gateway validation** by introducing `IPFS_FORBIDDEN_GATEWAY` (currently `gateway.ipfs.io`) in `shared/constants/network` and reusing it across onboarding and settings.
> 
> Refactors the Settings v2 IPFS gateway input handler to use clear early-return validation and only dispatch `setIpfsGateway` when the URL is non-empty, parseable, and not the forbidden host; legacy settings/onboarding checks now reference the shared constant instead of an inline string.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2143e6bbde31bf9e8b8802d14d6f66516c67cd6a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->