### PR TITLE
test:stabilize WebSocket balance update test

### DIFF
--- a/test/e2e/tests/tokens/add-hide-token.spec.ts
+++ b/test/e2e/tests/tokens/add-hide-token.spec.ts
@@ -5,10 +5,13 @@ import { SMART_CONTRACTS } from '../../seeder/smart-contracts';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import AssetListPage from '../../page-objects/pages/home/asset-list';
 import { login } from '../../page-objects/flows/login.flow';
-import { DEFAULT_FIXTURE_ACCOUNT_LOWERCASE } from '../../constants';
+import {
+  DEFAULT_FIXTURE_ACCOUNT,
+  DEFAULT_FIXTURE_ACCOUNT_LOWERCASE,
+} from '../../constants';
 import {
   createBalanceUpdateNotification,
-  waitForAccountActivitySubscription,
+  getLastAccountActivitySubscriptionId,
 } from '../../websocket/account-activity-mocks';
 import WebSocketRegistry from '../../websocket/registry';
 import { WEBSOCKET_SERVICES } from '../../websocket/constants';
@@ -102,20 +105,25 @@ describe('Add hide token', function () {
           WEBSOCKET_SERVICES.accountActivity,
         );
 
-        // Register the subscription waiter BEFORE login so we don't miss
-        // the subscribe handshake if auth completes quickly.
-        const subscriptionPromise = waitForAccountActivitySubscription();
-
         await login(driver, { localNode: localNodes[0] });
 
         const assetListPage = new AssetListPage(driver);
+
         await assetListPage.checkTokenAmountIsDisplayed('10 TST');
 
-        const subscriptionId = await subscriptionPromise;
-        console.log(`Subscription established: ${subscriptionId}`);
+        await driver.waitUntil(
+          async () => getLastAccountActivitySubscriptionId() !== null,
+          { timeout: 15000, interval: 100 },
+        );
+        const subscriptionId = getLastAccountActivitySubscriptionId();
+        if (!subscriptionId) {
+          throw new Error(
+            'Expected Account Activity WebSocket subscription id after login',
+          );
+        }
         const notification = createBalanceUpdateNotification({
           subscriptionId,
-          channel: `account-activity.v1.eip155:0:${account}`,
+          channel: `account-activity.v1.eip155:0:${DEFAULT_FIXTURE_ACCOUNT}`,
           address: account,
           chain: `eip155:${chainId}`,
           updates: [

--- a/test/e2e/websocket/account-activity-mocks.ts
+++ b/test/e2e/websocket/account-activity-mocks.ts
@@ -15,6 +15,14 @@ type SubscriptionWaiter = {
 };
 
 let subscriptionWaiters: SubscriptionWaiter[] = [];
+let lastAccountActivitySubscriptionId: string | null = null;
+
+/**
+ * @returns The latest subscription id from the Account Activity mock, or null.
+ */
+export function getLastAccountActivitySubscriptionId(): string | null {
+  return lastAccountActivitySubscriptionId;
+}
 
 /**
  * Returns a Promise that resolves with the subscriptionId once the next
@@ -55,6 +63,7 @@ export function resetAccountActivityMockState(): void {
     clearTimeout(waiter.timer);
   }
   subscriptionWaiters = [];
+  lastAccountActivitySubscriptionId = null;
 }
 
 const DEFAULT_CHAINS_UP = [
@@ -173,6 +182,7 @@ async function setupAccountActivityWebsocketMocks(
 
           setTimeout(() => {
             socket.send(JSON.stringify(subscribeResponse));
+            lastAccountActivitySubscriptionId = subscriptionId;
             console.log(
               `[AccountActivity Mock] Subscribe response sent: subscriptionId=${subscriptionId}`,
             );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The Account Activity E2E mock now records the latest WebSocket subscriptionId on each subscribe. The add-hide-token test uses that id when sending a balance notification, because the client only handles notifications for the active subscription—after a reconnect, the first id can be stale and the UI never updates. The test also aligns the notification channel with the extension’s CAIP-10 account format 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/41157?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are isolated to E2E test/mocking code, mainly adjusting how WebSocket subscription readiness is detected to reduce flakiness.
> 
> **Overview**
> Stabilizes the "WebSocket balance update" token E2E by **removing the pre-login subscription waiter** and instead waiting post-login until the Account Activity mock records a subscription id via new `getLastAccountActivitySubscriptionId()`.
> 
> Updates the Account Activity WebSocket mock to **persist and reset** the latest `subscriptionId` on subscribe responses, and tweaks the test notification channel to use `DEFAULT_FIXTURE_ACCOUNT`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b318493060910514901d9c68bbfcb6ba5bea8d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->