### PR TITLE
test: remove ManifestPlugin debug logging

### DIFF
--- a/development/webpack/test/plugins.ManifestPlugin.test.ts
+++ b/development/webpack/test/plugins.ManifestPlugin.test.ts
@@ -354,7 +354,6 @@ describe('ManifestPlugin', () => {
       assert(transform, 'transform should be truthy');
 
       const transformed = transform(emptyTestManifest, 'chrome');
-      console.log('Transformed:', transformed);
       assert.deepStrictEqual(
         transformed,
         mockFlags,


### PR DESCRIPTION
## **Description**

This removes a stray `console.log` from the `manifest flags in development mode` tests in `plugins.ManifestPlugin.test.ts`.

Most of the file keeps test output quiet, but this one assertion path was still printing the transformed manifest during normal runs. The change is test-only and does not affect `ManifestPlugin` behavior.

Note: the full `plugins.ManifestPlugin.test.ts` file still has a separate Windows path assertion issue on `main`. That is tracked independently in #41105 and is not part of this cleanup.

## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Run `yarn.cmd tsx --test --test-name-pattern "manifest flags in development mode" development/webpack/test/plugins.ManifestPlugin.test.ts`.
2. Run `yarn.cmd lint:changed:fix`.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability.
- [x] I’ve included tests if applicable.