### PR TITLE
fix(perps): Added an available balance guard for close/modify

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5412,6 +5412,10 @@
     "message": "Available to trade",
     "description": "Label for the available balance that can be used for trading"
   },
+  "perpsOrderValidationInsufficientBalance": {
+    "message": "Insufficient balance: need $1, have $2",
+    "description": "$1 is the required margin amount and $2 is the available balance amount"
+  },
   "perpsCancelAllOrders": {
     "message": "Cancel all"
   },
@@ -5732,6 +5736,10 @@
   },
   "perpsStatusFilled": {
     "message": "Filled"
+  },
+  "perpsToastOrderFilled": {
+    "message": "Order filled",
+    "description": "Toast title shown when an order is filled"
   },
   "perpsStatusOpen": {
     "message": "Open"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5412,10 +5412,6 @@
     "message": "Available to trade",
     "description": "Label for the available balance that can be used for trading"
   },
-  "perpsOrderValidationInsufficientBalance": {
-    "message": "Insufficient balance: need $1, have $2",
-    "description": "$1 is the required margin amount and $2 is the available balance amount"
-  },
   "perpsCancelAllOrders": {
     "message": "Cancel all"
   },
@@ -5634,6 +5630,10 @@
   "perpsOraclePriceTooltip": {
     "message": "The median of external prices reported by validators, used for computing funding rate"
   },
+  "perpsOrderValidationInsufficientBalance": {
+    "message": "Insufficient balance: need $1, have $2",
+    "description": "$1 is the required margin amount and $2 is the available balance amount"
+  },
   "perpsOrders": {
     "message": "Orders"
   },
@@ -5737,10 +5737,6 @@
   "perpsStatusFilled": {
     "message": "Filled"
   },
-  "perpsToastOrderFilled": {
-    "message": "Order filled",
-    "description": "Toast title shown when an order is filled"
-  },
   "perpsStatusOpen": {
     "message": "Open"
   },
@@ -5764,6 +5760,10 @@
   "perpsTakeProfit": {
     "message": "Take Profit",
     "description": "Label for take profit price input"
+  },
+  "perpsToastOrderFilled": {
+    "message": "Order filled",
+    "description": "Toast title shown when an order is filled"
   },
   "perpsTotalBalance": {
     "message": "Total Balance"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5761,10 +5761,6 @@
     "message": "Take Profit",
     "description": "Label for take profit price input"
   },
-  "perpsToastOrderFilled": {
-    "message": "Order filled",
-    "description": "Toast title shown when an order is filled"
-  },
   "perpsTotalBalance": {
     "message": "Total Balance"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -5630,6 +5630,10 @@
   "perpsOraclePriceTooltip": {
     "message": "The median of external prices reported by validators, used for computing funding rate"
   },
+  "perpsOrderValidationInsufficientBalance": {
+    "message": "Insufficient balance: need $1, have $2",
+    "description": "$1 is the required margin amount and $2 is the available balance amount"
+  },
   "perpsOrders": {
     "message": "Orders"
   },

--- a/ui/components/app/perps/edit-margin/edit-margin-expandable.test.tsx
+++ b/ui/components/app/perps/edit-margin/edit-margin-expandable.test.tsx
@@ -149,6 +149,27 @@ describe('EditMarginExpandable', () => {
   });
 
   describe('slider', () => {
+    it('does not underflow at max slider value for IEEE-754 edge balances', () => {
+      renderWithProvider(
+        <EditMarginExpandable
+          {...defaultProps}
+          account={{ ...mockAccountState, availableBalance: '1.15' }}
+          isExpanded
+        />,
+        mockStore,
+      );
+
+      fireEvent.keyDown(screen.getByRole('slider'), {
+        key: 'End',
+        code: 'End',
+      });
+
+      expect(screen.getByPlaceholderText('0.00')).toHaveValue('1.15');
+      expect(
+        screen.getByRole('button', { name: /Add Margin/iu }),
+      ).not.toBeDisabled();
+    });
+
     it('keeps add margin submit enabled when max slider value floors to 2dp', () => {
       renderWithProvider(
         <EditMarginExpandable

--- a/ui/components/app/perps/edit-margin/edit-margin-expandable.test.tsx
+++ b/ui/components/app/perps/edit-margin/edit-margin-expandable.test.tsx
@@ -1,12 +1,12 @@
 import { screen, fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
 
-import { EditMarginExpandable } from './edit-margin-expandable';
 import mockState from '../../../../../test/data/mock-state.json';
 import { enLocale as messages } from '../../../../../test/lib/i18n-helpers';
 import { renderWithProvider } from '../../../../../test/lib/render-helpers-navigate';
 import configureStore from '../../../../store/store';
 import { mockPositions, mockAccountState } from '../mocks';
+import { EditMarginExpandable } from './edit-margin-expandable';
 
 const mockGetPerpsStreamManager = jest.fn();
 const mockSubmitRequestToBackground = jest.fn();

--- a/ui/components/app/perps/edit-margin/edit-margin-expandable.test.tsx
+++ b/ui/components/app/perps/edit-margin/edit-margin-expandable.test.tsx
@@ -1,11 +1,12 @@
-import React from 'react';
 import { screen, fireEvent, waitFor } from '@testing-library/react';
-import { renderWithProvider } from '../../../../../test/lib/render-helpers-navigate';
-import configureStore from '../../../../store/store';
+import React from 'react';
+
+import { EditMarginExpandable } from './edit-margin-expandable';
 import mockState from '../../../../../test/data/mock-state.json';
 import { enLocale as messages } from '../../../../../test/lib/i18n-helpers';
+import { renderWithProvider } from '../../../../../test/lib/render-helpers-navigate';
+import configureStore from '../../../../store/store';
 import { mockPositions, mockAccountState } from '../mocks';
-import { EditMarginExpandable } from './edit-margin-expandable';
 
 const mockGetPerpsStreamManager = jest.fn();
 const mockSubmitRequestToBackground = jest.fn();
@@ -144,6 +145,29 @@ describe('EditMarginExpandable', () => {
       expect(
         screen.getByText(messages.perpsAvailableToAdd.message),
       ).toBeInTheDocument();
+    });
+  });
+
+  describe('slider', () => {
+    it('keeps add margin submit enabled when max slider value floors to 2dp', () => {
+      renderWithProvider(
+        <EditMarginExpandable
+          {...defaultProps}
+          account={{ ...mockAccountState, availableBalance: '3.066' }}
+          isExpanded
+        />,
+        mockStore,
+      );
+
+      fireEvent.keyDown(screen.getByRole('slider'), {
+        key: 'End',
+        code: 'End',
+      });
+
+      expect(screen.getByPlaceholderText('0.00')).toHaveValue('3.06');
+      expect(
+        screen.getByRole('button', { name: /Add Margin/iu }),
+      ).not.toBeDisabled();
     });
   });
 

--- a/ui/components/app/perps/edit-margin/edit-margin-modal-content.tsx
+++ b/ui/components/app/perps/edit-margin/edit-margin-modal-content.tsx
@@ -1,4 +1,3 @@
-import React, { useState, useCallback, useEffect, useMemo } from 'react';
 import {
   Box,
   BoxFlexDirection,
@@ -17,19 +16,22 @@ import {
   IconColor,
 } from '@metamask/design-system-react';
 import type { Position as PerpsPosition } from '@metamask/perps-controller';
-import { useI18nContext } from '../../../../hooks/useI18nContext';
-import { TextField, TextFieldSize } from '../../../component-library';
+import React, { useState, useCallback, useEffect, useMemo } from 'react';
+
 import {
   BorderRadius,
   BackgroundColor,
 } from '../../../../helpers/constants/design-system';
-import { submitRequestToBackground } from '../../../../store/background-connection';
-import { getPerpsStreamManager } from '../../../../providers/perps';
-import { useFormatters } from '../../../../hooks/useFormatters';
 import { usePerpsEligibility } from '../../../../hooks/perps';
+import { MARGIN_ADJUSTMENT_CONFIG } from '../../../../hooks/perps/marginUtils';
 import { usePerpsMarginCalculations } from '../../../../hooks/perps/usePerpsMarginCalculations';
-import type { Position, AccountState } from '../types';
+import { useFormatters } from '../../../../hooks/useFormatters';
+import { useI18nContext } from '../../../../hooks/useI18nContext';
+import { getPerpsStreamManager } from '../../../../providers/perps';
+import { submitRequestToBackground } from '../../../../store/background-connection';
+import { TextField, TextFieldSize } from '../../../component-library';
 import { PerpsSlider } from '../perps-slider';
+import type { Position, AccountState } from '../types';
 
 export type EditMarginModalContentProps = {
   position: Position;
@@ -96,8 +98,14 @@ export const EditMarginModalContent: React.FC<EditMarginModalContentProps> = ({
     anchorLiquidationDistance,
     estimatedLiquidationDistance,
     riskAssessment,
-    isValid,
   } = calculations;
+  const flooredMaxAmount = Math.floor(maxAmount * 100) / 100;
+  const amountNum = Number.parseFloat(marginAmount.replaceAll(',', '')) || 0;
+  const currentMargin = Number.parseFloat(position.marginUsed) || 0;
+  const isAmountValid =
+    amountNum >= MARGIN_ADJUSTMENT_CONFIG.MinAdjustmentAmount &&
+    amountNum <= flooredMaxAmount &&
+    (marginMode === 'add' || amountNum <= currentMargin);
 
   const amountNumForDisplay = useMemo(
     () => Number.parseFloat(marginAmount.replaceAll(',', '')) || 0,
@@ -194,16 +202,16 @@ export const EditMarginModalContent: React.FC<EditMarginModalContentProps> = ({
       const { value } = e.target;
       if (value === '' || /^[\d,]*\.?\d{0,2}$/u.test(value)) {
         let cleaned = value.replaceAll(',', '');
-        if (marginMode === 'remove' && maxAmount > 0) {
+        if (marginMode === 'remove' && flooredMaxAmount > 0) {
           const num = Number.parseFloat(cleaned) || 0;
-          if (num > maxAmount) {
-            cleaned = maxAmount.toFixed(2);
+          if (num > flooredMaxAmount) {
+            cleaned = flooredMaxAmount.toFixed(2);
           }
         }
         setMarginAmount(cleaned);
       }
     },
-    [marginMode, maxAmount],
+    [marginMode, flooredMaxAmount],
   );
 
   const handleSliderChange = useCallback(
@@ -228,12 +236,11 @@ export const EditMarginModalContent: React.FC<EditMarginModalContentProps> = ({
   );
 
   const handleSaveMargin = useCallback(async () => {
-    if (!isEligible || !isValid) {
+    if (!isEligible || !isAmountValid) {
       return;
     }
 
     const rawMarginAmount = marginAmount.replaceAll(',', '');
-    const amountNum = Number.parseFloat(rawMarginAmount) || 0;
     if (amountNum <= 0) {
       return;
     }
@@ -281,7 +288,8 @@ export const EditMarginModalContent: React.FC<EditMarginModalContentProps> = ({
     isEligible,
     marginMode,
     marginAmount,
-    isValid,
+    isAmountValid,
+    amountNum,
     position.symbol,
     onClose,
     onSavingChange,
@@ -294,10 +302,7 @@ export const EditMarginModalContent: React.FC<EditMarginModalContentProps> = ({
       riskAssessment.riskLevel === 'danger');
 
   const confirmDisabled =
-    !isEligible ||
-    !isValid ||
-    isSaving ||
-    Number.parseFloat(marginAmount.replaceAll(',', '')) <= 0;
+    !isEligible || !isAmountValid || isSaving || amountNum <= 0;
 
   useEffect(() => {
     if (onSaveRef) {

--- a/ui/components/app/perps/edit-margin/edit-margin-modal-content.tsx
+++ b/ui/components/app/perps/edit-margin/edit-margin-modal-content.tsx
@@ -32,6 +32,7 @@ import { submitRequestToBackground } from '../../../../store/background-connecti
 import { TextField, TextFieldSize } from '../../../component-library';
 import { PerpsSlider } from '../perps-slider';
 import type { Position, AccountState } from '../types';
+import { floorToDecimals } from '../utils/number';
 
 export type EditMarginModalContentProps = {
   position: Position;
@@ -99,19 +100,18 @@ export const EditMarginModalContent: React.FC<EditMarginModalContentProps> = ({
     estimatedLiquidationDistance,
     riskAssessment,
   } = calculations;
-  const flooredMaxAmount = Math.floor(maxAmount * 100) / 100;
-  const amountNum = Number.parseFloat(marginAmount.replaceAll(',', '')) || 0;
-  const currentMargin = Number.parseFloat(position.marginUsed) || 0;
-  const isAmountValid =
-    amountNum >= MARGIN_ADJUSTMENT_CONFIG.MinAdjustmentAmount &&
-    amountNum <= flooredMaxAmount &&
-    (marginMode === 'add' || amountNum <= currentMargin);
-
-  const amountNumForDisplay = useMemo(
+  const flooredMaxAmount = floorToDecimals(maxAmount);
+  const parsedAmount = useMemo(
     () => Number.parseFloat(marginAmount.replaceAll(',', '')) || 0,
     [marginAmount],
   );
-  const showLiquidationComparison = amountNumForDisplay > 0;
+  const currentMargin = Number.parseFloat(position.marginUsed) || 0;
+  const isAmountValid =
+    parsedAmount >= MARGIN_ADJUSTMENT_CONFIG.MinAdjustmentAmount &&
+    parsedAmount <= flooredMaxAmount &&
+    (marginMode === 'add' || parsedAmount <= currentMargin);
+
+  const showLiquidationComparison = parsedAmount > 0;
 
   const liquidationPriceDisplay = useMemo(() => {
     if (
@@ -193,9 +193,8 @@ export const EditMarginModalContent: React.FC<EditMarginModalContentProps> = ({
     if (maxAmount <= 0) {
       return 0;
     }
-    const n = Number.parseFloat(marginAmount.replaceAll(',', '')) || 0;
-    return Math.min(100, Math.round((n / maxAmount) * 100));
-  }, [marginAmount, maxAmount]);
+    return Math.min(100, Math.round((parsedAmount / maxAmount) * 100));
+  }, [parsedAmount, maxAmount]);
 
   const handleAmountChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -225,7 +224,7 @@ export const EditMarginModalContent: React.FC<EditMarginModalContentProps> = ({
         return;
       }
       const raw = (maxAmount * percent) / 100;
-      const floored = Math.floor(raw * 100) / 100;
+      const floored = floorToDecimals(raw);
       if (floored <= 0) {
         setMarginAmount('');
         return;
@@ -241,7 +240,7 @@ export const EditMarginModalContent: React.FC<EditMarginModalContentProps> = ({
     }
 
     const rawMarginAmount = marginAmount.replaceAll(',', '');
-    if (amountNum <= 0) {
+    if (parsedAmount <= 0) {
       return;
     }
 
@@ -289,7 +288,7 @@ export const EditMarginModalContent: React.FC<EditMarginModalContentProps> = ({
     marginMode,
     marginAmount,
     isAmountValid,
-    amountNum,
+    parsedAmount,
     position.symbol,
     onClose,
     onSavingChange,
@@ -302,7 +301,7 @@ export const EditMarginModalContent: React.FC<EditMarginModalContentProps> = ({
       riskAssessment.riskLevel === 'danger');
 
   const confirmDisabled =
-    !isEligible || !isAmountValid || isSaving || amountNum <= 0;
+    !isEligible || !isAmountValid || isSaving || parsedAmount <= 0;
 
   useEffect(() => {
     if (onSaveRef) {

--- a/ui/components/app/perps/order-entry/components/amount-input/amount-input.test.tsx
+++ b/ui/components/app/perps/order-entry/components/amount-input/amount-input.test.tsx
@@ -224,6 +224,50 @@ describe('AmountInput', () => {
       const input = container.querySelector('input');
       expect(input).toHaveValue('1000.50');
     });
+
+    it('floors amount to 2 decimals on blur', () => {
+      const onAmountChange = jest.fn();
+      renderWithProvider(
+        <AmountInput
+          {...defaultProps}
+          amount="3.067"
+          onAmountChange={onAmountChange}
+        />,
+        mockStore,
+      );
+
+      const container = screen.getByTestId('amount-input-field');
+      const input = container.querySelector('input');
+      expect(input).not.toBeNull();
+      fireEvent.blur(input as HTMLInputElement);
+
+      expect(onAmountChange).toHaveBeenCalledWith('3.06');
+    });
+  });
+
+  describe('token input', () => {
+    it('floors converted USD amount to 2 decimals', () => {
+      const onAmountChange = jest.fn();
+      renderWithProvider(
+        <AmountInput
+          {...defaultProps}
+          onAmountChange={onAmountChange}
+          availableBalance={3.066}
+          currentPrice={1}
+          leverage={1}
+        />,
+        mockStore,
+      );
+
+      const container = screen.getByTestId('amount-input-token-field');
+      const input = container.querySelector('input');
+      expect(input).not.toBeNull();
+      fireEvent.change(input as HTMLInputElement, {
+        target: { value: '3.067' },
+      });
+
+      expect(onAmountChange).toHaveBeenCalledWith('3.06');
+    });
   });
 
   describe('slider', () => {

--- a/ui/components/app/perps/order-entry/components/amount-input/amount-input.test.tsx
+++ b/ui/components/app/perps/order-entry/components/amount-input/amount-input.test.tsx
@@ -1,11 +1,11 @@
 import { screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 
-import { AmountInput } from './amount-input';
 import mockState from '../../../../../../../test/data/mock-state.json';
 import { enLocale as messages } from '../../../../../../../test/lib/i18n-helpers';
 import { renderWithProvider } from '../../../../../../../test/lib/render-helpers-navigate';
 import configureStore from '../../../../../../store/store';
+import { AmountInput } from './amount-input';
 
 const mockStore = configureStore({
   metamask: {

--- a/ui/components/app/perps/order-entry/components/amount-input/amount-input.test.tsx
+++ b/ui/components/app/perps/order-entry/components/amount-input/amount-input.test.tsx
@@ -279,6 +279,30 @@ describe('AmountInput', () => {
   });
 
   describe('percent input', () => {
+    it('does not underflow at 100% for IEEE-754 edge values', () => {
+      const onAmountChange = jest.fn();
+      const onBalancePercentChange = jest.fn();
+      renderWithProvider(
+        <AmountInput
+          {...defaultProps}
+          onAmountChange={onAmountChange}
+          onBalancePercentChange={onBalancePercentChange}
+          availableBalance={1.15}
+        />,
+        mockStore,
+      );
+
+      const container = screen.getByTestId('balance-percent-input');
+      const input = container.querySelector('input');
+      expect(input).not.toBeNull();
+      fireEvent.change(input as HTMLInputElement, {
+        target: { value: '100' },
+      });
+
+      expect(onBalancePercentChange).toHaveBeenCalledWith(100);
+      expect(onAmountChange).toHaveBeenCalledWith('1.15');
+    });
+
     it('floors generated 100% amount to 2 decimals', () => {
       const onAmountChange = jest.fn();
       const onBalancePercentChange = jest.fn();

--- a/ui/components/app/perps/order-entry/components/amount-input/amount-input.test.tsx
+++ b/ui/components/app/perps/order-entry/components/amount-input/amount-input.test.tsx
@@ -1,11 +1,11 @@
 import { screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 
+import { AmountInput } from './amount-input';
 import mockState from '../../../../../../../test/data/mock-state.json';
 import { enLocale as messages } from '../../../../../../../test/lib/i18n-helpers';
 import { renderWithProvider } from '../../../../../../../test/lib/render-helpers-navigate';
 import configureStore from '../../../../../../store/store';
-import { AmountInput } from './amount-input';
 
 const mockStore = configureStore({
   metamask: {
@@ -231,6 +231,57 @@ describe('AmountInput', () => {
       renderWithProvider(<AmountInput {...defaultProps} />, mockStore);
 
       expect(screen.getByTestId('amount-slider')).toBeInTheDocument();
+    });
+  });
+
+  describe('percent input', () => {
+    it('floors generated 100% amount to 2 decimals', () => {
+      const onAmountChange = jest.fn();
+      const onBalancePercentChange = jest.fn();
+      renderWithProvider(
+        <AmountInput
+          {...defaultProps}
+          onAmountChange={onAmountChange}
+          onBalancePercentChange={onBalancePercentChange}
+          availableBalance={3.066}
+        />,
+        mockStore,
+      );
+
+      const container = screen.getByTestId('balance-percent-input');
+      const input = container.querySelector('input');
+      expect(input).not.toBeNull();
+      fireEvent.change(input as HTMLInputElement, {
+        target: { value: '100' },
+      });
+
+      expect(onBalancePercentChange).toHaveBeenCalledWith(100);
+      expect(onAmountChange).toHaveBeenCalledWith('3.06');
+    });
+
+    it('floors clamped amount when percent input is above 100 on blur', () => {
+      const onAmountChange = jest.fn();
+      const onBalancePercentChange = jest.fn();
+      renderWithProvider(
+        <AmountInput
+          {...defaultProps}
+          onAmountChange={onAmountChange}
+          onBalancePercentChange={onBalancePercentChange}
+          availableBalance={3.066}
+        />,
+        mockStore,
+      );
+
+      const container = screen.getByTestId('balance-percent-input');
+      const input = container.querySelector('input');
+      expect(input).not.toBeNull();
+      fireEvent.change(input as HTMLInputElement, {
+        target: { value: '101' },
+      });
+      fireEvent.blur(input as HTMLInputElement);
+
+      expect(onBalancePercentChange).toHaveBeenCalledWith(100);
+      expect(onAmountChange).toHaveBeenCalledWith('3.06');
     });
   });
 });

--- a/ui/components/app/perps/order-entry/components/amount-input/amount-input.tsx
+++ b/ui/components/app/perps/order-entry/components/amount-input/amount-input.tsx
@@ -123,12 +123,12 @@ export const AmountInput: React.FC<AmountInputProps> = ({
 
     const numValue = Number.parseFloat(amount);
     if (Number.isFinite(numValue) && numValue > 0) {
-      onAmountChange(numValue.toFixed(2));
+      onAmountChange(formatFlooredAmount(numValue));
       return;
     }
 
     onAmountChange('');
-  }, [amount, onAmountChange]);
+  }, [amount, onAmountChange, formatFlooredAmount]);
 
   const handleTokenAmountChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -153,7 +153,7 @@ export const AmountInput: React.FC<AmountInputProps> = ({
           return;
         }
         const usdMargin = (numToken * currentPrice) / leverage;
-        onAmountChange(usdMargin.toFixed(2));
+        onAmountChange(formatFlooredAmount(usdMargin));
         if (availableBalance > 0) {
           const pct = Math.min(
             Math.round((usdMargin / availableBalance) * 100),
@@ -173,6 +173,7 @@ export const AmountInput: React.FC<AmountInputProps> = ({
       availableBalance,
       onAmountChange,
       onBalancePercentChange,
+      formatFlooredAmount,
     ],
   );
 

--- a/ui/components/app/perps/order-entry/components/amount-input/amount-input.tsx
+++ b/ui/components/app/perps/order-entry/components/amount-input/amount-input.tsx
@@ -21,6 +21,7 @@ import { useFormatters } from '../../../../../../hooks/useFormatters';
 import { useI18nContext } from '../../../../../../hooks/useI18nContext';
 import { TextField, TextFieldSize } from '../../../../../component-library';
 import { PerpsSlider } from '../../../perps-slider';
+import { formatFlooredDecimals } from '../../../utils/number';
 import type { AmountInputProps } from '../../order-entry.types';
 import { isDigitsOnlyInput, isUnsignedDecimalInput } from '../../utils';
 
@@ -110,11 +111,6 @@ export const AmountInput: React.FC<AmountInputProps> = ({
     [availableBalance, onAmountChange, onBalancePercentChange],
   );
 
-  const formatFlooredAmount = useCallback(
-    (value: number): string => (Math.floor(value * 100) / 100).toFixed(2),
-    [],
-  );
-
   const handleAmountBlur = useCallback(() => {
     if (!amount) {
       onAmountChange('');
@@ -123,12 +119,12 @@ export const AmountInput: React.FC<AmountInputProps> = ({
 
     const numValue = Number.parseFloat(amount);
     if (Number.isFinite(numValue) && numValue > 0) {
-      onAmountChange(formatFlooredAmount(numValue));
+      onAmountChange(formatFlooredDecimals(numValue));
       return;
     }
 
     onAmountChange('');
-  }, [amount, onAmountChange, formatFlooredAmount]);
+  }, [amount, onAmountChange]);
 
   const handleTokenAmountChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -153,7 +149,7 @@ export const AmountInput: React.FC<AmountInputProps> = ({
           return;
         }
         const usdMargin = (numToken * currentPrice) / leverage;
-        onAmountChange(formatFlooredAmount(usdMargin));
+        onAmountChange(formatFlooredDecimals(usdMargin));
         if (availableBalance > 0) {
           const pct = Math.min(
             Math.round((usdMargin / availableBalance) * 100),
@@ -173,7 +169,6 @@ export const AmountInput: React.FC<AmountInputProps> = ({
       availableBalance,
       onAmountChange,
       onBalancePercentChange,
-      formatFlooredAmount,
     ],
   );
 
@@ -190,15 +185,10 @@ export const AmountInput: React.FC<AmountInputProps> = ({
         onAmountChange('');
       } else {
         const newAmount = (availableBalance * percent) / 100;
-        onAmountChange(formatFlooredAmount(newAmount));
+        onAmountChange(formatFlooredDecimals(newAmount));
       }
     },
-    [
-      onAmountChange,
-      onBalancePercentChange,
-      availableBalance,
-      formatFlooredAmount,
-    ],
+    [onAmountChange, onBalancePercentChange, availableBalance],
   );
 
   const handlePercentInputChange = useCallback(
@@ -213,17 +203,12 @@ export const AmountInput: React.FC<AmountInputProps> = ({
             onAmountChange('');
           } else {
             const newAmount = (availableBalance * num) / 100;
-            onAmountChange(formatFlooredAmount(newAmount));
+            onAmountChange(formatFlooredDecimals(newAmount));
           }
         }
       }
     },
-    [
-      onAmountChange,
-      onBalancePercentChange,
-      availableBalance,
-      formatFlooredAmount,
-    ],
+    [onAmountChange, onBalancePercentChange, availableBalance],
   );
 
   const handlePercentInputBlur = useCallback(() => {
@@ -235,7 +220,7 @@ export const AmountInput: React.FC<AmountInputProps> = ({
     } else if (num > 100) {
       onBalancePercentChange(100);
       setPercentInputValue('100');
-      onAmountChange(formatFlooredAmount(availableBalance));
+      onAmountChange(formatFlooredDecimals(availableBalance));
     } else {
       onBalancePercentChange(num);
       setPercentInputValue(String(num));
@@ -245,7 +230,6 @@ export const AmountInput: React.FC<AmountInputProps> = ({
     onAmountChange,
     onBalancePercentChange,
     availableBalance,
-    formatFlooredAmount,
   ]);
 
   return (

--- a/ui/components/app/perps/order-entry/components/amount-input/amount-input.tsx
+++ b/ui/components/app/perps/order-entry/components/amount-input/amount-input.tsx
@@ -110,6 +110,11 @@ export const AmountInput: React.FC<AmountInputProps> = ({
     [availableBalance, onAmountChange, onBalancePercentChange],
   );
 
+  const formatFlooredAmount = useCallback(
+    (value: number): string => (Math.floor(value * 100) / 100).toFixed(2),
+    [],
+  );
+
   const handleAmountBlur = useCallback(() => {
     if (!amount) {
       onAmountChange('');
@@ -184,10 +189,15 @@ export const AmountInput: React.FC<AmountInputProps> = ({
         onAmountChange('');
       } else {
         const newAmount = (availableBalance * percent) / 100;
-        onAmountChange(newAmount.toFixed(2));
+        onAmountChange(formatFlooredAmount(newAmount));
       }
     },
-    [onAmountChange, onBalancePercentChange, availableBalance],
+    [
+      onAmountChange,
+      onBalancePercentChange,
+      availableBalance,
+      formatFlooredAmount,
+    ],
   );
 
   const handlePercentInputChange = useCallback(
@@ -202,12 +212,17 @@ export const AmountInput: React.FC<AmountInputProps> = ({
             onAmountChange('');
           } else {
             const newAmount = (availableBalance * num) / 100;
-            onAmountChange(newAmount.toFixed(2));
+            onAmountChange(formatFlooredAmount(newAmount));
           }
         }
       }
     },
-    [onAmountChange, onBalancePercentChange, availableBalance],
+    [
+      onAmountChange,
+      onBalancePercentChange,
+      availableBalance,
+      formatFlooredAmount,
+    ],
   );
 
   const handlePercentInputBlur = useCallback(() => {
@@ -219,7 +234,7 @@ export const AmountInput: React.FC<AmountInputProps> = ({
     } else if (num > 100) {
       onBalancePercentChange(100);
       setPercentInputValue('100');
-      onAmountChange(availableBalance.toFixed(2));
+      onAmountChange(formatFlooredAmount(availableBalance));
     } else {
       onBalancePercentChange(num);
       setPercentInputValue(String(num));
@@ -229,6 +244,7 @@ export const AmountInput: React.FC<AmountInputProps> = ({
     onAmountChange,
     onBalancePercentChange,
     availableBalance,
+    formatFlooredAmount,
   ]);
 
   return (

--- a/ui/components/app/perps/utils/number.test.ts
+++ b/ui/components/app/perps/utils/number.test.ts
@@ -1,0 +1,23 @@
+import { floorToDecimals, formatFlooredDecimals } from './number';
+
+describe('perps number utils', () => {
+  describe('floorToDecimals', () => {
+    it('avoids extra-cent underflow for IEEE-754 edge values', () => {
+      expect(floorToDecimals(0.29, 2)).toBe(0.29);
+      expect(floorToDecimals(1.15, 2)).toBe(1.15);
+      expect(floorToDecimals(2.29, 2)).toBe(2.29);
+    });
+
+    it('still floors values above the target precision', () => {
+      expect(floorToDecimals(3.066, 2)).toBe(3.06);
+      expect(floorToDecimals(1.159, 2)).toBe(1.15);
+    });
+  });
+
+  describe('formatFlooredDecimals', () => {
+    it('returns fixed-width floored strings', () => {
+      expect(formatFlooredDecimals(3.066, 2)).toBe('3.06');
+      expect(formatFlooredDecimals(1.15, 2)).toBe('1.15');
+    });
+  });
+});

--- a/ui/components/app/perps/utils/number.ts
+++ b/ui/components/app/perps/utils/number.ts
@@ -1,0 +1,27 @@
+/**
+ * Floors a number to a fixed decimal precision while guarding against
+ * IEEE-754 underflow around integer boundaries (e.g. 0.29 * 100).
+ *
+ * @param value - Numeric value to floor.
+ * @param decimals - Decimal places to keep.
+ * @returns Floored numeric value at the requested precision.
+ */
+export function floorToDecimals(value: number, decimals = 2): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+
+  const factor = 10 ** decimals;
+  return Math.floor((value + Number.EPSILON) * factor) / factor;
+}
+
+/**
+ * Floors a number to a fixed decimal precision and returns a fixed-width string.
+ *
+ * @param value - Numeric value to floor.
+ * @param decimals - Decimal places to keep.
+ * @returns Fixed-width floored decimal string.
+ */
+export function formatFlooredDecimals(value: number, decimals = 2): string {
+  return floorToDecimals(value, decimals).toFixed(decimals);
+}

--- a/ui/pages/perps/perps-order-entry-page.test.tsx
+++ b/ui/pages/perps/perps-order-entry-page.test.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
+import PerpsOrderEntryPage from './perps-order-entry-page';
 import mockState from '../../../test/data/mock-state.json';
 import { enLocale as messages } from '../../../test/lib/i18n-helpers';
 import { renderWithProvider } from '../../../test/lib/render-helpers-navigate';
@@ -17,7 +18,6 @@ import {
   mockCryptoMarkets,
   mockHip3Markets,
 } from '../../components/app/perps/mocks';
-import PerpsOrderEntryPage from './perps-order-entry-page';
 
 jest.mock('../../hooks/perps/usePerpsEligibility', () => ({
   usePerpsEligibility: () => ({ isEligible: true }),
@@ -563,6 +563,34 @@ describe('PerpsOrderEntryPage', () => {
       expect(
         screen.getByText(getInsufficientBalanceMessage('20.00', '3.06')),
       ).toBeInTheDocument();
+    });
+
+    it('does not disable submit in modify mode when 100% amount is floored to available balance', () => {
+      mockSearchParams.set('mode', 'modify');
+      mockLivePositions.mockReturnValue({
+        positions: mockPositions,
+        isInitialLoading: false,
+      });
+      mockLiveAccount.mockReturnValue({
+        account: {
+          ...mockAccountState,
+          availableBalance: '3.066',
+        },
+        isInitialLoading: false,
+      });
+      const store = mockStore(createMockState());
+      renderWithProvider(<PerpsOrderEntryPage />, store);
+
+      const percentContainer = screen.getByTestId('balance-percent-input');
+      const percentInput = percentContainer.querySelector('input');
+      fireEvent.change(percentInput as HTMLInputElement, {
+        target: { value: '100' },
+      });
+
+      expect(screen.getByTestId('submit-order-button')).not.toBeDisabled();
+      expect(
+        screen.queryByText(getInsufficientBalanceMessage('3.07', '3.07')),
+      ).not.toBeInTheDocument();
     });
 
     it('does not disable submit when amount equals available balance', () => {

--- a/ui/pages/perps/perps-order-entry-page.test.tsx
+++ b/ui/pages/perps/perps-order-entry-page.test.tsx
@@ -8,7 +8,6 @@ import React from 'react';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 
-import PerpsOrderEntryPage from './perps-order-entry-page';
 import mockState from '../../../test/data/mock-state.json';
 import { enLocale as messages } from '../../../test/lib/i18n-helpers';
 import { renderWithProvider } from '../../../test/lib/render-helpers-navigate';
@@ -18,6 +17,7 @@ import {
   mockCryptoMarkets,
   mockHip3Markets,
 } from '../../components/app/perps/mocks';
+import PerpsOrderEntryPage from './perps-order-entry-page';
 
 jest.mock('../../hooks/perps/usePerpsEligibility', () => ({
   usePerpsEligibility: () => ({ isEligible: true }),

--- a/ui/pages/perps/perps-order-entry-page.test.tsx
+++ b/ui/pages/perps/perps-order-entry-page.test.tsx
@@ -593,6 +593,32 @@ describe('PerpsOrderEntryPage', () => {
       ).not.toBeInTheDocument();
     });
 
+    it('shows floored available balance in insufficient balance message', () => {
+      mockLiveAccount.mockReturnValue({
+        account: {
+          ...mockAccountState,
+          availableBalance: '3.066',
+        },
+        isInitialLoading: false,
+      });
+      const store = mockStore(createMockState());
+      renderWithProvider(<PerpsOrderEntryPage />, store);
+
+      const amountContainer = screen.getByTestId('amount-input-field');
+      const input = amountContainer.querySelector('input');
+      fireEvent.change(input as HTMLInputElement, {
+        target: { value: '3.07' },
+      });
+
+      expect(screen.getByTestId('submit-order-button')).toBeDisabled();
+      expect(
+        screen.getByText(getInsufficientBalanceMessage('3.07', '3.06')),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText(getInsufficientBalanceMessage('3.07', '3.07')),
+      ).not.toBeInTheDocument();
+    });
+
     it('does not disable submit when amount equals available balance', () => {
       mockLiveAccount.mockReturnValue({
         account: {

--- a/ui/pages/perps/perps-order-entry-page.test.tsx
+++ b/ui/pages/perps/perps-order-entry-page.test.tsx
@@ -50,9 +50,45 @@ jest.mock('../../store/background-connection', () => ({
     mockSubmitRequestToBackground(...args),
 }));
 
+let priceSubscriptionCallback: ((updates: unknown[]) => void) | undefined;
+let orderBookSubscriptionCallback: ((book: unknown) => void) | undefined;
+
+const setBackgroundRequestDefaults = () => {
+  mockSubmitRequestToBackground.mockImplementation((method: string) => {
+    if (method === 'perpsActivateStreaming') {
+      return Promise.resolve(undefined);
+    }
+    return Promise.resolve({ success: true });
+  });
+};
+
+// Mock controller for usePerpsController() - delegates to submitRequestToBackground so test assertions pass
+const mockPerpsController = {
+  placeOrder: jest
+    .fn()
+    .mockImplementation((...args: unknown[]) =>
+      mockSubmitRequestToBackground('perpsPlaceOrder', args),
+    ),
+  closePosition: jest
+    .fn()
+    .mockImplementation((...args: unknown[]) =>
+      mockSubmitRequestToBackground('perpsClosePosition', args),
+    ),
+  updatePositionTPSL: jest
+    .fn()
+    .mockImplementation((...args: unknown[]) =>
+      mockSubmitRequestToBackground('perpsUpdatePositionTPSL', args),
+    ),
+  subscribeToPrices: jest.fn(() => jest.fn()),
+  subscribeToOrderBook: jest.fn(() => jest.fn()),
+};
+
 jest.mock('../../providers/perps', () => {
   return {
     getPerpsStreamManager: () => mockGetPerpsStreamManager(),
+    PerpsControllerProvider: ({ children }: { children: React.ReactNode }) =>
+      children,
+    usePerpsController: () => mockPerpsController,
   };
 });
 
@@ -173,6 +209,9 @@ describe('PerpsOrderEntryPage', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    setBackgroundRequestDefaults();
+    priceSubscriptionCallback = undefined;
+    orderBookSubscriptionCallback = undefined;
     const { isNearLiquidationPrice: realIsNearLiquidation } =
       jest.requireActual(
         '../../components/app/perps/order-entry/limit-price-warnings',
@@ -194,6 +233,7 @@ describe('PerpsOrderEntryPage', () => {
       markets: [...mockCryptoMarkets, ...mockHip3Markets],
       isInitialLoading: false,
     });
+    mockGetPerpsStreamManager.mockReturnValue(mockStreamManagerBase);
   });
 
   describe('rendering', () => {
@@ -465,11 +505,67 @@ describe('PerpsOrderEntryPage', () => {
         screen.getByTestId('limit-price-liquidation-warning'),
       ).toBeInTheDocument();
     });
+
+    it('disables submit and shows validation message when amount exceeds available balance', () => {
+      mockLiveAccount.mockReturnValue({
+        account: {
+          ...mockAccountState,
+          availableBalance: '3.06',
+        },
+        isInitialLoading: false,
+      });
+      const store = mockStore(createMockState());
+      renderWithProvider(<PerpsOrderEntryPage />, store);
+
+      const amountContainer = screen.getByTestId('amount-input-field');
+      const input = amountContainer.querySelector('input');
+      fireEvent.change(input as HTMLInputElement, {
+        target: { value: '20' },
+      });
+
+      expect(screen.getByTestId('submit-order-button')).toBeDisabled();
+      expect(
+        screen.getByText('Insufficient balance: need 20.00, have 3.06'),
+      ).toBeInTheDocument();
+    });
+
+    it('does not disable submit when amount equals available balance', () => {
+      mockLiveAccount.mockReturnValue({
+        account: {
+          ...mockAccountState,
+          availableBalance: '3.06',
+        },
+        isInitialLoading: false,
+      });
+      const store = mockStore(createMockState());
+      renderWithProvider(<PerpsOrderEntryPage />, store);
+
+      const amountContainer = screen.getByTestId('amount-input-field');
+      const input = amountContainer.querySelector('input');
+      fireEvent.change(input as HTMLInputElement, {
+        target: { value: '3.06' },
+      });
+
+      expect(screen.getByTestId('submit-order-button')).not.toBeDisabled();
+    });
+
+    it('disables submit in close mode when position is missing', () => {
+      mockSearchParams.set('mode', 'close');
+      mockLivePositions.mockReturnValue({
+        positions: [],
+        isInitialLoading: false,
+      });
+
+      const store = mockStore(createMockState());
+      renderWithProvider(<PerpsOrderEntryPage />, store);
+
+      expect(screen.getByTestId('submit-order-button')).toBeDisabled();
+    });
   });
 
   describe('order submission', () => {
     beforeEach(() => {
-      mockSubmitRequestToBackground.mockResolvedValue({ success: true });
+      setBackgroundRequestDefaults();
     });
 
     it('calls placeOrder on submit for new market order', async () => {
@@ -498,8 +594,39 @@ describe('PerpsOrderEntryPage', () => {
       );
     });
 
+    it('does not call placeOrder when amount exceeds available balance', async () => {
+      mockLiveAccount.mockReturnValue({
+        account: {
+          ...mockAccountState,
+          availableBalance: '3.06',
+        },
+        isInitialLoading: false,
+      });
+
+      const store = mockStore(createMockState());
+      renderWithProvider(<PerpsOrderEntryPage />, store);
+
+      const amountContainer = screen.getByTestId('amount-input-field');
+      const input = amountContainer.querySelector('input');
+      fireEvent.change(input as HTMLInputElement, {
+        target: { value: '20' },
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('submit-order-button'));
+      });
+
+      const hasPlaceOrderCall = mockSubmitRequestToBackground.mock.calls.some(
+        (call) => call[0] === 'perpsPlaceOrder',
+      );
+      expect(hasPlaceOrderCall).toBe(false);
+    });
+
     it('shows error when order fails', async () => {
       mockSubmitRequestToBackground.mockImplementation((method: string) => {
+        if (method === 'perpsActivateStreaming') {
+          return Promise.resolve(undefined);
+        }
         if (method === 'perpsPlaceOrder') {
           return Promise.resolve({
             success: false,
@@ -522,11 +649,16 @@ describe('PerpsOrderEntryPage', () => {
         fireEvent.click(screen.getByTestId('submit-order-button'));
       });
 
-      expect(screen.getByText('Insufficient margin')).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByText('Insufficient margin')).toBeInTheDocument();
+      });
     });
 
     it('shows error when controller throws', async () => {
       mockSubmitRequestToBackground.mockImplementation((method: string) => {
+        if (method === 'perpsActivateStreaming') {
+          return Promise.resolve(undefined);
+        }
         if (method === 'perpsPlaceOrder') {
           return Promise.reject(new Error('Network error'));
         }
@@ -546,7 +678,9 @@ describe('PerpsOrderEntryPage', () => {
         fireEvent.click(screen.getByTestId('submit-order-button'));
       });
 
-      expect(screen.getByText('Network error')).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByText('Network error')).toBeInTheDocument();
+      });
     });
 
     it('calls closePosition when in close mode', async () => {
@@ -734,6 +868,30 @@ describe('PerpsOrderEntryPage', () => {
         expect.anything(),
       );
     });
+
+    it('does not fall back to placeOrder in close mode when position is missing', async () => {
+      mockSearchParams.set('mode', 'close');
+      mockLivePositions.mockReturnValue({
+        positions: [],
+        isInitialLoading: false,
+      });
+
+      const store = mockStore(createMockState());
+      renderWithProvider(<PerpsOrderEntryPage />, store);
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('submit-order-button'));
+      });
+
+      expect(mockSubmitRequestToBackground).not.toHaveBeenCalledWith(
+        'perpsPlaceOrder',
+        expect.anything(),
+      );
+      expect(mockSubmitRequestToBackground).not.toHaveBeenCalledWith(
+        'perpsClosePosition',
+        expect.anything(),
+      );
+    });
   });
 
   describe('formStateToOrderParams', () => {
@@ -743,7 +901,7 @@ describe('PerpsOrderEntryPage', () => {
         positions: mockPositions,
         isInitialLoading: false,
       });
-      mockSubmitRequestToBackground.mockResolvedValue({ success: true });
+      setBackgroundRequestDefaults();
 
       const store = mockStore(createMockState());
       renderWithProvider(<PerpsOrderEntryPage />, store);
@@ -803,6 +961,7 @@ describe('PerpsOrderEntryPage', () => {
         prices: {
           subscribe: jest.fn((cb: (updates: unknown[]) => void) => {
             priceCallback = cb;
+            priceSubscriptionCallback = cb;
             return jest.fn();
           }) as jest.Mock,
           getCachedData: () => [],
@@ -810,6 +969,7 @@ describe('PerpsOrderEntryPage', () => {
         orderBook: {
           subscribe: jest.fn((cb: (book: unknown) => void) => {
             orderBookCallback = cb;
+            orderBookSubscriptionCallback = cb;
             return jest.fn();
           }) as jest.Mock,
           getCachedData: () => null,
@@ -826,11 +986,11 @@ describe('PerpsOrderEntryPage', () => {
       renderWithProvider(<PerpsOrderEntryPage />, store);
 
       await waitFor(() => {
-        expect(typeof priceCallback).toBe('function');
+        expect(typeof priceSubscriptionCallback).toBe('function');
       });
 
       act(() => {
-        priceCallback([
+        priceSubscriptionCallback?.([
           {
             symbol: 'ETH',
             price: '3200.50',
@@ -848,11 +1008,11 @@ describe('PerpsOrderEntryPage', () => {
       renderWithProvider(<PerpsOrderEntryPage />, store);
 
       await waitFor(() => {
-        expect(typeof priceCallback).toBe('function');
+        expect(typeof priceSubscriptionCallback).toBe('function');
       });
 
       act(() => {
-        priceCallback([
+        priceSubscriptionCallback?.([
           {
             symbol: 'ETH',
             price: '3100.00',
@@ -868,11 +1028,11 @@ describe('PerpsOrderEntryPage', () => {
       renderWithProvider(<PerpsOrderEntryPage />, store);
 
       await waitFor(() => {
-        expect(typeof priceCallback).toBe('function');
+        expect(typeof priceSubscriptionCallback).toBe('function');
       });
 
       act(() => {
-        priceCallback([
+        priceSubscriptionCallback?.([
           { symbol: 'BTC', price: '50000.00', markPrice: '50001.00' },
         ]);
       });
@@ -885,11 +1045,11 @@ describe('PerpsOrderEntryPage', () => {
       renderWithProvider(<PerpsOrderEntryPage />, store);
 
       await waitFor(() => {
-        expect(typeof orderBookCallback).toBe('function');
+        expect(typeof orderBookSubscriptionCallback).toBe('function');
       });
 
       act(() => {
-        orderBookCallback({
+        orderBookSubscriptionCallback?.({
           bids: [{ price: '3199', size: '10' }],
           asks: [{ price: '3201', size: '10' }],
           midPrice: '3200.00',
@@ -904,11 +1064,11 @@ describe('PerpsOrderEntryPage', () => {
       renderWithProvider(<PerpsOrderEntryPage />, store);
 
       await waitFor(() => {
-        expect(typeof orderBookCallback).toBe('function');
+        expect(typeof orderBookSubscriptionCallback).toBe('function');
       });
 
       act(() => {
-        orderBookCallback({
+        orderBookSubscriptionCallback?.({
           bids: [],
           asks: [],
           midPrice: null,
@@ -921,7 +1081,7 @@ describe('PerpsOrderEntryPage', () => {
 
   describe('order submission error paths', () => {
     beforeEach(() => {
-      mockSubmitRequestToBackground.mockResolvedValue({ success: true });
+      setBackgroundRequestDefaults();
     });
 
     it('shows error when closePosition fails', async () => {
@@ -931,8 +1091,14 @@ describe('PerpsOrderEntryPage', () => {
         isInitialLoading: false,
       });
       mockSubmitRequestToBackground.mockImplementation((method: string) => {
+        if (method === 'perpsActivateStreaming') {
+          return Promise.resolve(undefined);
+        }
         if (method === 'perpsClosePosition') {
-          return Promise.resolve({ success: false, error: 'Close failed' });
+          return Promise.resolve({
+            success: false,
+            error: 'Close failed',
+          });
         }
         return Promise.resolve({ success: true });
       });
@@ -944,7 +1110,9 @@ describe('PerpsOrderEntryPage', () => {
         fireEvent.click(screen.getByTestId('submit-order-button'));
       });
 
-      expect(screen.getByText('Close failed')).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByText('Close failed')).toBeInTheDocument();
+      });
     });
 
     it('shows error when updatePositionTPSL fails', async () => {
@@ -954,6 +1122,9 @@ describe('PerpsOrderEntryPage', () => {
         isInitialLoading: false,
       });
       mockSubmitRequestToBackground.mockImplementation((method: string) => {
+        if (method === 'perpsActivateStreaming') {
+          return Promise.resolve(undefined);
+        }
         if (method === 'perpsUpdatePositionTPSL') {
           return Promise.resolve({
             success: false,
@@ -970,14 +1141,19 @@ describe('PerpsOrderEntryPage', () => {
         fireEvent.click(screen.getByTestId('submit-order-button'));
       });
 
-      expect(screen.getByText('TPSL update failed')).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByText('TPSL update failed')).toBeInTheDocument();
+      });
     });
 
     it('shows generic error for non-Error throws', async () => {
+      const nonErrorReason: unknown = 'string error';
       mockSubmitRequestToBackground.mockImplementation((method: string) => {
+        if (method === 'perpsActivateStreaming') {
+          return Promise.resolve(undefined);
+        }
         if (method === 'perpsPlaceOrder') {
-          // eslint-disable-next-line prefer-promise-reject-errors
-          return Promise.reject('string error');
+          return Promise.reject(nonErrorReason);
         }
         return Promise.resolve({ success: true });
       });
@@ -995,7 +1171,11 @@ describe('PerpsOrderEntryPage', () => {
         fireEvent.click(screen.getByTestId('submit-order-button'));
       });
 
-      expect(screen.getByText('An unknown error occurred')).toBeInTheDocument();
+      await waitFor(() => {
+        expect(
+          screen.getByText('An unknown error occurred'),
+        ).toBeInTheDocument();
+      });
     });
 
     it('navigates back after successful limit order', async () => {
@@ -1066,7 +1246,7 @@ describe('PerpsOrderEntryPage', () => {
   describe('pending order effects', () => {
     beforeEach(() => {
       jest.useFakeTimers();
-      mockSubmitRequestToBackground.mockResolvedValue({ success: true });
+      setBackgroundRequestDefaults();
     });
 
     afterEach(() => {

--- a/ui/pages/perps/perps-order-entry-page.test.tsx
+++ b/ui/pages/perps/perps-order-entry-page.test.tsx
@@ -62,6 +62,14 @@ const setBackgroundRequestDefaults = () => {
   });
 };
 
+const getInsufficientBalanceMessage = (
+  requiredMargin: string,
+  availableBalance: string,
+) =>
+  messages.perpsOrderValidationInsufficientBalance.message
+    .replace('$1', requiredMargin)
+    .replace('$2', availableBalance);
+
 // Mock controller for usePerpsController() - delegates to submitRequestToBackground so test assertions pass
 const mockPerpsController = {
   placeOrder: jest
@@ -525,7 +533,35 @@ describe('PerpsOrderEntryPage', () => {
 
       expect(screen.getByTestId('submit-order-button')).toBeDisabled();
       expect(
-        screen.getByText('Insufficient balance: need 20.00, have 3.06'),
+        screen.getByText(getInsufficientBalanceMessage('20.00', '3.06')),
+      ).toBeInTheDocument();
+    });
+
+    it('disables submit in modify mode when add-to-position amount exceeds available balance', () => {
+      mockSearchParams.set('mode', 'modify');
+      mockLivePositions.mockReturnValue({
+        positions: mockPositions,
+        isInitialLoading: false,
+      });
+      mockLiveAccount.mockReturnValue({
+        account: {
+          ...mockAccountState,
+          availableBalance: '3.06',
+        },
+        isInitialLoading: false,
+      });
+      const store = mockStore(createMockState());
+      renderWithProvider(<PerpsOrderEntryPage />, store);
+
+      const amountContainer = screen.getByTestId('amount-input-field');
+      const input = amountContainer.querySelector('input');
+      fireEvent.change(input as HTMLInputElement, {
+        target: { value: '20' },
+      });
+
+      expect(screen.getByTestId('submit-order-button')).toBeDisabled();
+      expect(
+        screen.getByText(getInsufficientBalanceMessage('20.00', '3.06')),
       ).toBeInTheDocument();
     });
 
@@ -595,6 +631,39 @@ describe('PerpsOrderEntryPage', () => {
     });
 
     it('does not call placeOrder when amount exceeds available balance', async () => {
+      mockLiveAccount.mockReturnValue({
+        account: {
+          ...mockAccountState,
+          availableBalance: '3.06',
+        },
+        isInitialLoading: false,
+      });
+
+      const store = mockStore(createMockState());
+      renderWithProvider(<PerpsOrderEntryPage />, store);
+
+      const amountContainer = screen.getByTestId('amount-input-field');
+      const input = amountContainer.querySelector('input');
+      fireEvent.change(input as HTMLInputElement, {
+        target: { value: '20' },
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('submit-order-button'));
+      });
+
+      const hasPlaceOrderCall = mockSubmitRequestToBackground.mock.calls.some(
+        (call) => call[0] === 'perpsPlaceOrder',
+      );
+      expect(hasPlaceOrderCall).toBe(false);
+    });
+
+    it('does not call placeOrder in modify mode when add-to-position amount exceeds available balance', async () => {
+      mockSearchParams.set('mode', 'modify');
+      mockLivePositions.mockReturnValue({
+        positions: mockPositions,
+        isInitialLoading: false,
+      });
       mockLiveAccount.mockReturnValue({
         account: {
           ...mockAccountState,

--- a/ui/pages/perps/perps-order-entry-page.tsx
+++ b/ui/pages/perps/perps-order-entry-page.tsx
@@ -336,11 +336,14 @@ const PerpsOrderEntryPage: React.FC = () => {
   );
   const requiredMargin = Number.isFinite(parsedAmount) ? parsedAmount : 0;
   const isOrderPlacementMode = orderMode !== 'close' && orderMode !== 'modify';
+  const isModifyAddToPositionMode =
+    orderMode === 'modify' && Boolean(position) && requiredMargin > 0;
   const isPositionRequiredMode =
     orderMode === 'close' || orderMode === 'modify';
   const isPositionMissing = isPositionRequiredMode && !position;
   const isInsufficientBalance =
-    isOrderPlacementMode && requiredMargin > availableBalance;
+    (isOrderPlacementMode || isModifyAddToPositionMode) &&
+    requiredMargin > availableBalance;
   const insufficientBalanceError = isInsufficientBalance
     ? t('perpsOrderValidationInsufficientBalance', [
         requiredMargin.toFixed(2),

--- a/ui/pages/perps/perps-order-entry-page.tsx
+++ b/ui/pages/perps/perps-order-entry-page.tsx
@@ -58,6 +58,7 @@ import {
   getChangeColor,
   safeDecodeURIComponent,
 } from '../../components/app/perps/utils';
+import { formatFlooredDecimals } from '../../components/app/perps/utils/number';
 import {
   DEFAULT_ROUTE,
   PERPS_MARKET_DETAIL_ROUTE,
@@ -83,10 +84,6 @@ function toNormalizedPositivePrice(value?: string): string | undefined {
   }
 
   return parsed.toString();
-}
-
-function formatFlooredUsd(value: number): string {
-  return (Math.floor(value * 100) / 100).toFixed(2);
 }
 
 /**
@@ -351,8 +348,8 @@ const PerpsOrderEntryPage: React.FC = () => {
     requiredMargin > availableBalance;
   const insufficientBalanceError = isInsufficientBalance
     ? t('perpsOrderValidationInsufficientBalance', [
-        formatFlooredUsd(requiredMargin),
-        formatFlooredUsd(availableBalance),
+        formatFlooredDecimals(requiredMargin),
+        formatFlooredDecimals(availableBalance),
       ])
     : null;
 

--- a/ui/pages/perps/perps-order-entry-page.tsx
+++ b/ui/pages/perps/perps-order-entry-page.tsx
@@ -328,7 +328,25 @@ const PerpsOrderEntryPage: React.FC = () => {
 
   const currentPrice = chartCurrentPrice > 0 ? chartCurrentPrice : marketPrice;
 
-  const availableBalance = account ? parseFloat(account.availableBalance) : 0;
+  const availableBalance = account
+    ? parseFloat(account.availableBalance) || 0
+    : 0;
+  const parsedAmount = parseFloat(
+    orderFormState?.amount?.replace(/,/gu, '') ?? '',
+  );
+  const requiredMargin = Number.isFinite(parsedAmount) ? parsedAmount : 0;
+  const isOrderPlacementMode = orderMode !== 'close' && orderMode !== 'modify';
+  const isPositionRequiredMode =
+    orderMode === 'close' || orderMode === 'modify';
+  const isPositionMissing = isPositionRequiredMode && !position;
+  const isInsufficientBalance =
+    isOrderPlacementMode && requiredMargin > availableBalance;
+  const insufficientBalanceError = isInsufficientBalance
+    ? t('perpsOrderValidationInsufficientBalance', [
+        requiredMargin.toFixed(2),
+        availableBalance.toFixed(2),
+      ])
+    : null;
 
   const isLimitPriceUnfavorable = useMemo(() => {
     if (orderType !== 'limit' || !orderFormState) {
@@ -364,7 +382,9 @@ const PerpsOrderEntryPage: React.FC = () => {
     isLimitPriceInvalid ||
     isLimitPriceUnfavorable ||
     isNearLiquidation ||
-    currentPrice <= 0;
+    currentPrice <= 0 ||
+    isPositionMissing ||
+    isInsufficientBalance;
 
   const maxLeverage = useMemo(() => {
     if (!market) {
@@ -435,7 +455,9 @@ const PerpsOrderEntryPage: React.FC = () => {
       !isEligible ||
       !orderFormState ||
       !selectedAddress ||
-      currentPrice <= 0
+      currentPrice <= 0 ||
+      isPositionMissing ||
+      isInsufficientBalance
     ) {
       return;
     }
@@ -444,7 +466,7 @@ const PerpsOrderEntryPage: React.FC = () => {
     setSubmitError(null);
 
     try {
-      if (orderMode === 'close' && position) {
+      if (orderMode === 'close') {
         const closeParams = {
           symbol: orderFormState.asset,
           orderType: 'market' as const,
@@ -556,6 +578,8 @@ const PerpsOrderEntryPage: React.FC = () => {
     orderMode,
     position,
     currentPrice,
+    isPositionMissing,
+    isInsufficientBalance,
     handleBackClick,
   ]);
 
@@ -761,7 +785,7 @@ const PerpsOrderEntryPage: React.FC = () => {
             liquidationPrice={orderCalculations.liquidationPrice}
           />
         )}
-        {submitError && (
+        {(insufficientBalanceError || submitError) && (
           <Box
             className="bg-error-muted rounded-lg"
             padding={3}
@@ -775,7 +799,7 @@ const PerpsOrderEntryPage: React.FC = () => {
               color={IconColor.ErrorDefault}
             />
             <Text variant={TextVariant.BodySm} color={TextColor.ErrorDefault}>
-              {submitError}
+              {insufficientBalanceError ?? submitError}
             </Text>
           </Box>
         )}

--- a/ui/pages/perps/perps-order-entry-page.tsx
+++ b/ui/pages/perps/perps-order-entry-page.tsx
@@ -29,6 +29,7 @@ import {
   useParams,
   useSearchParams,
 } from 'react-router-dom';
+
 import {
   selectPerpsTradeConfigurations,
   selectPerpsIsTestnet,
@@ -39,10 +40,6 @@ import {
 } from '../../components/app/perps/constants/chartConfig';
 import { usePerpsDepositConfirmation } from '../../components/app/perps/hooks/usePerpsDepositConfirmation';
 import {
-  isLimitPriceUnfavorable as checkLimitPriceUnfavorable,
-  isNearLiquidationPrice as checkNearLiquidationPrice,
-} from '../../components/app/perps/order-entry/limit-price-warnings';
-import {
   OrderEntry,
   DirectionTabs,
   OrderSummary,
@@ -51,6 +48,10 @@ import {
   type OrderMode,
   type OrderCalculations,
 } from '../../components/app/perps/order-entry';
+import {
+  isLimitPriceUnfavorable as checkLimitPriceUnfavorable,
+  isNearLiquidationPrice as checkNearLiquidationPrice,
+} from '../../components/app/perps/order-entry/limit-price-warnings';
 import { PerpsDetailPageSkeleton } from '../../components/app/perps/perps-skeletons';
 import {
   getDisplayName,
@@ -68,8 +69,8 @@ import {
   usePerpsLiveMarketData,
   usePerpsLiveCandles,
 } from '../../hooks/perps/stream';
-import { useI18nContext } from '../../hooks/useI18nContext';
 import { useFormatters } from '../../hooks/useFormatters';
+import { useI18nContext } from '../../hooks/useI18nContext';
 import { getPerpsStreamManager } from '../../providers/perps';
 import { getSelectedInternalAccount } from '../../selectors/accounts';
 import { getIsPerpsExperienceAvailable } from '../../selectors/perps/feature-flags';
@@ -82,6 +83,10 @@ function toNormalizedPositivePrice(value?: string): string | undefined {
   }
 
   return parsed.toString();
+}
+
+function formatFlooredUsd(value: number): string {
+  return (Math.floor(value * 100) / 100).toFixed(2);
 }
 
 /**
@@ -346,8 +351,8 @@ const PerpsOrderEntryPage: React.FC = () => {
     requiredMargin > availableBalance;
   const insufficientBalanceError = isInsufficientBalance
     ? t('perpsOrderValidationInsufficientBalance', [
-        requiredMargin.toFixed(2),
-        availableBalance.toFixed(2),
+        formatFlooredUsd(requiredMargin),
+        formatFlooredUsd(availableBalance),
       ])
     : null;
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR improves validation in Perps order entry to prevent invalid submissions before they reach the background controller.

Reason for change

  - Users could attempt actions that should be blocked in the UI:
      - Submitting an order with margin amount greater than available balance.
      - Submitting close/modify flows when no matching position exists.
  - This led to avoidable failed requests and a less clear UX.

Improvement / solution

  - Added client-side guards in PerpsOrderEntryPage to:
      - Disable submit when required margin exceeds available balance (for order placement flows).
      - Disable submit when close or modify is requested but no position is found.
  - Added explicit insufficient-balance error messaging in the form.
  - Updated/expanded unit tests to cover the new guard and submission-blocking behavior.
  - Added corresponding i18n string for the validation message.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**
Feature: Perps order entry validation guards

  Scenario: Block submit when order amount exceeds available balance
    Given I am on "/perps/trade/ETH?direction=long&mode=new&orderType=market"
    And my available balance is "3.06"
    When I enter "20" in the amount input
    Then the submit button is disabled
    And I see an "Insufficient balance" validation message

  Scenario: Allow submit when order amount equals available balance
    Given I am on "/perps/trade/ETH?direction=long&mode=new&orderType=market"
    And my available balance is "3.06"
    When I enter "3.06" in the amount input
    Then the submit button is enabled

  Scenario: Block close submission when no position exists
    Given I am on "/perps/trade/ETH?direction=long&mode=close&orderType=market"
    And I do not have an open ETH position
    Then the submit button is disabled
    When I click submit
    Then no close-position request is sent

  Scenario: Block modify submission when no position exists
    Given I am on "/perps/trade/ETH?direction=long&mode=modify&orderType=market"
    And I do not have an open ETH position
    Then the submit button is disabled

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new client-side validation that blocks perps order submission when balance is insufficient or required position is missing, which changes trading UX and could prevent some previously-allowed submissions. Decimal flooring changes affect displayed/used amounts, so edge-case rounding behavior should be rechecked across order/margin flows.
> 
> **Overview**
> Prevents invalid perps order submissions in `PerpsOrderEntryPage` by **disabling submit** when the required margin exceeds the user’s available balance (including modify add-to-position) and when `close`/`modify` modes have **no matching position**.
> 
> Adds a localized *insufficient balance* validation message and displays it inline, and introduces shared number helpers (`floorToDecimals` / `formatFlooredDecimals`) to **floor** (not round) amounts to 2dp while avoiding IEEE-754 underflow; applies this flooring to order size inputs/sliders and edit-margin slider/validation, with expanded test coverage for edge balances and new guard behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6173215642336d0adedb5193fc0c8d3e790582ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->