### PR TITLE
perf(sentry): Filter sentry spans for local fetches of snap manifests, locale files

### DIFF
--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -85,10 +85,7 @@ function getClientOptions() {
         // Creates ui.long-animation-frame spans (falls back to ui.long-task).
         // Pairs with TBT aggregate measurements from performance-observers.ts.
         enableLongAnimationFrame: true,
-        shouldCreateSpanForRequest: (url) => {
-          // Do not create spans for outgoing requests to a 'sentry.io' domain.
-          return !url.match(/^https?:\/\/([\w\d.@-]+\.)?sentry\.io(\/|$)/u);
-        },
+        shouldCreateSpanForRequest,
       }),
       metaMetricsIntegration({
         getMetaMetricsState,
@@ -275,6 +272,22 @@ export function beforeBreadcrumb() {
     const newBreadcrumb = removeUrlsFromBreadCrumb(breadcrumb);
     return newBreadcrumb;
   };
+}
+
+/**
+ * Returns whether a span should be created for a given request URL.
+ * Filters out Sentry domain requests.
+ *
+ * @param {string} url - The request URL.
+ * @returns {boolean} Whether to create a span for the request.
+ */
+export function shouldCreateSpanForRequest(url) {
+  // Do not create spans for outgoing requests to a 'sentry.io' domain.
+  if (url.match(/^https?:\/\/(?:[\w\d.@-]+\.)?sentry\.io(?:\/|$)/u)) {
+    return false;
+  }
+  // Create spans for all other requests.
+  return true;
 }
 
 /**

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -276,14 +276,22 @@ export function beforeBreadcrumb() {
 
 /**
  * Returns whether a span should be created for a given request URL.
- * Filters out Sentry domain requests.
+ * Filters out Sentry domain requests and local extension file fetches.
  *
  * @param {string} url - The request URL.
  * @returns {boolean} Whether to create a span for the request.
  */
 export function shouldCreateSpanForRequest(url) {
   // Do not create spans for outgoing requests to a 'sentry.io' domain.
-  if (url.match(/^https?:\/\/(?:[\w\d.@-]+\.)?sentry\.io(?:\/|$)/u)) {
+  if (/^https?:\/\/(?:[\w\d.@-]+\.)?sentry\.io(?:\/|$)/u.test(url)) {
+    return false;
+  }
+  // Block span creation on fetches for preinstalled snap manifest and locale files.
+  // Snap manifests are fetched on every MV3 SW restart,
+  // and locale files are fetched on every popup open.
+  // These are high volume, local file reads with no diagnostic value.
+  // TODO: Consider blocking all local extension file fetches.
+  if (/^(?:chrome|moz)-extension:\/\/[^/]+\/(?:snaps|_locales)\//u.test(url)) {
     return false;
   }
   // Create spans for all other requests.

--- a/app/scripts/lib/setupSentry.test.js
+++ b/app/scripts/lib/setupSentry.test.js
@@ -1,4 +1,8 @@
-import { removeUrlsFromBreadCrumb, rewriteReport } from './setupSentry';
+import {
+  removeUrlsFromBreadCrumb,
+  rewriteReport,
+  shouldCreateSpanForRequest,
+} from './setupSentry';
 
 describe('Setup Sentry', () => {
   describe('rewriteReport', () => {
@@ -152,6 +156,63 @@ describe('Setup Sentry', () => {
       };
       rewriteReport(testReport);
       expect(testReport.message).toStrictEqual('This is a simple report');
+    });
+  });
+
+  describe('shouldCreateSpanForRequest', () => {
+    it('should return false for snap manifest fetches', () => {
+      expect(
+        shouldCreateSpanForRequest(
+          'chrome-extension://abcdefg/snaps/npm:@metamask/preinstalled-example-snap/snap.manifest.json',
+        ),
+      ).toStrictEqual(false);
+      expect(
+        shouldCreateSpanForRequest(
+          'moz-extension://abcdefg/snaps/npm:@metamask/message-signing-snap/snap.manifest.json',
+        ),
+      ).toStrictEqual(false);
+    });
+
+    it('should return false for locale file fetches', () => {
+      expect(
+        shouldCreateSpanForRequest(
+          'chrome-extension://abcdefg/_locales/en/messages.json',
+        ),
+      ).toStrictEqual(false);
+      expect(
+        shouldCreateSpanForRequest(
+          'moz-extension://abcdefg/_locales/es/messages.json',
+        ),
+      ).toStrictEqual(false);
+    });
+
+    it('should return false for sentry.io domains', () => {
+      expect(
+        shouldCreateSpanForRequest('https://sentry.io/api/123'),
+      ).toStrictEqual(false);
+      expect(
+        shouldCreateSpanForRequest('https://o123.ingest.sentry.io/envelope'),
+      ).toStrictEqual(false);
+    });
+
+    it('should return true for other local extension file fetches', () => {
+      expect(
+        shouldCreateSpanForRequest(
+          'chrome-extension://abcdefg/scripts/ppom-validator.wasm',
+        ),
+      ).toStrictEqual(true);
+      expect(
+        shouldCreateSpanForRequest('chrome-extension://abcdefg/home.html'),
+      ).toStrictEqual(true);
+    });
+
+    it('should return true for external API URLs', () => {
+      expect(
+        shouldCreateSpanForRequest('https://mainnet.infura.io/v3/abc'),
+      ).toStrictEqual(true);
+      expect(
+        shouldCreateSpanForRequest('https://api.coingecko.com/v3/simple/price'),
+      ).toStrictEqual(true);
     });
   });
 


### PR DESCRIPTION
## Description

This commit removes billable spans created by `browserTracingIntegration` for two categories of local extension file fetches that are high-volume and have little to no diagnostic value. Together, these account for 3.75 billion spans over a 90 day period.

- Preinstalled snap manifests (fetched on every MV3 service worker restart) ([sentry search](https://metamask.sentry.io/explore/traces/?aggregateField=%7B%22groupBy%22%3A%22span.description%22%7D&aggregateField=%7B%22yAxes%22%3A%5B%22p75%28span.duration%29%22%5D%2C%22visible%22%3Afalse%7D&aggregateField=%7B%22yAxes%22%3A%5B%22p95%28span.duration%29%22%5D%2C%22visible%22%3Afalse%7D&aggregateField=%7B%22yAxes%22%3A%5B%22count%28span.duration%29%22%5D%7D&aggregateSort=-count%28span.duration%29&environment=production&field=id&field=span.name&field=span.description&field=span.duration&field=transaction&field=timestamp&field=http.url&mode=aggregate&project=273505&query=span.op%3A%EF%80%8DContains%EF%80%8Dhttp.client%20span.description%3A%EF%80%8DContains%EF%80%8D%5Bchrome-extension%3A%2F%2F%2Cmoz-extension%3A%2F%2F%5D%20span.description%3A%EF%80%8DContains%EF%80%8Dsnap.json%20count%28span.duration%29%3A%3E100m&sort=-span.duration&statsPeriod=90d) for `*snap.json` fetches with over 100M spans)
<img width="1091" height="345" alt="Screenshot 2026-04-09 at 1 55 40 PM" src="https://github.com/user-attachments/assets/a0d86396-0f61-470f-aa25-556be79d62af" />

- Locale files (fetched on every popup open) ([sentry search](https://metamask.sentry.io/explore/traces/?aggregateField=%7B%22groupBy%22%3A%22span.description%22%7D&aggregateField=%7B%22yAxes%22%3A%5B%22p75%28span.duration%29%22%5D%2C%22visible%22%3Afalse%7D&aggregateField=%7B%22yAxes%22%3A%5B%22p95%28span.duration%29%22%5D%2C%22visible%22%3Afalse%7D&aggregateField=%7B%22yAxes%22%3A%5B%22count%28span.duration%29%22%5D%7D&aggregateSort=-count%28span.duration%29&environment=production&field=id&field=span.name&field=span.description&field=span.duration&field=transaction&field=timestamp&field=http.url&mode=aggregate&project=273505&query=span.op%3A%EF%80%8DContains%EF%80%8Dhttp.client%20span.description%3A%EF%80%8DContains%EF%80%8Dmessages.json%20count%28span.duration%29%3A%3E10m&sort=-span.duration&statsPeriod=90d) for `message.json` fetches with over 10M spans)

<img width="1091" height="187" alt="Screenshot 2026-04-09 at 1 57 29 PM" src="https://github.com/user-attachments/assets/63e3bd50-e11f-4ae9-a3cb-9113b027e341" />

Other local extension fetches (e.g. WASM) are left instrumented to minimize disruption, but we can consider removing more unnecessary spans.

## Changelog

CHANGELOG entry: null

## Related Issues

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/7168
Parent Epic: https://github.com/MetaMask/MetaMask-planning/issues/6759

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only narrows Sentry Browser Tracing span creation for specific URL patterns, with focused unit test coverage; potential impact is limited to reduced performance trace visibility for those filtered requests.
> 
> **Overview**
> Reduces billable Sentry performance tracing by extracting `shouldCreateSpanForRequest` and expanding it to *skip span creation* for high-volume local extension fetches to `chrome-extension://.../snaps/...` and `.../_locales/...`, while continuing to exclude `sentry.io` requests.
> 
> Adds unit tests covering the new URL filtering behavior and ensures other extension resources and external API calls remain traced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit baedbbb9035a2d1821aae3657194b895d3130f95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->