### PR TITLE
chore: cache Firefox extension XPI to reduce test setup time by 80%

### DIFF
--- a/test/e2e/webdriver/firefox.js
+++ b/test/e2e/webdriver/firefox.js
@@ -132,14 +132,36 @@ class FirefoxDriver {
       .digest('hex')
       .slice(0, 12);
     const xpiPath = path.join(os.tmpdir(), `metamask-e2e-${dirHash}.xpi`);
+    const manifestHashPath = `${xpiPath}.manifest-sha256`;
 
     let needsRebuild = true;
     try {
-      // Rebuild if any file in the source directory is newer than the cached XPI.
       const xpiMtime = fs.statSync(xpiPath).mtimeMs;
-      needsRebuild = FirefoxDriver._hasNewerFile(absDir, xpiMtime);
+
+      // manifest.json is excluded from mtime checks because setManifestFlags()
+      // rewrites it before every test even when content is identical. Instead
+      // we compare its content hash to detect real changes.
+      const manifestContent = fs.readFileSync(
+        path.join(absDir, 'manifest.json'),
+      );
+      const manifestHash = nodeCrypto
+        .createHash('sha256')
+        .update(manifestContent)
+        .digest('hex');
+      const cachedManifestHash = fs
+        .readFileSync(manifestHashPath, 'utf8')
+        .trim();
+
+      const manifestChanged = manifestHash !== cachedManifestHash;
+      const filesChanged = FirefoxDriver._hasNewerFile(
+        absDir,
+        xpiMtime,
+        'manifest.json',
+      );
+
+      needsRebuild = manifestChanged || filesChanged;
     } catch (_) {
-      // XPI doesn't exist yet
+      // XPI or hash file doesn't exist yet
     }
 
     if (needsRebuild) {
@@ -156,6 +178,15 @@ class FirefoxDriver {
             `Ensure the extension has been built (e.g. yarn build:test:mv2): ${e.message}`,
         );
       }
+
+      const manifestContent = fs.readFileSync(
+        path.join(absDir, 'manifest.json'),
+      );
+      const manifestHash = nodeCrypto
+        .createHash('sha256')
+        .update(manifestContent)
+        .digest('hex');
+      fs.writeFileSync(manifestHashPath, manifestHash);
     }
 
     return xpiPath;
@@ -167,10 +198,14 @@ class FirefoxDriver {
    *
    * @param {string} dir - Directory to scan
    * @param {number} thresholdMs - mtime threshold in milliseconds
+   * @param {string} [skipFile] - Filename to skip (checked at top-level only)
    * @returns {boolean} true if at least one file is newer
    */
-  static _hasNewerFile(dir, thresholdMs) {
+  static _hasNewerFile(dir, thresholdMs, skipFile) {
     for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (skipFile && entry.name === skipFile) {
+        continue;
+      }
       const fullPath = path.join(dir, entry.name);
       if (entry.isDirectory()) {
         if (FirefoxDriver._hasNewerFile(fullPath, thresholdMs)) {

--- a/test/e2e/webdriver/firefox.js
+++ b/test/e2e/webdriver/firefox.js
@@ -175,7 +175,7 @@ class FirefoxDriver {
       } catch {
         // file didn't exist
       }
-      try {
+        return absDir;
         execFileSync('zip', ['-r', '-1', '-q', xpiPath, '.'], { cwd: absDir });
       } catch {
         // `zip` not installed — fall back to the unpacked directory.

--- a/test/e2e/webdriver/firefox.js
+++ b/test/e2e/webdriver/firefox.js
@@ -175,7 +175,7 @@ class FirefoxDriver {
       } catch (err) {
         console.warn('[Firefox E2E] Pre-rebuild unlink of XPI failed:', err.message);
       }
-        return absDir;
+      try {
         execFileSync('zip', ['-r', '-1', '-q', xpiPath, '.'], { cwd: absDir });
       } catch {
         // `zip` failed or not installed — fall back to unpacked directory.

--- a/test/e2e/webdriver/firefox.js
+++ b/test/e2e/webdriver/firefox.js
@@ -1,6 +1,6 @@
 const nodeCrypto = require('crypto');
 const fs = require('fs');
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 const os = require('os');
 const path = require('path');
 const {
@@ -117,32 +117,37 @@ class FirefoxDriver {
 
   /**
    * Returns the path to a cached XPI for the given unpacked extension directory.
-   * Builds the XPI on first call; reuses it when manifest.json content is unchanged.
-   * Uses a content hash because setManifestFlags rewrites the file (changing mtime)
-   * even when the content is identical.
+   * Builds the XPI on first call; reuses it as long as no file in the directory
+   * is newer than the cached XPI. The cache filename is derived from the
+   * directory path so different addon dirs get independent caches.
    *
    * @param {string} addonDir - Path to the unpacked extension directory
    * @returns {string} Path to the XPI file
    */
   static _getOrBuildXpi(addonDir) {
     const absDir = path.resolve(addonDir);
-    const xpiPath = path.join(os.tmpdir(), 'metamask-e2e-cached.xpi');
-    const hashPath = `${xpiPath}.sha256`;
-
-    const manifestContent = fs.readFileSync(path.join(absDir, 'manifest.json'));
-    const currentHash = nodeCrypto
+    const dirHash = nodeCrypto
       .createHash('sha256')
-      .update(manifestContent)
-      .digest('hex');
+      .update(absDir)
+      .digest('hex')
+      .slice(0, 12);
+    const xpiPath = path.join(os.tmpdir(), `metamask-e2e-${dirHash}.xpi`);
 
-    let needsRebuild = true;
-    try {
-      const cachedHash = fs.readFileSync(hashPath, 'utf8').trim();
-      if (cachedHash === currentHash && fs.existsSync(xpiPath)) {
-        needsRebuild = false;
+    let needsRebuild = !fs.existsSync(xpiPath);
+
+    if (!needsRebuild) {
+      // Rebuild if any file in the source directory is newer than the cached XPI.
+      // `find -newer` exits on first match, so this is fast even for large dirs.
+      try {
+        const result = execFileSync(
+          'find',
+          [absDir, '-newer', xpiPath, '-type', 'f', '-print', '-quit'],
+          { encoding: 'utf8' },
+        ).trim();
+        needsRebuild = result.length > 0;
+      } catch (_) {
+        needsRebuild = true;
       }
-    } catch (_) {
-      // hash file doesn't exist yet
     }
 
     if (needsRebuild) {
@@ -151,8 +156,14 @@ class FirefoxDriver {
       } catch (_) {
         // file didn't exist
       }
-      execSync(`cd "${absDir}" && zip -r -1 -q "${xpiPath}" .`);
-      fs.writeFileSync(hashPath, currentHash);
+      try {
+        execFileSync('zip', ['-r', '-1', '-q', xpiPath, '.'], { cwd: absDir });
+      } catch (e) {
+        throw new Error(
+          `Failed to build XPI from ${absDir}. ` +
+            `Ensure the extension has been built (e.g. yarn build:test:mv2): ${e.message}`,
+        );
+      }
     }
 
     return xpiPath;

--- a/test/e2e/webdriver/firefox.js
+++ b/test/e2e/webdriver/firefox.js
@@ -172,11 +172,10 @@ class FirefoxDriver {
       }
       try {
         execFileSync('zip', ['-r', '-1', '-q', xpiPath, '.'], { cwd: absDir });
-      } catch (e) {
-        throw new Error(
-          `Failed to build XPI from ${absDir}. ` +
-            `Ensure the extension has been built (e.g. yarn build:test:mv2): ${e.message}`,
-        );
+      } catch (_) {
+        // `zip` not installed — fall back to the unpacked directory.
+        // Selenium's installAddon() will zip it on every call (~10s slower).
+        return addonDir;
       }
 
       const manifestContent = fs.readFileSync(

--- a/test/e2e/webdriver/firefox.js
+++ b/test/e2e/webdriver/firefox.js
@@ -116,6 +116,22 @@ class FirefoxDriver {
   }
 
   /**
+   * Returns the SHA-256 hash of manifest.json content for cache invalidation.
+   *
+   * @param {string} absDir - Absolute path to the unpacked extension directory
+   * @returns {string} Hex-encoded SHA-256 hash
+   */
+  static _getManifestSha256(absDir) {
+    const manifestContent = fs.readFileSync(
+      path.join(absDir, 'manifest.json'),
+    );
+    return nodeCrypto
+      .createHash('sha256')
+      .update(manifestContent)
+      .digest('hex');
+  }
+
+  /**
    * Returns the path to a cached XPI for the given unpacked extension directory.
    * Builds the XPI on first call; reuses it as long as no file in the directory
    * is newer than the cached XPI. The cache filename is derived from the
@@ -143,13 +159,7 @@ class FirefoxDriver {
       // manifest.json is excluded from mtime checks because setManifestFlags()
       // rewrites it before every test even when content is identical. Instead
       // we compare its content hash to detect real changes.
-      const manifestContent = fs.readFileSync(
-        path.join(absDir, 'manifest.json'),
-      );
-      const manifestHash = nodeCrypto
-        .createHash('sha256')
-        .update(manifestContent)
-        .digest('hex');
+      const manifestHash = FirefoxDriver._getManifestSha256(absDir);
       manifestHashForStorage = manifestHash;
 
       const cachedManifestHash = fs
@@ -199,11 +209,7 @@ class FirefoxDriver {
       console.log('[Firefox E2E] Built cached XPI');
 
       const hashToStore =
-        manifestHashForStorage ??
-        nodeCrypto
-          .createHash('sha256')
-          .update(fs.readFileSync(path.join(absDir, 'manifest.json')))
-          .digest('hex');
+        manifestHashForStorage ?? FirefoxDriver._getManifestSha256(absDir);
       fs.writeFileSync(manifestHashPath, hashToStore);
     }
 

--- a/test/e2e/webdriver/firefox.js
+++ b/test/e2e/webdriver/firefox.js
@@ -133,21 +133,13 @@ class FirefoxDriver {
       .slice(0, 12);
     const xpiPath = path.join(os.tmpdir(), `metamask-e2e-${dirHash}.xpi`);
 
-    let needsRebuild = !fs.existsSync(xpiPath);
-
-    if (!needsRebuild) {
+    let needsRebuild = true;
+    try {
       // Rebuild if any file in the source directory is newer than the cached XPI.
-      // `find -newer` exits on first match, so this is fast even for large dirs.
-      try {
-        const result = execFileSync(
-          'find',
-          [absDir, '-newer', xpiPath, '-type', 'f', '-print', '-quit'],
-          { encoding: 'utf8' },
-        ).trim();
-        needsRebuild = result.length > 0;
-      } catch (_) {
-        needsRebuild = true;
-      }
+      const xpiMtime = fs.statSync(xpiPath).mtimeMs;
+      needsRebuild = FirefoxDriver._hasNewerFile(absDir, xpiMtime);
+    } catch (_) {
+      // XPI doesn't exist yet
     }
 
     if (needsRebuild) {
@@ -167,6 +159,28 @@ class FirefoxDriver {
     }
 
     return xpiPath;
+  }
+
+  /**
+   * Checks whether any file inside `dir` has an mtime newer than `thresholdMs`.
+   * Returns early on the first match for speed.
+   *
+   * @param {string} dir - Directory to scan
+   * @param {number} thresholdMs - mtime threshold in milliseconds
+   * @returns {boolean} true if at least one file is newer
+   */
+  static _hasNewerFile(dir, thresholdMs) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (FirefoxDriver._hasNewerFile(fullPath, thresholdMs)) {
+          return true;
+        }
+      } else if (fs.statSync(fullPath).mtimeMs > thresholdMs) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/test/e2e/webdriver/firefox.js
+++ b/test/e2e/webdriver/firefox.js
@@ -135,6 +135,8 @@ class FirefoxDriver {
     const manifestHashPath = `${xpiPath}.manifest-sha256`;
 
     let needsRebuild = true;
+    let manifestHashForStorage = null;
+
     try {
       const xpiMtime = fs.statSync(xpiPath).mtimeMs;
 
@@ -148,6 +150,8 @@ class FirefoxDriver {
         .createHash('sha256')
         .update(manifestContent)
         .digest('hex');
+      manifestHashForStorage = manifestHash;
+
       const cachedManifestHash = fs
         .readFileSync(manifestHashPath, 'utf8')
         .trim();
@@ -160,32 +164,36 @@ class FirefoxDriver {
       );
 
       needsRebuild = manifestChanged || filesChanged;
-    } catch (_) {
-      // XPI or hash file doesn't exist yet
+    } catch {
+      // XPI or hash file doesn't exist yet — first run or cache invalid
+      console.log('[Firefox E2E] Cache cold, building XPI');
     }
 
     if (needsRebuild) {
       try {
         fs.unlinkSync(xpiPath);
-      } catch (_) {
+      } catch {
         // file didn't exist
       }
       try {
         execFileSync('zip', ['-r', '-1', '-q', xpiPath, '.'], { cwd: absDir });
-      } catch (_) {
+      } catch {
         // `zip` not installed — fall back to the unpacked directory.
         // Selenium's installAddon() will zip it on every call (~10s slower).
+        console.warn(
+          '[Firefox E2E] zip not installed, using unpacked directory (slower)',
+        );
         return addonDir;
       }
+      console.log('[Firefox E2E] Built cached XPI');
 
-      const manifestContent = fs.readFileSync(
-        path.join(absDir, 'manifest.json'),
-      );
-      const manifestHash = nodeCrypto
-        .createHash('sha256')
-        .update(manifestContent)
-        .digest('hex');
-      fs.writeFileSync(manifestHashPath, manifestHash);
+      const hashToStore =
+        manifestHashForStorage ??
+        nodeCrypto
+          .createHash('sha256')
+          .update(fs.readFileSync(path.join(absDir, 'manifest.json')))
+          .digest('hex');
+      fs.writeFileSync(manifestHashPath, hashToStore);
     }
 
     return xpiPath;

--- a/test/e2e/webdriver/firefox.js
+++ b/test/e2e/webdriver/firefox.js
@@ -122,9 +122,7 @@ class FirefoxDriver {
    * @returns {string} Hex-encoded SHA-256 hash
    */
   static _getManifestSha256(absDir) {
-    const manifestContent = fs.readFileSync(
-      path.join(absDir, 'manifest.json'),
-    );
+    const manifestContent = fs.readFileSync(path.join(absDir, 'manifest.json'));
     return nodeCrypto
       .createHash('sha256')
       .update(manifestContent)
@@ -183,7 +181,10 @@ class FirefoxDriver {
       try {
         fs.unlinkSync(xpiPath);
       } catch (err) {
-        console.warn('[Firefox E2E] Pre-rebuild unlink of XPI failed:', err.message);
+        console.warn(
+          '[Firefox E2E] Pre-rebuild unlink of XPI failed:',
+          err.message,
+        );
       }
       try {
         execFileSync('zip', ['-r', '-1', '-q', xpiPath, '.'], { cwd: absDir });
@@ -194,19 +195,28 @@ class FirefoxDriver {
         try {
           fs.unlinkSync(xpiPath);
         } catch (err) {
-          console.warn('[Firefox E2E] Cleanup of partial XPI failed:', err.message);
+          console.warn(
+            '[Firefox E2E] Cleanup of partial XPI failed:',
+            err.message,
+          );
         }
         try {
           fs.unlinkSync(manifestHashPath);
         } catch (err) {
-          console.warn('[Firefox E2E] Cleanup of manifest hash failed:', err.message);
+          console.warn(
+            '[Firefox E2E] Cleanup of manifest hash failed:',
+            err.message,
+          );
         }
         // If unlink failed, overwrite with sentinel so next run won't treat
         // a corrupted XPI as valid (manifestHash will never match '').
         try {
           fs.writeFileSync(manifestHashPath, '');
         } catch (err) {
-          console.warn('[Firefox E2E] Failed to invalidate manifest hash:', err.message);
+          console.warn(
+            '[Firefox E2E] Failed to invalidate manifest hash:',
+            err.message,
+          );
         }
         console.warn(
           '[Firefox E2E] zip not installed or failed, using unpacked directory (slower)',

--- a/test/e2e/webdriver/firefox.js
+++ b/test/e2e/webdriver/firefox.js
@@ -201,6 +201,13 @@ class FirefoxDriver {
         } catch (err) {
           console.warn('[Firefox E2E] Cleanup of manifest hash failed:', err.message);
         }
+        // If unlink failed, overwrite with sentinel so next run won't treat
+        // a corrupted XPI as valid (manifestHash will never match '').
+        try {
+          fs.writeFileSync(manifestHashPath, '');
+        } catch (err) {
+          console.warn('[Firefox E2E] Failed to invalidate manifest hash:', err.message);
+        }
         console.warn(
           '[Firefox E2E] zip not installed or failed, using unpacked directory (slower)',
         );

--- a/test/e2e/webdriver/firefox.js
+++ b/test/e2e/webdriver/firefox.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const { execSync } = require('child_process');
 const os = require('os');
 const path = require('path');
 const {
@@ -95,7 +96,11 @@ class FirefoxDriver {
     const driver = builder.build();
     const fxDriver = new FirefoxDriver(driver);
 
-    const extensionId = await fxDriver.installExtension('dist/firefox');
+    // Pre-build a compressed XPI and cache it across test runs.
+    // Without this, installAddon() zips the 348MB unpacked dir on every call,
+    // adding ~10s of overhead per test.
+    const xpiPath = FirefoxDriver._getOrBuildXpi('dist/firefox');
+    const installedExtensionId = await fxDriver.installExtension(xpiPath);
     const internalExtensionId = await fxDriver.getInternalId();
 
     if (responsive || constrainWindowSize) {
@@ -104,9 +109,52 @@ class FirefoxDriver {
 
     return {
       driver,
-      extensionId,
+      extensionId: installedExtensionId,
       extensionUrl: `moz-extension://${internalExtensionId}`,
     };
+  }
+
+  /**
+   * Returns the path to a cached XPI for the given unpacked extension directory.
+   * Builds the XPI on first call; reuses it when manifest.json content is unchanged.
+   * Uses a content hash because setManifestFlags rewrites the file (changing mtime)
+   * even when the content is identical.
+   *
+   * @param {string} addonDir - Path to the unpacked extension directory
+   * @returns {string} Path to the XPI file
+   */
+  static _getOrBuildXpi(addonDir) {
+    const absDir = path.resolve(addonDir);
+    const xpiPath = path.join(os.tmpdir(), 'metamask-e2e-cached.xpi');
+    const hashPath = `${xpiPath}.sha256`;
+
+    const manifestContent = fs.readFileSync(path.join(absDir, 'manifest.json'));
+    const currentHash = crypto
+      .createHash('sha256')
+      .update(manifestContent)
+      .digest('hex');
+
+    let needsRebuild = true;
+    try {
+      const cachedHash = fs.readFileSync(hashPath, 'utf8').trim();
+      if (cachedHash === currentHash && fs.existsSync(xpiPath)) {
+        needsRebuild = false;
+      }
+    } catch (_) {
+      // hash file doesn't exist yet
+    }
+
+    if (needsRebuild) {
+      try {
+        fs.unlinkSync(xpiPath);
+      } catch (_) {
+        // file didn't exist
+      }
+      execSync(`cd "${absDir}" && zip -r -1 -q "${xpiPath}" .`);
+      fs.writeFileSync(hashPath, currentHash);
+    }
+
+    return xpiPath;
   }
 
   /**

--- a/test/e2e/webdriver/firefox.js
+++ b/test/e2e/webdriver/firefox.js
@@ -172,16 +172,27 @@ class FirefoxDriver {
     if (needsRebuild) {
       try {
         fs.unlinkSync(xpiPath);
-      } catch {
-        // file didn't exist
+      } catch (err) {
+        console.warn('[Firefox E2E] Pre-rebuild unlink of XPI failed:', err.message);
       }
         return absDir;
         execFileSync('zip', ['-r', '-1', '-q', xpiPath, '.'], { cwd: absDir });
       } catch {
-        // `zip` not installed — fall back to the unpacked directory.
-        // Selenium's installAddon() will zip it on every call (~10s slower).
+        // `zip` failed or not installed — fall back to unpacked directory.
+        // Clean up any partial/corrupted XPI and stale hash so we don't reuse
+        // them on the next run (which would cause hard-to-diagnose install failures).
+        try {
+          fs.unlinkSync(xpiPath);
+        } catch (err) {
+          console.warn('[Firefox E2E] Cleanup of partial XPI failed:', err.message);
+        }
+        try {
+          fs.unlinkSync(manifestHashPath);
+        } catch (err) {
+          console.warn('[Firefox E2E] Cleanup of manifest hash failed:', err.message);
+        }
         console.warn(
-          '[Firefox E2E] zip not installed, using unpacked directory (slower)',
+          '[Firefox E2E] zip not installed or failed, using unpacked directory (slower)',
         );
         return addonDir;
       }

--- a/test/e2e/webdriver/firefox.js
+++ b/test/e2e/webdriver/firefox.js
@@ -1,4 +1,4 @@
-const crypto = require('crypto');
+const nodeCrypto = require('crypto');
 const fs = require('fs');
 const { execSync } = require('child_process');
 const os = require('os');
@@ -130,7 +130,7 @@ class FirefoxDriver {
     const hashPath = `${xpiPath}.sha256`;
 
     const manifestContent = fs.readFileSync(path.join(absDir, 'manifest.json'));
-    const currentHash = crypto
+    const currentHash = nodeCrypto
       .createHash('sha256')
       .update(manifestContent)
       .digest('hex');

--- a/test/e2e/webdriver/firefox.js
+++ b/test/e2e/webdriver/firefox.js
@@ -1,3 +1,4 @@
+const crypto = require('crypto');
 const fs = require('fs');
 const { execSync } = require('child_process');
 const os = require('os');


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

**Problem**
Every Firefox E2E test calls installAddon('dist/firefox', true), which zips the entire 348MB unpacked extension directory and base64-transfers it to geckodriver over HTTP. This adds ~12.2 seconds of overhead per test — 88% of total Firefox setup time.

**Solution**
Pre-build a compressed XPI (107MB) on first use and cache it in the system temp directory. Subsequent tests in the same session reuse the cached XPI, skipping the re-zip entirely. Cache invalidation uses a SHA-256 hash of manifest.json content (mtime-based caching doesn't work because setManifestFlags rewrites the file before each test even when content is identical).


Q raised in comments: Why not taking the ci test build artifact directly?
During yarn build:test:mv2, the zip is built from dist/firefox right after the build. At that point, setManifestFlags has not run yet.
Before each test, setManifestFlags updates dist/firefox/manifest.json with:
_flags (feature flags, etc.)
flags.ci (branch, commit, job, matrix index, PR number)
Flags from fetchManifestFlagsFromPRAndGit

That's why we zip after that happen. Then we cache, and apply the cache invalidation). Decision to rebuild:
- manifestChanged → manifest content differs from the cached hash
- filesChanged → any non-manifest file in dist/firefox is newer than the cached XPI



<img width="705" height="200" alt="image" src="https://github.com/user-attachments/assets/1bce4546-8d86-4747-85c4-39590b425a7a" />

<img width="1100" height="265" alt="image" src="https://github.com/user-attachments/assets/cf29bb54-6002-40f2-9754-27d89de643ae" />




[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/41015?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


https://github.com/user-attachments/assets/65cafee5-b50a-4263-b149-466bbe8c432f



### **After**


https://github.com/user-attachments/assets/f9f3153d-f807-4aec-bd59-2468200e07b7


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes Firefox E2E setup behavior and introduces a temp-dir cache plus an external `zip` invocation, which could cause stale/corrupt addon installs or environment-specific failures (with a fallback to unpacked installs).
> 
> **Overview**
> Speeds up Firefox E2E startup by **caching a prebuilt XPI** for `dist/firefox` and installing that instead of re-zipping the unpacked extension on every test run.
> 
> Adds cache invalidation based on a SHA-256 hash of `manifest.json` (to avoid false rebuilds from flag rewrites) plus mtime checks for other files, and falls back to installing the unpacked directory if `zip` is unavailable or XPI creation fails (with cleanup of partial cache artifacts).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95372b47d0c78c0aa68e7d38772a04139597ad92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->