### PR TITLE
fix: gas-included swaps with STX/eth_sendBundle cp-13.24.0:

### DIFF
--- a/.yarn/patches/@metamask-bridge-status-controller-npm-69.0.0-15106ec5e0.patch
+++ b/.yarn/patches/@metamask-bridge-status-controller-npm-69.0.0-15106ec5e0.patch
@@ -1,0 +1,17 @@
+diff --git a/dist/utils/transaction.cjs b/dist/utils/transaction.cjs
+index 5ba85f2f336d8cf2bda4d71cf625901251bcb6f2..746b9412f93c82513831d476c49925193e31ec9c 100644
+--- a/dist/utils/transaction.cjs
++++ b/dist/utils/transaction.cjs
+@@ -238,7 +238,11 @@ const getAddTransactionBatchParams = async ({ messenger, isBridgeTx, approval, r
+     // Enable 7702 batching when the quote includes gasless 7702 support,
+     // or when the account is already delegated (to avoid the in-flight
+     // transaction limit for delegated accounts)
+-    const disable7702 = !skipGasFields && !isDelegatedAccount;
++    let disable7702 = !skipGasFields && !isDelegatedAccount;
++    // For gasless transactions with STX/sendBundle we keep disabling 7702.
++    if (gasIncluded && !gasIncluded7702) {
++        disable7702 = true;
++    }
+     const transactions = [];
+     if (resetApproval) {
+         const gasFees = await (0, gas_1.calculateGasFees)(skipGasFields, messenger, estimateGasFeeFn, resetApproval, networkClientId, hexChainId, isGasless ? txFee : undefined);

--- a/package.json
+++ b/package.json
@@ -265,7 +265,8 @@
     "minimatch@npm:^10.1.1": "10.2.4",
     "@metamask/snaps-controllers": "^18.0.4",
     "@metamask/multichain-account-service@npm:^7.0.0": "patch:@metamask/multichain-account-service@npm%3A7.1.0#~/.yarn/patches/@metamask-multichain-account-service-npm-7.1.0-4b0ce989c3.patch",
-    "@metamask/multichain-account-service@npm:^7.1.0": "patch:@metamask/multichain-account-service@npm%3A7.1.0#~/.yarn/patches/@metamask-multichain-account-service-npm-7.1.0-4b0ce989c3.patch"
+    "@metamask/multichain-account-service@npm:^7.1.0": "patch:@metamask/multichain-account-service@npm%3A7.1.0#~/.yarn/patches/@metamask-multichain-account-service-npm-7.1.0-4b0ce989c3.patch",
+    "@metamask/bridge-status-controller@npm:^69.0.0": "patch:@metamask/bridge-status-controller@npm%3A69.0.0#~/.yarn/patches/@metamask-bridge-status-controller-npm-69.0.0-15106ec5e0.patch"
   },
   "dependencies": {
     "@babel/runtime": "patch:@babel/runtime@npm%3A7.26.10#~/.yarn/patches/@babel-runtime-npm-7.26.10-fe8c62510a.patch",
@@ -304,7 +305,7 @@
     "@metamask/base-controller": "^9.0.0",
     "@metamask/bitcoin-wallet-snap": "^1.10.0",
     "@metamask/bridge-controller": "^68.0.0",
-    "@metamask/bridge-status-controller": "^69.0.0",
+    "@metamask/bridge-status-controller": "patch:@metamask/bridge-status-controller@npm%3A69.0.0#~/.yarn/patches/@metamask-bridge-status-controller-npm-69.0.0-15106ec5e0.patch",
     "@metamask/browser-passworder": "^6.0.0",
     "@metamask/chain-agnostic-permission": "^1.4.0",
     "@metamask/claims-controller": "^0.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6041,7 +6041,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/bridge-status-controller@npm:^69.0.0":
+"@metamask/bridge-status-controller@npm:69.0.0":
   version: 69.0.0
   resolution: "@metamask/bridge-status-controller@npm:69.0.0"
   dependencies:
@@ -6061,6 +6061,29 @@ __metadata:
     bignumber.js: "npm:^9.1.2"
     uuid: "npm:^8.3.2"
   checksum: 10/65a08737028eff08ce1b0438e3836418f70a7c30fd49ed5117df98271cd94923e08cfe29790dfb600c8d8232401afb0807b7d92d237204d4b86190bccc47d809
+  languageName: node
+  linkType: hard
+
+"@metamask/bridge-status-controller@patch:@metamask/bridge-status-controller@npm%3A69.0.0#~/.yarn/patches/@metamask-bridge-status-controller-npm-69.0.0-15106ec5e0.patch":
+  version: 69.0.0
+  resolution: "@metamask/bridge-status-controller@patch:@metamask/bridge-status-controller@npm%3A69.0.0#~/.yarn/patches/@metamask-bridge-status-controller-npm-69.0.0-15106ec5e0.patch::version=69.0.0&hash=ca26bd"
+  dependencies:
+    "@metamask/accounts-controller": "npm:^37.0.0"
+    "@metamask/base-controller": "npm:^9.0.0"
+    "@metamask/bridge-controller": "npm:^69.1.1"
+    "@metamask/controller-utils": "npm:^11.19.0"
+    "@metamask/gas-fee-controller": "npm:^26.1.0"
+    "@metamask/keyring-controller": "npm:^25.1.0"
+    "@metamask/network-controller": "npm:^30.0.0"
+    "@metamask/polling-controller": "npm:^16.0.3"
+    "@metamask/profile-sync-controller": "npm:^28.0.0"
+    "@metamask/snaps-controllers": "npm:^17.2.0"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/transaction-controller": "npm:^63.0.0"
+    "@metamask/utils": "npm:^11.9.0"
+    bignumber.js: "npm:^9.1.2"
+    uuid: "npm:^8.3.2"
+  checksum: 10/e3c4aa4b0b493c179edda3d1eb80df14b2bfd3c326897f74c5c1f3ce5691c3c99a15a0d5d1cbddd9a8336eaeb8b441bdad735e0d78879fbfbcc52cbff4fa2c88
   languageName: node
   linkType: hard
 
@@ -33949,7 +33972,7 @@ __metadata:
     "@metamask/base-controller": "npm:^9.0.0"
     "@metamask/bitcoin-wallet-snap": "npm:^1.10.0"
     "@metamask/bridge-controller": "npm:^68.0.0"
-    "@metamask/bridge-status-controller": "npm:^69.0.0"
+    "@metamask/bridge-status-controller": "patch:@metamask/bridge-status-controller@npm%3A69.0.0#~/.yarn/patches/@metamask-bridge-status-controller-npm-69.0.0-15106ec5e0.patch"
     "@metamask/browser-passworder": "npm:^6.0.0"
     "@metamask/build-utils": "npm:^3.0.0"
     "@metamask/chain-agnostic-permission": "npm:^1.4.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Continue to disable 7702 for gasless with STX/eth_sendBundle

bridge-status-controller@69.0.0 sets disable7702 to false as long as the user has got a smart account on the network but that does not account for gasless transactions on networks like Ethereum and BNB where STX/eth_sendBundle is used even though the user has got a smart account

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/41132?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/41107

## **Manual testing steps**

With a smart account on BNB or Ethereum and STX on. 

1. Go to the Swap/Bridge page
2. Initiate a gas-included swap from the native currency (using MAX) to any token 
3. Submit

1. Go to the Swap/Bridge page
2. Initiate a gas-included swap from USDT to native currency
3. Submit

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts transaction batching behavior in `@metamask/bridge-status-controller`, which can affect swap/bridge submission paths for smart accounts and gasless quotes. Risk is moderate because it changes how transactions are constructed/sent for specific gas-included scenarios.
> 
> **Overview**
> Fixes gas-included swap/bridge flows that use STX `eth_sendBundle` by **forcing 7702 batching to remain disabled** when the quote is gas-included but does not support gas-included 7702 (`gasIncluded && !gasIncluded7702`).
> 
> Wires this behavior in via a Yarn patch for `@metamask/bridge-status-controller@69.0.0`, updating `package.json` and `yarn.lock` to consume the patched package.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9012adfb55b1b2c3594331cb50fe110a42dd03e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->