### PR TITLE
fix: flaky test multi-SRP Reveal Imported SRP

### DIFF
--- a/test/e2e/flask/multi-srp/common-multi-srp.ts
+++ b/test/e2e/flask/multi-srp/common-multi-srp.ts
@@ -51,6 +51,8 @@ export async function withMultiSrp(
       await accountListPage.checkPageIsLoaded();
       await accountListPage.startImportSecretPhrase(srpToUse);
       await homePage.checkNewSrpAddedToastIsDisplayed();
+      await homePage.dismissSrpAddedToast();
+      await homePage.checkPageIsLoaded();
       await test(driver);
     },
   );

--- a/test/e2e/page-objects/pages/home/homepage.ts
+++ b/test/e2e/page-objects/pages/home/homepage.ts
@@ -103,6 +103,9 @@ class HomePage {
 
   private readonly srpAddedToast = '.toasts-container__banner-base';
 
+  private readonly srpAddedToastCloseButton =
+    '.toasts-container__banner-base button[aria-label="Close"]';
+
   private readonly surveyToast = '[data-testid="survey-toast"]';
 
   private readonly tokensTab = {
@@ -558,6 +561,11 @@ class HomePage {
     // await this.driver.waitForSelector({
     //   text: `Wallet ${srpNumber} imported`,
     // });
+  }
+
+  async dismissSrpAddedToast(): Promise<void> {
+    console.log('Dismiss SRP added toast');
+    await this.driver.clickElementSafe(this.srpAddedToastCloseButton, 3000);
   }
 
   async checkNoSurveyToastIsDisplayed(): Promise<void> {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The multi-SRP E2E tests (`settings-reveal-srp.spec.ts`) are flaky on Firefox CI with the error `Element did not stop moving within the timeout period` at `HeaderNavbar.openGlobalMenu`.

See error logs:
https://github.com/MetaMask/metamask-extension/actions/runs/23870699799/job/69603211477 

https://github.com/MetaMask/metamask-extension/actions/runs/23849417001/job/69526806929 

After importing a new SRP, the toast's auto-dismiss animation and background network activity from the new wallet cause continuous layout shifts. This prevents `waitForElementToStopMoving` from detecting the drawer-close-button as stationary within the 5-second timeout on Firefox CI.

Fix: Dismiss the SRP-added toast and re-verify homepage stability in `withMultiSrp` before proceeding, following the established `clickElementSafe` pattern for toast dismissal.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts E2E test flow by explicitly closing a toast and re-checking page readiness, without touching production logic.
> 
> **Overview**
> Stabilizes the multi-SRP E2E flow by explicitly dismissing the “SRP imported” toast after importing a new Secret Recovery Phrase, then re-validating the home page is loaded before continuing.
> 
> Adds a `HomePage.dismissSrpAddedToast()` helper that clicks the toast close button via `clickElementSafe`, reducing layout-shift related flakiness (notably in Firefox CI).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b82b22320cc5d572fc48c68afaf252b4847144d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->