### PR TITLE
fix: remove "Maximum amount" in stream permissions when none is specified  cp-13.24.0

### DIFF
--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/erc20-token-stream-details.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/erc20-token-stream-details.test.tsx
@@ -10,6 +10,7 @@ import {
 import * as tokenUtils from '../../../../../utils/token';
 import { Erc20TokenStreamDetails } from './erc20-token-stream-details';
 import { TestErrorBoundary } from './test-error-boundary';
+import { MAX_UINT256 } from './typed-sign-permission-util';
 
 jest.mock('../../../../../utils/token', () => ({
   ...jest.requireActual('../../../../../utils/token'),
@@ -208,6 +209,31 @@ describe('Erc20TokenStreamDetails', () => {
       (
         tokenUtils as jest.Mocked<typeof tokenUtils>
       ).fetchErc20DecimalsOrThrow.mockResolvedValue(2);
+    });
+  });
+
+  describe('max amount display', () => {
+    it('does not display max allowance row when maxAmount equals uint256 max', async () => {
+      const permissionWithMaxUint256 = {
+        ...mockPermission,
+        data: {
+          ...mockPermission.data,
+          maxAmount: MAX_UINT256,
+        },
+      } as const;
+
+      const { detailsSection } = await renderAndGetSections({
+        ...defaultProps,
+        permission: permissionWithMaxUint256,
+      });
+
+      expect(detailsSection?.textContent).not.toContain('Max allowance');
+    });
+
+    it('displays max allowance row when maxAmount is not uint256 max', async () => {
+      const { detailsSection } = await renderAndGetSections(defaultProps);
+
+      expect(detailsSection?.textContent).toContain('Max allowance');
     });
   });
 

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/erc20-token-stream-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/erc20-token-stream-details.tsx
@@ -13,6 +13,7 @@ import { TokenAmountRow } from './token-amount-row';
 import { DateAndTimeRow } from './date-and-time-row';
 import { Expiry } from './expiry';
 import { TotalExposure } from './total-exposure';
+import { MAX_UINT256 } from './typed-sign-permission-util';
 
 /**
  * Component for displaying ERC20 token stream permission details.
@@ -53,6 +54,8 @@ export const Erc20TokenStreamDetails: React.FC<{
 
   const decimals = metadataResult.value;
 
+  const hasMaxAmount = maxAmount && maxAmount.toLowerCase() !== MAX_UINT256;
+
   return (
     <>
       <ConfirmInfoSection data-testid="erc20-token-stream-details-section">
@@ -66,7 +69,7 @@ export const Erc20TokenStreamDetails: React.FC<{
           />
         )}
 
-        {maxAmount && (
+        {hasMaxAmount && (
           <TokenAmountRow
             label={t('confirmFieldMaxAllowance')}
             value={maxAmount}

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/native-token-stream-details.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/native-token-stream-details.test.tsx
@@ -4,6 +4,7 @@ import configureMockStore from 'redux-mock-store';
 import { getMockTypedSignPermissionConfirmState } from '../../../../../../../../test/data/confirmations/helper';
 import { renderWithConfirmContextProvider } from '../../../../../../../../test/lib/confirmations/render-helpers';
 import { NativeTokenStreamDetails } from './native-token-stream-details';
+import { MAX_UINT256 } from './typed-sign-permission-util';
 
 describe('NativeTokenStreamDetails', () => {
   const mockDecodedPermission = {
@@ -156,6 +157,31 @@ describe('NativeTokenStreamDetails', () => {
       expect(
         streamRateSection?.textContent?.includes('Available per day'),
       ).toBe(true);
+    });
+  });
+
+  describe('max amount display', () => {
+    it('does not display max allowance row when maxAmount equals uint256 max', () => {
+      const permissionWithMaxUint256 = {
+        ...mockPermission,
+        data: {
+          ...mockPermission.data,
+          maxAmount: MAX_UINT256,
+        },
+      } as const;
+
+      const { detailsSection } = renderAndGetSections({
+        ...defaultProps,
+        permission: permissionWithMaxUint256,
+      });
+
+      expect(detailsSection?.textContent).not.toContain('Max allowance');
+    });
+
+    it('displays max allowance row when maxAmount is not uint256 max', () => {
+      const { detailsSection } = renderAndGetSections(defaultProps);
+
+      expect(detailsSection?.textContent).toContain('Max allowance');
     });
   });
 

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/native-token-stream-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/native-token-stream-details.tsx
@@ -17,6 +17,7 @@ import { NativeAmountRow } from './native-amount-row';
 import { DateAndTimeRow } from './date-and-time-row';
 import { Expiry } from './expiry';
 import { TotalExposure } from './total-exposure';
+import { MAX_UINT256 } from './typed-sign-permission-util';
 
 /**
  * Component for displaying native token stream permission details.
@@ -46,6 +47,8 @@ export const NativeTokenStreamDetails: React.FC<{
   // DAY is in milliseconds, so we divide by 1000 to get seconds
   const amountPerDay = new BigNumber(amountPerSecond).mul(DAY / 1000);
 
+  const hasMaxAmount = maxAmount && maxAmount.toLowerCase() !== MAX_UINT256;
+
   const { symbol, decimals } = useSelector((state: MetaMaskReduxState) =>
     getNativeTokenInfo(state.metamask.networkConfigurationsByChainId, chainId),
   );
@@ -64,7 +67,7 @@ export const NativeTokenStreamDetails: React.FC<{
             imageUrl={tokenImageUrl}
           />
         )}
-        {maxAmount && (
+        {hasMaxAmount && (
           <NativeAmountRow
             label={t('confirmFieldMaxAllowance')}
             value={maxAmount}

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/total-exposure.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/total-exposure.tsx
@@ -14,9 +14,7 @@ import { useI18nContext } from '../../../../../../../hooks/useI18nContext';
 import Name from '../../../../../../../components/app/name';
 import { NativeAmountRow } from './native-amount-row';
 import { TokenAmountRow } from './token-amount-row';
-
-const MAX_UINT256 =
-  '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+import { MAX_UINT256 } from './typed-sign-permission-util';
 
 /**
  * Parses an amount represented as a hex string to BigNumber.

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/typed-sign-permission-util.ts
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-permission/typed-sign-permission-util.ts
@@ -15,6 +15,9 @@ import { selectNetworkConfigurationByChainId } from '../../../../../../../select
 import { getTokenByAccountAndAddressAndChainId } from '../../../../../../../selectors/assets';
 import type { useI18nContext } from '../../../../../../../hooks/useI18nContext';
 
+export const MAX_UINT256 =
+  '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+
 /**
  * Formats a period duration in seconds to a human-readable string.
  * Converts common durations (daily, weekly) to readable labels, otherwise shows seconds.


### PR DESCRIPTION
## **Description**

When a stream permission doesn't include a "Maximum amount", the field is set to the maximum value of uint256 - 
`0xffffff....ffffff`.

Previously this was rendered in the Sign Permission confirmation as a (large) decimal amount. Although this isn't _strictly_ inaccurate, it is confusing and misleading.

This change explicitly excludes the "Maximum amount" field if the value is equal to `UINT256_MAX`.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/41034?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: "Maximum amount" is no longer shown on stream type Advanced Permission signature screens, when it isn't specified in the permission

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page Advanced Permissions test site
2. Request any stream permission
3. Remove any maximum amount
4. Click grant

Expect the maximum amount to _not_ be shown in the signature confirmation

1. Go to this page Advanced Permissions test site
2. Request any stream permission
3. Add any valid maximum amount
4. Click grant

Expect the maximum amount _to_ be shown in the signature confirmation

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="494" height="226" alt="image" src="https://github.com/user-attachments/assets/57137dfb-0850-46f3-8641-16388e1144f3" />

### **After**

<img width="551" height="716" alt="image" src="https://github.com/user-attachments/assets/d06e9c48-e89a-455f-a142-5be63d4fc059" />

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change to confirmation display logic, plus targeted unit tests; no changes to signing, storage, or network behavior.
> 
> **Overview**
> Stream permission confirmation screens no longer show the **Max allowance** row when `maxAmount` is effectively unspecified (represented as `MAX_UINT256`).
> 
> This adds a shared `MAX_UINT256` constant in `typed-sign-permission-util.ts`, reuses it in `native-token-stream-details`, `erc20-token-stream-details`, and `total-exposure`, and adds tests covering the new hide/show behavior for both native and ERC20 stream permissions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd91ad49234c3b177299a04d208a2ca155d3204c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->