### PR TITLE
test: normalize ManifestPlugin watch path assertions

### DIFF
--- a/development/webpack/test/plugins.ManifestPlugin.test.ts
+++ b/development/webpack/test/plugins.ManifestPlugin.test.ts
@@ -9,6 +9,9 @@ import { transformManifest } from '../utils/plugins/ManifestPlugin/helpers';
 import { MANIFEST_DEV_KEY } from '../../build/constants';
 import { generateCases, type Combination, mockWebpack } from './helpers';
 
+const endsWithPath = (value: string, ...segments: string[]) =>
+  value.endsWith(join(...segments));
+
 describe('ManifestPlugin', () => {
   describe('Plugin', () => {
     const matrix = {
@@ -1309,7 +1312,7 @@ describe('ManifestPlugin', () => {
       // Get the watched files from fileDependencies
       const deps = [...compilation.fileDependencies];
       const baseManifestDep = deps.find((d) =>
-        d.endsWith('manifest/v3/_base.json'),
+        endsWithPath(d, 'manifest', 'v3', '_base.json'),
       );
       assert.ok(baseManifestDep, 'should have base manifest in dependencies');
 
@@ -1373,22 +1376,22 @@ describe('ManifestPlugin', () => {
       const deps = [...compilation.fileDependencies];
       // Should include base manifest
       assert.ok(
-        deps.some((d) => d.endsWith('manifest/v3/_base.json')),
+        deps.some((d) => endsWithPath(d, 'manifest', 'v3', '_base.json')),
         'should watch the base manifest file',
       );
       // Should include browser-specific manifest
       assert.ok(
-        deps.some((d) => d.endsWith('manifest/v3/chrome.json')),
+        deps.some((d) => endsWithPath(d, 'manifest', 'v3', 'chrome.json')),
         'should watch the browser-specific manifest file',
       );
       // Should include build type base manifest
       assert.ok(
-        deps.some((d) => d.endsWith('beta/manifest/_base.json')),
+        deps.some((d) => endsWithPath(d, 'beta', 'manifest', '_base.json')),
         'should watch the build type base manifest file',
       );
       // Should include build type browser manifest
       assert.ok(
-        deps.some((d) => d.endsWith('beta/manifest/chrome.json')),
+        deps.some((d) => endsWithPath(d, 'beta', 'manifest', 'chrome.json')),
         'should watch the build type browser-specific manifest file',
       );
     });
@@ -1451,7 +1454,7 @@ describe('ManifestPlugin', () => {
       const deps = [...compilation.fileDependencies];
       // Should include base manifest (exists)
       assert.ok(
-        deps.some((d) => d.endsWith('manifest/v3/_base.json')),
+        deps.some((d) => endsWithPath(d, 'manifest', 'v3', '_base.json')),
         'should watch the base manifest file',
       );
       // Should NOT include non-existent build type files


### PR DESCRIPTION
## **Description**

The watch-mode ManifestPlugin tests were asserting `compilation.fileDependencies` with hardcoded POSIX-style suffixes. On Windows, the plugin records native filesystem paths with backslashes, so those assertions failed even though the plugin behavior was correct.

This change keeps the test intent the same, but switches the affected assertions to path-aware suffix matching via `path.join(...)`. That makes the tests pass on both Windows and POSIX without changing the plugin itself.

## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Run `yarn.cmd tsx --test development/webpack/test/plugins.ManifestPlugin.test.ts`.
2. Run `yarn.cmd lint:changed:fix`.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability.
- [x] I’ve included tests if applicable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only updates test assertions to use path-aware suffix matching, without changing ManifestPlugin behavior or production code paths.
> 
> **Overview**
> Normalizes `ManifestPlugin` watch-mode tests to be Windows/POSIX compatible by replacing hardcoded POSIX-style `endsWith('manifest/...')` assertions with a shared `endsWithPath()` helper based on `path.join()`.
> 
> This keeps the test intent the same while avoiding failures due to platform-specific path separators in `compilation.fileDependencies`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ffdf0150a6d84b0f01100937d3d2d570051534c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->