### PR TITLE
feat: added export your data button

### DIFF
--- a/test/e2e/page-objects/pages/settings/privacy-settings.ts
+++ b/test/e2e/page-objects/pages/settings/privacy-settings.ts
@@ -43,6 +43,12 @@ class PrivacySettings {
   private readonly downloadStateLogsModalButton =
     '[data-testid="download-state-logs-modal-button"]';
 
+  private readonly exportYourDataButton =
+    '[data-testid="privacy-tab-export-your-data-button"]';
+
+  private readonly exportYourDataModalDownloadButton =
+    '[data-testid="export-your-data-modal-download-button"]';
+
   private readonly deleteMetaMetricsModalTitle = {
     text: 'Delete MetaMetrics data?',
     tag: 'h4',
@@ -185,6 +191,18 @@ class PrivacySettings {
     console.log('Downloading state logs on privacy settings page');
     await this.driver.clickElement(this.downloadStateLogsButton);
     await this.driver.clickElement(this.downloadStateLogsModalButton);
+  }
+
+  /**
+   * Settings V2 Privacy → Export your data: opens confirmation modal then downloads
+   * the JSON backup (preferences, accounts, address book, networks) from `backupUserData`.
+   */
+  async exportYourData(): Promise<void> {
+    console.log(
+      'Exporting user data (account settings backup) on privacy settings page',
+    );
+    await this.driver.clickElement(this.exportYourDataButton);
+    await this.driver.clickElement(this.exportYourDataModalDownloadButton);
   }
 
   async deleteMetaMetrics(): Promise<void> {

--- a/test/e2e/tests/settings/backup-restore.spec.ts
+++ b/test/e2e/tests/settings/backup-restore.spec.ts
@@ -2,9 +2,9 @@ import { strict as assert } from 'assert';
 import { promises as fs } from 'fs';
 import { withFixtures } from '../../helpers';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
-import AdvancedSettings from '../../page-objects/pages/settings/advanced-settings';
 import HeaderNavbar from '../../page-objects/pages/header-navbar';
 import SettingsPage from '../../page-objects/pages/settings/settings-page';
+import PrivacySettings from '../../page-objects/pages/settings/privacy-settings';
 import { login } from '../../page-objects/flows/login.flow';
 
 const downloadsFolder = `${process.cwd()}/test-artifacts/downloads`;
@@ -48,9 +48,7 @@ const getBackupJson = async (): Promise<BackupData | null> => {
 };
 
 describe('Backup and Restore', function () {
-  // Export button removed from settings page in v2 settings
-  // eslint-disable-next-line mocha/no-skipped-tests
-  it.skip('should backup the account settings', async function () {
+  it('should backup the account settings', async function () {
     if (process.env.SELENIUM_BROWSER === 'chrome') {
       // Chrome shows OS level download prompt which can't be dismissed by Selenium
       this.skip();
@@ -63,16 +61,15 @@ describe('Backup and Restore', function () {
       async ({ driver }) => {
         await login(driver);
 
-        // Download user settings
         await new HeaderNavbar(driver).openSettingsPage();
         const settingsPage = new SettingsPage(driver);
         await settingsPage.checkPageIsLoaded();
-        await settingsPage.goToAdvancedSettings();
-        const advancedSettings = new AdvancedSettings(driver);
-        await advancedSettings.checkPageIsLoaded();
-        await advancedSettings.downloadData();
+        await settingsPage.goToPrivacySettings();
 
-        // Verify download
+        const privacySettings = new PrivacySettings(driver);
+        await privacySettings.checkPageIsLoaded();
+        await privacySettings.exportYourData();
+
         let info: BackupData | null = null;
         await driver.wait(async () => {
           info = await getBackupJson();
@@ -83,7 +80,6 @@ describe('Backup and Restore', function () {
           throw new Error('Backup data is null after waiting');
         }
         const backupData = info as BackupData;
-        // Verify Json
         assert.equal(
           backupData.network?.networkConfigurationsByChainId?.['0x539']
             ?.chainId,

--- a/ui/pages/settings-v2/privacy-tab/__snapshots__/privacy-tab.test.tsx.snap
+++ b/ui/pages/settings-v2/privacy-tab/__snapshots__/privacy-tab.test.tsx.snap
@@ -359,6 +359,23 @@ exports[`PrivacyTab snapshot matches snapshot 1`] = `
         </span>
       </button>
     </div>
+    <div>
+      <div
+        class="mt-2"
+      >
+        <button
+          class="inline-flex items-center justify-center rounded-xl font-medium min-w-20 overflow-hidden relative h-12 transition-all duration-100 ease-linear active:scale-[0.97] active:ease-[cubic-bezier(0.3,0.8,0.3,1)] bg-icon-default hover:bg-icon-default-hover active:bg-icon-default-pressed focus-visible:ring-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-default text-text-default !bg-transparent p-0 text-left"
+          data-testid="privacy-tab-export-your-data-button"
+          role="button"
+        >
+          <span
+            class="text-inherit text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default"
+          >
+            Export your data
+          </span>
+        </button>
+      </div>
+    </div>
   </div>
 </div>
 `;

--- a/ui/pages/settings-v2/privacy-tab/export-your-data-item.test.tsx
+++ b/ui/pages/settings-v2/privacy-tab/export-your-data-item.test.tsx
@@ -1,0 +1,192 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import mockState from '../../../../test/data/mock-state.json';
+import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
+import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
+import { captureException } from '../../../../shared/lib/sentry';
+import { MetaMetricsContext } from '../../../contexts/metametrics';
+import * as exportUtils from '../../../helpers/utils/export-utils';
+import { backupUserData } from '../../../store/actions';
+import { ExportYourDataItem } from './export-your-data-item';
+
+jest.mock('../../../helpers/utils/export-utils', () => ({
+  ...jest.requireActual('../../../helpers/utils/export-utils'),
+  exportAsFile: jest.fn(),
+}));
+
+jest.mock('../../../store/actions', () => ({
+  ...jest.requireActual('../../../store/actions'),
+  backupUserData: jest.fn(),
+}));
+
+jest.mock('../../../../shared/lib/sentry', () => ({
+  ...jest.requireActual('../../../../shared/lib/sentry'),
+  captureException: jest.fn(),
+}));
+
+const mockExportAsFile = exportUtils.exportAsFile as jest.Mock;
+const mockBackupUserData = backupUserData as jest.MockedFunction<
+  typeof backupUserData
+>;
+const mockCaptureException = captureException as jest.MockedFunction<
+  typeof captureException
+>;
+
+const metricsProvider = (children: React.ReactNode) => (
+  <MetaMetricsContext.Provider
+    value={{
+      trackEvent: jest.fn().mockResolvedValue(undefined),
+      bufferedTrace: jest.fn(),
+      bufferedEndTrace: jest.fn(),
+      onboardingParentContext: { current: null },
+    }}
+  >
+    {children}
+  </MetaMetricsContext.Provider>
+);
+
+describe('ExportYourDataItem', () => {
+  const mockStore = configureMockStore([thunk])(mockState);
+  const trackEvent = jest.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the button with correct text', () => {
+    renderWithProvider(<ExportYourDataItem />, mockStore);
+
+    expect(
+      screen.getByTestId('privacy-tab-export-your-data-button'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(messages.exportYourData.message),
+    ).toBeInTheDocument();
+  });
+
+  it('opens the export modal when the row is clicked', () => {
+    renderWithProvider(metricsProvider(<ExportYourDataItem />), mockStore);
+
+    fireEvent.click(screen.getByTestId('privacy-tab-export-your-data-button'));
+
+    expect(
+      screen.getByText(messages.exportYourDataDescription.message),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('export-your-data-modal-download-button'),
+    ).toBeInTheDocument();
+  });
+
+  it('backs up and exports the user data when Download is clicked in the modal', async () => {
+    mockBackupUserData.mockResolvedValue({
+      fileName: 'MetaMaskUserData.json',
+      data: '{"accounts":[]}',
+    } as never);
+    mockExportAsFile.mockResolvedValue(undefined);
+
+    renderWithProvider(
+      <MetaMetricsContext.Provider
+        value={{
+          trackEvent,
+          bufferedTrace: jest.fn(),
+          bufferedEndTrace: jest.fn(),
+          onboardingParentContext: { current: null },
+        }}
+      >
+        <ExportYourDataItem />
+      </MetaMetricsContext.Provider>,
+      mockStore,
+    );
+
+    fireEvent.click(screen.getByTestId('privacy-tab-export-your-data-button'));
+    fireEvent.click(
+      screen.getByTestId('export-your-data-modal-download-button'),
+    );
+
+    await waitFor(() => {
+      expect(mockBackupUserData).toHaveBeenCalled();
+    });
+
+    expect(mockExportAsFile).toHaveBeenCalledWith(
+      'MetaMaskUserData.json',
+      '{"accounts":[]}',
+      exportUtils.ExportableContentType.JSON,
+    );
+    expect(trackEvent).toHaveBeenCalledWith({
+      event: 'User Data Exported',
+      category: 'Backup',
+      properties: {},
+    });
+  });
+
+  it('supports filename responses from the typed action', async () => {
+    mockBackupUserData.mockResolvedValue({
+      filename: 'MetaMaskUserData.typed.json',
+      data: '{"accounts":[]}',
+    });
+    mockExportAsFile.mockResolvedValue(undefined);
+
+    renderWithProvider(
+      <MetaMetricsContext.Provider
+        value={{
+          trackEvent,
+          bufferedTrace: jest.fn(),
+          bufferedEndTrace: jest.fn(),
+          onboardingParentContext: { current: null },
+        }}
+      >
+        <ExportYourDataItem />
+      </MetaMetricsContext.Provider>,
+      mockStore,
+    );
+
+    fireEvent.click(screen.getByTestId('privacy-tab-export-your-data-button'));
+    fireEvent.click(
+      screen.getByTestId('export-your-data-modal-download-button'),
+    );
+
+    await waitFor(() => {
+      expect(mockExportAsFile).toHaveBeenCalledWith(
+        'MetaMaskUserData.typed.json',
+        '{"accounts":[]}',
+        exportUtils.ExportableContentType.JSON,
+      );
+    });
+  });
+
+  it('closes the modal and captures the error when backup fails', async () => {
+    mockBackupUserData.mockRejectedValue(new Error('backup failed'));
+
+    renderWithProvider(
+      <MetaMetricsContext.Provider
+        value={{
+          trackEvent,
+          bufferedTrace: jest.fn(),
+          bufferedEndTrace: jest.fn(),
+          onboardingParentContext: { current: null },
+        }}
+      >
+        <ExportYourDataItem />
+      </MetaMetricsContext.Provider>,
+      mockStore,
+    );
+
+    fireEvent.click(screen.getByTestId('privacy-tab-export-your-data-button'));
+    fireEvent.click(
+      screen.getByTestId('export-your-data-modal-download-button'),
+    );
+
+    await waitFor(() => {
+      expect(mockCaptureException).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'backup failed' }),
+      );
+    });
+
+    expect(
+      screen.queryByTestId('export-your-data-modal-download-button'),
+    ).not.toBeInTheDocument();
+    expect(trackEvent).not.toHaveBeenCalled();
+  });
+});

--- a/ui/pages/settings-v2/privacy-tab/export-your-data-item.tsx
+++ b/ui/pages/settings-v2/privacy-tab/export-your-data-item.tsx
@@ -1,0 +1,25 @@
+import React, { useState } from 'react';
+import { Box, Button } from '@metamask/design-system-react';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import { PRIVACY_ITEMS } from '../search-config';
+import ExportYourDataModal from './export-your-data-modal';
+
+export const ExportYourDataItem = () => {
+  const t = useI18nContext();
+  const [showModal, setShowModal] = useState(false);
+
+  return (
+    <>
+      <Box className="mt-2">
+        <Button
+          data-testid="privacy-tab-export-your-data-button"
+          onClick={() => setShowModal(true)}
+          className="text-text-default !bg-transparent p-0 text-left"
+        >
+          {t(PRIVACY_ITEMS['export-your-data'])}
+        </Button>
+      </Box>
+      {showModal && <ExportYourDataModal onClose={() => setShowModal(false)} />}
+    </>
+  );
+};

--- a/ui/pages/settings-v2/privacy-tab/export-your-data-modal.tsx
+++ b/ui/pages/settings-v2/privacy-tab/export-your-data-modal.tsx
@@ -1,0 +1,109 @@
+import React, { useContext } from 'react';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxJustifyContent,
+  Button,
+  ButtonVariant,
+  Text,
+  TextVariant,
+  TextColor,
+} from '@metamask/design-system-react';
+import {
+  Modal,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+} from '../../../components/component-library';
+import {
+  AlignItems,
+  Display,
+  FlexDirection,
+} from '../../../helpers/constants/design-system';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import {
+  exportAsFile,
+  ExportableContentType,
+} from '../../../helpers/utils/export-utils';
+import { captureException } from '../../../../shared/lib/sentry';
+import { MetaMetricsContext } from '../../../contexts/metametrics';
+import { backupUserData } from '../../../store/actions';
+
+type BackupUserDataResponse = {
+  data: string;
+  fileName?: string;
+  filename?: string;
+};
+
+type ExportYourDataModalProps = {
+  onClose: () => void;
+};
+
+export default function ExportYourDataModal({
+  onClose,
+}: Readonly<ExportYourDataModalProps>) {
+  const t = useI18nContext();
+  const { trackEvent } = useContext(MetaMetricsContext);
+
+  const handleDownload = async () => {
+    try {
+      const { data, fileName, filename } =
+        (await backupUserData()) as BackupUserDataResponse;
+
+      await exportAsFile(
+        fileName ?? filename ?? 'MetaMaskUserData.json',
+        data,
+        ExportableContentType.JSON,
+      );
+
+      await trackEvent({
+        event: 'User Data Exported',
+        category: 'Backup',
+        properties: {},
+      });
+    } catch (error) {
+      captureException(error);
+    }
+    onClose();
+  };
+
+  return (
+    <Modal isOpen onClose={onClose}>
+      <ModalOverlay />
+      <ModalContent
+        alignItems={AlignItems.center}
+        modalDialogProps={{
+          display: Display.Flex,
+          flexDirection: FlexDirection.Column,
+        }}
+      >
+        <ModalHeader onClose={onClose}>
+          <Box
+            flexDirection={BoxFlexDirection.Column}
+            alignItems={BoxAlignItems.Center}
+            justifyContent={BoxJustifyContent.Center}
+          >
+            <Text variant={TextVariant.HeadingSm}>{t('exportYourData')}</Text>
+          </Box>
+        </ModalHeader>
+        <Box marginHorizontal={4} marginBottom={3}>
+          <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
+            {t('exportYourDataDescription')}
+          </Text>
+        </Box>
+        <ModalFooter>
+          <Button
+            data-testid="export-your-data-modal-download-button"
+            className="w-full"
+            variant={ButtonVariant.Primary}
+            onClick={handleDownload}
+          >
+            {t('exportYourDataButton')}
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/ui/pages/settings-v2/privacy-tab/privacy-tab.tsx
+++ b/ui/pages/settings-v2/privacy-tab/privacy-tab.tsx
@@ -14,6 +14,7 @@ import { MetametricsToggleItem } from './metametrics-item';
 import { DataCollectionToggleItem } from './data-collection-item';
 import { DeleteMetametricsDataItem } from './delete-metametrics-data-item';
 import { DownloadStateLogsItem } from './download-state-logs-item';
+import { ExportYourDataItem } from './export-your-data-item';
 
 const BatchAccountBalanceRequestsToggleItem = createToggleItem({
   name: 'BatchAccountBalanceRequestsToggleItem',
@@ -55,6 +56,10 @@ const PRIVACY_SETTING_ITEMS: SettingItemConfig[] = [
     id: 'download-state-logs',
     component: DownloadStateLogsItem,
     hasDividerBefore: true,
+  },
+  {
+    id: 'export-your-data',
+    component: ExportYourDataItem,
   },
 ];
 

--- a/ui/pages/settings-v2/search-config.ts
+++ b/ui/pages/settings-v2/search-config.ts
@@ -63,6 +63,7 @@ export const PRIVACY_ITEMS = {
   'data-collection': 'dataCollectionForMarketing',
   'delete-metametrics-data': 'deleteMetaMetricsData',
   'download-state-logs': 'downloadStateLogs',
+  'export-your-data': 'exportYourData',
 } as const;
 
 export const THIRD_PARTY_API_ITEMS = {


### PR DESCRIPTION
This PR i sto add Export your data button in privacy settings 

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: added export data button

## **Related issues**

Fixes:

## **Manual testing steps**

1. Run extension and to settings > privacy
2. Click on export data button > Click on download in modal


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/6636e357-2518-4cff-917b-1dbd4b2b0eb0



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Settings V2 UI flow that triggers `backupUserData` and downloads a JSON file, affecting user-data export and download behavior. Risk is moderate due to new modal/action wiring and updated E2E coverage, though it reuses existing backup/export utilities.
> 
> **Overview**
> Adds an **“Export your data”** entry to Settings V2 Privacy that opens a confirmation modal and downloads a JSON backup via `backupUserData` using `exportAsFile`, with Sentry capture on failure and a MetaMetrics event on success.
> 
> Updates Settings V2 search config and snapshots to include the new item, and re-enables/rewires the backup E2E test to use the new Privacy export flow (new page-object helper) instead of the legacy Advanced settings export path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab7f492f8ff6c2ca7d421f02265d5725c77d8fa6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->