### PR TITLE
ci: fix release version number on stable main sync PR

### DIFF
--- a/.github/scripts/get-stable-released-version.sh
+++ b/.github/scripts/get-stable-released-version.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Resolves the semver for Stable Branch Sync PRs. Uses the version at the tip
+# of `stable` (from package.json), i.e. the release that was just merged — not
+# the "next" release derived from remote release/* branches (see
+# get-next-semver-version.sh for that).
+
+set -euo pipefail
+
+if [ -z "${GITHUB_OUTPUT:-}" ]; then
+  echo "GITHUB_OUTPUT is not set; this script is only meant to run in GitHub Actions." >&2
+  exit 1
+fi
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+PACKAGE_JSON="${ROOT}/package.json"
+
+if [ ! -f "$PACKAGE_JSON" ]; then
+  echo "Expected package.json at ${PACKAGE_JSON}" >&2
+  exit 1
+fi
+
+VERSION=$(jq -r '.version | select(type == "string")' "$PACKAGE_JSON")
+
+if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
+  echo "Could not read .version from ${PACKAGE_JSON}" >&2
+  exit 1
+fi
+
+# Same rule as .github/scripts/shared/utils.ts isValidVersionFormat (stable-sync branch names expect x.y.z).
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Invalid version in ${PACKAGE_JSON}: ${VERSION} (expected numeric x.y.z)" >&2
+  exit 1
+fi
+
+echo "stable_version=${VERSION}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/stable-branch-sync.yml
+++ b/.github/workflows/stable-branch-sync.yml
@@ -18,8 +18,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Configure Git
         run: |

--- a/.github/workflows/stable-branch-sync.yml
+++ b/.github/workflows/stable-branch-sync.yml
@@ -9,12 +9,12 @@ permissions:
   contents: write
 
 jobs:
-  get-next-version:
-    name: Get next version vX.Y.Z
+  get-stable-version:
+    name: Get stable release version
     runs-on: ubuntu-latest
     timeout-minutes: 30
     outputs:
-      next-version: ${{ env.NEXT_SEMVER_VERSION }}
+      stable-version: ${{ steps.resolve-stable-version.outputs.stable_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -26,22 +26,20 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Get the next semver version
-        id: get-next-semver-version
-        env:
-          FORCE_NEXT_SEMVER_VERSION: ${{ vars.FORCE_NEXT_SEMVER_VERSION }}
-        run: ./get-next-semver-version.sh "$FORCE_NEXT_SEMVER_VERSION"
+      - name: Get stable release version
+        id: resolve-stable-version
+        run: ./get-stable-released-version.sh
         working-directory: '.github/scripts'
 
   run-stable-sync:
     name: Run Stable branch sync
-    needs: get-next-version
+    needs: get-stable-version
     runs-on: ubuntu-latest
     steps:
       - name: Run stable sync
         uses: MetaMask/github-tools/.github/actions/stable-sync@v1
         with:
-          semver-version: ${{ needs.get-next-version.outputs.next-version }}
+          semver-version: ${{ needs['get-stable-version'].outputs['stable-version'] }}
           repo-type: 'extension'
           stable-branch-name: 'stable'
           github-token: ${{ secrets.STABLE_SYNC_TOKEN }}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Stable sync script runs when we merge release PR to stable. The workflow used `get-next-semver-version.sh`, which is the next semver version, indicated the package.json on main, which is not what we want.
Here's for example the [stable-sync PR](https://github.com/MetaMask/metamask-extension/pull/38210) that got created by the Gitub Action right after we merged release/13.10.2 to stable. We have to rename everything to `13.10.2` in the PR title and description, but initially, all was set to 13.12.0, i.e. the next semver version, indicated in package.json on main, not the version on stable branch.

In this PR: 

- Added `.github/scripts/get-stable-released-version.sh ` to read the version from `package.json` on the checked-out stable branch, validate x.y.z.

- Updated `.github/workflows/stable-branch-sync.yml `to run that script, and `pass needs['get-stable-version'].outputs['stable-version']` into semver-version.


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/INFRA-3168

## **Manual testing steps**

on the next push to stable, open `Actions → Stable Branch Sync` and confirm `semver-version` and the opened sync PR and branch match `package.json` on that stable branch.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[skip-e2e]
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GitHub Actions logic that drives automated stable sync PR creation; a mistake could generate incorrectly versioned branches/PRs or fail the workflow, but it’s isolated to CI.
> 
> **Overview**
> Fixes stable-branch sync PRs being created with the *next* semver by switching the workflow to read the **current stable release version** directly from `package.json` on the checked-out `stable` branch.
> 
> Adds `.github/scripts/get-stable-released-version.sh` to extract and validate an `x.y.z` version and updates `stable-branch-sync.yml` to pass this `stable_version` output into the `stable-sync` action (removing the prior `get-next-semver-version.sh` step).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 425616a4f1faa0bbac2cf941db1309837f971cb5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->