### PR TITLE
bump: serialize-javascript to 7.0.5 for yarn audit cp-13.25.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -204,7 +204,7 @@
     "async-done@^1.2.0": "patch:async-done@npm%3A1.3.2#./.yarn/patches/async-done-npm-1.3.2-1f0a4a8997.patch",
     "async-done@^1.2.2": "patch:async-done@npm%3A1.3.2#./.yarn/patches/async-done-npm-1.3.2-1f0a4a8997.patch",
     "fast-json-patch@^3.1.1": "patch:fast-json-patch@npm%3A3.1.1#./.yarn/patches/fast-json-patch-npm-3.1.1-7e8bb70a45.patch",
-    "serialize-javascript": "7.0.3",
+    "serialize-javascript": "7.0.5",
     "@types/readable-stream-2@^2.3.15": "npm:@types/readable-stream@^2.3.15",
     "@types/readable-stream-3@^4.0.4": "npm:@types/readable-stream@^4.0.4",
     "readable-stream-2@^2.3.3": "npm:readable-stream@^2.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -41150,10 +41150,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"serialize-javascript@npm:7.0.3":
-  version: 7.0.3
-  resolution: "serialize-javascript@npm:7.0.3"
-  checksum: 10/ce45e28663ee1fa6f32c408c0a563c4a96e872cdc83dc3064c73126f2412048c6c984bfc1160c40188fcfa06cf5e075f5cc2e3261b0384dc8fdef34675c5adef
+"serialize-javascript@npm:7.0.5":
+  version: 7.0.5
+  resolution: "serialize-javascript@npm:7.0.5"
+  checksum: 10/6237c76ef6df3d1ad61dd4a393b71ca758c7654f4d1cf77529e513134c0f0660302e03b7ec88a8f3a3daa79e1f93d6de8218ecbc45e073d7cc6b66284a1d3e83
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

Fixes
```
└─ serialize-javascript
   ├─ ID: 1115519
   ├─ Issue: Serialize JavaScript has CPU Exhaustion Denial of Service via crafted array-like objects
   ├─ URL: https://github.com/advisories/GHSA-qj8w-gfj5-8c6v
   ├─ Severity: moderate
   ├─ Vulnerable Versions: <7.0.5
   │
   ├─ Tree Versions
   │  └─ 7.0.3
   │
   └─ Dependents
      └─ terser-webpack-plugin@npm:5.3.16 [e4394]
```

## **Changelog**

CHANGELOG entry: null

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**
[skip-e2e]-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-only change; primary impact is in build tooling consumers of `serialize-javascript`, with minimal chance of runtime behavior changes outside updated library semantics.
> 
> **Overview**
> Updates the pinned `serialize-javascript` resolution from `7.0.3` to `7.0.5` and refreshes `yarn.lock` accordingly.
> 
> This is a security-driven bump to address a moderate DoS advisory affecting versions `<7.0.5`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b71464d66d0c54adaa17516c4420aee07a69c38. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->