### PR TITLE
feat: bump snap bitcoin 1.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -301,7 +301,7 @@
     "@metamask/assets-controller": "^3.2.1",
     "@metamask/assets-controllers": "^103.0.0",
     "@metamask/base-controller": "^9.0.1",
-    "@metamask/bitcoin-wallet-snap": "^1.10.0",
+    "@metamask/bitcoin-wallet-snap": "^1.10.1",
     "@metamask/bridge-controller": "^69.2.3",
     "@metamask/bridge-status-controller": "^70.0.3",
     "@metamask/browser-passworder": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5910,10 +5910,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/bitcoin-wallet-snap@npm:^1.10.0":
-  version: 1.10.0
-  resolution: "@metamask/bitcoin-wallet-snap@npm:1.10.0"
-  checksum: 10/43bc519f0d6f243658c32ddce3418277f2c7b745a37713ad2eb7927ff6fcc038f7c23dc6fb1933b56bc7ffb5e6dacf403470ee215cf5e0a138e765cd0b14ada5
+"@metamask/bitcoin-wallet-snap@npm:^1.10.1":
+  version: 1.10.1
+  resolution: "@metamask/bitcoin-wallet-snap@npm:1.10.1"
+  checksum: 10/647c0c6211011a54f97fe58f97e930693c8dd64a861969d3546486fdadc8f0efb7b39328469a07408c8ab76fc79d63a74d06c12de91e60204ce040f8ee89741d
   languageName: node
   linkType: hard
 
@@ -34048,7 +34048,7 @@ __metadata:
     "@metamask/assets-controllers": "npm:^103.0.0"
     "@metamask/auto-changelog": "npm:^5.3.1"
     "@metamask/base-controller": "npm:^9.0.1"
-    "@metamask/bitcoin-wallet-snap": "npm:^1.10.0"
+    "@metamask/bitcoin-wallet-snap": "npm:^1.10.1"
     "@metamask/bridge-controller": "npm:^69.2.3"
     "@metamask/bridge-status-controller": "npm:^70.0.3"
     "@metamask/browser-passworder": "npm:^6.0.0"


### PR DESCRIPTION
## **Description**

Bumps `@metamask/bitcoin-wallet-snap` from `^1.10.0` to `^1.10.1`.

Release PR: https://github.com/MetaMask/snap-bitcoin-wallet/pull/595

Notable change:
- [fix: include BDK cause in PSBT build error message](https://github.com/MetaMask/snap-bitcoin-wallet/pull/594) — surfaces the underlying BDK root cause (e.g. `InsufficientFunds`, `OutputBelowDustLimit`) in PSBT build error messages so they appear in Sentry/Mixpanel instead of being lost at the RPC boundary.

## **Changelog**

CHANGELOG entry: Fixed Bitcoin PSBT build errors now include the underlying cause for better diagnostics

## **Related issues**

Fixes:

## **Manual testing steps**

1. Create a Bitcoin account
2. Trigger a PSBT build failure (e.g. insufficient funds swap)
3. Verify the error message in Sentry/Mixpanel includes the BDK cause

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it deletes the entire `.circleci` pipeline and related scripts, which can break CI/release and test automation if no equivalent pipeline is in place; the browserslist bump may also drop support for older browser versions.
> 
> **Overview**
> **CI/release automation is removed.** The PR deletes `.circleci/config.yml` and all CircleCI helper scripts, eliminating the existing build/test/release workflows and related tooling.
> 
> **Browser support baseline is raised.** Updates `.browserslistrc` to require newer Chrome/Firefox versions.
> 
> **Developer/agent workflow docs are added.** Introduces new `.agents`, `.claude`, and `.cursor` skill/command/rules documentation (notably for adding non-EVM swaps/bridge networks and Playwright-based visual testing) to standardize agent-driven implementation and review workflows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ad3e0fac6f48db1773ae5ee55ed83de5a44e42f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->