### PR TITLE
ci: Update `lint:tsc` build script to increase memory limit to 6GB

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "lint:shellcheck": "./development/shellcheck.sh",
     "lint:styles": "stylelint '*/**/*.scss'",
     "lint:styles:fix": "yarn lint:styles --fix",
-    "lint:tsc": "tsc",
+    "lint:tsc": "NODE_OPTIONS='--max-old-space-size=6144' tsc",
     "lint:images": "tsx development/optimize-media.mts",
     "lint:images:fix": "tsx development/optimize-media.mts --fix",
     "lint:baseline": "node development/lint-baseline.mts",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

`test-lint` workflow is flaking due to the `tsc` process exceeding the default memory limit of 4GB. This commit increases the `tsc` memory limit to 6GB to resolve this issue.

This is safe because `test-lint` job is run by a single runner and the lint steps are run sequentially, so dedicating 6GB of the standard runner's 7GB RAM to `tsc` leaves 1GB for OS and node overhead.

### Example Error Output

```
Run yarn lint
Checking formatting...
All matched files use Prettier code style!

<--- Last few GCs --->

[2539:0x2948d000]   956844 ms: Scavenge 4050.0 (4100.1) -> 4040.4 (4135.8) MB, pooled: 0 MB, 6.04 / 0.00 ms  (average mu = 0.301, current mu = 0.211) allocation failure; 
[2539:0x2948d000]   958520 ms: Mark-Compact (reduce) 4059.2 (4136.1) -> 3993.1 (4062.3) MB, pooled: 0 MB, 67.11 / 0.00 ms  (+ 1502.1 ms in 289 steps since start of marking, biggest step 7.2 ms, walltime since start of marking 1677 ms) (average mu = 0.332,
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
----- Native stack trace -----

 1: 0x733eec node::OOMErrorHandler(char const*, v8::OOMDetails const&) [/opt/hostedtoolcache/node/24.13.1/x64/bin/node]
 2: 0xbab3f0  [/opt/hostedtoolcache/node/24.13.1/x64/bin/node]
 3: 0xbab4df  [/opt/hostedtoolcache/node/24.13.1/x64/bin/node]
 4: 0xe43fd5  [/opt/hostedtoolcache/node/24.13.1/x64/bin/node]
 5: 0xe44002  [/opt/hostedtoolcache/node/24.13.1/x64/bin/node]
 6: 0xe442fa  [/opt/hostedtoolcache/node/24.13.1/x64/bin/node]
 7: 0xe5481a  [/opt/hostedtoolcache/node/24.13.1/x64/bin/node]
 8: 0xe58bc0  [/opt/hostedtoolcache/node/24.13.1/x64/bin/node]
 9: 0x18eb671  [/opt/hostedtoolcache/node/24.13.1/x64/bin/node]
Error: Process completed with exit code 129.
```
> -- https://github.com/MetaMask/metamask-extension/actions/runs/23922022251/job/69770871604?pr=39716
> -- https://github.com/MetaMask/metamask-extension/actions/runs/23948759467/job/69850929419?pr=39715

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts the `lint:tsc` script’s Node heap limit to reduce CI flakiness, with no runtime or production code changes.
> 
> **Overview**
> Updates the `lint:tsc` npm script to run TypeScript compilation with `NODE_OPTIONS='--max-old-space-size=6144'`, increasing the heap limit to 6GB to prevent out-of-memory failures during CI linting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 655f0dd5757459f1f0c17937ff148bd11199fc30. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->