### PR TITLE
fix: cp-13.24.0 Remove `actionId` to force generate random unique identifier for Transaction events

### DIFF
--- a/app/scripts/lib/transaction/metrics.test.ts
+++ b/app/scripts/lib/transaction/metrics.test.ts
@@ -346,4 +346,41 @@ describe('transaction metrics handlers', () => {
 
     expect(request.trackEvent).not.toHaveBeenCalled();
   });
+
+  it.each([
+    { name: 'added', handler: handleTransactionAdded },
+    { name: 'approved', handler: handleTransactionApproved },
+    { name: 'submitted', handler: handleTransactionSubmitted },
+    { name: 'rejected', handler: handleTransactionRejected },
+    { name: 'failed', handler: handleTransactionFailed },
+    { name: 'dropped', handler: handleTransactionDropped },
+  ])(
+    'does not include actionId in trackEvent payload for $name',
+    async ({ handler }) => {
+      const request = createRequest();
+      await handler(request, {
+        actionId: 'some-action-id',
+        transactionMeta: createTxMeta(),
+      });
+
+      const payload = (request.trackEvent as jest.Mock).mock.calls[0][0];
+      expect(payload).not.toHaveProperty('actionId');
+    },
+  );
+
+  it('does not include actionId in trackEvent payload for confirmed', async () => {
+    const request = createRequest();
+    const now = Date.now();
+    await handleTransactionConfirmed(request, {
+      ...createTxMeta({
+        actionId: 'some-action-id',
+        status: TransactionStatus.confirmed,
+        submittedTime: now - 3000,
+        txReceipt: { gasUsed: '0x5208', blockNumber: '0x10', status: '0x1' },
+      }),
+    } as any);
+
+    const payload = (request.trackEvent as jest.Mock).mock.calls[0][0];
+    expect(payload).not.toHaveProperty('actionId');
+  });
 });

--- a/app/scripts/lib/transaction/metrics.test.ts
+++ b/app/scripts/lib/transaction/metrics.test.ts
@@ -347,40 +347,43 @@ describe('transaction metrics handlers', () => {
     expect(request.trackEvent).not.toHaveBeenCalled();
   });
 
-  it.each([
-    { name: 'added', handler: handleTransactionAdded },
-    { name: 'approved', handler: handleTransactionApproved },
-    { name: 'submitted', handler: handleTransactionSubmitted },
-    { name: 'rejected', handler: handleTransactionRejected },
-    { name: 'failed', handler: handleTransactionFailed },
-    { name: 'dropped', handler: handleTransactionDropped },
-  ])(
-    'does not include actionId in trackEvent payload for $name',
-    async ({ handler }) => {
-      const request = createRequest();
-      await handler(request, {
-        actionId: 'some-action-id',
-        transactionMeta: createTxMeta(),
+  describe('does not include actionId in trackEvent payload', () => {
+    const handlers = [
+      { name: 'added', handler: handleTransactionAdded },
+      { name: 'approved', handler: handleTransactionApproved },
+      { name: 'submitted', handler: handleTransactionSubmitted },
+      { name: 'rejected', handler: handleTransactionRejected },
+      { name: 'failed', handler: handleTransactionFailed },
+      { name: 'dropped', handler: handleTransactionDropped },
+    ];
+
+    for (const { name, handler } of handlers) {
+      it(`${name}`, async () => {
+        const request = createRequest();
+        await handler(request, {
+          actionId: 'some-action-id',
+          transactionMeta: createTxMeta(),
+        });
+
+        const payload = (request.trackEvent as jest.Mock).mock.calls[0][0];
+        expect(payload).not.toHaveProperty('actionId');
       });
+    }
+
+    it('confirmed', async () => {
+      const request = createRequest();
+      const now = Date.now();
+      await handleTransactionConfirmed(request, {
+        ...createTxMeta({
+          actionId: 'some-action-id',
+          status: TransactionStatus.confirmed,
+          submittedTime: now - 3000,
+          txReceipt: { gasUsed: '0x5208', blockNumber: '0x10', status: '0x1' },
+        }),
+      } as any);
 
       const payload = (request.trackEvent as jest.Mock).mock.calls[0][0];
       expect(payload).not.toHaveProperty('actionId');
-    },
-  );
-
-  it('does not include actionId in trackEvent payload for confirmed', async () => {
-    const request = createRequest();
-    const now = Date.now();
-    await handleTransactionConfirmed(request, {
-      ...createTxMeta({
-        actionId: 'some-action-id',
-        status: TransactionStatus.confirmed,
-        submittedTime: now - 3000,
-        txReceipt: { gasUsed: '0x5208', blockNumber: '0x10', status: '0x1' },
-      }),
-    } as any);
-
-    const payload = (request.trackEvent as jest.Mock).mock.calls[0][0];
-    expect(payload).not.toHaveProperty('actionId');
+    });
   });
 });

--- a/app/scripts/lib/transaction/metrics.ts
+++ b/app/scripts/lib/transaction/metrics.ts
@@ -50,7 +50,6 @@ export const handleTransactionConfirmed = async (
     eventName: TransactionMetaMetricsEvent.finalized,
     transactionMetricsRequest,
     transactionEventPayload: {
-      actionId: transactionEventPayload.actionId,
       transactionMeta: transactionEventPayload,
     },
   });

--- a/app/scripts/lib/transaction/metrics.ts
+++ b/app/scripts/lib/transaction/metrics.ts
@@ -114,7 +114,6 @@ async function trackTransactionEvent({
     category: MetaMetricsEventCategory.Transactions,
     properties,
     sensitiveProperties,
-    actionId: transactionEventPayload.actionId,
   });
 }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR aims to remove `actionId` from `trackEvent` calls that Transaction events doing.

`buildUniqueMessageId` only uses `actionId` + `uniqueIdentifier` to build the `messageId` ([metametrics-controller.ts#L126-L147](https://github.com/MetaMask/metamask-extension/blob/main/app/scripts/controllers/metametrics-controller.ts#L126-L147)). Since transaction lifecycle events (Added, Approved, Submitted, Finalized) share the same actionId and none of them set a `uniqueIdentifier` ([metrics.ts#L112-L118](https://github.com/MetaMask/metamask-extension/blob/main/app/scripts/lib/transaction/metrics.ts#L112-L118)), they all produce identical `messageId` values.

This causes two problems:

- Segment server-side deduplication - Segment uses messageId to deduplicate events. When multiple events arrive with the same messageId, only the first is kept. So events like "Transaction Finalized" are silently dropped.
- Local state overwrite - In #submitSegmentAPICall, events are stored in state.segmentApiCalls[messageId] ([metametrics-controller.ts#L1789](https://github.com/MetaMask/metamask-extension/blob/main/app/scripts/controllers/metametrics-controller.ts#L1789)). If a second event is fired before the first callback resolves, it overwrites the first entry, breaking the local retry/persistence tracking.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/41198?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/41202

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk functional impact since changes only affect MetaMetrics event payload shape, but it may alter analytics correlation/deduplication behavior for transaction lifecycle events.
> 
> **Overview**
> Stops passing `actionId` into MetaMetrics `trackEvent` calls for transaction lifecycle events (including `handleTransactionConfirmed` and the shared `trackTransactionEvent` helper) so each event can generate a distinct `messageId`.
> 
> Adds tests asserting that `actionId` is **not** present in the `trackEvent` payload across added/approved/submitted/rejected/failed/dropped/confirmed handlers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ced78cd1bcf988b82cad338f3312d9120056eb8f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->