### PR TITLE
fix: Fix insufficient balance alert when other network is selected by network picker

### DIFF
--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -915,7 +915,7 @@
       "Reselect: Identity function warnings": 3
     },
     "ui/pages/confirmations/components/confirm/info/shared/gas-fees-section/gas-fees-section.test.tsx": {
-      "MetaMask: Background connection not initialized": 34,
+      "MetaMask: Background connection not initialized": 52,
       "Reselect: Identity function warnings": 5
     },
     "ui/pages/confirmations/components/confirm/info/shared/network-row/network-row.test.tsx": {

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -885,7 +885,7 @@
       "Reselect: Identity function warnings": 3
     },
     "ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.test.tsx": {
-      "MetaMask: Background connection not initialized": 78,
+      "MetaMask: Background connection not initialized": 114,
       "Reselect: Identity function warnings": 4
     },
     "ui/pages/confirmations/components/confirm/info/shared/edit-gas-icon/edit-gas-icon-button.test.tsx": {
@@ -908,8 +908,7 @@
       "Reselect: Identity function warnings": 4
     },
     "ui/pages/confirmations/components/confirm/info/shared/gas-fees-details/gas-fees-details.test.tsx": {
-
-      "MetaMask: Background connection not initialized": 272,
+      "MetaMask: Background connection not initialized": 416,
       "Reselect: Identity function warnings": 5
     },
     "ui/pages/confirmations/components/confirm/info/shared/gas-fees-row/gas-fees-row.test.tsx": {
@@ -1202,6 +1201,7 @@
       "Reselect: Identity function warnings": 3
     },
     "ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.test.ts": {
+      "MetaMask: Background connection not initialized": 84,
       "Reselect: Identity function warnings": 3
     },
     "ui/pages/confirmations/hooks/alerts/transactions/useInsufficientPayTokenBalanceAlert.test.ts": {
@@ -1368,6 +1368,7 @@
       "React: Act warnings (component updates not wrapped)": 1
     },
     "ui/pages/confirmations/hooks/useHasInsufficientBalance.test.ts": {
+      "MetaMask: Background connection not initialized": 30,
       "Reselect: Identity function warnings": 3
     },
     "ui/pages/confirmations/hooks/useLedgerConnection.test.ts": {

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -1202,7 +1202,6 @@
       "Reselect: Identity function warnings": 3
     },
     "ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.test.ts": {
-
       "Reselect: Identity function warnings": 3
     },
     "ui/pages/confirmations/hooks/alerts/transactions/useInsufficientPayTokenBalanceAlert.test.ts": {

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -777,7 +777,7 @@
       "Reselect: Identity function warnings": 4
     },
     "ui/pages/confirmations/components/confirm/info/approve/approve.test.tsx": {
-      "MetaMask: Background connection not initialized": 27,
+      "MetaMask: Background connection not initialized": 39,
       "React: Act warnings (component updates not wrapped)": 14,
       "Reselect: Identity function warnings": 5
     },
@@ -794,7 +794,7 @@
       "Reselect: Identity function warnings": 4
     },
     "ui/pages/confirmations/components/confirm/info/base-transaction-info/base-transaction-info.test.tsx": {
-      "MetaMask: Background connection not initialized": 53,
+      "MetaMask: Background connection not initialized": 77,
       "React: Act warnings (component updates not wrapped)": 14,
       "Reselect: Identity function warnings": 5,
       "Reselect: Input stability warnings": 1
@@ -839,19 +839,19 @@
       "Reselect: Identity function warnings": 3
     },
     "ui/pages/confirmations/components/confirm/info/info.test.tsx": {
-      "MetaMask: Background connection not initialized": 86,
+      "MetaMask: Background connection not initialized": 122,
       "React: Act warnings (component updates not wrapped)": 21,
       "Reselect: Identity function warnings": 5,
       "Reselect: Input stability warnings": 1,
       "Test errors: Uncaught Errors": 2
     },
     "ui/pages/confirmations/components/confirm/info/native-transfer/native-transfer.test.tsx": {
-      "MetaMask: Background connection not initialized": 29,
+      "MetaMask: Background connection not initialized": 41,
       "React: Act warnings (component updates not wrapped)": 14,
       "Reselect: Identity function warnings": 5
     },
     "ui/pages/confirmations/components/confirm/info/nft-token-transfer/nft-token-transfer.test.tsx": {
-      "MetaMask: Background connection not initialized": 28,
+      "MetaMask: Background connection not initialized": 40,
       "React: Act warnings (component updates not wrapped)": 15,
       "Reselect: Identity function warnings": 5
     },
@@ -865,7 +865,7 @@
       "Reselect: Identity function warnings": 4
     },
     "ui/pages/confirmations/components/confirm/info/set-approval-for-all-info/set-approval-for-all-info.test.tsx": {
-      "MetaMask: Background connection not initialized": 27,
+      "MetaMask: Background connection not initialized": 39,
       "React: Act warnings (component updates not wrapped)": 15,
       "Reselect: Identity function warnings": 5
     },
@@ -888,6 +888,9 @@
       "MetaMask: Background connection not initialized": 78,
       "Reselect: Identity function warnings": 4
     },
+    "ui/pages/confirmations/components/confirm/info/shared/edit-gas-icon/edit-gas-icon-button.test.tsx": {
+      "warn: ⚠️ React Router Future Flag": 2
+    },
     "ui/pages/confirmations/components/confirm/info/shared/gas-fee-token-icon/gas-fee-token-icon.test.tsx": {
       "Reselect: Identity function warnings": 4
     },
@@ -905,6 +908,7 @@
       "Reselect: Identity function warnings": 4
     },
     "ui/pages/confirmations/components/confirm/info/shared/gas-fees-details/gas-fees-details.test.tsx": {
+
       "MetaMask: Background connection not initialized": 272,
       "Reselect: Identity function warnings": 5
     },
@@ -949,7 +953,7 @@
       "Reselect: Input stability warnings": 1
     },
     "ui/pages/confirmations/components/confirm/info/shield-subscription-approve/shield-subscription-approve.test.tsx": {
-      "MetaMask: Background connection not initialized": 34,
+      "MetaMask: Background connection not initialized": 52,
       "React: Act warnings (component updates not wrapped)": 19,
       "Reselect: Identity function warnings": 5
     },
@@ -957,7 +961,7 @@
       "Reselect: Identity function warnings": 4
     },
     "ui/pages/confirmations/components/confirm/info/token-transfer/token-transfer.test.tsx": {
-      "MetaMask: Background connection not initialized": 27,
+      "MetaMask: Background connection not initialized": 39,
       "React: Act warnings (component updates not wrapped)": 15,
       "Reselect: Identity function warnings": 5
     },
@@ -1144,7 +1148,7 @@
       "Reselect: Identity function warnings": 4
     },
     "ui/pages/confirmations/confirm/confirm.test.tsx": {
-      "MetaMask: Background connection not initialized": 210,
+      "MetaMask: Background connection not initialized": 262,
       "React: Act warnings (component updates not wrapped)": 4,
       "Reselect: Identity function warnings": 7
     },
@@ -1198,6 +1202,7 @@
       "Reselect: Identity function warnings": 3
     },
     "ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.test.ts": {
+
       "Reselect: Identity function warnings": 3
     },
     "ui/pages/confirmations/hooks/alerts/transactions/useInsufficientPayTokenBalanceAlert.test.ts": {
@@ -1335,7 +1340,7 @@
       "Reselect: Identity function warnings": 3
     },
     "ui/pages/confirmations/hooks/useConfirmationAlerts.test.ts": {
-      "MetaMask: Background connection not initialized": 2,
+      "MetaMask: Background connection not initialized": 7,
       "React: Act warnings (component updates not wrapped)": 4,
       "Reselect: Identity function warnings": 6
     },

--- a/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.test.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.test.ts
@@ -40,6 +40,7 @@ describe('useFeeCalculations', () => {
         "l2FeeNative": "",
         "maxFeeFiat": "< $0.01",
         "maxFeeFiatWith18SignificantDigits": "0",
+        "maxFeeHex": "0x0",
         "maxFeeNative": "0",
       }
     `);
@@ -70,6 +71,7 @@ describe('useFeeCalculations', () => {
         "l2FeeNative": "",
         "maxFeeFiat": "$0.07",
         "maxFeeFiatWith18SignificantDigits": null,
+        "maxFeeHex": "0x720087dcfc95",
         "maxFeeNative": "0.0001",
       }
     `);
@@ -121,6 +123,7 @@ describe('useFeeCalculations', () => {
         "l2FeeNative": "",
         "maxFeeFiat": "",
         "maxFeeFiatWith18SignificantDigits": null,
+        "maxFeeHex": "0x720087dcfc95",
         "maxFeeNative": "0.0001",
       }
     `);

--- a/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.ts
@@ -299,7 +299,7 @@ export function useFeeCalculations(transactionMeta: TransactionMeta) {
     l2FeeNative: feesL2.nativeCurrencyFee,
     maxFeeFiat,
     maxFeeFiatWith18SignificantDigits,
-    maxFeeHex,
+    maxFeeHex: add0x(maxFeeHex),
     maxFeeNative,
   };
 }

--- a/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.ts
@@ -175,6 +175,7 @@ export function useFeeCalculations(transactionMeta: TransactionMeta) {
     currentCurrencyFeeWith18SignificantDigits:
       maxFeeFiatWith18SignificantDigits,
     nativeCurrencyFee: maxFeeNative,
+    hexFee: maxFeeHex,
   } = getFeesFromHex(maxFee);
 
   // Estimated fee
@@ -298,6 +299,7 @@ export function useFeeCalculations(transactionMeta: TransactionMeta) {
     l2FeeNative: feesL2.nativeCurrencyFee,
     maxFeeFiat,
     maxFeeFiatWith18SignificantDigits,
+    maxFeeHex,
     maxFeeNative,
   };
 }

--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.test.ts
@@ -36,6 +36,7 @@ const useTransactionPayTokenMock = jest.mocked(useTransactionPayToken);
 
 const TRANSACTION_ID_MOCK = '123-456';
 const TRANSACTION_ID_MOCK_2 = '456-789';
+const ACCOUNT_ADDRESS = '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc';
 
 const TRANSACTION_MOCK = {
   ...genUnapprovedContractInteractionConfirmation({
@@ -43,7 +44,7 @@ const TRANSACTION_MOCK = {
   }),
   id: TRANSACTION_ID_MOCK,
   txParams: {
-    from: '0x123',
+    from: ACCOUNT_ADDRESS,
     value: '0x2',
     maxFeePerGas: '0x2',
     gas: '0x3',
@@ -263,16 +264,18 @@ describe('useInsufficientBalanceAlerts', () => {
         },
       ],
     };
+    // Balance of 1500000005 is sufficient for a single send (value=0x2, gas=0x6)
+    // but insufficient for the batch total (value + nested values + gas = 1500000008)
     expect(
       runHook({
-        balance: 210000000002,
+        balance: 1500000005,
         currentConfirmation: TRANSACTION_MOCK as Partial<TransactionMeta>,
         transaction: TRANSACTION_MOCK as Partial<TransactionMeta>,
       }),
     ).toEqual([]);
     expect(
       runHook({
-        balance: 210000000002,
+        balance: 1500000005,
         currentConfirmation: BATCH_TRANSACTION_MOCK as Partial<TransactionMeta>,
         transaction: BATCH_TRANSACTION_MOCK as Partial<TransactionMeta>,
       }),

--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.test.ts
@@ -1,4 +1,8 @@
-import { ApprovalType, toHex } from '@metamask/controller-utils';
+import {
+  ApprovalType,
+  toChecksumHexAddress,
+  toHex,
+} from '@metamask/controller-utils';
 import {
   GasFeeToken,
   TransactionMeta,
@@ -100,7 +104,9 @@ function buildState({
       pendingApprovals,
       accountsByChainId: {
         [chainId ?? '0x5']: {
-          [accountAddress]: { balance: toHex(balance ?? 0) },
+          [toChecksumHexAddress(accountAddress)]: {
+            balance: toHex(balance ?? 0),
+          },
         },
       },
       transactions: transaction ? [transaction] : [],

--- a/ui/pages/confirmations/hooks/useHasInsufficientBalance.test.ts
+++ b/ui/pages/confirmations/hooks/useHasInsufficientBalance.test.ts
@@ -10,13 +10,14 @@ import { genUnapprovedContractInteractionConfirmation } from '../../../../test/d
 import { useHasInsufficientBalance } from './useHasInsufficientBalance';
 
 const TRANSACTION_ID_MOCK = '123-456';
+const ACCOUNT_ADDRESS = '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc';
 const TRANSACTION_MOCK = {
   ...genUnapprovedContractInteractionConfirmation({
     chainId: '0x5',
   }),
   id: TRANSACTION_ID_MOCK,
   txParams: {
-    from: '0x123',
+    from: ACCOUNT_ADDRESS,
     value: '0x2',
     maxFeePerGas: '0x2',
     gas: '0x3',

--- a/ui/pages/confirmations/hooks/useHasInsufficientBalance.test.ts
+++ b/ui/pages/confirmations/hooks/useHasInsufficientBalance.test.ts
@@ -3,7 +3,11 @@ import {
   TransactionParams,
   TransactionType,
 } from '@metamask/transaction-controller';
-import { ApprovalType, toHex } from '@metamask/controller-utils';
+import {
+  ApprovalType,
+  toChecksumHexAddress,
+  toHex,
+} from '@metamask/controller-utils';
 import { renderHookWithConfirmContextProvider } from '../../../../test/lib/confirmations/render-helpers';
 import { getMockConfirmState } from '../../../../test/data/confirmations/helper';
 import { genUnapprovedContractInteractionConfirmation } from '../../../../test/data/confirmations/contract-interaction';
@@ -55,7 +59,9 @@ function buildState({
       pendingApprovals,
       accountsByChainId: {
         [chainId ?? '0x5']: {
-          [accountAddress]: { balance: toHex(balance ?? 0) },
+          [toChecksumHexAddress(accountAddress)]: {
+            balance: toHex(balance ?? 0),
+          },
         },
       },
       transactions: transaction ? [transaction] : [],

--- a/ui/pages/confirmations/hooks/useHasInsufficientBalance.ts
+++ b/ui/pages/confirmations/hooks/useHasInsufficientBalance.ts
@@ -35,7 +35,11 @@ export function useHasInsufficientBalance(): {
 
   const totalValue = sumHexes(value, ...batchTransactionValues);
 
-  const { maxFeeHex } = useFeeCalculations(currentConfirmation);
+  const { maxFeeHex } = useFeeCalculations(
+    currentConfirmation?.txParams
+      ? currentConfirmation
+      : ({} as TransactionMeta),
+  );
 
   const [multichainNetworks, evmNetworks] = useSelector(
     getMultichainNetworkConfigurationsByChainId,

--- a/ui/pages/confirmations/hooks/useHasInsufficientBalance.ts
+++ b/ui/pages/confirmations/hooks/useHasInsufficientBalance.ts
@@ -5,11 +5,11 @@ import { useSelector } from 'react-redux';
 import { sumHexes } from '../../../../shared/lib/conversion.utils';
 import {
   getMultichainNetworkConfigurationsByChainId,
-  getNativeTokenCachedBalanceByChainIdSelector,
-  selectTransactionFeeById,
+  selectTransactionAvailableBalance,
 } from '../../../selectors';
 import { useConfirmContext } from '../context/confirm';
 import { isBalanceSufficient } from '../send-utils/send.utils';
+import { useFeeCalculations } from '../components/confirm/info/hooks/useFeeCalculations';
 
 const ZERO_HEX_FALLBACK = '0x0';
 
@@ -21,7 +21,7 @@ export function useHasInsufficientBalance(): {
   const {
     id: transactionId,
     chainId,
-    txParams: { value = ZERO_HEX_FALLBACK, from: fromAddress = '' } = {},
+    txParams: { value = ZERO_HEX_FALLBACK } = {},
   } = currentConfirmation ?? {};
 
   const batchTransactionValues =
@@ -29,16 +29,16 @@ export function useHasInsufficientBalance(): {
       (trxn) => (trxn.value as Hex) ?? ZERO_HEX_FALLBACK,
     ) ?? [];
 
-  const chainBalances = useSelector((state) =>
-    getNativeTokenCachedBalanceByChainIdSelector(state, fromAddress ?? ''),
-  ) as Record<Hex, Hex>;
-
-  const balance = chainBalances?.[chainId as Hex] ?? ZERO_HEX_FALLBACK;
+  const balance = (useSelector((state) =>
+    selectTransactionAvailableBalance(state, transactionId, chainId),
+  ) ?? ZERO_HEX_FALLBACK) as Hex;
 
   const totalValue = sumHexes(value, ...batchTransactionValues);
 
-  const { hexMaximumTransactionFee } = useSelector((state) =>
-    selectTransactionFeeById(state, transactionId),
+  const { maxFeeHex } = useFeeCalculations(
+    currentConfirmation?.txParams
+      ? currentConfirmation
+      : ({ txParams: {} } as TransactionMeta),
   );
 
   const [multichainNetworks, evmNetworks] = useSelector(
@@ -51,7 +51,7 @@ export function useHasInsufficientBalance(): {
 
   const insufficientBalance = !isBalanceSufficient({
     amount: totalValue,
-    gasTotal: hexMaximumTransactionFee,
+    gasTotal: maxFeeHex,
     balance,
   });
 

--- a/ui/pages/confirmations/hooks/useHasInsufficientBalance.ts
+++ b/ui/pages/confirmations/hooks/useHasInsufficientBalance.ts
@@ -38,7 +38,7 @@ export function useHasInsufficientBalance(): {
   const { maxFeeHex } = useFeeCalculations(
     currentConfirmation?.txParams
       ? currentConfirmation
-      : ({} as TransactionMeta),
+      : ({ txParams: {} } as TransactionMeta),
   );
 
   const [multichainNetworks, evmNetworks] = useSelector(

--- a/ui/pages/confirmations/hooks/useHasInsufficientBalance.ts
+++ b/ui/pages/confirmations/hooks/useHasInsufficientBalance.ts
@@ -5,7 +5,7 @@ import { useSelector } from 'react-redux';
 import { sumHexes } from '../../../../shared/lib/conversion.utils';
 import {
   getMultichainNetworkConfigurationsByChainId,
-  selectTransactionAvailableBalance,
+  getNativeTokenCachedBalanceByChainIdSelector,
 } from '../../../selectors';
 import { useConfirmContext } from '../context/confirm';
 import { isBalanceSufficient } from '../send-utils/send.utils';
@@ -19,9 +19,8 @@ export function useHasInsufficientBalance(): {
 } {
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
   const {
-    id: transactionId,
     chainId,
-    txParams: { value = ZERO_HEX_FALLBACK } = {},
+    txParams: { value = ZERO_HEX_FALLBACK, from: fromAddress = '' } = {},
   } = currentConfirmation ?? {};
 
   const batchTransactionValues =
@@ -29,9 +28,11 @@ export function useHasInsufficientBalance(): {
       (trxn) => (trxn.value as Hex) ?? ZERO_HEX_FALLBACK,
     ) ?? [];
 
-  const balance = (useSelector((state) =>
-    selectTransactionAvailableBalance(state, transactionId, chainId),
-  ) ?? ZERO_HEX_FALLBACK) as Hex;
+  const chainBalances = useSelector((state) =>
+    getNativeTokenCachedBalanceByChainIdSelector(state, fromAddress ?? ''),
+  ) as Record<Hex, Hex>;
+
+  const balance = chainBalances?.[chainId as Hex] ?? ZERO_HEX_FALLBACK;
 
   const totalValue = sumHexes(value, ...batchTransactionValues);
 

--- a/ui/pages/confirmations/hooks/useHasInsufficientBalance.ts
+++ b/ui/pages/confirmations/hooks/useHasInsufficientBalance.ts
@@ -35,9 +35,7 @@ export function useHasInsufficientBalance(): {
 
   const totalValue = sumHexes(value, ...batchTransactionValues);
 
-  const { maxFeeHex } = useFeeCalculations(
-    currentConfirmation as TransactionMeta,
-  );
+  const { maxFeeHex } = useFeeCalculations(currentConfirmation);
 
   const [multichainNetworks, evmNetworks] = useSelector(
     getMultichainNetworkConfigurationsByChainId,

--- a/ui/pages/confirmations/hooks/useHasInsufficientBalance.ts
+++ b/ui/pages/confirmations/hooks/useHasInsufficientBalance.ts
@@ -36,9 +36,7 @@ export function useHasInsufficientBalance(): {
   const totalValue = sumHexes(value, ...batchTransactionValues);
 
   const { maxFeeHex } = useFeeCalculations(
-    currentConfirmation?.txParams
-      ? currentConfirmation
-      : ({ txParams: {} } as TransactionMeta),
+    currentConfirmation as TransactionMeta,
   );
 
   const [multichainNetworks, evmNetworks] = useSelector(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to fix insuficient balance alert when network picker is selected other than the selected network.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40962?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1046

## **Manual testing steps**

1. Have no gas on Polygon
2. Have gas on Ethereum
3. Set the network in the home page to Ethereum
4. Start a send on Polygon
5. Notice how you’ll be allowed to submit the transaction with no insufficient funds warning and without using gas station
6. Submitting the transaction will make it fail with insufficient funds for gas
7. Now, do the opposite
8. Set the network in the home page to Polygon
9. Start a send on Ethereum
10. Notice how gas will default to use gas station even though you have plenty of ETH for gas

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the insufficient-balance check to use `useFeeCalculations`/transaction-specific max fee instead of a selector keyed by transaction id, which can affect blocking alerts and send flow across networks. Low code churn but touches fee/balance validation logic used during confirmations.
> 
> **Overview**
> Fixes insufficient-balance detection during confirmations when the user has a different network selected in the network picker by switching `useHasInsufficientBalance` to compute gas cost from `useFeeCalculations` (`maxFeeHex`) rather than `selectTransactionFeeById`.
> 
> Updates `useFeeCalculations` to expose `maxFeeHex` (and adjusts snapshots), and updates/strengthens related tests to use checksum addresses and a clearer batch-balance edge case. Jest console baselines are refreshed to match new warnings/output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 235a4e9c216addf3ce321bd17591cc1b6cb82a28. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->