### PR TITLE
feat: add QR adapter

### DIFF
--- a/ui/contexts/hardware-wallets/__mocks__/webConnectionUtils.ts
+++ b/ui/contexts/hardware-wallets/__mocks__/webConnectionUtils.ts
@@ -1,3 +1,4 @@
+import { CameraPermissionState } from '../constants';
 import {
   HardwareWalletType,
   HardwareConnectionPermissionState,
@@ -10,11 +11,15 @@ import {
 // Mock functions
 export const isWebHidAvailable = jest.fn();
 export const isWebUsbAvailable = jest.fn();
+export const isCameraAvailable = jest.fn();
 export const checkWebHidPermission = jest.fn();
 export const checkWebUsbPermission = jest.fn();
+export const checkCameraPermissionState = jest.fn();
+export const checkCameraPermission = jest.fn();
 export const checkHardwareWalletPermission = jest.fn();
 export const requestWebHidPermission = jest.fn();
 export const requestWebUsbPermission = jest.fn();
+export const requestCameraPermission = jest.fn();
 export const requestHardwareWalletPermission = jest.fn();
 export const getConnectedDevices = jest.fn();
 export const subscribeToWebHidEvents = jest.fn();
@@ -24,6 +29,7 @@ export const subscribeToHardwareWalletEvents = jest.fn();
 // Default mock implementations
 isWebHidAvailable.mockReturnValue(true);
 isWebUsbAvailable.mockReturnValue(true);
+isCameraAvailable.mockReturnValue(true);
 checkWebHidPermission.mockResolvedValue(
   HardwareConnectionPermissionState.Granted,
 );
@@ -37,18 +43,26 @@ checkHardwareWalletPermission.mockImplementation(
         return Promise.resolve(HardwareConnectionPermissionState.Granted);
       case HardwareWalletType.Trezor:
         return Promise.resolve(HardwareConnectionPermissionState.Granted);
+      case HardwareWalletType.Qr:
+        return Promise.resolve(HardwareConnectionPermissionState.Granted);
       default:
         return Promise.resolve(HardwareConnectionPermissionState.Denied);
     }
   },
 );
+checkCameraPermissionState.mockResolvedValue(
+  HardwareConnectionPermissionState.Granted,
+);
+checkCameraPermission.mockResolvedValue(CameraPermissionState.Granted);
 requestWebHidPermission.mockResolvedValue(true);
 requestWebUsbPermission.mockResolvedValue(true);
+requestCameraPermission.mockResolvedValue(true);
 requestHardwareWalletPermission.mockImplementation(
   (walletType: HardwareWalletType) => {
     switch (walletType) {
       case HardwareWalletType.Ledger:
       case HardwareWalletType.Trezor:
+      case HardwareWalletType.Qr:
         return Promise.resolve(true);
       default:
         return Promise.resolve(false);
@@ -64,6 +78,7 @@ subscribeToHardwareWalletEvents.mockReturnValue(jest.fn());
 export const resetwebConnectionUtilsMocks = () => {
   isWebHidAvailable.mockReturnValue(true);
   isWebUsbAvailable.mockReturnValue(true);
+  isCameraAvailable.mockReturnValue(true);
   checkWebHidPermission.mockResolvedValue(
     HardwareConnectionPermissionState.Granted,
   );
@@ -76,19 +91,26 @@ export const resetwebConnectionUtilsMocks = () => {
         case HardwareWalletType.Ledger:
           return Promise.resolve(HardwareConnectionPermissionState.Granted);
         case HardwareWalletType.Trezor:
+        case HardwareWalletType.Qr:
           return Promise.resolve(HardwareConnectionPermissionState.Granted);
         default:
           return Promise.resolve(HardwareConnectionPermissionState.Denied);
       }
     },
   );
+  checkCameraPermissionState.mockResolvedValue(
+    HardwareConnectionPermissionState.Granted,
+  );
+  checkCameraPermission.mockResolvedValue(CameraPermissionState.Granted);
   requestWebHidPermission.mockResolvedValue(true);
   requestWebUsbPermission.mockResolvedValue(true);
+  requestCameraPermission.mockResolvedValue(true);
   requestHardwareWalletPermission.mockImplementation(
     (walletType: HardwareWalletType) => {
       switch (walletType) {
         case HardwareWalletType.Ledger:
         case HardwareWalletType.Trezor:
+        case HardwareWalletType.Qr:
           return Promise.resolve(true);
         default:
           return Promise.resolve(false);
@@ -114,11 +136,16 @@ export const mockPermissionsDenied = () => {
   checkWebUsbPermission.mockResolvedValue(
     HardwareConnectionPermissionState.Denied,
   );
+  checkCameraPermissionState.mockResolvedValue(
+    HardwareConnectionPermissionState.Denied,
+  );
+  checkCameraPermission.mockResolvedValue(CameraPermissionState.Denied);
   checkHardwareWalletPermission.mockResolvedValue(
     HardwareConnectionPermissionState.Denied,
   );
   requestWebHidPermission.mockResolvedValue(false);
   requestWebUsbPermission.mockResolvedValue(false);
+  requestCameraPermission.mockResolvedValue(false);
   requestHardwareWalletPermission.mockResolvedValue(false);
 };
 
@@ -130,6 +157,10 @@ export const mockPermissionsPrompt = () => {
   checkWebUsbPermission.mockResolvedValue(
     HardwareConnectionPermissionState.Prompt,
   );
+  checkCameraPermissionState.mockResolvedValue(
+    HardwareConnectionPermissionState.Prompt,
+  );
+  checkCameraPermission.mockResolvedValue(CameraPermissionState.Prompt);
   checkHardwareWalletPermission.mockResolvedValue(
     HardwareConnectionPermissionState.Prompt,
   );

--- a/ui/contexts/hardware-wallets/adapters/QrAdapter.test.ts
+++ b/ui/contexts/hardware-wallets/adapters/QrAdapter.test.ts
@@ -52,9 +52,32 @@ describe('QrAdapter', () => {
     });
   });
 
+  it('disconnect calls onDisconnect when onDeviceEvent throws', async () => {
+    await adapter.connect();
+    const handlerError = new Error('onDeviceEvent failed');
+    jest.mocked(mockOptions.onDeviceEvent).mockImplementation(() => {
+      throw handlerError;
+    });
+
+    await adapter.disconnect();
+
+    expect(mockOptions.onDisconnect).toHaveBeenCalledWith(handlerError);
+  });
+
   it('ensureDeviceReady returns true when camera permission is granted', async () => {
     mockCheckCameraPermission.mockResolvedValue(CameraPermissionState.Granted);
     await expect(adapter.ensureDeviceReady()).resolves.toBe(true);
+  });
+
+  it('ensureDeviceReady does not call connect again when already connected', async () => {
+    mockCheckCameraPermission.mockResolvedValue(CameraPermissionState.Granted);
+    await adapter.connect();
+    const connectSpy = jest.spyOn(adapter, 'connect');
+
+    await expect(adapter.ensureDeviceReady()).resolves.toBe(true);
+
+    expect(connectSpy).not.toHaveBeenCalled();
+    connectSpy.mockRestore();
   });
 
   it('ensureDeviceReady throws PermissionCameraDenied when camera permission is denied', async () => {

--- a/ui/contexts/hardware-wallets/adapters/QrAdapter.test.ts
+++ b/ui/contexts/hardware-wallets/adapters/QrAdapter.test.ts
@@ -1,0 +1,119 @@
+import {
+  Category,
+  ErrorCode,
+  HardwareWalletError,
+  Severity,
+} from '@metamask/hw-wallet-sdk';
+import { CameraPermissionState } from '../constants';
+import { DeviceEvent, type HardwareWalletAdapterOptions } from '../types';
+import * as webConnectionUtils from '../webConnectionUtils';
+import { QrAdapter } from './QrAdapter';
+
+jest.mock('../webConnectionUtils', () => ({
+  ...jest.requireActual('../webConnectionUtils'),
+  checkCameraPermission: jest.fn(),
+}));
+
+const mockCheckCameraPermission =
+  webConnectionUtils.checkCameraPermission as jest.MockedFunction<
+    typeof webConnectionUtils.checkCameraPermission
+  >;
+
+describe('QrAdapter', () => {
+  let adapter: QrAdapter;
+  let mockOptions: HardwareWalletAdapterOptions;
+
+  const createMockOptions = (): HardwareWalletAdapterOptions => ({
+    onDisconnect: jest.fn(),
+    onAwaitingConfirmation: jest.fn(),
+    onDeviceLocked: jest.fn(),
+    onAppNotOpen: jest.fn(),
+    onDeviceEvent: jest.fn(),
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockOptions = createMockOptions();
+    adapter = new QrAdapter(mockOptions);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    adapter.destroy();
+  });
+
+  it('connect marks adapter as connected', async () => {
+    await adapter.connect();
+    expect(adapter.isConnected()).toBe(true);
+  });
+
+  it('disconnect emits disconnected event', async () => {
+    await adapter.connect();
+    await adapter.disconnect();
+
+    expect(adapter.isConnected()).toBe(false);
+    expect(mockOptions.onDeviceEvent).toHaveBeenCalledWith({
+      event: DeviceEvent.Disconnected,
+    });
+  });
+
+  it('ensureDeviceReady returns true when camera permission is granted', async () => {
+    mockCheckCameraPermission.mockResolvedValue(CameraPermissionState.Granted);
+    await expect(adapter.ensureDeviceReady()).resolves.toBe(true);
+  });
+
+  it('ensureDeviceReady throws PermissionCameraDenied when camera permission is denied', async () => {
+    mockCheckCameraPermission.mockResolvedValue(CameraPermissionState.Denied);
+
+    await expect(adapter.ensureDeviceReady()).rejects.toThrow(
+      HardwareWalletError,
+    );
+
+    expect(mockOptions.onDeviceEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: DeviceEvent.ConnectionFailed,
+        error: expect.objectContaining({
+          code: ErrorCode.PermissionCameraDenied,
+        }),
+      }),
+    );
+  });
+
+  it('ensureDeviceReady throws PermissionCameraPromptDismissed when camera permission is prompt', async () => {
+    mockCheckCameraPermission.mockResolvedValue(CameraPermissionState.Prompt);
+
+    await expect(adapter.ensureDeviceReady()).rejects.toThrow(
+      HardwareWalletError,
+    );
+
+    expect(mockOptions.onDeviceEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: DeviceEvent.ConnectionFailed,
+        error: expect.objectContaining({
+          code: ErrorCode.PermissionCameraPromptDismissed,
+        }),
+      }),
+    );
+  });
+
+  it('maps unexpected errors to hardware wallet errors and emits device event', async () => {
+    const unknownError = new HardwareWalletError('Unknown error', {
+      code: ErrorCode.Unknown,
+      severity: Severity.Err,
+      category: Category.Unknown,
+      userMessage: 'Unknown',
+    });
+    mockCheckCameraPermission.mockRejectedValue(unknownError);
+
+    await expect(adapter.ensureDeviceReady()).rejects.toThrow(
+      HardwareWalletError,
+    );
+
+    expect(mockOptions.onDeviceEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: DeviceEvent.ConnectionFailed,
+        error: expect.any(HardwareWalletError),
+      }),
+    );
+  });
+});

--- a/ui/contexts/hardware-wallets/adapters/QrAdapter.test.ts
+++ b/ui/contexts/hardware-wallets/adapters/QrAdapter.test.ts
@@ -1,9 +1,4 @@
-import {
-  Category,
-  ErrorCode,
-  HardwareWalletError,
-  Severity,
-} from '@metamask/hw-wallet-sdk';
+import { ErrorCode, HardwareWalletError } from '@metamask/hw-wallet-sdk';
 import { CameraPermissionState } from '../constants';
 import { DeviceEvent, type HardwareWalletAdapterOptions } from '../types';
 import * as webConnectionUtils from '../webConnectionUtils';
@@ -97,13 +92,9 @@ describe('QrAdapter', () => {
   });
 
   it('maps unexpected errors to hardware wallet errors and emits device event', async () => {
-    const unknownError = new HardwareWalletError('Unknown error', {
-      code: ErrorCode.Unknown,
-      severity: Severity.Err,
-      category: Category.Unknown,
-      userMessage: 'Unknown',
-    });
-    mockCheckCameraPermission.mockRejectedValue(unknownError);
+    mockCheckCameraPermission.mockRejectedValue(
+      new Error('Unable to read camera permission'),
+    );
 
     await expect(adapter.ensureDeviceReady()).rejects.toThrow(
       HardwareWalletError,
@@ -112,7 +103,9 @@ describe('QrAdapter', () => {
     expect(mockOptions.onDeviceEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         event: DeviceEvent.ConnectionFailed,
-        error: expect.any(HardwareWalletError),
+        error: expect.objectContaining({
+          code: ErrorCode.Unknown,
+        }),
       }),
     );
   });

--- a/ui/contexts/hardware-wallets/adapters/QrAdapter.ts
+++ b/ui/contexts/hardware-wallets/adapters/QrAdapter.ts
@@ -17,7 +17,7 @@ import { checkCameraPermission } from '../webConnectionUtils';
  * Readiness depends on camera availability and permission state for QR scanning.
  */
 export class QrAdapter implements HardwareWalletAdapter {
-  private options: HardwareWalletAdapterOptions;
+  private readonly options: HardwareWalletAdapterOptions;
 
   private connected = false;
 

--- a/ui/contexts/hardware-wallets/adapters/QrAdapter.ts
+++ b/ui/contexts/hardware-wallets/adapters/QrAdapter.ts
@@ -1,0 +1,120 @@
+import { ErrorCode, type HardwareWalletError } from '@metamask/hw-wallet-sdk';
+import { createHardwareWalletError, getDeviceEventForError } from '../errors';
+import { toHardwareWalletError } from '../rpcErrorUtils';
+import {
+  DeviceEvent,
+  HardwareWalletType,
+  type EnsureDeviceReadyOptions,
+  type HardwareWalletAdapter,
+  type HardwareWalletAdapterOptions,
+} from '../types';
+import { CameraPermissionState } from '../constants';
+import { checkCameraPermission } from '../webConnectionUtils';
+
+/**
+ * QR hardware wallet adapter.
+ *
+ * Readiness depends on camera availability and permission state for QR scanning.
+ */
+export class QrAdapter implements HardwareWalletAdapter {
+  private options: HardwareWalletAdapterOptions;
+
+  private connected = false;
+
+  constructor(options: HardwareWalletAdapterOptions) {
+    this.options = options;
+  }
+
+  /**
+   * Marks the adapter as connected.
+   */
+  async connect(): Promise<void> {
+    this.connected = true;
+  }
+
+  /**
+   * Clears connection state and notifies listeners that the QR flow is no longer active.
+   */
+  async disconnect(): Promise<void> {
+    try {
+      this.connected = false;
+      this.options.onDeviceEvent({
+        event: DeviceEvent.Disconnected,
+      });
+    } catch (error) {
+      this.options.onDisconnect(error);
+    }
+  }
+
+  /**
+   * Whether the adapter considers the QR account flow active (after connection).
+   */
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  /**
+   * Resets local connection state.
+   */
+  destroy(): void {
+    this.connected = false;
+  }
+
+  /**
+   * Emits a device event for the given error and returns a rejected promise with that error.
+   *
+   * @param hwError - Structured hardware wallet error to surface to the UI layer.
+   * @returns A promise that rejects with `hwError`.
+   */
+  private failEnsureDeviceReady(hwError: HardwareWalletError): Promise<never> {
+    this.options.onDeviceEvent({
+      event: getDeviceEventForError(hwError.code),
+      error: hwError,
+    });
+    return Promise.reject(hwError);
+  }
+
+  /**
+   * Ensures camera permission state allows QR scanning (via Permissions API probe).
+   * Rejects with `HardwareWalletError` when permission is denied, still prompt, or the probe fails.
+   *
+   * @param _options - Reserved for parity with other hardware adapters; ignored for QR.
+   * @returns True when camera permission is granted.
+   */
+  async ensureDeviceReady(
+    _options?: EnsureDeviceReadyOptions,
+  ): Promise<boolean> {
+    if (!this.isConnected()) {
+      await this.connect();
+    }
+
+    let permissionState: PermissionState;
+    try {
+      permissionState = await checkCameraPermission();
+    } catch (error) {
+      return this.failEnsureDeviceReady(
+        toHardwareWalletError(error, HardwareWalletType.Qr),
+      );
+    }
+
+    if (permissionState === CameraPermissionState.Granted) {
+      return true;
+    }
+
+    if (permissionState === CameraPermissionState.Denied) {
+      return this.failEnsureDeviceReady(
+        createHardwareWalletError(
+          ErrorCode.PermissionCameraDenied,
+          HardwareWalletType.Qr,
+        ),
+      );
+    }
+
+    return this.failEnsureDeviceReady(
+      createHardwareWalletError(
+        ErrorCode.PermissionCameraPromptDismissed,
+        HardwareWalletType.Qr,
+      ),
+    );
+  }
+}

--- a/ui/contexts/hardware-wallets/adapters/factory.test.ts
+++ b/ui/contexts/hardware-wallets/adapters/factory.test.ts
@@ -5,6 +5,7 @@ import {
 import { createAdapterForHardwareWalletType } from './factory';
 import { LedgerAdapter } from './LedgerAdapter';
 import { NonHardwareAdapter } from './NonHardwareAdapter';
+import { QrAdapter } from './QrAdapter';
 
 describe('createAdapterForHardwareWalletType', () => {
   const mockOptions: HardwareWalletAdapterOptions = {
@@ -26,6 +27,14 @@ describe('createAdapterForHardwareWalletType', () => {
         mockOptions,
       );
       expect(adapter).toBeInstanceOf(LedgerAdapter);
+    });
+
+    it('creates QrAdapter for QR wallet type', () => {
+      const adapter = createAdapterForHardwareWalletType(
+        HardwareWalletType.Qr,
+        mockOptions,
+      );
+      expect(adapter).toBeInstanceOf(QrAdapter);
     });
   });
 

--- a/ui/contexts/hardware-wallets/adapters/factory.ts
+++ b/ui/contexts/hardware-wallets/adapters/factory.ts
@@ -5,6 +5,7 @@ import {
 } from '../types';
 import { LedgerAdapter } from './LedgerAdapter';
 import { NonHardwareAdapter } from './NonHardwareAdapter';
+import { QrAdapter } from './QrAdapter';
 
 /**
  * Creates an adapter for the given hardware wallet type.
@@ -20,6 +21,8 @@ export function createAdapterForHardwareWalletType(
   switch (walletType) {
     case HardwareWalletType.Ledger:
       return new LedgerAdapter(adapterOptions);
+    case HardwareWalletType.Qr:
+      return new QrAdapter(adapterOptions);
     default:
       return new NonHardwareAdapter(adapterOptions);
   }

--- a/ui/contexts/hardware-wallets/adapters/index.ts
+++ b/ui/contexts/hardware-wallets/adapters/index.ts
@@ -1,2 +1,3 @@
 export { LedgerAdapter } from './LedgerAdapter';
 export { NonHardwareAdapter } from './NonHardwareAdapter';
+export { QrAdapter } from './QrAdapter';

--- a/ui/contexts/hardware-wallets/constants.ts
+++ b/ui/contexts/hardware-wallets/constants.ts
@@ -1,1 +1,11 @@
 export const HARDWARE_WALLET_ERROR_MODAL_NAME = 'HARDWARE_WALLET_ERROR';
+
+/**
+ * Named values for the browser `PermissionStatus.state` union when querying the
+ * `camera` permission ({@link https://developer.mozilla.org/en-US/docs/Web/API/PermissionStatus/state}).
+ */
+export const CameraPermissionState = {
+  Granted: 'granted',
+  Denied: 'denied',
+  Prompt: 'prompt',
+} as const;

--- a/ui/contexts/hardware-wallets/errors.ts
+++ b/ui/contexts/hardware-wallets/errors.ts
@@ -4,6 +4,7 @@ import {
   Severity,
   Category,
   LEDGER_ERROR_MAPPINGS,
+  QR_WALLET_ERROR_MAPPINGS,
 } from '@metamask/hw-wallet-sdk';
 import { ConnectionState } from './connectionState';
 import {
@@ -86,6 +87,7 @@ const ERROR_PROPERTIES_MAP = (() => {
 
   // Extract from Ledger
   extractFromMappings(LEDGER_ERROR_MAPPINGS);
+  extractFromMappings(QR_WALLET_ERROR_MAPPINGS);
 
   return map;
 })();

--- a/ui/contexts/hardware-wallets/webConnectionUtils.test.ts
+++ b/ui/contexts/hardware-wallets/webConnectionUtils.test.ts
@@ -22,6 +22,7 @@ import {
   getConnectedDevices,
   subscribeToWebHidEvents,
   subscribeToWebUsbEvents,
+  subscribeToHardwareWalletEvents,
 } from './webConnectionUtils';
 
 // Default device identifiers for testing
@@ -322,6 +323,16 @@ describe('webConnectionUtils', () => {
 
       expect(isCameraAvailable()).toBe(false);
     });
+
+    it('returns false when getUserMedia is not a function', () => {
+      Object.defineProperty(window.navigator, 'mediaDevices', {
+        value: {},
+        writable: true,
+        configurable: true,
+      });
+
+      expect(isCameraAvailable()).toBe(false);
+    });
   });
 
   describe('checkHardwareWalletPermission', () => {
@@ -478,6 +489,16 @@ describe('webConnectionUtils', () => {
       getMockedMediaDevices().getUserMedia.mockRejectedValue(
         new Error('Permission denied'),
       );
+
+      await expect(requestCameraPermission()).resolves.toBe(false);
+    });
+
+    it('requestCameraPermission returns false when camera APIs are unavailable', async () => {
+      Object.defineProperty(window.navigator, 'mediaDevices', {
+        value: undefined,
+        writable: true,
+        configurable: true,
+      });
 
       await expect(requestCameraPermission()).resolves.toBe(false);
     });
@@ -1309,6 +1330,24 @@ describe('webConnectionUtils', () => {
         'disconnect',
         disconnectHandler,
       );
+    });
+  });
+
+  describe('subscribeToHardwareWalletEvents', () => {
+    it('returns a no-op unsubscribe for QR wallet type', () => {
+      const mockOnConnect = jest.fn();
+      const mockOnDisconnect = jest.fn();
+
+      const unsubscribe = subscribeToHardwareWalletEvents(
+        HardwareWalletType.Qr,
+        mockOnConnect,
+        mockOnDisconnect,
+      );
+
+      expect(typeof unsubscribe).toBe('function');
+      expect(() => unsubscribe()).not.toThrow();
+      expect(getMockedHid().addEventListener).not.toHaveBeenCalled();
+      expect(getMockedUsb().addEventListener).not.toHaveBeenCalled();
     });
   });
 

--- a/ui/contexts/hardware-wallets/webConnectionUtils.test.ts
+++ b/ui/contexts/hardware-wallets/webConnectionUtils.test.ts
@@ -305,6 +305,14 @@ describe('webConnectionUtils', () => {
       expect(isCameraAvailable()).toBe(true);
     });
 
+    it('returns false when window is undefined', () => {
+      setupUndefinedWindow();
+
+      expect(isCameraAvailable()).toBe(false);
+
+      restoreWindow();
+    });
+
     it('returns false when mediaDevices is not available', () => {
       Object.defineProperty(window.navigator, 'mediaDevices', {
         value: undefined,
@@ -382,6 +390,10 @@ describe('webConnectionUtils', () => {
     });
 
     it('checkCameraPermission returns prompt when permissions API is unavailable', async () => {
+      // Camera capture APIs must remain available; otherwise isCameraAvailable() short-circuits
+      // to denied and this test would not exercise the permissions branch.
+      expect(isCameraAvailable()).toBe(true);
+
       Object.defineProperty(window.navigator, 'permissions', {
         value: undefined,
         writable: true,
@@ -390,6 +402,48 @@ describe('webConnectionUtils', () => {
 
       await expect(checkCameraPermission()).resolves.toBe(
         CameraPermissionState.Prompt,
+      );
+    });
+
+    it('checkCameraPermission returns prompt when permissions.query is missing', async () => {
+      expect(isCameraAvailable()).toBe(true);
+
+      Object.defineProperty(window.navigator, 'permissions', {
+        value: {},
+        writable: true,
+        configurable: true,
+      });
+
+      await expect(checkCameraPermission()).resolves.toBe(
+        CameraPermissionState.Prompt,
+      );
+    });
+
+    it('checkCameraPermissionState returns Prompt when permissions API is unavailable', async () => {
+      expect(isCameraAvailable()).toBe(true);
+
+      Object.defineProperty(window.navigator, 'permissions', {
+        value: undefined,
+        writable: true,
+        configurable: true,
+      });
+
+      await expect(checkCameraPermissionState()).resolves.toBe(
+        HardwareConnectionPermissionState.Prompt,
+      );
+    });
+
+    it('checkCameraPermission returns denied when camera APIs are unavailable', async () => {
+      Object.defineProperty(window.navigator, 'mediaDevices', {
+        value: undefined,
+        writable: true,
+        configurable: true,
+      });
+
+      expect(isCameraAvailable()).toBe(false);
+
+      await expect(checkCameraPermission()).resolves.toBe(
+        CameraPermissionState.Denied,
       );
     });
 

--- a/ui/contexts/hardware-wallets/webConnectionUtils.test.ts
+++ b/ui/contexts/hardware-wallets/webConnectionUtils.test.ts
@@ -393,6 +393,22 @@ describe('webConnectionUtils', () => {
       );
     });
 
+    it('checkCameraPermissionState returns Unknown when permissions.query rejects', async () => {
+      getMockedPermissions().query.mockRejectedValue(new Error('query failed'));
+
+      await expect(checkCameraPermissionState()).resolves.toBe(
+        HardwareConnectionPermissionState.Unknown,
+      );
+    });
+
+    it('checkCameraPermission rejects when permissions.query rejects', async () => {
+      getMockedPermissions().query.mockRejectedValue(new Error('query failed'));
+
+      await expect(checkCameraPermission()).rejects.toThrow(
+        'Unable to determine camera permission state',
+      );
+    });
+
     it('requestCameraPermission returns true and closes stream tracks on success', async () => {
       const stop = jest.fn();
       const mockTrack = { stop } as unknown as MediaStreamTrack;

--- a/ui/contexts/hardware-wallets/webConnectionUtils.test.ts
+++ b/ui/contexts/hardware-wallets/webConnectionUtils.test.ts
@@ -430,20 +430,6 @@ describe('webConnectionUtils', () => {
       );
     });
 
-    it('checkCameraPermissionState returns Prompt when permissions API is unavailable', async () => {
-      expect(isCameraAvailable()).toBe(true);
-
-      Object.defineProperty(window.navigator, 'permissions', {
-        value: undefined,
-        writable: true,
-        configurable: true,
-      });
-
-      await expect(checkCameraPermissionState()).resolves.toBe(
-        HardwareConnectionPermissionState.Prompt,
-      );
-    });
-
     it('checkCameraPermission returns denied when camera APIs are unavailable', async () => {
       Object.defineProperty(window.navigator, 'mediaDevices', {
         value: undefined,

--- a/ui/contexts/hardware-wallets/webConnectionUtils.test.ts
+++ b/ui/contexts/hardware-wallets/webConnectionUtils.test.ts
@@ -2,16 +2,21 @@ import {
   LEDGER_USB_VENDOR_ID,
   TREZOR_USB_VENDOR_IDS,
 } from '../../../shared/constants/hardware-wallets';
+import { CameraPermissionState } from './constants';
 import { HardwareWalletType, HardwareConnectionPermissionState } from './types';
 import {
   isWebHidAvailable,
   isWebUsbAvailable,
+  isCameraAvailable,
   checkHardwareWalletPermission,
   checkWebHidPermission,
   checkWebUsbPermission,
+  checkCameraPermissionState,
+  checkCameraPermission,
   requestHardwareWalletPermission,
   requestWebHidPermission,
   requestWebUsbPermission,
+  requestCameraPermission,
   getConnectedLedgerDevices,
   getConnectedTrezorDevices,
   getConnectedDevices,
@@ -113,6 +118,20 @@ describe('webConnectionUtils', () => {
       },
       configurable: true,
     });
+
+    Object.defineProperty(window.navigator, 'mediaDevices', {
+      value: {
+        getUserMedia: jest.fn(),
+      },
+      configurable: true,
+    });
+
+    Object.defineProperty(window.navigator, 'permissions', {
+      value: {
+        query: jest.fn(),
+      },
+      configurable: true,
+    });
   };
 
   // Helper function to restore navigator
@@ -160,6 +179,20 @@ describe('webConnectionUtils', () => {
 
   const getMockedUsb = (): jest.Mocked<USB> => {
     return window.navigator.usb as jest.Mocked<USB>;
+  };
+
+  const getMockedMediaDevices = (): {
+    getUserMedia: jest.Mock;
+  } => {
+    return window.navigator.mediaDevices as unknown as {
+      getUserMedia: jest.Mock;
+    };
+  };
+
+  const getMockedPermissions = (): {
+    query: jest.Mock;
+  } => {
+    return window.navigator.permissions as unknown as { query: jest.Mock };
   };
 
   beforeEach(() => {
@@ -267,6 +300,22 @@ describe('webConnectionUtils', () => {
     });
   });
 
+  describe('isCameraAvailable', () => {
+    it('returns true when camera APIs are available', () => {
+      expect(isCameraAvailable()).toBe(true);
+    });
+
+    it('returns false when mediaDevices is not available', () => {
+      Object.defineProperty(window.navigator, 'mediaDevices', {
+        value: undefined,
+        writable: true,
+        configurable: true,
+      });
+
+      expect(isCameraAvailable()).toBe(false);
+    });
+  });
+
   describe('checkHardwareWalletPermission', () => {
     it('returns Granted when Ledger devices are paired', async () => {
       (window.navigator.hid.getDevices as jest.Mock).mockResolvedValue([
@@ -298,6 +347,69 @@ describe('webConnectionUtils', () => {
       );
 
       expect(result).toBe(HardwareConnectionPermissionState.Denied);
+    });
+
+    it('returns camera permission state for QR wallet type', async () => {
+      getMockedPermissions().query.mockResolvedValue({
+        state: CameraPermissionState.Granted,
+      });
+
+      const result = await checkHardwareWalletPermission(HardwareWalletType.Qr);
+
+      expect(result).toBe(HardwareConnectionPermissionState.Granted);
+    });
+  });
+
+  describe('camera permission helpers', () => {
+    it('checkCameraPermissionState returns Granted when camera permission is granted', async () => {
+      getMockedPermissions().query.mockResolvedValue({
+        state: CameraPermissionState.Granted,
+      });
+
+      await expect(checkCameraPermissionState()).resolves.toBe(
+        HardwareConnectionPermissionState.Granted,
+      );
+    });
+
+    it('checkCameraPermissionState returns Denied when camera permission is denied', async () => {
+      getMockedPermissions().query.mockResolvedValue({
+        state: CameraPermissionState.Denied,
+      });
+
+      await expect(checkCameraPermissionState()).resolves.toBe(
+        HardwareConnectionPermissionState.Denied,
+      );
+    });
+
+    it('checkCameraPermission returns prompt when permissions API is unavailable', async () => {
+      Object.defineProperty(window.navigator, 'permissions', {
+        value: undefined,
+        writable: true,
+        configurable: true,
+      });
+
+      await expect(checkCameraPermission()).resolves.toBe(
+        CameraPermissionState.Prompt,
+      );
+    });
+
+    it('requestCameraPermission returns true and closes stream tracks on success', async () => {
+      const stop = jest.fn();
+      const mockTrack = { stop } as unknown as MediaStreamTrack;
+      getMockedMediaDevices().getUserMedia.mockResolvedValue({
+        getTracks: () => [mockTrack],
+      });
+
+      await expect(requestCameraPermission()).resolves.toBe(true);
+      expect(stop).toHaveBeenCalledTimes(1);
+    });
+
+    it('requestCameraPermission returns false when user denies camera access', async () => {
+      getMockedMediaDevices().getUserMedia.mockRejectedValue(
+        new Error('Permission denied'),
+      );
+
+      await expect(requestCameraPermission()).resolves.toBe(false);
     });
   });
 
@@ -448,6 +560,18 @@ describe('webConnectionUtils', () => {
       );
 
       expect(result).toBe(false);
+    });
+
+    it('returns true when camera permission is granted for QR wallet type', async () => {
+      getMockedMediaDevices().getUserMedia.mockResolvedValue({
+        getTracks: () => [],
+      });
+
+      const result = await requestHardwareWalletPermission(
+        HardwareWalletType.Qr,
+      );
+
+      expect(result).toBe(true);
     });
   });
 

--- a/ui/contexts/hardware-wallets/webConnectionUtils.ts
+++ b/ui/contexts/hardware-wallets/webConnectionUtils.ts
@@ -31,12 +31,12 @@ export function isWebUsbAvailable(): boolean {
  * Check if camera APIs are available in the current browser.
  */
 export function isCameraAvailable(): boolean {
-  if (typeof globalThis.window === 'undefined') {
+  if (globalThis.window === undefined) {
     return false;
   }
   const { navigator } = globalThis;
   return (
-    typeof navigator.mediaDevices !== 'undefined' &&
+    navigator.mediaDevices !== undefined &&
     typeof navigator.mediaDevices.getUserMedia === 'function'
   );
 }

--- a/ui/contexts/hardware-wallets/webConnectionUtils.ts
+++ b/ui/contexts/hardware-wallets/webConnectionUtils.ts
@@ -2,6 +2,7 @@ import {
   LEDGER_USB_VENDOR_ID,
   TREZOR_USB_VENDOR_IDS,
 } from '../../../shared/constants/hardware-wallets';
+import { CameraPermissionState } from './constants';
 import { HardwareWalletType, HardwareConnectionPermissionState } from './types';
 
 /**
@@ -23,6 +24,18 @@ export function isWebUsbAvailable(): boolean {
     typeof window !== 'undefined' &&
     typeof window.navigator !== 'undefined' &&
     'usb' in window.navigator
+  );
+}
+
+/**
+ * Check if camera APIs are available in the current browser.
+ */
+export function isCameraAvailable(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.navigator !== 'undefined' &&
+    typeof window.navigator.mediaDevices !== 'undefined' &&
+    typeof window.navigator.mediaDevices.getUserMedia === 'function'
   );
 }
 
@@ -84,8 +97,41 @@ export async function checkHardwareWalletPermission(
       return await checkWebHidPermission(walletType);
     case HardwareWalletType.Trezor:
       return await checkWebUsbPermission(walletType);
+    case HardwareWalletType.Qr:
+      return await checkCameraPermissionState();
     default:
       return HardwareConnectionPermissionState.Denied;
+  }
+}
+
+/**
+ * Check camera permission state.
+ */
+export async function checkCameraPermissionState(): Promise<HardwareConnectionPermissionState> {
+  if (!isCameraAvailable()) {
+    return HardwareConnectionPermissionState.Denied;
+  }
+
+  try {
+    const { permissions } = window.navigator;
+    if (!permissions?.query) {
+      return HardwareConnectionPermissionState.Prompt;
+    }
+
+    const result = await permissions.query({
+      name: 'camera' as PermissionName,
+    });
+
+    switch (result.state) {
+      case CameraPermissionState.Granted:
+        return HardwareConnectionPermissionState.Granted;
+      case CameraPermissionState.Denied:
+        return HardwareConnectionPermissionState.Denied;
+      default:
+        return HardwareConnectionPermissionState.Prompt;
+    }
+  } catch {
+    return HardwareConnectionPermissionState.Unknown;
   }
 }
 
@@ -165,8 +211,53 @@ export async function requestHardwareWalletPermission(
       return requestWebHidPermission(walletType);
     case HardwareWalletType.Trezor:
       return requestWebUsbPermission(walletType);
+    case HardwareWalletType.Qr:
+      return requestCameraPermission();
     default:
       return false;
+  }
+}
+
+/**
+ * Request camera permission from the user.
+ */
+export async function requestCameraPermission(): Promise<boolean> {
+  if (!isCameraAvailable()) {
+    return false;
+  }
+
+  try {
+    const stream = await window.navigator.mediaDevices.getUserMedia({
+      video: true,
+    });
+
+    stream.getTracks().forEach((track) => track.stop());
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Return browser camera permission state.
+ */
+export async function checkCameraPermission(): Promise<PermissionState> {
+  if (!isCameraAvailable()) {
+    return CameraPermissionState.Denied;
+  }
+
+  try {
+    const { permissions } = window.navigator;
+    if (!permissions?.query) {
+      return CameraPermissionState.Prompt;
+    }
+
+    const result = await permissions.query({
+      name: 'camera' as PermissionName,
+    });
+    return result.state;
+  } catch {
+    return CameraPermissionState.Prompt;
   }
 }
 

--- a/ui/contexts/hardware-wallets/webConnectionUtils.ts
+++ b/ui/contexts/hardware-wallets/webConnectionUtils.ts
@@ -39,6 +39,34 @@ export function isCameraAvailable(): boolean {
   );
 }
 
+/** Message for the error thrown by {@link checkCameraPermission} when the probe fails. */
+const CAMERA_PERMISSION_PROBE_FAILED_MESSAGE =
+  'Unable to determine camera permission state';
+
+/**
+ * Shared probe for the browser camera permission. Returns `null` when
+ * `permissions.query` throws so callers can map to `Unknown` vs surface an error.
+ */
+async function queryCameraPermissionDomState(): Promise<PermissionState | null> {
+  if (!isCameraAvailable()) {
+    return CameraPermissionState.Denied;
+  }
+
+  try {
+    const { permissions } = window.navigator;
+    if (!permissions?.query) {
+      return CameraPermissionState.Prompt;
+    }
+
+    const result = await permissions.query({
+      name: 'camera' as PermissionName,
+    });
+    return result.state;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Check if a device matches the vendor filters for a specific hardware wallet type
  *
@@ -105,33 +133,21 @@ export async function checkHardwareWalletPermission(
 }
 
 /**
- * Check camera permission state.
+ * Check camera permission state for hardware-wallet permission UI.
  */
 export async function checkCameraPermissionState(): Promise<HardwareConnectionPermissionState> {
-  if (!isCameraAvailable()) {
-    return HardwareConnectionPermissionState.Denied;
+  const domState = await queryCameraPermissionDomState();
+  if (domState === null) {
+    return HardwareConnectionPermissionState.Unknown;
   }
 
-  try {
-    const { permissions } = window.navigator;
-    if (!permissions?.query) {
+  switch (domState) {
+    case CameraPermissionState.Granted:
+      return HardwareConnectionPermissionState.Granted;
+    case CameraPermissionState.Denied:
+      return HardwareConnectionPermissionState.Denied;
+    default:
       return HardwareConnectionPermissionState.Prompt;
-    }
-
-    const result = await permissions.query({
-      name: 'camera' as PermissionName,
-    });
-
-    switch (result.state) {
-      case CameraPermissionState.Granted:
-        return HardwareConnectionPermissionState.Granted;
-      case CameraPermissionState.Denied:
-        return HardwareConnectionPermissionState.Denied;
-      default:
-        return HardwareConnectionPermissionState.Prompt;
-    }
-  } catch {
-    return HardwareConnectionPermissionState.Unknown;
   }
 }
 
@@ -239,26 +255,17 @@ export async function requestCameraPermission(): Promise<boolean> {
 }
 
 /**
- * Return browser camera permission state.
+ * Return browser camera permission state for adapter readiness checks.
+ *
+ * @throws {Error} When the permission probe fails (equivalent to
+ * `HardwareConnectionPermissionState.Unknown` from `checkCameraPermissionState`).
  */
 export async function checkCameraPermission(): Promise<PermissionState> {
-  if (!isCameraAvailable()) {
-    return CameraPermissionState.Denied;
+  const domState = await queryCameraPermissionDomState();
+  if (domState === null) {
+    throw new Error(CAMERA_PERMISSION_PROBE_FAILED_MESSAGE);
   }
-
-  try {
-    const { permissions } = window.navigator;
-    if (!permissions?.query) {
-      return CameraPermissionState.Prompt;
-    }
-
-    const result = await permissions.query({
-      name: 'camera' as PermissionName,
-    });
-    return result.state;
-  } catch {
-    return CameraPermissionState.Prompt;
-  }
+  return domState;
 }
 
 /**

--- a/ui/contexts/hardware-wallets/webConnectionUtils.ts
+++ b/ui/contexts/hardware-wallets/webConnectionUtils.ts
@@ -31,11 +31,13 @@ export function isWebUsbAvailable(): boolean {
  * Check if camera APIs are available in the current browser.
  */
 export function isCameraAvailable(): boolean {
+  if (typeof globalThis.window === 'undefined') {
+    return false;
+  }
+  const { navigator } = globalThis;
   return (
-    typeof window !== 'undefined' &&
-    typeof window.navigator !== 'undefined' &&
-    typeof window.navigator.mediaDevices !== 'undefined' &&
-    typeof window.navigator.mediaDevices.getUserMedia === 'function'
+    typeof navigator.mediaDevices !== 'undefined' &&
+    typeof navigator.mediaDevices.getUserMedia === 'function'
   );
 }
 
@@ -53,7 +55,8 @@ async function queryCameraPermissionDomState(): Promise<PermissionState | null> 
   }
 
   try {
-    const { permissions } = window.navigator;
+    const { navigator } = globalThis;
+    const { permissions } = navigator;
     if (!permissions?.query) {
       return CameraPermissionState.Prompt;
     }
@@ -243,7 +246,8 @@ export async function requestCameraPermission(): Promise<boolean> {
   }
 
   try {
-    const stream = await window.navigator.mediaDevices.getUserMedia({
+    const { navigator } = globalThis;
+    const stream = await navigator.mediaDevices.getUserMedia({
       video: true,
     });
 


### PR DESCRIPTION
## **Description**
This PR adds QR adapter which will be used for the new QR hardware wallet flow.

## **Changelog**
<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**
Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1643

## **Manual testing steps**
Nothing specifically here that we can manually test. 
Unit tests are added to cover all new functionalities.

## **Screenshots/Recordings**
### **Before**
No UI changes. Nothing to show here.

### **After**
No UI changes. Nothing to show here.

## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new `QrAdapter` and adds camera permission probing/requesting to shared `webConnectionUtils`, which could affect hardware-wallet permission UX and error mapping if browser permission APIs behave unexpectedly.
> 
> **Overview**
> Adds **QR hardware wallet support** via a new `QrAdapter` that manages QR-flow connection state and gates `ensureDeviceReady` on browser camera permission, emitting mapped device events/errors for denied/prompt/unknown cases.
> 
> Extends `webConnectionUtils` to support camera availability checks, camera permission probing (`checkCameraPermission`/`checkCameraPermissionState`), and camera permission requests (`requestCameraPermission`), and wires these into `checkHardwareWalletPermission`/`requestHardwareWalletPermission` for `HardwareWalletType.Qr` (with a no-op event subscription path).
> 
> Updates error-property mapping to include `QR_WALLET_ERROR_MAPPINGS`, and expands mocks and unit tests to cover the new QR adapter and camera permission behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46822f708fce01e795ed3e8b627189555fc26231. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->