### PR TITLE
feat: add danger alert banner on price impact modal

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1147,6 +1147,9 @@
   "bridgePriceImpact": {
     "message": "Price impact"
   },
+  "bridgePriceImpactFiatAlert": {
+    "message": "You will lose $1 on this trade"
+  },
   "bridgePriceImpactHigh": {
     "message": "High price impact"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -1147,6 +1147,9 @@
   "bridgePriceImpact": {
     "message": "Price impact"
   },
+  "bridgePriceImpactFiatAlert": {
+    "message": "You will lose $1 on this trade"
+  },
   "bridgePriceImpactHigh": {
     "message": "High price impact"
   },

--- a/ui/ducks/bridge/selectors.test.ts
+++ b/ui/ducks/bridge/selectors.test.ts
@@ -22,6 +22,7 @@ import { CHAIN_IDS, FEATURED_RPCS } from '../../../shared/constants/network';
 import { mockNetworkState } from '../../../test/stub/networks';
 import mockErc20Erc20Quotes from '../../../test/data/bridge/mock-quotes-erc20-erc20.json';
 import mockBridgeQuotesNativeErc20 from '../../../test/data/bridge/mock-quotes-native-erc20.json';
+import { DummyQuotesNoApproval } from '../../../test/data/bridge/dummy-quotes';
 import { MultichainNetworks } from '../../../shared/constants/multichain/networks';
 import { NETWORK_TO_SHORT_NETWORK_NAME_MAP } from '../../../shared/constants/bridge';
 import {
@@ -59,7 +60,8 @@ import {
   getFromAmountInCurrency,
   getValidatedFromValue,
   getPriceImpact,
-  getFormattedPriceImpact,
+  getFormattedPriceImpactPercentage,
+  getFormattedPriceImpactFiat,
   getIsStockMarketClosed,
   getWarningLabels,
   getIsQuoteExpired,
@@ -3116,7 +3118,7 @@ describe('Bridge selectors', () => {
           })) as unknown as QuoteResponse[],
         },
       });
-      const result = getFormattedPriceImpact(state as never);
+      const result = getFormattedPriceImpactPercentage(state as never);
       expect(result).toBe('15%');
     });
 
@@ -3124,8 +3126,73 @@ describe('Bridge selectors', () => {
       const state = createBridgeMockStore({
         bridgeStateOverrides: { quotes: [] },
       });
-      const result = getFormattedPriceImpact(state as never);
+      const result = getFormattedPriceImpactPercentage(state as never);
       expect(result).toBe('0%');
+    });
+  });
+
+  describe('getFormattedPriceImpactFiat', () => {
+    it('returns a formatted fiat string when active quote has both fiat amounts', () => {
+      // ETH (native, OP) → ETH (native, ARB); quoteRequest srcChainId/destChainId must be set
+      // so selectBridgeQuotesWithMetadata can look up exchange rates and compute valueInCurrency.
+      const state = createBridgeMockStore({
+        bridgeStateOverrides: {
+          quotes:
+            DummyQuotesNoApproval.OP_0_005_ETH_TO_ARB as unknown as QuoteResponse[],
+          quoteRequest: {
+            srcChainId: 10,
+            srcTokenAddress: zeroAddress(),
+            destChainId: 42161,
+            destTokenAddress: zeroAddress(),
+          },
+        },
+        metamaskStateOverrides: {
+          currentCurrency: 'usd',
+          currencyRates: {
+            ETH: { conversionRate: 2524.25, usdConversionRate: 2524.25 },
+          },
+        },
+      });
+      const result = getFormattedPriceImpactFiat(state as never);
+      expect(result).toBeDefined();
+      expect(typeof result).toBe('string');
+    });
+
+    it('returns undefined when there are no quotes', () => {
+      const state = createBridgeMockStore({
+        bridgeStateOverrides: { quotes: [] },
+        metamaskStateOverrides: { currentCurrency: 'usd' },
+      });
+      const result = getFormattedPriceImpactFiat(state as never);
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined when sentAmount.valueInCurrency is null', () => {
+      const state = createBridgeMockStore({
+        bridgeStateOverrides: {
+          quotes: DummyQuotesNoApproval.OP_0_005_ETH_TO_ARB.map((quote) => ({
+            ...quote,
+            sentAmount: { ...quote.sentAmount, valueInCurrency: null },
+          })) as unknown as QuoteResponse[],
+        },
+        metamaskStateOverrides: { currentCurrency: 'usd' },
+      });
+      const result = getFormattedPriceImpactFiat(state as never);
+      expect(result).toBeUndefined();
+    });
+
+    it('returns undefined when toTokenAmount.valueInCurrency is null', () => {
+      const state = createBridgeMockStore({
+        bridgeStateOverrides: {
+          quotes: DummyQuotesNoApproval.OP_0_005_ETH_TO_ARB.map((quote) => ({
+            ...quote,
+            toTokenAmount: { ...quote.toTokenAmount, valueInCurrency: null },
+          })) as unknown as QuoteResponse[],
+        },
+        metamaskStateOverrides: { currentCurrency: 'usd' },
+      });
+      const result = getFormattedPriceImpactFiat(state as never);
+      expect(result).toBeUndefined();
     });
   });
 

--- a/ui/ducks/bridge/selectors.ts
+++ b/ui/ducks/bridge/selectors.ts
@@ -92,7 +92,11 @@ import {
   isStockRWAToken,
   isTokenTradingOpenAt,
 } from '../../pages/bridge/hooks/useRWAToken';
-import { formatPriceImpact } from '../../pages/bridge/utils/price-impact';
+import {
+  formatPriceImpactFiat,
+  formatPriceImpactPercentage,
+} from '../../pages/bridge/utils/price-impact';
+import { getCurrentCurrency } from '../metamask/metamask';
 import {
   exchangeRateFromMarketData,
   tokenPriceInNativeAsset,
@@ -705,9 +709,18 @@ export const getPriceImpact = createSelector(
   },
 );
 
-export const getFormattedPriceImpact = createSelector(
+export const getFormattedPriceImpactPercentage = createSelector(
   [getPriceImpact],
-  (priceImpact) => formatPriceImpact(priceImpact),
+  (priceImpact) => formatPriceImpactPercentage(priceImpact),
+);
+
+export const getFormattedPriceImpactFiat = createSelector(
+  [
+    (state: BridgeAppState) => getBridgeQuotes(state).activeQuote,
+    getCurrentCurrency,
+  ],
+  (activeQuote, currentCurrency) =>
+    formatPriceImpactFiat(activeQuote, currentCurrency),
 );
 
 const _getBaseValidationErrors = createDeepEqualSelector(

--- a/ui/pages/bridge/prepare/__snapshots__/bridge-price-impact-modal.test.tsx.snap
+++ b/ui/pages/bridge/prepare/__snapshots__/bridge-price-impact-modal.test.tsx.snap
@@ -112,13 +112,6 @@ exports[`BridgePriceImpactModal quote-card should render when there is a price i
             </p>
           </div>
           <div
-            class="mm-box mm-container mm-container--max-width-undefined mm-box--padding-bottom-4 mm-box--padding-inline-4 mm-box--display-flex mm-box--gap-3 mm-box--flex-direction-column mm-box--width-full"
-          >
-            <div
-              class=""
-            />
-          </div>
-          <div
             class="mm-box mm-modal-footer mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-left-4"
           >
             <div
@@ -225,13 +218,6 @@ exports[`BridgePriceImpactModal quote-card should render when there is a price i
             >
               You'll lose approximately 27% of your token's market price on this swap. Try a smaller trade or a more liquid route to improve your rate.
             </p>
-          </div>
-          <div
-            class="mm-box mm-container mm-container--max-width-undefined mm-box--padding-bottom-4 mm-box--padding-inline-4 mm-box--display-flex mm-box--gap-3 mm-box--flex-direction-column mm-box--width-full"
-          >
-            <div
-              class=""
-            />
           </div>
           <div
             class="mm-box mm-modal-footer mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-left-4"
@@ -341,13 +327,6 @@ exports[`BridgePriceImpactModal submit-cta should disable the submit button when
             >
               You'll lose approximately 90% of your token's market price on this swap. Try a smaller trade or a more liquid route to improve your rate.
             </p>
-          </div>
-          <div
-            class="mm-box mm-container mm-container--max-width-undefined mm-box--padding-bottom-4 mm-box--padding-inline-4 mm-box--display-flex mm-box--gap-3 mm-box--flex-direction-column mm-box--width-full"
-          >
-            <div
-              class=""
-            />
           </div>
           <div
             class="mm-box mm-modal-footer mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-left-4"
@@ -539,13 +518,6 @@ exports[`BridgePriceImpactModal submit-cta should render when there is a price i
             >
               You'll lose approximately 90% of your token's market price on this swap. Try a smaller trade or a more liquid route to improve your rate.
             </p>
-          </div>
-          <div
-            class="mm-box mm-container mm-container--max-width-undefined mm-box--padding-bottom-4 mm-box--padding-inline-4 mm-box--display-flex mm-box--gap-3 mm-box--flex-direction-column mm-box--width-full"
-          >
-            <div
-              class=""
-            />
           </div>
           <div
             class="mm-box mm-modal-footer mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-left-4"

--- a/ui/pages/bridge/prepare/__snapshots__/bridge-price-impact-modal.test.tsx.snap
+++ b/ui/pages/bridge/prepare/__snapshots__/bridge-price-impact-modal.test.tsx.snap
@@ -112,6 +112,13 @@ exports[`BridgePriceImpactModal quote-card should render when there is a price i
             </p>
           </div>
           <div
+            class="mm-box mm-container mm-container--max-width-undefined mm-box--padding-bottom-4 mm-box--padding-inline-4 mm-box--display-flex mm-box--gap-3 mm-box--flex-direction-column mm-box--width-full"
+          >
+            <div
+              class=""
+            />
+          </div>
+          <div
             class="mm-box mm-modal-footer mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-left-4"
           >
             <div
@@ -218,6 +225,13 @@ exports[`BridgePriceImpactModal quote-card should render when there is a price i
             >
               You'll lose approximately 27% of your token's market price on this swap. Try a smaller trade or a more liquid route to improve your rate.
             </p>
+          </div>
+          <div
+            class="mm-box mm-container mm-container--max-width-undefined mm-box--padding-bottom-4 mm-box--padding-inline-4 mm-box--display-flex mm-box--gap-3 mm-box--flex-direction-column mm-box--width-full"
+          >
+            <div
+              class=""
+            />
           </div>
           <div
             class="mm-box mm-modal-footer mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-left-4"
@@ -327,6 +341,13 @@ exports[`BridgePriceImpactModal submit-cta should disable the submit button when
             >
               You'll lose approximately 90% of your token's market price on this swap. Try a smaller trade or a more liquid route to improve your rate.
             </p>
+          </div>
+          <div
+            class="mm-box mm-container mm-container--max-width-undefined mm-box--padding-bottom-4 mm-box--padding-inline-4 mm-box--display-flex mm-box--gap-3 mm-box--flex-direction-column mm-box--width-full"
+          >
+            <div
+              class=""
+            />
           </div>
           <div
             class="mm-box mm-modal-footer mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-left-4"
@@ -518,6 +539,13 @@ exports[`BridgePriceImpactModal submit-cta should render when there is a price i
             >
               You'll lose approximately 90% of your token's market price on this swap. Try a smaller trade or a more liquid route to improve your rate.
             </p>
+          </div>
+          <div
+            class="mm-box mm-container mm-container--max-width-undefined mm-box--padding-bottom-4 mm-box--padding-inline-4 mm-box--display-flex mm-box--gap-3 mm-box--flex-direction-column mm-box--width-full"
+          >
+            <div
+              class=""
+            />
           </div>
           <div
             class="mm-box mm-modal-footer mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-left-4"

--- a/ui/pages/bridge/prepare/bridge-price-impact-modal.test.tsx
+++ b/ui/pages/bridge/prepare/bridge-price-impact-modal.test.tsx
@@ -2,9 +2,11 @@ import React from 'react';
 import { act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QuoteResponse } from '@metamask/bridge-controller';
+import { zeroAddress } from 'ethereumjs-util';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import { createBridgeMockStore } from '../../../../test/data/bridge/mock-bridge-store';
 import mockBridgeQuotesNativeErc20 from '../../../../test/data/bridge/mock-quotes-native-erc20.json';
+import { DummyQuotesNoApproval } from '../../../../test/data/bridge/dummy-quotes';
 import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
 import configureStore from '../../../store/store';
 import { HardwareWalletProvider } from '../../../contexts/hardware-wallets/HardwareWalletContext';
@@ -37,6 +39,43 @@ const renderModal = (
             priceData: { ...quote.quote.priceData, priceImpact },
           },
         })) as unknown as QuoteResponse[],
+      },
+    }),
+  );
+  return renderWithProvider(
+    <HardwareWalletProvider>
+      <BridgePriceImpactWarningModal variant={variant} onClose={mockOnClose} />
+    </HardwareWalletProvider>,
+    mockStore,
+  );
+};
+
+const renderModalWithFiat = (
+  variant: 'submit-cta' | 'quote-card' | null = null,
+  priceImpact: string = '0.05',
+) => {
+  const mockStore = configureStore(
+    createBridgeMockStore({
+      bridgeStateOverrides: {
+        quotes: DummyQuotesNoApproval.OP_0_005_ETH_TO_ARB.map((quote) => ({
+          ...quote,
+          quote: {
+            ...quote.quote,
+            priceData: { priceImpact },
+          },
+        })) as unknown as QuoteResponse[],
+        quoteRequest: {
+          srcChainId: 10,
+          srcTokenAddress: zeroAddress(),
+          destChainId: 42161,
+          destTokenAddress: zeroAddress(),
+        },
+      },
+      metamaskStateOverrides: {
+        currentCurrency: 'usd',
+        currencyRates: {
+          ETH: { conversionRate: 2524.25, usdConversionRate: 2524.25 },
+        },
       },
     }),
   );
@@ -185,5 +224,32 @@ describe('BridgePriceImpactModal', () => {
         expect(baseElement).toMatchSnapshot();
       },
     );
+  });
+
+  describe('fiat alert banner', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('shows the fiat loss banner when isPriceImpactError is true and fiat amount is available', () => {
+      const { queryByText } = renderModalWithFiat('submit-cta', '0.9');
+      expect(
+        queryByText(/you will lose/i),
+      ).toBeInTheDocument();
+    });
+
+    it('does not show the fiat loss banner when isPriceImpactError is false (warning)', () => {
+      const { queryByText } = renderModalWithFiat('quote-card', '0.07');
+      expect(
+        queryByText(/you will lose/i),
+      ).not.toBeInTheDocument();
+    });
+
+    it('does not show the fiat loss banner when fiat amount is unavailable (no exchange rates)', () => {
+      const { queryByText } = renderModal('submit-cta', '0.9');
+      expect(
+        queryByText(/you will lose/i),
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/ui/pages/bridge/prepare/bridge-price-impact-modal.test.tsx
+++ b/ui/pages/bridge/prepare/bridge-price-impact-modal.test.tsx
@@ -233,23 +233,17 @@ describe('BridgePriceImpactModal', () => {
 
     it('shows the fiat loss banner when isPriceImpactError is true and fiat amount is available', () => {
       const { queryByText } = renderModalWithFiat('submit-cta', '0.9');
-      expect(
-        queryByText(/you will lose/i),
-      ).toBeInTheDocument();
+      expect(queryByText(/you will lose/i)).toBeInTheDocument();
     });
 
     it('does not show the fiat loss banner when isPriceImpactError is false (warning)', () => {
       const { queryByText } = renderModalWithFiat('quote-card', '0.07');
-      expect(
-        queryByText(/you will lose/i),
-      ).not.toBeInTheDocument();
+      expect(queryByText(/you will lose/i)).not.toBeInTheDocument();
     });
 
     it('does not show the fiat loss banner when fiat amount is unavailable (no exchange rates)', () => {
       const { queryByText } = renderModal('submit-cta', '0.9');
-      expect(
-        queryByText(/you will lose/i),
-      ).not.toBeInTheDocument();
+      expect(queryByText(/you will lose/i)).not.toBeInTheDocument();
     });
   });
 });

--- a/ui/pages/bridge/prepare/bridge-price-impact-modal.test.tsx
+++ b/ui/pages/bridge/prepare/bridge-price-impact-modal.test.tsx
@@ -233,17 +233,17 @@ describe('BridgePriceImpactModal', () => {
 
     it('shows the fiat loss banner when isPriceImpactError is true and fiat amount is available', () => {
       const { queryByText } = renderModalWithFiat('submit-cta', '0.9');
-      expect(queryByText(/you will lose/i)).toBeInTheDocument();
+      expect(queryByText(/you will lose/iu)).toBeInTheDocument();
     });
 
     it('does not show the fiat loss banner when isPriceImpactError is false (warning)', () => {
       const { queryByText } = renderModalWithFiat('quote-card', '0.07');
-      expect(queryByText(/you will lose/i)).not.toBeInTheDocument();
+      expect(queryByText(/you will lose/iu)).not.toBeInTheDocument();
     });
 
     it('does not show the fiat loss banner when fiat amount is unavailable (no exchange rates)', () => {
       const { queryByText } = renderModal('submit-cta', '0.9');
-      expect(queryByText(/you will lose/i)).not.toBeInTheDocument();
+      expect(queryByText(/you will lose/iu)).not.toBeInTheDocument();
     });
   });
 });

--- a/ui/pages/bridge/prepare/bridge-price-impact-modal.tsx
+++ b/ui/pages/bridge/prepare/bridge-price-impact-modal.tsx
@@ -116,19 +116,15 @@ export const BridgePriceImpactWarningModal = ({
               [formattedPriceImpactPercentage ?? ''],
             )}
           </Text>
+          {formattedPriceImpactFiat && isPriceImpactError && (
+            <BannerAlert
+              severity={BannerAlertSeverity.Danger}
+              description={t('bridgePriceImpactFiatAlert', [
+                formattedPriceImpactFiat,
+              ])}
+            />
+          )}
         </Column>
-        {formattedPriceImpactFiat && isPriceImpactError && (
-          <Column gap={3} paddingInline={4} paddingBottom={4}>
-            <Box>
-              <BannerAlert
-                severity={BannerAlertSeverity.Danger}
-                description={t('bridgePriceImpactFiatAlert', [
-                  formattedPriceImpactFiat,
-                ])}
-              />
-            </Box>
-          </Column>
-        )}
         <ModalFooter>
           <Row gap={4}>
             {variant === 'submit-cta' && isPriceImpactError && (

--- a/ui/pages/bridge/prepare/bridge-price-impact-modal.tsx
+++ b/ui/pages/bridge/prepare/bridge-price-impact-modal.tsx
@@ -1,6 +1,9 @@
 import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import {
+  BannerAlert,
+  BannerAlertSeverity,
+  Box,
   Button,
   ButtonSize,
   ButtonVariant,
@@ -22,7 +25,8 @@ import { useI18nContext } from '../../../hooks/useI18nContext';
 import { AlignItems } from '../../../helpers/constants/design-system';
 import {
   getBridgeQuotes,
-  getFormattedPriceImpact,
+  getFormattedPriceImpactFiat,
+  getFormattedPriceImpactPercentage,
   getValidationErrors,
 } from '../../../ducks/bridge/selectors';
 import { Column, Row } from '../layout';
@@ -42,7 +46,10 @@ export const BridgePriceImpactWarningModal = ({
   const { activeQuote } = useSelector(getBridgeQuotes);
   const { isPriceImpactError, isPriceImpactWarning } =
     useSelector(getValidationErrors);
-  const formattedPriceImpact = useSelector(getFormattedPriceImpact);
+  const formattedPriceImpactPercentage = useSelector(
+    getFormattedPriceImpactPercentage,
+  );
+  const formattedPriceImpactFiat = useSelector(getFormattedPriceImpactFiat);
 
   const shouldShowModal = useMemo(() => {
     // Hide the modal if the user closes it or if it has not been opened
@@ -106,9 +113,21 @@ export const BridgePriceImpactWarningModal = ({
               isPriceImpactError
                 ? 'bridgePriceImpactVeryHighDescription'
                 : 'bridgePriceImpactHighDescription',
-              [formattedPriceImpact ?? ''],
+              [formattedPriceImpactPercentage ?? ''],
             )}
           </Text>
+        </Column>
+        <Column gap={3} paddingInline={4} paddingBottom={4}>
+          <Box>
+            {formattedPriceImpactFiat && isPriceImpactError && (
+              <BannerAlert
+                severity={BannerAlertSeverity.Danger}
+                description={t('bridgePriceImpactFiatAlert', [
+                  formattedPriceImpactFiat,
+                ])}
+              />
+            )}
+          </Box>
         </Column>
         <ModalFooter>
           <Row gap={4}>

--- a/ui/pages/bridge/prepare/bridge-price-impact-modal.tsx
+++ b/ui/pages/bridge/prepare/bridge-price-impact-modal.tsx
@@ -117,18 +117,18 @@ export const BridgePriceImpactWarningModal = ({
             )}
           </Text>
         </Column>
-        <Column gap={3} paddingInline={4} paddingBottom={4}>
-          <Box>
-            {formattedPriceImpactFiat && isPriceImpactError && (
+        {formattedPriceImpactFiat && isPriceImpactError && (
+          <Column gap={3} paddingInline={4} paddingBottom={4}>
+            <Box>
               <BannerAlert
                 severity={BannerAlertSeverity.Danger}
                 description={t('bridgePriceImpactFiatAlert', [
                   formattedPriceImpactFiat,
                 ])}
               />
-            )}
-          </Box>
-        </Column>
+            </Box>
+          </Column>
+        )}
         <ModalFooter>
           <Row gap={4}>
             {variant === 'submit-cta' && isPriceImpactError && (

--- a/ui/pages/bridge/quotes/multichain-bridge-quote-card.tsx
+++ b/ui/pages/bridge/quotes/multichain-bridge-quote-card.tsx
@@ -27,7 +27,7 @@ import {
   getIsStxEnabled,
   getValidationErrors,
   getPriceImpact,
-  getFormattedPriceImpact,
+  getFormattedPriceImpactPercentage,
 } from '../../../ducks/bridge/selectors';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { formatNetworkFee, formatTokenAmount } from '../utils/quote';
@@ -105,7 +105,7 @@ export const MultichainBridgeQuoteCard = ({
   );
 
   const priceImpact = useSelector(getPriceImpact);
-  const formattedPriceImpact = useSelector(getFormattedPriceImpact);
+  const formattedPriceImpact = useSelector(getFormattedPriceImpactPercentage);
 
   const [showAllQuotes, setShowAllQuotes] = useState(false);
   const gasSponsored = activeQuote?.quote?.gasSponsored ?? false;

--- a/ui/pages/bridge/utils/price-impact.test.ts
+++ b/ui/pages/bridge/utils/price-impact.test.ts
@@ -1,48 +1,150 @@
-import { formatPriceImpact } from './price-impact';
+import {
+  formatPriceImpactFiat,
+  formatPriceImpactPercentage,
+} from './price-impact';
 
 describe('formatPriceImpact', () => {
   it('should return 0% for undefined', () => {
-    expect(formatPriceImpact(undefined)).toBe('0%');
+    expect(formatPriceImpactPercentage(undefined)).toBe('0%');
   });
 
   it('should return 0% for 0', () => {
-    expect(formatPriceImpact(0)).toBe('0%');
-    expect(formatPriceImpact('0')).toBe('0%');
+    expect(formatPriceImpactPercentage(0)).toBe('0%');
+    expect(formatPriceImpactPercentage('0')).toBe('0%');
   });
 
   it('should return <0.01% for very small positive values', () => {
-    expect(formatPriceImpact('0.00007998969070672714')).toBe('<0.01%');
-    expect(formatPriceImpact('0.00009')).toBe('<0.01%');
-    expect(formatPriceImpact('0.00009')).toBe('<0.01%');
+    expect(formatPriceImpactPercentage('0.00007998969070672714')).toBe(
+      '<0.01%',
+    );
+    expect(formatPriceImpactPercentage('0.00009')).toBe('<0.01%');
+    expect(formatPriceImpactPercentage('0.00009')).toBe('<0.01%');
   });
 
   it('should return 0% for very small negative values', () => {
-    expect(formatPriceImpact(-0.00007)).toBe('0%');
-    expect(formatPriceImpact(-0.00009)).toBe('0%');
-    expect(formatPriceImpact('-0.00009')).toBe('0%');
+    expect(formatPriceImpactPercentage(-0.00007)).toBe('0%');
+    expect(formatPriceImpactPercentage(-0.00009)).toBe('0%');
+    expect(formatPriceImpactPercentage('-0.00009')).toBe('0%');
   });
 
   it('should format with expected precision for typical ranges', () => {
     // <1% → 2 decimals
-    expect(formatPriceImpact(0.0001)).toBe('0.01%');
-    expect(formatPriceImpact(0.001)).toBe('0.10%');
+    expect(formatPriceImpactPercentage(0.0001)).toBe('0.01%');
+    expect(formatPriceImpactPercentage(0.001)).toBe('0.10%');
     // 1%–10% → 1 decimal
-    expect(formatPriceImpact(0.01)).toBe('1.0%');
-    expect(formatPriceImpact(0.015)).toBe('1.5%');
-    expect(formatPriceImpact(0.031415)).toBe('3.1%');
+    expect(formatPriceImpactPercentage(0.01)).toBe('1.0%');
+    expect(formatPriceImpactPercentage(0.015)).toBe('1.5%');
+    expect(formatPriceImpactPercentage(0.031415)).toBe('3.1%');
     // ≥10% → no decimals
-    expect(formatPriceImpact(0.10999)).toBe('11%');
+    expect(formatPriceImpactPercentage(0.10999)).toBe('11%');
   });
 
   it('should handle negative values correctly', () => {
-    expect(formatPriceImpact(-0.001)).toBe('0%');
-    expect(formatPriceImpact(-0.015)).toBe('0%');
-    expect(formatPriceImpact(-0.1)).toBe('0%');
+    expect(formatPriceImpactPercentage(-0.001)).toBe('0%');
+    expect(formatPriceImpactPercentage(-0.015)).toBe('0%');
+    expect(formatPriceImpactPercentage(-0.1)).toBe('0%');
   });
 
   it('should handle string inputs', () => {
-    expect(formatPriceImpact('0.015')).toBe('1.5%');
-    expect(formatPriceImpact('0.00007')).toBe('<0.01%');
-    expect(formatPriceImpact('-0.02567')).toBe('0%');
+    expect(formatPriceImpactPercentage('0.015')).toBe('1.5%');
+    expect(formatPriceImpactPercentage('0.00007')).toBe('<0.01%');
+    expect(formatPriceImpactPercentage('-0.02567')).toBe('0%');
+  });
+});
+
+describe('formatPriceImpactFiat', () => {
+  it('returns undefined when activeQuote is null', () => {
+    expect(formatPriceImpactFiat(null, 'usd')).toBeUndefined();
+  });
+
+  it('returns undefined when activeQuote is undefined', () => {
+    expect(formatPriceImpactFiat(undefined, 'usd')).toBeUndefined();
+  });
+
+  it('returns undefined when sentAmount.valueInCurrency is null', () => {
+    expect(
+      formatPriceImpactFiat(
+        {
+          sentAmount: { valueInCurrency: null },
+          toTokenAmount: { valueInCurrency: '900' },
+        },
+        'usd',
+      ),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when toTokenAmount.valueInCurrency is undefined', () => {
+    expect(
+      formatPriceImpactFiat(
+        {
+          sentAmount: { valueInCurrency: '1000' },
+          toTokenAmount: { valueInCurrency: undefined },
+        },
+        'usd',
+      ),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when sentAmount is missing', () => {
+    expect(
+      formatPriceImpactFiat(
+        { toTokenAmount: { valueInCurrency: '900' } },
+        'usd',
+      ),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when toTokenAmount is missing', () => {
+    expect(
+      formatPriceImpactFiat({ sentAmount: { valueInCurrency: '1000' } }, 'usd'),
+    ).toBeUndefined();
+  });
+
+  it('formats the absolute difference between source and destination fiat amounts', () => {
+    const result = formatPriceImpactFiat(
+      {
+        sentAmount: { valueInCurrency: '1000' },
+        toTokenAmount: { valueInCurrency: '995.77' },
+      },
+      'usd',
+    );
+    expect(result).toBeDefined();
+    expect(result).toContain('4.23');
+  });
+
+  it('uses the absolute value so a favourable quote does not produce a negative result', () => {
+    const result = formatPriceImpactFiat(
+      {
+        sentAmount: { valueInCurrency: '900' },
+        toTokenAmount: { valueInCurrency: '1000' },
+      },
+      'usd',
+    );
+    expect(result).toBeDefined();
+    expect(result).toContain('100');
+  });
+
+  it('handles string numeric inputs', () => {
+    const result = formatPriceImpactFiat(
+      {
+        sentAmount: { valueInCurrency: '500.50' },
+        toTokenAmount: { valueInCurrency: '496.27' },
+      },
+      'usd',
+    );
+    expect(result).toBeDefined();
+    expect(result).toContain('4.23');
+  });
+
+  it('handles numeric inputs', () => {
+    const result = formatPriceImpactFiat(
+      {
+        sentAmount: { valueInCurrency: 1000 },
+        toTokenAmount: { valueInCurrency: 990 },
+      },
+      'usd',
+    );
+    expect(result).toBeDefined();
+    expect(result).toContain('10');
   });
 });

--- a/ui/pages/bridge/utils/price-impact.ts
+++ b/ui/pages/bridge/utils/price-impact.ts
@@ -1,10 +1,13 @@
+import { QuoteMetadata } from '@metamask/bridge-controller';
+import { formatCurrencyAmount } from './quote';
+
 /**
  * Formats price impact percentage for display.
  *
  * @param priceImpact - The price impact value from the API (in decimal form, e.g., 0.87 = 87%).
  * @returns Formatted price impact string.
  */
-export function formatPriceImpact(
+export function formatPriceImpactPercentage(
   priceImpact: string | number | undefined | null,
 ): string {
   if (priceImpact === undefined || priceImpact === null) {
@@ -37,4 +40,37 @@ export function formatPriceImpact(
 
   // For values 10% and above, show with no decimal places
   return `${Math.round(percentageImpact)}%`;
+}
+
+/**
+ * Returns the fiat price impact for a bridge quote — the difference between
+ * the source input fiat amount and the destination output fiat amount,
+ * formatted in the user's current currency (e.g. "$4.23", "€3.90").
+ *
+ * @param activeQuote - The active bridge quote metadata.
+ * @param currentCurrency - The user's current display currency (e.g. "usd").
+ * @returns Formatted fiat impact string, or `undefined` when either fiat value is unavailable.
+ */
+export function formatPriceImpactFiat(
+  activeQuote: QuoteMetadata | null | undefined,
+  currentCurrency: string,
+): string | undefined {
+  if (!activeQuote) {
+    return undefined;
+  }
+
+  const sourceFiat = activeQuote.sentAmount?.valueInCurrency;
+  const destFiat = activeQuote.toTokenAmount?.valueInCurrency;
+
+  if (
+    sourceFiat === null ||
+    sourceFiat === undefined ||
+    destFiat === null ||
+    destFiat === undefined
+  ) {
+    return undefined;
+  }
+
+  const diff = Math.abs(Number(sourceFiat) - Number(destFiat));
+  return formatCurrencyAmount(String(diff), currentCurrency, 2);
 }

--- a/ui/pages/bridge/utils/price-impact.ts
+++ b/ui/pages/bridge/utils/price-impact.ts
@@ -1,4 +1,3 @@
-import { QuoteMetadata } from '@metamask/bridge-controller';
 import { formatCurrencyAmount } from './quote';
 
 /**
@@ -52,7 +51,13 @@ export function formatPriceImpactPercentage(
  * @returns Formatted fiat impact string, or `undefined` when either fiat value is unavailable.
  */
 export function formatPriceImpactFiat(
-  activeQuote: QuoteMetadata | null | undefined,
+  activeQuote:
+    | {
+        sentAmount?: { valueInCurrency?: string | number | null } | null;
+        toTokenAmount?: { valueInCurrency?: string | number | null } | null;
+      }
+    | null
+    | undefined,
   currentCurrency: string,
 ): string | undefined {
   if (!activeQuote) {


### PR DESCRIPTION
## **Description**

When a bridge trade has a high price impact error, users currently see a percentage-based warning (e.g. "27% loss") but no indication of the real-money cost. This makes it hard for users to assess the actual risk of proceeding.

This PR adds a fiat loss banner to the Bridge Price Impact Warning Modal that shows when `isPriceImpactError` is `true` and the active quote has fiat values available for both the source and destination amounts. The banner displays the absolute currency difference (e.g. "You will lose $4.23 on this trade"), giving users a concrete sense of what the price impact means in their local currency.

**Changes:**
- Added `formatPriceImpactFiat` utility — computes the absolute difference between `sentAmount.valueInCurrency` and `toTokenAmount.valueInCurrency` and formats it using `formatCurrencyAmount`
- Added `getFormattedPriceImpactFiat` reselect selector — wires `getBridgeQuotes().activeQuote` and `getCurrentCurrency` into the utility
- Renamed `formatPriceImpact` → `formatPriceImpactPercentage` and `getFormattedPriceImpact` → `getFormattedPriceImpactPercentage` for clarity
- Added `bridgePriceImpactFiatAlert` i18n key to `en` and `en_GB` locales
- Added `BannerAlert` in `BridgePriceImpactWarningModal`, guarded by `formattedPriceImpactFiat && isPriceImpactError`

## **Changelog**

CHANGELOG entry: Added a fiat loss amount to the bridge high price impact warning, showing users how much they will lose in their local currency when a trade has a severe price impact.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-4294

## **Manual testing steps**

1. Open the Bridge UI and select a source and destination token/chain
2. Configure a trade where the bridge API returns a high price impact (≥ 25%, `priceImpact ≥ 0.25`) — this triggers `isPriceImpactError`
3. Verify the Price Impact Warning Modal opens and shows the percentage warning text
4. Verify a red "You will lose $X.XX on this trade" banner appears below the description text
5. Configure a trade with a medium price impact (7–24%, warning only) — verify the modal shows the percentage warning but the fiat banner is **not** shown
6. Set a trade where exchange rates are unavailable — verify the fiat banner is **not** shown (graceful degradation)

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->
<img width="384" height="322" alt="Screenshot 2026-04-06 at 1 46 27 PM" src="https://github.com/user-attachments/assets/a8d384e2-1d7d-4c8b-8c4a-b3288fe22668" />
<img width="384" height="322" alt="Screenshot 2026-04-06 at 1 46 42 PM" src="https://github.com/user-attachments/assets/3a453175-e79d-4411-b7da-cca645a1a6fc" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> User-facing changes that display computed fiat loss amounts; formatting/currency-rate availability and i18n interpolation issues could lead to incorrect or confusing values, though the impact is limited to UI presentation.
> 
> **Overview**
> Adds a *fiat-denominated loss indicator* to the Bridge high price impact flow: when `isPriceImpactError` is triggered and the active quote has both `sentAmount.valueInCurrency` and `toTokenAmount.valueInCurrency`, the price impact modal now renders a danger `BannerAlert` showing the absolute fiat difference (e.g., “You will lose $X.XX on this trade”).
> 
> Refactors price impact formatting to split percentage vs fiat concerns by renaming `formatPriceImpact`/`getFormattedPriceImpact` to `formatPriceImpactPercentage`/`getFormattedPriceImpactPercentage` and introducing `formatPriceImpactFiat` plus a new selector `getFormattedPriceImpactFiat`; updates quote card/modal usage, adds i18n strings, and extends unit/component tests around the new banner and formatter edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4acc828061720ea8c9f6431567e377c8c22f1ed0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->