### PR TITLE
test: fix flaky `MetaMask onboarding  should prevent network requests to advanced functionality endpoints when the advanced assets functionality toggle is off`

### DIFF
--- a/test/e2e/page-objects/pages/onboarding/onboarding-privacy-settings-page.ts
+++ b/test/e2e/page-objects/pages/onboarding/onboarding-privacy-settings-page.ts
@@ -185,7 +185,7 @@ class OnboardingPrivacySettingsPage {
   }
 
   /**
-   * Go to assets settings, toggle all options off, verify their state, then navigate back.
+   * Go to assets settings and toggle options, then navigate back.
    */
   async toggleAssetsSettings(): Promise<void> {
     console.log('Toggle advanced assets settings in privacy settings');

--- a/test/e2e/page-objects/pages/onboarding/onboarding-privacy-settings-page.ts
+++ b/test/e2e/page-objects/pages/onboarding/onboarding-privacy-settings-page.ts
@@ -80,9 +80,7 @@ class OnboardingPrivacySettingsPage {
   // Assets settings
   private readonly assetsPrivacyToggle = '.toggle-button.toggle-button--on';
 
-  private assetsPrivacyToggleState(state: 'on' | 'off') {
-    return `.toggle-button.toggle-button--${state}`;
-  }
+  private readonly assetsPrivacyToggleOn = '.toggle-button.toggle-button--on';
 
   private readonly assetsSettingsMessage = { text: 'Assets', tag: 'h2' };
 
@@ -198,15 +196,13 @@ class OnboardingPrivacySettingsPage {
       ),
     );
     console.log('Verify all asset privacy toggles are off');
-    await this.driver.assertElementNotPresent(
-      this.assetsPrivacyToggleState('on'),
-    );
+    await this.driver.assertElementNotPresent(this.assetsPrivacyToggleOn);
 
     await this.navigateBackToSettingsPage();
   }
 
   /**
-   * Go to general settings and toggle basic functionality off, then navigate back.
+   * Go to general settings and toggle options, then navigate back.
    */
   async toggleBasicFunctionalitySettings(): Promise<void> {
     console.log('Toggle basic functionality settings in privacy settings');

--- a/test/e2e/page-objects/pages/onboarding/onboarding-privacy-settings-page.ts
+++ b/test/e2e/page-objects/pages/onboarding/onboarding-privacy-settings-page.ts
@@ -21,6 +21,9 @@ class OnboardingPrivacySettingsPage {
   private readonly basicFunctionalityToggle =
     '[data-testid="basic-functionality-toggle"] .toggle-button';
 
+  private readonly basicFunctionalityToggleOffState =
+    '[data-testid="basic-functionality-toggle"] .toggle-button.toggle-button--off';
+
   private readonly basicFunctionalityTurnOffButton =
     '[data-testid="basic-configuration-modal-toggle-button"]';
 
@@ -76,6 +79,10 @@ class OnboardingPrivacySettingsPage {
 
   // Assets settings
   private readonly assetsPrivacyToggle = '.toggle-button.toggle-button--on';
+
+  private assetsPrivacyToggleState(state: 'on' | 'off') {
+    return `.toggle-button.toggle-button--${state}`;
+  }
 
   private readonly assetsSettingsMessage = { text: 'Assets', tag: 'h2' };
 
@@ -194,42 +201,19 @@ class OnboardingPrivacySettingsPage {
       ),
     );
 
-    const expectedClass = `toggle-button--${targetState}`;
-    const oppositeClass = `toggle-button--${targetState === 'off' ? 'on' : 'off'}`;
-
     console.log(`Verify all asset privacy toggles are ${targetState}`);
-    await this.driver.waitUntil(
-      async () => {
-        const toggles = await this.driver.findElements('.toggle-button');
-        if (toggles.length === 0) {
-          return false;
-        }
-        for (const toggle of toggles) {
-          const className = await toggle.getAttribute('class');
-          if (
-            !className.includes(expectedClass) ||
-            className.includes(oppositeClass)
-          ) {
-            return false;
-          }
-        }
-        return true;
-      },
-      { interval: 500, timeout: 5000 },
+    const oppositeState = targetState === 'off' ? 'on' : 'off';
+    await this.driver.assertElementNotPresent(
+      this.assetsPrivacyToggleState(oppositeState),
     );
 
     await this.navigateBackToSettingsPage();
   }
 
   /**
-   * Go to general settings and toggle options, then navigate back.
-   *
-   * @param targetState - The expected state of the toggle after clicking.
-   * Defaults to 'off'.
+   * Go to general settings and toggle basic functionality off, then navigate back.
    */
-  async toggleBasicFunctionalitySettings(
-    targetState: 'on' | 'off' = 'off',
-  ): Promise<void> {
+  async toggleBasicFunctionalitySettings(): Promise<void> {
     console.log('Toggle basic functionality settings in privacy settings');
     await this.navigateToGeneralSettings();
     await this.driver.clickElement(this.basicFunctionalityToggle);
@@ -237,18 +221,8 @@ class OnboardingPrivacySettingsPage {
     await this.driver.clickElement(this.basicFunctionalityCheckbox);
     await this.driver.clickElement(this.basicFunctionalityTurnOffButton);
 
-    console.log(`Verify basic functionality toggle is ${targetState}`);
-    const expectedClass = `toggle-button--${targetState}`;
-    await this.driver.waitUntil(
-      async () => {
-        const toggle = await this.driver.findElement(
-          this.basicFunctionalityToggle,
-        );
-        const className = await toggle.getAttribute('class');
-        return className.includes(expectedClass);
-      },
-      { interval: 500, timeout: 5000 },
-    );
+    console.log('Verify basic functionality toggle is off');
+    await this.driver.waitForSelector(this.basicFunctionalityToggleOffState);
 
     await this.navigateBackToSettingsPage();
   }

--- a/test/e2e/page-objects/pages/onboarding/onboarding-privacy-settings-page.ts
+++ b/test/e2e/page-objects/pages/onboarding/onboarding-privacy-settings-page.ts
@@ -80,8 +80,6 @@ class OnboardingPrivacySettingsPage {
   // Assets settings
   private readonly assetsPrivacyToggle = '.toggle-button.toggle-button--on';
 
-  private readonly assetsPrivacyToggleOn = '.toggle-button.toggle-button--on';
-
   private readonly assetsSettingsMessage = { text: 'Assets', tag: 'h2' };
 
   constructor(driver: Driver) {
@@ -196,7 +194,7 @@ class OnboardingPrivacySettingsPage {
       ),
     );
     console.log('Verify all asset privacy toggles are off');
-    await this.driver.assertElementNotPresent(this.assetsPrivacyToggleOn);
+    await this.driver.assertElementNotPresent(this.assetsPrivacyToggle);
 
     await this.navigateBackToSettingsPage();
   }

--- a/test/e2e/page-objects/pages/onboarding/onboarding-privacy-settings-page.ts
+++ b/test/e2e/page-objects/pages/onboarding/onboarding-privacy-settings-page.ts
@@ -178,9 +178,12 @@ class OnboardingPrivacySettingsPage {
   }
 
   /**
-   * Go to assets settings and toggle options, then navigate back.
+   * Go to assets settings, toggle all options, verify their state, then navigate back.
+   *
+   * @param targetState - The expected state of all toggles after clicking.
+   * Defaults to 'off'.
    */
-  async toggleAssetsSettings(): Promise<void> {
+  async toggleAssetsSettings(targetState: 'on' | 'off' = 'off'): Promise<void> {
     console.log('Toggle advanced assets settings in privacy settings');
     await this.checkPageIsLoaded();
     await this.driver.clickElement(this.assetsSettings);
@@ -190,19 +193,63 @@ class OnboardingPrivacySettingsPage {
         (toggle) => toggle.click(),
       ),
     );
+
+    const expectedClass = `toggle-button--${targetState}`;
+    const oppositeClass = `toggle-button--${targetState === 'off' ? 'on' : 'off'}`;
+
+    console.log(`Verify all asset privacy toggles are ${targetState}`);
+    await this.driver.waitUntil(
+      async () => {
+        const toggles = await this.driver.findElements('.toggle-button');
+        if (toggles.length === 0) {
+          return false;
+        }
+        for (const toggle of toggles) {
+          const className = await toggle.getAttribute('class');
+          if (
+            !className.includes(expectedClass) ||
+            className.includes(oppositeClass)
+          ) {
+            return false;
+          }
+        }
+        return true;
+      },
+      { interval: 500, timeout: 5000 },
+    );
+
     await this.navigateBackToSettingsPage();
   }
 
   /**
    * Go to general settings and toggle options, then navigate back.
+   *
+   * @param targetState - The expected state of the toggle after clicking.
+   * Defaults to 'off'.
    */
-  async toggleBasicFunctionalitySettings(): Promise<void> {
+  async toggleBasicFunctionalitySettings(
+    targetState: 'on' | 'off' = 'off',
+  ): Promise<void> {
     console.log('Toggle basic functionality settings in privacy settings');
     await this.navigateToGeneralSettings();
     await this.driver.clickElement(this.basicFunctionalityToggle);
     await this.driver.waitForSelector(this.basicFunctionalityTurnOffMessage);
     await this.driver.clickElement(this.basicFunctionalityCheckbox);
     await this.driver.clickElement(this.basicFunctionalityTurnOffButton);
+
+    console.log(`Verify basic functionality toggle is ${targetState}`);
+    const expectedClass = `toggle-button--${targetState}`;
+    await this.driver.waitUntil(
+      async () => {
+        const toggle = await this.driver.findElement(
+          this.basicFunctionalityToggle,
+        );
+        const className = await toggle.getAttribute('class');
+        return className.includes(expectedClass);
+      },
+      { interval: 500, timeout: 5000 },
+    );
+
     await this.navigateBackToSettingsPage();
   }
 }

--- a/test/e2e/page-objects/pages/onboarding/onboarding-privacy-settings-page.ts
+++ b/test/e2e/page-objects/pages/onboarding/onboarding-privacy-settings-page.ts
@@ -185,12 +185,9 @@ class OnboardingPrivacySettingsPage {
   }
 
   /**
-   * Go to assets settings, toggle all options, verify their state, then navigate back.
-   *
-   * @param targetState - The expected state of all toggles after clicking.
-   * Defaults to 'off'.
+   * Go to assets settings, toggle all options off, verify their state, then navigate back.
    */
-  async toggleAssetsSettings(targetState: 'on' | 'off' = 'off'): Promise<void> {
+  async toggleAssetsSettings(): Promise<void> {
     console.log('Toggle advanced assets settings in privacy settings');
     await this.checkPageIsLoaded();
     await this.driver.clickElement(this.assetsSettings);
@@ -200,11 +197,9 @@ class OnboardingPrivacySettingsPage {
         (toggle) => toggle.click(),
       ),
     );
-
-    console.log(`Verify all asset privacy toggles are ${targetState}`);
-    const oppositeState = targetState === 'off' ? 'on' : 'off';
+    console.log('Verify all asset privacy toggles are off');
     await this.driver.assertElementNotPresent(
-      this.assetsPrivacyToggleState(oppositeState),
+      this.assetsPrivacyToggleState('on'),
     );
 
     await this.navigateBackToSettingsPage();

--- a/test/e2e/tests/privacy/advanced-functionality-privacy.spec.ts
+++ b/test/e2e/tests/privacy/advanced-functionality-privacy.spec.ts
@@ -58,7 +58,7 @@ async function mockApis(mockServer: Mockttp): Promise<MockedEndpoint[]> {
     */
   ];
 }
-describe('MetaMask onboarding TEST', function () {
+describe('MetaMask onboarding ', function () {
   it('should prevent network requests to advanced functionality endpoints when the advanced assets functionality toggle is off', async function () {
     await withFixtures(
       {

--- a/test/e2e/tests/privacy/advanced-functionality-privacy.spec.ts
+++ b/test/e2e/tests/privacy/advanced-functionality-privacy.spec.ts
@@ -58,7 +58,7 @@ async function mockApis(mockServer: Mockttp): Promise<MockedEndpoint[]> {
     */
   ];
 }
-describe('MetaMask onboarding ', function () {
+describe('MetaMask onboarding TEST', function () {
   it('should prevent network requests to advanced functionality endpoints when the advanced assets functionality toggle is off', async function () {
     await withFixtures(
       {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

There is a race condition where a request to price api happens, despite setting the privacy toggles off.
The fix is to ensure the toggles are off, before going back to the settings page.


<img width="2312" height="442" alt="image" src="https://github.com/user-attachments/assets/8c4def11-c843-4e13-b7dc-0011a2bd497f" />

<img width="1302" height="1390" alt="image" src="https://github.com/user-attachments/assets/1c67d275-91f1-4b0e-9d82-d307a061911f" />


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/41371


## **Manual testing steps**

1. I triggered the quality gate to run this spec multiple times in ci 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to e2e page-object assertions to reduce race-condition flakiness, with no production logic impact.
> 
> **Overview**
> Improves onboarding privacy e2e stability by adding explicit post-toggle assertions before leaving the settings screens.
> 
> After clicking *advanced assets* toggles, the page object now asserts no `.toggle-button--on` elements remain, and after turning off *basic functionality* it waits for the toggle’s explicit off-state selector (`.toggle-button--off`) before navigating back.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ab060dbd0016f6bd86de8dfa4614bfe4f9308f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->