### PR TITLE
feat: enable webpack e2e in mq

### DIFF
--- a/.github/workflows/e2e-chrome.yml
+++ b/.github/workflows/e2e-chrome.yml
@@ -136,7 +136,7 @@ jobs:
   test-e2e-chrome-flask-webpack:
     uses: ./.github/workflows/run-e2e.yml
     strategy:
-      fail-fast: false
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix: ${{ fromJson(inputs.use-matrix)['test-e2e-chrome-flask-webpack'] }}
     with:
       test-suite-name: test-e2e-chrome-flask-webpack

--- a/.github/workflows/e2e-chrome.yml
+++ b/.github/workflows/e2e-chrome.yml
@@ -101,7 +101,6 @@ jobs:
 
   test-e2e-chrome-webpack:
     uses: ./.github/workflows/run-e2e.yml
-    if: ${{ github.event_name != 'merge_group' }}
     secrets:
       INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
     strategy:
@@ -118,7 +117,6 @@ jobs:
 
   test-e2e-chrome-multiple-providers-webpack:
     uses: ./.github/workflows/run-e2e.yml
-    if: ${{ github.event_name != 'merge_group' }}
     with:
       test-suite-name: test-e2e-chrome-multiple-providers-webpack
       build-artifact: build-test-webpack
@@ -128,7 +126,6 @@ jobs:
 
   test-e2e-chrome-rpc-webpack:
     uses: ./.github/workflows/run-e2e.yml
-    if: ${{ github.event_name != 'merge_group' }}
     with:
       test-suite-name: test-e2e-chrome-rpc-webpack
       build-artifact: build-test-webpack
@@ -138,7 +135,6 @@ jobs:
 
   test-e2e-chrome-flask-webpack:
     uses: ./.github/workflows/run-e2e.yml
-    if: ${{ github.event_name != 'merge_group' }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(inputs.use-matrix)['test-e2e-chrome-flask-webpack'] }}
@@ -162,7 +158,6 @@ jobs:
 
   test-e2e-chrome-api-specs-webpack:
     uses: ./.github/workflows/run-e2e.yml
-    if: ${{ github.event_name != 'merge_group' }}
     with:
       test-suite-name: test-e2e-chrome-api-specs-webpack
       build-artifact: build-test-webpack
@@ -173,7 +168,6 @@ jobs:
 
   test-e2e-chrome-api-specs-multichain-webpack:
     uses: ./.github/workflows/run-e2e.yml
-    if: ${{ github.event_name != 'merge_group' }}
     with:
       test-suite-name: test-e2e-chrome-api-specs-multichain-webpack
       build-artifact: build-test-flask-webpack

--- a/.github/workflows/e2e-chrome.yml
+++ b/.github/workflows/e2e-chrome.yml
@@ -148,7 +148,8 @@ jobs:
       matrix-total: ${{ strategy.job-total }}
 
   test-e2e-chrome-dist-webpack:
-    if: ${{ github.event_name != 'merge_group' && !(github.event.pull_request.head.repo.fork || github.event.repository.fork) }}
+    # This if statement is equivalent to !IS_FORK
+    if: ${{ !(github.event.pull_request.head.repo.fork || github.event.repository.fork) }}
     uses: ./.github/workflows/run-e2e.yml
     with:
       test-suite-name: test-e2e-chrome-dist-webpack

--- a/.github/workflows/e2e-firefox.yml
+++ b/.github/workflows/e2e-firefox.yml
@@ -90,7 +90,8 @@ jobs:
       matrix-total: ${{ strategy.job-total }}
 
   test-e2e-firefox-dist-webpack:
-    if: ${{ github.event_name != 'merge_group' && !(github.event.pull_request.head.repo.fork || github.event.repository.fork) }}
+    # This if statement is equivalent to !IS_FORK
+    if: ${{ !(github.event.pull_request.head.repo.fork || github.event.repository.fork) }}
     uses: ./.github/workflows/run-e2e.yml
     with:
       test-suite-name: test-e2e-firefox-dist-webpack

--- a/.github/workflows/e2e-firefox.yml
+++ b/.github/workflows/e2e-firefox.yml
@@ -61,7 +61,6 @@ jobs:
 
   test-e2e-firefox-webpack:
     uses: ./.github/workflows/run-e2e.yml
-    if: ${{ github.event_name != 'merge_group' }}
     secrets:
       INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
     strategy:
@@ -78,7 +77,6 @@ jobs:
 
   test-e2e-firefox-flask-webpack:
     uses: ./.github/workflows/run-e2e.yml
-    if: ${{ github.event_name != 'merge_group' }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(inputs.use-matrix)['test-e2e-firefox-flask-webpack'] }}

--- a/.github/workflows/e2e-firefox.yml
+++ b/.github/workflows/e2e-firefox.yml
@@ -78,7 +78,7 @@ jobs:
   test-e2e-firefox-flask-webpack:
     uses: ./.github/workflows/run-e2e.yml
     strategy:
-      fail-fast: false
+      fail-fast: ${{ github.event_name == 'merge_group' }}
       matrix: ${{ fromJson(inputs.use-matrix)['test-e2e-firefox-flask-webpack'] }}
     with:
       test-suite-name: test-e2e-firefox-flask-webpack


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

All webpack E2E jobs in e2e-chrome.yml (7 jobs) and e2e-firefox.yml (3 jobs) currently have if: github.event_name != 'merge_group', meaning merge queue only validates browserify E2E. This PR removes that guard so webpack E2E becomes a merge gate.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/7141

## **Manual testing steps**

1. Should run on MQ on merge

## **Screenshots/Recordings**

Not applicable

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes merge-queue gating behavior and can increase CI load or introduce new merge blockers if webpack E2E is flaky, though it does not affect product/runtime code.
> 
> **Overview**
> **Merge queue now validates webpack E2E.** Removes the `if: github.event_name != 'merge_group'` guards from the webpack E2E jobs in `e2e-chrome.yml` and `e2e-firefox.yml`, so these suites run as part of merge queue checks.
> 
> Adjusts job behavior for merge queue by making `strategy.fail-fast` conditional on `merge_group` for the Flask webpack matrix jobs, and simplifies the dist-webpack job condition to only skip forked runs (with an explanatory comment).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7c494a28790959f4007fb5e9e09d3ff43e5add8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->