### PR TITLE
test(tron): add extension account/network e2e coverage

### DIFF
--- a/test/e2e/page-objects/pages/multichain/address-list-modal.ts
+++ b/test/e2e/page-objects/pages/multichain/address-list-modal.ts
@@ -76,6 +76,22 @@ class AddressListModal {
     await qrButton.click();
   }
 
+  async clickQRbuttonForNetwork(networkName: string): Promise<void> {
+    console.log(`Click QR button for network "${networkName}"`);
+    const networkNameElements = await this.driver.findElements(
+      this.networkName,
+    );
+    for (const [index, networkElement] of networkNameElements.entries()) {
+      const text = (await networkElement.getText()).trim();
+      if (text === networkName) {
+        await this.clickQRbutton(index);
+        return;
+      }
+    }
+
+    throw new Error(`Network row "${networkName}" was not found`);
+  }
+
   async getTruncatedAccountAddress(addressIndex: number = 0): Promise<string> {
     console.log('Get truncated account address');
     const addressElements = await this.driver.findElements(this.accountAddress);

--- a/test/e2e/tests/tron/account-creation.spec.ts
+++ b/test/e2e/tests/tron/account-creation.spec.ts
@@ -1,3 +1,4 @@
+import { strict as assert } from 'assert';
 import { Suite } from 'mocha';
 import { Mockttp } from 'mockttp';
 import { withFixtures } from '../../helpers';
@@ -8,6 +9,7 @@ import NonEvmHomepage from '../../page-objects/pages/home/non-evm-homepage';
 import NetworkManager from '../../page-objects/pages/network-manager';
 import HeaderNavbar from '../../page-objects/pages/header-navbar';
 import AccountListPage from '../../page-objects/pages/account-list-page';
+import MultichainAccountDetailsPage from '../../page-objects/pages/multichain/multichain-account-details-page';
 import { mockTronApis, TRON_ACCOUNT_ADDRESS } from './mocks/common-tron';
 
 describe('Tron account creation', function (this: Suite) {
@@ -32,21 +34,7 @@ describe('Tron account creation', function (this: Suite) {
 
         const accountListPage = new AccountListPage(driver);
         await accountListPage.checkPageIsLoaded();
-
-        // Click the "Add account" action button, then select "Tron account"
-        await driver.clickElement(
-          '[data-testid="multichain-account-menu-popover-action-button"]',
-        );
-        await driver.clickElement({
-          text: 'Tron account',
-          tag: 'button',
-        });
-        await driver.clickElementAndWaitToDisappear(
-          '[data-testid="submit-add-account-with-name"]',
-        );
-
-        // Re-open account menu and verify the Tron account appears
-        await headerNavbar.openAccountMenu();
+        await accountListPage.addMultichainAccount();
         await accountListPage.checkAccountDisplayedInAccountList('Tron 1');
       },
     );
@@ -74,10 +62,18 @@ describe('Tron account creation', function (this: Suite) {
         await networkManager.selectTab('Popular');
         await networkManager.selectNetworkByNameWithWait('Tron');
 
-        // Verify the shortened Tron address is displayed in the header
         const headerNavbar = new HeaderNavbar(driver);
-        const shortenedAddress = `${TRON_ACCOUNT_ADDRESS.slice(0, 5)}...${TRON_ACCOUNT_ADDRESS.slice(-4)}`;
-        await headerNavbar.checkAccountAddress(shortenedAddress);
+        await headerNavbar.openAccountDetailsModalDetailsTab();
+
+        const accountDetailsPage = new MultichainAccountDetailsPage(driver);
+        await accountDetailsPage.checkPageIsLoaded();
+
+        const actualAddress = await accountDetailsPage.getAccountAddress();
+        assert.equal(
+          actualAddress,
+          TRON_ACCOUNT_ADDRESS,
+          `Expected Tron address "${TRON_ACCOUNT_ADDRESS}" but got "${actualAddress}"`,
+        );
       },
     );
   });

--- a/test/e2e/tests/tron/account-creation.spec.ts
+++ b/test/e2e/tests/tron/account-creation.spec.ts
@@ -75,7 +75,7 @@ describe('Tron account creation', function (this: Suite) {
 
         const addressListModal = new AddressListModal(driver);
         await addressListModal.checkPageIsLoaded();
-        await addressListModal.clickQRbutton();
+        await addressListModal.clickQRbuttonForNetwork('Tron');
 
         const accountAddressModal = new AccountAddressModal(driver);
         await accountAddressModal.checkPageIsLoaded();

--- a/test/e2e/tests/tron/account-creation.spec.ts
+++ b/test/e2e/tests/tron/account-creation.spec.ts
@@ -35,7 +35,7 @@ describe('Tron account creation', function (this: Suite) {
         const accountListPage = new AccountListPage(driver);
         await accountListPage.checkPageIsLoaded();
         await accountListPage.addMultichainAccount();
-        await accountListPage.checkAccountDisplayedInAccountList('Tron 1');
+        await accountListPage.checkAccountDisplayedInAccountList('Account 2');
       },
     );
   });
@@ -63,7 +63,14 @@ describe('Tron account creation', function (this: Suite) {
         await networkManager.selectNetworkByNameWithWait('Tron');
 
         const headerNavbar = new HeaderNavbar(driver);
-        await headerNavbar.openAccountDetailsModalDetailsTab();
+        await headerNavbar.openAccountMenu();
+
+        const accountListPage = new AccountListPage(driver);
+        await accountListPage.checkPageIsLoaded();
+        await accountListPage.openMultichainAccountMenu({
+          accountLabel: 'Account 1',
+        });
+        await accountListPage.clickMultichainAccountMenuItem('Account details');
 
         const accountDetailsPage = new MultichainAccountDetailsPage(driver);
         await accountDetailsPage.checkPageIsLoaded();

--- a/test/e2e/tests/tron/account-creation.spec.ts
+++ b/test/e2e/tests/tron/account-creation.spec.ts
@@ -9,7 +9,8 @@ import NonEvmHomepage from '../../page-objects/pages/home/non-evm-homepage';
 import NetworkManager from '../../page-objects/pages/network-manager';
 import HeaderNavbar from '../../page-objects/pages/header-navbar';
 import AccountListPage from '../../page-objects/pages/account-list-page';
-import MultichainAccountDetailsPage from '../../page-objects/pages/multichain/multichain-account-details-page';
+import AddressListModal from '../../page-objects/pages/multichain/address-list-modal';
+import AccountAddressModal from '../../page-objects/pages/multichain/account-address-modal';
 import { mockTronApis, TRON_ACCOUNT_ADDRESS } from './mocks/common-tron';
 
 describe('Tron account creation', function (this: Suite) {
@@ -70,12 +71,16 @@ describe('Tron account creation', function (this: Suite) {
         await accountListPage.openMultichainAccountMenu({
           accountLabel: 'Account 1',
         });
-        await accountListPage.clickMultichainAccountMenuItem('Account details');
+        await accountListPage.clickMultichainAccountMenuItem('Addresses');
 
-        const accountDetailsPage = new MultichainAccountDetailsPage(driver);
-        await accountDetailsPage.checkPageIsLoaded();
+        const addressListModal = new AddressListModal(driver);
+        await addressListModal.checkPageIsLoaded();
+        await addressListModal.clickQRbutton();
 
-        const actualAddress = await accountDetailsPage.getAccountAddress();
+        const accountAddressModal = new AccountAddressModal(driver);
+        await accountAddressModal.checkPageIsLoaded();
+
+        const actualAddress = await accountAddressModal.getAccountAddress();
         assert.equal(
           actualAddress,
           TRON_ACCOUNT_ADDRESS,

--- a/test/e2e/tests/tron/account-creation.spec.ts
+++ b/test/e2e/tests/tron/account-creation.spec.ts
@@ -1,0 +1,111 @@
+import { Suite } from 'mocha';
+import { Mockttp } from 'mockttp';
+import { withFixtures } from '../../helpers';
+import FixtureBuilder from '../../fixtures/fixture-builder';
+import { Driver } from '../../webdriver/driver';
+import { login } from '../../page-objects/flows/login.flow';
+import NonEvmHomepage from '../../page-objects/pages/home/non-evm-homepage';
+import NetworkManager from '../../page-objects/pages/network-manager';
+import HeaderNavbar from '../../page-objects/pages/header-navbar';
+import AccountListPage from '../../page-objects/pages/account-list-page';
+import { mockTronApis, TRON_ACCOUNT_ADDRESS } from './mocks/common-tron';
+
+describe('Tron account creation', function (this: Suite) {
+  it('Creates a Tron account and verifies it appears in the account list', async function () {
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilder().build(),
+        title: this.test?.fullTitle(),
+        testSpecificMock: (mockServer: Mockttp) =>
+          mockTronApis(mockServer, true),
+        manifestFlags: {
+          remoteFeatureFlags: {
+            tronAccounts: { enabled: true, minimumVersion: '13.6.0' },
+          },
+        },
+      },
+      async ({ driver }: { driver: Driver }) => {
+        await login(driver);
+
+        const headerNavbar = new HeaderNavbar(driver);
+        await headerNavbar.openAccountMenu();
+
+        const accountListPage = new AccountListPage(driver);
+        await accountListPage.checkPageIsLoaded();
+
+        // Click the "Add account" action button, then select "Tron account"
+        await driver.clickElement(
+          '[data-testid="multichain-account-menu-popover-action-button"]',
+        );
+        await driver.clickElement({
+          text: 'Tron account',
+          tag: 'button',
+        });
+        await driver.clickElementAndWaitToDisappear(
+          '[data-testid="submit-add-account-with-name"]',
+        );
+
+        // Re-open account menu and verify the Tron account appears
+        await headerNavbar.openAccountMenu();
+        await accountListPage.checkAccountDisplayedInAccountList('Tron 1');
+      },
+    );
+  });
+
+  it('Verifies the exact base58 address derived from the test SRP', async function () {
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilder().build(),
+        title: this.test?.fullTitle(),
+        testSpecificMock: (mockServer: Mockttp) =>
+          mockTronApis(mockServer, true),
+        manifestFlags: {
+          remoteFeatureFlags: {
+            tronAccounts: { enabled: true, minimumVersion: '13.6.0' },
+          },
+        },
+      },
+      async ({ driver }: { driver: Driver }) => {
+        await login(driver);
+
+        // Navigate to the Tron network so the Tron account is active
+        const networkManager = new NetworkManager(driver);
+        await networkManager.openNetworkManager();
+        await networkManager.selectTab('Popular');
+        await networkManager.selectNetworkByNameWithWait('Tron');
+
+        // Verify the shortened Tron address is displayed in the header
+        const headerNavbar = new HeaderNavbar(driver);
+        const shortenedAddress = `${TRON_ACCOUNT_ADDRESS.slice(0, 5)}...${TRON_ACCOUNT_ADDRESS.slice(-4)}`;
+        await headerNavbar.checkAccountAddress(shortenedAddress);
+      },
+    );
+  });
+
+  it('Shows zero balance for a newly created Tron account', async function () {
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilder().build(),
+        title: this.test?.fullTitle(),
+        testSpecificMock: (mockServer: Mockttp) =>
+          mockTronApis(mockServer, true),
+        manifestFlags: {
+          remoteFeatureFlags: {
+            tronAccounts: { enabled: true, minimumVersion: '13.6.0' },
+          },
+        },
+      },
+      async ({ driver }: { driver: Driver }) => {
+        await login(driver);
+
+        const networkManager = new NetworkManager(driver);
+        await networkManager.openNetworkManager();
+        await networkManager.selectTab('Popular');
+        await networkManager.selectNetworkByNameWithWait('Tron');
+
+        const homePage = new NonEvmHomepage(driver);
+        await homePage.checkPageIsLoaded({ amount: '0 TRX' });
+      },
+    );
+  });
+});

--- a/test/e2e/tests/tron/account-creation.spec.ts
+++ b/test/e2e/tests/tron/account-creation.spec.ts
@@ -106,6 +106,15 @@ describe('Tron account creation', function (this: Suite) {
       async ({ driver }: { driver: Driver }) => {
         await login(driver);
 
+        const headerNavbar = new HeaderNavbar(driver);
+        await headerNavbar.openAccountMenu();
+
+        const accountListPage = new AccountListPage(driver);
+        await accountListPage.checkPageIsLoaded();
+        await accountListPage.addMultichainAccount();
+        await accountListPage.checkAccountDisplayedInAccountList('Account 2');
+        await accountListPage.selectAccount('Account 2');
+
         const networkManager = new NetworkManager(driver);
         await networkManager.openNetworkManager();
         await networkManager.selectTab('Popular');


### PR DESCRIPTION
## Summary
- add Tron extension E2E coverage for account creation, address derivation, and zero-balance account setup
- target the Tron row explicitly in the multichain address modal QR flow
- align the spec with the current multichain account UI flow

## Testing
- yarn eslint --no-ignore .worktrees/NEB-851-extension-tron-account-network/test/e2e/tests/tron/account-creation.spec.ts
- yarn prettier --check .worktrees/NEB-851-extension-tron-account-network/test/e2e/tests/tron/account-creation.spec.ts
- SELENIUM_BROWSER=chrome E2E_DEBUG=true yarn mocha --config=test/e2e/.mocharc.js --timeout=80000 --color --reporter=test/e2e/reporters/enhanced-spec-reporter.js /Users/ulisses/Desktop/metamask-extension/.worktrees/NEB-851-extension-tron-account-network/test/e2e/tests/tron/account-creation.spec.ts --exit