### PR TITLE
refactor: simplify benchmark threshold resolution and consolidate utilities

### DIFF
--- a/development/metamaskbot-build-announce/compare-benchmarks.test.ts
+++ b/development/metamaskbot-build-announce/compare-benchmarks.test.ts
@@ -27,16 +27,18 @@ function makeBenchmarkResults(
 
 describe('compare-benchmarks', () => {
   describe('resolveThresholdConfig', () => {
-    it('resolves a direct kebab-case match', () => {
-      const config = resolveThresholdConfig('onboarding-import-wallet');
+    it('resolves camelCase benchmark names', () => {
+      const config = resolveThresholdConfig('onboardingImportWallet');
       expect(config).toBeDefined();
       expect(config).toHaveProperty('importWalletToSocialScreen');
     });
 
-    it('strips benchmark prefix before matching', () => {
-      const config = resolveThresholdConfig('benchmark-chrome-browserify-swap');
+    it('resolves startup benchmarks with platform prefix', () => {
+      const config = resolveThresholdConfig(
+        'chrome-browserify-startupStandardHome',
+      );
       expect(config).toBeDefined();
-      expect(config).toHaveProperty('openSwapPageFromHome');
+      expect(config).toHaveProperty('uiStartup');
     });
 
     it('returns undefined for unknown benchmarks', () => {
@@ -56,9 +58,9 @@ describe('compare-benchmarks', () => {
     it('passes when results are within thresholds', () => {
       const benchmarks = [
         {
-          name: 'onboarding-import-wallet',
+          name: 'benchmark-chrome-browserify-userJourneyOnboardingImport',
           data: {
-            'onboarding-import-wallet': makeBenchmarkResults({
+            onboardingImportWallet: makeBenchmarkResults({
               p75: { importWalletToSocialScreen: 1500 },
               p95: { importWalletToSocialScreen: 2000 },
               mean: { importWalletToSocialScreen: 1200 },
@@ -75,9 +77,9 @@ describe('compare-benchmarks', () => {
     it('fails when p75 exceeds fail threshold', () => {
       const benchmarks = [
         {
-          name: 'onboarding-import-wallet',
+          name: 'benchmark-chrome-browserify-userJourneyOnboardingImport',
           data: {
-            'onboarding-import-wallet': makeBenchmarkResults({
+            onboardingImportWallet: makeBenchmarkResults({
               p75: { importWalletToSocialScreen: 99999 },
               p95: { importWalletToSocialScreen: 99999 },
               mean: { importWalletToSocialScreen: 99999 },
@@ -93,9 +95,9 @@ describe('compare-benchmarks', () => {
     it('includes relative metrics when baseline is available', () => {
       const benchmarks = [
         {
-          name: 'onboarding-import-wallet',
+          name: 'benchmark-chrome-browserify-userJourneyOnboardingImport',
           data: {
-            'onboarding-import-wallet': makeBenchmarkResults({
+            onboardingImportWallet: makeBenchmarkResults({
               p75: { importWalletToSocialScreen: 1500 },
               p95: { importWalletToSocialScreen: 2000 },
               mean: { importWalletToSocialScreen: 1200 },
@@ -105,7 +107,7 @@ describe('compare-benchmarks', () => {
       ];
 
       const baseline = {
-        'onboarding-import-wallet': {
+        'userJourneyOnboardingImport/onboardingImportWallet': {
           importWalletToSocialScreen: { mean: 1100, p75: 1400, p95: 1900 },
         },
       };

--- a/shared/lib/string-utils.test.js
+++ b/shared/lib/string-utils.test.js
@@ -2,6 +2,7 @@ import {
   isEqualCaseInsensitive,
   prependZero,
   toKebabCase,
+  toCamelCase,
 } from './string-utils';
 
 describe('string-utils', () => {
@@ -30,32 +31,24 @@ describe('string-utils', () => {
   });
 
   describe('toKebabCase', () => {
-    it('converts camelCase to kebab-case', () => {
+    it('converts camelCase and PascalCase to kebab-case', () => {
       expect(toKebabCase('startupStandardHome')).toBe('startup-standard-home');
-    });
-
-    it('converts PascalCase to kebab-case', () => {
       expect(toKebabCase('SwapPage')).toBe('swap-page');
-    });
-
-    it('converts single lowercase word unchanged', () => {
-      expect(toKebabCase('startup')).toBe('startup');
-    });
-
-    it('handles consecutive uppercase letters', () => {
       expect(toKebabCase('getHTTPSUrl')).toBe('get-h-t-t-p-s-url');
     });
+  });
 
-    it('handles single uppercase letter', () => {
-      expect(toKebabCase('A')).toBe('a');
+  describe('toCamelCase', () => {
+    it('converts kebab-case to camelCase', () => {
+      expect(toCamelCase('onboarding-import-wallet')).toBe(
+        'onboardingImportWallet',
+      );
+      expect(toCamelCase('load-new-account')).toBe('loadNewAccount');
     });
 
-    it('returns empty string for empty input', () => {
-      expect(toKebabCase('')).toBe('');
-    });
-
-    it('handles already-kebab-case input', () => {
-      expect(toKebabCase('already-kebab')).toBe('already-kebab');
+    it('is the inverse of toKebabCase', () => {
+      const original = 'myVariableName';
+      expect(toCamelCase(toKebabCase(original))).toBe(original);
     });
   });
 });

--- a/shared/lib/string-utils.ts
+++ b/shared/lib/string-utils.ts
@@ -37,6 +37,18 @@ export function prependZero(num: number, maxLength: number): string {
  */
 export function toKebabCase(str: string): string {
   return str
-    .replace(/([A-Z])/gu, (char) => `-${char.toLowerCase()}`)
+    .replaceAll(/([A-Z])/gu, (char) => `-${char.toLowerCase()}`)
     .replace(/^-/u, '');
+}
+
+/**
+ * Converts a kebab-case string to camelCase.
+ * Used to convert filenames (e.g., 'onboarding-import-wallet')
+ * to benchmark names (e.g., 'onboardingImportWallet').
+ *
+ * @param str - Kebab-case string (e.g., 'load-new-account')
+ * @returns camelCase string (e.g., 'loadNewAccount')
+ */
+export function toCamelCase(str: string): string {
+  return str.replaceAll(/-([a-z])/gu, (_, letter) => letter.toUpperCase());
 }

--- a/test/e2e/benchmarks/flows/README.md
+++ b/test/e2e/benchmarks/flows/README.md
@@ -83,8 +83,10 @@ Every benchmark **must** have a threshold entry in `THRESHOLD_REGISTRY` inside `
 
 To add thresholds for a new benchmark:
 
-1. Define a constant named after the file in UPPER_SNAKE_CASE (e.g. `my-benchmark.ts` -> `MY_BENCHMARK`)
-2. Add it to the `THRESHOLD_REGISTRY` entries
+1. Define a threshold config constant in `test/e2e/benchmarks/utils/constants.ts`
+2. Add it to the appropriate collection:
+   - **Interaction/User Journey:** Add to `BENCHMARK_THRESHOLDS`
+   - **Startup:** Add to `STARTUP_BENCHMARK_CONFIGS` (auto-generates 8 platform-combo entries)
 
 ```typescript
 const MY_BENCHMARK: ThresholdConfig = {
@@ -95,10 +97,18 @@ const MY_BENCHMARK: ThresholdConfig = {
   },
 };
 
-// Then add MY_BENCHMARK to the THRESHOLD_REGISTRY entries
+// For interaction/user journey:
+const BENCHMARK_THRESHOLDS = {
+  myBenchmark: MY_BENCHMARK, // camelCase key matching filename
+};
+
+// For startup:
+const STARTUP_BENCHMARK_CONFIGS = {
+  startupMyBenchmark: MY_BENCHMARK, // Will generate 8 platform-combo entries
+};
 ```
 
-The constant name is auto-converted to the file name (`MY_BENCHMARK` -> `my-benchmark`).
+The key must be **camelCase matching the filename**: `my-benchmark.ts` → `myBenchmark`.
 
 ### 3. Add to a preset (optional)
 

--- a/test/e2e/benchmarks/run-benchmark.ts
+++ b/test/e2e/benchmarks/run-benchmark.ts
@@ -18,6 +18,7 @@ import type {
   BenchmarkResults,
   ThresholdViolation,
 } from '../../../shared/constants/benchmarks';
+import { toCamelCase } from '../../../shared/lib/string-utils';
 import { runBenchmarkWithIterations, convertSummaryToResults } from './utils';
 import {
   THRESHOLD_REGISTRY,
@@ -37,6 +38,54 @@ import {
  */
 function supportsIterations(filePath: string): boolean {
   return !filePath.includes('/startup/');
+}
+
+/**
+ * Builds the registry key for threshold lookup and JSON output.
+ *
+ * Startup benchmarks require platform-buildType prefix because:
+ * - Each platform/buildType combo has its own baseline (platform-specific performance)
+ * - JSON output keys are: 'chrome-webpack-startupStandardHome'
+ * - Registry keys are: 'chrome-webpack-startupStandardHome'
+ *
+ * Other benchmarks use simple camelCase:
+ * - All platforms share one baseline (platform-agnostic performance)
+ * - JSON output keys are: 'loadNewAccount', 'onboardingImportWallet'
+ * - Registry keys are: 'loadNewAccount', 'onboardingImportWallet'
+ *
+ * @param fileName - Benchmark flow filename (e.g., 'standard-home', 'load-new-account')
+ * @param filePath - Full file path (to detect startup benchmarks)
+ * @param preset - Preset name (e.g., 'startupStandardHome', 'interactionUserActions')
+ * @param outputFilename - Output filename from --out arg (used to extract platform/buildType)
+ * @returns Registry key (e.g., 'chrome-webpack-startupStandardHome', 'loadNewAccount')
+ */
+function buildRegistryKey(
+  fileName: string,
+  filePath: string,
+  preset?: string,
+  outputFilename?: string,
+): string {
+  const baseName = toCamelCase(fileName);
+  const isStartup =
+    (preset &&
+      Object.values(STARTUP_PRESETS).includes(
+        preset as (typeof STARTUP_PRESETS)[keyof typeof STARTUP_PRESETS],
+      )) ||
+    filePath.includes('/startup/');
+
+  if (isStartup) {
+    if (outputFilename) {
+      const outputBasename = path.basename(outputFilename, '.json');
+      const match = outputBasename.match(/^benchmark-([^-]+)-([^-]+)-/u);
+      if (match) {
+        const [, platform, buildType] = match;
+        return `${platform}-${buildType}-startup${baseName.charAt(0).toUpperCase()}${baseName.slice(1)}`;
+      }
+    }
+    return `startup${baseName.charAt(0).toUpperCase()}${baseName.slice(1)}`;
+  }
+
+  return baseName;
 }
 
 const BENCHMARK_DIR = 'test/e2e/benchmarks/flows';
@@ -96,11 +145,12 @@ async function runBenchmarkFile(
     browserLoads: number;
     pageLoads: number;
   },
+  preset?: string,
+  outputFilename?: string,
 ): Promise<unknown> {
   const absolutePath = pathToFileURL(path.resolve(filePath)).href;
   const fileName = path.basename(filePath, path.extname(filePath));
 
-  // Playwright benchmarks run via yarn playwright
   if (filePath.includes('/playwright/')) {
     await runPlaywrightBenchmark(filePath);
     return undefined; // Playwright writes its own output file
@@ -113,10 +163,16 @@ async function runBenchmarkFile(
   }
 
   const { run: runFn } = benchmark;
-  const thresholdConfig = THRESHOLD_REGISTRY[fileName];
+  const registryKey = buildRegistryKey(
+    fileName,
+    filePath,
+    preset,
+    outputFilename,
+  );
+  const thresholdConfig = THRESHOLD_REGISTRY[registryKey];
   if (!thresholdConfig) {
     throw new Error(
-      `No threshold config for "${fileName}". Add an entry to THRESHOLD_REGISTRY in constants.ts.`,
+      `No threshold config for "${fileName}" (registry key "${registryKey}"). Add an entry to THRESHOLD_REGISTRY in constants.ts.`,
     );
   }
 
@@ -269,12 +325,20 @@ async function main(): Promise<void> {
 
   for (const filePath of filesToRun) {
     const fileName = path.basename(filePath, path.extname(filePath));
-    const resultKey = fileName.replace(/-([a-z])/gu, (_, letter) =>
-      letter.toUpperCase(),
+    const resultKey = buildRegistryKey(
+      fileName,
+      filePath,
+      argv.preset,
+      argv.out,
     );
 
     try {
-      const result = await runBenchmarkFile(filePath, options);
+      const result = await runBenchmarkFile(
+        filePath,
+        options,
+        argv.preset,
+        argv.out,
+      );
       // Playwright benchmarks write their own output file, skip storing
       if (filePath.includes('/playwright/')) {
         continue;

--- a/test/e2e/benchmarks/utils/constants.ts
+++ b/test/e2e/benchmarks/utils/constants.ts
@@ -1,9 +1,10 @@
 import type { ThresholdConfig } from '../../../../shared/constants/benchmarks';
-
-export {
+import {
   BENCHMARK_PLATFORMS,
   BENCHMARK_BUILD_TYPES,
 } from '../../../../shared/constants/benchmarks';
+
+export { BENCHMARK_PLATFORMS, BENCHMARK_BUILD_TYPES };
 export const STARTUP_PRESETS = {
   STANDARD_HOME: 'startupStandardHome',
   POWER_USER_HOME: 'startupPowerUserHome',
@@ -222,8 +223,8 @@ const STANDARD_HOME: ThresholdConfig = {
 
 const POWER_USER_HOME: ThresholdConfig = {
   uiStartup: {
-    p75: { warn: 3000, fail: 4000 },
-    p95: { warn: 4000, fail: 5500 },
+    p75: { warn: 4000, fail: 4700 },
+    p95: { warn: 7000, fail: 10000 },
     ciMultiplier: DEFAULT_CI_MULTIPLIER,
   },
   load: {
@@ -276,23 +277,67 @@ const BRIDGE_USER_ACTIONS: ThresholdConfig = {
 /* eslint-enable @typescript-eslint/naming-convention */
 
 /**
- * Registry keyed by benchmark file name (kebab-case), auto-converted from
- * UPPER_SNAKE_CASE, e.g. ONBOARDING_IMPORT_WALLET -> onboarding-import-wallet.
+ * Threshold configurations for interaction and user journey benchmarks.
  */
-export const THRESHOLD_REGISTRY: Record<string, ThresholdConfig> =
-  Object.fromEntries(
-    Object.entries({
-      ONBOARDING_IMPORT_WALLET,
-      ONBOARDING_NEW_WALLET,
-      IMPORT_SRP_HOME,
-      SWAP,
-      SEND_TRANSACTIONS,
-      ASSET_DETAILS,
-      SOLANA_ASSET_DETAILS,
-      STANDARD_HOME,
-      POWER_USER_HOME,
-      LOAD_NEW_ACCOUNT,
-      CONFIRM_TX,
-      BRIDGE_USER_ACTIONS,
-    }).map(([key, config]) => [key.toLowerCase().replace(/_/gu, '-'), config]),
-  );
+const BENCHMARK_THRESHOLDS = {
+  // Interaction benchmarks (run on all 4 combos, shared baseline)
+  loadNewAccount: LOAD_NEW_ACCOUNT,
+  confirmTx: CONFIRM_TX,
+  bridgeUserActions: BRIDGE_USER_ACTIONS,
+
+  // User journey benchmarks (chrome-browserify in PRs, chrome-webpack on main/release)
+  onboardingImportWallet: ONBOARDING_IMPORT_WALLET,
+  onboardingNewWallet: ONBOARDING_NEW_WALLET,
+  importSrpHome: IMPORT_SRP_HOME,
+  assetDetails: ASSET_DETAILS,
+  solanaAssetDetails: SOLANA_ASSET_DETAILS,
+  sendTransactions: SEND_TRANSACTIONS,
+  swap: SWAP,
+
+  // Startup benchmarks (fallback when platform/buildType not available)
+  startupStandardHome: STANDARD_HOME,
+  startupPowerUserHome: POWER_USER_HOME,
+};
+
+/**
+ * Startup benchmark configurations.
+ * Generated for all platform/buildType combos with platform-prefixed keys.
+ */
+const STARTUP_BENCHMARK_CONFIGS = {
+  startupStandardHome: STANDARD_HOME,
+  startupPowerUserHome: POWER_USER_HOME,
+};
+
+/**
+ * Generates startup benchmark thresholds for all platform/buildType combinations.
+ * Creates keys like 'chrome-browserify-startupStandardHome'.
+ */
+function generateStartupThresholds(): Record<string, ThresholdConfig> {
+  const platforms = Object.values(BENCHMARK_PLATFORMS);
+  const buildTypes = Object.values(BENCHMARK_BUILD_TYPES);
+  const result: Record<string, ThresholdConfig> = {};
+
+  for (const [benchmarkName, config] of Object.entries(
+    STARTUP_BENCHMARK_CONFIGS,
+  )) {
+    for (const platform of platforms) {
+      for (const buildType of buildTypes) {
+        result[`${platform}-${buildType}-${benchmarkName}`] = config;
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Registry of threshold configurations keyed by benchmark name (camelCase).
+ *
+ * To add a new benchmark:
+ * - Interaction/User Journey: Add to BENCHMARK_THRESHOLDS (works for all platforms)
+ * - Startup: Add to STARTUP_BENCHMARK_CONFIGS (auto-generates 8 platform-combo entries)
+ */
+export const THRESHOLD_REGISTRY: Record<string, ThresholdConfig> = {
+  ...BENCHMARK_THRESHOLDS,
+  ...generateStartupThresholds(),
+};


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
We had a mismatch between threshold keys in code and the keys that actually show up in benchmark JSON / CI.

`Startup` benchmarks are measured separately per browser and build (for example `chrome-webpack-startupStandardHome`). The old registry was really organized around kebab-case names derived from constants, which didn’t line up cleanly with those real keys, so lookups were fragile and docs were easy to misunderstand.

`Interaction` and `user journey` benchmarks are different: they use one shared key for every platform (like `loadNewAccount`). Startup needs platform-specific keys. That two different naming models wasn’t spelled out or implemented in one obvious place.

`POWER_USER_HOME` thresholds were stricter than what we reliably see in CI, so we got red builds / noise without a strong signal that something actually regressed for users.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/41130?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how benchmark result keys map to `THRESHOLD_REGISTRY` (including platform/buildType-specific startup keys) and updates thresholds, which can alter CI pass/fail behavior and baseline comparisons.
> 
> **Overview**
> **Benchmark threshold resolution is reworked to match real JSON/CI keys.** Threshold registry keys are now *camelCase* for interaction/user-journey benchmarks and *platform/buildType-prefixed* for startup benchmarks (auto-generated for all platform/build combos), reducing fragile kebab-case/prefix matching.
> 
> The benchmark runner now derives a single registry/output key via `buildRegistryKey` (using new `toCamelCase`) and uses it for both threshold lookup and JSON output. Tests and docs are updated to reflect the new naming model, and `startupPowerUserHome` thresholds are loosened to reduce noisy CI failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34540b481d3f3b9f7f904622db68b433db81c622. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->