### PR TITLE
ci: Merge Queue Triage and Retry system (Part 1 of 2)

### DIFF
--- a/.github/scripts/verify-ci-checks.sh
+++ b/.github/scripts/verify-ci-checks.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
-# Verifies 'all-jobs-pass' CI check has passed on RELEASE_SHA.
+# Verifies the 'All jobs pass' commit status has succeeded on RELEASE_SHA.
+#
+# ci-status-gate.yml posts a commit status with context "All jobs pass"
+# after every CI run. This script queries the commit statuses API to
+# confirm the release SHA passed CI before publishing.
+#
 # Required env: GITHUB_TOKEN, GITHUB_REPOSITORY, RELEASE_SHA
 
 set -euo pipefail
@@ -19,60 +24,45 @@ if [[ -z "${RELEASE_SHA:-}" ]]; then
     exit 1
 fi
 
-echo "Verifying CI checks on SHA: ${RELEASE_SHA}"
+echo "Verifying CI status on SHA: ${RELEASE_SHA}"
 
-# Fetch all check runs for the commit
-CHECK_RUNS=$(
+# Fetch the combined status (latest state per context) for this commit.
+COMBINED_STATUS=$(
   gh api \
     -H "Accept: application/vnd.github+json" \
-    "/repos/${GITHUB_REPOSITORY}/commits/${RELEASE_SHA}/check-runs" \
-    --paginate |
-    jq -s '{check_runs: [.[].check_runs[]]}'
+    "/repos/${GITHUB_REPOSITORY}/commits/${RELEASE_SHA}/status"
 )
 
-print_check_run_names() {
+print_commit_statuses() {
     echo ""
-    echo "=== Check runs found on SHA ${RELEASE_SHA} ==="
-    echo "${CHECK_RUNS}" | jq -r '.check_runs[] | "\(.name) (status: \(.status), conclusion: \(.conclusion))"' | sort -u
+    echo "=== Commit statuses found on SHA ${RELEASE_SHA} ==="
+    echo "${COMBINED_STATUS}" | jq -r '.statuses[] | "\(.context) (state: \(.state))"' | sort -u
 }
 
-# Look for 'all-jobs-pass' or 'All jobs pass' (the check that gates all CI)
-# Prefer the most recent check-run (reruns can create multiple).
-CHECK_RESULT=$(
-    echo "${CHECK_RUNS}" | jq -c '
-      [.check_runs[] | select(.name == "all-jobs-pass" or .name == "All jobs pass")]
-      | sort_by(.completed_at // .started_at // "")
-      | reverse
-      | .[0]
-      | if . == null then empty else {name: .name, status: .status, conclusion: .conclusion} end
+# Find the "All jobs pass" commit status (posted by ci-status-gate.yml).
+STATUS_STATE=$(
+    echo "${COMBINED_STATUS}" | jq -r '
+      .statuses[]
+      | select(.context == "All jobs pass")
+      | .state
     '
 )
 
-if [[ -z "${CHECK_RESULT}" ]]; then
-    echo "::error::Required check 'all-jobs-pass' not found on SHA ${RELEASE_SHA}"
+if [[ -z "${STATUS_STATE}" ]]; then
+    echo "::error::Required commit status 'All jobs pass' not found on SHA ${RELEASE_SHA}"
     echo "::error::Ensure CI has run on this SHA before publishing."
-    print_check_run_names
+    print_commit_statuses
     exit 1
 fi
 
-CHECK_NAME=$(echo "${CHECK_RESULT}" | jq -r '.name')
-STATUS=$(echo "${CHECK_RESULT}" | jq -r '.status')
-CONCLUSION=$(echo "${CHECK_RESULT}" | jq -r '.conclusion')
+echo "Found commit status: All jobs pass (state: ${STATUS_STATE})"
 
-echo "Found check: ${CHECK_NAME} (status: ${STATUS}, conclusion: ${CONCLUSION})"
-
-if [[ "${STATUS}" != "completed" ]]; then
-    echo "::error::Check '${CHECK_NAME}' is still running (status: ${STATUS})"
-    echo "::error::Wait for CI to complete before publishing."
-    exit 1
-fi
-
-if [[ "${CONCLUSION}" != "success" ]]; then
-    echo "::error::Check '${CHECK_NAME}' did not succeed (conclusion: ${CONCLUSION})"
+if [[ "${STATUS_STATE}" != "success" ]]; then
+    echo "::error::Commit status 'All jobs pass' did not succeed (state: ${STATUS_STATE})"
     echo "::error::All CI checks must pass before publishing."
-    print_check_run_names
+    print_commit_statuses
     exit 1
 fi
 
 echo ""
-echo "✅ CI check '${CHECK_NAME}' passed - all required checks verified"
+echo "✅ Commit status 'All jobs pass' succeeded — all required checks verified"

--- a/.github/workflows/ci-status-gate.yml
+++ b/.github/workflows/ci-status-gate.yml
@@ -1,0 +1,113 @@
+# Aggregates all CI job results and posts a commit status.
+#
+# Called exclusively by main.yml via workflow_call. Extracted to keep
+# main.yml lean, not for reuse — it is tightly coupled to Main's
+# job graph and event context.
+#
+# Responsibilities:
+#   1. Check that all jobs passed (from caller's needs-json)
+#   2. Post "All jobs pass" commit status (success or failure)
+#   3. Fail the job if any checks failed
+#   4. Log merge group failures to Google Sheets
+
+name: CI status gate (controls all-jobs-pass)
+
+on:
+  workflow_call:
+    inputs:
+      needs-json:
+        description: JSON-encoded needs context from the caller (toJson(needs)). Used to check that all upstream jobs passed.
+        required: true
+        type: string
+      builds-from-run:
+        description: Run ID that produced the build artifacts. Used to warn when builds come from a different run (builds-from-run shortcut).
+        required: true
+        type: string
+
+jobs:
+  gate:
+    name: CI status gate (controls all-jobs-pass)
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      statuses: write
+    env:
+      RUN_ID: ${{ github.run_id }}
+      HEAD_COMMIT_HASH: ${{ github.event.pull_request.head.sha || github.sha }}
+    steps:
+      # NOTE on output naming: actions/github-script@v8 reserves
+      # outputs.result for the script's return value (JSON.stringified).
+      # We use 'checkResult' to avoid that collision.
+      - name: Check that all jobs have passed
+        id: check
+        uses: actions/github-script@v8
+        env:
+          NEEDS_JSON: ${{ inputs.needs-json }}
+          BUILDS_FROM_RUN: ${{ inputs.builds-from-run }}
+        with:
+          script: |
+            const needs = JSON.parse(process.env.NEEDS_JSON);
+            let allPassed = true;
+
+            for (const [job, { result }] of Object.entries(needs)) {
+              if (!result) {
+                core.error(`Could not determine result for job: ${job}`);
+                allPassed = false;
+              } else if (result !== 'success' && result !== 'skipped') {
+                core.error(`${job} did not succeed (result: ${result})`);
+                allPassed = false;
+              }
+            }
+
+            if (process.env.BUILDS_FROM_RUN !== process.env.RUN_ID) {
+              core.warning(`Builds were used from a different GHA run: ${process.env.BUILDS_FROM_RUN}`);
+              core.info('Right now you can use this feature to test and iterate faster, but to merge a PR, you have to disable it.');
+              allPassed = false;
+            }
+
+            core.setOutput('checkResult', allPassed ? 'success' : 'failure');
+
+      # Post a commit status named "All jobs pass".
+      #
+      # Why a commit status instead of a check run?
+      # The Checks API (checks.create) assigns new check runs to a
+      # non-deterministic check suite. On merge_group branches, multiple
+      # suites exist (one per triggered workflow), and the check can land
+      # in the wrong suite — one the merge queue doesn't monitor. Commit
+      # statuses have no suites, so they always work reliably.
+      #
+      # No continue-on-error here: if the API call fails, we WANT the job
+      # to fail so check-retry-ci can re-run it. Adding continue-on-error
+      # would make the job "succeed" without posting the status, leaving
+      # the merge queue stuck.
+      - name: Post commit status
+        uses: actions/github-script@v8
+        env:
+          STATUS_STATE: ${{ steps.check.outputs.checkResult }}
+        with:
+          script: |
+            const state = process.env.STATUS_STATE;
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: process.env.HEAD_COMMIT_HASH,
+              state,
+              context: 'All jobs pass',
+              description: state === 'success'
+                ? 'All CI jobs completed successfully'
+                : 'One or more CI jobs failed',
+            });
+            core.info(`Posted commit status: ${state}`);
+
+      - name: Fail job if checks failed
+        if: ${{ steps.check.outputs.checkResult == 'failure' }}
+        run: exit 1
+
+      - name: Log merge group failure
+        if: ${{ github.event_name == 'merge_group' && failure() && !github.event.repository.fork }}
+        uses: MetaMask/github-tools/.github/actions/log-merge-group-failure@v1
+        with:
+          google-application-credentials: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+          google-service-account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
+          spreadsheet-id: ${{ secrets.GOOGLE_MERGE_QUEUE_SPREADSHEET_ID }}
+          sheet-name: ${{ secrets.GOOGLE_MERGE_QUEUE_SHEET_NAME }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -769,11 +769,10 @@ jobs:
 
           echo "Regression validation triggered successfully"
 
-  all-jobs-pass:
-    name: All jobs pass
+  ci-status-gate:
     if: ${{ !cancelled() }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
+    permissions:
+      statuses: write
     # We list every job we want to validate in `needs`, because `needs` only contains results for jobs explicitly
     # named here. A failing job can cause downstream jobs to be `skipped`, which can hide the true failure unless
     # the upstream job is also included.
@@ -782,7 +781,7 @@ jobs:
     #
     # Jobs intentionally excluded:
     # - Publish jobs (not required for CI pass)
-    # - Jobs that depend on all-jobs-pass (e.g., log-merge-group-failure) cannot be included here
+    # - Jobs that depend on ci-status-gate (e.g., log-merge-group-failure) cannot be included here
     needs:
       - get-requirements
       - locales-changed-only
@@ -823,67 +822,25 @@ jobs:
       - build-source-map-explorer
       - build-lavamoat-viz
       - trigger-regression-validation
-    steps:
-      - name: Check that all jobs have passed
-        env:
-          NEEDS_JSON: ${{ toJson(needs) }} # This is required for the the job_result lookup and the job_id loop
-          BUILDS_FROM_RUN: ${{ needs.get-requirements.outputs.builds-from-run }}
-        run: |
-          # Function to ensure a job's result is either 'success' or 'skipped'
-          requireJobSuccessOrSkipped() {
-            local job_id="$1"
-            local job_result="$2"
-
-            if [[ -z "$job_result" ]]; then
-              echo "Could not determine result for job: $job_id"
-              exit 1
-            fi
-
-            if [[ "$job_result" != "skipped" && "$job_result" != "success" ]]; then
-              echo "$job_id did not succeed (result: $job_result)"
-              exit 1
-            fi
-          }
-
-          # Loop through each job in the needs array to ensure it succeeded or was skipped
-          while IFS=$'\t' read -r job_id job_result; do
-            # job_result is effectively `needs[$job_id].result`
-            requireJobSuccessOrSkipped "$job_id" "$job_result"
-          done < <(
-            jq -r 'to_entries[] | [.key, (.value.result // "")] | @tsv' <<<"$NEEDS_JSON"
-          )
-
-          # # Check if the builds-from-run output is the current run ID
-          if [[ "$BUILDS_FROM_RUN" != "$RUN_ID" ]]; then
-            echo "Builds were used from a different GHA run: $BUILDS_FROM_RUN"
-            echo "Right now you can use this feature to test and iterate faster, but to merge a PR, you have to disable it."
-            exit 1
-          fi
-
-          echo "All required jobs either passed or were skipped"
-
-      - name: Log merge group failure
-        if: ${{ github.event_name == 'merge_group' && failure() && !github.event.repository.fork }}
-        uses: MetaMask/github-tools/.github/actions/log-merge-group-failure@v1
-        with:
-          google-application-credentials: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
-          google-service-account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
-          spreadsheet-id: ${{ secrets.GOOGLE_MERGE_QUEUE_SPREADSHEET_ID }}
-          sheet-name: ${{ secrets.GOOGLE_MERGE_QUEUE_SHEET_NAME }}
+    uses: ./.github/workflows/ci-status-gate.yml
+    with:
+      needs-json: ${{ toJson(needs) }}
+      builds-from-run: ${{ needs.get-requirements.outputs.builds-from-run }}
+    secrets: inherit
 
   check-retry-ci:
     name: Check for retry-ci label and retry
     if: >-
       ${{
         !cancelled() &&
-        needs.all-jobs-pass.result == 'failure' &&
+        needs.ci-status-gate.result == 'failure' &&
         github.event_name == 'pull_request' &&
         !(github.event.pull_request.head.repo.fork || github.event.repository.fork)
       }}
     runs-on: ubuntu-latest
     timeout-minutes: 2
     needs:
-      - all-jobs-pass
+      - ci-status-gate
       - publish-prerelease
     env:
       GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/publish-release-from-release-head.yml
+++ b/.github/workflows/publish-release-from-release-head.yml
@@ -9,7 +9,7 @@ on:
 
 permissions:
   contents: read # publish-release uses EXTENSION_PUBLISH_TOKEN for write operations
-  checks: read # Required to verify CI check-runs on the SHA
+  statuses: read # Required by verify-ci-checks.sh to read commit statuses
   actions: read # Required to download artifacts from build jobs
   id-token: write # Required for OIDC authentication in S3 uploads
 


### PR DESCRIPTION
## **Description**

### Context

The `all-jobs-pass` job in `main.yml` was a 65-line inline bash script that aggregates CI results and gates the merge queue.  I've built a **Merge Queue Triage and Retry** feature that automatically classifies transient failures, retries them, and defers the gate commit status so retried runs get a chance to succeed.  It's already written and tested, but I'm rolling it out in two parts to reduce and separate risk.  Part 2 would require a job that is more than 300 lines long, so I have moved it from `main.yml` into `ci-status-gate.yml`.

### Problem

1. The gate currently produces a **check run** named `All jobs pass`.  Check runs are assigned to non-deterministic check suites — on `merge_group` branches, multiple suites exist (one per triggered workflow), and the check can land in the wrong suite, one the merge queue doesn't monitor.  This has been tested and creates a race condition, especially racing against `merge-previous-release-branches.yml`. Commit statuses don't have this problem.
2. The release verification script (verify-ci-checks.sh) queries the check runs API, coupling it to this fragile mechanism.

### Solution

**This is PR 1 of 2.** It extracts the gate into its own reusable workflow and swaps the mechanism from check runs to commit statuses.

1. **Extract** the gate job from `main.yml` into` ci-status-gate.yml` — a `workflow_call` reusable workflow.  Rewrites the bash to JS (`actions/github-script@v8`) for more reliable `needs` iteration (no TSV parsing, no subshells).

2. **Post a commit status** with context `All jobs pass` instead of relying on the check run.  `All jobs pass` is already a required status check — the commit status satisfies the same requirement that the check run did, but without check-suite non-determinism.  The transition is seamless: GitHub matches required status checks against both check run names and commit status contexts in the same namespace.

3. **Update verify-ci-checks.sh** to query the commit statuses API (`/commits/{sha}/status`) instead of the check runs API. Also update `publish-release-from-release-head.yml` permissions: remove `checks: read` (no longer needed), add `statuses: read`.

### Release branch compatibility

Release branches are self-consistent: `main.yml`, `ci-status-gate.yml`, `verify-ci-checks.sh`, and the publish workflow are all on the **same branch commit**.  A release cut before this PR merges has old-script + old-CI (check runs).  A release cut after has new-script + new-CI (commit statuses).  There is no cross-version mismatch because the publish workflow checks out `ref: ${{ github.sha }}` (the branch HEAD).

### What Part 2 adds on top

Part 2 will extend ci-status-gate.yml with:
- **Retry gate**: defer the commit status when `retry-ci` label is present, giving the triage workflow time to classify failures and trigger a rerun before the merge queue sees a failure status
- **Failure classification**: `main-ci-failure-triage.yml` + `classify-failures.mts` to auto-categorize flaky tests vs. real failures
- **Sentry observability**: emit events for merge queue failures with structured tags

## **Changelog**

CHANGELOG entry: null

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**
[skip-e2e]-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI gating and release verification logic; misconfiguration could incorrectly block merges/releases or allow them without a proper CI pass.
> 
> **Overview**
> Switches merge-queue gating from a Checks API *check run* to a **commit status** with context `All jobs pass`, avoiding check-suite routing issues on `merge_group` branches.
> 
> Extracts the former inline `all-jobs-pass` logic from `main.yml` into a new reusable workflow `ci-status-gate.yml` (JS via `actions/github-script`) that evaluates `needs` results, posts the commit status, and fails the job when any required jobs fail.
> 
> Updates `verify-ci-checks.sh` and `publish-release-from-release-head.yml` to verify CI via the commit statuses API (`/commits/{sha}/status`) and to use `statuses: read` permissions instead of `checks: read`; updates downstream dependencies (e.g., `check-retry-ci`) to reference `ci-status-gate`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62dd46e15abb9d923ca6a1288d921b65ee1b877f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->