### PR TITLE
feat: webpack nightly builds

### DIFF
--- a/.github/scripts/post-nightly-builds.ts
+++ b/.github/scripts/post-nightly-builds.ts
@@ -196,6 +196,14 @@ async function postSuccessNotification(env: any, version: string) {
       chrome: `${env.HOST_URL}/build-experimental-browserify/builds/metamask-experimental-chrome-${experimentalVersion}.zip`,
       firefox: `${env.HOST_URL}/build-experimental-mv2-browserify/builds/metamask-experimental-firefox-${experimentalVersion}.zip`,
     },
+    'webpack builds': {
+      chrome: `${env.HOST_URL}/build-dist-webpack/builds/metamask-chrome-${version}.zip`,
+      firefox: `${env.HOST_URL}/build-dist-mv2-webpack/builds/metamask-firefox-${version}.zip`,
+    },
+    'webpack builds (experimental)': {
+      chrome: `${env.HOST_URL}/build-experimental-webpack/builds/metamask-chrome-${experimentalVersion}.zip`,
+      firefox: `${env.HOST_URL}/build-experimental-mv2-webpack/builds/metamask-firefox-${experimentalVersion}.zip`,
+    },
   };
 
   const webhook = new IncomingWebhook(env.SLACK_NIGHTLY_BUILDS_WEBHOOK_URL);
@@ -354,6 +362,98 @@ async function postSuccessNotification(env: any, version: string) {
             {
               type: 'link' as const,
               url: buildMap['builds (experimental)'].firefox,
+              text: 'Experimental Firefox Extension',
+            },
+            {
+              type: 'text' as const,
+              text: '\n',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      type: 'divider',
+    },
+    {
+      type: 'rich_text',
+      elements: [
+        {
+          type: 'rich_text_section',
+          elements: [
+            {
+              type: 'emoji' as const,
+              name: 'package',
+            },
+            {
+              type: 'text' as const,
+              text: ' Webpack Download Links:\n',
+              style: {
+                bold: true,
+              },
+            },
+            {
+              type: 'emoji' as const,
+              name: 'chrome',
+            },
+            {
+              type: 'text' as const,
+              text: ' ',
+            },
+            {
+              type: 'link' as const,
+              url: buildMap['webpack builds'].chrome,
+              text: 'Main Chrome Extension',
+            },
+            {
+              type: 'text' as const,
+              text: '\n',
+            },
+            {
+              type: 'emoji' as const,
+              name: 'firefox',
+            },
+            {
+              type: 'text' as const,
+              text: ' ',
+            },
+            {
+              type: 'link' as const,
+              url: buildMap['webpack builds'].firefox,
+              text: 'Main Firefox Extension',
+            },
+            {
+              type: 'text' as const,
+              text: '\n',
+            },
+            {
+              type: 'emoji' as const,
+              name: 'test_tube',
+            },
+            {
+              type: 'text' as const,
+              text: ' ',
+            },
+            {
+              type: 'link' as const,
+              url: buildMap['webpack builds (experimental)'].chrome,
+              text: 'Experimental Chrome Extension',
+            },
+            {
+              type: 'text' as const,
+              text: '\n',
+            },
+            {
+              type: 'emoji' as const,
+              name: 'test_tube',
+            },
+            {
+              type: 'text' as const,
+              text: ' ',
+            },
+            {
+              type: 'link' as const,
+              url: buildMap['webpack builds (experimental)'].firefox,
               text: 'Experimental Firefox Extension',
             },
             {

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -43,12 +43,56 @@ jobs:
       builds-from-run: ${{ github.run_id }}
     secrets: inherit
 
+  build-dist-webpack:
+    uses: ./.github/workflows/run-build.yml
+    with:
+      is-high-risk-environment: false
+      build-name: build-dist-webpack
+      build-command: yarn webpack:lavamoat:build
+      builds-from-run: ${{ github.run_id }}
+      zip: true
+    secrets: inherit
+
+  build-dist-mv2-webpack:
+    uses: ./.github/workflows/run-build.yml
+    with:
+      is-high-risk-environment: false
+      build-name: build-dist-mv2-webpack
+      build-command: yarn webpack:lavamoat:build:mv2
+      builds-from-run: ${{ github.run_id }}
+      zip: true
+    secrets: inherit
+
+  build-experimental-webpack:
+    uses: ./.github/workflows/run-build.yml
+    with:
+      is-high-risk-environment: false
+      build-name: build-experimental-webpack
+      build-command: yarn webpack:lavamoat:build --type experimental
+      builds-from-run: ${{ github.run_id }}
+      zip: true
+    secrets: inherit
+
+  build-experimental-mv2-webpack:
+    uses: ./.github/workflows/run-build.yml
+    with:
+      is-high-risk-environment: false
+      build-name: build-experimental-mv2-webpack
+      build-command: yarn webpack:lavamoat:build:mv2 --type experimental
+      builds-from-run: ${{ github.run_id }}
+      zip: true
+    secrets: inherit
+
   post-nightly-builds:
     needs:
       - build-dist-browserify
       - build-dist-mv2-browserify
       - build-experimental-browserify
       - build-experimental-mv2-browserify
+      - build-dist-webpack
+      - build-dist-mv2-webpack
+      - build-experimental-webpack
+      - build-experimental-mv2-webpack
     runs-on: ubuntu-latest
     if: ${{ always() }}
     env:
@@ -59,7 +103,7 @@ jobs:
       BRANCH: ${{ github.ref_name || 'main' }}
       HOST_URL: ${{ vars.AWS_CLOUDFRONT_URL }}/${{ github.event.repository.name }}/${{ github.run_id }}
       SLACK_NIGHTLY_BUILDS_WEBHOOK_URL: ${{ secrets.SLACK_NIGHTLY_BUILDS_WEBHOOK_URL }}
-      BUILD_STATUS: ${{ needs.build-dist-browserify.result == 'success' && needs.build-dist-mv2-browserify.result == 'success' && needs.build-experimental-browserify.result == 'success' && needs.build-experimental-mv2-browserify.result == 'success' && 'success' || 'failure' }}
+      BUILD_STATUS: ${{ needs.build-dist-browserify.result == 'success' && needs.build-dist-mv2-browserify.result == 'success' && needs.build-experimental-browserify.result == 'success' && needs.build-experimental-mv2-browserify.result == 'success' && needs.build-dist-webpack.result == 'success' && needs.build-dist-mv2-webpack.result == 'success' && needs.build-experimental-webpack.result == 'success' && needs.build-experimental-mv2-webpack.result == 'success' && 'success' || 'failure' }}
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v3


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/41062?quickstart=1)

This PR introduces webpack nightly builds.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/7139

## **Manual testing steps**

1. Can only be tested after merging (unless you set up your own slack webhook for yourself to test with)

## **Screenshots/Recordings**

Not applicable

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it expands the nightly CI matrix and changes success/failure gating; misconfiguration could break nightly build publishing or create misleading Slack notifications.
> 
> **Overview**
> Adds **webpack-based nightly build artifacts** alongside the existing browserify builds, including MV2 and experimental variants, by introducing four new jobs that run `yarn webpack:lavamoat:build*` and upload zipped outputs.
> 
> Updates the nightly Slack notification script to include a new **Webpack Download Links** section and extends the workflow’s `BUILD_STATUS` calculation and `post-nightly-builds` dependencies to require all webpack jobs to pass before reporting success.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23ca1642ec1108c38f1e3a6b29a25f419b86cd2f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->