### PR TITLE
test: fix flaky test `Remove Network: should remove the chainId from existing permissions when a network configuration is removed entirely`

### DIFF
--- a/test/e2e/page-objects/pages/dialog/select-network.ts
+++ b/test/e2e/page-objects/pages/dialog/select-network.ts
@@ -29,6 +29,9 @@ class SelectNetwork {
     testId: 'network-list-item-options-discover',
   };
 
+  private readonly drawerOverlay =
+    'div[class*="bg-[var(--color-overlay-default)]"]';
+
   private readonly editNetworkButton =
     '[data-testid="network-list-item-options-edit"]';
 
@@ -123,6 +126,10 @@ class SelectNetwork {
     await this.openNetworkListOptions(chainId);
     await this.driver.clickElementAndWaitToDisappear(this.deleteNetworkButton);
     await this.driver.waitForSelector(this.confirmDeleteNetworkModal);
+    // Ensure drawer overlay is not present to avoid ElementClickInterceptedError
+    await this.driver.assertElementNotPresent(this.drawerOverlay, {
+      waitAtLeastGuard: 200,
+    });
     await this.driver.clickElementAndWaitToDisappear(
       this.confirmDeleteNetworkButton,
     );

--- a/test/e2e/tests/network/remove-network.spec.ts
+++ b/test/e2e/tests/network/remove-network.spec.ts
@@ -13,7 +13,7 @@ import HeaderNavbar from '../../page-objects/pages/header-navbar';
 import HomePage from '../../page-objects/pages/home/homepage';
 import { getPermittedChains } from './common';
 
-describe('Remove Network:', function (this: Suite) {
+describe('Remove Network', function (this: Suite) {
   it('should remove the chainId from existing permissions when a network configuration is removed entirely', async function () {
     await withFixtures(
       {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The test is flaky as whenever we click Delete, it can be that there's the loading overlay and intercepts the click, causing the click to take no effect and failing with the intercepted click error

<img width="1152" height="836" alt="image" src="https://github.com/user-attachments/assets/1dc5c889-6562-4574-8e03-057ba0df270d" />

<img width="1950" height="226" alt="image" src="https://github.com/user-attachments/assets/83f658b5-d6a4-4569-ac1d-d8df773aeb91" />


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to E2E test utilities and a test description, with no production logic impact. Main risk is only potential for added wait to mask real UI issues or slow tests slightly.
> 
> **Overview**
> Stabilizes the `Remove Network` E2E flow by adding a guard in `SelectNetwork.deleteNetwork` to wait until the drawer overlay is gone before clicking the confirm **Delete** button, avoiding `ElementClickInterceptedError` flakiness.
> 
> Also tweaks the `remove-network.spec.ts` suite name (removes the trailing colon) for consistency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5d8558771a65f686c4c2b52a78ddb8a2cf2e660. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->