### PR TITLE
feat: Add support for data services extending `BaseDataService`

### DIFF
--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -2007,6 +2007,13 @@
         "@metamask/utils": true
       }
     },
+    "@metamask/react-data-query": {
+      "packages": {
+        "@metamask/utils": true,
+        "@tanstack/react-query>@tanstack/query-core": true,
+        "@tanstack/react-query": true
+      }
+    },
     "@metamask/remote-feature-flag-controller": {
       "globals": {
         "TextEncoder": true

--- a/lavamoat/browserify/experimental/policy.json
+++ b/lavamoat/browserify/experimental/policy.json
@@ -2007,6 +2007,13 @@
         "@metamask/utils": true
       }
     },
+    "@metamask/react-data-query": {
+      "packages": {
+        "@metamask/utils": true,
+        "@tanstack/react-query>@tanstack/query-core": true,
+        "@tanstack/react-query": true
+      }
+    },
     "@metamask/remote-feature-flag-controller": {
       "globals": {
         "TextEncoder": true

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -2007,6 +2007,13 @@
         "@metamask/utils": true
       }
     },
+    "@metamask/react-data-query": {
+      "packages": {
+        "@metamask/utils": true,
+        "@tanstack/react-query>@tanstack/query-core": true,
+        "@tanstack/react-query": true
+      }
+    },
     "@metamask/remote-feature-flag-controller": {
       "globals": {
         "TextEncoder": true

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -2007,6 +2007,13 @@
         "@metamask/utils": true
       }
     },
+    "@metamask/react-data-query": {
+      "packages": {
+        "@metamask/utils": true,
+        "@tanstack/react-query>@tanstack/query-core": true,
+        "@tanstack/react-query": true
+      }
+    },
     "@metamask/remote-feature-flag-controller": {
       "globals": {
         "TextEncoder": true

--- a/lavamoat/webpack/mv2/beta/policy.json
+++ b/lavamoat/webpack/mv2/beta/policy.json
@@ -1986,6 +1986,12 @@
         "@metamask/utils": true
       }
     },
+    "@metamask/react-data-query": {
+      "packages": {
+        "@metamask/utils": true,
+        "@tanstack/react-query>@tanstack/query-core": true
+      }
+    },
     "@metamask/remote-feature-flag-controller": {
       "globals": {
         "TextEncoder": true

--- a/lavamoat/webpack/mv2/experimental/policy.json
+++ b/lavamoat/webpack/mv2/experimental/policy.json
@@ -1986,6 +1986,12 @@
         "@metamask/utils": true
       }
     },
+    "@metamask/react-data-query": {
+      "packages": {
+        "@metamask/utils": true,
+        "@tanstack/react-query>@tanstack/query-core": true
+      }
+    },
     "@metamask/remote-feature-flag-controller": {
       "globals": {
         "TextEncoder": true

--- a/lavamoat/webpack/mv2/flask/policy.json
+++ b/lavamoat/webpack/mv2/flask/policy.json
@@ -1986,6 +1986,12 @@
         "@metamask/utils": true
       }
     },
+    "@metamask/react-data-query": {
+      "packages": {
+        "@metamask/utils": true,
+        "@tanstack/react-query>@tanstack/query-core": true
+      }
+    },
     "@metamask/remote-feature-flag-controller": {
       "globals": {
         "TextEncoder": true

--- a/lavamoat/webpack/mv2/main/policy.json
+++ b/lavamoat/webpack/mv2/main/policy.json
@@ -1986,6 +1986,12 @@
         "@metamask/utils": true
       }
     },
+    "@metamask/react-data-query": {
+      "packages": {
+        "@metamask/utils": true,
+        "@tanstack/react-query>@tanstack/query-core": true
+      }
+    },
     "@metamask/remote-feature-flag-controller": {
       "globals": {
         "TextEncoder": true

--- a/lavamoat/webpack/mv3/beta/policy.json
+++ b/lavamoat/webpack/mv3/beta/policy.json
@@ -1275,6 +1275,12 @@
         "@metamask/providers>readable-stream": true
       }
     },
+    "@metamask/react-data-query": {
+      "packages": {
+        "@metamask/utils": true,
+        "@tanstack/react-query>@tanstack/query-core": true
+      }
+    },
     "@metamask/rpc-errors": {
       "packages": {
         "@metamask/utils": true,

--- a/lavamoat/webpack/mv3/experimental/policy.json
+++ b/lavamoat/webpack/mv3/experimental/policy.json
@@ -1275,6 +1275,12 @@
         "@metamask/providers>readable-stream": true
       }
     },
+    "@metamask/react-data-query": {
+      "packages": {
+        "@metamask/utils": true,
+        "@tanstack/react-query>@tanstack/query-core": true
+      }
+    },
     "@metamask/rpc-errors": {
       "packages": {
         "@metamask/utils": true,

--- a/lavamoat/webpack/mv3/flask/policy.json
+++ b/lavamoat/webpack/mv3/flask/policy.json
@@ -1275,6 +1275,12 @@
         "@metamask/providers>readable-stream": true
       }
     },
+    "@metamask/react-data-query": {
+      "packages": {
+        "@metamask/utils": true,
+        "@tanstack/react-query>@tanstack/query-core": true
+      }
+    },
     "@metamask/rpc-errors": {
       "packages": {
         "@metamask/utils": true,

--- a/lavamoat/webpack/mv3/main/policy.json
+++ b/lavamoat/webpack/mv3/main/policy.json
@@ -1275,6 +1275,12 @@
         "@metamask/providers>readable-stream": true
       }
     },
+    "@metamask/react-data-query": {
+      "packages": {
+        "@metamask/utils": true,
+        "@tanstack/react-query>@tanstack/query-core": true
+      }
+    },
     "@metamask/rpc-errors": {
       "packages": {
         "@metamask/utils": true,

--- a/package.json
+++ b/package.json
@@ -379,7 +379,7 @@
     "@metamask/profile-sync-controller": "^28.0.0",
     "@metamask/providers": "^22.1.1",
     "@metamask/rate-limit-controller": "^7.0.0",
-    "@metamask/react-data-query": "^0.1.0",
+    "@metamask/react-data-query": "^0.2.0",
     "@metamask/remote-feature-flag-controller": "^4.1.0",
     "@metamask/rpc-errors": "^7.0.0",
     "@metamask/safe-event-emitter": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -379,6 +379,7 @@
     "@metamask/profile-sync-controller": "^28.0.0",
     "@metamask/providers": "^22.1.1",
     "@metamask/rate-limit-controller": "^7.0.0",
+    "@metamask/react-data-query": "^0.1.0",
     "@metamask/remote-feature-flag-controller": "^4.1.0",
     "@metamask/rpc-errors": "^7.0.0",
     "@metamask/safe-event-emitter": "^3.1.1",

--- a/shared/constants/data-services.ts
+++ b/shared/constants/data-services.ts
@@ -1,2 +1,2 @@
-// A list of all data services available in the client.
-export const DATA_SERVICES = [];
+// A list of all names of data services available in the client.
+export const DATA_SERVICES: string[] = [];

--- a/shared/constants/data-services.ts
+++ b/shared/constants/data-services.ts
@@ -1,0 +1,2 @@
+// A list of all data services available in the client.
+export const DATA_SERVICES = [];

--- a/ui/contexts/query-client.ts
+++ b/ui/contexts/query-client.ts
@@ -14,12 +14,12 @@ const subscriptions = new Map();
 const adapter = {
   call: (method: string, ...params: Json[]) =>
     submitRequestToBackground<Json>('messengerCall', [method, params]),
-  subscribe: (method: string, callback: JsonSubscriptionCallback) => {
-    subscribeToMessengerEvent(method as NamespacedName, callback)
+  subscribe: (event: string, callback: JsonSubscriptionCallback) => {
+    subscribeToMessengerEvent(event as NamespacedName, callback)
       .then((unsubscribe) => subscriptions.set(callback, unsubscribe))
       .catch(console.error);
   },
-  unsubscribe: (_method: string, callback: JsonSubscriptionCallback) => {
+  unsubscribe: (_event: string, callback: JsonSubscriptionCallback) => {
     const unsubscribe = subscriptions.get(callback);
     unsubscribe?.().catch(console.error);
   },

--- a/ui/contexts/query-client.ts
+++ b/ui/contexts/query-client.ts
@@ -14,12 +14,10 @@ const subscriptions = new Map();
 const adapter = {
   call: (method: string, ...params: Json[]) =>
     submitRequestToBackground<Json>('messengerCall', [method, params]),
-  subscribe: async (method: string, callback: JsonSubscriptionCallback) => {
-    const unsubscribe = await subscribeToMessengerEvent(
-      method as NamespacedName,
-      callback,
-    );
-    subscriptions.set(callback, unsubscribe);
+  subscribe: (method: string, callback: JsonSubscriptionCallback) => {
+    subscribeToMessengerEvent(method as NamespacedName, callback)
+      .then((unsubscribe) => subscriptions.set(callback, unsubscribe))
+      .catch(console.error);
   },
   unsubscribe: (_method: string, callback: JsonSubscriptionCallback) => {
     const unsubscribe = subscriptions.get(callback);

--- a/ui/contexts/query-client.ts
+++ b/ui/contexts/query-client.ts
@@ -1,3 +1,30 @@
-import { QueryClient } from '@tanstack/react-query';
+import { createUIQueryClient } from '@metamask/react-data-query';
+import { NamespacedName } from '@metamask/messenger';
+import { Json } from '@metamask/utils';
+import { DATA_SERVICES } from '../../shared/constants/data-services';
+import {
+  submitRequestToBackground,
+  subscribeToMessengerEvent,
+} from '../store/background-connection';
 
-export const queryClient = new QueryClient();
+type JsonSubscriptionCallback = (data: Json) => void;
+
+const subscriptions = new Map();
+
+const adapter = {
+  call: (method: string, ...params: Json[]) =>
+    submitRequestToBackground<Json>('messengerCall', [method, params]),
+  subscribe: async (method: string, callback: JsonSubscriptionCallback) => {
+    const unsubscribe = await subscribeToMessengerEvent(
+      method as NamespacedName,
+      callback,
+    );
+    subscriptions.set(callback, unsubscribe);
+  },
+  unsubscribe: (_method: string, callback: JsonSubscriptionCallback) => {
+    const unsubscribe = subscriptions.get(callback);
+    unsubscribe?.().catch(console.error);
+  },
+};
+
+export const queryClient = createUIQueryClient(DATA_SERVICES, adapter);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7852,9 +7852,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/react-data-query@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "@metamask/react-data-query@npm:0.1.0"
+"@metamask/react-data-query@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "@metamask/react-data-query@npm:0.2.0"
   dependencies:
     "@metamask/base-data-service": "npm:^0.1.0"
     "@metamask/utils": "npm:^11.9.0"
@@ -7864,7 +7864,7 @@ __metadata:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     react-native: "*"
-  checksum: 10/68f11a3b826c3fe56f28296f5f4af8299275912f5120ee1e86f5b9c46efca0d4064f6fffb0e2c30b685674930f36b8524bf9669175ca2a6746953f05b3dced73
+  checksum: 10/c54a9943bb68ad46ad9964864d4ee81604e61216ebed00026a1a4681a1e1091b6e413b9812d25e38d028493f3c75e91c8102b9d1c0232f409cd6f1dd4d22b211
   languageName: node
   linkType: hard
 
@@ -34118,7 +34118,7 @@ __metadata:
     "@metamask/profile-sync-controller": "npm:^28.0.0"
     "@metamask/providers": "npm:^22.1.1"
     "@metamask/rate-limit-controller": "npm:^7.0.0"
-    "@metamask/react-data-query": "npm:^0.1.0"
+    "@metamask/react-data-query": "npm:^0.2.0"
     "@metamask/remote-feature-flag-controller": "npm:^4.1.0"
     "@metamask/rpc-errors": "npm:^7.0.0"
     "@metamask/safe-event-emitter": "npm:^3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5969,6 +5969,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/base-data-service@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "@metamask/base-data-service@npm:0.1.0"
+  dependencies:
+    "@metamask/controller-utils": "npm:^11.19.0"
+    "@metamask/messenger": "npm:^0.3.0"
+    "@metamask/utils": "npm:^11.9.0"
+    "@tanstack/query-core": "npm:^4.43.0"
+    fast-deep-equal: "npm:^3.1.3"
+  checksum: 10/1a6c7cde54fa3a1d5378cfbb33891cb640c913421e747126587dc432e4c52c0510ba1f6dc18ab615528bf721b0f122c48707ba382dfa80fe9eff60fff0a0d26a
+  languageName: node
+  linkType: hard
+
 "@metamask/bitcoin-wallet-snap@npm:^1.10.0":
   version: 1.10.0
   resolution: "@metamask/bitcoin-wallet-snap@npm:1.10.0"
@@ -7836,6 +7849,22 @@ __metadata:
     "@metamask/rpc-errors": "npm:^7.0.2"
     "@metamask/utils": "npm:^11.8.1"
   checksum: 10/6bc52d4fb6f844f189173c72debce4cb342ece42a7fb36dfa3bffbfdfe0e821691e7a96b50d6a5b5e588ac658d0a3158f5fd9dfc54d8287c052aeee28a47a54b
+  languageName: node
+  linkType: hard
+
+"@metamask/react-data-query@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "@metamask/react-data-query@npm:0.1.0"
+  dependencies:
+    "@metamask/base-data-service": "npm:^0.1.0"
+    "@metamask/utils": "npm:^11.9.0"
+    "@tanstack/query-core": "npm:^4.43.0"
+    "@tanstack/react-query": "npm:^4.43.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-native: "*"
+  checksum: 10/68f11a3b826c3fe56f28296f5f4af8299275912f5120ee1e86f5b9c46efca0d4064f6fffb0e2c30b685674930f36b8524bf9669175ca2a6746953f05b3dced73
   languageName: node
   linkType: hard
 
@@ -14732,7 +14761,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/query-core@npm:4.43.0":
+"@tanstack/query-core@npm:4.43.0, @tanstack/query-core@npm:^4.43.0":
   version: 4.43.0
   resolution: "@tanstack/query-core@npm:4.43.0"
   checksum: 10/c2a5a151c7adaea8311e01a643255f31946ae3164a71567ba80048242821ae14043f13f5516b695baebe5ea7e4b2cf717fd60908a929d18a5c5125fee925ff67
@@ -14746,7 +14775,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/react-query@npm:^4.36.1":
+"@tanstack/react-query@npm:^4.36.1, @tanstack/react-query@npm:^4.43.0":
   version: 4.43.0
   resolution: "@tanstack/react-query@npm:4.43.0"
   dependencies:
@@ -34089,6 +34118,7 @@ __metadata:
     "@metamask/profile-sync-controller": "npm:^28.0.0"
     "@metamask/providers": "npm:^22.1.1"
     "@metamask/rate-limit-controller": "npm:^7.0.0"
+    "@metamask/react-data-query": "npm:^0.1.0"
     "@metamask/remote-feature-flag-controller": "npm:^4.1.0"
     "@metamask/rpc-errors": "npm:^7.0.0"
     "@metamask/safe-event-emitter": "npm:^3.1.1"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Replace the default `QueryClient` with a custom `QueryClient` from `createUIQueryClient`. This establishes the query client required for using the `BaseDataService` pattern from the core repo, which handles cache syncing. Existing UI-only queries should work as they did previously.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/41183?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

https://consensyssoftware.atlassian.net/browse/WPC-445


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Replaces the app-wide React Query client with a custom client that bridges to background messaging, which could impact caching/query behavior across the UI if misconfigured. Also introduces new dependency and LavaMoat policy entries that affect build/runtime module access.
> 
> **Overview**
> Replaces the default TanStack `QueryClient` with a `createUIQueryClient` instance wired to the background via `submitRequestToBackground`/`subscribeToMessengerEvent`, enabling cache syncing for data services that follow the `BaseDataService` pattern.
> 
> Adds a `DATA_SERVICES` registry (currently empty) and updates dependencies/lockfile plus LavaMoat policies to allow `@metamask/react-data-query` (and its TanStack Query deps) in browserify/webpack builds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94d0a5575c97f3ec35b0d172eafb6622ae87ad42. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->