### PR TITLE
chore: default address component preserves static multichain avatars

### DIFF
--- a/ui/components/multichain-accounts/multichain-account-network-group-with-copy-icon/multichain-account-network-group-with-copy-icon.tsx
+++ b/ui/components/multichain-accounts/multichain-account-network-group-with-copy-icon/multichain-account-network-group-with-copy-icon.tsx
@@ -50,7 +50,7 @@ export const MultichainAccountNetworkGroupWithCopyIcon = ({
   const showDefaultAddressPreference = useSelector(
     getShowDefaultAddressPreference,
   );
-  const { defaultAddress, defaultScopes } = useSelector((state) =>
+  const { defaultAddress } = useSelector((state) =>
     getDefaultScopeAndAddressByAccountGroupId(state, groupId),
   );
   const shouldShowDefaultAddress =

--- a/ui/components/multichain-accounts/multichain-account-network-group-with-copy-icon/multichain-account-network-group-with-copy-icon.tsx
+++ b/ui/components/multichain-accounts/multichain-account-network-group-with-copy-icon/multichain-account-network-group-with-copy-icon.tsx
@@ -80,7 +80,7 @@ export const MultichainAccountNetworkGroupWithCopyIcon = ({
       padding={1}
       gap={1}
       className={classnames(
-        'rounded-lg',
+        'rounded-lg h-6',
         shouldShowDefaultAddress && 'cursor-pointer',
       )}
       data-testid="network-group-with-copy-icon"
@@ -102,8 +102,7 @@ export const MultichainAccountNetworkGroupWithCopyIcon = ({
           color={
             addressCopied ? TextColor.SuccessDefault : TextColor.TextAlternative
           }
-          className="flex-1 min-w-0"
-          style={{ lineHeight: 0 }}
+          className="flex-1"
           data-testid="default-address-container"
         >
           {addressCopied

--- a/ui/components/multichain-accounts/multichain-account-network-group-with-copy-icon/multichain-account-network-group-with-copy-icon.tsx
+++ b/ui/components/multichain-accounts/multichain-account-network-group-with-copy-icon/multichain-account-network-group-with-copy-icon.tsx
@@ -32,7 +32,7 @@ const MAX_NETWORK_AVATARS = 4;
 
 export type MultichainAccountNetworkGroupWithCopyIconProps = {
   groupId: AccountGroupId;
-  isAppHeader?: boolean;
+  showStaticNetworkAvatars?: boolean;
 };
 
 /**
@@ -45,7 +45,7 @@ export type MultichainAccountNetworkGroupWithCopyIconProps = {
  */
 export const MultichainAccountNetworkGroupWithCopyIcon = ({
   groupId,
-  isAppHeader = false,
+  showStaticNetworkAvatars = false,
 }: MultichainAccountNetworkGroupWithCopyIconProps) => {
   const t = useI18nContext();
   const isDefaultAddressEnabled = useSelector(getIsDefaultAddressEnabled);
@@ -88,7 +88,7 @@ export const MultichainAccountNetworkGroupWithCopyIcon = ({
       <MultichainAccountNetworkGroup
         groupId={groupId}
         chainIds={
-          shouldShowDefaultAddress && !isAppHeader
+          shouldShowDefaultAddress && !showStaticNetworkAvatars
             ? defaultScopes.slice(0, MAX_NETWORK_AVATARS)
             : undefined
         }

--- a/ui/components/multichain-accounts/multichain-account-network-group-with-copy-icon/multichain-account-network-group-with-copy-icon.tsx
+++ b/ui/components/multichain-accounts/multichain-account-network-group-with-copy-icon/multichain-account-network-group-with-copy-icon.tsx
@@ -80,7 +80,7 @@ export const MultichainAccountNetworkGroupWithCopyIcon = ({
       padding={1}
       gap={1}
       className={classnames(
-        'rounded-lg inline-flex',
+        'rounded-lg',
         shouldShowDefaultAddress && 'cursor-pointer',
       )}
       data-testid="network-group-with-copy-icon"
@@ -96,11 +96,13 @@ export const MultichainAccountNetworkGroupWithCopyIcon = ({
       />
       {shouldShowDefaultAddress && (
         <Text
+          ellipsis
           variant={TextVariant.BodySm}
           fontWeight={FontWeight.Medium}
           color={
             addressCopied ? TextColor.SuccessDefault : TextColor.TextAlternative
           }
+          className="flex-1 min-w-0"
           style={{ lineHeight: 0 }}
           data-testid="default-address-container"
         >

--- a/ui/components/multichain-accounts/multichain-account-network-group-with-copy-icon/multichain-account-network-group-with-copy-icon.tsx
+++ b/ui/components/multichain-accounts/multichain-account-network-group-with-copy-icon/multichain-account-network-group-with-copy-icon.tsx
@@ -42,6 +42,7 @@ export type MultichainAccountNetworkGroupWithCopyIconProps = {
  *
  * @param options0
  * @param options0.groupId
+ * @param options0.showStaticNetworkAvatars
  */
 export const MultichainAccountNetworkGroupWithCopyIcon = ({
   groupId,

--- a/ui/components/multichain-accounts/multichain-account-network-group-with-copy-icon/multichain-account-network-group-with-copy-icon.tsx
+++ b/ui/components/multichain-accounts/multichain-account-network-group-with-copy-icon/multichain-account-network-group-with-copy-icon.tsx
@@ -32,6 +32,7 @@ const MAX_NETWORK_AVATARS = 4;
 
 export type MultichainAccountNetworkGroupWithCopyIconProps = {
   groupId: AccountGroupId;
+  isAppHeader?: boolean;
 };
 
 /**
@@ -44,6 +45,7 @@ export type MultichainAccountNetworkGroupWithCopyIconProps = {
  */
 export const MultichainAccountNetworkGroupWithCopyIcon = ({
   groupId,
+  isAppHeader = false,
 }: MultichainAccountNetworkGroupWithCopyIconProps) => {
   const t = useI18nContext();
   const isDefaultAddressEnabled = useSelector(getIsDefaultAddressEnabled);
@@ -86,7 +88,7 @@ export const MultichainAccountNetworkGroupWithCopyIcon = ({
       <MultichainAccountNetworkGroup
         groupId={groupId}
         chainIds={
-          shouldShowDefaultAddress && defaultScopes.length > 0
+          shouldShowDefaultAddress && !isAppHeader
             ? defaultScopes.slice(0, MAX_NETWORK_AVATARS)
             : undefined
         }

--- a/ui/components/multichain-accounts/multichain-account-network-group-with-copy-icon/multichain-account-network-group-with-copy-icon.tsx
+++ b/ui/components/multichain-accounts/multichain-account-network-group-with-copy-icon/multichain-account-network-group-with-copy-icon.tsx
@@ -32,7 +32,6 @@ const MAX_NETWORK_AVATARS = 4;
 
 export type MultichainAccountNetworkGroupWithCopyIconProps = {
   groupId: AccountGroupId;
-  showStaticNetworkAvatars?: boolean;
 };
 
 /**
@@ -42,11 +41,9 @@ export type MultichainAccountNetworkGroupWithCopyIconProps = {
  *
  * @param options0
  * @param options0.groupId
- * @param options0.showStaticNetworkAvatars
  */
 export const MultichainAccountNetworkGroupWithCopyIcon = ({
   groupId,
-  showStaticNetworkAvatars = false,
 }: MultichainAccountNetworkGroupWithCopyIconProps) => {
   const t = useI18nContext();
   const isDefaultAddressEnabled = useSelector(getIsDefaultAddressEnabled);
@@ -88,11 +85,6 @@ export const MultichainAccountNetworkGroupWithCopyIcon = ({
     >
       <MultichainAccountNetworkGroup
         groupId={groupId}
-        chainIds={
-          shouldShowDefaultAddress && !showStaticNetworkAvatars
-            ? defaultScopes.slice(0, MAX_NETWORK_AVATARS)
-            : undefined
-        }
         limit={MAX_NETWORK_AVATARS}
       />
       {shouldShowDefaultAddress && (

--- a/ui/components/multichain-accounts/multichain-address-rows-hovered-list/multichain-hovered-address-rows-hovered-list.tsx
+++ b/ui/components/multichain-accounts/multichain-address-rows-hovered-list/multichain-hovered-address-rows-hovered-list.tsx
@@ -343,6 +343,7 @@ export const MultichainHoveredAddressRowsList = ({
         ref={setReferenceElement}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
+        className="min-w-0"
       >
         {children}
       </Box>

--- a/ui/components/multichain/app-header/__snapshots__/app-header.test.js.snap
+++ b/ui/components/multichain/app-header/__snapshots__/app-header.test.js.snap
@@ -99,7 +99,8 @@ exports[`App Header unlocked state matches snapshot: unlocked 1`] = `
         class="mm-box min-w-0 mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center"
       >
         <div
-          class="mm-box min-w-0 overflow-hidden mm-box--display-flex mm-box--flex-direction-column"
+          class="mm-box"
+          style="overflow: hidden;"
         >
           <div
             class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--display-flex mm-box--flex-direction-column mm-box--align-items-flex-start mm-box--color-text-default"
@@ -134,7 +135,7 @@ exports[`App Header unlocked state matches snapshot: unlocked 1`] = `
             </div>
           </div>
           <div
-            class="mm-box min-w-0 mm-box--margin-top-1 mm-box--margin-left-2 mm-box--display-flex"
+            class="mm-box mm-box--margin-top-1 mm-box--margin-left-2"
             data-testid="networks-subtitle-test-id"
           >
             <div

--- a/ui/components/multichain/app-header/__snapshots__/app-header.test.js.snap
+++ b/ui/components/multichain/app-header/__snapshots__/app-header.test.js.snap
@@ -99,8 +99,7 @@ exports[`App Header unlocked state matches snapshot: unlocked 1`] = `
         class="mm-box min-w-0 mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center"
       >
         <div
-          class="mm-box"
-          style="overflow: hidden;"
+          class="mm-box min-w-0 overflow-hidden mm-box--display-flex mm-box--flex-direction-column"
         >
           <div
             class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--display-flex mm-box--flex-direction-column mm-box--align-items-flex-start mm-box--color-text-default"
@@ -135,14 +134,14 @@ exports[`App Header unlocked state matches snapshot: unlocked 1`] = `
             </div>
           </div>
           <div
-            class="mm-box mm-box--margin-top-1 mm-box--margin-left-2"
+            class="mm-box min-w-0 mm-box--margin-top-1 mm-box--margin-left-2 mm-box--display-flex"
             data-testid="networks-subtitle-test-id"
           >
             <div
-              class=""
+              class="min-w-0"
             >
               <div
-                class="flex-row gap-1 items-center p-1 bg-muted rounded-lg inline-flex"
+                class="flex flex-row gap-1 items-center p-1 bg-muted rounded-lg h-6"
                 data-testid="network-group-with-copy-icon"
               >
                 <div

--- a/ui/components/multichain/app-header/app-header-unlocked-content.tsx
+++ b/ui/components/multichain/app-header/app-header-unlocked-content.tsx
@@ -233,6 +233,7 @@ export const AppHeaderUnlockedContent = ({
             >
               <MultichainAccountNetworkGroupWithCopyIcon
                 groupId={selectedMultichainAccountId}
+                isAppHeader={true}
               />
             </MultichainHoveredAddressRowsList>
           </BoxDeprecated>

--- a/ui/components/multichain/app-header/app-header-unlocked-content.tsx
+++ b/ui/components/multichain/app-header/app-header-unlocked-content.tsx
@@ -4,16 +4,6 @@ import browser from 'webextension-polyfill';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import {
-  Box,
-  BoxAlignItems,
-  BoxBackgroundColor,
-  BoxFlexDirection,
-  Icon,
-  IconName,
-  IconSize,
-  IconColor,
-} from '@metamask/design-system-react';
-import {
   AlignItems,
   BlockSize,
   Display,
@@ -172,7 +162,11 @@ export const AppHeaderUnlockedContent = ({
 
   const multichainAccountAppContent = useMemo(() => {
     return (
-      <BoxDeprecated style={{ overflow: 'hidden' }}>
+      <BoxDeprecated
+        display={Display.Flex}
+        flexDirection={FlexDirection.Column}
+        className="min-w-0 overflow-hidden"
+      >
         {/* Prevent overflow of account picker by long account names */}
         <Text
           as="div"
@@ -215,9 +209,10 @@ export const AppHeaderUnlockedContent = ({
         </Text>
         {selectedMultichainAccountId && (
           <BoxDeprecated
+            display={Display.Flex}
             marginTop={1}
             marginLeft={2}
-            style={{ width: 'fit-content' }}
+            className="min-w-0"
             data-testid="networks-subtitle-test-id"
           >
             <MultichainHoveredAddressRowsList

--- a/ui/components/multichain/app-header/app-header-unlocked-content.tsx
+++ b/ui/components/multichain/app-header/app-header-unlocked-content.tsx
@@ -162,11 +162,7 @@ export const AppHeaderUnlockedContent = ({
 
   const multichainAccountAppContent = useMemo(() => {
     return (
-      <BoxDeprecated
-        display={Display.Flex}
-        flexDirection={FlexDirection.Column}
-        className="min-w-0 overflow-hidden"
-      >
+      <BoxDeprecated style={{ overflow: 'hidden' }}>
         {/* Prevent overflow of account picker by long account names */}
         <Text
           as="div"
@@ -209,10 +205,9 @@ export const AppHeaderUnlockedContent = ({
         </Text>
         {selectedMultichainAccountId && (
           <BoxDeprecated
-            display={Display.Flex}
             marginTop={1}
             marginLeft={2}
-            className="min-w-0"
+            style={{ width: 'fit-content' }}
             data-testid="networks-subtitle-test-id"
           >
             <MultichainHoveredAddressRowsList

--- a/ui/components/multichain/app-header/app-header-unlocked-content.tsx
+++ b/ui/components/multichain/app-header/app-header-unlocked-content.tsx
@@ -228,7 +228,6 @@ export const AppHeaderUnlockedContent = ({
             >
               <MultichainAccountNetworkGroupWithCopyIcon
                 groupId={selectedMultichainAccountId}
-                showStaticNetworkAvatars={true}
               />
             </MultichainHoveredAddressRowsList>
           </BoxDeprecated>

--- a/ui/components/multichain/app-header/app-header-unlocked-content.tsx
+++ b/ui/components/multichain/app-header/app-header-unlocked-content.tsx
@@ -233,7 +233,7 @@ export const AppHeaderUnlockedContent = ({
             >
               <MultichainAccountNetworkGroupWithCopyIcon
                 groupId={selectedMultichainAccountId}
-                isAppHeader={true}
+                showStaticNetworkAvatars={true}
               />
             </MultichainHoveredAddressRowsList>
           </BoxDeprecated>


### PR DESCRIPTION
## **Description**

This PR improves the default address display based on product review:

1. **Showing static network avatars** - The network avatars now display all available networks for the account group instead of only the networks associated with the default address. This is because the priority is to indicate that this component contains multichain addresses when hovered over. 

Solana is set as default address: we show Solana address but multichain network avatars on app header
<img width="729" height="638" alt="image" src="https://github.com/user-attachments/assets/a645819f-9945-42fb-8cfe-5cae6badacf3" />

Tron is set as default address: we show Tron address but multichain network avatars on account list
<img width="852" height="491" alt="image" src="https://github.com/user-attachments/assets/fb3229e2-6a29-40df-8838-129f1869f1e3" />

2. **Adding text truncation with ellipsis** - When the viewport is narrow or the account value is large, the default address text now properly truncates with an ellipsis instead of the entire component being cut off. This means the whole component with the copy icon remains visible.

<img width="339" height="175" alt="image" src="https://github.com/user-attachments/assets/d795a650-ffdb-4298-a7dc-485c3e45f3e3" />


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/41238?quickstart=1)

## **Changelog**

CHANGELOG entry: Static multichain network avatars are now preserved when default address is enabled

## **Related issues**

Fixes:

## **Manual testing steps**

1. Open the extension with an account that has multiple networks (e.g., EVM + Bitcoin + Solana)
2. Verify the app header shows all network avatars in the network group badge
4. Enable "Show default address" in Settings > General
5. Verify the network avatars remain the same
6. Go to Account List
7. Verify the network avatars show multichain networks
8. Resize the browser window to a narrow width
9. Verify the address text truncates with an ellipsis instead of being cut off
10. Disable "Show default address" and verify the container height remains the same

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout and display logic changes; no changes to address selection, persistence, or security-sensitive flows.
> 
> **Overview**
> When the *Show default address* preference is enabled, the network avatar badge now always shows the account group’s normal multichain avatars (no longer overriding `MultichainAccountNetworkGroup` with `defaultScopes`-derived `chainIds`).
> 
> Improves header/account list layout so the default address label truncates with an ellipsis and the copy icon remains visible (adds `min-w-0`, sets a consistent `h-6`, and updates the header snapshot accordingly).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 133375214da7ba819b27a4c93f8fb51489e2adfc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->