### PR TITLE
feat: localize Contentful banners [GE-56]

### DIFF
--- a/ui/hooks/useCarouselManagement/fetchCarouselSlidesFromContentful.test.ts
+++ b/ui/hooks/useCarouselManagement/fetchCarouselSlidesFromContentful.test.ts
@@ -1,0 +1,130 @@
+import { captureException } from '../../../shared/lib/sentry';
+import {
+  fetchCarouselSlidesFromContentful,
+  getContentfulEnvironmentDetails,
+  UnknownLocaleError,
+} from './fetchCarouselSlidesFromContentful';
+
+jest.mock('../../../shared/lib/sentry', () => ({
+  captureException: jest.fn(),
+}));
+
+jest.mock('../../../shared/lib/environment', () => ({
+  isProduction: jest.fn().mockReturnValue(false),
+}));
+
+const mockCaptureException = jest.mocked(captureException);
+
+const SPACE_ID = 'test-space';
+const ACCESS_TOKEN = 'test-token';
+
+const makeBannerResponse = (overrides = {}) => ({
+  items: [
+    {
+      sys: { id: 'banner-1' },
+      fields: {
+        headline: 'Test Banner',
+        teaser: 'Test description',
+        image: { sys: { id: 'asset-1' } },
+        linkUrl: 'https://example.com',
+        undismissable: false,
+        showInExtension: true,
+        variableName: 'test',
+      },
+    },
+  ],
+  includes: {
+    Asset: [
+      {
+        sys: { id: 'asset-1' },
+        fields: { file: { url: '//images.ctfassets.net/img.png' } },
+      },
+    ],
+  },
+  ...overrides,
+});
+
+const unknownLocaleResponse = {
+  sys: { type: 'Error', id: 'BadRequest' },
+  message: 'Unknown locale: fr-B',
+};
+
+describe('fetchCarouselSlidesFromContentful', () => {
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.CONTENTFUL_ACCESS_SPACE_ID = SPACE_ID;
+    process.env.CONTENTFUL_ACCESS_TOKEN = ACCESS_TOKEN;
+
+    fetchSpy = jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => makeBannerResponse(),
+    } as Response);
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    delete process.env.CONTENTFUL_ACCESS_SPACE_ID;
+    delete process.env.CONTENTFUL_ACCESS_TOKEN;
+  });
+
+  it('passes locale param to Contentful API', async () => {
+    await fetchCarouselSlidesFromContentful('fr');
+
+    const calledUrl = new URL(fetchSpy.mock.calls[0][0]);
+    expect(calledUrl.searchParams.get('locale')).toBe('fr');
+  });
+
+  it('omits locale param when not provided', async () => {
+    await fetchCarouselSlidesFromContentful();
+
+    const calledUrl = new URL(fetchSpy.mock.calls[0][0]);
+    expect(calledUrl.searchParams.has('locale')).toBe(false);
+  });
+
+  it('retries without locale on UnknownLocaleError and reports to Sentry', async () => {
+    fetchSpy
+      .mockResolvedValueOnce({
+        ok: false,
+        json: async () => unknownLocaleResponse,
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => makeBannerResponse(),
+      } as Response);
+
+    const result = await fetchCarouselSlidesFromContentful('fr-B');
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+    const firstUrl = new URL(fetchSpy.mock.calls[0][0]);
+    expect(firstUrl.searchParams.get('locale')).toBe('fr-B');
+
+    const retryUrl = new URL(fetchSpy.mock.calls[1][0]);
+    expect(retryUrl.searchParams.has('locale')).toBe(false);
+
+    expect(mockCaptureException).toHaveBeenCalledTimes(1);
+    expect(mockCaptureException).toHaveBeenCalledWith(
+      expect.any(UnknownLocaleError),
+    );
+
+    expect(result.regularSlides).toHaveLength(1);
+    expect(result.regularSlides[0].title).toBe('Test Banner');
+  });
+
+  it('throws non-locale Contentful errors without retrying', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: false,
+      statusText: 'Internal Server Error',
+      json: async () => ({ message: 'Something went wrong' }),
+    } as Response);
+
+    await expect(fetchCarouselSlidesFromContentful('en')).rejects.toThrow(
+      'Contentful error: Something went wrong',
+    );
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+});

--- a/ui/hooks/useCarouselManagement/fetchCarouselSlidesFromContentful.ts
+++ b/ui/hooks/useCarouselManagement/fetchCarouselSlidesFromContentful.ts
@@ -97,11 +97,13 @@ async function fetchEntries(
   const res = await fetch(url);
   const json = await res.json();
 
-  if (json?.message?.includes('Unknown locale')) {
-    throw new UnknownLocaleError(json.message);
-  }
-
   if (!res.ok) {
+    if (
+      typeof json?.message === 'string' &&
+      json.message.includes('Unknown locale')
+    ) {
+      throw new UnknownLocaleError(json.message);
+    }
     throw new Error(`Contentful error: ${json?.message ?? res.statusText}`);
   }
 

--- a/ui/hooks/useCarouselManagement/fetchCarouselSlidesFromContentful.ts
+++ b/ui/hooks/useCarouselManagement/fetchCarouselSlidesFromContentful.ts
@@ -1,6 +1,7 @@
 import semver from 'semver';
 import { CarouselSlide } from '../../../shared/constants/app-state';
 import { isProduction } from '../../../shared/lib/environment';
+import { captureException } from '../../../shared/lib/sentry';
 import packageJson from '../../../package.json';
 
 const APP_VERSION = packageJson.version;
@@ -78,7 +79,38 @@ type ContentfulBannerResponse = {
   };
 };
 
-export async function fetchCarouselSlidesFromContentful(): Promise<{
+export class UnknownLocaleError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'UnknownLocaleError';
+  }
+}
+
+async function fetchEntries(
+  baseUrl: URL,
+  locale?: string,
+): Promise<ContentfulBannerResponse> {
+  const url = new URL(baseUrl.toString());
+  if (locale) {
+    url.searchParams.set('locale', locale);
+  }
+  const res = await fetch(url);
+  const json = await res.json();
+
+  if (json?.message?.includes('Unknown locale')) {
+    throw new UnknownLocaleError(json.message);
+  }
+
+  if (!res.ok) {
+    throw new Error(`Contentful error: ${json?.message ?? res.statusText}`);
+  }
+
+  return json as ContentfulBannerResponse;
+}
+
+export async function fetchCarouselSlidesFromContentful(
+  locale?: string,
+): Promise<{
   prioritySlides: CarouselSlide[];
   regularSlides: CarouselSlide[];
 }> {
@@ -95,7 +127,19 @@ export async function fetchCarouselSlidesFromContentful(): Promise<{
   url.searchParams.set('access_token', accessToken);
   url.searchParams.set('content_type', CONTENT_TYPE);
   url.searchParams.set('fields.showInExtension', 'true');
-  const res: ContentfulBannerResponse = await fetch(url).then((r) => r.json());
+
+  let res: ContentfulBannerResponse;
+  try {
+    res = await fetchEntries(url, locale);
+  } catch (error) {
+    if (error instanceof UnknownLocaleError && locale) {
+      captureException(error);
+      // In case of unknown locale, fallback to default locale
+      res = await fetchEntries(url);
+    } else {
+      throw error;
+    }
+  }
 
   const assets = res.includes?.Asset || [];
   const resolveImage = (imageRef: ContentfulSysField) => {

--- a/ui/hooks/useCarouselManagement/useCarouselManagement.test.ts
+++ b/ui/hooks/useCarouselManagement/useCarouselManagement.test.ts
@@ -10,12 +10,16 @@ import {
   getShowDownloadMobileAppSlide,
   getRemoteFeatureFlags,
 } from '../../selectors';
+import { getCurrentLocale } from '../../ducks/locale/locale';
 import { updateSlides } from '../../store/actions';
 import type { CarouselSlide } from '../../../shared/constants/app-state';
 import { useCarouselManagement } from './useCarouselManagement';
 import { fetchCarouselSlidesFromContentful } from './fetchCarouselSlidesFromContentful';
 
 jest.mock('./fetchCarouselSlidesFromContentful');
+jest.mock('../../ducks/locale/locale', () => ({
+  getCurrentLocale: jest.fn(),
+}));
 jest.mock('react-redux', () => ({
   useDispatch: jest.fn(),
   useSelector: jest.fn((selector) => selector()),
@@ -55,6 +59,7 @@ const mockGetSelectedInternalAccount = jest
   .mockReturnValue({ address: '0xabc' });
 const mockGetShowDownloadMobileAppSlide = jest.fn().mockReturnValue(true);
 const mockGetRemoteFeatureFlags = jest.fn();
+const mockGetCurrentLocale = jest.fn().mockReturnValue('en-US');
 
 describe('useCarouselManagement (simple Contentful tests)', () => {
   beforeEach(() => {
@@ -86,6 +91,9 @@ describe('useCarouselManagement (simple Contentful tests)', () => {
         if (selector === (getRemoteFeatureFlags as MockSelector)) {
           return mockGetRemoteFeatureFlags() as TSelected;
         }
+        if (selector === (getCurrentLocale as MockSelector)) {
+          return mockGetCurrentLocale() as TSelected;
+        }
         return undefined as unknown as TSelected;
       },
     );
@@ -97,6 +105,7 @@ describe('useCarouselManagement (simple Contentful tests)', () => {
     mockGetRemoteFeatureFlags.mockReturnValue({
       contentfulCarouselEnabled: true,
     });
+    mockGetCurrentLocale.mockReturnValue('en');
 
     jest.clearAllMocks();
   });

--- a/ui/hooks/useCarouselManagement/useCarouselManagement.ts
+++ b/ui/hooks/useCarouselManagement/useCarouselManagement.ts
@@ -17,6 +17,7 @@ import {
   getSlides,
   getUseExternalServices,
 } from '../../selectors';
+import { getCurrentLocale } from '../../ducks/locale/locale';
 import { fetchCarouselSlidesFromContentful } from './fetchCarouselSlidesFromContentful';
 
 type UseSlideManagementProps = { testDate?: string; enabled?: boolean };
@@ -100,9 +101,12 @@ export const useCarouselManagement = ({
   const useExternalServices = useSelector(getUseExternalServices);
   const showDownloadMobileAppSlide = useSelector(getShowDownloadMobileAppSlide);
   const prevSlidesRef = useRef<CarouselSlide[]>();
+  const slidesRef = useRef(slides);
+  slidesRef.current = slides;
   const hasZeroBalance = new BigNumber(totalBalance ?? ZERO_BALANCE).eq(
     ZERO_BALANCE,
   );
+  const currentLocale = useSelector(getCurrentLocale);
   const contentfulEnabled =
     remoteFeatureFlags?.contentfulCarouselEnabled ?? false;
 
@@ -182,7 +186,7 @@ export const useCarouselManagement = ({
       if (contentfulEnabled) {
         try {
           const { prioritySlides, regularSlides } =
-            await fetchCarouselSlidesFromContentful();
+            await fetchCarouselSlidesFromContentful(currentLocale);
 
           const pRaw = [...prioritySlides];
           const rRaw = [...regularSlides];
@@ -192,7 +196,7 @@ export const useCarouselManagement = ({
 
           const normalizeList = (list: CarouselSlide[]) =>
             list
-              .map((s) => normalize(s, slides))
+              .map((s) => normalize(s, slidesRef.current ?? []))
               .filter((s): s is CarouselSlide => Boolean(s))
               .filter(isNowActive);
 
@@ -252,9 +256,9 @@ export const useCarouselManagement = ({
     dispatch,
     hasZeroBalance,
     contentfulEnabled,
+    currentLocale,
     testDate,
     inTest,
-    slides,
     downloadEligibilityReady,
   ]);
 

--- a/ui/hooks/useCarouselManagement/useCarouselManagement.ts
+++ b/ui/hooks/useCarouselManagement/useCarouselManagement.ts
@@ -172,85 +172,89 @@ export const useCarouselManagement = ({
       }
       return;
     }
+    let cancelled = false;
+
     const maybeFetchContentful = async () => {
       // Early Return if Contentful is disabled
       if (!contentfulEnabled) {
         const empty: CarouselSlide[] = [];
-        if (!isEqual(prevSlidesRef.current, empty)) {
+        if (!cancelled && !isEqual(prevSlidesRef.current, empty)) {
           dispatch(updateSlides(empty));
           prevSlidesRef.current = empty;
         }
         return;
       }
 
-      if (contentfulEnabled) {
-        try {
-          const { prioritySlides, regularSlides } =
-            await fetchCarouselSlidesFromContentful(currentLocale);
+      try {
+        const { prioritySlides, regularSlides } =
+          await fetchCarouselSlidesFromContentful(currentLocale);
 
-          const pRaw = [...prioritySlides];
-          const rRaw = [...regularSlides];
+        if (cancelled) {
+          return;
+        }
 
-          const isNowActive = (s: CarouselSlide) =>
-            isActive(s, testDate ? new Date(testDate) : new Date());
+        const pRaw = [...prioritySlides];
+        const rRaw = [...regularSlides];
 
-          const normalizeList = (list: CarouselSlide[]) =>
-            list
-              .map((s) => normalize(s, slidesRef.current ?? []))
-              .filter((s): s is CarouselSlide => Boolean(s))
-              .filter(isNowActive);
+        const isNowActive = (s: CarouselSlide) =>
+          isActive(s, testDate ? new Date(testDate) : new Date());
 
-          // Fund: force undismissable on zero balance
-          const fundCheck = (s: CarouselSlide): CarouselSlide => {
-            if (s.variableName === 'fund') {
-              return {
-                ...s,
-                undismissable: hasZeroBalance || s.undismissable,
-              };
-            }
-            return s;
-          };
+        const normalizeList = (list: CarouselSlide[]) =>
+          list
+            .map((s) => normalize(s, slidesRef.current ?? []))
+            .filter((s): s is CarouselSlide => Boolean(s))
+            .filter(isNowActive);
 
-          const isEligible = (s: CarouselSlide) => {
-            // Show Download Mobile App (only if not already on mobile + flags)
-            if (s.variableName === 'downloadMobileApp') {
-              return downloadEligible;
-            }
-            return true;
-          };
-
-          const activePrioritySlides = normalizeList(pRaw)
-            .map(fundCheck)
-            .filter(isEligible);
-          const activeRegularSlides = normalizeList(rRaw)
-            .map(fundCheck)
-            .filter(isEligible);
-
-          // Order based on cardPlacement
-          const orderedNonPriority = orderByCardPlacement(activeRegularSlides);
-          const mergedSlides = [...activePrioritySlides, ...orderedNonPriority];
-
-          if (!isEqual(prevSlidesRef.current, mergedSlides)) {
-            dispatch(updateSlides(mergedSlides));
-            prevSlidesRef.current = mergedSlides;
+        // Fund: force undismissable on zero balance
+        const fundCheck = (s: CarouselSlide): CarouselSlide => {
+          if (s.variableName === 'fund') {
+            return {
+              ...s,
+              undismissable: hasZeroBalance || s.undismissable,
+            };
           }
-        } catch (err) {
-          log.warn('Failed to fetch Contentful slides:', err);
-          if (!isEqual(prevSlidesRef.current, [])) {
-            dispatch(updateSlides([]));
-            prevSlidesRef.current = [];
+          return s;
+        };
+
+        const isEligible = (s: CarouselSlide) => {
+          // Show Download Mobile App (only if not already on mobile + flags)
+          if (s.variableName === 'downloadMobileApp') {
+            return downloadEligible;
           }
+          return true;
+        };
+
+        const activePrioritySlides = normalizeList(pRaw)
+          .map(fundCheck)
+          .filter(isEligible);
+        const activeRegularSlides = normalizeList(rRaw)
+          .map(fundCheck)
+          .filter(isEligible);
+
+        // Order based on cardPlacement
+        const orderedNonPriority = orderByCardPlacement(activeRegularSlides);
+        const mergedSlides = [...activePrioritySlides, ...orderedNonPriority];
+
+        if (!isEqual(prevSlidesRef.current, mergedSlides)) {
+          dispatch(updateSlides(mergedSlides));
+          prevSlidesRef.current = mergedSlides;
+        }
+      } catch (err) {
+        log.warn('Failed to fetch Contentful slides:', err);
+        if (!cancelled && !isEqual(prevSlidesRef.current, [])) {
+          dispatch(updateSlides([]));
+          prevSlidesRef.current = [];
         }
       }
     };
 
-    (async () => {
-      try {
-        await maybeFetchContentful();
-      } catch (err) {
-        log.warn('Failed to load carousel slides:', err);
-      }
-    })();
+    maybeFetchContentful().catch((err) => {
+      log.warn('Failed to load carousel slides:', err);
+    });
+
+    return () => {
+      cancelled = true;
+    };
   }, [
     enabled,
     dispatch,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
This PR adds localization support for Contentful banners. It gracefully handles errors from Contentful saying the requested locale hasn't been added to Contentful yet, by trying again without specifying a locale.

All locales must be added to Contentful with a fallback to English to limit failing Contentful requests => to be performed manually on the main workspace once this PR is approved

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added banners localization

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/GE-56

## **Manual testing steps**

1. Build the extension with a Contentful preview token
2. Make sure you see some banners
3. Switch to french language in MetaMask settings
4. Some banners should now be translated

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
https://github.com/user-attachments/assets/427062ea-765d-4978-a589-b2e5856bc6e2

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the carousel slide-fetching flow to depend on the active locale and adds retry/error handling around Contentful responses, which could affect what banners users see and when slide state updates occur.
> 
> **Overview**
> Adds locale-aware fetching for Contentful carousel banners by passing the app’s `getCurrentLocale` into `fetchCarouselSlidesFromContentful`, and appending `locale` to the Contentful entries request.
> 
> Introduces `UnknownLocaleError` detection for Contentful “Unknown locale” responses; the fetch now reports to Sentry via `captureException` and retries once without a locale to fall back to the default.
> 
> Hardens `useCarouselManagement` against async race conditions by using a `cancelled` flag and a `slidesRef` to preserve dismissal state without re-triggering the effect, and updates/extends unit tests to cover locale param behavior and the retry path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36bb37a1606e01facbb6b287450baffa4fe57a9a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->