### PR TITLE
fix: flaky test `Speed Up and Cancel Transaction Tests Cancel transaction Successfully cancels a pending transaction`

### DIFF
--- a/test/e2e/page-objects/pages/home/activity-list.ts
+++ b/test/e2e/page-objects/pages/home/activity-list.ts
@@ -48,7 +48,7 @@ class ActivityListPage {
     '[data-testid="transaction-breakdown__gas-price"]';
 
   private readonly pendingTransactionItems =
-    '.transaction-list__pending-transactions .activity-list-item';
+    '.transaction-status-label--pending';
 
   private readonly speedupInlineButton = '[data-testid="speed-up-button"]';
 

--- a/test/e2e/tests/confirmations/transactions/speed-up-and-cancel-confirmations.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/speed-up-and-cancel-confirmations.spec.ts
@@ -55,7 +55,7 @@ describe('Speed Up and Cancel Transaction Tests', function () {
           await homePage.goToActivityList();
 
           const activityListPage = new ActivityListPage(driver);
-          await activityListPage.checkCompletedTxNumberDisplayedInActivity(1);
+          await activityListPage.checkPendingTxNumberDisplayedInActivity(1);
 
           await activityListPage.checkSpeedUpInlineButtonIsPresent();
           await activityListPage.clickTransactionListItem();
@@ -114,7 +114,7 @@ describe('Speed Up and Cancel Transaction Tests', function () {
           await homePage.goToActivityList();
 
           const activityListPage = new ActivityListPage(driver);
-          await activityListPage.checkCompletedTxNumberDisplayedInActivity(1);
+          await activityListPage.checkPendingTxNumberDisplayedInActivity(1);
 
           await activityListPage.clickCancelTransaction();
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The test is flaky as sometimes we click the Cancel button while the transaction is in the `Unapproved` state. Then we click, but a re-render happens where the tx updates to `Pending` state, causing the click to take no effect

<img width="1636" height="424" alt="image" src="https://github.com/user-attachments/assets/da57a6ba-5804-4f4e-87f5-595a46d18f84" />

<img width="1152" height="836" alt="image" src="https://github.com/user-attachments/assets/f520ccc0-8b5b-4dcd-96b2-bda1ff29d987" />


The fix is to wait for Pending tx (1) instead of just tx's in the tx list (completed != confirmed)


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to E2E test selectors/waits and don’t affect production logic. Potential risk is only test brittleness if the pending-status CSS/testid changes again.
> 
> **Overview**
> Fixes flakiness in the speed up/cancel transaction E2E specs by waiting for a *pending* transaction to appear in the activity list before interacting with `Speed up`/`Cancel`.
> 
> Updates the activity-list page object’s pending-transaction selector to target `.transaction-status-label--pending`, and switches the specs from `checkCompletedTxNumberDisplayedInActivity` to `checkPendingTxNumberDisplayedInActivity` to avoid clicks during transient `Unapproved`/re-render states.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ab84117d3337287a93023549c240f9c606150e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->