### PR TITLE
ci: speedups for some release-related PRs

### DIFF
--- a/.github/rules/filter-rules.yml
+++ b/.github/rules/filter-rules.yml
@@ -57,3 +57,11 @@ all_changes:
 # To inform needs-locales
 locales:
   - 'app/_locales/**'
+
+# To inform just-repository-health-checks
+repository_health_checks_related:
+  - 'CHANGELOG.md'
+
+# To inform just-package-json-version
+package_json:
+  - 'package.json'

--- a/.github/workflows/get-requirements.yml
+++ b/.github/workflows/get-requirements.yml
@@ -27,6 +27,9 @@ on:
       needs-e2e:
         description: Whether E2E tests are needed
         value: ${{ jobs.detect-changes.outputs.needs-e2e }}
+      just-repository-health-checks:
+        description: Whether repository health checks are needed
+        value: ${{ jobs.detect-changes.outputs.just-repository-health-checks }}
 
 env:
   # For a `pull_request` event, the head commit hash is `github.event.pull_request.head.sha`.
@@ -37,6 +40,7 @@ env:
   RUN_ID: ${{ github.run_id }}
   IS_FORK: ${{ github.event.pull_request.head.repo.fork || github.event.repository.fork }}
   EVENT_NAME: ${{ github.event_name }}
+  PR_NUMBER: ${{ github.event.pull_request.number }}
 
 jobs:
   detect-changes:
@@ -52,6 +56,7 @@ jobs:
       needs-releases: ${{ steps.set-needs-releases.outputs.needs-releases || 'false'}}
       needs-benchmarks: ${{ steps.set-needs-benchmarks.outputs.needs-benchmarks || 'false'}}
       needs-e2e: ${{ steps.set-needs-e2e.outputs.needs-e2e || 'false'}}
+      just-repository-health-checks: ${{ steps.set-just-repository-health-checks.outputs.just-repository-health-checks || 'false'}}
     steps:
       - name: Check pull request merge queue status
         id: check-skip-merge-queue
@@ -116,10 +121,40 @@ jobs:
             echo "needs-locales=false" >> "$GITHUB_OUTPUT"
           fi
 
-      # skip-everything is a shortcut for up-to-date == 'true' || needs-locales == 'true'
+      - name: Compute just-repository-health-checks flag
+        id: set-just-repository-health-checks
+        if: ${{ steps.filter.outputs.repository_health_checks_related_count != '0' && steps.filter.outputs.all_changes_count == steps.filter.outputs.repository_health_checks_related_count }}
+        run: echo "just-repository-health-checks=true" >> "$GITHUB_OUTPUT"
+
+      # If the only change is in package.json, and the only line changed is "version", then we can skip everything
+      - name: Compute just-package-json-version flag
+        id: set-just-package-json-version
+        if: ${{ env.EVENT_NAME == 'pull_request' && steps.filter.outputs.package_json_count == '1' && steps.filter.outputs.all_changes_count == '1' }}
+        run: |
+          # At this point we already know the *only* changed file is package.json.
+          # Emit true only if the diff is exactly a single "version" line replacement.
+          export GH_PAGER=cat
+          DIFF="$(gh pr diff "${PR_NUMBER}" || true)"
+          CHANGES="$(printf '%s\n' "$DIFF" | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' || true)"
+          CHANGES_COUNT="$(printf '%s\n' "$CHANGES" | sed '/^$/d' | wc -l | tr -d ' ')"
+
+          if [[ "$CHANGES_COUNT" == '2' ]] && \
+             printf '%s\n' "$CHANGES" | grep -Eq '^-[[:space:]]*"version"[[:space:]]*:' && \
+             printf '%s\n' "$CHANGES" | grep -Eq '^\+[[:space:]]*"version"[[:space:]]*:'; then
+            echo "The only change is in package.json, and the only line changed is 'version'."
+            echo "just-package-json-version=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # skip-everything is a shortcut for up-to-date == 'true' || needs-locales == 'true' || just-repository-health-checks = 'true' || just-package-json-version == 'true'
       - name: Compute skip-everything flag
         id: set-skip-everything
-        if: ${{ env.IS_RUN_EVERYTHING_BRANCH == 'false' && (steps.check-skip-merge-queue.outputs.up-to-date == 'true' || steps.set-needs-locales.outputs.needs-locales == 'true') }}
+        if: >-
+          env.IS_RUN_EVERYTHING_BRANCH == 'false' && (
+            steps.check-skip-merge-queue.outputs.up-to-date == 'true' ||
+            steps.set-needs-locales.outputs.needs-locales == 'true' ||
+            steps.set-just-repository-health-checks.outputs.just-repository-health-checks == 'true' ||
+            steps.set-just-package-json-version.outputs.just-package-json-version == 'true'
+          )
         run: echo "skip-everything=true" >> "$GITHUB_OUTPUT"
 
       # This is very simple right now (and equivalent to !skip-everything)

--- a/.github/workflows/get-requirements.yml
+++ b/.github/workflows/get-requirements.yml
@@ -123,13 +123,23 @@ jobs:
 
       - name: Compute just-repository-health-checks flag
         id: set-just-repository-health-checks
-        if: ${{ steps.filter.outputs.repository_health_checks_related_count != '0' && steps.filter.outputs.all_changes_count == steps.filter.outputs.repository_health_checks_related_count }}
+        if: >-
+          ${{
+            steps.check-skip-merge-queue.outputs.up-to-date != 'true' &&
+            steps.filter.outputs.repository_health_checks_related_count != '0' &&
+            steps.filter.outputs.all_changes_count == steps.filter.outputs.repository_health_checks_related_count
+          }}
         run: echo "just-repository-health-checks=true" >> "$GITHUB_OUTPUT"
 
       # If the only change is in package.json, and the only line changed is "version", then we can skip everything
       - name: Compute just-package-json-version flag
         id: set-just-package-json-version
-        if: ${{ env.EVENT_NAME == 'pull_request' && steps.filter.outputs.package_json_count == '1' && steps.filter.outputs.all_changes_count == '1' }}
+        if: >-
+          ${{
+            env.EVENT_NAME == 'pull_request' &&
+            steps.filter.outputs.package_json_count == '1' &&
+            steps.filter.outputs.all_changes_count == '1'
+          }}
         run: |
           # At this point we already know the *only* changed file is package.json.
           # Emit true only if the diff is exactly a single "version" line replacement.
@@ -149,12 +159,14 @@ jobs:
       - name: Compute skip-everything flag
         id: set-skip-everything
         if: >-
-          env.IS_RUN_EVERYTHING_BRANCH == 'false' && (
-            steps.check-skip-merge-queue.outputs.up-to-date == 'true' ||
-            steps.set-needs-locales.outputs.needs-locales == 'true' ||
-            steps.set-just-repository-health-checks.outputs.just-repository-health-checks == 'true' ||
-            steps.set-just-package-json-version.outputs.just-package-json-version == 'true'
-          )
+          ${{
+            env.IS_RUN_EVERYTHING_BRANCH == 'false' && (
+              steps.check-skip-merge-queue.outputs.up-to-date == 'true' ||
+              steps.set-needs-locales.outputs.needs-locales == 'true' ||
+              steps.set-just-repository-health-checks.outputs.just-repository-health-checks == 'true' ||
+              steps.set-just-package-json-version.outputs.just-package-json-version == 'true'
+            )
+          }}
         run: echo "skip-everything=true" >> "$GITHUB_OUTPUT"
 
       # This is very simple right now (and equivalent to !skip-everything)
@@ -173,14 +185,24 @@ jobs:
       - name: Compute needs-releases flag
         id: set-needs-releases
         # Do not do releases on a fork
-        if: ${{ env.IS_FORK == 'false' && env.EVENT_NAME != 'merge_group' && steps.set-skip-everything.outputs.skip-everything != 'true' }}
+        if: >-
+          ${{
+            env.IS_FORK == 'false' &&
+            env.EVENT_NAME != 'merge_group' &&
+            steps.set-skip-everything.outputs.skip-everything != 'true'
+          }}
         run: echo "needs-releases=true" >> "$GITHUB_OUTPUT"
 
       # This is very simple right now, but is built to have future complexity
       - name: Compute needs-benchmarks flag
         id: set-needs-benchmarks
         # Do not run benchmarks on a fork or in the merge queue
-        if: ${{ env.IS_FORK == 'false' && env.EVENT_NAME != 'merge_group' && steps.set-skip-everything.outputs.skip-everything != 'true' }}
+        if: >-
+          ${{
+            env.IS_FORK == 'false' &&
+            env.EVENT_NAME != 'merge_group' &&
+            steps.set-skip-everything.outputs.skip-everything != 'true'
+          }}
         run: echo "needs-benchmarks=true" >> "$GITHUB_OUTPUT"
 
       - name: Compute needs-e2e flag

--- a/.github/workflows/identify-codeowners.yml
+++ b/.github/workflows/identify-codeowners.yml
@@ -15,7 +15,14 @@ concurrency:
 jobs:
   identify-codeowners:
     # Avoid running on forks since we need to write a PR comment
-    if: ${{ !(github.event.pull_request.head.repo.fork || github.event.repository.fork) }}
+    # Avoid running on release branches and bot PRs
+    if: >-
+      ${{
+        !(github.event.pull_request.head.repo.fork || github.event.repository.fork)
+        && !startsWith(github.head_ref, 'release/')
+        && github.event.pull_request.user.login != 'metamaskbot'
+        && github.event.pull_request.user.login != 'runway-github[bot]'
+      }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: pr-comment

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,7 +125,15 @@ jobs:
     needs:
       - get-requirements
       - prep-deps
-    if: ${{ needs.get-requirements.outputs.skip-everything != 'true' || (!cancelled() && needs.get-requirements.outputs.just-repository-health-checks == 'true') }}
+    if: >-
+      ${{
+        !cancelled() &&
+        !contains(needs.*.result, 'failure') &&
+        (
+          needs.get-requirements.outputs.skip-everything != 'true' ||
+          needs.get-requirements.outputs.just-repository-health-checks == 'true'
+        )
+      }}
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,7 +125,7 @@ jobs:
     needs:
       - get-requirements
       - prep-deps
-    if: ${{ needs.get-requirements.outputs.skip-everything != 'true' }}
+    if: ${{ needs.get-requirements.outputs.skip-everything != 'true' || (!cancelled() && needs.get-requirements.outputs.just-repository-health-checks == 'true') }}
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/merge-my-pr.yml
+++ b/.github/workflows/merge-my-pr.yml
@@ -13,12 +13,14 @@ jobs:
   merge-my-pr:
     # Only run if the comment is on a PR and the comment body matches exactly "Merge my PR"
     if: >-
-      github.event.issue.pull_request &&
-      github.event.comment.body == 'Merge my PR' &&
-      (
-        github.event.comment.author_association == 'MEMBER' ||
-        github.event.comment.author_association == 'OWNER'
-      )
+      ${{
+        github.event.issue.pull_request &&
+        github.event.comment.body == 'Merge my PR' &&
+        (
+          github.event.comment.author_association == 'MEMBER' ||
+          github.event.comment.author_association == 'OWNER'
+        )
+      }}
     runs-on: ubuntu-latest
     environment: default-branch
     permissions:


### PR DESCRIPTION
## **Description**

- Do not run identify-codeowners.yml on release branches and bot PRs
- For stable sync PRs - if the only change is CHANGELOG.md, just run the repository-health-checks
- For version bump PRs - if the only change is in package.json, and the only line changed is "version", skip everything
- Made more consistent multiline `if: >-` statements

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Progresses: MetaMask/MetaMask-planning#2676

<!--## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**
[skip-e2e]-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI gating logic to conditionally skip most jobs based on file/line-level diffs, which could accidentally under-test PRs if the filters or `gh pr diff` checks misclassify changes.
> 
> **Overview**
> Optimizes CI by adding new change filters and flags so certain low-signal PRs run less work.
> 
> `get-requirements.yml` now detects **CHANGELOG-only** PRs (runs only `repository-health-checks`) and **package.json version-only** PRs (skips everything), and exposes a `just-repository-health-checks` output consumed by `main.yml`.
> 
> `identify-codeowners.yml` is further scoped to not run on `release/*` branches or PRs authored by specific bots, and workflow `if:` conditions were normalized to a consistent multiline style.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83d23946a38a6b11cb5e0a5d0751b191f2d884f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->