### PR TITLE
chore: bump @metamask/hw-wallet-sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -335,7 +335,7 @@
     "@metamask/gas-fee-controller": "^26.1.0",
     "@metamask/gator-permissions-controller": "^3.0.0",
     "@metamask/gator-permissions-snap": "^1.3.1",
-    "@metamask/hw-wallet-sdk": "^0.5.0",
+    "@metamask/hw-wallet-sdk": "^0.8.0",
     "@metamask/institutional-wallet-snap": "1.3.4",
     "@metamask/jazzicon": "patch:@metamask/jazzicon@npm%3A2.0.0#~/.yarn/patches/@metamask-jazzicon-npm-2.0.0-36957be38d.patch",
     "@metamask/json-rpc-engine": "^10.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6787,10 +6787,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/hw-wallet-sdk@npm:^0.5.0":
-  version: 0.5.0
-  resolution: "@metamask/hw-wallet-sdk@npm:0.5.0"
-  checksum: 10/ed306846a35723968f45ee24198fd04ce6d53a461077015eda777a85efe36569009a737be74d4945a3aba894b6f193b3acd66bf19c2f7a0de4dc75d07dd24d0a
+"@metamask/hw-wallet-sdk@npm:^0.8.0":
+  version: 0.8.0
+  resolution: "@metamask/hw-wallet-sdk@npm:0.8.0"
+  checksum: 10/99e045af2f881d27b827e0f2a0546c056476f5704cbede5a7733f98bff482508e05f5cdcf3969666ccd16e97b6f362c84012390e403cd2da6b7f809fe6ad72e5
   languageName: node
   linkType: hard
 
@@ -34103,7 +34103,7 @@ __metadata:
     "@metamask/gas-fee-controller": "npm:^26.1.0"
     "@metamask/gator-permissions-controller": "npm:^3.0.0"
     "@metamask/gator-permissions-snap": "npm:^1.3.1"
-    "@metamask/hw-wallet-sdk": "npm:^0.5.0"
+    "@metamask/hw-wallet-sdk": "npm:^0.8.0"
     "@metamask/institutional-wallet-snap": "npm:1.3.4"
     "@metamask/jazzicon": "patch:@metamask/jazzicon@npm%3A2.0.0#~/.yarn/patches/@metamask-jazzicon-npm-2.0.0-36957be38d.patch"
     "@metamask/json-rpc-engine": "npm:^10.2.3"


### PR DESCRIPTION
## **Description**
This PR bumps `@metamask/hw-wallet-sdk` to the latest version.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**
Fixes: null

## **Manual testing steps**
Nothing to test since this is just package bump.

## **Screenshots/Recordings**

### **Before**
No UI changes. Nothing to show here.

### **After**
No UI changes. Nothing to show here.

## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates a hardware-wallet integration dependency, which could affect Ledger/Trezor connection and signing behavior despite being a simple version/lockfile change.
> 
> **Overview**
> Bumps `@metamask/hw-wallet-sdk` from `^0.5.0` to `^0.8.0` and updates `yarn.lock` to resolve the new `0.8.0` package version/checksum (removing the `0.5.0` resolution).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c26d21a1391befd783b211b43c36e2dc045bafcf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->