### PR TITLE
feat: improve EIP-712 typed data normalization

### DIFF
--- a/app/scripts/lib/ppom/ppom-util.ts
+++ b/app/scripts/lib/ppom/ppom-util.ts
@@ -181,11 +181,50 @@ export function handlePPOMError(
   };
 }
 
+/**
+ * Ensures only standard EIP-712 top-level keys are retained when params[1]
+ * is received as a parsed object rather than a JSON string.
+ */
+function sanitizeTypedDataParams(request: PPOMRequest): PPOMRequest {
+  if (
+    request.method !== MESSAGE_TYPE.ETH_SIGN_TYPED_DATA_V3 &&
+    request.method !== MESSAGE_TYPE.ETH_SIGN_TYPED_DATA_V4
+  ) {
+    return request;
+  }
+
+  if (!Array.isArray(request.params) || !request.params[1]) {
+    return request;
+  }
+
+  const rawParam = request.params[1];
+
+  if (typeof rawParam !== 'object') {
+    return request;
+  }
+
+  const typedData = rawParam as Record<string, unknown>;
+
+  return {
+    ...request,
+    params: [
+      request.params[0],
+      {
+        primaryType: typedData.primaryType,
+        domain: typedData.domain,
+        types: typedData.types,
+        message: typedData.message,
+      },
+    ],
+  };
+}
+
 function normalizePPOMRequest(
   request: PPOMRequest,
   controllerObject: TransactionMeta | SignatureRequest,
 ): PPOMRequest {
-  let normalizedRequest = cloneDeep(request);
+  const sanitizedRequest = sanitizeTypedDataParams(request);
+  let normalizedRequest = cloneDeep(sanitizedRequest);
 
   normalizedRequest = normalizeSignatureRequest(
     normalizedRequest,
@@ -290,7 +329,9 @@ export function normalizeSignatureRequest(
     params: [
       request.params[0],
       JSON.stringify({
-        ...typedDataMessage,
+        primaryType: typedDataMessage.primaryType,
+        domain: typedDataMessage.domain,
+        types: typedDataMessage.types,
         message: sanitizedMessageRecursively,
       }),
     ],


### PR DESCRIPTION
Improves EIP-712 typed data normalization in the PPOM validation pipeline.

When `params[1]` is received as a parsed object rather than a JSON string, the normalization now explicitly selects only the four standard EIP-712 top-level keys (`primaryType`, `domain`, `types`, `message`) before processing. This ensures consistent handling regardless of how typed data is delivered by dapps.

Also updates `normalizeSignatureRequest` to use explicit key selection instead of object spread for the normalized output.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the PPOM security-validation path for EIP-712 signing requests; incorrect sanitization or serialization could change what gets validated and potentially break some dapp signature flows.
> 
> **Overview**
> Improves PPOM request normalization for `eth_signTypedData_v3/v4` by sanitizing `params[1]` when it arrives as an object, keeping only the standard EIP-712 top-level keys (`primaryType`, `domain`, `types`, `message`) before further processing.
> 
> Updates typed-data signature normalization to explicitly serialize only those keys (instead of spreading the parsed object) while still applying recursive message sanitization, making validation input consistent regardless of how dapps supply typed data.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c50c741ea326b21be16ed268f678094cde77368. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->