### PR TITLE
test: harden Firefox phishing window switching

### DIFF
--- a/test/e2e/page-objects/pages/phishing-warning-page.ts
+++ b/test/e2e/page-objects/pages/phishing-warning-page.ts
@@ -1,5 +1,8 @@
 import { WebElement } from 'selenium-webdriver';
+import { WINDOW_TITLES } from '../../constants';
 import { Driver } from '../../webdriver/driver';
+
+const PHISHING_WINDOW_TIMEOUT_MS = 15000;
 
 class PhishingWarningPage {
   private readonly driver: Driver;
@@ -70,6 +73,10 @@ class PhishingWarningPage {
       { interval: 1000, timeout: 10000 },
     );
     await this.driver.clickElement(this.openWarningInNewTabLink);
+    await this.driver.waitForWindowWithTitleToBePresent(
+      WINDOW_TITLES.Phishing,
+      PHISHING_WINDOW_TIMEOUT_MS,
+    );
   }
 
   async clickProceedAnywayButton(): Promise<void> {

--- a/test/e2e/tests/phishing-controller/phishing-detection.spec.ts
+++ b/test/e2e/tests/phishing-controller/phishing-detection.spec.ts
@@ -18,6 +18,7 @@ import MockedPage from '../../page-objects/pages/mocked-page';
 import PhishingWarningPage from '../../page-objects/pages/phishing-warning-page';
 import { login } from '../../page-objects/flows/login.flow';
 import TestDapp from '../../page-objects/pages/test-dapp';
+import type { Driver } from '../../webdriver/driver';
 import {
   setupPhishingDetectionMocks,
   mockConfigLookupOnWarningPage,
@@ -31,6 +32,27 @@ import {
 // Common test constants
 const DEFAULT_BLOCKED_DOMAIN =
   'a379a6f6eeafb9a55e378c118034e2751e682fab9f2d30ab13d2125586ce1947';
+const PHISHING_WINDOW_TIMEOUT_MS = 15000;
+
+async function openIframeWarningInNewTab(
+  driver: Driver,
+  phishingWarningPage: PhishingWarningPage,
+): Promise<void> {
+  await phishingWarningPage.clickOpenWarningInNewTabLinkOnIframe();
+  await driver.waitForWindowWithTitleToBePresent(
+    WINDOW_TITLES.Phishing,
+    PHISHING_WINDOW_TIMEOUT_MS,
+  );
+}
+
+async function switchToWindowWithTitleWhenPresent(
+  driver: Driver,
+  title: string,
+  timeout = PHISHING_WINDOW_TIMEOUT_MS,
+): Promise<void> {
+  await driver.waitForWindowWithTitleToBePresent(title, timeout);
+  await driver.switchToWindowWithTitle(title);
+}
 
 describe('Phishing Detection', function (this: Suite) {
   describe('Phishing Detection Mock', function () {
@@ -153,16 +175,23 @@ describe('Phishing Detection', function (this: Suite) {
           await login(driver);
           await driver.openNewPage(DAPP_WITH_IFRAMED_PAGE_ON_BLOCKLIST);
           const phishingWarningPage = new PhishingWarningPage(driver);
-          await phishingWarningPage.clickOpenWarningInNewTabLinkOnIframe();
-          await driver.switchToWindowWithTitle(
+          await openIframeWarningInNewTab(driver, phishingWarningPage);
+          await switchToWindowWithTitleWhenPresent(
+            driver,
             WINDOW_TITLES.ExtensionInFullScreenView,
           );
           await new HomePage(driver).checkPageIsLoaded();
 
-          await driver.switchToWindowWithTitle('MetaMask Phishing Detection');
+          await switchToWindowWithTitleWhenPresent(
+            driver,
+            WINDOW_TITLES.Phishing,
+          );
           await phishingWarningPage.checkPageIsLoaded();
           await phishingWarningPage.clickProceedAnywayButton();
-          await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
+          await switchToWindowWithTitleWhenPresent(
+            driver,
+            WINDOW_TITLES.TestDApp,
+          );
         },
       );
     });
@@ -195,8 +224,11 @@ describe('Phishing Detection', function (this: Suite) {
         );
 
         const phishingWarningPage = new PhishingWarningPage(driver);
-        await phishingWarningPage.clickOpenWarningInNewTabLinkOnIframe();
-        await driver.switchToWindowWithTitle('MetaMask Phishing Detection');
+        await openIframeWarningInNewTab(driver, phishingWarningPage);
+        await switchToWindowWithTitleWhenPresent(
+          driver,
+          WINDOW_TITLES.Phishing,
+        );
 
         // we need to wait for this selector to mitigate a race condition on the phishing page site
         // see more here https://github.com/MetaMask/phishing-warning/pull/173
@@ -315,8 +347,11 @@ describe('Phishing Detection', function (this: Suite) {
         );
 
         const phishingWarningPage = new PhishingWarningPage(driver);
-        await phishingWarningPage.clickOpenWarningInNewTabLinkOnIframe();
-        await driver.switchToWindowWithTitle('MetaMask Phishing Detection');
+        await openIframeWarningInNewTab(driver, phishingWarningPage);
+        await switchToWindowWithTitleWhenPresent(
+          driver,
+          WINDOW_TITLES.Phishing,
+        );
         await phishingWarningPage.checkPageIsLoaded();
         await phishingWarningPage.clickBackToSafetyButton();
 

--- a/test/e2e/tests/phishing-controller/phishing-detection.spec.ts
+++ b/test/e2e/tests/phishing-controller/phishing-detection.spec.ts
@@ -34,17 +34,6 @@ const DEFAULT_BLOCKED_DOMAIN =
   'a379a6f6eeafb9a55e378c118034e2751e682fab9f2d30ab13d2125586ce1947';
 const PHISHING_WINDOW_TIMEOUT_MS = 15000;
 
-async function openIframeWarningInNewTab(
-  driver: Driver,
-  phishingWarningPage: PhishingWarningPage,
-): Promise<void> {
-  await phishingWarningPage.clickOpenWarningInNewTabLinkOnIframe();
-  await driver.waitForWindowWithTitleToBePresent(
-    WINDOW_TITLES.Phishing,
-    PHISHING_WINDOW_TIMEOUT_MS,
-  );
-}
-
 async function switchToWindowWithTitleWhenPresent(
   driver: Driver,
   title: string,
@@ -175,7 +164,7 @@ describe('Phishing Detection', function (this: Suite) {
           await login(driver);
           await driver.openNewPage(DAPP_WITH_IFRAMED_PAGE_ON_BLOCKLIST);
           const phishingWarningPage = new PhishingWarningPage(driver);
-          await openIframeWarningInNewTab(driver, phishingWarningPage);
+          await phishingWarningPage.clickOpenWarningInNewTabLinkOnIframe();
           await switchToWindowWithTitleWhenPresent(
             driver,
             WINDOW_TITLES.ExtensionInFullScreenView,
@@ -224,7 +213,7 @@ describe('Phishing Detection', function (this: Suite) {
         );
 
         const phishingWarningPage = new PhishingWarningPage(driver);
-        await openIframeWarningInNewTab(driver, phishingWarningPage);
+        await phishingWarningPage.clickOpenWarningInNewTabLinkOnIframe();
         await switchToWindowWithTitleWhenPresent(
           driver,
           WINDOW_TITLES.Phishing,
@@ -347,7 +336,7 @@ describe('Phishing Detection', function (this: Suite) {
         );
 
         const phishingWarningPage = new PhishingWarningPage(driver);
-        await openIframeWarningInNewTab(driver, phishingWarningPage);
+        await phishingWarningPage.clickOpenWarningInNewTabLinkOnIframe();
         await switchToWindowWithTitleWhenPresent(
           driver,
           WINDOW_TITLES.Phishing,


### PR DESCRIPTION
## **Description**

This follow-up hardens the Firefox phishing iframe/new-tab flows that were still intermittently failing with `NoSuchWindowError: Browsing context has been discarded`.

The change waits for the phishing warning window title to exist before switching into it, and reuses the same wait-before-switch pattern when returning to the test dapp. That keeps Firefox from switching into a window while its browsing context is still being replaced.

## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Run `yarn.cmd eslint test/e2e/tests/phishing-controller/phishing-detection.spec.ts`
2. Run `yarn.cmd lint:changed:fix`
3. Optionally run `yarn.cmd test:e2e:single test/e2e/tests/phishing-controller/phishing-detection.spec.ts --browser=firefox --debug=false`

## **Implementation notes**

- Adds a small helper in the phishing spec to wait for a window title before switching.
- Applies the helper to the iframe/new-tab phishing flows that switch into the warning page and back out to the dapp.
- Leaves the shared fixture-session changes from the parent branch untouched.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.