### PR TITLE
ci: add GH_TOKEN to get-requirements.yml

### DIFF
--- a/.github/workflows/get-requirements.yml
+++ b/.github/workflows/get-requirements.yml
@@ -41,6 +41,7 @@ env:
   IS_FORK: ${{ github.event.pull_request.head.repo.fork || github.event.repository.fork }}
   EVENT_NAME: ${{ github.event_name }}
   PR_NUMBER: ${{ github.event.pull_request.number }}
+  GH_TOKEN: ${{ github.token }}
 
 jobs:
   detect-changes:


### PR DESCRIPTION
## **Description**

A previous PR #41318 was supposed to make version bumps faster, but I made a mistake.  This fixes that mistake.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Followup to: #41318

<!--## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**
[skip-e2e]-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that just exposes `github.token` as `GH_TOKEN` so `gh` CLI commands in this workflow can authenticate; no product code or runtime behavior is affected.
> 
> **Overview**
> Exports `github.token` as `GH_TOKEN` in `.github/workflows/get-requirements.yml`, enabling `gh` CLI usage (e.g., `gh pr diff`) within the workflow without additional setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d62ee135b69abb54324045775dcc8b427dbd5082. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->