### PR TITLE
fix: gasless support check in hook useAutomaticGasFeeTokenSelect

### DIFF
--- a/ui/pages/confirmations/hooks/useAutomaticGasFeeTokenSelect.test.ts
+++ b/ui/pages/confirmations/hooks/useAutomaticGasFeeTokenSelect.test.ts
@@ -145,6 +145,21 @@ describe('useAutomaticGasFeeTokenSelect', () => {
     expect(forceUpdateMetamaskStateMock).toHaveBeenCalledWith(store.dispatch);
   });
 
+  it('does not select first gas fee token if gasless not supported', async () => {
+    useIsGaslessSupportedMock.mockReturnValue({
+      isSupported: false,
+      isSmartTransaction: false,
+      pending: false,
+    });
+
+    runHook();
+
+    await flushAsyncUpdates();
+
+    expect(updateSelectedGasFeeTokenMock).toHaveBeenCalledTimes(0);
+    expect(forceUpdateMetamaskStateMock).toHaveBeenCalledTimes(0);
+  });
+
   it('does not select first gas fee token if sufficient balance', async () => {
     useHasInsufficientBalanceMock.mockReturnValue({
       hasInsufficientBalance: false,

--- a/ui/pages/confirmations/hooks/useAutomaticGasFeeTokenSelect.ts
+++ b/ui/pages/confirmations/hooks/useAutomaticGasFeeTokenSelect.ts
@@ -12,7 +12,11 @@ import { useHasInsufficientBalance } from './useHasInsufficientBalance';
 
 export function useAutomaticGasFeeTokenSelect() {
   const dispatch = useDispatch();
-  const { isSmartTransaction } = useIsGaslessSupported();
+  const {
+    isSupported: isGaslessSupported,
+    isSmartTransaction,
+    pending,
+  } = useIsGaslessSupported();
   const [firstCheck, setFirstCheck] = useState(true);
 
   const { currentConfirmation: transactionMeta } =
@@ -37,7 +41,10 @@ export function useAutomaticGasFeeTokenSelect() {
     await forceUpdateMetamaskState(dispatch);
   }, [dispatch, transactionId, firstGasFeeTokenAddress]);
 
+  const isGaslessSupportedAndFinished = isGaslessSupported && !pending;
+
   const shouldSelect =
+    isGaslessSupportedAndFinished &&
     hasInsufficientBalance &&
     !selectedGasFeeToken &&
     Boolean(firstGasFeeTokenAddress);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

fix gasless support check in hook useAutomaticGasFeeTokenSelect

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1059

## **Manual testing steps**

1. Disable smart transaction
2. Check that gas station is not available on non 7702 networks

## **Screenshots/Recordings**
<img width="804" height="746" alt="Screenshot 2026-03-19 at 3 32 50 PM" src="https://github.com/user-attachments/assets/041d37b1-12c5-458e-9bb6-e83b291cba96" />

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the eligibility logic for automatically selecting gas fee tokens during confirmations, which can affect transaction UX on certain networks. Scope is small and covered by an added unit test.
> 
> **Overview**
> Prevents `useAutomaticGasFeeTokenSelect` from auto-selecting a gas fee token unless gasless is **supported** and the `useIsGaslessSupported` check is **finished** (`!pending`).
> 
> Adds a regression test ensuring no token is selected (and no state update is forced) when gasless is not supported.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f500d9cb7d10059136f95dbf5d644b1425bdb0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->