### PR TITLE
fix(webpack): align manifest transform behavior

### DIFF
--- a/development/webpack/test/plugins.ManifestPlugin.test.ts
+++ b/development/webpack/test/plugins.ManifestPlugin.test.ts
@@ -5,8 +5,12 @@ import { type Compilation } from 'webpack';
 import { ManifestPlugin } from '../utils/plugins/ManifestPlugin';
 import { ZipOptions } from '../utils/plugins/ManifestPlugin/types';
 import { Manifest } from '../utils/helpers';
+import {
+  CHROME_MANIFEST_KEY_NON_PRODUCTION,
+  CHROME_MANIFEST_KEY_RELEASE_CANDIDATE,
+  ENVIRONMENTS,
+} from '../utils/constants';
 import { transformManifest } from '../utils/plugins/ManifestPlugin/helpers';
-import { MANIFEST_DEV_KEY } from '../../build/constants';
 import { generateCases, type Combination, mockWebpack } from './helpers';
 
 const endsWithPath = (value: string, ...segments: string[]) =>
@@ -182,9 +186,7 @@ describe('ManifestPlugin', () => {
           if (testCase.webAccessibleResources) {
             if (baseManifest.manifest_version === 3) {
               // Extend expected resources for manifest version 3
-              // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-              expectedWar = baseManifest.web_accessible_resources || [];
+              expectedWar = baseManifest.web_accessible_resources ?? [];
               expectedWar = [
                 {
                   // the manifest plugin only supports `<all_urls>` for manifest version 3
@@ -197,9 +199,7 @@ describe('ManifestPlugin', () => {
                 },
               ];
             } else {
-              // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-              expectedWar = baseManifest.web_accessible_resources || [];
+              expectedWar = baseManifest.web_accessible_resources ?? [];
               // Keep or extend expected resources for manifest version 2
               expectedWar = [
                 ...expectedWar,
@@ -207,15 +207,11 @@ describe('ManifestPlugin', () => {
               ];
             }
           } else {
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-            expectedWar = baseManifest.web_accessible_resources || [];
+            expectedWar = baseManifest.web_accessible_resources ?? [];
           }
 
           assert.deepStrictEqual(
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-            json.web_accessible_resources || [],
+            json.web_accessible_resources ?? [],
             expectedWar,
             "should have the correct 'web_accessible_resources' in the manifest",
           );
@@ -272,7 +268,7 @@ describe('ManifestPlugin', () => {
     const keep = ['scripts/contentscript.js', 'scripts/inpage.js'];
     const argsMatrix = {
       test: [true, false],
-      manifest_version: [2, 3] as const,
+      env: [ENVIRONMENTS.PRODUCTION],
     };
     const manifestMatrix = {
       content_scripts: [
@@ -290,12 +286,10 @@ describe('ManifestPlugin', () => {
 
       function runTest(baseManifest: Combination<typeof manifestMatrix>) {
         const manifest = baseManifest as unknown as chrome.runtime.Manifest;
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        const hasTabsPermission = (manifest.permissions || []).includes('tabs');
+        const hasTabsPermission = (manifest.permissions ?? []).includes('tabs');
         const transform = transformManifest(args, false);
 
-        if (args.test && args.manifest_version === 2 && hasTabsPermission) {
+        if (args.test && hasTabsPermission) {
           it("throws in test mode when manifest already contains 'tabs' permission", () => {
             assert(transform, 'transform should be truthy');
             const p = () => {
@@ -307,7 +301,7 @@ describe('ManifestPlugin', () => {
               'should throw when manifest contains tabs already',
             );
           });
-        } else if (args.test && args.manifest_version === 2) {
+        } else if (args.test) {
           it(`works for args.test of ${args.test}. Manifest: ${JSON.stringify(manifest)}`, () => {
             assert(transform, 'transform should be truthy');
             const transformed = transform(manifest, 'chrome');
@@ -315,9 +309,7 @@ describe('ManifestPlugin', () => {
             if (args.test) {
               assert.deepStrictEqual(
                 transformed.permissions,
-                // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-                // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-                [...(manifest.permissions || []), 'tabs'],
+                [...(manifest.permissions ?? []), 'tabs'],
                 "manifest should have 'tabs' permission",
               );
             }
@@ -334,7 +326,6 @@ describe('ManifestPlugin', () => {
     } as unknown as chrome.runtime.Manifest;
     const mockFlags = {
       _flags: { remoteFeatureFlags: { testFlag: true } },
-      key: MANIFEST_DEV_KEY,
     };
     const manifestOverridesPath = 'testManifestOverridesPath.json';
     const fs = require('node:fs');
@@ -350,7 +341,10 @@ describe('ManifestPlugin', () => {
         return fs.readFileSync.original(path, options);
       });
       const transform = transformManifest(
-        { test: false, manifest_version: 3 },
+        {
+          env: ENVIRONMENTS.DEVELOPMENT,
+          test: false,
+        },
         true,
         manifestOverridesPath,
       );
@@ -359,7 +353,10 @@ describe('ManifestPlugin', () => {
       const transformed = transform(emptyTestManifest, 'chrome');
       assert.deepStrictEqual(
         transformed,
-        mockFlags,
+        {
+          ...mockFlags,
+          key: CHROME_MANIFEST_KEY_NON_PRODUCTION,
+        },
         'manifest should have flags in development mode',
       );
     });
@@ -372,7 +369,10 @@ describe('ManifestPlugin', () => {
         return fs.readFileSync.original(path, options);
       });
       const transform = transformManifest(
-        { test: false, manifest_version: 3 },
+        {
+          env: ENVIRONMENTS.DEVELOPMENT,
+          test: false,
+        },
         true,
         manifestOverridesPath,
       );
@@ -388,7 +388,7 @@ describe('ManifestPlugin', () => {
               testFlag: true,
             },
           },
-          key: MANIFEST_DEV_KEY,
+          key: CHROME_MANIFEST_KEY_NON_PRODUCTION,
         },
         'manifest should merge original properties with overrides, with overrides taking precedence',
       );
@@ -402,7 +402,10 @@ describe('ManifestPlugin', () => {
       });
 
       const transform = transformManifest(
-        { test: false, manifest_version: 3 },
+        {
+          env: ENVIRONMENTS.DEVELOPMENT,
+          test: false,
+        },
         true,
         manifestOverridesPath,
       );
@@ -419,7 +422,10 @@ describe('ManifestPlugin', () => {
 
     it('silently ignores non-ENOENT filesystem errors', () => {
       const transform = transformManifest(
-        { test: false, manifest_version: 3 },
+        {
+          env: ENVIRONMENTS.DEVELOPMENT,
+          test: false,
+        },
         true,
         manifestOverridesPath,
       );
@@ -439,6 +445,83 @@ describe('ManifestPlugin', () => {
         transformed._flags,
         undefined,
         'should not have flags when file read fails with non-ENOENT error',
+      );
+    });
+  });
+
+  describe('manifest key behavior', () => {
+    it('adds the default non-production manifest key for non-production builds', () => {
+      const transform = transformManifest(
+        { env: ENVIRONMENTS.OTHER, test: false },
+        false,
+      );
+      assert(transform, 'transform should be truthy');
+
+      const transformed = transform(
+        { manifest_version: 3 } as chrome.runtime.Manifest,
+        'chrome',
+      );
+
+      assert.strictEqual(
+        transformed.key,
+        CHROME_MANIFEST_KEY_NON_PRODUCTION,
+        'should add the default non-production manifest key outside production',
+      );
+    });
+
+    it('adds the release candidate manifest key for release-candidate builds', () => {
+      const transform = transformManifest(
+        {
+          env: ENVIRONMENTS.RELEASE_CANDIDATE,
+          test: false,
+        },
+        false,
+      );
+      assert(transform, 'transform should be truthy');
+
+      const transformed = transform(
+        { manifest_version: 3 } as chrome.runtime.Manifest,
+        'chrome',
+      );
+
+      assert.strictEqual(
+        transformed.key,
+        CHROME_MANIFEST_KEY_RELEASE_CANDIDATE,
+        'should add the release-candidate manifest key on release-candidate builds',
+      );
+    });
+
+    it('returns undefined for production builds with no other manifest transforms', () => {
+      const transform = transformManifest(
+        { env: ENVIRONMENTS.PRODUCTION, test: false },
+        false,
+      );
+
+      assert.strictEqual(
+        transform,
+        undefined,
+        'should preserve the conditional transform return for production builds',
+      );
+    });
+
+    it('does not add the manifest key for firefox builds based on the browser argument', () => {
+      const transform = transformManifest(
+        { env: ENVIRONMENTS.DEVELOPMENT, test: false },
+        false,
+      );
+      assert(transform, 'transform should be truthy');
+
+      const transformed = transform(
+        {
+          manifest_version: 2,
+        } as unknown as chrome.runtime.Manifest,
+        'firefox',
+      );
+
+      assert.strictEqual(
+        transformed.key,
+        undefined,
+        'should not add the manifest key for Firefox builds',
       );
     });
   });

--- a/development/webpack/test/webpack.config.test.ts
+++ b/development/webpack/test/webpack.config.test.ts
@@ -13,7 +13,7 @@ import { noop } from '../utils/helpers';
 import { ManifestPlugin } from '../utils/plugins/ManifestPlugin';
 import { getLatestCommit } from '../utils/git';
 import { ManifestPluginOptions } from '../utils/plugins/ManifestPlugin/types';
-import { MANIFEST_DEV_KEY } from '../../build/constants';
+import { CHROME_MANIFEST_KEY_NON_PRODUCTION } from '../utils/constants';
 
 function getWebpackInstance(config: Configuration) {
   // webpack logs a warning if we pass config.watch to it without a callback
@@ -162,7 +162,7 @@ ${Object.entries(env)
           js: ['scripts/contentscript.js', 'scripts/inpage.js'],
         },
       ],
-      key: MANIFEST_DEV_KEY,
+      key: CHROME_MANIFEST_KEY_NON_PRODUCTION,
     });
     assert.strictEqual(manifestPlugin.options.zip, false);
     const manifestOpts = manifestPlugin.options as ManifestPluginOptions<true>;
@@ -180,6 +180,9 @@ ${Object.entries(env)
       [
         '--mode',
         'production',
+        '--env',
+        'production',
+        '--no-validateEnv',
         '--watch',
         '--stats',
         '--no-progress',

--- a/development/webpack/utils/constants.ts
+++ b/development/webpack/utils/constants.ts
@@ -16,6 +16,15 @@ export const ENVIRONMENTS = {
   TESTING: 'testing',
 } as const;
 
+// Manifest key used for non-production Chrome builds to keep a stable
+// extension ID for OAuth flows.
+export const CHROME_MANIFEST_KEY_NON_PRODUCTION =
+  'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqZDxqBR1jHc1TygPHRO+GEyjMENrt3GLn2zXZg0VJ+S8EDuPSQR3sh14qDGWqbqpVk6+6ZF5QI5Ofx9lqAbNV7KjZT4W4RcXJ0VnTqPKUvhWm5+PfUbWMmnuQPebLjuVAkjiZUtY6OfVDowJdYmz4OLp6s64g+lH/Skz3lPKgVQKkWqrDDOy+wPsMBhiYWVGJvRkWA1f73mzhu6yTex/VivXg5PCck/xFN2/UiWTOYK4a/f8/XdVvN6yJd6XHH2lC7BJ+e8Trx0YeIC+3GNgv85rnlb4h31TzF4tmGV2cXB6d1Xw2KT0K+eS4KbTct5tCHOnnDZXvGhJDBrCH786jQIDAQAB';
+
+// Only used for Chrome builds produced from the release-candidate branch.
+export const CHROME_MANIFEST_KEY_RELEASE_CANDIDATE =
+  'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAlcgI4VVL4JUvo6hlSgeCZp9mGltZrzFvc2Asqzb1dDGO9baoYOe+QRoh27/YyVXugxni480Q/R147INhBOyQZVMhZOD5pFMVutia9MHMaZhgRXzrK3BHtNSkKLL1c5mhutQNwiLqLtFkMSGvka91LoMEC8WTI0wi4tACnJ5FyFZQYzvtqy5sXo3VS3gzfOBluLKi7BxYcaUJjNrhOIxl1xL2qgK5lDrDOLKcbaurDiwqofVtAFOL5sM3uJ6D8nOO9tG+T7hoobRFN+nxk43PHgCv4poicOv+NMZQEk3da1m/xfuzXV88NcE/YRbRLwAS82m3gsJZKc6mLqm4wZHzBwIDAQAB';
+
 /**
  * Collection of variable declarations required for the production build.
  * Grouped by build type.

--- a/development/webpack/utils/plugins/ManifestPlugin/helpers.ts
+++ b/development/webpack/utils/plugins/ManifestPlugin/helpers.ts
@@ -30,9 +30,9 @@ function getManifestKey(env: Pick<Args, 'env'>['env']): string | undefined {
  * given build args.
  *
  * Applies the following transformations:
- * - If `env` is `release-candidate`, sets the release-candidate manifest key
- * - If `env` is any other non-production environment, sets the default
- * non-production manifest key
+ * - For non-firefox builds, if `env` is `release-candidate`, sets the
+ * release-candidate manifest key, otherwise sets the default non-production
+ * manifest key.
  * - If `isDevelopment` is `true`, merges manifest override flags from the file
  * specified by `MANIFEST_OVERRIDES`
  * - If `test` is `true`, adds the "tabs" permission to the manifest
@@ -78,13 +78,11 @@ export function transformManifest(
     browserManifest: chrome.runtime.Manifest,
     browser: Browser,
   ) {
-    if (browser === 'firefox') {
+    if (browser === 'chrome') {
       // firefox uses a different key generation method and does not need this
       // fixed Chrome manifest key.
-      return;
+      browserManifest.key = manifestKey;
     }
-
-    browserManifest.key = manifestKey;
   }
 
   if (manifestKey) {

--- a/development/webpack/utils/plugins/ManifestPlugin/helpers.ts
+++ b/development/webpack/utils/plugins/ManifestPlugin/helpers.ts
@@ -1,37 +1,101 @@
 import merge from 'lodash/merge';
-import { MANIFEST_DEV_KEY } from '../../../../build/constants';
+import {
+  CHROME_MANIFEST_KEY_NON_PRODUCTION,
+  CHROME_MANIFEST_KEY_RELEASE_CANDIDATE,
+  ENVIRONMENTS,
+} from '../../constants';
 import type { Args } from '../../cli';
+import type { Browser } from '../../helpers';
+
+/**
+ * Returns the appropriate manifest key based on the given environment.
+ *
+ * @param env - The environment for which to get the manifest key
+ * @returns The manifest key for the given environment, or `undefined` for
+ * production.
+ */
+function getManifestKey(env: Pick<Args, 'env'>['env']): string | undefined {
+  switch (env) {
+    case ENVIRONMENTS.PRODUCTION:
+      return undefined;
+    case ENVIRONMENTS.RELEASE_CANDIDATE:
+      return CHROME_MANIFEST_KEY_RELEASE_CANDIDATE;
+    default:
+      return CHROME_MANIFEST_KEY_NON_PRODUCTION;
+  }
+}
+
 /**
  * Returns a function that will transform a manifest JSON object based on the
  * given build args.
  *
  * Applies the following transformations:
- * - If `test` is `true`, adds the "tabs" permission to the manifest in MV2
+ * - If `env` is `release-candidate`, sets the release-candidate manifest key
+ * - If `env` is any other non-production environment, sets the default
+ * non-production manifest key
+ * - If `isDevelopment` is `true`, merges manifest override flags from the file
+ * specified by `MANIFEST_OVERRIDES`
+ * - If `test` is `true`, adds the "tabs" permission to the manifest
  *
  * @param args
+ * @param args.env
  * @param args.test
- * @param args.manifest_version
  * @param isDevelopment
  * @param manifestOverridesPath
- * @returns a function that will transform the manifest JSON object
- * @throws an error if the manifest already contains the "tabs" permission and
- * `test` is `true` in MV2
+ * @returns a function that will transform the manifest JSON object. The
+ * returned function throws if `test` is `true` and the manifest already
+ * contains the "tabs" permission.
  */
 export function transformManifest(
-  args: Pick<Args, 'test' | 'manifest_version'>,
+  args: Pick<Args, 'env' | 'test'>,
   isDevelopment: boolean,
   manifestOverridesPath?: string | undefined,
 ) {
   const transforms: ((
     manifest: chrome.runtime.Manifest,
-    browser?: string,
+    browser: Browser,
   ) => chrome.runtime.Manifest | void)[] = [];
+
+  const manifestKey = getManifestKey(args.env);
+
+  /**
+   * Adds a fixed `key` value to the manifest for consistent extension ID in
+   * non-production Chrome builds.
+   *
+   * This is necessary to ensure that the extension ID remains consistent
+   * across builds, which is required for OAuth authentication outside
+   * production. In production, the Chrome Web Store generates a unique key, so
+   * we do not set a fixed key.
+   *
+   * This transform needs to be applied before the manifest flags transform,
+   * otherwise the manifest flags transform would not be able to override the
+   * key when the manifest overrides file is used to set a different one.
+   *
+   * @param browserManifest - The Chrome extension manifest object to modify
+   * @param browser - The target browser for the manifest
+   */
+  function addManifestKey(
+    browserManifest: chrome.runtime.Manifest,
+    browser: Browser,
+  ) {
+    if (browser === 'firefox') {
+      // firefox uses a different key generation method and does not need this
+      // fixed Chrome manifest key.
+      return;
+    }
+
+    browserManifest.key = manifestKey;
+  }
+
+  if (manifestKey) {
+    transforms.push(addManifestKey);
+  }
 
   /**
    * This function sets predefined flags in the manifest's _flags property
    * that are stored in the file specified by the `MANIFEST_OVERRIDES` build variable
    *
-   * @param browserManifest - The Chrome extension manifest object to modify
+   * @param browserManifest - The extension manifest object to modify
    */
   function addManifestFlags(browserManifest: chrome.runtime.Manifest): void {
     let manifestFlags;
@@ -87,20 +151,10 @@ export function transformManifest(
     transforms.push(addTabsPermission);
   }
 
-  function addManifestKey(browserManifest: chrome.runtime.Manifest) {
-    if (!browserManifest.key) {
-      browserManifest.key = MANIFEST_DEV_KEY;
-    }
-  }
-
-  if (isDevelopment || args.test) {
-    transforms.push(addManifestKey);
-  }
-
   return transforms.length
-    ? (browserManifest: chrome.runtime.Manifest, _browser: string) => {
+    ? (browserManifest: chrome.runtime.Manifest, browser: Browser) => {
         const manifestClone = structuredClone(browserManifest);
-        transforms.forEach((transform) => transform(manifestClone));
+        transforms.forEach((transform) => transform(manifestClone, browser));
         return manifestClone;
       }
     : undefined;

--- a/development/webpack/utils/plugins/ManifestPlugin/helpers.ts
+++ b/development/webpack/utils/plugins/ManifestPlugin/helpers.ts
@@ -71,7 +71,7 @@ export function transformManifest(
    * otherwise the manifest flags transform would not be able to override the
    * key when the manifest overrides file is used to set a different one.
    *
-   * @param browserManifest - The Chrome extension manifest object to modify
+   * @param browserManifest - The extension manifest object to modify
    * @param browser - The target browser for the manifest
    */
   function addManifestKey(
@@ -92,12 +92,14 @@ export function transformManifest(
   }
 
   /**
-   * This function sets predefined flags in the manifest's _flags property
-   * that are stored in the file specified by the `MANIFEST_OVERRIDES` build variable
+   * This function merges manifest overrides from the file specified by
+   * `MANIFEST_OVERRIDES` into the manifest.
    *
    * @param browserManifest - The extension manifest object to modify
    */
-  function addManifestFlags(browserManifest: chrome.runtime.Manifest): void {
+  function applyManifestOverrides(
+    browserManifest: chrome.runtime.Manifest,
+  ): void {
     let manifestFlags;
 
     if (manifestOverridesPath) {
@@ -129,8 +131,8 @@ export function transformManifest(
   }
 
   if (isDevelopment) {
-    // Add manifest flags only for development builds
-    transforms.push(addManifestFlags);
+    // Apply manifest overrides only for development builds
+    transforms.push(applyManifestOverrides);
   }
 
   function addTabsPermission(browserManifest: chrome.runtime.Manifest) {


### PR DESCRIPTION
## **Description**

Refactor some manifest transforms so that the prerelease build key for chrome builds is correct.

## **Changelog**

CHANGELOG entry: null


## **Related issues**

Fixes: #41097, #41089

## **Manual testing steps**

1. install an actual release candidate build from a release channel, then onboard.
2. run `yarn webpack --env release-candidate` on this branch
3. install this `webpack` build into the same browser that contains the release-candidate build from step 1. It should automatically replace the release-candidate build from step 1, instead of adding another MetaMask extension installation.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 51d6397485ef2c55a72db01a1cd511296a52d21a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->