### PR TITLE
docs(button-link): clarify deprecation guidance for inline vs standalone usage

### DIFF
--- a/ui/components/component-library/button-link/button-link.tsx
+++ b/ui/components/component-library/button-link/button-link.tsx
@@ -11,7 +11,16 @@ import type { ButtonLinkProps } from './button-link.types';
 import { ButtonLinkSize, ButtonLinkComponent } from './button-link.types';
 
 /**
- * @deprecated Please update your code to use `TextButton` from `@metamask/design-system-react`
+ * @deprecated ButtonLink is deprecated.
+ * - Use `TextButton` from `@metamask/design-system-react` for inline links within text.
+ * - For standalone link-style actions, use `Button` from `@metamask/design-system-react`
+ * with `variant={ButtonVariant.Tertiary}` (e.g., for "Forgot password?" on unlock).
+ *
+ * Examples:
+ * Inline: `<TextButton>Learn more</TextButton>`
+ * Standalone: `<Button variant={ButtonVariant.Tertiary}>Forgot password?</Button>`
+ *
+ * This component will be removed in a future release.
  */
 export const ButtonLink: ButtonLinkComponent = React.forwardRef(
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Clarifies the `@deprecated` JSDoc on `ui/components/component-library/button-link/button-link.tsx` to make usage guidance explicit:
- Use `TextButton` from `@metamask/design-system-react` for inline links within text.
- Use `Button` with `variant={ButtonVariant.Tertiary}` for standalone link‑style actions.

Includes concise inline examples. No runtime logic changes.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/41058?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

<!--
## **Manual testing steps**

1. N/A (documentation-only change)
-->

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://consensys.slack.com/archives/C0354T27M5M/p1773898792873879?thread_ts=1773898792.873879&cid=C0354T27M5M)

<div><a href="https://cursor.com/agents/bc-e8ec7a18-9015-5085-8da4-abad1abd44b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8ec7a18-9015-5085-8da4-abad1abd44b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

