### PR TITLE
fix: restrict Contentful localization to maintained locales [GE-56]

### DIFF
--- a/shared/constants/locales.ts
+++ b/shared/constants/locales.ts
@@ -1,0 +1,31 @@
+/**
+ * Locale codes that are actively maintained by the MetaMask team.
+ * All other locales in app/_locales/index.json are community-submitted.
+ */
+export const MAINTAINED_LOCALE_CODES: ReadonlySet<string> = new Set([
+  'de',
+  'el',
+  'en',
+  'es',
+  'fr',
+  'hi',
+  'id',
+  'ja',
+  'ko',
+  'pt',
+  'ru',
+  'tl',
+  'tr',
+  'vi',
+  'zh_CN',
+]);
+
+/**
+ * Returns `true` when the locale is actively maintained, `false` otherwise.
+ *
+ * @param locale - A locale code such as `'fr'` or `'pt_BR'`.
+ * @returns `true` when the locale is actively maintained, `false` otherwise.
+ */
+export function isMaintainedLocale(locale: string | undefined): boolean {
+  return Boolean(locale && MAINTAINED_LOCALE_CODES.has(locale));
+}

--- a/ui/hooks/useCarouselManagement/useCarouselManagement.ts
+++ b/ui/hooks/useCarouselManagement/useCarouselManagement.ts
@@ -18,6 +18,7 @@ import {
   getUseExternalServices,
 } from '../../selectors';
 import { getCurrentLocale } from '../../ducks/locale/locale';
+import { isMaintainedLocale } from '../../../shared/constants/locales';
 import { fetchCarouselSlidesFromContentful } from './fetchCarouselSlidesFromContentful';
 
 type UseSlideManagementProps = { testDate?: string; enabled?: boolean };
@@ -187,7 +188,9 @@ export const useCarouselManagement = ({
 
       try {
         const { prioritySlides, regularSlides } =
-          await fetchCarouselSlidesFromContentful(currentLocale);
+          await fetchCarouselSlidesFromContentful(
+            isMaintainedLocale(currentLocale) ? currentLocale : undefined,
+          );
 
         if (cancelled) {
           return;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
This PR restricts Contentful localization to maintained locales, as community-submitted locales won't be added to Contentful. This PR avoids an unnecessary failing call.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Related to https://github.com/MetaMask/metamask-extension/pull/41387

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk behavioral change that only affects which `locale` parameter is sent to Contentful when fetching carousel slides; could alter localization for community locales but avoids predictable request failures.
> 
> **Overview**
> Prevents Contentful carousel slide fetches from requesting unsupported localizations by introducing `shared/constants/locales.ts` with a maintained-locale allowlist and an `isMaintainedLocale` helper.
> 
> `useCarouselManagement` now only passes `currentLocale` into `fetchCarouselSlidesFromContentful` when it’s in the maintained set, otherwise it omits the `locale` param to fall back to the default Contentful locale.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f56c05bf5e1476d65c1299fc1febf4edaeb73cca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->