### PR TITLE
fix: hide approvals in batch transactions when simulation fails

### DIFF
--- a/ui/pages/confirmations/components/simulation-details/simulation-details.test.tsx
+++ b/ui/pages/confirmations/components/simulation-details/simulation-details.test.tsx
@@ -397,6 +397,42 @@ describe('SimulationDetails', () => {
     );
   });
 
+  it('renders error instead of static rows when simulation is reverted', () => {
+    (useBalanceChanges as jest.Mock).mockReturnValue({
+      pending: false,
+      value: [],
+    });
+
+    const staticRows: StaticRow[] = [
+      {
+        label: 'Approve',
+        balanceChanges: [
+          {
+            asset: {
+              address: '0x123',
+              chainId: '0x321',
+              standard: TokenStandard.ERC20,
+            },
+            amount: new BigNumber(123),
+            fiatAmount: 456,
+            usdAmount: 789,
+          },
+        ],
+      },
+    ];
+
+    renderSimulationDetails(
+      { error: { code: SimulationErrorCode.Reverted, message: '' } },
+      false,
+      staticRows,
+    );
+
+    expect(
+      screen.getByText(/transaction is likely to fail/u),
+    ).toBeInTheDocument();
+    expect(BalanceChangeList).not.toHaveBeenCalled();
+  });
+
   it('indicates that simulation details are enforced', () => {
     (useBalanceChanges as jest.Mock).mockReturnValue({
       pending: false,

--- a/ui/pages/confirmations/components/simulation-details/simulation-details.test.tsx
+++ b/ui/pages/confirmations/components/simulation-details/simulation-details.test.tsx
@@ -433,6 +433,50 @@ describe('SimulationDetails', () => {
     expect(BalanceChangeList).not.toHaveBeenCalled();
   });
 
+  it('renders static rows when simulation error is chain not supported', () => {
+    (useBalanceChanges as jest.Mock).mockReturnValue({
+      pending: false,
+      value: [],
+    });
+
+    const staticRows: StaticRow[] = [
+      {
+        label: 'Approve',
+        balanceChanges: [
+          {
+            asset: {
+              address: '0x123',
+              chainId: '0x321',
+              standard: TokenStandard.ERC20,
+            },
+            amount: new BigNumber(123),
+            fiatAmount: 456,
+            usdAmount: 789,
+          },
+        ],
+      },
+    ];
+
+    renderSimulationDetails(
+      {
+        error: {
+          code: SimulationErrorCode.ChainNotSupported,
+          message: 'Chain is not supported',
+        },
+      },
+      false,
+      staticRows,
+    );
+
+    expect(BalanceChangeList).toHaveBeenCalledWith(
+      expect.objectContaining({
+        heading: 'Approve',
+        balanceChanges: staticRows[0].balanceChanges,
+      }),
+      {},
+    );
+  });
+
   it('indicates that simulation details are enforced', () => {
     (useBalanceChanges as jest.Mock).mockReturnValue({
       pending: false,

--- a/ui/pages/confirmations/components/simulation-details/simulation-details.tsx
+++ b/ui/pages/confirmations/components/simulation-details/simulation-details.tsx
@@ -469,7 +469,7 @@ export const SimulationDetails: React.FC<SimulationDetailsProps> = ({
     return null;
   }
 
-  if (error && !hasStaticData) {
+  if (error) {
     const inHeaderProp = error.code !== SimulationErrorCode.Reverted && {
       inHeader: <ErrorContent error={error} />,
     };

--- a/ui/pages/confirmations/components/simulation-details/simulation-details.tsx
+++ b/ui/pages/confirmations/components/simulation-details/simulation-details.tsx
@@ -469,7 +469,10 @@ export const SimulationDetails: React.FC<SimulationDetailsProps> = ({
     return null;
   }
 
-  if (error) {
+  if (
+    error &&
+    (error.code === SimulationErrorCode.Reverted || !hasStaticData)
+  ) {
     const inHeaderProp = error.code !== SimulationErrorCode.Reverted && {
       inHeader: <ErrorContent error={error} />,
     };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

In case there is error in simulation result static data should not be show, rather error should be shown.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Submit batched transaction with an approval
2. If simulation fails no static data should be displayed

## **Screenshots/Recordings**
TODO

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-logic change gated to `SimulationErrorCode.Reverted`, with new unit tests covering the intended rendering behavior.
> 
> **Overview**
> When simulation results include an error, `SimulationDetails` now **suppresses static balance-change rows for `SimulationErrorCode.Reverted`** and shows the reverted warning content instead.
> 
> For other errors (e.g., `ChainNotSupported`), static rows can still render when provided. Tests were added to assert both behaviors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dbc17bf23a7d912a28f897d7a04bbddb637d0d35. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->