### PR TITLE
fix(webpack): use stable chunk filenames in development to partially fix `webpack --watch`

### DIFF
--- a/development/webpack/webpack.config.ts
+++ b/development/webpack/webpack.config.ts
@@ -267,11 +267,18 @@ const config = {
   output: {
     wasmLoading: 'fetch',
     // filenames for *initial* files (essentially JS entry points)
-    filename: '[name].[contenthash].js',
+    // content hashes are only useful in production for cache-busting; in
+    // development they cause a race condition in watch mode where
+    // service-worker.js is rewritten with new chunk hash references before the
+    // new chunk files have finished being written to disk, which causes
+    // importScripts() to fail when Chrome restarts the MV3 service worker.
+    filename: isDevelopment ? '[name].js' : '[name].[contenthash].js',
     path: join(context, '..', 'dist'),
-    // Clean the output directory before emit, so that only the latest build
-    // files remain. Nearly 0 performance penalty for this clean up step.
-    clean: true,
+    // Clean the output directory before emit in production so that only the
+    // latest build files remain. Disabled in development so that existing
+    // extension files survive across the initial build and incremental rebuilds,
+    // keeping the extension loadable in Chrome throughout.
+    clean: !isDevelopment,
     // relative to HTML page. This value is essentially prepended to asset URLs
     // in the output HTML, i.e., `<script src="<publicPath><resourcePath>">`.
     publicPath: '',

--- a/development/webpack/webpack.config.ts
+++ b/development/webpack/webpack.config.ts
@@ -273,11 +273,9 @@ const config = {
     // to fail and prevent the app from initializing.
     filename: isDevelopment ? '[name].js' : '[name].[contenthash].js',
     path: join(context, '..', 'dist'),
-    // Clean the output directory before emit in production so that only the
-    // latest build files remain. Disabled in development so that existing
-    // extension files survive across the initial build and incremental rebuilds,
-    // keeping the extension loadable in Chrome throughout.
-    clean: !isDevelopment,
+    // Clean the output directory before emit, so that only the latest build
+    // files remain. Nearly 0 performance penalty for this clean up step.
+    clean: true,
     // relative to HTML page. This value is essentially prepended to asset URLs
     // in the output HTML, i.e., `<script src="<publicPath><resourcePath>">`.
     publicPath: '',

--- a/development/webpack/webpack.config.ts
+++ b/development/webpack/webpack.config.ts
@@ -266,12 +266,18 @@ const config = {
   devtool: args.devtool === 'none' ? false : args.devtool,
   output: {
     wasmLoading: 'fetch',
-    // filenames for *initial* files (essentially JS entry points)
-    // content hashes are only useful in production for cache-busting; in
-    // development they can cause the chunk file names registered in the service
-    // worker to become out-of-sync with the files on disk, causing importScripts()
-    // to fail and prevent the app from initializing.
-    filename: isDevelopment ? '[name].js' : '[name].[contenthash].js',
+    // At some point we added the contenthash to filenames. People do this for cache
+    // busting in production, but as an extension, that is not relevant for us.
+    // Primarily, we are concerned here with making builds go faster, and it's not
+    // clear how including the contenthash furthers that goal.
+    // Eventually, we discovered that including the contenthash in the filenames
+    // breaks watched builds, because the filenames used by the background service
+    // worker for importScripts() somehow become out of sync with the files on
+    // disk on rebuilds.
+    // Although we aren't certain why we enabled content hashes in the first place,
+    // for now we only disable them in watched builds, and leave resolution of what
+    // to do for production builds to the future.
+    filename: args.watch ? '[name].js' : '[name].[contenthash].js',
     path: join(context, '..', 'dist'),
     // Clean the output directory before emit, so that only the latest build
     // files remain. Nearly 0 performance penalty for this clean up step.

--- a/development/webpack/webpack.config.ts
+++ b/development/webpack/webpack.config.ts
@@ -268,10 +268,9 @@ const config = {
     wasmLoading: 'fetch',
     // filenames for *initial* files (essentially JS entry points)
     // content hashes are only useful in production for cache-busting; in
-    // development they cause a race condition in watch mode where
-    // service-worker.js is rewritten with new chunk hash references before the
-    // new chunk files have finished being written to disk, which causes
-    // importScripts() to fail when Chrome restarts the MV3 service worker.
+    // development they can cause the chunk file names registered in the service
+    // worker to become out-of-sync with the files on disk, causing importScripts()
+    // to fail and prevent the app from initializing.
     filename: isDevelopment ? '[name].js' : '[name].[contenthash].js',
     path: join(context, '..', 'dist'),
     // Clean the output directory before emit in production so that only the


### PR DESCRIPTION
## **Description**

Content-hashed chunk filenames in development completely break watched builds in some circumstances: after modifying files in e.g. `app/offscreen/` and reloading the extension, `importScripts()` throws due to missing chunk files. It's possible that `service-worker.js` is rewritten with the wrong chunk file names, or not rewritten at all. Either way, it prevents the app from initializing.

Fix by omitting `[contenthash]` from `output.filename` in development mode so chunk filenames are generally stable across rebuilds. It is still possible for new chunks to be added or removed, in which case the bug in the service worker persists; a follow up PR is coming to fully fix this issue.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/41172?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

1. Run `yarn webpack --watch`
2. Reload the extension in Chrome
3. Change a file (modifying files in `app/offscreen` reliably triggered the behavior on my device)
4. Reload the extension
5. Everything should still work as normal

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes webpack output naming in `--watch` mode and should primarily affect development rebuild behavior; main risk is unexpected caching/regression if any tooling relied on hashed filenames during watch.
> 
> **Overview**
> Fixes `webpack --watch` rebuilds by making JS entry/chunk output filenames stable during watched builds.
> 
> `output.filename` now conditionally omits `[contenthash]` when `args.watch` is enabled (keeping hashed filenames for non-watch builds), with added inline rationale documenting the service worker `importScripts()` desync issue.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b80d31d55edb2e965ad4167728c961bdfc0b0a65. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->