### PR TITLE
feat: Recent Activity, Risk Disclaimer, misc cleanup

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5541,7 +5541,7 @@
     "message": "Direction"
   },
   "perpsDisclaimer": {
-    "message": "Trading perpetuals involves significant risk. You may lose more than your initial investment. This is not financial advice."
+    "message": "Perpetual contracts are very risky, and you could suddenly and without notice lose your entire investment. You trade entirely at your own risk. Powered by Hyperliquid. Price chart powered by TradingView."
   },
   "perpsEmptyDescription": {
     "message": "Trade perpetuals with leverage. Open your first position to get started."

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -5541,7 +5541,7 @@
     "message": "Direction"
   },
   "perpsDisclaimer": {
-    "message": "Trading perpetuals involves significant risk. You may lose more than your initial investment. This is not financial advice."
+    "message": "Perpetual contracts are very risky, and you could suddenly and without notice lose your entire investment. You trade entirely at your own risk. Powered by Hyperliquid. Price chart powered by TradingView."
   },
   "perpsEmptyDescription": {
     "message": "Trade perpetuals with leverage. Open your first position to get started."

--- a/shared/constants/perps.ts
+++ b/shared/constants/perps.ts
@@ -1,3 +1,6 @@
+/** Max items shown in the Perps tab Recent Activity preview (matches Activity page slice). */
+export const PERPS_RECENT_ACTIVITY_MAX_TRANSACTIONS = 5;
+
 export const VALID_MARKET_FILTERS = [
   'all',
   'crypto',

--- a/test/e2e/page-objects/pages/perps/perps-home-page.ts
+++ b/test/e2e/page-objects/pages/perps/perps-home-page.ts
@@ -89,7 +89,7 @@ export class PerpsHomePage extends PerpsPositionsBase {
 
   /**
    * Clicks the "See All" link in the Recent Activity section (navigates to Perps Activity).
-   * Requires positions so Recent Activity section is visible.
+   * Requires at least one perps transaction so the non-empty list and See All are shown.
    */
   async clickRecentActivitySeeAll(): Promise<void> {
     await this.driver.clickElement(this.perpsRecentActivitySeeAll);
@@ -158,7 +158,8 @@ export class PerpsHomePage extends PerpsPositionsBase {
   }
 
   /**
-   * Waits for the Recent Activity section to be visible (when user has positions).
+   * Waits for the Recent Activity list (non-empty) to be visible.
+   * When there is no history, the section uses `perps-recent-activity-empty` instead.
    */
   async waitForRecentActivitySection(): Promise<void> {
     await this.driver.waitForSelector(this.perpsRecentActivity);

--- a/ui/components/app/perps/perps-explore-markets/perps-explore-markets.tsx
+++ b/ui/components/app/perps/perps-explore-markets/perps-explore-markets.tsx
@@ -68,6 +68,7 @@ export const PerpsExploreMarkets: React.FC<PerpsExploreMarketsProps> = ({
             name={market.name}
             price={market.price}
             change24hPercent={market.change24hPercent}
+            volume={market.volume}
             onClick={handleMarketClick}
             data-testid={`explore-crypto-${market.symbol}`}
           />
@@ -79,6 +80,7 @@ export const PerpsExploreMarkets: React.FC<PerpsExploreMarketsProps> = ({
             name={market.name}
             price={market.price}
             change24hPercent={market.change24hPercent}
+            volume={market.volume}
             onClick={handleMarketClick}
             data-testid={`explore-hip3-${market.symbol.replace(/:/gu, '-')}`}
           />

--- a/ui/components/app/perps/perps-market-card/perps-market-card.tsx
+++ b/ui/components/app/perps/perps-market-card/perps-market-card.tsx
@@ -60,9 +60,11 @@ export const PerpsMarketCard: React.FC<PerpsMarketCardProps> = ({
         gap={1}
       >
         <Text fontWeight={FontWeight.Medium}>{displayName}</Text>
-        <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
-          {displaySymbol}-USD
-        </Text>
+        {volume ? (
+          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+            {volume}
+          </Text>
+        ) : null}
       </Box>
       <Box
         className="shrink-0"
@@ -81,11 +83,6 @@ export const PerpsMarketCard: React.FC<PerpsMarketCardProps> = ({
         >
           {change24hPercent}
         </Text>
-        {volume && (
-          <Text variant={TextVariant.BodyXs} color={TextColor.TextAlternative}>
-            {volume}
-          </Text>
-        )}
       </Box>
     </ButtonBase>
   );

--- a/ui/components/app/perps/perps-recent-activity/perps-recent-activity.test.tsx
+++ b/ui/components/app/perps/perps-recent-activity/perps-recent-activity.test.tsx
@@ -289,3 +289,40 @@ describe('PerpsRecentActivity - Empty State', () => {
     ).toBeInTheDocument();
   });
 });
+
+describe('PerpsRecentActivity - Loading state', () => {
+  it('shows loading skeleton when isLoading and no transactions yet', () => {
+    renderWithProvider(
+      <PerpsRecentActivity transactions={[]} isLoading />,
+      mockStore,
+    );
+
+    expect(
+      screen.getByTestId('perps-recent-activity-loading'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows transactions when loading but data already present', () => {
+    renderWithProvider(
+      <PerpsRecentActivity transactions={mockTransactions} isLoading />,
+      mockStore,
+    );
+
+    expect(screen.getByTestId('perps-recent-activity')).toBeInTheDocument();
+  });
+});
+
+describe('PerpsRecentActivity - Error state', () => {
+  it('shows error message in empty state when error is set', () => {
+    const errorMessage = 'Network error';
+    renderWithProvider(
+      <PerpsRecentActivity transactions={[]} error={errorMessage} />,
+      mockStore,
+    );
+
+    expect(
+      screen.getByTestId('perps-recent-activity-empty'),
+    ).toBeInTheDocument();
+    expect(screen.getByText(errorMessage)).toBeInTheDocument();
+  });
+});

--- a/ui/components/app/perps/perps-recent-activity/perps-recent-activity.tsx
+++ b/ui/components/app/perps/perps-recent-activity/perps-recent-activity.tsx
@@ -13,13 +13,20 @@ import {
 import { useNavigate } from 'react-router-dom';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { TransactionCard } from '../transaction-card';
+import { PERPS_RECENT_ACTIVITY_MAX_TRANSACTIONS } from '../../../../../shared/constants/perps';
 import { PERPS_ACTIVITY_ROUTE } from '../../../../helpers/constants/routes';
+import { BorderRadius } from '../../../../helpers/constants/design-system';
+import { Skeleton } from '../../../component-library/skeleton';
+import { PerpsCardSkeleton } from '../perps-skeletons/perps-card-skeleton';
 import type { PerpsTransaction } from '../types';
 
 export type PerpsRecentActivityProps = {
   transactions?: PerpsTransaction[];
   maxTransactions?: number;
   onTransactionClick?: (transaction: PerpsTransaction) => void;
+  /** When true and there are no transactions yet, show a loading skeleton. */
+  isLoading?: boolean;
+  error?: string | null;
 };
 
 /**
@@ -28,13 +35,17 @@ export type PerpsRecentActivityProps = {
  *
  * @param options0 - Component props
  * @param options0.transactions - Array of transactions to display
- * @param options0.maxTransactions - Maximum number of transactions to show (default: 5)
+ * @param options0.maxTransactions - Maximum number of transactions to show
  * @param options0.onTransactionClick - Optional click handler for transactions
+ * @param options0.isLoading - Loading state for initial fetch (skeleton when no rows yet)
+ * @param options0.error - Error message when fetch failed and there are no rows
  */
 export const PerpsRecentActivity: React.FC<PerpsRecentActivityProps> = ({
   transactions = [],
-  maxTransactions = 5,
+  maxTransactions = PERPS_RECENT_ACTIVITY_MAX_TRANSACTIONS,
   onTransactionClick,
+  isLoading = false,
+  error = null,
 }) => {
   const t = useI18nContext();
   const navigate = useNavigate();
@@ -44,10 +55,39 @@ export const PerpsRecentActivity: React.FC<PerpsRecentActivityProps> = ({
     .slice(0, maxTransactions);
 
   const hasTransactions = recentTransactions.length > 0;
+  const showLoadingSkeleton = isLoading && !hasTransactions;
 
   const handleSeeAll = () => {
     navigate(PERPS_ACTIVITY_ROUTE);
   };
+
+  if (showLoadingSkeleton) {
+    return (
+      <Box
+        flexDirection={BoxFlexDirection.Column}
+        gap={2}
+        data-testid="perps-recent-activity-loading"
+      >
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          justifyContent={BoxJustifyContent.Between}
+          alignItems={BoxAlignItems.Center}
+          paddingLeft={4}
+          paddingRight={4}
+          paddingTop={4}
+          marginBottom={2}
+        >
+          <Skeleton className="h-5 w-36" borderRadius={BorderRadius.SM} />
+          <Skeleton className="h-4 w-14" borderRadius={BorderRadius.SM} />
+        </Box>
+        <Box flexDirection={BoxFlexDirection.Column}>
+          {[1, 2, 3].map((cardIndex) => (
+            <PerpsCardSkeleton key={cardIndex} />
+          ))}
+        </Box>
+      </Box>
+    );
+  }
 
   if (!hasTransactions) {
     return (
@@ -68,8 +108,13 @@ export const PerpsRecentActivity: React.FC<PerpsRecentActivityProps> = ({
           <Text fontWeight={FontWeight.Medium}>{t('perpsRecentActivity')}</Text>
         </Box>
         <Box paddingLeft={4} paddingRight={4} paddingBottom={4}>
-          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
-            {t('perpsNoTransactions')}
+          <Text
+            variant={TextVariant.BodySm}
+            color={
+              error ? TextColor.ErrorDefault : TextColor.TextAlternative
+            }
+          >
+            {error ? error : t('perpsNoTransactions')}
           </Text>
         </Box>
       </Box>

--- a/ui/components/app/perps/perps-recent-activity/perps-recent-activity.tsx
+++ b/ui/components/app/perps/perps-recent-activity/perps-recent-activity.tsx
@@ -110,11 +110,9 @@ export const PerpsRecentActivity: React.FC<PerpsRecentActivityProps> = ({
         <Box paddingLeft={4} paddingRight={4} paddingBottom={4}>
           <Text
             variant={TextVariant.BodySm}
-            color={
-              error ? TextColor.ErrorDefault : TextColor.TextAlternative
-            }
+            color={error ? TextColor.ErrorDefault : TextColor.TextAlternative}
           >
-            {error ? error : t('perpsNoTransactions')}
+            {error || t('perpsNoTransactions')}
           </Text>
         </Box>
       </Box>

--- a/ui/components/app/perps/perps-view.test.tsx
+++ b/ui/components/app/perps/perps-view.test.tsx
@@ -4,7 +4,17 @@ import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate
 import configureStore from '../../../store/store';
 import mockState from '../../../../test/data/mock-state.json';
 import * as mocks from './mocks';
+import { usePerpsTransactionHistory } from '../../../hooks/perps/usePerpsTransactionHistory';
 import { PerpsView } from './perps-view';
+
+jest.mock('../../../hooks/perps/usePerpsTransactionHistory', () => ({
+  usePerpsTransactionHistory: jest.fn(() => ({
+    transactions: [],
+    isLoading: false,
+    error: null,
+    refetch: jest.fn(),
+  })),
+}));
 
 jest.mock('../../../store/background-connection', () => ({
   submitRequestToBackground: jest.fn().mockResolvedValue(undefined),
@@ -144,6 +154,22 @@ describe('PerpsView', () => {
 
       expect(
         screen.getByTestId('perps-recent-activity-empty'),
+      ).toBeInTheDocument();
+    });
+
+    it('shows Recent Activity list when transaction history has items', () => {
+      jest.mocked(usePerpsTransactionHistory).mockReturnValueOnce({
+        transactions: mocks.mockTransactions,
+        isLoading: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      renderWithProvider(<PerpsView />, mockStore);
+
+      expect(screen.getByTestId('perps-recent-activity')).toBeInTheDocument();
+      expect(
+        screen.getByTestId('perps-recent-activity-see-all'),
       ).toBeInTheDocument();
     });
 

--- a/ui/components/app/perps/perps-view.test.tsx
+++ b/ui/components/app/perps/perps-view.test.tsx
@@ -3,8 +3,8 @@ import { screen } from '@testing-library/react';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import configureStore from '../../../store/store';
 import mockState from '../../../../test/data/mock-state.json';
-import * as mocks from './mocks';
 import { usePerpsTransactionHistory } from '../../../hooks/perps/usePerpsTransactionHistory';
+import * as mocks from './mocks';
 import { PerpsView } from './perps-view';
 
 jest.mock('../../../hooks/perps/usePerpsTransactionHistory', () => ({

--- a/ui/components/app/perps/perps-view.tsx
+++ b/ui/components/app/perps/perps-view.tsx
@@ -1,12 +1,12 @@
 import { Box, BoxFlexDirection } from '@metamask/design-system-react';
 import React, { useMemo } from 'react';
-import { useSelector } from 'react-redux';
 import {
   usePerpsLivePositions,
   usePerpsLiveOrders,
   usePerpsLiveMarketData,
 } from '../../../hooks/perps/stream';
-import { getSelectedInternalAccount } from '../../../selectors';
+import { usePerpsTransactionHistory } from '../../../hooks/perps/usePerpsTransactionHistory';
+import { PERPS_RECENT_ACTIVITY_MAX_TRANSACTIONS } from '../../../../shared/constants/perps';
 
 import { usePerpsDepositConfirmation } from './hooks/usePerpsDepositConfirmation';
 import { PerpsBalanceDropdown } from './perps-balance-dropdown';
@@ -31,8 +31,6 @@ import { PerpsWatchlist } from './perps-watchlist';
 export const PerpsView: React.FC = () => {
   const { trigger: triggerDeposit } = usePerpsDepositConfirmation();
 
-  const selectedAccount = useSelector(getSelectedInternalAccount);
-
   // Stream hooks must run before any effects that touch PerpsStreamManager.
   // `usePerpsStreamManager` (inside these hooks) calls `perpsInit` then `init(address)`;
   // prewarm/init in an effect above these hooks used to run first and triggered
@@ -46,6 +44,12 @@ export const PerpsView: React.FC = () => {
     hip3Markets: allHip3Markets,
     isInitialLoading: marketsLoading,
   } = usePerpsLiveMarketData();
+
+  const {
+    transactions: recentActivityTransactions,
+    isLoading: recentActivityLoading,
+    error: recentActivityError,
+  } = usePerpsTransactionHistory();
 
   // Show only user-placed limit orders resting on the orderbook.
   // Excludes all position-attached orders:
@@ -69,7 +73,9 @@ export const PerpsView: React.FC = () => {
     return allHip3Markets.slice(0, 5);
   }, [allHip3Markets]);
 
-  // Show loading state while initial data is being fetched
+  // Show loading state while initial stream data is being fetched.
+  // Transaction history loads in parallel; Recent Activity skeleton is included here
+  // so the section is represented before the main view mounts.
   if (isLoading) {
     return (
       <Box
@@ -80,6 +86,9 @@ export const PerpsView: React.FC = () => {
         <PerpsControlBarSkeleton />
         <PerpsSectionSkeleton cardCount={5} showStartTradeCta />
         <PerpsSectionSkeleton cardCount={5} />
+        <Box data-testid="perps-recent-activity-skeleton">
+          <PerpsSectionSkeleton cardCount={3} showStartTradeCta={false} />
+        </Box>
       </Box>
     );
   }
@@ -112,7 +121,12 @@ export const PerpsView: React.FC = () => {
       />
 
       {/* Recent Activity */}
-      <PerpsRecentActivity />
+      <PerpsRecentActivity
+        transactions={recentActivityTransactions}
+        maxTransactions={PERPS_RECENT_ACTIVITY_MAX_TRANSACTIONS}
+        isLoading={recentActivityLoading}
+        error={recentActivityError}
+      />
 
       {/* Support & Learn */}
       <PerpsSupportLearn />

--- a/ui/components/app/perps/perps-watchlist/perps-watchlist.test.tsx
+++ b/ui/components/app/perps/perps-watchlist/perps-watchlist.test.tsx
@@ -58,11 +58,13 @@ describe('PerpsWatchlist', () => {
     expect(screen.getByTestId('perps-watchlist-ETH')).toBeInTheDocument();
   });
 
-  it('displays market name and price for each watchlist item', () => {
+  it('displays market name, volume, and price for each watchlist item', () => {
     renderWithProvider(<PerpsWatchlist />, mockStore);
 
     expect(screen.getByText(tEn('networkNameBitcoin'))).toBeInTheDocument();
     expect(screen.getByText(tEn('networkNameEthereum'))).toBeInTheDocument();
+    expect(screen.getByText('$1.2B')).toBeInTheDocument();
+    expect(screen.getByText('$850M')).toBeInTheDocument();
     expect(screen.getByText('$45,250.00')).toBeInTheDocument();
     expect(screen.getByText('$3,025.50')).toBeInTheDocument();
   });

--- a/ui/components/app/perps/perps-watchlist/perps-watchlist.tsx
+++ b/ui/components/app/perps/perps-watchlist/perps-watchlist.tsx
@@ -77,6 +77,7 @@ export const PerpsWatchlist: React.FC = () => {
             name={market.name}
             price={market.price}
             change24hPercent={market.change24hPercent}
+            volume={market.volume}
             onClick={handleMarketClick}
             data-testid={`perps-watchlist-${market.symbol}`}
           />


### PR DESCRIPTION
Integrates Recent Activity into Perps Tab. Fixes issue with Perps disclaimer being incorrect. Also fixes an issue where 24hr volume was incorrectly being rendered, and sometimes omitted entirely from each list item.

## **Description**

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/41174?quickstart=1)

## **Changelog**

CHANGELOG entry: Adds Recent Activity component, and miscellaneous UI improvements to Perps tab

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2690
Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2693
Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2697

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**


https://github.com/user-attachments/assets/4fc2e566-1e1b-4f39-9418-6ca9bb055f53



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI/data-flow change: the Perps tab now fetches and renders transaction history with new loading/error handling, which could impact perceived performance or state edge-cases but does not touch auth or funds movement logic.
> 
> **Overview**
> Adds *Recent Activity* to the Perps tab by wiring `PerpsView` to `usePerpsTransactionHistory`, including a dedicated skeleton during initial fetch and passing through error/loading state.
> 
> Enhances `PerpsRecentActivity` with a shared max-item constant, explicit loading and error empty-states, and new unit tests/E2E page-object guidance for the non-empty list behavior.
> 
> Updates Perps UI copy and market cards: the perps risk disclaimer text is revised, and 24h volume is consistently passed into `PerpsMarketCard` and displayed in the left metadata area for watchlist/explore lists.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a4dd66d0619b53888699003f960a07fbf2a589be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->