### PR TITLE
fix(confirmations): stabilize cancel/speed-up gas estimates

### DIFF
--- a/ui/hooks/useGasFeeEstimates.js
+++ b/ui/hooks/useGasFeeEstimates.js
@@ -21,7 +21,7 @@ import usePolling from './usePolling';
  *   '@metamask/gas-fee-controller'
  * ).GasFeeState['gasFeeEstimates']} gasFeeEstimates - The estimate object
  * @property {object} gasEstimateType - The type of estimate provided
- * @property {boolean} isGasEstimateLoading - indicates whether the gas
+ * @property {boolean} isGasEstimatesLoading - indicates whether the gas
  *  estimates are currently loading.
  * @property {boolean} isNetworkBusy - indicates whether the network is busy.
  */

--- a/ui/pages/confirmations/cancel-speedup/cancel-speedup.tsx
+++ b/ui/pages/confirmations/cancel-speedup/cancel-speedup.tsx
@@ -334,6 +334,7 @@ const CancelSpeedupContent = ({
   const {
     effectiveTransaction,
     gasFeeEstimates,
+    isGasEstimatesLoading,
     cancelTransaction,
     speedUpTransaction,
     updateTransactionToTenPercentIncreasedGasFee,
@@ -343,6 +344,7 @@ const CancelSpeedupContent = ({
   const { isInitialGasReady } = useCancelSpeedupInitialGas({
     effectiveTransaction,
     gasFeeEstimates,
+    isGasEstimatesLoading,
     updateTransactionUsingEstimate,
     updateTransactionToTenPercentIncreasedGasFee,
     appIsLoading,

--- a/ui/pages/confirmations/hooks/useCancelSpeedupGasState.test.ts
+++ b/ui/pages/confirmations/hooks/useCancelSpeedupGasState.test.ts
@@ -5,6 +5,7 @@ import {
   GasEstimateTypes,
 } from '../../../../shared/constants/gas';
 import { useGasFeeEstimates } from '../../../hooks/useGasFeeEstimates';
+import { useSupportsEIP1559 } from '../components/confirm/info/hooks/useSupportsEIP1559';
 import { useCancelSpeedupGasState } from './useCancelSpeedupGasState';
 
 import { useTransactionFunctions } from './useTransactionFunctions';
@@ -12,6 +13,10 @@ import { useLegacyCancelSpeedupFlow } from './useLegacyCancelSpeedupFlow';
 
 jest.mock('../../../hooks/useGasFeeEstimates', () => ({
   useGasFeeEstimates: jest.fn(),
+}));
+
+jest.mock('../components/confirm/info/hooks/useSupportsEIP1559', () => ({
+  useSupportsEIP1559: jest.fn(),
 }));
 
 jest.mock('./useTransactionFunctions', () => ({
@@ -26,17 +31,10 @@ const mockUseLegacyCancelSpeedupFlow = jest.mocked(useLegacyCancelSpeedupFlow);
 
 const mockUseGasFeeEstimates = jest.mocked(useGasFeeEstimates);
 const mockUseTransactionFunctions = jest.mocked(useTransactionFunctions);
+const mockUseSupportsEIP1559 = jest.mocked(useSupportsEIP1559);
 
-const mockNetwork = {
-  rpcEndpoints: [{ networkClientId: 'mainnet' }],
-  defaultRpcEndpointIndex: 0,
-};
-
-const mockSelectNetworkConfigurationByChainId = jest.fn();
 const mockSelectTransactionMetadata = jest.fn();
 jest.mock('../../../selectors', () => ({
-  selectNetworkConfigurationByChainId: (...args: unknown[]) =>
-    mockSelectNetworkConfigurationByChainId(...args),
   selectTransactionMetadata: (...args: unknown[]) =>
     mockSelectTransactionMetadata(...args),
 }));
@@ -51,6 +49,7 @@ function createMockTransaction(overrides: Partial<TransactionMeta> = {}) {
   return {
     id: 'tx-1',
     chainId: '0x1',
+    networkClientId: 'mainnet',
     txParams: {
       gas: '0x5208',
       gasLimit: '0x5208',
@@ -77,8 +76,8 @@ describe('useCancelSpeedupGasState', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockSelectNetworkConfigurationByChainId.mockReturnValue(mockNetwork);
     mockSelectTransactionMetadata.mockReturnValue(undefined);
+    mockUseSupportsEIP1559.mockReturnValue({ supportsEIP1559: true });
     mockUseGasFeeEstimates.mockReturnValue({
       gasFeeEstimates: { medium: { suggestedMaxFeePerGas: '0x2' } },
       gasEstimateType: GasEstimateTypes.feeMarket,
@@ -103,7 +102,7 @@ describe('useCancelSpeedupGasState', () => {
     });
   });
 
-  it('returns effectiveTransaction, gasFeeEstimates, and transaction action functions', () => {
+  it('returns effectiveTransaction, gasFeeEstimates, isGasEstimatesLoading, and transaction action functions', () => {
     const transaction = createMockTransaction();
 
     const { result } = renderHook(() =>
@@ -112,6 +111,7 @@ describe('useCancelSpeedupGasState', () => {
 
     expect(result.current).toMatchObject({
       gasFeeEstimates: { medium: { suggestedMaxFeePerGas: '0x2' } },
+      isGasEstimatesLoading: false,
     });
     expect(result.current.effectiveTransaction).toBeDefined();
     expect(result.current.cancelTransaction).toBe(mockCancelTransaction);
@@ -122,6 +122,22 @@ describe('useCancelSpeedupGasState', () => {
     expect(result.current.updateTransactionUsingEstimate).toBe(
       mockUpdateTransactionUsingEstimate,
     );
+  });
+
+  it('returns isGasEstimatesLoading as true when estimates are still loading', () => {
+    mockUseGasFeeEstimates.mockReturnValue({
+      gasFeeEstimates: {},
+      gasEstimateType: GasEstimateTypes.feeMarket,
+      isGasEstimatesLoading: true,
+      isNetworkBusy: false,
+    } as unknown as ReturnType<typeof useGasFeeEstimates>);
+
+    const transaction = createMockTransaction();
+    const { result } = renderHook(() =>
+      useCancelSpeedupGasState(transaction, EditGasModes.speedUp),
+    );
+
+    expect(result.current.isGasEstimatesLoading).toBe(true);
   });
 
   it('uses transaction as effectiveTransaction when store has no matching tx (speedUp)', () => {
@@ -205,7 +221,8 @@ describe('useCancelSpeedupGasState', () => {
       );
     });
 
-    it('returns legacy functions when transaction has no maxFeePerGas (gasPrice only)', () => {
+    it('returns legacy functions when transaction does not support EIP-1559', () => {
+      mockUseSupportsEIP1559.mockReturnValue({ supportsEIP1559: false });
       const legacyTransaction = createMockTransaction({
         txParams: {
           gas: '0x5208',
@@ -233,6 +250,7 @@ describe('useCancelSpeedupGasState', () => {
     });
 
     it('calls useLegacyCancelSpeedupFlow with effectiveTransaction and gasFeeEstimates', () => {
+      mockUseSupportsEIP1559.mockReturnValue({ supportsEIP1559: false });
       const legacyTransaction = createMockTransaction({
         txParams: {
           gas: '0x5208',

--- a/ui/pages/confirmations/hooks/useCancelSpeedupGasState.ts
+++ b/ui/pages/confirmations/hooks/useCancelSpeedupGasState.ts
@@ -10,15 +10,13 @@ import {
   EditGasModes,
   GasRecommendations,
 } from '../../../../shared/constants/gas';
-import {
-  selectNetworkConfigurationByChainId,
-  selectTransactionMetadata,
-} from '../../../selectors';
+import { selectTransactionMetadata } from '../../../selectors';
 import { useGasFeeEstimates } from '../../../hooks/useGasFeeEstimates';
 import {
   hexToDecimal,
   hexWEIToDecGWEI,
 } from '../../../../shared/lib/conversion.utils';
+import { useSupportsEIP1559 } from '../components/confirm/info/hooks/useSupportsEIP1559';
 import { useTransactionFunctions } from './useTransactionFunctions';
 import { useLegacyCancelSpeedupFlow } from './useLegacyCancelSpeedupFlow';
 
@@ -30,6 +28,7 @@ export type UseCancelSpeedupGasStateReturn = {
     | LegacyGasPriceEstimate
     | Record<string, never>
     | null;
+  isGasEstimatesLoading: boolean;
   cancelTransaction: () => void;
   speedUpTransaction: () => void;
   updateTransactionToTenPercentIncreasedGasFee: (
@@ -53,33 +52,18 @@ export function useCancelSpeedupGasState(
     selectTransactionMetadata(state, transaction?.id),
   );
 
-  const network = useSelector((state: Record<string, unknown>) =>
-    selectNetworkConfigurationByChainId(state, transaction?.chainId),
+  const effectiveTransaction = useMemo(() => {
+    return transactionFromStore ?? transaction;
+  }, [transactionFromStore, transaction]);
+
+  const { gasFeeEstimates, isGasEstimatesLoading } = useGasFeeEstimates(
+    effectiveTransaction.networkClientId,
   );
 
-  const networkClientId = (
-    network as {
-      rpcEndpoints?: { networkClientId?: string }[];
-      defaultRpcEndpointIndex?: number;
-    }
-  )?.rpcEndpoints?.[
-    (network as { defaultRpcEndpointIndex?: number })
-      ?.defaultRpcEndpointIndex ?? 0
-  ]?.networkClientId;
-
-  const effectiveTransaction = useMemo(() => {
-    const sourceTx = transactionFromStore ?? transaction;
-    return {
-      ...sourceTx,
-      networkClientId:
-        (sourceTx as TransactionMeta & { networkClientId?: string })
-          .networkClientId ?? networkClientId,
-    };
-  }, [transactionFromStore, transaction, networkClientId]);
-
-  const { gasFeeEstimates } = useGasFeeEstimates(networkClientId);
-
-  const isLegacy = !effectiveTransaction?.txParams?.maxFeePerGas;
+  const { supportsEIP1559 } = useSupportsEIP1559(
+    effectiveTransaction as TransactionMeta,
+  );
+  const isLegacy = !supportsEIP1559;
 
   // EIP-1559 flow
   const gasLimitNum = Number(
@@ -95,15 +79,11 @@ export function useCancelSpeedupGasState(
     ? hexWEIToDecGWEI(effectiveTransaction.txParams.maxPriorityFeePerGas)
     : '0';
 
-  const effectiveGasFeeEstimates =
-    gasFeeEstimates ?? effectiveTransaction.gasFeeEstimates;
-
   const eip1559Functions = useTransactionFunctions({
     defaultEstimateToUse: GasRecommendations.medium,
     editGasMode,
-    estimatedBaseFee: (effectiveGasFeeEstimates as GasFeeEstimates)
-      ?.estimatedBaseFee,
-    gasFeeEstimates: effectiveGasFeeEstimates,
+    estimatedBaseFee: (gasFeeEstimates as GasFeeEstimates)?.estimatedBaseFee,
+    gasFeeEstimates,
     gasLimit: gasLimitNum,
     maxPriorityFeePerGas: maxPriorityFeePerGasGwei,
     transaction: effectiveTransaction as TransactionMeta,
@@ -112,7 +92,7 @@ export function useCancelSpeedupGasState(
   // Legacy flow
   const legacyFunctions = useLegacyCancelSpeedupFlow({
     transaction: effectiveTransaction as TransactionMeta,
-    gasFeeEstimates: effectiveGasFeeEstimates,
+    gasFeeEstimates,
   });
 
   const {
@@ -124,7 +104,8 @@ export function useCancelSpeedupGasState(
 
   return {
     effectiveTransaction: effectiveTransaction as TransactionMeta,
-    gasFeeEstimates: effectiveGasFeeEstimates ?? null,
+    gasFeeEstimates: gasFeeEstimates ?? null,
+    isGasEstimatesLoading,
     cancelTransaction,
     speedUpTransaction,
     updateTransactionToTenPercentIncreasedGasFee,

--- a/ui/pages/confirmations/hooks/useCancelSpeedupInitialGas.test.ts
+++ b/ui/pages/confirmations/hooks/useCancelSpeedupInitialGas.test.ts
@@ -3,7 +3,10 @@ import { TransactionMeta } from '@metamask/transaction-controller';
 import { GasFeeEstimates } from '@metamask/gas-fee-controller';
 import { PriorityLevels } from '../../../../shared/constants/gas';
 import * as gasUtils from '../../../helpers/utils/gas';
-import { useCancelSpeedupInitialGas } from './useCancelSpeedupInitialGas';
+import {
+  UseCancelSpeedupInitialGasParams,
+  useCancelSpeedupInitialGas,
+} from './useCancelSpeedupInitialGas';
 
 const mockGasFeeEstimatesWithMedium = {
   medium: { suggestedMaxFeePerGas: '0x2' },
@@ -54,6 +57,22 @@ describe('useCancelSpeedupInitialGas', () => {
   const mockUpdateTransactionToTenPercentIncreasedGasFee = jest.fn();
   const CANCEL_SPEEDUP_MODAL = 'cancelSpeedUpTransaction';
 
+  function buildHookParams(
+    overrides: Partial<UseCancelSpeedupInitialGasParams> = {},
+  ): UseCancelSpeedupInitialGasParams {
+    return {
+      effectiveTransaction: createMockTransaction(),
+      gasFeeEstimates: mockGasFeeEstimatesWithMedium,
+      isGasEstimatesLoading: false,
+      updateTransactionUsingEstimate: mockUpdateTransactionUsingEstimate,
+      updateTransactionToTenPercentIncreasedGasFee:
+        mockUpdateTransactionToTenPercentIncreasedGasFee,
+      appIsLoading: false,
+      currentModal: CANCEL_SPEEDUP_MODAL,
+      ...overrides,
+    };
+  }
+
   beforeEach(() => {
     jest.clearAllMocks();
     mockDispatch.mockClear();
@@ -61,42 +80,25 @@ describe('useCancelSpeedupInitialGas', () => {
 
   describe('isInitialGasReady', () => {
     it('returns true when effectiveTransaction.previousGas is set', () => {
-      const effectiveTransaction = createMockTransaction({
-        previousGas: {
-          maxFeePerGas: '0x1',
-          maxPriorityFeePerGas: '0x1',
-          gasLimit: '0x5208',
-        },
+      const params = buildHookParams({
+        effectiveTransaction: createMockTransaction({
+          previousGas: {
+            maxFeePerGas: '0x1',
+            maxPriorityFeePerGas: '0x1',
+            gasLimit: '0x5208',
+          },
+        }),
+        gasFeeEstimates: {},
       });
 
-      const { result } = renderHook(() =>
-        useCancelSpeedupInitialGas({
-          effectiveTransaction,
-          gasFeeEstimates: {},
-          updateTransactionUsingEstimate: mockUpdateTransactionUsingEstimate,
-          updateTransactionToTenPercentIncreasedGasFee:
-            mockUpdateTransactionToTenPercentIncreasedGasFee,
-          appIsLoading: false,
-          currentModal: CANCEL_SPEEDUP_MODAL,
-        }),
-      );
+      const { result } = renderHook(() => useCancelSpeedupInitialGas(params));
 
       expect(result.current.isInitialGasReady).toBe(true);
     });
 
     it('returns false when effectiveTransaction.previousGas is not set', () => {
-      const effectiveTransaction = createMockTransaction();
-
       const { result } = renderHook(() =>
-        useCancelSpeedupInitialGas({
-          effectiveTransaction,
-          gasFeeEstimates: mockGasFeeEstimatesWithMedium,
-          updateTransactionUsingEstimate: mockUpdateTransactionUsingEstimate,
-          updateTransactionToTenPercentIncreasedGasFee:
-            mockUpdateTransactionToTenPercentIncreasedGasFee,
-          appIsLoading: false,
-          currentModal: CANCEL_SPEEDUP_MODAL,
-        }),
+        useCancelSpeedupInitialGas(buildHookParams()),
       );
 
       expect(result.current.isInitialGasReady).toBe(false);
@@ -104,27 +106,7 @@ describe('useCancelSpeedupInitialGas', () => {
   });
 
   describe('when initial gas rule is skipped', () => {
-    it('does not call updates when effectiveTransaction.previousGas is set', () => {
-      const effectiveTransaction = createMockTransaction({
-        previousGas: {
-          maxFeePerGas: '0x1',
-          maxPriorityFeePerGas: '0x1',
-          gasLimit: '0x5208',
-        },
-      });
-
-      renderHook(() =>
-        useCancelSpeedupInitialGas({
-          effectiveTransaction,
-          gasFeeEstimates: {},
-          updateTransactionUsingEstimate: mockUpdateTransactionUsingEstimate,
-          updateTransactionToTenPercentIncreasedGasFee:
-            mockUpdateTransactionToTenPercentIncreasedGasFee,
-          appIsLoading: false,
-          currentModal: CANCEL_SPEEDUP_MODAL,
-        }),
-      );
-
+    function expectNoUpdates() {
       expect(
         gasEstimateGreaterThanGasUsedPlusTenPercent,
       ).not.toHaveBeenCalled();
@@ -132,76 +114,63 @@ describe('useCancelSpeedupInitialGas', () => {
       expect(
         mockUpdateTransactionToTenPercentIncreasedGasFee,
       ).not.toHaveBeenCalled();
+    }
+
+    it('does not call updates when effectiveTransaction.previousGas is set', () => {
+      renderHook(() =>
+        useCancelSpeedupInitialGas(
+          buildHookParams({
+            effectiveTransaction: createMockTransaction({
+              previousGas: {
+                maxFeePerGas: '0x1',
+                maxPriorityFeePerGas: '0x1',
+                gasLimit: '0x5208',
+              },
+            }),
+            gasFeeEstimates: {},
+          }),
+        ),
+      );
+
+      expectNoUpdates();
     });
 
     it('does not call updates when appIsLoading is true', () => {
-      const effectiveTransaction = createMockTransaction();
-
       renderHook(() =>
-        useCancelSpeedupInitialGas({
-          effectiveTransaction,
-          gasFeeEstimates: mockGasFeeEstimatesWithMedium,
-          updateTransactionUsingEstimate: mockUpdateTransactionUsingEstimate,
-          updateTransactionToTenPercentIncreasedGasFee:
-            mockUpdateTransactionToTenPercentIncreasedGasFee,
-          appIsLoading: true,
-          currentModal: CANCEL_SPEEDUP_MODAL,
-        }),
+        useCancelSpeedupInitialGas(buildHookParams({ appIsLoading: true })),
       );
 
-      expect(
-        gasEstimateGreaterThanGasUsedPlusTenPercent,
-      ).not.toHaveBeenCalled();
-      expect(mockUpdateTransactionUsingEstimate).not.toHaveBeenCalled();
-      expect(
-        mockUpdateTransactionToTenPercentIncreasedGasFee,
-      ).not.toHaveBeenCalled();
+      expectNoUpdates();
+    });
+
+    it('does not call updates when isGasEstimatesLoading is true', () => {
+      renderHook(() =>
+        useCancelSpeedupInitialGas(
+          buildHookParams({ isGasEstimatesLoading: true }),
+        ),
+      );
+
+      expectNoUpdates();
     });
 
     it('does not call updates when currentModal is not cancelSpeedUpTransaction', () => {
-      const effectiveTransaction = createMockTransaction();
-
       renderHook(() =>
-        useCancelSpeedupInitialGas({
-          effectiveTransaction,
-          gasFeeEstimates: mockGasFeeEstimatesWithMedium,
-          updateTransactionUsingEstimate: mockUpdateTransactionUsingEstimate,
-          updateTransactionToTenPercentIncreasedGasFee:
-            mockUpdateTransactionToTenPercentIncreasedGasFee,
-          appIsLoading: false,
-          currentModal: 'other',
-        }),
+        useCancelSpeedupInitialGas(buildHookParams({ currentModal: 'other' })),
       );
 
-      expect(
-        gasEstimateGreaterThanGasUsedPlusTenPercent,
-      ).not.toHaveBeenCalled();
-      expect(mockUpdateTransactionUsingEstimate).not.toHaveBeenCalled();
-      expect(
-        mockUpdateTransactionToTenPercentIncreasedGasFee,
-      ).not.toHaveBeenCalled();
+      expectNoUpdates();
     });
   });
 
   describe('when initial gas rule runs', () => {
     it('calls updateTransactionUsingEstimate with medium when medium estimate is greater than gas used + 10%', () => {
-      const effectiveTransaction = createMockTransaction();
       gasEstimateGreaterThanGasUsedPlusTenPercent.mockReturnValue(true);
+      const params = buildHookParams();
 
-      renderHook(() =>
-        useCancelSpeedupInitialGas({
-          effectiveTransaction,
-          gasFeeEstimates: mockGasFeeEstimatesWithMedium,
-          updateTransactionUsingEstimate: mockUpdateTransactionUsingEstimate,
-          updateTransactionToTenPercentIncreasedGasFee:
-            mockUpdateTransactionToTenPercentIncreasedGasFee,
-          appIsLoading: false,
-          currentModal: CANCEL_SPEEDUP_MODAL,
-        }),
-      );
+      renderHook(() => useCancelSpeedupInitialGas(params));
 
       expect(gasEstimateGreaterThanGasUsedPlusTenPercent).toHaveBeenCalledWith(
-        effectiveTransaction.txParams,
+        params.effectiveTransaction.txParams,
         mockGasFeeEstimatesWithMedium,
         PriorityLevels.medium,
       );
@@ -214,23 +183,13 @@ describe('useCancelSpeedupInitialGas', () => {
     });
 
     it('calls updateTransactionToTenPercentIncreasedGasFee when medium estimate is not greater than gas used + 10%', () => {
-      const effectiveTransaction = createMockTransaction();
       gasEstimateGreaterThanGasUsedPlusTenPercent.mockReturnValue(false);
+      const params = buildHookParams();
 
-      renderHook(() =>
-        useCancelSpeedupInitialGas({
-          effectiveTransaction,
-          gasFeeEstimates: mockGasFeeEstimatesWithMedium,
-          updateTransactionUsingEstimate: mockUpdateTransactionUsingEstimate,
-          updateTransactionToTenPercentIncreasedGasFee:
-            mockUpdateTransactionToTenPercentIncreasedGasFee,
-          appIsLoading: false,
-          currentModal: CANCEL_SPEEDUP_MODAL,
-        }),
-      );
+      renderHook(() => useCancelSpeedupInitialGas(params));
 
       expect(gasEstimateGreaterThanGasUsedPlusTenPercent).toHaveBeenCalledWith(
-        effectiveTransaction.txParams,
+        params.effectiveTransaction.txParams,
         mockGasFeeEstimatesWithMedium,
         PriorityLevels.medium,
       );
@@ -241,18 +200,8 @@ describe('useCancelSpeedupInitialGas', () => {
     });
 
     it('calls updateTransactionToTenPercentIncreasedGasFee when gasFeeEstimates is null', () => {
-      const effectiveTransaction = createMockTransaction();
-
       renderHook(() =>
-        useCancelSpeedupInitialGas({
-          effectiveTransaction,
-          gasFeeEstimates: null,
-          updateTransactionUsingEstimate: mockUpdateTransactionUsingEstimate,
-          updateTransactionToTenPercentIncreasedGasFee:
-            mockUpdateTransactionToTenPercentIncreasedGasFee,
-          appIsLoading: false,
-          currentModal: CANCEL_SPEEDUP_MODAL,
-        }),
+        useCancelSpeedupInitialGas(buildHookParams({ gasFeeEstimates: null })),
       );
 
       expect(
@@ -265,22 +214,17 @@ describe('useCancelSpeedupInitialGas', () => {
     });
 
     it('does not call updates again when effect re-runs for same transaction (e.g. after gasFeeEstimates reference change)', () => {
-      const effectiveTransaction = createMockTransaction();
       gasEstimateGreaterThanGasUsedPlusTenPercent.mockReturnValue(true);
+      const baseParams = buildHookParams();
 
       const { rerender } = renderHook(
         ({ gasFeeEstimates }) =>
-          useCancelSpeedupInitialGas({
-            effectiveTransaction,
-            gasFeeEstimates,
-            updateTransactionUsingEstimate: mockUpdateTransactionUsingEstimate,
-            updateTransactionToTenPercentIncreasedGasFee:
-              mockUpdateTransactionToTenPercentIncreasedGasFee,
-            appIsLoading: false,
-            currentModal: CANCEL_SPEEDUP_MODAL,
-          }),
+          useCancelSpeedupInitialGas({ ...baseParams, gasFeeEstimates }),
         {
-          initialProps: { gasFeeEstimates: mockGasFeeEstimatesWithMedium },
+          initialProps: {
+            gasFeeEstimates:
+              mockGasFeeEstimatesWithMedium as UseCancelSpeedupInitialGasParams['gasFeeEstimates'],
+          },
         },
       );
 
@@ -298,25 +242,15 @@ describe('useCancelSpeedupInitialGas', () => {
     });
 
     it('dispatches updatePreviousGasParams once when modal opens and previousGas is not set', () => {
-      const effectiveTransaction = createMockTransaction();
       gasEstimateGreaterThanGasUsedPlusTenPercent.mockReturnValue(true);
+      const params = buildHookParams();
 
-      renderHook(() =>
-        useCancelSpeedupInitialGas({
-          effectiveTransaction,
-          gasFeeEstimates: mockGasFeeEstimatesWithMedium,
-          updateTransactionUsingEstimate: mockUpdateTransactionUsingEstimate,
-          updateTransactionToTenPercentIncreasedGasFee:
-            mockUpdateTransactionToTenPercentIncreasedGasFee,
-          appIsLoading: false,
-          currentModal: CANCEL_SPEEDUP_MODAL,
-        }),
-      );
+      renderHook(() => useCancelSpeedupInitialGas(params));
 
       expect(mockDispatch).toHaveBeenCalled();
       expect(mockUpdatePreviousGasParams).toHaveBeenCalledTimes(1);
       expect(mockUpdatePreviousGasParams).toHaveBeenCalledWith(
-        effectiveTransaction.id,
+        params.effectiveTransaction.id,
         {
           maxFeePerGas: '0x1',
           maxPriorityFeePerGas: '0x1',
@@ -340,18 +274,12 @@ describe('useCancelSpeedupInitialGas', () => {
     }
 
     it('dispatches updatePreviousGasParams with gasPrice and gasLimit for legacy tx', () => {
-      const effectiveTransaction = createLegacyTransaction();
-
       renderHook(() =>
-        useCancelSpeedupInitialGas({
-          effectiveTransaction,
-          gasFeeEstimates: mockGasFeeEstimatesWithMedium,
-          updateTransactionUsingEstimate: mockUpdateTransactionUsingEstimate,
-          updateTransactionToTenPercentIncreasedGasFee:
-            mockUpdateTransactionToTenPercentIncreasedGasFee,
-          appIsLoading: false,
-          currentModal: CANCEL_SPEEDUP_MODAL,
-        }),
+        useCancelSpeedupInitialGas(
+          buildHookParams({
+            effectiveTransaction: createLegacyTransaction(),
+          }),
+        ),
       );
 
       expect(mockDispatch).toHaveBeenCalled();
@@ -363,21 +291,18 @@ describe('useCancelSpeedupInitialGas', () => {
     });
 
     it('does not store previousGas again on re-render for the same legacy transaction', () => {
-      const effectiveTransaction = createLegacyTransaction();
+      const baseParams = buildHookParams({
+        effectiveTransaction: createLegacyTransaction(),
+      });
 
       const { rerender } = renderHook(
         ({ gasFeeEstimates }) =>
-          useCancelSpeedupInitialGas({
-            effectiveTransaction,
-            gasFeeEstimates,
-            updateTransactionUsingEstimate: mockUpdateTransactionUsingEstimate,
-            updateTransactionToTenPercentIncreasedGasFee:
-              mockUpdateTransactionToTenPercentIncreasedGasFee,
-            appIsLoading: false,
-            currentModal: CANCEL_SPEEDUP_MODAL,
-          }),
+          useCancelSpeedupInitialGas({ ...baseParams, gasFeeEstimates }),
         {
-          initialProps: { gasFeeEstimates: mockGasFeeEstimatesWithMedium },
+          initialProps: {
+            gasFeeEstimates:
+              mockGasFeeEstimatesWithMedium as UseCancelSpeedupInitialGasParams['gasFeeEstimates'],
+          },
         },
       );
 
@@ -389,20 +314,14 @@ describe('useCancelSpeedupInitialGas', () => {
     });
 
     it('does not dispatch previousGas when legacy tx has no gasPrice', () => {
-      const effectiveTransaction = createLegacyTransaction({
-        txParams: { gas: '0x5208' } as TransactionMeta['txParams'],
-      });
-
       renderHook(() =>
-        useCancelSpeedupInitialGas({
-          effectiveTransaction,
-          gasFeeEstimates: mockGasFeeEstimatesWithMedium,
-          updateTransactionUsingEstimate: mockUpdateTransactionUsingEstimate,
-          updateTransactionToTenPercentIncreasedGasFee:
-            mockUpdateTransactionToTenPercentIncreasedGasFee,
-          appIsLoading: false,
-          currentModal: CANCEL_SPEEDUP_MODAL,
-        }),
+        useCancelSpeedupInitialGas(
+          buildHookParams({
+            effectiveTransaction: createLegacyTransaction({
+              txParams: { gas: '0x5208' } as TransactionMeta['txParams'],
+            }),
+          }),
+        ),
       );
 
       expect(mockUpdatePreviousGasParams).not.toHaveBeenCalled();

--- a/ui/pages/confirmations/hooks/useCancelSpeedupInitialGas.ts
+++ b/ui/pages/confirmations/hooks/useCancelSpeedupInitialGas.ts
@@ -18,6 +18,7 @@ export type UseCancelSpeedupInitialGasParams = {
     | LegacyGasPriceEstimate
     | Record<string, never>
     | null;
+  isGasEstimatesLoading: boolean;
   updateTransactionUsingEstimate: (level: string) => void;
   updateTransactionToTenPercentIncreasedGasFee: (
     initTransaction?: boolean,
@@ -36,6 +37,7 @@ const CANCEL_SPEEDUP_MODAL = 'cancelSpeedUpTransaction';
  * @param options0
  * @param options0.effectiveTransaction
  * @param options0.gasFeeEstimates
+ * @param options0.isGasEstimatesLoading
  * @param options0.updateTransactionUsingEstimate
  * @param options0.updateTransactionToTenPercentIncreasedGasFee
  * @param options0.appIsLoading
@@ -44,6 +46,7 @@ const CANCEL_SPEEDUP_MODAL = 'cancelSpeedUpTransaction';
 export function useCancelSpeedupInitialGas({
   effectiveTransaction,
   gasFeeEstimates,
+  isGasEstimatesLoading,
   updateTransactionUsingEstimate,
   updateTransactionToTenPercentIncreasedGasFee,
   appIsLoading,
@@ -59,7 +62,11 @@ export function useCancelSpeedupInitialGas({
       return;
     }
 
-    if (effectiveTransaction.previousGas || appIsLoading) {
+    if (
+      effectiveTransaction.previousGas ||
+      appIsLoading ||
+      isGasEstimatesLoading
+    ) {
       return;
     }
 
@@ -123,6 +130,7 @@ export function useCancelSpeedupInitialGas({
     effectiveTransaction.previousGas,
     effectiveTransaction.txParams,
     appIsLoading,
+    isGasEstimatesLoading,
     currentModal,
     gasFeeEstimates,
     updateTransactionUsingEstimate,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Cancel and speed-up use network gas estimates to choose between the medium fee level and a +10% bump. That path must only consume estimates in the shape returned by the gas fee layer (decimal GWEI fields such as `suggestedMaxFeePerGas`). A separate shape on transaction metadata (hex WEI `maxFeePerGas` per level) is not interchangeable.

**Problem**

- Initial gas logic could run while estimates were still loading or with the wrong object shape, so comparisons in `gasEstimateGreaterThanGasUsedPlusTenPercent` could be wrong or misleading.
- `networkClientId` was derived from network configuration even though it is already present on transaction metadata.
- Legacy vs EIP-1559 branching relied on a narrow check instead of the same rules used elsewhere (`useSupportsEIP1559`).

**Solution**

- Source `networkClientId` from the effective transaction (store or prop) and pass it into `useGasFeeEstimates`.
- Expose `isGasEstimatesLoading` from cancel/speed-up gas state and skip initial gas application until loading finishes (alongside existing app loading guard).
- Route legacy vs EIP-1559 cancel/speed-up using `useSupportsEIP1559`.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed reliability of gas handling when canceling or speeding up a pending transaction

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1007

## **Manual testing steps**

1. Submit an EIP-1559 send with custom advanced gas, then open **Speed up** or **Cancel**.
2. Confirm the modal finishes loading, fees look sane, and confirm succeeds without the transaction staying stuck due to bad initial fee math.
3. Repeat on a legacy `gasPrice` transaction.

## **Screenshots/Recordings**

[fix_ethe_mainnet_cancel.webm](https://github.com/user-attachments/assets/4be03b93-f584-4d4b-93dd-93c47357fd0b)

[fix_base_cancel.webm](https://github.com/user-attachments/assets/090135c9-fa3b-4062-870f-3cc145db3244)


<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cancel/speed-up fee selection and legacy/EIP-1559 branching, which can affect replacement transaction fees and user ability to unstick transactions. Changes are localized and covered by updated tests, but regressions could impact transaction confirmation behavior.
> 
> **Overview**
> **Cancel/Speed-up now waits for valid network gas estimates before applying the initial fee rule.** The cancel/speed-up modal wires through `isGasEstimatesLoading` from `useGasFeeEstimates` and `useCancelSpeedupGasState`, and `useCancelSpeedupInitialGas` skips applying medium-vs-+10% logic while estimates are still loading.
> 
> **Gas estimate sourcing and flow selection were tightened.** `useCancelSpeedupGasState` now takes `networkClientId` directly from the effective transaction when calling `useGasFeeEstimates` (removing network config derivation/fallback), and legacy vs EIP-1559 routing is based on `useSupportsEIP1559` rather than checking for `maxFeePerGas`. Tests were updated/added to cover the new loading guard and EIP-1559 support branching.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d509095c88fa8f72d45d4e8837b9236fc90d1de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->