### PR TITLE
docs: add stories for ClaimsForm and ErrorPage

### DIFF
--- a/ui/pages/error-page/error-page.component.stories.tsx
+++ b/ui/pages/error-page/error-page.component.stories.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import ErrorPage from './error-page.component';
+
+export default {
+  title: 'Pages/ErrorPage',
+  component: ErrorPage,
+};
+
+export const DefaultStory = () => (
+  <ErrorPage
+    error={{
+      message: 'Something went wrong',
+      name: 'Error',
+      stack: 'Error: Something went wrong\n    at App (app.tsx:42)',
+    }}
+  />
+);
+
+DefaultStory.storyName = 'Default';

--- a/ui/pages/settings/transaction-shield-tab/claims-form/claims-form.stories.tsx
+++ b/ui/pages/settings/transaction-shield-tab/claims-form/claims-form.stories.tsx
@@ -1,0 +1,34 @@
+import { Provider } from 'react-redux';
+import React from 'react';
+import mockState from '../../../../../test/data/mock-state.json';
+import configureStore from '../../../../store/store';
+import { ClaimsProvider } from '../../../../contexts/claims/claims';
+import ClaimsForm from './claims-form';
+
+const store = configureStore({
+  ...mockState,
+  metamask: {
+    ...mockState.metamask,
+    claimsConfigurations: {
+      validSubmissionWindowDays: 10,
+      supportedNetworks: ['0x1', '0x5'],
+    },
+    drafts: [],
+  },
+});
+
+export default {
+  title: 'Pages/Settings/TransactionShieldTab/ClaimsForm',
+  component: ClaimsForm,
+  decorators: [
+    (story: () => React.ReactNode) => (
+      <Provider store={store}>
+        <ClaimsProvider>{story()}</ClaimsProvider>
+      </Provider>
+    ),
+  ],
+};
+
+export const DefaultStory = () => <ClaimsForm />;
+
+DefaultStory.storyName = 'Default';


### PR DESCRIPTION
## **Description**

Adds Storybook stories for two components that were missing them, enabling work in isolation and visual regression testing.

- **`ClaimsForm`** (`ui/pages/settings/transaction-shield-tab/claims-form/`) — Requires a custom Redux store decorator to provide `metamask.drafts` and `metamask.claimsConfigurations`, which are not present in the global Storybook test data. Also wraps the component in `ClaimsProvider` which is not part of the global decorator.
- **`ErrorPage`** (`ui/pages/error-page/`) — Uses only `useSelector` and `useI18nContext`, both satisfied by the global Storybook decorator; no custom store needed.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Run `yarn storybook`
2. Navigate to **Pages/Settings/TransactionShieldTab/ClaimsForm** — verify the claims form renders with all fields visible
3. Navigate to **Pages/ErrorPage** — verify the error page renders with message, name, and stack trace

## **Screenshots/Recordings**

### **Before**

No stories existed for these components.

### **After**

Both components are browsable and testable in isolation via Storybook.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds Storybook-only files and wiring (Redux/Claims context decorators) without modifying runtime application logic, so risk is limited to Storybook build/maintenance.
> 
> **Overview**
> Adds new Storybook entries for `ErrorPage` and the Transaction Shield `ClaimsForm` so they can be rendered and tested in isolation.
> 
> The `ClaimsForm` story bootstraps a custom Redux store seeded from `mock-state.json` (with `metamask.claimsConfigurations` and empty `drafts`) and wraps the component in `ClaimsProvider`; the `ErrorPage` story renders a default error payload for display/testing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a2a0544feec3a84af242c5e451dc43cc3e6fca4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->