### PR TITLE
feat: add claim cta clicked event to extension

### DIFF
--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -820,6 +820,7 @@ export enum MetaMetricsEventName {
   MetricsOptOut = 'Metrics Opt Out',
   MetricsDataDeletionRequest = 'Delete MetaMetrics Data Request Submitted',
   MusdClaimBonusButtonClicked = 'MUSD Claim Bonus Button Clicked',
+  MusdClaimBonusCtaDisplayed = 'mUSD Claim Bonus CTA Displayed',
   MusdClaimBonusStatusUpdated = 'MUSD Claim Bonus Status Updated',
   MusdConversionCompleted = 'MUSD Conversion Completed',
   MusdConversionCtaClicked = 'MUSD Conversion CTA Clicked',

--- a/ui/components/app/assets/token-cell/token-cell.test.tsx
+++ b/ui/components/app/assets/token-cell/token-cell.test.tsx
@@ -69,6 +69,8 @@ jest.mock('react-router-dom', () => {
 const mockUseMerklRewards = jest.fn().mockReturnValue({
   isEligible: false,
   hasClaimableReward: false,
+  hasClaimedBefore: false,
+  claimableRewardDisplay: null,
   refetch: jest.fn(),
 });
 jest.mock('../../musd', () => ({
@@ -316,6 +318,8 @@ describe('Token Cell', () => {
       mockUseMerklRewards.mockReturnValue({
         isEligible: false,
         hasClaimableReward: false,
+        hasClaimedBefore: false,
+        claimableRewardDisplay: null,
         refetch: jest.fn(),
       });
     });
@@ -324,6 +328,8 @@ describe('Token Cell', () => {
       mockUseMerklRewards.mockReturnValue({
         isEligible: true,
         hasClaimableReward: true,
+        hasClaimedBefore: false,
+        claimableRewardDisplay: '10.50',
         refetch: jest.fn(),
       });
 
@@ -339,6 +345,8 @@ describe('Token Cell', () => {
       mockUseMerklRewards.mockReturnValue({
         isEligible: false,
         hasClaimableReward: true,
+        hasClaimedBefore: false,
+        claimableRewardDisplay: null,
         refetch: jest.fn(),
       });
 
@@ -354,6 +362,8 @@ describe('Token Cell', () => {
       mockUseMerklRewards.mockReturnValue({
         isEligible: true,
         hasClaimableReward: false,
+        hasClaimedBefore: false,
+        claimableRewardDisplay: null,
         refetch: jest.fn(),
       });
 

--- a/ui/components/app/assets/token-cell/token-cell.tsx
+++ b/ui/components/app/assets/token-cell/token-cell.tsx
@@ -2,6 +2,9 @@ import React, { useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import type { Hex } from '@metamask/utils';
+import type { MusdMerklClaimCtaLocation } from '../../musd/musd-events';
+import { MUSD_EVENTS_CONSTANTS } from '../../musd/musd-events';
+import { getBonusAmountRange } from '../../musd/merkl-bonus-analytics';
 import { useTokenDisplayInfo } from '../hooks';
 import {
   ButtonSecondary,
@@ -42,6 +45,8 @@ export type TokenCellProps = {
   showMerklBadge?: boolean;
   /** When true, shows the mUSD convert CTA in the footer (e.g. on the home token list). */
   showMusdConvertCta?: boolean;
+  /** Analytics: where the Merkl claim CTA is shown (default home/list). */
+  merklClaimCtaLocation?: MusdMerklClaimCtaLocation;
 };
 
 // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
@@ -54,6 +59,7 @@ export default function TokenCell({
   safeChains,
   showMerklBadge = false,
   showMusdConvertCta = false,
+  merklClaimCtaLocation = MUSD_EVENTS_CONSTANTS.EVENT_LOCATIONS.TOKEN_LIST_ITEM,
 }: TokenCellProps) {
   const dispatch = useDispatch();
   const navigate = useNavigate();
@@ -69,6 +75,8 @@ export default function TokenCell({
   const {
     hasClaimableReward,
     isEligible,
+    hasClaimedBefore,
+    claimableRewardDisplay,
     refetch: refetchMerklRewards,
   } = useMerklRewards({
     tokenAddress: token.address,
@@ -113,6 +121,11 @@ export default function TokenCell({
     [token, tokenDisplayInfo],
   );
 
+  const merklBonusAmountRange = useMemo(
+    () => getBonusAmountRange(claimableRewardDisplay ?? '< 0.01'),
+    [claimableRewardDisplay],
+  );
+
   const handleScamWarningModal = (arg: boolean) => {
     setShowScamWarningModal(arg);
   };
@@ -135,6 +148,10 @@ export default function TokenCell({
           chainId={token.chainId as Hex}
           label={t('merklRewardsClaimBonus')}
           refetchRewards={refetchMerklRewards}
+          location={merklClaimCtaLocation}
+          assetSymbol={token.symbol}
+          bonusAmountRange={merklBonusAmountRange}
+          hasClaimedBefore={hasClaimedBefore}
         />
       );
     }

--- a/ui/components/app/musd/claim-bonus-badge.test.tsx
+++ b/ui/components/app/musd/claim-bonus-badge.test.tsx
@@ -3,6 +3,10 @@
  */
 import React from 'react';
 import { render, fireEvent, screen } from '@testing-library/react';
+import {
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
+} from '../../../../shared/constants/metametrics';
 import { ClaimBonusBadge } from './claim-bonus-badge';
 
 const mockClaimRewards = jest.fn();
@@ -61,12 +65,20 @@ jest.mock('../../../contexts/metametrics', () => {
     __mockTrackEvent: _trackEvent,
   };
 });
+const { __mockTrackEvent: mockTrackEvent } = jest.requireMock<{
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  __mockTrackEvent: jest.Mock;
+}>('../../../contexts/metametrics');
 
 const defaultProps = {
   label: 'Claim 5% bonus',
   tokenAddress: '0xabc123',
   chainId: '0x1' as const,
   refetchRewards: jest.fn(),
+  location: 'token_list_item' as const,
+  assetSymbol: 'MUSD',
+  bonusAmountRange: '10.00 - 99.99',
+  hasClaimedBefore: false,
 };
 
 describe('ClaimBonusBadge', () => {
@@ -85,6 +97,52 @@ describe('ClaimBonusBadge', () => {
     expect(screen.getByTestId('claim-bonus-badge')).toHaveTextContent(
       'Claim 5% bonus',
     );
+  });
+
+  it('fires MusdClaimBonusCtaDisplayed once when the claim button is shown', () => {
+    render(<ClaimBonusBadge {...defaultProps} />);
+
+    expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+    /* eslint-disable @typescript-eslint/naming-convention */
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      event: MetaMetricsEventName.MusdClaimBonusCtaDisplayed,
+      category: MetaMetricsEventCategory.MusdConversion,
+      properties: {
+        location: 'token_list_item',
+        view_trigger: 'component_mounted',
+        button_text: 'Claim 5% bonus',
+        network_chain_id: '0x1',
+        network_name: 'Ethereum Mainnet',
+        asset_symbol: 'MUSD',
+        bonus_amount_range: '10.00 - 99.99',
+        has_claimed_before: false,
+      },
+    });
+    /* eslint-enable @typescript-eslint/naming-convention */
+  });
+
+  it('does not fire MusdClaimBonusCtaDisplayed when showing spinner', () => {
+    mockUseMerklClaim.mockReturnValue({
+      claimRewards: mockClaimRewards,
+      isClaiming: true,
+      error: null,
+    });
+
+    render(<ClaimBonusBadge {...defaultProps} />);
+
+    expect(mockTrackEvent).not.toHaveBeenCalled();
+  });
+
+  it('does not fire MusdClaimBonusCtaDisplayed when showing error', () => {
+    mockUseMerklClaim.mockReturnValue({
+      claimRewards: mockClaimRewards,
+      isClaiming: false,
+      error: 'Something went wrong',
+    });
+
+    render(<ClaimBonusBadge {...defaultProps} />);
+
+    expect(mockTrackEvent).not.toHaveBeenCalled();
   });
 
   it('calls claimRewards and stopPropagation on click', () => {

--- a/ui/components/app/musd/claim-bonus-badge.tsx
+++ b/ui/components/app/musd/claim-bonus-badge.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext } from 'react';
+import React, { useCallback, useContext, useEffect, useRef } from 'react';
 import type { Hex } from '@metamask/utils';
 import { useSelector } from 'react-redux';
 import {
@@ -23,6 +23,8 @@ import { useOnMerklClaimConfirmed } from './hooks/useOnMerklClaimConfirmed';
 import {
   MUSD_EVENTS_CONSTANTS,
   type MusdClaimBonusButtonClickedEventProperties,
+  type MusdClaimBonusCtaDisplayedEventProperties,
+  type MusdMerklClaimCtaLocation,
 } from './musd-events';
 
 export const ClaimBonusBadge = ({
@@ -30,14 +32,23 @@ export const ClaimBonusBadge = ({
   tokenAddress,
   chainId,
   refetchRewards,
+  location,
+  assetSymbol,
+  bonusAmountRange,
+  hasClaimedBefore,
 }: {
   label: string;
   tokenAddress: string;
   chainId: Hex;
   refetchRewards: () => void;
+  location: MusdMerklClaimCtaLocation;
+  assetSymbol: string;
+  bonusAmountRange: string;
+  hasClaimedBefore: boolean;
 }) => {
   const t = useI18nContext();
   const { trackEvent } = useContext(MetaMetricsContext);
+  const hasFiredCtaDisplayedEvent = useRef(false);
 
   // Get network name for analytics
   const networkConfigurationsByChainId = useSelector(
@@ -53,6 +64,49 @@ export const ClaimBonusBadge = ({
     tokenAddress,
     chainId,
   });
+
+  useEffect(() => {
+    if (
+      hasFiredCtaDisplayedEvent.current ||
+      isClaiming ||
+      error ||
+      !bonusAmountRange
+    ) {
+      return;
+    }
+    hasFiredCtaDisplayedEvent.current = true;
+
+    /* eslint-disable @typescript-eslint/naming-convention */
+    const impressionProperties: MusdClaimBonusCtaDisplayedEventProperties = {
+      location,
+      view_trigger: 'component_mounted',
+      button_text: label,
+      network_chain_id: chainId,
+      network_name: networkName,
+      asset_symbol: assetSymbol,
+      bonus_amount_range: bonusAmountRange,
+      has_claimed_before: hasClaimedBefore,
+    };
+    /* eslint-enable @typescript-eslint/naming-convention */
+
+    trackEvent({
+      event: MetaMetricsEventName.MusdClaimBonusCtaDisplayed,
+      category: MetaMetricsEventCategory.MusdConversion,
+      properties: impressionProperties,
+    });
+  }, [
+    assetSymbol,
+    bonusAmountRange,
+    chainId,
+    error,
+    hasClaimedBefore,
+    isClaiming,
+    label,
+    location,
+    networkName,
+    trackEvent,
+  ]);
+
   // Trigger the claim transaction directly, routing to the confirmation page.
   const handleBadgeClick = useCallback(
     (e: React.MouseEvent) => {

--- a/ui/components/app/musd/hooks/useMerklRewards.test.ts
+++ b/ui/components/app/musd/hooks/useMerklRewards.test.ts
@@ -157,6 +157,8 @@ describe('useMerklRewards', () => {
     expect(result.current.isEligible).toBe(false);
     expect(result.current.hasClaimableReward).toBe(false);
     expect(result.current.rewardAmountFiat).toBeNull();
+    expect(result.current.hasClaimedBefore).toBe(false);
+    expect(result.current.claimableRewardDisplay).toBeNull();
     expect(mockFetchMerklRewardsForAsset).not.toHaveBeenCalled();
   });
 
@@ -224,6 +226,8 @@ describe('useMerklRewards', () => {
 
     expect(result.current.hasClaimableReward).toBe(true);
     expect(result.current.rewardAmountFiat).toBe(10.5);
+    expect(result.current.hasClaimedBefore).toBe(false);
+    expect(result.current.claimableRewardDisplay).toBe('10.50');
   });
 
   it('uses on-chain claimed amount when available', async () => {
@@ -261,6 +265,8 @@ describe('useMerklRewards', () => {
     // 10.5 - 5.5 = 5.0 MUSD claimable
     expect(result.current.hasClaimableReward).toBe(true);
     expect(result.current.rewardAmountFiat).toBe(5.0);
+    expect(result.current.hasClaimedBefore).toBe(true);
+    expect(result.current.claimableRewardDisplay).toBe('5.00');
     expect(mockGetClaimedAmountFromContract).toHaveBeenCalledWith(
       MOCK_ADDRESS,
       MUSD_TOKEN_ADDRESS,
@@ -301,6 +307,8 @@ describe('useMerklRewards', () => {
 
     expect(result.current.hasClaimableReward).toBe(false);
     expect(result.current.rewardAmountFiat).toBeNull();
+    expect(result.current.hasClaimedBefore).toBe(true);
+    expect(result.current.claimableRewardDisplay).toBeNull();
   });
 
   it('returns false when API returns no matching reward', async () => {
@@ -324,6 +332,8 @@ describe('useMerklRewards', () => {
     expect(mockFetchMerklRewardsForAsset).toHaveBeenCalled();
     expect(result.current.hasClaimableReward).toBe(false);
     expect(result.current.rewardAmountFiat).toBeNull();
+    expect(result.current.hasClaimedBefore).toBe(false);
+    expect(result.current.claimableRewardDisplay).toBeNull();
   });
 
   it('returns false when all rewards are claimed (API)', async () => {
@@ -357,6 +367,8 @@ describe('useMerklRewards', () => {
     });
 
     expect(result.current.hasClaimableReward).toBe(false);
+    expect(result.current.hasClaimedBefore).toBe(true);
+    expect(result.current.claimableRewardDisplay).toBeNull();
   });
 
   it('handles API errors gracefully', async () => {
@@ -380,6 +392,8 @@ describe('useMerklRewards', () => {
     });
 
     expect(result.current.hasClaimableReward).toBe(false);
+    expect(result.current.hasClaimedBefore).toBe(false);
+    expect(result.current.claimableRewardDisplay).toBeNull();
   });
 
   it('aborts fetch on unmount', () => {
@@ -433,6 +447,8 @@ describe('useMerklRewards', () => {
     });
 
     expect(result.current.hasClaimableReward).toBe(false);
+    expect(result.current.hasClaimedBefore).toBe(false);
+    expect(result.current.claimableRewardDisplay).toBeNull();
   });
 
   it('returns true for exactly 1 cent unclaimed amount', async () => {
@@ -468,6 +484,8 @@ describe('useMerklRewards', () => {
 
     expect(result.current.hasClaimableReward).toBe(true);
     expect(result.current.rewardAmountFiat).toBe(0.01);
+    expect(result.current.hasClaimedBefore).toBe(false);
+    expect(result.current.claimableRewardDisplay).toBe('0.01');
   });
 
   it('returns false and skips API call when user is geoblocked', async () => {
@@ -492,6 +510,8 @@ describe('useMerklRewards', () => {
     });
 
     expect(result.current.hasClaimableReward).toBe(false);
+    expect(result.current.hasClaimedBefore).toBe(false);
+    expect(result.current.claimableRewardDisplay).toBeNull();
     expect(mockFetchMerklRewardsForAsset).not.toHaveBeenCalled();
   });
 
@@ -530,6 +550,8 @@ describe('useMerklRewards', () => {
     // Falls back to API value (claimed=0), so full amount is claimable
     expect(result.current.hasClaimableReward).toBe(true);
     expect(result.current.rewardAmountFiat).toBe(10.5);
+    expect(result.current.hasClaimedBefore).toBe(false);
+    expect(result.current.claimableRewardDisplay).toBe('10.50');
   });
 
   it('returns null rewardAmountFiat when token price is null', async () => {
@@ -565,6 +587,8 @@ describe('useMerklRewards', () => {
 
     expect(result.current.hasClaimableReward).toBe(true);
     expect(result.current.rewardAmountFiat).toBeNull();
+    expect(result.current.hasClaimedBefore).toBe(false);
+    expect(result.current.claimableRewardDisplay).toBe('10.50');
   });
 
   it('returns cached data on remount without refetching', async () => {
@@ -603,6 +627,7 @@ describe('useMerklRewards', () => {
     });
 
     expect(firstResult.current.hasClaimableReward).toBe(true);
+    expect(firstResult.current.claimableRewardDisplay).toBe('10.50');
     expect(mockFetchMerklRewardsForAsset).toHaveBeenCalledTimes(1);
 
     // Unmount (simulates switching to another tab)
@@ -616,6 +641,7 @@ describe('useMerklRewards', () => {
 
     // Should immediately have the cached value, no additional fetch
     expect(secondResult.current.hasClaimableReward).toBe(true);
+    expect(secondResult.current.claimableRewardDisplay).toBe('10.50');
     expect(mockFetchMerklRewardsForAsset).toHaveBeenCalledTimes(1);
   });
 
@@ -668,5 +694,7 @@ describe('useMerklRewards', () => {
 
     // Must be false despite the warm cache
     expect(secondResult.current.hasClaimableReward).toBe(false);
+    expect(secondResult.current.hasClaimedBefore).toBe(false);
+    expect(secondResult.current.claimableRewardDisplay).toBeNull();
   });
 });

--- a/ui/components/app/musd/hooks/useMerklRewards.ts
+++ b/ui/components/app/musd/hooks/useMerklRewards.ts
@@ -49,17 +49,24 @@ type UseMerklRewardsOptions = {
 type MerklRewardQueryResult = {
   hasClaimable: boolean;
   unclaimedFiat: number | null;
+  hasClaimedBefore: boolean;
+  /** Formatted unclaimed amount for analytics bucketing; null when not claimable */
+  claimableRewardDisplay: string | null;
 };
 
 const EMPTY_RESULT: MerklRewardQueryResult = {
   hasClaimable: false,
   unclaimedFiat: null,
+  hasClaimedBefore: false,
+  claimableRewardDisplay: null,
 };
 
 type UseMerklRewardsReturn = {
   isEligible: boolean;
   hasClaimableReward: boolean;
   rewardAmountFiat: number | null;
+  hasClaimedBefore: boolean;
+  claimableRewardDisplay: string | null;
   refetch: () => void;
 };
 
@@ -137,6 +144,19 @@ export const useMerklRewards = ({
       const oneCentInBaseUnits =
         10n ** BigInt(matchingReward.token.decimals - 2);
       const hasClaimable = unclaimedBaseUnits >= oneCentInBaseUnits;
+      const hasClaimedBefore = BigInt(claimedAmount) > 0n;
+
+      const tokenDecimals = matchingReward.token.decimals;
+      let claimableRewardDisplay: string | null = null;
+      if (hasClaimable) {
+        const unclaimedDecimal =
+          Number(unclaimedBaseUnits) / 10 ** tokenDecimals;
+        const displayAmount =
+          unclaimedDecimal < 0.01 ? '< 0.01' : unclaimedDecimal.toFixed(2);
+        if (displayAmount !== '0' && displayAmount !== '0.00') {
+          claimableRewardDisplay = displayAmount;
+        }
+      }
 
       let unclaimedFiat: number | null = null;
       if (hasClaimable && matchingReward.token.price !== null) {
@@ -145,7 +165,12 @@ export const useMerklRewards = ({
           (Number(unclaimedBaseUnits) / divisor) * matchingReward.token.price;
       }
 
-      return { hasClaimable, unclaimedFiat };
+      return {
+        hasClaimable,
+        unclaimedFiat,
+        hasClaimedBefore,
+        claimableRewardDisplay,
+      };
     },
     enabled: isEligible && Boolean(selectedAddress) && Boolean(tokenAddress),
     staleTime: MERKL_REWARDS_STALE_TIME,
@@ -167,6 +192,9 @@ export const useMerklRewards = ({
     isEligible,
     hasClaimableReward: hasClaimableRewardData?.hasClaimable ?? false,
     rewardAmountFiat: hasClaimableRewardData?.unclaimedFiat ?? null,
+    hasClaimedBefore: hasClaimableRewardData?.hasClaimedBefore ?? false,
+    claimableRewardDisplay:
+      hasClaimableRewardData?.claimableRewardDisplay ?? null,
     refetch,
   };
 };

--- a/ui/components/app/musd/merkl-bonus-analytics.test.ts
+++ b/ui/components/app/musd/merkl-bonus-analytics.test.ts
@@ -1,0 +1,28 @@
+import { getBonusAmountRange } from './merkl-bonus-analytics';
+
+describe('getBonusAmountRange', () => {
+  it('returns "< 0.01" for strings starting with <', () => {
+    expect(getBonusAmountRange('< 0.01')).toBe('< 0.01');
+    expect(getBonusAmountRange('<0.005')).toBe('< 0.01');
+  });
+
+  it('returns "< 0.01" for non-numeric input', () => {
+    expect(getBonusAmountRange('invalid')).toBe('< 0.01');
+  });
+
+  it('buckets fractional amounts below 1', () => {
+    expect(getBonusAmountRange('0.50')).toBe('0.01 - 0.99');
+    expect(getBonusAmountRange('0.01')).toBe('0.01 - 0.99');
+  });
+
+  it('buckets amounts in 1–10, 10–100, 100–1000, and 1000+', () => {
+    expect(getBonusAmountRange('1.00')).toBe('1.00 - 9.99');
+    expect(getBonusAmountRange('9.99')).toBe('1.00 - 9.99');
+    expect(getBonusAmountRange('10.00')).toBe('10.00 - 99.99');
+    expect(getBonusAmountRange('99.99')).toBe('10.00 - 99.99');
+    expect(getBonusAmountRange('100.00')).toBe('100.00 - 999.99');
+    expect(getBonusAmountRange('999.99')).toBe('100.00 - 999.99');
+    expect(getBonusAmountRange('1000.00')).toBe('1000.00+');
+    expect(getBonusAmountRange('5000')).toBe('1000.00+');
+  });
+});

--- a/ui/components/app/musd/merkl-bonus-analytics.ts
+++ b/ui/components/app/musd/merkl-bonus-analytics.ts
@@ -1,0 +1,29 @@
+/**
+ * Analytics helpers for Merkl claim bonus (bucketed reward ranges for Segment).
+ * Mirrors mobile `getBonusAmountRange` in useMerklBonusClaim.
+ *
+ * @param bonusAmount - Formatted claimable amount (e.g. "< 0.01", "1.23")
+ * @returns Bucket label for event properties
+ */
+export function getBonusAmountRange(bonusAmount: string): string {
+  if (bonusAmount.startsWith('<')) {
+    return '< 0.01';
+  }
+  const value = parseFloat(bonusAmount);
+  if (Number.isNaN(value)) {
+    return '< 0.01';
+  }
+  if (value < 1) {
+    return '0.01 - 0.99';
+  }
+  if (value < 10) {
+    return '1.00 - 9.99';
+  }
+  if (value < 100) {
+    return '10.00 - 99.99';
+  }
+  if (value < 1000) {
+    return '100.00 - 999.99';
+  }
+  return '1000.00+';
+}

--- a/ui/components/app/musd/musd-events.ts
+++ b/ui/components/app/musd/musd-events.ts
@@ -202,6 +202,31 @@ export type MusdClaimBonusButtonClickedEventProperties = {
   network_name: string;
 };
 
+/** Where the Merkl claim bonus CTA can appear (impression + click context) */
+export type MusdMerklClaimCtaLocation = 'token_list_item' | 'asset_overview';
+
+/**
+ * Properties for mUSD Claim Bonus CTA Displayed (Merkl claim CTA impression)
+ */
+export type MusdClaimBonusCtaDisplayedEventProperties = {
+  location: MusdMerklClaimCtaLocation;
+  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  view_trigger: 'component_mounted';
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  button_text: string;
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  network_chain_id: string;
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  network_name: string;
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  asset_symbol: string;
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  bonus_amount_range: string;
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  has_claimed_before: boolean;
+};
+
 /**
  * Properties for MUSD_CLAIM_BONUS_STATUS_UPDATED event
  * Tracks Merkl claim transaction status changes

--- a/ui/pages/asset/components/asset-page.tsx
+++ b/ui/pages/asset/components/asset-page.tsx
@@ -41,6 +41,7 @@ import { endTrace, TraceName } from '../../../../shared/lib/trace';
 import { hexToDecimal } from '../../../../shared/lib/conversion.utils';
 import { toChecksumHexAddress } from '../../../../shared/lib/hexstring-utils';
 import TokenCell from '../../../components/app/assets/token-cell';
+import { MUSD_EVENTS_CONSTANTS } from '../../../components/app/musd/musd-events';
 import { MarketClosedModal } from '../../../components/app/assets/market-closed-modal';
 import {
   TokenFiatDisplayInfo,
@@ -363,6 +364,9 @@ const AssetPage = ({
             token={tokenWithFiatAmount as TokenWithFiatAmount}
             safeChains={safeChains}
             showMerklBadge
+            merklClaimCtaLocation={
+              MUSD_EVENTS_CONSTANTS.EVENT_LOCATIONS.ASSET_OVERVIEW
+            }
           />
         )}
         {/* mUSD Conversion CTA - shows for eligible stablecoins */}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Add Segment-aligned impression event when the Merkl "Claim bonus" CTA is shown.

- Register MetaMetricsEventName.MusdClaimBonusCtaDisplayed ('mUSD Claim Bonus CTA Displayed')
- Add MusdClaimBonusCtaDisplayedEventProperties, MusdMerklClaimCtaLocation in musd-events
- Add getBonusAmountRange helper (mirrors mobile) with unit tests
- Extend useMerklRewards with hasClaimedBefore and claimableRewardDisplay for analytics
- Fire impression once per ClaimBonusBadge mount (when button visible, not spinner/error)
  with location, view_trigger, button_text, network metadata, bonus_amount_range,
  has_claimed_before
- Plumb merklClaimCtaLocation from TokenCell (default token_list_item), asset overview

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/41229?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: n/a

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-534

## **Manual testing steps**

- Test that segment event fires when claim bonus is shown, view the network tab and limit by segment. View the token list and the asset detail pages, which should fire separate events 1 time per mount of token cell component

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
n/a
### **After**

<!-- [screenshots/recordings] -->
n/a
## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes `useMerklRewards` return shape/logic and adds new MetaMetrics tracking fired on component mount, which could affect badge rendering and analytics volume if the gating conditions are wrong.
> 
> **Overview**
> Adds a new MetaMetrics event `MusdClaimBonusCtaDisplayed` and fires it once per `ClaimBonusBadge` mount when the claim button is actually visible (not spinner/error), including location/network metadata plus bucketed bonus amount range and whether the user has claimed before.
> 
> Plumbs new analytics inputs through the UI: `useMerklRewards` now returns `hasClaimedBefore` and a formatted `claimableRewardDisplay`, `TokenCell` computes a bucket via new `getBonusAmountRange` helper, and callers (e.g. asset overview) pass a `merklClaimCtaLocation` so impressions are distinguished between token list and asset detail. Tests were updated/added to cover the new helper, hook fields, and impression tracking behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5614695444fdc0646a31c2f8e1becf66899831f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->