### PR TITLE
fix: Retry attempts to resolve erc20 decimals in sign permission confirmation cp-13.24.0

### DIFF
--- a/ui/pages/confirmations/utils/token.test.ts
+++ b/ui/pages/confirmations/utils/token.test.ts
@@ -107,6 +107,105 @@ describe('fetchErc20DecimalsOrThrow', () => {
       fetchErc20DecimalsOrThrow(MOCK_ADDRESS, MOCK_CHAIN_ID),
     ).rejects.toThrow('Network error');
   });
+
+  it('uses default tries of 2 when config is omitted', async () => {
+    const networkError = new Error('Network error');
+    (getTokenStandardAndDetailsByChain as jest.Mock)
+      .mockRejectedValueOnce(networkError)
+      .mockRejectedValueOnce(networkError);
+
+    await expect(
+      fetchErc20DecimalsOrThrow(MOCK_ADDRESS, MOCK_CHAIN_ID),
+    ).rejects.toThrow('Network error');
+
+    expect(getTokenStandardAndDetailsByChain).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses default tries of 2 when config.tries is omitted', async () => {
+    const networkError = new Error('Network error');
+    (getTokenStandardAndDetailsByChain as jest.Mock)
+      .mockRejectedValueOnce(networkError)
+      .mockRejectedValueOnce(networkError);
+
+    await expect(
+      fetchErc20DecimalsOrThrow(MOCK_ADDRESS, MOCK_CHAIN_ID, {}),
+    ).rejects.toThrow('Network error');
+
+    expect(getTokenStandardAndDetailsByChain).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries up to config.tries times and returns on success', async () => {
+    (getTokenStandardAndDetailsByChain as jest.Mock)
+      .mockRejectedValueOnce(new Error('Network error'))
+      .mockRejectedValueOnce(new Error('Timeout'))
+      .mockResolvedValueOnce({ decimals: MOCK_DECIMALS });
+
+    const decimals = await fetchErc20DecimalsOrThrow(
+      MOCK_ADDRESS,
+      MOCK_CHAIN_ID,
+      {
+        tries: 3,
+      },
+    );
+
+    expect(decimals).toBe(MOCK_DECIMALS);
+    expect(getTokenStandardAndDetailsByChain).toHaveBeenCalledTimes(3);
+  });
+
+  it('stops after first successful attempt when tries > 1', async () => {
+    (getTokenStandardAndDetailsByChain as jest.Mock).mockResolvedValue({
+      decimals: MOCK_DECIMALS,
+    });
+
+    const decimals = await fetchErc20DecimalsOrThrow(
+      MOCK_ADDRESS,
+      MOCK_CHAIN_ID,
+      {
+        tries: 3,
+      },
+    );
+
+    expect(decimals).toBe(MOCK_DECIMALS);
+    expect(getTokenStandardAndDetailsByChain).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws the last error after all tries are exhausted', async () => {
+    const lastError = new Error('Final failure');
+    (getTokenStandardAndDetailsByChain as jest.Mock)
+      .mockRejectedValueOnce(new Error('First failure'))
+      .mockRejectedValueOnce(lastError);
+
+    await expect(
+      fetchErc20DecimalsOrThrow(MOCK_ADDRESS, MOCK_CHAIN_ID, { tries: 2 }),
+    ).rejects.toThrow('Final failure');
+
+    expect(getTokenStandardAndDetailsByChain).toHaveBeenCalledTimes(2);
+  });
+
+  it('wraps non-Error rejections and throws after tries exhausted', async () => {
+    (getTokenStandardAndDetailsByChain as jest.Mock)
+      .mockRejectedValueOnce('string rejection')
+      .mockRejectedValueOnce(123);
+
+    const promise = fetchErc20DecimalsOrThrow(MOCK_ADDRESS, MOCK_CHAIN_ID, {
+      tries: 2,
+    });
+
+    await expect(promise).rejects.toThrow('123');
+    expect(getTokenStandardAndDetailsByChain).toHaveBeenCalledTimes(2);
+  });
+
+  it('with tries 0, does not call getTokenStandardAndDetailsByChain and throws', async () => {
+    (getTokenStandardAndDetailsByChain as jest.Mock).mockResolvedValue({
+      decimals: MOCK_DECIMALS,
+    });
+
+    await expect(
+      fetchErc20DecimalsOrThrow(MOCK_ADDRESS, MOCK_CHAIN_ID, { tries: 0 }),
+    ).rejects.toThrow('Unknown error fetching token decimals');
+
+    expect(getTokenStandardAndDetailsByChain).not.toHaveBeenCalled();
+  });
 });
 
 describe('memoizedGetTokenStandardAndDetailsByChain', () => {

--- a/ui/pages/confirmations/utils/token.ts
+++ b/ui/pages/confirmations/utils/token.ts
@@ -130,35 +130,49 @@ export const fetchErc20Decimals = async (
  *
  * @param address - The ethereum token contract address. It is expected to be in hex format.
  * @param chainId - ChainId on which we need to check token. It is expected to be in hex format.
- * @throws Error if token decimals cannot be resolved
+ * @param config - Optional config.
+ * @param config.tries - The number of attempts before throwing. Default is 2.
+ * @throws Error if token decimals cannot be resolved after the specified number of tries
  */
 export const fetchErc20DecimalsOrThrow = async (
   address: Hex | string,
   chainId?: Hex | string,
+  config: { tries?: number } = {},
 ): Promise<number> => {
-  const result = await getTokenStandardAndDetailsByChain(
-    address,
-    undefined,
-    undefined,
-    chainId,
-  );
+  const { tries = 2 } = config;
+  let lastError: Error | undefined;
 
-  if (!result) {
-    throw new Error(
-      `Unable to resolve token decimals for address ${address} on chain ${chainId}`,
-    );
+  for (let attempt = 0; attempt < tries; attempt++) {
+    try {
+      const result = await getTokenStandardAndDetailsByChain(
+        address,
+        undefined,
+        undefined,
+        chainId,
+      );
+
+      if (!result) {
+        throw new Error(
+          `Unable to resolve token decimals for address ${address} on chain ${chainId}`,
+        );
+      }
+
+      const { decimals: decStr } = result;
+      const decimals = parseTokenDetailDecimals(decStr);
+
+      if (decimals === undefined) {
+        throw new Error(
+          `Unable to resolve token decimals for address ${address} on chain ${chainId}`,
+        );
+      }
+
+      return decimals;
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+    }
   }
 
-  const { decimals: decStr } = result;
-  const decimals = parseTokenDetailDecimals(decStr);
-
-  if (decimals === undefined) {
-    throw new Error(
-      `Unable to resolve token decimals for address ${address} on chain ${chainId}`,
-    );
-  }
-
-  return decimals;
+  throw lastError ?? new Error('Unknown error fetching token decimals');
 };
 
 /**


### PR DESCRIPTION
## **Description**

When rendering an erc20 token permission, failure to resolve the token decimals will raise an error. It should be impossible to reproduce this with an actually invalid token address, as the initial request will be rejected by the snap if the token is unresolvable. This implies that failures are likely network related, or other intermittent failures.

This change adds a retry when resolving the token decimals in the sign permission confirmation via an optional `config: { tries }` parameter added to `fetchErc20DecimalsOrThrow`, defaulting to 2.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/40992?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: retries when "Unable to resolve token decimals for address" error thrown when requesting permission signature

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: localized change to token-decimals lookup that only adds bounded retry behavior and improves error propagation, with expanded unit test coverage.
> 
> **Overview**
> Improves resilience of permission-signing ERC20 metadata resolution by adding a bounded retry loop to `fetchErc20DecimalsOrThrow(address, chainId, { tries })`, defaulting to 2 attempts and rethrowing the last encountered failure.
> 
> Extends `token.test.ts` to cover default retry behavior, early success, exhausted retries, non-`Error` rejections, and `tries: 0` edge cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c7292fd5bc0610c663fd403392aaf7bca9843ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->