### PR TITLE
fix: relax network symbol length validation to 10 characters

### DIFF
--- a/app/scripts/lib/rpc-method-middleware/handlers/ethereum-chain-utils.js
+++ b/app/scripts/lib/rpc-method-middleware/handlers/ethereum-chain-utils.js
@@ -143,10 +143,10 @@ export function validateAddEthereumChainParams(params) {
   const ticker = nativeCurrency?.symbol || UNKNOWN_TICKER_SYMBOL;
   if (
     ticker !== UNKNOWN_TICKER_SYMBOL &&
-    (typeof ticker !== 'string' || ticker.length < 1 || ticker.length > 6)
+    (typeof ticker !== 'string' || ticker.length < 1 || ticker.length > 10)
   ) {
     throw rpcErrors.invalidParams({
-      message: `Expected 1-6 character string 'nativeCurrency.symbol'. Received:\n${ticker}`,
+      message: `Expected 1-10 character string 'nativeCurrency.symbol'. Received:\n${ticker}`,
     });
   }
 


### PR DESCRIPTION
## Summary

When adding a network with `wallet_addEthereumChain`, MetaMask caps the chain's symbol to 6 characters. Some networks use longer symbols (up to 10 characters) that are currently rejected. This PR relaxes the maximum length from 6 to 10.

**Changes:**
- `ticker.length > 6` → `ticker.length > 10`
- Error message updated: `Expected 1-6 character string` → `Expected 1-10 character string`

## Reference

Similar to #24872 which relaxed the minimum length from 2 to 1.

## Manual testing steps

1. Use `wallet_addEthereumChain` with a network whose `nativeCurrency.symbol` is 7–10 characters
2. Verify the network is added successfully
3. Verify symbols longer than 10 characters are still rejected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only expands input validation and updates the related error message, with no behavioral changes beyond accepting longer symbols.
> 
> **Overview**
> Allows `wallet_addEthereumChain` to accept `nativeCurrency.symbol` values up to **10 characters** (previously capped at 6).
> 
> Updates the validation error message to reflect the new **1–10** length constraint.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 87a8422140bea301567a78349878c0042388dbd1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->