### PR TITLE
feat: add hardware wallet recovery MetaMetrics (modal and shared utils)

### DIFF
--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -1064,6 +1064,9 @@ export enum MetaMetricsEventName {
   HardwareWalletForgotten = 'Hardware Wallet Forgotten',
   HardwareWalletMarketingButtonClicked = 'Hardware Wallet Marketing Button Clicked',
   HardwareWalletConnectionFailed = 'Hardware Wallet Connection Failed',
+  HardwareWalletRecoveryModalViewed = 'Hardware Wallet Recovery Modal Viewed',
+  HardwareWalletRecoverySuccessModalViewed = 'Hardware Wallet Recovery Success Modal Viewed',
+  HardwareWalletRecoveryCtaClicked = 'Hardware Wallet Recovery CTA Clicked',
   ViewportSwitched = 'Viewport Switched',
   // Rewards
   RewardsOptInStarted = 'REWARDS_OPT_IN_STARTED',
@@ -1100,6 +1103,41 @@ export enum MetaMetricsEventName {
   ContactUpdated = 'Contact Updated',
   DeleteContactClicked = 'Delete Contact Clicked',
   ContactDeleted = 'Contact Deleted',
+}
+
+/**
+ * Segment `location` for hardware wallet recovery.
+ * String values must match `segment-schema/libraries/properties/metamask-hardware-wallet-recovery-globals.yaml` (`location` enum).
+ */
+export enum MetaMetricsHardwareWalletRecoveryLocation {
+  Connection = 'Connection',
+  Transaction = 'Transaction',
+  Message = 'Message',
+  Swaps = 'Swaps',
+  Send = 'Send',
+}
+
+/**
+ * Segment `error_type` for hardware wallet recovery.
+ * String values must match `metamask-hardware-wallet-recovery-globals` / `metamask-hardware-wallet-recovery-error-globals` enums in segment-schema.
+ */
+export enum MetaMetricsHardwareWalletRecoveryErrorType {
+  DeviceLocked = 'Device Locked',
+  DeviceDisconnected = 'Device Disconnected',
+  EthereumAppNotOpened = 'Ethereum App Not Opened',
+  BlindSigningNotEnabled = 'Blind Signing Not Enabled',
+  GenericError = 'Generic Error',
+}
+
+/**
+ * Segment `device_type` (manufacturer) for hardware wallet events.
+ * String values must match `segment-schema/libraries/properties/metamask-hardware-wallet-globals.yaml` (`device_type` enum).
+ */
+export enum MetaMetricsHardwareWalletDeviceType {
+  Ledger = 'Ledger',
+  Trezor = 'Trezor',
+  QrHardware = 'QR Hardware',
+  Lattice = 'Lattice',
 }
 
 export enum MetaMetricsEventAccountType {

--- a/shared/lib/hardware-wallet-recovery-metrics.test.ts
+++ b/shared/lib/hardware-wallet-recovery-metrics.test.ts
@@ -36,19 +36,10 @@ describe('hardware-wallet-recovery-metrics', () => {
       );
     });
 
-    it('defaults unknown or schema-unlisted wallet types to Ledger', () => {
-      expect(mapHardwareWalletTypeToMetricDeviceType(undefined)).toBe(
-        MetaMetricsHardwareWalletDeviceType.Ledger,
-      );
-      expect(mapHardwareWalletTypeToMetricDeviceType(null)).toBe(
-        MetaMetricsHardwareWalletDeviceType.Ledger,
-      );
-      expect(mapHardwareWalletTypeToMetricDeviceType('oneKey')).toBe(
-        MetaMetricsHardwareWalletDeviceType.Ledger,
-      );
-      expect(mapHardwareWalletTypeToMetricDeviceType('unknown')).toBe(
-        MetaMetricsHardwareWalletDeviceType.Ledger,
-      );
+    it('returns null for unknown or schema-unlisted wallet types', () => {
+      expect(mapHardwareWalletTypeToMetricDeviceType(undefined)).toBeNull();
+      expect(mapHardwareWalletTypeToMetricDeviceType(null)).toBeNull();
+      expect(mapHardwareWalletTypeToMetricDeviceType('unknown')).toBeNull();
     });
   });
 

--- a/shared/lib/hardware-wallet-recovery-metrics.test.ts
+++ b/shared/lib/hardware-wallet-recovery-metrics.test.ts
@@ -1,0 +1,282 @@
+/* eslint-disable @typescript-eslint/naming-convention, camelcase -- Segment-shaped assertions and destructuring match analytics schema */
+import {
+  Category,
+  ErrorCode,
+  HardwareWalletError,
+  Severity,
+} from '@metamask/hw-wallet-sdk';
+import {
+  MetaMetricsHardwareWalletDeviceType,
+  MetaMetricsHardwareWalletRecoveryErrorType,
+  MetaMetricsHardwareWalletRecoveryLocation,
+} from '../constants/metametrics';
+import {
+  buildHardwareWalletRecoverySegmentProperties,
+  extractHardwareWalletRecoveryErrorCodeAndMessage,
+  getHardwareWalletMetricDeviceModel,
+  HARDWARE_WALLET_RECOVERY_SEGMENT_PAYLOAD_KEYS,
+  mapHardwareWalletRecoveryErrorType,
+  mapHardwareWalletTypeToMetricDeviceType,
+} from './hardware-wallet-recovery-metrics';
+
+describe('hardware-wallet-recovery-metrics', () => {
+  describe('mapHardwareWalletTypeToMetricDeviceType', () => {
+    it('maps known wallet types to Segment device_type values', () => {
+      expect(mapHardwareWalletTypeToMetricDeviceType('ledger')).toBe(
+        MetaMetricsHardwareWalletDeviceType.Ledger,
+      );
+      expect(mapHardwareWalletTypeToMetricDeviceType('trezor')).toBe(
+        MetaMetricsHardwareWalletDeviceType.Trezor,
+      );
+      expect(mapHardwareWalletTypeToMetricDeviceType('qr')).toBe(
+        MetaMetricsHardwareWalletDeviceType.QrHardware,
+      );
+      expect(mapHardwareWalletTypeToMetricDeviceType('lattice')).toBe(
+        MetaMetricsHardwareWalletDeviceType.Lattice,
+      );
+    });
+
+    it('defaults unknown or schema-unlisted wallet types to Ledger', () => {
+      expect(mapHardwareWalletTypeToMetricDeviceType(undefined)).toBe(
+        MetaMetricsHardwareWalletDeviceType.Ledger,
+      );
+      expect(mapHardwareWalletTypeToMetricDeviceType(null)).toBe(
+        MetaMetricsHardwareWalletDeviceType.Ledger,
+      );
+      expect(mapHardwareWalletTypeToMetricDeviceType('oneKey')).toBe(
+        MetaMetricsHardwareWalletDeviceType.Ledger,
+      );
+      expect(mapHardwareWalletTypeToMetricDeviceType('unknown')).toBe(
+        MetaMetricsHardwareWalletDeviceType.Ledger,
+      );
+    });
+  });
+
+  describe('mapHardwareWalletRecoveryErrorType', () => {
+    it('maps locked device errors from numeric code', () => {
+      expect(
+        mapHardwareWalletRecoveryErrorType({
+          code: ErrorCode.AuthenticationDeviceLocked,
+        }),
+      ).toBe(MetaMetricsHardwareWalletRecoveryErrorType.DeviceLocked);
+    });
+
+    it('maps blind signing errors from numeric code', () => {
+      expect(
+        mapHardwareWalletRecoveryErrorType({
+          code: ErrorCode.DeviceStateBlindSignNotSupported,
+        }),
+      ).toBe(MetaMetricsHardwareWalletRecoveryErrorType.BlindSigningNotEnabled);
+    });
+
+    it('maps connection transport missing to DeviceDisconnected', () => {
+      expect(
+        mapHardwareWalletRecoveryErrorType({
+          code: ErrorCode.ConnectionTransportMissing,
+        }),
+      ).toBe(MetaMetricsHardwareWalletRecoveryErrorType.DeviceDisconnected);
+    });
+
+    it('maps device blocked to DeviceLocked', () => {
+      expect(
+        mapHardwareWalletRecoveryErrorType({
+          code: ErrorCode.AuthenticationDeviceBlocked,
+        }),
+      ).toBe(MetaMetricsHardwareWalletRecoveryErrorType.DeviceLocked);
+    });
+
+    it('maps connection timeout to DeviceDisconnected', () => {
+      expect(
+        mapHardwareWalletRecoveryErrorType({
+          code: ErrorCode.ConnectionTimeout,
+        }),
+      ).toBe(MetaMetricsHardwareWalletRecoveryErrorType.DeviceDisconnected);
+    });
+
+    it('maps Ethereum app closed to EthereumAppNotOpened', () => {
+      expect(
+        mapHardwareWalletRecoveryErrorType({
+          code: ErrorCode.DeviceStateEthAppClosed,
+        }),
+      ).toBe(MetaMetricsHardwareWalletRecoveryErrorType.EthereumAppNotOpened);
+    });
+
+    it('maps unrecognized codes to GenericError', () => {
+      expect(
+        mapHardwareWalletRecoveryErrorType({ code: ErrorCode.Unknown }),
+      ).toBe(MetaMetricsHardwareWalletRecoveryErrorType.GenericError);
+    });
+
+    it('maps missing code to GenericError', () => {
+      expect(mapHardwareWalletRecoveryErrorType({})).toBe(
+        MetaMetricsHardwareWalletRecoveryErrorType.GenericError,
+      );
+      expect(mapHardwareWalletRecoveryErrorType('oops')).toBe(
+        MetaMetricsHardwareWalletRecoveryErrorType.GenericError,
+      );
+    });
+  });
+
+  describe('getHardwareWalletMetricDeviceModel', () => {
+    it('reads device model from metadata when present', () => {
+      const err = new HardwareWalletError('x', {
+        code: ErrorCode.Unknown,
+        severity: Severity.Info,
+        category: Category.Unknown,
+        userMessage: 'x',
+        metadata: { deviceModel: 'Nano X' },
+      });
+      expect(getHardwareWalletMetricDeviceModel(err)).toBe('Nano X');
+    });
+
+    it('prefers device_model then model in metadata', () => {
+      expect(
+        getHardwareWalletMetricDeviceModel(
+          new HardwareWalletError('x', {
+            code: ErrorCode.Unknown,
+            severity: Severity.Info,
+            category: Category.Unknown,
+            userMessage: 'x',
+            metadata: { device_model: 'Model A' },
+          }),
+        ),
+      ).toBe('Model A');
+      expect(
+        getHardwareWalletMetricDeviceModel(
+          new HardwareWalletError('x', {
+            code: ErrorCode.Unknown,
+            severity: Severity.Info,
+            category: Category.Unknown,
+            userMessage: 'x',
+            metadata: { model: 'Model B' },
+          }),
+        ),
+      ).toBe('Model B');
+    });
+
+    it('returns N/A when error is not HardwareWalletError or metadata missing', () => {
+      expect(getHardwareWalletMetricDeviceModel(new Error('x'))).toBe('N/A');
+      expect(
+        getHardwareWalletMetricDeviceModel(
+          new HardwareWalletError('x', {
+            code: ErrorCode.Unknown,
+            severity: Severity.Info,
+            category: Category.Unknown,
+            userMessage: 'x',
+          }),
+        ),
+      ).toBe('N/A');
+    });
+  });
+
+  describe('extractHardwareWalletRecoveryErrorCodeAndMessage', () => {
+    it('serializes HardwareWalletError code and user message', () => {
+      const err = new HardwareWalletError('msg', {
+        code: ErrorCode.DeviceDisconnected,
+        severity: Severity.Err,
+        category: Category.Connection,
+        userMessage: 'user facing',
+      });
+      const { error_code, error_message } =
+        extractHardwareWalletRecoveryErrorCodeAndMessage(err);
+      expect(error_code).toBe(ErrorCode[ErrorCode.DeviceDisconnected]);
+      expect(error_message).toContain('user facing');
+    });
+
+    it('uses message when userMessage is absent on HardwareWalletError', () => {
+      const err = new HardwareWalletError('internal', {
+        code: ErrorCode.Unknown,
+        severity: Severity.Info,
+        category: Category.Unknown,
+        userMessage: '',
+      });
+      const { error_message } =
+        extractHardwareWalletRecoveryErrorCodeAndMessage(err);
+      expect(error_message).toContain('internal');
+    });
+
+    it('extracts code and message from plain Error and object shapes', () => {
+      expect(
+        extractHardwareWalletRecoveryErrorCodeAndMessage(
+          new Error('plain failure'),
+        ),
+      ).toMatchObject({
+        error_code: '',
+        error_message: 'plain failure',
+      });
+
+      expect(
+        extractHardwareWalletRecoveryErrorCodeAndMessage({
+          code: ErrorCode.ConnectionClosed,
+          message: 'lost',
+        }),
+      ).toMatchObject({
+        error_code: ErrorCode[ErrorCode.ConnectionClosed],
+        error_message: 'lost',
+      });
+    });
+
+    it('truncates long messages and stringifies unknown primitives', () => {
+      const long = `${'x'.repeat(520)}`;
+      const { error_message } =
+        extractHardwareWalletRecoveryErrorCodeAndMessage(long);
+      expect(error_message.endsWith('…')).toBe(true);
+      expect(error_message.length).toBeLessThanOrEqual(502);
+
+      expect(
+        extractHardwareWalletRecoveryErrorCodeAndMessage(404),
+      ).toMatchObject({
+        error_code: '',
+        error_message: '404',
+      });
+    });
+  });
+
+  describe('buildHardwareWalletRecoverySegmentProperties', () => {
+    it('returns Segment-shaped property keys', () => {
+      const err = new HardwareWalletError('msg', {
+        code: ErrorCode.AuthenticationDeviceLocked,
+        severity: Severity.Err,
+        category: Category.Authentication,
+        userMessage: 'unlock',
+      });
+      const props = buildHardwareWalletRecoverySegmentProperties({
+        location: MetaMetricsHardwareWalletRecoveryLocation.Send,
+        deviceType: MetaMetricsHardwareWalletDeviceType.Ledger,
+        deviceModel: 'Nano S',
+        errorType: MetaMetricsHardwareWalletRecoveryErrorType.DeviceLocked,
+        errorTypeViewCount: 2,
+        error: err,
+      });
+      expect(props).toMatchObject({
+        location: MetaMetricsHardwareWalletRecoveryLocation.Send,
+        device_type: MetaMetricsHardwareWalletDeviceType.Ledger,
+        device_model: 'Nano S',
+        error_type: MetaMetricsHardwareWalletRecoveryErrorType.DeviceLocked,
+        error_type_view_count: 2,
+      });
+      expect(props.error_code).toBeTruthy();
+      expect(props.error_message).toBeTruthy();
+    });
+
+    it('exposes only snake_case keys that match segment-schema hardware wallet + recovery globals', () => {
+      const err = new HardwareWalletError('x', {
+        code: ErrorCode.Unknown,
+        severity: Severity.Info,
+        category: Category.Unknown,
+        userMessage: 'x',
+      });
+      const props = buildHardwareWalletRecoverySegmentProperties({
+        location: MetaMetricsHardwareWalletRecoveryLocation.Swaps,
+        deviceType: MetaMetricsHardwareWalletDeviceType.Trezor,
+        deviceModel: 'N/A',
+        errorType: MetaMetricsHardwareWalletRecoveryErrorType.GenericError,
+        errorTypeViewCount: 1,
+        error: err,
+      });
+      expect(Object.keys(props).sort()).toStrictEqual(
+        [...HARDWARE_WALLET_RECOVERY_SEGMENT_PAYLOAD_KEYS].sort(),
+      );
+    });
+  });
+});

--- a/shared/lib/hardware-wallet-recovery-metrics.ts
+++ b/shared/lib/hardware-wallet-recovery-metrics.ts
@@ -190,24 +190,30 @@ export function extractHardwareWalletRecoveryErrorCodeAndMessage(
  * Maps internal wallet type keys to Segment `device_type` enum values.
  *
  * Segment schema only defines Ledger, Trezor, QR Hardware, and Lattice.
- * Other keys such as `unknown` are not in the schema and are reported as Ledger for consistency.
+ * Unknown/unmapped wallet types are intentionally not tracked.
  *
- * @param walletType - Value from {@link HardwareWalletType} or keyring-derived string (e.g. `ledger`, `qr`).
- * @returns Corresponding {@link MetaMetricsHardwareWalletDeviceType}, or Ledger when unmapped.
+ * @param walletType - Hardware wallet type key from UI/hardware contexts.
+ * @returns Corresponding {@link MetaMetricsHardwareWalletDeviceType}, or null when unmapped.
  */
 export function mapHardwareWalletTypeToMetricDeviceType(
   walletType?: string | null,
-): MetaMetricsHardwareWalletDeviceType {
+): MetaMetricsHardwareWalletDeviceType | null {
   if (
-    walletType !== undefined &&
-    walletType !== null &&
-    Object.hasOwn(HARDWARE_WALLET_TYPE_KEY_TO_SEGMENT_DEVICE_TYPE, walletType)
+    walletType === null ||
+    walletType === undefined ||
+    walletType === 'unknown'
   ) {
-    return HARDWARE_WALLET_TYPE_KEY_TO_SEGMENT_DEVICE_TYPE[
-      walletType as MappableHardwareWalletTypeKey
-    ];
+    return null;
   }
-  return MetaMetricsHardwareWalletDeviceType.Ledger;
+
+  return Object.hasOwn(
+    HARDWARE_WALLET_TYPE_KEY_TO_SEGMENT_DEVICE_TYPE,
+    walletType,
+  )
+    ? HARDWARE_WALLET_TYPE_KEY_TO_SEGMENT_DEVICE_TYPE[
+        walletType as MappableHardwareWalletTypeKey
+      ]
+    : null;
 }
 
 /**

--- a/shared/lib/hardware-wallet-recovery-metrics.ts
+++ b/shared/lib/hardware-wallet-recovery-metrics.ts
@@ -1,0 +1,267 @@
+/* eslint-disable @typescript-eslint/naming-convention, camelcase -- Segment event properties use snake_case */
+import { ErrorCode, HardwareWalletError } from '@metamask/hw-wallet-sdk';
+import { Json } from '@metamask/utils';
+import {
+  MetaMetricsHardwareWalletDeviceType,
+  MetaMetricsHardwareWalletRecoveryErrorType,
+  MetaMetricsHardwareWalletRecoveryLocation,
+} from '../constants/metametrics';
+
+const UNKNOWN_DEVICE_MODEL = 'N/A';
+const MAX_ERROR_MESSAGE_LENGTH = 500;
+
+/**
+ * Canonical Segment `properties` keys produced by {@link buildHardwareWalletRecoverySegmentProperties}.
+ * Must stay aligned with `segment-schema`:
+ * `libraries/properties/metamask-hardware-wallet-globals.yaml` and
+ * `libraries/properties/metamask-hardware-wallet-recovery-globals.yaml`.
+ */
+export const HARDWARE_WALLET_RECOVERY_SEGMENT_PAYLOAD_KEYS = [
+  'device_model',
+  'device_type',
+  'error_code',
+  'error_message',
+  'error_type',
+  'error_type_view_count',
+  'location',
+] as const;
+
+/**
+ * UI / keyring wallet keys (see {@link HardwareWalletType}) that have a defined Segment `device_type`.
+ * Values are {@link MetaMetricsHardwareWalletDeviceType} — Segment uses different strings than our keys
+ * (e.g. `qr` → `QR Hardware`), so a lookup table is required; we cannot use the UI enum value alone as the payload.
+ */
+const HARDWARE_WALLET_TYPE_KEY_TO_SEGMENT_DEVICE_TYPE = {
+  ledger: MetaMetricsHardwareWalletDeviceType.Ledger,
+  trezor: MetaMetricsHardwareWalletDeviceType.Trezor,
+  qr: MetaMetricsHardwareWalletDeviceType.QrHardware,
+  lattice: MetaMetricsHardwareWalletDeviceType.Lattice,
+} as const satisfies Record<string, MetaMetricsHardwareWalletDeviceType>;
+
+type MappableHardwareWalletTypeKey =
+  keyof typeof HARDWARE_WALLET_TYPE_KEY_TO_SEGMENT_DEVICE_TYPE;
+
+/**
+ * Arguments for {@link buildHardwareWalletRecoverySegmentProperties} (camelCase for TS/ESLint).
+ * These map to Segment snake_case keys — they are **not** the wire property names.
+ */
+type RecoverySegmentPropertyArgs = {
+  /** Segment key: `location` */
+  location: MetaMetricsHardwareWalletRecoveryLocation;
+  /** Segment key: `device_type` */
+  deviceType: MetaMetricsHardwareWalletDeviceType;
+  /** Segment key: `device_model` */
+  deviceModel: string;
+  /** Segment key: `error_type` */
+  errorType: MetaMetricsHardwareWalletRecoveryErrorType;
+  /** Segment key: `error_type_view_count` */
+  errorTypeViewCount: number;
+  /** Used to derive Segment keys `error_code` and `error_message` */
+  error: unknown;
+};
+
+/**
+ * Builds `trackEvent` `properties` for hardware wallet recovery events.
+ *
+ * Composes `metamask-hardware-wallet-globals` + `metamask-hardware-wallet-recovery-globals`
+ * (and satisfies `metamask-hardware-wallet-recovery-error-globals` when that library is on the event).
+ *
+ * @param args - Recovery context; camelCase fields are mapped to Segment snake_case keys.
+ * @returns Object whose keys match Segment (`device_type`, not `deviceType`).
+ */
+export function buildHardwareWalletRecoverySegmentProperties(
+  args: RecoverySegmentPropertyArgs,
+): Record<string, Json> {
+  const { error_code, error_message } =
+    extractHardwareWalletRecoveryErrorCodeAndMessage(args.error);
+  return {
+    location: args.location,
+    device_type: args.deviceType,
+    device_model: args.deviceModel,
+    error_type: args.errorType,
+    error_type_view_count: args.errorTypeViewCount,
+    error_code,
+    error_message,
+  };
+}
+
+/**
+ * Resolves a numeric hardware wallet error code when available.
+ *
+ * @param error - Unknown error shape from RPC or UI.
+ * @returns The {@link ErrorCode} when recognized, otherwise null.
+ */
+function resolveHardwareWalletErrorCode(error: unknown): ErrorCode | null {
+  if (error instanceof HardwareWalletError) {
+    return error.code;
+  }
+
+  if (
+    error &&
+    typeof error === 'object' &&
+    'code' in error &&
+    typeof (error as { code: unknown }).code === 'number'
+  ) {
+    return (error as { code: ErrorCode }).code;
+  }
+
+  return null;
+}
+
+/**
+ * Reads a human-readable message from an unknown error value.
+ *
+ * @param error - Any thrown value or RPC error object.
+ * @returns Message string, or empty string if none.
+ */
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (
+    error &&
+    typeof error === 'object' &&
+    'message' in error &&
+    typeof (error as { message: unknown }).message === 'string'
+  ) {
+    return (error as { message: string }).message;
+  }
+  return '';
+}
+
+/**
+ * Normalizes whitespace and caps length for Segment `error_message`.
+ *
+ * @param message - Raw error text.
+ * @returns Sanitized message safe to send in analytics.
+ */
+function sanitizeErrorMessage(message: string): string {
+  const trimmed = message.replace(/\s+/gu, ' ').trim();
+  if (trimmed.length <= MAX_ERROR_MESSAGE_LENGTH) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, MAX_ERROR_MESSAGE_LENGTH)}…`;
+}
+
+/**
+ * Maps an {@link ErrorCode} numeric value to its enum name string for Segment `error_code`.
+ *
+ * @param code - Hardware wallet SDK error code.
+ * @returns String label (e.g. `DeviceDisconnected`).
+ */
+function errorCodeToLabel(code: ErrorCode): string {
+  return ErrorCode[code];
+}
+
+/**
+ * Builds Segment `error_code` and `error_message` from an error (or empty strings when absent).
+ *
+ * @param error - Underlying error.
+ * @returns Object with snake_case keys matching the Segment recovery-error library.
+ */
+export function extractHardwareWalletRecoveryErrorCodeAndMessage(
+  error: unknown,
+): { error_code: string; error_message: string } {
+  if (error instanceof HardwareWalletError) {
+    return {
+      error_code: errorCodeToLabel(error.code),
+      error_message: sanitizeErrorMessage(
+        error.userMessage || error.message || '',
+      ),
+    };
+  }
+
+  const code = resolveHardwareWalletErrorCode(error);
+  const message = getErrorMessage(error);
+  if (code !== null) {
+    return {
+      error_code: errorCodeToLabel(code),
+      error_message: sanitizeErrorMessage(message),
+    };
+  }
+
+  return {
+    error_code: '',
+    error_message: sanitizeErrorMessage(message || String(error)),
+  };
+}
+
+/**
+ * Maps internal wallet type keys to Segment `device_type` enum values.
+ *
+ * Segment schema only defines Ledger, Trezor, QR Hardware, and Lattice.
+ * Other keys such as `unknown` are not in the schema and are reported as Ledger for consistency.
+ *
+ * @param walletType - Value from {@link HardwareWalletType} or keyring-derived string (e.g. `ledger`, `qr`).
+ * @returns Corresponding {@link MetaMetricsHardwareWalletDeviceType}, or Ledger when unmapped.
+ */
+export function mapHardwareWalletTypeToMetricDeviceType(
+  walletType?: string | null,
+): MetaMetricsHardwareWalletDeviceType {
+  if (
+    walletType !== undefined &&
+    walletType !== null &&
+    Object.hasOwn(HARDWARE_WALLET_TYPE_KEY_TO_SEGMENT_DEVICE_TYPE, walletType)
+  ) {
+    return HARDWARE_WALLET_TYPE_KEY_TO_SEGMENT_DEVICE_TYPE[
+      walletType as MappableHardwareWalletTypeKey
+    ];
+  }
+  return MetaMetricsHardwareWalletDeviceType.Ledger;
+}
+
+/**
+ * Best-effort device model for analytics (matches Hardware Wallet Account Connected usage).
+ *
+ * @param error - Hardware wallet error that may carry metadata.
+ * @returns Model name or {@link UNKNOWN_DEVICE_MODEL}.
+ */
+export function getHardwareWalletMetricDeviceModel(error: unknown): string {
+  if (!(error instanceof HardwareWalletError)) {
+    return UNKNOWN_DEVICE_MODEL;
+  }
+
+  const meta = error.metadata as
+    | { deviceModel?: string; device_model?: string; model?: string }
+    | undefined;
+  if (!meta) {
+    return UNKNOWN_DEVICE_MODEL;
+  }
+
+  return (
+    meta.deviceModel ?? meta.device_model ?? meta.model ?? UNKNOWN_DEVICE_MODEL
+  );
+}
+
+/**
+ * Normalizes a hardware wallet error into the Segment `error_type` enum.
+ *
+ * @param error - Error shown in the recovery modal or connection failure.
+ * @returns value for analytics.
+ */
+export function mapHardwareWalletRecoveryErrorType(
+  error: unknown,
+): MetaMetricsHardwareWalletRecoveryErrorType {
+  const code = resolveHardwareWalletErrorCode(error);
+
+  if (code === null) {
+    return MetaMetricsHardwareWalletRecoveryErrorType.GenericError;
+  }
+
+  switch (code) {
+    case ErrorCode.AuthenticationDeviceLocked:
+    case ErrorCode.AuthenticationDeviceBlocked:
+      return MetaMetricsHardwareWalletRecoveryErrorType.DeviceLocked;
+    case ErrorCode.DeviceDisconnected:
+    case ErrorCode.ConnectionClosed:
+    case ErrorCode.ConnectionTimeout:
+    case ErrorCode.ConnectionTransportMissing:
+      return MetaMetricsHardwareWalletRecoveryErrorType.DeviceDisconnected;
+    case ErrorCode.DeviceStateEthAppClosed:
+      return MetaMetricsHardwareWalletRecoveryErrorType.EthereumAppNotOpened;
+    case ErrorCode.DeviceStateBlindSignNotSupported:
+      return MetaMetricsHardwareWalletRecoveryErrorType.BlindSigningNotEnabled;
+    default:
+      return MetaMetricsHardwareWalletRecoveryErrorType.GenericError;
+  }
+}

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -639,6 +639,9 @@
       "Reselect: Identity function warnings": 1,
       "error: Unexpected key \"DNS\" found in": 1
     },
+    "ui/hooks/useHardwareWalletRecoveryLocation.test.tsx": {
+      "Reselect: Identity function warnings": 1
+    },
     "ui/hooks/useMultiPolling.test.ts": {
       "error: Error: Network error": 1
     },

--- a/test/lib/confirmations/render-helpers.tsx
+++ b/test/lib/confirmations/render-helpers.tsx
@@ -24,6 +24,7 @@ export function renderWithConfirmContextProvider(
   store: unknown,
   pathname = DEFAULT_ROUTE,
   confirmationId?: string,
+  getMockTrackEvent?: () => jest.Mock,
 ) {
   return renderWithProvider(
     <HardwareWalletErrorProvider>
@@ -35,6 +36,8 @@ export function renderWithConfirmContextProvider(
     </HardwareWalletErrorProvider>,
     store,
     pathname,
+    render,
+    getMockTrackEvent,
   );
 }
 

--- a/test/lib/render-helpers-navigate.js
+++ b/test/lib/render-helpers-navigate.js
@@ -87,7 +87,7 @@ export function createMemoryRouterWrapper(options = {}) {
   return Wrapper;
 }
 
-function createProviderWrapper(
+export function createProviderWrapper(
   store,
   pathname = '/',
   getMockTrackEvent = () => jest.fn().mockResolvedValue(undefined),
@@ -133,8 +133,13 @@ export function renderWithProvider(
   store,
   pathname = '/',
   renderer = render,
+  getMockTrackEvent,
 ) {
-  const wrapper = createProviderWrapper(store, pathname);
+  const wrapper = createProviderWrapper(
+    store,
+    pathname,
+    getMockTrackEvent ?? (() => jest.fn().mockResolvedValue(undefined)),
+  );
 
   return renderer(component, { wrapper });
 }

--- a/ui/components/app/modals/hardware-wallet-error-modal/hardware-wallet-error-modal.test.tsx
+++ b/ui/components/app/modals/hardware-wallet-error-modal/hardware-wallet-error-modal.test.tsx
@@ -7,7 +7,13 @@ import {
   Route,
   Routes,
 } from 'react-router-dom';
-import { ErrorCode, type HardwareWalletError } from '@metamask/hw-wallet-sdk';
+import {
+  Category,
+  ErrorCode,
+  HardwareWalletError,
+  Severity,
+  type HardwareWalletError as HardwareWalletErrorType,
+} from '@metamask/hw-wallet-sdk';
 import { getMockContractInteractionConfirmState } from '../../../../../test/data/confirmations/helper';
 import { MetaMetricsEventName } from '../../../../../shared/constants/metametrics';
 import { MetaMetricsContext } from '../../../../contexts/metametrics';
@@ -49,7 +55,7 @@ const createTestError = (
   code: ErrorCode,
   message: string,
   userMessage?: string,
-): HardwareWalletError => {
+): HardwareWalletErrorType => {
   return createHardwareWalletError(
     code,
     'ledger' as HardwareWalletType,
@@ -167,6 +173,30 @@ describe('HardwareWalletErrorModal', () => {
       expect(
         getByText('[hardwareWalletErrorTitleDeviceLocked]'),
       ).toBeInTheDocument();
+    });
+
+    it('renders modal but skips tracking when wallet type is unknown', async () => {
+      const error = new HardwareWalletError('Device is locked', {
+        code: ErrorCode.AuthenticationDeviceLocked,
+        severity: Severity.Info,
+        category: Category.Unknown,
+        userMessage: 'Your device is locked.',
+      });
+      mockUseHardwareWalletConfig.mockReturnValue({
+        walletType: HardwareWalletType.Unknown,
+      });
+
+      const { getByText } = renderWithMetrics(
+        <HardwareWalletErrorModal error={error} />,
+      );
+
+      expect(
+        getByText('[hardwareWalletErrorTitleDeviceLocked]'),
+      ).toBeInTheDocument();
+
+      await waitFor(() => {
+        expect(mockTrackEvent).not.toHaveBeenCalled();
+      });
     });
 
     it('renders nothing for user-rejected errors', () => {

--- a/ui/components/app/modals/hardware-wallet-error-modal/hardware-wallet-error-modal.test.tsx
+++ b/ui/components/app/modals/hardware-wallet-error-modal/hardware-wallet-error-modal.test.tsx
@@ -1,16 +1,22 @@
 import React from 'react';
 import { render, fireEvent, waitFor, act } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import {
+  MemoryRouter,
+  type MemoryRouterProps,
+  Route,
+  Routes,
+} from 'react-router-dom';
 import { ErrorCode, type HardwareWalletError } from '@metamask/hw-wallet-sdk';
+import { getMockContractInteractionConfirmState } from '../../../../../test/data/confirmations/helper';
 import { MetaMetricsEventName } from '../../../../../shared/constants/metametrics';
 import { MetaMetricsContext } from '../../../../contexts/metametrics';
 import { createHardwareWalletError } from '../../../../contexts/hardware-wallets/errors';
 import { HardwareWalletType } from '../../../../contexts/hardware-wallets/types';
+import configureStore from '../../../../store/store';
 import { HardwareWalletErrorModal } from './hardware-wallet-error-modal';
 
 const mockTrackEvent = jest.fn();
-jest.mock('../../../../hooks/useHardwareWalletRecoveryLocation', () => ({
-  useHardwareWalletRecoveryLocation: jest.fn(() => 'Send'),
-}));
 
 const mockHideModal = jest.fn();
 jest.mock('../../../../hooks/useModalProps', () => ({
@@ -58,12 +64,47 @@ const metricsProviderValue = {
   onboardingParentContext: { current: null },
 };
 
-function renderWithMetrics(ui: React.ReactElement) {
-  return render(
-    <MetaMetricsContext.Provider value={metricsProviderValue}>
-      {ui}
-    </MetaMetricsContext.Provider>,
+const memoryRouterFuture = {
+  ['v7_startTransition' as keyof NonNullable<MemoryRouterProps['future']>]:
+    true,
+  ['v7_relativeSplatPath' as keyof NonNullable<MemoryRouterProps['future']>]:
+    true,
+} as NonNullable<MemoryRouterProps['future']>;
+
+/**
+ * `HardwareWalletErrorModal` uses {@link useHardwareWalletRecoveryLocation}, which needs
+ * React Router and Redux. Default route `/` yields `Send`, matching prior mock behavior.
+ * @param store
+ * @param ui
+ */
+function wrapHardwareWalletModalTree(
+  store: ReturnType<typeof configureStore>,
+  ui: React.ReactElement,
+) {
+  return (
+    <Provider store={store}>
+      <MemoryRouter initialEntries={['/']} future={memoryRouterFuture}>
+        <Routes>
+          <Route
+            path="*"
+            element={
+              <MetaMetricsContext.Provider value={metricsProviderValue}>
+                {ui}
+              </MetaMetricsContext.Provider>
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    </Provider>
   );
+}
+
+function renderWithMetrics(ui: React.ReactElement) {
+  const store = configureStore(getMockContractInteractionConfirmState());
+  return {
+    store,
+    ...render(wrapHardwareWalletModalTree(store, ui)),
+  };
 }
 
 describe('HardwareWalletErrorModal', () => {
@@ -413,7 +454,7 @@ describe('HardwareWalletErrorModal', () => {
         'Device not found.',
       );
 
-      const { rerender } = renderWithMetrics(
+      const { rerender, store } = renderWithMetrics(
         <HardwareWalletErrorModal error={error} />,
       );
 
@@ -428,15 +469,14 @@ describe('HardwareWalletErrorModal', () => {
       });
 
       rerender(
-        <MetaMetricsContext.Provider value={metricsProviderValue}>
-          <HardwareWalletErrorModal />
-        </MetaMetricsContext.Provider>,
+        wrapHardwareWalletModalTree(store, <HardwareWalletErrorModal />),
       );
 
       rerender(
-        <MetaMetricsContext.Provider value={metricsProviderValue}>
-          <HardwareWalletErrorModal error={error} />
-        </MetaMetricsContext.Provider>,
+        wrapHardwareWalletModalTree(
+          store,
+          <HardwareWalletErrorModal error={error} />,
+        ),
       );
 
       await waitFor(() => {
@@ -481,7 +521,7 @@ describe('HardwareWalletErrorModal', () => {
 
       mockEnsureDeviceReady.mockResolvedValueOnce(true);
 
-      const { getByText, rerender } = renderWithMetrics(
+      const { getByText, rerender, store } = renderWithMetrics(
         <HardwareWalletErrorModal error={error} />,
       );
 
@@ -490,9 +530,10 @@ describe('HardwareWalletErrorModal', () => {
       });
 
       rerender(
-        <MetaMetricsContext.Provider value={metricsProviderValue}>
-          <HardwareWalletErrorModal error={error} />
-        </MetaMetricsContext.Provider>,
+        wrapHardwareWalletModalTree(
+          store,
+          <HardwareWalletErrorModal error={error} />,
+        ),
       );
 
       expect(getByText('[hardwareWalletTypeConnected]')).toBeInTheDocument();

--- a/ui/components/app/modals/hardware-wallet-error-modal/hardware-wallet-error-modal.test.tsx
+++ b/ui/components/app/modals/hardware-wallet-error-modal/hardware-wallet-error-modal.test.tsx
@@ -1,9 +1,16 @@
 import React from 'react';
 import { render, fireEvent, waitFor, act } from '@testing-library/react';
 import { ErrorCode, type HardwareWalletError } from '@metamask/hw-wallet-sdk';
+import { MetaMetricsEventName } from '../../../../../shared/constants/metametrics';
+import { MetaMetricsContext } from '../../../../contexts/metametrics';
 import { createHardwareWalletError } from '../../../../contexts/hardware-wallets/errors';
 import { HardwareWalletType } from '../../../../contexts/hardware-wallets/types';
 import { HardwareWalletErrorModal } from './hardware-wallet-error-modal';
+
+const mockTrackEvent = jest.fn();
+jest.mock('../../../../hooks/useHardwareWalletRecoveryLocation', () => ({
+  useHardwareWalletRecoveryLocation: jest.fn(() => 'Send'),
+}));
 
 const mockHideModal = jest.fn();
 jest.mock('../../../../hooks/useModalProps', () => ({
@@ -44,6 +51,21 @@ const createTestError = (
   );
 };
 
+const metricsProviderValue = {
+  trackEvent: mockTrackEvent,
+  bufferedTrace: jest.fn(),
+  bufferedEndTrace: jest.fn(),
+  onboardingParentContext: { current: null },
+};
+
+function renderWithMetrics(ui: React.ReactElement) {
+  return render(
+    <MetaMetricsContext.Provider value={metricsProviderValue}>
+      {ui}
+    </MetaMetricsContext.Provider>,
+  );
+}
+
 describe('HardwareWalletErrorModal', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -61,7 +83,9 @@ describe('HardwareWalletErrorModal', () => {
         'Your Ledger device is locked. Please unlock it to continue.',
       );
 
-      const { getByText } = render(<HardwareWalletErrorModal error={error} />);
+      const { getByText } = renderWithMetrics(
+        <HardwareWalletErrorModal error={error} />,
+      );
 
       expect(
         getByText('[hardwareWalletErrorTitleDeviceLocked]'),
@@ -76,7 +100,7 @@ describe('HardwareWalletErrorModal', () => {
 
     it('renders nothing when error is not provided', () => {
       const onClose = jest.fn();
-      const { container } = render(
+      const { container } = renderWithMetrics(
         <HardwareWalletErrorModal onClose={onClose} />,
       );
 
@@ -95,7 +119,9 @@ describe('HardwareWalletErrorModal', () => {
         walletType: null,
       });
 
-      const { getByText } = render(<HardwareWalletErrorModal error={error} />);
+      const { getByText } = renderWithMetrics(
+        <HardwareWalletErrorModal error={error} />,
+      );
 
       expect(
         getByText('[hardwareWalletErrorTitleDeviceLocked]'),
@@ -109,7 +135,7 @@ describe('HardwareWalletErrorModal', () => {
         'You cancelled the operation.',
       );
       const onCancel = jest.fn();
-      const { container } = render(
+      const { container } = renderWithMetrics(
         <HardwareWalletErrorModal error={error} onCancel={onCancel} />,
       );
 
@@ -128,7 +154,9 @@ describe('HardwareWalletErrorModal', () => {
         'Your device is locked.',
       );
 
-      const { getByText } = render(<HardwareWalletErrorModal error={error} />);
+      const { getByText } = renderWithMetrics(
+        <HardwareWalletErrorModal error={error} />,
+      );
 
       expect(
         getByText('[hardwareWalletErrorTitleDeviceLocked]'),
@@ -148,7 +176,9 @@ describe('HardwareWalletErrorModal', () => {
         'Blind sign not supported.',
       );
 
-      const { getByText } = render(<HardwareWalletErrorModal error={error} />);
+      const { getByText } = renderWithMetrics(
+        <HardwareWalletErrorModal error={error} />,
+      );
 
       expect(
         getByText('[hardwareWalletErrorTitleBlindSignNotSupported]'),
@@ -172,7 +202,9 @@ describe('HardwareWalletErrorModal', () => {
         'Please open the Ethereum app.',
       );
 
-      const { getByText } = render(<HardwareWalletErrorModal error={error} />);
+      const { getByText } = renderWithMetrics(
+        <HardwareWalletErrorModal error={error} />,
+      );
 
       expect(
         getByText('[hardwareWalletTitleEthAppNotOpen]'),
@@ -189,7 +221,9 @@ describe('HardwareWalletErrorModal', () => {
         'Device not found.',
       );
 
-      const { getByText } = render(<HardwareWalletErrorModal error={error} />);
+      const { getByText } = renderWithMetrics(
+        <HardwareWalletErrorModal error={error} />,
+      );
 
       expect(
         getByText('[hardwareWalletErrorTitleConnectYourDevice]'),
@@ -212,7 +246,9 @@ describe('HardwareWalletErrorModal', () => {
         'Connection lost.',
       );
 
-      const { getByText } = render(<HardwareWalletErrorModal error={error} />);
+      const { getByText } = renderWithMetrics(
+        <HardwareWalletErrorModal error={error} />,
+      );
 
       expect(
         getByText('[hardwareWalletErrorTitleConnectYourDevice]'),
@@ -232,7 +268,9 @@ describe('HardwareWalletErrorModal', () => {
         'Unknown error.',
       );
 
-      const { getByText } = render(<HardwareWalletErrorModal error={error} />);
+      const { getByText } = renderWithMetrics(
+        <HardwareWalletErrorModal error={error} />,
+      );
 
       expect(
         getByText('[hardwareWalletErrorUnknownErrorDescription]'),
@@ -250,7 +288,7 @@ describe('HardwareWalletErrorModal', () => {
       const onRetry = jest.fn();
       const onCancel = jest.fn();
 
-      const { getByText, queryByText } = render(
+      const { getByText, queryByText } = renderWithMetrics(
         <HardwareWalletErrorModal
           error={error}
           onRetry={onRetry}
@@ -272,7 +310,7 @@ describe('HardwareWalletErrorModal', () => {
       );
       const onCancel = jest.fn();
 
-      const { getByText, queryByText } = render(
+      const { getByText, queryByText } = renderWithMetrics(
         <HardwareWalletErrorModal error={error} onCancel={onCancel} />,
       );
 
@@ -290,7 +328,7 @@ describe('HardwareWalletErrorModal', () => {
       );
       const onCancel = jest.fn();
 
-      const { getByText, queryByText } = render(
+      const { getByText, queryByText } = renderWithMetrics(
         <HardwareWalletErrorModal error={error} onCancel={onCancel} />,
       );
 
@@ -309,7 +347,7 @@ describe('HardwareWalletErrorModal', () => {
       const onRetry = jest.fn();
       const onCancel = jest.fn();
 
-      const { getByText } = render(
+      const { getByText } = renderWithMetrics(
         <HardwareWalletErrorModal
           error={error}
           onRetry={onRetry}
@@ -328,6 +366,89 @@ describe('HardwareWalletErrorModal', () => {
       expect(mockSetConnectionReady).toHaveBeenCalledTimes(1);
     });
 
+    it('tracks incremented modal view count when reconnect fails', async () => {
+      mockEnsureDeviceReady.mockResolvedValue(false);
+      const error = createTestError(
+        ErrorCode.DeviceDisconnected,
+        'Device disconnected',
+        'Device not found.',
+      );
+
+      const { getByText } = renderWithMetrics(
+        <HardwareWalletErrorModal error={error} />,
+      );
+
+      await waitFor(() => {
+        const modalViewed = mockTrackEvent.mock.calls.filter(
+          (call) =>
+            call[0].event ===
+            MetaMetricsEventName.HardwareWalletRecoveryModalViewed,
+        );
+        expect(modalViewed).toHaveLength(1);
+        expect(modalViewed[0][0].properties.error_type_view_count).toBe(1);
+      });
+
+      await act(async () => {
+        fireEvent.click(getByText('[hardwareWalletErrorContinueButton]'));
+      });
+
+      await waitFor(() => {
+        const modalViewed = mockTrackEvent.mock.calls.filter(
+          (call) =>
+            call[0].event ===
+            MetaMetricsEventName.HardwareWalletRecoveryModalViewed,
+        );
+        expect(modalViewed.length).toBeGreaterThanOrEqual(2);
+        expect(
+          modalViewed[modalViewed.length - 1][0].properties
+            .error_type_view_count,
+        ).toBe(2);
+      });
+    });
+
+    it('tracks modal viewed again after error clears and is shown again', async () => {
+      const error = createTestError(
+        ErrorCode.DeviceDisconnected,
+        'Device disconnected',
+        'Device not found.',
+      );
+
+      const { rerender } = renderWithMetrics(
+        <HardwareWalletErrorModal error={error} />,
+      );
+
+      await waitFor(() => {
+        expect(
+          mockTrackEvent.mock.calls.some(
+            (call) =>
+              call[0].event ===
+              MetaMetricsEventName.HardwareWalletRecoveryModalViewed,
+          ),
+        ).toBe(true);
+      });
+
+      rerender(
+        <MetaMetricsContext.Provider value={metricsProviderValue}>
+          <HardwareWalletErrorModal />
+        </MetaMetricsContext.Provider>,
+      );
+
+      rerender(
+        <MetaMetricsContext.Provider value={metricsProviderValue}>
+          <HardwareWalletErrorModal error={error} />
+        </MetaMetricsContext.Provider>,
+      );
+
+      await waitFor(() => {
+        const modalViewed = mockTrackEvent.mock.calls.filter(
+          (call) =>
+            call[0].event ===
+            MetaMetricsEventName.HardwareWalletRecoveryModalViewed,
+        );
+        expect(modalViewed.length).toBeGreaterThanOrEqual(2);
+      });
+    });
+
     it('handles Confirm button click for non-retryable errors', async () => {
       const error = createTestError(
         ErrorCode.Unknown,
@@ -336,7 +457,7 @@ describe('HardwareWalletErrorModal', () => {
       );
       const onCancel = jest.fn();
 
-      const { getByText } = render(
+      const { getByText } = renderWithMetrics(
         <HardwareWalletErrorModal error={error} onCancel={onCancel} />,
       );
 
@@ -360,7 +481,7 @@ describe('HardwareWalletErrorModal', () => {
 
       mockEnsureDeviceReady.mockResolvedValueOnce(true);
 
-      const { getByText, rerender } = render(
+      const { getByText, rerender } = renderWithMetrics(
         <HardwareWalletErrorModal error={error} />,
       );
 
@@ -368,7 +489,11 @@ describe('HardwareWalletErrorModal', () => {
         fireEvent.click(getByText('[hardwareWalletErrorReconnectButton]'));
       });
 
-      rerender(<HardwareWalletErrorModal error={error} />);
+      rerender(
+        <MetaMetricsContext.Provider value={metricsProviderValue}>
+          <HardwareWalletErrorModal error={error} />
+        </MetaMetricsContext.Provider>,
+      );
 
       expect(getByText('[hardwareWalletTypeConnected]')).toBeInTheDocument();
       expect(mockSetConnectionReady).toHaveBeenCalledTimes(1);
@@ -383,7 +508,7 @@ describe('HardwareWalletErrorModal', () => {
 
       mockEnsureDeviceReady.mockResolvedValueOnce(true);
 
-      const { getByText, getByLabelText } = render(
+      const { getByText, getByLabelText } = renderWithMetrics(
         <HardwareWalletErrorModal error={error} />,
       );
 
@@ -411,7 +536,9 @@ describe('HardwareWalletErrorModal', () => {
 
       mockEnsureDeviceReady.mockResolvedValueOnce(true);
 
-      const { getByText } = render(<HardwareWalletErrorModal error={error} />);
+      const { getByText } = renderWithMetrics(
+        <HardwareWalletErrorModal error={error} />,
+      );
 
       await act(async () => {
         fireEvent.click(getByText('[hardwareWalletErrorReconnectButton]'));
@@ -438,7 +565,9 @@ describe('HardwareWalletErrorModal', () => {
         'Your device is locked.',
       );
 
-      const { getByText } = render(<HardwareWalletErrorModal error={error} />);
+      const { getByText } = renderWithMetrics(
+        <HardwareWalletErrorModal error={error} />,
+      );
 
       expect(
         getByText('[hardwareWalletErrorTitleDeviceLocked]'),

--- a/ui/components/app/modals/hardware-wallet-error-modal/hardware-wallet-error-modal.test.tsx
+++ b/ui/components/app/modals/hardware-wallet-error-modal/hardware-wallet-error-modal.test.tsx
@@ -199,6 +199,47 @@ describe('HardwareWalletErrorModal', () => {
       });
     });
 
+    it('tracks modal viewed if wallet type becomes known after initial unknown render', async () => {
+      const error = new HardwareWalletError('Device is locked', {
+        code: ErrorCode.AuthenticationDeviceLocked,
+        severity: Severity.Info,
+        category: Category.Unknown,
+        userMessage: 'Your device is locked.',
+      });
+      mockUseHardwareWalletConfig.mockReturnValue({
+        walletType: HardwareWalletType.Unknown,
+      });
+
+      const { rerender, store } = renderWithMetrics(
+        <HardwareWalletErrorModal error={error} />,
+      );
+
+      await waitFor(() => {
+        expect(mockTrackEvent).not.toHaveBeenCalled();
+      });
+
+      mockUseHardwareWalletConfig.mockReturnValue({
+        walletType: HardwareWalletType.Ledger,
+      });
+
+      rerender(
+        wrapHardwareWalletModalTree(
+          store,
+          <HardwareWalletErrorModal error={error} />,
+        ),
+      );
+
+      await waitFor(() => {
+        const modalViewed = mockTrackEvent.mock.calls.filter(
+          (call) =>
+            call[0].event ===
+            MetaMetricsEventName.HardwareWalletRecoveryModalViewed,
+        );
+        expect(modalViewed).toHaveLength(1);
+        expect(modalViewed[0][0].properties.error_type_view_count).toBe(1);
+      });
+    });
+
     it('renders nothing for user-rejected errors', () => {
       const error = createTestError(
         ErrorCode.UserCancelled,

--- a/ui/components/app/modals/hardware-wallet-error-modal/hardware-wallet-error-modal.tsx
+++ b/ui/components/app/modals/hardware-wallet-error-modal/hardware-wallet-error-modal.tsx
@@ -163,14 +163,14 @@ export const HardwareWalletErrorModal: React.FC<HardwareWalletErrorModalProps> =
       if (!error || isUserRejectedError || !errorIdentityKey) {
         return;
       }
+      if (!trackableMetricDeviceType) {
+        return;
+      }
       if (lastTrackedErrorKeyRef.current === errorIdentityKey) {
         return;
       }
       lastTrackedErrorKeyRef.current = errorIdentityKey;
       errorTypeViewCountRef.current += 1;
-      if (!trackableMetricDeviceType) {
-        return;
-      }
       const deviceModel = getHardwareWalletMetricDeviceModel(error);
       trackEvent({
         category: MetaMetricsEventCategory.Accounts,

--- a/ui/components/app/modals/hardware-wallet-error-modal/hardware-wallet-error-modal.tsx
+++ b/ui/components/app/modals/hardware-wallet-error-modal/hardware-wallet-error-modal.tsx
@@ -1,4 +1,11 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { ErrorCode, type HardwareWalletError } from '@metamask/hw-wallet-sdk';
 import {
   Text,
@@ -29,8 +36,21 @@ import {
 } from '../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { useModalProps } from '../../../../hooks/useModalProps';
+import { useHardwareWalletRecoveryLocation } from '../../../../hooks/useHardwareWalletRecoveryLocation';
+import {
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
+} from '../../../../../shared/constants/metametrics';
+import {
+  buildHardwareWalletRecoverySegmentProperties,
+  getHardwareWalletMetricDeviceModel,
+  mapHardwareWalletRecoveryErrorType,
+  mapHardwareWalletTypeToMetricDeviceType,
+} from '../../../../../shared/lib/hardware-wallet-recovery-metrics';
+import { MetaMetricsContext } from '../../../../contexts/metametrics';
 import {
   HardwareWalletType,
+  getHardwareWalletErrorCode,
   isUserRejectedHardwareWalletError,
   isRetryableHardwareWalletError,
   useHardwareWalletActions,
@@ -57,26 +77,154 @@ const RECOVERY_SUCCESS_AUTO_DISMISS_MS = 3000;
 export const HardwareWalletErrorModal: React.FC<HardwareWalletErrorModalProps> =
   React.memo((props) => {
     const t = useI18nContext();
+    const { trackEvent } = useContext(MetaMetricsContext);
+    const recoveryLocation = useHardwareWalletRecoveryLocation();
     const { hideModal, props: modalProps } = useModalProps();
     const [isLoading, setIsLoading] = useState(false);
     const [recovered, setRecovered] = useState(false);
     const recoveredDismissTimeoutRef = useRef<ReturnType<
       typeof setTimeout
     > | null>(null);
+    const errorTypeViewCountRef = useRef(0);
+    const lastTrackedErrorKeyRef = useRef<string | null>(null);
+    const prevNonNullErrorIdentityKeyRef = useRef<string | null>(null);
+    const successModalMetricSentRef = useRef(false);
     const { error, onClose, onCancel, onRetry } = { ...modalProps, ...props };
 
     const { walletType: selectedAccountWalletType } = useHardwareWalletConfig();
     const { ensureDeviceReady, clearError, setConnectionReady } =
       useHardwareWalletActions();
 
+    const errorMetadata =
+      error === undefined
+        ? undefined
+        : ((error as { metadata?: { walletType?: HardwareWalletType } })
+            .metadata ??
+          (
+            error as {
+              data?: { metadata?: { walletType?: HardwareWalletType } };
+            }
+          ).data?.metadata);
+    const displayWalletType = useMemo(
+      () =>
+        errorMetadata?.walletType ??
+        selectedAccountWalletType ??
+        HardwareWalletType.Ledger,
+      [errorMetadata?.walletType, selectedAccountWalletType],
+    );
+
+    const isUserRejectedError =
+      error !== undefined && isUserRejectedHardwareWalletError(error);
+
+    const errorIdentityKey = useMemo(() => {
+      if (!error) {
+        return null;
+      }
+      const code = getHardwareWalletErrorCode(error);
+      return `${recoveryLocation}:${String(code)}:${mapHardwareWalletRecoveryErrorType(error)}`;
+    }, [error, recoveryLocation]);
+
+    useEffect(() => {
+      setRecovered(false);
+      successModalMetricSentRef.current = false;
+
+      if (errorIdentityKey === null) {
+        prevNonNullErrorIdentityKeyRef.current = null;
+        return;
+      }
+
+      if (
+        prevNonNullErrorIdentityKeyRef.current !== null &&
+        prevNonNullErrorIdentityKeyRef.current !== errorIdentityKey
+      ) {
+        errorTypeViewCountRef.current = 0;
+      }
+      prevNonNullErrorIdentityKeyRef.current = errorIdentityKey;
+    }, [errorIdentityKey]);
+
+    useEffect(() => {
+      if (error) {
+        return;
+      }
+      lastTrackedErrorKeyRef.current = null;
+    }, [error]);
+
+    useEffect(() => {
+      if (!error || isUserRejectedError || !errorIdentityKey) {
+        return;
+      }
+      if (lastTrackedErrorKeyRef.current === errorIdentityKey) {
+        return;
+      }
+      lastTrackedErrorKeyRef.current = errorIdentityKey;
+      errorTypeViewCountRef.current += 1;
+      const deviceType =
+        mapHardwareWalletTypeToMetricDeviceType(displayWalletType);
+      const deviceModel = getHardwareWalletMetricDeviceModel(error);
+      trackEvent({
+        category: MetaMetricsEventCategory.Accounts,
+        event: MetaMetricsEventName.HardwareWalletRecoveryModalViewed,
+        properties: buildHardwareWalletRecoverySegmentProperties({
+          location: recoveryLocation,
+          deviceType,
+          deviceModel,
+          errorType: mapHardwareWalletRecoveryErrorType(error),
+          errorTypeViewCount: errorTypeViewCountRef.current,
+          error,
+        }),
+      });
+    }, [
+      displayWalletType,
+      error,
+      errorIdentityKey,
+      isUserRejectedError,
+      recoveryLocation,
+      trackEvent,
+    ]);
+
     const handleRetry = async () => {
       onRetry?.();
+      if (error) {
+        const deviceType =
+          mapHardwareWalletTypeToMetricDeviceType(displayWalletType);
+        const deviceModel = getHardwareWalletMetricDeviceModel(error);
+        trackEvent({
+          category: MetaMetricsEventCategory.Accounts,
+          event: MetaMetricsEventName.HardwareWalletRecoveryCtaClicked,
+          properties: buildHardwareWalletRecoverySegmentProperties({
+            location: recoveryLocation,
+            deviceType,
+            deviceModel,
+            errorType: mapHardwareWalletRecoveryErrorType(error),
+            errorTypeViewCount: errorTypeViewCountRef.current,
+            error,
+          }),
+        });
+      }
+
       setIsLoading(true);
       try {
         const result = await ensureDeviceReady();
         if (result) {
           setConnectionReady();
           setRecovered(true);
+        } else if (error) {
+          errorTypeViewCountRef.current += 1;
+          const deviceType =
+            mapHardwareWalletTypeToMetricDeviceType(displayWalletType);
+          const deviceModel = getHardwareWalletMetricDeviceModel(error);
+          trackEvent({
+            category: MetaMetricsEventCategory.Accounts,
+            event: MetaMetricsEventName.HardwareWalletRecoveryModalViewed,
+            properties: buildHardwareWalletRecoverySegmentProperties({
+              location: recoveryLocation,
+              deviceType,
+              deviceModel,
+              errorType: mapHardwareWalletRecoveryErrorType(error),
+              errorTypeViewCount: errorTypeViewCountRef.current,
+              error,
+            }),
+          });
         }
       } finally {
         setIsLoading(false);
@@ -112,8 +260,30 @@ export const HardwareWalletErrorModal: React.FC<HardwareWalletErrorModalProps> =
       };
     }, [handleRecoveredClose, recovered]);
 
-    const isUserRejectedError =
-      error !== undefined && isUserRejectedHardwareWalletError(error);
+    useEffect(() => {
+      if (!recovered || !error || successModalMetricSentRef.current) {
+        return;
+      }
+      successModalMetricSentRef.current = true;
+      const deviceType =
+        mapHardwareWalletTypeToMetricDeviceType(displayWalletType);
+      const deviceModel = getHardwareWalletMetricDeviceModel(error);
+      trackEvent({
+        category: MetaMetricsEventCategory.Accounts,
+        event: MetaMetricsEventName.HardwareWalletRecoverySuccessModalViewed,
+        properties: buildHardwareWalletRecoverySegmentProperties({
+          location: recoveryLocation,
+          deviceType,
+          deviceModel,
+          errorType: mapHardwareWalletRecoveryErrorType(error),
+          errorTypeViewCount: errorTypeViewCountRef.current,
+          error,
+        }),
+      });
+      lastTrackedErrorKeyRef.current = null;
+      errorTypeViewCountRef.current = 0;
+      prevNonNullErrorIdentityKeyRef.current = null;
+    }, [displayWalletType, error, recovered, recoveryLocation, trackEvent]);
 
     useEffect(() => {
       if (!isUserRejectedError) {
@@ -140,22 +310,6 @@ export const HardwareWalletErrorModal: React.FC<HardwareWalletErrorModalProps> =
     if (isUserRejectedError) {
       return null;
     }
-
-    // Get wallet type from error metadata first (for signature flows where
-    // the signing account may differ from the selected account), then fall
-    // back to the selected account's wallet type.
-    // Handle both direct metadata and RPC error format (data.metadata)
-    const errorMetadata =
-      (error as { metadata?: { walletType?: HardwareWalletType } }).metadata ??
-      (error as { data?: { metadata?: { walletType?: HardwareWalletType } } })
-        .data?.metadata;
-    const errorWalletType = errorMetadata?.walletType;
-
-    // Use errorWalletType, then selectedAccountWalletType, then default to Ledger
-    // as a fallback since most hardware wallet users are Ledger users.
-    // This ensures the modal always shows rather than silently closing.
-    const displayWalletType =
-      errorWalletType ?? selectedAccountWalletType ?? HardwareWalletType.Ledger;
 
     const errorContent = buildErrorContent(
       error,

--- a/ui/components/app/modals/hardware-wallet-error-modal/hardware-wallet-error-modal.tsx
+++ b/ui/components/app/modals/hardware-wallet-error-modal/hardware-wallet-error-modal.tsx
@@ -107,12 +107,20 @@ export const HardwareWalletErrorModal: React.FC<HardwareWalletErrorModalProps> =
               data?: { metadata?: { walletType?: HardwareWalletType } };
             }
           ).data?.metadata);
+    const errorWalletType = errorMetadata?.walletType;
     const displayWalletType = useMemo(
       () =>
-        errorMetadata?.walletType ??
+        errorWalletType ??
         selectedAccountWalletType ??
         HardwareWalletType.Ledger,
-      [errorMetadata?.walletType, selectedAccountWalletType],
+      [errorWalletType, selectedAccountWalletType],
+    );
+    const trackableMetricDeviceType = useMemo(
+      () =>
+        mapHardwareWalletTypeToMetricDeviceType(
+          errorWalletType ?? selectedAccountWalletType,
+        ),
+      [errorWalletType, selectedAccountWalletType],
     );
 
     const isUserRejectedError =
@@ -160,15 +168,16 @@ export const HardwareWalletErrorModal: React.FC<HardwareWalletErrorModalProps> =
       }
       lastTrackedErrorKeyRef.current = errorIdentityKey;
       errorTypeViewCountRef.current += 1;
-      const deviceType =
-        mapHardwareWalletTypeToMetricDeviceType(displayWalletType);
+      if (!trackableMetricDeviceType) {
+        return;
+      }
       const deviceModel = getHardwareWalletMetricDeviceModel(error);
       trackEvent({
         category: MetaMetricsEventCategory.Accounts,
         event: MetaMetricsEventName.HardwareWalletRecoveryModalViewed,
         properties: buildHardwareWalletRecoverySegmentProperties({
           location: recoveryLocation,
-          deviceType,
+          deviceType: trackableMetricDeviceType,
           deviceModel,
           errorType: mapHardwareWalletRecoveryErrorType(error),
           errorTypeViewCount: errorTypeViewCountRef.current,
@@ -176,26 +185,24 @@ export const HardwareWalletErrorModal: React.FC<HardwareWalletErrorModalProps> =
         }),
       });
     }, [
-      displayWalletType,
       error,
       errorIdentityKey,
       isUserRejectedError,
       recoveryLocation,
+      trackableMetricDeviceType,
       trackEvent,
     ]);
 
     const handleRetry = async () => {
       onRetry?.();
-      if (error) {
-        const deviceType =
-          mapHardwareWalletTypeToMetricDeviceType(displayWalletType);
+      if (error && trackableMetricDeviceType) {
         const deviceModel = getHardwareWalletMetricDeviceModel(error);
         trackEvent({
           category: MetaMetricsEventCategory.Accounts,
           event: MetaMetricsEventName.HardwareWalletRecoveryCtaClicked,
           properties: buildHardwareWalletRecoverySegmentProperties({
             location: recoveryLocation,
-            deviceType,
+            deviceType: trackableMetricDeviceType,
             deviceModel,
             errorType: mapHardwareWalletRecoveryErrorType(error),
             errorTypeViewCount: errorTypeViewCountRef.current,
@@ -210,17 +217,15 @@ export const HardwareWalletErrorModal: React.FC<HardwareWalletErrorModalProps> =
         if (result) {
           setConnectionReady();
           setRecovered(true);
-        } else if (error) {
+        } else if (error && trackableMetricDeviceType) {
           errorTypeViewCountRef.current += 1;
-          const deviceType =
-            mapHardwareWalletTypeToMetricDeviceType(displayWalletType);
           const deviceModel = getHardwareWalletMetricDeviceModel(error);
           trackEvent({
             category: MetaMetricsEventCategory.Accounts,
             event: MetaMetricsEventName.HardwareWalletRecoveryModalViewed,
             properties: buildHardwareWalletRecoverySegmentProperties({
               location: recoveryLocation,
-              deviceType,
+              deviceType: trackableMetricDeviceType,
               deviceModel,
               errorType: mapHardwareWalletRecoveryErrorType(error),
               errorTypeViewCount: errorTypeViewCountRef.current,
@@ -266,16 +271,17 @@ export const HardwareWalletErrorModal: React.FC<HardwareWalletErrorModalProps> =
       if (!recovered || !error || successModalMetricSentRef.current) {
         return;
       }
+      if (!trackableMetricDeviceType) {
+        return;
+      }
       successModalMetricSentRef.current = true;
-      const deviceType =
-        mapHardwareWalletTypeToMetricDeviceType(displayWalletType);
       const deviceModel = getHardwareWalletMetricDeviceModel(error);
       trackEvent({
         category: MetaMetricsEventCategory.Accounts,
         event: MetaMetricsEventName.HardwareWalletRecoverySuccessModalViewed,
         properties: buildHardwareWalletRecoverySegmentProperties({
           location: recoveryLocation,
-          deviceType,
+          deviceType: trackableMetricDeviceType,
           deviceModel,
           errorType: mapHardwareWalletRecoveryErrorType(error),
           errorTypeViewCount: errorTypeViewCountRef.current,
@@ -285,7 +291,13 @@ export const HardwareWalletErrorModal: React.FC<HardwareWalletErrorModalProps> =
       lastTrackedErrorKeyRef.current = null;
       errorTypeViewCountRef.current = 0;
       prevNonNullErrorIdentityKeyRef.current = null;
-    }, [displayWalletType, error, recovered, recoveryLocation, trackEvent]);
+    }, [
+      error,
+      recovered,
+      recoveryLocation,
+      trackEvent,
+      trackableMetricDeviceType,
+    ]);
 
     useEffect(() => {
       if (!isUserRejectedError) {

--- a/ui/components/app/modals/hardware-wallet-error-modal/hardware-wallet-error-modal.tsx
+++ b/ui/components/app/modals/hardware-wallet-error-modal/hardware-wallet-error-modal.tsx
@@ -56,7 +56,6 @@ import {
   useHardwareWalletActions,
   useHardwareWalletConfig,
 } from '../../../../contexts/hardware-wallets';
-// HardwareWalletType is used as a default fallback when walletType cannot be extracted
 import { buildErrorContent } from './error-content-builder';
 
 type HardwareWalletErrorModalProps = {
@@ -95,6 +94,9 @@ export const HardwareWalletErrorModal: React.FC<HardwareWalletErrorModalProps> =
     const { ensureDeviceReady, clearError, setConnectionReady } =
       useHardwareWalletActions();
 
+    // Prefer `walletType` from error metadata first (e.g. signature flows where the signing
+    // account may differ from the selected account). Read both top-level `metadata` and RPC-style
+    // `data.metadata`. Then selected account, then Ledger so copy/icons still resolve if metadata is missing.
     const errorMetadata =
       error === undefined
         ? undefined

--- a/ui/hooks/useHardwareWalletRecoveryLocation.test.tsx
+++ b/ui/hooks/useHardwareWalletRecoveryLocation.test.tsx
@@ -23,8 +23,6 @@ import {
   CONFIRMATION_V_NEXT_ROUTE,
   CONFIRM_TRANSACTION_ROUTE,
   CROSS_CHAIN_SWAP_ROUTE,
-  DECRYPT_MESSAGE_REQUEST_PATH,
-  ENCRYPTION_PUBLIC_KEY_REQUEST_PATH,
   SIGNATURE_REQUEST_PATH,
 } from '../helpers/constants/routes';
 import { useHardwareWalletRecoveryLocation } from './useHardwareWalletRecoveryLocation';
@@ -90,21 +88,15 @@ describe('useHardwareWalletRecoveryLocation', () => {
     );
   });
 
-  const signatureLikePaths: readonly (readonly [string, string])[] = [
-    [`/dapp${SIGNATURE_REQUEST_PATH}/1`, '*'],
-    [`/dapp${DECRYPT_MESSAGE_REQUEST_PATH}/1`, '*'],
-    [`/dapp${ENCRYPTION_PUBLIC_KEY_REQUEST_PATH}/1`, '*'],
-  ];
-  signatureLikePaths.forEach(([path, routePath]) => {
-    it(`returns Message for signature-related path ${path}`, () => {
-      const store = configureStore(getMockContractInteractionConfirmState());
-      const { result } = renderHook(() => useHardwareWalletRecoveryLocation(), {
-        wrapper: createHookWrapper(store, path, routePath),
-      });
-      expect(result.current).toBe(
-        MetaMetricsHardwareWalletRecoveryLocation.Message,
-      );
+  it('returns Message for signature request path', () => {
+    const path = `/dapp${SIGNATURE_REQUEST_PATH}/1`;
+    const store = configureStore(getMockContractInteractionConfirmState());
+    const { result } = renderHook(() => useHardwareWalletRecoveryLocation(), {
+      wrapper: createHookWrapper(store, path, '*'),
     });
+    expect(result.current).toBe(
+      MetaMetricsHardwareWalletRecoveryLocation.Message,
+    );
   });
 
   it('returns Message on confirm route when pending message matches confirmation id', () => {

--- a/ui/hooks/useHardwareWalletRecoveryLocation.test.tsx
+++ b/ui/hooks/useHardwareWalletRecoveryLocation.test.tsx
@@ -1,0 +1,193 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { Provider } from 'react-redux';
+import {
+  MemoryRouter,
+  type MemoryRouterProps,
+  Route,
+  Routes,
+} from 'react-router-dom';
+import {
+  type TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
+import configureStore from '../store/store';
+import {
+  getMockContractInteractionConfirmState,
+  getMockPersonalSignConfirmStateForRequest,
+} from '../../test/data/confirmations/helper';
+import { unapprovedPersonalSignMsg } from '../../test/data/confirmations/personal_sign';
+import { SignatureRequestType } from '../pages/confirmations/types/confirm';
+import { MetaMetricsHardwareWalletRecoveryLocation } from '../../shared/constants/metametrics';
+import {
+  CONFIRMATION_V_NEXT_ROUTE,
+  CONFIRM_TRANSACTION_ROUTE,
+  CROSS_CHAIN_SWAP_ROUTE,
+  DECRYPT_MESSAGE_REQUEST_PATH,
+  ENCRYPTION_PUBLIC_KEY_REQUEST_PATH,
+  SIGNATURE_REQUEST_PATH,
+} from '../helpers/constants/routes';
+import { useHardwareWalletRecoveryLocation } from './useHardwareWalletRecoveryLocation';
+
+function getFirstTransactionMeta(
+  base: ReturnType<typeof getMockContractInteractionConfirmState>,
+): TransactionMeta {
+  // Mock root state types `transactions` loosely; contract-interaction data is TransactionMeta.
+  return base.metamask.transactions[0] as unknown as TransactionMeta;
+}
+
+function createHookWrapper(
+  store: ReturnType<typeof configureStore>,
+  initialPath: string,
+  routePath = '*',
+) {
+  const memoryRouterFuture = {
+    ['v7_startTransition' as keyof NonNullable<MemoryRouterProps['future']>]:
+      true,
+    ['v7_relativeSplatPath' as keyof NonNullable<MemoryRouterProps['future']>]:
+      true,
+  } as NonNullable<MemoryRouterProps['future']>;
+
+  function hookTestWrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[initialPath]}
+          future={memoryRouterFuture}
+        >
+          <Routes>
+            <Route path={routePath} element={<>{children}</>} />
+          </Routes>
+        </MemoryRouter>
+      </Provider>
+    );
+  }
+  return hookTestWrapper;
+}
+
+describe('useHardwareWalletRecoveryLocation', () => {
+  it('returns Swaps for cross-chain route', () => {
+    const store = configureStore(getMockContractInteractionConfirmState());
+    const { result } = renderHook(() => useHardwareWalletRecoveryLocation(), {
+      wrapper: createHookWrapper(
+        store,
+        `${CROSS_CHAIN_SWAP_ROUTE}/prepare`,
+        `${CROSS_CHAIN_SWAP_ROUTE}/*`,
+      ),
+    });
+    expect(result.current).toBe(
+      MetaMetricsHardwareWalletRecoveryLocation.Swaps,
+    );
+  });
+
+  it('returns Swaps when pathname includes /swaps/', () => {
+    const store = configureStore(getMockContractInteractionConfirmState());
+    const { result } = renderHook(() => useHardwareWalletRecoveryLocation(), {
+      wrapper: createHookWrapper(store, '/foo/swaps/bar', '*'),
+    });
+    expect(result.current).toBe(
+      MetaMetricsHardwareWalletRecoveryLocation.Swaps,
+    );
+  });
+
+  const signatureLikePaths: readonly (readonly [string, string])[] = [
+    [`/dapp${SIGNATURE_REQUEST_PATH}/1`, '*'],
+    [`/dapp${DECRYPT_MESSAGE_REQUEST_PATH}/1`, '*'],
+    [`/dapp${ENCRYPTION_PUBLIC_KEY_REQUEST_PATH}/1`, '*'],
+  ];
+  signatureLikePaths.forEach(([path, routePath]) => {
+    it(`returns Message for signature-related path ${path}`, () => {
+      const store = configureStore(getMockContractInteractionConfirmState());
+      const { result } = renderHook(() => useHardwareWalletRecoveryLocation(), {
+        wrapper: createHookWrapper(store, path, routePath),
+      });
+      expect(result.current).toBe(
+        MetaMetricsHardwareWalletRecoveryLocation.Message,
+      );
+    });
+  });
+
+  it('returns Message on confirm route when pending message matches confirmation id', () => {
+    const msg = {
+      ...unapprovedPersonalSignMsg,
+      id: 'sig-1',
+    } as SignatureRequestType;
+    const state = getMockPersonalSignConfirmStateForRequest(msg);
+    const store = configureStore(state);
+    const { result } = renderHook(() => useHardwareWalletRecoveryLocation(), {
+      wrapper: createHookWrapper(
+        store,
+        `${CONFIRM_TRANSACTION_ROUTE}/sig-1`,
+        `${CONFIRM_TRANSACTION_ROUTE}/:id/*`,
+      ),
+    });
+    expect(result.current).toBe(
+      MetaMetricsHardwareWalletRecoveryLocation.Message,
+    );
+  });
+
+  const swapFlowTypes = [
+    TransactionType.swap,
+    TransactionType.swapApproval,
+    TransactionType.bridge,
+  ] as const;
+  swapFlowTypes.forEach((txType) => {
+    it(`returns Swaps on confirm route when transaction type is ${txType}`, () => {
+      const base = getMockContractInteractionConfirmState();
+      const tx = getFirstTransactionMeta(base);
+      const store = configureStore({
+        ...base,
+        metamask: {
+          ...base.metamask,
+          transactions: [{ ...tx, type: txType }],
+        },
+      });
+      const { result } = renderHook(() => useHardwareWalletRecoveryLocation(), {
+        wrapper: createHookWrapper(
+          store,
+          `${CONFIRM_TRANSACTION_ROUTE}/${tx.id}`,
+          `${CONFIRM_TRANSACTION_ROUTE}/:id/*`,
+        ),
+      });
+      expect(result.current).toBe(
+        MetaMetricsHardwareWalletRecoveryLocation.Swaps,
+      );
+    });
+  });
+
+  it('returns Send on confirm route for non-swap transaction', () => {
+    const base = getMockContractInteractionConfirmState();
+    const tx = getFirstTransactionMeta(base);
+    const store = configureStore(base);
+    const { result } = renderHook(() => useHardwareWalletRecoveryLocation(), {
+      wrapper: createHookWrapper(
+        store,
+        `${CONFIRM_TRANSACTION_ROUTE}/${tx.id}`,
+        `${CONFIRM_TRANSACTION_ROUTE}/:id/*`,
+      ),
+    });
+    expect(result.current).toBe(MetaMetricsHardwareWalletRecoveryLocation.Send);
+  });
+
+  it('returns Send for confirmation v-next route without swap or message', () => {
+    const base = getMockContractInteractionConfirmState();
+    const tx = getFirstTransactionMeta(base);
+    const store = configureStore(base);
+    const { result } = renderHook(() => useHardwareWalletRecoveryLocation(), {
+      wrapper: createHookWrapper(
+        store,
+        `${CONFIRMATION_V_NEXT_ROUTE}/${tx.id}`,
+        `${CONFIRMATION_V_NEXT_ROUTE}/:id/*`,
+      ),
+    });
+    expect(result.current).toBe(MetaMetricsHardwareWalletRecoveryLocation.Send);
+  });
+
+  it('returns Send as default for unrelated routes', () => {
+    const store = configureStore(getMockContractInteractionConfirmState());
+    const { result } = renderHook(() => useHardwareWalletRecoveryLocation(), {
+      wrapper: createHookWrapper(store, '/settings', '*'),
+    });
+    expect(result.current).toBe(MetaMetricsHardwareWalletRecoveryLocation.Send);
+  });
+});

--- a/ui/hooks/useHardwareWalletRecoveryLocation.ts
+++ b/ui/hooks/useHardwareWalletRecoveryLocation.ts
@@ -1,0 +1,77 @@
+import { TransactionType } from '@metamask/transaction-controller';
+import { useSelector } from 'react-redux';
+import { useLocation, useParams } from 'react-router-dom';
+import { MetaMetricsHardwareWalletRecoveryLocation } from '../../shared/constants/metametrics';
+import {
+  CONFIRM_TRANSACTION_ROUTE,
+  CONFIRMATION_V_NEXT_ROUTE,
+  CROSS_CHAIN_SWAP_ROUTE,
+  DECRYPT_MESSAGE_REQUEST_PATH,
+  ENCRYPTION_PUBLIC_KEY_REQUEST_PATH,
+  SIGNATURE_REQUEST_PATH,
+} from '../helpers/constants/routes';
+import { getUnapprovedTransaction } from '../selectors';
+import { selectUnapprovedMessage } from '../selectors/signatures';
+
+const SWAP_FLOW_TRANSACTION_TYPES: ReadonlySet<TransactionType> = new Set([
+  TransactionType.swap,
+  TransactionType.swapApproval,
+  TransactionType.swapAndSend,
+  TransactionType.bridge,
+  TransactionType.bridgeApproval,
+]);
+
+/**
+ * Derives the Segment `location` property for hardware wallet recovery UI.
+ *
+ * @returns Location for the current route and pending request.
+ */
+export function useHardwareWalletRecoveryLocation(): MetaMetricsHardwareWalletRecoveryLocation {
+  const { pathname } = useLocation();
+  const { id: confirmationId } = useParams();
+
+  const transaction = useSelector((state) =>
+    confirmationId
+      ? getUnapprovedTransaction(state, confirmationId)
+      : undefined,
+  );
+  const message = useSelector((state) =>
+    confirmationId ? selectUnapprovedMessage(state, confirmationId) : undefined,
+  );
+
+  if (
+    pathname.startsWith(CROSS_CHAIN_SWAP_ROUTE) ||
+    pathname.includes('/swaps/')
+  ) {
+    return MetaMetricsHardwareWalletRecoveryLocation.Swaps;
+  }
+
+  if (
+    pathname.includes(SIGNATURE_REQUEST_PATH) ||
+    pathname.includes(DECRYPT_MESSAGE_REQUEST_PATH) ||
+    pathname.includes(ENCRYPTION_PUBLIC_KEY_REQUEST_PATH)
+  ) {
+    return MetaMetricsHardwareWalletRecoveryLocation.Message;
+  }
+
+  if (
+    pathname.startsWith(CONFIRM_TRANSACTION_ROUTE) ||
+    pathname.startsWith(CONFIRMATION_V_NEXT_ROUTE)
+  ) {
+    if (message) {
+      return MetaMetricsHardwareWalletRecoveryLocation.Message;
+    }
+    if (
+      transaction?.type &&
+      SWAP_FLOW_TRANSACTION_TYPES.has(transaction.type as TransactionType)
+    ) {
+      return MetaMetricsHardwareWalletRecoveryLocation.Swaps;
+    }
+    if (transaction) {
+      return MetaMetricsHardwareWalletRecoveryLocation.Send;
+    }
+    return MetaMetricsHardwareWalletRecoveryLocation.Send;
+  }
+
+  return MetaMetricsHardwareWalletRecoveryLocation.Send;
+}

--- a/ui/hooks/useHardwareWalletRecoveryLocation.ts
+++ b/ui/hooks/useHardwareWalletRecoveryLocation.ts
@@ -6,8 +6,6 @@ import {
   CONFIRM_TRANSACTION_ROUTE,
   CONFIRMATION_V_NEXT_ROUTE,
   CROSS_CHAIN_SWAP_ROUTE,
-  DECRYPT_MESSAGE_REQUEST_PATH,
-  ENCRYPTION_PUBLIC_KEY_REQUEST_PATH,
   SIGNATURE_REQUEST_PATH,
 } from '../helpers/constants/routes';
 import { getUnapprovedTransaction } from '../selectors';
@@ -46,11 +44,7 @@ export function useHardwareWalletRecoveryLocation(): MetaMetricsHardwareWalletRe
     return MetaMetricsHardwareWalletRecoveryLocation.Swaps;
   }
 
-  if (
-    pathname.includes(SIGNATURE_REQUEST_PATH) ||
-    pathname.includes(DECRYPT_MESSAGE_REQUEST_PATH) ||
-    pathname.includes(ENCRYPTION_PUBLIC_KEY_REQUEST_PATH)
-  ) {
+  if (pathname.includes(SIGNATURE_REQUEST_PATH)) {
     return MetaMetricsHardwareWalletRecoveryLocation.Message;
   }
 

--- a/ui/hooks/useHardwareWalletRecoveryLocation.ts
+++ b/ui/hooks/useHardwareWalletRecoveryLocation.ts
@@ -61,10 +61,6 @@ export function useHardwareWalletRecoveryLocation(): MetaMetricsHardwareWalletRe
     ) {
       return MetaMetricsHardwareWalletRecoveryLocation.Swaps;
     }
-    if (transaction) {
-      return MetaMetricsHardwareWalletRecoveryLocation.Send;
-    }
-    return MetaMetricsHardwareWalletRecoveryLocation.Send;
   }
 
   return MetaMetricsHardwareWalletRecoveryLocation.Send;


### PR DESCRIPTION
## **Description**
This PR adds first part of the MetaMetrics integration for hardware wallet recovery flow tracking.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/41207?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: n/a

Related ticket: https://consensyssoftware.atlassian.net/browse/MUL-1483

#### Main PR: https://github.com/MetaMask/metamask-extension/pull/41154

## **Manual testing steps**

1. Add hardware wallet account
2. Setup local Segment event tracking
3. Disconnect hardware wallet
4. Go to Swaps and try to do a swap with hardware wallet account while hardware wallet is disconnected
5. Click on button to start recovery flow for hardware wallet
6. Observe event tracking result in local Segment console

#### To run Segment tracking locally do the following:

Add/replace the `SEGMENT_HOST` and `SEGMENT_WRITE_KEY` variables in `.metamaskrc`:

```
SEGMENT_HOST='http://localhost:9090/'
SEGMENT_WRITE_KEY='FAKE'
```

Run the following:
```
node development/mock-segment.js
yarn start
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
This type of tracking was not available before. Nothing to show here.

### **After**
No UI changes, but here are some Segment events intercepted locally.

<img width="609" height="244" alt="Screenshot 2026-03-25 at 16 57 45" src="https://github.com/user-attachments/assets/b2c13870-21aa-44c7-b0f4-03daf84340af" />
<img width="609" height="479" alt="Screenshot 2026-03-25 at 17 08 17" src="https://github.com/user-attachments/assets/54737e3e-3cfd-4839-927e-3a50d7c81ee6" />

<img width="606" height="242" alt="Screenshot 2026-03-26 at 15 10 03" src="https://github.com/user-attachments/assets/dfd5c4ca-37d7-4d15-ac8d-eeca11981813" />


## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new MetaMetrics tracking with additional state/side-effect logic in `HardwareWalletErrorModal`, which could affect modal lifecycle and event deduping/counting if edge cases are missed.
> 
> **Overview**
> Adds first-class MetaMetrics coverage for the hardware wallet recovery flow by introducing new Segment-aligned enums (`location`, `device_type`, `error_type`) and three new events: `HardwareWalletRecoveryModalViewed`, `HardwareWalletRecoverySuccessModalViewed`, and `HardwareWalletRecoveryCtaClicked`.
> 
> Implements shared helpers to build a schema-compliant Segment `properties` payload (including sanitized/truncated `error_message`, `error_code` labeling, device type/model mapping, and `error_type` normalization), plus a new `useHardwareWalletRecoveryLocation` hook to derive `location` from the current route/confirmation context.
> 
> Updates `HardwareWalletErrorModal` to emit these events with deduping and an `error_type_view_count` that increments on repeated views/reconnect failures, and expands test harness utilities to allow injecting a mock `trackEvent`; adds unit tests for the new helpers, hook, and modal tracking behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a746a852f0c4c7724a453e83e7683333f5193705. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->