### PR TITLE
fix: ensure Send max is full balance if gas sponsored

### DIFF
--- a/ui/components/multichain/network-list-item/network-list-item.tsx
+++ b/ui/components/multichain/network-list-item/network-list-item.tsx
@@ -7,8 +7,6 @@ import React, {
 } from 'react';
 import classnames from 'clsx';
 import PropTypes from 'prop-types';
-import { CaipChainId } from '@metamask/utils';
-import { useSelector } from 'react-redux';
 import {
   AlignItems,
   BackgroundColor,
@@ -37,11 +35,7 @@ import { useI18nContext } from '../../../hooks/useI18nContext';
 import { getAvatarNetworkColor } from '../../../helpers/utils/accounts';
 import Tooltip from '../../ui/tooltip/tooltip';
 import { NetworkListItemMenu } from '../network-list-item-menu';
-import {
-  getGasFeesSponsoredNetworkEnabled,
-  isHardwareWallet,
-} from '../../../selectors';
-import { convertCaipToHexChainId } from '../../../../shared/lib/network.utils';
+import { useIsNetworkGasSponsored } from '../../../hooks/useIsNetworkGasSponsored';
 
 const isIconSrc = (iconSrc?: string | IconName): iconSrc is IconName =>
   Object.values(IconName).includes(iconSrc as IconName);
@@ -120,43 +114,7 @@ export const NetworkListItem = ({
     setIsMenuClosing(true);
   }, []);
 
-  // This selector provides the indication if the "Gas sponsored" label
-  // is enabled based on the remote feature flag.
-  const isGasFeesSponsoredNetworkEnabled = useSelector(
-    getGasFeesSponsoredNetworkEnabled,
-  );
-  const isHardwareWalletAccount = useSelector(isHardwareWallet);
-
-  // Check if a network has gas sponsorship enabled
-  const isNetworkGasSponsored = useCallback(
-    (networkChainId: string | undefined): boolean => {
-      if (!networkChainId || isHardwareWalletAccount) {
-        return false;
-      }
-
-      // Convert chainId to hex if it's in CAIP format, otherwise use as-is
-      let hexChainId: string;
-      try {
-        // Check if it's in CAIP format (contains ':')
-        if (networkChainId.includes(':')) {
-          hexChainId = convertCaipToHexChainId(networkChainId as CaipChainId);
-        } else {
-          // Already in hex format
-          hexChainId = networkChainId;
-        }
-      } catch (error) {
-        // If conversion fails, use the original chainId
-        hexChainId = networkChainId;
-      }
-
-      return Boolean(
-        isGasFeesSponsoredNetworkEnabled?.[
-          hexChainId as keyof typeof isGasFeesSponsoredNetworkEnabled
-        ],
-      );
-    },
-    [isGasFeesSponsoredNetworkEnabled, isHardwareWalletAccount],
-  );
+  const { isNetworkGasSponsored } = useIsNetworkGasSponsored(chainId);
 
   const renderButton = useCallback(() => {
     // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
@@ -288,7 +246,7 @@ export const NetworkListItem = ({
               {name}
             </Text>
           </Tooltip>
-          {isNetworkGasSponsored(chainId) && (
+          {isNetworkGasSponsored && (
             <SuccessPill
               label={t('noNetworkFee')}
               display={Display.InlineFlex}

--- a/ui/components/multichain/network-manager/components/default-networks/default-networks.tsx
+++ b/ui/components/multichain/network-manager/components/default-networks/default-networks.tsx
@@ -2,6 +2,7 @@ import { CaipChainId, Hex } from '@metamask/utils';
 import React, { memo, useCallback, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { BtcScope, EthScope, SolScope, TrxScope } from '@metamask/keyring-api';
+import { AddNetworkFields } from '@metamask/network-controller';
 import {
   CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP,
   FEATURED_RPCS,
@@ -55,13 +56,70 @@ import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import {
   getOrderedNetworksList,
   getMultichainNetworkConfigurationsByChainId,
-  getGasFeesSponsoredNetworkEnabled,
   getUseExternalServices,
-  isHardwareWallet,
 } from '../../../../../selectors';
 import { getInternalAccountBySelectedAccountGroupAndCaip } from '../../../../../selectors/multichain-accounts/account-tree';
 import { selectAdditionalNetworksBlacklistFeatureFlag } from '../../../../../selectors/network-blacklist/network-blacklist';
 import { isEvmChainId } from '../../../../../../shared/lib/asset-utils';
+import { useIsNetworkGasSponsored } from '../../../../../hooks/useIsNetworkGasSponsored';
+
+const AdditionalNetwork = ({ network }: { network: AddNetworkFields }) => {
+  const t = useI18nContext();
+  const networkImageUrl =
+    CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP[
+      network.chainId as keyof typeof CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP
+    ];
+
+  // Use the additional network handlers hook
+  const { handleAdditionalNetworkClick } = useAdditionalNetworkHandlers();
+  const { isNetworkGasSponsored } = useIsNetworkGasSponsored(network.chainId);
+
+  return (
+    <Box
+      display={Display.Flex}
+      alignItems={AlignItems.center}
+      justifyContent={JustifyContent.flexStart}
+      width={BlockSize.Full}
+      onClick={() => handleAdditionalNetworkClick(network)}
+      paddingLeft={4}
+      paddingRight={4}
+      paddingTop={4}
+      paddingBottom={4}
+      gap={4}
+      data-testid="additional-network-item"
+      className="network-manager__additional-network-item"
+      key={network.chainId}
+    >
+      <AvatarNetwork
+        name={network.name}
+        size={AvatarNetworkSize.Md}
+        src={networkImageUrl}
+        borderRadius={BorderRadius.LG}
+      />
+      <Box
+        display={Display.Flex}
+        flexDirection={FlexDirection.Row}
+        alignItems={AlignItems.center}
+        gap={2}
+      >
+        <Text variant={TextVariant.bodyMdMedium} color={TextColor.textDefault}>
+          {network.name}
+        </Text>
+        {isNetworkGasSponsored && (
+          <SuccessPill label={t('noNetworkFee')} display={Display.InlineFlex} />
+        )}
+      </Box>
+      <ButtonIcon
+        size={ButtonIconSize.Md}
+        color={IconColor.iconDefault}
+        iconName={IconName.Add}
+        padding={0}
+        marginLeft={'auto'}
+        ariaLabel={t('addNetwork')}
+      />
+    </Box>
+  );
+};
 
 const DefaultNetworks = memo(() => {
   const t = useI18nContext();
@@ -78,9 +136,6 @@ const DefaultNetworks = memo(() => {
 
   // Use the shared network change handlers hook
   const { handleNetworkChange } = useNetworkChangeHandlers();
-
-  // Use the additional network handlers hook
-  const { handleAdditionalNetworkClick } = useAdditionalNetworkHandlers();
 
   const isEvmNetworkSelected = useSelector(getMultichainIsEvm);
 
@@ -114,29 +169,6 @@ const DefaultNetworks = memo(() => {
   // Get blacklisted chain IDs from feature flag
   const blacklistedChainIds = useSelector(
     selectAdditionalNetworksBlacklistFeatureFlag,
-  );
-
-  // This selector provides the indication if the "Gas sponsored" label
-  // is enabled based on the remote feature flag.
-  const isGasFeesSponsoredNetworkEnabled = useSelector(
-    getGasFeesSponsoredNetworkEnabled,
-  );
-  const isHardwareWalletAccount = useSelector(isHardwareWallet);
-
-  // Check if a network has gas sponsorship enabled
-  const isNetworkGasSponsored = useCallback(
-    (chainId: string | undefined): boolean => {
-      if (!chainId || isHardwareWalletAccount) {
-        return false;
-      }
-
-      return Boolean(
-        isGasFeesSponsoredNetworkEnabled?.[
-          chainId as keyof typeof isGasFeesSponsoredNetworkEnabled
-        ],
-      );
-    },
-    [isGasFeesSponsoredNetworkEnabled, isHardwareWalletAccount],
   );
 
   // Use the shared state hook
@@ -338,70 +370,13 @@ const DefaultNetworks = memo(() => {
 
   // Memoize the additional network list items
   const additionalNetworkListItems = useMemo(() => {
-    return featuredNetworksNotYetEnabled.map((network) => {
-      const networkImageUrl =
-        CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP[
-          network.chainId as keyof typeof CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP
-        ];
-
-      return (
-        <Box
-          display={Display.Flex}
-          alignItems={AlignItems.center}
-          justifyContent={JustifyContent.flexStart}
-          width={BlockSize.Full}
-          onClick={() => handleAdditionalNetworkClick(network)}
-          paddingLeft={4}
-          paddingRight={4}
-          paddingTop={4}
-          paddingBottom={4}
-          gap={4}
-          data-testid="additional-network-item"
-          className="network-manager__additional-network-item"
-          key={network.chainId}
-        >
-          <AvatarNetwork
-            name={network.name}
-            size={AvatarNetworkSize.Md}
-            src={networkImageUrl}
-            borderRadius={BorderRadius.LG}
-          />
-          <Box
-            display={Display.Flex}
-            flexDirection={FlexDirection.Row}
-            alignItems={AlignItems.center}
-            gap={2}
-          >
-            <Text
-              variant={TextVariant.bodyMdMedium}
-              color={TextColor.textDefault}
-            >
-              {network.name}
-            </Text>
-            {isNetworkGasSponsored(network.chainId) && (
-              <SuccessPill
-                label={t('noNetworkFee')}
-                display={Display.InlineFlex}
-              />
-            )}
-          </Box>
-          <ButtonIcon
-            size={ButtonIconSize.Md}
-            color={IconColor.iconDefault}
-            iconName={IconName.Add}
-            padding={0}
-            marginLeft={'auto'}
-            ariaLabel={t('addNetwork')}
-          />
-        </Box>
-      );
-    });
-  }, [
-    featuredNetworksNotYetEnabled,
-    handleAdditionalNetworkClick,
-    t,
-    isNetworkGasSponsored,
-  ]);
+    return featuredNetworksNotYetEnabled.map((network) => (
+      <AdditionalNetwork
+        key={`additionnal-network-${network.chainId}`}
+        network={network}
+      ></AdditionalNetwork>
+    ));
+  }, [featuredNetworksNotYetEnabled]);
 
   return (
     <>

--- a/ui/hooks/useIsNetworkGasSponsored.test.ts
+++ b/ui/hooks/useIsNetworkGasSponsored.test.ts
@@ -1,0 +1,94 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useSelector } from 'react-redux';
+import {
+  getGasFeesSponsoredNetworkEnabled,
+  isHardwareWallet,
+} from '../selectors';
+import { useIsNetworkGasSponsored } from './useIsNetworkGasSponsored';
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+jest.mock('../selectors', () => ({
+  getGasFeesSponsoredNetworkEnabled: jest.fn(),
+  isHardwareWallet: jest.fn(),
+}));
+
+const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
+
+const renderWithMock = ({
+  chainId,
+  mockIsHardwareWallet = false,
+  mockGasFeesSponsoredNetworkEnabled = {
+    '0x1': true,
+    '0x2': false,
+  },
+}: {
+  chainId: string | undefined;
+  mockIsHardwareWallet?: boolean;
+  mockGasFeesSponsoredNetworkEnabled?: { [key: string]: boolean };
+}) => {
+  mockUseSelector.mockImplementation((selector) => {
+    if (selector === isHardwareWallet) {
+      return mockIsHardwareWallet;
+    }
+    if (selector === getGasFeesSponsoredNetworkEnabled) {
+      return mockGasFeesSponsoredNetworkEnabled;
+    }
+  });
+  return renderHook(() => useIsNetworkGasSponsored(chainId));
+};
+
+describe('useIsNetworkGasSponsored', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  it('returns true when network is enabled using hex chainId', () => {
+    const { result } = renderWithMock({ chainId: '0x1' });
+    expect(result.current).toEqual({ isNetworkGasSponsored: true });
+  });
+
+  it('returns false when network is disabled using hex chainId', () => {
+    const { result } = renderWithMock({ chainId: '0x2' });
+    expect(result.current).toEqual({ isNetworkGasSponsored: false });
+  });
+
+  it('returns false when network is missing from flag using hex chainId', () => {
+    const { result } = renderWithMock({ chainId: '0x3' });
+    expect(result.current).toEqual({ isNetworkGasSponsored: false });
+  });
+
+  it('returns true when network is enabled using CAIP chainId', () => {
+    const { result } = renderWithMock({ chainId: 'eip155:1' });
+    expect(result.current).toEqual({ isNetworkGasSponsored: true });
+  });
+
+  it('returns false when network is disabled using CAIP chainId', () => {
+    const { result } = renderWithMock({ chainId: 'eip155:2' });
+    expect(result.current).toEqual({ isNetworkGasSponsored: false });
+  });
+
+  it('returns false when network is missing from flag using CAIP chainId', () => {
+    const { result } = renderWithMock({ chainId: 'eip155:3' });
+    expect(result.current).toEqual({ isNetworkGasSponsored: false });
+  });
+
+  it('returns false when network is enabled using hex chainId BUT is hardware wallet', () => {
+    const { result } = renderWithMock({
+      chainId: '0x1',
+      mockIsHardwareWallet: true,
+    });
+    expect(result.current).toEqual({ isNetworkGasSponsored: false });
+  });
+
+  it('returns false when network is enabled using CAIP chainId BUT is hardware wallet', () => {
+    const { result } = renderWithMock({
+      chainId: 'eip155:1',
+      mockIsHardwareWallet: true,
+    });
+    expect(result.current).toEqual({ isNetworkGasSponsored: false });
+  });
+});

--- a/ui/hooks/useIsNetworkGasSponsored.ts
+++ b/ui/hooks/useIsNetworkGasSponsored.ts
@@ -1,0 +1,50 @@
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { CaipChainId } from '@metamask/utils';
+import {
+  getGasFeesSponsoredNetworkEnabled,
+  isHardwareWallet,
+} from '../selectors';
+import { convertCaipToHexChainId } from '../../shared/lib/network.utils';
+
+export const useIsNetworkGasSponsored = (
+  networkChainId: string | undefined,
+): { isNetworkGasSponsored: boolean } => {
+  // This selector provides the indication if the "Gas sponsored" label
+  // is enabled based on the remote feature flag.
+  const gasFeesSponsoredNetworkEnabledMap = useSelector(
+    getGasFeesSponsoredNetworkEnabled,
+  );
+  const isHardwareWalletAccount = useSelector(isHardwareWallet);
+  // Check if a network has gas sponsorship enabled
+  return useMemo(() => {
+    if (!networkChainId || isHardwareWalletAccount) {
+      return { isNetworkGasSponsored: false };
+    }
+    // Convert chainId to hex if it's in CAIP format, otherwise use as-is
+    let hexChainId: string;
+    try {
+      // Check if it's in CAIP format (contains ':')
+      if (networkChainId.includes(':')) {
+        hexChainId = convertCaipToHexChainId(networkChainId as CaipChainId);
+      } else {
+        // Already in hex format
+        hexChainId = networkChainId;
+      }
+    } catch (error) {
+      // If conversion fails, use the original chainId
+      hexChainId = networkChainId;
+    }
+    return {
+      isNetworkGasSponsored: Boolean(
+        gasFeesSponsoredNetworkEnabledMap?.[
+          hexChainId as keyof typeof gasFeesSponsoredNetworkEnabledMap
+        ],
+      ),
+    };
+  }, [
+    gasFeesSponsoredNetworkEnabledMap,
+    isHardwareWalletAccount,
+    networkChainId,
+  ]);
+};

--- a/ui/pages/confirmations/components/confirm/info/hooks/useMaxValueRefresher.test.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useMaxValueRefresher.test.ts
@@ -312,6 +312,29 @@ describe('useMaxValueRefresher', () => {
         );
       });
 
+      it('calculates value as full balance if gas is sponsored', () => {
+        const transactionMeta = merge({}, baseTransactionMeta, {
+          txParams: {
+            gas: '0x5208', // 21000
+            maxFeePerGas: '0x77359400', // 2 gwei
+          },
+          isGasFeeSponsored: true,
+        });
+
+        useConfirmContextMock.mockReturnValue({
+          currentConfirmation: transactionMeta,
+        } as unknown as ReturnType<typeof useConfirmContext>);
+
+        renderHook(() => useMaxValueRefresher());
+
+        expect(updateEditableParamsMock).toHaveBeenCalledWith(
+          transactionMeta.id,
+          {
+            value: defaultBalance,
+          },
+        );
+      });
+
       it('handles missing maxFeePerGas by using HEX_ZERO', () => {
         const transactionMeta = {
           ...baseTransactionMeta,

--- a/ui/pages/confirmations/components/confirm/info/hooks/useMaxValueRefresher.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useMaxValueRefresher.ts
@@ -85,13 +85,19 @@ export const useMaxValueRefresher = () => {
       return;
     }
 
-    let gasFeeInHex = multiplyHexes(
-      gas,
-      supportsEIP1559 ? maxFeePerGas : gasPrice,
-    );
+    let gasFeeInHex = HEX_ZERO;
 
-    if (layer1GasFee) {
-      gasFeeInHex = addHexes(gasFeeInHex, layer1GasFee) as Hex;
+    // Gas Sponsorship means the user has no native gas to pay at all.
+    // This will allow to send the full max value of the native balance.
+    if (!transactionMeta.isGasFeeSponsored) {
+      gasFeeInHex = multiplyHexes(
+        gas,
+        supportsEIP1559 ? maxFeePerGas : gasPrice,
+      );
+
+      if (layer1GasFee) {
+        gasFeeInHex = addHexes(gasFeeInHex, layer1GasFee) as Hex;
+      }
     }
 
     const remainingBalance = new Numeric(balance || HEX_ZERO, 16).minus(

--- a/ui/pages/confirmations/components/send/amount/amount.tsx
+++ b/ui/pages/confirmations/components/send/amount/amount.tsx
@@ -105,7 +105,6 @@ export const Amount = ({
     amount,
     fiatMode,
     getFiatValue,
-    getNativeValue,
     setAmount,
     setAmountInputTypeFiat,
     setAmountInputTypeToken,

--- a/ui/pages/confirmations/hooks/send/useMaxAmount.ts
+++ b/ui/pages/confirmations/hooks/send/useMaxAmount.ts
@@ -9,6 +9,7 @@ import { useAsyncResult } from '../../../../hooks/useAsync';
 import { Asset } from '../../types/send';
 import { getLayer1GasFees, toTokenMinimalUnit } from '../../utils/send';
 import { useSendContext } from '../../context/send';
+import { useIsNetworkGasSponsored } from '../../../../hooks/useIsNetworkGasSponsored';
 import { useBalance } from './useBalance';
 import { useSendType } from './useSendType';
 
@@ -44,6 +45,7 @@ type GetMaxAmountArgs = {
   isEvmNativeSendType?: boolean;
   gasFeeEstimates?: GasFeeEstimatesType;
   rawBalanceNumeric: Numeric;
+  isNetworkGasSponsored: boolean;
 };
 
 const getMaxAmountFn = ({
@@ -52,6 +54,7 @@ const getMaxAmountFn = ({
   gasFeeEstimates,
   isEvmNativeSendType,
   rawBalanceNumeric,
+  isNetworkGasSponsored,
 }: GetMaxAmountArgs) => {
   if (!asset) {
     return '0';
@@ -59,7 +62,7 @@ const getMaxAmountFn = ({
 
   let estimatedTotalGas = new Numeric('0', 10);
 
-  if (isEvmNativeSendType) {
+  if (isEvmNativeSendType && !isNetworkGasSponsored) {
     estimatedTotalGas = getEstimatedTotalGas(layer1GasFees, gasFeeEstimates);
   }
 
@@ -74,6 +77,7 @@ export const useMaxAmount = () => {
   const { asset, chainId, from, value } = useSendContext();
   const { isEvmSendType, isEvmNativeSendType } = useSendType();
   const { rawBalanceNumeric } = useBalance();
+  const { isNetworkGasSponsored } = useIsNetworkGasSponsored(chainId);
 
   const gasFeeEstimates = useSelector((state) => {
     if (chainId && isEvmSendType) {
@@ -106,6 +110,7 @@ export const useMaxAmount = () => {
       isEvmNativeSendType,
       layer1GasFees: layer1GasFees ?? '0x0',
       rawBalanceNumeric,
+      isNetworkGasSponsored,
     });
   }, [
     asset,
@@ -113,6 +118,7 @@ export const useMaxAmount = () => {
     isEvmNativeSendType,
     layer1GasFees,
     rawBalanceNumeric,
+    isNetworkGasSponsored,
   ]);
 
   return {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

When we (MetaMask) paid for the fee (aka "Gas Sponsorship"), some gas calculation is occurring, making the "max" behavior not taking the full balance of the account when sending a native token - some part reserved for gas.
This PR disables this "reserve" behavior when a transaction will be gas-sponsored, since we know in advance that gas consumption will be 0.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/41299?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: On Gas-Sponsored networks, allow sending full native balance using `Max`.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
- When sending the native token, the "max" button takes in account gas fees and subtract that from the sent amount.
- On gas-sponsored networks, this behavior has been preserved, but doesn't really make sense in that case.

### **After**

- When sending the native token, the "max" button takes in account gas fees and subtract that from the sent amount UNLESS the transaction is gas-sponsored, allowing to send 100% of the native balance.

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes max-send value calculations in confirmations and send flow; incorrect handling could lead to over/under-sending amounts on some networks, though coverage was added for sponsored-gas scenarios.
> 
> **Overview**
> Ensures the **Send “Max” amount** logic no longer subtracts gas fees when the transaction/network is gas-sponsored, allowing users to send their full native balance.
> 
> Introduces a shared `useIsNetworkGasSponsored` hook (with tests) to centralize feature-flag + hardware-wallet gating and CAIP→hex chainId handling, then wires it into network list UIs (to show the “No network fee” pill) and into `useMaxAmount`/`useMaxValueRefresher` (with added test coverage for sponsored gas behavior).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c2f31383f567f6f995911f05717084aef5b47e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->