### PR TITLE
fix: update MegaETH explorer display name to Megaeth Explorer

### DIFF
--- a/shared/constants/common.ts
+++ b/shared/constants/common.ts
@@ -35,8 +35,7 @@ const MONAD_DEFAULT_BLOCK_EXPLORER_HUMAN_READABLE_URL = 'MonadScan';
 const HYPEREVM_DEFAULT_BLOCK_EXPLORER_URL = 'https://hyperevmscan.io/';
 const HYPEREVM_DEFAULT_BLOCK_EXPLORER_HUMAN_READABLE_URL = 'HyperEVMScan';
 const MEGAETH_DEFAULT_BLOCK_EXPLORER_URL = 'https://megaeth.blockscout.com/';
-const MEGAETH_DEFAULT_BLOCK_EXPLORER_HUMAN_READABLE_URL =
-  'MEGA Mainnet Explorer';
+const MEGAETH_DEFAULT_BLOCK_EXPLORER_HUMAN_READABLE_URL = 'Megaeth Explorer';
 
 type BlockExplorerUrlMap = {
   [key: string]: string;

--- a/shared/constants/common.ts
+++ b/shared/constants/common.ts
@@ -35,7 +35,7 @@ const MONAD_DEFAULT_BLOCK_EXPLORER_HUMAN_READABLE_URL = 'MonadScan';
 const HYPEREVM_DEFAULT_BLOCK_EXPLORER_URL = 'https://hyperevmscan.io/';
 const HYPEREVM_DEFAULT_BLOCK_EXPLORER_HUMAN_READABLE_URL = 'HyperEVMScan';
 const MEGAETH_DEFAULT_BLOCK_EXPLORER_URL = 'https://megaeth.blockscout.com/';
-const MEGAETH_DEFAULT_BLOCK_EXPLORER_HUMAN_READABLE_URL = 'Megaeth Explorer';
+const MEGAETH_DEFAULT_BLOCK_EXPLORER_HUMAN_READABLE_URL = 'MegaETH Explorer';
 
 type BlockExplorerUrlMap = {
   [key: string]: string;


### PR DESCRIPTION
## **Description**

  Updates the MegaETH block explorer display name from "MEGA Mainnet Explorer" to "Megaeth Explorer" in the Receive flow. The button now reads "View on Megaeth Explorer" instead of "View on MEGA Mainnet
  Explorer".

  Changes the `MEGAETH_DEFAULT_BLOCK_EXPLORER_HUMAN_READABLE_URL` constant in `shared/constants/common.ts`.

  [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/41003?quickstart=1)

  ## **Changelog**

  CHANGELOG entry: Fixed MegaETH explorer button to display "View on Megaeth Explorer" instead of "View on MEGA Mainnet Explorer"

  ## **Related issues**

  Fixes:

  ## **Manual testing steps**

  1. Add MegaETH network if not already added
  2. Select ETH on MegaETH network and click Receive
  3. Verify the button at the bottom reads "View on Megaeth Explorer"
  4. Check other networks' Receive flow to confirm their explorer buttons are unaffected

  ## **Screenshots/Recordings**

  ### **Before**

  "View on MEGA Mainnet Explorer"

  ### **After**

  "View on Megaeth Explorer"

  ## **Pre-merge author checklist**

  - [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding
  Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
  - [x] I've completed the PR template to the best of my ability
  - [ ] I've included tests if applicable
  - [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
  - [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external
  contributors.

  ## **Pre-merge reviewer checklist**

  - [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
  - [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates only a human-readable block explorer label for MegaETH with no functional or data-handling changes.
> 
> **Overview**
> Updates the MegaETH block explorer *display name* constant in `shared/constants/common.ts` from "MEGA Mainnet Explorer" to "MegaETH Explorer", affecting the text shown in UI links/buttons that reference the default MegaETH explorer.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6462de0586cd6889b92c63674961d6b66a994cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->