### PR TITLE
fix: external account bridges cause app to crash

### DIFF
--- a/test/data/bridge/mock-bridge-store.ts
+++ b/test/data/bridge/mock-bridge-store.ts
@@ -169,6 +169,9 @@ export const MOCK_BITCOIN_ACCOUNT = {
   },
 };
 
+export const MOCK_EXTERNAL_SOLANA_ADDRESS =
+  '8sKQHfjNhvmAw94PhfvfMcytmqW6jmxvwieYyzXCCPu';
+
 export const createBridgeMockStore = ({
   featureFlagOverrides = { bridgeConfig: {} },
   bridgeSliceOverrides = {},

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -562,6 +562,14 @@
     "ui/hooks/accounts/useAccountsOperationsLoadingStates.test.ts": {
       "MetaMask: Background connection not initialized": 2
     },
+    "ui/hooks/bridge/usePopularTokens.test.ts": {
+      "React: Act warnings (component updates not wrapped)": 16,
+      "Reselect: Input stability warnings": 1
+    },
+    "ui/hooks/bridge/useTokenSearchResults.test.ts": {
+      "React: Act warnings (component updates not wrapped)": 2,
+      "Reselect: Input stability warnings": 1
+    },
     "ui/hooks/gator-permissions/useGatorPermissionTokenInfo.test.tsx": {
       "React: Act warnings (component updates not wrapped)": 10,
       "Reselect: Identity function warnings": 1

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -562,12 +562,6 @@
     "ui/hooks/accounts/useAccountsOperationsLoadingStates.test.ts": {
       "MetaMask: Background connection not initialized": 2
     },
-    "ui/hooks/bridge/usePopularTokens.test.ts": {
-      "React: Act warnings (component updates not wrapped)": 8
-    },
-    "ui/hooks/bridge/useTokenSearchResults.test.ts": {
-      "React: Act warnings (component updates not wrapped)": 1
-    },
     "ui/hooks/gator-permissions/useGatorPermissionTokenInfo.test.tsx": {
       "React: Act warnings (component updates not wrapped)": 10,
       "Reselect: Identity function warnings": 1

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -562,6 +562,12 @@
     "ui/hooks/accounts/useAccountsOperationsLoadingStates.test.ts": {
       "MetaMask: Background connection not initialized": 2
     },
+    "ui/hooks/bridge/usePopularTokens.test.ts": {
+      "React: Act warnings (component updates not wrapped)": 8
+    },
+    "ui/hooks/bridge/useTokenSearchResults.test.ts": {
+      "React: Act warnings (component updates not wrapped)": 1
+    },
     "ui/hooks/gator-permissions/useGatorPermissionTokenInfo.test.tsx": {
       "React: Act warnings (component updates not wrapped)": 10,
       "Reselect: Identity function warnings": 1

--- a/ui/ducks/bridge/asset-selectors.test.ts
+++ b/ui/ducks/bridge/asset-selectors.test.ts
@@ -7,10 +7,13 @@ import {
 import { CHAIN_IDS } from '../../../shared/constants/network';
 import { MultichainNetworks } from '../../../shared/constants/multichain/networks';
 import { getAccountGroupsByAddress } from '../../selectors/multichain-accounts/account-tree';
+import { EMPTY_ARRAY, EMPTY_OBJECT } from '../../selectors/shared';
 import {
   getBridgeBalancesByChainId,
   getBridgeAssetsByAssetId,
   getBridgeSortedAssets,
+  getOwnedAssetsByAssetId,
+  getOwnedAssetsWithBalanceByAssetId,
 } from './asset-selectors';
 
 describe('Bridge asset selectors', () => {
@@ -312,6 +315,128 @@ describe('Bridge asset selectors', () => {
       expect(assetsWithBalance).toEqual([]);
       expect(balanceByAssetId).toEqual({});
       expect(balanceByChainId).toEqual({});
+    });
+  });
+
+  describe('getOwnedAssetsByAssetId', () => {
+    it('returns assets keyed by lowercased asset ID for a known account address', () => {
+      const state = createBridgeMockStore({
+        featureFlagOverrides: {
+          bridgeConfig: {
+            refreshRate: 30000,
+            priceImpactThreshold: { normal: 1, gasless: 2 },
+            maxRefreshCount: 5,
+            support: true,
+            chains: {
+              [CHAIN_IDS.MAINNET]: { isActiveSrc: true, isActiveDest: true },
+              [CHAIN_IDS.OPTIMISM]: { isActiveSrc: true, isActiveDest: true },
+            },
+            chainRanking: [
+              { chainId: formatChainIdToCaip(CHAIN_IDS.MAINNET) },
+              { chainId: formatChainIdToCaip(CHAIN_IDS.OPTIMISM) },
+            ],
+          },
+        },
+      });
+
+      const [accountGroup] = getAccountGroupsByAddress(state, [
+        MOCK_EVM_ACCOUNT.address,
+      ]);
+
+      const result = getOwnedAssetsByAssetId(state, MOCK_EVM_ACCOUNT.address);
+
+      expect(result).toEqual(getBridgeAssetsByAssetId(state, accountGroup.id));
+      expect(Object.keys(result)).toEqual(
+        expect.arrayContaining([expect.stringMatching(/^eip155:/u)]),
+      );
+    });
+
+    it('returns EMPTY_OBJECT when address does not belong to any account group', () => {
+      const state = createBridgeMockStore({
+        featureFlagOverrides: {
+          bridgeConfig: {
+            refreshRate: 30000,
+            priceImpactThreshold: { normal: 1, gasless: 2 },
+            maxRefreshCount: 5,
+            support: true,
+            chains: {
+              [CHAIN_IDS.MAINNET]: { isActiveSrc: true, isActiveDest: true },
+            },
+            chainRanking: [{ chainId: formatChainIdToCaip(CHAIN_IDS.MAINNET) }],
+          },
+        },
+      });
+
+      const result = getOwnedAssetsByAssetId(
+        state,
+        MOCK_EXTERNAL_SOLANA_ADDRESS,
+      );
+
+      expect(result).toBe(EMPTY_OBJECT);
+    });
+  });
+
+  describe('getOwnedAssetsWithBalanceByAssetId', () => {
+    it('returns sorted assets for a known account address', () => {
+      const state = createBridgeMockStore({
+        featureFlagOverrides: {
+          bridgeConfig: {
+            refreshRate: 30000,
+            priceImpactThreshold: { normal: 1, gasless: 2 },
+            maxRefreshCount: 5,
+            support: true,
+            chains: {
+              [CHAIN_IDS.MAINNET]: { isActiveSrc: true, isActiveDest: true },
+              [CHAIN_IDS.OPTIMISM]: { isActiveSrc: true, isActiveDest: true },
+            },
+            chainRanking: [
+              { chainId: formatChainIdToCaip(CHAIN_IDS.MAINNET) },
+              { chainId: formatChainIdToCaip(CHAIN_IDS.OPTIMISM) },
+            ],
+          },
+        },
+      });
+
+      const [accountGroup] = getAccountGroupsByAddress(state, [
+        MOCK_EVM_ACCOUNT.address,
+      ]);
+
+      const result = getOwnedAssetsWithBalanceByAssetId(
+        state,
+        MOCK_EVM_ACCOUNT.address,
+      );
+
+      expect(result).toEqual(getBridgeSortedAssets(state, accountGroup.id));
+      expect(result.length).toBeGreaterThan(0);
+      for (let i = 1; i < result.length; i++) {
+        expect(result[i - 1].tokenFiatAmount ?? 0).toBeGreaterThanOrEqual(
+          result[i].tokenFiatAmount ?? 0,
+        );
+      }
+    });
+
+    it('returns EMPTY_ARRAY when address does not belong to any account group', () => {
+      const state = createBridgeMockStore({
+        featureFlagOverrides: {
+          bridgeConfig: {
+            refreshRate: 30000,
+            priceImpactThreshold: { normal: 1, gasless: 2 },
+            maxRefreshCount: 5,
+            support: true,
+            chains: {
+              [CHAIN_IDS.MAINNET]: { isActiveSrc: true, isActiveDest: true },
+            },
+            chainRanking: [{ chainId: formatChainIdToCaip(CHAIN_IDS.MAINNET) }],
+          },
+        },
+      });
+
+      const result = getOwnedAssetsWithBalanceByAssetId(
+        state,
+        MOCK_EXTERNAL_SOLANA_ADDRESS,
+      );
+
+      expect(result).toBe(EMPTY_ARRAY);
     });
   });
 });

--- a/ui/ducks/bridge/asset-selectors.test.ts
+++ b/ui/ducks/bridge/asset-selectors.test.ts
@@ -2,18 +2,14 @@ import { formatChainIdToCaip } from '@metamask/bridge-controller';
 import {
   createBridgeMockStore,
   MOCK_EVM_ACCOUNT,
-  MOCK_EXTERNAL_SOLANA_ADDRESS,
 } from '../../../test/data/bridge/mock-bridge-store';
 import { CHAIN_IDS } from '../../../shared/constants/network';
 import { MultichainNetworks } from '../../../shared/constants/multichain/networks';
 import { getAccountGroupsByAddress } from '../../selectors/multichain-accounts/account-tree';
-import { EMPTY_ARRAY, EMPTY_OBJECT } from '../../selectors/shared';
 import {
   getBridgeBalancesByChainId,
   getBridgeAssetsByAssetId,
   getBridgeSortedAssets,
-  getOwnedAssetsByAssetId,
-  getOwnedAssetsWithBalanceByAssetId,
 } from './asset-selectors';
 
 describe('Bridge asset selectors', () => {
@@ -272,7 +268,7 @@ describe('Bridge asset selectors', () => {
       `);
     });
 
-    it('returns empty results when address does not belong to any account group', () => {
+    it('returns empty results when accountGroupId is undefined', () => {
       const state = createBridgeMockStore({
         featureFlagOverrides: {
           bridgeConfig: {
@@ -294,149 +290,15 @@ describe('Bridge asset selectors', () => {
         },
       });
 
-      const externalAddress = MOCK_EXTERNAL_SOLANA_ADDRESS;
-      const accountGroups = getAccountGroupsByAddress(state, [externalAddress]);
-
-      expect(accountGroups).toHaveLength(0);
-
-      const [accountGroup] = accountGroups;
+      // Simulate the caller pattern: accountGroup is undefined when address has no matching group
+      const [accountGroup] = getAccountGroupsByAddress(state, [
+        'non-existent-address',
+      ]);
       expect(accountGroup).toBeUndefined();
 
-      const assetsWithBalance = accountGroup
-        ? getBridgeSortedAssets(state, accountGroup.id)
-        : [];
-      const balanceByAssetId = accountGroup
-        ? getBridgeAssetsByAssetId(state, accountGroup.id)
-        : {};
-      const balanceByChainId = accountGroup
-        ? getBridgeBalancesByChainId(state, accountGroup.id)
-        : {};
-
-      expect(assetsWithBalance).toEqual([]);
-      expect(balanceByAssetId).toEqual({});
-      expect(balanceByChainId).toEqual({});
-    });
-  });
-
-  describe('getOwnedAssetsByAssetId', () => {
-    it('returns assets keyed by lowercased asset ID for a known account address', () => {
-      const state = createBridgeMockStore({
-        featureFlagOverrides: {
-          bridgeConfig: {
-            refreshRate: 30000,
-            priceImpactThreshold: { normal: 1, gasless: 2 },
-            maxRefreshCount: 5,
-            support: true,
-            chains: {
-              [CHAIN_IDS.MAINNET]: { isActiveSrc: true, isActiveDest: true },
-              [CHAIN_IDS.OPTIMISM]: { isActiveSrc: true, isActiveDest: true },
-            },
-            chainRanking: [
-              { chainId: formatChainIdToCaip(CHAIN_IDS.MAINNET) },
-              { chainId: formatChainIdToCaip(CHAIN_IDS.OPTIMISM) },
-            ],
-          },
-        },
-      });
-
-      const [accountGroup] = getAccountGroupsByAddress(state, [
-        MOCK_EVM_ACCOUNT.address,
-      ]);
-
-      const result = getOwnedAssetsByAssetId(state, MOCK_EVM_ACCOUNT.address);
-
-      expect(result).toEqual(getBridgeAssetsByAssetId(state, accountGroup.id));
-      expect(Object.keys(result)).toEqual(
-        expect.arrayContaining([expect.stringMatching(/^eip155:/u)]),
-      );
-    });
-
-    it('returns EMPTY_OBJECT when address does not belong to any account group', () => {
-      const state = createBridgeMockStore({
-        featureFlagOverrides: {
-          bridgeConfig: {
-            refreshRate: 30000,
-            priceImpactThreshold: { normal: 1, gasless: 2 },
-            maxRefreshCount: 5,
-            support: true,
-            chains: {
-              [CHAIN_IDS.MAINNET]: { isActiveSrc: true, isActiveDest: true },
-            },
-            chainRanking: [{ chainId: formatChainIdToCaip(CHAIN_IDS.MAINNET) }],
-          },
-        },
-      });
-
-      const result = getOwnedAssetsByAssetId(
-        state,
-        MOCK_EXTERNAL_SOLANA_ADDRESS,
-      );
-
-      expect(result).toBe(EMPTY_OBJECT);
-    });
-  });
-
-  describe('getOwnedAssetsWithBalanceByAssetId', () => {
-    it('returns sorted assets for a known account address', () => {
-      const state = createBridgeMockStore({
-        featureFlagOverrides: {
-          bridgeConfig: {
-            refreshRate: 30000,
-            priceImpactThreshold: { normal: 1, gasless: 2 },
-            maxRefreshCount: 5,
-            support: true,
-            chains: {
-              [CHAIN_IDS.MAINNET]: { isActiveSrc: true, isActiveDest: true },
-              [CHAIN_IDS.OPTIMISM]: { isActiveSrc: true, isActiveDest: true },
-            },
-            chainRanking: [
-              { chainId: formatChainIdToCaip(CHAIN_IDS.MAINNET) },
-              { chainId: formatChainIdToCaip(CHAIN_IDS.OPTIMISM) },
-            ],
-          },
-        },
-      });
-
-      const [accountGroup] = getAccountGroupsByAddress(state, [
-        MOCK_EVM_ACCOUNT.address,
-      ]);
-
-      const result = getOwnedAssetsWithBalanceByAssetId(
-        state,
-        MOCK_EVM_ACCOUNT.address,
-      );
-
-      expect(result).toEqual(getBridgeSortedAssets(state, accountGroup.id));
-      expect(result.length).toBeGreaterThan(0);
-      for (let i = 1; i < result.length; i++) {
-        expect(result[i - 1].tokenFiatAmount ?? 0).toBeGreaterThanOrEqual(
-          result[i].tokenFiatAmount ?? 0,
-        );
-      }
-    });
-
-    it('returns EMPTY_ARRAY when address does not belong to any account group', () => {
-      const state = createBridgeMockStore({
-        featureFlagOverrides: {
-          bridgeConfig: {
-            refreshRate: 30000,
-            priceImpactThreshold: { normal: 1, gasless: 2 },
-            maxRefreshCount: 5,
-            support: true,
-            chains: {
-              [CHAIN_IDS.MAINNET]: { isActiveSrc: true, isActiveDest: true },
-            },
-            chainRanking: [{ chainId: formatChainIdToCaip(CHAIN_IDS.MAINNET) }],
-          },
-        },
-      });
-
-      const result = getOwnedAssetsWithBalanceByAssetId(
-        state,
-        MOCK_EXTERNAL_SOLANA_ADDRESS,
-      );
-
-      expect(result).toBe(EMPTY_ARRAY);
+      expect(getBridgeSortedAssets(state, accountGroup?.id)).toEqual([]);
+      expect(getBridgeAssetsByAssetId(state, accountGroup?.id)).toEqual({});
+      expect(getBridgeBalancesByChainId(state, accountGroup?.id)).toEqual({});
     });
   });
 });

--- a/ui/ducks/bridge/asset-selectors.test.ts
+++ b/ui/ducks/bridge/asset-selectors.test.ts
@@ -2,6 +2,7 @@ import { formatChainIdToCaip } from '@metamask/bridge-controller';
 import {
   createBridgeMockStore,
   MOCK_EVM_ACCOUNT,
+  MOCK_EXTERNAL_SOLANA_ADDRESS,
 } from '../../../test/data/bridge/mock-bridge-store';
 import { CHAIN_IDS } from '../../../shared/constants/network';
 import { MultichainNetworks } from '../../../shared/constants/multichain/networks';
@@ -266,6 +267,51 @@ describe('Bridge asset selectors', () => {
           "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp": 212.89214978478,
         }
       `);
+    });
+
+    it('returns empty results when address does not belong to any account group', () => {
+      const state = createBridgeMockStore({
+        featureFlagOverrides: {
+          bridgeConfig: {
+            refreshRate: 30000,
+            priceImpactThreshold: {
+              normal: 1,
+              gasless: 2,
+            },
+            maxRefreshCount: 5,
+            support: true,
+            chains: {
+              [CHAIN_IDS.MAINNET]: {
+                isActiveSrc: true,
+                isActiveDest: true,
+              },
+            },
+            chainRanking: [{ chainId: formatChainIdToCaip(CHAIN_IDS.MAINNET) }],
+          },
+        },
+      });
+
+      const externalAddress = MOCK_EXTERNAL_SOLANA_ADDRESS;
+      const accountGroups = getAccountGroupsByAddress(state, [externalAddress]);
+
+      expect(accountGroups).toHaveLength(0);
+
+      const [accountGroup] = accountGroups;
+      expect(accountGroup).toBeUndefined();
+
+      const assetsWithBalance = accountGroup
+        ? getBridgeSortedAssets(state, accountGroup.id)
+        : [];
+      const balanceByAssetId = accountGroup
+        ? getBridgeAssetsByAssetId(state, accountGroup.id)
+        : {};
+      const balanceByChainId = accountGroup
+        ? getBridgeBalancesByChainId(state, accountGroup.id)
+        : {};
+
+      expect(assetsWithBalance).toEqual([]);
+      expect(balanceByAssetId).toEqual({});
+      expect(balanceByChainId).toEqual({});
     });
   });
 });

--- a/ui/ducks/bridge/asset-selectors.ts
+++ b/ui/ducks/bridge/asset-selectors.ts
@@ -411,4 +411,3 @@ export const getBridgeBalancesByChainId = createSelector(
       return acc;
     }, {}),
 );
-

--- a/ui/ducks/bridge/asset-selectors.ts
+++ b/ui/ducks/bridge/asset-selectors.ts
@@ -30,11 +30,8 @@ import {
   getAssetsMetadata,
   getAssetsRates,
 } from '../../selectors/assets';
-import {
-  getAccountGroupsByAddress,
-  getInternalAccountByGroupAndCaip,
-} from '../../selectors/multichain-accounts/account-tree';
-import { EMPTY_ARRAY, EMPTY_OBJECT } from '../../selectors/shared';
+import { getInternalAccountByGroupAndCaip } from '../../selectors/multichain-accounts/account-tree';
+import { EMPTY_ARRAY } from '../../selectors/shared';
 import { type BridgeAppState, getFromChains } from './selectors';
 import { type BridgeToken } from './types';
 import { getMaybeHexChainId } from './utils';
@@ -321,17 +318,23 @@ const getNonEvmAssetsWithBalance = createSelector(
 // Combines EVM and non-EVM assets and appends tokenFiatAmount to each asset
 const getBridgeAssetsForAccountGroupId = createSelector(
   [
+    (_: BridgeAppState, id: AccountGroupId | undefined) => id,
     getEvmAssetsWithBalance,
     getEvmExchangeRates,
     getNonEvmAssetsWithBalance,
     getAssetsRates,
   ],
   (
+    id,
     evmAssetsWithBalance,
     evmExchangeRatesByAssetId,
     nonEvmAssetsWithBalance,
     nonEvmExchangeRatesByAssetId,
   ): BridgeToken[] => {
+    if (!id) {
+      return EMPTY_ARRAY as unknown as BridgeToken[];
+    }
+
     const evmAssetsWithFiatBalances = evmAssetsWithBalance.map((asset) => ({
       ...asset,
       tokenFiatAmount: new BigNumber(asset.balance ?? '0')
@@ -409,22 +412,3 @@ export const getBridgeBalancesByChainId = createSelector(
     }, {}),
 );
 
-export const getOwnedAssetsByAssetId = (
-  state: BridgeAppState,
-  accountAddress: string,
-) => {
-  const [accountGroup] = getAccountGroupsByAddress(state, [accountAddress]);
-  return accountGroup
-    ? getBridgeAssetsByAssetId(state, accountGroup.id)
-    : EMPTY_OBJECT;
-};
-
-export const getOwnedAssetsWithBalanceByAssetId = (
-  state: BridgeAppState,
-  accountAddress: string,
-) => {
-  const [accountGroup] = getAccountGroupsByAddress(state, [accountAddress]);
-  return accountGroup
-    ? getBridgeSortedAssets(state, accountGroup.id)
-    : EMPTY_ARRAY;
-};

--- a/ui/ducks/bridge/asset-selectors.ts
+++ b/ui/ducks/bridge/asset-selectors.ts
@@ -30,7 +30,11 @@ import {
   getAssetsMetadata,
   getAssetsRates,
 } from '../../selectors/assets';
-import { getInternalAccountByGroupAndCaip } from '../../selectors/multichain-accounts/account-tree';
+import {
+  getAccountGroupsByAddress,
+  getInternalAccountByGroupAndCaip,
+} from '../../selectors/multichain-accounts/account-tree';
+import { EMPTY_ARRAY, EMPTY_OBJECT } from '../../selectors/shared';
 import { type BridgeAppState, getFromChains } from './selectors';
 import { type BridgeToken } from './types';
 import { getMaybeHexChainId } from './utils';
@@ -404,3 +408,23 @@ export const getBridgeBalancesByChainId = createSelector(
       return acc;
     }, {}),
 );
+
+export const getOwnedAssetsByAssetId = (
+  state: BridgeAppState,
+  accountAddress: string,
+) => {
+  const [accountGroup] = getAccountGroupsByAddress(state, [accountAddress]);
+  return accountGroup
+    ? getBridgeAssetsByAssetId(state, accountGroup.id)
+    : EMPTY_OBJECT;
+};
+
+export const getOwnedAssetsWithBalanceByAssetId = (
+  state: BridgeAppState,
+  accountAddress: string,
+) => {
+  const [accountGroup] = getAccountGroupsByAddress(state, [accountAddress]);
+  return accountGroup
+    ? getBridgeSortedAssets(state, accountGroup.id)
+    : EMPTY_ARRAY;
+};

--- a/ui/hooks/bridge/usePopularTokens.test.ts
+++ b/ui/hooks/bridge/usePopularTokens.test.ts
@@ -1,0 +1,50 @@
+import { formatChainIdToCaip } from '@metamask/bridge-controller';
+import { renderHookWithProvider } from '../../../test/lib/render-helpers-navigate';
+import { CHAIN_IDS } from '../../../shared/constants/network';
+import {
+  createBridgeMockStore,
+  MOCK_EXTERNAL_SOLANA_ADDRESS,
+} from '../../../test/data/bridge/mock-bridge-store';
+import { usePopularTokens } from './usePopularTokens';
+
+jest.mock('../../pages/bridge/utils/tokens', () => ({
+  fetchPopularTokens: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('../../store/actions', () => ({
+  getBearerToken: jest.fn().mockResolvedValue('mock-jwt'),
+}));
+
+describe('usePopularTokens', () => {
+  it('does not crash when accountAddress is an external address with no matching account group', () => {
+    const mockStoreState = createBridgeMockStore({
+      featureFlagOverrides: {
+        bridgeConfig: {
+          refreshRate: 30000,
+          maxRefreshCount: 5,
+          support: true,
+          chains: {
+            [CHAIN_IDS.MAINNET]: {
+              isActiveSrc: true,
+              isActiveDest: true,
+            },
+          },
+          chainRanking: [{ chainId: formatChainIdToCaip(CHAIN_IDS.MAINNET) }],
+        },
+      },
+    });
+
+    const { result } = renderHookWithProvider(
+      () =>
+        usePopularTokens({
+          assetsToInclude: [],
+          accountAddress: MOCK_EXTERNAL_SOLANA_ADDRESS,
+          chainIds: new Set([formatChainIdToCaip(CHAIN_IDS.MAINNET)]),
+        }),
+      mockStoreState,
+    );
+
+    expect(result.current.popularTokensList).toEqual([]);
+    expect(result.current.isLoading).toBe(true);
+  });
+});

--- a/ui/hooks/bridge/usePopularTokens.test.ts
+++ b/ui/hooks/bridge/usePopularTokens.test.ts
@@ -3,6 +3,7 @@ import { renderHookWithProvider } from '../../../test/lib/render-helpers-navigat
 import { CHAIN_IDS } from '../../../shared/constants/network';
 import {
   createBridgeMockStore,
+  MOCK_EVM_ACCOUNT,
   MOCK_EXTERNAL_SOLANA_ADDRESS,
 } from '../../../test/data/bridge/mock-bridge-store';
 import { usePopularTokens } from './usePopularTokens';
@@ -44,6 +45,41 @@ describe('usePopularTokens', () => {
       mockStoreState,
     );
 
+    expect(result.current.popularTokensList).toEqual([]);
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('returns owned assets when accountAddress belongs to a known account group', () => {
+    const mockStoreState = createBridgeMockStore({
+      featureFlagOverrides: {
+        bridgeConfig: {
+          refreshRate: 30000,
+          maxRefreshCount: 5,
+          support: true,
+          chains: {
+            [CHAIN_IDS.MAINNET]: {
+              isActiveSrc: true,
+              isActiveDest: true,
+            },
+          },
+          chainRanking: [{ chainId: formatChainIdToCaip(CHAIN_IDS.MAINNET) }],
+        },
+      },
+    });
+
+    const { result } = renderHookWithProvider(
+      () =>
+        usePopularTokens({
+          assetsToInclude: [],
+          accountAddress: MOCK_EVM_ACCOUNT.address,
+          chainIds: new Set([formatChainIdToCaip(CHAIN_IDS.MAINNET)]),
+        }),
+      mockStoreState,
+    );
+
+    // The hook resolves the account group and calls getBridgeAssetsByAssetId
+    // (truthy branch of: accountGroup ? getBridgeAssetsByAssetId(...) : {})
+    // popularTokensList falls back to assetsToInclude while token list loads
     expect(result.current.popularTokensList).toEqual([]);
     expect(result.current.isLoading).toBe(true);
   });

--- a/ui/hooks/bridge/usePopularTokens.ts
+++ b/ui/hooks/bridge/usePopularTokens.ts
@@ -11,6 +11,7 @@ import { getBridgeAssetsByAssetId } from '../../ducks/bridge/asset-selectors';
 import { getAccountGroupsByAddress } from '../../selectors/multichain-accounts/account-tree';
 import { fetchPopularTokens } from '../../pages/bridge/utils/tokens';
 import { useAsyncResult } from '../useAsync';
+import { EMPTY_OBJECT } from '../../selectors/shared';
 
 /**
  * Returns a sorted token list from the bridge api
@@ -37,7 +38,9 @@ export const usePopularTokens = ({
     getAccountGroupsByAddress(state, [accountAddress]),
   );
   const ownedAssetsByAssetId = useSelector((state: BridgeAppState) =>
-    accountGroup ? getBridgeAssetsByAssetId(state, accountGroup.id) : {},
+    accountGroup
+      ? getBridgeAssetsByAssetId(state, accountGroup.id)
+      : EMPTY_OBJECT,
   );
 
   const abortControllerRef = useRef<AbortController | null>(null);

--- a/ui/hooks/bridge/usePopularTokens.ts
+++ b/ui/hooks/bridge/usePopularTokens.ts
@@ -37,7 +37,7 @@ export const usePopularTokens = ({
     getAccountGroupsByAddress(state, [accountAddress]),
   );
   const ownedAssetsByAssetId = useSelector((state: BridgeAppState) =>
-    getBridgeAssetsByAssetId(state, accountGroup.id),
+    accountGroup ? getBridgeAssetsByAssetId(state, accountGroup.id) : {},
   );
 
   const abortControllerRef = useRef<AbortController | null>(null);

--- a/ui/hooks/bridge/usePopularTokens.ts
+++ b/ui/hooks/bridge/usePopularTokens.ts
@@ -7,11 +7,9 @@ import { getBearerToken } from '../../store/actions';
 import { BridgeToken } from '../../ducks/bridge/types';
 import { toBridgeToken } from '../../ducks/bridge/utils';
 import { type BridgeAppState } from '../../ducks/bridge/selectors';
-import { getBridgeAssetsByAssetId } from '../../ducks/bridge/asset-selectors';
-import { getAccountGroupsByAddress } from '../../selectors/multichain-accounts/account-tree';
+import { getOwnedAssetsByAssetId } from '../../ducks/bridge/asset-selectors';
 import { fetchPopularTokens } from '../../pages/bridge/utils/tokens';
 import { useAsyncResult } from '../useAsync';
-import { EMPTY_OBJECT } from '../../selectors/shared';
 
 /**
  * Returns a sorted token list from the bridge api
@@ -34,13 +32,8 @@ export const usePopularTokens = ({
   assetsToInclude: BridgeToken[];
   accountAddress: string;
 }) => {
-  const [accountGroup] = useSelector((state: BridgeAppState) =>
-    getAccountGroupsByAddress(state, [accountAddress]),
-  );
   const ownedAssetsByAssetId = useSelector((state: BridgeAppState) =>
-    accountGroup
-      ? getBridgeAssetsByAssetId(state, accountGroup.id)
-      : EMPTY_OBJECT,
+    getOwnedAssetsByAssetId(state, accountAddress),
   );
 
   const abortControllerRef = useRef<AbortController | null>(null);

--- a/ui/hooks/bridge/usePopularTokens.ts
+++ b/ui/hooks/bridge/usePopularTokens.ts
@@ -7,7 +7,8 @@ import { getBearerToken } from '../../store/actions';
 import { BridgeToken } from '../../ducks/bridge/types';
 import { toBridgeToken } from '../../ducks/bridge/utils';
 import { type BridgeAppState } from '../../ducks/bridge/selectors';
-import { getOwnedAssetsByAssetId } from '../../ducks/bridge/asset-selectors';
+import { getBridgeAssetsByAssetId } from '../../ducks/bridge/asset-selectors';
+import { getAccountGroupsByAddress } from '../../selectors/multichain-accounts/account-tree';
 import { fetchPopularTokens } from '../../pages/bridge/utils/tokens';
 import { useAsyncResult } from '../useAsync';
 
@@ -32,8 +33,11 @@ export const usePopularTokens = ({
   assetsToInclude: BridgeToken[];
   accountAddress: string;
 }) => {
+  const [accountGroup] = useSelector((state: BridgeAppState) =>
+    getAccountGroupsByAddress(state, [accountAddress]),
+  );
   const ownedAssetsByAssetId = useSelector((state: BridgeAppState) =>
-    getOwnedAssetsByAssetId(state, accountAddress),
+    getBridgeAssetsByAssetId(state, accountGroup?.id),
   );
 
   const abortControllerRef = useRef<AbortController | null>(null);

--- a/ui/hooks/bridge/useTokenSearchResults.test.ts
+++ b/ui/hooks/bridge/useTokenSearchResults.test.ts
@@ -3,6 +3,7 @@ import { renderHookWithProvider } from '../../../test/lib/render-helpers-navigat
 import { CHAIN_IDS } from '../../../shared/constants/network';
 import {
   createBridgeMockStore,
+  MOCK_EVM_ACCOUNT,
   MOCK_EXTERNAL_SOLANA_ADDRESS,
 } from '../../../test/data/bridge/mock-bridge-store';
 import { useTokenSearchResults } from './useTokenSearchResults';
@@ -49,6 +50,43 @@ describe('useTokenSearchResults', () => {
       mockStoreState,
     );
 
+    expect(result.current.searchResults).toEqual([]);
+    expect(result.current.isSearchResultsLoading).toBe(false);
+    expect(result.current.hasMoreResults).toBe(false);
+  });
+
+  it('returns empty search results when accountAddress belongs to a known account group', () => {
+    const mockStoreState = createBridgeMockStore({
+      featureFlagOverrides: {
+        bridgeConfig: {
+          refreshRate: 30000,
+          maxRefreshCount: 5,
+          support: true,
+          chains: {
+            [CHAIN_IDS.MAINNET]: {
+              isActiveSrc: true,
+              isActiveDest: true,
+            },
+          },
+          chainRanking: [{ chainId: formatChainIdToCaip(CHAIN_IDS.MAINNET) }],
+        },
+      },
+    });
+
+    const { result } = renderHookWithProvider(
+      () =>
+        useTokenSearchResults({
+          searchQuery: '',
+          assetsToInclude: [],
+          accountAddress: MOCK_EVM_ACCOUNT.address,
+          chainIds: new Set([formatChainIdToCaip(CHAIN_IDS.MAINNET)]),
+        }),
+      mockStoreState,
+    );
+
+    // The hook resolves the account group and calls getBridgeAssetsByAssetId
+    // (truthy branch of: accountGroup ? getBridgeAssetsByAssetId(...) : {})
+    // No search query → no fetch triggered, empty results
     expect(result.current.searchResults).toEqual([]);
     expect(result.current.isSearchResultsLoading).toBe(false);
     expect(result.current.hasMoreResults).toBe(false);

--- a/ui/hooks/bridge/useTokenSearchResults.test.ts
+++ b/ui/hooks/bridge/useTokenSearchResults.test.ts
@@ -1,0 +1,56 @@
+import { formatChainIdToCaip } from '@metamask/bridge-controller';
+import { renderHookWithProvider } from '../../../test/lib/render-helpers-navigate';
+import { CHAIN_IDS } from '../../../shared/constants/network';
+import {
+  createBridgeMockStore,
+  MOCK_EXTERNAL_SOLANA_ADDRESS,
+} from '../../../test/data/bridge/mock-bridge-store';
+import { useTokenSearchResults } from './useTokenSearchResults';
+
+jest.mock('../../pages/bridge/utils/tokens', () => ({
+  fetchTokensBySearchQuery: jest.fn().mockResolvedValue({
+    tokens: [],
+    endCursor: undefined,
+    hasNextPage: false,
+  }),
+}));
+
+jest.mock('../../store/actions', () => ({
+  getBearerToken: jest.fn().mockResolvedValue('mock-jwt'),
+}));
+
+describe('useTokenSearchResults', () => {
+  it('does not crash when accountAddress is an external address with no matching account group', () => {
+    const mockStoreState = createBridgeMockStore({
+      featureFlagOverrides: {
+        bridgeConfig: {
+          refreshRate: 30000,
+          maxRefreshCount: 5,
+          support: true,
+          chains: {
+            [CHAIN_IDS.MAINNET]: {
+              isActiveSrc: true,
+              isActiveDest: true,
+            },
+          },
+          chainRanking: [{ chainId: formatChainIdToCaip(CHAIN_IDS.MAINNET) }],
+        },
+      },
+    });
+
+    const { result } = renderHookWithProvider(
+      () =>
+        useTokenSearchResults({
+          searchQuery: '',
+          assetsToInclude: [],
+          accountAddress: MOCK_EXTERNAL_SOLANA_ADDRESS,
+          chainIds: new Set([formatChainIdToCaip(CHAIN_IDS.MAINNET)]),
+        }),
+      mockStoreState,
+    );
+
+    expect(result.current.searchResults).toEqual([]);
+    expect(result.current.isSearchResultsLoading).toBe(false);
+    expect(result.current.hasMoreResults).toBe(false);
+  });
+});

--- a/ui/hooks/bridge/useTokenSearchResults.ts
+++ b/ui/hooks/bridge/useTokenSearchResults.ts
@@ -7,7 +7,8 @@ import { BRIDGE_API_BASE_URL } from '../../../shared/constants/bridge';
 import { BridgeToken } from '../../ducks/bridge/types';
 import { toBridgeToken } from '../../ducks/bridge/utils';
 import { type BridgeAppState } from '../../ducks/bridge/selectors';
-import { getOwnedAssetsByAssetId } from '../../ducks/bridge/asset-selectors';
+import { getBridgeAssetsByAssetId } from '../../ducks/bridge/asset-selectors';
+import { getAccountGroupsByAddress } from '../../selectors/multichain-accounts/account-tree';
 import { fetchTokensBySearchQuery } from '../../pages/bridge/utils/tokens';
 import { getBearerToken } from '../../store/actions';
 import { useAsyncResult } from '../useAsync';
@@ -32,8 +33,11 @@ export const useTokenSearchResults = ({
   accountAddress: string;
   assetsToInclude: BridgeToken[];
 }) => {
+  const [accountGroup] = useSelector((state: BridgeAppState) =>
+    getAccountGroupsByAddress(state, [accountAddress]),
+  );
   const ownedAssetsByAssetId = useSelector((state: BridgeAppState) =>
-    getOwnedAssetsByAssetId(state, accountAddress),
+    getBridgeAssetsByAssetId(state, accountGroup?.id),
   );
 
   const abortControllerRef = useRef<AbortController>(new AbortController());

--- a/ui/hooks/bridge/useTokenSearchResults.ts
+++ b/ui/hooks/bridge/useTokenSearchResults.ts
@@ -12,6 +12,7 @@ import { getAccountGroupsByAddress } from '../../selectors/multichain-accounts/a
 import { fetchTokensBySearchQuery } from '../../pages/bridge/utils/tokens';
 import { getBearerToken } from '../../store/actions';
 import { useAsyncResult } from '../useAsync';
+import { EMPTY_OBJECT } from '../../selectors/shared';
 
 /**
  * Returns a list of tokens from the bridge api that match the search query
@@ -37,7 +38,9 @@ export const useTokenSearchResults = ({
     getAccountGroupsByAddress(state, [accountAddress]),
   );
   const ownedAssetsByAssetId = useSelector((state: BridgeAppState) =>
-    accountGroup ? getBridgeAssetsByAssetId(state, accountGroup.id) : {},
+    accountGroup
+      ? getBridgeAssetsByAssetId(state, accountGroup.id)
+      : EMPTY_OBJECT,
   );
 
   const abortControllerRef = useRef<AbortController>(new AbortController());

--- a/ui/hooks/bridge/useTokenSearchResults.ts
+++ b/ui/hooks/bridge/useTokenSearchResults.ts
@@ -37,7 +37,7 @@ export const useTokenSearchResults = ({
     getAccountGroupsByAddress(state, [accountAddress]),
   );
   const ownedAssetsByAssetId = useSelector((state: BridgeAppState) =>
-    getBridgeAssetsByAssetId(state, accountGroup.id),
+    accountGroup ? getBridgeAssetsByAssetId(state, accountGroup.id) : {},
   );
 
   const abortControllerRef = useRef<AbortController>(new AbortController());

--- a/ui/hooks/bridge/useTokenSearchResults.ts
+++ b/ui/hooks/bridge/useTokenSearchResults.ts
@@ -7,12 +7,10 @@ import { BRIDGE_API_BASE_URL } from '../../../shared/constants/bridge';
 import { BridgeToken } from '../../ducks/bridge/types';
 import { toBridgeToken } from '../../ducks/bridge/utils';
 import { type BridgeAppState } from '../../ducks/bridge/selectors';
-import { getBridgeAssetsByAssetId } from '../../ducks/bridge/asset-selectors';
-import { getAccountGroupsByAddress } from '../../selectors/multichain-accounts/account-tree';
+import { getOwnedAssetsByAssetId } from '../../ducks/bridge/asset-selectors';
 import { fetchTokensBySearchQuery } from '../../pages/bridge/utils/tokens';
 import { getBearerToken } from '../../store/actions';
 import { useAsyncResult } from '../useAsync';
-import { EMPTY_OBJECT } from '../../selectors/shared';
 
 /**
  * Returns a list of tokens from the bridge api that match the search query
@@ -34,13 +32,8 @@ export const useTokenSearchResults = ({
   accountAddress: string;
   assetsToInclude: BridgeToken[];
 }) => {
-  const [accountGroup] = useSelector((state: BridgeAppState) =>
-    getAccountGroupsByAddress(state, [accountAddress]),
-  );
   const ownedAssetsByAssetId = useSelector((state: BridgeAppState) =>
-    accountGroup
-      ? getBridgeAssetsByAssetId(state, accountGroup.id)
-      : EMPTY_OBJECT,
+    getOwnedAssetsByAssetId(state, accountAddress),
   );
 
   const abortControllerRef = useRef<AbortController>(new AbortController());

--- a/ui/pages/bridge/prepare/components/bridge-asset-picker/index.tsx
+++ b/ui/pages/bridge/prepare/components/bridge-asset-picker/index.tsx
@@ -41,7 +41,7 @@ import {
 } from '../../../../../helpers/constants/design-system';
 import { getAccountGroupsByAddress } from '../../../../../selectors/multichain-accounts/account-tree';
 import { type BridgeAppState } from '../../../../../ducks/bridge/selectors';
-import { getOwnedAssetsWithBalanceByAssetId } from '../../../../../ducks/bridge/asset-selectors';
+import { getBridgeSortedAssets } from '../../../../../ducks/bridge/asset-selectors';
 import { usePopularTokens } from '../../../../../hooks/bridge/usePopularTokens';
 import { type BridgeToken } from '../../../../../ducks/bridge/types';
 import { toBridgeToken } from '../../../../../ducks/bridge/utils';
@@ -78,7 +78,7 @@ export const BridgeAssetPicker = ({
     getAccountGroupsByAddress(state, [accountAddress]),
   );
   const assetsWithBalance = useSelector((state: BridgeAppState) =>
-    getOwnedAssetsWithBalanceByAssetId(state, accountAddress),
+    getBridgeSortedAssets(state, accountGroup?.id),
   );
 
   const t = useI18nContext();

--- a/ui/pages/bridge/prepare/components/bridge-asset-picker/index.tsx
+++ b/ui/pages/bridge/prepare/components/bridge-asset-picker/index.tsx
@@ -47,6 +47,7 @@ import { type BridgeToken } from '../../../../../ducks/bridge/types';
 import { toBridgeToken } from '../../../../../ducks/bridge/utils';
 import { MarketClosedModal } from '../../../../../components/app/assets/market-closed-modal';
 import { useRWAToken } from '../../../hooks/useRWAToken';
+import { EMPTY_ARRAY } from '../../../../../selectors/shared';
 import { NetworkPicker } from './network-picker';
 import { BridgeAssetList } from './lazy-asset-list';
 
@@ -78,7 +79,7 @@ export const BridgeAssetPicker = ({
     getAccountGroupsByAddress(state, [accountAddress]),
   );
   const assetsWithBalance = useSelector((state: BridgeAppState) =>
-    accountGroup ? getBridgeSortedAssets(state, accountGroup.id) : [],
+    accountGroup ? getBridgeSortedAssets(state, accountGroup.id) : EMPTY_ARRAY,
   );
 
   const t = useI18nContext();

--- a/ui/pages/bridge/prepare/components/bridge-asset-picker/index.tsx
+++ b/ui/pages/bridge/prepare/components/bridge-asset-picker/index.tsx
@@ -78,7 +78,7 @@ export const BridgeAssetPicker = ({
     getAccountGroupsByAddress(state, [accountAddress]),
   );
   const assetsWithBalance = useSelector((state: BridgeAppState) =>
-    getBridgeSortedAssets(state, accountGroup.id),
+    accountGroup ? getBridgeSortedAssets(state, accountGroup.id) : [],
   );
 
   const t = useI18nContext();
@@ -117,7 +117,7 @@ export const BridgeAssetPicker = ({
         (a) => a.assetId?.toLowerCase(),
       ).map((token) => toBridgeToken(token)),
     // Ignore warnings about assetsWithBalance to prevent re-fetching token list excessively
-    [chainIdsSet, accountGroup.id, accountAddress],
+    [chainIdsSet, accountGroup?.id, accountAddress],
   );
 
   const { popularTokensList, isLoading: isPopularTokensLoading } =

--- a/ui/pages/bridge/prepare/components/bridge-asset-picker/index.tsx
+++ b/ui/pages/bridge/prepare/components/bridge-asset-picker/index.tsx
@@ -41,13 +41,12 @@ import {
 } from '../../../../../helpers/constants/design-system';
 import { getAccountGroupsByAddress } from '../../../../../selectors/multichain-accounts/account-tree';
 import { type BridgeAppState } from '../../../../../ducks/bridge/selectors';
-import { getBridgeSortedAssets } from '../../../../../ducks/bridge/asset-selectors';
+import { getOwnedAssetsWithBalanceByAssetId } from '../../../../../ducks/bridge/asset-selectors';
 import { usePopularTokens } from '../../../../../hooks/bridge/usePopularTokens';
 import { type BridgeToken } from '../../../../../ducks/bridge/types';
 import { toBridgeToken } from '../../../../../ducks/bridge/utils';
 import { MarketClosedModal } from '../../../../../components/app/assets/market-closed-modal';
 import { useRWAToken } from '../../../hooks/useRWAToken';
-import { EMPTY_ARRAY } from '../../../../../selectors/shared';
 import { NetworkPicker } from './network-picker';
 import { BridgeAssetList } from './lazy-asset-list';
 
@@ -79,7 +78,7 @@ export const BridgeAssetPicker = ({
     getAccountGroupsByAddress(state, [accountAddress]),
   );
   const assetsWithBalance = useSelector((state: BridgeAppState) =>
-    accountGroup ? getBridgeSortedAssets(state, accountGroup.id) : EMPTY_ARRAY,
+    getOwnedAssetsWithBalanceByAssetId(state, accountAddress),
   );
 
   const t = useI18nContext();


### PR DESCRIPTION
## **Description**

When a user performs an EVM ↔ non-EVM bridge and selects a custom recipient address that is not derived from their SRP (labeled "External account"), the extension crashes with `TypeError: Cannot read properties of undefined (reading 'id')`.

The root cause is that `getAccountGroupsByAddress` returns an empty array for addresses not belonging to any wallet account group. Destructuring `const [accountGroup] = []` yields `undefined`, and subsequent accesses to `accountGroup.id` crash in three locations:

- `BridgeAssetPicker` component (`getBridgeSortedAssets` call and `useMemo` deps)
- `usePopularTokens` hook (`getBridgeAssetsByAssetId` call)
- `useTokenSearchResults` hook (`getBridgeAssetsByAssetId` call)

The fix adds a guard check before accessing `accountGroup.id` in all three locations, returning safe empty defaults (`[]` or `{}`) when no matching account group exists. Tests are added to cover this scenario.

## **Changelog**

CHANGELOG entry: Fixed a crash when selecting an external recipient address during cross-chain bridge transactions

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-4264

## **Manual testing steps**

1. Open MetaMask and navigate to the Bridge page
2. Set up an EVM to non-EVM bridge (e.g., Ethereum → Solana)
3. Click the Recipient field and enter an external address not generated from your SRP
4. Select the external account record that appears in the dropdown
5. Verify the app does not crash and the bridge page remains usable

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk defensive changes that add `undefined` handling around bridge asset lookups for external addresses, plus targeted unit tests. Main risk is minor behavior changes where selectors now return empty results instead of throwing when no account group is found.
> 
> **Overview**
> Prevents bridge UI crashes when the selected address is *external* (not part of any account group) by making `accountGroup.id` access safe across the asset picker and token-list hooks.
> 
> Bridge asset selectors now short-circuit on missing `accountGroupId` and return empty defaults, and new unit tests cover the undefined-group scenario for `getBridgeSortedAssets`/`getBridgeAssetsByAssetId`/`getBridgeBalancesByChainId`, `usePopularTokens`, and `useTokenSearchResults`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79a3c095e2b999b4a049ef7192dcda611ec6d7c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->