### PR TITLE
chore: compute Chrome extension ID from manifest key for e2e setup

### DIFF
--- a/test/e2e/set-manifest-flags.ts
+++ b/test/e2e/set-manifest-flags.ts
@@ -1,3 +1,4 @@
+import nodeCrypto from 'crypto';
 import fs from 'fs';
 import { merge } from 'lodash';
 import { ManifestFlags } from '../../shared/lib/manifestFlags';
@@ -54,10 +55,15 @@ export async function setManifestFlags(flags: ManifestFlags = {}) {
   manifest._flags = flags;
 
   if (process.env.MULTIPROVIDER && 'key' in manifest) {
-    // for multi-provider tests, we need to install the second extension
-    // if any key is present, we need to remove it to generate a new random key (id) for each extension
-    // since two extensions with the same key can't be installed at the same time
-    delete manifest.key;
+    // Replace the key with a freshly generated one so dist/chrome gets a
+    // different deterministic extension ID than dist/chrome2 (which keeps
+    // the original key from the copy). This avoids the same-key conflict
+    // while keeping both IDs computable without scraping chrome://extensions.
+    manifest.key = nodeCrypto
+      .generateKeyPairSync('rsa', { modulusLength: 2048 })
+      .publicKey.export({ type: 'spki', format: 'pem' })
+      .toString()
+      .replace(/-----(BEGIN|END) PUBLIC KEY-----|\n/gu, '');
   }
 
   fs.writeFileSync(

--- a/test/e2e/webdriver/chrome.js
+++ b/test/e2e/webdriver/chrome.js
@@ -118,7 +118,6 @@ class ChromeDriver {
 
     // When the manifest has a `key`, the extension ID is deterministic and can
     // be computed locally — skipping the chrome://extensions round-trip (~880ms).
-    // MULTIPROVIDER mode strips the key, so we fall back to scraping.
     let extensionId = ChromeDriver._computeExtensionId('dist/chrome');
     if (!extensionId) {
       const chromeDriver = new ChromeDriver(driver);
@@ -134,7 +133,7 @@ class ChromeDriver {
 
   /**
    * Computes the deterministic Chrome extension ID from the manifest's `key` field.
-   * Returns null if the key is absent (e.g. MULTIPROVIDER mode).
+   * Returns null if the key is absent.
    *
    * @param {string} extensionDir - Path to the unpacked extension directory
    * @returns {string|null} The 32-char extension ID, or null

--- a/test/e2e/webdriver/chrome.js
+++ b/test/e2e/webdriver/chrome.js
@@ -157,7 +157,7 @@ class ChromeDriver {
         .split('')
         .map((c) => String.fromCharCode('a'.charCodeAt(0) + parseInt(c, 16)))
         .join('');
-    } catch (_) {
+    } catch {
       return null;
     }
   }

--- a/test/e2e/webdriver/chrome.js
+++ b/test/e2e/webdriver/chrome.js
@@ -1,3 +1,6 @@
+const nodeCrypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
 const { Builder } = require('selenium-webdriver');
 const chrome = require('selenium-webdriver/chrome');
 const { ThenableWebDriver } = require('selenium-webdriver'); // eslint-disable-line no-unused-vars -- this is imported for JSDoc
@@ -112,14 +115,51 @@ class ChromeDriver {
 
     builder.setChromeService(service);
     const driver = builder.build();
-    const chromeDriver = new ChromeDriver(driver);
-    const extensionId = await chromeDriver.getExtensionIdByName('MetaMask');
+
+    // When the manifest has a `key`, the extension ID is deterministic and can
+    // be computed locally — skipping the chrome://extensions round-trip (~880ms).
+    // MULTIPROVIDER mode strips the key, so we fall back to scraping.
+    let extensionId = ChromeDriver._computeExtensionId('dist/chrome');
+    if (!extensionId) {
+      const chromeDriver = new ChromeDriver(driver);
+      extensionId = await chromeDriver.getExtensionIdByName('MetaMask');
+    }
 
     return {
       driver,
       extensionId,
       extensionUrl: `chrome-extension://${extensionId}`,
     };
+  }
+
+  /**
+   * Computes the deterministic Chrome extension ID from the manifest's `key` field.
+   * Returns null if the key is absent (e.g. MULTIPROVIDER mode).
+   *
+   * @param {string} extensionDir - Path to the unpacked extension directory
+   * @returns {string|null} The 32-char extension ID, or null
+   */
+  static _computeExtensionId(extensionDir) {
+    try {
+      const manifest = JSON.parse(
+        fs.readFileSync(path.join(extensionDir, 'manifest.json'), 'utf8'),
+      );
+      if (!manifest.key) {
+        return null;
+      }
+      const keyBytes = Buffer.from(manifest.key, 'base64');
+      const hash = nodeCrypto
+        .createHash('sha256')
+        .update(keyBytes)
+        .digest('hex');
+      return hash
+        .slice(0, 32)
+        .split('')
+        .map((c) => String.fromCharCode('a'.charCodeAt(0) + parseInt(c, 16)))
+        .join('');
+    } catch (_) {
+      return null;
+    }
   }
 
   /**

--- a/test/e2e/webdriver/chrome.js
+++ b/test/e2e/webdriver/chrome.js
@@ -153,7 +153,9 @@ class ChromeDriver {
         .digest('hex');
       return hash
         .slice(0, 32)
-        .replace(/[0-9a-f]/gu, c => String.fromCharCode(97 + parseInt(c, 16)))
+        .replace(/[0-9a-f]/gu, (c) =>
+          String.fromCharCode(97 + parseInt(c, 16)),
+        );
     } catch {
       return null;
     }

--- a/test/e2e/webdriver/chrome.js
+++ b/test/e2e/webdriver/chrome.js
@@ -154,9 +154,7 @@ class ChromeDriver {
         .digest('hex');
       return hash
         .slice(0, 32)
-        .split('')
-        .map((c) => String.fromCharCode('a'.charCodeAt(0) + parseInt(c, 16)))
-        .join('');
+        .replace(/[0-9a-f]/gu, c => String.fromCharCode(97 + parseInt(c, 16)))
     } catch {
       return null;
     }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
**Problem**
Every Chrome E2E test calls getExtensionIdByName(), which navigates to chrome://extensions and scrapes shadow DOM to find the MetaMask extension ID. This adds ~880ms per test, even though the ID is deterministic — Chrome derives it from the key field in manifest.json, which never changes.

**Solution**
Compute the extension ID locally using the same algorithm Chrome uses: SHA-256 hash of the decoded key bytes, mapped to a-p characters. Falls back to the original scraping method when key is absent (MULTIPROVIDER mode, where the key is stripped to allow two extensions simultaneously).


<img width="610" height="171" alt="image" src="https://github.com/user-attachments/assets/ce28f183-8972-4621-a3bf-1002740b4733" />

<img width="1376" height="768" alt="image" src="https://github.com/user-attachments/assets/67779177-29e3-4da3-87c8-8c7c7dca529b" />



[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/41016?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that optimize E2E setup by avoiding `chrome://extensions` scraping, with a fallback to the existing method if key-based computation fails.
> 
> **Overview**
> Speeds up Chrome E2E startup by computing the MetaMask extension ID locally from `manifest.json`’s `key` (SHA-256-derived deterministic ID) and only falling back to `chrome://extensions` scraping when the key is missing.
> 
> In `MULTIPROVIDER` mode, `setManifestFlags` now **replaces** the manifest `key` with a freshly generated public key (instead of deleting it) so both extensions can coexist while still having deterministic, computable IDs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4d741c4fcd5c7d272240a65967f205ff7a816f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->