### PR TITLE
chore: convert setTimeouts to waitForNextUpdate cp-13.25.0

### DIFF
--- a/ui/components/app/musd/hooks/useMerklRewards.test.ts
+++ b/ui/components/app/musd/hooks/useMerklRewards.test.ts
@@ -291,7 +291,7 @@ describe('useMerklRewards', () => {
     // On-chain says all claimed
     mockGetClaimedAmountFromContract.mockResolvedValueOnce('1000000');
 
-    const { result } = renderHook(
+    const { result, waitForNextUpdate } = renderHook(
       () =>
         useMerklRewards({
           tokenAddress: MUSD_TOKEN_ADDRESS,
@@ -302,7 +302,7 @@ describe('useMerklRewards', () => {
     );
 
     await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 0));
+      await waitForNextUpdate();
     });
 
     expect(result.current.hasClaimableReward).toBe(false);
@@ -314,7 +314,7 @@ describe('useMerklRewards', () => {
   it('returns false when API returns no matching reward', async () => {
     mockFetchMerklRewardsForAsset.mockResolvedValueOnce(null);
 
-    const { result } = renderHook(
+    const { result, waitForNextUpdate } = renderHook(
       () =>
         useMerklRewards({
           tokenAddress: MUSD_TOKEN_ADDRESS,
@@ -326,7 +326,7 @@ describe('useMerklRewards', () => {
 
     // Allow the query to execute and resolve
     await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 0));
+      await waitForNextUpdate();
     });
 
     expect(mockFetchMerklRewardsForAsset).toHaveBeenCalled();
@@ -352,7 +352,7 @@ describe('useMerklRewards', () => {
       recipient: MOCK_ADDRESS,
     });
 
-    const { result } = renderHook(
+    const { result, waitForNextUpdate } = renderHook(
       () =>
         useMerklRewards({
           tokenAddress: MUSD_TOKEN_ADDRESS,
@@ -363,7 +363,7 @@ describe('useMerklRewards', () => {
     );
 
     await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 0));
+      await waitForNextUpdate();
     });
 
     expect(result.current.hasClaimableReward).toBe(false);
@@ -387,6 +387,9 @@ describe('useMerklRewards', () => {
       { wrapper: createWrapper() },
     );
 
+    // The query fires but rejects. With retry: false the error is immediate,
+    // yet the hook output stays at defaults (EMPTY_RESULT) so we just need to
+    // flush the microtask that delivers the error to react-query.
     await act(async () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
     });
@@ -432,7 +435,7 @@ describe('useMerklRewards', () => {
     });
     mockGetClaimedAmountFromContract.mockResolvedValueOnce(null);
 
-    const { result } = renderHook(
+    const { result, waitForNextUpdate } = renderHook(
       () =>
         useMerklRewards({
           tokenAddress: MUSD_TOKEN_ADDRESS,
@@ -443,7 +446,7 @@ describe('useMerklRewards', () => {
     );
 
     await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 0));
+      await waitForNextUpdate();
     });
 
     expect(result.current.hasClaimableReward).toBe(false);
@@ -505,10 +508,6 @@ describe('useMerklRewards', () => {
       { wrapper: createWrapper() },
     );
 
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-
     expect(result.current.hasClaimableReward).toBe(false);
     expect(result.current.hasClaimedBefore).toBe(false);
     expect(result.current.claimableRewardDisplay).toBeNull();
@@ -533,7 +532,7 @@ describe('useMerklRewards', () => {
       recipient: MOCK_ADDRESS,
     });
 
-    const { result } = renderHook(
+    const { result, waitForNextUpdate } = renderHook(
       () =>
         useMerklRewards({
           tokenAddress: MUSD_TOKEN_ADDRESS,
@@ -544,7 +543,7 @@ describe('useMerklRewards', () => {
     );
 
     await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      await waitForNextUpdate();
     });
 
     // Falls back to API value (claimed=0), so full amount is claimable
@@ -571,7 +570,7 @@ describe('useMerklRewards', () => {
     });
     mockGetClaimedAmountFromContract.mockResolvedValueOnce(null);
 
-    const { result } = renderHook(
+    const { result, waitForNextUpdate } = renderHook(
       () =>
         useMerklRewards({
           tokenAddress: MUSD_TOKEN_ADDRESS,
@@ -582,7 +581,7 @@ describe('useMerklRewards', () => {
     );
 
     await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      await waitForNextUpdate();
     });
 
     expect(result.current.hasClaimableReward).toBe(true);
@@ -617,13 +616,14 @@ describe('useMerklRewards', () => {
     const wrapper = createWrapper();
 
     // First mount — fetches from API
-    const { result: firstResult, unmount } = renderHook(
-      () => useMerklRewards(hookArgs),
-      { wrapper },
-    );
+    const {
+      result: firstResult,
+      unmount,
+      waitForNextUpdate,
+    } = renderHook(() => useMerklRewards(hookArgs), { wrapper });
 
     await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      await waitForNextUpdate();
     });
 
     expect(firstResult.current.hasClaimableReward).toBe(true);

--- a/ui/components/app/musd/hooks/useMerklRewards.test.ts
+++ b/ui/components/app/musd/hooks/useMerklRewards.test.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { renderHook, act, cleanup } from '@testing-library/react-hooks';
+import { renderHook, cleanup } from '@testing-library/react-hooks';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import * as merklClient from '../merkl-client';
 import {
@@ -114,13 +114,7 @@ describe('useMerklRewards', () => {
       typeof merklClient.getClaimedAmountFromContract
     >;
 
-  afterEach(async () => {
-    // Flush pending TanStack Query observer notification microtasks BEFORE
-    // the testing library unmounts hooks, preventing "state update on
-    // unmounted component" warnings from deferred scheduleMicrotask calls.
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
+  afterEach(() => {
     cleanup();
     queryClient.clear();
     jest.restoreAllMocks();
@@ -210,7 +204,7 @@ describe('useMerklRewards', () => {
     // On-chain read returns null → fallback to API claimed value (0)
     mockGetClaimedAmountFromContract.mockResolvedValueOnce(null);
 
-    const { result, waitForNextUpdate } = renderHook(
+    const { result, waitFor } = renderHook(
       () =>
         useMerklRewards({
           tokenAddress: MUSD_TOKEN_ADDRESS,
@@ -220,11 +214,10 @@ describe('useMerklRewards', () => {
       { wrapper: createWrapper() },
     );
 
-    await act(async () => {
-      await waitForNextUpdate();
+    await waitFor(() => {
+      expect(result.current.hasClaimableReward).toBe(true);
     });
 
-    expect(result.current.hasClaimableReward).toBe(true);
     expect(result.current.rewardAmountFiat).toBe(10.5);
     expect(result.current.hasClaimedBefore).toBe(false);
     expect(result.current.claimableRewardDisplay).toBe('10.50');
@@ -248,7 +241,7 @@ describe('useMerklRewards', () => {
     // On-chain read says 5.5 MUSD already claimed
     mockGetClaimedAmountFromContract.mockResolvedValueOnce('5500000');
 
-    const { result, waitForNextUpdate } = renderHook(
+    const { result, waitFor } = renderHook(
       () =>
         useMerklRewards({
           tokenAddress: MUSD_TOKEN_ADDRESS,
@@ -258,12 +251,11 @@ describe('useMerklRewards', () => {
       { wrapper: createWrapper() },
     );
 
-    await act(async () => {
-      await waitForNextUpdate();
+    // 10.5 - 5.5 = 5.0 MUSD claimable
+    await waitFor(() => {
+      expect(result.current.hasClaimableReward).toBe(true);
     });
 
-    // 10.5 - 5.5 = 5.0 MUSD claimable
-    expect(result.current.hasClaimableReward).toBe(true);
     expect(result.current.rewardAmountFiat).toBe(5.0);
     expect(result.current.hasClaimedBefore).toBe(true);
     expect(result.current.claimableRewardDisplay).toBe('5.00');
@@ -291,7 +283,7 @@ describe('useMerklRewards', () => {
     // On-chain says all claimed
     mockGetClaimedAmountFromContract.mockResolvedValueOnce('1000000');
 
-    const { result, waitForNextUpdate } = renderHook(
+    const { result, waitFor } = renderHook(
       () =>
         useMerklRewards({
           tokenAddress: MUSD_TOKEN_ADDRESS,
@@ -301,20 +293,19 @@ describe('useMerklRewards', () => {
       { wrapper: createWrapper() },
     );
 
-    await act(async () => {
-      await waitForNextUpdate();
+    await waitFor(() => {
+      expect(result.current.hasClaimedBefore).toBe(true);
     });
 
     expect(result.current.hasClaimableReward).toBe(false);
     expect(result.current.rewardAmountFiat).toBeNull();
-    expect(result.current.hasClaimedBefore).toBe(true);
     expect(result.current.claimableRewardDisplay).toBeNull();
   });
 
   it('returns false when API returns no matching reward', async () => {
     mockFetchMerklRewardsForAsset.mockResolvedValueOnce(null);
 
-    const { result, waitForNextUpdate } = renderHook(
+    const { result, waitFor } = renderHook(
       () =>
         useMerklRewards({
           tokenAddress: MUSD_TOKEN_ADDRESS,
@@ -324,12 +315,10 @@ describe('useMerklRewards', () => {
       { wrapper: createWrapper() },
     );
 
-    // Allow the query to execute and resolve
-    await act(async () => {
-      await waitForNextUpdate();
+    await waitFor(() => {
+      expect(mockFetchMerklRewardsForAsset).toHaveBeenCalled();
     });
 
-    expect(mockFetchMerklRewardsForAsset).toHaveBeenCalled();
     expect(result.current.hasClaimableReward).toBe(false);
     expect(result.current.rewardAmountFiat).toBeNull();
     expect(result.current.hasClaimedBefore).toBe(false);
@@ -352,7 +341,7 @@ describe('useMerklRewards', () => {
       recipient: MOCK_ADDRESS,
     });
 
-    const { result, waitForNextUpdate } = renderHook(
+    const { result, waitFor } = renderHook(
       () =>
         useMerklRewards({
           tokenAddress: MUSD_TOKEN_ADDRESS,
@@ -362,12 +351,11 @@ describe('useMerklRewards', () => {
       { wrapper: createWrapper() },
     );
 
-    await act(async () => {
-      await waitForNextUpdate();
+    await waitFor(() => {
+      expect(result.current.hasClaimedBefore).toBe(true);
     });
 
     expect(result.current.hasClaimableReward).toBe(false);
-    expect(result.current.hasClaimedBefore).toBe(true);
     expect(result.current.claimableRewardDisplay).toBeNull();
   });
 
@@ -377,7 +365,7 @@ describe('useMerklRewards', () => {
       new Error('Network error'),
     );
 
-    const { result } = renderHook(
+    const { result, waitFor } = renderHook(
       () =>
         useMerklRewards({
           tokenAddress: MUSD_TOKEN_ADDRESS,
@@ -387,14 +375,10 @@ describe('useMerklRewards', () => {
       { wrapper: createWrapper() },
     );
 
-    // The query fires but rejects. With retry: false the error is immediate,
-    // yet the hook output stays at defaults (EMPTY_RESULT) so we just need to
-    // flush the microtask that delivers the error to react-query.
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 0));
+    await waitFor(() => {
+      expect(result.current.hasClaimableReward).toBe(false);
     });
 
-    expect(result.current.hasClaimableReward).toBe(false);
     expect(result.current.hasClaimedBefore).toBe(false);
     expect(result.current.claimableRewardDisplay).toBeNull();
   });
@@ -435,7 +419,7 @@ describe('useMerklRewards', () => {
     });
     mockGetClaimedAmountFromContract.mockResolvedValueOnce(null);
 
-    const { result, waitForNextUpdate } = renderHook(
+    const { result, waitFor } = renderHook(
       () =>
         useMerklRewards({
           tokenAddress: MUSD_TOKEN_ADDRESS,
@@ -445,8 +429,8 @@ describe('useMerklRewards', () => {
       { wrapper: createWrapper() },
     );
 
-    await act(async () => {
-      await waitForNextUpdate();
+    await waitFor(() => {
+      expect(mockFetchMerklRewardsForAsset).toHaveBeenCalled();
     });
 
     expect(result.current.hasClaimableReward).toBe(false);
@@ -471,7 +455,7 @@ describe('useMerklRewards', () => {
     });
     mockGetClaimedAmountFromContract.mockResolvedValueOnce(null);
 
-    const { result, waitForNextUpdate } = renderHook(
+    const { result, waitFor } = renderHook(
       () =>
         useMerklRewards({
           tokenAddress: MUSD_TOKEN_ADDRESS,
@@ -481,11 +465,10 @@ describe('useMerklRewards', () => {
       { wrapper: createWrapper() },
     );
 
-    await act(async () => {
-      await waitForNextUpdate();
+    await waitFor(() => {
+      expect(result.current.hasClaimableReward).toBe(true);
     });
 
-    expect(result.current.hasClaimableReward).toBe(true);
     expect(result.current.rewardAmountFiat).toBe(0.01);
     expect(result.current.hasClaimedBefore).toBe(false);
     expect(result.current.claimableRewardDisplay).toBe('0.01');
@@ -498,7 +481,7 @@ describe('useMerklRewards', () => {
       isLoading: false,
     });
 
-    const { result } = renderHook(
+    const { result, waitFor } = renderHook(
       () =>
         useMerklRewards({
           tokenAddress: MUSD_TOKEN_ADDRESS,
@@ -508,7 +491,10 @@ describe('useMerklRewards', () => {
       { wrapper: createWrapper() },
     );
 
-    expect(result.current.hasClaimableReward).toBe(false);
+    await waitFor(() => {
+      expect(result.current.hasClaimableReward).toBe(false);
+    });
+
     expect(result.current.hasClaimedBefore).toBe(false);
     expect(result.current.claimableRewardDisplay).toBeNull();
     expect(mockFetchMerklRewardsForAsset).not.toHaveBeenCalled();
@@ -532,7 +518,7 @@ describe('useMerklRewards', () => {
       recipient: MOCK_ADDRESS,
     });
 
-    const { result, waitForNextUpdate } = renderHook(
+    const { result, waitFor } = renderHook(
       () =>
         useMerklRewards({
           tokenAddress: MUSD_TOKEN_ADDRESS,
@@ -542,12 +528,11 @@ describe('useMerklRewards', () => {
       { wrapper: createWrapper() },
     );
 
-    await act(async () => {
-      await waitForNextUpdate();
+    // Falls back to API value (claimed=0), so full amount is claimable
+    await waitFor(() => {
+      expect(result.current.hasClaimableReward).toBe(true);
     });
 
-    // Falls back to API value (claimed=0), so full amount is claimable
-    expect(result.current.hasClaimableReward).toBe(true);
     expect(result.current.rewardAmountFiat).toBe(10.5);
     expect(result.current.hasClaimedBefore).toBe(false);
     expect(result.current.claimableRewardDisplay).toBe('10.50');
@@ -570,7 +555,7 @@ describe('useMerklRewards', () => {
     });
     mockGetClaimedAmountFromContract.mockResolvedValueOnce(null);
 
-    const { result, waitForNextUpdate } = renderHook(
+    const { result, waitFor } = renderHook(
       () =>
         useMerklRewards({
           tokenAddress: MUSD_TOKEN_ADDRESS,
@@ -580,11 +565,10 @@ describe('useMerklRewards', () => {
       { wrapper: createWrapper() },
     );
 
-    await act(async () => {
-      await waitForNextUpdate();
+    await waitFor(() => {
+      expect(result.current.hasClaimableReward).toBe(true);
     });
 
-    expect(result.current.hasClaimableReward).toBe(true);
     expect(result.current.rewardAmountFiat).toBeNull();
     expect(result.current.hasClaimedBefore).toBe(false);
     expect(result.current.claimableRewardDisplay).toBe('10.50');
@@ -619,14 +603,13 @@ describe('useMerklRewards', () => {
     const {
       result: firstResult,
       unmount,
-      waitForNextUpdate,
+      waitFor,
     } = renderHook(() => useMerklRewards(hookArgs), { wrapper });
 
-    await act(async () => {
-      await waitForNextUpdate();
+    await waitFor(() => {
+      expect(firstResult.current.hasClaimableReward).toBe(true);
     });
 
-    expect(firstResult.current.hasClaimableReward).toBe(true);
     expect(firstResult.current.claimableRewardDisplay).toBe('10.50');
     expect(mockFetchMerklRewardsForAsset).toHaveBeenCalledTimes(1);
 
@@ -665,7 +648,7 @@ describe('useMerklRewards', () => {
     const wrapper = createWrapper();
 
     // First render with showMerklBadge=true — populates the cache
-    const { result: firstResult, waitForNextUpdate } = renderHook(
+    const { result: firstResult, waitFor } = renderHook(
       () =>
         useMerklRewards({
           tokenAddress: MUSD_TOKEN_ADDRESS,
@@ -675,11 +658,9 @@ describe('useMerklRewards', () => {
       { wrapper },
     );
 
-    await act(async () => {
-      await waitForNextUpdate();
+    await waitFor(() => {
+      expect(firstResult.current.hasClaimableReward).toBe(true);
     });
-
-    expect(firstResult.current.hasClaimableReward).toBe(true);
 
     // Second render with showMerklBadge=false — same queryKey, cache is warm
     const { result: secondResult } = renderHook(

--- a/ui/components/app/musd/hooks/useMerklRewards.test.ts
+++ b/ui/components/app/musd/hooks/useMerklRewards.test.ts
@@ -375,10 +375,13 @@ describe('useMerklRewards', () => {
       { wrapper: createWrapper() },
     );
 
+    // Wait for the rejected promise to be processed — the mock being called
+    // proves react-query ran the queryFn and settled (not just default state).
     await waitFor(() => {
-      expect(result.current.hasClaimableReward).toBe(false);
+      expect(mockFetchMerklRewardsForAsset).toHaveBeenCalled();
     });
 
+    expect(result.current.hasClaimableReward).toBe(false);
     expect(result.current.hasClaimedBefore).toBe(false);
     expect(result.current.claimableRewardDisplay).toBeNull();
   });
@@ -474,14 +477,16 @@ describe('useMerklRewards', () => {
     expect(result.current.claimableRewardDisplay).toBe('0.01');
   });
 
-  it('returns false and skips API call when user is geoblocked', async () => {
+  it('returns false and skips API call when user is geoblocked', () => {
     useMusdGeoBlocking.mockReturnValue({
       isBlocked: true,
       userCountry: 'GB',
       isLoading: false,
     });
 
-    const { result, waitFor } = renderHook(
+    // Query is disabled when geoblocked (enabled: false), so state is
+    // synchronous — no async cycle to wait for.
+    const { result } = renderHook(
       () =>
         useMerklRewards({
           tokenAddress: MUSD_TOKEN_ADDRESS,
@@ -491,10 +496,7 @@ describe('useMerklRewards', () => {
       { wrapper: createWrapper() },
     );
 
-    await waitFor(() => {
-      expect(result.current.hasClaimableReward).toBe(false);
-    });
-
+    expect(result.current.hasClaimableReward).toBe(false);
     expect(result.current.hasClaimedBefore).toBe(false);
     expect(result.current.claimableRewardDisplay).toBeNull();
     expect(mockFetchMerklRewardsForAsset).not.toHaveBeenCalled();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Updates a test to use waitForNextUpdate rather than setTimeout, as setTimeout seemed to be causing some inconsistent results.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/41308?quickstart=1)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that update async waiting semantics; low product risk, with minor risk of altering test reliability if the new `waitFor` assertions are too permissive or timing-sensitive.
> 
> **Overview**
> Refactors `useMerklRewards.test.ts` to remove `setTimeout`/`act`-based async flushing and instead wait on specific state transitions via `renderHook`’s `waitFor`.
> 
> Cleans up teardown logic (dropping the extra microtask flush) and makes the geoblocked case explicitly synchronous since the query is disabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 014f0f8cd0a78528073200e71cde858a5bec21ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->