### PR TITLE
fix: update copy related to mUSD claims cp-13.24.0

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -4193,11 +4193,11 @@
     "description": "$1 is the dapp and $2 is the number of snaps it wants to connect to."
   },
   "musdBonusExplanation": {
-    "message": "Convert your stablecoins to mUSD, MetaMask's US dollar-backed stablecoin, and receive up to a $1% bonus. Powered by Relay. $2",
+    "message": "Convert your stablecoins to mUSD, MetaMask's US dollar-backed stablecoin, and earn up to a $1% annualized bonus that you can claim daily. Powered by Relay. $2",
     "description": "$1 is the bonus APY percentage, $2 is the 'Terms apply' link"
   },
   "musdBoostDescription": {
-    "message": "Convert your stablecoins to mUSD and receive up to a $1% bonus.",
+    "message": "Convert your stablecoins to mUSD and get a $1% annualized bonus.",
     "description": "$1 is the bonus percentage (e.g., 3)"
   },
   "musdBoostTitle": {
@@ -4239,7 +4239,10 @@
     "description": "$1 is the source token symbol (e.g., USDC)"
   },
   "musdConversionToastSuccess": {
-    "message": "Your mUSD is here!"
+    "message": "mUSD conversion successful"
+  },
+  "musdConversionToastSuccessDescription": {
+    "message": "Bonus will be claimable within a day."
   },
   "musdConvert": {
     "message": "Convert"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -4193,11 +4193,11 @@
     "description": "$1 is the dapp and $2 is the number of snaps it wants to connect to."
   },
   "musdBonusExplanation": {
-    "message": "Convert your stablecoins to mUSD, MetaMask's US dollar-backed stablecoin, and receive up to a $1% bonus. Powered by Relay. $2",
+    "message": "Convert your stablecoins to mUSD, MetaMask's US dollar-backed stablecoin, and earn up to a $1% annualized bonus that you can claim daily. Powered by Relay. $2",
     "description": "$1 is the bonus APY percentage, $2 is the 'Terms apply' link"
   },
   "musdBoostDescription": {
-    "message": "Convert your stablecoins to mUSD and receive up to a $1% bonus.",
+    "message": "Convert your stablecoins to mUSD and get a $1% annualized bonus.",
     "description": "$1 is the bonus percentage (e.g., 3)"
   },
   "musdBoostTitle": {
@@ -4239,7 +4239,10 @@
     "description": "$1 is the source token symbol (e.g., USDC)"
   },
   "musdConversionToastSuccess": {
-    "message": "Your mUSD is here!"
+    "message": "mUSD conversion successful"
+  },
+  "musdConversionToastSuccessDescription": {
+    "message": "Bonus will be claimable within a day."
   },
   "musdConvert": {
     "message": "Convert"

--- a/ui/components/app/musd/musd-asset-cta.test.tsx
+++ b/ui/components/app/musd/musd-asset-cta.test.tsx
@@ -12,7 +12,7 @@ jest.mock('../../../hooks/useI18nContext', () => ({
   useI18nContext: () => (key: string, values?: string[]) => {
     const translations: Record<string, string> = {
       musdBoostTitle: `Get ${values?.[0] || '3'}% on your stablecoins`,
-      musdBoostDescription: `Convert your stablecoins to mUSD and receive up to a ${values?.[0] || '3'}% bonus.`,
+      musdBoostDescription: `Convert your stablecoins to mUSD and get a ${values?.[0] || '3'}% annualized bonus.`,
       musdConvert: 'Convert',
       dismiss: 'Dismiss',
     };
@@ -125,7 +125,7 @@ describe('MusdAssetCta', () => {
       ).toBeInTheDocument();
       expect(
         screen.getByText(
-          'Convert your stablecoins to mUSD and receive up to a 3% bonus.',
+          'Convert your stablecoins to mUSD and get a 3% annualized bonus.',
         ),
       ).toBeInTheDocument();
     });

--- a/ui/components/app/musd/musd-conversion-toast.test.tsx
+++ b/ui/components/app/musd/musd-conversion-toast.test.tsx
@@ -12,7 +12,9 @@ jest.mock('../../../hooks/useI18nContext', () => ({
   useI18nContext: () => (key: string, values?: string[]) => {
     const translations: Record<string, string> = {
       musdConversionToastInProgress: `Converting ${values?.[0] ?? 'Token'}...`,
-      musdConversionToastSuccess: 'Conversion successful!',
+      musdConversionToastSuccess: 'mUSD conversion successful',
+      musdConversionToastSuccessDescription:
+        'Bonus will be claimable within a day.',
       musdConversionToastFailed: 'Conversion failed.',
     };
     return translations[key] ?? key;
@@ -99,7 +101,11 @@ describe('MusdConversionToast', () => {
     render(<MusdConversionToast />);
 
     expect(screen.getByTestId('musd-conversion-toast')).toHaveTextContent(
-      'Conversion successful!',
+      'mUSD conversion successful',
+    );
+    expect(capturedToastProps).toHaveProperty(
+      'description',
+      'Bonus will be claimable within a day.',
     );
     expect(capturedToastProps).toHaveProperty('autoHideTime', 5000);
     expect(capturedToastProps).toHaveProperty(

--- a/ui/components/app/musd/musd-conversion-toast.tsx
+++ b/ui/components/app/musd/musd-conversion-toast.tsx
@@ -49,6 +49,10 @@ export function MusdConversionToast() {
     }
   })();
 
+  const toastDescription = isSuccess
+    ? (t('musdConversionToastSuccessDescription') as string)
+    : undefined;
+
   const startAdornment = (() => {
     if (isInProgress) {
       return (
@@ -83,6 +87,7 @@ export function MusdConversionToast() {
       key="musd-conversion-toast"
       dataTestId="musd-conversion-toast"
       text={toastText}
+      description={toastDescription}
       startAdornment={startAdornment}
       onClose={dismissToast}
       {...(!isInProgress && {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

inconsistent copy around the mUSD bonus percentage. Previously several screens described the bonus without clarifying it was annualised and claimable daily, which could mislead users into thinking the 3% was paid per conversion. All copy now consistently communicates a 3% annualised bonus paid daily.

I've used US spelling (annualized)

## **Changelog**

CHANGELOG entry: update mUSD claim copy

## **Related issues**

Fixes: #41140 
https://consensyssoftware.atlassian.net/browse/MUSD-463

## **Manual testing steps**

1. Education splash screen
2. Look at conversion header tooltip
3. Look at home banner card 
4. Look at asset detail page
5.

## **Screenshots/Recordings**

### **After**

Education splash screen body copy reads "...earn up to a 3% annualized bonus that you can claim daily."
<img width="481" height="1209" alt="image" src="https://github.com/user-attachments/assets/b6eaeded-46a7-4d82-a623-5bd68b7cc117" />


Conversion header tooltip (info icon on "Convert and get 3%" screen) shows the updated body copy
<img width="504" height="441" alt="image" src="https://github.com/user-attachments/assets/2f5198ef-1b46-4102-8d97-f4d6ae1ceb06" />

Home banner card and asset detail card show "...get a 3% annualized bonus."
<img width="481" height="1209" alt="image" src="https://github.com/user-attachments/assets/d1662284-5d3f-4d72-b1ff-e1f441a5f4a3" />



<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: copy-only locale updates plus a small UI tweak to show an extra description line on the success toast; no business logic or data flow changes.
> 
> **Overview**
> Updates mUSD promotional copy to consistently describe the bonus as **annualized and claimable daily**, including changes to the education/CTA text and conversion success messaging.
> 
> Enhances `MusdConversionToast` to show a success *description* (“Bonus will be claimable within a day.”) and adjusts related unit tests and i18n keys (`musdConversionToastSuccessDescription`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de01fe7496da20bed1cc137b61825c43c3b35369. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->