### PR TITLE
feat: migrate stock and market closure components to design-system-react and adjust styling

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1070,7 +1070,7 @@
     "message": "Lowest cost"
   },
   "bridgeMarketClosedAction": {
-    "message": "Market is closed"
+    "message": "Market closed"
   },
   "bridgeMarketClosedDescription": {
     "message": "This stock token is currently outside trading hours. Try again when the market reopens."

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -1070,7 +1070,7 @@
     "message": "Lowest cost"
   },
   "bridgeMarketClosedAction": {
-    "message": "Market is closed"
+    "message": "Market closed"
   },
   "bridgeMarketClosedDescription": {
     "message": "This stock token is currently outside trading hours. Try again when the market reopens."

--- a/ui/components/app/assets/market-closed-modal.tsx
+++ b/ui/components/app/assets/market-closed-modal.tsx
@@ -20,9 +20,7 @@ import {
   ModalOverlay,
 } from '../../component-library';
 
-import {
-  AlignItems,
-} from '../../../helpers/constants/design-system';
+import { AlignItems } from '../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 
 const MARKET_CLOSED_LEARN_MORE_URL = 'https://status.ondo.finance/market';
@@ -46,10 +44,7 @@ export const MarketClosedModal = ({
           {t('bridgeMarketClosedModalTitle')}
         </ModalHeader>
         <ModalBody>
-          <Box
-            flexDirection={BoxFlexDirection.Column}
-            gap={4}
-          >
+          <Box flexDirection={BoxFlexDirection.Column} gap={4}>
             <Text
               variant={TextVariant.BodyMd}
               color={TextColor.TextDefault}

--- a/ui/components/app/assets/market-closed-modal.tsx
+++ b/ui/components/app/assets/market-closed-modal.tsx
@@ -1,26 +1,27 @@
 import React from 'react';
 import {
   Box,
+  BoxFlexDirection,
   Button,
-  ButtonLink,
-  ButtonLinkSize,
+  TextButton,
   ButtonVariant,
+  Text,
+  TextAlign,
+  TextVariant,
+  TextColor,
+} from '@metamask/design-system-react';
+
+import {
   Modal,
   ModalBody,
   ModalContent,
   ModalFooter,
   ModalHeader,
   ModalOverlay,
-  Text,
 } from '../../component-library';
+
 import {
   AlignItems,
-  BlockSize,
-  Display,
-  FlexDirection,
-  TextAlign,
-  TextColor,
-  TextVariant,
 } from '../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 
@@ -46,36 +47,39 @@ export const MarketClosedModal = ({
         </ModalHeader>
         <ModalBody>
           <Box
-            display={Display.Flex}
-            flexDirection={FlexDirection.Column}
+            flexDirection={BoxFlexDirection.Column}
             gap={4}
           >
             <Text
-              variant={TextVariant.bodyMd}
-              color={TextColor.textDefault}
+              variant={TextVariant.BodyMd}
+              color={TextColor.TextDefault}
               textAlign={TextAlign.Left}
             >
               {t('bridgeMarketClosedModalDescription')}&nbsp;
-              <ButtonLink
+              <TextButton
+                asChild
                 data-testid="market-closed-modal-learn-more"
-                size={ButtonLinkSize.Inherit}
-                href={MARKET_CLOSED_LEARN_MORE_URL}
                 textProps={{
-                  variant: TextVariant.bodyMd,
+                  variant: TextVariant.BodyMd,
+                }}
+                style={{
                   alignItems: AlignItems.flexStart,
                 }}
-                target="_blank"
-                as="a"
-                rel="noopener noreferrer"
               >
-                {t('bridgeMarketClosedModalLearnMore')}
-              </ButtonLink>
+                <a
+                  href={MARKET_CLOSED_LEARN_MORE_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {t('bridgeMarketClosedModalLearnMore')}
+                </a>
+              </TextButton>
             </Text>
           </Box>
         </ModalBody>
         <ModalFooter>
           <Button
-            width={BlockSize.Full}
+            isFullWidth
             variant={ButtonVariant.Secondary}
             onClick={onClose}
             data-testid="market-closed-modal-close"

--- a/ui/components/app/assets/stock-badge/stock-badge.tsx
+++ b/ui/components/app/assets/stock-badge/stock-badge.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { IconName, Tag } from '../../../component-library';
+import { IconName, IconSize } from '@metamask/design-system-react';
+import { Tag } from '../../../component-library';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 
 type StockBadgeProps = {
@@ -12,7 +13,9 @@ export const StockBadge = ({ isMarketClosed }: StockBadgeProps) => {
   return (
     <Tag
       label={t('tokenStock')}
-      {...(isMarketClosed ? { startIconName: IconName.Clock } : {})}
+      {...(isMarketClosed
+        ? { iconName: IconName.AfterHours, iconSize: IconSize.Xs }
+        : {})}
     />
   );
 };

--- a/ui/pages/asset/components/market-closed-action-button.tsx
+++ b/ui/pages/asset/components/market-closed-action-button.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
-import {
-  Button,
-  ButtonVariant,
-  IconName,
-} from '../../../components/component-library';
-import { BlockSize } from '../../../helpers/constants/design-system';
+import { Button, ButtonVariant, IconName } from '@metamask/design-system-react';
 import { useI18nContext } from '../../../hooks/useI18nContext';
+import { JustifyContent } from '../../../helpers/constants/design-system';
 
 type MarketClosedActionButtonProps = {
   onClick: () => void;
@@ -18,11 +14,19 @@ export const MarketClosedActionButton = ({
 
   return (
     <Button
-      width={BlockSize.Full}
+      isFullWidth
       variant={ButtonVariant.Secondary}
-      startIconName={IconName.Clock}
+      startIconName={IconName.AfterHours}
       endIconName={IconName.Info}
+      endIconProps={{
+        style: {
+          marginLeft: 'auto',
+        },
+      }}
       onClick={onClick}
+      style={{
+        justifyContent: JustifyContent.flexStart,
+      }}
       data-testid="market-closed-action-button"
     >
       {t('bridgeMarketClosedAction')}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Migrate a few components that were using `component-library` components so they use instead `@metamask/design-system-react` ones.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/41059?quickstart=1)

## **Changelog**

CHANGELOG entry: migrate stock and market closure components so they use design-system-react library
CHANGELOG entry: adjust stock and market closure components styling to design guidelines

## **Related issues**

Fixes:
- https://consensyssoftware.atlassian.net/browse/BETR-355
- https://consensyssoftware.atlassian.net/browse/BETR-356

## **Manual testing steps**

**Component changes:**
Check there's no regression on component behavior after migration on:
- tokens homepage (stock label)
- tokens details page (stock label, market closed button and market closed modal)


**Style changes:**
1. Check tokens list on homepage and see that clock icon is now using after hours icon
2. Check tokens list on swap page and see that clock icon is now using after hours icon
3. Check token details page and see that market closed button is now aligned left as required on [Figma file](https://www.figma.com/design/bVurOkjl5xHu8v6lWnazWp/Stocks?node-id=442-10474&t=vg4WzFNsByI0bI0y-0) and after hours icon is now used

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="200" alt="Capture d’écran 2026-03-19 à 19 16 16" src="https://github.com/user-attachments/assets/a6512373-a1b0-4b1d-83d7-22bdf824498a" />
<img width="200" alt="Capture d’écran 2026-03-19 à 19 16 24" src="https://github.com/user-attachments/assets/fa0b8c8f-54ac-4060-9151-6677e5ea672b" />
<img width="200" alt="Capture d’écran 2026-03-19 à 19 16 31" src="https://github.com/user-attachments/assets/e876d6e4-b154-4f23-8d19-f351dceb705d" />
<img width="200" alt="Capture d’écran 2026-03-19 à 19 17 17" src="https://github.com/user-attachments/assets/0546388d-44ce-45d1-b9b4-4affffc3638a" />


### **After**

<img width="200"  alt="Capture d’écran 2026-03-19 à 17 35 24" src="https://github.com/user-attachments/assets/54b1fe6c-84b1-4a58-8747-765a5f63f2ff" />
<img width="200"  alt="Capture d’écran 2026-03-19 à 17 35 34" src="https://github.com/user-attachments/assets/e3f34720-c9c9-4146-b62b-62eacd57d826" />
<img width="200"  alt="Capture d’écran 2026-03-19 à 17 35 45" src="https://github.com/user-attachments/assets/eac2bac0-afc0-4bca-939f-b197dada6663" />
<img width="200" alt="Capture d’écran 2026-03-19 à 19 27 37" src="https://github.com/user-attachments/assets/2cac49f8-63ab-42b4-a874-03b21f88e53d" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only changes that swap component implementations and tweak styling/iconography; primary risk is minor visual/layout regressions.
> 
> **Overview**
> Updates stock and market-closure UI to use `@metamask/design-system-react` components and props, including the market-closed modal link/button styling and full-width button behavior.
> 
> Adjusts visuals to match updated guidelines: switches the market-closed icon from `Clock` to `AfterHours`, left-aligns the market-closed action button content, and shortens the action label string to “Market closed” in `en`/`en_GB` locales.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f24ffc992b8622cc1cc1495d7698324c6170a840. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->