### PR TITLE
fix: flaky test `Send NFT ERC1155 Wallet initiated sends ERC1155`

### DIFF
--- a/test/e2e/tests/send/send-nft.spec.ts
+++ b/test/e2e/tests/send/send-nft.spec.ts
@@ -27,7 +27,6 @@ import {
   DEFAULT_FIXTURE_ACCOUNT_LOWERCASE,
   WINDOW_TITLES,
 } from '../../constants';
-import { veryLargeDelayMs } from '../../helpers';
 import { SMART_CONTRACTS } from '../../seeder/smart-contracts';
 import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow';
 import ContractAddressRegistry from '../../seeder/contract-address-registry';
@@ -202,7 +201,6 @@ describe('Send NFT', function () {
             );
             await testDapp.clickERC721MintButton();
 
-            await driver.delay(veryLargeDelayMs);
             await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
             const mintConfirmation = new TransactionConfirmation(driver);
             await mintConfirmation.clickFooterConfirmButtonAndAndWaitForWindowToClose();

--- a/test/e2e/tests/send/send-nft.spec.ts
+++ b/test/e2e/tests/send/send-nft.spec.ts
@@ -22,7 +22,11 @@ import TransactionConfirmation from '../../page-objects/pages/confirmations/tran
 import WatchAssetConfirmation from '../../page-objects/pages/confirmations/watch-asset-confirmation';
 import { Driver } from '../../webdriver/driver';
 import { Anvil } from '../../seeder/anvil';
-import { DAPP_URL, WINDOW_TITLES } from '../../constants';
+import {
+  DAPP_URL,
+  DEFAULT_FIXTURE_ACCOUNT_LOWERCASE,
+  WINDOW_TITLES,
+} from '../../constants';
 import { veryLargeDelayMs } from '../../helpers';
 import { SMART_CONTRACTS } from '../../seeder/smart-contracts';
 import { loginWithBalanceValidation } from '../../page-objects/flows/login.flow';
@@ -126,7 +130,10 @@ describe('Send NFT', function () {
 
             // Mint NFT first
             await testDapp.openTestDappPage({ contractAddress, url: DAPP_URL });
-            await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
+            await testDapp.verifyAccountConnection(
+              DEFAULT_FIXTURE_ACCOUNT_LOWERCASE,
+              '0x539',
+            );
             await testDapp.clickERC721MintButton();
 
             await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
@@ -189,6 +196,10 @@ describe('Send NFT', function () {
 
             // Mint NFT first
             await testDapp.openTestDappPage({ contractAddress, url: DAPP_URL });
+            await testDapp.verifyAccountConnection(
+              DEFAULT_FIXTURE_ACCOUNT_LOWERCASE,
+              '0x539',
+            );
             await testDapp.clickERC721MintButton();
 
             await driver.delay(veryLargeDelayMs);
@@ -249,11 +260,14 @@ describe('Send NFT', function () {
 
             // Mint ERC1155
             await testDapp.openTestDappPage({ contractAddress, url: DAPP_URL });
+            await testDapp.verifyAccountConnection(
+              DEFAULT_FIXTURE_ACCOUNT_LOWERCASE,
+              '0x539',
+            );
             await testDapp.fillERC1155TokenID('1');
             await testDapp.fillERC1155TokenAmount('1');
             await testDapp.clickERC1155MintButton();
 
-            await driver.delay(veryLargeDelayMs);
             await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
             const mintConfirmation = new TransactionConfirmation(driver);
             await mintConfirmation.clickFooterConfirmButton();

--- a/test/e2e/tests/send/send-nft.spec.ts
+++ b/test/e2e/tests/send/send-nft.spec.ts
@@ -138,7 +138,7 @@ describe('Send NFT', function () {
 
             await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
             const mintConfirmation = new TransactionConfirmation(driver);
-            await mintConfirmation.clickFooterConfirmButton();
+            await mintConfirmation.clickFooterConfirmButtonAndAndWaitForWindowToClose();
 
             // Wait for mint and navigate to NFT
             await driver.switchToWindowWithTitle(
@@ -205,20 +205,19 @@ describe('Send NFT', function () {
             await driver.delay(veryLargeDelayMs);
             await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
             const mintConfirmation = new TransactionConfirmation(driver);
-            await mintConfirmation.clickFooterConfirmButton();
+            await mintConfirmation.clickFooterConfirmButtonAndAndWaitForWindowToClose();
 
             // Transfer via dApp
             await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
             await testDapp.clickERC721TransferFromButton();
 
-            await driver.delay(veryLargeDelayMs);
             await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
             const tokenTransferConfirmation =
               new TokenTransferTransactionConfirmation(driver);
             await tokenTransferConfirmation.checkDappInitiatedHeadingTitle();
             await tokenTransferConfirmation.clickScrollToBottomButton();
-            await tokenTransferConfirmation.clickFooterConfirmButton();
+            await tokenTransferConfirmation.clickFooterConfirmButtonAndAndWaitForWindowToClose();
 
             await driver.switchToWindowWithTitle(
               WINDOW_TITLES.ExtensionInFullScreenView,
@@ -270,16 +269,15 @@ describe('Send NFT', function () {
 
             await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
             const mintConfirmation = new TransactionConfirmation(driver);
-            await mintConfirmation.clickFooterConfirmButton();
+            await mintConfirmation.clickFooterConfirmButtonAndAndWaitForWindowToClose();
 
             // Watch the token
             await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
             await testDapp.clickERC1155WatchButton();
 
-            await driver.delay(veryLargeDelayMs);
             await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
             const watchAssetConfirmation = new WatchAssetConfirmation(driver);
-            await watchAssetConfirmation.clickFooterConfirmButton();
+            await watchAssetConfirmation.clickFooterConfirmButtonAndAndWaitForWindowToClose();
 
             // Navigate to NFT and send
             await driver.switchToWindowWithTitle(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Whenever we click Mint, the test dapp thinks it's on Mainnet. There's a chain miss-match that causes the dialog never opening (see chaind id vs you are on. Mainnet message below).

Now, we ensure we are in the right chainId, before triggering the tx

<img width="1518" height="772" alt="image" src="https://github.com/user-attachments/assets/cddd2eb1-ae1b-4525-8863-0e02f9e651ec" />

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/41037?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to E2E test synchronization and assertions, with no production code impact. Main risk is increased test strictness causing failures if fixtures or chain IDs change.
> 
> **Overview**
> Stabilizes the `send-nft.spec.ts` E2E flows by **verifying the TestDapp is connected to the expected fixture account and chain (`0x539`) before minting/transferring**, preventing chain-mismatch cases where the confirmation dialog never opens.
> 
> Replaces `veryLargeDelayMs` sleeps and manual window switching with explicit synchronization via `clickFooterConfirmButtonAndAndWaitForWindowToClose()` for mint, transfer, and watch-asset confirmations to reduce race conditions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78f162de21b5e3193ba0e4c54dfbb819b804adc0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->