### PR TITLE
fix: webpack build menu misalignment

### DIFF
--- a/development/webpack/utils/plugins/LavamoatPlugin/index.ts
+++ b/development/webpack/utils/plugins/LavamoatPlugin/index.ts
@@ -123,9 +123,6 @@ export const lavamoatPlugin = (args: Args) =>
         'Promise',
         'JSON',
         'Date',
-        'setTimeout',
-        'clearTimeout',
-        'ResizeObserver',
         // globals sentry needs to function
         '__SENTRY__',
         'appState',
@@ -134,15 +131,20 @@ export const lavamoatPlugin = (args: Args) =>
         'sentryHooks',
         'sentry',
         'logEncryptedVault',
-        'history', // needed by Sentry and react-router-dom v6 HashRouter
+        // needed by Sentry and react-router-dom v6 HashRouter
+        'history',
         // globals used by react-dom
         'getSelection',
         // globals opera needs to function
         'opr',
+        // for @popperjs/core and snap simple keyring site
+        'devicePixelRatio',
+        // for @tanstack/react-virtual
+        'ResizeObserver',
+        'setTimeout',
+        'clearTimeout',
         // globals used by e2e
-        ...(args.test
-          ? ['ret_nodes', 'browser', 'chrome', 'indexedDB', 'devicePixelRatio']
-          : []),
+        ...(args.test ? ['ret_nodes', 'browser', 'chrome', 'indexedDB'] : []),
       ],
     },
   });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/41171?quickstart=1)



## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/41084

## **Manual testing steps**

1. run `yarn webpack --mode production`
2. menus shouldn't be misaligned

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="3112" height="1650" alt="image" src="https://github.com/user-attachments/assets/1159e933-22d0-4766-b1e4-ec0389a02d35" />

### **After**

<img width="1263" height="886" alt="image" src="https://github.com/user-attachments/assets/463e0f1b-6cc4-41af-8eaf-1ab8f58fb05d" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts LavaMoat `scuttleGlobalThis` exception allowlist, which slightly changes the extension’s global hardening/security posture. Low code churn, but mistakes here can surface as runtime-only UI/layout regressions or widen global access.
> 
> **Overview**
> Fixes production UI/menu misalignment by expanding the LavaMoat `scuttleGlobalThis` exception list to include browser globals required by dependencies (notably `devicePixelRatio`, `ResizeObserver`, `setTimeout`, and `clearTimeout`).
> 
> Cleans up the test-only exception list by removing `devicePixelRatio` (now always allowed) while keeping other e2e globals gated on `args.test`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7dffec1df03888a9439b155305640788a2b8b57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->