### PR TITLE
fix: network manager modal views cp-13.24.0

### DIFF
--- a/ui/components/multichain/network-manager/components/add-network/AddNetwork.tsx
+++ b/ui/components/multichain/network-manager/components/add-network/AddNetwork.tsx
@@ -1,6 +1,6 @@
 import { UpdateNetworkFields } from '@metamask/network-controller';
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import { NetworksForm } from '../../../../../pages/settings/networks-tab/networks-form/networks-form';
 import { useNetworkFormState } from '../../../../../pages/settings/networks-tab/networks-form/networks-form-state';
 
@@ -15,24 +15,25 @@ export const AddNetwork: React.FC<AddNetworkProps> = ({
   network,
   isEdit = false,
 }) => {
-  const navigate = useNavigate();
+  const [, setSearchParams] = useSearchParams();
   return (
     <NetworksForm
       toggleNetworkMenuAfterSubmit={false}
       onComplete={() => {
-        console.log(`onComplete pushing to /?tab=custom-networks`);
-        navigate('/?tab=custom-networks');
+        setSearchParams({});
       }}
       onEdit={() => {
-        navigate('/edit');
+        setSearchParams({ view: 'edit' });
       }}
       networkFormState={networkFormState}
       existingNetwork={network}
       onRpcAdd={() => {
-        navigate(isEdit ? '/edit-rpc' : '/add-rpc');
+        setSearchParams({ view: isEdit ? 'edit-rpc' : 'add-rpc' });
       }}
       onBlockExplorerAdd={() => {
-        navigate(isEdit ? '/edit-explorer-url' : '/add-explorer-url');
+        setSearchParams({
+          view: isEdit ? 'edit-explorer-url' : 'add-explorer-url',
+        });
       }}
     />
   );

--- a/ui/components/multichain/network-manager/components/custom-networks/custom-networks.tsx
+++ b/ui/components/multichain/network-manager/components/custom-networks/custom-networks.tsx
@@ -1,7 +1,7 @@
 import { type MultichainNetworkConfiguration } from '@metamask/multichain-network-controller';
 import React, { useCallback, useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useNavigate } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import { endTrace, TraceName } from '../../../../../../shared/lib/trace';
 import {
   convertCaipToHexChainId,
@@ -41,7 +41,7 @@ import { hideModal } from '../../../../../store/actions';
 
 export const CustomNetworks = React.memo(() => {
   const t = useI18nContext();
-  const navigate = useNavigate();
+  const [, setSearchParams] = useSearchParams();
   const dispatch = useDispatch();
   const orderedNetworksList = useSelector(getOrderedNetworksList);
   const [, evmNetworks] = useSelector(
@@ -186,8 +186,8 @@ export const CustomNetworks = React.memo(() => {
 
   // Memoize the add button click handler
   const handleAddNetworkClick = useCallback(() => {
-    navigate('/add');
-  }, [navigate]);
+    setSearchParams({ view: 'add' });
+  }, [setSearchParams]);
 
   return (
     <>

--- a/ui/components/multichain/network-manager/hooks/useNetworkItemCallbacks.ts
+++ b/ui/components/multichain/network-manager/hooks/useNetworkItemCallbacks.ts
@@ -3,7 +3,7 @@ import { EthScope } from '@metamask/keyring-api';
 import { type MultichainNetworkConfiguration } from '@metamask/multichain-network-controller';
 import { type Hex } from '@metamask/utils';
 import { useDispatch, useSelector } from 'react-redux';
-import { useNavigate } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import { CHAIN_ID_PORTFOLIO_LANDING_PAGE_URL_MAP } from '../../../../../shared/constants/network';
 import {
   convertCaipToHexChainId,
@@ -24,7 +24,7 @@ import { useAccountCreationOnNetworkChange } from '../../../../hooks/accounts/us
 
 export const useNetworkItemCallbacks = () => {
   const dispatch = useDispatch();
-  const navigate = useNavigate();
+  const [, setSearchParams] = useSearchParams();
   const isUnlocked = useSelector(getIsUnlocked);
   const currentChainId = useSelector(getSelectedMultichainNetworkChainId);
   const isNetworkDiscoverButtonEnabled = useSelector(
@@ -116,7 +116,7 @@ export const useNetworkItemCallbacks = () => {
               nickname: network.name,
             }),
           );
-          navigate('/edit');
+          setSearchParams({ view: 'edit' });
         },
         onDiscoverClick: isDiscoverBtnEnabled(hexChainId)
           ? () => {
@@ -128,7 +128,7 @@ export const useNetworkItemCallbacks = () => {
           : undefined,
         onRpcConfigEdit: hasMultiRpcOptions(network)
           ? () => {
-              navigate('/add-rpc');
+              setSearchParams({ view: 'add-rpc' });
               dispatch(
                 setEditedNetwork({
                   chainId: hexChainId,
@@ -142,7 +142,7 @@ export const useNetworkItemCallbacks = () => {
               chainId: hexChainId,
             }),
           );
-          navigate('/select-rpc');
+          setSearchParams({ view: 'select-rpc' });
         },
       };
     },
@@ -152,7 +152,7 @@ export const useNetworkItemCallbacks = () => {
       hasMultiRpcOptions,
       isUnlocked,
       isDiscoverBtnEnabled,
-      navigate,
+      setSearchParams,
     ],
   );
 

--- a/ui/components/multichain/network-manager/network-manager.test.tsx
+++ b/ui/components/multichain/network-manager/network-manager.test.tsx
@@ -13,6 +13,7 @@ import { NetworkManager } from './network-manager';
 // Mock the store actions
 jest.mock('../../../store/actions', () => ({
   hideModal: jest.fn(),
+  setEditedNetwork: jest.fn(),
 }));
 
 // Mock useDispatch
@@ -101,7 +102,7 @@ const mockNetworkConfigurations = {
 };
 
 describe('NetworkManager Component', () => {
-  const renderNetworkManager = () => {
+  const renderNetworkManager = (pathname = '/') => {
     const store = configureStore({
       ...mockState,
       metamask: {
@@ -125,7 +126,34 @@ describe('NetworkManager Component', () => {
         },
       },
     });
-    return renderWithProvider(<NetworkManager />, store);
+    return renderWithProvider(<NetworkManager />, store, pathname);
+  };
+
+  const renderNetworkManagerWithEditedNetwork = (pathname = '/') => {
+    const store = configureStore({
+      ...mockState,
+      metamask: {
+        ...mockState.metamask,
+        networkConfigurationsByChainId: mockNetworkConfigurations,
+        selectedNetworkClientId: 'mainnet',
+        providerConfig: {
+          chainId: '0x1',
+          rpcUrl: 'https://mainnet.infura.io/v3/123',
+          type: 'rpc',
+          ticker: 'ETH',
+        },
+        enabledNetworkMap: {
+          eip155: {
+            '0x1': true,
+          },
+        },
+      },
+      appState: {
+        ...mockState.appState,
+        editedNetwork: { chainId: '0x1', nickname: 'Ethereum' },
+      },
+    });
+    return renderWithProvider(<NetworkManager />, store, pathname);
   };
 
   const renderNetworkManagerWithNonEvmNetworkSelected = (stateOverrides?: {
@@ -237,5 +265,41 @@ describe('NetworkManager Component', () => {
     expect(
       screen.getByText(messages.addCustomNetwork.message),
     ).toBeInTheDocument();
+  });
+
+  it('submitting a new RPC URL from add-rpc view switches to add view', async () => {
+    renderNetworkManager('/?view=add-rpc');
+    fireEvent.change(screen.getByTestId('rpc-url-input-test'), {
+      target: { value: 'https://new-rpc.example.com' },
+    });
+    fireEvent.click(screen.getByText(messages.addUrl.message));
+    expect(screen.getByText(messages.addNetwork.message)).toBeInTheDocument();
+  });
+
+  it('submitting a new RPC URL from edit-rpc view switches to edit view', async () => {
+    renderNetworkManagerWithEditedNetwork('/?view=edit-rpc');
+    fireEvent.change(screen.getByTestId('rpc-url-input-test'), {
+      target: { value: 'https://new-rpc.example.com' },
+    });
+    fireEvent.click(screen.getByText(messages.addUrl.message));
+    expect(screen.getByText(messages.editNetwork.message)).toBeInTheDocument();
+  });
+
+  it('submitting a block explorer URL from add-explorer-url view switches to add view', async () => {
+    renderNetworkManager('/?view=add-explorer-url');
+    fireEvent.change(screen.getByTestId('explorer-url-input'), {
+      target: { value: 'https://explorer.example.com' },
+    });
+    fireEvent.click(screen.getByText(messages.addUrl.message));
+    expect(screen.getByText(messages.addNetwork.message)).toBeInTheDocument();
+  });
+
+  it('submitting a block explorer URL from edit-explorer-url view switches to edit view', async () => {
+    renderNetworkManagerWithEditedNetwork('/?view=edit-explorer-url');
+    fireEvent.change(screen.getByTestId('explorer-url-input'), {
+      target: { value: 'https://explorer.example.com' },
+    });
+    fireEvent.click(screen.getByText(messages.addUrl.message));
+    expect(screen.getByText(messages.editNetwork.message)).toBeInTheDocument();
   });
 });

--- a/ui/components/multichain/network-manager/network-manager.tsx
+++ b/ui/components/multichain/network-manager/network-manager.tsx
@@ -5,7 +5,7 @@ import {
 } from '@metamask/network-controller';
 import React, { useCallback, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Route, Routes, useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import * as URI from 'uri-js';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useNetworkFormState } from '../../../pages/settings/networks-tab/networks-form/networks-form-state';
@@ -32,11 +32,12 @@ export const NetworkManager = () => {
   const dispatch = useDispatch();
   const t = useI18nContext();
   const navigate = useNavigate();
-  const location = useLocation();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const view = searchParams.get('view') ?? '';
 
   const { initialTab } = useNetworkManagerInitialTab();
   const handleNewNetwork = () => {
-    navigate('/add');
+    setSearchParams({ view: 'add' });
   };
 
   const [, evmNetworks] = useSelector(
@@ -46,10 +47,10 @@ export const NetworkManager = () => {
     useSelector(getEditedNetwork) ?? {};
 
   const editedNetwork = useMemo((): UpdateNetworkFields | undefined => {
-    if (location.pathname === '/add') {
+    if (view === 'add') {
       return undefined;
     }
-    if (location.pathname === '/select-rpc') {
+    if (view === 'select-rpc') {
       return editingChainId
         ? evmNetworks[editingChainId as keyof typeof evmNetworks]
         : undefined;
@@ -59,7 +60,7 @@ export const NetworkManager = () => {
       : Object.entries(evmNetworks).find(
           ([chainId]) => chainId === editingChainId,
         )?.[1];
-  }, [editingChainId, editCompleted, evmNetworks, location.pathname]);
+  }, [editingChainId, editCompleted, evmNetworks, view]);
 
   const networkFormState = useNetworkFormState(editedNetwork);
 
@@ -78,14 +79,14 @@ export const NetworkManager = () => {
           defaultRpcEndpointIndex: networkFormState.rpcUrls.rpcEndpoints.length,
         });
 
-        if (location.pathname === '/edit-rpc') {
-          navigate('/edit');
+        if (view === 'edit-rpc') {
+          setSearchParams({ view: 'edit' });
         } else {
-          navigate('/add');
+          setSearchParams({ view: 'add' });
         }
       }
     },
-    [navigate, networkFormState, location.pathname],
+    [setSearchParams, networkFormState, view],
   );
 
   const handleAddExplorerUrl = useCallback(
@@ -104,16 +105,16 @@ export const NetworkManager = () => {
             defaultBlockExplorerUrlIndex:
               networkFormState.blockExplorers.blockExplorerUrls.length,
           });
-          if (location.pathname === '/edit-explorer-url') {
-            navigate('/edit');
+          if (view === 'edit-explorer-url') {
+            setSearchParams({ view: 'edit' });
           } else {
-            navigate('/add');
+            setSearchParams({ view: 'add' });
           }
           onComplete?.();
         }
       };
     },
-    [networkFormState, navigate, location.pathname],
+    [networkFormState, setSearchParams, view],
   );
 
   const handleClose = () => {
@@ -123,16 +124,16 @@ export const NetworkManager = () => {
   };
 
   const handleGoHome = () => {
-    navigate(DEFAULT_ROUTE);
+    setSearchParams({});
   };
 
   const handleEditOnComplete = useCallback(() => {
-    navigate('/edit');
-  }, [navigate]);
+    setSearchParams({ view: 'edit' });
+  }, [setSearchParams]);
 
   const handleAddOnComplete = useCallback(() => {
-    navigate('/add');
-  }, [navigate]);
+    setSearchParams({ view: 'add' });
+  }, [setSearchParams]);
 
   return (
     <Modal
@@ -142,142 +143,119 @@ export const NetworkManager = () => {
       isClosedOnOutsideClick
     >
       <ModalContent size={ModalContentSize.Md}>
-        <Routes>
-          <Route
-            path="/add"
-            element={
-              <>
-                <ModalHeader
-                  onClose={handleClose}
-                  onBack={handleGoHome}
-                  closeButtonProps={{
-                    'data-testid': 'modal-header-close-button',
-                  }}
-                >
-                  {t('addNetwork')}
-                </ModalHeader>
-                <AddNetwork
-                  networkFormState={networkFormState}
-                  network={editedNetwork as UpdateNetworkFields}
-                />
-              </>
-            }
-          />
-          <Route
-            path="/add-rpc"
-            element={
-              <>
-                <ModalHeader
-                  onClose={handleClose}
-                  onBack={handleNewNetwork}
-                  closeButtonProps={{
-                    'data-testid': 'modal-header-close-button',
-                  }}
-                >
-                  {t('addRpcUrl')}
-                </ModalHeader>
-                <AddRpcUrlModal onAdded={handleAddRPC} />
-              </>
-            }
-          />
-          <Route
-            path="/edit-rpc"
-            element={
-              <>
-                <ModalHeader
-                  onClose={handleClose}
-                  onBack={handleEditOnComplete}
-                  closeButtonProps={{
-                    'data-testid': 'modal-header-close-button',
-                  }}
-                >
-                  {t('addRpcUrl')}
-                </ModalHeader>
-                <AddRpcUrlModal onAdded={handleAddRPC} />
-              </>
-            }
-          />
-          <Route
-            path="/add-explorer-url"
-            element={
-              <>
-                <ModalHeader
-                  onClose={handleClose}
-                  onBack={handleNewNetwork}
-                  closeButtonProps={{
-                    'data-testid': 'modal-header-close-button',
-                  }}
-                >
-                  {t('addBlockExplorerUrl')}
-                </ModalHeader>
-                <AddBlockExplorerModal
-                  onAdded={handleAddExplorerUrl(handleAddOnComplete)}
-                />
-              </>
-            }
-          />
-          <Route
-            path="/edit-explorer-url"
-            element={
-              <>
-                <ModalHeader
-                  onClose={handleClose}
-                  onBack={handleNewNetwork}
-                  closeButtonProps={{
-                    'data-testid': 'modal-header-close-button',
-                  }}
-                >
-                  {t('addBlockExplorerUrl')}
-                </ModalHeader>
-                <AddBlockExplorerModal
-                  onAdded={handleAddExplorerUrl(handleEditOnComplete)}
-                />
-              </>
-            }
-          />
-          <Route
-            path="/edit"
-            element={
-              <>
-                <ModalHeader
-                  onClose={handleClose}
-                  onBack={handleGoHome}
-                  closeButtonProps={{
-                    'data-testid': 'modal-header-close-button',
-                  }}
-                >
-                  {t('editNetwork')}
-                </ModalHeader>
-                <AddNetwork
-                  networkFormState={networkFormState}
-                  network={editedNetwork as UpdateNetworkFields}
-                  isEdit={true}
-                />
-              </>
-            }
-          />
-          <Route
-            path="/select-rpc"
-            element={
-              <>
-                <ModalHeader
-                  onClose={handleClose}
-                  onBack={handleGoHome}
-                  closeButtonProps={{
-                    'data-testid': 'modal-header-close-button',
-                  }}
-                >
-                  {t('selectRpcUrl')}
-                </ModalHeader>
-                <SelectRpcUrlModal
-                  networkConfiguration={editedNetwork as NetworkConfiguration}
-                  onNetworkChange={handleClose}
-                />
-              </>
-            }
-          />
-          <Route path="/" element={<NetworkTabs initialTab={initialTab} />} />
-        </Routes>
+        {view === '' && <NetworkTabs initialTab={initialTab} />}
+        {view === 'add' && (
+          <>
+            <ModalHeader
+              onClose={handleClose}
+              onBack={handleGoHome}
+              closeButtonProps={{
+                'data-testid': 'modal-header-close-button',
+              }}
+            >
+              {t('addNetwork')}
+            </ModalHeader>
+            <AddNetwork
+              networkFormState={networkFormState}
+              network={editedNetwork as UpdateNetworkFields}
+            />
+          </>
+        )}
+        {view === 'add-rpc' && (
+          <>
+            <ModalHeader
+              onClose={handleClose}
+              onBack={handleNewNetwork}
+              closeButtonProps={{
+                'data-testid': 'modal-header-close-button',
+              }}
+            >
+              {t('addRpcUrl')}
+            </ModalHeader>
+            <AddRpcUrlModal onAdded={handleAddRPC} />
+          </>
+        )}
+        {view === 'edit-rpc' && (
+          <>
+            <ModalHeader
+              onClose={handleClose}
+              onBack={handleEditOnComplete}
+              closeButtonProps={{
+                'data-testid': 'modal-header-close-button',
+              }}
+            >
+              {t('addRpcUrl')}
+            </ModalHeader>
+            <AddRpcUrlModal onAdded={handleAddRPC} />
+          </>
+        )}
+        {view === 'add-explorer-url' && (
+          <>
+            <ModalHeader
+              onClose={handleClose}
+              onBack={handleNewNetwork}
+              closeButtonProps={{
+                'data-testid': 'modal-header-close-button',
+              }}
+            >
+              {t('addBlockExplorerUrl')}
+            </ModalHeader>
+            <AddBlockExplorerModal
+              onAdded={handleAddExplorerUrl(handleAddOnComplete)}
+            />
+          </>
+        )}
+        {view === 'edit-explorer-url' && (
+          <>
+            <ModalHeader
+              onClose={handleClose}
+              onBack={handleNewNetwork}
+              closeButtonProps={{
+                'data-testid': 'modal-header-close-button',
+              }}
+            >
+              {t('addBlockExplorerUrl')}
+            </ModalHeader>
+            <AddBlockExplorerModal
+              onAdded={handleAddExplorerUrl(handleEditOnComplete)}
+            />
+          </>
+        )}
+        {view === 'edit' && (
+          <>
+            <ModalHeader
+              onClose={handleClose}
+              onBack={handleGoHome}
+              closeButtonProps={{
+                'data-testid': 'modal-header-close-button',
+              }}
+            >
+              {t('editNetwork')}
+            </ModalHeader>
+            <AddNetwork
+              networkFormState={networkFormState}
+              network={editedNetwork as UpdateNetworkFields}
+              isEdit={true}
+            />
+          </>
+        )}
+        {view === 'select-rpc' && (
+          <>
+            <ModalHeader
+              onClose={handleClose}
+              onBack={handleGoHome}
+              closeButtonProps={{
+                'data-testid': 'modal-header-close-button',
+              }}
+            >
+              {t('selectRpcUrl')}
+            </ModalHeader>
+            <SelectRpcUrlModal
+              networkConfiguration={editedNetwork as NetworkConfiguration}
+              onNetworkChange={handleClose}
+            />
+          </>
+        )}
       </ModalContent>
     </Modal>
   );


### PR DESCRIPTION

## **Description**

Replace the Network Manager component's internal `<Routes>` view switching with conditional rendering. This is used for the add/edit custom networks views.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: #41042 

## **Manual testing steps**

1. Click Network Manager dropdown
2. Click Edit on any popular, custom or test network

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI routing refactor: replaces `react-router` path-based `<Routes>` with `useSearchParams` state, which can affect in-modal navigation/back behavior and any callers relying on prior sub-routes.
> 
> **Overview**
> Refactors the Network Manager modal to **stop using internal `<Routes>`/sub-paths** and instead drive its view state via the `view` query param (`useSearchParams`). Navigation actions in `AddNetwork`, `CustomNetworks`, and `useNetworkItemCallbacks` now update `view` (and clear it to return home) rather than calling `navigate()` to `/add`, `/edit`, etc.
> 
> Updates Network Manager logic that derives the `editedNetwork` and post-submit transitions (RPC/block explorer URL add flows) to use the query-param view, and extends `network-manager.test.tsx` with coverage for switching back to `add`/`edit` after submitting RPC or block explorer URLs from the corresponding `view` states.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 559efb726b7db355761d1be72e1407059a628be3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->