### PR TITLE
feat(perps): display limit orders on market detail screen

### DIFF
--- a/ui/components/app/perps/utils/index.ts
+++ b/ui/components/app/perps/utils/index.ts
@@ -15,3 +15,14 @@ export {
   type WithdrawalRequest,
   type DepositRequest,
 } from './transactionTransforms';
+
+export {
+  normalizeMarketDetailsOrders,
+  shouldDisplayOrderInMarketDetailsOrders,
+  buildDisplayOrdersWithSyntheticTpsl,
+  isOrderAssociatedWithFullPosition,
+  resolveOrderDisplayPriceAndLabel,
+  getValidTriggerPrice,
+  getValidOrderPrice,
+  formatOrderLabel,
+} from './orderUtils';

--- a/ui/components/app/perps/utils/index.ts
+++ b/ui/components/app/perps/utils/index.ts
@@ -21,8 +21,4 @@ export {
   shouldDisplayOrderInMarketDetailsOrders,
   buildDisplayOrdersWithSyntheticTpsl,
   isOrderAssociatedWithFullPosition,
-  resolveOrderDisplayPriceAndLabel,
-  getValidTriggerPrice,
-  getValidOrderPrice,
-  formatOrderLabel,
 } from './orderUtils';

--- a/ui/components/app/perps/utils/orderUtils.test.ts
+++ b/ui/components/app/perps/utils/orderUtils.test.ts
@@ -4,10 +4,6 @@ import {
   shouldDisplayOrderInMarketDetailsOrders,
   buildDisplayOrdersWithSyntheticTpsl,
   normalizeMarketDetailsOrders,
-  resolveOrderDisplayPriceAndLabel,
-  getValidTriggerPrice,
-  getValidOrderPrice,
-  formatOrderLabel,
 } from './orderUtils';
 
 const makeOrder = (overrides: Partial<Order> = {}): Order => ({
@@ -39,40 +35,6 @@ const makePosition = (overrides: Partial<Position> = {}): Position =>
   }) as Position;
 
 describe('orderUtils', () => {
-  describe('getValidTriggerPrice', () => {
-    it('returns parsed trigger price for valid value', () => {
-      expect(getValidTriggerPrice(makeOrder({ triggerPrice: '100.5' }))).toBe(
-        100.5,
-      );
-    });
-
-    it('returns null for undefined trigger price', () => {
-      expect(getValidTriggerPrice(makeOrder({ triggerPrice: undefined }))).toBe(
-        null,
-      );
-    });
-
-    it('returns null for zero trigger price', () => {
-      expect(getValidTriggerPrice(makeOrder({ triggerPrice: '0' }))).toBe(null);
-    });
-
-    it('returns null for negative trigger price', () => {
-      expect(getValidTriggerPrice(makeOrder({ triggerPrice: '-10' }))).toBe(
-        null,
-      );
-    });
-  });
-
-  describe('getValidOrderPrice', () => {
-    it('returns parsed price for valid value', () => {
-      expect(getValidOrderPrice(makeOrder({ price: '3000.50' }))).toBe(3000.5);
-    });
-
-    it('returns null for empty price', () => {
-      expect(getValidOrderPrice(makeOrder({ price: '' }))).toBe(null);
-    });
-  });
-
   describe('isOrderAssociatedWithFullPosition', () => {
     it('returns false for non-reduce-only orders', () => {
       const order = makeOrder({ reduceOnly: false });
@@ -366,116 +328,6 @@ describe('orderUtils', () => {
         orders: [limitOrder],
       });
       expect(result).toHaveLength(3);
-    });
-  });
-
-  describe('resolveOrderDisplayPriceAndLabel', () => {
-    it('returns trigger price for trigger orders', () => {
-      const order = makeOrder({
-        isTrigger: true,
-        triggerPrice: '3200.00',
-        price: '3000.00',
-      });
-      const result = resolveOrderDisplayPriceAndLabel(order);
-      expect(result.priceValue).toBe(3200);
-      expect(result.labelKey).toBe('perpsTriggerPrice');
-    });
-
-    it('returns limit price for limit orders', () => {
-      const order = makeOrder({
-        orderType: 'limit',
-        price: '3000.00',
-      });
-      const result = resolveOrderDisplayPriceAndLabel(order);
-      expect(result.priceValue).toBe(3000);
-      expect(result.labelKey).toBe('perpsLimitPrice');
-    });
-
-    it('returns market price for market orders', () => {
-      const order = makeOrder({
-        orderType: 'market',
-        price: '3000.00',
-      });
-      const result = resolveOrderDisplayPriceAndLabel(order);
-      expect(result.priceValue).toBe(3000);
-      expect(result.labelKey).toBe('perpsMarket');
-    });
-
-    it('returns trigger price for TPSL order types', () => {
-      const order = makeOrder({
-        detailedOrderType: 'Take Profit Limit',
-        triggerPrice: '3500.00',
-        price: '3000.00',
-      });
-      const result = resolveOrderDisplayPriceAndLabel(order);
-      expect(result.priceValue).toBe(3500);
-      expect(result.labelKey).toBe('perpsTriggerPrice');
-    });
-  });
-
-  describe('formatOrderLabel', () => {
-    it('formats limit long', () => {
-      const order = makeOrder({ orderType: 'limit', side: 'buy' });
-      expect(formatOrderLabel(order)).toBe('Limit long');
-    });
-
-    it('formats limit short', () => {
-      const order = makeOrder({ orderType: 'limit', side: 'sell' });
-      expect(formatOrderLabel(order)).toBe('Limit short');
-    });
-
-    it('formats market long', () => {
-      const order = makeOrder({ orderType: 'market', side: 'buy' });
-      expect(formatOrderLabel(order)).toBe('Market long');
-    });
-
-    it('formats limit close long for reduce-only sell', () => {
-      const order = makeOrder({
-        orderType: 'limit',
-        side: 'sell',
-        reduceOnly: true,
-      });
-      expect(formatOrderLabel(order)).toBe('Limit close long');
-    });
-
-    it('formats stop market close short for reduce-only trigger buy', () => {
-      const order = makeOrder({
-        side: 'buy',
-        isTrigger: true,
-        reduceOnly: true,
-        detailedOrderType: 'Stop Market',
-      });
-      expect(formatOrderLabel(order)).toBe('Stop Market close short');
-    });
-
-    it('formats take profit limit close long for reduce-only trigger sell', () => {
-      const order = makeOrder({
-        side: 'sell',
-        isTrigger: true,
-        reduceOnly: true,
-        detailedOrderType: 'Take Profit Limit',
-      });
-      expect(formatOrderLabel(order)).toBe('Take Profit Limit close long');
-    });
-
-    it('formats stop market long for non-reduce-only trigger buy (stop-entry)', () => {
-      const order = makeOrder({
-        side: 'buy',
-        isTrigger: true,
-        reduceOnly: false,
-        detailedOrderType: 'Stop Market',
-      });
-      expect(formatOrderLabel(order)).toBe('Stop Market long');
-    });
-
-    it('formats stop limit short for non-reduce-only trigger sell (stop-entry)', () => {
-      const order = makeOrder({
-        side: 'sell',
-        isTrigger: true,
-        reduceOnly: false,
-        detailedOrderType: 'Stop Limit',
-      });
-      expect(formatOrderLabel(order)).toBe('Stop Limit short');
     });
   });
 });

--- a/ui/components/app/perps/utils/orderUtils.test.ts
+++ b/ui/components/app/perps/utils/orderUtils.test.ts
@@ -1,0 +1,459 @@
+import type { Order, Position } from '@metamask/perps-controller';
+import {
+  isOrderAssociatedWithFullPosition,
+  shouldDisplayOrderInMarketDetailsOrders,
+  buildDisplayOrdersWithSyntheticTpsl,
+  normalizeMarketDetailsOrders,
+  resolveOrderDisplayPriceAndLabel,
+  getValidTriggerPrice,
+  getValidOrderPrice,
+  formatOrderLabel,
+} from './orderUtils';
+
+const makeOrder = (overrides: Partial<Order> = {}): Order => ({
+  orderId: 'order-1',
+  symbol: 'ETH',
+  side: 'buy',
+  orderType: 'limit',
+  size: '1.0',
+  originalSize: '1.0',
+  price: '3000.00',
+  filledSize: '0',
+  remainingSize: '1.0',
+  status: 'open',
+  timestamp: Date.now(),
+  reduceOnly: false,
+  ...overrides,
+});
+
+const makePosition = (overrides: Partial<Position> = {}): Position =>
+  ({
+    symbol: 'ETH',
+    size: '1.0',
+    entryPrice: '3000.00',
+    leverage: '10',
+    liquidationPrice: '2700.00',
+    unrealizedPnl: '50.00',
+    marginUsed: '300.00',
+    ...overrides,
+  }) as Position;
+
+describe('orderUtils', () => {
+  describe('getValidTriggerPrice', () => {
+    it('returns parsed trigger price for valid value', () => {
+      expect(getValidTriggerPrice(makeOrder({ triggerPrice: '100.5' }))).toBe(
+        100.5,
+      );
+    });
+
+    it('returns null for undefined trigger price', () => {
+      expect(getValidTriggerPrice(makeOrder({ triggerPrice: undefined }))).toBe(
+        null,
+      );
+    });
+
+    it('returns null for zero trigger price', () => {
+      expect(getValidTriggerPrice(makeOrder({ triggerPrice: '0' }))).toBe(null);
+    });
+
+    it('returns null for negative trigger price', () => {
+      expect(getValidTriggerPrice(makeOrder({ triggerPrice: '-10' }))).toBe(
+        null,
+      );
+    });
+  });
+
+  describe('getValidOrderPrice', () => {
+    it('returns parsed price for valid value', () => {
+      expect(getValidOrderPrice(makeOrder({ price: '3000.50' }))).toBe(3000.5);
+    });
+
+    it('returns null for empty price', () => {
+      expect(getValidOrderPrice(makeOrder({ price: '' }))).toBe(null);
+    });
+  });
+
+  describe('isOrderAssociatedWithFullPosition', () => {
+    it('returns false for non-reduce-only orders', () => {
+      const order = makeOrder({ reduceOnly: false });
+      const position = makePosition();
+      expect(isOrderAssociatedWithFullPosition(order, position)).toBe(false);
+    });
+
+    it('returns true when isPositionTpsl is true', () => {
+      const order = makeOrder({
+        reduceOnly: true,
+        isPositionTpsl: true,
+      });
+      expect(isOrderAssociatedWithFullPosition(order)).toBe(true);
+    });
+
+    it('returns false when no position provided and isPositionTpsl is not true', () => {
+      const order = makeOrder({ reduceOnly: true });
+      expect(isOrderAssociatedWithFullPosition(order)).toBe(false);
+    });
+
+    it('returns false when symbols do not match', () => {
+      const order = makeOrder({
+        reduceOnly: true,
+        symbol: 'BTC',
+        side: 'sell',
+      });
+      const position = makePosition({ symbol: 'ETH', size: '1.0' });
+      expect(isOrderAssociatedWithFullPosition(order, position)).toBe(false);
+    });
+
+    it('returns false when isPositionTpsl is explicitly false', () => {
+      const order = makeOrder({
+        reduceOnly: true,
+        isPositionTpsl: false,
+        symbol: 'ETH',
+        side: 'sell',
+        size: '1.0',
+      });
+      const position = makePosition({ symbol: 'ETH', size: '1.0' });
+      expect(isOrderAssociatedWithFullPosition(order, position)).toBe(false);
+    });
+
+    it('returns true when reduce-only order matches full position size (sell closing long)', () => {
+      const order = makeOrder({
+        reduceOnly: true,
+        symbol: 'ETH',
+        side: 'sell',
+        size: '1.0',
+        originalSize: '1.0',
+      });
+      const position = makePosition({ symbol: 'ETH', size: '1.0' });
+      expect(isOrderAssociatedWithFullPosition(order, position)).toBe(true);
+    });
+
+    it('returns true when reduce-only order matches full position size (buy closing short)', () => {
+      const order = makeOrder({
+        reduceOnly: true,
+        symbol: 'ETH',
+        side: 'buy',
+        size: '2.0',
+        originalSize: '2.0',
+      });
+      const position = makePosition({ symbol: 'ETH', size: '-2.0' });
+      expect(isOrderAssociatedWithFullPosition(order, position)).toBe(true);
+    });
+
+    it('returns false when order size does not match position size', () => {
+      const order = makeOrder({
+        reduceOnly: true,
+        symbol: 'ETH',
+        side: 'sell',
+        size: '0.5',
+        originalSize: '0.5',
+      });
+      const position = makePosition({ symbol: 'ETH', size: '1.0' });
+      expect(isOrderAssociatedWithFullPosition(order, position)).toBe(false);
+    });
+  });
+
+  describe('shouldDisplayOrderInMarketDetailsOrders', () => {
+    it('shows non-reduce-only orders', () => {
+      const order = makeOrder({ reduceOnly: false });
+      expect(shouldDisplayOrderInMarketDetailsOrders(order)).toBe(true);
+    });
+
+    it('shows limit orders', () => {
+      const order = makeOrder({ orderType: 'limit', reduceOnly: false });
+      expect(shouldDisplayOrderInMarketDetailsOrders(order)).toBe(true);
+    });
+
+    it('shows trigger orders that are not position-attached', () => {
+      const order = makeOrder({
+        isTrigger: true,
+        reduceOnly: false,
+        triggerPrice: '3200.00',
+      });
+      expect(shouldDisplayOrderInMarketDetailsOrders(order)).toBe(true);
+    });
+
+    it('shows reduce-only orders not associated with full position', () => {
+      const order = makeOrder({
+        reduceOnly: true,
+        symbol: 'ETH',
+        side: 'sell',
+        size: '0.5',
+        originalSize: '0.5',
+      });
+      const position = makePosition({ symbol: 'ETH', size: '1.0' });
+      expect(shouldDisplayOrderInMarketDetailsOrders(order, position)).toBe(
+        true,
+      );
+    });
+
+    it('hides reduce-only orders associated with full position', () => {
+      const order = makeOrder({
+        reduceOnly: true,
+        symbol: 'ETH',
+        side: 'sell',
+        size: '1.0',
+        originalSize: '1.0',
+      });
+      const position = makePosition({ symbol: 'ETH', size: '1.0' });
+      expect(shouldDisplayOrderInMarketDetailsOrders(order, position)).toBe(
+        false,
+      );
+    });
+
+    it('hides orders with isPositionTpsl true', () => {
+      const order = makeOrder({
+        reduceOnly: true,
+        isPositionTpsl: true,
+      });
+      expect(shouldDisplayOrderInMarketDetailsOrders(order)).toBe(false);
+    });
+  });
+
+  describe('buildDisplayOrdersWithSyntheticTpsl', () => {
+    it('returns empty array for empty input', () => {
+      expect(buildDisplayOrdersWithSyntheticTpsl([])).toEqual([]);
+    });
+
+    it('returns orders as-is when no TP/SL prices are set', () => {
+      const order = makeOrder();
+      const result = buildDisplayOrdersWithSyntheticTpsl([order]);
+      expect(result).toHaveLength(1);
+      expect(result[0].orderId).toBe('order-1');
+    });
+
+    it('adds synthetic TP row when takeProfitPrice is set on parent', () => {
+      const order = makeOrder({
+        takeProfitPrice: '3200.00',
+        takeProfitOrderId: '',
+      });
+      const result = buildDisplayOrdersWithSyntheticTpsl([order]);
+      expect(result).toHaveLength(2);
+      expect(result[0].orderId).toBe('order-1');
+      expect(result[1].isSynthetic).toBe(true);
+      expect(result[1].detailedOrderType).toBe('Take Profit Limit');
+      expect(result[1].triggerPrice).toBe('3200');
+    });
+
+    it('adds synthetic SL row when stopLossPrice is set on parent', () => {
+      const order = makeOrder({
+        stopLossPrice: '2800.00',
+        stopLossOrderId: '',
+      });
+      const result = buildDisplayOrdersWithSyntheticTpsl([order]);
+      expect(result).toHaveLength(2);
+      expect(result[1].isSynthetic).toBe(true);
+      expect(result[1].detailedOrderType).toBe('Stop Limit');
+      expect(result[1].triggerPrice).toBe('2800');
+    });
+
+    it('adds both synthetic TP and SL rows when both are set', () => {
+      const order = makeOrder({
+        takeProfitPrice: '3200.00',
+        stopLossPrice: '2800.00',
+      });
+      const result = buildDisplayOrdersWithSyntheticTpsl([order]);
+      expect(result).toHaveLength(3);
+      expect(result[1].detailedOrderType).toBe('Take Profit Limit');
+      expect(result[2].detailedOrderType).toBe('Stop Limit');
+    });
+
+    it('uses market type for synthetic rows when parent is market order', () => {
+      const order = makeOrder({
+        orderType: 'market',
+        takeProfitPrice: '3200.00',
+      });
+      const result = buildDisplayOrdersWithSyntheticTpsl([order]);
+      expect(result[1].detailedOrderType).toBe('Take Profit Market');
+      expect(result[1].orderType).toBe('market');
+    });
+
+    it('does not add synthetic row when real trigger order already exists', () => {
+      const parentOrder = makeOrder({
+        orderId: 'parent-1',
+        side: 'buy',
+        takeProfitPrice: '3200.00',
+        takeProfitOrderId: 'tp-1',
+      });
+      const realTpOrder = makeOrder({
+        orderId: 'tp-1',
+        parentOrderId: 'parent-1',
+        side: 'sell',
+        symbol: 'ETH',
+        reduceOnly: true,
+        isTrigger: true,
+        triggerPrice: '3200.00',
+        price: '3200.00',
+      });
+      const result = buildDisplayOrdersWithSyntheticTpsl([
+        parentOrder,
+        realTpOrder,
+      ]);
+      const syntheticOrders = result.filter((o) => o.isSynthetic);
+      expect(syntheticOrders).toHaveLength(0);
+    });
+
+    it('skips synthetic rows for trigger orders (no recursion)', () => {
+      const triggerOrder = makeOrder({
+        isTrigger: true,
+        takeProfitPrice: '3200.00',
+      });
+      const result = buildDisplayOrdersWithSyntheticTpsl([triggerOrder]);
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  describe('normalizeMarketDetailsOrders', () => {
+    it('shows limit orders without position', () => {
+      const limitOrder = makeOrder({
+        orderType: 'limit',
+        reduceOnly: false,
+      });
+      const result = normalizeMarketDetailsOrders({ orders: [limitOrder] });
+      expect(result).toHaveLength(1);
+      expect(result[0].orderId).toBe('order-1');
+    });
+
+    it('shows stop limit orders when not full-position TP/SL', () => {
+      const stopLimitOrder = makeOrder({
+        orderType: 'limit',
+        isTrigger: true,
+        triggerPrice: '3200.00',
+        detailedOrderType: 'Stop Limit',
+        reduceOnly: false,
+      });
+      const result = normalizeMarketDetailsOrders({
+        orders: [stopLimitOrder],
+      });
+      expect(result).toHaveLength(1);
+    });
+
+    it('hides full-position TP/SL reduce-only orders', () => {
+      const tpslOrder = makeOrder({
+        reduceOnly: true,
+        isPositionTpsl: true,
+        isTrigger: true,
+        triggerPrice: '3200.00',
+        detailedOrderType: 'Take Profit Limit',
+      });
+      const result = normalizeMarketDetailsOrders({ orders: [tpslOrder] });
+      expect(result).toHaveLength(0);
+    });
+
+    it('shows partial-close reduce-only orders', () => {
+      const partialClose = makeOrder({
+        reduceOnly: true,
+        symbol: 'ETH',
+        side: 'sell',
+        size: '0.5',
+        originalSize: '0.5',
+      });
+      const position = makePosition({ symbol: 'ETH', size: '1.0' });
+      const result = normalizeMarketDetailsOrders({
+        orders: [partialClose],
+        existingPosition: position,
+      });
+      expect(result).toHaveLength(1);
+    });
+
+    it('adds synthetic TP/SL rows and filters them through position check', () => {
+      const limitOrder = makeOrder({
+        orderType: 'limit',
+        reduceOnly: false,
+        takeProfitPrice: '3200.00',
+        stopLossPrice: '2800.00',
+      });
+      const result = normalizeMarketDetailsOrders({
+        orders: [limitOrder],
+      });
+      expect(result).toHaveLength(3);
+    });
+  });
+
+  describe('resolveOrderDisplayPriceAndLabel', () => {
+    it('returns trigger price for trigger orders', () => {
+      const order = makeOrder({
+        isTrigger: true,
+        triggerPrice: '3200.00',
+        price: '3000.00',
+      });
+      const result = resolveOrderDisplayPriceAndLabel(order);
+      expect(result.priceValue).toBe(3200);
+      expect(result.labelKey).toBe('perpsTriggerPrice');
+    });
+
+    it('returns limit price for limit orders', () => {
+      const order = makeOrder({
+        orderType: 'limit',
+        price: '3000.00',
+      });
+      const result = resolveOrderDisplayPriceAndLabel(order);
+      expect(result.priceValue).toBe(3000);
+      expect(result.labelKey).toBe('perpsLimitPrice');
+    });
+
+    it('returns market price for market orders', () => {
+      const order = makeOrder({
+        orderType: 'market',
+        price: '3000.00',
+      });
+      const result = resolveOrderDisplayPriceAndLabel(order);
+      expect(result.priceValue).toBe(3000);
+      expect(result.labelKey).toBe('perpsMarket');
+    });
+
+    it('returns trigger price for TPSL order types', () => {
+      const order = makeOrder({
+        detailedOrderType: 'Take Profit Limit',
+        triggerPrice: '3500.00',
+        price: '3000.00',
+      });
+      const result = resolveOrderDisplayPriceAndLabel(order);
+      expect(result.priceValue).toBe(3500);
+      expect(result.labelKey).toBe('perpsTriggerPrice');
+    });
+  });
+
+  describe('formatOrderLabel', () => {
+    it('formats limit long', () => {
+      const order = makeOrder({ orderType: 'limit', side: 'buy' });
+      expect(formatOrderLabel(order)).toBe('Limit long');
+    });
+
+    it('formats limit short', () => {
+      const order = makeOrder({ orderType: 'limit', side: 'sell' });
+      expect(formatOrderLabel(order)).toBe('Limit short');
+    });
+
+    it('formats market long', () => {
+      const order = makeOrder({ orderType: 'market', side: 'buy' });
+      expect(formatOrderLabel(order)).toBe('Market long');
+    });
+
+    it('formats limit close long for reduce-only sell', () => {
+      const order = makeOrder({
+        orderType: 'limit',
+        side: 'sell',
+        reduceOnly: true,
+      });
+      expect(formatOrderLabel(order)).toBe('Limit close long');
+    });
+
+    it('formats stop market close short for trigger buy', () => {
+      const order = makeOrder({
+        side: 'buy',
+        isTrigger: true,
+        detailedOrderType: 'Stop Market',
+      });
+      expect(formatOrderLabel(order)).toBe('Stop Market close short');
+    });
+
+    it('formats take profit limit close long for trigger sell', () => {
+      const order = makeOrder({
+        side: 'sell',
+        isTrigger: true,
+        detailedOrderType: 'Take Profit Limit',
+      });
+      expect(formatOrderLabel(order)).toBe('Take Profit Limit close long');
+    });
+  });
+});

--- a/ui/components/app/perps/utils/orderUtils.test.ts
+++ b/ui/components/app/perps/utils/orderUtils.test.ts
@@ -438,22 +438,44 @@ describe('orderUtils', () => {
       expect(formatOrderLabel(order)).toBe('Limit close long');
     });
 
-    it('formats stop market close short for trigger buy', () => {
+    it('formats stop market close short for reduce-only trigger buy', () => {
       const order = makeOrder({
         side: 'buy',
         isTrigger: true,
+        reduceOnly: true,
         detailedOrderType: 'Stop Market',
       });
       expect(formatOrderLabel(order)).toBe('Stop Market close short');
     });
 
-    it('formats take profit limit close long for trigger sell', () => {
+    it('formats take profit limit close long for reduce-only trigger sell', () => {
       const order = makeOrder({
         side: 'sell',
         isTrigger: true,
+        reduceOnly: true,
         detailedOrderType: 'Take Profit Limit',
       });
       expect(formatOrderLabel(order)).toBe('Take Profit Limit close long');
+    });
+
+    it('formats stop market long for non-reduce-only trigger buy (stop-entry)', () => {
+      const order = makeOrder({
+        side: 'buy',
+        isTrigger: true,
+        reduceOnly: false,
+        detailedOrderType: 'Stop Market',
+      });
+      expect(formatOrderLabel(order)).toBe('Stop Market long');
+    });
+
+    it('formats stop limit short for non-reduce-only trigger sell (stop-entry)', () => {
+      const order = makeOrder({
+        side: 'sell',
+        isTrigger: true,
+        reduceOnly: false,
+        detailedOrderType: 'Stop Limit',
+      });
+      expect(formatOrderLabel(order)).toBe('Stop Limit short');
     });
   });
 });

--- a/ui/components/app/perps/utils/orderUtils.ts
+++ b/ui/components/app/perps/utils/orderUtils.ts
@@ -406,8 +406,8 @@ export const resolveOrderDisplayPriceAndLabel = (
  * @returns Formatted order label string
  */
 export const formatOrderLabel = (order: Order): string => {
-  const { side, detailedOrderType, orderType, reduceOnly, isTrigger } = order;
-  const isClosing = Boolean(reduceOnly || isTrigger);
+  const { side, detailedOrderType, orderType, reduceOnly } = order;
+  const isClosing = Boolean(reduceOnly);
 
   let direction: string;
   if (isClosing) {

--- a/ui/components/app/perps/utils/orderUtils.ts
+++ b/ui/components/app/perps/utils/orderUtils.ts
@@ -1,20 +1,6 @@
 import BigNumber from 'bignumber.js';
 import type { Order, Position } from '@metamask/perps-controller';
 
-const TPSL_DETAILED_ORDER_TYPES = new Set([
-  'Stop Limit',
-  'Stop Market',
-  'Take Profit Limit',
-  'Take Profit Market',
-]);
-
-const isTPSLOrder = (detailedOrderType?: string): boolean => {
-  if (!detailedOrderType) {
-    return false;
-  }
-  return TPSL_DETAILED_ORDER_TYPES.has(detailedOrderType);
-};
-
 const FULL_POSITION_SIZE_TOLERANCE = new BigNumber('0.00000001');
 const ORDER_PRICE_MATCH_TOLERANCE = new BigNumber('0.00000001');
 const SYNTHETIC_TP_ID_SUFFIX = '-synthetic-tp';
@@ -37,28 +23,6 @@ const safeBigNumber = (value: string | undefined | null): BigNumber | null => {
   } catch {
     return null;
   }
-};
-
-/**
- * Parses the trigger price from an order, returning null when absent or invalid.
- *
- * @param order - The order to extract trigger price from
- * @returns The trigger price or null
- */
-export const getValidTriggerPrice = (order: Order): number | null => {
-  const parsed = Number.parseFloat(order.triggerPrice ?? '');
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
-};
-
-/**
- * Parses the execution/limit price from an order, returning null when absent or invalid.
- *
- * @param order - The order to extract price from
- * @returns The order price or null
- */
-export const getValidOrderPrice = (order: Order): number | null => {
-  const parsed = Number.parseFloat(order.price ?? '');
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
 };
 
 const getAbsoluteOrderSize = (order: Order): BigNumber | null => {
@@ -360,69 +324,4 @@ export const normalizeMarketDetailsOrders = ({
   return ordersWithSyntheticTpsl.filter((order) =>
     shouldDisplayOrderInMarketDetailsOrders(order, existingPosition),
   );
-};
-
-/**
- * Resolves the display price and label key for an order.
- *
- * Returns the appropriate price (trigger or limit) and a translation key
- * indicating the price type for display in compact order rows.
- *
- * @param order - The order to resolve display info for
- * @returns Object with priceValue and labelKey
- */
-export const resolveOrderDisplayPriceAndLabel = (
-  order: Order,
-): { priceValue: number | null; labelKey: string } => {
-  const detailedOrderType = order.detailedOrderType ?? '';
-  const normalizedDetailedOrderType = detailedOrderType.toLowerCase();
-  const isTriggerOrder = Boolean(
-    order.isTrigger || isTPSLOrder(order.detailedOrderType),
-  );
-  const isLimitOrder = Boolean(
-    order.orderType === 'limit' ||
-      normalizedDetailedOrderType.includes('limit'),
-  );
-  const validTriggerPrice = getValidTriggerPrice(order);
-  const validOrderPrice = getValidOrderPrice(order);
-
-  if (isTriggerOrder && validTriggerPrice !== null) {
-    return { priceValue: validTriggerPrice, labelKey: 'perpsTriggerPrice' };
-  }
-
-  if (isLimitOrder && validOrderPrice !== null) {
-    return { priceValue: validOrderPrice, labelKey: 'perpsLimitPrice' };
-  }
-
-  return { priceValue: validOrderPrice, labelKey: 'perpsMarket' };
-};
-
-/**
- * Format an order label following the pattern: [Type] [Close?] [Direction]
- *
- * Examples: "Limit long", "Market close short", "Stop Market close long"
- *
- * @param order - The order to format
- * @returns Formatted order label string
- */
-export const formatOrderLabel = (order: Order): string => {
-  const { side, detailedOrderType, orderType, reduceOnly } = order;
-  const isClosing = Boolean(reduceOnly);
-
-  let direction: string;
-  if (isClosing) {
-    direction = side === 'sell' ? 'long' : 'short';
-  } else {
-    direction = side === 'buy' ? 'long' : 'short';
-  }
-
-  const typeString =
-    detailedOrderType || (orderType === 'limit' ? 'Limit' : 'Market');
-
-  const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
-
-  if (isClosing) {
-    return capitalize(`${typeString} close ${direction}`);
-  }
-  return capitalize(`${typeString} ${direction}`);
 };

--- a/ui/components/app/perps/utils/orderUtils.ts
+++ b/ui/components/app/perps/utils/orderUtils.ts
@@ -1,0 +1,428 @@
+import BigNumber from 'bignumber.js';
+import type { Order, Position } from '@metamask/perps-controller';
+
+const TPSL_DETAILED_ORDER_TYPES = new Set([
+  'Stop Limit',
+  'Stop Market',
+  'Take Profit Limit',
+  'Take Profit Market',
+]);
+
+const isTPSLOrder = (detailedOrderType?: string): boolean => {
+  if (!detailedOrderType) {
+    return false;
+  }
+  return TPSL_DETAILED_ORDER_TYPES.has(detailedOrderType);
+};
+
+const FULL_POSITION_SIZE_TOLERANCE = new BigNumber('0.00000001');
+const ORDER_PRICE_MATCH_TOLERANCE = new BigNumber('0.00000001');
+const SYNTHETIC_TP_ID_SUFFIX = '-synthetic-tp';
+const SYNTHETIC_SL_ID_SUFFIX = '-synthetic-sl';
+
+/**
+ * Safely creates a BigNumber, returning null for empty/invalid values.
+ * bignumber.js v4.x throws on empty strings and non-numeric values.
+ *
+ * @param value - The string value to parse
+ * @returns BigNumber or null
+ */
+const safeBigNumber = (value: string | undefined | null): BigNumber | null => {
+  if (!value || value.trim() === '') {
+    return null;
+  }
+  try {
+    const bn = new BigNumber(value);
+    return bn.isFinite() ? bn : null;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Parses the trigger price from an order, returning null when absent or invalid.
+ *
+ * @param order - The order to extract trigger price from
+ * @returns The trigger price or null
+ */
+export const getValidTriggerPrice = (order: Order): number | null => {
+  const parsed = Number.parseFloat(order.triggerPrice ?? '');
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+};
+
+/**
+ * Parses the execution/limit price from an order, returning null when absent or invalid.
+ *
+ * @param order - The order to extract price from
+ * @returns The order price or null
+ */
+export const getValidOrderPrice = (order: Order): number | null => {
+  const parsed = Number.parseFloat(order.price ?? '');
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+};
+
+const getAbsoluteOrderSize = (order: Order): BigNumber | null => {
+  const size = order.originalSize || order.size;
+  const parsedSize = safeBigNumber(size);
+  if (!parsedSize || parsedSize.lte(0)) {
+    return null;
+  }
+  return parsedSize.abs();
+};
+
+const getAbsolutePositionSize = (position?: Position): BigNumber | null => {
+  const parsedSize = safeBigNumber(position?.size);
+  if (!parsedSize || parsedSize.isZero()) {
+    return null;
+  }
+  return parsedSize.abs();
+};
+
+const getOrderTriggerPrice = (order: Order): BigNumber | null => {
+  const rawPrice = order.triggerPrice || order.price;
+  const parsedPrice = safeBigNumber(rawPrice);
+  if (!parsedPrice || parsedPrice.lte(0)) {
+    return null;
+  }
+  return parsedPrice;
+};
+
+const isClosingSideForPosition = (
+  order: Order,
+  position: Position,
+): boolean => {
+  const positionSize = safeBigNumber(position.size) ?? new BigNumber(0);
+  if (!positionSize.isFinite() || positionSize.isZero()) {
+    return false;
+  }
+  return positionSize.gt(0) ? order.side === 'sell' : order.side === 'buy';
+};
+
+const hasMatchingRealReduceOnlyTrigger = (
+  orders: Order[],
+  syntheticOrder: Order,
+): boolean => {
+  if (!syntheticOrder.parentOrderId) {
+    return false;
+  }
+
+  const parentOrder = orders.find(
+    (order) => order.orderId === syntheticOrder.parentOrderId,
+  );
+
+  return orders.some((order) => {
+    if (order.isSynthetic) {
+      return false;
+    }
+
+    const isSameParentByChildLink = Boolean(
+      order.parentOrderId &&
+        order.parentOrderId === syntheticOrder.parentOrderId,
+    );
+    const isSameParentByParentReference = Boolean(
+      parentOrder &&
+        (parentOrder.takeProfitOrderId === order.orderId ||
+          parentOrder.stopLossOrderId === order.orderId),
+    );
+
+    if (!isSameParentByChildLink && !isSameParentByParentReference) {
+      return false;
+    }
+
+    if (
+      order.symbol !== syntheticOrder.symbol ||
+      order.side !== syntheticOrder.side ||
+      order.reduceOnly !== true ||
+      order.isTrigger !== true
+    ) {
+      return false;
+    }
+
+    const existingOrderPrice = getOrderTriggerPrice(order);
+    const syntheticOrderPrice = getOrderTriggerPrice(syntheticOrder);
+
+    if (!existingOrderPrice || !syntheticOrderPrice) {
+      return false;
+    }
+
+    return existingOrderPrice
+      .minus(syntheticOrderPrice)
+      .abs()
+      .lte(ORDER_PRICE_MATCH_TOLERANCE);
+  });
+};
+
+/**
+ * Determines whether an order is associated with the full active position.
+ *
+ * Position association logic:
+ * 1. Order must be reduce-only.
+ * 2. Order and position must match symbol and closing side semantics.
+ * 3. Prefer native isPositionTpsl flag when available.
+ * 4. Fallback to full-size matching with decimal tolerance.
+ *
+ * @param order - The order to check
+ * @param position - The current position (if any)
+ * @returns Whether the order is associated with the full position
+ */
+export const isOrderAssociatedWithFullPosition = (
+  order: Order,
+  position?: Position,
+): boolean => {
+  if (!order.reduceOnly) {
+    return false;
+  }
+
+  if (order.isPositionTpsl === true) {
+    return true;
+  }
+
+  if (!position) {
+    return false;
+  }
+
+  if (
+    order.symbol !== position.symbol ||
+    !isClosingSideForPosition(order, position)
+  ) {
+    return false;
+  }
+
+  if (order.isPositionTpsl === false) {
+    return false;
+  }
+
+  const orderSize = getAbsoluteOrderSize(order);
+  const positionSize = getAbsolutePositionSize(position);
+  if (!orderSize || !positionSize) {
+    return false;
+  }
+
+  return orderSize.minus(positionSize).abs().lte(FULL_POSITION_SIZE_TOLERANCE);
+};
+
+/**
+ * Determines whether an order should be shown in Market Details > Orders.
+ *
+ * - All non-reduce-only orders are shown.
+ * - Reduce-only orders are shown only when they are NOT full-position TP/SL.
+ *
+ * @param order - The order to check
+ * @param position - The current position (if any)
+ * @returns Whether the order should be displayed
+ */
+export const shouldDisplayOrderInMarketDetailsOrders = (
+  order: Order,
+  position?: Position,
+): boolean => {
+  if (!order.reduceOnly) {
+    return true;
+  }
+  return !isOrderAssociatedWithFullPosition(order, position);
+};
+
+const buildSyntheticTriggerOrder = (
+  parentOrder: Order,
+  triggerType: 'tp' | 'sl',
+): Order | null => {
+  const triggerPrice =
+    triggerType === 'tp'
+      ? parentOrder.takeProfitPrice
+      : parentOrder.stopLossPrice;
+  const parsedTriggerPrice = safeBigNumber(triggerPrice);
+  if (!parsedTriggerPrice || parsedTriggerPrice.lte(0)) {
+    return null;
+  }
+  const normalizedTriggerPrice = parsedTriggerPrice.toFixed();
+
+  const syntheticSide = parentOrder.side === 'buy' ? 'sell' : 'buy';
+  const isMarketParent =
+    parentOrder.orderType === 'market' ||
+    (parentOrder.detailedOrderType || '').toLowerCase().includes('market');
+  const syntheticOrderType = isMarketParent ? 'market' : 'limit';
+  const executionStyle = isMarketParent ? 'Market' : 'Limit';
+  const syntheticDetailedType =
+    triggerType === 'tp'
+      ? `Take Profit ${executionStyle}`
+      : `Stop ${executionStyle}`;
+  const size = parentOrder.originalSize || parentOrder.size;
+  if (!size) {
+    return null;
+  }
+  const existingChildOrderId =
+    triggerType === 'tp'
+      ? parentOrder.takeProfitOrderId
+      : parentOrder.stopLossOrderId;
+  const syntheticOrderIdSuffix =
+    triggerType === 'tp' ? SYNTHETIC_TP_ID_SUFFIX : SYNTHETIC_SL_ID_SUFFIX;
+  const syntheticOrderId =
+    existingChildOrderId && existingChildOrderId.trim().length > 0
+      ? existingChildOrderId
+      : `${parentOrder.orderId}${syntheticOrderIdSuffix}`;
+
+  return {
+    orderId: syntheticOrderId,
+    parentOrderId: parentOrder.orderId,
+    isSynthetic: true,
+    isPositionTpsl: false,
+    symbol: parentOrder.symbol,
+    side: syntheticSide,
+    orderType: syntheticOrderType,
+    size,
+    originalSize: size,
+    price: normalizedTriggerPrice,
+    filledSize: '0',
+    remainingSize: size,
+    status: 'open',
+    timestamp: parentOrder.timestamp,
+    detailedOrderType: syntheticDetailedType,
+    isTrigger: true,
+    reduceOnly: true,
+    triggerPrice: normalizedTriggerPrice,
+    providerId: parentOrder.providerId,
+  };
+};
+
+/**
+ * Builds display orders with synthetic TP/SL rows for untriggered parent orders.
+ *
+ * Synthetic rows are display-only and are not created when a real reduce-only
+ * trigger already exists with matching symbol, side, and trigger price.
+ *
+ * @param orders - The orders to enrich with synthetic rows
+ * @returns Orders array with synthetic TP/SL rows added
+ */
+export const buildDisplayOrdersWithSyntheticTpsl = (
+  orders: Order[],
+): Order[] => {
+  if (!orders.length) {
+    return orders;
+  }
+
+  const displayOrders: Order[] = [];
+  const realOrderIds = new Set(orders.map((order) => order.orderId));
+
+  orders.forEach((order) => {
+    displayOrders.push(order);
+
+    if (order.isTrigger) {
+      return;
+    }
+
+    const syntheticTpOrder = buildSyntheticTriggerOrder(order, 'tp');
+    if (
+      syntheticTpOrder &&
+      !hasMatchingRealReduceOnlyTrigger(orders, syntheticTpOrder) &&
+      !realOrderIds.has(syntheticTpOrder.orderId) &&
+      !displayOrders.some(
+        (displayOrder) => displayOrder.orderId === syntheticTpOrder.orderId,
+      )
+    ) {
+      displayOrders.push(syntheticTpOrder);
+    }
+
+    const syntheticSlOrder = buildSyntheticTriggerOrder(order, 'sl');
+    if (
+      syntheticSlOrder &&
+      !hasMatchingRealReduceOnlyTrigger(orders, syntheticSlOrder) &&
+      !realOrderIds.has(syntheticSlOrder.orderId) &&
+      !displayOrders.some(
+        (displayOrder) => displayOrder.orderId === syntheticSlOrder.orderId,
+      )
+    ) {
+      displayOrders.push(syntheticSlOrder);
+    }
+  });
+
+  return displayOrders;
+};
+
+/**
+ * Normalizes orders for the Perps Market Details > Orders section.
+ *
+ * Composes display-order enrichment (synthetic TP/SL rows) with visibility
+ * filtering (hides full-position TP/SL, keeps everything else).
+ *
+ * @param options0 - Options object
+ * @param options0.orders - The orders to normalize
+ * @param options0.existingPosition - The current position (if any)
+ * @returns Normalized orders for display
+ */
+export const normalizeMarketDetailsOrders = ({
+  orders,
+  existingPosition,
+}: {
+  orders: Order[];
+  existingPosition?: Position;
+}): Order[] => {
+  const ordersWithSyntheticTpsl = buildDisplayOrdersWithSyntheticTpsl(orders);
+
+  return ordersWithSyntheticTpsl.filter((order) =>
+    shouldDisplayOrderInMarketDetailsOrders(order, existingPosition),
+  );
+};
+
+/**
+ * Resolves the display price and label key for an order.
+ *
+ * Returns the appropriate price (trigger or limit) and a translation key
+ * indicating the price type for display in compact order rows.
+ *
+ * @param order - The order to resolve display info for
+ * @returns Object with priceValue and labelKey
+ */
+export const resolveOrderDisplayPriceAndLabel = (
+  order: Order,
+): { priceValue: number | null; labelKey: string } => {
+  const detailedOrderType = order.detailedOrderType ?? '';
+  const normalizedDetailedOrderType = detailedOrderType.toLowerCase();
+  const isTriggerOrder = Boolean(
+    order.isTrigger || isTPSLOrder(order.detailedOrderType),
+  );
+  const isLimitOrder = Boolean(
+    order.orderType === 'limit' ||
+      normalizedDetailedOrderType.includes('limit'),
+  );
+  const validTriggerPrice = getValidTriggerPrice(order);
+  const validOrderPrice = getValidOrderPrice(order);
+
+  if (isTriggerOrder && validTriggerPrice !== null) {
+    return { priceValue: validTriggerPrice, labelKey: 'perpsTriggerPrice' };
+  }
+
+  if (isLimitOrder && validOrderPrice !== null) {
+    return { priceValue: validOrderPrice, labelKey: 'perpsLimitPrice' };
+  }
+
+  return { priceValue: validOrderPrice, labelKey: 'perpsMarket' };
+};
+
+/**
+ * Format an order label following the pattern: [Type] [Close?] [Direction]
+ *
+ * Examples: "Limit long", "Market close short", "Stop Market close long"
+ *
+ * @param order - The order to format
+ * @returns Formatted order label string
+ */
+export const formatOrderLabel = (order: Order): string => {
+  const { side, detailedOrderType, orderType, reduceOnly, isTrigger } = order;
+  const isClosing = Boolean(reduceOnly || isTrigger);
+
+  let direction: string;
+  if (isClosing) {
+    direction = side === 'sell' ? 'long' : 'short';
+  } else {
+    direction = side === 'buy' ? 'long' : 'short';
+  }
+
+  const typeString =
+    detailedOrderType || (orderType === 'limit' ? 'Limit' : 'Market');
+
+  const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
+
+  if (isClosing) {
+    return capitalize(`${typeString} close ${direction}`);
+  }
+  return capitalize(`${typeString} ${direction}`);
+};

--- a/ui/pages/perps/perps-market-detail-page.tsx
+++ b/ui/pages/perps/perps-market-detail-page.tsx
@@ -62,6 +62,7 @@ import {
   safeDecodeURIComponent,
   getChangeColor,
 } from '../../components/app/perps/utils';
+import { normalizeMarketDetailsOrders } from '../../components/app/perps/utils/orderUtils';
 import { PerpsDetailPageSkeleton } from '../../components/app/perps/perps-skeletons';
 import { Skeleton } from '../../components/component-library/skeleton';
 import { Popover, PopoverPosition } from '../../components/component-library';
@@ -278,34 +279,26 @@ const PerpsMarketDetailPage: React.FC = () => {
     positionRef.current = position;
   }, [position]);
 
-  // Find user-placed limit orders resting on the orderbook for this market.
-  // Excludes all position-attached orders:
-  // - isTrigger: TP/SL trigger orders
-  // - reduceOnly: close/reduce orders tied to positions
-  // - triggerPrice: any order with a trigger condition (TP/SL variant)
-  // - detailedOrderType containing "Take Profit" or "Stop" (belt-and-suspenders)
+  // Filter and sort open orders for this market, then normalize for display.
+  // Normalization adds synthetic TP/SL rows for parent orders and filters out
+  // full-position TP/SL (those stay on the position card / auto-close section).
   const orders = useMemo(() => {
     if (!decodedSymbol) {
       return [];
     }
-    return allOrders.filter((order) => {
-      if (order.symbol.toLowerCase() !== decodedSymbol.toLowerCase()) {
-        return false;
-      }
-      if (order.status !== 'open') {
-        return false;
-      }
-      // Exclude position-attached orders
-      if (order.isTrigger || order.reduceOnly || order.triggerPrice) {
-        return false;
-      }
-      const detailed = order.detailedOrderType?.toLowerCase() ?? '';
-      if (detailed.includes('take profit') || detailed.includes('stop')) {
-        return false;
-      }
-      return true;
+    const marketOrders = allOrders
+      .filter(
+        (order) =>
+          order.symbol.toLowerCase() === decodedSymbol.toLowerCase() &&
+          order.status === 'open',
+      )
+      .sort((a, b) => (b.timestamp || 0) - (a.timestamp || 0));
+
+    return normalizeMarketDetailsOrders({
+      orders: marketOrders,
+      existingPosition: position,
     });
-  }, [decodedSymbol, allOrders]);
+  }, [decodedSymbol, allOrders, position]);
 
   // Candle period state and chart ref
   const [selectedPeriod, setSelectedPeriod] = useState<CandlePeriod>(

--- a/ui/pages/perps/perps-market-detail-page.tsx
+++ b/ui/pages/perps/perps-market-detail-page.tsx
@@ -61,8 +61,8 @@ import {
   getDisplayName,
   safeDecodeURIComponent,
   getChangeColor,
+  normalizeMarketDetailsOrders,
 } from '../../components/app/perps/utils';
-import { normalizeMarketDetailsOrders } from '../../components/app/perps/utils/orderUtils';
 import { PerpsDetailPageSkeleton } from '../../components/app/perps/perps-skeletons';
 import { Skeleton } from '../../components/component-library/skeleton';
 import { Popover, PopoverPosition } from '../../components/component-library';

--- a/ui/pages/perps/perps-market-detail-page.tsx
+++ b/ui/pages/perps/perps-market-detail-page.tsx
@@ -61,8 +61,8 @@ import {
   getDisplayName,
   safeDecodeURIComponent,
   getChangeColor,
-  normalizeMarketDetailsOrders,
 } from '../../components/app/perps/utils';
+import { normalizeMarketDetailsOrders } from '../../components/app/perps/utils/orderUtils';
 import { PerpsDetailPageSkeleton } from '../../components/app/perps/perps-skeletons';
 import { Skeleton } from '../../components/component-library/skeleton';
 import { Popover, PopoverPosition } from '../../components/component-library';


### PR DESCRIPTION
## **Description**

The Market Details orders section previously used an inline filter that excluded **all** trigger and reduce-only orders. This meant users could not see resting limit orders

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/41186?quickstart=1)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2701?atlOrigin=eyJpIjoiNDIwNWM2NjdlMGEyNGYyN2JiN2E3YTg5NGZlMjU1NzYiLCJwIjoiaiJ9

## **Manual testing steps**

1. Open the extension and navigate to a perps market with an existing position.
2. Place a limit order
3. Verify the limit order is showing up in the UI

## **Screenshots/Recordings**

### **Before**

### **After**

<img width="353" height="784" alt="Screenshot 2026-03-25 at 11 28 44" src="https://github.com/user-attachments/assets/3a6617da-587e-4dc1-8826-eb22fbb80351" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
