### PR TITLE
fix(errors): treat Firefox unexpected storage error as state corruption

### DIFF
--- a/shared/constants/errors.test.ts
+++ b/shared/constants/errors.test.ts
@@ -1,0 +1,44 @@
+import {
+  CORRUPTION_BLOCK_CHECKSUM_MISMATCH,
+  FIREFOX_STORAGE_UNEXPECTED_ERROR,
+  MISSING_VAULT_ERROR,
+  isStateCorruptionError,
+} from './errors';
+
+describe('isStateCorruptionError', () => {
+  it('returns true for missing vault persistence error', () => {
+    expect(
+      isStateCorruptionError({
+        message: MISSING_VAULT_ERROR,
+        name: 'PersistenceError',
+      }),
+    ).toBe(true);
+  });
+
+  it('returns true for block checksum mismatch', () => {
+    expect(
+      isStateCorruptionError({
+        message: CORRUPTION_BLOCK_CHECKSUM_MISMATCH,
+        name: 'Error',
+      }),
+    ).toBe(true);
+  });
+
+  it('returns true for Firefox generic storage failure message', () => {
+    expect(
+      isStateCorruptionError({
+        message: FIREFOX_STORAGE_UNEXPECTED_ERROR,
+        name: 'Error',
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false for unrelated errors', () => {
+    expect(
+      isStateCorruptionError({
+        message: 'Network request failed',
+        name: 'Error',
+      }),
+    ).toBe(false);
+  });
+});

--- a/shared/constants/errors.ts
+++ b/shared/constants/errors.ts
@@ -12,9 +12,13 @@ export const MISSING_VAULT_ERROR =
 export const CORRUPTION_BLOCK_CHECKSUM_MISMATCH =
   'Corruption: block checksum mismatch';
 
+// This error comes from the Firefox browser
+export const FIREFOX_STORAGE_UNEXPECTED_ERROR = 'An unexpected error occurred';
+
 export function isStateCorruptionError(err: ErrorLike) {
   return (
     err.message === MISSING_VAULT_ERROR ||
-    err.message === CORRUPTION_BLOCK_CHECKSUM_MISMATCH
+    err.message === CORRUPTION_BLOCK_CHECKSUM_MISMATCH ||
+    err.message === FIREFOX_STORAGE_UNEXPECTED_ERROR
   );
 }


### PR DESCRIPTION
## **Description**

This PR recognizes Firefox's generic storage.local failure message ('An unexpected error occurred') as a state corruption error so init failures route to CorruptionHandler and the recovery UI instead of the generic critical error screen.

## **Changelog**

CHANGELOG entry: Handle Firefox's 'An unexpected error occurred' error as a state corruption error

## **Related issues**

Fixes: None

See [Slack thread](https://consensys.slack.com/archives/C8RSKCNCD/p1774855106726699?thread_ts=1774531178.961629&cid=C8RSKCNCD)

## **Manual testing steps**

### Prerequisites
- Firefox browser
- MetaMask installed from Firefox Add-ons store (or local build with `yarn dist:mv2`)
- The `test-vault-corruption-firefox.sh` script from this [PR](https://github.com/MetaMask/metamask-extension/pull/38940)

### Test: Unrecoverable vault screen is displayed upon 'An unexpected error occurred' state corruption error

1. Install MetaMask and complete onboarding
2. Open the inspector and manually delete the vault backup in IndexedDB (called 'metamask-backup')
3. Close Firefox completely immediately after (before the vault backup gets re-created)
4. Run `./test-vault-corruption-firefox.sh` and select option **5** (Rename files off-by-one)
5. Open Firefox and click the MetaMask icon
6. **Expected**: You should see the unrecoverable vault screen with "Reset MetaMask State" button

## **Screenshots/Recordings**

### **Before**

<img width="395" height="600" alt="Screenshot 2026-03-31 at 15 33 36" src="https://github.com/user-attachments/assets/9a6fd41e-8085-45cb-b496-f6afc354264b" />

### **After**

<img width="396" height="597" alt="Screenshot 2026-03-31 at 15 52 24" src="https://github.com/user-attachments/assets/a2fe19e8-49da-40cc-a333-0451b017fb28" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
