### PR TITLE
feat: open to Activity tab on failed transaction

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -28,6 +28,9 @@ import {
   ENVIRONMENT_TYPE_SIDEPANEL,
   PLATFORM_FIREFOX,
   MESSAGE_TYPE,
+  POPUP_FILE,
+  POPUP_INIT_FILE,
+  SIDEPANEL_FILE,
 } from '../../shared/constants/app';
 import { EXTENSION_MESSAGES } from '../../shared/constants/messages';
 import { BACKGROUND_LIVENESS_METHOD } from '../../shared/constants/ui-initialization';
@@ -154,6 +157,7 @@ log.setLevel(process.env.METAMASK_DEBUG ? 'debug' : 'info', false);
 const platform = new ExtensionPlatform();
 const notificationManager = new NotificationManager();
 const isFirefox = getPlatform() === PLATFORM_FIREFOX;
+const POPUP_LAUNCH_FILE = isFirefox ? POPUP_FILE : POPUP_INIT_FILE;
 
 /**
  * Parses port connection info for routing decisions.
@@ -1837,18 +1841,29 @@ export function setupController(
     onTransactionFailed,
   );
 
-  function onTransactionFailed() {
-    failedTxCount += 1;
-    const popupFile = isFirefox ? 'popup.html' : 'popup-init.html';
+  function setClientOpenOptions(tab) {
+    const popup = tab ? `${POPUP_LAUNCH_FILE}?tab=${tab}` : POPUP_LAUNCH_FILE;
+    const sidepanelPath = tab ? `${SIDEPANEL_FILE}?tab=${tab}` : SIDEPANEL_FILE;
+
     try {
       if (isManifestV3) {
-        browser.action.setPopup({ popup: `${popupFile}?tab=activity` });
+        browser.action.setPopup({ popup });
+        browser.sidePanel?.setOptions?.({ path: sidepanelPath });
       } else {
-        browser.browserAction.setPopup({ popup: `${popupFile}?tab=activity` });
+        browser.browserAction.setPopup({ popup });
       }
     } catch (e) {
-      console.error('Error setting failed tx badge popup:', e);
+      console.error('Error setting extension action URLs:', e);
     }
+  }
+
+  function onTransactionFailed() {
+    if (isClientOpenStatus()) {
+      return;
+    }
+
+    failedTxCount += 1;
+    setClientOpenOptions('activity');
     updateBadge();
   }
 
@@ -1856,17 +1871,9 @@ export function setupController(
     if (!failedTxCount) {
       return;
     }
+
     failedTxCount = 0;
-    const popupFile = isFirefox ? 'popup.html' : 'popup-init.html';
-    try {
-      if (isManifestV3) {
-        browser.action.setPopup({ popup: popupFile });
-      } else {
-        browser.browserAction.setPopup({ popup: popupFile });
-      }
-    } catch (e) {
-      console.error('Error clearing failed tx badge popup:', e);
-    }
+    setClientOpenOptions();
     updateBadge();
   }
 

--- a/shared/constants/app.ts
+++ b/shared/constants/app.ts
@@ -20,6 +20,10 @@ export const ENVIRONMENT_TYPE_FULLSCREEN = 'fullscreen';
 export const ENVIRONMENT_TYPE_SIDEPANEL = 'sidepanel';
 export const ENVIRONMENT_TYPE_BACKGROUND = 'background';
 
+export const POPUP_FILE = 'popup.html';
+export const POPUP_INIT_FILE = 'popup-init.html';
+export const SIDEPANEL_FILE = 'sidepanel.html';
+
 export const PLATFORM_BRAVE = 'Brave';
 export const PLATFORM_CHROME = 'Chrome';
 export const PLATFORM_CHROMIUM = 'Chromium';

--- a/shared/lib/environment-type.ts
+++ b/shared/lib/environment-type.ts
@@ -5,6 +5,8 @@ import {
   ENVIRONMENT_TYPE_NOTIFICATION,
   ENVIRONMENT_TYPE_POPUP,
   ENVIRONMENT_TYPE_SIDEPANEL,
+  POPUP_FILE,
+  SIDEPANEL_FILE,
 } from '../constants/app';
 
 /**
@@ -12,13 +14,13 @@ import {
  */
 const getEnvironmentTypeMemo = memoize((url: string) => {
   const parsedUrl = new URL(url);
-  if (parsedUrl.pathname === '/popup.html') {
+  if (parsedUrl.pathname === `/${POPUP_FILE}`) {
     return ENVIRONMENT_TYPE_POPUP;
   } else if (['/home.html'].includes(parsedUrl.pathname)) {
     return ENVIRONMENT_TYPE_FULLSCREEN;
   } else if (parsedUrl.pathname === '/notification.html') {
     return ENVIRONMENT_TYPE_NOTIFICATION;
-  } else if (parsedUrl.pathname === '/sidepanel.html') {
+  } else if (parsedUrl.pathname === `/${SIDEPANEL_FILE}`) {
     return ENVIRONMENT_TYPE_SIDEPANEL;
   }
   return ENVIRONMENT_TYPE_BACKGROUND;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

When a transaction fails while the extension is closed, a red badge now shows on the extension icon. 

This PR restores ensures it opens directly to the Activity tab.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: feat: open to Activity tab when badge is clicked on failed transaction

## **Related issues**

Fixes:

## **Manual testing steps**

1. Submit a transaction that will fail
2. Close the extension and wait for transaction to fail
3. Click on red badge

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how the extension action popup (and MV3 side panel path) are configured at runtime, which could alter what UI opens across browsers if paths/query params are wrong.
> 
> **Overview**
> Ensures that when a transaction fails while the UI is closed, clicking the extension icon opens directly to the *Activity* tab by dynamically setting the action popup URL (and resetting it when the failure badge is cleared).
> 
> This refactors action URL handling into `setClientOpenOptions`, adds shared constants for `popup.html`/`popup-init.html`/`sidepanel.html`, and updates environment-type detection to use those constants (including setting MV3 `sidePanel` options where supported).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4c3bbd171d9abe7c1b38799f20cdedf45591fad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->