### PR TITLE
fix: improve dapp connection control bar styling

### DIFF
--- a/ui/components/multichain/dapp-connection-control-bar/dapp-connection-control-bar.tsx
+++ b/ui/components/multichain/dapp-connection-control-bar/dapp-connection-control-bar.tsx
@@ -298,7 +298,8 @@ export const DappConnectionControlBar: React.FC = () => {
               type="button"
             >
               <AvatarNetwork
-                size={AvatarNetworkSize.Sm}
+                className="dapp-connection-control-bar__network-icon"
+                size={AvatarNetworkSize.Xs}
                 name={
                   (dappActiveNetwork as { name?: string })?.name ??
                   (dappActiveNetwork as { nickname?: string })?.nickname ??

--- a/ui/components/multichain/dapp-connection-control-bar/index.scss
+++ b/ui/components/multichain/dapp-connection-control-bar/index.scss
@@ -45,10 +45,17 @@
       background-color: var(--color-background-hover);
     }
 
-    .mm-avatar-network {
-      border: none;
+    > * {
+      border: none !important;
       box-shadow: none;
+      background-color: transparent !important;
     }
+  }
+
+  &__network-icon {
+    width: 1.25rem !important;
+    height: 1.25rem !important;
+    border-radius: 0.375rem !important;
   }
 
   &__combined-actions {
@@ -77,7 +84,8 @@
 
   &__divider {
     width: 1px;
-    height: 16px;
+    height: 18px;
+    margin-bottom: 8px;
     background-color: var(--color-border-muted);
     flex-shrink: 0;
   }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- Reduced the network avatar icon size in the dapp connection control bar from `Sm` (24px) to a custom 20px, making it visually lighter and better proportioned within its button container
- Removed unintended dark borders/backgrounds that appeared on the network icon and arrow in dark mode by clearing `border`, `box-shadow`, and `background-color` on the button's children
- Increased the border-radius on the network icon for a rounder appearance
- Adjusted the vertical divider between action buttons (taller + bottom margin) for better visual alignment

## Changes

### `dapp-connection-control-bar.tsx`
- Switched `AvatarNetwork` from `AvatarNetworkSize.Sm` to `AvatarNetworkSize.Xs` as a base size
- Added a BEM className (`dapp-connection-control-bar__network-icon`) to enable targeted style overrides since the `@metamask/design-system-react` component renders with Tailwind utility classes rather than the legacy `.mm-avatar-network` BEM class

### `index.scss`
- Replaced the non-matching `.mm-avatar-network` rule inside `__network-button` with a `> *` child selector that strips `border`, `box-shadow`, and `background-color` from all direct children — fixing dark-mode artifacts on both the avatar and the arrow icon
- Added `__network-icon` overrides to fine-tune dimensions (20px) and border-radius (6px) between the `Xs` (16px) and `Sm` (24px) design tokens
- Increased `__divider` height from 16px to 18px and added `margin-bottom: 8px` for better vertical alignment with adjacent buttons
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: dapp connection control bar style adjustments

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/WAPI-1374

## **Manual testing steps**

1. Go to [metamask test dapp](https://metamask.github.io/test-dapp/)
2. Establish a connection
3. The divider line between the gear icon and the disconnect icon needs to match the design spec. Before, the gear and disconnect icons were visually colliding without proper separation.
4. The network selector icon was slightly too large compared to spec. Should to be reduced in size to match the intended design.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="819" height="153" alt="Screenshot 2026-03-31 at 13 13 58" src="https://github.com/user-attachments/assets/391d0228-8353-4a15-a7fe-69126db6a781" />

<!-- [screenshots/recordings] -->

### **After**

<img width="400" height="71" alt="Screenshot 2026-03-31 at 13 13 14" src="https://github.com/user-attachments/assets/aba66509-65d5-4a8f-94df-10f8d1ee8204" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only SCSS/markup tweaks with no behavioral or data-flow changes.
> 
> **Overview**
> Improves `DappConnectionControlBar` styling by shrinking the network `AvatarNetwork` (switching to `AvatarNetworkSize.Xs`) and adding a dedicated `__network-icon` class to fine-tune its dimensions and border radius.
> 
> Cleans up dark-mode artifacts by removing borders/shadows/backgrounds from direct children of the network button, and adjusts the action divider to be slightly taller with a bottom margin for better alignment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5312db627da8c6c62bea28cef7ecd08a6b7cce64. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->