### PR TITLE
ci: Fix update workflow for hosted Storybook instance

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "announce": "node development/announcer.js",
     "storybook": "storybook dev -p 6006 -c .storybook",
     "storybook:build": "storybook build -c .storybook -o storybook-build",
-    "storybook:deploy": "storybook-to-ghpages --existing-output-dir storybook-build --remote storybook --branch stable",
+    "storybook:deploy": "storybook-to-ghpages --existing-output-dir storybook-build --remote storybook --branch main",
     "update-changelog": "auto-changelog update --rc --autoCategorize --useChangelogEntry --useShortPrLink --requirePrNumbers",
     "generate:migration": "./development/generate-migration.sh",
     "lavamoat:build": "lavamoat development/build/index.js --policy lavamoat/build-system/policy.json --policyOverride lavamoat/build-system/policy-override.json",


### PR DESCRIPTION
## **Description**

The hosted Storybook instance we have that tracks the `main` branch was accidentally updated a few months back to push changes to the wrong branch on the `metamask-storybook` repository (it used to push to `master`, which was impacted by the rename of `master` to `stable` on this repository). This in turn meant that these updates were not being hosted properly on GitHub pages.

`metamask-storybook` has been updated to use the standard `main` default branch name, and the deployment script has been updated to push to that branch. This will ensure each commit is properly reflected on the `metamask-storybook` GitHub pages site again.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/41100?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes the `storybook:deploy` script target branch for GitHub Pages and does not affect runtime code or builds beyond deployment destination.
> 
> **Overview**
> Updates the `storybook:deploy` npm script in `package.json` to publish the built Storybook site to the `main` branch (instead of `stable`) on the `storybook` remote, aligning deployments with the hosted Storybook repo’s default branch.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1608daa68a92ace01b24c5b3848bfd4c8bc956b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->