### PR TITLE
ci: Update `lint:eslint` build script to increase memory limit to 6GB

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "lint:changelog:rc": "auto-changelog validate --prettier --rc",
     "slack:rc-notify": "tsx ./.github/scripts/slack-rc-notification.ts",
     "lint:debug": "DEBUG=eslint:cli-engine yarn lint",
-    "lint:eslint": "eslint . --ext js,ts,tsx,snap --cache --cache-location node_modules/.cache/eslint/.eslint-cache",
+    "lint:eslint": "NODE_OPTIONS='--max-old-space-size=6144' eslint . --ext js,ts,tsx,snap --cache --cache-location node_modules/.cache/eslint/.eslint-cache",
     "lint:eslint:fix": "yarn lint:eslint --fix --cache --cache-location node_modules/.cache/eslint/.eslint-cache",
     "lint:lockfile:dedupe": "yarn dedupe --check",
     "lint:lockfile:dedupe:fix": "yarn dedupe",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

`test-lint` workflow is flaking due to the `eslint` process exceeding the default memory limit of 4GB. This commit increases the `eslint` memory limit to 6GB to resolve this issue.

This is safe because `test-lint` job is run by a single runner and the lint steps are run sequentially, so dedicating 6GB of the standard runner's 7GB RAM to `eslint` leaves 1GB for OS and node overhead.

- See: https://github.com/MetaMask/metamask-extension/pull/41483
  - Both `tsc` and `eslint` are exceeding the 4GB limit in both local and CI environments.

### Example Error Output

```
Run yarn lint
Checking formatting...
All matched files use Prettier code style!

<--- Last few GCs --->

[2476:0x2b497000]   972762 ms: Scavenge 4050.2 (4097.5) -> 4036.9 (4131.5) MB, pooled: 0 MB, 5.67 / 0.00 ms  (average mu = 0.343, current mu = 0.275) allocation failure; 
[2476:0x2b497000]   974582 ms: Mark-Compact (reduce) 4058.0 (4134.2) -> 3994.7 (4054.7) MB, pooled: 0 MB, 73.78 / 0.00 ms  (+ 1613.0 ms in 311 steps since start of marking, biggest step 7.7 ms, walltime since start of marking 1820 ms) (average mu = 0.380,
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
----- Native stack trace -----

 1: 0x733eec node::OOMErrorHandler(char const*, v8::OOMDetails const&) [/opt/hostedtoolcache/node/24.13.1/x64/bin/node]
 2: 0xbab3f0  [/opt/hostedtoolcache/node/24.13.1/x64/bin/node]
 3: 0xbab4df  [/opt/hostedtoolcache/node/24.13.1/x64/bin/node]
 4: 0xe43fd5  [/opt/hostedtoolcache/node/24.13.1/x64/bin/node]
 5: 0xe44002  [/opt/hostedtoolcache/node/24.13.1/x64/bin/node]
 6: 0xe442fa  [/opt/hostedtoolcache/node/24.13.1/x64/bin/node]
 7: 0xe5481a  [/opt/hostedtoolcache/node/24.13.1/x64/bin/node]
 8: 0xe58bc0  [/opt/hostedtoolcache/node/24.13.1/x64/bin/node]
 9: 0x18eb671  [/opt/hostedtoolcache/node/24.13.1/x64/bin/node]
Error: Process completed with exit code 129.
```

> -- https://github.com/MetaMask/metamask-extension/actions/runs/24044787503/job/70125384851?pr=41494
> -- https://github.com/MetaMask/metamask-extension/actions/runs/23846496713/job/69525703360?pr=41412

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
