### PR TITLE
feat: better build links

### DIFF
--- a/.devcontainer/download-builds.ts
+++ b/.devcontainer/download-builds.ts
@@ -2,6 +2,7 @@ import { execSync } from 'node:child_process';
 import unzipper from 'unzipper';
 import { version } from '../package.json';
 import { program, Option } from 'commander';
+import { getBuildLinks } from '../development/metamaskbot-build-announce/artifacts';
 
 const getBranch = () => {
   try {
@@ -16,7 +17,7 @@ interface DownloadBuildsArgs {
   repository: string;
   workflowId: string;
   branch: string;
-  buildType: string;
+  buildType: 'main' | 'beta' | 'experimental' | 'flask' | 'test' | 'test-flask';
   githubToken: string;
   awsCloudfrontUrl: string;
 }
@@ -46,7 +47,7 @@ program
     new Option('-t, --build-type <string>', 'build type')
       .default('main')
       .env('BUILD_TYPE')
-      .choices(['main', 'beta', 'flask', 'test', 'test-flask']),
+      .choices(['main', 'beta', 'experimental', 'flask', 'test', 'test-flask']),
   )
   .addOption(
     new Option('-g, --github-token <string>', 'github token')
@@ -85,34 +86,9 @@ program
 
     const HOST_URL = `${args.awsCloudfrontUrl}/${args.repository}/${latestRun.id}`;
 
-    const buildMap = {
-      main: {
-        chrome: `${HOST_URL}/build-dist-browserify/builds/metamask-chrome-${version}.zip`,
-        firefox: `${HOST_URL}/build-dist-mv2-browserify/builds/metamask-firefox-${version}.zip`,
-      },
-      beta: {
-        chrome: `${HOST_URL}/build-beta-browserify/builds/metamask-beta-chrome-${version}-beta.0.zip`,
-        firefox: `${HOST_URL}/build-beta-mv2-browserify/builds/metamask-beta-firefox-${version}-beta.0.zip`,
-      },
-      flask: {
-        chrome: `${HOST_URL}/build-flask-browserify/builds/metamask-flask-chrome-${version}-flask.0.zip`,
-        firefox: `${HOST_URL}/build-flask-mv2-browserify/builds/metamask-flask-firefox-${version}-flask.0.zip`,
-      },
-      test: {
-        chrome: `${HOST_URL}/build-test-browserify/builds/metamask-chrome-${version}.zip`,
-        firefox: `${HOST_URL}/build-test-mv2-browserify/builds/metamask-firefox-${version}.zip`,
-      },
-      'test-flask': {
-        chrome: `${HOST_URL}/build-test-flask-browserify/builds/metamask-flask-chrome-${version}-flask.0.zip`,
-        firefox: `${HOST_URL}/build-test-flask-mv2-browserify/builds/metamask-flask-firefox-${version}-flask.0.zip`,
-      },
-    };
+    const buildLinks = getBuildLinks({ hostUrl: HOST_URL, version });
 
-    const builds: { chrome: string; firefox: string } | undefined =
-      buildMap[args.buildType];
-
-    if (!builds)
-      throw new Error(`No builds found for build type '${args.buildType}'`);
+    const builds = buildLinks.browserify[args.buildType];
 
     console.log(`Downloading build for chrome from ${builds.chrome}`);
     console.log(`Downloading build for firefox from ${builds.firefox}`);

--- a/.devcontainer/download-builds.ts
+++ b/.devcontainer/download-builds.ts
@@ -2,7 +2,10 @@ import { execSync } from 'node:child_process';
 import unzipper from 'unzipper';
 import { version } from '../package.json';
 import { program, Option } from 'commander';
-import { getBuildLinks } from '../development/metamaskbot-build-announce/artifacts';
+import {
+  BuildType,
+  getBuildLinks,
+} from '../development/metamaskbot-build-announce/artifacts';
 
 const getBranch = () => {
   try {
@@ -17,7 +20,7 @@ interface DownloadBuildsArgs {
   repository: string;
   workflowId: string;
   branch: string;
-  buildType: 'main' | 'beta' | 'experimental' | 'flask' | 'test' | 'test-flask';
+  buildType: BuildType;
   githubToken: string;
   awsCloudfrontUrl: string;
 }

--- a/.github/scripts/post-nightly-builds.ts
+++ b/.github/scripts/post-nightly-builds.ts
@@ -196,6 +196,14 @@ async function postSuccessNotification(env: any, version: string) {
       chrome: `${env.HOST_URL}/build-experimental-browserify/builds/metamask-experimental-chrome-${experimentalVersion}.zip`,
       firefox: `${env.HOST_URL}/build-experimental-mv2-browserify/builds/metamask-experimental-firefox-${experimentalVersion}.zip`,
     },
+    'webpack builds': {
+      chrome: `${env.HOST_URL}/build-dist-webpack/builds/metamask-chrome-${version}.zip`,
+      firefox: `${env.HOST_URL}/build-dist-mv2-webpack/builds/metamask-firefox-${version}.zip`,
+    },
+    'webpack builds (experimental)': {
+      chrome: `${env.HOST_URL}/build-experimental-webpack/builds/metamask-chrome-${experimentalVersion}.zip`,
+      firefox: `${env.HOST_URL}/build-experimental-mv2-webpack/builds/metamask-firefox-${experimentalVersion}.zip`,
+    },
   };
 
   const webhook = new IncomingWebhook(env.SLACK_NIGHTLY_BUILDS_WEBHOOK_URL);
@@ -354,6 +362,98 @@ async function postSuccessNotification(env: any, version: string) {
             {
               type: 'link' as const,
               url: buildMap['builds (experimental)'].firefox,
+              text: 'Experimental Firefox Extension',
+            },
+            {
+              type: 'text' as const,
+              text: '\n',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      type: 'divider',
+    },
+    {
+      type: 'rich_text',
+      elements: [
+        {
+          type: 'rich_text_section',
+          elements: [
+            {
+              type: 'emoji' as const,
+              name: 'package',
+            },
+            {
+              type: 'text' as const,
+              text: ' Webpack Download Links:\n',
+              style: {
+                bold: true,
+              },
+            },
+            {
+              type: 'emoji' as const,
+              name: 'chrome',
+            },
+            {
+              type: 'text' as const,
+              text: ' ',
+            },
+            {
+              type: 'link' as const,
+              url: buildMap['webpack builds'].chrome,
+              text: 'Main Chrome Extension',
+            },
+            {
+              type: 'text' as const,
+              text: '\n',
+            },
+            {
+              type: 'emoji' as const,
+              name: 'firefox',
+            },
+            {
+              type: 'text' as const,
+              text: ' ',
+            },
+            {
+              type: 'link' as const,
+              url: buildMap['webpack builds'].firefox,
+              text: 'Main Firefox Extension',
+            },
+            {
+              type: 'text' as const,
+              text: '\n',
+            },
+            {
+              type: 'emoji' as const,
+              name: 'test_tube',
+            },
+            {
+              type: 'text' as const,
+              text: ' ',
+            },
+            {
+              type: 'link' as const,
+              url: buildMap['webpack builds (experimental)'].chrome,
+              text: 'Experimental Chrome Extension',
+            },
+            {
+              type: 'text' as const,
+              text: '\n',
+            },
+            {
+              type: 'emoji' as const,
+              name: 'test_tube',
+            },
+            {
+              type: 'text' as const,
+              text: ' ',
+            },
+            {
+              type: 'link' as const,
+              url: buildMap['webpack builds (experimental)'].firefox,
               text: 'Experimental Firefox Extension',
             },
             {

--- a/.github/scripts/post-nightly-builds.ts
+++ b/.github/scripts/post-nightly-builds.ts
@@ -1,6 +1,7 @@
 import { IncomingWebhook } from '@slack/webhook';
 import type { AnyBlock } from '@slack/types';
 import { version } from '../../package.json';
+import { getBuildLinks } from '../../development/metamaskbot-build-announce/artifacts';
 
 async function main() {
   const env = {
@@ -12,7 +13,7 @@ async function main() {
     SLACK_NIGHTLY_BUILDS_WEBHOOK_URL:
       process.env.SLACK_NIGHTLY_BUILDS_WEBHOOK_URL || '',
     BUILD_STATUS: process.env.BUILD_STATUS || 'unknown',
-    BUILD_VERSION: process.env.BUILD_VERSION || '0',
+    RELEASE_VERSION: process.env.RELEASE_VERSION || '0',
   };
 
   if (!env.RUN_ID) throw new Error('RUN_ID not found');
@@ -185,26 +186,11 @@ async function postFailureNotification(env: any, version: string) {
 }
 
 async function postSuccessNotification(env: any, version: string) {
-  const experimentalVersion = `${version}-experimental.${env.BUILD_VERSION}`;
-
-  const buildMap = {
-    builds: {
-      chrome: `${env.HOST_URL}/build-dist-browserify/builds/metamask-chrome-${version}.zip`,
-      firefox: `${env.HOST_URL}/build-dist-mv2-browserify/builds/metamask-firefox-${version}.zip`,
-    },
-    'builds (experimental)': {
-      chrome: `${env.HOST_URL}/build-experimental-browserify/builds/metamask-experimental-chrome-${experimentalVersion}.zip`,
-      firefox: `${env.HOST_URL}/build-experimental-mv2-browserify/builds/metamask-experimental-firefox-${experimentalVersion}.zip`,
-    },
-    'webpack builds': {
-      chrome: `${env.HOST_URL}/build-dist-webpack/builds/metamask-chrome-${version}.zip`,
-      firefox: `${env.HOST_URL}/build-dist-mv2-webpack/builds/metamask-firefox-${version}.zip`,
-    },
-    'webpack builds (experimental)': {
-      chrome: `${env.HOST_URL}/build-experimental-webpack/builds/metamask-chrome-${experimentalVersion}.zip`,
-      firefox: `${env.HOST_URL}/build-experimental-mv2-webpack/builds/metamask-firefox-${experimentalVersion}.zip`,
-    },
-  };
+  const buildLinks = getBuildLinks({
+    hostUrl: env.HOST_URL,
+    version,
+    releaseVersion: env.RELEASE_VERSION,
+  });
 
   const webhook = new IncomingWebhook(env.SLACK_NIGHTLY_BUILDS_WEBHOOK_URL);
 
@@ -310,7 +296,7 @@ async function postSuccessNotification(env: any, version: string) {
             },
             {
               type: 'link' as const,
-              url: buildMap.builds.chrome,
+              url: buildLinks.browserify.main.chrome,
               text: 'Main Chrome Extension',
             },
             {
@@ -327,7 +313,7 @@ async function postSuccessNotification(env: any, version: string) {
             },
             {
               type: 'link' as const,
-              url: buildMap.builds.firefox,
+              url: buildLinks.browserify.main.firefox,
               text: 'Main Firefox Extension',
             },
             {
@@ -344,7 +330,7 @@ async function postSuccessNotification(env: any, version: string) {
             },
             {
               type: 'link' as const,
-              url: buildMap['builds (experimental)'].chrome,
+              url: buildLinks.browserify.experimental.chrome,
               text: 'Experimental Chrome Extension',
             },
             {
@@ -361,7 +347,7 @@ async function postSuccessNotification(env: any, version: string) {
             },
             {
               type: 'link' as const,
-              url: buildMap['builds (experimental)'].firefox,
+              url: buildLinks.browserify.experimental.firefox,
               text: 'Experimental Firefox Extension',
             },
             {
@@ -402,7 +388,7 @@ async function postSuccessNotification(env: any, version: string) {
             },
             {
               type: 'link' as const,
-              url: buildMap['webpack builds'].chrome,
+              url: buildLinks.webpack.main.chrome,
               text: 'Main Chrome Extension',
             },
             {
@@ -419,7 +405,7 @@ async function postSuccessNotification(env: any, version: string) {
             },
             {
               type: 'link' as const,
-              url: buildMap['webpack builds'].firefox,
+              url: buildLinks.webpack.main.firefox,
               text: 'Main Firefox Extension',
             },
             {
@@ -436,7 +422,7 @@ async function postSuccessNotification(env: any, version: string) {
             },
             {
               type: 'link' as const,
-              url: buildMap['webpack builds (experimental)'].chrome,
+              url: buildLinks.webpack.experimental.chrome,
               text: 'Experimental Chrome Extension',
             },
             {
@@ -453,7 +439,7 @@ async function postSuccessNotification(env: any, version: string) {
             },
             {
               type: 'link' as const,
-              url: buildMap['webpack builds (experimental)'].firefox,
+              url: buildLinks.webpack.experimental.firefox,
               text: 'Experimental Firefox Extension',
             },
             {

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -43,12 +43,56 @@ jobs:
       builds-from-run: ${{ github.run_id }}
     secrets: inherit
 
+  build-dist-webpack:
+    uses: ./.github/workflows/run-build.yml
+    with:
+      is-high-risk-environment: false
+      build-name: build-dist-webpack
+      build-command: yarn webpack:lavamoat:build
+      builds-from-run: ${{ github.run_id }}
+      zip: true
+    secrets: inherit
+
+  build-dist-mv2-webpack:
+    uses: ./.github/workflows/run-build.yml
+    with:
+      is-high-risk-environment: false
+      build-name: build-dist-mv2-webpack
+      build-command: yarn webpack:lavamoat:build:mv2
+      builds-from-run: ${{ github.run_id }}
+      zip: true
+    secrets: inherit
+
+  build-experimental-webpack:
+    uses: ./.github/workflows/run-build.yml
+    with:
+      is-high-risk-environment: false
+      build-name: build-experimental-webpack
+      build-command: yarn webpack:lavamoat:build --type experimental
+      builds-from-run: ${{ github.run_id }}
+      zip: true
+    secrets: inherit
+
+  build-experimental-mv2-webpack:
+    uses: ./.github/workflows/run-build.yml
+    with:
+      is-high-risk-environment: false
+      build-name: build-experimental-mv2-webpack
+      build-command: yarn webpack:lavamoat:build:mv2 --type experimental
+      builds-from-run: ${{ github.run_id }}
+      zip: true
+    secrets: inherit
+
   post-nightly-builds:
     needs:
       - build-dist-browserify
       - build-dist-mv2-browserify
       - build-experimental-browserify
       - build-experimental-mv2-browserify
+      - build-dist-webpack
+      - build-dist-mv2-webpack
+      - build-experimental-webpack
+      - build-experimental-mv2-webpack
     runs-on: ubuntu-latest
     if: ${{ always() }}
     env:
@@ -59,7 +103,7 @@ jobs:
       BRANCH: ${{ github.ref_name || 'main' }}
       HOST_URL: ${{ vars.AWS_CLOUDFRONT_URL }}/${{ github.event.repository.name }}/${{ github.run_id }}
       SLACK_NIGHTLY_BUILDS_WEBHOOK_URL: ${{ secrets.SLACK_NIGHTLY_BUILDS_WEBHOOK_URL }}
-      BUILD_STATUS: ${{ needs.build-dist-browserify.result == 'success' && needs.build-dist-mv2-browserify.result == 'success' && needs.build-experimental-browserify.result == 'success' && needs.build-experimental-mv2-browserify.result == 'success' && 'success' || 'failure' }}
+      BUILD_STATUS: ${{ needs.build-dist-browserify.result == 'success' && needs.build-dist-mv2-browserify.result == 'success' && needs.build-experimental-browserify.result == 'success' && needs.build-experimental-mv2-browserify.result == 'success' && needs.build-dist-webpack.result == 'success' && needs.build-dist-mv2-webpack.result == 'success' && needs.build-experimental-webpack.result == 'success' && needs.build-experimental-mv2-webpack.result == 'success' && 'success' || 'failure' }}
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v3

--- a/development/metamaskbot-build-announce/artifacts.test.ts
+++ b/development/metamaskbot-build-announce/artifacts.test.ts
@@ -1,7 +1,6 @@
 import {
   getArtifactLinks,
   getBuildLinks,
-  getWebpackBuildLinks,
   formatBuildLinks,
   artifactExists,
   discoverBundleArtifacts,
@@ -9,6 +8,7 @@ import {
 } from './artifacts';
 
 const HOST = 'https://ci.example.com';
+const VERSION = '12.0.0';
 
 describe('getArtifactLinks', () => {
   it('returns URLs using the provided host, owner, repo, and runId', () => {
@@ -38,63 +38,65 @@ describe('getArtifactLinks', () => {
 });
 
 describe('getBuildLinks', () => {
-  it('returns chrome and firefox URLs for each build variant', () => {
-    const builds = getBuildLinks(HOST, '12.0.0');
+  it('returns browserify and webpack build URLs', () => {
+    const builds = getBuildLinks({ hostUrl: HOST, version: VERSION });
 
-    expect(builds.builds.chrome).toContain('metamask-chrome-12.0.0.zip');
-    expect(builds.builds.firefox).toContain('metamask-firefox-12.0.0.zip');
-    expect(builds['builds (flask)'].chrome).toContain('flask');
-  });
-
-  it('includes all five build variants', () => {
-    const builds = getBuildLinks(HOST, '1.0.0');
-    const keys = Object.keys(builds);
-
-    expect(keys).toHaveLength(5);
-    expect(keys).toContain('builds');
-    expect(keys).toContain('builds (beta)');
-    expect(keys).toContain('builds (flask)');
-    expect(keys).toContain('builds (test)');
-    expect(keys).toContain('builds (test-flask)');
-  });
-});
-
-describe('getWebpackBuildLinks', () => {
-  it('returns chrome and firefox URLs for each webpack build variant', () => {
-    const builds = getWebpackBuildLinks(HOST, '12.0.0');
-
-    expect(builds['webpack builds'].chrome).toContain('build-dist-webpack');
-    expect(builds['webpack builds'].chrome).toContain(
-      'metamask-chrome-12.0.0.zip',
+    expect(builds.browserify.main.chrome).toContain(
+      `metamask-chrome-${VERSION}.zip`,
     );
-    expect(builds['webpack builds'].firefox).toContain(
-      'build-dist-mv2-webpack',
+    expect(builds.browserify.main.firefox).toContain(
+      `metamask-firefox-${VERSION}.zip`,
     );
-    expect(builds['webpack builds (flask)'].chrome).toContain('flask');
+    expect(builds.browserify.flask.chrome).toContain('flask');
   });
 
-  it('includes all five webpack build variants', () => {
-    const builds = getWebpackBuildLinks(HOST, '1.0.0');
-    const keys = Object.keys(builds);
+  it('includes all six build variants for each bundler', () => {
+    const builds = getBuildLinks({ hostUrl: HOST, version: VERSION });
+    const expected = [
+      'main',
+      'beta',
+      'experimental',
+      'flask',
+      'test',
+      'test-flask',
+    ];
 
-    expect(keys).toHaveLength(5);
-    expect(keys).toContain('webpack builds');
-    expect(keys).toContain('webpack builds (beta)');
-    expect(keys).toContain('webpack builds (flask)');
-    expect(keys).toContain('webpack builds (test)');
-    expect(keys).toContain('webpack builds (test-flask)');
+    expect(Object.keys(builds.browserify)).toStrictEqual(expected);
+    expect(Object.keys(builds.webpack)).toStrictEqual(expected);
+  });
+
+  it('uses correct artifact names for webpack builds', () => {
+    const builds = getBuildLinks({ hostUrl: HOST, version: VERSION });
+
+    expect(builds.webpack.main.chrome).toContain('build-dist-webpack');
+    expect(builds.webpack.main.chrome).toContain(
+      `metamask-chrome-${VERSION}.zip`,
+    );
+    expect(builds.webpack.main.firefox).toContain('build-dist-mv2-webpack');
+    expect(builds.webpack.flask.chrome).toContain('flask');
   });
 });
 
 describe('formatBuildLinks', () => {
-  it('renders label: platform links for each variant', () => {
-    const builds = getBuildLinks(HOST, '1.0.0');
-    const rows = formatBuildLinks(builds);
+  it('renders rows for both browserify and webpack builds', () => {
+    const buildLinks = getBuildLinks({ hostUrl: HOST, version: VERSION });
+    const rows = formatBuildLinks(buildLinks);
 
-    expect(rows).toHaveLength(5);
+    // 5 build types (excluding experimental) × 2 bundlers = 10 rows
+    expect(rows).toHaveLength(10);
     expect(rows[0]).toMatch(
       /^builds: <a href=".*">chrome<\/a>, <a href=".*">firefox<\/a>$/u,
     );
+  });
+
+  it('uses "builds" prefix for browserify and "webpack builds" for webpack', () => {
+    const buildLinks = getBuildLinks({ hostUrl: HOST, version: VERSION });
+    const rows = formatBuildLinks(buildLinks);
+
+    expect(rows[0]).toContain('builds:');
+    expect(rows[1]).toContain('builds (beta):');
+    expect(rows[5]).toContain('webpack builds:');
+    expect(rows[6]).toContain('webpack builds (beta):');
   });
 });
 
@@ -188,34 +190,34 @@ describe('buildArtifactsBody', () => {
   it('includes build links when postNewBuilds is true', async () => {
     const result = await buildArtifactsBody({
       hostUrl: HOST,
-      version: '12.0.0',
+      version: VERSION,
       shortSha: 'abc1234',
       artifacts: makeArtifacts(),
       postNewBuilds: true,
       lavamoatPolicyChanged: false,
     });
 
-    expect(result).toContain('metamask-chrome-12.0.0.zip');
+    expect(result).toContain(`metamask-chrome-${VERSION}.zip`);
     expect(result).toContain('build-dist-webpack');
   });
 
   it('omits build links when postNewBuilds is false', async () => {
     const result = await buildArtifactsBody({
       hostUrl: HOST,
-      version: '12.0.0',
+      version: VERSION,
       shortSha: 'abc1234',
       artifacts: makeArtifacts(),
       postNewBuilds: false,
       lavamoatPolicyChanged: false,
     });
 
-    expect(result).not.toContain('metamask-chrome-12.0.0.zip');
+    expect(result).not.toContain(`metamask-chrome-${VERSION}.zip`);
   });
 
   it('includes lavamoat viz link when lavamoatPolicyChanged is true', async () => {
     const result = await buildArtifactsBody({
       hostUrl: HOST,
-      version: '12.0.0',
+      version: VERSION,
       shortSha: 'abc1234',
       artifacts: makeArtifacts(),
       postNewBuilds: false,
@@ -228,7 +230,7 @@ describe('buildArtifactsBody', () => {
   it('wraps everything in a collapsible details element with the sha', async () => {
     const result = await buildArtifactsBody({
       hostUrl: HOST,
-      version: '12.0.0',
+      version: VERSION,
       shortSha: 'abc1234',
       artifacts: makeArtifacts(),
       postNewBuilds: false,

--- a/development/metamaskbot-build-announce/artifacts.ts
+++ b/development/metamaskbot-build-announce/artifacts.ts
@@ -81,70 +81,94 @@ export function getArtifactLinks(
   return { ...ARTIFACT_LINK_MAP, link };
 }
 
-type BuildType = {
-  chrome?: string;
-  firefox?: string;
+export type BuildType =
+  | 'main'
+  | 'beta'
+  | 'experimental'
+  | 'flask'
+  | 'test'
+  | 'test-flask';
+
+export type BuildBrowser = {
+  chrome: string;
+  firefox: string;
+};
+
+export type BuildLinks = {
+  browserify: Record<BuildType, BuildBrowser>;
+  webpack: Record<BuildType, BuildBrowser>;
 };
 
 /**
- * Returns a map of extension build download links keyed by build variant.
+ * Returns a map of extension build download links.
  *
- * @param hostUrl - Base URL for hosted artifacts.
- * @param version - The extension version string (from package.json).
- * @returns Map of label → { chrome?, firefox? } URLs.
+ * @param options - Configuration for build link generation.
+ * @param options.hostUrl - Base URL for hosted artifacts.
+ * @param options.version - The extension version string, e.g., `18.7.25`.
+ * @param options.releaseVersion - The (pre)release version of the extension, e.g., the `6` in `18.7.25-flask.6`.
+ * @returns `{ browserify, webpack }` each mapping BuildType → BuildBrowser URLs.
  */
-export function getBuildLinks(
-  hostUrl: string,
-  version: string,
-): Record<string, BuildType> {
+export function getBuildLinks({
+  hostUrl,
+  version,
+  releaseVersion = '0',
+}: {
+  hostUrl: string;
+  version: string;
+  releaseVersion?: string;
+}): BuildLinks {
   return {
-    builds: {
-      chrome: `${hostUrl}/build-dist-browserify/builds/metamask-chrome-${version}.zip`,
-      firefox: `${hostUrl}/build-dist-mv2-browserify/builds/metamask-firefox-${version}.zip`,
+    browserify: {
+      main: {
+        chrome: `${hostUrl}/build-dist-browserify/builds/metamask-chrome-${version}.zip`,
+        firefox: `${hostUrl}/build-dist-mv2-browserify/builds/metamask-firefox-${version}.zip`,
+      },
+      beta: {
+        chrome: `${hostUrl}/build-beta-browserify/builds/metamask-beta-chrome-${version}-beta.${releaseVersion}.zip`,
+        firefox: `${hostUrl}/build-beta-mv2-browserify/builds/metamask-beta-firefox-${version}-beta.${releaseVersion}.zip`,
+      },
+      experimental: {
+        chrome: `${hostUrl}/build-experimental-browserify/builds/metamask-experimental-chrome-${version}-experimental.${releaseVersion}.zip`,
+        firefox: `${hostUrl}/build-experimental-mv2-browserify/builds/metamask-experimental-firefox-${version}-experimental.${releaseVersion}.zip`,
+      },
+      flask: {
+        chrome: `${hostUrl}/build-flask-browserify/builds/metamask-flask-chrome-${version}-flask.${releaseVersion}.zip`,
+        firefox: `${hostUrl}/build-flask-mv2-browserify/builds/metamask-flask-firefox-${version}-flask.${releaseVersion}.zip`,
+      },
+      test: {
+        chrome: `${hostUrl}/build-test-browserify/builds/metamask-chrome-${version}.zip`,
+        firefox: `${hostUrl}/build-test-mv2-browserify/builds/metamask-firefox-${version}.zip`,
+      },
+      'test-flask': {
+        chrome: `${hostUrl}/build-test-flask-browserify/builds/metamask-flask-chrome-${version}-flask.${releaseVersion}.zip`,
+        firefox: `${hostUrl}/build-test-flask-mv2-browserify/builds/metamask-flask-firefox-${version}-flask.${releaseVersion}.zip`,
+      },
     },
-    'builds (beta)': {
-      chrome: `${hostUrl}/build-beta-browserify/builds/metamask-beta-chrome-${version}-beta.0.zip`,
-      firefox: `${hostUrl}/build-beta-mv2-browserify/builds/metamask-beta-firefox-${version}-beta.0.zip`,
-    },
-    'builds (flask)': {
-      chrome: `${hostUrl}/build-flask-browserify/builds/metamask-flask-chrome-${version}-flask.0.zip`,
-      firefox: `${hostUrl}/build-flask-mv2-browserify/builds/metamask-flask-firefox-${version}-flask.0.zip`,
-    },
-    'builds (test)': {
-      chrome: `${hostUrl}/build-test-browserify/builds/metamask-chrome-${version}.zip`,
-      firefox: `${hostUrl}/build-test-mv2-browserify/builds/metamask-firefox-${version}.zip`,
-    },
-    'builds (test-flask)': {
-      chrome: `${hostUrl}/build-test-flask-browserify/builds/metamask-flask-chrome-${version}-flask.0.zip`,
-      firefox: `${hostUrl}/build-test-flask-mv2-browserify/builds/metamask-flask-firefox-${version}-flask.0.zip`,
-    },
-  };
-}
-
-export function getWebpackBuildLinks(
-  hostUrl: string,
-  version: string,
-): Record<string, BuildType> {
-  return {
-    'webpack builds': {
-      chrome: `${hostUrl}/build-dist-webpack/builds/metamask-chrome-${version}.zip`,
-      firefox: `${hostUrl}/build-dist-mv2-webpack/builds/metamask-firefox-${version}.zip`,
-    },
-    'webpack builds (beta)': {
-      chrome: `${hostUrl}/build-beta-webpack/builds/metamask-chrome-${version}-beta.0.zip`,
-      firefox: `${hostUrl}/build-beta-mv2-webpack/builds/metamask-firefox-${version}-beta.0.zip`,
-    },
-    'webpack builds (flask)': {
-      chrome: `${hostUrl}/build-flask-webpack/builds/metamask-chrome-${version}-flask.0.zip`,
-      firefox: `${hostUrl}/build-flask-mv2-webpack/builds/metamask-firefox-${version}-flask.0.zip`,
-    },
-    'webpack builds (test)': {
-      chrome: `${hostUrl}/build-test-webpack/builds/metamask-chrome-${version}.zip`,
-      firefox: `${hostUrl}/build-test-mv2-webpack/builds/metamask-firefox-${version}.zip`,
-    },
-    'webpack builds (test-flask)': {
-      chrome: `${hostUrl}/build-test-flask-webpack/builds/metamask-chrome-${version}-flask.0.zip`,
-      firefox: `${hostUrl}/build-test-flask-mv2-webpack/builds/metamask-firefox-${version}-flask.0.zip`,
+    webpack: {
+      main: {
+        chrome: `${hostUrl}/build-dist-webpack/builds/metamask-chrome-${version}.zip`,
+        firefox: `${hostUrl}/build-dist-mv2-webpack/builds/metamask-firefox-${version}.zip`,
+      },
+      beta: {
+        chrome: `${hostUrl}/build-beta-webpack/builds/metamask-chrome-${version}-beta.${releaseVersion}.zip`,
+        firefox: `${hostUrl}/build-beta-mv2-webpack/builds/metamask-firefox-${version}-beta.${releaseVersion}.zip`,
+      },
+      experimental: {
+        chrome: `${hostUrl}/build-experimental-webpack/builds/metamask-chrome-${version}-experimental.${releaseVersion}.zip`,
+        firefox: `${hostUrl}/build-experimental-mv2-webpack/builds/metamask-firefox-${version}-experimental.${releaseVersion}.zip`,
+      },
+      flask: {
+        chrome: `${hostUrl}/build-flask-webpack/builds/metamask-chrome-${version}-flask.${releaseVersion}.zip`,
+        firefox: `${hostUrl}/build-flask-mv2-webpack/builds/metamask-firefox-${version}-flask.${releaseVersion}.zip`,
+      },
+      test: {
+        chrome: `${hostUrl}/build-test-webpack/builds/metamask-chrome-${version}.zip`,
+        firefox: `${hostUrl}/build-test-mv2-webpack/builds/metamask-firefox-${version}.zip`,
+      },
+      'test-flask': {
+        chrome: `${hostUrl}/build-test-flask-webpack/builds/metamask-chrome-${version}-flask.${releaseVersion}.zip`,
+        firefox: `${hostUrl}/build-test-flask-mv2-webpack/builds/metamask-firefox-${version}-flask.${releaseVersion}.zip`,
+      },
     },
   };
 }
@@ -152,17 +176,25 @@ export function getWebpackBuildLinks(
 /**
  * Renders build links as HTML content rows (e.g. "builds: chrome, firefox").
  *
- * @param buildLinks - Map from getBuildLinks.
- * @returns Array of HTML strings, one per build variant.
+ * @param buildLinks - BuildLinks from getBuildLinks.
+ * @returns Array of HTML strings, one per bundler/build type combination.
  */
-export function formatBuildLinks(
-  buildLinks: Record<string, BuildType>,
-): string[] {
-  return Object.entries(buildLinks).map(([label, builds]) => {
-    const links = Object.entries(builds).map(
-      ([platform, url]) => `<a href="${url}">${platform}</a>`,
+export function formatBuildLinks(buildLinks: BuildLinks): string[] {
+  return Object.entries(buildLinks).flatMap(([bundler, types]) => {
+    const prefix = bundler === 'browserify' ? 'builds' : 'webpack builds';
+    return (
+      Object.entries(types)
+        // Experimental builds are only created nightly, not on PRs
+        // so we exclude them from the PR comment to avoid confusion.
+        .filter(([variant]) => variant !== 'experimental')
+        .map(([variant, builds]) => {
+          const label = variant === 'main' ? prefix : `${prefix} (${variant})`;
+          const links = Object.entries(builds).map(
+            ([platform, url]) => `<a href="${url}">${platform}</a>`,
+          );
+          return `${label}: ${links.join(', ')}`;
+        })
     );
-    return `${label}: ${links.join(', ')}`;
   });
 }
 
@@ -210,7 +242,7 @@ export async function discoverBundleArtifacts(
  *
  * @param options - Configuration for the artifacts body.
  * @param options.hostUrl - Base URL for hosted artifacts.
- * @param options.version - Extension version string (from package.json).
+ * @param options.version - The extension version string (from package.json).
  * @param options.shortSha - Abbreviated commit hash.
  * @param options.artifacts - Artifact links from getArtifactLinks.
  * @param options.postNewBuilds - Whether to include extension build links.
@@ -235,10 +267,7 @@ export async function buildArtifactsBody({
   const contentRows: string[] = [];
 
   if (postNewBuilds) {
-    contentRows.push(
-      ...formatBuildLinks(getBuildLinks(hostUrl, version)),
-      ...formatBuildLinks(getWebpackBuildLinks(hostUrl, version)),
-    );
+    contentRows.push(...formatBuildLinks(getBuildLinks({ hostUrl, version })));
   }
 
   if (lavamoatPolicyChanged) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/41073?quickstart=1)

The `buildMap` variable maps build types to file URLs (e.g., `build-dist-browserify`, `build-beta-mv2-browserify`, `build-flask-browserify`), is currently duplicated across three different files in the codebase. This causes redundancy and makes it difficult to manage. The objective is to consolidate this variable into a single location and ensure all scripts utilize this unified definition.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/5440

## **Manual testing steps**

1. All the build links should still work in the metamaskbot comment.

## **Screenshots/Recordings**

Not applicable

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how multiple automation scripts construct artifact URLs (Slack nightly notifications, PR comments, and devcontainer downloads), which could break build links if naming/versioning assumptions are wrong.
> 
> **Overview**
> Consolidates extension artifact URL construction into `development/metamaskbot-build-announce/artifacts.ts` via a new `getBuildLinks({ hostUrl, version, releaseVersion })` API that returns both **browserify** and **webpack** links and introduces a typed `BuildType` including `experimental`.
> 
> Updates the devcontainer `download-builds` script, the Slack nightly build notifier, and the PR “Builds ready” comment generator to consume this shared link map; PR comments now render rows for both bundlers while intentionally excluding `experimental` links. Tests are updated to match the new link structure and release-versioned filename patterns.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5fe9d04e27264b0747387c28b64baf910c431ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->