### PR TITLE
feat(ci): Extension RC Slack notifications after Main

### DIFF
--- a/.github/scripts/slack-rc-notification.ts
+++ b/.github/scripts/slack-rc-notification.ts
@@ -236,7 +236,7 @@ function buildSlackMessage(options: {
     actionsRunUrl,
   } = options;
 
-  const buildIdLabel = runId ? `run ${runId}` : 'unknown run';
+  const buildIdLabel = `run ${runId}`;
 
   const b = links.browserify;
   const w = links.webpack;
@@ -447,21 +447,25 @@ async function main(): Promise<void> {
   }
 
   const botToken = process.env.SLACK_BOT_TOKEN;
-  const hostUrl = process.env.HOST_URL?.trim();
+  const trimmedHostUrl = process.env.HOST_URL?.trim() ?? '';
   const channelOverride = getChannelOverride();
 
   const packageVersion = packageJson.version ?? semver;
 
-  const links: MainBrowserLinks = hostUrl
-    ? getExtensionMainBuildLinks(hostUrl, packageVersion)
+  const hostUrlOk = trimmedHostUrl !== '' && isValidUrl(trimmedHostUrl);
+
+  const links: MainBrowserLinks = hostUrlOk
+    ? getExtensionMainBuildLinks(trimmedHostUrl, packageVersion)
     : {
         browserify: { chrome: '', firefox: '' },
         webpack: { chrome: '', firefox: '' },
       };
 
-  if (!hostUrl) {
+  if (!hostUrlOk) {
     console.warn(
-      '⚠️ HOST_URL not set — download links will show as unavailable (in CI this is AWS_CLOUDFRONT_URL/repo/GITHUB_RUN_ID)',
+      trimmedHostUrl === ''
+        ? '⚠️ HOST_URL unset — artifact links omitted'
+        : `⚠️ Invalid HOST_URL (expect https://…; check AWS_CLOUDFRONT_URL): ${trimmedHostUrl}`,
     );
   }
 
@@ -472,9 +476,7 @@ async function main(): Promise<void> {
     `\n📣 Preparing Slack notification for Extension RC v${semver} (run ${runId})`,
   );
   if (isOverride) {
-    console.log(
-      `🧪 Channel override (SLACK_RC_CHANNEL / SLACK_CHANNEL / TEST_CHANNEL): ${expectedChannelName}`,
-    );
+    console.log(`🧪 Channel override: ${expectedChannelName}`);
   } else {
     console.log(`📍 Target channel: ${expectedChannelName}`);
   }

--- a/.github/scripts/slack-rc-notification.ts
+++ b/.github/scripts/slack-rc-notification.ts
@@ -1,0 +1,486 @@
+/**
+ * Slack RC Build Notification (Extension)
+ *
+ * Posts a Block Kit message when a release-candidate Main workflow completes, aligned with
+ * metamask-mobile/scripts/slack-rc-notification.mjs (bot token + chat.postMessage).
+ *
+ * Build URLs use `getBuildLinks` from development/metamaskbot-build-announce/artifacts.ts
+ * (main Chrome/Firefox for Browserify + Webpack).
+ *
+ * Local / manual testing
+ * ----------------------
+ * Dry-run (no Slack API):
+ *   DRY_RUN=1 SEMVER=13.26.0 GITHUB_RUN_ID=12345678 \
+ *   HOST_URL='https://<cloudfront>/metamask-extension/12345678' \
+ *   ./node_modules/.bin/tsx ./.github/scripts/slack-rc-notification.ts
+ *
+ * Post to a specific channel (first non-empty wins):
+ *   SLACK_RC_CHANNEL, SLACK_CHANNEL, or TEST_CHANNEL (Mobile parity)
+ *   Example:
+ *   SEMVER=… GITHUB_RUN_ID=… SLACK_BOT_TOKEN='xoxb-…' SLACK_CHANNEL='#my-test' HOST_URL=… \
+ *   ./node_modules/.bin/tsx ./.github/scripts/slack-rc-notification.ts
+ *
+ * Requires `yarn install` at repo root for `@metamask/auto-changelog`.
+ *
+ * @see metamask-mobile/scripts/slack-rc-notification.mjs
+ */
+
+import { readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { parseChangelog } from '@metamask/auto-changelog';
+import { getBuildLinks } from '../../development/metamaskbot-build-announce/artifacts';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.join(__dirname, '..', '..');
+
+const REPO_URL = process.env.GITHUB_REPOSITORY
+  ? `https://github.com/${process.env.GITHUB_REPOSITORY}`
+  : 'https://github.com/MetaMask/metamask-extension';
+
+type SlackPayload = {
+  blocks: Record<string, unknown>[];
+  text: string;
+};
+
+type MainBrowserLinks = {
+  browserify: { chrome: string; firefox: string };
+  webpack: { chrome: string; firefox: string };
+};
+
+function escapeSlackMrkdwn(text: string | undefined | null): string {
+  if (text === undefined || text === null) {
+    return '';
+  }
+  return String(text)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function getExtensionMainBuildLinks(
+  hostUrl: string,
+  packageVersion: string,
+): MainBrowserLinks {
+  const full = getBuildLinks({ hostUrl: hostUrl.replace(/\/$/, ''), version: packageVersion });
+  return {
+    browserify: full.browserify.main,
+    webpack: full.webpack.main,
+  };
+}
+
+function extractChangelogEntries(version: string): Record<string, unknown[]> | null {
+  const changelogPath = path.join(REPO_ROOT, 'CHANGELOG.md');
+
+  let changelogContent: string;
+  try {
+    changelogContent = readFileSync(changelogPath, 'utf8');
+  } catch (error) {
+    const err = error as Error;
+    console.error(`Failed to read CHANGELOG.md: ${err.message}`);
+    return null;
+  }
+
+  try {
+    const changelog = parseChangelog({
+      changelogContent,
+      repoUrl: REPO_URL,
+      shouldExtractPrLinks: true,
+    });
+
+    return (changelog.getReleaseChanges(version) as Record<string, unknown[]> | undefined) ?? null;
+  } catch (error) {
+    const err = error as Error;
+    console.error(`Failed to parse CHANGELOG.md: ${err.message}`);
+    return null;
+  }
+}
+
+function formatChangesForSlack(
+  changes: Record<string, unknown[]>,
+  maxEntries = 15,
+): string {
+  const formattedEntries: string[] = [];
+
+  const categoryOrder = [
+    'Added',
+    'Fixed',
+    'Changed',
+    'Deprecated',
+    'Removed',
+    'Uncategorized',
+  ];
+
+  for (const category of categoryOrder) {
+    const entries = (changes[category] || []) as {
+      description: string;
+      prNumbers?: number[];
+    }[];
+    for (const entry of entries) {
+      if (formattedEntries.length >= maxEntries) {
+        break;
+      }
+
+      let description = escapeSlackMrkdwn(entry.description);
+
+      if (entry.prNumbers && entry.prNumbers.length > 0) {
+        const prLinks = entry.prNumbers
+          .map((prNum) => `<${REPO_URL}/pull/${prNum}|#${prNum}>`)
+          .join(', ');
+        description = `${description} (${prLinks})`;
+      }
+
+      formattedEntries.push(`• ${description}`);
+    }
+  }
+
+  const allEntriesCount = Object.values(changes)
+    .flat()
+    .filter(Boolean).length;
+  const remaining = allEntriesCount - formattedEntries.length;
+
+  if (remaining > 0) {
+    formattedEntries.push(`\n_...and ${remaining} more changes_`);
+  }
+
+  return formattedEntries.join('\n');
+}
+
+function isValidUrl(url: string | undefined): boolean {
+  if (!url || typeof url !== 'string') {
+    return false;
+  }
+  const trimmed = url.trim().toLowerCase();
+  if (trimmed === '' || trimmed === 'n/a' || trimmed === 'null' || trimmed === 'undefined') {
+    return false;
+  }
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'https:' || parsed.protocol === 'http:';
+  } catch {
+    return false;
+  }
+}
+
+function readPackageVersion(): string | null {
+  try {
+    const pkgPath = path.join(REPO_ROOT, 'package.json');
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as { version: string };
+    return pkg.version;
+  } catch (e) {
+    const err = e as Error;
+    console.warn(`Could not read package.json version: ${err.message}`);
+    return null;
+  }
+}
+
+function buildSlackMessage(options: {
+  semver: string;
+  packageVersion: string;
+  runId: string;
+  links: MainBrowserLinks;
+  changelogText: string;
+  hasChangelog: boolean;
+  actionsRunUrl: string | undefined;
+}): SlackPayload {
+  const { semver, packageVersion, runId, links, changelogText, hasChangelog, actionsRunUrl } =
+    options;
+
+  const buildIdLabel = runId ? `run ${runId}` : 'unknown run';
+
+  const b = links.browserify;
+  const w = links.webpack;
+
+  const blocks: Record<string, unknown>[] = [
+    {
+      type: 'header',
+      text: {
+        type: 'plain_text',
+        text: `🧩 Extension RC Build v${semver} (${buildIdLabel})`,
+        emoji: true,
+      },
+    },
+    {
+      type: 'section',
+      fields: [
+        {
+          type: 'mrkdwn',
+          text: `*Release branch version:*\n${semver}`,
+        },
+        {
+          type: 'mrkdwn',
+          text: `*package.json version:*\n${packageVersion}`,
+        },
+      ],
+    },
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: '*📦 Main build zips (Browserify)*',
+      },
+    },
+    {
+      type: 'section',
+      fields: [
+        {
+          type: 'mrkdwn',
+          text: isValidUrl(b.chrome)
+            ? `*Chrome (MV3):*\n<${b.chrome}|Download zip>`
+            : '*Chrome (MV3):*\n_Not available_',
+        },
+        {
+          type: 'mrkdwn',
+          text: isValidUrl(b.firefox)
+            ? `*Firefox (MV2):*\n<${b.firefox}|Download zip>`
+            : '*Firefox (MV2):*\n_Not available_',
+        },
+      ],
+    },
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: '*📦 Main build zips (Webpack)*',
+      },
+    },
+    {
+      type: 'section',
+      fields: [
+        {
+          type: 'mrkdwn',
+          text: isValidUrl(w.chrome)
+            ? `*Chrome (MV3):*\n<${w.chrome}|Download zip>`
+            : '*Chrome (MV3):*\n_Not available_',
+        },
+        {
+          type: 'mrkdwn',
+          text: isValidUrl(w.firefox)
+            ? `*Firefox (MV2):*\n<${w.firefox}|Download zip>`
+            : '*Firefox (MV2):*\n_Not available_',
+        },
+      ],
+    },
+  ];
+
+  if (hasChangelog && changelogText) {
+    blocks.push(
+      { type: 'divider' },
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `*📋 What's in this RC:*\n${changelogText}`,
+        },
+      },
+    );
+  } else {
+    blocks.push({
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: '_No changelog entries found for this version in CHANGELOG.md (section may not exist yet)._',
+      },
+    });
+  }
+
+  const footerBits = [
+    actionsRunUrl ? `<${actionsRunUrl}|GitHub Actions run>` : null,
+    `<${REPO_URL}/blob/release/${semver}/CHANGELOG.md|CHANGELOG.md on release/${semver}>`,
+  ].filter(Boolean);
+
+  blocks.push(
+    { type: 'divider' },
+    {
+      type: 'context',
+      elements: [
+        {
+          type: 'mrkdwn',
+          text: footerBits.join(' | '),
+        },
+      ],
+    },
+  );
+
+  return {
+    blocks,
+    text: `Extension RC Build v${semver} (${buildIdLabel}) is ready.`,
+  };
+}
+
+async function postToSlack(
+  botToken: string,
+  channelName: string,
+  payload: SlackPayload,
+): Promise<{ success: boolean; channelNotFound: boolean }> {
+  try {
+    const response = await fetch('https://slack.com/api/chat.postMessage', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${botToken}`,
+        'Content-Type': 'application/json; charset=utf-8',
+      },
+      body: JSON.stringify({
+        channel: channelName,
+        blocks: payload.blocks,
+        text: payload.text,
+      }),
+    });
+
+    const data = (await response.json()) as { ok: boolean; error?: string };
+
+    if (!data.ok) {
+      if (data.error === 'channel_not_found') {
+        return { success: false, channelNotFound: true };
+      }
+      throw new Error(`Slack API error: ${data.error}`);
+    }
+
+    console.log('✅ Slack notification sent successfully');
+    return { success: true, channelNotFound: false };
+  } catch (error) {
+    const err = error as Error;
+    console.error(`❌ Failed to post to Slack: ${err.message}`);
+    return { success: false, channelNotFound: false };
+  }
+}
+
+function getSlackChannel(version: string): string {
+  const formattedVersion = version.replace(/\./g, '-');
+  return `#release-extension-${formattedVersion}`;
+}
+
+/**
+ * Optional destination channel for testing or staging.
+ * Priority: SLACK_RC_CHANNEL → SLACK_CHANNEL → TEST_CHANNEL (same as Mobile).
+ *
+ * @returns Channel name (e.g. `#foo`) or undefined to use default `#release-extension-x-y-z`.
+ */
+function getChannelOverride(): string | undefined {
+  const raw =
+    process.env.SLACK_RC_CHANNEL?.trim() ||
+    process.env.SLACK_CHANNEL?.trim() ||
+    process.env.TEST_CHANNEL?.trim();
+  return raw || undefined;
+}
+
+async function main(): Promise<void> {
+  const dryRun = process.env.DRY_RUN === '1' || process.env.DRY_RUN === 'true';
+
+  const semver = process.env.SEMVER;
+  const runId = process.env.GITHUB_RUN_ID;
+
+  if (!semver) {
+    console.warn('⚠️ SEMVER is required');
+    return;
+  }
+  if (!runId) {
+    console.warn('⚠️ GITHUB_RUN_ID is required');
+    return;
+  }
+
+  const requiredForPost = ['SLACK_BOT_TOKEN'];
+  const missingVars = requiredForPost.filter((v) => !process.env[v]);
+
+  if (missingVars.length > 0 && !dryRun) {
+    console.warn(`⚠️ Missing required environment variables: ${missingVars.join(', ')}`);
+    console.warn('Skipping Slack notification (non-critical)');
+    return;
+  }
+
+  if (dryRun && missingVars.length > 0) {
+    console.warn(`⚠️ DRY_RUN: missing ${missingVars.join(', ')} — printing payload only`);
+  }
+
+  const botToken = process.env.SLACK_BOT_TOKEN;
+  const hostUrl = process.env.HOST_URL?.trim();
+  const channelOverride = getChannelOverride();
+
+  const packageVersion = readPackageVersion() ?? semver;
+
+  const links: MainBrowserLinks = hostUrl
+    ? getExtensionMainBuildLinks(hostUrl, packageVersion)
+    : {
+        browserify: { chrome: '', firefox: '' },
+        webpack: { chrome: '', firefox: '' },
+      };
+
+  if (!hostUrl) {
+    console.warn(
+      '⚠️ HOST_URL not set — download links will show as unavailable (in CI this is AWS_CLOUDFRONT_URL/repo/GITHUB_RUN_ID)',
+    );
+  }
+
+  const expectedChannelName = channelOverride ?? getSlackChannel(semver);
+  const isOverride = Boolean(channelOverride);
+
+  console.log(`\n📣 Preparing Slack notification for Extension RC v${semver} (run ${runId})`);
+  if (isOverride) {
+    console.log(
+      `🧪 Channel override (SLACK_RC_CHANNEL / SLACK_CHANNEL / TEST_CHANNEL): ${expectedChannelName}`,
+    );
+  } else {
+    console.log(`📍 Target channel: ${expectedChannelName}`);
+  }
+
+  console.log('\n📖 Reading CHANGELOG.md...');
+  const changes = extractChangelogEntries(semver);
+
+  let changelogText = '';
+  let hasChangelog = false;
+
+  if (changes) {
+    const totalChanges = Object.values(changes)
+      .flat()
+      .filter(Boolean).length;
+    console.log(`   Found ${totalChanges} changelog entries for v${semver}`);
+
+    if (totalChanges > 0) {
+      hasChangelog = true;
+      changelogText = formatChangesForSlack(changes);
+    }
+  } else {
+    console.log('   ⚠️ Could not read changelog for this version');
+  }
+
+  const [owner, repo] = (process.env.GITHUB_REPOSITORY || 'MetaMask/metamask-extension').split(
+    '/',
+  );
+  const actionsRunUrl =
+    runId && owner && repo
+      ? `https://github.com/${owner}/${repo}/actions/runs/${runId}`
+      : undefined;
+
+  const payload = buildSlackMessage({
+    semver,
+    packageVersion,
+    runId,
+    links,
+    changelogText,
+    hasChangelog,
+    actionsRunUrl,
+  });
+
+  if (dryRun) {
+    console.log('\n--- DRY_RUN payload (not sent) ---\n');
+    console.log(JSON.stringify(payload, null, 2));
+    return;
+  }
+
+  console.log('\n📤 Posting to Slack...');
+
+  const result = await postToSlack(botToken!, expectedChannelName, payload);
+
+  if (result.success) {
+    console.log(`\n✅ RC notification sent to ${expectedChannelName}`);
+  } else if (result.channelNotFound) {
+    console.warn(`\n⚠️ Channel ${expectedChannelName} not found`);
+    console.warn('Skipping Slack notification (non-critical)');
+  } else {
+    console.log('\n⚠️ RC notification failed but continuing (non-critical)');
+  }
+}
+
+main().catch((error) => {
+  console.error('⚠️ Unexpected error (non-critical):', error);
+});

--- a/.github/scripts/slack-rc-notification.ts
+++ b/.github/scripts/slack-rc-notification.ts
@@ -58,18 +58,45 @@ function escapeSlackMrkdwn(text: string | undefined | null): string {
     .replace(/>/g, '&gt;');
 }
 
+/**
+ * Changelog lines use GitHub-style `(#12345)` PR refs. Some lines use markdown
+ * `[#123](https://github.com/org/repo/pull/123)`. After escaping the line for Slack,
+ * turn those into mrkdwn links. Parentheses stay plain text around the link: `(<url|#123>)`.
+ */
+function linkifyChangelogPrRefs(text: string, repoBaseUrl: string): string {
+  let out = text.replace(/\(#(\d+)\)/g, (_match, prNumber: string) => {
+    return `(<${repoBaseUrl}/pull/${prNumber}|#${prNumber}>)`;
+  });
+  out = out.replace(
+    /\[#(\d+)\]\((https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+)\)/g,
+    (_match, prNumber: string, url: string) => {
+      return `(<${url}|#${prNumber}>)`;
+    },
+  );
+  return out;
+}
+
 function getExtensionMainBuildLinks(
   hostUrl: string,
   packageVersion: string,
 ): MainBrowserLinks {
-  const full = getBuildLinks({ hostUrl: hostUrl.replace(/\/$/, ''), version: packageVersion });
+  const full = getBuildLinks({
+    hostUrl: hostUrl.replace(/\/$/, ''),
+    version: packageVersion,
+  });
   return {
     browserify: full.browserify.main,
     webpack: full.webpack.main,
   };
 }
 
-function extractChangelogEntries(version: string): Record<string, unknown[]> | null {
+/**
+ * `@metamask/auto-changelog` `getReleaseChanges` returns each line as a plain string
+ * (not `{ description, prNumbers }`). See `Changelog.getReleaseChanges` → `string[]`.
+ */
+function extractChangelogEntries(
+  version: string,
+): Record<string, string[]> | null {
   const changelogPath = path.join(REPO_ROOT, 'CHANGELOG.md');
 
   let changelogContent: string;
@@ -85,10 +112,9 @@ function extractChangelogEntries(version: string): Record<string, unknown[]> | n
     const changelog = parseChangelog({
       changelogContent,
       repoUrl: REPO_URL,
-      shouldExtractPrLinks: true,
     });
 
-    return (changelog.getReleaseChanges(version) as Record<string, unknown[]> | undefined) ?? null;
+    return changelog.getReleaseChanges(version) ?? null;
   } catch (error) {
     const err = error as Error;
     console.error(`Failed to parse CHANGELOG.md: ${err.message}`);
@@ -96,47 +122,70 @@ function extractChangelogEntries(version: string): Record<string, unknown[]> | n
   }
 }
 
+function changelogLineToText(entry: unknown): string {
+  if (typeof entry === 'string') {
+    return entry;
+  }
+  if (entry && typeof entry === 'object' && 'description' in entry) {
+    const d = (entry as { description: unknown }).description;
+    if (typeof d === 'string') {
+      return d;
+    }
+  }
+  return '';
+}
+
 function formatChangesForSlack(
-  changes: Record<string, unknown[]>,
+  changes: Record<string, string[]>,
   maxEntries = 15,
 ): string {
   const formattedEntries: string[] = [];
 
+  /** Keep a Changelog — https://keepachangelog.com/en/1.0.0/ */
   const categoryOrder = [
     'Added',
-    'Fixed',
     'Changed',
     'Deprecated',
     'Removed',
+    'Fixed',
+    'Security',
     'Uncategorized',
   ];
 
-  for (const category of categoryOrder) {
-    const entries = (changes[category] || []) as {
-      description: string;
-      prNumbers?: number[];
-    }[];
+  const knownCategories = new Set(categoryOrder);
+  const extraCategories = Object.keys(changes)
+    .filter((k) => !knownCategories.has(k))
+    .sort((a, b) => a.localeCompare(b));
+
+  const categoriesToIterate = [...categoryOrder, ...extraCategories];
+
+  outer: for (const category of categoriesToIterate) {
+    const entries = changes[category] ?? [];
     for (const entry of entries) {
       if (formattedEntries.length >= maxEntries) {
-        break;
+        break outer;
       }
 
-      let description = escapeSlackMrkdwn(entry.description);
-
-      if (entry.prNumbers && entry.prNumbers.length > 0) {
-        const prLinks = entry.prNumbers
-          .map((prNum) => `<${REPO_URL}/pull/${prNum}|#${prNum}>`)
-          .join(', ');
-        description = `${description} (${prLinks})`;
+      const line = changelogLineToText(entry).trim();
+      if (line === '') {
+        continue;
       }
 
+      const description = linkifyChangelogPrRefs(
+        escapeSlackMrkdwn(line),
+        REPO_URL,
+      );
       formattedEntries.push(`• ${description}`);
     }
   }
 
-  const allEntriesCount = Object.values(changes)
-    .flat()
-    .filter(Boolean).length;
+  const allEntriesCount = categoriesToIterate.reduce((sum, category) => {
+    const entries = changes[category];
+    if (!Array.isArray(entries)) {
+      return sum;
+    }
+    return sum + entries.filter(Boolean).length;
+  }, 0);
   const remaining = allEntriesCount - formattedEntries.length;
 
   if (remaining > 0) {
@@ -151,7 +200,12 @@ function isValidUrl(url: string | undefined): boolean {
     return false;
   }
   const trimmed = url.trim().toLowerCase();
-  if (trimmed === '' || trimmed === 'n/a' || trimmed === 'null' || trimmed === 'undefined') {
+  if (
+    trimmed === '' ||
+    trimmed === 'n/a' ||
+    trimmed === 'null' ||
+    trimmed === 'undefined'
+  ) {
     return false;
   }
   try {
@@ -165,7 +219,9 @@ function isValidUrl(url: string | undefined): boolean {
 function readPackageVersion(): string | null {
   try {
     const pkgPath = path.join(REPO_ROOT, 'package.json');
-    const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as { version: string };
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as {
+      version: string;
+    };
     return pkg.version;
   } catch (e) {
     const err = e as Error;
@@ -183,8 +239,15 @@ function buildSlackMessage(options: {
   hasChangelog: boolean;
   actionsRunUrl: string | undefined;
 }): SlackPayload {
-  const { semver, packageVersion, runId, links, changelogText, hasChangelog, actionsRunUrl } =
-    options;
+  const {
+    semver,
+    packageVersion,
+    runId,
+    links,
+    changelogText,
+    hasChangelog,
+    actionsRunUrl,
+  } = options;
 
   const buildIdLabel = runId ? `run ${runId}` : 'unknown run';
 
@@ -383,13 +446,17 @@ async function main(): Promise<void> {
   const missingVars = requiredForPost.filter((v) => !process.env[v]);
 
   if (missingVars.length > 0 && !dryRun) {
-    console.warn(`⚠️ Missing required environment variables: ${missingVars.join(', ')}`);
+    console.warn(
+      `⚠️ Missing required environment variables: ${missingVars.join(', ')}`,
+    );
     console.warn('Skipping Slack notification (non-critical)');
     return;
   }
 
   if (dryRun && missingVars.length > 0) {
-    console.warn(`⚠️ DRY_RUN: missing ${missingVars.join(', ')} — printing payload only`);
+    console.warn(
+      `⚠️ DRY_RUN: missing ${missingVars.join(', ')} — printing payload only`,
+    );
   }
 
   const botToken = process.env.SLACK_BOT_TOKEN;
@@ -414,7 +481,9 @@ async function main(): Promise<void> {
   const expectedChannelName = channelOverride ?? getSlackChannel(semver);
   const isOverride = Boolean(channelOverride);
 
-  console.log(`\n📣 Preparing Slack notification for Extension RC v${semver} (run ${runId})`);
+  console.log(
+    `\n📣 Preparing Slack notification for Extension RC v${semver} (run ${runId})`,
+  );
   if (isOverride) {
     console.log(
       `🧪 Channel override (SLACK_RC_CHANNEL / SLACK_CHANNEL / TEST_CHANNEL): ${expectedChannelName}`,
@@ -430,9 +499,7 @@ async function main(): Promise<void> {
   let hasChangelog = false;
 
   if (changes) {
-    const totalChanges = Object.values(changes)
-      .flat()
-      .filter(Boolean).length;
+    const totalChanges = Object.values(changes).flat().filter(Boolean).length;
     console.log(`   Found ${totalChanges} changelog entries for v${semver}`);
 
     if (totalChanges > 0) {
@@ -443,9 +510,9 @@ async function main(): Promise<void> {
     console.log('   ⚠️ Could not read changelog for this version');
   }
 
-  const [owner, repo] = (process.env.GITHUB_REPOSITORY || 'MetaMask/metamask-extension').split(
-    '/',
-  );
+  const [owner, repo] = (
+    process.env.GITHUB_REPOSITORY || 'MetaMask/metamask-extension'
+  ).split('/');
   const actionsRunUrl =
     runId && owner && repo
       ? `https://github.com/${owner}/${repo}/actions/runs/${runId}`

--- a/.github/scripts/slack-rc-notification.ts
+++ b/.github/scripts/slack-rc-notification.ts
@@ -29,6 +29,7 @@ import { readFileSync } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { parseChangelog } from '@metamask/auto-changelog';
+import packageJson from '../../package.json';
 import { getBuildLinks } from '../../development/metamaskbot-build-announce/artifacts';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -213,20 +214,6 @@ function isValidUrl(url: string | undefined): boolean {
     return parsed.protocol === 'https:' || parsed.protocol === 'http:';
   } catch {
     return false;
-  }
-}
-
-function readPackageVersion(): string | null {
-  try {
-    const pkgPath = path.join(REPO_ROOT, 'package.json');
-    const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as {
-      version: string;
-    };
-    return pkg.version;
-  } catch (e) {
-    const err = e as Error;
-    console.warn(`Could not read package.json version: ${err.message}`);
-    return null;
   }
 }
 
@@ -463,7 +450,7 @@ async function main(): Promise<void> {
   const hostUrl = process.env.HOST_URL?.trim();
   const channelOverride = getChannelOverride();
 
-  const packageVersion = readPackageVersion() ?? semver;
+  const packageVersion = packageJson.version ?? semver;
 
   const links: MainBrowserLinks = hostUrl
     ? getExtensionMainBuildLinks(hostUrl, packageVersion)

--- a/.github/workflows/rc-slack-notify.yml
+++ b/.github/workflows/rc-slack-notify.yml
@@ -12,8 +12,6 @@
 name: RC Slack notify
 
 on:
-  # Only enqueue this workflow when Main ran for a release/* branch (not every push to main/stable/PRs).
-  # The job `if` still requires success + push + same repo + release/ prefix + gate (auto-rc-builds).
   workflow_run:
     workflows:
       - Main
@@ -85,13 +83,19 @@ jobs:
         if: >-
           github.event_name == 'workflow_dispatch' ||
           (github.event_name == 'workflow_run' && steps.gate.outputs.skip == 'false')
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_RUN_ID: ${{ inputs.github_run_id }}
+          INPUT_SEMVER: ${{ inputs.semver }}
+          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
+          GATE_SEMVER: ${{ steps.gate.outputs.semver }}
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "run_id=${{ inputs.github_run_id }}" >> "$GITHUB_OUTPUT"
-            echo "semver=${{ inputs.semver }}" >> "$GITHUB_OUTPUT"
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            echo "run_id=${INPUT_RUN_ID}" >> "$GITHUB_OUTPUT"
+            echo "semver=${INPUT_SEMVER}" >> "$GITHUB_OUTPUT"
           else
-            echo "run_id=${{ github.event.workflow_run.id }}" >> "$GITHUB_OUTPUT"
-            echo "semver=${{ steps.gate.outputs.semver }}" >> "$GITHUB_OUTPUT"
+            echo "run_id=${WORKFLOW_RUN_ID}" >> "$GITHUB_OUTPUT"
+            echo "semver=${GATE_SEMVER}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Checkout and setup

--- a/.github/workflows/rc-slack-notify.yml
+++ b/.github/workflows/rc-slack-notify.yml
@@ -120,5 +120,6 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           # Dispatch: workflow input. Automated runs: optional vars.SLACK_RC_CHANNEL to test destinations.
           SLACK_RC_CHANNEL: ${{ github.event_name == 'workflow_dispatch' && inputs.test_channel || vars.SLACK_RC_CHANNEL || '' }}
+          # AWS_CLOUDFRONT_URL: full origin (https://…); if empty, artifact links are skipped.
           HOST_URL: ${{ vars.AWS_CLOUDFRONT_URL }}/${{ github.event.repository.name }}/${{ steps.notif.outputs.run_id }}
         run: yarn exec tsx ./.github/scripts/slack-rc-notification.ts

--- a/.github/workflows/rc-slack-notify.yml
+++ b/.github/workflows/rc-slack-notify.yml
@@ -12,11 +12,15 @@
 name: RC Slack notify
 
 on:
+  # Only enqueue this workflow when Main ran for a release/* branch (not every push to main/stable/PRs).
+  # The job `if` still requires success + push + same repo + release/ prefix + gate (auto-rc-builds).
   workflow_run:
     workflows:
       - Main
     types:
       - completed
+    branches:
+      - 'release/**'
   workflow_dispatch:
     inputs:
       head_sha:

--- a/.github/workflows/rc-slack-notify.yml
+++ b/.github/workflows/rc-slack-notify.yml
@@ -20,16 +20,16 @@ on:
   workflow_dispatch:
     inputs:
       head_sha:
-        description: "Commit SHA to checkout (must include CHANGELOG.md / package.json for that RC)"
+        description: 'Commit SHA to checkout (must include CHANGELOG.md / package.json for that RC)'
         required: true
       semver:
-        description: "Semver X.Y.Z (same as release/X.Y.Z)"
+        description: 'Semver X.Y.Z (same as release/X.Y.Z)'
         required: true
       github_run_id:
-        description: "GitHub Actions run ID for CloudFront HOST_URL path and run link (e.g. from a recent Main run)"
+        description: 'GitHub Actions run ID for CloudFront HOST_URL path and run link (e.g. from a recent Main run)'
         required: true
       test_channel:
-        description: "Slack channel (#name or ID). Sets SLACK_RC_CHANNEL for the script. Bot must be in the channel."
+        description: 'Slack channel (#name or ID). Sets SLACK_RC_CHANNEL for the script. Bot must be in the channel.'
         required: true
 
 permissions:

--- a/.github/workflows/rc-slack-notify.yml
+++ b/.github/workflows/rc-slack-notify.yml
@@ -1,0 +1,116 @@
+# Posts a Slack Block Kit message after a successful Main workflow run on release/X.Y.Z,
+# when the release PR (into stable) has the `auto-rc-builds` label — parity with Mobile RC Slack.
+# See .github/scripts/slack-rc-notification.ts
+#
+# Test without waiting for Main:
+#   Actions → RC Slack notify → Run workflow → fill head_sha, semver, github_run_id, test_channel
+#   (requires SLACK_BOT_TOKEN secret and vars.AWS_CLOUDFRONT_URL for real download URLs)
+#
+# Optional repo variable (Settings → Variables): SLACK_RC_CHANNEL — if set, automated workflow_run
+# posts there instead of #release-extension-* (use only for staging; clear when done).
+
+name: RC Slack notify
+
+on:
+  workflow_run:
+    workflows:
+      - Main
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      head_sha:
+        description: "Commit SHA to checkout (must include CHANGELOG.md / package.json for that RC)"
+        required: true
+      semver:
+        description: "Semver X.Y.Z (same as release/X.Y.Z)"
+        required: true
+      github_run_id:
+        description: "GitHub Actions run ID for CloudFront HOST_URL path and run link (e.g. from a recent Main run)"
+        required: true
+      test_channel:
+        description: "Slack channel (#name or ID). Sets SLACK_RC_CHANNEL for the script. Bot must be in the channel."
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    # workflow_dispatch: manual test to a channel. workflow_run: successful push to semver release branch in this repo.
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        (github.event_name == 'workflow_run' &&
+          github.event.workflow_run.conclusion == 'success' &&
+          github.event.workflow_run.event == 'push' &&
+          github.event.workflow_run.head_repository.full_name == github.repository &&
+          startsWith(github.event.workflow_run.head_branch, 'release/'))
+      }}
+    steps:
+      - name: Gate — release PR must have auto-rc-builds (workflow_run only)
+        id: gate
+        if: github.event_name == 'workflow_run'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          set -euo pipefail
+          echo "skip=true" >> "$GITHUB_OUTPUT"
+          if [[ ! "$BRANCH" =~ ^release/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Not release/x.y.z: $BRANCH — skipping Slack."
+            exit 0
+          fi
+          PR_JSON="$(gh pr list --head "$BRANCH" --base stable --json number,labels --jq '.[0]' 2>/dev/null || true)"
+          if [[ -z "$PR_JSON" || "$PR_JSON" == "null" ]]; then
+            echo "No PR with base stable for head $BRANCH — skipping Slack."
+            exit 0
+          fi
+          if ! echo "$PR_JSON" | jq -r '.labels[].name' | grep -qx 'auto-rc-builds'; then
+            echo "PR exists but missing auto-rc-builds label — skipping Slack."
+            exit 0
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          echo "semver=${BRANCH#release/}" >> "$GITHUB_OUTPUT"
+          echo "Proceeding: release PR has auto-rc-builds."
+
+      - name: Set notification variables
+        id: notif
+        if: >-
+          github.event_name == 'workflow_dispatch' ||
+          (github.event_name == 'workflow_run' && steps.gate.outputs.skip == 'false')
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "run_id=${{ inputs.github_run_id }}" >> "$GITHUB_OUTPUT"
+            echo "semver=${{ inputs.semver }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_id=${{ github.event.workflow_run.id }}" >> "$GITHUB_OUTPUT"
+            echo "semver=${{ steps.gate.outputs.semver }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout and setup
+        if: >-
+          github.event_name == 'workflow_dispatch' ||
+          (github.event_name == 'workflow_run' && steps.gate.outputs.skip == 'false')
+        uses: MetaMask/action-checkout-and-setup@v3
+        with:
+          is-high-risk-environment: false
+          skip-allow-scripts: true
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.head_sha || github.event.workflow_run.head_sha }}
+
+      - name: Post RC Slack notification
+        if: >-
+          github.event_name == 'workflow_dispatch' ||
+          (github.event_name == 'workflow_run' && steps.gate.outputs.skip == 'false')
+        continue-on-error: true
+        env:
+          SEMVER: ${{ steps.notif.outputs.semver }}
+          GITHUB_RUN_ID: ${{ steps.notif.outputs.run_id }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          # Dispatch: workflow input. Automated runs: optional vars.SLACK_RC_CHANNEL to test destinations.
+          SLACK_RC_CHANNEL: ${{ github.event_name == 'workflow_dispatch' && inputs.test_channel || vars.SLACK_RC_CHANNEL || '' }}
+          HOST_URL: ${{ vars.AWS_CLOUDFRONT_URL }}/${{ github.event.repository.name }}/${{ steps.notif.outputs.run_id }}
+        run: yarn exec tsx ./.github/scripts/slack-rc-notification.ts

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "lint:changed:fix": "node development/lint-changed.mts --fix",
     "lint:changelog": "auto-changelog validate --prettier",
     "lint:changelog:rc": "auto-changelog validate --prettier --rc",
+    "slack:rc-notify": "tsx ./.github/scripts/slack-rc-notification.ts",
     "lint:debug": "DEBUG=eslint:cli-engine yarn lint",
     "lint:eslint": "eslint . --ext js,ts,tsx,snap --cache --cache-location node_modules/.cache/eslint/.eslint-cache",
     "lint:eslint:fix": "yarn lint:eslint --fix --cache --cache-location node_modules/.cache/eslint/.eslint-cache",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Extension RC builds run in GitHub Actions (Main + publish-prerelease), not Bitrise. This PR adds parity with Mobile’s RC Slack flow: after **Main** completes successfully on a semver **`release/X.Y.Z`** branch (from a **`push`**), we post a **Block Kit** message via the Slack **Web API** (`chat.postMessage` + bot token) when the release PR into **`stable`** has the **`auto-rc-builds`** label.

The message includes version/run id, **main** Browserify/Webpack Chrome & Firefox zip links (same rules as `getBuildLinks`), an optional **CHANGELOG** excerpt via `@metamask/auto-changelog`, and a link to the **GitHub Actions** run. Slack failures are **fail-open** (do not fail CI). Channel defaults to `#release-extension-x-y-z`; overrides are supported via **`SLACK_RC_CHANNEL`**, **`SLACK_CHANNEL`**, **`TEST_CHANNEL`**, optional repo variable **`SLACK_RC_CHANNEL`** for automated runs, and **`workflow_dispatch`** with a test channel for manual verification.

**Reason:** Release engineering needs one reliable place to see “RC is green” with actionable links.  
**Solution:** New workflow `rc-slack-notify.yml` + script `.github/scripts/slack-rc-notification.ts`; export **`getBuildLinks`** from `artifacts.ts` for reuse.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Related: [INFRA-3273](https://consensyssoftware.atlassian.net/browse/INFRA-3273) — Extension RC Slack notifications (parity with Mobile)

## **Manual testing steps**

1. **Local dry-run (no Slack):**  
   `DRY_RUN=1 SEMVER=<x.y.z> GITHUB_RUN_ID=<id> [HOST_URL=<cloudfront>/metamask-extension/<runId>] ./node_modules/.bin/tsx ./.github/scripts/slack-rc-notification.ts` — confirm JSON payload (blocks, links, changelog section or fallback).

2. **Local live Slack:**  
   Set `SLACK_BOT_TOKEN` (bot with `chat:write` / `chat:write.public` or bot invited to channel), `SLACK_CHANNEL` or `SLACK_RC_CHANNEL`, `SEMVER`, `GITHUB_RUN_ID`, `HOST_URL` from a real green Main run — run the same script without `DRY_RUN`; confirm message in test channel.

3. **CI:**  
   Actions → **RC Slack notify** → **Run workflow** with `head_sha`, `semver`, `github_run_id`, `test_channel`; ensure `SLACK_BOT_TOKEN` secret and `vars.AWS_CLOUDFRONT_URL` are set.

4. **After merge (optional):**  
   Push to `release/X.Y.Z` with PR to `stable` + `auto-rc-builds`; after Main succeeds, confirm post to default or override channel if `vars.SLACK_RC_CHANNEL` is set for staging.

5. **Regression:**  
   Confirm `publish-prerelease` / metamaskbot PR comments still behave as before (only `getBuildLinks` export added).

## **Screenshots/Recordings**

Not applicable (CI / Slack automation).

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable (N/A — script exercised manually / via workflow_dispatch; no new unit tests required for this automation)
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable (file-level and key helpers documented in the script)
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

---

**Ops note:** Add repository secret **`SLACK_BOT_TOKEN`** and confirm **`vars.AWS_CLOUDFRONT_URL`** before relying on the automated `workflow_run` path. Leave **`vars.SLACK_RC_CHANNEL`** empty in production unless intentionally redirecting RC posts to a staging channel.


[INFRA-3273]: https://consensyssoftware.atlassian.net/browse/INFRA-3273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new GitHub Actions workflow that posts to Slack using a bot token and parses `CHANGELOG.md`, introducing new CI automation and external API calls (fail-open) that could misfire or spam channels if misconfigured.
> 
> **Overview**
> Adds automated Extension RC Slack notifications: after a successful `Main` workflow run on `release/X.Y.Z` (or via manual `workflow_dispatch`), CI posts a Slack Block Kit message with artifact download links and an optional `CHANGELOG.md` excerpt.
> 
> Introduces `.github/scripts/slack-rc-notification.ts` to build the message (including build links via `getBuildLinks`, changelog parsing/linkification, channel override support, and dry-run mode) and `.github/workflows/rc-slack-notify.yml` to gate notifications on the `auto-rc-builds` label and run the script with `SLACK_BOT_TOKEN`/CloudFront `HOST_URL`.
> 
> Adds a `slack:rc-notify` package script to run the notifier locally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36ee1fe6c775044e92f21880748e962febeb524a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->