### PR TITLE
fix(perps): use preformatted activity amounts in transaction card

### DIFF
--- a/ui/components/app/perps/transaction-card/transaction-card.test.tsx
+++ b/ui/components/app/perps/transaction-card/transaction-card.test.tsx
@@ -264,7 +264,9 @@ describe('TransactionCard', () => {
         mockStore,
       );
 
-      expect(screen.getByText('+$5000.00')).toBeInTheDocument();
+      const amountElement = screen.getByText('+$5000.00');
+      expect(amountElement).toBeInTheDocument();
+      expect(amountElement).toHaveClass('text-success-default');
     });
 
     it('shows withdrawal amount with negative sign', () => {
@@ -290,7 +292,9 @@ describe('TransactionCard', () => {
         mockStore,
       );
 
-      expect(screen.getByText('-$2000.00')).toBeInTheDocument();
+      const amountElement = screen.getByText('-$2000.00');
+      expect(amountElement).toBeInTheDocument();
+      expect(amountElement).toHaveClass('text-error-default');
     });
 
     it('shows "Completed" status for deposits', () => {

--- a/ui/components/app/perps/transaction-card/transaction-card.test.tsx
+++ b/ui/components/app/perps/transaction-card/transaction-card.test.tsx
@@ -81,7 +81,7 @@ describe('TransactionCard', () => {
   });
 
   describe('Trade transactions', () => {
-    it('shows pnl with profit color for positive values', () => {
+    it('shows trade amount with profit color for positive values', () => {
       const transaction = createMockTransaction({
         type: 'trade',
         category: 'position_close',
@@ -105,10 +105,12 @@ describe('TransactionCard', () => {
         mockStore,
       );
 
-      expect(screen.getByText('+$125.00')).toBeInTheDocument();
+      const amountElement = screen.getByText('+$125.00');
+      expect(amountElement).toBeInTheDocument();
+      expect(amountElement).toHaveClass('text-success-default');
     });
 
-    it('shows pnl with loss color for negative values', () => {
+    it('shows trade amount with loss color for negative values', () => {
       const transaction = createMockTransaction({
         type: 'trade',
         category: 'position_close',
@@ -132,7 +134,38 @@ describe('TransactionCard', () => {
         mockStore,
       );
 
-      expect(screen.getByText('-$45.50')).toBeInTheDocument();
+      const amountElement = screen.getByText('-$45.50');
+      expect(amountElement).toBeInTheDocument();
+      expect(amountElement).toHaveClass('text-error-default');
+    });
+
+    it('uses amount polarity for color when pnl string is unsigned', () => {
+      const transaction = createMockTransaction({
+        type: 'trade',
+        category: 'position_close',
+        fill: {
+          shortTitle: 'Closed long',
+          amount: '+$125.00',
+          amountNumber: 125,
+          isPositive: true,
+          size: '0.5',
+          entryPrice: '45250.00',
+          points: '0',
+          pnl: '125.00',
+          fee: '22.63',
+          action: 'Closed',
+          feeToken: 'USDC',
+          fillType: FillType.Standard,
+        },
+      });
+      renderWithProvider(
+        <TransactionCard transaction={transaction} />,
+        mockStore,
+      );
+
+      const amountElement = screen.getByText('+$125.00');
+      expect(amountElement).toBeInTheDocument();
+      expect(amountElement).toHaveClass('text-success-default');
     });
 
     it('displays size and symbol in subtitle for trades', () => {

--- a/ui/components/app/perps/transaction-card/transaction-card.test.tsx
+++ b/ui/components/app/perps/transaction-card/transaction-card.test.tsx
@@ -172,7 +172,7 @@ describe('TransactionCard', () => {
         fill: undefined,
         fundingAmount: {
           isPositive: true,
-          fee: '+8.30',
+          fee: '+$8.30',
           feeNumber: 8.3,
           rate: '0.0001',
         },
@@ -193,7 +193,7 @@ describe('TransactionCard', () => {
         fill: undefined,
         fundingAmount: {
           isPositive: false,
-          fee: '-3.10',
+          fee: '-$3.10',
           feeNumber: -3.1,
           rate: '-0.00005',
         },
@@ -217,7 +217,7 @@ describe('TransactionCard', () => {
         title: 'Deposited 5000 USDC',
         fill: undefined,
         depositWithdrawal: {
-          amount: '5000.00',
+          amount: '+$5000.00',
           amountNumber: 5000,
           isPositive: true,
           asset: 'USDC',
@@ -243,7 +243,7 @@ describe('TransactionCard', () => {
         title: 'Withdrew 2000 USDC',
         fill: undefined,
         depositWithdrawal: {
-          amount: '2000.00',
+          amount: '-$2000.00',
           amountNumber: 2000,
           isPositive: false,
           asset: 'USDC',
@@ -268,7 +268,7 @@ describe('TransactionCard', () => {
         title: 'Deposited 5000 USDC',
         fill: undefined,
         depositWithdrawal: {
-          amount: '5000.00',
+          amount: '+$5000.00',
           amountNumber: 5000,
           isPositive: true,
           asset: 'USDC',

--- a/ui/components/app/perps/transaction-card/transaction-card.tsx
+++ b/ui/components/app/perps/transaction-card/transaction-card.tsx
@@ -13,7 +13,7 @@ import {
 } from '@metamask/design-system-react';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { PerpsTokenLogo } from '../perps-token-logo';
-import { getDisplayName, getTransactionAmountColor } from '../utils';
+import { getDisplayName } from '../utils';
 import type { PerpsTransaction } from '../types';
 
 export type TransactionCardProps = {
@@ -61,10 +61,12 @@ export const TransactionCard: React.FC<TransactionCardProps> = ({
 
   // Determine the amount to display based on transaction type
   const getAmountDisplay = (): { text: string; color: TextColor } => {
-    if (transaction.fill?.pnl) {
+    if (transaction.fill) {
       return {
-        text: `${transaction.fill.pnl.startsWith('-') ? '-' : '+'}$${transaction.fill.pnl.replace(/^[+-]/u, '')}`,
-        color: getTransactionAmountColor(transaction.fill.pnl),
+        text: transaction.fill.amount,
+        color: transaction.fill.isPositive
+          ? TextColor.SuccessDefault
+          : TextColor.ErrorDefault,
       };
     }
     if (transaction.fundingAmount) {

--- a/ui/components/app/perps/transaction-card/transaction-card.tsx
+++ b/ui/components/app/perps/transaction-card/transaction-card.tsx
@@ -68,18 +68,19 @@ export const TransactionCard: React.FC<TransactionCardProps> = ({
       };
     }
     if (transaction.fundingAmount) {
-      const { fee } = transaction.fundingAmount;
-      const isNegative = fee.startsWith('-');
       return {
-        text: `${isNegative ? '-' : '+'}$${fee.replace(/^[+-]/u, '')}`,
-        color: isNegative ? TextColor.ErrorDefault : TextColor.SuccessDefault,
+        text: transaction.fundingAmount.fee,
+        color: transaction.fundingAmount.isPositive
+          ? TextColor.SuccessDefault
+          : TextColor.ErrorDefault,
       };
     }
     if (transaction.depositWithdrawal) {
-      const isWithdrawal = transaction.type === 'withdrawal';
       return {
-        text: `${isWithdrawal ? '-' : '+'}$${transaction.depositWithdrawal.amount}`,
-        color: isWithdrawal ? TextColor.ErrorDefault : TextColor.SuccessDefault,
+        text: transaction.depositWithdrawal.amount,
+        color: transaction.depositWithdrawal.isPositive
+          ? TextColor.SuccessDefault
+          : TextColor.ErrorDefault,
       };
     }
     // For trades without realized PnL, return empty (don't show symbol)

--- a/ui/components/app/perps/utils/transactionTransforms.test.ts
+++ b/ui/components/app/perps/utils/transactionTransforms.test.ts
@@ -461,6 +461,8 @@ describe('Transaction Transform Utilities', () => {
       expect(result[0].type).toBe('withdrawal');
       expect(result[0].title).toBe('Withdrew 250.00 USDC');
       expect(result[0].depositWithdrawal?.amount).toBe('-$250.00');
+      expect(result[0].depositWithdrawal?.amountNumber).toBe(-250);
+      expect(result[0].depositWithdrawal?.isPositive).toBe(false);
     });
 
     it('filters out non-completed withdrawal requests', () => {

--- a/ui/components/app/perps/utils/transactionTransforms.ts
+++ b/ui/components/app/perps/utils/transactionTransforms.ts
@@ -635,9 +635,10 @@ export function transformWithdrawalRequestsToTransactions(
       const amountBN = new BigNumber(amount);
       const displayAmount = `-$${amountBN.toFixed(2)}`;
 
-      // For completed withdrawals, status is always positive (green)
+      // Completion status is separate from amount polarity.
+      // Withdrawals are outflows, so they are always negative for styling.
       const statusText = 'Completed';
-      const isPositive = true;
+      const isPositive = false;
 
       return {
         id: `withdrawal-${id}`,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
**Reason for the change**
  The activity list was inconsistently handling transformed values.
  transactionTransforms.ts already outputs formatted display strings and polarity flags, but transaction-card.tsx was re-deriving display values in some paths. That caused:

  - doubled dollar signs for funding and deposit/withdrawal rows (for example +$$8.30, +$+$5000.00)
  - incorrect neutral/white text for some profitable trade rows when color depended on pnl string formatting instead of explicit polarity

**Improvement / solution**
  Updated getAmountDisplay to treat transform output as source-of-truth:

  - funding: use fundingAmount.fee directly, color from fundingAmount.isPositive
  - deposit/withdrawal: use depositWithdrawal.amount directly, color from depositWithdrawal.isPositive
  - trades: use fill.amount directly, color from fill.isPositive (instead of parsing fill.pnl sign)

Also updated tests to reflect real transform output and added coverage for trade color behavior when pnl is unsigned.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/41181?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**
https://consensyssoftware.atlassian.net/browse/TAT-2579

Fixes:

## **Manual testing steps**

Background:
    Given the Perps activity list is available
    And activity data includes funding, deposit, and withdrawal entries from transforms

    Scenario: Funding amount renders without duplicated currency symbol
      Given a funding transaction with fee "+$8.30" and isPositive true
      When I open the activity list
      Then I should see "+$8.30" on that row
      And I should not see "$$" on that row
      And the amount should be styled as positive (success)

    Scenario: Negative funding amount renders correctly
      Given a funding transaction with fee "-$3.10" and isPositive false
      When I open the activity list
      Then I should see "-$3.10" on that row
      And I should not see "$$" on that row
      And the amount should be styled as negative (error)

    Scenario: Deposit amount uses preformatted transform value
      Given a deposit transaction with amount "+$5000.00" and isPositive true
      When I open the activity list
      Then I should see "+$5000.00" on that row
      And I should not see "$$" on that row

    Scenario: Withdrawal amount uses preformatted transform value
      Given a withdrawal transaction with amount "-$2000.00" and isPositive false
      When I open the activity list
      Then I should see "-$2000.00" on that row
      And I should not see "$$" on that row

    Scenario: Existing trade amount rendering is unchanged
      Given a trade transaction with pnl "-45.50"
      When I open the activity list
      Then I should see "-$45.50" on that row

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/7aabfe52-53e5-4647-a8b1-6d588b27b26e



### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/38f4023d-0155-445a-b28a-6bd54a04936d



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change: it stops re-formatting Perps activity amounts and relies on existing `isPositive` flags for styling. Main risk is visual regressions if upstream transforms provide unexpected formatting/polarity.
> 
> **Overview**
> **Perps Activity `TransactionCard` now renders amounts directly from transform output** instead of re-deriving signs/currency and parsing `pnl` strings. Trade/funding/deposit/withdrawal rows use the preformatted `amount`/`fee` strings and color by the corresponding `isPositive` flag, preventing duplicated `$`/signs and incorrect neutral coloring.
> 
> **Withdrawal request transforms now mark withdrawals as negative for styling**, and tests were updated/expanded to assert the new formatting and success/error classes (including a new case where `pnl` is unsigned but `isPositive` drives color).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42ee062b4433a48f8f2fc4f7978a5f0a732e74e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->