### PR TITLE
fix: flaky tests `Check balance For a non 0 balance account - USD balance`

### DIFF
--- a/test/e2e/tests/tron/check-balance.spec.ts
+++ b/test/e2e/tests/tron/check-balance.spec.ts
@@ -5,6 +5,7 @@ import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { Driver } from '../../webdriver/driver';
 import { login } from '../../page-objects/flows/login.flow';
 import NonEvmHomepage from '../../page-objects/pages/home/non-evm-homepage';
+import HomePage from '../../page-objects/pages/home/homepage';
 import NetworkManager from '../../page-objects/pages/network-manager';
 import { mockTronApis } from './mocks/common-tron';
 
@@ -19,14 +20,16 @@ describe('Check balance', function (this: Suite) {
       },
       async ({ driver }: { driver: Driver }) => {
         await login(driver);
+        const homePage = new HomePage(driver);
+        await homePage.waitForNonEvmAccountsLoaded();
 
         const networkManager = new NetworkManager(driver);
         await networkManager.openNetworkManager();
         await networkManager.selectTab('Popular');
         await networkManager.selectNetworkByNameWithWait('Tron');
 
-        const homePage = new NonEvmHomepage(driver);
-        await homePage.checkPageIsLoaded({ amount: '0 TRX' });
+        const nonEvmHomePage = new NonEvmHomepage(driver);
+        await nonEvmHomePage.checkPageIsLoaded({ amount: '0 TRX' });
       },
     );
   });
@@ -42,15 +45,17 @@ describe('Check balance', function (this: Suite) {
       },
       async ({ driver }: { driver: Driver }) => {
         await login(driver, { validateBalance: false });
+        const homePage = new HomePage(driver);
+        await homePage.waitForNonEvmAccountsLoaded();
 
         const networkManager = new NetworkManager(driver);
         await networkManager.openNetworkManager();
         await networkManager.selectTab('Popular');
         await networkManager.selectNetworkByNameWithWait('Tron');
 
-        const homePage = new NonEvmHomepage(driver);
+        const nonEvmHomePage = new NonEvmHomepage(driver);
         // TRX_BALANCE = 6072392 SUN = ~6.07 TRX * $0.29469 = ~$1.79
-        await homePage.checkPageIsLoaded({ amount: '$10.18' });
+        await nonEvmHomePage.checkPageIsLoaded({ amount: '$10.18' });
       },
     );
   });
@@ -64,15 +69,17 @@ describe('Check balance', function (this: Suite) {
       },
       async ({ driver }: { driver: Driver }) => {
         await login(driver);
+        const homePage = new HomePage(driver);
+        await homePage.waitForNonEvmAccountsLoaded();
 
         const networkManager = new NetworkManager(driver);
         await networkManager.openNetworkManager();
         await networkManager.selectTab('Popular');
         await networkManager.selectNetworkByNameWithWait('Tron');
 
-        const homePage = new NonEvmHomepage(driver);
+        const nonEvmHomePage = new NonEvmHomepage(driver);
         // TRX_BALANCE = 6072392 SUN = ~6.07 TRX
-        await homePage.checkPageIsLoaded({ amount: '6.072 TRX' });
+        await nonEvmHomePage.checkPageIsLoaded({ amount: '6.072 TRX' });
       },
     );
   });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The test is flaky as we tried to add Tron, before waiting for nonEVM accounts to be ready, meaning the network doesn't appear in the network list, until the snaps are ready, failing with the error `TimeoutError: Waiting for element to be located By(css selector, [data-testid="Tron"]) Wait timed out after 10152ms     at /__w/metamask-extension/met...`

<img width="1050" height="812" alt="image" src="https://github.com/user-attachments/assets/00070204-0533-485f-9c60-c5f0313c42e8" />


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/41237?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts E2E Tron balance tests by adding an explicit readiness wait to reduce flakiness, with no product code changes.
> 
> **Overview**
> Fixes flakiness in `test/e2e/tests/tron/check-balance.spec.ts` by waiting for non-EVM accounts to finish loading (`HomePage.waitForNonEvmAccountsLoaded()`) before opening the network manager and selecting `Tron`.
> 
> Also cleans up the tests’ page-object usage by separating `HomePage` vs `NonEvmHomepage` instances to avoid variable reuse while keeping the balance assertions unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd0f4f54baf717468b0307285348887eaba028e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->