### PR TITLE
fix: responsiveness of education splash screen for musd convert

### DIFF
--- a/ui/pages/musd/index.tsx
+++ b/ui/pages/musd/index.tsx
@@ -38,7 +38,7 @@ const MusdConversionPage: React.FC = () => {
   }
 
   return (
-    <div className="musd-conversion-page" style={{ height: '100%', flex: 1 }}>
+    <div className="musd-conversion-page" style={{ minHeight: '100%', flex: 1, display: 'flex', flexDirection: 'column' }}>
       <Routes>
         {/* Education screen */}
         <Route

--- a/ui/pages/musd/index.tsx
+++ b/ui/pages/musd/index.tsx
@@ -38,7 +38,18 @@ const MusdConversionPage: React.FC = () => {
   }
 
   return (
-    <div className="musd-conversion-page" style={{ minHeight: '100%', flex: 1, display: 'flex', flexDirection: 'column' }}>
+    <div
+      className="musd-conversion-page"
+      style={{
+        flex: 1,
+        minHeight: 0,
+        overflow: 'hidden',
+        display: 'flex',
+        flexDirection: 'column',
+        width: '100%',
+        backgroundColor: 'var(--color-background-default)',
+      }}
+    >
       <Routes>
         {/* Education screen */}
         <Route

--- a/ui/pages/musd/screens/education.tsx
+++ b/ui/pages/musd/screens/education.tsx
@@ -263,7 +263,12 @@ const MusdEducationScreen: React.FC = () => {
   return (
     <Box
       className="musd-education-screen"
-      style={{ display: 'flex', flexDirection: 'column', height: '100%' }}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        minHeight: '100%',
+        flex: 1,
+      }}
       flexDirection={BoxFlexDirection.Column}
       backgroundColor={BoxBackgroundColor.BackgroundDefault}
     >

--- a/ui/pages/musd/screens/education.tsx
+++ b/ui/pages/musd/screens/education.tsx
@@ -266,8 +266,10 @@ const MusdEducationScreen: React.FC = () => {
       style={{
         display: 'flex',
         flexDirection: 'column',
-        minHeight: '100%',
         flex: 1,
+        minHeight: 0,
+        width: '100%',
+        overflow: 'hidden',
       }}
       flexDirection={BoxFlexDirection.Column}
       backgroundColor={BoxBackgroundColor.BackgroundDefault}
@@ -278,6 +280,7 @@ const MusdEducationScreen: React.FC = () => {
         justifyContent={BoxJustifyContent.End}
         paddingTop={3}
         paddingRight={4}
+        style={{ flexShrink: 0 }}
       >
         <ButtonIcon
           iconName={IconName.Close}
@@ -289,82 +292,101 @@ const MusdEducationScreen: React.FC = () => {
         />
       </Box>
 
-      {/* Main content – vertically centered */}
+      {/* Main content – scrolls on short viewports; CTAs stay pinned below */}
       <Box
         flexDirection={BoxFlexDirection.Column}
-        alignItems={BoxAlignItems.Center}
-        justifyContent={BoxJustifyContent.Center}
         paddingLeft={4}
         paddingRight={4}
-        style={{ flex: 1 }}
+        style={{ flex: 1, minHeight: 0, overflowY: 'auto' }}
       >
-        {/* Hero headline */}
-        <Box marginBottom={3}>
-          <Text
-            variant={TextVariant.DisplayMd}
-            fontFamily={FontFamily.Hero}
-            textAlign={TextAlign.Center}
-            color={TextColor.TextDefault}
-            textTransform={TextTransform.Uppercase}
-          >
-            {t('musdEducationHeadline', [String(MUSD_CONVERSION_APY)])}
-          </Text>
-        </Box>
-
-        {/* Body copy */}
-        <Box marginBottom={4}>
-          <Text
-            variant={TextVariant.BodyMd}
-            textAlign={TextAlign.Center}
-            color={TextColor.TextAlternative}
-          >
-            {t('musdBonusExplanation', [
-              String(MUSD_CONVERSION_APY),
-              <TextButton key="terms-link" size={TextButtonSize.BodyMd} asChild>
-                <a
-                  href={MUSD_CONVERSION_BONUS_TERMS_OF_USE}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  onClick={() => {
-                    const properties = {
-                      location: 'conversion_education_screen',
-                      url: MUSD_CONVERSION_BONUS_TERMS_OF_USE,
-                    };
-
-                    trackEvent({
-                      event: MetaMetricsEventName.MusdBonusTermsOfUsePressed,
-                      category: MetaMetricsEventCategory.MusdConversion,
-                      properties,
-                    });
-                  }}
-                >
-                  {t('musdTermsApply')}
-                </a>
-              </TextButton>,
-            ])}
-          </Text>
-        </Box>
-
-        {/* Central illustration */}
+        {/* Inner wrapper – safe center: vertically centers when content fits; start-aligns when it would overflow (Chromium). */}
         <Box
-          justifyContent={BoxJustifyContent.Center}
+          flexDirection={BoxFlexDirection.Column}
           alignItems={BoxAlignItems.Center}
+          style={{
+            minHeight: '100%',
+            // `safe center` avoids unsafe flex centering that clips the top of the hero when scrolling.
+            justifyContent: 'safe center',
+          }}
         >
-          <img
-            src={
-              theme === ThemeType.dark
-                ? MUSD_EDUCATION_COIN_IMAGE_DARK
-                : MUSD_EDUCATION_COIN_IMAGE_LIGHT
-            }
-            alt={t('musdGetMusd') as string}
-            width={252}
-            height={252}
-          />
+          {/* Hero headline */}
+          <Box marginBottom={3}>
+            <Text
+              variant={TextVariant.DisplayMd}
+              fontFamily={FontFamily.Hero}
+              textAlign={TextAlign.Center}
+              color={TextColor.TextDefault}
+              textTransform={TextTransform.Uppercase}
+            >
+              {t('musdEducationHeadline', [String(MUSD_CONVERSION_APY)])}
+            </Text>
+          </Box>
+
+          {/* Body copy */}
+          <Box marginBottom={4}>
+            <Text
+              variant={TextVariant.BodyMd}
+              textAlign={TextAlign.Center}
+              color={TextColor.TextAlternative}
+            >
+              {t('musdBonusExplanation', [
+                String(MUSD_CONVERSION_APY),
+                <TextButton
+                  key="terms-link"
+                  size={TextButtonSize.BodyMd}
+                  asChild
+                >
+                  <a
+                    href={MUSD_CONVERSION_BONUS_TERMS_OF_USE}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onClick={() => {
+                      const properties = {
+                        location: 'conversion_education_screen',
+                        url: MUSD_CONVERSION_BONUS_TERMS_OF_USE,
+                      };
+
+                      trackEvent({
+                        event: MetaMetricsEventName.MusdBonusTermsOfUsePressed,
+                        category: MetaMetricsEventCategory.MusdConversion,
+                        properties,
+                      });
+                    }}
+                  >
+                    {t('musdTermsApply')}
+                  </a>
+                </TextButton>,
+              ])}
+            </Text>
+          </Box>
+
+          {/* Central illustration */}
+          <Box
+            justifyContent={BoxJustifyContent.Center}
+            alignItems={BoxAlignItems.Center}
+          >
+            <img
+              src={
+                theme === ThemeType.dark
+                  ? MUSD_EDUCATION_COIN_IMAGE_DARK
+                  : MUSD_EDUCATION_COIN_IMAGE_LIGHT
+              }
+              alt={t('musdGetMusd') as string}
+              width={252}
+              height={252}
+              style={{ maxWidth: '100%', height: 'auto' }}
+            />
+          </Box>
         </Box>
       </Box>
 
       {/* Footer actions – full-width buttons with padding to match Figma */}
-      <Box flexDirection={BoxFlexDirection.Column} gap={2} padding={4}>
+      <Box
+        flexDirection={BoxFlexDirection.Column}
+        gap={2}
+        padding={4}
+        style={{ flexShrink: 0 }}
+      >
         <Box style={{ width: '100%' }}>
           <Button
             variant={ButtonVariant.Primary}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The mUSD education splash screen showed empty space below the content on shorter screen heights at initial load. The layout would self-correct after any resize event, but the initial render was broken.

Root cause: Both musd-conversion-page and musd-education-screen used height: 100%, which pins containers to exactly the viewport height. On short screens where the content (headline + body + image + buttons) overflows the viewport, the container doesn't grow — it stays fixed at viewport height while inner content spills out, creating a gap at the bottom when scrolling.

Fix: Replaced height: 100% with minHeight: 100% on both containers and ensured proper flex participation (flex: 1, display: flex, flex-direction: column). This allows containers to fill the viewport when content fits, but grow naturally when content overflows — eliminating the empty space.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/41077?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Update mUSD education splash screen showing empty space at the bottom on shorter screens

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-526

## **Manual testing steps**

- Open the extension in a browser window with a short height (e.g. ~500px tall)
- Navigate to the mUSD education splash screen
- Verify there is no empty space below the footer buttons
- Resize the window taller/shorter and confirm the layout adapts correctly
- On a tall window, verify content is still vertically centered as before

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="675" height="981" alt="image" src="https://github.com/user-attachments/assets/7eac7f28-ad29-466a-a660-666e56a68a2b" />

https://www.loom.com/share/2d841bf2dea54b5e95852171c3519119

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: layout-only style adjustments to the mUSD conversion/education screens with no changes to conversion logic, routing behavior, or data handling.
> 
> **Overview**
> Fixes initial-render layout issues on short viewports in the mUSD conversion education flow by reworking the page/screen containers to use a flex column layout with explicit `minHeight`/`overflow` handling.
> 
> The education screen now keeps the footer CTAs pinned, makes the main content area scrollable when needed, applies safer vertical centering (`justifyContent: 'safe center'`), and makes the hero image responsive to prevent clipping/extra whitespace.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a653fee9745978bf7f6b6e7a72e0d287128074d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->