### PR TITLE
fix: round token balance down to prevent insufficient funds error

### DIFF
--- a/ui/pages/bridge/prepare/bridge-input-group.tsx
+++ b/ui/pages/bridge/prepare/bridge-input-group.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
+import { BigNumber } from 'bignumber.js';
 import { useSelector, shallowEqual } from 'react-redux';
 import {
   formatChainIdToCaip,
@@ -112,6 +113,21 @@ export const BridgeInputGroup = ({
   const shouldShowAmountSkeleton = Boolean(
     showAmountSkeleton && isAmountReadOnly,
   );
+
+  const formattedTokenAmount = useMemo(() => {
+    if (!balanceAmount) {
+      return null;
+    }
+
+    // Use ROUND_DOWN so the displayed balance never exceeds what the user holds,
+    // e.g. 0.00054598 renders as 0.000545 instead of 0.000546.
+    return formatTokenAmount(
+      locale,
+      balanceAmount,
+      token.symbol,
+      BigNumber.ROUND_DOWN as number,
+    );
+  }, [locale, balanceAmount, token.symbol]);
 
   useEffect(() => {
     if (!isAmountReadOnly && inputRef.current) {
@@ -285,7 +301,7 @@ export const BridgeInputGroup = ({
               textDecoration: 'none',
             }}
           >
-            {formatTokenAmount(locale, balanceAmount, token.symbol)}
+            {formattedTokenAmount}
             {onMaxButtonClick && (
               <ButtonLink
                 variant={TextVariant.bodyMd}

--- a/ui/pages/bridge/utils/quote.ts
+++ b/ui/pages/bridge/utils/quote.ts
@@ -9,8 +9,13 @@ export const formatTokenAmount = (
   locale: string,
   amount: string,
   symbol: string = '',
+  roundingMode?: number,
 ) => {
-  const stringifiedAmount = formatAmount(locale, new BigNumber(amount));
+  const stringifiedAmount = formatAmount(
+    locale,
+    new BigNumber(amount),
+    roundingMode,
+  );
 
   return [stringifiedAmount, symbol].join(' ').trim();
 };

--- a/ui/pages/confirmations/components/simulation-details/formatAmount.test.ts
+++ b/ui/pages/confirmations/components/simulation-details/formatAmount.test.ts
@@ -50,4 +50,61 @@ describe('formatAmount', () => {
       },
     );
   });
+
+  describe('#formatAmount with ROUND_DOWN', () => {
+    const locale = 'en-US';
+    const roundDown = BigNumber.ROUND_DOWN;
+
+    it('returns "0" for zero amount regardless of rounding mode', () => {
+      expect(formatAmount(locale, new BigNumber(0), roundDown)).toBe('0');
+    });
+
+    it('returns "<0.000001" for amounts below MIN_AMOUNT regardless of rounding mode', () => {
+      expect(formatAmount(locale, new BigNumber(0.0000009), roundDown)).toBe(
+        '<0.000001',
+      );
+    });
+
+    // @ts-expect-error This is missing from the Mocha type definitions
+    it.each([
+      // Already at 3 sig figs — no rounding occurs
+      [0.0000456, '0.0000456'],
+      // 4th sig fig (7) would round up; ROUND_DOWN truncates to 0.000456
+      [0.0004567, '0.000456'],
+      // 4th sig fig (6) would round up; ROUND_DOWN truncates to 0.00345
+      [0.003456, '0.00345'],
+      // 4th sig fig (5) would round up; ROUND_DOWN truncates to 0.0234
+      [0.023456, '0.0234'],
+      // 4th sig fig (4) would not round up anyway; same result
+      [0.125456, '0.125'],
+    ])(
+      'truncates amount less than 1 toward zero (%s => %s)',
+      (amount: number, expected: string) => {
+        expect(formatAmount(locale, new BigNumber(amount), roundDown)).toBe(
+          expected,
+        );
+      },
+    );
+
+    // @ts-expect-error This is missing from the Mocha type definitions
+    it.each([
+      // 1 integer digit → maxFrac = 3; 4th decimal (4) would not round up anyway
+      [1.0034, '1.003'],
+      // 1 integer digit → maxFrac = 3; truncates rather than rounds up
+      [1.3034, '1.303'],
+      // 2 integer digits → maxFrac = 2; 3rd decimal (5) would round up; ROUND_DOWN gives 12.03
+      [12.0345, '12.03'],
+      // 3 integer digits → maxFrac = 1; 2nd decimal (5) would round up; ROUND_DOWN gives 121.4
+      [121.456, '121.4'],
+      // 4 integer digits → maxFrac = 0; result is whole number
+      [1034.123, '1,034'],
+    ])(
+      'truncates amount greater than or equal to 1 toward zero (%s => %s)',
+      (amount: number, expected: string) => {
+        expect(formatAmount(locale, new BigNumber(amount), roundDown)).toBe(
+          expected,
+        );
+      },
+    );
+  });
 });

--- a/ui/pages/confirmations/components/simulation-details/formatAmount.ts
+++ b/ui/pages/confirmations/components/simulation-details/formatAmount.ts
@@ -28,41 +28,45 @@ export function formatAmountMaxPrecision(
 }
 
 /**
- * Formats the a token amount with variable precision and significant
- * digits.
+ * Formats a token amount with variable precision and significant digits.
  *
- * If |amount| < 1, we display a maximum number of significant
- * digits.
+ * For |amount| < 1, displays up to 3 significant digits, rounded according to `roundingMode`.
+ * For |amount| >= 1, displays all integer digits and reduces decimal
+ * precision as the integer grows (rounded per `roundingMode`), until only whole numbers are shown.
  *
- * If |amount| >= 1, we display all digits left of the decimal point.
- * We also display some decimal places for smaller amounts, and
- * gradually reduce the decimal precision as the amount
- * gets bigger until we only show whole numbers.
+ * The optional `roundingMode` controls how the last displayed digit is
+ * determined. The default (ROUND_HALF_UP) rounds conventionally. Pass
+ * ROUND_DOWN to truncate — useful for balance display where the shown
+ * value must never exceed what the user actually holds.
  *
- * Examples:
- *
- * | Amount               | Formatted          |
- * |----------------------|--------------------|
- * | 0                    | 0                  |
- * | 0.0000009            | <0.000001          |
- * | 0.0000456            | 0.000046           |
- * | 0.0004567            | 0.000457           |
- * | 0.003456             | 0.00346            |
- * | 0.023456             | 0.0235             |
- * | 0.125456             | 0.125              |
- * | 1.0034               | 1.003              |
- * | 1.034                | 1.034              |
- * | 1.3034               | 1.303              |
- * | 12.0345              | 12.03              |
- * | 121.456              | 121.5              |
- * | 1,034.123            | 1,034              |
- * | 47,361,034.006       | 47,361,034         |
- * | 12,130,982,923,409.5 | 12,130,982,923,410 |
+ * | Amount               | ROUND_HALF_UP (default) | ROUND_DOWN |
+ * |----------------------|-------------------------|------------|
+ * | 0                    | 0                       | 0          |
+ * | 0.0000009            | <0.000001               | <0.000001  |
+ * | 0.0000456            | 0.0000456               | 0.0000456  |
+ * | 0.0004567            | 0.000457                | 0.000456   |
+ * | 0.003456             | 0.00346                 | 0.00345    |
+ * | 0.023456             | 0.0235                  | 0.0234     |
+ * | 0.125456             | 0.125                   | 0.125      |
+ * | 1.0034               | 1.003                   | 1.003      |
+ * | 1.3034               | 1.303                   | 1.303      |
+ * | 12.0345              | 12.03                   | 12.03      |
+ * | 121.456              | 121.5                   | 121.4      |
+ * | 1,034.123            | 1,034                   | 1,034      |
+ * | 47,361,034.006       | 47,361,034              | 47,361,034 |
+ * | 12,130,982,923,409.5 | 12,130,982,923,410      | 12,130,982,923,409 |
  *
  * @param locale
  * @param amount
+ * @param roundingMode - BigNumber rounding mode (0–8). Defaults to
+ * BigNumber.ROUND_HALF_UP. Pass BigNumber.ROUND_DOWN to truncate, e.g.
+ * for balance display so values never appear larger than the user holds.
  */
-export function formatAmount(locale: string, amount: BigNumber): string {
+export function formatAmount(
+  locale: string,
+  amount: BigNumber,
+  roundingMode?: number,
+): string {
   if (amount.isZero()) {
     return ZERO_DISPLAY;
   }
@@ -72,11 +76,25 @@ export function formatAmount(locale: string, amount: BigNumber): string {
   }
 
   if (amount.abs().lessThan(1)) {
+    // When a rounding mode is explicitly provided, pre-round to the exact
+    // display precision before passing to Intl.NumberFormat so the formatter
+    // never applies a second, independent rounding step.
+    // e.g. ROUND_DOWN: 0.00054598 → 0.000545 instead of 0.000546
+    //
+    // Without a rounding mode, fall back to the original approach
+    // (round to DEFAULT_PRECISION then let Intl.NumberFormat apply maxSigDigits)
+    // to preserve backward-compatible output for all existing callers.
+    const valueToFormat =
+      roundingMode === undefined
+        ? amount.round(DEFAULT_PRECISION).toNumber()
+        : (amount.toPrecision(
+            MAX_SIGNIFICANT_DECIMAL_PLACES,
+            roundingMode,
+          ) as unknown as number);
+
     return new Intl.NumberFormat(locale, {
       maximumSignificantDigits: MAX_SIGNIFICANT_DECIMAL_PLACES,
-    } as Intl.NumberFormatOptions).format(
-      amount.round(DEFAULT_PRECISION).toNumber(),
-    );
+    } as Intl.NumberFormatOptions).format(valueToFormat);
   }
 
   // Preserve all digits left of the decimal point.
@@ -95,6 +113,6 @@ export function formatAmount(locale: string, amount: BigNumber): string {
     // string is valid parameter for format function
     // for some reason it gives TS issue
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/format#number
-    amount.toFixed(maximumFractionDigits) as unknown as number,
+    amount.toFixed(maximumFractionDigits, roundingMode) as unknown as number,
   );
 }


### PR DESCRIPTION
## **Description**

The bridge token balance display was rounding amounts upward, causing the UI to show a value slightly higher than what the user actually holds. For example, a balance of `0.00054598 ETH` was displayed as `0.000546` instead of `0.000545`.

**Root cause:** `formatAmount` (used internally by `formatTokenAmount`) was applying two sequential rounding steps for sub-1 values:
1. `amount.round(DEFAULT_PRECISION).toNumber()` — rounds to 6 decimal places using `ROUND_HALF_UP`
2. `Intl.NumberFormat` with `maximumSignificantDigits: 3` — rounds again to 3 significant figures

For values like `0.00054598`, the intermediate step produced `0.000546` (the 7th decimal `9` bumped up the 6th), and the second step confirmed it — resulting in an inflated display.

**Solution:** Added an optional `roundingMode` parameter to `formatAmount` and threaded it through `formatTokenAmount`. When a `roundingMode` is explicitly provided, the function uses `BigNumber.toPrecision(3, roundingMode)` — a single, precise rounding step — bypassing the double-rounding artefact. The default path (no `roundingMode`) preserves the original `round(DEFAULT_PRECISION).toNumber()` behaviour exactly, so all existing callers are unaffected. The bridge balance display now passes `BigNumber.ROUND_DOWN`, ensuring the displayed amount never exceeds what the user holds.

## **Changelog**

CHANGELOG entry: Fixed a bug where bridge token balances were displayed as slightly higher than the user's actual balance due to double-rounding in the amount formatter.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-4337

## **Manual testing steps**

1. Open the Bridge UI and select a source token with a small fractional balance (e.g. a token with a balance like `0.00054598`)
2. Verify the balance displayed in the source input group shows the truncated value (`0.000545`) rather than a rounded-up value (`0.000546`)
3. Repeat with a balance `>= 1` (e.g. `121.456`) and verify it displays `121.4` with truncation rather than `121.5`
4. Verify other areas that display token amounts (transaction details, confirmation gas fee display) are **unchanged** compared to `main`

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x]  I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to number-formatting behavior and are backward-compatible by default; only the bridge balance display opts into `ROUND_DOWN`, so the main risk is minor UI formatting regressions.
> 
> **Overview**
> Fixes bridge balance display so it **never rounds up** and accidentally shows more tokens than the user holds.
> 
> This threads an optional `roundingMode` through `formatTokenAmount` into `formatAmount`, adds ROUND_DOWN-aware formatting logic (avoiding double-rounding for sub-1 values and using rounding mode for `toFixed`), updates the bridge input group to display balances using `BigNumber.ROUND_DOWN` (memoized), and adds unit tests covering the new truncation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39c60e65437ae293a8d879a85f5dde86f6d914f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->