### PR TITLE
feat: add developer options tab with testnet conversion item

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -7505,6 +7505,10 @@
   "showFiatConversionInTestnetsDescription": {
     "message": "Select this to show fiat conversion on test networks"
   },
+  "showFiatConversionInTestnetsDescriptionV2": {
+    "message": "Shows network tokens as local currency on test networks. If you've been asked to turn this feature on, you might be getting scammed. For testing purposes only. $1",
+    "description": "$1 is the 'Learn more' link"
+  },
   "showHexData": {
     "message": "Show hex data"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -7505,6 +7505,10 @@
   "showFiatConversionInTestnetsDescription": {
     "message": "Select this to show fiat conversion on test networks"
   },
+  "showFiatConversionInTestnetsDescriptionV2": {
+    "message": "Shows network tokens as local currency on test networks. If you've been asked to turn this feature on, you might be getting scammed. For testing purposes only. $1",
+    "description": "$1 is the 'Learn more' link"
+  },
   "showHexData": {
     "message": "Show hex data"
   },

--- a/shared/lib/ui-utils.js
+++ b/shared/lib/ui-utils.js
@@ -32,3 +32,6 @@ export const VAULT_RECOVERY_LINK = `https://support.metamask.io/configure/wallet
 
 export const SHIELD_TERMS_OF_USE_URL =
   'https://consensys.io/transaction-shield-supplemental-terms-and-privacy-notice';
+
+export const TESTNET_ETH_SCAMS_LEARN_MORE_LINK =
+  'https://support.metamask.io/stay-safe/protect-yourself/tokens-and-transactions/testnet-eth-scams/';

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -2865,6 +2865,10 @@
     "ui/pages/settings-v2/assets-tab/local-currency-item.test.tsx": {
       "warn: ⚠️ React Router Future Flag": 2
     },
+    "ui/pages/settings-v2/developer-options-tab/developer-options-tab.test.tsx": {
+      "React: componentWill* lifecycle deprecations": 1,
+      "warn: ⚠️ React Router Future Flag": 2
+    },
     "ui/pages/settings-v2/preferences-and-display-tab/account-identicon-item.test.tsx": {
       "React: Act warnings (component updates not wrapped)": 4,
       "warn: ⚠️ React Router Future Flag": 2

--- a/ui/helpers/constants/routes.ts
+++ b/ui/helpers/constants/routes.ts
@@ -26,6 +26,7 @@ export const ACCOUNT_IDENTICON_ROUTE =
   '/settings-v2/preferences-and-display/account-identicon';
 export const PRIVACY_ROUTE = '/settings-v2/privacy';
 export const THIRD_PARTY_APIS_ROUTE = '/settings-v2/privacy/third-party-apis';
+export const DEVELOPER_OPTIONS_V2_ROUTE = '/settings-v2/developer-options';
 export const GENERAL_ROUTE = '/settings/general';
 export const ADVANCED_ROUTE = '/settings/advanced';
 export const DEVELOPER_OPTIONS_ROUTE = '/settings/developer-options';

--- a/ui/pages/settings-v2/developer-options-tab/__snapshots__/developer-options-tab.test.tsx.snap
+++ b/ui/pages/settings-v2/developer-options-tab/__snapshots__/developer-options-tab.test.tsx.snap
@@ -70,6 +70,36 @@ exports[`DeveloperOptionsTab snapshot matches snapshot 1`] = `
         </span>
       </div>
     </div>
+    <div
+      class="flex flex-col gap-1 py-3"
+      data-testid="developer-options-auto-reset-account"
+    >
+      <p
+        class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default"
+      >
+        Clear activity and nonce data
+      </p>
+      <p
+        class="text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default"
+      >
+        This resets the account's nonce and erases data from the activity tab in your wallet. Only the current account and network will be affected. Your balances and incoming transactions won't change.
+      </p>
+      <div
+        class="pt-2"
+      >
+        <button
+          class="inline-flex items-center justify-center rounded-xl px-4 font-medium min-w-20 overflow-hidden relative h-12 transition-all duration-100 ease-linear active:scale-[0.97] active:ease-[cubic-bezier(0.3,0.8,0.3,1)] bg-icon-default text-primary-inverse hover:bg-icon-default-hover active:bg-icon-default-pressed focus-visible:ring-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-default"
+          data-testid="developer-options-auto-reset-account-button"
+          role="button"
+        >
+          <span
+            class="text-inherit text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default"
+          >
+            Clear activity tab data
+          </span>
+        </button>
+      </div>
+    </div>
   </div>
 </div>
 `;

--- a/ui/pages/settings-v2/developer-options-tab/__snapshots__/developer-options-tab.test.tsx.snap
+++ b/ui/pages/settings-v2/developer-options-tab/__snapshots__/developer-options-tab.test.tsx.snap
@@ -1,0 +1,62 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DeveloperOptionsTab snapshot matches snapshot 1`] = `
+<div>
+  <div
+    class="pb-4 px-4"
+  >
+    <div
+      class="flex flex-col gap-1 py-3"
+    >
+      <div
+        class="flex flex-row items-center justify-between"
+      >
+        <p
+          class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default"
+        >
+          Show conversion on test networks
+        </p>
+        <div>
+          <label
+            class="toggle-button toggle-button--off"
+            tabindex="0"
+          >
+            <div
+              style="display: flex; width: 40px; align-items: center; justify-content: flex-start; position: relative; cursor: pointer; background-color: transparent; border: 0px; padding: 0px; user-select: none;"
+            >
+              <div
+                style="width: 40px; height: 24px; padding: 0px; border-radius: 26px; display: flex; align-items: center; justify-content: center; background-color: rgb(186, 187, 190);"
+              >
+                <div
+                  style="font-size: 11px; display: flex; align-items: center; justify-content: center; font-family: 'Helvetica Neue', Helvetica, sans-serif; position: relative; color: rgb(250, 250, 250); margin-top: auto; margin-bottom: auto; line-height: 0; opacity: 0; width: 26px; height: 20px; left: 4px;"
+                />
+                <div
+                  style="font-size: 11px; display: flex; align-items: center; justify-content: center; font-family: 'Helvetica Neue', Helvetica, sans-serif; position: relative; color: rgba(255, 255, 255, 0.6); bottom: 0px; margin-top: auto; margin-bottom: auto; padding-right: 5px; line-height: 0; width: 26px; height: 20px; opacity: 1;"
+                />
+              </div>
+              <div
+                style="position: absolute; height: 100%; top: 0px; left: 0px; display: flex; flex: 1; align-self: stretch; align-items: center; justify-content: flex-start;"
+              >
+                <div
+                  style="width: 18px; height: 18px; display: flex; align-self: center; box-shadow: var(--shadow-size-xs) var(--color-shadow-default); border-radius: 50%; box-sizing: border-box; position: relative; background-color: rgb(255, 255, 255); left: 3px;"
+                />
+              </div>
+              <input
+                data-testid="developer-options-show-testnet-conversion-toggle"
+                style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px;"
+                type="checkbox"
+                value="false"
+              />
+            </div>
+          </label>
+        </div>
+      </div>
+      <p
+        class="text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default"
+      >
+        Select this to show fiat conversion on test networks
+      </p>
+    </div>
+  </div>
+</div>
+`;

--- a/ui/pages/settings-v2/developer-options-tab/__snapshots__/developer-options-tab.test.tsx.snap
+++ b/ui/pages/settings-v2/developer-options-tab/__snapshots__/developer-options-tab.test.tsx.snap
@@ -51,11 +51,24 @@ exports[`DeveloperOptionsTab snapshot matches snapshot 1`] = `
           </label>
         </div>
       </div>
-      <p
+      <div
         class="text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default"
       >
-        Select this to show fiat conversion on test networks
-      </p>
+        <span>
+           
+          Shows network tokens as local currency on test networks. If you've been asked to turn this feature on, you might be getting scammed. For testing purposes only. 
+          <a
+            class="font-medium text-primary-default"
+            href="https://support.metamask.io/stay-safe/protect-yourself/tokens-and-transactions/testnet-eth-scams/"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Learn more
+          </a>
+          
+           
+        </span>
+      </div>
     </div>
   </div>
 </div>

--- a/ui/pages/settings-v2/developer-options-tab/auto-reset-account-item.tsx
+++ b/ui/pages/settings-v2/developer-options-tab/auto-reset-account-item.tsx
@@ -1,0 +1,59 @@
+import React, { useContext } from 'react';
+import { useDispatch } from 'react-redux';
+import {
+  Box,
+  Button,
+  ButtonVariant,
+  Text,
+  TextColor,
+  TextVariant,
+  FontWeight,
+  BoxFlexDirection,
+} from '@metamask/design-system-react';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import { MetaMetricsContext } from '../../../contexts/metametrics';
+import {
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
+} from '../../../../shared/constants/metametrics';
+import { showModal } from '../../../store/actions';
+
+export const AutoResetAccountItem = () => {
+  const t = useI18nContext();
+  const dispatch = useDispatch();
+  const { trackEvent } = useContext(MetaMetricsContext);
+
+  const handleClearActivity = () => {
+    trackEvent({
+      category: MetaMetricsEventCategory.Settings,
+      event: MetaMetricsEventName.AccountReset,
+      properties: {},
+    });
+    dispatch(showModal({ name: 'CONFIRM_RESET_ACCOUNT' }));
+  };
+
+  return (
+    <Box
+      flexDirection={BoxFlexDirection.Column}
+      gap={1}
+      paddingVertical={3}
+      data-testid="developer-options-auto-reset-account"
+    >
+      <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
+        {t('clearActivity')}
+      </Text>
+      <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
+        {t('clearActivityDescription')}
+      </Text>
+      <Box paddingTop={2}>
+        <Button
+          variant={ButtonVariant.Primary}
+          onClick={handleClearActivity}
+          data-testid="developer-options-auto-reset-account-button"
+        >
+          {t('clearActivityButton')}
+        </Button>
+      </Box>
+    </Box>
+  );
+};

--- a/ui/pages/settings-v2/developer-options-tab/developer-options-tab.test.tsx
+++ b/ui/pages/settings-v2/developer-options-tab/developer-options-tab.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import mockState from '../../../../test/data/mock-state.json';
+import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
+import { setBackgroundConnection } from '../../../store/background-connection';
+import DeveloperOptionsTab from './developer-options-tab';
+
+const backgroundConnectionMock = new Proxy(
+  {},
+  { get: () => jest.fn().mockResolvedValue(undefined) },
+);
+
+describe('DeveloperOptionsTab', () => {
+  const mockStore = configureMockStore([thunk])(mockState);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setBackgroundConnection(backgroundConnectionMock as never);
+  });
+
+  describe('snapshot', () => {
+    it('matches snapshot', () => {
+      const { container } = renderWithProvider(
+        <DeveloperOptionsTab />,
+        mockStore,
+      );
+
+      expect(container).toMatchSnapshot();
+    });
+  });
+
+  describe('setting items', () => {
+    it('renders all toggle items with expected test ids', () => {
+      renderWithProvider(<DeveloperOptionsTab />, mockStore);
+
+      const expectedTestIds = [
+        'developer-options-show-testnet-conversion-toggle',
+      ];
+
+      for (const testId of expectedTestIds) {
+        expect(screen.getByTestId(testId)).toBeInTheDocument();
+      }
+    });
+  });
+});

--- a/ui/pages/settings-v2/developer-options-tab/developer-options-tab.test.tsx
+++ b/ui/pages/settings-v2/developer-options-tab/developer-options-tab.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { screen } from '@testing-library/react';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import mockState from '../../../../test/data/mock-state.json';

--- a/ui/pages/settings-v2/developer-options-tab/developer-options-tab.test.tsx
+++ b/ui/pages/settings-v2/developer-options-tab/developer-options-tab.test.tsx
@@ -30,18 +30,4 @@ describe('DeveloperOptionsTab', () => {
       expect(container).toMatchSnapshot();
     });
   });
-
-  describe('setting items', () => {
-    it('renders all toggle items with expected test ids', () => {
-      renderWithProvider(<DeveloperOptionsTab />, mockStore);
-
-      const expectedTestIds = [
-        'developer-options-show-testnet-conversion-toggle',
-      ];
-
-      for (const testId of expectedTestIds) {
-        expect(screen.getByTestId(testId)).toBeInTheDocument();
-      }
-    });
-  });
 });

--- a/ui/pages/settings-v2/developer-options-tab/developer-options-tab.tsx
+++ b/ui/pages/settings-v2/developer-options-tab/developer-options-tab.tsx
@@ -5,10 +5,10 @@ import {
   createToggleItem,
   createDescriptionWithLearnMore,
 } from '../shared';
+import { TESTNET_ETH_SCAMS_LEARN_MORE_LINK } from '../../../../shared/lib/ui-utils';
 import { getShowFiatInTestnets } from '../../../selectors';
 import { setShowFiatConversionOnTestnetsPreference } from '../../../store/actions';
 import { AutoResetAccountItem } from './auto-reset-account-item';
-import { TESTNET_ETH_SCAMS_LEARN_MORE_LINK } from '../../../../shared/lib/ui-utils';
 
 const ShowConversionInTestnetsItem = createToggleItem({
   name: 'ShowConversionInTestnetsItem',

--- a/ui/pages/settings-v2/developer-options-tab/developer-options-tab.tsx
+++ b/ui/pages/settings-v2/developer-options-tab/developer-options-tab.tsx
@@ -4,12 +4,15 @@ import { SettingsTab, createToggleItem, createDescriptionWithLearnMore } from '.
 import { getShowFiatInTestnets } from '../../../selectors';
 import { setShowFiatConversionOnTestnetsPreference } from '../../../store/actions';
 
+const SHOW_CONVERSION_IN_TESTNETS_LEARN_MORE_LINK =
+  "https://support.metamask.io/stay-safe/protect-yourself/tokens-and-transactions/testnet-eth-scams/";
+
 const ShowConversionInTestnetsItem = createToggleItem({
   name: 'ShowConversionInTestnetsItem',
   titleKey: 'showFiatConversionInTestnets',
   formatDescription: createDescriptionWithLearnMore(
     'showFiatConversionInTestnetsDescriptionV2',
-    "https://metamask.io/learn-more",
+    SHOW_CONVERSION_IN_TESTNETS_LEARN_MORE_LINK,
   ),
   selector: getShowFiatInTestnets,
   action: setShowFiatConversionOnTestnetsPreference,

--- a/ui/pages/settings-v2/developer-options-tab/developer-options-tab.tsx
+++ b/ui/pages/settings-v2/developer-options-tab/developer-options-tab.tsx
@@ -10,7 +10,7 @@ import { setShowFiatConversionOnTestnetsPreference } from '../../../store/action
 import { AutoResetAccountItem } from './auto-reset-account-item';
 
 const SHOW_CONVERSION_IN_TESTNETS_LEARN_MORE_LINK =
-  "https://support.metamask.io/stay-safe/protect-yourself/tokens-and-transactions/testnet-eth-scams/";
+  'https://support.metamask.io/stay-safe/protect-yourself/tokens-and-transactions/testnet-eth-scams/';
 
 const ShowConversionInTestnetsItem = createToggleItem({
   name: 'ShowConversionInTestnetsItem',

--- a/ui/pages/settings-v2/developer-options-tab/developer-options-tab.tsx
+++ b/ui/pages/settings-v2/developer-options-tab/developer-options-tab.tsx
@@ -8,16 +8,14 @@ import {
 import { getShowFiatInTestnets } from '../../../selectors';
 import { setShowFiatConversionOnTestnetsPreference } from '../../../store/actions';
 import { AutoResetAccountItem } from './auto-reset-account-item';
-
-const SHOW_CONVERSION_IN_TESTNETS_LEARN_MORE_LINK =
-  'https://support.metamask.io/stay-safe/protect-yourself/tokens-and-transactions/testnet-eth-scams/';
+import { TESTNET_ETH_SCAMS_LEARN_MORE_LINK } from 'shared/lib/ui-utils';
 
 const ShowConversionInTestnetsItem = createToggleItem({
   name: 'ShowConversionInTestnetsItem',
   titleKey: 'showFiatConversionInTestnets',
   formatDescription: createDescriptionWithLearnMore(
     'showFiatConversionInTestnetsDescriptionV2',
-    SHOW_CONVERSION_IN_TESTNETS_LEARN_MORE_LINK,
+    TESTNET_ETH_SCAMS_LEARN_MORE_LINK,
   ),
   selector: getShowFiatInTestnets,
   action: setShowFiatConversionOnTestnetsPreference,

--- a/ui/pages/settings-v2/developer-options-tab/developer-options-tab.tsx
+++ b/ui/pages/settings-v2/developer-options-tab/developer-options-tab.tsx
@@ -8,7 +8,7 @@ import {
 import { getShowFiatInTestnets } from '../../../selectors';
 import { setShowFiatConversionOnTestnetsPreference } from '../../../store/actions';
 import { AutoResetAccountItem } from './auto-reset-account-item';
-import { TESTNET_ETH_SCAMS_LEARN_MORE_LINK } from 'shared/lib/ui-utils';
+import { TESTNET_ETH_SCAMS_LEARN_MORE_LINK } from '../../../../shared/lib/ui-utils';
 
 const ShowConversionInTestnetsItem = createToggleItem({
   name: 'ShowConversionInTestnetsItem',

--- a/ui/pages/settings-v2/developer-options-tab/developer-options-tab.tsx
+++ b/ui/pages/settings-v2/developer-options-tab/developer-options-tab.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
 import { SettingItemConfig } from '../types';
-import { SettingsTab, createToggleItem, createDescriptionWithLearnMore } from '../shared';
+import {
+  SettingsTab,
+  createToggleItem,
+  createDescriptionWithLearnMore,
+} from '../shared';
 import { getShowFiatInTestnets } from '../../../selectors';
 import { setShowFiatConversionOnTestnetsPreference } from '../../../store/actions';
+import { AutoResetAccountItem } from './auto-reset-account-item';
 
 const SHOW_CONVERSION_IN_TESTNETS_LEARN_MORE_LINK =
   "https://support.metamask.io/stay-safe/protect-yourself/tokens-and-transactions/testnet-eth-scams/";
@@ -22,6 +27,7 @@ const ShowConversionInTestnetsItem = createToggleItem({
 /** Registry of setting items for the Developer Options page. Add new items here */
 const DEVELOPER_OPTIONS_SETTING_ITEMS: SettingItemConfig[] = [
   { id: 'show-fiat-in-testnets', component: ShowConversionInTestnetsItem },
+  { id: 'auto-reset-account', component: AutoResetAccountItem },
 ];
 
 const DeveloperOptionsTab = () => (

--- a/ui/pages/settings-v2/developer-options-tab/developer-options-tab.tsx
+++ b/ui/pages/settings-v2/developer-options-tab/developer-options-tab.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { SettingItemConfig } from '../types';
+import { SettingsTab, createToggleItem, createDescriptionWithLearnMore } from '../shared';
+import { getShowFiatInTestnets } from '../../../selectors';
+import { setShowFiatConversionOnTestnetsPreference } from '../../../store/actions';
+
+const ShowConversionInTestnetsItem = createToggleItem({
+  name: 'ShowConversionInTestnetsItem',
+  titleKey: 'showFiatConversionInTestnets',
+  formatDescription: createDescriptionWithLearnMore(
+    'showFiatConversionInTestnetsDescriptionV2',
+    "https://metamask.io/learn-more",
+  ),
+  selector: getShowFiatInTestnets,
+  action: setShowFiatConversionOnTestnetsPreference,
+  dataTestId: 'developer-options-show-testnet-conversion-toggle',
+});
+
+/** Registry of setting items for the Developer Options page. Add new items here */
+const DEVELOPER_OPTIONS_SETTING_ITEMS: SettingItemConfig[] = [
+  { id: 'show-fiat-in-testnets', component: ShowConversionInTestnetsItem },
+];
+
+const DeveloperOptionsTab = () => (
+  <SettingsTab items={DEVELOPER_OPTIONS_SETTING_ITEMS} />
+);
+
+export default DeveloperOptionsTab;

--- a/ui/pages/settings-v2/developer-options-tab/index.ts
+++ b/ui/pages/settings-v2/developer-options-tab/index.ts
@@ -1,0 +1,1 @@
+export { default } from './developer-options-tab';

--- a/ui/pages/settings-v2/settings-registry.ts
+++ b/ui/pages/settings-v2/settings-registry.ts
@@ -5,6 +5,7 @@ import {
   ACCOUNT_IDENTICON_ROUTE,
   ASSETS_ROUTE,
   CURRENCY_ROUTE,
+  DEVELOPER_OPTIONS_V2_ROUTE,
   LANGUAGE_ROUTE,
   PREFERENCES_AND_DISPLAY_ROUTE,
   SETTINGS_V2_ROUTE,
@@ -79,6 +80,11 @@ export const SETTINGS_V2_ROUTE_META: Record<string, SettingsV2RouteMeta> = {
     labelKey: 'thirdPartyApis',
     parentPath: PRIVACY_ROUTE,
   },
+  // Developer options tab
+  [DEVELOPER_OPTIONS_V2_ROUTE]: {
+    labelKey: 'developerOptions',
+    parentPath: SETTINGS_V2_ROUTE,
+  },
 };
 
 /**
@@ -120,5 +126,12 @@ export const SETTINGS_V2_MENU_LIST_ITEM_REGISTRY: SettingsV2MenuListItem[] = [
     labelKey: 'privacy',
     iconName: IconName.Lock,
     component: mmLazy(() => import('./privacy-tab/index.ts')),
+  },
+  {
+    id: 'developer-options',
+    path: DEVELOPER_OPTIONS_V2_ROUTE,
+    labelKey: 'developerOptions',
+    iconName: IconName.Code,
+    component: mmLazy(() => import('./developer-options-tab/index.ts')),
   },
 ];

--- a/ui/pages/settings-v2/shared/description-with-learn-more.tsx
+++ b/ui/pages/settings-v2/shared/description-with-learn-more.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import type { ToggleItemConfig } from './create-toggle-item';
+
+/**
+ * Creates a formatDescription function that includes a "Learn more" link.
+ * Use with createToggleItem's formatDescription option.
+ *
+ * @param descriptionKey - i18n key for the description text (should contain $1 placeholder for link)
+ * @param href - URL for the learn more link
+ * @returns A formatDescription function compatible with ToggleItemConfig
+ */
+export const createDescriptionWithLearnMore =
+  (
+    descriptionKey: string,
+    href: string,
+  ): ToggleItemConfig['formatDescription'] =>
+  (t) =>
+    t(descriptionKey, [
+      <a
+        key="learn_more_link"
+        href={href}
+        rel="noopener noreferrer"
+        target="_blank"
+        className="font-medium text-primary-default"
+      >
+        {t('learnMoreUpperCase')}
+      </a>,
+    ]);

--- a/ui/pages/settings-v2/shared/index.ts
+++ b/ui/pages/settings-v2/shared/index.ts
@@ -2,6 +2,7 @@ export { createSelectItem } from './create-select-item';
 export type { SelectItemConfig } from './create-select-item';
 export { createToggleItem } from './create-toggle-item';
 export type { ToggleItemConfig } from './create-toggle-item';
+export { createDescriptionWithLearnMore } from './description-with-learn-more';
 export { Divider } from './divider';
 export { PrivacyPolicyLink } from './privacy-policy-link';
 export { SettingsTab } from './settings-tab';

--- a/ui/pages/settings-v2/transactions-tab/transactions-tab.tsx
+++ b/ui/pages/settings-v2/transactions-tab/transactions-tab.tsx
@@ -10,7 +10,7 @@ import { SettingItemConfig } from '../types';
 import {
   SettingsTab,
   createToggleItem,
-  type ToggleItemConfig,
+  createDescriptionWithLearnMore,
 } from '../shared';
 import {
   getIsSecurityAlertsEnabled,
@@ -33,28 +33,10 @@ const selectIsDisabledByShieldSubscription = (state: MetaMaskReduxState) =>
     state as unknown as Parameters<typeof getIsActiveShieldSubscription>[0],
   );
 
-const descriptionWithLearnMore =
-  (
-    descriptionKey: string,
-    href: string,
-  ): ToggleItemConfig['formatDescription'] =>
-  (t) =>
-    t(descriptionKey, [
-      <a
-        key="learn_more_link"
-        href={href}
-        rel="noopener noreferrer"
-        target="_blank"
-        className="font-medium text-primary-default"
-      >
-        {t('learnMoreUpperCase')}
-      </a>,
-    ]);
-
 const TransactionSimulationsItem = createToggleItem({
   name: 'TransactionSimulationsItem',
   titleKey: 'simulationsSettingSubHeader',
-  formatDescription: descriptionWithLearnMore(
+  formatDescription: createDescriptionWithLearnMore(
     'simulationsSettingDescriptionV2',
     TRANSACTION_SIMULATIONS_LEARN_MORE_LINK,
   ),
@@ -68,7 +50,7 @@ const TransactionSimulationsItem = createToggleItem({
 const SecurityAlertsItem = createToggleItem({
   name: 'SecurityAlertsItem',
   titleKey: 'securityAlerts',
-  formatDescription: descriptionWithLearnMore(
+  formatDescription: createDescriptionWithLearnMore(
     'securityAlertsDescriptionV2',
     SECURITY_ALERTS_LEARN_MORE_LINK,
   ),
@@ -89,7 +71,7 @@ const SecurityAlertsItem = createToggleItem({
 const SmartTransactionsItem = createToggleItem({
   name: 'SmartTransactionsItem',
   titleKey: 'smartTransactions',
-  formatDescription: descriptionWithLearnMore(
+  formatDescription: createDescriptionWithLearnMore(
     'stxOptInDescriptionV2',
     SMART_TRANSACTIONS_LEARN_MORE_URL,
   ),


### PR DESCRIPTION
## **Description**
Adds the Developer options tab to Settings V2. Includes:

- Show conversion on test networks
- Clear activity and nonce data (this setting has not been updated to the Figma design as there are still questions to its functionality that are not yet answered)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="797" height="457" alt="image" src="https://github.com/user-attachments/assets/b0f47412-de0d-4452-9916-c560c520eb75" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI/settings changes that introduce a new settings route and wire toggles/buttons to Redux actions and a reset-account modal; risk is mainly around navigation/setting wiring rather than security-critical logic.
> 
> **Overview**
> Adds a new **Settings V2** `Developer options` tab/route (`/settings-v2/developer-options`) and registers it in the settings menu and route meta.
> 
> The tab includes (1) a toggle for *showing fiat conversion on test networks* with updated warning copy and a new “Learn more” link to a support article, and (2) a **Clear activity and nonce data** button that tracks a metrics event and opens the `CONFIRM_RESET_ACCOUNT` modal.
> 
> Refactors the “description + Learn more link” pattern into a reusable `createDescriptionWithLearnMore` helper and switches the Transactions tab toggles to use it, plus updates snapshots/console baseline accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 556c5b9433323ca8e7505d1a8c2c087ac3a3cfa8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->