### PR TITLE
fix: fixed insufficient substituition in Irish('ga') locale

### DIFF
--- a/app/_locales/ga/messages.json
+++ b/app/_locales/ga/messages.json
@@ -4909,7 +4909,7 @@
     "message": "Nochtadh Frása Rúnda Aisghabhála"
   },
   "revealSeedWordsDescription1": {
-    "message": "Tugann an $1 $2",
+    "message": "Tugann do $1 rochtain iomlán ar do sparán, cistí agus cuntais.",
     "description": "This is a sentence consisting of link using 'revealSeedWordsSRPName' as $1."
   },
   "revealSeedWordsQR": {


### PR DESCRIPTION
## **Description**

### Root Cause

The `feat: reveal srp UI` change (#40243) redesigned the `revealSeedWordsDescription1` i18n key in English from a **two-substitution** format to a **one-substitution** format:

| | Message | Substitutions |
|---|---|---|
| **Before** | `"The $1 provides $2"` | `$1` = SRP name link, `$2` = description text |
| **After** | `"Your $1 gives full access to your wallet, funds, and accounts."` | `$1` = SRP name link only |

The `reveal-seed.tsx` component was updated to pass only one substitution. However, the translations for non-English locales were **not updated at the same time** — they still contained the old two-substitution format (e.g. `"$1 дает $2"` in Russian, `"$1 cung cấp $2"` in Vietnamese).

When a user with one of these locales visited the Reveal Secret Recovery Phrase page, the i18n `applySubstitutions` function tried to resolve `$2` against `substitutions[1]`, which was `undefined`, triggering:


This affected **all non-English locale users** during the window between the feature change and the subsequent Crowdin batch update.

All the locales were updated in this PR, https://github.com/MetaMask/metamask-extension/pull/40351, but Irish (`ga`) was still remaining with the old substitution.

### How It Was Fixed

A Crowdin batch translation update (`f194c4baf8`) corrected 14 locales (`de`, `el`, `es`, `fr`, `hi`, `id`, `ja`, `ko`, `pt`, `ru`, `tl`, `tr`, `vi`, `zh_CN`) with proper translations using only `$1`.

However, the **Irish (`ga`) locale was missed** by that Crowdin update and still contained the stale `"Tugann an $1 $2"` message. This PR fixes it by completing the Irish translation:

- **Before:** `"Tugann an $1 $2"` ❌ (dangling `$2`, no substitution provided)
- **After:** `"Tugann do $1 rochtain iomlán ar do sparán, cistí agus cuntais."` ✅ (only `$1`)

---

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/41047?quickstart=1)

## **Changelog**

CHANGELOG entry: Fixed a translation error on the Reveal Secret Recovery Phrase page that caused a crash for users with the Irish (ga) locale.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/40968

## **Manual testing steps**

1. Set MetaMask language to **Irish (Gaeilge)** via Settings → General → Language.
2. Navigate to Settings → Security & Privacy → **Reveal Secret Recovery Phrase**.
3. Verify the page loads without a console error and the description text renders correctly with the SRP name as a clickable link.
4. Repeat with another previously-affected locale (e.g. Russian) to confirm those remain fixed.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 82fcd6435d7fb6062ed4c91f83f70dc94fd76bf1. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->