### PR TITLE
feat: perps/withdraw funds

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5895,6 +5895,15 @@
   "perpsWithdraw": {
     "message": "Withdraw"
   },
+  "perpsWithdrawAssetUnavailableError": {
+    "message": "Withdrawal asset unavailable. Please try again."
+  },
+  "perpsWithdrawEnterValidAmountError": {
+    "message": "Enter a valid amount to withdraw."
+  },
+  "perpsWithdrawInvalidDestinationError": {
+    "message": "Invalid withdrawal destination."
+  },
   "perpsYouWillReceive": {
     "message": "You'll receive"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -5895,6 +5895,15 @@
   "perpsWithdraw": {
     "message": "Withdraw"
   },
+  "perpsWithdrawAssetUnavailableError": {
+    "message": "Withdrawal asset unavailable. Please try again."
+  },
+  "perpsWithdrawEnterValidAmountError": {
+    "message": "Enter a valid amount to withdraw."
+  },
+  "perpsWithdrawInvalidDestinationError": {
+    "message": "Invalid withdrawal destination."
+  },
   "perpsYouWillReceive": {
     "message": "You'll receive"
   },

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -289,13 +289,81 @@
       "error: Error: Network error": 1
     },
     "ui/components/app/name/name-details/name-details.test.tsx": {
-      "React: Act warnings (component updates not wrapped)": 12
+      "React: Act warnings (component updates not wrapped)": 12,
+      "warn: ⚠️ React Router Future Flag": 2
+    },
+    "ui/components/app/name/name-details/name-display.test.tsx": {
+      "warn: ⚠️ React Router Future Flag": 2
+    },
+    "ui/components/app/name/name.test.tsx": {
+      "warn: ⚠️ React Router Future Flag": 2
+    },
+    "ui/components/app/network-connection-banner/network-connection-banner.test.tsx": {
+      "warn: ⚠️ React Router Future Flag": 2
+    },
+    "ui/components/app/permission-cell/permission-cell.test.js": {
+      "warn: ⚠️ React Router Future Flag": 2
+    },
+    "ui/components/app/permission-connect-header/permission-connect-header.test.js": {
+      "warn: ⚠️ React Router Future Flag": 2
+    },
+    "ui/components/app/perps/edit-margin/edit-margin-expandable.test.tsx": {
+      "warn: ⚠️ React Router Future Flag": 2
+    },
+    "ui/components/app/perps/hooks/usePerpsDepositConfirmation.test.ts": {
+      "warn: ⚠️ React Router Future Flag": 2
+    },
+    "ui/components/app/perps/hooks/usePerpsWithdraw.test.ts": {
+      "warn: ⚠️ React Router Future Flag": 2
+    },
+    "ui/components/app/perps/order-card/order-card.test.tsx": {
+      "warn: ⚠️ React Router Future Flag": 2
+    },
+    "ui/components/app/perps/order-entry/components/amount-input/amount-input.test.tsx": {
+      "warn: ⚠️ React Router Future Flag": 2
     },
     "ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.test.tsx": {
       "React: componentWill* lifecycle deprecations": 1
     },
     "ui/components/app/perps/order-entry/order-entry.test.tsx": {
-      "React: componentWill* lifecycle deprecations": 1
+      "React: componentWill* lifecycle deprecations": 1,
+      "warn: ⚠️ React Router Future Flag": 2
+    },
+    "ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.test.tsx": {
+      "warn: ⚠️ React Router Future Flag": 2
+    },
+    "ui/components/app/perps/perps-empty-state/perps-empty-state.test.tsx": {
+      "warn: ⚠️ React Router Future Flag": 2
+    },
+    "ui/components/app/perps/perps-recent-activity/perps-recent-activity.test.tsx": {
+      "warn: ⚠️ React Router Future Flag": 2
+    },
+    "ui/components/app/perps/perps-tab-view.test.tsx": {
+      "warn: ⚠️ React Router Future Flag": 2
+    },
+    "ui/components/app/perps/perps-token-logo/perps-token-logo.test.tsx": {
+      "warn: ⚠️ React Router Future Flag": 2
+    },
+    "ui/components/app/perps/perps-watchlist/perps-watchlist.test.tsx": {
+      "warn: ⚠️ React Router Future Flag": 2
+    },
+    "ui/components/app/perps/position-card/position-card.test.tsx": {
+      "warn: ⚠️ React Router Future Flag": 2
+    },
+    "ui/components/app/perps/reverse-position/reverse-position-modal.test.tsx": {
+      "warn: ⚠️ React Router Future Flag": 2
+    },
+    "ui/components/app/perps/start-trade-cta/start-trade-cta.test.tsx": {
+      "warn: ⚠️ React Router Future Flag": 2
+    },
+    "ui/components/app/perps/transaction-card/transaction-card.test.tsx": {
+      "warn: ⚠️ React Router Future Flag": 2
+    },
+    "ui/components/app/perps/withdraw-funds-modal/withdraw-funds-modal.test.tsx": {
+      "warn: ⚠️ React Router Future Flag": 2
+    },
+    "ui/components/app/perps/update-tpsl/update-tpsl-modal-content.test.tsx": {
+      "warn: ⚠️ React Router Future Flag": 2
     },
     "ui/components/app/qr-hardware-popover/base-reader.test.js": {
       "React: Component update warnings": 1

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -289,81 +289,13 @@
       "error: Error: Network error": 1
     },
     "ui/components/app/name/name-details/name-details.test.tsx": {
-      "React: Act warnings (component updates not wrapped)": 12,
-      "warn: ⚠️ React Router Future Flag": 2
-    },
-    "ui/components/app/name/name-details/name-display.test.tsx": {
-      "warn: ⚠️ React Router Future Flag": 2
-    },
-    "ui/components/app/name/name.test.tsx": {
-      "warn: ⚠️ React Router Future Flag": 2
-    },
-    "ui/components/app/network-connection-banner/network-connection-banner.test.tsx": {
-      "warn: ⚠️ React Router Future Flag": 2
-    },
-    "ui/components/app/permission-cell/permission-cell.test.js": {
-      "warn: ⚠️ React Router Future Flag": 2
-    },
-    "ui/components/app/permission-connect-header/permission-connect-header.test.js": {
-      "warn: ⚠️ React Router Future Flag": 2
-    },
-    "ui/components/app/perps/edit-margin/edit-margin-expandable.test.tsx": {
-      "warn: ⚠️ React Router Future Flag": 2
-    },
-    "ui/components/app/perps/hooks/usePerpsDepositConfirmation.test.ts": {
-      "warn: ⚠️ React Router Future Flag": 2
-    },
-    "ui/components/app/perps/hooks/usePerpsWithdraw.test.ts": {
-      "warn: ⚠️ React Router Future Flag": 2
-    },
-    "ui/components/app/perps/order-card/order-card.test.tsx": {
-      "warn: ⚠️ React Router Future Flag": 2
-    },
-    "ui/components/app/perps/order-entry/components/amount-input/amount-input.test.tsx": {
-      "warn: ⚠️ React Router Future Flag": 2
+      "React: Act warnings (component updates not wrapped)": 12
     },
     "ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.test.tsx": {
       "React: componentWill* lifecycle deprecations": 1
     },
     "ui/components/app/perps/order-entry/order-entry.test.tsx": {
-      "React: componentWill* lifecycle deprecations": 1,
-      "warn: ⚠️ React Router Future Flag": 2
-    },
-    "ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.test.tsx": {
-      "warn: ⚠️ React Router Future Flag": 2
-    },
-    "ui/components/app/perps/perps-empty-state/perps-empty-state.test.tsx": {
-      "warn: ⚠️ React Router Future Flag": 2
-    },
-    "ui/components/app/perps/perps-recent-activity/perps-recent-activity.test.tsx": {
-      "warn: ⚠️ React Router Future Flag": 2
-    },
-    "ui/components/app/perps/perps-tab-view.test.tsx": {
-      "warn: ⚠️ React Router Future Flag": 2
-    },
-    "ui/components/app/perps/perps-token-logo/perps-token-logo.test.tsx": {
-      "warn: ⚠️ React Router Future Flag": 2
-    },
-    "ui/components/app/perps/perps-watchlist/perps-watchlist.test.tsx": {
-      "warn: ⚠️ React Router Future Flag": 2
-    },
-    "ui/components/app/perps/position-card/position-card.test.tsx": {
-      "warn: ⚠️ React Router Future Flag": 2
-    },
-    "ui/components/app/perps/reverse-position/reverse-position-modal.test.tsx": {
-      "warn: ⚠️ React Router Future Flag": 2
-    },
-    "ui/components/app/perps/start-trade-cta/start-trade-cta.test.tsx": {
-      "warn: ⚠️ React Router Future Flag": 2
-    },
-    "ui/components/app/perps/transaction-card/transaction-card.test.tsx": {
-      "warn: ⚠️ React Router Future Flag": 2
-    },
-    "ui/components/app/perps/withdraw-funds-modal/withdraw-funds-modal.test.tsx": {
-      "warn: ⚠️ React Router Future Flag": 2
-    },
-    "ui/components/app/perps/update-tpsl/update-tpsl-modal-content.test.tsx": {
-      "warn: ⚠️ React Router Future Flag": 2
+      "React: componentWill* lifecycle deprecations": 1
     },
     "ui/components/app/qr-hardware-popover/base-reader.test.js": {
       "React: Component update warnings": 1

--- a/ui/components/app/perps/constants.ts
+++ b/ui/components/app/perps/constants.ts
@@ -19,6 +19,32 @@ export const HYPERLIQUID_ASSET_ICONS_BASE_URL =
   'https://app.hyperliquid.xyz/coins/';
 
 /**
+ * Mobile-parity Perps withdraw asset configuration.
+ *
+ * Current Perps withdraw flow is USDC-only and requires a CAIP asset ID
+ * when calling controller.withdraw.
+ */
+export const PERPS_WITHDRAW_ASSET_CONFIGS = {
+  usdc: {
+    mainnet:
+      'eip155:42161/erc20:0xaf88d065e77c8cC2239327C5EDb3A432268e5831/default',
+    testnet:
+      'eip155:421614/erc20:0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d/default',
+  },
+} as const;
+
+/**
+ * Get the CAIP asset ID used for Perps USDC withdrawals.
+ *
+ * @param isTestnet - Whether Perps is in testnet mode.
+ * @returns CAIP asset ID for USDC on the current Perps network.
+ */
+export const getPerpsWithdrawUsdcAssetId = (isTestnet: boolean): string =>
+  isTestnet
+    ? PERPS_WITHDRAW_ASSET_CONFIGS.usdc.testnet
+    : PERPS_WITHDRAW_ASSET_CONFIGS.usdc.mainnet;
+
+/**
  * General perps display constants
  * Fallback values for when data is unavailable or invalid
  */

--- a/ui/components/app/perps/constants.ts
+++ b/ui/components/app/perps/constants.ts
@@ -33,6 +33,11 @@ export const PERPS_WITHDRAW_ASSET_CONFIGS = {
   },
 } as const;
 
+export const PERPS_WITHDRAW_AMOUNT_REGEX = /^\d*\.?\d{0,6}$/u;
+
+export const isValidPerpsWithdrawAmount = (amount: string): boolean =>
+  PERPS_WITHDRAW_AMOUNT_REGEX.test(amount);
+
 /**
  * Get the CAIP asset ID used for Perps USDC withdrawals.
  *

--- a/ui/components/app/perps/hooks/createPerpsWithdrawTransaction.test.ts
+++ b/ui/components/app/perps/hooks/createPerpsWithdrawTransaction.test.ts
@@ -1,0 +1,51 @@
+import { submitRequestToBackground } from '../../../../store/background-connection';
+import { createPerpsWithdrawTransaction } from './createPerpsWithdrawTransaction';
+
+jest.mock('../../../../store/background-connection', () => ({
+  submitRequestToBackground: jest.fn(),
+}));
+
+const mockSubmitRequestToBackground =
+  submitRequestToBackground as jest.MockedFunction<
+    typeof submitRequestToBackground
+  >;
+
+describe('createPerpsWithdrawTransaction', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('submits withdraw request and returns result', async () => {
+    mockSubmitRequestToBackground.mockResolvedValue({
+      success: true,
+      txHash: '0x123',
+      withdrawalId: 'withdraw-1',
+    });
+
+    const result = await createPerpsWithdrawTransaction({
+      amount: '12.5',
+    });
+
+    expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+      'perpsWithdraw',
+      [{ amount: '12.5' }],
+    );
+    expect(result).toStrictEqual({
+      success: true,
+      txHash: '0x123',
+      withdrawalId: 'withdraw-1',
+    });
+  });
+
+  it('propagates background errors', async () => {
+    mockSubmitRequestToBackground.mockRejectedValue(
+      new Error('withdraw failed'),
+    );
+
+    await expect(
+      createPerpsWithdrawTransaction({
+        amount: '1',
+      }),
+    ).rejects.toThrow('withdraw failed');
+  });
+});

--- a/ui/components/app/perps/hooks/createPerpsWithdrawTransaction.test.ts
+++ b/ui/components/app/perps/hooks/createPerpsWithdrawTransaction.test.ts
@@ -24,11 +24,19 @@ describe('createPerpsWithdrawTransaction', () => {
 
     const result = await createPerpsWithdrawTransaction({
       amount: '12.5',
+      assetId:
+        'eip155:42161/erc20:0xaf88d065e77c8cC2239327C5EDb3A432268e5831/default',
     });
 
     expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
       'perpsWithdraw',
-      [{ amount: '12.5' }],
+      [
+        {
+          amount: '12.5',
+          assetId:
+            'eip155:42161/erc20:0xaf88d065e77c8cC2239327C5EDb3A432268e5831/default',
+        },
+      ],
     );
     expect(result).toStrictEqual({
       success: true,
@@ -45,6 +53,8 @@ describe('createPerpsWithdrawTransaction', () => {
     await expect(
       createPerpsWithdrawTransaction({
         amount: '1',
+        assetId:
+          'eip155:42161/erc20:0xaf88d065e77c8cC2239327C5EDb3A432268e5831/default',
       }),
     ).rejects.toThrow('withdraw failed');
   });

--- a/ui/components/app/perps/hooks/createPerpsWithdrawTransaction.ts
+++ b/ui/components/app/perps/hooks/createPerpsWithdrawTransaction.ts
@@ -2,6 +2,7 @@ import { submitRequestToBackground } from '../../../../store/background-connecti
 
 export type CreatePerpsWithdrawTransactionParams = {
   amount: string;
+  assetId: string;
 };
 
 export type CreatedPerpsWithdrawTransaction = {
@@ -16,13 +17,15 @@ export type CreatedPerpsWithdrawTransaction = {
  *
  * @param params - Parameters for the withdraw request
  * @param params.amount - Withdraw amount
+ * @param params.assetId
  * @returns The withdraw result
  */
 export async function createPerpsWithdrawTransaction({
   amount,
+  assetId,
 }: CreatePerpsWithdrawTransactionParams): Promise<CreatedPerpsWithdrawTransaction> {
   return submitRequestToBackground<CreatedPerpsWithdrawTransaction>(
     'perpsWithdraw',
-    [{ amount }],
+    [{ amount, assetId }],
   );
 }

--- a/ui/components/app/perps/hooks/createPerpsWithdrawTransaction.ts
+++ b/ui/components/app/perps/hooks/createPerpsWithdrawTransaction.ts
@@ -1,0 +1,28 @@
+import { submitRequestToBackground } from '../../../../store/background-connection';
+
+export type CreatePerpsWithdrawTransactionParams = {
+  amount: string;
+};
+
+export type CreatedPerpsWithdrawTransaction = {
+  success: boolean;
+  error?: string;
+  txHash?: string;
+  withdrawalId?: string;
+};
+
+/**
+ * Creates a perps withdraw request via the background controller.
+ *
+ * @param params - Parameters for the withdraw request
+ * @param params.amount - Withdraw amount
+ * @returns The withdraw result
+ */
+export async function createPerpsWithdrawTransaction({
+  amount,
+}: CreatePerpsWithdrawTransactionParams): Promise<CreatedPerpsWithdrawTransaction> {
+  return submitRequestToBackground<CreatedPerpsWithdrawTransaction>(
+    'perpsWithdraw',
+    [{ amount }],
+  );
+}

--- a/ui/components/app/perps/hooks/usePerpsWithdraw.test.ts
+++ b/ui/components/app/perps/hooks/usePerpsWithdraw.test.ts
@@ -1,6 +1,7 @@
 import { act } from '@testing-library/react-hooks';
 import mockState from '../../../../../test/data/mock-state.json';
 import { renderHookWithProvider } from '../../../../../test/lib/render-helpers-navigate';
+import { getPerpsWithdrawUsdcAssetId } from '../constants';
 import { createPerpsWithdrawTransaction } from './createPerpsWithdrawTransaction';
 import { usePerpsWithdraw } from './usePerpsWithdraw';
 
@@ -36,9 +37,31 @@ describe('usePerpsWithdraw', () => {
 
     expect(mockCreatePerpsWithdrawTransaction).toHaveBeenCalledWith({
       amount: '10',
+      assetId: getPerpsWithdrawUsdcAssetId(false),
     });
     expect(response).toStrictEqual({ success: true });
     expect(result.current.error).toBeNull();
+  });
+
+  it('uses testnet withdraw asset id when perps testnet is enabled', async () => {
+    mockCreatePerpsWithdrawTransaction.mockResolvedValue({ success: true });
+
+    const { result } = renderHookWithProvider(() => usePerpsWithdraw(), {
+      ...mockState,
+      metamask: {
+        ...mockState.metamask,
+        isTestnet: true,
+      },
+    });
+
+    await act(async () => {
+      await result.current.trigger({ amount: '5' });
+    });
+
+    expect(mockCreatePerpsWithdrawTransaction).toHaveBeenCalledWith({
+      amount: '5',
+      assetId: getPerpsWithdrawUsdcAssetId(true),
+    });
   });
 
   it('surfaces controller error when withdraw fails', async () => {

--- a/ui/components/app/perps/hooks/usePerpsWithdraw.test.ts
+++ b/ui/components/app/perps/hooks/usePerpsWithdraw.test.ts
@@ -1,0 +1,121 @@
+import { act } from '@testing-library/react-hooks';
+import mockState from '../../../../../test/data/mock-state.json';
+import { renderHookWithProvider } from '../../../../../test/lib/render-helpers-navigate';
+import { createPerpsWithdrawTransaction } from './createPerpsWithdrawTransaction';
+import { usePerpsWithdraw } from './usePerpsWithdraw';
+
+jest.mock('./createPerpsWithdrawTransaction', () => ({
+  createPerpsWithdrawTransaction: jest.fn(),
+}));
+
+const mockCreatePerpsWithdrawTransaction =
+  createPerpsWithdrawTransaction as jest.MockedFunction<
+    typeof createPerpsWithdrawTransaction
+  >;
+
+describe('usePerpsWithdraw', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('submits withdraw and returns success', async () => {
+    mockCreatePerpsWithdrawTransaction.mockResolvedValue({ success: true });
+
+    const { result } = renderHookWithProvider(
+      () => usePerpsWithdraw(),
+      mockState,
+    );
+
+    let response: Awaited<ReturnType<typeof result.current.trigger>> = {
+      success: false,
+    };
+
+    await act(async () => {
+      response = await result.current.trigger({ amount: '10' });
+    });
+
+    expect(mockCreatePerpsWithdrawTransaction).toHaveBeenCalledWith({
+      amount: '10',
+    });
+    expect(response).toStrictEqual({ success: true });
+    expect(result.current.error).toBeNull();
+  });
+
+  it('surfaces controller error when withdraw fails', async () => {
+    mockCreatePerpsWithdrawTransaction.mockResolvedValue({
+      success: false,
+      error: 'Insufficient withdrawable balance',
+    });
+
+    const { result } = renderHookWithProvider(
+      () => usePerpsWithdraw(),
+      mockState,
+    );
+
+    await act(async () => {
+      await result.current.trigger({ amount: '10000' });
+    });
+
+    expect(result.current.error).toBe('Insufficient withdrawable balance');
+  });
+
+  it('rejects invalid amount before background call', async () => {
+    const { result } = renderHookWithProvider(
+      () => usePerpsWithdraw(),
+      mockState,
+    );
+
+    let response: Awaited<ReturnType<typeof result.current.trigger>> = {
+      success: true,
+    };
+    await act(async () => {
+      response = await result.current.trigger({ amount: '-1' });
+    });
+
+    expect(mockCreatePerpsWithdrawTransaction).not.toHaveBeenCalled();
+    expect(response).toStrictEqual({
+      success: false,
+      error: 'Invalid amount',
+    });
+    expect(result.current.error).toBe('Invalid amount');
+  });
+
+  it('prevents duplicate in-flight requests', async () => {
+    let resolveWithdraw:
+      | ((value: { success: boolean; error?: string }) => void)
+      | undefined;
+    mockCreatePerpsWithdrawTransaction.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveWithdraw = resolve;
+        }),
+    );
+
+    const { result } = renderHookWithProvider(
+      () => usePerpsWithdraw(),
+      mockState,
+    );
+
+    let firstCall:
+      | Promise<Awaited<ReturnType<typeof result.current.trigger>>>
+      | undefined;
+    await act(async () => {
+      firstCall = result.current.trigger({ amount: '5' });
+    });
+
+    let secondResponse: Awaited<ReturnType<typeof result.current.trigger>> = {
+      success: true,
+    };
+    await act(async () => {
+      secondResponse = await result.current.trigger({ amount: '5' });
+    });
+
+    expect(secondResponse).toStrictEqual({ success: false });
+    expect(mockCreatePerpsWithdrawTransaction).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveWithdraw?.({ success: true });
+      await firstCall;
+    });
+  });
+});

--- a/ui/components/app/perps/hooks/usePerpsWithdraw.test.ts
+++ b/ui/components/app/perps/hooks/usePerpsWithdraw.test.ts
@@ -103,6 +103,27 @@ describe('usePerpsWithdraw', () => {
     expect(result.current.error).toBe('Invalid amount');
   });
 
+  it('rejects bare dot amount before background call', async () => {
+    const { result } = renderHookWithProvider(
+      () => usePerpsWithdraw(),
+      mockState,
+    );
+
+    let response: Awaited<ReturnType<typeof result.current.trigger>> = {
+      success: true,
+    };
+    await act(async () => {
+      response = await result.current.trigger({ amount: '.' });
+    });
+
+    expect(mockCreatePerpsWithdrawTransaction).not.toHaveBeenCalled();
+    expect(response).toStrictEqual({
+      success: false,
+      error: 'Invalid amount',
+    });
+    expect(result.current.error).toBe('Invalid amount');
+  });
+
   it('prevents duplicate in-flight requests', async () => {
     let resolveWithdraw:
       | ((value: { success: boolean; error?: string }) => void)

--- a/ui/components/app/perps/hooks/usePerpsWithdraw.ts
+++ b/ui/components/app/perps/hooks/usePerpsWithdraw.ts
@@ -1,0 +1,100 @@
+import { useCallback, useRef, useState } from 'react';
+import { useSelector } from 'react-redux';
+
+import { getSelectedInternalAccount } from '../../../../selectors';
+import { createPerpsWithdrawTransaction } from './createPerpsWithdrawTransaction';
+
+const MAX_DECIMALS = 6;
+
+function isValidAmount(amount: string): boolean {
+  return /^\d*\.?\d{0,6}$/u.test(amount);
+}
+
+export type PerpsWithdrawParams = {
+  amount: string;
+};
+
+export type PerpsWithdrawResult = {
+  success: boolean;
+  error?: string;
+};
+
+export type UsePerpsWithdrawResult = {
+  trigger: (params: PerpsWithdrawParams) => Promise<PerpsWithdrawResult>;
+  isLoading: boolean;
+  error: string | null;
+  resetError: () => void;
+};
+
+export function usePerpsWithdraw(): UsePerpsWithdrawResult {
+  const selectedAccount = useSelector(getSelectedInternalAccount);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const isInFlightRef = useRef(false);
+
+  const resetError = useCallback(() => {
+    setError(null);
+  }, []);
+
+  const trigger = useCallback(
+    async ({ amount }: PerpsWithdrawParams): Promise<PerpsWithdrawResult> => {
+      if (isInFlightRef.current || isLoading) {
+        return { success: false };
+      }
+
+      if (!selectedAccount?.address) {
+        const nextError = 'No selected account';
+        setError(nextError);
+        return { success: false, error: nextError };
+      }
+
+      const normalizedAmount = amount.trim();
+      if (
+        !normalizedAmount ||
+        !isValidAmount(normalizedAmount) ||
+        normalizedAmount.split('.')[1]?.length > MAX_DECIMALS ||
+        Number(normalizedAmount) <= 0
+      ) {
+        const nextError = 'Invalid amount';
+        setError(nextError);
+        return { success: false, error: nextError };
+      }
+
+      isInFlightRef.current = true;
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const result = await createPerpsWithdrawTransaction({
+          amount: normalizedAmount,
+        });
+
+        if (!result.success) {
+          const nextError = result.error ?? 'Withdraw failed';
+          setError(nextError);
+          return { success: false, error: nextError };
+        }
+
+        return { success: true };
+      } catch (withdrawError) {
+        const nextError =
+          withdrawError instanceof Error
+            ? withdrawError.message
+            : 'Withdraw failed';
+        setError(nextError);
+        return { success: false, error: nextError };
+      } finally {
+        isInFlightRef.current = false;
+        setIsLoading(false);
+      }
+    },
+    [isLoading, selectedAccount?.address],
+  );
+
+  return {
+    trigger,
+    isLoading,
+    error,
+    resetError,
+  };
+}

--- a/ui/components/app/perps/hooks/usePerpsWithdraw.ts
+++ b/ui/components/app/perps/hooks/usePerpsWithdraw.ts
@@ -2,6 +2,8 @@ import { useCallback, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import { getSelectedInternalAccount } from '../../../../selectors';
+import { selectPerpsIsTestnet } from '../../../../selectors/perps-controller';
+import { getPerpsWithdrawUsdcAssetId } from '../constants';
 import { createPerpsWithdrawTransaction } from './createPerpsWithdrawTransaction';
 
 const MAX_DECIMALS = 6;
@@ -28,6 +30,7 @@ export type UsePerpsWithdrawResult = {
 
 export function usePerpsWithdraw(): UsePerpsWithdrawResult {
   const selectedAccount = useSelector(getSelectedInternalAccount);
+  const isPerpsTestnet = useSelector(selectPerpsIsTestnet);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const isInFlightRef = useRef(false);
@@ -65,8 +68,10 @@ export function usePerpsWithdraw(): UsePerpsWithdrawResult {
       setError(null);
 
       try {
+        const assetId = getPerpsWithdrawUsdcAssetId(isPerpsTestnet);
         const result = await createPerpsWithdrawTransaction({
           amount: normalizedAmount,
+          assetId,
         });
 
         if (!result.success) {
@@ -88,7 +93,7 @@ export function usePerpsWithdraw(): UsePerpsWithdrawResult {
         setIsLoading(false);
       }
     },
-    [isLoading, selectedAccount?.address],
+    [isLoading, isPerpsTestnet, selectedAccount?.address],
   );
 
   return {

--- a/ui/components/app/perps/hooks/usePerpsWithdraw.ts
+++ b/ui/components/app/perps/hooks/usePerpsWithdraw.ts
@@ -50,10 +50,12 @@ export function usePerpsWithdraw(): UsePerpsWithdrawResult {
       }
 
       const normalizedAmount = amount.trim();
+      const amountNum = Number(normalizedAmount);
       if (
         !normalizedAmount ||
         !isValidAmount(normalizedAmount) ||
-        Number(normalizedAmount) <= 0
+        !Number.isFinite(amountNum) ||
+        amountNum <= 0
       ) {
         const nextError = 'Invalid amount';
         setError(nextError);

--- a/ui/components/app/perps/hooks/usePerpsWithdraw.ts
+++ b/ui/components/app/perps/hooks/usePerpsWithdraw.ts
@@ -3,12 +3,11 @@ import { useSelector } from 'react-redux';
 
 import { getSelectedInternalAccount } from '../../../../selectors';
 import { selectPerpsIsTestnet } from '../../../../selectors/perps-controller';
-import { getPerpsWithdrawUsdcAssetId } from '../constants';
+import {
+  getPerpsWithdrawUsdcAssetId,
+  isValidPerpsWithdrawAmount,
+} from '../constants';
 import { createPerpsWithdrawTransaction } from './createPerpsWithdrawTransaction';
-
-function isValidAmount(amount: string): boolean {
-  return /^\d*\.?\d{0,6}$/u.test(amount);
-}
 
 export type PerpsWithdrawParams = {
   amount: string;
@@ -53,7 +52,7 @@ export function usePerpsWithdraw(): UsePerpsWithdrawResult {
       const amountNum = Number(normalizedAmount);
       if (
         !normalizedAmount ||
-        !isValidAmount(normalizedAmount) ||
+        !isValidPerpsWithdrawAmount(normalizedAmount) ||
         !Number.isFinite(amountNum) ||
         amountNum <= 0
       ) {

--- a/ui/components/app/perps/hooks/usePerpsWithdraw.ts
+++ b/ui/components/app/perps/hooks/usePerpsWithdraw.ts
@@ -6,8 +6,6 @@ import { selectPerpsIsTestnet } from '../../../../selectors/perps-controller';
 import { getPerpsWithdrawUsdcAssetId } from '../constants';
 import { createPerpsWithdrawTransaction } from './createPerpsWithdrawTransaction';
 
-const MAX_DECIMALS = 6;
-
 function isValidAmount(amount: string): boolean {
   return /^\d*\.?\d{0,6}$/u.test(amount);
 }
@@ -41,7 +39,7 @@ export function usePerpsWithdraw(): UsePerpsWithdrawResult {
 
   const trigger = useCallback(
     async ({ amount }: PerpsWithdrawParams): Promise<PerpsWithdrawResult> => {
-      if (isInFlightRef.current || isLoading) {
+      if (isInFlightRef.current) {
         return { success: false };
       }
 
@@ -55,7 +53,6 @@ export function usePerpsWithdraw(): UsePerpsWithdrawResult {
       if (
         !normalizedAmount ||
         !isValidAmount(normalizedAmount) ||
-        normalizedAmount.split('.')[1]?.length > MAX_DECIMALS ||
         Number(normalizedAmount) <= 0
       ) {
         const nextError = 'Invalid amount';
@@ -93,7 +90,7 @@ export function usePerpsWithdraw(): UsePerpsWithdrawResult {
         setIsLoading(false);
       }
     },
-    [isLoading, isPerpsTestnet, selectedAccount?.address],
+    [isPerpsTestnet, selectedAccount?.address],
   );
 
   return {

--- a/ui/components/app/perps/perps-view.test.tsx
+++ b/ui/components/app/perps/perps-view.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import configureStore from '../../../store/store';
 import mockState from '../../../../test/data/mock-state.json';
@@ -53,6 +53,14 @@ jest.mock('../../../hooks/perps/stream', () => ({
     hip3Markets: mocks.mockHip3Markets,
     isInitialLoading: false,
   }),
+}));
+
+jest.mock('./withdraw-funds-modal', () => ({
+  WithdrawFundsModal: ({ isOpen }: { isOpen: boolean }) => (
+    <div data-testid="perps-withdraw-modal-state">
+      {isOpen ? 'open' : 'closed'}
+    </div>
+  ),
 }));
 
 const mockStore = configureStore({
@@ -177,6 +185,21 @@ describe('PerpsView', () => {
       renderWithProvider(<PerpsView />, mockStore);
 
       expect(screen.getByTestId('perps-watchlist')).toBeInTheDocument();
+    });
+
+    it('opens withdraw modal when withdraw is clicked from balance dropdown', () => {
+      renderWithProvider(<PerpsTabView />, mockStore);
+
+      expect(
+        screen.getByTestId('perps-withdraw-modal-state'),
+      ).toHaveTextContent('closed');
+
+      fireEvent.click(screen.getByTestId('perps-balance-dropdown-balance'));
+      fireEvent.click(screen.getByTestId('perps-balance-dropdown-withdraw'));
+
+      expect(
+        screen.getByTestId('perps-withdraw-modal-state'),
+      ).toHaveTextContent('open');
     });
   });
 

--- a/ui/components/app/perps/perps-view.test.tsx
+++ b/ui/components/app/perps/perps-view.test.tsx
@@ -188,7 +188,7 @@ describe('PerpsView', () => {
     });
 
     it('opens withdraw modal when withdraw is clicked from balance dropdown', () => {
-      renderWithProvider(<PerpsTabView />, mockStore);
+      renderWithProvider(<PerpsView />, mockStore);
 
       expect(
         screen.getByTestId('perps-withdraw-modal-state'),

--- a/ui/components/app/perps/perps-view.tsx
+++ b/ui/components/app/perps/perps-view.tsx
@@ -1,5 +1,5 @@
+import React, { useMemo, useState, useCallback } from 'react';
 import { Box, BoxFlexDirection } from '@metamask/design-system-react';
-import React, { useMemo } from 'react';
 import {
   usePerpsLivePositions,
   usePerpsLiveOrders,
@@ -13,6 +13,7 @@ import { PerpsBalanceDropdown } from './perps-balance-dropdown';
 import { PerpsExploreMarkets } from './perps-explore-markets';
 import { PerpsPositionsOrders } from './perps-positions-orders';
 import { PerpsRecentActivity } from './perps-recent-activity';
+import { WithdrawFundsModal } from './withdraw-funds-modal';
 import {
   PerpsControlBarSkeleton,
   PerpsSectionSkeleton,
@@ -30,6 +31,7 @@ import { PerpsWatchlist } from './perps-watchlist';
  */
 export const PerpsView: React.FC = () => {
   const { trigger: triggerDeposit } = usePerpsDepositConfirmation();
+  const [isWithdrawModalOpen, setIsWithdrawModalOpen] = useState(false);
 
   // Stream hooks must run before any effects that touch PerpsStreamManager.
   // `usePerpsStreamManager` (inside these hooks) calls `perpsInit` then `init(address)`;
@@ -73,6 +75,14 @@ export const PerpsView: React.FC = () => {
     return allHip3Markets.slice(0, 5);
   }, [allHip3Markets]);
 
+  const handleOpenWithdrawModal = useCallback(() => {
+    setIsWithdrawModalOpen(true);
+  }, []);
+
+  const handleCloseWithdrawModal = useCallback(() => {
+    setIsWithdrawModalOpen(false);
+  }, []);
+
   // Show loading state while initial stream data is being fetched.
   // Transaction history loads in parallel; Recent Activity skeleton is included here
   // so the section is represented before the main view mounts.
@@ -103,9 +113,7 @@ export const PerpsView: React.FC = () => {
       <PerpsBalanceDropdown
         hasPositions={hasPositions}
         onAddFunds={triggerDeposit}
-        onWithdraw={() => {
-          // TODO: Navigate to withdraw flow
-        }}
+        onWithdraw={handleOpenWithdrawModal}
       />
 
       {/* Positions + Orders sections */}
@@ -132,6 +140,10 @@ export const PerpsView: React.FC = () => {
       <PerpsSupportLearn />
       {/* Tutorial Modal */}
       <PerpsTutorialModal />
+      <WithdrawFundsModal
+        isOpen={isWithdrawModalOpen}
+        onClose={handleCloseWithdrawModal}
+      />
     </Box>
   );
 };

--- a/ui/components/app/perps/withdraw-funds-modal/index.ts
+++ b/ui/components/app/perps/withdraw-funds-modal/index.ts
@@ -1,0 +1,1 @@
+export { default as WithdrawFundsModal } from './withdraw-funds-modal';

--- a/ui/components/app/perps/withdraw-funds-modal/index.ts
+++ b/ui/components/app/perps/withdraw-funds-modal/index.ts
@@ -1,1 +1,1 @@
-export { default as WithdrawFundsModal } from './withdraw-funds-modal';
+export { WithdrawFundsModal } from './withdraw-funds-modal';

--- a/ui/components/app/perps/withdraw-funds-modal/withdraw-funds-modal.test.tsx
+++ b/ui/components/app/perps/withdraw-funds-modal/withdraw-funds-modal.test.tsx
@@ -135,4 +135,33 @@ describe('WithdrawFundsModal', () => {
       'Failed',
     );
   });
+
+  it('shows readable message for known withdraw error codes', async () => {
+    mockUsePerpsWithdraw.mockReturnValue({
+      trigger: triggerMock.mockResolvedValue({
+        success: false,
+        error: 'WITHDRAW_ASSET_ID_REQUIRED',
+      }),
+      isLoading: false,
+      error: 'WITHDRAW_ASSET_ID_REQUIRED',
+      resetError: resetErrorMock,
+    });
+
+    renderWithProvider(
+      <WithdrawFundsModal isOpen onClose={onCloseMock} />,
+      mockStore,
+    );
+
+    const input = screen.getByPlaceholderText('0.00') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '10' } });
+
+    fireEvent.click(screen.getByTestId('perps-withdraw-submit'));
+
+    await waitFor(() => {
+      expect(onCloseMock).not.toHaveBeenCalled();
+    });
+    expect(screen.getByTestId('perps-withdraw-error')).toHaveTextContent(
+      'Withdrawal asset unavailable. Please try again.',
+    );
+  });
 });

--- a/ui/components/app/perps/withdraw-funds-modal/withdraw-funds-modal.test.tsx
+++ b/ui/components/app/perps/withdraw-funds-modal/withdraw-funds-modal.test.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+
+import mockState from '../../../../../test/data/mock-state.json';
+import { renderWithProvider } from '../../../../../test/lib/render-helpers-navigate';
+import { usePerpsLiveAccount } from '../../../../hooks/perps/stream';
+import configureStore from '../../../../store/store';
+import { usePerpsWithdraw } from '../hooks/usePerpsWithdraw';
+import { WithdrawFundsModal } from './withdraw-funds-modal';
+
+jest.mock('../../../../hooks/perps/stream', () => ({
+  usePerpsLiveAccount: jest.fn(),
+}));
+
+jest.mock('../hooks/usePerpsWithdraw', () => ({
+  usePerpsWithdraw: jest.fn(),
+}));
+
+const mockUsePerpsLiveAccount = jest.mocked(usePerpsLiveAccount);
+const mockUsePerpsWithdraw = jest.mocked(usePerpsWithdraw);
+const mockStore = configureStore({
+  metamask: {
+    ...mockState.metamask,
+  },
+});
+
+describe('WithdrawFundsModal', () => {
+  const triggerMock = jest.fn();
+  const onCloseMock = jest.fn();
+  const resetErrorMock = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUsePerpsLiveAccount.mockReturnValue({
+      account: {
+        availableBalance: '100',
+      },
+      isInitialLoading: false,
+    } as ReturnType<typeof usePerpsLiveAccount>);
+
+    mockUsePerpsWithdraw.mockReturnValue({
+      trigger: triggerMock,
+      isLoading: false,
+      error: null,
+      resetError: resetErrorMock,
+    });
+  });
+
+  it('renders when open', () => {
+    renderWithProvider(
+      <WithdrawFundsModal isOpen onClose={onCloseMock} />,
+      mockStore,
+    );
+
+    expect(
+      screen.getByTestId('perps-withdraw-funds-modal'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('perps-withdraw-amount-input'),
+    ).toBeInTheDocument();
+  });
+
+  it('sets amount using percentage preset', () => {
+    renderWithProvider(
+      <WithdrawFundsModal isOpen onClose={onCloseMock} />,
+      mockStore,
+    );
+
+    fireEvent.click(screen.getByTestId('perps-withdraw-preset-50'));
+
+    const input = screen.getByPlaceholderText('0.00') as HTMLInputElement;
+    expect(input).toHaveValue('50.00');
+  });
+
+  it('disables submit for insufficient amount', () => {
+    renderWithProvider(
+      <WithdrawFundsModal isOpen onClose={onCloseMock} />,
+      mockStore,
+    );
+
+    const input = screen.getByPlaceholderText('0.00') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '1000' } });
+
+    const submit = screen.getByTestId('perps-withdraw-submit');
+    expect(submit).toBeDisabled();
+    expect(screen.getByTestId('perps-withdraw-error')).toHaveTextContent(
+      'Insufficient funds',
+    );
+  });
+
+  it('submits amount and closes modal on success', async () => {
+    triggerMock.mockResolvedValue({ success: true });
+
+    renderWithProvider(
+      <WithdrawFundsModal isOpen onClose={onCloseMock} />,
+      mockStore,
+    );
+
+    const input = screen.getByPlaceholderText('0.00') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '10' } });
+
+    fireEvent.click(screen.getByTestId('perps-withdraw-submit'));
+
+    await waitFor(() => {
+      expect(triggerMock).toHaveBeenCalledWith({ amount: '10' });
+      expect(onCloseMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('keeps modal open on failure and shows returned error', async () => {
+    mockUsePerpsWithdraw.mockReturnValue({
+      trigger: triggerMock.mockResolvedValue({
+        success: false,
+        error: 'Failed',
+      }),
+      isLoading: false,
+      error: 'Failed',
+      resetError: resetErrorMock,
+    });
+
+    renderWithProvider(
+      <WithdrawFundsModal isOpen onClose={onCloseMock} />,
+      mockStore,
+    );
+
+    const input = screen.getByPlaceholderText('0.00') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '10' } });
+
+    fireEvent.click(screen.getByTestId('perps-withdraw-submit'));
+
+    await waitFor(() => {
+      expect(onCloseMock).not.toHaveBeenCalled();
+    });
+    expect(screen.getByTestId('perps-withdraw-error')).toHaveTextContent(
+      'Failed',
+    );
+  });
+});

--- a/ui/components/app/perps/withdraw-funds-modal/withdraw-funds-modal.test.tsx
+++ b/ui/components/app/perps/withdraw-funds-modal/withdraw-funds-modal.test.tsx
@@ -72,6 +72,27 @@ describe('WithdrawFundsModal', () => {
     expect(input).toHaveValue('50.00');
   });
 
+  it('max preset does not round above available balance', () => {
+    mockUsePerpsLiveAccount.mockReturnValueOnce({
+      account: {
+        availableBalance: '99.999',
+      },
+      isInitialLoading: false,
+    } as ReturnType<typeof usePerpsLiveAccount>);
+
+    renderWithProvider(
+      <WithdrawFundsModal isOpen onClose={onCloseMock} />,
+      mockStore,
+    );
+
+    fireEvent.click(screen.getByTestId('perps-withdraw-preset-100'));
+
+    const input = screen.getByPlaceholderText('0.00') as HTMLInputElement;
+    expect(input).toHaveValue('99.999');
+    expect(screen.getByTestId('perps-withdraw-submit')).not.toBeDisabled();
+    expect(screen.getByTestId('perps-withdraw-error')).toHaveTextContent('');
+  });
+
   it('disables submit for insufficient amount', () => {
     renderWithProvider(
       <WithdrawFundsModal isOpen onClose={onCloseMock} />,

--- a/ui/components/app/perps/withdraw-funds-modal/withdraw-funds-modal.test.tsx
+++ b/ui/components/app/perps/withdraw-funds-modal/withdraw-funds-modal.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 
 import mockState from '../../../../../test/data/mock-state.json';
+import { enLocale as messages } from '../../../../../test/lib/i18n-helpers';
 import { renderWithProvider } from '../../../../../test/lib/render-helpers-navigate';
 import { usePerpsLiveAccount } from '../../../../hooks/perps/stream';
 import configureStore from '../../../../store/store';
@@ -105,7 +106,7 @@ describe('WithdrawFundsModal', () => {
     const submit = screen.getByTestId('perps-withdraw-submit');
     expect(submit).toBeDisabled();
     expect(screen.getByTestId('perps-withdraw-error')).toHaveTextContent(
-      'Insufficient funds',
+      messages.insufficientFunds.message,
     );
   });
 
@@ -121,8 +122,21 @@ describe('WithdrawFundsModal', () => {
     const submit = screen.getByTestId('perps-withdraw-submit');
     expect(submit).toBeDisabled();
     expect(screen.getByTestId('perps-withdraw-error')).toHaveTextContent(
-      'Enter a valid amount to withdraw.',
+      messages.perpsWithdrawEnterValidAmountError.message,
     );
+  });
+
+  it('clears hook error when modal reopens', () => {
+    const { rerender } = renderWithProvider(
+      <WithdrawFundsModal isOpen={false} onClose={onCloseMock} />,
+      mockStore,
+    );
+
+    resetErrorMock.mockClear();
+
+    rerender(<WithdrawFundsModal isOpen onClose={onCloseMock} />);
+
+    expect(resetErrorMock).toHaveBeenCalledTimes(1);
   });
 
   it('submits amount and closes modal on success', async () => {
@@ -198,7 +212,7 @@ describe('WithdrawFundsModal', () => {
       expect(onCloseMock).not.toHaveBeenCalled();
     });
     expect(screen.getByTestId('perps-withdraw-error')).toHaveTextContent(
-      'Withdrawal asset unavailable. Please try again.',
+      messages.perpsWithdrawAssetUnavailableError.message,
     );
   });
 });

--- a/ui/components/app/perps/withdraw-funds-modal/withdraw-funds-modal.test.tsx
+++ b/ui/components/app/perps/withdraw-funds-modal/withdraw-funds-modal.test.tsx
@@ -88,6 +88,22 @@ describe('WithdrawFundsModal', () => {
     );
   });
 
+  it('shows invalid amount message for non-positive amount', () => {
+    renderWithProvider(
+      <WithdrawFundsModal isOpen onClose={onCloseMock} />,
+      mockStore,
+    );
+
+    const input = screen.getByPlaceholderText('0.00') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '0' } });
+
+    const submit = screen.getByTestId('perps-withdraw-submit');
+    expect(submit).toBeDisabled();
+    expect(screen.getByTestId('perps-withdraw-error')).toHaveTextContent(
+      'Enter a valid amount to withdraw.',
+    );
+  });
+
   it('submits amount and closes modal on success', async () => {
     triggerMock.mockResolvedValue({ success: true });
 

--- a/ui/components/app/perps/withdraw-funds-modal/withdraw-funds-modal.tsx
+++ b/ui/components/app/perps/withdraw-funds-modal/withdraw-funds-modal.tsx
@@ -44,6 +44,31 @@ function isAllowedAmountInput(value: string): boolean {
   return /^\d*\.?\d{0,6}$/u.test(value);
 }
 
+const WITHDRAW_ERROR_CODES = {
+  ASSET_ID_REQUIRED: 'WITHDRAW_ASSET_ID_REQUIRED',
+  AMOUNT_REQUIRED: 'WITHDRAW_AMOUNT_REQUIRED',
+  AMOUNT_POSITIVE: 'WITHDRAW_AMOUNT_POSITIVE',
+  INVALID_DESTINATION: 'WITHDRAW_INVALID_DESTINATION',
+} as const;
+
+function getReadableWithdrawError(error: string | null): string | null {
+  if (!error) {
+    return null;
+  }
+
+  switch (error) {
+    case WITHDRAW_ERROR_CODES.ASSET_ID_REQUIRED:
+      return 'Withdrawal asset unavailable. Please try again.';
+    case WITHDRAW_ERROR_CODES.AMOUNT_REQUIRED:
+    case WITHDRAW_ERROR_CODES.AMOUNT_POSITIVE:
+      return 'Enter a valid amount to withdraw.';
+    case WITHDRAW_ERROR_CODES.INVALID_DESTINATION:
+      return 'Invalid withdrawal destination.';
+    default:
+      return error;
+  }
+}
+
 export const WithdrawFundsModal: React.FC<WithdrawFundsModalProps> = ({
   isOpen,
   onClose,
@@ -119,7 +144,7 @@ export const WithdrawFundsModal: React.FC<WithdrawFundsModalProps> = ({
   }, [amount, validationError, trigger, onClose]);
 
   const submitDisabled = isLoading || !amount || Boolean(validationError);
-  const displayError = validationError ?? error;
+  const displayError = validationError ?? getReadableWithdrawError(error);
 
   return (
     <Modal

--- a/ui/components/app/perps/withdraw-funds-modal/withdraw-funds-modal.tsx
+++ b/ui/components/app/perps/withdraw-funds-modal/withdraw-funds-modal.tsx
@@ -1,0 +1,230 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Box,
+  BoxFlexDirection,
+  BoxAlignItems,
+  BoxJustifyContent,
+  Text,
+  TextVariant,
+  TextColor,
+  FontWeight,
+} from '@metamask/design-system-react';
+
+import {
+  Modal,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+  ModalContentSize,
+  ModalBody,
+  ModalFooter,
+  TextField,
+  TextFieldSize,
+} from '../../../component-library';
+import { useFormatters } from '../../../../hooks/useFormatters';
+import { useI18nContext } from '../../../../hooks/useI18nContext';
+import { usePerpsLiveAccount } from '../../../../hooks/perps/stream';
+import { usePerpsWithdraw } from '../hooks/usePerpsWithdraw';
+
+const WITHDRAW_PRESETS = [25, 50, 100] as const;
+
+type WithdrawFundsModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+function formatPresetAmount(value: number): string {
+  if (value < 0.01 && value > 0) {
+    return value.toFixed(6);
+  }
+  return value.toFixed(2);
+}
+
+function isAllowedAmountInput(value: string): boolean {
+  return /^\d*\.?\d{0,6}$/u.test(value);
+}
+
+export const WithdrawFundsModal: React.FC<WithdrawFundsModalProps> = ({
+  isOpen,
+  onClose,
+}) => {
+  const t = useI18nContext();
+  const { formatCurrencyWithMinThreshold } = useFormatters();
+  const { account } = usePerpsLiveAccount();
+  const { trigger, isLoading, error, resetError } = usePerpsWithdraw();
+
+  const [amount, setAmount] = useState('');
+
+  const availableBalance = useMemo(
+    () => parseFloat(account?.availableBalance ?? '0') || 0,
+    [account?.availableBalance],
+  );
+
+  const amountNum = useMemo(() => parseFloat(amount) || 0, [amount]);
+  const hasAmount = amount.length > 0;
+  const isInsufficient = hasAmount && amountNum > availableBalance;
+  const isInvalidAmount = hasAmount && amountNum <= 0;
+
+  const validationError = useMemo(() => {
+    if (isInvalidAmount) {
+      return t('insufficientBalance');
+    }
+    if (isInsufficient) {
+      return t('insufficientFunds');
+    }
+    return null;
+  }, [isInvalidAmount, isInsufficient, t]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setAmount('');
+      resetError();
+    }
+  }, [isOpen, resetError]);
+
+  const handleAmountChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const next = event.target.value.replace(/,/gu, '');
+      if (!isAllowedAmountInput(next)) {
+        return;
+      }
+      setAmount(next);
+      if (error) {
+        resetError();
+      }
+    },
+    [error, resetError],
+  );
+
+  const handlePreset = useCallback(
+    (preset: number) => {
+      const next = formatPresetAmount((availableBalance * preset) / 100);
+      setAmount(next);
+      if (error) {
+        resetError();
+      }
+    },
+    [availableBalance, error, resetError],
+  );
+
+  const handleSubmit = useCallback(async () => {
+    if (!amount || validationError) {
+      return;
+    }
+
+    const result = await trigger({ amount });
+    if (result.success) {
+      onClose();
+    }
+  }, [amount, validationError, trigger, onClose]);
+
+  const submitDisabled = isLoading || !amount || Boolean(validationError);
+  const displayError = validationError ?? error;
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      data-testid="perps-withdraw-funds-modal"
+    >
+      <ModalOverlay />
+      <ModalContent size={ModalContentSize.Sm}>
+        <ModalHeader onClose={onClose}>{t('perpsWithdraw')}</ModalHeader>
+        <ModalBody>
+          <Box flexDirection={BoxFlexDirection.Column} gap={4}>
+            <Box
+              flexDirection={BoxFlexDirection.Row}
+              justifyContent={BoxJustifyContent.Between}
+              alignItems={BoxAlignItems.Center}
+            >
+              <Text
+                variant={TextVariant.BodySm}
+                color={TextColor.TextAlternative}
+                fontWeight={FontWeight.Medium}
+              >
+                {t('perpsAvailableBalance')}
+              </Text>
+              <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
+                {formatCurrencyWithMinThreshold(availableBalance, 'USD')}
+              </Text>
+            </Box>
+
+            <Box flexDirection={BoxFlexDirection.Column} gap={2}>
+              <Text
+                variant={TextVariant.BodySm}
+                color={TextColor.TextAlternative}
+                fontWeight={FontWeight.Medium}
+              >
+                {t('amount')}
+              </Text>
+              <TextField
+                size={TextFieldSize.Md}
+                value={amount}
+                onChange={handleAmountChange}
+                placeholder="0.00"
+                className="w-full"
+                disabled={isLoading}
+                data-testid="perps-withdraw-amount-input"
+                startAccessory={
+                  <Text
+                    variant={TextVariant.BodyMd}
+                    color={TextColor.TextAlternative}
+                  >
+                    $
+                  </Text>
+                }
+              />
+            </Box>
+
+            <Box flexDirection={BoxFlexDirection.Row} gap={2}>
+              {WITHDRAW_PRESETS.map((preset) => (
+                <Box
+                  key={`withdraw-preset-${preset}`}
+                  onClick={
+                    isLoading ? undefined : () => handlePreset(Number(preset))
+                  }
+                  className={`flex-1 py-1.5 rounded-lg bg-background-default cursor-pointer text-center hover:bg-muted-hover active:bg-muted-pressed border border-muted transition-colors duration-150${
+                    isLoading ? ' opacity-50 pointer-events-none' : ''
+                  }`}
+                  data-testid={`perps-withdraw-preset-${preset}`}
+                >
+                  <Text
+                    variant={TextVariant.BodySm}
+                    color={TextColor.TextAlternative}
+                  >
+                    {preset === 100 ? t('perpsMax') : `${preset}%`}
+                  </Text>
+                </Box>
+              ))}
+            </Box>
+
+            <Text
+              variant={TextVariant.BodySm}
+              color={TextColor.ErrorDefault}
+              data-testid="perps-withdraw-error"
+              style={{ minHeight: 20 }}
+            >
+              {displayError ?? ''}
+            </Text>
+          </Box>
+        </ModalBody>
+        <ModalFooter
+          onCancel={onClose}
+          onSubmit={handleSubmit}
+          cancelButtonProps={{
+            children: t('cancel'),
+            disabled: isLoading,
+            'data-testid': 'perps-withdraw-cancel',
+          }}
+          submitButtonProps={{
+            children: isLoading ? t('perpsSubmitting') : t('perpsWithdraw'),
+            disabled: submitDisabled,
+            'data-testid': 'perps-withdraw-submit',
+          }}
+        />
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default WithdrawFundsModal;

--- a/ui/components/app/perps/withdraw-funds-modal/withdraw-funds-modal.tsx
+++ b/ui/components/app/perps/withdraw-funds-modal/withdraw-funds-modal.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import classnames from 'clsx';
 import {
   Box,
   BoxFlexDirection,
@@ -51,19 +52,22 @@ const WITHDRAW_ERROR_CODES = {
   INVALID_DESTINATION: 'WITHDRAW_INVALID_DESTINATION',
 } as const;
 
-function getReadableWithdrawError(error: string | null): string | null {
+function getReadableWithdrawError(
+  error: string | null,
+  t: ReturnType<typeof useI18nContext>,
+): string | null {
   if (!error) {
     return null;
   }
 
   switch (error) {
     case WITHDRAW_ERROR_CODES.ASSET_ID_REQUIRED:
-      return 'Withdrawal asset unavailable. Please try again.';
+      return t('perpsWithdrawAssetUnavailableError');
     case WITHDRAW_ERROR_CODES.AMOUNT_REQUIRED:
     case WITHDRAW_ERROR_CODES.AMOUNT_POSITIVE:
-      return 'Enter a valid amount to withdraw.';
+      return t('perpsWithdrawEnterValidAmountError');
     case WITHDRAW_ERROR_CODES.INVALID_DESTINATION:
-      return 'Invalid withdrawal destination.';
+      return t('perpsWithdrawInvalidDestinationError');
     default:
       return error;
   }
@@ -80,12 +84,8 @@ export const WithdrawFundsModal: React.FC<WithdrawFundsModalProps> = ({
 
   const [amount, setAmount] = useState('');
 
-  const availableBalance = useMemo(
-    () => parseFloat(account?.availableBalance ?? '0') || 0,
-    [account?.availableBalance],
-  );
-
-  const amountNum = useMemo(() => parseFloat(amount) || 0, [amount]);
+  const availableBalance = parseFloat(account?.availableBalance ?? '0') || 0;
+  const amountNum = parseFloat(amount) || 0;
   const hasAmount = amount.length > 0;
   const isInsufficient = hasAmount && amountNum > availableBalance;
   const isInvalidAmount = hasAmount && amountNum <= 0;
@@ -144,7 +144,7 @@ export const WithdrawFundsModal: React.FC<WithdrawFundsModalProps> = ({
   }, [amount, validationError, trigger, onClose]);
 
   const submitDisabled = isLoading || !amount || Boolean(validationError);
-  const displayError = validationError ?? getReadableWithdrawError(error);
+  const displayError = validationError ?? getReadableWithdrawError(error, t);
 
   return (
     <Modal
@@ -205,12 +205,13 @@ export const WithdrawFundsModal: React.FC<WithdrawFundsModalProps> = ({
               {WITHDRAW_PRESETS.map((preset) => (
                 <Box
                   key={`withdraw-preset-${preset}`}
-                  onClick={
-                    isLoading ? undefined : () => handlePreset(Number(preset))
-                  }
-                  className={`flex-1 py-1.5 rounded-lg bg-background-default cursor-pointer text-center hover:bg-muted-hover active:bg-muted-pressed border border-muted transition-colors duration-150${
-                    isLoading ? ' opacity-50 pointer-events-none' : ''
-                  }`}
+                  onClick={isLoading ? undefined : () => handlePreset(preset)}
+                  className={classnames(
+                    'flex-1 py-1.5 rounded-lg bg-background-default cursor-pointer text-center hover:bg-muted-hover active:bg-muted-pressed border border-muted transition-colors duration-150',
+                    {
+                      'opacity-50 pointer-events-none': isLoading,
+                    },
+                  )}
                   data-testid={`perps-withdraw-preset-${preset}`}
                 >
                   <Text
@@ -251,5 +252,3 @@ export const WithdrawFundsModal: React.FC<WithdrawFundsModalProps> = ({
     </Modal>
   );
 };
-
-export default WithdrawFundsModal;

--- a/ui/components/app/perps/withdraw-funds-modal/withdraw-funds-modal.tsx
+++ b/ui/components/app/perps/withdraw-funds-modal/withdraw-funds-modal.tsx
@@ -108,8 +108,8 @@ export const WithdrawFundsModal: React.FC<WithdrawFundsModalProps> = ({
   useEffect(() => {
     if (!isOpen) {
       setAmount('');
-      resetError();
     }
+    resetError();
   }, [isOpen, resetError]);
 
   const handleAmountChange = useCallback(

--- a/ui/components/app/perps/withdraw-funds-modal/withdraw-funds-modal.tsx
+++ b/ui/components/app/perps/withdraw-funds-modal/withdraw-funds-modal.tsx
@@ -25,9 +25,11 @@ import {
 import { useFormatters } from '../../../../hooks/useFormatters';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { usePerpsLiveAccount } from '../../../../hooks/perps/stream';
+import { isValidPerpsWithdrawAmount } from '../constants';
 import { usePerpsWithdraw } from '../hooks/usePerpsWithdraw';
 
 const WITHDRAW_PRESETS = [25, 50, 100] as const;
+const MAX_WITHDRAW_DECIMALS = 6;
 
 type WithdrawFundsModalProps = {
   isOpen: boolean;
@@ -41,8 +43,10 @@ function formatPresetAmount(value: number): string {
   return value.toFixed(2);
 }
 
-function isAllowedAmountInput(value: string): boolean {
-  return /^\d*\.?\d{0,6}$/u.test(value);
+function formatMaxPresetAmount(value: number): string {
+  const factor = 10 ** MAX_WITHDRAW_DECIMALS;
+  const floored = Math.floor(value * factor) / factor;
+  return floored.toFixed(MAX_WITHDRAW_DECIMALS).replace(/\.?0+$/u, '');
 }
 
 const WITHDRAW_ERROR_CODES = {
@@ -111,7 +115,7 @@ export const WithdrawFundsModal: React.FC<WithdrawFundsModalProps> = ({
   const handleAmountChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       const next = event.target.value.replace(/,/gu, '');
-      if (!isAllowedAmountInput(next)) {
+      if (!isValidPerpsWithdrawAmount(next)) {
         return;
       }
       setAmount(next);
@@ -124,7 +128,11 @@ export const WithdrawFundsModal: React.FC<WithdrawFundsModalProps> = ({
 
   const handlePreset = useCallback(
     (preset: number) => {
-      const next = formatPresetAmount((availableBalance * preset) / 100);
+      const rawPresetAmount = (availableBalance * preset) / 100;
+      const next =
+        preset === 100
+          ? formatMaxPresetAmount(rawPresetAmount)
+          : formatPresetAmount(rawPresetAmount);
       setAmount(next);
       if (error) {
         resetError();

--- a/ui/components/app/perps/withdraw-funds-modal/withdraw-funds-modal.tsx
+++ b/ui/components/app/perps/withdraw-funds-modal/withdraw-funds-modal.tsx
@@ -88,11 +88,12 @@ export const WithdrawFundsModal: React.FC<WithdrawFundsModalProps> = ({
   const amountNum = parseFloat(amount) || 0;
   const hasAmount = amount.length > 0;
   const isInsufficient = hasAmount && amountNum > availableBalance;
-  const isInvalidAmount = hasAmount && amountNum <= 0;
+  const isInvalidAmount =
+    hasAmount && (!Number.isFinite(amountNum) || amountNum <= 0);
 
   const validationError = useMemo(() => {
     if (isInvalidAmount) {
-      return t('insufficientBalance');
+      return t('perpsWithdrawEnterValidAmountError');
     }
     if (isInsufficient) {
       return t('insufficientFunds');


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--

-->

  1. Reason for the change
    - main still had a placeholder/TODO for withdraw navigation in the Perps balance actions.

  2. Improvement / solution
    - Adds the withdraw UX in Perps:
    - wires the balance dropdown Withdraw action to open a withdraw modal
    - introduces withdraw transaction hooks (usePerpsWithdraw, createPerpsWithdrawTransaction)
    - includes assetId support in withdrawal transaction creation
    - Updates/keeps relevant unit tests passing for the new flow.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/41220?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2390

## **Manual testing steps**
 Feature: Perps Withdraw Funds flow
     Background:
       Given I am logged into MetaMask
       And I have an active Perps account
       And I am on the Perps tab

    Scenario: Open Withdraw modal from Perps balance dropdown
      Given the Perps balance dropdown is visible
      When I click the Perps balance dropdown
      And I click "Withdraw"
      Then the Withdraw Funds modal is displayed

    Scenario: Close Withdraw modal without submitting
      Given the Withdraw Funds modal is open
      When I click the modal close button
      Then the Withdraw Funds modal is closed
      And no withdraw transaction is created

    Scenario: Create a withdraw transaction successfully
      Given the Withdraw Funds modal is open
      And I enter a valid withdraw amount
      When I confirm the withdrawal
      Then a Perps withdraw transaction is created
      And the transaction payload includes the correct assetId
      And I see the withdraw confirmation/progress state

    Scenario: Prevent invalid withdraw submission
      Given the Withdraw Funds modal is open
      When I enter an invalid withdraw amount
      And I attempt to confirm
      Then the withdrawal is not submitted
      And I see validation feedback

    Scenario: Deposit action still works from balance dropdown
      Given the Perps balance dropdown is visible
      When I click the Perps balance dropdown
      And I click "Add funds"
      Then the deposit flow opens as before

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Perps withdrawal UI flow and wires it to a background `perpsWithdraw` request, including asset-id selection and input validation; regressions could affect funds movement UX or block withdrawals if validation/asset IDs are wrong.
> 
> **Overview**
> Adds an end-to-end Perps **Withdraw Funds** flow: clicking *Withdraw* from the Perps balance dropdown now opens a new `WithdrawFundsModal` and closes on successful submission.
> 
> Introduces withdrawal plumbing via `usePerpsWithdraw` and `createPerpsWithdrawTransaction`, including USDC CAIP `assetId` selection for mainnet vs testnet and client-side amount validation/duplicate-request prevention.
> 
> Updates i18n strings and adds comprehensive unit tests covering modal presets/validation, error-code-to-message mapping, and the new withdraw trigger wiring in `PerpsView`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b55c0b3ba13d1e6588a0287722549096cefd3ab1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->