### PR TITLE
fix: Incorrect value for size or margin

### DIFF
--- a/ui/components/app/perps/order-entry/components/amount-input/amount-input.test.tsx
+++ b/ui/components/app/perps/order-entry/components/amount-input/amount-input.test.tsx
@@ -178,6 +178,72 @@ describe('AmountInput', () => {
     });
   });
 
+  describe('token display', () => {
+    it('displays token amount as size divided by price (not multiplied by leverage)', () => {
+      renderWithProvider(
+        <AmountInput
+          {...defaultProps}
+          amount="9000"
+          leverage={10}
+          currentPrice={45000}
+        />,
+        mockStore,
+      );
+
+      const container = screen.getByTestId('amount-input-token-field');
+      const input = container.querySelector('input');
+      // Size $9000 / price $45000 = 0.2 BTC (not 0.2 × 10 = 2)
+      expect(input).toHaveValue('0.2');
+    });
+  });
+
+  describe('leveraged size calculations', () => {
+    it('computes balance percent using max size (available × leverage)', () => {
+      const onBalancePercentChange = jest.fn();
+      renderWithProvider(
+        <AmountInput
+          {...defaultProps}
+          onBalancePercentChange={onBalancePercentChange}
+          availableBalance={1000}
+          leverage={10}
+        />,
+        mockStore,
+      );
+
+      const container = screen.getByTestId('amount-input-field');
+      const input = container.querySelector('input');
+      // Size $5000 with available $1000 × 10x leverage = max size $10000
+      // So $5000 / $10000 = 50%
+      fireEvent.change(input as HTMLInputElement, {
+        target: { value: '5000' },
+      });
+
+      expect(onBalancePercentChange).toHaveBeenCalledWith(50);
+    });
+
+    it('caps percent at 100% when size exceeds max leveraged size', () => {
+      const onBalancePercentChange = jest.fn();
+      renderWithProvider(
+        <AmountInput
+          {...defaultProps}
+          onBalancePercentChange={onBalancePercentChange}
+          availableBalance={1000}
+          leverage={5}
+        />,
+        mockStore,
+      );
+
+      const container = screen.getByTestId('amount-input-field');
+      const input = container.querySelector('input');
+      // Max size = $1000 × 5 = $5000. Entering $6000 should cap at 100%
+      fireEvent.change(input as HTMLInputElement, {
+        target: { value: '6000' },
+      });
+
+      expect(onBalancePercentChange).toHaveBeenCalledWith(100);
+    });
+  });
+
   describe('slider', () => {
     it('renders the slider container', () => {
       renderWithProvider(<AmountInput {...defaultProps} />, mockStore);

--- a/ui/components/app/perps/order-entry/components/amount-input/amount-input.tsx
+++ b/ui/components/app/perps/order-entry/components/amount-input/amount-input.tsx
@@ -65,9 +65,8 @@ export const AmountInput: React.FC<AmountInputProps> = ({
     if (numAmount === 0 || currentPrice === 0) {
       return null;
     }
-    const positionValue = numAmount * leverage;
-    return currentPrice > 0 ? positionValue / currentPrice : null;
-  }, [amount, currentPrice, leverage]);
+    return currentPrice > 0 ? numAmount / currentPrice : null;
+  }, [amount, currentPrice]);
 
   const tokenDisplayValue = useMemo(() => {
     if (tokenAmount === null || tokenAmount === 0) {
@@ -85,13 +84,11 @@ export const AmountInput: React.FC<AmountInputProps> = ({
       if (value === '' || /^[\d,]*\.?\d*$/u.test(value)) {
         onAmountChange(value);
         const cleanValue = value.replace(/,/gu, '');
-        if (cleanValue && availableBalance > 0) {
+        const maxSize = availableBalance * leverage;
+        if (cleanValue && maxSize > 0) {
           const numValue = parseFloat(cleanValue);
           if (!isNaN(numValue) && numValue > 0) {
-            const pct = Math.min(
-              Math.round((numValue / availableBalance) * 100),
-              100,
-            );
+            const pct = Math.min(Math.round((numValue / maxSize) * 100), 100);
             onBalancePercentChange(pct);
             setPercentInputValue(String(pct));
           } else {
@@ -104,7 +101,7 @@ export const AmountInput: React.FC<AmountInputProps> = ({
         }
       }
     },
-    [onAmountChange, onBalancePercentChange, availableBalance],
+    [onAmountChange, onBalancePercentChange, availableBalance, leverage],
   );
 
   const formatAmount = useCallback(
@@ -136,24 +133,17 @@ export const AmountInput: React.FC<AmountInputProps> = ({
           return;
         }
         const numToken = parseFloat(value);
-        if (
-          isNaN(numToken) ||
-          numToken <= 0 ||
-          currentPrice === 0 ||
-          leverage === 0
-        ) {
+        if (isNaN(numToken) || numToken <= 0 || currentPrice === 0) {
           onAmountChange('');
           onBalancePercentChange(0);
           setPercentInputValue('0');
           return;
         }
-        const usdMargin = (numToken * currentPrice) / leverage;
-        onAmountChange(formatAmount(usdMargin));
-        if (availableBalance > 0) {
-          const pct = Math.min(
-            Math.round((usdMargin / availableBalance) * 100),
-            100,
-          );
+        const usdSize = numToken * currentPrice;
+        onAmountChange(formatAmount(usdSize));
+        const maxSize = availableBalance * leverage;
+        if (maxSize > 0) {
+          const pct = Math.min(Math.round((usdSize / maxSize) * 100), 100);
           onBalancePercentChange(pct);
           setPercentInputValue(String(pct));
         } else {
@@ -184,11 +174,18 @@ export const AmountInput: React.FC<AmountInputProps> = ({
       if (percent === 0) {
         onAmountChange('');
       } else {
-        const newAmount = (availableBalance * percent) / 100;
+        const maxSize = availableBalance * leverage;
+        const newAmount = (maxSize * percent) / 100;
         onAmountChange(formatAmount(newAmount));
       }
     },
-    [onAmountChange, onBalancePercentChange, availableBalance, formatAmount],
+    [
+      onAmountChange,
+      onBalancePercentChange,
+      availableBalance,
+      leverage,
+      formatAmount,
+    ],
   );
 
   const handlePercentInputChange = useCallback(
@@ -202,13 +199,20 @@ export const AmountInput: React.FC<AmountInputProps> = ({
           if (num === 0) {
             onAmountChange('');
           } else {
-            const newAmount = (availableBalance * num) / 100;
+            const maxSize = availableBalance * leverage;
+            const newAmount = (maxSize * num) / 100;
             onAmountChange(formatAmount(newAmount));
           }
         }
       }
     },
-    [onAmountChange, onBalancePercentChange, availableBalance, formatAmount],
+    [
+      onAmountChange,
+      onBalancePercentChange,
+      availableBalance,
+      leverage,
+      formatAmount,
+    ],
   );
 
   const handlePercentInputBlur = useCallback(() => {
@@ -220,7 +224,7 @@ export const AmountInput: React.FC<AmountInputProps> = ({
     } else if (num > 100) {
       onBalancePercentChange(100);
       setPercentInputValue('100');
-      onAmountChange(formatAmount(availableBalance));
+      onAmountChange(formatAmount(availableBalance * leverage));
     } else {
       onBalancePercentChange(num);
       setPercentInputValue(String(num));
@@ -230,6 +234,7 @@ export const AmountInput: React.FC<AmountInputProps> = ({
     onAmountChange,
     onBalancePercentChange,
     availableBalance,
+    leverage,
     formatAmount,
   ]);
 

--- a/ui/hooks/perps/usePerpsOrderForm.test.ts
+++ b/ui/hooks/perps/usePerpsOrderForm.test.ts
@@ -303,6 +303,68 @@ describe('usePerpsOrderForm', () => {
       expect(result.current.calculations.liquidationPrice).toBeNull();
     });
 
+    it('calculates margin as size divided by leverage', () => {
+      const { result } = renderHookWithProvider(
+        () => usePerpsOrderForm(defaultOptions),
+        mockStateWithLocale,
+      );
+
+      act(() => {
+        result.current.handleAmountChange('10000');
+        result.current.handleLeverageChange(10);
+      });
+
+      // Size = $10000, leverage = 10x → margin = $1000
+      // marginRequired should NOT equal the amount (size) when leverage > 1
+      expect(result.current.calculations.marginRequired).not.toBeNull();
+      expect(result.current.calculations.marginRequired).toContain('1,000');
+      expect(result.current.calculations.marginRequired).not.toContain(
+        '10,000',
+      );
+    });
+
+    it('sets orderValue equal to size (not size × leverage)', () => {
+      const { result } = renderHookWithProvider(
+        () => usePerpsOrderForm(defaultOptions),
+        mockStateWithLocale,
+      );
+
+      act(() => {
+        result.current.handleAmountChange('5000');
+        result.current.handleLeverageChange(5);
+      });
+
+      // orderValue should be $5000 (the size), not $25000 (size × leverage)
+      expect(result.current.calculations.orderValue).toContain('5,000');
+      expect(result.current.calculations.orderValue).not.toContain('25,000');
+    });
+
+    it('recalculates balancePercent when leverage changes', () => {
+      const { result } = renderHookWithProvider(
+        () =>
+          usePerpsOrderForm({
+            ...defaultOptions,
+            availableBalance: 1000,
+          }),
+        mockStateWithLocale,
+      );
+
+      act(() => {
+        result.current.handleAmountChange('5000');
+        result.current.handleLeverageChange(10);
+      });
+
+      // Size $5000, available $1000, leverage 10x → maxSize $10000 → 50%
+      expect(result.current.formState.balancePercent).toBe(50);
+
+      act(() => {
+        result.current.handleLeverageChange(5);
+      });
+
+      // Same size $5000, now leverage 5x → maxSize $5000 → 100%
+      expect(result.current.formState.balancePercent).toBe(100);
+    });
+
     it('recalculates when closePercent changes', () => {
       const existingPosition = {
         size: '2.0',

--- a/ui/hooks/perps/usePerpsOrderForm.ts
+++ b/ui/hooks/perps/usePerpsOrderForm.ts
@@ -9,6 +9,7 @@ import type {
 import {
   mockOrderFormDefaults,
   calculatePositionSize,
+  calculateMarginRequired,
   estimateLiquidationPrice,
 } from '../../components/app/perps/order-entry/order-entry.mocks';
 
@@ -271,23 +272,22 @@ export function usePerpsOrderForm({
       }
     }
 
-    // User enters MARGIN amount. Position value = margin × leverage
-    const positionValue = amount * formState.leverage;
-    const positionSize = calculatePositionSize(positionValue, effectivePrice);
-    const marginRequired = amount; // The entered amount IS the margin
+    // User enters SIZE (position notional value). Margin = size / leverage
+    const positionSize = calculatePositionSize(amount, effectivePrice);
+    const marginRequired = calculateMarginRequired(amount, formState.leverage);
     const liquidationPrice = estimateLiquidationPrice(
       effectivePrice,
       formState.leverage,
       formState.direction === 'long',
     );
-    // Mock fee calculation: 0.05% of position value (not margin)
-    const estimatedFees = positionValue * 0.0005;
+    // Mock fee calculation: 0.05% of position size
+    const estimatedFees = amount * 0.0005;
 
     return {
       positionSize: formatTokenQuantity(positionSize, asset),
       marginRequired: formatCurrencyWithMinThreshold(marginRequired, 'USD'),
       liquidationPrice: formatCurrencyWithMinThreshold(liquidationPrice, 'USD'),
-      orderValue: formatCurrencyWithMinThreshold(positionValue, 'USD'),
+      orderValue: formatCurrencyWithMinThreshold(amount, 'USD'),
       estimatedFees: formatCurrencyWithMinThreshold(estimatedFees, 'USD'),
     };
   }, [
@@ -314,9 +314,18 @@ export function usePerpsOrderForm({
     setFormState((prev) => ({ ...prev, balancePercent }));
   }, []);
 
-  const handleLeverageChange = useCallback((leverage: number) => {
-    setFormState((prev) => ({ ...prev, leverage }));
-  }, []);
+  const handleLeverageChange = useCallback(
+    (leverage: number) => {
+      setFormState((prev) => {
+        const amount = parseFloat(prev.amount.replace(/,/gu, '')) || 0;
+        const maxSize = availableBalance * leverage;
+        const balancePercent =
+          maxSize > 0 ? Math.min(Math.round((amount / maxSize) * 100), 100) : 0;
+        return { ...prev, leverage, balancePercent };
+      });
+    },
+    [availableBalance],
+  );
 
   const handleAutoCloseEnabledChange = useCallback((enabled: boolean) => {
     setFormState((prev) => ({ ...prev, autoCloseEnabled: enabled }));


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The perps order entry form treated the "Size" input as margin, causing Size and Margin to display the same value when leverage > 1. Fixed by treating the amount as position notional size (consistent with mobile) and computing `margin = size / leverage`.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/41354?quickstart=1)

## **Changelog**

CHANGELOG entry: Fixed incorrect margin value on perps order entry when leverage is applied

## **Related issues**

Fixes: [TAT-2684](https://consensyssoftware.atlassian.net/browse/TAT-2684)

## **Manual testing steps**

1. Navigate to Perps tab, select a market (e.g. ETH)
2. Tap Long, enter a Size (e.g. $32) with leverage > 1 (e.g. 8x)
3. Verify Margin in summary = Size / Leverage ($4.00)
4. Verify the token display matches Size / price
5. Adjust the slider and confirm amounts scale with available balance × leverage

## **Screenshots/Recordings**

### **Before**

_Evidence available in task artifacts — will be added by reviewer if needed._

### **After**

_Evidence available in task artifacts — will be added by reviewer if needed._

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[TAT-2684]: https://consensyssoftware.atlassian.net/browse/TAT-2684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core perps order-entry calculations (size, margin, balance percent, slider) and could impact displayed order values and user inputs if any edge cases are missed. Covered by added unit tests, but still affects trading-critical UX math.
> 
> **Overview**
> Fixes perps order entry math by treating the USD `amount` field as **position size (notional)** rather than margin.
> 
> Updates `AmountInput` to derive token display as `size / price` and to compute slider/percent against **max leveraged size** (`availableBalance × leverage`), including token-input and percent/slider interactions. Updates `usePerpsOrderForm` calculations so `marginRequired = size / leverage`, `orderValue = size`, fees are based on size, and `balancePercent` is recomputed when leverage changes; adds tests covering these behaviors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4281ce53c5464b5dd5c178180da70e23363f1cd1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

