### PR TITLE
refactor: migrate onboarding change-password ui to design-system

### DIFF
--- a/ui/pages/settings/security-tab/change-password/change-password-warning.test.tsx
+++ b/ui/pages/settings/security-tab/change-password/change-password-warning.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react';
+import { renderWithLocalization } from '../../../../../test/lib/render-helpers-navigate';
+import { enLocale as messages } from '../../../../../test/lib/i18n-helpers';
+import ZENDESK_URLS from '../../../../helpers/constants/zendesk-url';
+import ChangePasswordWarning from './change-password-warning';
+
+describe('ChangePasswordWarning', () => {
+  const mockOnConfirm = jest.fn();
+  const mockOnCancel = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function renderWarning() {
+    return renderWithLocalization(
+      <ChangePasswordWarning onConfirm={mockOnConfirm} onCancel={mockOnCancel} />,
+    );
+  }
+
+  it('renders the warning modal with title, description, and action buttons', () => {
+    const { getByTestId, getByText } = renderWarning();
+
+    expect(getByTestId('change-password-warning-modal')).toBeInTheDocument();
+    expect(getByText(messages.changePasswordWarning.message)).toBeInTheDocument();
+    expect(
+      getByText(messages.changePasswordWarningDescription.message, {
+        exact: false,
+      }),
+    ).toBeInTheDocument();
+    expect(getByTestId('change-password-warning-cancel')).toBeInTheDocument();
+    expect(getByTestId('change-password-warning-confirm')).toBeInTheDocument();
+  });
+
+  it('renders a learn more link pointing to the password reset article', () => {
+    const { getByRole } = renderWarning();
+
+    const learnMoreLink = getByRole('link', {
+      name: messages.learnMoreUpperCase.message,
+    });
+    expect(learnMoreLink).toBeInTheDocument();
+    expect(learnMoreLink).toHaveAttribute('href', ZENDESK_URLS.PASSWORD_RESET);
+  });
+
+  it('calls onCancel when the cancel button is clicked', () => {
+    const { getByTestId } = renderWarning();
+
+    fireEvent.click(getByTestId('change-password-warning-cancel'));
+
+    expect(mockOnCancel).toHaveBeenCalledTimes(1);
+    expect(mockOnConfirm).not.toHaveBeenCalled();
+  });
+
+  it('calls onConfirm when the confirm button is clicked', () => {
+    const { getByTestId } = renderWarning();
+
+    fireEvent.click(getByTestId('change-password-warning-confirm'));
+
+    expect(mockOnConfirm).toHaveBeenCalledTimes(1);
+    expect(mockOnCancel).not.toHaveBeenCalled();
+  });
+
+});

--- a/ui/pages/settings/security-tab/change-password/change-password-warning.test.tsx
+++ b/ui/pages/settings/security-tab/change-password/change-password-warning.test.tsx
@@ -15,7 +15,10 @@ describe('ChangePasswordWarning', () => {
 
   function renderWarning() {
     return renderWithLocalization(
-      <ChangePasswordWarning onConfirm={mockOnConfirm} onCancel={mockOnCancel} />,
+      <ChangePasswordWarning
+        onConfirm={mockOnConfirm}
+        onCancel={mockOnCancel}
+      />,
     );
   }
 
@@ -23,7 +26,9 @@ describe('ChangePasswordWarning', () => {
     const { getByTestId, getByText } = renderWarning();
 
     expect(getByTestId('change-password-warning-modal')).toBeInTheDocument();
-    expect(getByText(messages.changePasswordWarning.message)).toBeInTheDocument();
+    expect(
+      getByText(messages.changePasswordWarning.message),
+    ).toBeInTheDocument();
     expect(
       getByText(messages.changePasswordWarningDescription.message, {
         exact: false,
@@ -60,5 +65,4 @@ describe('ChangePasswordWarning', () => {
     expect(mockOnConfirm).toHaveBeenCalledTimes(1);
     expect(mockOnCancel).not.toHaveBeenCalled();
   });
-
 });

--- a/ui/pages/settings/security-tab/change-password/change-password-warning.tsx
+++ b/ui/pages/settings/security-tab/change-password/change-password-warning.tsx
@@ -1,20 +1,6 @@
 import React from 'react';
-
-import { useI18nContext } from '../../../../hooks/useI18nContext';
-import {
-  AlignItems,
-  Display,
-  IconColor,
-  JustifyContent,
-  TextAlign,
-  TextVariant,
-} from '../../../../helpers/constants/design-system';
 import {
   Box,
-  Modal,
-  ModalContent,
-  ModalHeader,
-  ModalOverlay,
   Text,
   ButtonSize,
   Button,
@@ -22,6 +8,20 @@ import {
   IconSize,
   IconName,
   ButtonVariant,
+  BoxJustifyContent,
+  IconColor,
+  TextVariant,
+  TextAlign,
+  BoxAlignItems,
+  BoxFlexDirection,
+} from '@metamask/design-system-react';
+import { useI18nContext } from '../../../../hooks/useI18nContext';
+import { AlignItems } from '../../../../helpers/constants/design-system';
+import {
+  Modal,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
 } from '../../../../components/component-library';
 import ZENDESK_URLS from '../../../../helpers/constants/zendesk-url';
 
@@ -60,32 +60,36 @@ export default function ChangePasswordWarning({
       <ModalContent alignItems={AlignItems.center}>
         <ModalHeader>
           <Box>
-            <Box display={Display.Flex} justifyContent={JustifyContent.center}>
+            <Box
+              flexDirection={BoxFlexDirection.Row}
+              justifyContent={BoxJustifyContent.Center}
+              alignItems={BoxAlignItems.Center}
+            >
               <Icon
                 name={IconName.Danger}
                 size={IconSize.Xl}
-                color={IconColor.warningDefault}
+                color={IconColor.WarningDefault}
               />
             </Box>
             <Text
-              variant={TextVariant.headingMd}
+              variant={TextVariant.HeadingMd}
               textAlign={TextAlign.Center}
-              marginTop={4}
+              className="mt-4"
             >
               {t('changePasswordWarning')}
             </Text>
-            <Text variant={TextVariant.bodySm} marginTop={4}>
+            <Text variant={TextVariant.BodySm} className="mt-4">
               {t('changePasswordWarningDescription')} {changePasswordLearnMore}
             </Text>
           </Box>
         </ModalHeader>
         <Box paddingLeft={4} paddingRight={4}>
-          <Box display={Display.Flex} marginTop={2} gap={4}>
+          <Box flexDirection={BoxFlexDirection.Row} marginTop={2} gap={4}>
             <Button
               variant={ButtonVariant.Secondary}
               data-testid="change-password-warning-cancel"
               size={ButtonSize.Lg}
-              block
+              className="w-full"
               onClick={() => onCancel()}
             >
               {t('cancel')}
@@ -93,7 +97,7 @@ export default function ChangePasswordWarning({
             <Button
               data-testid="change-password-warning-confirm"
               size={ButtonSize.Lg}
-              block
+              className="w-full"
               onClick={() => onConfirm()}
             >
               {t('confirm')}

--- a/ui/pages/settings/security-tab/change-password/change-password.test.tsx
+++ b/ui/pages/settings/security-tab/change-password/change-password.test.tsx
@@ -2,8 +2,10 @@ import React from 'react';
 import configureMockStore from 'redux-mock-store';
 import { fireEvent, waitFor } from '@testing-library/react';
 import { renderWithProvider } from '../../../../../test/lib/render-helpers-navigate';
+import { enLocale as messages } from '../../../../../test/lib/i18n-helpers';
 import mockState from '../../../../../test/data/mock-state.json';
 import { SECURITY_ROUTE } from '../../../../helpers/constants/routes';
+import * as selectors from '../../../../selectors';
 import ChangePassword from './change-password';
 
 const mockUseNavigate = jest.fn();
@@ -39,80 +41,219 @@ jest.mock('../../../../store/actions', () => ({
   },
 }));
 
+jest.mock('../../../../selectors', () => ({
+  ...jest.requireActual('../../../../selectors'),
+  getIsSocialLoginFlow: jest.fn().mockReturnValue(false),
+}));
+
 describe('ChangePassword', () => {
   const mockStore = configureMockStore()(mockState);
   const mockPassword = '12345678';
   const mockNewPassword = '87654321';
 
-  it('should render correctly', () => {
-    const { getByTestId } = renderWithProvider(<ChangePassword />, mockStore);
-
-    const verifyCurrentPasswordInput = getByTestId(
-      'verify-current-password-input',
-    );
-
-    expect(verifyCurrentPasswordInput).toBeInTheDocument();
-    expect(verifyCurrentPasswordInput).toHaveAttribute('type', 'password');
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (selectors.getIsSocialLoginFlow as jest.Mock).mockReturnValue(false);
   });
 
-  it('should go to the next step when the current password verification is successful', async () => {
-    const { getByTestId } = renderWithProvider(<ChangePassword />, mockStore);
-
-    const verifyCurrentPasswordInput = getByTestId(
-      'verify-current-password-input',
-    );
-
-    expect(verifyCurrentPasswordInput).toBeInTheDocument();
-    expect(verifyCurrentPasswordInput).toHaveAttribute('type', 'password');
-
-    const verifyCurrentPasswordButton = getByTestId(
-      'verify-current-password-button',
-    );
-    expect(verifyCurrentPasswordButton).toBeInTheDocument();
-    expect(verifyCurrentPasswordButton).toBeDisabled();
-
-    fireEvent.change(verifyCurrentPasswordInput, {
+  async function advanceToChangePasswordStep(
+    getByTestId: (id: string) => HTMLElement,
+  ) {
+    fireEvent.change(getByTestId('verify-current-password-input'), {
       target: { value: mockPassword },
     });
-    expect(verifyCurrentPasswordButton).toBeEnabled();
-
-    fireEvent.click(verifyCurrentPasswordButton);
-
+    fireEvent.click(getByTestId('verify-current-password-button'));
     await waitFor(() => {
       expect(mockVerifyPassword).toHaveBeenCalledWith(mockPassword);
     });
+  }
 
-    const changePasswordButton = getByTestId('change-password-button');
-    const changePasswordInput = getByTestId('change-password-input');
-    const checkTerms = getByTestId('change-password-terms');
-    const changePasswordConfirmInput = getByTestId(
-      'change-password-confirm-input',
-    );
+  describe('Step 1: verify current password', () => {
+    it('renders the current password input', () => {
+      const { getByTestId } = renderWithProvider(<ChangePassword />, mockStore);
 
-    expect(changePasswordInput).toBeInTheDocument();
-    expect(changePasswordConfirmInput).toBeInTheDocument();
-    expect(changePasswordButton).toBeInTheDocument();
-    expect(changePasswordButton).toBeDisabled();
-
-    fireEvent.click(checkTerms);
-
-    fireEvent.change(changePasswordInput, {
-      target: { value: mockNewPassword },
-    });
-    fireEvent.change(changePasswordConfirmInput, {
-      target: { value: mockNewPassword },
+      const input = getByTestId('verify-current-password-input');
+      expect(input).toBeInTheDocument();
+      expect(input).toHaveAttribute('type', 'password');
     });
 
-    expect(changePasswordButton).toBeEnabled();
+    it('disables the continue button when the password field is empty', () => {
+      const { getByTestId } = renderWithProvider(<ChangePassword />, mockStore);
 
-    fireEvent.click(changePasswordButton);
+      expect(getByTestId('verify-current-password-button')).toBeDisabled();
+    });
 
-    await waitFor(() => {
-      expect(mockChangePassword).toHaveBeenCalledWith(
-        mockNewPassword,
-        mockPassword,
+    it('shows an error when an incorrect password is submitted', async () => {
+      mockVerifyPassword.mockRejectedValueOnce(new Error('Incorrect password'));
+      const { getByTestId, getByText } = renderWithProvider(
+        <ChangePassword />,
+        mockStore,
       );
-      expect(mockUseNavigate).toHaveBeenCalledWith(SECURITY_ROUTE);
+
+      fireEvent.change(getByTestId('verify-current-password-input'), {
+        target: { value: 'wrongpassword' },
+      });
+      fireEvent.click(getByTestId('verify-current-password-button'));
+
+      await waitFor(() => {
+        expect(
+          getByText(messages.unlockPageIncorrectPassword.message),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('advances to the change password step on successful password verification', async () => {
+      const { getByTestId } = renderWithProvider(<ChangePassword />, mockStore);
+
+      await advanceToChangePasswordStep(getByTestId);
+
+      expect(getByTestId('change-password-input')).toBeInTheDocument();
+      expect(getByTestId('change-password-confirm-input')).toBeInTheDocument();
+      expect(getByTestId('change-password-button')).toBeInTheDocument();
+    });
+  });
+
+  describe('Step 2: set new password (standard flow)', () => {
+    it('disables the save button until new password, confirm password, and terms are all provided', async () => {
+      const { getByTestId } = renderWithProvider(<ChangePassword />, mockStore);
+
+      await advanceToChangePasswordStep(getByTestId);
+
+      const saveButton = getByTestId('change-password-button');
+      expect(saveButton).toBeDisabled();
+
+      fireEvent.change(getByTestId('change-password-input'), {
+        target: { value: mockNewPassword },
+      });
+      fireEvent.change(getByTestId('change-password-confirm-input'), {
+        target: { value: mockNewPassword },
+      });
+      expect(saveButton).toBeDisabled();
+
+      fireEvent.click(getByTestId('change-password-terms'));
+      expect(saveButton).toBeEnabled();
+    });
+
+    it('changes the password and navigates to security settings on save', async () => {
+      const { getByTestId } = renderWithProvider(<ChangePassword />, mockStore);
+
+      await advanceToChangePasswordStep(getByTestId);
+
+      fireEvent.change(getByTestId('change-password-input'), {
+        target: { value: mockNewPassword },
+      });
+      fireEvent.change(getByTestId('change-password-confirm-input'), {
+        target: { value: mockNewPassword },
+      });
+      fireEvent.click(getByTestId('change-password-terms'));
+      fireEvent.click(getByTestId('change-password-button'));
+
+      await waitFor(() => {
+        expect(mockChangePassword).toHaveBeenCalledWith(
+          mockNewPassword,
+          mockPassword,
+        );
+        expect(mockUseNavigate).toHaveBeenCalledWith(SECURITY_ROUTE);
+      });
+    });
+  });
+
+  describe('Step 2: set new password (social login flow)', () => {
+    beforeEach(() => {
+      (selectors.getIsSocialLoginFlow as jest.Mock).mockReturnValue(true);
+    });
+
+    it('shows the warning modal on form submission instead of immediately changing the password', async () => {
+      const { getByTestId, queryByTestId } = renderWithProvider(
+        <ChangePassword />,
+        mockStore,
+      );
+
+      await advanceToChangePasswordStep(getByTestId);
+
+      fireEvent.change(getByTestId('change-password-input'), {
+        target: { value: mockNewPassword },
+      });
+      fireEvent.change(getByTestId('change-password-confirm-input'), {
+        target: { value: mockNewPassword },
+      });
+      fireEvent.click(getByTestId('change-password-terms'));
+      fireEvent.click(getByTestId('change-password-button'));
+
+      await waitFor(() => {
+        expect(
+          queryByTestId('change-password-warning-modal'),
+        ).toBeInTheDocument();
+      });
+      expect(mockChangePassword).not.toHaveBeenCalled();
+    });
+
+    it('canceling the warning modal returns to the change password form', async () => {
+      const { getByTestId, queryByTestId } = renderWithProvider(
+        <ChangePassword />,
+        mockStore,
+      );
+
+      await advanceToChangePasswordStep(getByTestId);
+
+      fireEvent.change(getByTestId('change-password-input'), {
+        target: { value: mockNewPassword },
+      });
+      fireEvent.change(getByTestId('change-password-confirm-input'), {
+        target: { value: mockNewPassword },
+      });
+      fireEvent.click(getByTestId('change-password-terms'));
+      fireEvent.click(getByTestId('change-password-button'));
+
+      await waitFor(() => {
+        expect(
+          queryByTestId('change-password-warning-modal'),
+        ).toBeInTheDocument();
+      });
+
+      fireEvent.click(getByTestId('change-password-warning-cancel'));
+
+      await waitFor(() => {
+        expect(
+          queryByTestId('change-password-warning-modal'),
+        ).not.toBeInTheDocument();
+      });
+      expect(getByTestId('change-password-button')).toBeInTheDocument();
+      expect(mockChangePassword).not.toHaveBeenCalled();
+    });
+
+    it('confirming the warning modal proceeds with the password change', async () => {
+      const { getByTestId, queryByTestId } = renderWithProvider(
+        <ChangePassword />,
+        mockStore,
+      );
+
+      await advanceToChangePasswordStep(getByTestId);
+
+      fireEvent.change(getByTestId('change-password-input'), {
+        target: { value: mockNewPassword },
+      });
+      fireEvent.change(getByTestId('change-password-confirm-input'), {
+        target: { value: mockNewPassword },
+      });
+      fireEvent.click(getByTestId('change-password-terms'));
+      fireEvent.click(getByTestId('change-password-button'));
+
+      await waitFor(() => {
+        expect(
+          queryByTestId('change-password-warning-modal'),
+        ).toBeInTheDocument();
+      });
+
+      fireEvent.click(getByTestId('change-password-warning-confirm'));
+
+      await waitFor(() => {
+        expect(mockChangePassword).toHaveBeenCalledWith(
+          mockNewPassword,
+          mockPassword,
+        );
+        expect(mockUseNavigate).toHaveBeenCalledWith(SECURITY_ROUTE);
+      });
     });
   });
 });

--- a/ui/pages/settings/security-tab/change-password/change-password.tsx
+++ b/ui/pages/settings/security-tab/change-password/change-password.tsx
@@ -254,7 +254,7 @@ const ChangePassword = () => {
               >
                 <Checkbox
                   id="change-password-terms"
-                  inputProps={{ 'data-testid': 'change-password-terms' }}
+                  data-testid="change-password-terms"
                   isSelected={termsChecked}
                   onChange={() => {
                     setTermsChecked(!termsChecked);

--- a/ui/pages/settings/security-tab/change-password/change-password.tsx
+++ b/ui/pages/settings/security-tab/change-password/change-password.tsx
@@ -7,20 +7,19 @@ import {
   Button,
   ButtonSize,
   Checkbox,
+  Text,
+  TextVariant,
+  TextColor,
+  BoxFlexDirection,
+  BoxJustifyContent,
+  BoxAlignItems,
+  FontWeight,
+} from '@metamask/design-system-react';
+import {
   FormTextField,
   FormTextFieldSize,
-  Text,
   TextFieldType,
 } from '../../../../components/component-library';
-import {
-  AlignItems,
-  BlockSize,
-  Display,
-  FlexDirection,
-  JustifyContent,
-  TextColor,
-  TextVariant,
-} from '../../../../helpers/constants/design-system';
 import { isBeta, isFlask } from '../../../../../shared/lib/build-types';
 import Mascot from '../../../../components/ui/mascot';
 import Spinner from '../../../../components/ui/spinner';
@@ -164,134 +163,143 @@ const ChangePassword = () => {
     <Box padding={4} className="change-password">
       {step === ChangePasswordSteps.VerifyCurrentPassword && (
         <Box
-          as="form"
-          display={Display.Flex}
-          flexDirection={FlexDirection.Column}
+          flexDirection={BoxFlexDirection.Column}
           gap={6}
-          justifyContent={JustifyContent.spaceBetween}
-          height={BlockSize.Full}
-          onSubmit={(e: React.FormEvent<HTMLFormElement>) => {
-            e.preventDefault();
-            handleSubmitCurrentPassword();
-          }}
+          justifyContent={BoxJustifyContent.Between}
+          asChild
+          className="h-full"
         >
-          <FormTextField
-            id="current-password"
-            label={t('enterPasswordCurrent')}
-            textFieldProps={{ type: TextFieldType.Password }}
-            size={FormTextFieldSize.Lg}
-            labelProps={{
-              marginBottom: 1,
+          <form
+            onSubmit={(e: React.FormEvent<HTMLFormElement>) => {
+              e.preventDefault();
+              handleSubmitCurrentPassword();
             }}
-            inputProps={{
-              autoFocus: true,
-              'data-testid': 'verify-current-password-input',
-            }}
-            value={currentPassword}
-            error={isIncorrectPasswordError}
-            helpText={
-              isIncorrectPasswordError ? t('unlockPageIncorrectPassword') : null
-            }
-            onChange={(e) => {
-              setCurrentPassword(e.target.value);
-              setIsIncorrectPasswordError(false);
-            }}
-          />
-
-          <Button
-            type="submit"
-            block
-            size={ButtonSize.Lg}
-            disabled={isIncorrectPasswordError || !currentPassword}
-            data-testid="verify-current-password-button"
           >
-            {t('continue')}
-          </Button>
+            <FormTextField
+              id="current-password"
+              label={t('enterPasswordCurrent')}
+              textFieldProps={{ type: TextFieldType.Password }}
+              size={FormTextFieldSize.Lg}
+              labelProps={{
+                marginBottom: 1,
+              }}
+              inputProps={{
+                autoFocus: true,
+                'data-testid': 'verify-current-password-input',
+              }}
+              value={currentPassword}
+              error={isIncorrectPasswordError}
+              helpText={
+                isIncorrectPasswordError
+                  ? t('unlockPageIncorrectPassword')
+                  : null
+              }
+              onChange={(e) => {
+                setCurrentPassword(e.target.value);
+                setIsIncorrectPasswordError(false);
+              }}
+            />
+            <Button
+              type="submit"
+              className="w-full"
+              size={ButtonSize.Lg}
+              disabled={isIncorrectPasswordError || !currentPassword}
+              data-testid="verify-current-password-button"
+            >
+              {t('continue')}
+            </Button>
+          </form>
         </Box>
       )}
 
       {step === ChangePasswordSteps.ChangePassword && (
         <Box
-          as="form"
-          display={Display.Flex}
-          flexDirection={FlexDirection.Column}
+          flexDirection={BoxFlexDirection.Column}
           gap={6}
-          justifyContent={JustifyContent.spaceBetween}
-          height={BlockSize.Full}
-          onSubmit={(e: React.FormEvent<HTMLFormElement>) => {
-            e.preventDefault();
-            if (isSocialLoginFlow) {
-              setShowChangePasswordWarning(true);
-            } else {
-              onChangePassword();
-            }
-          }}
+          justifyContent={BoxJustifyContent.Between}
+          className="h-full"
+          asChild
         >
-          <Box>
-            <Text
-              variant={TextVariant.bodyMd}
-              color={TextColor.textAlternative}
-              marginBottom={4}
-              as="h2"
-            >
-              {isSocialLoginFlow
-                ? t('changePasswordDetailsSocial')
-                : t('createPasswordDetails')}
-            </Text>
-            <PasswordForm
-              onChange={(password) => setNewPassword(password)}
-              pwdInputTestId="change-password-input"
-              confirmPwdInputTestId="change-password-confirm-input"
-            />
-            <Box
-              className="create-password__terms-container"
-              alignItems={AlignItems.center}
-              justifyContent={JustifyContent.spaceBetween}
-              marginTop={6}
-            >
-              <Checkbox
-                inputProps={{ 'data-testid': 'change-password-terms' }}
-                alignItems={AlignItems.flexStart}
-                isChecked={termsChecked}
-                onChange={() => {
-                  setTermsChecked(!termsChecked);
-                }}
-                label={
-                  <>
-                    {isSocialLoginFlow
-                      ? t('passwordTermsWarningSocial')
-                      : t('passwordTermsWarning')}
-                    &nbsp;
-                    {createPasswordLink}
-                  </>
-                }
-              />
-            </Box>
-          </Box>
-          <Button
-            type="submit"
-            disabled={!currentPassword || !newPassword || !termsChecked}
-            data-testid="change-password-button"
-            block
+          <form
+            onSubmit={(e: React.FormEvent<HTMLFormElement>) => {
+              e.preventDefault();
+              if (isSocialLoginFlow) {
+                setShowChangePasswordWarning(true);
+              } else {
+                onChangePassword();
+              }
+            }}
           >
-            {t('save')}
-          </Button>
+            <Box>
+              <Text
+                variant={TextVariant.BodyMd}
+                color={TextColor.TextAlternative}
+                className="mb-4"
+              >
+                {isSocialLoginFlow
+                  ? t('changePasswordDetailsSocial')
+                  : t('createPasswordDetails')}
+              </Text>
+              <PasswordForm
+                onChange={(password) => setNewPassword(password)}
+                pwdInputTestId="change-password-input"
+                confirmPwdInputTestId="change-password-confirm-input"
+              />
+              <Box
+                className="create-password__terms-container"
+                flexDirection={BoxFlexDirection.Row}
+                alignItems={BoxAlignItems.Center}
+                justifyContent={BoxJustifyContent.Between}
+                marginTop={6}
+              >
+                <Checkbox
+                  id="change-password-terms"
+                  inputProps={{ 'data-testid': 'change-password-terms' }}
+                  isSelected={termsChecked}
+                  onChange={() => {
+                    setTermsChecked(!termsChecked);
+                  }}
+                  label={
+                    <>
+                      {isSocialLoginFlow
+                        ? t('passwordTermsWarningSocial')
+                        : t('passwordTermsWarning')}
+                      &nbsp;
+                      {createPasswordLink}
+                    </>
+                  }
+                  className="items-start flex"
+                />
+              </Box>
+            </Box>
+            <Button
+              type="submit"
+              disabled={!currentPassword || !newPassword || !termsChecked}
+              data-testid="change-password-button"
+              className="w-full"
+            >
+              {t('save')}
+            </Button>
+          </form>
         </Box>
       )}
 
       {step === ChangePasswordSteps.ChangePasswordLoading && (
         <Box
-          display={Display.Flex}
-          flexDirection={FlexDirection.Column}
-          alignItems={AlignItems.center}
+          flexDirection={BoxFlexDirection.Column}
+          alignItems={BoxAlignItems.Center}
           marginTop={12}
         >
-          <div>{renderMascot()}</div>
+          <Box>{renderMascot()}</Box>
           <Spinner className="change-password__spinner" />
-          <Text variant={TextVariant.bodyLgMedium} marginBottom={4}>
+          <Text
+            variant={TextVariant.BodyLg}
+            fontWeight={FontWeight.Medium}
+            className="mb-4"
+          >
             {t('changePasswordLoading')}
           </Text>
-          <Text variant={TextVariant.bodySm} color={TextColor.textAlternative}>
+          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
             {t('changePasswordLoadingNote')}
           </Text>
         </Box>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The onboarding flow pages "ChangePassword UI" (seedless onboarding) currently use the legacy component library and design-system constants (Display, AlignItems, JustifyContent, BlockSize, etc.). The codebase is moving to @metamask/design-system-react for consistency and maintainability.

Jira Link: https://consensyssoftware.atlassian.net/browse/TO-638

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/41188?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: migrate onboarding change-password ui to design-system

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/3c25b718-af52-4a61-9fb9-4c239c25c95e


https://github.com/user-attachments/assets/579df0fc-cde2-4451-b89d-3a99ecbeae6e


https://github.com/user-attachments/assets/c2425c2c-5b76-4441-9fc6-286e86e445e9



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the password-change UI flow (including social-login warning modal and form submission wiring), so regressions could block users from changing passwords despite being largely a UI refactor.
> 
> **Overview**
> Migrates the Change Password screens and `ChangePasswordWarning` modal from legacy layout/style constants to `@metamask/design-system-react`, updating layout props, typography variants, button/checkbox APIs, and form structure (using `asChild`/explicit `<form>` wrappers and Tailwind-style classes like `w-full`).
> 
> Adds a new unit test for `ChangePasswordWarning`, and significantly expands `change-password.test.tsx` to cover validation/error messaging, the standard save path, and the *social-login* path where submitting shows a warning modal and only changes the password after confirmation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a577a2ba494e5cad91c9c34a4e571bb493d3895a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->