### PR TITLE
fix: preserve perps market cache when refresh fails

### DIFF
--- a/ui/providers/perps/PerpsStreamManager.test.ts
+++ b/ui/providers/perps/PerpsStreamManager.test.ts
@@ -82,7 +82,7 @@ describe('PerpsStreamManager', () => {
       jest.useFakeTimers();
     });
 
-    it('notifies subscribers with empty markets when fetch fails', async () => {
+    it('notifies subscribers with empty markets when initial fetch fails without cache', async () => {
       const consoleErrorSpy = jest
         .spyOn(console, 'error')
         .mockImplementation(() => undefined);
@@ -102,6 +102,57 @@ describe('PerpsStreamManager', () => {
         await Promise.resolve();
 
         expect(onData).toHaveBeenCalledWith([]);
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          '[PerpsStreamManager] Failed to fetch markets',
+          expect.any(Error),
+        );
+      } finally {
+        consoleErrorSpy.mockRestore();
+      }
+    });
+
+    it('preserves cached markets when a refresh fails', async () => {
+      const consoleErrorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => undefined);
+
+      try {
+        const cachedMarkets = [
+          {
+            symbol: 'BTC',
+            name: 'Bitcoin',
+          },
+        ] as never[];
+
+        let marketFetchCount = 0;
+        mockSubmitRequestToBackground.mockImplementation((method: string) => {
+          if (method === 'perpsGetMarketDataWithPrices') {
+            marketFetchCount += 1;
+            if (marketFetchCount === 1) {
+              return Promise.resolve(cachedMarkets);
+            }
+            return Promise.reject(new Error('network'));
+          }
+          return Promise.resolve(undefined);
+        });
+
+        const onData = jest.fn();
+        const unsubscribe = manager.markets.subscribe(onData);
+
+        await Promise.resolve();
+        await Promise.resolve();
+
+        unsubscribe();
+
+        const onDataAfterReconnect = jest.fn();
+        manager.markets.subscribe(onDataAfterReconnect);
+
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(onData).toHaveBeenCalledWith(cachedMarkets);
+        expect(onDataAfterReconnect).toHaveBeenCalledWith(cachedMarkets);
+        expect(onDataAfterReconnect).not.toHaveBeenCalledWith([]);
         expect(consoleErrorSpy).toHaveBeenCalledWith(
           '[PerpsStreamManager] Failed to fetch markets',
           expect.any(Error),

--- a/ui/providers/perps/PerpsStreamManager.ts
+++ b/ui/providers/perps/PerpsStreamManager.ts
@@ -177,6 +177,15 @@ class PerpsStreamManager {
           })
           .catch((err) => {
             console.error('[PerpsStreamManager] Failed to fetch markets', err);
+            const cachedMarkets = this.markets.getCachedData();
+            const hasCachedMarkets = this.markets.hasCachedData();
+
+            // Preserve the last known good market list when refresh fails.
+            if (hasCachedMarkets) {
+              push(cachedMarkets);
+              return;
+            }
+
             push(EMPTY_MARKETS);
           });
         // eslint-disable-next-line no-empty-function, @typescript-eslint/no-empty-function


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## Context
Perps market pages in the extension were intermittently showing empty-state regressions during testing. We reproduced two symptoms:
  - `No markets found` on the market list page
  - `Market not found` after clicking into a market that had just been visible in the list

Console investigation showed that the market list initially had valid cached data, but a later `perpsGetMarketDataWithPrices` refresh failed and the extension replaced the cached market list with an empty array.

## Problem

  The extension was treating a failed market refresh like a successful empty market response.

  That caused the markets channel to overwrite the last known good cache with `[]`, which then propagated to the list and detail pages. As a result:
  - the market list could render `No markets found`
  - detail pages could fail to resolve symbols that were visible just moments earlier

## Solution

  This change updates the Perps markets stream behavior to preserve the last known good cached market list when a refresh fails.

  Specifically:
  - if market fetch fails and cached markets already exist, subscribers receive the cached markets instead of `[]`
  - if the initial fetch fails and there is no cache yet, behavior remains unchanged and the channel still emits `[]`

  This keeps the fix narrowly scoped to the extension stream layer and aligns the failure behavior with the defensive approach used in MetaMask Mobile.

## Implementation Notes

  - Updated `ui/providers/perps/PerpsStreamManager.ts` to keep cached markets on refresh failure
  - Added regression coverage in `ui/providers/perps/PerpsStreamManager.test.ts`
  - Removed the temporary console instrumentation used during investigation

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2841

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

<img width="397" height="605" alt="Screenshot 2026-04-06 at 10 45 03 AM" src="https://github.com/user-attachments/assets/17b17fd8-7315-45b5-ab35-c0e8844d0706" />
<img width="784" height="425" alt="Screenshot 2026-04-06 at 9 49 02 PM" src="https://github.com/user-attachments/assets/52b3389a-d8dd-4f24-8d74-b0e4f6d65bf4" />


### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change to error-handling in the perps markets data channel plus targeted tests; main concern is ensuring stale cached markets aren’t shown longer than intended during outages.
> 
> **Overview**
> Prevents perps market list regressions on transient fetch errors by **keeping the last known good `markets` cache** when `perpsGetMarketDataWithPrices` fails after previously succeeding; only the *first* fetch without cache still emits `[]`.
> 
> Adds/updates unit tests in `PerpsStreamManager.test.ts` to cover both scenarios: initial fetch failure yields empty markets, while a later refresh failure preserves and re-emits cached markets across re-subscription.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 019b916314a0d3833767650271c5994a154232ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->