### PR TITLE
fix(snaps): Use account group name in `SnapUIAccountSelector` cp-13.23.0

### DIFF
--- a/ui/components/app/snaps/snap-ui-account-selector/snap-ui-account-selector.tsx
+++ b/ui/components/app/snaps/snap-ui-account-selector/snap-ui-account-selector.tsx
@@ -14,6 +14,7 @@ import { setSelectedInternalAccountWithoutLoading } from '../../../../store/acti
 import { useSnapInterfaceContext } from '../../../../contexts/snaps';
 import AccountListItem from '../../../multichain/account-list-item/account-list-item';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
+import { getAllAccountGroups } from '../../../../selectors/multichain-accounts/account-tree';
 
 export type SnapUIAccountSelectorProps = {
   name: string;
@@ -55,6 +56,7 @@ export const SnapUIAccountSelector: FunctionComponent<
   const internalAccounts: InternalAccountWithBalance[] = useSelector(
     getMetaMaskAccountsOrdered,
   );
+  const accountGroups = useSelector(getAllAccountGroups);
 
   const accounts = useMemo(() => {
     // Filter out the accounts that are not owned by the snap
@@ -86,14 +88,32 @@ export const SnapUIAccountSelector: FunctionComponent<
     disabled: false,
   }));
 
-  const optionComponents = accounts.map((account, index) => (
-    <AccountListItem
-      account={account}
-      selected={false}
-      key={index}
-      showConnectedStatus={false}
-    />
-  ));
+  const optionComponents = accounts.map((account, index) => {
+    // Get the name from the account group if it exists, otherwise use the account name
+    // This is necessary because the account name is empty now and the group name is used instead,
+    // but we still want to show the account name if the group name is not available.
+    const name =
+      accountGroups.find(({ accounts: accountGroup }) =>
+        accountGroup.includes(account.id),
+      )?.metadata.name ?? account.metadata.name;
+
+    const mergedAccount = {
+      ...account,
+      metadata: {
+        ...account.metadata,
+        name,
+      },
+    };
+
+    return (
+      <AccountListItem
+        account={mergedAccount}
+        selected={false}
+        key={index}
+        showConnectedStatus={false}
+      />
+    );
+  });
 
   const handleSelect = (value: State) => {
     if (switchGlobalAccount) {

--- a/ui/components/app/snaps/snap-ui-account-selector/snap-ui-account-selector.tsx
+++ b/ui/components/app/snaps/snap-ui-account-selector/snap-ui-account-selector.tsx
@@ -73,8 +73,26 @@ export const SnapUIAccountSelector: FunctionComponent<
       return filteredChainIds.length > 0;
     });
 
-    return filteredAccounts;
-  }, [internalAccounts, chainIds, hideExternalAccounts, snapId]);
+    // Get the name from the account group if it exists, otherwise use the account name
+    // This is necessary because the account name is empty now and the group name is used instead,
+    // but we still want to show the account name if the group name is not available.
+    const updatedAccounts = filteredAccounts.map((account) => {
+      const name =
+        accountGroups.find(({ accounts: accountGroup }) =>
+          accountGroup.includes(account.id),
+        )?.metadata.name ?? account.metadata.name;
+
+      return {
+        ...account,
+        metadata: {
+          ...account.metadata,
+          name,
+        },
+      };
+    });
+
+    return updatedAccounts;
+  }, [internalAccounts, chainIds, hideExternalAccounts, snapId, accountGroups]);
 
   const options = accounts.map((account) => ({
     key: 'accountId',
@@ -88,32 +106,14 @@ export const SnapUIAccountSelector: FunctionComponent<
     disabled: false,
   }));
 
-  const optionComponents = accounts.map((account, index) => {
-    // Get the name from the account group if it exists, otherwise use the account name
-    // This is necessary because the account name is empty now and the group name is used instead,
-    // but we still want to show the account name if the group name is not available.
-    const name =
-      accountGroups.find(({ accounts: accountGroup }) =>
-        accountGroup.includes(account.id),
-      )?.metadata.name ?? account.metadata.name;
-
-    const mergedAccount = {
-      ...account,
-      metadata: {
-        ...account.metadata,
-        name,
-      },
-    };
-
-    return (
-      <AccountListItem
-        account={mergedAccount}
-        selected={false}
-        key={index}
-        showConnectedStatus={false}
-      />
-    );
-  });
+  const optionComponents = accounts.map((account, index) => (
+    <AccountListItem
+      account={account}
+      selected={false}
+      key={index}
+      showConnectedStatus={false}
+    />
+  ));
 
   const handleSelect = (value: State) => {
     if (switchGlobalAccount) {

--- a/ui/components/app/snaps/snap-ui-account-selector/snap-ui-account-selector.tsx
+++ b/ui/components/app/snaps/snap-ui-account-selector/snap-ui-account-selector.tsx
@@ -81,7 +81,7 @@ export const SnapUIAccountSelector: FunctionComponent<
         accountGroups.find(({ accounts: accountGroup }) =>
           accountGroup.includes(account.id),
         )?.metadata.name ?? account.metadata.name;
-      console.log(name);
+
       return {
         ...account,
         metadata: {

--- a/ui/components/app/snaps/snap-ui-account-selector/snap-ui-account-selector.tsx
+++ b/ui/components/app/snaps/snap-ui-account-selector/snap-ui-account-selector.tsx
@@ -81,7 +81,7 @@ export const SnapUIAccountSelector: FunctionComponent<
         accountGroups.find(({ accounts: accountGroup }) =>
           accountGroup.includes(account.id),
         )?.metadata.name ?? account.metadata.name;
-
+      console.log(name);
       return {
         ...account,
         metadata: {

--- a/ui/components/app/snaps/snap-ui-renderer/components/__snapshots__/account-selector.test.ts.snap
+++ b/ui/components/app/snaps/snap-ui-renderer/components/__snapshots__/account-selector.test.ts.snap
@@ -152,7 +152,7 @@ exports[`SnapUIAccountSelector renders an account selector 1`] = `
                           <button
                             class="mm-box mm-text multichain-account-list-item__account-name__button mm-text--body-md-medium mm-text--ellipsis mm-text--text-align-left mm-box--padding-0 mm-box--width-full mm-box--color-text-default mm-box--background-color-transparent"
                           >
-                            Test Account
+                            Account 1
                           </button>
                         </div>
                         <div
@@ -463,7 +463,7 @@ exports[`SnapUIAccountSelector renders inside a field 1`] = `
                           <button
                             class="mm-box mm-text multichain-account-list-item__account-name__button mm-text--body-md-medium mm-text--ellipsis mm-text--text-align-left mm-box--padding-0 mm-box--width-full mm-box--color-text-default mm-box--background-color-transparent"
                           >
-                            Test Account
+                            Account 1
                           </button>
                         </div>
                         <div
@@ -511,7 +511,7 @@ exports[`SnapUIAccountSelector renders inside a field 1`] = `
                         >
                           <div>
                             <div
-                              aria-describedby="tippy-tooltip-13"
+                              aria-describedby="tippy-tooltip-14"
                               class=""
                               data-original-title="This can be changed in "Settings > Alerts""
                               data-tooltipped=""

--- a/ui/components/app/snaps/snap-ui-renderer/components/account-selector.test.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/account-selector.test.ts
@@ -59,7 +59,7 @@ describe('SnapUIAccountSelector', () => {
 
     fireEvent.click(accountOptions[1]);
 
-    expect(getByText('Test Account 2')).toBeInTheDocument();
+    expect(getByText('Account 1')).toBeInTheDocument();
   });
 
   it('can filter accounts owned by the snap', () => {

--- a/ui/components/app/snaps/snap-ui-renderer/components/account-selector.test.ts
+++ b/ui/components/app/snaps/snap-ui-renderer/components/account-selector.test.ts
@@ -57,9 +57,9 @@ describe('SnapUIAccountSelector', () => {
 
     expect(accountOptions).toHaveLength(6);
 
-    fireEvent.click(accountOptions[1]);
+    fireEvent.click(accountOptions[3]);
 
-    expect(getByText('Account 1')).toBeInTheDocument();
+    expect(getByText('Account 2')).toBeInTheDocument();
   });
 
   it('can filter accounts owned by the snap', () => {


### PR DESCRIPTION
## **Description**

This PR fixes the account name not showing due to it being stored in the `AccountTreeController` now.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/41007?quickstart=1)

## **Changelog**

CHANGELOG entry: Fix `SnapUIAccountSelector` account name.

## **Related issues**

Fixes: #40996 

## **Manual testing steps**

1. Go to https://jeff.dripfund.xyz/
2. Click "Connect wallet"
3. Click "Donate"
4. Expect an account name to be displayed in the Account Selector

## **Screenshots/Recordings**

### **Before**

<img width="412" height="630" alt="Screenshot 2026-03-18 at 11 17 12" src="https://github.com/user-attachments/assets/d6c9ece4-228e-45c4-a111-28a773bfd33c" />


### **After**

<img width="414" height="631" alt="Screenshot 2026-03-18 at 12 01 14" src="https://github.com/user-attachments/assets/df52a2aa-a665-4586-a5fe-1ee96e6e1078" />
<img width="419" height="636" alt="Screenshot 2026-03-18 at 12 01 24" src="https://github.com/user-attachments/assets/46d645ae-ed61-4585-a5f9-a44a414dfdc2" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts display names in the Snap account selector based on account-tree group metadata, with corresponding test updates.
> 
> **Overview**
> Fixes `SnapUIAccountSelector` to display the **account group name** from the account tree when an internal account’s `metadata.name` is empty/unused. The selector now derives each displayed account name by matching the account ID to `getAllAccountGroups()` and falls back to the account’s own name if no group is found.
> 
> Updates the account selector renderer tests/snapshots to expect the new naming (e.g., `Account 1/2`) and adjusts the selection index accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b15c4012e657f1eee04336a22818b7319d56b291. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->