### PR TITLE
fix: update legacy tooltip icon color for Firefox compatibility

### DIFF
--- a/ui/pages/confirmations/components/info-popover-tooltip/info-popover-tooltip.test.tsx
+++ b/ui/pages/confirmations/components/info-popover-tooltip/info-popover-tooltip.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { act, render, fireEvent } from '@testing-library/react';
 import {
   ButtonIconSize,
   IconColor,
@@ -91,6 +91,33 @@ describe('InfoPopoverTooltip', () => {
     fireEvent.click(button);
     expect(getByTestId('question-tooltip')).toHaveTextContent(
       'Question content',
+    );
+  });
+
+  it('renders a plain icon with the correct icon name when plainIcon is true', async () => {
+    const { getByTestId, getByRole } = render(
+      <InfoPopoverTooltip
+        data-testid="plain-tooltip"
+        iconName={IconName.Question}
+        iconColor={IconColor.IconAlternative}
+        plainIcon
+        ariaLabel="bonus info"
+      >
+        <span>Plain icon content</span>
+      </InfoPopoverTooltip>,
+    );
+
+    const button = getByRole('button', { name: 'bonus info' });
+    expect(button).toBeInTheDocument();
+
+    const svg = button.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(getByTestId('plain-tooltip-button'));
+    });
+    expect(getByTestId('plain-tooltip')).toHaveTextContent(
+      'Plain icon content',
     );
   });
 });

--- a/ui/pages/confirmations/components/info-popover-tooltip/info-popover-tooltip.tsx
+++ b/ui/pages/confirmations/components/info-popover-tooltip/info-popover-tooltip.tsx
@@ -3,17 +3,15 @@ import {
   Box,
   ButtonIcon,
   ButtonIconSize,
+  Icon,
   IconColor,
   IconName,
+  IconSize,
 } from '@metamask/design-system-react';
 import {
-  Icon,
-  IconName as LegacyIconName,
-  IconSize,
   Popover,
   PopoverPosition,
 } from '../../../../components/component-library';
-import { IconColor as LegacyIconColor } from '../../../../helpers/constants/design-system';
 
 const POPOVER_STYLE = {
   zIndex: 3,
@@ -30,7 +28,7 @@ type InfoPopoverTooltipProps = {
   position?: PopoverPosition;
   iconName?: IconName;
   iconSize?: ButtonIconSize;
-  iconColor?: IconColor | LegacyIconColor | string;
+  iconColor?: IconColor | string;
   iconMarginLeft?: number;
   /**
    * When true, renders a plain Icon instead of a ButtonIcon so the trigger
@@ -88,9 +86,9 @@ export function InfoPopoverTooltip({
           }}
         >
           <Icon
-            name={iconName as unknown as LegacyIconName}
+            name={iconName}
             size={IconSize.Sm}
-            color={iconColor as LegacyIconColor}
+            color={iconColor as IconColor}
           />
         </button>
       ) : (

--- a/ui/pages/confirmations/components/rows/claimable-bonus-row/claimable-bonus-row.tsx
+++ b/ui/pages/confirmations/components/rows/claimable-bonus-row/claimable-bonus-row.tsx
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react';
 import {
   FontWeight,
+  IconColor,
   IconName,
   Text,
   TextButton,
@@ -9,7 +10,6 @@ import {
   TextVariant,
 } from '@metamask/design-system-react';
 import { PopoverPosition } from '../../../../../components/component-library';
-import { Color } from '../../../../../helpers/constants/design-system';
 import { InfoPopoverTooltip } from '../../info-popover-tooltip';
 import {
   ConfirmInfoRow,
@@ -60,7 +60,7 @@ export function ClaimableBonusRow({
         <InfoPopoverTooltip
           position={PopoverPosition.TopStart}
           iconName={IconName.Question}
-          iconColor={Color.iconAlternative}
+          iconColor={IconColor.IconAlternative}
           iconMarginLeft={1}
           plainIcon
           ariaLabel={t('musdClaimableBonusTooltipAria') as string}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The plainIcon branch in InfoPopoverTooltip was using the legacy Icon component (which renders icons via CSS mask-image with file URLs like ./images/icons/{name}.svg) but receiving PascalCase icon names from @metamask/design-system-react (e.g. "Question"). The legacy icon files are kebab-case (question.svg). On macOS (case-insensitive FS), Chrome resolves Question.svg to question.svg; Firefox's extension resource loading (moz-extension://) is case-sensitive, so the icon silently fails to load.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Update tooltip icon in claimable bonus row for Firefox compatibility

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-567

## **Manual testing steps**

Enter an amount in the convert to musd flow
Click the claimable bonus row info icon in firefox
It should pop up a tooltip
## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
<img width="381" height="79" alt="Screenshot 2026-03-31 at 5 02 59 PM" src="https://github.com/user-attachments/assets/6b3ee453-67bb-432a-9911-6aed7cff828f" />
<img width="214" height="63" alt="Screenshot 2026-03-31 at 5 03 31 PM" src="https://github.com/user-attachments/assets/d13daf69-834e-456a-8ca6-f914888fdca3" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that swaps the icon implementation/types and updates a single row’s icon color; main risk is minor visual regressions in tooltip triggers.
> 
> **Overview**
> **Fixes Firefox icon rendering for `InfoPopoverTooltip` when `plainIcon` is enabled** by switching the trigger to use `@metamask/design-system-react`’s `Icon` (removing legacy icon name/color casting and legacy color types).
> 
> Updates the claimable bonus row to pass `IconColor.IconAlternative` from the design system, and extends tests to cover the `plainIcon` rendering/click behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ae25efeb4ee4fbc203d618a83f5ef300f716e31. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->