### PR TITLE
chore: tweak survey banner

### DIFF
--- a/ui/components/ui/survey-toast/__snapshots__/survey-toast.test.tsx.snap
+++ b/ui/components/ui/survey-toast/__snapshots__/survey-toast.test.tsx.snap
@@ -14,6 +14,20 @@ exports[`SurveyToast should match snapshot 1`] = `
         data-testid="survey-toast"
       >
         <div
+          class="mm-box flex-shrink-0"
+        >
+          <svg
+            class="inline-block w-6 h-6 text-icon-default"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 15q.424 0 .713-.287c.289-.287.287-.43.287-.713s-.096-.52-.287-.712S12.283 13 12 13s-.52.096-.712.288S11 13.717 11 14s.096.52.288.713.429.287.712.287m-1-4h2V5h-2zM2 22V4q0-.824.588-1.412C3.175 1.999 3.45 2 4 2h16q.824 0 1.413.588C22.002 3.175 22 3.45 22 4v12q0 .824-.587 1.413c-.587.589-.863.587-1.413.587H6zm3.15-6H20V4H4v13.125z"
+            />
+          </svg>
+        </div>
+        <div
           class="mm-box"
         >
           <p

--- a/ui/components/ui/survey-toast/survey-toast.tsx
+++ b/ui/components/ui/survey-toast/survey-toast.tsx
@@ -22,7 +22,7 @@ import { Toast } from '../../multichain';
 type Survey = {
   url: string;
   description: string;
-  description2?: string;
+  content?: string;
   cta: string;
   id: number;
 };
@@ -140,7 +140,7 @@ export function SurveyToast() {
       dataTestId="survey-toast"
       key="survey-toast"
       text={survey.description}
-      description={survey.description2}
+      description={survey.content}
       actionText={survey.cta}
       onActionClick={handleActionClick}
       onClose={handleClose}

--- a/ui/components/ui/survey-toast/survey-toast.tsx
+++ b/ui/components/ui/survey-toast/survey-toast.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useContext, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
+import { Icon, IconName, IconSize } from '@metamask/design-system-react';
 import fetchWithCache from '../../../../shared/lib/fetch-with-cache';
 import { DAY } from '../../../../shared/constants/time';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
@@ -21,6 +22,7 @@ import { Toast } from '../../multichain';
 type Survey = {
   url: string;
   description: string;
+  description2?: string;
   cta: string;
   id: number;
 };
@@ -138,10 +140,11 @@ export function SurveyToast() {
       dataTestId="survey-toast"
       key="survey-toast"
       text={survey.description}
+      description={survey.description2}
       actionText={survey.cta}
       onActionClick={handleActionClick}
       onClose={handleClose}
-      startAdornment={null}
+      startAdornment={<Icon name={IconName.Feedback} size={IconSize.Lg} />}
     />
   );
 }


### PR DESCRIPTION

## **Description**

Add icon and optional line to the survey toast 

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: chore: tweak survey banner

## **Related issues**

Fixes:
https://consensyssoftware.atlassian.net/browse/CEUX-947

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="338" height="141" alt="image" src="https://github.com/user-attachments/assets/86f490e9-bab9-43a8-905b-e12f61a9027a" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds an icon and optional secondary text to the survey toast; no changes to survey fetch/metrics behavior beyond passing through an additional field.
> 
> **Overview**
> Updates the survey toast to support **an optional second line of copy** by introducing `Survey.content` and passing it to the `Toast` as `description`.
> 
> Also adds a **feedback icon start adornment** to the toast (and updates the Jest snapshot accordingly), replacing the previous `startAdornment={null}`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa4756414ce670ac4bd65b206d3b5669805858e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->