### PR TITLE
fix: cp-13.24.0 prevent relay quote refresh loop on input when multiple tabs open

### DIFF
--- a/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
+++ b/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
@@ -408,4 +408,95 @@ describe('useTransactionCustomAmount', () => {
       expect(result.current.amountFiat).toBe('50');
     });
   });
+
+  describe('infinite loop prevention', () => {
+    it('does not trigger infinite updates when updateTokenAmount callback is recreated', () => {
+      const updateTokenAmountMock = jest.fn();
+      const { result, rerender } = runHook({
+        disableUpdate: false,
+        updateTokenAmountMock,
+      });
+
+      // User types amount
+      act(() => {
+        result.current.updatePendingAmount('50');
+      });
+
+      // Fast-forward through debounce
+      act(() => {
+        jest.advanceTimersByTime(500);
+      });
+
+      // Should have been called once
+      expect(updateTokenAmountMock).toHaveBeenCalledTimes(1);
+      expect(updateTokenAmountMock).toHaveBeenCalledWith('50');
+
+      // Clear the mock to track new calls
+      updateTokenAmountMock.mockClear();
+
+      // Simulate callback recreation (as would happen from Redux updates)
+      // by creating a new mock and rerendering
+      const newUpdateTokenAmountMock = jest.fn();
+      jest
+        .mocked(useUpdateTokenAmountModule.useUpdateTokenAmount)
+        .mockReturnValue({
+          updateTokenAmount: newUpdateTokenAmountMock,
+          isUpdating: false,
+        });
+
+      // Rerender to trigger the effect that recreates the debounced function
+      rerender();
+
+      // Fast-forward to ensure no debounced calls are pending
+      act(() => {
+        jest.advanceTimersByTime(1000);
+      });
+
+      // The new callback should NOT have been called automatically
+      // (this was the bug - callback recreation was triggering the effect)
+      expect(newUpdateTokenAmountMock).not.toHaveBeenCalled();
+    });
+
+    it('only calls updateTokenAmount when amountHuman actually changes, not when callback recreates', () => {
+      const updateTokenAmountMock = jest.fn();
+      const { result, rerender } = runHook({
+        disableUpdate: false,
+        tokenFiatRate: 2,
+        isMaxAmount: true,
+        requiredTokens: [{ amountUsd: '100', skipIfBalance: false }],
+        updateTokenAmountMock,
+      });
+
+      // Initial render - amountHuman is 50 (100 / 2)
+      // Fast-forward to clear any initial debounce calls
+      act(() => {
+        jest.advanceTimersByTime(500);
+      });
+
+      const initialCallCount = updateTokenAmountMock.mock.calls.length;
+
+      // Simulate multiple callback recreations without amountHuman changing
+      for (let i = 0; i < 5; i++) {
+        const newMock = jest.fn();
+        jest
+          .mocked(useUpdateTokenAmountModule.useUpdateTokenAmount)
+          .mockReturnValue({
+            updateTokenAmount: newMock,
+            isUpdating: false,
+          });
+
+        rerender();
+
+        act(() => {
+          jest.advanceTimersByTime(500);
+        });
+
+        // Should not have triggered additional calls
+        expect(newMock).not.toHaveBeenCalled();
+      }
+
+      // Verify no additional calls were made
+      expect(updateTokenAmountMock).toHaveBeenCalledTimes(initialCallCount);
+    });
+  });
 });

--- a/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmount.ts
+++ b/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmount.ts
@@ -42,9 +42,12 @@ export function useTransactionCustomAmount({
     null,
   );
 
-  const debounceSetAmountDelayed = useMemo(() => {
+  // Create and update debounced function
+  useEffect(() => {
+    // Cancel any existing debounced calls
     debounceRef.current?.cancel();
 
+    // Create new debounced function
     const debouncedFn = debounce((value: string) => {
       setAmountHumanDebounced(value);
       if (!disableUpdate) {
@@ -52,8 +55,13 @@ export function useTransactionCustomAmount({
       }
     }, DEBOUNCE_DELAY);
 
+    // Store in ref
     debounceRef.current = debouncedFn;
-    return debouncedFn;
+
+    // Cleanup: cancel on unmount or when dependencies change
+    return () => {
+      debouncedFn.cancel();
+    };
   }, [disableUpdate, updateTokenAmountCallback]);
 
   const primaryRequiredToken = useTransactionPayPrimaryRequiredToken();
@@ -85,14 +93,11 @@ export function useTransactionCustomAmount({
   );
 
   useEffect(() => {
-    debounceSetAmountDelayed(amountHuman);
-  }, [amountHuman, debounceSetAmountDelayed]);
-
-  useEffect(() => {
-    return () => {
-      debounceRef.current?.cancel();
-    };
-  }, []);
+    // Use ref directly to avoid re-running when callback is recreated
+    if (debounceRef.current) {
+      debounceRef.current(amountHuman);
+    }
+  }, [amountHuman]);
 
   useEffect(() => {
     if (amountHumanDebounced !== '0') {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

On the transaction pay / custom amount flow, `useTransactionCustomAmount` built the debounced updater with useMemo and had a second effect that depended on `debounceSetAmountDelayed`. 

When `updateTokenAmount` from `useUpdateTokenAmount` was recreated (e.g. after Redux updates or with multiple extension contexts/tabs), that dependency changed, the effect re-ran, and debounced updates could fire again without a real `amountHuman` change—leading to repeated relay quote refresh and a “screen reloading” feel.

Solution

- Recreate the debounced function in a useEffect with `[disableUpdate, updateTokenAmountCallback]`, store it on debounceRef, and cancel on cleanup or when deps change.
- Drive debouncing from `amountHuman` only: one effect with `[amountHuman]` that calls `debounceRef.current(amountHuman)`, so callback identity changes do not re-trigger the debounce path.
- Add unit tests for “infinite loop prevention” when the callback is recreated or re-rendered without `amountHuman` changing.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/41148?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed an issue where entering a custom amount could repeatedly refresh the quote when multiple browser tabs were open

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/41121

## **Manual testing steps**

- Open two (or more) tabs on a flow that uses custom pay amount and relay quotes (e.g. MUSD / pay confirmation as in MUSD-552).
- Focus the amount field and type or edit the amount.
- Confirm the confirmation UI does not continuously reload or flicker; quote updates only after debounce when the amount meaningfully changes.
- Single-tab regression: change amount, wait for debounce, confirm the displayed amount and quote still update as before.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://www.loom.com/share/52101c21a9e8478eb376e49fa59a8b67

### **After**

<!-- [screenshots/recordings] -->

https://www.loom.com/share/dd0da0c758b44549bcb4e7c92717c955

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches transaction confirmation amount/quote update flow by changing debounce lifecycle; regressions could cause missed or extra quote refreshes during custom amount entry. Changes are localized and covered by new unit tests simulating callback recreation.
> 
> **Overview**
> Prevents custom amount entry from re-triggering debounced `updateTokenAmount` calls when the `useUpdateTokenAmount` callback identity changes (e.g., multiple tabs/Redux updates), avoiding repeated relay quote refresh/flicker.
> 
> Refactors `useTransactionCustomAmount` to create/cancel the debounced function in a `useEffect` stored in a ref, and drives the debounce only from `amountHuman` changes (instead of depending on the debounced function’s identity). Adds focused tests to ensure rerenders/callback recreation do not cause additional updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 58dc4feb3d5497f218151272c890a827044b4b78. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->