### PR TITLE
refactor(snap-keyring): migrate IconName import to @metamask/design-system-react

### DIFF
--- a/app/scripts/lib/snap-keyring/snap-keyring.ts
+++ b/app/scripts/lib/snap-keyring/snap-keyring.ts
@@ -7,6 +7,7 @@ import {
 import browser from 'webextension-polyfill';
 import { SnapId } from '@metamask/snaps-sdk';
 import { assertIsValidSnapId } from '@metamask/snaps-utils';
+import { IconName } from '@metamask/design-system-react';
 import {
   MetaMetricsEventAccountType,
   MetaMetricsEventCategory,
@@ -14,9 +15,6 @@ import {
 } from '../../../../shared/constants/metametrics';
 import { SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES } from '../../../../shared/constants/app';
 import { t } from '../../../../shared/lib/translate';
-// TODO: Remove restricted import
-// eslint-disable-next-line import-x/no-restricted-paths
-import { IconName } from '../../../../ui/components/component-library/icon';
 import MetaMetricsController from '../../controllers/metametrics-controller';
 import { isSnapPreinstalled } from '../../../../shared/lib/snaps/snaps';
 import {

--- a/app/scripts/lib/snap-keyring/utils/showResult.ts
+++ b/app/scripts/lib/snap-keyring/utils/showResult.ts
@@ -2,9 +2,7 @@ import type {
   ResultComponent,
   ErrorResult,
 } from '@metamask/approval-controller';
-// TODO: Remove restricted import
-// eslint-disable-next-line import-x/no-restricted-paths
-import { IconName } from '../../../../../ui/components/component-library/icon';
+import { IconName } from '@metamask/design-system-react';
 import { SnapKeyringBuilderMessenger } from '../types';
 
 const snapAuthorshipHeader = (snapId: string): ResultComponent => {


### PR DESCRIPTION
## **Description**

`IconName` was imported from the deprecated `ui/components/component-library/icon` into two background-script files in `app/scripts/lib/snap-keyring/`. This was a restricted cross-layer import (background → UI) that required an `eslint-disable` comment to suppress the `import-x/no-restricted-paths` rule, along with a `TODO` to remove it.

`@metamask/design-system-react` exports the same `IconName` enum (including `UserCircleAdd` and `UserCircleRemove` used here), so we can import it from the shared package directly — removing the cross-layer violation entirely.

1. **Why:** `ui/components/component-library/icon` is deprecated and importing UI code into background scripts is a restricted pattern.
2. **Solution:** Replace both imports with `IconName` from `@metamask/design-system-react` and remove the associated `eslint-disable` and `TODO` comments.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

<!--
## **Manual testing steps**

1. Go to this page...
2.
3.
-->

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only changes where `IconName` is imported from, removing a background→UI cross-layer dependency. Runtime behavior should be unchanged aside from any potential enum mismatch/regression if the design-system export diverges.
> 
> **Overview**
> Updates the snap-keyring background code to import `IconName` from `@metamask/design-system-react` instead of the deprecated UI component library, and removes the associated `eslint-disable`/TODO comments.
> 
> This eliminates a restricted cross-layer (background → UI) import in `snap-keyring.ts` and `utils/showResult.ts` without changing the surrounding snap account flow logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6efcb638d8b7d099cf04f0022727baffa82dd73c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->