### PR TITLE
fix: mUSD conversion amount input broken on Firefox cp-13.24.0

### DIFF
--- a/ui/pages/confirmations/components/transactions/custom-amount/custom-amount.tsx
+++ b/ui/pages/confirmations/components/transactions/custom-amount/custom-amount.tsx
@@ -149,8 +149,7 @@ export const CustomAmount: React.FC<CustomAmountProps> = React.memo(
               border: 'none',
               background: 'transparent',
               outline: 'none',
-              fieldSizing: 'content',
-              minWidth: '1ch',
+              width: `${Math.max(1, amountLength)}ch`,
               cursor: disabled ? 'default' : 'text',
             } as React.CSSProperties
           }


### PR DESCRIPTION
## **Description**

The mUSD "Convert and get 3%" screen was rendering broken UI on Firefox — the `$0` amount input was invisible/missing because the `field-sizing: content` CSS property is not supported in Firefox. Replaced it with a `width` calculated from the input length using `ch` units, which works cross-browser.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/41201?quickstart=1)

## **Changelog**

CHANGELOG entry: Fixed mUSD conversion screen not displaying the amount input on Firefox

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1100

## **Manual testing steps**

1. Open MetaMask in Firefox
2. Navigate to a token with "Get 3% mUSD bonus" (e.g. USDC or DAI)
3. Click the "Get 3% mUSD bonus" link
4. Verify the "$0" amount input is visible and centered on the "Convert and get 3%" screen
5. Type a value and confirm the input resizes correctly
6. Repeat on Chrome/Brave to verify no regression

## **Screenshots/Recordings**

### **Before**

<!-- Firefox: $0 amount input missing from the Convert and get 3% screen -->

### **After**

<!-- Firefox: $0 amount input visible and correctly sized, matching Chrome/Brave -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change: replaces the unsupported `field-sizing` style with an explicit `ch`-based `width`, which could slightly affect input sizing/layout across browsers.
> 
> **Overview**
> Fixes the `CustomAmount` fiat input sizing by removing the unsupported `fieldSizing: 'content'`/`minWidth` styling and instead setting `width` based on the current input length using `ch` units (with a 1-character minimum). This prevents the amount input from disappearing on Firefox while keeping the field auto-sizing as the user types.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49c9e186983498e553e6c17484238e9560b34210. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->