### PR TITLE
fix(storage): always end extension store overwrite timer

### DIFF
--- a/app/scripts/lib/stores/extension-store.test.ts
+++ b/app/scripts/lib/stores/extension-store.test.ts
@@ -69,6 +69,36 @@ describe('ExtensionStore', () => {
 
       expect(setMock).toHaveBeenCalledWith(MOCK_STATE);
     });
+
+    it('ends the overwrite timer when browser storage.local.set throws', async () => {
+      const timeSpy = jest
+        .spyOn(console, 'time')
+        .mockImplementation(() => undefined);
+      const timeEndSpy = jest
+        .spyOn(console, 'timeEnd')
+        .mockImplementation(() => undefined);
+      const localStore = setup({
+        localMock: {
+          set: jest.fn().mockRejectedValue(new Error('Failed to write state')),
+        },
+      });
+
+      try {
+        await expect(localStore.set(MOCK_STATE)).rejects.toThrow(
+          'Failed to write state',
+        );
+
+        expect(timeSpy).toHaveBeenCalledWith(
+          '[ExtensionStore]: Overwriting local store',
+        );
+        expect(timeEndSpy).toHaveBeenCalledWith(
+          '[ExtensionStore]: Overwriting local store',
+        );
+      } finally {
+        timeSpy.mockRestore();
+        timeEndSpy.mockRestore();
+      }
+    });
   });
 
   describe('get', () => {

--- a/app/scripts/lib/stores/extension-store.ts
+++ b/app/scripts/lib/stores/extension-store.ts
@@ -166,12 +166,15 @@ export default class ExtensionStore implements BaseStore {
 
     const { local } = browser.storage;
     console.time('[ExtensionStore]: Overwriting local store');
-    await local.set({ data, meta });
-    // we ensure we keep track of data and meta in the manifest if we need to
-    // reset later
-    this.#manifest.add('data');
-    this.#manifest.add('meta');
-    console.timeEnd('[ExtensionStore]: Overwriting local store');
+    try {
+      await local.set({ data, meta });
+      // we ensure we keep track of data and meta in the manifest if we need to
+      // reset later
+      this.#manifest.add('data');
+      this.#manifest.add('meta');
+    } finally {
+      console.timeEnd('[ExtensionStore]: Overwriting local store');
+    }
   }
 
   /**


### PR DESCRIPTION
## **Description**

Fixes `ExtensionStore.set` so the overwrite timer is always closed when `browser.storage.local.set` rejects. Without this, the failed write leaves the timer open and the next overwrite attempt hits the duplicate timer label warning.

## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Run `yarn test:unit app/scripts/lib/stores/extension-store.test.ts`.
2. Verify the new regression test covers a rejected `browser.storage.local.set` call and still expects `console.timeEnd`.
3. Run `yarn lint:changed:fix`.

<!--
## **Screenshots/Recordings**

### **Before**

Not applicable.

### **After**

Not applicable.
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is limited to wrapping `ExtensionStore.set` timing/logging in a `try/finally`, with a regression test to cover the failure path; it does not alter persisted data or storage semantics beyond ensuring cleanup on errors.
> 
> **Overview**
> Ensures `ExtensionStore.set` always calls `console.timeEnd` for the overwrite timer by wrapping `browser.storage.local.set` and manifest updates in a `try/finally`, preventing duplicate timer label warnings after failed writes.
> 
> Adds a unit test that simulates a rejected `storage.local.set` call and asserts the overwrite timer is still ended.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc587cda0852766b725ae9782246f5a20b4275b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->