### PR TITLE
ci: scope EXTENSION_BENCHMARK_STATS_TOKEN to environment in run-benchmarks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -399,9 +399,7 @@ jobs:
       - build-test-mv2-webpack
     with:
       builds-from-run: ${{ needs.get-requirements.outputs.builds-from-run }}
-    secrets:
-      INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
-      TEST_SRP_2: ${{ secrets.TEST_SRP_2 }}
+    secrets: inherit
 
   run-tests:
     name: Run tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -402,7 +402,6 @@ jobs:
     secrets:
       INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
       TEST_SRP_2: ${{ secrets.TEST_SRP_2 }}
-      EXTENSION_BENCHMARK_STATS_TOKEN: ${{ secrets.EXTENSION_BENCHMARK_STATS_TOKEN }}
 
   run-tests:
     name: Run tests

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -5,12 +5,6 @@ on:
         required: true
         type: string
         description: The run ID to get builds from
-    secrets:
-      INFURA_PROJECT_ID:
-        required: true
-      TEST_SRP_2:
-        required: false
-        description: Required for userJourneyAccountManagement (import-srp-home). 12-word seed phrase.
 env:
   COMMANDS: |
     {

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -11,10 +11,6 @@ on:
       TEST_SRP_2:
         required: false
         description: Required for userJourneyAccountManagement (import-srp-home). 12-word seed phrase.
-      EXTENSION_BENCHMARK_STATS_TOKEN:
-        required: false
-        description: Required for committing benchmark stats to extension_benchmark_stats on main.
-
 env:
   COMMANDS: |
     {
@@ -302,6 +298,7 @@ jobs:
       }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    environment: ${{ github.ref_name == github.event.repository.default_branch && 'default-branch' || 'release-ci' }}
     env:
       EXTENSION_BENCHMARK_STATS_TOKEN: ${{ secrets.EXTENSION_BENCHMARK_STATS_TOKEN }}
       HEAD_COMMIT_HASH: ${{ github.sha }}


### PR DESCRIPTION
## **Description**

Fixes a gap left by the concurrent merge of #41021 and #41013. PR #41021 moved `store-benchmark-stats` from `main.yml` to `run-benchmarks.yml`, but the environment scoping added by #41013 was lost in the move. The token was still being passed explicitly from the caller (repo-level scope), which will break once the Patroll cleanup ([MetaMask/patroll#71](https://github.com/MetaMask/patroll/pull/71)) removes the repo-level duplicate.

**What:**

1. Remove `EXTENSION_BENCHMARK_STATS_TOKEN` from `workflow_call.secrets` in `run-benchmarks.yml`
2. Remove `EXTENSION_BENCHMARK_STATS_TOKEN` from the caller's explicit `secrets:` block in `main.yml`
3. Add `environment` declaration to `store-benchmark-stats` job so the token resolves directly from `default-branch` (on `main` pushes) or `release-ci` (on `release/*` pushes)

**Why:**

Without this change, merging [MetaMask/patroll#71](https://github.com/MetaMask/patroll/pull/71) would cause `store-benchmark-stats` to fail with `exit 1` because the token would be empty (repo-level secret removed, no environment to resolve from).

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/41095?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [INFRA-3387](https://consensyssoftware.atlassian.net/browse/INFRA-3387)
Prerequisite for: [MetaMask/patroll#71](https://github.com/MetaMask/patroll/pull/71)

## **Manual testing steps**

1. Merge this PR to `main`
2. Verify `store-benchmark-stats` job completes successfully on the next push to `main`
3. Once verified, merge Patroll PR [#71](https://github.com/MetaMask/patroll/pull/71)

## **Screenshots/Recordings**

### **Before**

N/A — CI workflow changes only

### **After**

N/A — CI workflow changes only

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[INFRA-3387]: https://consensyssoftware.atlassian.net/browse/INFRA-3387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ