### PR TITLE
refactor: add useBoolean hook for repeated boolean state

### DIFF
--- a/ui/components/app/assets/hooks/useTokenDisplayInfo.tsx
+++ b/ui/components/app/assets/hooks/useTokenDisplayInfo.tsx
@@ -73,15 +73,19 @@ export const useTokenDisplayInfo = ({
         )
       : undefined;
 
-  const formattedPrimary = formatWithThreshold(
-    Number((isEvm ? token.string : token.primary) || token.balance),
-    0.00001,
-    locale,
-    {
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 5,
-    },
-  );
+  console.log('>>> useTokenDisplayInfo', { isEvm, token });
+
+  const formattedPrimary = 'YO FORMATTED PRIMARY';
+  // const formattedPrimary = formatWithThreshold(
+  //   Number((isEvm ? token.string : token.primary) || token.balance),
+  //   0.00001,
+
+  //   locale,
+  //   {
+  //     minimumFractionDigits: 0,
+  //     maximumFractionDigits: 5,
+  //   },
+  // );
 
   const isEvmMainnet =
     token.chainId && isEvm ? isChainIdMainnet(token.chainId) : false;

--- a/ui/components/app/assets/token-cell/cells/token-cell-primary-display.tsx
+++ b/ui/components/app/assets/token-cell/cells/token-cell-primary-display.tsx
@@ -1,4 +1,7 @@
 import React from 'react';
+// @ts-expect-error Need to configure this project to work with ESM imports
+import { formatUnits } from 'viem/_cjs/utils/unit/formatUnits';
+import { hexToBigInt } from 'viem/_cjs/utils/encoding/fromHex';
 import {
   TextAlign,
   TextColor,
@@ -9,6 +12,7 @@ import {
   SensitiveTextLength,
 } from '../../../../component-library';
 import { TokenFiatDisplayInfo } from '../../types';
+import { useFormatters } from '../../../../../helpers/formatters';
 
 type TokenCellPrimaryDisplayProps = {
   token: TokenFiatDisplayInfo;
@@ -17,6 +21,32 @@ type TokenCellPrimaryDisplayProps = {
 
 export const TokenCellPrimaryDisplay = React.memo(
   ({ token, privacyMode }: TokenCellPrimaryDisplayProps) => {
+    const { formatTokenQuantity } = useFormatters();
+
+    console.log('>>> TokenCellPrimaryDisplay', { token });
+
+    let fromViem = '----';
+
+    try {
+      console.log(
+        '>>> TEST 1',
+        formatUnits(hexToBigInt(token.balanceRaw), token.decimals),
+      );
+      fromViem = formatUnits(hexToBigInt(token.balanceRaw), token.decimals);
+    } catch (error) {
+      console.log('>>> TEST 1 error', error);
+    }
+
+    // Use viem's formatUnits to convert from wei/raw units to human readable
+    // const fromViem = formatUnits(BigInt(token.balance ?? 0), token.decimals);
+    // console.log('>>> fromViem', { fromViem });
+
+    const tokenAmount = formatTokenQuantity(
+      fromViem,
+      // token.primary,
+      token.symbol,
+    );
+
     return (
       <SensitiveText
         data-testid="multichain-token-list-item-value"
@@ -26,7 +56,7 @@ export const TokenCellPrimaryDisplay = React.memo(
         isHidden={privacyMode}
         length={SensitiveTextLength.Short}
       >
-        {token.primary} {token.symbol}
+        {tokenAmount}
       </SensitiveText>
     );
   },

--- a/ui/components/app/transaction-list-item/smart-transaction-list-item.component.js
+++ b/ui/components/app/transaction-list-item/smart-transaction-list-item.component.js
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import TransactionStatusLabel from '../transaction-status-label/transaction-status-label';
@@ -26,6 +26,7 @@ import {
   Display,
 } from '../../../helpers/constants/design-system';
 import { getCurrentNetwork } from '../../../selectors';
+import { useBoolean } from '../../../hooks/useBoolean';
 
 export default function SmartTransactionListItem({
   smartTransaction,
@@ -35,7 +36,7 @@ export default function SmartTransactionListItem({
 }) {
   const dispatch = useDispatch();
   const [cancelSwapLinkClicked, setCancelSwapLinkClicked] = useState(false);
-  const [showDetails, setShowDetails] = useState(false);
+  const { value: showDetails, toggle: toggleShowDetails } = useBoolean();
   const {
     title,
     category,
@@ -57,9 +58,6 @@ export default function SmartTransactionListItem({
   const showCancelSwapLink =
     smartTransaction.cancellable && !cancelSwapLinkClicked;
   const className = 'transaction-list-item transaction-list-item--unconfirmed';
-  const toggleShowDetails = useCallback(() => {
-    setShowDetails((prev) => !prev);
-  }, []);
   return (
     <>
       <ActivityListItem

--- a/ui/components/multichain/connected-accounts-menu/connected-accounts-menu.tsx
+++ b/ui/components/multichain/connected-accounts-menu/connected-accounts-menu.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useCallback, useEffect, useState } from 'react';
+import React, { useRef, useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
   PopoverRole,
@@ -23,6 +23,7 @@ import {
 import { getPermissionsForActiveTab } from '../../../selectors';
 import { PermissionDetailsModal } from '../permission-details-modal/permission-details-modal';
 import { Identity } from './connected-accounts-menu.types';
+import { useBoolean } from '../../../hooks/useBoolean';
 
 // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -48,7 +49,11 @@ export const ConnectedAccountsMenu = ({
   const dispatch = useDispatch();
   const t = useI18nContext();
   const popoverDialogRef = useRef<HTMLDivElement | null>(null);
-  const [showPermissionModal, setShowPermissionModal] = useState(false);
+  const {
+    value: isModalOpen,
+    setTrue: showModal,
+    setFalse: hideModal,
+  } = useBoolean();
   const permissions = useSelector(getPermissionsForActiveTab);
 
   const handleClickOutside = useCallback(
@@ -105,7 +110,7 @@ export const ConnectedAccountsMenu = ({
                 iconName={IconName.SecurityTick}
                 data-testid="permission-details-menu-item"
                 onClick={() => {
-                  setShowPermissionModal(true);
+                  showModal();
                   onClose();
                 }}
               >
@@ -146,14 +151,14 @@ export const ConnectedAccountsMenu = ({
           </Box>
         </ModalFocus>
       </Popover>
-      {showPermissionModal ? (
+      {isModalOpen ? (
         <PermissionDetailsModal
-          isOpen={showPermissionModal}
+          isOpen={isModalOpen}
           account={account}
           onClick={() => {
             dispatch(removePermittedAccount(activeTabOrigin, account.address));
           }}
-          onClose={() => setShowPermissionModal(false)}
+          onClose={hideModal}
           permissions={permissions}
         />
       ) : null}

--- a/ui/components/multichain/connected-site-menu/connected-site-menu.js
+++ b/ui/components/multichain/connected-site-menu/connected-site-menu.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { useSelector } from 'react-redux';
@@ -31,9 +31,14 @@ import { getDappActiveNetwork } from '../../../selectors/dapp';
 import { ConnectedSitePopover } from '../connected-site-popover';
 import { STATUS_CONNECTED } from '../../../helpers/constants/connected-sites';
 import { CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP } from '../../../../shared/constants/network';
+import { useBoolean } from '../../../hooks/useBoolean';
 
 export const ConnectedSiteMenu = ({ className, disabled, onClick, status }) => {
-  const [showPopover, setShowPopover] = useState(false);
+  const {
+    value: showPopover,
+    setTrue: openPopover,
+    setFalse: closePopover,
+  } = useBoolean();
 
   const referenceElement = useRef(null);
 
@@ -95,7 +100,7 @@ export const ConnectedSiteMenu = ({ className, disabled, onClick, status }) => {
         justifyContent={JustifyContent.center}
         backgroundColor={BackgroundColor.backgroundDefault}
         ref={referenceElement}
-        onClick={() => setShowPopover(true)}
+        onClick={openPopover}
         borderRadius={BorderRadius.LG}
       >
         <>{iconElement}</>
@@ -106,7 +111,7 @@ export const ConnectedSiteMenu = ({ className, disabled, onClick, status }) => {
           isOpen={showPopover}
           isConnected={status === STATUS_CONNECTED}
           onClick={onClick}
-          onClose={() => setShowPopover(false)}
+          onClose={closePopover}
           connectedOrigin={connectedOrigin}
         />
       )}

--- a/ui/components/multichain/network-list-menu/network-confirmation-popover/network-confirmation-popover.tsx
+++ b/ui/components/multichain/network-list-menu/network-confirmation-popover/network-confirmation-popover.tsx
@@ -1,13 +1,18 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { ApprovalType } from '@metamask/controller-utils';
 import { ORIGIN_METAMASK } from '@metamask/approval-controller';
 import Popover from '../../../ui/popover';
 import ConfirmationPage from '../../../../pages/confirmations/confirmation/confirmation';
 import { getUnapprovedConfirmations } from '../../../../selectors';
+import { useBoolean } from '../../../../hooks/useBoolean';
 
 const NetworkConfirmationPopover = () => {
-  const [showPopover, setShowPopover] = useState(false);
+  const {
+    value: isOpen,
+    setTrue: openPopover,
+    setFalse: closePopover,
+  } = useBoolean();
 
   const unapprovedConfirmations = useSelector(getUnapprovedConfirmations);
 
@@ -19,14 +24,14 @@ const NetworkConfirmationPopover = () => {
           confirmation.type === ApprovalType.AddEthereumChain,
       );
 
-    if (!showPopover && anAddNetworkConfirmationFromMetaMaskExists) {
-      setShowPopover(true);
-    } else if (showPopover && !anAddNetworkConfirmationFromMetaMaskExists) {
-      setShowPopover(false);
+    if (!isOpen && anAddNetworkConfirmationFromMetaMaskExists) {
+      openPopover();
+    } else if (isOpen && !anAddNetworkConfirmationFromMetaMaskExists) {
+      closePopover();
     }
-  }, [unapprovedConfirmations, showPopover]);
+  }, [closePopover, openPopover, isOpen, unapprovedConfirmations]);
 
-  if (!showPopover) {
+  if (!isOpen) {
     return null;
   }
 

--- a/ui/components/multichain/network-list-menu/popular-network-list/popular-network-list.tsx
+++ b/ui/components/multichain/network-list-menu/popular-network-list/popular-network-list.tsx
@@ -42,6 +42,7 @@ import {
 } from '../../../../helpers/constants/design-system';
 import { CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP } from '../../../../../shared/constants/network';
 import ZENDESK_URLS from '../../../../helpers/constants/zendesk-url';
+import { useBoolean } from '../../../../hooks/useBoolean';
 
 const PopularNetworkList = ({
   searchAddNetworkResults,
@@ -51,15 +52,7 @@ const PopularNetworkList = ({
   const t = useI18nContext();
   const isPopUp = getEnvironmentType() === ENVIRONMENT_TYPE_POPUP;
   const dispatch = useDispatch();
-  const [isOpen, setIsOpen] = useState(false);
-
-  const handleMouseEnter = () => {
-    setIsOpen(true);
-  };
-
-  const handleMouseLeave = () => {
-    setIsOpen(false);
-  };
+  const { value: isOpen, setTrue: open, setFalse: close } = useBoolean();
 
   const [referenceElement, setReferenceElement] = useState();
 
@@ -87,7 +80,7 @@ const PopularNetworkList = ({
             {t('additionalNetworks')}
           </Text>
 
-          <Box onMouseEnter={handleMouseEnter} marginTop={1}>
+          <Box onMouseEnter={open} marginTop={1}>
             <Icon
               className="add-network__warning-icon"
               name={IconName.Info}
@@ -104,7 +97,7 @@ const PopularNetworkList = ({
               isOpen={isOpen}
               flip
               backgroundColor={BackgroundColor.backgroundSection}
-              onMouseLeave={handleMouseLeave}
+              onMouseLeave={close}
               style={{
                 width: '326px',
               }}
@@ -153,7 +146,7 @@ const PopularNetworkList = ({
             paddingTop={4}
             className="new-network-list__list-of-networks"
             data-testid={`popular-network-${network.chainId}`}
-            onMouseEnter={handleMouseLeave}
+            onMouseEnter={close}
           >
             <Box display={Display.Flex} alignItems={AlignItems.center}>
               <AvatarNetwork

--- a/ui/components/multichain/notification-detail-network-fee/notification-detail-network-fee.tsx
+++ b/ui/components/multichain/notification-detail-network-fee/notification-detail-network-fee.tsx
@@ -35,6 +35,7 @@ import {
   FlexDirection,
 } from '../../../helpers/constants/design-system';
 import Preloader from '../../ui/icon/preloader/preloader-icon.component';
+import { useBoolean } from '../../../hooks/useBoolean';
 
 type OnChainRawNotificationsWithNetworkFields =
   NotificationServicesController.Types.OnChainRawNotificationsWithNetworkFields;
@@ -92,7 +93,7 @@ const _NotificationDetailNetworkFee: FC<NotificationDetailNetworkFeeProps> = ({
 }) => {
   const t = useI18nContext();
   const trackEvent = useContext(MetaMetricsContext);
-  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const { value: isOpen, toggle } = useBoolean();
   const [networkFees, setNetworkFees] = useState<NetworkFees>(null);
   const [networkFeesError, setNetworkFeesError] = useState<boolean>(false);
 
@@ -147,7 +148,7 @@ const _NotificationDetailNetworkFee: FC<NotificationDetailNetworkFeeProps> = ({
         },
       });
     }
-    setIsOpen(!isOpen);
+    toggle();
   };
 
   if (!networkFees && !networkFeesError) {

--- a/ui/components/multichain/token-list-item/token-list-item.tsx
+++ b/ui/components/multichain/token-list-item/token-list-item.tsx
@@ -340,7 +340,7 @@ export const TokenListItemComponent = ({
                 textAlign={TextAlign.End}
                 isHidden={privacyMode}
                 length={SensitiveTextLength.Short}
-              >
+              >PRIMARY
                 {primary} {isPrimaryTokenSymbolHidden ? '' : tokenSymbol}
               </SensitiveText>
             ) : (
@@ -351,7 +351,7 @@ export const TokenListItemComponent = ({
                 textAlign={TextAlign.End}
                 isHidden={privacyMode}
                 length={SensitiveTextLength.Short}
-              >
+              >PRIMARY
                 {primary} {isPrimaryTokenSymbolHidden ? '' : tokenSymbol}
               </SensitiveText>
             )}

--- a/ui/components/ui/currency-display/currency-display.component.js
+++ b/ui/components/ui/currency-display/currency-display.component.js
@@ -69,6 +69,7 @@ export default function CurrencyDisplay({
         {parts.prefix}
         {parts.value}
       </SensitiveText>
+
       {parts.suffix ? (
         <SensitiveText
           as="span"

--- a/ui/helpers/formatters.test.ts
+++ b/ui/helpers/formatters.test.ts
@@ -2,104 +2,164 @@ import { createFormatters } from './formatters';
 
 const locale = 'en-US';
 
+const invalidValues = [
+  Number.NaN,
+  Number.POSITIVE_INFINITY,
+  Number.NEGATIVE_INFINITY,
+];
+
 describe('formatCurrency', () => {
-  it('formats values with currency code', () => {
-    const { formatCurrency } = createFormatters({ locale });
-    expect(formatCurrency(1234.56, 'USD')).toBe('$1,234.56');
-  });
+  const { formatCurrency } = createFormatters({ locale });
 
-  it('handles zero', () => {
-    const { formatCurrency } = createFormatters({ locale });
-    expect(formatCurrency(0, 'USD')).toBe('$0.00');
-  });
+  const testCases = [
+    { value: 1_234.56, expected: '$1,234.56' },
+    { value: 0, expected: '$0.00' },
+    { value: -42.5, expected: '-$42.50' },
+  ];
 
-  it('handles negative values', () => {
-    const { formatCurrency } = createFormatters({ locale });
-    expect(formatCurrency(-42.5, 'USD')).toBe('-$42.50');
+  it('formats values correctly', () => {
+    testCases.forEach(({ value, expected }) => {
+      expect(formatCurrency(value, 'USD')).toBe(expected);
+    });
   });
 
   it('handles invalid values', () => {
-    const { formatCurrency } = createFormatters({ locale });
-    for (const input of [
-      Number.NaN,
-      Number.POSITIVE_INFINITY,
-      Number.NEGATIVE_INFINITY,
-    ]) {
+    invalidValues.forEach((input) => {
       expect(formatCurrency(input, 'USD')).toBe('');
-    }
+    });
+  });
+
+  it('formats values correctly with different locale', () => {
+    const { formatCurrency: formatCurrencyGB } = createFormatters({
+      locale: 'en-GB',
+    });
+    expect(formatCurrencyGB(1234.56, 'GBP')).toBe('£1,234.56');
   });
 });
 
 describe('formatCurrencyWithMinThreshold', () => {
+  const { formatCurrencyWithMinThreshold } = createFormatters({ locale });
+
   const testCases = [
+    { value: 0, expected: '$0.00' },
+
+    // Values below minimum threshold
     { value: 0.000001, expected: '<$0.01' },
     { value: 0.001, expected: '<$0.01' },
+
+    // Values at and above minimum threshold
     { value: 0.01, expected: '$0.01' },
     { value: 0.1, expected: '$0.10' },
-    { value: 0, expected: '$0.00' },
     { value: 1, expected: '$1.00' },
     { value: 1_000, expected: '$1,000.00' },
     { value: 1_000_000, expected: '$1,000,000.00' },
   ];
 
   it('formats values correctly', () => {
-    const { formatCurrencyWithMinThreshold } = createFormatters({ locale });
     testCases.forEach(({ value, expected }) => {
       expect(formatCurrencyWithMinThreshold(value, 'USD')).toBe(expected);
     });
   });
 
   it('handles invalid values', () => {
-    const { formatCurrencyWithMinThreshold } = createFormatters({ locale });
-    [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY].forEach(
-      (input) => {
-        expect(formatCurrencyWithMinThreshold(input, 'USD')).toBe('');
-      },
-    );
+    invalidValues.forEach((input) => {
+      expect(formatCurrencyWithMinThreshold(input, 'USD')).toBe('');
+    });
   });
 });
 
 describe('formatCurrencyTokenPrice', () => {
+  const { formatCurrencyTokenPrice } = createFormatters({ locale });
+
   const testCases = [
+    { value: 0, expected: '$0.00' },
+
+    // Values below minimum threshold
     { value: 0.000000001, expected: '<$0.00000001' },
+
+    // Values above minimum threshold but less than 1
     { value: 0.0000123, expected: '$0.0000123' },
     { value: 0.001, expected: '$0.00100' },
     { value: 0.999, expected: '$0.999' },
-    { value: 0, expected: '$0.00' },
+
+    // Values at and above 1 but less than 1,000,000
     { value: 1, expected: '$1.00' },
+
+    // Values 1,000,000 and above
     { value: 1_000_000, expected: '$1.00M' },
   ];
 
   it('formats values correctly', () => {
-    const { formatCurrencyTokenPrice } = createFormatters({ locale });
     testCases.forEach(({ value, expected }) => {
       expect(formatCurrencyTokenPrice(value, 'USD')).toBe(expected);
     });
   });
 
   it('handles invalid values', () => {
-    const { formatCurrencyTokenPrice } = createFormatters({ locale });
-    [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY].forEach(
-      (input) => {
-        expect(formatCurrencyTokenPrice(input, 'USD')).toBe('');
-      },
-    );
+    invalidValues.forEach((input) => {
+      expect(formatCurrencyTokenPrice(input, 'USD')).toBe('');
+    });
   });
 });
 
-describe('locale variations', () => {
-  describe('en-GB GBP', () => {
-    it('formats standard value', () => {
-      const { formatCurrency } = createFormatters({ locale: 'en-GB' });
-      expect(formatCurrency(1234.56, 'GBP')).toBe('£1,234.56');
-    });
+describe('formatToken', () => {
+  const { formatToken } = createFormatters({ locale });
 
-    it('min threshold logic', () => {
-      const { formatCurrencyWithMinThreshold } = createFormatters({
-        locale: 'en-GB',
-      });
-      expect(formatCurrencyWithMinThreshold(0.005, 'GBP')).toBe('<£0.01');
-      expect(formatCurrencyWithMinThreshold(1_000, 'GBP')).toBe('£1,000.00');
+  const testCases = [
+    { value: 1.234, symbol: 'ETH', expected: '1.234 ETH' },
+    { value: 0, symbol: 'USDC', expected: '0 USDC' },
+    { value: 1_000, symbol: 'DAI', expected: '1,000 DAI' },
+  ];
+
+  it('formats token values', () => {
+    testCases.forEach(({ value, symbol, expected }) => {
+      expect(formatToken(value, symbol)).toBe(expected);
+    });
+  });
+
+  it('handles invalid values', () => {
+    invalidValues.forEach((input) => {
+      expect(formatToken(input, 'ETH')).toBe('');
+    });
+  });
+});
+
+describe('formatTokenQuantity', () => {
+  const { formatTokenQuantity } = createFormatters({ locale });
+
+  const testCases = [
+    { value: 0, symbol: 'ETH', expected: '0 ETH' },
+
+    // Values below minimum threshold
+    { value: 0.000000001, symbol: 'ETH', expected: '<0.00001 ETH' },
+    { value: 0.0000005, symbol: 'USDC', expected: '<0.00001 USDC' },
+
+    // Values above minimum threshold but less than 1
+    { value: 0.00001, symbol: 'ETH', expected: '0.0000100 ETH' },
+    { value: 0.001234, symbol: 'BTC', expected: '0.00123 BTC' },
+    { value: 0.123456, symbol: 'USDC', expected: '0.123 USDC' },
+
+    // Values 1 and above but less than 1,000,000
+    { value: 1, symbol: 'ETH', expected: '1 ETH' },
+    { value: 1.2345678, symbol: 'BTC', expected: '1.235 BTC' },
+    { value: 123.45678, symbol: 'USDC', expected: '123.457 USDC' },
+    { value: 999_999, symbol: 'DAI', expected: '999,999 DAI' },
+
+    // Values 1,000,000 and above
+    { value: 1_000_000, symbol: 'ETH', expected: '1.00M ETH' },
+    { value: 1_234_567, symbol: 'BTC', expected: '1.23M BTC' },
+    { value: 1_000_000_000, symbol: 'USDC', expected: '1.00B USDC' },
+  ];
+
+  it('formats token quantities correctly', () => {
+    testCases.forEach(({ value, symbol, expected }) => {
+      expect(formatTokenQuantity(value, symbol)).toBe(expected);
+    });
+  });
+
+  it('handles invalid values', () => {
+    invalidValues.forEach((input) => {
+      expect(formatTokenQuantity(input, 'ETH')).toBe('');
     });
   });
 });

--- a/ui/helpers/formatters.ts
+++ b/ui/helpers/formatters.ts
@@ -72,7 +72,6 @@ function formatCurrency(
     ...options,
   });
 
-  // @ts-expect-error Remove this comment once TypeScript is updated to 5.5+
   return numberFormat.format(value);
 }
 
@@ -108,6 +107,26 @@ function formatCurrencyWithMinThreshold(
   return formatCurrency(config, number, currency);
 }
 
+function formatToken(
+  config: { locale: string },
+  value: number | bigint | `${number}`,
+  symbol: string,
+  options: Intl.NumberFormatOptions = {},
+) {
+  if (!Number.isFinite(Number(value))) {
+    return '';
+  }
+
+  const numberFormat = getCachedNumberFormat(config.locale, {
+    style: 'decimal',
+    ...options,
+  });
+
+  const formattedNumber = numberFormat.format(value);
+
+  return `${formattedNumber} ${symbol}`;
+}
+
 function formatCurrencyTokenPrice(
   config: { locale: string },
   value: number | bigint | `${number}`,
@@ -137,6 +156,37 @@ function formatCurrencyTokenPrice(
   }
 
   return formatCurrencyCompact(config, number, currency);
+}
+
+function formatTokenQuantity(
+  config: { locale: string },
+  value: number | bigint | `${number}`,
+  symbol: string,
+) {
+  const minThreshold = 0.00001;
+  const number = Number(value);
+
+  if (!Number.isFinite(number)) {
+    return '';
+  }
+
+  if (number === 0) {
+    return formatToken(config, 0, symbol);
+  }
+
+  if (number < minThreshold) {
+    return `<${formatToken(config, minThreshold, symbol, oneSignificantDigit)}`;
+  }
+
+  if (number < 1) {
+    return formatToken(config, number, symbol, threeSignificantDigits);
+  }
+
+  if (number < 1_000_000) {
+    return formatToken(config, number, symbol);
+  }
+
+  return formatToken(config, number, symbol, compactTwoDecimals);
 }
 
 export function createFormatters({ locale = FALLBACK_LOCALE }) {
@@ -172,6 +222,21 @@ export function createFormatters({ locale = FALLBACK_LOCALE }) {
      * @param currency - ISO 4217 currency code.
      */
     formatCurrencyTokenPrice: formatCurrencyTokenPrice.bind(null, { locale }),
+    /**
+     * Format a value as a token string with symbol.
+     *
+     * @param value - Numeric value to format.
+     * @param symbol - Token symbol (e.g. 'ETH', 'SepoliaETH').
+     * @param options - Optional Intl.NumberFormat overrides.
+     */
+    formatToken: formatToken.bind(null, { locale }),
+    /**
+     * Format token quantity with varying precision based on value.
+     *
+     * @param value - Numeric value to format.
+     * @param symbol - Token symbol (e.g. 'ETH', 'SepoliaETH').
+     */
+    formatTokenQuantity: formatTokenQuantity.bind(null, { locale }),
   };
 }
 

--- a/ui/hooks/useBoolean.test.ts
+++ b/ui/hooks/useBoolean.test.ts
@@ -1,0 +1,62 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import { useBoolean } from './useBoolean';
+
+describe('useBoolean', () => {
+  it('defaults to false', () => {
+    const { result } = renderHook(() => useBoolean());
+
+    expect(result.current.value).toBe(false);
+  });
+
+  it('supports a custom initial value', () => {
+    const { result } = renderHook(() => useBoolean(true));
+
+    expect(result.current.value).toBe(true);
+  });
+
+  it('sets the value to true', () => {
+    const { result } = renderHook(() => useBoolean());
+
+    act(() => {
+      result.current.setTrue();
+    });
+
+    expect(result.current.value).toBe(true);
+  });
+
+  it('sets the value to false', () => {
+    const { result } = renderHook(() => useBoolean(true));
+
+    act(() => {
+      result.current.setFalse();
+    });
+
+    expect(result.current.value).toBe(false);
+  });
+
+  it('toggles the value', () => {
+    const { result } = renderHook(() => useBoolean());
+
+    act(() => {
+      result.current.toggle();
+    });
+
+    expect(result.current.value).toBe(true);
+
+    act(() => {
+      result.current.toggle();
+    });
+
+    expect(result.current.value).toBe(false);
+  });
+
+  it('exposes the raw setter for custom flows', () => {
+    const { result } = renderHook(() => useBoolean());
+
+    act(() => {
+      result.current.setValue((currentValue) => !currentValue);
+    });
+
+    expect(result.current.value).toBe(true);
+  });
+});

--- a/ui/hooks/useBoolean.ts
+++ b/ui/hooks/useBoolean.ts
@@ -1,0 +1,32 @@
+import {
+  type Dispatch,
+  type SetStateAction,
+  useCallback,
+  useState,
+} from 'react';
+
+type Props = {
+  value: boolean;
+  setValue: Dispatch<SetStateAction<boolean>>;
+  setTrue: () => void;
+  setFalse: () => void;
+  toggle: () => void;
+};
+
+export function useBoolean(defaultValue = false): Props {
+  const [value, setValue] = useState(defaultValue);
+
+  const setTrue = useCallback(() => {
+    setValue(true);
+  }, []);
+
+  const setFalse = useCallback(() => {
+    setValue(false);
+  }, []);
+
+  const toggle = useCallback(() => {
+    setValue((currentValue) => !currentValue);
+  }, []);
+
+  return { value, setValue, setTrue, setFalse, toggle };
+}

--- a/ui/hooks/useCurrencyDisplay.js
+++ b/ui/hooks/useCurrencyDisplay.js
@@ -41,6 +41,7 @@ function formatEthCurrencyDisplay({
   numberOfDecimals,
 }) {
   if (isNativeCurrency || (!isUserPreferredCurrency && !nativeCurrency)) {
+    // console.log('>>> WAT 2', { inputValue, denomination, numberOfDecimals, DEFAULT_PRECISION, MIN_AMOUNT_DISPLAY })
     const ethDisplayValue = new Numeric(inputValue, 16, EtherDenomination.WEI)
       .toDenomination(denomination || EtherDenomination.ETH)
       .round(numberOfDecimals || DEFAULT_PRECISION)
@@ -227,6 +228,7 @@ export function useCurrencyDisplay(
   if (!opts.hideLabel && !isFiatCurrency) {
     // if the currency we are displaying is the native currency of one of our preloaded test-nets (goerli, sepolia etc.)
     // then we allow lowercase characters, otherwise we force to uppercase any suffix passed as a currency
+    // console.log('>>> WAT', TEST_NETWORK_TICKER_MAP, MULTICHAIN_NETWORK_TICKER, currency, opts.suffix)
     const currencyTickerSymbol = [
       ...Object.values(TEST_NETWORK_TICKER_MAP),
       ...Object.values(MULTICHAIN_NETWORK_TICKER),

--- a/ui/selectors/assets.ts
+++ b/ui/selectors/assets.ts
@@ -177,6 +177,8 @@ export const getTokenBalancesEvm = createDeepEqualSelector(
         tokenList.forEach((token: Token) => {
           const { isNative, address, decimals } = token;
 
+console.log('>>> assets.ts', { token, nativeBalances, selectedAccountTokenBalancesAcrossChains })
+
           const balance =
             calculateTokenBalance({
               isNative,
@@ -231,6 +233,7 @@ export const getTokenBalancesEvm = createDeepEqualSelector(
               primary: '',
               secondary: 0,
               title,
+              balanceRaw: isNative? nativeBalances?.[chainId] : selectedAccountTokenBalancesAcrossChains?.[chainId]?.[token.address as Hex]
             });
           }
         });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- adds a re-usable useBoolean hook for common boolean UI state
- replace repeated useState(false) + open/close/toggle logic in multiple components

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly a UI-state refactor, but it also alters token balance display/formatting paths (including new raw balance plumbing) and includes debug/placeholder output that could affect user-visible balances if merged as-is.
> 
> **Overview**
> Introduces a reusable `useBoolean` hook (with tests) and refactors several UI components to replace ad-hoc `useState(false)` + open/close/toggle handlers with the shared API.
> 
> Extends `ui/helpers/formatters` with `formatToken` and `formatTokenQuantity` (plus expanded tests), and starts wiring raw EVM token balances (`balanceRaw`) through asset selectors into token display. **Token primary display logic is currently modified with debug `console.log`s and placeholder/experimental formatting in `useTokenDisplayInfo` and `TokenCellPrimaryDisplay`, which changes what is rendered for token amounts.**
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f17401c7ca4f1b63eafbe33dc98700ced0f48fa9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->