### PR TITLE
chore: Bump @metamask/gator-permissions-snap from ^1.3.0 to ^1.3.1 cp-13.24.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -336,7 +336,7 @@
     "@metamask/etherscan-link": "^3.0.0",
     "@metamask/gas-fee-controller": "^26.1.0",
     "@metamask/gator-permissions-controller": "^2.1.0",
-    "@metamask/gator-permissions-snap": "^1.3.0",
+    "@metamask/gator-permissions-snap": "^1.3.1",
     "@metamask/hw-wallet-sdk": "^0.5.0",
     "@metamask/institutional-wallet-snap": "1.3.4",
     "@metamask/jazzicon": "patch:@metamask/jazzicon@npm%3A2.0.0#~/.yarn/patches/@metamask-jazzicon-npm-2.0.0-36957be38d.patch",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6824,17 +6824,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/gator-permissions-snap@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "@metamask/gator-permissions-snap@npm:1.3.0"
+"@metamask/gator-permissions-snap@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "@metamask/gator-permissions-snap@npm:1.3.1"
   dependencies:
     "@metamask/abi-utils": "npm:3.0.0"
     "@metamask/delegation-core": "npm:0.3.0"
     "@metamask/profile-sync-controller": "npm:21.0.0"
-    "@metamask/snaps-sdk": "npm:10.2.0"
+    "@metamask/snaps-sdk": "npm:11.0.0"
     "@metamask/utils": "npm:11.4.2"
     zod: "npm:3.25.76"
-  checksum: 10/65b6371ee9858e4299907ad7973f11dd5e4093c8c44a8a007baae22afb6a04007a4e8af8882799954d147bb4cc93006f7b075b8124b6ca585b9d3369721c1ca9
+  checksum: 10/0d1b30fc670ca30700b56e1e870d18546408bd670f1a30d698e35ff30ad61c2c4811605d3d6f2ab01496afe14ef3588524f34c00c32b1614c6006179ff593795
   languageName: node
   linkType: hard
 
@@ -33992,7 +33992,7 @@ __metadata:
     "@metamask/foundryup": "npm:^1.0.1"
     "@metamask/gas-fee-controller": "npm:^26.1.0"
     "@metamask/gator-permissions-controller": "npm:^2.1.0"
-    "@metamask/gator-permissions-snap": "npm:^1.3.0"
+    "@metamask/gator-permissions-snap": "npm:^1.3.1"
     "@metamask/hw-wallet-sdk": "npm:^0.5.0"
     "@metamask/institutional-wallet-snap": "npm:1.3.4"
     "@metamask/jazzicon": "patch:@metamask/jazzicon@npm%3A2.0.0#~/.yarn/patches/@metamask-jazzicon-npm-2.0.0-36957be38d.patch"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Bumps  @metamask/gator-permissions-snap from ^1.3.0 to ^1.3.1 with the following changes:
- Use a banner with a list to display existing permissions. (https://github.com/MetaMask/snap-7715-permissions/pull/288)
- Change warning icon color to error red for malicious addresses (https://github.com/MetaMask/snap-7715-permissions/pull/287)

See https://github.com/MetaMask/snap-7715-permissions/releases/tag/v19.0.0 for more details

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/41129?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Existing permissions now shown in a banner when reviewing `wallet_requestExecutionPermissions` request

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency bump limited to the `@metamask/gator-permissions-snap` package and its lockfile resolution, with no direct application code changes.
> 
> **Overview**
> Bumps `@metamask/gator-permissions-snap` from `^1.3.0` to `^1.3.1`.
> 
> Updates the corresponding `yarn.lock` entry, including the resolved transitive dependency on `@metamask/snaps-sdk` (now `11.0.0`) and associated checksums.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66a6848d4b45262fcbfae8aaf027a2fed4468106. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->