### PR TITLE
fix: update locale substitutions 'revealSeedWordsDescription1`

### DIFF
--- a/app/_locales/de/messages.json
+++ b/app/_locales/de/messages.json
@@ -6006,7 +6006,7 @@
     "message": "Geheime Wiederherstellungsphrase anzeigen"
   },
   "revealSeedWordsDescription1": {
-    "message": "Die $1 bietet $2",
+    "message": "Ihr $1 gewährt Ihnen vollen Zugriff auf Ihre Wallet, Ihre Gelder und Ihre Konten.",
     "description": "This is a sentence consisting of link using 'revealSeedWordsSRPName' as $1."
   },
   "revealSeedWordsQR": {

--- a/app/_locales/el/messages.json
+++ b/app/_locales/el/messages.json
@@ -6006,7 +6006,7 @@
     "message": "Αποκάλυψη της Μυστικής Φράσης Ανάκτησης"
   },
   "revealSeedWordsDescription1": {
-    "message": "Το $1 παρέχει $2",
+    "message": "Το $1 σας δίνει πλήρη πρόσβαση στο πορτοφόλι, τα κεφάλαια και τους λογαριασμούς σας.",
     "description": "This is a sentence consisting of link using 'revealSeedWordsSRPName' as $1."
   },
   "revealSeedWordsQR": {

--- a/app/_locales/es/messages.json
+++ b/app/_locales/es/messages.json
@@ -6006,7 +6006,7 @@
     "message": "Revelar frase secreta de recuperación"
   },
   "revealSeedWordsDescription1": {
-    "message": "La $1 proporciona la $2",
+    "message": "Tu $1 te da acceso completo a tu billetera, fondos y cuentas.",
     "description": "This is a sentence consisting of link using 'revealSeedWordsSRPName' as $1."
   },
   "revealSeedWordsQR": {

--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -6003,7 +6003,7 @@
     "message": "Révéler la phrase secrète de récupération"
   },
   "revealSeedWordsDescription1": {
-    "message": "La $1 donne $2",
+    "message": "Votre $1 donne un accès complet à votre portefeuille, vos fonds et vos comptes.",
     "description": "This is a sentence consisting of link using 'revealSeedWordsSRPName' as $1."
   },
   "revealSeedWordsQR": {

--- a/app/_locales/ga/messages.json
+++ b/app/_locales/ga/messages.json
@@ -4925,7 +4925,7 @@
     "message": "Nochtadh Frása Rúnda Aisghabhála"
   },
   "revealSeedWordsDescription1": {
-    "message": "Tugann an $1 $2",
+    "message": "Tugann do $1 rochtain iomlán ar do sparán, cistí agus cuntais.",
     "description": "This is a sentence consisting of link using 'revealSeedWordsSRPName' as $1."
   },
   "revealSeedWordsQR": {

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -6000,7 +6000,7 @@
     "message": "सीक्रेट रिकवरी फ्रेज़ दिखाएं"
   },
   "revealSeedWordsDescription1": {
-    "message": "$1 प्रदान करता है $2",
+    "message": "आपका $1 आपके वॉलेट, फंड और अकाउंट तक फुल एक्सेस देता है।",
     "description": "This is a sentence consisting of link using 'revealSeedWordsSRPName' as $1."
   },
   "revealSeedWordsQR": {

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -6006,7 +6006,7 @@
     "message": "Tampilkan Frasa Pemulihan Rahasia"
   },
   "revealSeedWordsDescription1": {
-    "message": "$1 memberikan $2",
+    "message": "$1 memberikan akses penuh ke dompet, dana, dan akun Anda.",
     "description": "This is a sentence consisting of link using 'revealSeedWordsSRPName' as $1."
   },
   "revealSeedWordsQR": {

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -6000,7 +6000,7 @@
     "message": "シークレットリカバリーフレーズを確認"
   },
   "revealSeedWordsDescription1": {
-    "message": "$1は$2を提供します。",
+    "message": "$1があれば、ウォレット、資金、アカウントに自由にアクセスできます。",
     "description": "This is a sentence consisting of link using 'revealSeedWordsSRPName' as $1."
   },
   "revealSeedWordsQR": {

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -6006,7 +6006,7 @@
     "message": "비밀복구구문 공개"
   },
   "revealSeedWordsDescription1": {
-    "message": "$1 활용으로 $2 기능을 사용할 수 있습니다",
+    "message": "$1은(는) 지갑, 자금, 계정에 대한 완전한 접근 권한을 제공합니다.",
     "description": "This is a sentence consisting of link using 'revealSeedWordsSRPName' as $1."
   },
   "revealSeedWordsQR": {

--- a/app/_locales/pt/messages.json
+++ b/app/_locales/pt/messages.json
@@ -6006,7 +6006,7 @@
     "message": "Revelar Frase de Recuperação Secreta"
   },
   "revealSeedWordsDescription1": {
-    "message": "A $1 concede $2",
+    "message": "Seu $1 lhe permite acesso total à sua carteira, fundos e contas.",
     "description": "This is a sentence consisting of link using 'revealSeedWordsSRPName' as $1."
   },
   "revealSeedWordsQR": {

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -6006,7 +6006,7 @@
     "message": "Показать секретную фразу для восстановления"
   },
   "revealSeedWordsDescription1": {
-    "message": "$1 дает $2",
+    "message": "Ваша $1 дает полный доступ к вашему кошельку, средствам и счетам.",
     "description": "This is a sentence consisting of link using 'revealSeedWordsSRPName' as $1."
   },
   "revealSeedWordsQR": {

--- a/app/_locales/tl/messages.json
+++ b/app/_locales/tl/messages.json
@@ -6006,7 +6006,7 @@
     "message": "Ihayag ang Lihim na Parirala sa Pagbawi"
   },
   "revealSeedWordsDescription1": {
-    "message": "Ang $1 ay nagbibigay ng $2",
+    "message": "Nagbibigay sa iyo ang $1 mo ng buong access sa iyong wallet, mga pondo, at mga account.",
     "description": "This is a sentence consisting of link using 'revealSeedWordsSRPName' as $1."
   },
   "revealSeedWordsQR": {

--- a/app/_locales/tr/messages.json
+++ b/app/_locales/tr/messages.json
@@ -6006,7 +6006,7 @@
     "message": "Gizli Kurtarma İfadesini Açığa Çıkar"
   },
   "revealSeedWordsDescription1": {
-    "message": "$1 $2",
+    "message": "$1, cüzdanınıza, fonlarınıza ve hesaplarınıza tam erişim verir.",
     "description": "This is a sentence consisting of link using 'revealSeedWordsSRPName' as $1."
   },
   "revealSeedWordsQR": {

--- a/app/_locales/vi/messages.json
+++ b/app/_locales/vi/messages.json
@@ -6006,7 +6006,7 @@
     "message": "Hiện Cụm từ khôi phục bí mật"
   },
   "revealSeedWordsDescription1": {
-    "message": "$1 cung cấp $2",
+    "message": "$1 của bạn cho phép toàn quyền truy cập vào ví, tiền và tài khoản của bạn.",
     "description": "This is a sentence consisting of link using 'revealSeedWordsSRPName' as $1."
   },
   "revealSeedWordsQR": {

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -6000,7 +6000,7 @@
     "message": "显示私钥助记词"
   },
   "revealSeedWordsDescription1": {
-    "message": "$1 提供 $2",
+    "message": "您的 $1 可授予对您的钱包、资金和账户的完全访问权限。",
     "description": "This is a sentence consisting of link using 'revealSeedWordsSRPName' as $1."
   },
   "revealSeedWordsQR": {


### PR DESCRIPTION
## Description

Fixes the `revealSeedWordsDescription1` i18n key in 15 non-English locales that still contained the old two-substitution format (`$1 ... $2`) after the `revealSeedWordsDescription1` key was changed to a single-substitution format in the feat: reveal SRP UI change (#40243).

The `reveal-seed.tsx` component now only passes one substitution (`$1` = SRP name link), so any locale message still referencing `$2` would cause an `"Insufficient number of substitutions"` crash on the Reveal Secret Recovery Phrase page for users in those locales.

**Locales fixed:** `de`, `el`, `es`, `fr`, `hi`, `id`, `ja`, `ko`, `pt`, `ru`, `tl`, `tr`, `vi`, `zh_CN`, `ga`

## Changelog

CHANGELOG entry: Fixed a translation error on the Reveal Secret Recovery Phrase page that caused a crash for users in 15 non-English locales.

## Related issues

Fixes: #40968

## Manual testing steps

1. Set MetaMask language to any of the affected locales (e.g. Irish — Settings → General → Language).
2. Navigate to Settings → Security & Privacy → **Reveal Secret Recovery Phrase**.
3. Verify the page loads without console errors and the description renders correctly with the SRP name as a clickable link.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates localized copy strings (no logic changes). Main risk is minor formatting/grammar issues or placeholder mismatch in affected locales.
> 
> **Overview**
> Updates `revealSeedWordsDescription1` in multiple non-English locale `messages.json` files to replace the old two-placeholder phrasing with the newer full-sentence warning that uses only `$1` (matching the English copy about SRP granting full access).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac5c4786e6ccffe7aba5e17a460082f8f16ac270. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->