### PR TITLE
fix: claim bonus button persists after claiming cp-13.24.0

### DIFF
--- a/ui/components/app/musd/hooks/useOnMerklClaimConfirmed.test.ts
+++ b/ui/components/app/musd/hooks/useOnMerklClaimConfirmed.test.ts
@@ -13,9 +13,11 @@ const createMockTransaction = (
   id: string,
   status: string,
   to: string = MERKL_DISTRIBUTOR_ADDRESS,
+  time: number = Date.now(),
 ) => ({
   id,
   status,
+  time,
   txParams: { to },
 });
 
@@ -48,12 +50,12 @@ describe('useOnMerklClaimConfirmed', () => {
     expect(onConfirmed).toHaveBeenCalledTimes(1);
   });
 
-  it('does not fire callback for already-confirmed transactions', () => {
+  it('does not fire callback for already-confirmed transactions with no time field', () => {
     const onConfirmed = jest.fn();
 
-    // Start with already confirmed transaction
+    // Start with already confirmed transaction but no time field (old tx, no time data)
     useSelector.mockReturnValue([
-      createMockTransaction('tx1', TransactionStatus.confirmed),
+      { id: 'tx1', status: TransactionStatus.confirmed, txParams: { to: MERKL_DISTRIBUTOR_ADDRESS } },
     ]);
 
     renderHook(() => useOnMerklClaimConfirmed(onConfirmed));
@@ -91,5 +93,68 @@ describe('useOnMerklClaimConfirmed', () => {
     });
 
     expect(onConfirmed).not.toHaveBeenCalled();
+  });
+
+  describe('remount after confirmation flow', () => {
+    it('fires callback on mount when a recent confirmed claim exists', () => {
+      const onConfirmed = jest.fn();
+
+      // Component mounts with an already-confirmed tx that happened recently
+      useSelector.mockReturnValue([
+        createMockTransaction('tx1', TransactionStatus.confirmed, MERKL_DISTRIBUTOR_ADDRESS, Date.now() - 30_000),
+      ]);
+
+      renderHook(() => useOnMerklClaimConfirmed(onConfirmed));
+
+      expect(onConfirmed).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not fire callback on mount for an old confirmed claim (beyond 5-minute window)', () => {
+      const onConfirmed = jest.fn();
+
+      // Confirmed tx is 10 minutes old — should not trigger
+      const TEN_MINUTES_AGO = Date.now() - 10 * 60 * 1000;
+      useSelector.mockReturnValue([
+        createMockTransaction('tx1', TransactionStatus.confirmed, MERKL_DISTRIBUTOR_ADDRESS, TEN_MINUTES_AGO),
+      ]);
+
+      renderHook(() => useOnMerklClaimConfirmed(onConfirmed));
+
+      expect(onConfirmed).not.toHaveBeenCalled();
+    });
+
+    it('does not fire the on-mount callback again on subsequent renders', () => {
+      const onConfirmed = jest.fn();
+
+      useSelector.mockReturnValue([
+        createMockTransaction('tx1', TransactionStatus.confirmed, MERKL_DISTRIBUTOR_ADDRESS, Date.now() - 30_000),
+      ]);
+
+      const { rerender } = renderHook(() =>
+        useOnMerklClaimConfirmed(onConfirmed),
+      );
+
+      // Subsequent re-renders with same data should not re-fire
+      act(() => {
+        rerender();
+      });
+      act(() => {
+        rerender();
+      });
+
+      expect(onConfirmed).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not fire on-mount callback for a recently confirmed non-Merkl tx', () => {
+      const onConfirmed = jest.fn();
+
+      useSelector.mockReturnValue([
+        createMockTransaction('tx1', TransactionStatus.confirmed, '0xOtherAddress', Date.now() - 30_000),
+      ]);
+
+      renderHook(() => useOnMerklClaimConfirmed(onConfirmed));
+
+      expect(onConfirmed).not.toHaveBeenCalled();
+    });
   });
 });

--- a/ui/components/app/musd/hooks/useOnMerklClaimConfirmed.test.ts
+++ b/ui/components/app/musd/hooks/useOnMerklClaimConfirmed.test.ts
@@ -55,7 +55,11 @@ describe('useOnMerklClaimConfirmed', () => {
 
     // Start with already confirmed transaction but no time field (old tx, no time data)
     useSelector.mockReturnValue([
-      { id: 'tx1', status: TransactionStatus.confirmed, txParams: { to: MERKL_DISTRIBUTOR_ADDRESS } },
+      {
+        id: 'tx1',
+        status: TransactionStatus.confirmed,
+        txParams: { to: MERKL_DISTRIBUTOR_ADDRESS },
+      },
     ]);
 
     renderHook(() => useOnMerklClaimConfirmed(onConfirmed));
@@ -101,7 +105,12 @@ describe('useOnMerklClaimConfirmed', () => {
 
       // Component mounts with an already-confirmed tx that happened recently
       useSelector.mockReturnValue([
-        createMockTransaction('tx1', TransactionStatus.confirmed, MERKL_DISTRIBUTOR_ADDRESS, Date.now() - 30_000),
+        createMockTransaction(
+          'tx1',
+          TransactionStatus.confirmed,
+          MERKL_DISTRIBUTOR_ADDRESS,
+          Date.now() - 30_000,
+        ),
       ]);
 
       renderHook(() => useOnMerklClaimConfirmed(onConfirmed));
@@ -115,7 +124,12 @@ describe('useOnMerklClaimConfirmed', () => {
       // Confirmed tx is 10 minutes old — should not trigger
       const TEN_MINUTES_AGO = Date.now() - 10 * 60 * 1000;
       useSelector.mockReturnValue([
-        createMockTransaction('tx1', TransactionStatus.confirmed, MERKL_DISTRIBUTOR_ADDRESS, TEN_MINUTES_AGO),
+        createMockTransaction(
+          'tx1',
+          TransactionStatus.confirmed,
+          MERKL_DISTRIBUTOR_ADDRESS,
+          TEN_MINUTES_AGO,
+        ),
       ]);
 
       renderHook(() => useOnMerklClaimConfirmed(onConfirmed));
@@ -127,7 +141,12 @@ describe('useOnMerklClaimConfirmed', () => {
       const onConfirmed = jest.fn();
 
       useSelector.mockReturnValue([
-        createMockTransaction('tx1', TransactionStatus.confirmed, MERKL_DISTRIBUTOR_ADDRESS, Date.now() - 30_000),
+        createMockTransaction(
+          'tx1',
+          TransactionStatus.confirmed,
+          MERKL_DISTRIBUTOR_ADDRESS,
+          Date.now() - 30_000,
+        ),
       ]);
 
       const { rerender } = renderHook(() =>
@@ -149,7 +168,12 @@ describe('useOnMerklClaimConfirmed', () => {
       const onConfirmed = jest.fn();
 
       useSelector.mockReturnValue([
-        createMockTransaction('tx1', TransactionStatus.confirmed, '0xOtherAddress', Date.now() - 30_000),
+        createMockTransaction(
+          'tx1',
+          TransactionStatus.confirmed,
+          '0xOtherAddress',
+          Date.now() - 30_000,
+        ),
       ]);
 
       renderHook(() => useOnMerklClaimConfirmed(onConfirmed));

--- a/ui/components/app/musd/hooks/useOnMerklClaimConfirmed.ts
+++ b/ui/components/app/musd/hooks/useOnMerklClaimConfirmed.ts
@@ -20,6 +20,14 @@ const IN_FLIGHT_STATUSES: string[] = [
 ];
 
 /**
+ * Window in which a confirmed claim tx is considered "recent enough" to
+ * trigger a refetch on component mount. Covers the case where the claim
+ * confirmed while ClaimBonusBadge was unmounted (during the confirmation
+ * flow), so the pending→confirmed transition was never observed.
+ */
+const RECENT_CLAIM_WINDOW_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
  * Check if a transaction is a Merkl claim by matching the distributor address.
  *
  * @param tx - The transaction metadata
@@ -33,6 +41,12 @@ const isMerklClaimTransaction = (tx: TransactionMeta): boolean =>
  * Tracks in-flight claim IDs so it only fires for transitions from
  * pending to confirmed, not for transactions that were already confirmed.
  *
+ * Also handles the remount case: when the component unmounts during the
+ * confirmation flow (navigation away) and remounts after the claim has already
+ * confirmed, the pending→confirmed transition is missed. To cover this, on the
+ * first effect run (mount) we check for recently confirmed claim txs and fire
+ * the callback if any are found within RECENT_CLAIM_WINDOW_MS.
+ *
  * @param onConfirmed - Callback fired when a pending claim is confirmed
  */
 export const useOnMerklClaimConfirmed = (onConfirmed: () => void): void => {
@@ -40,6 +54,9 @@ export const useOnMerklClaimConfirmed = (onConfirmed: () => void): void => {
 
   // Track IDs of pending claims we've seen
   const pendingClaimIdsRef = useRef<Set<string>>(new Set());
+
+  // True only on the very first effect run (mount)
+  const isMountRef = useRef(true);
 
   // Stable callback ref to avoid effect re-running
   const onConfirmedRef = useRef(onConfirmed);
@@ -65,11 +82,25 @@ export const useOnMerklClaimConfirmed = (onConfirmed: () => void): void => {
       pendingClaimIdsRef.current.has(id),
     );
 
+    // On mount, check for recently confirmed claim txs that were missed
+    // because the component was unmounted during the confirmation flow.
+    const isMount = isMountRef.current;
+    const hasRecentlyConfirmedOnMount =
+      isMount &&
+      merklClaimTxs.some(
+        (tx) =>
+          tx.status === TransactionStatus.confirmed &&
+          Date.now() - tx.time < RECENT_CLAIM_WINDOW_MS,
+      );
+
+    isMountRef.current = false;
+
     // Update our tracking set
     pendingClaimIdsRef.current = currentPendingIds;
 
-    // Fire callback if a pending claim was confirmed
-    if (hadPendingThatConfirmed) {
+    // Fire callback if a pending claim was confirmed, or if we mounted and
+    // found a recently confirmed claim that was missed while unmounted.
+    if (hadPendingThatConfirmed || hasRecentlyConfirmedOnMount) {
       onConfirmedRef.current();
     }
   }, [transactions]);


### PR DESCRIPTION
## **Description**

For mUSD merkl campaigns, the claim flow navigates to a confirmation page, unmounting ClaimBonusBadge and useOnMerklClaimConfirmed. On return, the hook remounts with a fresh empty pendingClaimIdsRef, so the pending -> confirmed transition was never detected, refetch() is never called, and TanStack Query serves stale cached data (hasClaimable: true) leaving the "Claim Bonus" button visible indefinitely.

The fix is on the first effect run (mount), check for any confirmed Merkl claim txs created within the last 5 minutes and fire the refetch callback immediately if found, covering the missed transition.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/41137?quickstart=1)

## **Changelog**

CHANGELOG entry: fix persistent claim bonus button

## **Related issues**

Fixes: #41092

## **Manual testing steps**

1. Claim a Merkl bonus
2. Go back to the page where the claim button is visible (e.g. the token list)
3. Observe that the claim button disappears/is gone


## **Screenshots/Recordings**


### **Before**

See @seaona's issue #41092 

### **After**


https://github.com/user-attachments/assets/1066ce56-1904-4069-bb12-420e94cbfd66


## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-state fix localized to the mUSD Merkl claim confirmation hook, with added tests to cover remount and time-window behavior.
> 
> **Overview**
> Fixes a stale UI state where the mUSD “Claim Bonus” button could persist after claiming if the claim component unmounted during the confirmation flow.
> 
> `useOnMerklClaimConfirmed` now also triggers the callback on initial mount when it detects a **recently confirmed** Merkl claim transaction (within a 5-minute window), covering missed pending→confirmed transitions. Tests were expanded to validate the remount/time-window behavior, avoid firing for old confirmations, non-Merkl transactions, and legacy confirmed txs without a `time` field.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47e0e573088a92dff81bc659386896d6bd5a49e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->