### PR TITLE
test: fix flaky `Send ETH - Max Amount adjusts max amount when gas estimations change`

### DIFF
--- a/test/e2e/page-objects/pages/confirmations/transaction-confirmation.ts
+++ b/test/e2e/page-objects/pages/confirmations/transaction-confirmation.ts
@@ -81,6 +81,11 @@ class TransactionConfirmation extends Confirmation {
 
   private readonly saveButton: RawLocator = { tag: 'button', text: 'Save' };
 
+  private readonly sendAmountFiat = (amount: string): RawLocator => ({
+    text: amount,
+    css: '.text-alternative',
+  });
+
   private readonly senderAccount: RawLocator = '[data-testid="sender-address"]';
 
   private readonly siteSuggestedGasFee = (estimatedTime: string) => ({
@@ -332,6 +337,13 @@ class TransactionConfirmation extends Confirmation {
       text: amount,
       tag: 'h2',
     });
+  }
+
+  async checkSendAmountConversion(amountFiat: string) {
+    console.log(
+      `Checking send amount conversion ${amountFiat} on transaction confirmation page.`,
+    );
+    await this.driver.waitForSelector(this.sendAmountFiat(amountFiat));
   }
 
   async checkSiteSuggestedGas(time: string) {

--- a/test/e2e/tests/send/send-eth-max.spec.ts
+++ b/test/e2e/tests/send/send-eth-max.spec.ts
@@ -104,10 +104,7 @@ describe('Send ETH - Max Amount', function () {
           await sendTokenConfirmPage.checkNativeCurrency('$1.00');
 
           // verify max amount after gas fee changes
-          await driver.waitForSelector({
-            text: '$42,494.90',
-            tag: 'p',
-          });
+          await transactionConfirmation.checkSendAmountConversion('$42,494.90');
 
           // confirms the transaction
           await transactionConfirmation.clickFooterConfirmButtonAndWaitToDisappear();
@@ -233,6 +230,7 @@ describe('Send ETH - Max Amount', function () {
 
         // verify initial max amount
         await transactionConfirmation.checkSendAmount('25 ETH');
+        await transactionConfirmation.checkSendAmountConversion('$42,498.19');
 
         // confirms the transaction
         await transactionConfirmation.clickFooterConfirmButtonAndWaitToDisappear();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The test is flaky as sometimes after clicking Confirm we stay in the Confirmation page. This is due to a re-render which causes the click to take no effect.

The total amount in fiat takes a bit longer to refresh (as it reloads after the gas values are set). Now we wait for the total amount to be the one expected after gas, and then proceed with the Confirm action, preventing a rerender afterwards


<img width="1152" height="836" alt="image" src="https://github.com/user-attachments/assets/50c62b08-5531-442f-a528-9e39d238fe9b" />


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only modifies e2e page-object helpers and assertions, with no production logic changes; the main risk is selector brittleness if UI classes/text change.
> 
> **Overview**
> Reduces flakiness in `Send ETH - Max Amount` e2e flows by waiting for the *fiat conversion* of the max send amount to settle after gas fee changes, before clicking Confirm.
> 
> Adds `TransactionConfirmation.checkSendAmountConversion()` (via a new `.text-alternative` locator) and updates the test to use it instead of an inline `waitForSelector` for the expected fiat amount.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59aa948aeda88c43982864a89468fe4711266e46. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->