### PR TITLE
chore: simplify benchmark workflow and consolidate stats storage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -402,6 +402,7 @@ jobs:
     secrets:
       INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
       TEST_SRP_2: ${{ secrets.TEST_SRP_2 }}
+      EXTENSION_BENCHMARK_STATS_TOKEN: ${{ secrets.EXTENSION_BENCHMARK_STATS_TOKEN }}
 
   run-tests:
     name: Run tests
@@ -491,64 +492,6 @@ jobs:
       browser-loads: 10
       page-loads: 10
       builds-from-run: ${{ needs.get-requirements.outputs.builds-from-run }}
-
-  # Pushes benchmark results (dapp page-load + performance) to extension_benchmark_stats
-  # for historical comparison in PR comments. Runs on main/release/* pushes only.
-  store-benchmark-stats:
-    needs:
-      - get-requirements
-      - run-benchmarks
-      - dapp-page-load-benchmark
-    if: >-
-      ${{
-        !cancelled() &&
-        github.event_name == 'push' &&
-        (github.ref_name == 'main' || startsWith(github.ref, 'refs/heads/release/')) &&
-        needs.get-requirements.outputs.needs-benchmarks == 'true' &&
-        !(github.event.pull_request.head.repo.fork || github.event.repository.fork)
-      }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    env:
-      EXTENSION_BENCHMARK_STATS_TOKEN: ${{ secrets.EXTENSION_BENCHMARK_STATS_TOKEN }}
-      HEAD_COMMIT_HASH: ${{ github.sha }}
-      OWNER: ${{ github.repository_owner }}
-      BRANCH_NAME: ${{ github.ref_name }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Download all performance benchmark artifacts
-        id: download-perf-benchmark
-        uses: actions/download-artifact@v7
-        continue-on-error: true
-        with:
-          pattern: benchmark-*.json
-          path: benchmark-results/
-          merge-multiple: true
-
-      - name: Commit performance stats to extension_benchmark_stats
-        if: steps.download-perf-benchmark.outcome == 'success'
-        continue-on-error: true
-        run: .github/scripts/benchmark-stats-commit.sh
-        env:
-          BENCHMARK_DATA_TYPE: performance
-          BENCHMARK_RESULTS_DIR: benchmark-results
-
-      - name: Download dapp page-load benchmark artifact
-        id: download-dapp-benchmark
-        uses: actions/download-artifact@v7
-        continue-on-error: true
-        with:
-          name: dapp-page-load-benchmark-results
-          path: test-artifacts/benchmarks/
-
-      - name: Commit dapp page-load stats to extension_benchmark_stats
-        if: steps.download-dapp-benchmark.outcome == 'success'
-        run: .github/scripts/benchmark-stats-commit.sh
-        env:
-          BENCHMARK_DATA_TYPE: dapp-page-load
-          BENCHMARK_FILE: test-artifacts/benchmarks/dapp-page-load-benchmark-results.json
 
   prep-e2e:
     needs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -482,17 +482,6 @@ jobs:
           s3-bucket: ${{ vars.AWS_S3_BUCKET }}/${{ github.event.repository.name }}/${{ env.RUN_ID }}/bundle-size
           path: test-artifacts/chrome
 
-  dapp-page-load-benchmark:
-    needs:
-      - get-requirements
-      - build-test-browserify
-    if: ${{ needs.get-requirements.outputs.needs-benchmarks == 'true' }}
-    uses: ./.github/workflows/dapp-page-load-benchmark.yml
-    with:
-      browser-loads: 10
-      page-loads: 10
-      builds-from-run: ${{ needs.get-requirements.outputs.builds-from-run }}
-
   prep-e2e:
     needs:
       - get-requirements
@@ -728,7 +717,6 @@ jobs:
       - build-test-flask-webpack
       - build-test-flask-mv2-webpack
       - run-benchmarks
-      - dapp-page-load-benchmark
       - bundle-size
       - build-storybook
       - build-ts-migration-dashboard
@@ -830,7 +818,6 @@ jobs:
       - run-benchmarks
       - run-tests
       - bundle-size
-      - dapp-page-load-benchmark
       - prep-e2e
       - e2e-chrome
       - e2e-firefox

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -285,9 +285,10 @@ jobs:
           path: test-artifacts/benchmarks/dapp-page-load-benchmark-results.json
 
   # Pushes benchmark results (performance + dapp page-load) to extension_benchmark_stats
-  # for historical comparison in PR comments. Runs on main branch pushes only.
+  # for historical comparison in PR comments. Runs on main/release branch pushes only.
   store-benchmark-stats:
-    name: store-benchmark-stats (main only)
+    name: store-benchmark-stats (main/release only)
+    continue-on-error: true
     needs:
       - benchmarks
       - benchmarks-webpack-perf
@@ -296,7 +297,7 @@ jobs:
       ${{
         !cancelled() &&
         github.event_name == 'push' &&
-        github.ref_name == 'main' &&
+        (github.ref_name == 'main' || startsWith(github.ref, 'refs/heads/release/')) &&
         !(github.event.pull_request.head.repo.fork || github.event.repository.fork)
       }}
     runs-on: ubuntu-latest
@@ -337,6 +338,7 @@ jobs:
 
       - name: Commit dapp page-load stats to extension_benchmark_stats
         if: steps.download-dapp-benchmark.outcome == 'success'
+        continue-on-error: true
         run: .github/scripts/benchmark-stats-commit.sh
         env:
           BENCHMARK_DATA_TYPE: dapp-page-load

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -213,12 +213,51 @@ jobs:
             --browser chrome \
             --buildType webpack
 
+  dapp-page-load-benchmark:
+    if: ${{ github.event_name != 'merge_group' }} # Skip this job for the Merge Queue
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: ${{ github.ref_name == 'main' && 'default-branch' || null }}
+    env:
+      OWNER: ${{ github.repository_owner }}
+      REPOSITORY: ${{ github.event.repository.name }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      HEAD_COMMIT_HASH: ${{ github.event.pull_request.head.sha || github.sha }}
+      BENCHMARK_BROWSER_LOADS: 10
+      BENCHMARK_PAGE_LOADS: 10
+    steps:
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v3
+        with:
+          is-high-risk-environment: false
+          skip-allow-scripts: true
+
+      - name: Download artifact 'build-test-browserify'
+        uses: actions/download-artifact@v7
+        with:
+          name: build-test-browserify
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ inputs.builds-from-run }}
+
+      - name: Install Playwright browsers
+        run: yarn playwright install chromium
+
+      - name: Run dapp page load benchmarks
+        run: yarn test:e2e:benchmark --preset=pageLoadBenchmark
+
+      - name: Upload benchmark results (github artifacts)
+        uses: actions/upload-artifact@v6
+        with:
+          name: dapp-page-load-benchmark-results
+          path: test-artifacts/benchmarks/dapp-page-load-benchmark-results.json
+
   # Pushes benchmark results (performance + dapp page-load) to extension_benchmark_stats
   # for historical comparison in PR comments. Runs on main branch pushes only.
-  store-benchmark-stats (main only):
+  store-benchmark-stats:
     needs:
       - benchmarks
       - benchmarks-webpack-perf
+      - dapp-page-load-benchmark
     if: >-
       ${{
         !cancelled() &&
@@ -268,4 +307,3 @@ jobs:
         env:
           BENCHMARK_DATA_TYPE: dapp-page-load
           BENCHMARK_FILE: test-artifacts/benchmarks/dapp-page-load-benchmark-results.json
-

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -110,13 +110,16 @@ jobs:
       - name: Configure Xvfb
         run: Xvfb -ac :99 -screen 0 1280x1024x16 &
 
+      - name: Install AWS CLI (needed in the container)
+        run: sudo apt-get update && sudo apt-get install python3-pip && sudo pip install awscli --break-system-packages
+
       - name: Run the benchmark
         # Choose a benchmark command from env.COMMANDS
         # Then replace the {0} placeholder with the browser, and the {1} placeholder with the buildType
         run: ${{ format(fromJson(env.COMMANDS)[matrix.pageType], matrix.browser, matrix.buildType) }}
 
       - name: Send benchmark results to Sentry
-        if: ${{ vars.SENTRY_DSN_PERFORMANCE }}
+        if: ${{ vars.SENTRY_DSN_PERFORMANCE && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) }}
         env:
           GH_HEAD_REF: ${{ github.head_ref }}
           GH_REF_NAME: ${{ github.ref_name }}
@@ -126,6 +129,15 @@ jobs:
             --results test-artifacts/benchmarks/${{ env.OUTPUT_NAME }} \
             --browser ${{ matrix.browser }} \
             --buildType ${{ matrix.buildType }}
+
+      - name: Upload '${{ env.OUTPUT_NAME }}' to S3
+        if: ${{ vars.AWS_REGION && vars.AWS_IAM_ROLE && vars.AWS_S3_BUCKET }}
+        uses: MetaMask/github-tools/.github/actions/upload-s3@v1
+        with:
+          aws-region: ${{ vars.AWS_REGION }}
+          role-to-assume: ${{ vars.AWS_IAM_ROLE }}
+          s3-bucket: ${{ vars.AWS_S3_BUCKET }}/${{ github.event.repository.name }}/${{ github.run_id }}/benchmarks/${{ env.OUTPUT_NAME }}
+          path: test-artifacts/benchmarks/${{ env.OUTPUT_NAME }}
 
       - name: Upload benchmark result as artifact
         if: ${{ always() }}
@@ -198,6 +210,9 @@ jobs:
       - name: Configure Xvfb
         run: Xvfb -ac :99 -screen 0 1280x1024x16 &
 
+      - name: Install AWS CLI (needed in the container)
+        run: sudo apt-get update && sudo apt-get install python3-pip && sudo pip install awscli --break-system-packages
+
       - name: Run the benchmark
         run: ${{ format(fromJson(env.COMMANDS)[matrix.pageType], 'chrome', 'webpack') }}
 
@@ -212,6 +227,24 @@ jobs:
             --results test-artifacts/benchmarks/${{ env.OUTPUT_NAME }} \
             --browser chrome \
             --buildType webpack
+
+      - name: Upload '${{ env.OUTPUT_NAME }}' to S3
+        if: ${{ vars.AWS_REGION && vars.AWS_IAM_ROLE && vars.AWS_S3_BUCKET }}
+        uses: MetaMask/github-tools/.github/actions/upload-s3@v1
+        with:
+          aws-region: ${{ vars.AWS_REGION }}
+          role-to-assume: ${{ vars.AWS_IAM_ROLE }}
+          s3-bucket: ${{ vars.AWS_S3_BUCKET }}/${{ github.event.repository.name }}/${{ github.run_id }}/benchmarks/${{ env.OUTPUT_NAME }}
+          path: test-artifacts/benchmarks/${{ env.OUTPUT_NAME }}
+
+      - name: Upload benchmark result as artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{ env.OUTPUT_NAME }}
+          path: test-artifacts/benchmarks/${{ env.OUTPUT_NAME }}
+          retention-days: 7
+          if-no-files-found: ignore
 
   dapp-page-load-benchmark:
     if: ${{ github.event_name != 'merge_group' }} # Skip this job for the Merge Queue

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -11,6 +11,9 @@ on:
       TEST_SRP_2:
         required: false
         description: Required for userJourneyAccountManagement (import-srp-home). 12-word seed phrase.
+      EXTENSION_BENCHMARK_STATS_TOKEN:
+        required: false
+        description: Required for committing benchmark stats to extension_benchmark_stats on main.
 
 env:
   COMMANDS: |
@@ -107,10 +110,6 @@ jobs:
       - name: Configure Xvfb
         run: Xvfb -ac :99 -screen 0 1280x1024x16 &
 
-      # TODO: Pre-install this in the container image
-      - name: Install AWS CLI (needed in the container)
-        run: sudo apt-get update && sudo apt-get install python3-pip && sudo pip install awscli --break-system-packages
-
       - name: Run the benchmark
         # Choose a benchmark command from env.COMMANDS
         # Then replace the {0} placeholder with the browser, and the {1} placeholder with the buildType
@@ -127,15 +126,6 @@ jobs:
             --results test-artifacts/benchmarks/${{ env.OUTPUT_NAME }} \
             --browser ${{ matrix.browser }} \
             --buildType ${{ matrix.buildType }}
-
-      - name: Upload '${{ env.OUTPUT_NAME }}' to S3
-        if: ${{ vars.AWS_REGION && vars.AWS_IAM_ROLE && vars.AWS_S3_BUCKET }}
-        uses: MetaMask/github-tools/.github/actions/upload-s3@v1
-        with:
-          aws-region: ${{ vars.AWS_REGION }}
-          role-to-assume: ${{ vars.AWS_IAM_ROLE }}
-          s3-bucket: ${{ vars.AWS_S3_BUCKET }}/${{ github.event.repository.name }}/${{ github.run_id }}/benchmarks/${{ env.OUTPUT_NAME }}
-          path: test-artifacts/benchmarks/${{ env.OUTPUT_NAME }}
 
       - name: Upload benchmark result as artifact
         if: ${{ always() }}
@@ -208,9 +198,6 @@ jobs:
       - name: Configure Xvfb
         run: Xvfb -ac :99 -screen 0 1280x1024x16 &
 
-      - name: Install AWS CLI (needed in the container)
-        run: sudo apt-get update && sudo apt-get install python3-pip && sudo pip install awscli --break-system-packages
-
       - name: Run the benchmark
         run: ${{ format(fromJson(env.COMMANDS)[matrix.pageType], 'chrome', 'webpack') }}
 
@@ -226,11 +213,59 @@ jobs:
             --browser chrome \
             --buildType webpack
 
-      - name: Upload '${{ env.OUTPUT_NAME }}' to S3
-        if: ${{ vars.AWS_REGION && vars.AWS_IAM_ROLE && vars.AWS_S3_BUCKET }}
-        uses: MetaMask/github-tools/.github/actions/upload-s3@v1
+  # Pushes benchmark results (performance + dapp page-load) to extension_benchmark_stats
+  # for historical comparison in PR comments. Runs on main branch pushes only.
+  store-benchmark-stats (main only):
+    needs:
+      - benchmarks
+      - benchmarks-webpack-perf
+    if: >-
+      ${{
+        !cancelled() &&
+        github.event_name == 'push' &&
+        github.ref_name == 'main' &&
+        !(github.event.pull_request.head.repo.fork || github.event.repository.fork)
+      }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      EXTENSION_BENCHMARK_STATS_TOKEN: ${{ secrets.EXTENSION_BENCHMARK_STATS_TOKEN }}
+      HEAD_COMMIT_HASH: ${{ github.sha }}
+      OWNER: ${{ github.repository_owner }}
+      BRANCH_NAME: ${{ github.ref_name }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Download all performance benchmark artifacts
+        id: download-perf-benchmark
+        uses: actions/download-artifact@v7
+        continue-on-error: true
         with:
-          aws-region: ${{ vars.AWS_REGION }}
-          role-to-assume: ${{ vars.AWS_IAM_ROLE }}
-          s3-bucket: ${{ vars.AWS_S3_BUCKET }}/${{ github.event.repository.name }}/${{ github.run_id }}/benchmarks/${{ env.OUTPUT_NAME }}
-          path: test-artifacts/benchmarks/${{ env.OUTPUT_NAME }}
+          pattern: benchmark-*.json
+          path: benchmark-results/
+          merge-multiple: true
+
+      - name: Commit performance stats to extension_benchmark_stats
+        if: steps.download-perf-benchmark.outcome == 'success'
+        continue-on-error: true
+        run: .github/scripts/benchmark-stats-commit.sh
+        env:
+          BENCHMARK_DATA_TYPE: performance
+          BENCHMARK_RESULTS_DIR: benchmark-results
+
+      - name: Download dapp page-load benchmark artifact
+        id: download-dapp-benchmark
+        uses: actions/download-artifact@v7
+        continue-on-error: true
+        with:
+          name: dapp-page-load-benchmark-results
+          path: test-artifacts/benchmarks/
+
+      - name: Commit dapp page-load stats to extension_benchmark_stats
+        if: steps.download-dapp-benchmark.outcome == 'success'
+        run: .github/scripts/benchmark-stats-commit.sh
+        env:
+          BENCHMARK_DATA_TYPE: dapp-page-load
+          BENCHMARK_FILE: test-artifacts/benchmarks/dapp-page-load-benchmark-results.json
+

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -104,8 +104,8 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           name: ${{ env.ARTIFACT_NAME }}
-          github-token: ${{ secrets.GITHUB_TOKEN }} # This is required when downloading artifacts from a different repository or from a different workflow run.
-          run-id: ${{ inputs.builds-from-run }} # Download from whatever run the identify-builds job said.
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ inputs.builds-from-run }}
 
       - name: Configure Xvfb
         run: Xvfb -ac :99 -screen 0 1280x1024x16 &
@@ -118,7 +118,7 @@ jobs:
         # Then replace the {0} placeholder with the browser, and the {1} placeholder with the buildType
         run: ${{ format(fromJson(env.COMMANDS)[matrix.pageType], matrix.browser, matrix.buildType) }}
 
-      - name: Send benchmark results to Sentry
+      - name: Send benchmark results to Sentry (main/release only)
         if: ${{ vars.SENTRY_DSN_PERFORMANCE && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) }}
         env:
           GH_HEAD_REF: ${{ github.head_ref }}
@@ -216,7 +216,7 @@ jobs:
       - name: Run the benchmark
         run: ${{ format(fromJson(env.COMMANDS)[matrix.pageType], 'chrome', 'webpack') }}
 
-      - name: Send benchmark results to Sentry
+      - name: Send benchmark results to Sentry (main/release only)
         if: ${{ vars.SENTRY_DSN_PERFORMANCE }}
         env:
           GH_HEAD_REF: ${{ github.head_ref }}
@@ -287,6 +287,7 @@ jobs:
   # Pushes benchmark results (performance + dapp page-load) to extension_benchmark_stats
   # for historical comparison in PR comments. Runs on main branch pushes only.
   store-benchmark-stats:
+    name: store-benchmark-stats (main only)
     needs:
       - benchmarks
       - benchmarks-webpack-perf


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- `dapp-page-load-benchmark` and `store-benchmark-stats` moved from `main.yml` into `run-benchmarks.yml` as inline jobs
- `store-benchmark-stats` now correctly waits on all three benchmark jobs (`benchmarks`, `benchmarks-webpack-perf`, `dapp-page-load-benchmark`) as siblings, previously it ran in parallel with the dapp benchmark
- Added missing `actions/upload-artifact` step to `benchmarks-webpack-perf` so its results are collected by `store-benchmark-stats`
- Sentry reporting (`send-to-sentry.ts`) restricted to `main`/`release/*` pushes only

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/41021?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
4.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
<img width="342" height="200" alt="Screenshot 2026-03-19 at 14 07 33" src="https://github.com/user-attachments/assets/dd3bb5fc-0be9-4af6-b0f9-fcfc8f0cbf6d" />
<img width="1359" height="755" alt="Screenshot 2026-03-19 at 14 07 45" src="https://github.com/user-attachments/assets/065791dc-2928-477a-ab1d-04657287d145" />


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI benchmark execution and reporting flow is refactored (jobs moved/rewired and new artifact publishing), which can break benchmark visibility or gating if misconfigured, but it doesn’t touch production code.
> 
> **Overview**
> Moves `dapp-page-load-benchmark` and `store-benchmark-stats` out of `main.yml` and into `run-benchmarks.yml`, consolidating benchmark execution and stats publishing under the called workflow.
> 
> Updates benchmark results handling so `store-benchmark-stats` waits for *all* benchmark jobs (including webpack perf and dapp page-load) and can collect results via newly uploaded `benchmark-*.json` artifacts, then commits both performance and page-load data to `extension_benchmark_stats` on `main`/`release/*` pushes.
> 
> Restricts benchmark Sentry reporting to `main`/`release/*` and wires `EXTENSION_BENCHMARK_STATS_TOKEN` through the workflow call secrets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bada8207c9b03e709d1cadd1952899ef4317704a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->