### PR TITLE
ci: fix post-nightly-builds Slack script

### DIFF
--- a/development/metamaskbot-build-announce/artifacts.ts
+++ b/development/metamaskbot-build-announce/artifacts.ts
@@ -113,7 +113,7 @@ export type BuildLinks = {
  * @param options.releaseVersion - The (pre)release version of the extension, e.g., the `6` in `18.7.25-flask.6`.
  * @returns `{ browserify, webpack }` each mapping BuildType → BuildBrowser URLs.
  */
-function getBuildLinks({
+export function getBuildLinks({
   hostUrl,
   version,
   releaseVersion = '0',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The nightly workflow is broken and didn't post nightly builds in slack channel since 2 days ago, the error is `import_artifacts.getBuildLinks is not a function`. Error job link: https://github.com/MetaMask/metamask-extension/actions/runs/23829825546/job/69510834971

It is likely caused by PR #41131, here: https://github.com/MetaMask/metamask-extension/pull/41131/changes#diff-7d3de79f2d8dc36741ceffab7332ab2a5b9d81b0f6e1639aa15bce6702f4f716R116 
So the import in `post-nightly-builds.ts` then resolved to `undefined`


The solution is to restore `export` on `getBuildLinks` .

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

Nightly builds should be posted in slack channel

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change that only adjusts module exports for a CI helper; behavior is unchanged aside from making `getBuildLinks` importable by other scripts.
> 
> **Overview**
> Makes `getBuildLinks` in `development/metamaskbot-build-announce/artifacts.ts` an exported function so other tooling can import and reuse the extension build download link generator (no functional changes to link generation logic).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9fe7e61e1b6de603e8d4c7a0feeeb5fd982d3f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->