### PR TITLE
feat: added metrics for settings v2

### DIFF
--- a/ui/pages/settings-v2/assets-tab/assets-tab.tsx
+++ b/ui/pages/settings-v2/assets-tab/assets-tab.tsx
@@ -39,6 +39,13 @@ const HideZeroBalanceTokensToggleItem = createToggleItem({
   selector: getShouldHideZeroBalanceTokens,
   action: setHideZeroBalanceTokens,
   dataTestId: 'toggle-zero-balance-button',
+  trackEvent: {
+    event: MetaMetricsEventName.SettingsUpdated,
+    properties: (newValue) => ({
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      hide_zero_balance_tokens: newValue,
+    }),
+  },
 });
 
 const AutodetectTokensToggleItem = createToggleItem({

--- a/ui/pages/settings-v2/developer-tools-tab/developer-tools-tab.tsx
+++ b/ui/pages/settings-v2/developer-tools-tab/developer-tools-tab.tsx
@@ -5,6 +5,7 @@ import {
   createToggleItem,
   createDescriptionWithLearnMore,
 } from '../shared';
+import { MetaMetricsEventName } from '../../../../shared/constants/metametrics';
 import { TESTNET_ETH_SCAMS_LEARN_MORE_LINK } from '../../../../shared/lib/ui-utils';
 import { getShowFiatInTestnets } from '../../../selectors';
 import { setShowFiatConversionOnTestnetsPreference } from '../../../store/actions';
@@ -21,6 +22,13 @@ const ShowConversionInTestnetsItem = createToggleItem({
   selector: getShowFiatInTestnets,
   action: setShowFiatConversionOnTestnetsPreference,
   dataTestId: 'developer-options-show-testnet-conversion-toggle',
+  trackEvent: {
+    event: MetaMetricsEventName.SettingsUpdated,
+    properties: (newValue) => ({
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      show_fiat_in_testnets: newValue,
+    }),
+  },
 });
 
 /** Registry of setting items for the Developer Options page. Add new items here */

--- a/ui/pages/settings-v2/privacy-tab/privacy-tab.tsx
+++ b/ui/pages/settings-v2/privacy-tab/privacy-tab.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { SettingItemConfig } from '../types';
 import { SettingsTab, createToggleItem } from '../shared';
+import { MetaMetricsEventName } from '../../../../shared/constants/metametrics';
 import { getPreferences } from '../../../selectors';
 import {
   setUseMultiAccountBalanceChecker,
@@ -24,6 +25,13 @@ const BatchAccountBalanceRequestsToggleItem = createToggleItem({
     state.metamask.useMultiAccountBalanceChecker,
   action: setUseMultiAccountBalanceChecker,
   dataTestId: 'batch-account-balance-requests-toggle',
+  trackEvent: {
+    event: MetaMetricsEventName.SettingsUpdated,
+    properties: (newValue) => ({
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      use_multi_account_balance_checker: newValue,
+    }),
+  },
 });
 
 const SkipLinkConfirmationToggleItem = createToggleItem({
@@ -34,6 +42,13 @@ const SkipLinkConfirmationToggleItem = createToggleItem({
     Boolean(getPreferences(state).skipDeepLinkInterstitial),
   action: setSkipDeepLinkInterstitial,
   dataTestId: 'skip-link-confirmation-toggle',
+  trackEvent: {
+    event: MetaMetricsEventName.SettingsUpdated,
+    properties: (newValue) => ({
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      skip_deep_link_interstitial: newValue,
+    }),
+  },
 });
 
 /** Registry of setting items for the Privacy page. Add new items here */

--- a/ui/pages/settings-v2/privacy-tab/third-party-apis-sub-page.tsx
+++ b/ui/pages/settings-v2/privacy-tab/third-party-apis-sub-page.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { SettingItemConfig } from '../types';
 import { SettingsTab, createToggleItem } from '../shared';
+import { MetaMetricsEventName } from '../../../../shared/constants/metametrics';
 import { DisplayNftMediaToggleItem } from '../shared/display-nft-media-item';
 import { AutodetectNftsToggleItem } from '../shared/autodetect-nfts-item';
 import {
@@ -67,6 +68,13 @@ const ProposedNicknamesToggleItem = createToggleItem({
     state.metamask.useExternalNameSources,
   action: setUseExternalNameSources,
   dataTestId: 'proposed-nicknames-toggle',
+  trackEvent: {
+    event: MetaMetricsEventName.SettingsUpdated,
+    properties: (newValue) => ({
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      use_external_name_sources: newValue,
+    }),
+  },
 });
 
 /** Registry of setting items for the Third-party APIs sub-page */

--- a/ui/pages/settings-v2/security-and-password-tab/auto-lock-sub-page.test.tsx
+++ b/ui/pages/settings-v2/security-and-password-tab/auto-lock-sub-page.test.tsx
@@ -93,7 +93,9 @@ describe('AutoLockSubPage', () => {
       category: MetaMetricsEventCategory.Settings,
       event: MetaMetricsEventName.SettingsUpdated,
       properties: {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         auto_lock_time_limit_minutes: 1,
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         previous_auto_lock_time_limit_minutes: 0,
       },
     });

--- a/ui/pages/settings-v2/security-and-password-tab/auto-lock-sub-page.test.tsx
+++ b/ui/pages/settings-v2/security-and-password-tab/auto-lock-sub-page.test.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
-import { fireEvent, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import mockState from '../../../../test/data/mock-state.json';
 import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
+import {
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
+} from '../../../../shared/constants/metametrics';
 import { setBackgroundConnection } from '../../../store/background-connection';
 import { SECURITY_AND_PASSWORD_ROUTE } from '../../../helpers/constants/routes';
 import AutoLockSubPage from './auto-lock-sub-page';
@@ -74,10 +78,25 @@ describe('AutoLockSubPage', () => {
   });
 
   it('dispatches setAutoLockTimeLimit and navigates on click', () => {
-    renderWithProvider(<AutoLockSubPage />, createMockStore());
+    const trackEvent = jest.fn().mockResolvedValue(undefined);
+    renderWithProvider(
+      <AutoLockSubPage />,
+      createMockStore(),
+      '/',
+      render,
+      () => trackEvent,
+    );
 
     fireEvent.click(screen.getByText(messages.autoLockAfter1Minute.message));
 
+    expect(trackEvent).toHaveBeenCalledWith({
+      category: MetaMetricsEventCategory.Settings,
+      event: MetaMetricsEventName.SettingsUpdated,
+      properties: {
+        auto_lock_time_limit_minutes: 1,
+        previous_auto_lock_time_limit_minutes: 0,
+      },
+    });
     expect(mockSetAutoLockTimeLimit).toHaveBeenCalledWith(1);
     expect(mockNavigate).toHaveBeenCalledWith(SECURITY_AND_PASSWORD_ROUTE);
   });

--- a/ui/pages/settings-v2/security-and-password-tab/auto-lock-sub-page.tsx
+++ b/ui/pages/settings-v2/security-and-password-tab/auto-lock-sub-page.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import {
@@ -20,16 +20,32 @@ import { SECURITY_AND_PASSWORD_ROUTE } from '../../../helpers/constants/routes';
 import { getPreferences } from '../../../selectors';
 import { DEFAULT_AUTO_LOCK_TIME_LIMIT } from '../../../../shared/constants/preferences';
 import { useI18nContext } from '../../../hooks/useI18nContext';
+import { MetaMetricsContext } from '../../../contexts/metametrics';
+import {
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
+} from '../../../../shared/constants/metametrics';
 import { AUTO_LOCK_OPTIONS } from './auto-lock-utils';
 
 const AutoLockSubPage = () => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
   const t = useI18nContext();
+  const { trackEvent } = useContext(MetaMetricsContext);
   const { autoLockTimeLimit = DEFAULT_AUTO_LOCK_TIME_LIMIT } =
     useSelector(getPreferences);
 
   const handleSelect = (value: number) => {
+    trackEvent({
+      category: MetaMetricsEventCategory.Settings,
+      event: MetaMetricsEventName.SettingsUpdated,
+      properties: {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        auto_lock_time_limit_minutes: value,
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        previous_auto_lock_time_limit_minutes: autoLockTimeLimit,
+      },
+    });
     dispatch(setAutoLockTimeLimit(value));
     navigate(SECURITY_AND_PASSWORD_ROUTE);
   };

--- a/ui/pages/settings-v2/transactions-tab/transactions-tab.tsx
+++ b/ui/pages/settings-v2/transactions-tab/transactions-tab.tsx
@@ -46,6 +46,13 @@ const TransactionSimulationsItem = createToggleItem({
   action: setUseTransactionSimulations,
   dataTestId: 'transactions-simulations-toggle',
   disabledSelector: selectIsDisabledByShieldSubscription,
+  trackEvent: {
+    event: MetaMetricsEventName.SettingsUpdated,
+    properties: (newValue) => ({
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      use_transaction_simulations: newValue,
+    }),
+  },
 });
 
 const SecurityAlertsItem = createToggleItem({
@@ -100,6 +107,13 @@ const ProposedNicknamesItem = createToggleItem({
     Boolean(getUseExternalNameSources(state)),
   action: setUseExternalNameSources,
   dataTestId: 'transactions-proposed-nicknames-toggle',
+  trackEvent: {
+    event: MetaMetricsEventName.SettingsUpdated,
+    properties: (newValue) => ({
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      use_external_name_sources: newValue,
+    }),
+  },
 });
 
 const ShowHexDataItem = createToggleItem({
@@ -111,6 +125,13 @@ const ShowHexDataItem = createToggleItem({
   action: (value: boolean) => setFeatureFlag('sendHexData', value, ''),
   dataTestId: 'transactions-show-hex-data-toggle',
   containerDataTestId: 'transactions-settings-hex-data-toggle',
+  trackEvent: {
+    event: MetaMetricsEventName.SettingsUpdated,
+    properties: (newValue) => ({
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      send_hex_data: newValue,
+    }),
+  },
 });
 
 const TRANSACTION_SETTING_ITEMS: SettingItemConfig[] = [


### PR DESCRIPTION
This PR is to add metrics for settings v2



| Setting | File | Property |
| --- | --- | --- |
| Batch account balance | `ui/pages/settings-v2/privacy-tab/privacy-tab.tsx` | `use_multi_account_balance_checker` |
| Skip link confirmation | `ui/pages/settings-v2/privacy-tab/privacy-tab.tsx` | `skip_deep_link_interstitial` |
| Estimate balance changes | `ui/pages/settings-v2/transactions-tab/transactions-tab.tsx` | `use_transaction_simulations` |
| Proposed nicknames | `ui/pages/settings-v2/transactions-tab/transactions-tab.tsx` and `ui/pages/settings-v2/privacy-tab/third-party-apis-sub-page.tsx` | `use_external_name_sources` |
| Show hex data | `ui/pages/settings-v2/transactions-tab/transactions-tab.tsx` | `send_hex_data` |
| Show conversion on testnets | `ui/pages/settings-v2/developer-tools-tab/developer-tools-tab.tsx` | `show_fiat_in_testnets` |
| Hide tokens without balance | `ui/pages/settings-v2/assets-tab/assets-tab.tsx` | `hide_zero_balance_tokens` |
| Auto-lock | `ui/pages/settings-v2/security-and-password-tab/auto-lock-sub-page.tsx` | `auto_lock_time_limit_minutes`, `previous_auto_lock_time_limit_minutes` |

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds MetaMetrics `SettingsUpdated` tracking to several settings toggles and auto-lock selection, with a small test update to assert event payloads.
> 
> **Overview**
> Adds MetaMetrics instrumentation for Settings V2 by emitting `SettingsUpdated` events when users change multiple toggles (assets, developer tools, privacy, third‑party APIs, and transactions), mapping each setting to a specific analytics property.
> 
> Also instruments the auto-lock time selection to track both the new and previous timeout values, and updates `auto-lock-sub-page` tests to mock and assert `trackEvent` calls alongside the existing dispatch/navigation behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c63da21ea1b7d92dcc85832fa12af644c18989b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->