### PR TITLE
test: add metametrics to collect qa stats

### DIFF
--- a/.github/scripts/collect-qa-stats-metametrics.ts
+++ b/.github/scripts/collect-qa-stats-metametrics.ts
@@ -3,10 +3,9 @@
  * Used by collect-qa-stats.ts for the `metametrics` namespace in qa-stats.json.
  */
 
-import { access, readFile, readdir } from 'fs/promises';
+import { access, readFile } from 'fs/promises';
 import { constants as fsConstants } from 'fs';
-import { join } from 'path';
-import type { Dirent } from 'fs';
+import { PATTERN_E2E_SPEC_FILE, walkFiles } from './collect-qa-stats-walk-files';
 
 /** Constants files whose string enums are resolved in E2E (imported by specs). */
 const METRICS_ENUM_SOURCE_FILES = [
@@ -23,34 +22,8 @@ export const LEGACY_INLINE_METAMETRICS_PATHS: readonly string[] = [
 ];
 
 const SCAN_E2E_ROOT = 'test/e2e';
-const PATTERN_E2E_SPEC_FILE = /\.spec\.(ts|js)$/u;
 
 type EnumMap = Record<string, Record<string, string>>;
-
-/**
- * Recursively collects file paths under `dir` that satisfy `predicate(filename)`.
- */
-async function walkFiles(
-  dir: string,
-  predicate: (name: string) => boolean,
-): Promise<string[]> {
-  const results: string[] = [];
-  let entries: Dirent[];
-  try {
-    entries = await readdir(dir, { withFileTypes: true });
-  } catch {
-    return results;
-  }
-  for (const entry of entries) {
-    const fullPath = join(dir, entry.name);
-    if (entry.isDirectory()) {
-      results.push(...(await walkFiles(fullPath, predicate)));
-    } else if (entry.isFile() && predicate(entry.name)) {
-      results.push(fullPath);
-    }
-  }
-  return results;
-}
 
 /**
  * Parses `enum Name { A = 'x', B = 'y' }` blocks into enumName -> member -> value.
@@ -345,7 +318,7 @@ async function gatherMetametricsE2eFilePaths(): Promise<string[]> {
     PATTERN_E2E_SPEC_FILE.test(name),
   );
   for (const p of specFiles) {
-    if (p.replace(/\\/gu, '/').includes('/test/e2e/websocket/')) {
+    if (p.replace(/\\/gu, '/').includes(`${SCAN_E2E_ROOT}/websocket/`)) {
       continue;
     }
     paths.add(p);

--- a/.github/scripts/collect-qa-stats-metametrics.ts
+++ b/.github/scripts/collect-qa-stats-metametrics.ts
@@ -1,0 +1,393 @@
+/**
+ * Static scan of E2E sources for MetaMetrics event display names asserted in tests.
+ * Used by collect-qa-stats.ts for the `metametrics` namespace in qa-stats.json.
+ */
+
+import { access, readFile, readdir } from 'fs/promises';
+import { constants as fsConstants } from 'fs';
+import { join } from 'path';
+import type { Dirent } from 'fs';
+
+/** Constants files whose string enums are resolved in E2E (imported by specs). */
+const METRICS_ENUM_SOURCE_FILES = [
+  'shared/constants/metametrics.ts',
+  'shared/constants/transaction.ts',
+] as const;
+
+/**
+ * E2E sources that assert MetaMetrics but are not `*.spec.ts` / `*.spec.js`.
+ * Add paths when migrating inline checks out of specs into shared helpers.
+ */
+export const LEGACY_INLINE_METAMETRICS_PATHS: readonly string[] = [
+  'test/e2e/tests/confirmations/signatures/signature-helpers.ts',
+];
+
+const SCAN_E2E_ROOT = 'test/e2e';
+const PATTERN_E2E_SPEC_FILE = /\.spec\.(ts|js)$/u;
+
+type EnumMap = Record<string, Record<string, string>>;
+
+/**
+ * Recursively collects file paths under `dir` that satisfy `predicate(filename)`.
+ */
+async function walkFiles(
+  dir: string,
+  predicate: (name: string) => boolean,
+): Promise<string[]> {
+  const results: string[] = [];
+  let entries: Dirent[];
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return results;
+  }
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...(await walkFiles(fullPath, predicate)));
+    } else if (entry.isFile() && predicate(entry.name)) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
+/**
+ * Parses `enum Name { A = 'x', B = 'y' }` blocks into enumName -> member -> value.
+ */
+export function parseEnumStringMembers(source: string): EnumMap {
+  const enums: EnumMap = {};
+  const re = /\benum\s+(\w+)\s*\{/gu;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(source)) !== null) {
+    const enumName = m[1];
+    const start = source.indexOf('{', m.index);
+    let depth = 0;
+    let i = start;
+    for (; i < source.length; i += 1) {
+      const c = source[i];
+      if (c === '{') depth += 1;
+      else if (c === '}') {
+        depth -= 1;
+        if (depth === 0) break;
+      }
+    }
+    const inner = source.slice(start + 1, i);
+    const members: Record<string, string> = {};
+    for (const em of inner.matchAll(/\b(\w+)\s*=\s*['"]([^'"]+)['"]\s*,?/gu)) {
+      members[em[1]] = em[2];
+    }
+    if (Object.keys(members).length > 0) {
+      enums[enumName] = members;
+    }
+  }
+  return enums;
+}
+
+/**
+ * Parses `const foo = 'bar';` at statement level.
+ */
+export function parseConstStringLiterals(source: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const m of source.matchAll(/\bconst\s+(\w+)\s*=\s*['"]([^'"]+)['"]\s*;/gu)) {
+    out[m[1]] = m[2];
+  }
+  return out;
+}
+
+/**
+ * Parses `const foo = { a: 'b', ... }` object literals with string values.
+ */
+export function parseConstObjectStringValues(source: string): EnumMap {
+  const maps: EnumMap = {};
+  for (const m of source.matchAll(/\bconst\s+(\w+)\s*=\s*\{/gu)) {
+    const start = source.indexOf('{', m.index);
+    let depth = 0;
+    let i = start;
+    for (; i < source.length; i += 1) {
+      const c = source[i];
+      if (c === '{') depth += 1;
+      else if (c === '}') {
+        depth -= 1;
+        if (depth === 0) break;
+      }
+    }
+    const inner = source.slice(start + 1, i);
+    const props: Record<string, string> = {};
+    for (const km of inner.matchAll(/\b(\w+)\s*:\s*['"]([^'"]+)['"]\s*,?/gu)) {
+      props[km[1]] = km[2];
+    }
+    const varName = m[1];
+    if (Object.keys(props).length > 0) {
+      maps[varName] = props;
+    }
+  }
+  return maps;
+}
+
+/**
+ * Merges multiple enum maps; later entries win per enum name and per member.
+ */
+export function mergeEnumMaps(maps: EnumMap[]): EnumMap {
+  const out: EnumMap = {};
+  for (const map of maps) {
+    for (const [enumName, members] of Object.entries(map)) {
+      out[enumName] = { ...(out[enumName] ?? {}), ...members };
+    }
+  }
+  return out;
+}
+
+function resolveMetaMetricsToken(
+  token: string,
+  onboardingMap: Record<string, string>,
+  enums: EnumMap,
+  objectMaps: EnumMap,
+  strConsts: Record<string, string>,
+): string | null {
+  const t = token.replace(/^\s+|\s+$/gu, '');
+  if (!t) return null;
+  const lit = t.match(/^['"]([^'"]+)['"]$/u);
+  if (lit) return lit[1];
+  const onb = t.match(/^onboardingEvents\.(\w+)$/u);
+  if (onb && onboardingMap[onb[1]]) return onboardingMap[onb[1]];
+  const qual = t.match(/^(\w+)\.(\w+)$/u);
+  if (qual) {
+    const [, base, mem] = qual;
+    if (enums[base]?.[mem]) return enums[base][mem];
+    if (objectMaps[base]?.[mem]) return objectMaps[base][mem];
+  }
+  if (strConsts[t]) return strConsts[t];
+  return null;
+}
+
+/**
+ * Collects event display names from one E2E/helper source file.
+ */
+export function collectMetametricsFromSource(
+  source: string,
+  globalEnumMap: EnumMap,
+  onboardingMap: Record<string, string>,
+  out: Set<string>,
+): void {
+  const localEnums = parseEnumStringMembers(source);
+  const enums: EnumMap = { ...globalEnumMap };
+  for (const [name, members] of Object.entries(localEnums)) {
+    enums[name] = { ...(enums[name] ?? {}), ...members };
+  }
+  const strConsts = parseConstStringLiterals(source);
+  const objectMaps = parseConstObjectStringValues(source);
+
+  for (const m of source.matchAll(/\bonboardingEvents\.(\w+)/gu)) {
+    const v = onboardingMap[m[1]];
+    if (v) out.add(v);
+  }
+
+  for (const m of source.matchAll(/event\.event\s*===\s*['"]([^'"]+)['"]/gu)) {
+    out.add(m[1]);
+  }
+
+  for (const m of source.matchAll(/event\.event\s*===\s*(\w+)\.(\w+)/gu)) {
+    const v = resolveMetaMetricsToken(
+      `${m[1]}.${m[2]}`,
+      onboardingMap,
+      enums,
+      objectMaps,
+      strConsts,
+    );
+    if (v) out.add(v);
+  }
+
+  // Segment / MetaMetrics track payloads use `type: 'track'` near `event: '...'`.
+  // Skip bare `event:` (e.g. WebSocket mock payloads) to reduce false positives.
+  for (const m of source.matchAll(
+    /type:\s*['"]track['"][\s\S]{0,200}?\bevent:\s*['"]([^'"]+)['"]/gu,
+  )) {
+    out.add(m[1]);
+  }
+  for (const m of source.matchAll(
+    /\bevent:\s*['"]([^'"]+)['"][\s\S]{0,120}?type:\s*['"]track['"]/gu,
+  )) {
+    out.add(m[1]);
+  }
+
+  for (const m of source.matchAll(/\bevent:\s*(\w+)\.(\w+)/gu)) {
+    const v = resolveMetaMetricsToken(
+      `${m[1]}.${m[2]}`,
+      onboardingMap,
+      enums,
+      objectMaps,
+      strConsts,
+    );
+    if (v) out.add(v);
+  }
+
+  for (const m of source.matchAll(/findEvent\([^,]+,\s*['"]([^'"]+)['"]/gu)) {
+    out.add(m[1]);
+  }
+  for (const m of source.matchAll(/findEvent\([^,]+,\s*onboardingEvents\.(\w+)/gu)) {
+    const v = onboardingMap[m[1]];
+    if (v) out.add(v);
+  }
+  for (const m of source.matchAll(/filterEvents\(\s*[^,]+,\s*['"]([^'"]+)['"]/gu)) {
+    out.add(m[1]);
+  }
+  for (const m of source.matchAll(
+    /filterEvents\(\s*[^,]+,\s*onboardingEvents\.(\w+)/gu,
+  )) {
+    const v = onboardingMap[m[1]];
+    if (v) out.add(v);
+  }
+
+  for (const m of source.matchAll(/\bevent:\s*([A-Za-z_]\w*)\s*[,}]/gu)) {
+    const v = strConsts[m[1]];
+    if (v) out.add(v);
+  }
+
+  for (const m of source.matchAll(
+    /getEventsPayloads\s*\(\s*[^,]+,\s*\[([\s\S]*?)\]\s*(?:,\s*[^)]+)?\s*\)/gu,
+  )) {
+    const inner = m[1];
+    for (const sm of inner.matchAll(/['"]([^'"]+)['"]/gu)) {
+      out.add(sm[1]);
+    }
+    for (const sm of inner.matchAll(/\bonboardingEvents\.(\w+)/gu)) {
+      const v = onboardingMap[sm[1]];
+      if (v) out.add(v);
+    }
+    for (const part of inner.split(',')) {
+      const v = resolveMetaMetricsToken(
+        part,
+        onboardingMap,
+        enums,
+        objectMaps,
+        strConsts,
+      );
+      if (v) out.add(v);
+    }
+  }
+
+  const reArrays = /\bconst\s+(\w+)\s*=\s*\[([\s\S]*?)\];/gu;
+  let am: RegExpExecArray | null;
+  while ((am = reArrays.exec(source)) !== null) {
+    const varName = am[1];
+    const inner = am[2];
+    // Avoid `expectedNetworkNames` and similar — they match "Names" but are not analytics events.
+    if (/NetworkNames$/u.test(varName)) {
+      continue;
+    }
+    const looksLikeEventList =
+      /(?:event|Event|Expected|expectation|analytics)/u.test(varName) ||
+      /\bNames\b/u.test(varName) ||
+      /\bonboardingEvents\b|\bexpectedEvents\b/u.test(inner);
+    if (!looksLikeEventList) continue;
+    for (const part of inner.split(',')) {
+      const v = resolveMetaMetricsToken(
+        part,
+        onboardingMap,
+        enums,
+        objectMaps,
+        strConsts,
+      );
+      if (v) out.add(v);
+    }
+  }
+
+  for (const m of source.matchAll(
+    /assertEventPropertiesMatch\s*\([^,]+,\s*['"]([^'"]+)['"]/gu,
+  )) {
+    out.add(m[1]);
+  }
+
+  for (const m of source.matchAll(
+    /mockedTrackedEvent\s*\([^,]+,\s*(\w+)\.(\w+)\s*\)/gu,
+  )) {
+    const v = resolveMetaMetricsToken(
+      `${m[1]}.${m[2]}`,
+      onboardingMap,
+      enums,
+      objectMaps,
+      strConsts,
+    );
+    if (v) out.add(v);
+  }
+
+  for (const m of source.matchAll(
+    /assert\.(?:equal|deepEqual|strictEqual)\(\s*[^)]*\.event\s*,\s*(\w+)\.(\w+)\s*\)/gu,
+  )) {
+    const v = resolveMetaMetricsToken(
+      `${m[1]}.${m[2]}`,
+      onboardingMap,
+      enums,
+      objectMaps,
+      strConsts,
+    );
+    if (v) out.add(v);
+  }
+}
+
+async function loadGlobalMetricsEnumMap(): Promise<EnumMap> {
+  const parts: EnumMap[] = [];
+  for (const rel of METRICS_ENUM_SOURCE_FILES) {
+    try {
+      const raw = await readFile(rel, 'utf8');
+      parts.push(parseEnumStringMembers(raw));
+    } catch {
+      console.warn(`[metametrics] could not read ${rel}, skipping enum definitions`);
+    }
+  }
+  return mergeEnumMaps(parts);
+}
+
+async function gatherMetametricsE2eFilePaths(): Promise<string[]> {
+  const paths = new Set<string>();
+  const specFiles = await walkFiles(SCAN_E2E_ROOT, (name) =>
+    PATTERN_E2E_SPEC_FILE.test(name),
+  );
+  for (const p of specFiles) {
+    if (p.replace(/\\/gu, '/').includes('/test/e2e/websocket/')) {
+      continue;
+    }
+    paths.add(p);
+  }
+  for (const p of LEGACY_INLINE_METAMETRICS_PATHS) {
+    try {
+      await access(p, fsConstants.F_OK);
+      paths.add(p);
+    } catch {
+      console.warn(
+        `[metametrics] legacy path missing (update LEGACY_INLINE_METAMETRICS_PATHS): ${p}`,
+      );
+    }
+  }
+  return [...paths].sort((a, b) => a.localeCompare(b));
+}
+
+/**
+ * Returns stable keys for qa-stats.json `metametrics` namespace (Grafana / TSDB).
+ */
+export async function collectE2EMetaMetricsEventCoverage(): Promise<
+  Record<string, number | string>
+> {
+  const globalEnumMap = await loadGlobalMetricsEnumMap();
+  const onboardingMap: Record<string, string> = {};
+  const names = new Set<string>();
+  const files = await gatherMetametricsE2eFilePaths();
+
+  console.log(`[metametrics] scanning ${files.length} file(s) for referenced event names`);
+
+  for (const filePath of files) {
+    const source = await readFile(filePath, 'utf8');
+    collectMetametricsFromSource(source, globalEnumMap, onboardingMap, names);
+  }
+
+  const sorted = [...names].sort((a, b) => a.localeCompare(b));
+  console.log(
+    `[metametrics] ${sorted.length} unique event name(s) referenced in E2E sources`,
+  );
+
+  return {
+    metametrics_events_checked_unique_count: sorted.length,
+    metametrics_events_checked_names_json: JSON.stringify(sorted),
+  };
+}

--- a/.github/scripts/collect-qa-stats-walk-files.ts
+++ b/.github/scripts/collect-qa-stats-walk-files.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared filesystem helpers for QA stats collectors (E2E spec discovery, static scans).
+ */
+
+import { readdir } from 'fs/promises';
+import { join } from 'path';
+import type { Dirent } from 'fs';
+
+/** E2E Playwright/Jest spec filenames under `test/e2e`. */
+export const PATTERN_E2E_SPEC_FILE = /\.spec\.(ts|js)$/u;
+
+/**
+ * Recursively collects file paths under `dir` that satisfy `predicate(filename)`.
+ *
+ * @param dir - Directory to walk.
+ * @param predicate - Returns true for filenames to include.
+ */
+export async function walkFiles(
+  dir: string,
+  predicate: (name: string) => boolean,
+): Promise<string[]> {
+  const results: string[] = [];
+  let entries: Dirent[];
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return results; // directory does not exist — skip silently
+  }
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...(await walkFiles(fullPath, predicate)));
+    } else if (entry.isFile() && predicate(entry.name)) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}

--- a/.github/scripts/collect-qa-stats.ts
+++ b/.github/scripts/collect-qa-stats.ts
@@ -3,6 +3,10 @@
  * Metrics that could not be collected (missing artifacts, tests did not run)
  * are omitted from the output, i.e., they will not appear in the output file.
  *
+ * Downstream (e.g. Grafana / TSDB) keys metrics by (project, run_id, namespace, metric_key).
+ * Do not rename existing metric keys once published — renaming creates a new time series and
+ * breaks dashboard continuity. Adding or removing keys is fine.
+ *
  * Required env vars:
  *   GITHUB_TOKEN      — GitHub Actions token for API access
  *   GITHUB_REPOSITORY — Repository in "owner/repo" format (set automatically in Actions)
@@ -16,6 +20,10 @@
  *        "key3": "[\"string1\", \"string2\", ...]",
  *      }
  *   2. Register it as a new namespace in the collectors array in main()
+ *
+ * The `metametrics` namespace is populated by a static scan of E2E sources (see
+ * collect-qa-stats-metametrics.ts): `metametrics_events_checked_unique_count` and
+ * `metametrics_events_checked_names_json` must keep stable names for observability pipelines.
  *
  * Example output:
  *   {
@@ -38,10 +46,15 @@
  *       "main_chrome_tests_run": 1200,
  *       "main_firefox_tests_run": 1185,
  *       "flask_tests_run": 200
+ *     },
+ *     "metametrics": {
+ *       "metametrics_events_checked_unique_count": 42,
+ *       "metametrics_events_checked_names_json": "[\"Dapp Viewed\", ...]"
  *     }
  *   }
  */
 
+import { collectE2EMetaMetricsEventCoverage } from './collect-qa-stats-metametrics';
 import { readFile, writeFile, mkdir, readdir } from 'fs/promises';
 import type { Dirent } from 'fs';
 import { execFileSync } from 'child_process';
@@ -884,6 +897,19 @@ async function collectBenchmarkScenarioCount(): Promise<
   return result;
 }
 
+/**
+ * Static scan of E2E MetaMetrics assertions (no GitHub artifacts). On failure, returns {}.
+ */
+async function collectMetametricsQaStats(): Promise<Record<string, number | string>> {
+  try {
+    return await collectE2EMetaMetricsEventCoverage();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(`[metametrics] static scan failed, skipping namespace: ${message}`);
+    return {};
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
@@ -896,6 +922,7 @@ async function main(): Promise<void> {
     { namespace: 'integration', collect: collectIntegrationTestCount },
     { namespace: 'e2e', collect: collectE2eTestCount },
     { namespace: 'benchmark', collect: collectBenchmarkScenarioCount },
+    { namespace: 'metametrics', collect: collectMetametricsQaStats },
   ];
 
   for (const { namespace, collect } of collectors) {

--- a/.github/scripts/collect-qa-stats.ts
+++ b/.github/scripts/collect-qa-stats.ts
@@ -55,8 +55,8 @@
  */
 
 import { collectE2EMetaMetricsEventCoverage } from './collect-qa-stats-metametrics';
-import { readFile, writeFile, mkdir, readdir } from 'fs/promises';
-import type { Dirent } from 'fs';
+import { PATTERN_E2E_SPEC_FILE, walkFiles } from './collect-qa-stats-walk-files';
+import { readFile, writeFile, mkdir } from 'fs/promises';
 import { execFileSync } from 'child_process';
 import { join } from 'path';
 
@@ -124,7 +124,6 @@ const SCAN_INTEGRATION_DIR = 'test/integration';
 const SCAN_E2E_DIR = 'test/e2e';
 
 const PATTERN_UNIT_TEST_FILE = /\.test\.(ts|tsx|js|jsx)$/u;
-const PATTERN_E2E_SPEC_FILE = /\.spec\.(ts|js)$/u;
 
 // ---------------------------------------------------------------------------
 // GitHub API helpers
@@ -342,34 +341,6 @@ function parseJUnitXml(rawXml: string): JUnitParseResult {
 // ---------------------------------------------------------------------------
 // Static analysis helpers
 // ---------------------------------------------------------------------------
-
-/**
- * Recursively collects file paths under `dir` that satisfy `predicate(filename)`.
- *
- * @param dir - Directory to walk.
- * @param predicate - Returns true for filenames to include.
- */
-async function walkFiles(
-  dir: string,
-  predicate: (name: string) => boolean,
-): Promise<string[]> {
-  const results: string[] = [];
-  let entries: Dirent[];
-  try {
-    entries = await readdir(dir, { withFileTypes: true });
-  } catch {
-    return results; // directory does not exist — skip silently
-  }
-  for (const entry of entries) {
-    const fullPath = join(dir, entry.name);
-    if (entry.isDirectory()) {
-      results.push(...(await walkFiles(fullPath, predicate)));
-    } else if (entry.isFile() && predicate(entry.name)) {
-      results.push(fullPath);
-    }
-  }
-  return results;
-}
 
 /**
  * Counts all individual test definitions in a source string — both active and


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds a **`metametrics`** namespace to **`qa-stats.json`**, in line with [metamask-mobile#27696](https://github.com/MetaMask/metamask-mobile/pull/27696), so observability (e.g. Grafana) can track how many **distinct MetaMetrics event display names** are asserted in E2E tests, plus a **sorted list** of those names.

## Changes

| Area | Description |
|------|-------------|
| `collect-qa-stats-metametrics.ts` | Static scan of `test/e2e/**/*.spec.{ts,js}` (excludes `test/e2e/websocket/`), `LEGACY_INLINE_METAMETRICS_PATHS` for non-spec helpers; resolves enums from `shared/constants/metametrics.ts` and `shared/constants/transaction.ts`. |
| `collect-qa-stats.ts` | Registers the collector; documents **stable metric keys** for TSDB/Grafana (do not rename once published). |

## Output shape

The artifact **`qa-stats.json`** gains a top-level key:

```json
"metametrics": {
  "metametrics_events_checked_unique_count": <number>,
  "metametrics_events_checked_names_json": "<string: JSON array of names, sorted>"
}
```
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/41160?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it adds a new QA stats namespace driven by regex-based static scanning of E2E sources, which could be brittle (false positives/negatives) or fail in CI and affect observability pipelines, but it does not impact production runtime.
> 
> **Overview**
> Adds a new `metametrics` namespace to `qa-stats.json` by statically scanning E2E source files for referenced MetaMetrics event display names and emitting both a unique count and a stable, sorted JSON list.
> 
> Refactors shared file-walking logic into `collect-qa-stats-walk-files.ts`, and wires the new collector into `collect-qa-stats.ts` with explicit guidance to keep published metric keys stable; the MetaMetrics scan is best-effort and skips the namespace on failure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3aeaf919b89c4e36f686836253ae482b5ee94c41. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->