### PR TITLE
test: add e2e tests for swap/bridge tx details page

### DIFF
--- a/test/e2e/page-objects/pages/home/activity-list.ts
+++ b/test/e2e/page-objects/pages/home/activity-list.ts
@@ -334,6 +334,88 @@ class ActivityListPage {
   }
 
   /**
+   * This function checks a swap or bridge transaction's details
+   *
+   * @param action - The expected action text for the Activity List item
+   * @param isBridge - Whether the transaction is a bridge or swap
+   * @param expectedStatus - The expected status of the transaction
+   * @param expectedSrcAmount - The expected source amount
+   * @param expectedSrcToken - The expected source token
+   * @param expectedDestAmount - The expected destination amount
+   * @param expectedDestToken - The expected destination token
+   * @returns A promise that resolves when the expected transaction details are displayed within the timeout period.
+   */
+  async checkBridgeTransactionDetails(
+    action: string,
+    isBridge: boolean,
+    expectedStatus: 'success' | 'failed' | 'pending',
+    expectedSrcAmount?: string,
+    expectedSrcToken?: string,
+    expectedDestAmount?: string,
+    expectedDestToken?: string,
+  ): Promise<void> {
+    console.log(`Open bridge transaction details`);
+    const [completedTx] = await this.driver.findElements({
+      text: action,
+    });
+    await completedTx.click();
+    await this.driver.waitForUrlContaining({
+      url: '/cross-chain/tx-details',
+    });
+    await this.driver.waitForSelector({
+      text: `${isBridge ? 'Bridge' : 'Swap'} details`,
+    });
+
+    console.log('Checking scanner links');
+    const scannerLinks = await this.driver.findElements({
+      tag: 'button',
+      text: 'View on',
+    });
+    assert.equal(
+      scannerLinks.length,
+      isBridge && expectedStatus === 'success' ? 2 : 1,
+      'Scanner links are displayed',
+    );
+
+    console.log(`Checking ${isBridge ? 'bridge' : 'swap'} status`);
+    const BRIDGE_STATUSES = {
+      success: 'complete',
+      failed: 'failed',
+      pending: 'pending',
+    };
+    const SWAP_STATUSES = {
+      success: 'confirmed',
+      failed: 'failed',
+      pending: 'pending',
+    };
+    const expectedStatusText = isBridge
+      ? BRIDGE_STATUSES[expectedStatus]
+      : SWAP_STATUSES[expectedStatus];
+    const statusElement = await this.driver.findElement({
+      text: expectedStatusText,
+    });
+    assert.equal(
+      (await statusElement.getText()).toLowerCase(),
+      expectedStatusText,
+      `Status is displayed as ${expectedStatusText}`,
+    );
+
+    console.log('Checking displayed amounts');
+    await this.driver.waitForSelector({
+      text: `${expectedSrcAmount} ${expectedSrcToken} on`,
+    });
+    if (expectedDestAmount) {
+      await this.driver.waitForSelector({
+        text: `${expectedDestAmount} ${expectedDestToken}`,
+      });
+    }
+
+    console.log('Navigating back to activity list');
+    const backButton = await this.driver.findElement('.mm-button-icon');
+    await backButton.click();
+  }
+
+  /**
    * This function checks if a specified transaction amount at the specified index matches the expected one.
    *
    * @param expectedAmount - The expected transaction amount to be displayed. Defaults to '-1 ETH'.

--- a/test/e2e/tests/bridge/bridge-negative-cases.spec.ts
+++ b/test/e2e/tests/bridge/bridge-negative-cases.spec.ts
@@ -161,6 +161,13 @@ describe('Bridge functionality', function (this: Suite) {
         await homePage.goToActivityList();
         const activityList = new ActivityListPage(driver);
         await activityList.checkPendingBridgeTransactionActivity();
+        await activityList.checkBridgeTransactionDetails(
+          'Bridged to Linea',
+          true,
+          'pending',
+          '1',
+          'ETH',
+        );
       },
     );
   });
@@ -194,6 +201,13 @@ describe('Bridge functionality', function (this: Suite) {
 
         const activityList = new ActivityListPage(driver);
         await activityList.checkFailedTxNumberDisplayedInActivity();
+        await activityList.checkBridgeTransactionDetails(
+          'Bridged to Linea',
+          true,
+          'failed',
+          '1',
+          'ETH',
+        );
       },
     );
   });
@@ -227,6 +241,13 @@ describe('Bridge functionality', function (this: Suite) {
 
         const activityList = new ActivityListPage(driver);
         await activityList.checkFailedTxNumberDisplayedInActivity();
+        await activityList.checkBridgeTransactionDetails(
+          'Bridged to Linea',
+          true,
+          'failed',
+          '1',
+          'ETH',
+        );
       },
     );
   });

--- a/test/e2e/tests/bridge/bridge-test-utils.ts
+++ b/test/e2e/tests/bridge/bridge-test-utils.ts
@@ -97,11 +97,13 @@ export class BridgePage {
  * @param testParams.expectedSwapTokens - The expected swap tokens shown in the activity list
  * @param testParams.expectedDestAmount - The expected quoted destination amounts in the quote page
  * @param testParams.submitDelay - The delay to wait before submitting the transaction, must be less than the refresh interval of the stream
+ * @param testParams.expectedStatus - The expected state of the transaction
  */
 export const bridgeTransaction = async ({
   driver,
   quote,
   expectedTransactionsCount = 1,
+  expectedStatus = 'success',
   expectedWalletBalance,
   expectedSwapTokens,
   expectedDestAmount,
@@ -110,6 +112,7 @@ export const bridgeTransaction = async ({
   driver: Driver;
   quote: BridgeQuote;
   expectedTransactionsCount: number;
+  expectedStatus?: 'success' | 'failed' | 'pending';
   expectedWalletBalance?: string;
   expectedSwapTokens?: Pick<BridgeQuote, 'tokenFrom' | 'tokenTo'>;
   expectedDestAmount: string;
@@ -141,29 +144,45 @@ export const bridgeTransaction = async ({
       ? quote.fromChain !== quote.toChain
       : false;
 
+  let action = '';
+  const expectedSrcToken = quote.tokenFrom ?? expectedSwapTokens?.tokenFrom;
+  const expectedDestToken = quote.tokenTo ?? expectedSwapTokens?.tokenTo;
+
   if (quote.unapproved) {
+    action = isBridge
+      ? `Bridged to ${quote.toChain}`
+      : `Swapped ${expectedSrcToken} to ${expectedDestToken}`;
     await activityList.checkTxAction({
-      action: isBridge
-        ? `Bridged to ${quote.toChain}`
-        : `Swapped ${quote.tokenFrom} to ${quote.tokenTo}`,
+      action,
       confirmedTx: expectedTransactionsCount,
     });
     await activityList.checkTxAction({
-      action: `Approve ${quote.tokenFrom} for ${isBridge ? 'bridge' : 'swap'}`,
+      action: `Approve ${expectedSrcToken} for ${isBridge ? 'bridge' : 'swap'}`,
       confirmedTx: expectedTransactionsCount,
       txIndex: 2,
     });
   } else {
+    action = isBridge
+      ? `Bridged to ${quote.toChain}`
+      : `Swap ${expectedSrcToken} to ${expectedDestToken}`;
     await activityList.checkTxAction({
-      action: isBridge
-        ? `Bridged to ${quote.toChain}`
-        : `Swap ${quote.tokenFrom ?? expectedSwapTokens?.tokenFrom} to ${quote.tokenTo ?? expectedSwapTokens?.tokenTo}`,
+      action,
       confirmedTx: expectedTransactionsCount,
     });
   }
   // Check the amount of ETH deducted in the activity is correct
   await activityList.checkTxAmountInActivity(
     `-${quote.amount} ${quote.tokenFrom ?? expectedSwapTokens?.tokenFrom}`,
+  );
+
+  await activityList.checkBridgeTransactionDetails(
+    action,
+    isBridge,
+    expectedStatus,
+    quote.amount,
+    expectedSrcToken,
+    expectedDestAmount,
+    expectedDestToken,
   );
 
   // Check the wallet ETH balance is correct


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adding tests for the swap/bridge transaction details page. The new test verifies that the app navigates to the custom TransactionDetails page and that it contains the expected data after tx submission

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/41269?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: test: add e2e tests for unified swap transaction details page

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-4269

## **Manual testing steps**

1. Tests should succeed

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since changes are limited to E2E test helpers and assertions, but they may introduce test flakiness due to new UI text/selector expectations and status mapping.
> 
> **Overview**
> Adds an `ActivityListPage.checkBridgeTransactionDetails` helper that opens the swap/bridge transaction details view and asserts navigation, status text, scanner link count, and displayed source/destination amounts.
> 
> Extends bridge E2E coverage by calling this helper in negative-case bridge tests (pending/failed) and wires it into the shared `bridgeTransaction` utility via a new `expectedStatus` param plus more consistent action/token label construction.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83404bfbbf23641f635ce674b0b98ec57934ecd0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->