### PR TITLE
chore: upgrade @metamask/design-system-react to v0.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -318,7 +318,7 @@
     "@metamask/delegation-controller": "^2.0.2",
     "@metamask/delegation-core": "^0.2.0-rc.1",
     "@metamask/delegation-deployments": "^1.0.0",
-    "@metamask/design-system-react": "^0.13.0",
+    "@metamask/design-system-react": "^0.14.0",
     "@metamask/design-system-tailwind-preset": "^0.6.1",
     "@metamask/design-tokens": "^8.3.0",
     "@metamask/eip-5792-middleware": "3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6194,11 +6194,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/design-system-react@npm:^0.13.0":
-  version: 0.13.0
-  resolution: "@metamask/design-system-react@npm:0.13.0"
+"@metamask/design-system-react@npm:^0.14.0":
+  version: 0.14.0
+  resolution: "@metamask/design-system-react@npm:0.14.0"
   dependencies:
-    "@metamask/design-system-shared": "npm:^0.6.0"
+    "@metamask/design-system-shared": "npm:^0.7.0"
     "@metamask/jazzicon": "npm:^2.0.0"
     "@radix-ui/react-slot": "npm:^1.1.0"
     blo: "npm:^2.0.0"
@@ -6206,19 +6206,21 @@ __metadata:
   peerDependencies:
     "@metamask/design-system-tailwind-preset": ^0.6.0
     "@metamask/design-tokens": ^8.1.0
-    "@metamask/utils": ^11.10.0
+    "@metamask/utils": ^11.11.0
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
-  checksum: 10/c32743950a3d859155e232304b57fe5eb5a464d75da0020803e7510b6257d1cf81510320d6bbd50da5f4b1e44c11d578332f6fe7b7c8aae3551fd4cdf39758d0
+  checksum: 10/17506712e71331f73c9cafa03b4ad7f4bfef3d97df8a71f6e79be8440712740561be765a7f0cdd717c5b366a42a30362e62d8bb205c64a88757e69470be2a322
   languageName: node
   linkType: hard
 
-"@metamask/design-system-shared@npm:^0.6.0":
-  version: 0.6.0
-  resolution: "@metamask/design-system-shared@npm:0.6.0"
+"@metamask/design-system-shared@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "@metamask/design-system-shared@npm:0.7.0"
   dependencies:
-    "@metamask/utils": "npm:^11.10.0"
-  checksum: 10/97d1aab66aea54532be2e7ec14a28f438bd695848690441ac7da8abf4bf8aa90318489b8984a23cdf992ae1800ef5ff36f405d3de581a09cfe44bf034150ee98
+    "@metamask/utils": "npm:^11.11.0"
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0
+  checksum: 10/6029af5621f4a80a1cdcfea226ab4391fce466ee8c0ed6259c0aa06e4ec4029c7b0049c93e6d53cf0bb0a77e630574c92242f80280d7a10e3fb1fdf0b9656a42
   languageName: node
   linkType: hard
 
@@ -8525,9 +8527,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:^11.0.0, @metamask/utils@npm:^11.0.1, @metamask/utils@npm:^11.1.0, @metamask/utils@npm:^11.10.0, @metamask/utils@npm:^11.4.0, @metamask/utils@npm:^11.4.2, @metamask/utils@npm:^11.8.1, @metamask/utils@npm:^11.9.0":
-  version: 11.10.0
-  resolution: "@metamask/utils@npm:11.10.0"
+"@metamask/utils@npm:^11.0.0, @metamask/utils@npm:^11.0.1, @metamask/utils@npm:^11.1.0, @metamask/utils@npm:^11.10.0, @metamask/utils@npm:^11.11.0, @metamask/utils@npm:^11.4.0, @metamask/utils@npm:^11.4.2, @metamask/utils@npm:^11.8.1, @metamask/utils@npm:^11.9.0":
+  version: 11.11.0
+  resolution: "@metamask/utils@npm:11.11.0"
   dependencies:
     "@ethereumjs/tx": "npm:^4.2.0"
     "@metamask/superstruct": "npm:^3.1.0"
@@ -8540,7 +8542,7 @@ __metadata:
     pony-cause: "npm:^2.1.10"
     semver: "npm:^7.5.4"
     uuid: "npm:^9.0.1"
-  checksum: 10/691a268af66593b60e9807a069127993cea3cdc941f99d5d7ca4664868754f08945821f1787b2f3e99e4497df63ceb0af37a2419ad494da29a1fddffe94f5797
+  checksum: 10/c4381b9e451a9616bde84ac659bc0d1848ef06b6e605f877bfa065b78c8ed5015706683ea88a3387de5eaeb3a50d1af9af0994f04f9e06258d992598fe2be3bf
   languageName: node
   linkType: hard
 
@@ -34153,7 +34155,7 @@ __metadata:
     "@metamask/delegation-controller": "npm:^2.0.2"
     "@metamask/delegation-core": "npm:^0.2.0-rc.1"
     "@metamask/delegation-deployments": "npm:^1.0.0"
-    "@metamask/design-system-react": "npm:^0.13.0"
+    "@metamask/design-system-react": "npm:^0.14.0"
     "@metamask/design-system-tailwind-preset": "npm:^0.6.1"
     "@metamask/design-tokens": "npm:^8.3.0"
     "@metamask/eip-5792-middleware": "npm:3.0.3"


### PR DESCRIPTION
## **Description**

Upgrades \`@metamask/design-system-react\` from \`^0.12.0\` to \`^0.14.0\` based on the [v29.0.0 monorepo release](https://github.com/MetaMask/metamask-design-system/releases/tag/v29.0.0).

> **Depends on:** #41467

**Breaking changes reviewed — no migration steps required for this repo:**

| Change | Impact |
|--------|--------|
| \`AvatarBase\` enum → const-object + string-union types (v0.14.0) | Extension uses its own deprecated local \`AvatarBaseSize\` enum; not affected |
| \`BadgeWrapper\` enum → string-union types (v0.13.0) | Extension uses its own deprecated local \`BadgeWrapperPosition\`/\`BadgeWrapperAnchorElementShape\`; not affected |
| \`FontWeight.Bold\` changed from \`700\` to \`600\` (v0.13.0) | Only 2 files import \`FontWeight\` from the package; neither uses \`.Bold\` |
| \`BottomSheet\` / React Native breaking changes | Not applicable (extension is web-only) |

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Build the extension and verify no TypeScript errors
2. Spot-check components that import from \`@metamask/design-system-react\` still render correctly

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency/lockfile update, but could surface build/TypeScript or subtle UI/styling regressions if the design system’s updated types or token defaults differ.
> 
> **Overview**
> Upgrades `@metamask/design-system-react` from `^0.13.0` to `^0.14.0`.
> 
> Updates the lockfile to pull in `@metamask/design-system-shared@^0.7.0` and the newer `@metamask/utils@^11.11.0` peer requirement associated with the design-system bump.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b3cf6209dd3d30c3ed8d503b1bb0eef8e80c128. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->