### PR TITLE
chore: activity tab error state

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -7923,7 +7923,7 @@
     "message": "Something's gone wrong. Try reloading the page."
   },
   "somethingWentWrong": {
-    "message": "We could not load this page."
+    "message": "We couldn't load this page."
   },
   "sortBy": {
     "message": "Sort by"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -7923,7 +7923,7 @@
     "message": "Something's gone wrong. Try reloading the page."
   },
   "somethingWentWrong": {
-    "message": "We could not load this page."
+    "message": "We couldn't load this page."
   },
   "sortBy": {
     "message": "Sort by"

--- a/ui/components/multichain/activity-v2/activity-list.tsx
+++ b/ui/components/multichain/activity-v2/activity-list.tsx
@@ -7,6 +7,7 @@ import { toEvmCaipChainId } from '@metamask/multichain-network-controller';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useScrollContainer } from '../../../contexts/scroll-container';
 import { TransactionActivityEmptyState } from '../../app/transaction-activity-empty-state';
+import { TabEmptyState } from '../../ui/tab-empty-state';
 import { PENDING_STATUS_HASH } from '../../../helpers/constants/transactions';
 import { selectLocalTransactions } from '../../../selectors/activity';
 import { selectEvmAddress } from '../../../selectors/accounts';
@@ -65,6 +66,8 @@ export const ActivityList = ({ filter }: Props) => {
   const {
     data,
     isInitialLoading,
+    isError,
+    refetch,
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
@@ -274,7 +277,16 @@ export const ActivityList = ({ filter }: Props) => {
         </>
       )}
 
-      {!isInitialLoading && flattenedItems.length === 0 && (
+      {!isInitialLoading && isError && flattenedItems.length === 0 && (
+        <TabEmptyState
+          className="mx-auto mt-5 mb-6"
+          description={t('somethingWentWrong')}
+          actionButtonText={t('tryAgain')}
+          onAction={refetch}
+        />
+      )}
+
+      {!isInitialLoading && !isError && flattenedItems.length === 0 && (
         <TransactionActivityEmptyState className="mx-auto mt-5 mb-6" />
       )}
 


### PR DESCRIPTION
## **Description**

Error state view for the Activity tab

Will render when API returns an error _and_ there is no local transaction data

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: chore: activity tab error state

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="265" height="127" alt="image" src="https://github.com/user-attachments/assets/b144951a-49c6-46f4-bb63-145e3c7b7423" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI change that only affects the Activity tab’s empty-state rendering when the transactions query fails, without altering transaction data processing or persistence.
> 
> **Overview**
> Adds an explicit error-state UI for the Activity tab when the EVM transactions query fails and no items are available.
> 
> `ActivityList` now reads `isError`/`refetch` from `useTransactionsQuery` and, on error, renders `TabEmptyState` with a “Try again” action that triggers `refetch`; the normal empty state is shown only when not in an error state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 265f0c173794e07d2667d8b8581131babdfccdcf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->