### PR TITLE
fix: Adjusted size and padding for sidebar width

### DIFF
--- a/ui/components/multichain/carousel/index.scss
+++ b/ui/components/multichain/carousel/index.scss
@@ -18,7 +18,7 @@
   border-radius: 12px;
   border: 1px solid var(--color-border-muted);
   background: var(--color-background-default);
-  padding: 12px;
+  padding: 12px 10px; // reduced left and right padding to make content fit in sidebar
   position: absolute;
   overflow: hidden;
   left: 0;
@@ -27,7 +27,7 @@
   cursor: pointer;
   display: flex;
   flex-direction: row;
-  gap: 16px; // 16px gap as per spec
+  gap: 12px; // reduced gap to make content fit in sidebar
 
   &:hover {
     background: var(--color-background-default-hover);

--- a/ui/components/multichain/carousel/index.scss
+++ b/ui/components/multichain/carousel/index.scss
@@ -18,8 +18,7 @@
   border-radius: 12px;
   border: 1px solid var(--color-border-muted);
   background: var(--color-background-default);
-  padding: 12px; // Adjusted top/bottom padding to fit 72px content
-  padding-left: 16px;
+  padding: 12px;
   position: absolute;
   overflow: hidden;
   left: 0;

--- a/ui/components/multichain/carousel/stack-card/stack-card.tsx
+++ b/ui/components/multichain/carousel/stack-card/stack-card.tsx
@@ -88,7 +88,7 @@ export const StackCard: React.FC<StackCardProps> = ({
         {/* Title and close button container */}
         <div className="carousel-card__text-header">
           <Text
-            variant={TextVariant.bodyMdMedium}
+            variant={TextVariant.bodySmMedium}
             color={TextColor.textDefault}
             className="carousel-card__title"
           >
@@ -112,7 +112,7 @@ export const StackCard: React.FC<StackCardProps> = ({
         {/* Description Text container */}
         <div className="carousel-card__text-body">
           <Text
-            variant={TextVariant.bodySmMedium}
+            variant={TextVariant.bodyXsMedium}
             color={TextColor.textAlternative}
             className="carousel-card__description"
           >


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Sidebar is more narrow than popup, causing banner content to get truncated even when the content is within our length limit. 

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40988?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed banner display in sidebar view

## **Related issues**

Fixes: #40978 

## **Manual testing steps**

1. Open extension in sidebar
2. Observe banner

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="388" height="412" alt="banner-sidebar" src="https://github.com/user-attachments/assets/202e5dc6-9b07-4850-acbe-5fd9b2a0c41a" />

### **After**

<img width="400" height="344" alt="updated-banner" src="https://github.com/user-attachments/assets/2d2d7c99-45ba-4b5f-9025-43c0d1dc6250" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable N/A
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only changes that adjust spacing and typography to fit carousel banner content in the sidebar without affecting behavior or data handling.
> 
> **Overview**
> Improves sidebar rendering of the multichain carousel banner by tightening the card layout.
> 
> Reduces `.carousel-card` horizontal padding and inter-element gap, and downgrades title/description `TextVariant`s in `StackCard` to smaller sizes so content fits within the narrower sidebar width.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4bc051a33db9a501869c8945acd321d81c1c073f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->