### PR TITLE
fix: reload after failed transaction cp-13.26.0

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -1843,9 +1843,6 @@ export function setupController(
     try {
       if (isManifestV3) {
         browser.action.setPopup({ popup: `${popupFile}?tab=activity` });
-        browser.sidePanel?.setOptions?.({
-          path: 'sidepanel.html?tab=activity',
-        });
       } else {
         browser.browserAction.setPopup({ popup: `${popupFile}?tab=activity` });
       }
@@ -1864,7 +1861,6 @@ export function setupController(
     try {
       if (isManifestV3) {
         browser.action.setPopup({ popup: popupFile });
-        browser.sidePanel?.setOptions?.({ path: 'sidepanel.html' });
       } else {
         browser.browserAction.setPopup({ popup: popupFile });
       }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Remove the `sidePanel.setOptions` call on failed transactions that caused the sidepanel to reload when already open.

This mitigates the issue, while considering alternative solutions for an "open-and-navigate-to-tab"

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: #41473 

## **Manual testing steps**

1. Submit a transaction that will fail while the sidepanel is open

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral change limited to MV3 UI configuration after failed/dropped transactions; risk is low and mainly involves ensuring the action popup still points to the Activity tab without unintended side effects.
> 
> **Overview**
> Prevents the side panel from reloading on failed/dropped transactions by **removing the MV3 `browser.sidePanel.setOptions` updates** that previously changed the side panel path to `?tab=activity` (and back when cleared).
> 
> Failed-transaction handling now only updates the extension action popup (`browser.action.setPopup`) while keeping the badge count/clearing behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47de11d867553e7a07bcf74cd172565f2c4e6387. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->