### PR TITLE
fix: flaky test `eth_requestAccounts prompts for login when there are no permitted accounts and the wallet is locked`

### DIFF
--- a/test/e2e/fixtures/fixture-builder-v2.ts
+++ b/test/e2e/fixtures/fixture-builder-v2.ts
@@ -225,6 +225,40 @@ class FixtureBuilderV2 {
                               CUSTOM METHODS
      ==================================================================
   */
+  /**
+   * Restricts the fixture to EVM accounts only (removes Solana, Bitcoin, etc.).
+   * Use when the test must avoid Snap-based accounts, e.g. to prevent permission
+   * grant errors before Snaps are ready.
+   */
+  withEvmAccountsOnly(): this {
+    const evmAccountId = 'd5e45e4a-3b04-4a09-a5e1-39762e5c6be4';
+    const accounts = (this.fixture.data.AccountsController.internalAccounts
+      ?.accounts ?? {}) as Record<string, unknown>;
+    const evmAccount = accounts[evmAccountId];
+    if (!evmAccount) {
+      throw new Error(
+        `EVM account ${evmAccountId} not found in fixture. Ensure default fixture includes it.`,
+      );
+    }
+    // Clear accounts first so merge replaces (merge doesn't remove keys)
+    (
+      this.fixture.data.AccountsController as Record<string, unknown>
+    ).internalAccounts = {
+      accounts: {} as AccountsControllerState['internalAccounts']['accounts'],
+      selectedAccount: evmAccountId,
+    };
+    return this.withAccountsController({
+      internalAccounts: {
+        accounts: {
+          [evmAccountId]: cloneDeep(
+            evmAccount,
+          ) as AccountsControllerState['internalAccounts']['accounts'][string],
+        },
+        selectedAccount: evmAccountId,
+      },
+    });
+  }
+
   withBadPreferencesControllerState(): this {
     (this.fixture.data as Record<string, unknown>).PreferencesController = 5;
     return this;

--- a/test/e2e/fixtures/fixture-builder-v2.ts
+++ b/test/e2e/fixtures/fixture-builder-v2.ts
@@ -225,40 +225,6 @@ class FixtureBuilderV2 {
                               CUSTOM METHODS
      ==================================================================
   */
-  /**
-   * Restricts the fixture to EVM accounts only (removes Solana, Bitcoin, etc.).
-   * Use when the test must avoid Snap-based accounts, e.g. to prevent permission
-   * grant errors before Snaps are ready.
-   */
-  withEvmAccountsOnly(): this {
-    const evmAccountId = 'd5e45e4a-3b04-4a09-a5e1-39762e5c6be4';
-    const accounts = (this.fixture.data.AccountsController.internalAccounts
-      ?.accounts ?? {}) as Record<string, unknown>;
-    const evmAccount = accounts[evmAccountId];
-    if (!evmAccount) {
-      throw new Error(
-        `EVM account ${evmAccountId} not found in fixture. Ensure default fixture includes it.`,
-      );
-    }
-    // Clear accounts first so merge replaces (merge doesn't remove keys)
-    (
-      this.fixture.data.AccountsController as Record<string, unknown>
-    ).internalAccounts = {
-      accounts: {} as AccountsControllerState['internalAccounts']['accounts'],
-      selectedAccount: evmAccountId,
-    };
-    return this.withAccountsController({
-      internalAccounts: {
-        accounts: {
-          [evmAccountId]: cloneDeep(
-            evmAccount,
-          ) as AccountsControllerState['internalAccounts']['accounts'][string],
-        },
-        selectedAccount: evmAccountId,
-      },
-    });
-  }
-
   withBadPreferencesControllerState(): this {
     (this.fixture.data as Record<string, unknown>).PreferencesController = 5;
     return this;

--- a/test/e2e/json-rpc/eth_requestAccounts.spec.ts
+++ b/test/e2e/json-rpc/eth_requestAccounts.spec.ts
@@ -82,7 +82,7 @@ describe('eth_requestAccounts', function () {
       await withFixtures(
         {
           dappOptions: { numberOfTestDapps: 1 },
-          fixtures: new FixtureBuilderV2().withEvmAccountsOnly().build(),
+          fixtures: new FixtureBuilderV2().build(),
           title: this.test?.fullTitle(),
         },
         async ({ driver }: { driver: Driver }) => {
@@ -106,6 +106,18 @@ describe('eth_requestAccounts', function () {
           await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
           await loginPage.checkPageIsLoaded();
           await loginPage.loginToHomepage();
+
+          // Wait for SnapController.isReady so the permission grant does not reject non-EVM accounts
+          await driver.wait(async () => {
+            const uiState = await driver.executeScript(() =>
+              (
+                window as {
+                  stateHooks?: { getCleanAppState?: () => Promise<unknown> };
+                }
+              ).stateHooks?.getCleanAppState?.(),
+            );
+            return uiState?.metamask?.isReady === true;
+          }, 30000);
 
           const connectAccountConfirmation = new ConnectAccountConfirmation(
             driver,

--- a/test/e2e/json-rpc/eth_requestAccounts.spec.ts
+++ b/test/e2e/json-rpc/eth_requestAccounts.spec.ts
@@ -115,29 +115,32 @@ describe('eth_requestAccounts', function () {
             'npm:@metamask/solana-wallet-snap',
             'npm:@metamask/tron-wallet-snap',
           ];
-          await driver.wait(async () => {
-            const persistedState = await driver.executeScript(
-              'return window.stateHooks.getPersistedState()',
-            );
-            const snapController = persistedState?.data?.SnapController ?? {};
-            const snaps = snapController.snaps ?? {};
-            const snapStates = snapController.snapStates ?? {};
-            const unencryptedSnapStates =
-              snapController.unencryptedSnapStates ?? {};
+          await driver.waitUntil(
+            async () => {
+              const persistedState = await driver.executeScript(
+                'return window.stateHooks.getPersistedState()',
+              );
+              const snapController = persistedState?.data?.SnapController ?? {};
+              const snaps = snapController.snaps ?? {};
+              const snapStates = snapController.snapStates ?? {};
+              const unencryptedSnapStates =
+                snapController.unencryptedSnapStates ?? {};
 
-            const snapsRegistered = nonEvmSnapIds.every((id) => id in snaps);
-            const snapStatesNotEmpty =
-              Object.keys(snapStates).length > 0 &&
-              Object.keys(unencryptedSnapStates).length > 0;
-            const nonEvmSnapsHaveState = nonEvmSnapIds.every(
-              (id) =>
-                (snapStates[id] && String(snapStates[id]).length > 0) ||
-                (unencryptedSnapStates[id] &&
-                  String(unencryptedSnapStates[id]).length > 0),
-            );
+              const snapsRegistered = nonEvmSnapIds.every((id) => id in snaps);
+              const snapStatesNotEmpty =
+                Object.keys(snapStates).length > 0 &&
+                Object.keys(unencryptedSnapStates).length > 0;
+              const nonEvmSnapsHaveState = nonEvmSnapIds.every(
+                (id) =>
+                  (snapStates[id] && String(snapStates[id]).length > 0) ||
+                  (unencryptedSnapStates[id] &&
+                    String(unencryptedSnapStates[id]).length > 0),
+              );
 
-            return snapsRegistered && snapStatesNotEmpty && nonEvmSnapsHaveState;
-          }, 30000);
+              return snapsRegistered && snapStatesNotEmpty && nonEvmSnapsHaveState;
+            },
+            { timeout: 20000, interval: 1000 },
+          );
 
           const connectAccountConfirmation = new ConnectAccountConfirmation(
             driver,

--- a/test/e2e/json-rpc/eth_requestAccounts.spec.ts
+++ b/test/e2e/json-rpc/eth_requestAccounts.spec.ts
@@ -78,64 +78,52 @@ describe('eth_requestAccounts', function () {
 
   // eslint-disable-next-line mocha/no-setup-in-describe
   for (let i = 0; i < 5; i++) {
-  it(`prompts for login when there are no permitted accounts and the wallet is locked (run ${i + 1})`, async function () {
-    await withFixtures(
-      {
-        dappOptions: { numberOfTestDapps: 1 },
-        fixtures: new FixtureBuilderV2().build(),
-        title: this.test?.fullTitle(),
-      },
-      async ({ driver }: { driver: Driver }) => {
-        await driver.navigate();
-        const loginPage = new LoginPage(driver);
-        await loginPage.checkPageIsLoaded();
-        const testDapp = new TestDapp(driver);
-        await testDapp.openTestDappPage();
-        await testDapp.checkPageIsLoaded();
+    it(`prompts for login when there are no permitted accounts and the wallet is locked (run ${i + 1})`, async function () {
+      await withFixtures(
+        {
+          dappOptions: { numberOfTestDapps: 1 },
+          fixtures: new FixtureBuilderV2().withEvmAccountsOnly().build(),
+          title: this.test?.fullTitle(),
+        },
+        async ({ driver }: { driver: Driver }) => {
+          await driver.navigate();
+          const loginPage = new LoginPage(driver);
+          await loginPage.checkPageIsLoaded();
+          const testDapp = new TestDapp(driver);
+          await testDapp.openTestDappPage();
+          await testDapp.checkPageIsLoaded();
 
-        const requestAccountRequest: string = JSON.stringify({
-          jsonrpc: '2.0',
-          method: 'eth_requestAccounts',
-        });
+          const requestAccountRequest: string = JSON.stringify({
+            jsonrpc: '2.0',
+            method: 'eth_requestAccounts',
+          });
 
-        await driver.executeScript(
-          `window.requestAccount = window.ethereum.request(${requestAccountRequest})`,
-        );
+          await driver.executeScript(
+            `window.requestAccount = window.ethereum.request(${requestAccountRequest})`,
+          );
 
-        await driver.waitUntilXWindowHandles(3);
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
-        await loginPage.checkPageIsLoaded();
-        await loginPage.loginToHomepage();
+          await driver.waitUntilXWindowHandles(3);
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+          await loginPage.checkPageIsLoaded();
+          await loginPage.loginToHomepage();
 
-        // Wait for preinstalled Snaps (Solana, Bitcoin) to finish loading
-        // so the permission grant doesn't reject non-EVM accounts
-        await driver.waitUntil(
-          async () => {
-            const ready = await driver.executeScript(
-              `return window.stateHooks?.getCleanAppState?.()?.metamask?.isReady`,
-            );
-            return ready === true;
-          },
-          { timeout: 30000, interval: 500 },
-        );
+          const connectAccountConfirmation = new ConnectAccountConfirmation(
+            driver,
+          );
+          await connectAccountConfirmation.checkPageIsLoaded();
+          await connectAccountConfirmation.confirmConnect();
+          await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
+          await testDapp.checkPageIsLoaded();
 
-        const connectAccountConfirmation = new ConnectAccountConfirmation(
-          driver,
-        );
-        await connectAccountConfirmation.checkPageIsLoaded();
-        await connectAccountConfirmation.confirmConnect();
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
-        await testDapp.checkPageIsLoaded();
+          const requestAccount = await driver.executeScript(
+            `return window.requestAccount;`,
+          );
 
-        const requestAccount = await driver.executeScript(
-          `return window.requestAccount;`,
-        );
-
-        assert.deepStrictEqual(requestAccount, [
-          '0x5cfe73b6021e818b776b421b1c4db2474086a7e1',
-        ]);
-      },
-    );
-  });
+          assert.deepStrictEqual(requestAccount, [
+            '0x5cfe73b6021e818b776b421b1c4db2474086a7e1',
+          ]);
+        },
+      );
+    });
   }
 });

--- a/test/e2e/json-rpc/eth_requestAccounts.spec.ts
+++ b/test/e2e/json-rpc/eth_requestAccounts.spec.ts
@@ -122,6 +122,8 @@ describe('eth_requestAccounts', function () {
             return nonEvmSnapIds.every((id) => id in snaps);
           }, 30000);
 
+          await driver.delay(5000)
+
           const connectAccountConfirmation = new ConnectAccountConfirmation(
             driver,
           );

--- a/test/e2e/json-rpc/eth_requestAccounts.spec.ts
+++ b/test/e2e/json-rpc/eth_requestAccounts.spec.ts
@@ -78,7 +78,7 @@ describe('eth_requestAccounts', function () {
 
   // eslint-disable-next-line mocha/no-setup-in-describe
   for (let i = 0; i < 5; i++) {
-    it(`prompts for login when there are no permitted accounts and the wallet is locked (run ${i + 1})`, async function () {
+    it.only(`prompts for login when there are no permitted accounts and the wallet is locked (run ${i + 1})`, async function () {
       await withFixtures(
         {
           dappOptions: { numberOfTestDapps: 1 },
@@ -107,16 +107,19 @@ describe('eth_requestAccounts', function () {
           await loginPage.checkPageIsLoaded();
           await loginPage.loginToHomepage();
 
-          // Wait for SnapController.isReady so the permission grant does not reject non-EVM accounts
+          // Wait for non-EVM snaps to load in persisted state (SnapController starts empty in fixture)
+          // so the permission grant does not reject non-EVM accounts
+          const nonEvmSnapIds = [
+            'npm:@metamask/bitcoin-wallet-snap',
+            'npm:@metamask/solana-wallet-snap',
+            'npm:@metamask/tron-wallet-snap',
+          ];
           await driver.wait(async () => {
-            const uiState = await driver.executeScript(() =>
-              (
-                window as {
-                  stateHooks?: { getCleanAppState?: () => Promise<unknown> };
-                }
-              ).stateHooks?.getCleanAppState?.(),
+            const persistedState = await driver.executeScript(
+              'return window.stateHooks.getPersistedState()',
             );
-            return uiState?.metamask?.isReady === true;
+            const snaps = persistedState?.data?.SnapController?.snaps ?? {};
+            return nonEvmSnapIds.every((id) => id in snaps);
           }, 30000);
 
           const connectAccountConfirmation = new ConnectAccountConfirmation(

--- a/test/e2e/json-rpc/eth_requestAccounts.spec.ts
+++ b/test/e2e/json-rpc/eth_requestAccounts.spec.ts
@@ -78,7 +78,7 @@ describe('eth_requestAccounts', function () {
 
   // eslint-disable-next-line mocha/no-setup-in-describe
   for (let i = 0; i < 5; i++) {
-    it.only(`prompts for login when there are no permitted accounts and the wallet is locked (run ${i + 1})`, async function () {
+    it(`prompts for login when there are no permitted accounts and the wallet is locked (run ${i + 1})`, async function () {
       await withFixtures(
         {
           dappOptions: { numberOfTestDapps: 1 },
@@ -108,7 +108,8 @@ describe('eth_requestAccounts', function () {
           await loginPage.loginToHomepage();
 
           // Wait for non-EVM snaps to load in persisted state (SnapController starts empty in fixture)
-          // so the permission grant does not reject non-EVM accounts
+          // so the permission grant does not reject non-EVM accounts. Ensure snaps exist and their
+          // snapStates/unencryptedSnapStates are populated before proceeding.
           const nonEvmSnapIds = [
             'npm:@metamask/bitcoin-wallet-snap',
             'npm:@metamask/solana-wallet-snap',
@@ -118,11 +119,25 @@ describe('eth_requestAccounts', function () {
             const persistedState = await driver.executeScript(
               'return window.stateHooks.getPersistedState()',
             );
-            const snaps = persistedState?.data?.SnapController?.snaps ?? {};
-            return nonEvmSnapIds.every((id) => id in snaps);
-          }, 30000);
+            const snapController = persistedState?.data?.SnapController ?? {};
+            const snaps = snapController.snaps ?? {};
+            const snapStates = snapController.snapStates ?? {};
+            const unencryptedSnapStates =
+              snapController.unencryptedSnapStates ?? {};
 
-          await driver.delay(5000)
+            const snapsRegistered = nonEvmSnapIds.every((id) => id in snaps);
+            const snapStatesNotEmpty =
+              Object.keys(snapStates).length > 0 &&
+              Object.keys(unencryptedSnapStates).length > 0;
+            const nonEvmSnapsHaveState = nonEvmSnapIds.every(
+              (id) =>
+                (snapStates[id] && String(snapStates[id]).length > 0) ||
+                (unencryptedSnapStates[id] &&
+                  String(unencryptedSnapStates[id]).length > 0),
+            );
+
+            return snapsRegistered && snapStatesNotEmpty && nonEvmSnapsHaveState;
+          }, 30000);
 
           const connectAccountConfirmation = new ConnectAccountConfirmation(
             driver,

--- a/test/e2e/json-rpc/eth_requestAccounts.spec.ts
+++ b/test/e2e/json-rpc/eth_requestAccounts.spec.ts
@@ -76,89 +76,87 @@ describe('eth_requestAccounts', function () {
     );
   });
 
-  // eslint-disable-next-line mocha/no-setup-in-describe
-  for (let i = 0; i < 5; i++) {
-    it(`prompts for login when there are no permitted accounts and the wallet is locked (run ${i + 1})`, async function () {
-      await withFixtures(
-        {
-          dappOptions: { numberOfTestDapps: 1 },
-          fixtures: new FixtureBuilderV2().build(),
-          title: this.test?.fullTitle(),
-        },
-        async ({ driver }: { driver: Driver }) => {
-          await driver.navigate();
-          const loginPage = new LoginPage(driver);
-          await loginPage.checkPageIsLoaded();
-          const testDapp = new TestDapp(driver);
-          await testDapp.openTestDappPage();
-          await testDapp.checkPageIsLoaded();
+  it('prompts for login when there are no permitted accounts and the wallet is locked', async function () {
+    await withFixtures(
+      {
+        dappOptions: { numberOfTestDapps: 1 },
+        fixtures: new FixtureBuilderV2().build(),
+        title: this.test?.fullTitle(),
+      },
+      async ({ driver }: { driver: Driver }) => {
+        await driver.navigate();
+        const loginPage = new LoginPage(driver);
+        await loginPage.checkPageIsLoaded();
+        const testDapp = new TestDapp(driver);
+        await testDapp.openTestDappPage();
+        await testDapp.checkPageIsLoaded();
 
-          const requestAccountRequest: string = JSON.stringify({
-            jsonrpc: '2.0',
-            method: 'eth_requestAccounts',
-          });
+        const requestAccountRequest: string = JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'eth_requestAccounts',
+        });
 
-          await driver.executeScript(
-            `window.requestAccount = window.ethereum.request(${requestAccountRequest})`,
-          );
+        await driver.executeScript(
+          `window.requestAccount = window.ethereum.request(${requestAccountRequest})`,
+        );
 
-          await driver.waitUntilXWindowHandles(3);
-          await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
-          await loginPage.checkPageIsLoaded();
-          await loginPage.loginToHomepage();
+        await driver.waitUntilXWindowHandles(3);
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+        await loginPage.checkPageIsLoaded();
+        await loginPage.loginToHomepage();
 
-          // Wait for non-EVM snaps to load in persisted state (SnapController starts empty in fixture)
-          // so the permission grant does not reject non-EVM accounts. Ensure snaps exist and their
-          // snapStates/unencryptedSnapStates are populated before proceeding.
-          const nonEvmSnapIds = [
-            'npm:@metamask/bitcoin-wallet-snap',
-            'npm:@metamask/solana-wallet-snap',
-            'npm:@metamask/tron-wallet-snap',
-          ];
-          await driver.waitUntil(
-            async () => {
-              const persistedState = await driver.executeScript(
-                'return window.stateHooks.getPersistedState()',
-              );
-              const snapController = persistedState?.data?.SnapController ?? {};
-              const snaps = snapController.snaps ?? {};
-              const snapStates = snapController.snapStates ?? {};
-              const unencryptedSnapStates =
-                snapController.unencryptedSnapStates ?? {};
+        // Wait for snaps to load in persisted state so the permission grant does not reject non-EVM accounts.
+        // Ensure snaps exist and their snapStates/unencryptedSnapStates are populated before proceeding
+        const nonEvmSnapIds = [
+          'npm:@metamask/bitcoin-wallet-snap',
+          'npm:@metamask/solana-wallet-snap',
+          'npm:@metamask/tron-wallet-snap',
+        ];
+        await driver.waitUntil(
+          async () => {
+            const persistedState = await driver.executeScript(
+              'return window.stateHooks.getPersistedState()',
+            );
+            const snapController = persistedState?.data?.SnapController ?? {};
+            const snaps = snapController.snaps ?? {};
+            const snapStates = snapController.snapStates ?? {};
+            const unencryptedSnapStates =
+              snapController.unencryptedSnapStates ?? {};
 
-              const snapsRegistered = nonEvmSnapIds.every((id) => id in snaps);
-              const snapStatesNotEmpty =
-                Object.keys(snapStates).length > 0 &&
-                Object.keys(unencryptedSnapStates).length > 0;
-              const nonEvmSnapsHaveState = nonEvmSnapIds.every(
-                (id) =>
-                  (snapStates[id] && String(snapStates[id]).length > 0) ||
-                  (unencryptedSnapStates[id] &&
-                    String(unencryptedSnapStates[id]).length > 0),
-              );
+            const snapsRegistered = nonEvmSnapIds.every((id) => id in snaps);
+            const snapStatesNotEmpty =
+              Object.keys(snapStates).length > 0 &&
+              Object.keys(unencryptedSnapStates).length > 0;
+            const nonEvmSnapsHaveState = nonEvmSnapIds.every(
+              (id) =>
+                (snapStates[id] && String(snapStates[id]).length > 0) ||
+                (unencryptedSnapStates[id] &&
+                  String(unencryptedSnapStates[id]).length > 0),
+            );
 
-              return snapsRegistered && snapStatesNotEmpty && nonEvmSnapsHaveState;
-            },
-            { timeout: 20000, interval: 1000 },
-          );
+            return (
+              snapsRegistered && snapStatesNotEmpty && nonEvmSnapsHaveState
+            );
+          },
+          { timeout: 20000, interval: 1000 },
+        );
 
-          const connectAccountConfirmation = new ConnectAccountConfirmation(
-            driver,
-          );
-          await connectAccountConfirmation.checkPageIsLoaded();
-          await connectAccountConfirmation.confirmConnect();
-          await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
-          await testDapp.checkPageIsLoaded();
+        const connectAccountConfirmation = new ConnectAccountConfirmation(
+          driver,
+        );
+        await connectAccountConfirmation.checkPageIsLoaded();
+        await connectAccountConfirmation.confirmConnect();
+        await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
+        await testDapp.checkPageIsLoaded();
 
-          const requestAccount = await driver.executeScript(
-            `return window.requestAccount;`,
-          );
+        const requestAccount = await driver.executeScript(
+          `return window.requestAccount;`,
+        );
 
-          assert.deepStrictEqual(requestAccount, [
-            '0x5cfe73b6021e818b776b421b1c4db2474086a7e1',
-          ]);
-        },
-      );
-    });
-  }
+        assert.deepStrictEqual(requestAccount, [
+          '0x5cfe73b6021e818b776b421b1c4db2474086a7e1',
+        ]);
+      },
+    );
+  });
 });

--- a/test/e2e/json-rpc/eth_requestAccounts.spec.ts
+++ b/test/e2e/json-rpc/eth_requestAccounts.spec.ts
@@ -76,7 +76,9 @@ describe('eth_requestAccounts', function () {
     );
   });
 
-  it('prompts for login when there are no permitted accounts and the wallet is locked', async function () {
+  // eslint-disable-next-line mocha/no-setup-in-describe
+  for (let i = 0; i < 5; i++) {
+  it(`prompts for login when there are no permitted accounts and the wallet is locked (run ${i + 1})`, async function () {
     await withFixtures(
       {
         dappOptions: { numberOfTestDapps: 1 },
@@ -105,6 +107,18 @@ describe('eth_requestAccounts', function () {
         await loginPage.checkPageIsLoaded();
         await loginPage.loginToHomepage();
 
+        // Wait for preinstalled Snaps (Solana, Bitcoin) to finish loading
+        // so the permission grant doesn't reject non-EVM accounts
+        await driver.waitUntil(
+          async () => {
+            const ready = await driver.executeScript(
+              `return window.stateHooks?.getCleanAppState?.()?.metamask?.isReady`,
+            );
+            return ready === true;
+          },
+          { timeout: 30000, interval: 500 },
+        );
+
         const connectAccountConfirmation = new ConnectAccountConfirmation(
           driver,
         );
@@ -123,4 +137,5 @@ describe('eth_requestAccounts', function () {
       },
     );
   });
+  }
 });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Flaky failure when confirm the account request (triggered with a locked wallet):
`JavascriptError: javascript error: {"status":-32603,"value":"Invalid approved permissions request: endowment:caip25 error: Received account value(s) f...`

The problem is that we have snap accounts in the wallet (non evm), but the snapcontroller is still not loaded --> this happens because in the default fixture the snaps controller starts empty but not the accounts controller, as we inject accounts to skip onboarding.
Here given we triggered the request with the locked wallet, there is a race condition where the snapscontroller is not yet loaded when we unlock and confirm right away.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/41040?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Fix has been run in ci 5 extra time both for webpack and browserify

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that adds synchronization to avoid a race when unlocking and confirming permissions while snaps state is still loading.
> 
> **Overview**
> Fixes flakiness in the `eth_requestAccounts` locked-wallet E2E by waiting for persisted `SnapController` data to be populated before confirming the connect dialog.
> 
> The test now polls `window.stateHooks.getPersistedState()` until non‑EVM snaps are registered and have `snapStates`/`unencryptedSnapStates` present, reducing intermittent permission-grant failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d08ffc58bb626010cc8285f752d3945e10eb938. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->