### PR TITLE
fix: showing 0 ETH for network fee when value is small

### DIFF
--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -822,7 +822,7 @@
       "Reselect: Identity function warnings": 3
     },
     "ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.test.ts": {
-      "MetaMask: Background connection not initialized": 42,
+      "MetaMask: Background connection not initialized": 48,
       "Reselect: Identity function warnings": 3
     },
     "ui/pages/confirmations/components/confirm/info/hooks/useGasFeeToken.test.ts": {

--- a/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.test.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.test.ts
@@ -223,7 +223,7 @@ describe('useFeeCalculations', () => {
     expect(result.current.maxFeeNative).toBe('0.0046');
   });
 
-  it('displays "< 0.00001" for very small non-zero estimated and max fees', () => {
+  it('displays "< 0.0001" for very small non-zero estimated and max fees', () => {
     const transactionMeta = genUnapprovedContractInteractionConfirmation({
       address: CONTRACT_INTERACTION_SENDER_ADDRESS,
     }) as TransactionMeta;
@@ -236,8 +236,8 @@ describe('useFeeCalculations', () => {
       mockState,
     );
 
-    expect(result.current.estimatedFeeNative).toBe('< 0.00001');
-    expect(result.current.maxFeeNative).toBe('< 0.00001');
+    expect(result.current.estimatedFeeNative).toBe('< 0.0001');
+    expect(result.current.maxFeeNative).toBe('< 0.0001');
   });
 
   it('returns the correct estimate if quoted swap is displayed in info', () => {

--- a/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.test.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.test.ts
@@ -223,6 +223,23 @@ describe('useFeeCalculations', () => {
     expect(result.current.maxFeeNative).toBe('0.0046');
   });
 
+  it('displays "< 0.00001" for very small non-zero estimated and max fees', () => {
+    const transactionMeta = genUnapprovedContractInteractionConfirmation({
+      address: CONTRACT_INTERACTION_SENDER_ADDRESS,
+    }) as TransactionMeta;
+
+    transactionMeta.txParams.gas = '0x1';
+    transactionMeta.gasLimitNoBuffer = undefined;
+
+    const { result } = renderHookWithConfirmContextProvider(
+      () => useFeeCalculations(transactionMeta),
+      mockState,
+    );
+
+    expect(result.current.estimatedFeeNative).toBe('< 0.00001');
+    expect(result.current.maxFeeNative).toBe('< 0.00001');
+  });
+
   it('returns the correct estimate if quoted swap is displayed in info', () => {
     jest.spyOn(DappSwapContext, 'useDappSwapContext').mockReturnValue({
       selectedQuote: mockBridgeQuotes[0] as unknown as QuoteResponse,

--- a/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.ts
@@ -32,6 +32,15 @@ const EMPTY_FEES = {
   nativeCurrencyFee: EMPTY_FEE,
 };
 
+const MIN_NATIVE_FEE_THRESHOLD = 0.00001;
+
+function applySmallNativeFeeThreshold(nativeFee: string, hexFee: Hex): string {
+  if (nativeFee === '0' && new Numeric(hexFee, 16).greaterThan(0, 10)) {
+    return `< ${MIN_NATIVE_FEE_THRESHOLD}`;
+  }
+  return nativeFee;
+}
+
 export function useFeeCalculations(transactionMeta: TransactionMeta) {
   const currentCurrency = useSelector(getCurrentCurrency);
   const { chainId } = transactionMeta;
@@ -287,7 +296,10 @@ export function useFeeCalculations(transactionMeta: TransactionMeta) {
     estimatedFeeFiat: estimatedFees.currentCurrencyFee,
     estimatedFeeFiatWith18SignificantDigits:
       estimatedFees.currentCurrencyFeeWith18SignificantDigits,
-    estimatedFeeNative: estimatedFees.nativeCurrencyFee,
+    estimatedFeeNative: applySmallNativeFeeThreshold(
+      estimatedFees.nativeCurrencyFee,
+      estimatedFees.hexFee,
+    ),
     estimatedFeeNativeHex: add0x(estimatedFees.hexFee),
     l1FeeFiat: feesL1.currentCurrencyFee,
     l1FeeFiatWith18SignificantDigits:
@@ -300,6 +312,6 @@ export function useFeeCalculations(transactionMeta: TransactionMeta) {
     maxFeeFiat,
     maxFeeFiatWith18SignificantDigits,
     maxFeeHex: add0x(maxFeeHex),
-    maxFeeNative,
+    maxFeeNative: applySmallNativeFeeThreshold(maxFeeNative, maxFeeHex),
   };
 }

--- a/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.ts
@@ -32,7 +32,7 @@ const EMPTY_FEES = {
   nativeCurrencyFee: EMPTY_FEE,
 };
 
-const MIN_NATIVE_FEE_THRESHOLD = 0.00001;
+const MIN_NATIVE_FEE_THRESHOLD = 0.0001;
 
 function applySmallNativeFeeThreshold(nativeFee: string, hexFee: Hex): string {
   if (nativeFee === '0' && new Numeric(hexFee, 16).greaterThan(0, 10)) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

If network fee value is very small we show 0, should be showing `< 0.00001` for those cases instead.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-736

## **Manual testing steps**

1. Submit a confirmation on network that has fee very small
2. Check formation on network section on confirmation page

## **Screenshots/Recordings**
<img width="801" height="747" alt="Screenshot 2026-03-20 at 4 31 02 PM" src="https://github.com/user-attachments/assets/2dde5873-1646-436b-b4c4-b8c3ecc1f7b9" />

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI formatting change that only affects how extremely small non-zero native fees are displayed; no transaction values or fee calculations are altered.
> 
> **Overview**
> Fixes confirmations fee display so **very small but non-zero** native network fees no longer render as `0`.
> 
> `useFeeCalculations` now applies a minimum display threshold (`< 0.0001`) for `estimatedFeeNative` and `maxFeeNative` when the underlying hex fee is greater than zero but rounds to `0`, and adds a unit test (plus baseline update) to cover this case.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb7b7f4c3be41ad2c43d236bd6d39a084ce58d03. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->