### PR TITLE
fix(background): handle orphan meta without persisted state data

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -1022,7 +1022,15 @@ export async function loadStateFromPersistence(backup) {
   });
 
   let writeAllKeysToState = false;
-  if (!preMigrationVersionedData?.data && !preMigrationVersionedData?.meta) {
+  const hasValidMigratorData = isObject(preMigrationVersionedData?.data);
+  const isCompletelyEmpty =
+    !preMigrationVersionedData?.data && !preMigrationVersionedData?.meta;
+  // Orphan `meta` cannot be migrated: v2 migrations expect `state.data` to be an object.
+  // When we are not restoring from backup, treat as first-time install.
+  // (Backup restore always builds a `data` object in the branch above.)
+  const willGenerateInitialState =
+    isCompletelyEmpty || (!backup && !hasValidMigratorData);
+  if (willGenerateInitialState) {
     // brand new state; write all keys!
     writeAllKeysToState = true;
     preMigrationVersionedData = migrator.generateInitialState(firstTimeState);


### PR DESCRIPTION
## **Description**

I noticed after breaking the Firefox database of an Extension without backup in IndexedDB, that the "Reset MetaMask State" button on the unrecoverable vault screen wasn't working: it was leading to a migration issue:
```
MetaMask - migrator data has invalid type: 'undefined'
```

This happens in cases where "meta" key is defined in local storage, but "data" key is empty.

The purpose of this PR is to properly reset MetaMask when that edge case occurs. 

## **Changelog**

CHANGELOG entry: Handle edge case where corrupted state leads to migration error

## **Related issues**

Fixes:

## **Manual testing steps**

### Prerequisites
- Firefox browser
- MetaMask installed from Firefox Add-ons store (or local build with `yarn dist:mv2`)
- The `test-vault-corruption-firefox.sh` script from this [PR](https://github.com/MetaMask/metamask-extension/pull/38940)

### Test: MetaMask resets as expected

1. Install MetaMask and complete onboarding
2. Open the inspector and manually delete the vault backup in IndexedDB (called 'metamask-backup')
3. Close Firefox completely immediately after (before the vault backup gets re-created)
4. Run `./test-vault-corruption-firefox.sh` and select option **5** (Rename files off-by-one)
5. Open Firefox and click the MetaMask icon
6. You should see the unrecoverable vault screen
7. Click the "Reset MetaMask State" button
8. **Expected**: You should see the first screen of the onboarding flow (same as on a new install)

## **Screenshots/Recordings**

### **Before**

<img width="394" height="597" alt="Screenshot 2026-03-31 at 15 55 43" src="https://github.com/user-attachments/assets/d8a0083c-bc04-44dd-b77a-bd324615fa2a" />

### **After**

<img width="470" height="692" alt="Screenshot 2026-03-31 at 16 43 33" src="https://github.com/user-attachments/assets/4221ad75-1b40-4bd6-96da-ea6ab39cbf7f" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the startup persistence/migration path and can change how corrupted or partially-missing storage is treated, which could affect initialization behavior for some users.
> 
> **Overview**
> Prevents migration from running on corrupted persistence where `meta` exists but `data` is missing/invalid by detecting this “orphan meta” case and generating a new initial state when **not** restoring from a backup.
> 
> This ensures the “reset state”/recovery flow can proceed instead of throwing `migrator data has invalid type` during startup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9cdb4396637e74fc6330a3ffad1dec85003bac2c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->