### PR TITLE
fix: skip toast for already-confirmed transactions cp-13.26.0

### DIFF
--- a/ui/hooks/useTransactionLifecycle.test.ts
+++ b/ui/hooks/useTransactionLifecycle.test.ts
@@ -80,11 +80,11 @@ describe('useTransactionLifecycle', () => {
     expect(onPending).not.toHaveBeenCalled();
   });
 
-  it('does not fire handlers for a tx that was already confirmed in the first snapshot', () => {
+  it('does not fire onSuccess when a tx first appears already confirmed', () => {
     const onSuccess = jest.fn();
     const { rerender } = renderHook(
       ({ txs }) => useTransactionLifecycle(txs, { onSuccess }),
-      { initialProps: { txs: [confirmed('1')] } },
+      { initialProps: { txs: [] as Tx[] } },
     );
 
     act(() => {

--- a/ui/hooks/useTransactionLifecycle.test.ts
+++ b/ui/hooks/useTransactionLifecycle.test.ts
@@ -40,21 +40,6 @@ describe('useTransactionLifecycle', () => {
     expect(onPending).toHaveBeenCalledWith(pending('1'));
   });
 
-  it('fires onPending when a known tx transitions into pending (unapproved → submitted)', () => {
-    const onPending = jest.fn();
-    const { rerender } = renderHook(
-      ({ txs }) => useTransactionLifecycle(txs, { onPending }),
-      { initialProps: { txs: [approved('1')] } },
-    );
-
-    act(() => {
-      rerender({ txs: [pending('1')] });
-    });
-
-    expect(onPending).toHaveBeenCalledTimes(1);
-    expect(onPending).toHaveBeenCalledWith(pending('1'));
-  });
-
   it('fires onSuccess when a pending tx is confirmed', () => {
     const onSuccess = jest.fn();
     const { rerender } = renderHook(
@@ -118,14 +103,16 @@ describe('useTransactionLifecycle', () => {
     const onSuccess = jest.fn();
     const { rerender } = renderHook(
       ({ txs }) => useTransactionLifecycle(txs, { onPending, onSuccess }),
-      { initialProps: { txs: [pending('1'), approved('2')] } },
+      { initialProps: { txs: [pending('1'), pending('2')] } },
     );
 
     act(() => {
-      rerender({ txs: [confirmed('1'), pending('2')] });
+      rerender({ txs: [confirmed('1'), confirmed('2')] });
     });
 
+    expect(onSuccess).toHaveBeenCalledTimes(2);
     expect(onSuccess).toHaveBeenCalledWith(confirmed('1'));
-    expect(onPending).toHaveBeenCalledWith(pending('2'));
+    expect(onSuccess).toHaveBeenCalledWith(confirmed('2'));
+    expect(onPending).not.toHaveBeenCalled();
   });
 });

--- a/ui/hooks/useTransactionLifecycle.test.ts
+++ b/ui/hooks/useTransactionLifecycle.test.ts
@@ -8,10 +8,6 @@ const pending = (id: string): Tx => ({
   id,
   status: TransactionStatus.submitted,
 });
-const approved = (id: string): Tx => ({
-  id,
-  status: TransactionStatus.approved,
-});
 const confirmed = (id: string): Tx => ({
   id,
   status: TransactionStatus.confirmed,

--- a/ui/hooks/useTransactionLifecycle.ts
+++ b/ui/hooks/useTransactionLifecycle.ts
@@ -40,24 +40,15 @@ export function useTransactionLifecycle<
       if (!previous) {
         if (isNowPending) {
           handlers.onPending?.(tx);
-        } else if (isNowSuccess) {
-          handlers.onSuccess?.(tx);
-        } else if (isNowFailed) {
-          handlers.onFailure?.(tx);
         }
+
         continue;
       }
 
       const wasPending = isPending(previous.status);
 
-      if (!wasPending && isNowPending) {
-        handlers.onPending?.(tx);
-        continue;
-      }
-
       if (wasPending && isNowSuccess) {
         handlers.onSuccess?.(tx);
-        continue;
       }
 
       if ((wasPending || previous.status === 'signed') && isNowFailed) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

When a transaction is seen for the first time, skips onSuccess/onFailure toast for already-confirmed statuses

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensys.slack.com/archives/C0AQ7U8QAH3/p1775462653284529

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes transaction lifecycle notifications, which can affect user-facing toasts and edge-case state transitions. Risk is limited in scope to `useTransactionLifecycle` and is covered by updated tests.
> 
> **Overview**
> Updates `useTransactionLifecycle` to **only** trigger `onPending` for newly discovered transactions, and to **skip `onSuccess`/`onFailure`** when a transaction is first seen already in a terminal state.
> 
> Refines tests to remove the unapproved→pending transition case, add coverage for “first appears confirmed” (no toast), and adjust the multi-transaction case to expect only success callbacks when both pending txs confirm.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 365140cf76775f9e61818a63bffda012e0a61a69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->