### PR TITLE
docs: update publishing dashboard links

### DIFF
--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -34,8 +34,8 @@ While we develop on the `main` branch, our production builds are created from th
 ## Publishing
 
 1. Publish to chrome store.
-2. Visit [the chrome developer dashboard](https://chrome.google.com/webstore/developer/dashboard?authuser=2).
-3. Publish to [firefox addon marketplace](http://addons.mozilla.org/en-us/firefox/addon/ether-metamask).
+2. Visit [the chrome developer dashboard](https://chrome.google.com/webstore/devconsole/).
+3. Publish to [firefox addon marketplace](https://addons.mozilla.org/en-us/firefox/addon/ether-metamask/).
 4. Publish to [Opera store](https://addons.opera.com/en/extensions/details/metamask/).
 5. Post on [Github releases](https://github.com/MetaMask/metamask-extension/releases) page.
 6. Run the `yarn announce` script, and post that announcement in our public places.


### PR DESCRIPTION
## **Description**

- update the Chrome developer dashboard link in publishing docs to the current dashboard path
- switch the Firefox marketplace link to its canonical HTTPS URL

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Open `docs/publishing.md`
2. Confirm the Chrome dashboard link points to `https://chrome.google.com/webstore/devconsole/`
3. Confirm the Firefox marketplace link points to the canonical HTTPS URL

## **Screenshots/Recordings**

### **Before**

- Not included (documentation-only URL cleanup)

### **After**

- Not included (documentation-only URL cleanup)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
