### PR TITLE
refactor: migrate `account-list-item` to `design-system-react`

### DIFF
--- a/ui/components/app/snaps/snap-ui-renderer/components/__snapshots__/account-selector.test.ts.snap
+++ b/ui/components/app/snaps/snap-ui-renderer/components/__snapshots__/account-selector.test.ts.snap
@@ -24,14 +24,14 @@ exports[`SnapUIAccountSelector renders an account selector 1`] = `
               class="mm-box mm-text mm-text--inherit mm-text--ellipsis mm-box--display-flex mm-box--width-full mm-box--color-text-default"
             >
               <div
-                class="mm-box multichain-account-list-item items-center mm-box--padding-4 mm-box--display-flex mm-box--background-color-transparent"
+                class="p-4 bg-transparent multichain-account-list-item flex items-center"
                 data-testid="account-item"
               >
                 <div
-                  class="mm-box flex w-full gap-2 items-center"
+                  class="flex w-full gap-2 items-center"
                 >
                   <div
-                    class="mm-box mm-box--display-flex mm-box--sm:display-none"
+                    class="flex sm:hidden"
                     data-testid="account-list-item-badge"
                   >
                     <button
@@ -91,7 +91,7 @@ exports[`SnapUIAccountSelector renders an account selector 1`] = `
                     </button>
                   </div>
                   <div
-                    class="mm-box mm-box--display-none mm-box--sm:display-flex"
+                    class="hidden sm:flex"
                   >
                     <div
                       class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
@@ -138,25 +138,26 @@ exports[`SnapUIAccountSelector renders an account selector 1`] = `
                     </div>
                   </div>
                   <div
-                    class="mm-box multichain-account-list-item__content mm-box--display-flex mm-box--flex-direction-column"
+                    class="flex-col multichain-account-list-item__content flex"
                   >
                     <div
-                      class="mm-box mm-box--display-flex mm-box--flex-direction-column"
+                      class="flex-col flex"
                     >
                       <div
-                        class="mm-box mm-box--display-flex mm-box--justify-content-space-between"
+                        class="justify-between flex"
                       >
                         <div
-                          class="mm-box multichain-account-list-item__account-name mm-box--margin-inline-end-2 mm-box--display-flex mm-box--gap-2 mm-box--align-items-center"
+                          class="gap-2 items-center multichain-account-list-item__account-name flex me-2"
                         >
                           <button
-                            class="mm-box mm-text multichain-account-list-item__account-name__button mm-text--body-md-medium mm-text--ellipsis mm-text--text-align-left mm-box--padding-0 mm-box--width-full mm-box--color-text-default mm-box--background-color-transparent"
+                            class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default truncate multichain-account-list-item__account-name__button p-0 bg-transparent w-full text-left"
+                            type="button"
                           >
                             Account 1
                           </button>
                         </div>
                         <div
-                          class="mm-box mm-text multichain-account-list-item__asset mm-text--body-md mm-text--ellipsis mm-text--text-align-end mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-flex-end mm-box--align-items-center mm-box--color-text-default"
+                          class="flex-row items-center justify-end multichain-account-list-item__asset flex overflow-hidden"
                         >
                           <div
                             class="mm-box currency-display-component mm-box--display-flex mm-box--flex-wrap-wrap mm-box--align-items-center"
@@ -179,20 +180,20 @@ exports[`SnapUIAccountSelector renders an account selector 1`] = `
                       </div>
                     </div>
                     <div
-                      class="mm-box mm-box--display-flex mm-box--justify-content-space-between"
+                      class="justify-between flex"
                     >
                       <div
-                        class="mm-box mm-box--display-flex mm-box--align-items-center"
+                        class="items-center flex"
                       >
                         <p
-                          class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
+                          class="text-alternative text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default"
                           data-testid="account-list-address"
                         >
                           0x0DCD5...3E7bc
                         </p>
                       </div>
                       <div
-                        class="mm-box network-indicator"
+                        class="network-indicator"
                       >
                         <div
                           class="mm-box"
@@ -285,7 +286,7 @@ exports[`SnapUIAccountSelector renders an account selector 1`] = `
                   </div>
                 </div>
                 <div
-                  class="mm-box mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center"
+                  class="items-center justify-center flex"
                 />
               </div>
             </span>
@@ -335,14 +336,14 @@ exports[`SnapUIAccountSelector renders inside a field 1`] = `
               class="mm-box mm-text mm-text--inherit mm-text--ellipsis mm-box--display-flex mm-box--width-full mm-box--color-text-default"
             >
               <div
-                class="mm-box multichain-account-list-item items-center mm-box--padding-4 mm-box--display-flex mm-box--background-color-transparent"
+                class="p-4 bg-transparent multichain-account-list-item flex items-center"
                 data-testid="account-item"
               >
                 <div
-                  class="mm-box flex w-full gap-2 items-center"
+                  class="flex w-full gap-2 items-center"
                 >
                   <div
-                    class="mm-box mm-box--display-flex mm-box--sm:display-none"
+                    class="flex sm:hidden"
                     data-testid="account-list-item-badge"
                   >
                     <button
@@ -402,7 +403,7 @@ exports[`SnapUIAccountSelector renders inside a field 1`] = `
                     </button>
                   </div>
                   <div
-                    class="mm-box mm-box--display-none mm-box--sm:display-flex"
+                    class="hidden sm:flex"
                   >
                     <div
                       class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
@@ -449,25 +450,26 @@ exports[`SnapUIAccountSelector renders inside a field 1`] = `
                     </div>
                   </div>
                   <div
-                    class="mm-box multichain-account-list-item__content mm-box--display-flex mm-box--flex-direction-column"
+                    class="flex-col multichain-account-list-item__content flex"
                   >
                     <div
-                      class="mm-box mm-box--display-flex mm-box--flex-direction-column"
+                      class="flex-col flex"
                     >
                       <div
-                        class="mm-box mm-box--display-flex mm-box--justify-content-space-between"
+                        class="justify-between flex"
                       >
                         <div
-                          class="mm-box multichain-account-list-item__account-name mm-box--margin-inline-end-2 mm-box--display-flex mm-box--gap-2 mm-box--align-items-center"
+                          class="gap-2 items-center multichain-account-list-item__account-name flex me-2"
                         >
                           <button
-                            class="mm-box mm-text multichain-account-list-item__account-name__button mm-text--body-md-medium mm-text--ellipsis mm-text--text-align-left mm-box--padding-0 mm-box--width-full mm-box--color-text-default mm-box--background-color-transparent"
+                            class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default truncate multichain-account-list-item__account-name__button p-0 bg-transparent w-full text-left"
+                            type="button"
                           >
                             Account 1
                           </button>
                         </div>
                         <div
-                          class="mm-box mm-text multichain-account-list-item__asset mm-text--body-md mm-text--ellipsis mm-text--text-align-end mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-flex-end mm-box--align-items-center mm-box--color-text-default"
+                          class="flex-row items-center justify-end multichain-account-list-item__asset flex overflow-hidden"
                         >
                           <div
                             class="mm-box currency-display-component mm-box--display-flex mm-box--flex-wrap-wrap mm-box--align-items-center"
@@ -490,20 +492,20 @@ exports[`SnapUIAccountSelector renders inside a field 1`] = `
                       </div>
                     </div>
                     <div
-                      class="mm-box mm-box--display-flex mm-box--justify-content-space-between"
+                      class="justify-between flex"
                     >
                       <div
-                        class="mm-box mm-box--display-flex mm-box--align-items-center"
+                        class="items-center flex"
                       >
                         <p
-                          class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
+                          class="text-alternative text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default"
                           data-testid="account-list-address"
                         >
                           0x0DCD5...3E7bc
                         </p>
                       </div>
                       <div
-                        class="mm-box network-indicator"
+                        class="network-indicator"
                       >
                         <div
                           class="mm-box"
@@ -596,7 +598,7 @@ exports[`SnapUIAccountSelector renders inside a field 1`] = `
                   </div>
                 </div>
                 <div
-                  class="mm-box mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center"
+                  class="items-center justify-center flex"
                 />
               </div>
             </span>

--- a/ui/components/multichain/account-list-item-menu/account-list-item-menu.js
+++ b/ui/components/multichain/account-list-item-menu/account-list-item-menu.js
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 
+import { IconName, Text, TextVariant } from '@metamask/design-system-react';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
   getPinnedAccountsList,
@@ -10,18 +11,15 @@ import {
 
 import { MenuItem } from '../../ui/menu';
 import {
-  IconName,
   ModalFocus,
   Popover,
   PopoverPosition,
   PopoverRole,
-  Text,
 } from '../../component-library';
 import {
   updateAccountsList,
   updateHiddenAccountsList,
 } from '../../../store/actions';
-import { TextVariant } from '../../../helpers/constants/design-system';
 import { AccountDetailsMenuItem, ViewExplorerMenuItem } from '../menu-items';
 
 const METRICS_LOCATION = 'Account Options';
@@ -141,12 +139,12 @@ export const AccountListItemMenu = ({
             metricsLocation={METRICS_LOCATION}
             closeMenu={closeMenu}
             address={account.address}
-            textProps={{ variant: TextVariant.bodySm }}
+            textProps={{ variant: TextVariant.BodySm }}
           />
           <ViewExplorerMenuItem
             metricsLocation={METRICS_LOCATION}
             closeMenu={closeMenu}
-            textProps={{ variant: TextVariant.bodySm }}
+            textProps={{ variant: TextVariant.BodySm }}
             account={account}
           />
           {isHidden ? null : (
@@ -160,7 +158,7 @@ export const AccountListItemMenu = ({
               }}
               iconNameLegacy={isPinned ? IconName.Unpin : IconName.Pin}
             >
-              <Text variant={TextVariant.bodySm}>
+              <Text variant={TextVariant.BodySm}>
                 {isPinned ? t('unpin') : t('pinToTop')}
               </Text>
             </MenuItem>
@@ -176,7 +174,7 @@ export const AccountListItemMenu = ({
             }}
             iconNameLegacy={isHidden ? IconName.Eye : IconName.EyeSlash}
           >
-            <Text variant={TextVariant.bodySm}>
+            <Text variant={TextVariant.BodySm}>
               {isHidden ? t('showAccount') : t('hideAccount')}
             </Text>
           </MenuItem>

--- a/ui/components/multichain/account-list-item/__snapshots__/account-list-item.test.js.snap
+++ b/ui/components/multichain/account-list-item/__snapshots__/account-list-item.test.js.snap
@@ -3,14 +3,14 @@
 exports[`AccountListItem renders AccountListItem component and shows account name, address, and balance for non-EVM account: non-EVM-account-list-item 1`] = `
 <div>
   <div
-    class="mm-box multichain-account-list-item items-center multichain-account-list-item--clickable mm-box--padding-4 mm-box--display-flex mm-box--background-color-transparent"
+    class="p-4 bg-transparent multichain-account-list-item flex items-center multichain-account-list-item--clickable"
     data-testid="account-item"
   >
     <div
-      class="mm-box flex w-full gap-2 items-center"
+      class="flex w-full gap-2 items-center"
     >
       <div
-        class="mm-box mm-box--display-flex mm-box--sm:display-none"
+        class="flex sm:hidden"
         data-testid="account-list-item-badge"
       >
         <button
@@ -86,7 +86,7 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
         </button>
       </div>
       <div
-        class="mm-box mm-box--display-none mm-box--sm:display-flex"
+        class="hidden sm:flex"
       >
         <div
           class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
@@ -133,25 +133,26 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
         </div>
       </div>
       <div
-        class="mm-box multichain-account-list-item__content mm-box--display-flex mm-box--flex-direction-column"
+        class="flex-col multichain-account-list-item__content flex"
       >
         <div
-          class="mm-box mm-box--display-flex mm-box--flex-direction-column"
+          class="flex-col flex"
         >
           <div
-            class="mm-box mm-box--display-flex mm-box--justify-content-space-between"
+            class="justify-between flex"
           >
             <div
-              class="mm-box multichain-account-list-item__account-name mm-box--margin-inline-end-2 mm-box--display-flex mm-box--gap-2 mm-box--align-items-center"
+              class="gap-2 items-center multichain-account-list-item__account-name flex me-2"
             >
               <button
-                class="mm-box mm-text multichain-account-list-item__account-name__button mm-text--body-md-medium mm-text--ellipsis mm-text--text-align-left mm-box--padding-0 mm-box--width-full mm-box--color-text-default mm-box--background-color-transparent"
+                class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default truncate multichain-account-list-item__account-name__button p-0 bg-transparent w-full text-left"
+                type="button"
               >
                 Test Account
               </button>
             </div>
             <div
-              class="mm-box mm-text multichain-account-list-item__asset mm-text--body-md mm-text--ellipsis mm-text--text-align-end mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-flex-end mm-box--align-items-center mm-box--color-text-default"
+              class="flex-row items-center justify-end multichain-account-list-item__asset flex overflow-hidden"
             >
               <div
                 class="mm-box currency-display-component mm-box--display-flex mm-box--flex-wrap-wrap mm-box--align-items-center"
@@ -169,20 +170,20 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
           </div>
         </div>
         <div
-          class="mm-box mm-box--display-flex mm-box--justify-content-space-between"
+          class="justify-between flex"
         >
           <div
-            class="mm-box mm-box--display-flex mm-box--align-items-center"
+            class="items-center flex"
           >
             <p
-              class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
+              class="text-alternative text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default"
               data-testid="account-list-address"
             >
               bc1qn3s...5eker
             </p>
           </div>
           <div
-            class="mm-box network-indicator"
+            class="network-indicator"
           >
             <div
               class="mm-box"
@@ -211,14 +212,14 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
           </div>
         </div>
         <div
-          class="mm-box mm-box--flex-direction-row"
+          class="flex-row flex"
         >
           <div
             class="mm-box mm-tag mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-background-section mm-box--rounded-sm"
             data-testid="account-list-item-tag-b7893c59-e376-4cc0-93ad-05ddaab574a6-Native SegWit"
           >
             <p
-              class="mm-box mm-text mm-text--body-xs mm-box--color-text-alternative"
+              class="text-alternative text-s-body-xs leading-s-body-xs tracking-s-body-xs md:text-l-body-xs md:leading-l-body-xs md:tracking-l-body-xs font-regular font-default"
             >
               Native SegWit
             </p>
@@ -227,7 +228,7 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
       </div>
     </div>
     <div
-      class="mm-box mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center"
+      class="items-center justify-center flex"
     />
   </div>
 </div>
@@ -236,14 +237,14 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
 exports[`AccountListItem renders AccountListItem component and shows account name, address, and balance: evm-account-list-item 1`] = `
 <div>
   <div
-    class="mm-box multichain-account-list-item items-center multichain-account-list-item--clickable mm-box--padding-4 mm-box--display-flex mm-box--background-color-transparent"
+    class="p-4 bg-transparent multichain-account-list-item flex items-center multichain-account-list-item--clickable"
     data-testid="account-item"
   >
     <div
-      class="mm-box flex w-full gap-2 items-center"
+      class="flex w-full gap-2 items-center"
     >
       <div
-        class="mm-box mm-box--display-flex mm-box--sm:display-none"
+        class="flex sm:hidden"
         data-testid="account-list-item-badge"
       >
         <button
@@ -319,7 +320,7 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
         </button>
       </div>
       <div
-        class="mm-box mm-box--display-none mm-box--sm:display-flex"
+        class="hidden sm:flex"
       >
         <div
           class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
@@ -366,25 +367,26 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
         </div>
       </div>
       <div
-        class="mm-box multichain-account-list-item__content mm-box--display-flex mm-box--flex-direction-column"
+        class="flex-col multichain-account-list-item__content flex"
       >
         <div
-          class="mm-box mm-box--display-flex mm-box--flex-direction-column"
+          class="flex-col flex"
         >
           <div
-            class="mm-box mm-box--display-flex mm-box--justify-content-space-between"
+            class="justify-between flex"
           >
             <div
-              class="mm-box multichain-account-list-item__account-name mm-box--margin-inline-end-2 mm-box--display-flex mm-box--gap-2 mm-box--align-items-center"
+              class="gap-2 items-center multichain-account-list-item__account-name flex me-2"
             >
               <button
-                class="mm-box mm-text multichain-account-list-item__account-name__button mm-text--body-md-medium mm-text--ellipsis mm-text--text-align-left mm-box--padding-0 mm-box--width-full mm-box--color-text-default mm-box--background-color-transparent"
+                class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default truncate multichain-account-list-item__account-name__button p-0 bg-transparent w-full text-left"
+                type="button"
               >
                 Test Account
               </button>
             </div>
             <div
-              class="mm-box mm-text multichain-account-list-item__asset mm-text--body-md mm-text--ellipsis mm-text--text-align-end mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-flex-end mm-box--align-items-center mm-box--color-text-default"
+              class="flex-row items-center justify-end multichain-account-list-item__asset flex overflow-hidden"
             >
               <div
                 class="mm-box currency-display-component mm-box--display-flex mm-box--flex-wrap-wrap mm-box--align-items-center"
@@ -407,20 +409,20 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
           </div>
         </div>
         <div
-          class="mm-box mm-box--display-flex mm-box--justify-content-space-between"
+          class="justify-between flex"
         >
           <div
-            class="mm-box mm-box--display-flex mm-box--align-items-center"
+            class="items-center flex"
           >
             <p
-              class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
+              class="text-alternative text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default"
               data-testid="account-list-address"
             >
               0x0DCD5...3E7bc
             </p>
           </div>
           <div
-            class="mm-box network-indicator"
+            class="network-indicator"
           >
             <div
               class="mm-box"
@@ -513,7 +515,7 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
       </div>
     </div>
     <div
-      class="mm-box mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center"
+      class="items-center justify-center flex"
     />
   </div>
 </div>

--- a/ui/components/multichain/account-list-item/account-list-item.js
+++ b/ui/components/multichain/account-list-item/account-list-item.js
@@ -2,30 +2,27 @@ import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'clsx';
 import { useSelector } from 'react-redux';
+import {
+  Box,
+  BoxAlignItems,
+  BoxBackgroundColor,
+  BoxFlexDirection,
+  BoxJustifyContent,
+  ButtonIcon,
+  ButtonIconSize,
+  FontWeight,
+  Icon,
+  IconName,
+  IconSize,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { getSnapName, shortenAddress } from '../../../helpers/utils/util';
 
 import { AccountListItemMenu } from '../account-list-item-menu';
-import {
-  Box,
-  ButtonIcon,
-  Icon,
-  IconName,
-  IconSize,
-  Tag,
-  Text,
-} from '../../component-library';
-import {
-  AlignItems,
-  BackgroundColor,
-  BlockSize,
-  Color,
-  Display,
-  FlexDirection,
-  JustifyContent,
-  TextAlign,
-  TextVariant,
-} from '../../../helpers/constants/design-system';
+import { Tag } from '../../component-library';
 import { PreferredAvatar } from '../../app/preferred-avatar';
 import { KeyringType } from '../../../../shared/constants/keyring';
 import UserPreferencedCurrencyDisplay from '../../app/user-preferenced-currency-display/user-preferenced-currency-display.component';
@@ -198,16 +195,17 @@ const AccountListItem = ({
 
   return (
     <Box
-      display={Display.Flex}
-      padding={4}
-      backgroundColor={
-        selected ? BackgroundColor.backgroundMuted : BackgroundColor.transparent
-      }
-      className={classnames('multichain-account-list-item items-center', {
+      className={classnames('multichain-account-list-item flex items-center', {
         'multichain-account-list-item--selected': selected,
         'multichain-account-list-item--connected': Boolean(connectedAvatar),
         'multichain-account-list-item--clickable': Boolean(onClick),
       })}
+      padding={4}
+      backgroundColor={
+        selected
+          ? BoxBackgroundColor.BackgroundMuted
+          : BoxBackgroundColor.Transparent
+      }
       data-testid="account-item"
       ref={itemRef}
       onClick={() => {
@@ -219,41 +217,30 @@ const AccountListItem = ({
       }}
     >
       {startAccessory ? (
-        <Box marginInlineEnd={2} marginTop={1}>
-          {startAccessory}
-        </Box>
+        <Box className="me-2 mt-1">{startAccessory}</Box>
       ) : null}
 
       <Box className="flex w-full gap-2 items-center">
-        <Box
-          display={[Display.Flex, Display.None]}
-          data-testid="account-list-item-badge"
-        >
+        <Box className="flex sm:hidden" data-testid="account-list-item-badge">
           <ConnectedStatus
             address={account.address}
             isActive={isActive}
             showConnectedStatus={shouldShowConnectedStatusBadge}
           />
         </Box>
-        <Box display={[Display.None, Display.Flex]}>
+        <Box className="hidden sm:flex">
           <PreferredAvatar address={account.address} />
         </Box>
 
         <Box
-          display={Display.Flex}
-          flexDirection={FlexDirection.Column}
-          className="multichain-account-list-item__content"
+          flexDirection={BoxFlexDirection.Column}
+          className="multichain-account-list-item__content flex"
         >
-          <Box display={Display.Flex} flexDirection={FlexDirection.Column}>
-            <Box
-              display={Display.Flex}
-              justifyContent={JustifyContent.spaceBetween}
-            >
+          <Box flexDirection={BoxFlexDirection.Column} className="flex">
+            <Box className="flex" justifyContent={BoxJustifyContent.Between}>
               <Box
-                className="multichain-account-list-item__account-name"
-                marginInlineEnd={2}
-                display={Display.Flex}
-                alignItems={AlignItems.center}
+                className="multichain-account-list-item__account-name flex me-2"
+                alignItems={BoxAlignItems.Center}
                 gap={2}
               >
                 {isPinned ? (
@@ -272,44 +259,41 @@ const AccountListItem = ({
                   />
                 ) : null}
                 <Text
-                  as="button"
-                  onClick={(e) => {
-                    if (onClick) {
-                      e.stopPropagation();
-                      onClick(account);
-                    }
-                  }}
-                  variant={TextVariant.bodyMdMedium}
-                  className="multichain-account-list-item__account-name__button"
-                  padding={0}
-                  backgroundColor={BackgroundColor.transparent}
-                  width={BlockSize.Full}
-                  textAlign={TextAlign.Left}
+                  asChild
+                  variant={TextVariant.BodyMd}
+                  fontWeight={FontWeight.Medium}
+                  className="multichain-account-list-item__account-name__button p-0 bg-transparent w-full text-left"
                   ellipsis
                 >
-                  {account.metadata.name.length >
-                  MAXIMUM_CHARACTERS_WITHOUT_TOOLTIP ? (
-                    <Tooltip
-                      title={account.metadata.name}
-                      position="bottom"
-                      wrapperClassName="multichain-account-list-item__tooltip"
-                    >
-                      {account.metadata.name}
-                    </Tooltip>
-                  ) : (
-                    account.metadata.name
-                  )}
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      if (onClick) {
+                        e.stopPropagation();
+                        onClick(account);
+                      }
+                    }}
+                  >
+                    {account.metadata.name.length >
+                    MAXIMUM_CHARACTERS_WITHOUT_TOOLTIP ? (
+                      <Tooltip
+                        title={account.metadata.name}
+                        position="bottom"
+                        wrapperClassName="multichain-account-list-item__tooltip"
+                      >
+                        {account.metadata.name}
+                      </Tooltip>
+                    ) : (
+                      account.metadata.name
+                    )}
+                  </button>
                 </Text>
               </Box>
-              <Text
-                as="div"
-                className="multichain-account-list-item__asset"
-                display={Display.Flex}
-                flexDirection={FlexDirection.Row}
-                alignItems={AlignItems.center}
-                justifyContent={JustifyContent.flexEnd}
-                ellipsis
-                textAlign={TextAlign.End}
+              <Box
+                className="multichain-account-list-item__asset flex overflow-hidden"
+                flexDirection={BoxFlexDirection.Row}
+                alignItems={BoxAlignItems.Center}
+                justifyContent={BoxJustifyContent.End}
               >
                 <UserPreferencedCurrencyDisplay
                   account={account}
@@ -321,17 +305,14 @@ const AccountListItem = ({
                   data-testid="first-currency-display"
                   privacyMode={privacyMode}
                 />
-              </Text>
+              </Box>
             </Box>
           </Box>
-          <Box
-            display={Display.Flex}
-            justifyContent={JustifyContent.spaceBetween}
-          >
-            <Box display={Display.Flex} alignItems={AlignItems.center}>
+          <Box className="flex" justifyContent={BoxJustifyContent.Between}>
+            <Box className="flex" alignItems={BoxAlignItems.Center}>
               <Text
-                variant={TextVariant.bodySm}
-                color={Color.textAlternative}
+                variant={TextVariant.BodySm}
+                color={TextColor.TextAlternative}
                 data-testid="account-list-address"
               >
                 {shortenAddress(normalizeSafeAddress(account.address))}
@@ -342,17 +323,14 @@ const AccountListItem = ({
             </Box>
           </Box>
           {showAccountLabels && accountLabels.length > 0 ? (
-            <Box flexDirection={FlexDirection.Row}>
+            <Box flexDirection={BoxFlexDirection.Row} className="flex">
               {accountLabels.map(({ label, icon }) => {
                 return (
                   <Tag
                     data-testid={`account-list-item-tag-${account.id}-${label}`}
                     key={label}
                     label={label}
-                    labelProps={{
-                      variant: TextVariant.bodyXs,
-                      color: Color.textAlternative,
-                    }}
+                    textVariant={TextVariant.BodyXs}
                     startIconName={icon}
                   />
                 );
@@ -363,15 +341,15 @@ const AccountListItem = ({
       </Box>
 
       <Box
-        display={Display.Flex}
-        justifyContent={JustifyContent.center}
-        alignItems={AlignItems.center}
+        className="flex"
+        justifyContent={BoxJustifyContent.Center}
+        alignItems={BoxAlignItems.Center}
       >
         {menuType === AccountListItemMenuTypes.None ? null : (
           <ButtonIcon
             ariaLabel={`${account.metadata.name} ${t('options')}`}
             iconName={IconName.MoreVertical}
-            size={IconSize.Sm}
+            size={ButtonIconSize.Sm}
             ref={setAccountListItemMenuRef}
             onClick={(e) => {
               e.stopPropagation();

--- a/ui/components/multichain/account-list-item/account-list-item.stories.js
+++ b/ui/components/multichain/account-list-item/account-list-item.stories.js
@@ -2,9 +2,9 @@ import React from 'react';
 
 import { Provider } from 'react-redux';
 
+import { Checkbox } from '@metamask/design-system-react';
 import testData from '../../../../.storybook/test-data';
 import configureStore from '../../../store/store';
-import { Checkbox } from '../../component-library';
 import { AccountListItem, AccountListItemMenuTypes } from '.';
 
 const store = configureStore(testData);

--- a/ui/components/multichain/connect-accounts-modal/__snapshots__/connect-accounts-modal.test.tsx.snap
+++ b/ui/components/multichain/connect-accounts-modal/__snapshots__/connect-accounts-modal.test.tsx.snap
@@ -103,11 +103,11 @@ exports[`Connect More Accounts Modal should render correctly 1`] = `
               </div>
             </div>
             <div
-              class="mm-box multichain-account-list-item items-center multichain-account-list-item--clickable mm-box--padding-4 mm-box--display-flex mm-box--background-color-transparent"
+              class="p-4 bg-transparent multichain-account-list-item flex items-center multichain-account-list-item--clickable"
               data-testid="account-item"
             >
               <div
-                class="mm-box mm-box--margin-top-1 mm-box--margin-inline-end-2"
+                class="me-2 mt-1"
               >
                 <label
                   class="mm-box mm-text mm-checkbox mm-text--body-md mm-box--display-inline-flex mm-box--align-items-center mm-box--color-text-default"
@@ -123,10 +123,10 @@ exports[`Connect More Accounts Modal should render correctly 1`] = `
                 </label>
               </div>
               <div
-                class="mm-box flex w-full gap-2 items-center"
+                class="flex w-full gap-2 items-center"
               >
                 <div
-                  class="mm-box mm-box--display-flex mm-box--sm:display-none"
+                  class="flex sm:hidden"
                   data-testid="account-list-item-badge"
                 >
                   <button
@@ -202,7 +202,7 @@ exports[`Connect More Accounts Modal should render correctly 1`] = `
                   </button>
                 </div>
                 <div
-                  class="mm-box mm-box--display-none mm-box--sm:display-flex"
+                  class="hidden sm:flex"
                 >
                   <div
                     class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
@@ -249,25 +249,26 @@ exports[`Connect More Accounts Modal should render correctly 1`] = `
                   </div>
                 </div>
                 <div
-                  class="mm-box multichain-account-list-item__content mm-box--display-flex mm-box--flex-direction-column"
+                  class="flex-col multichain-account-list-item__content flex"
                 >
                   <div
-                    class="mm-box mm-box--display-flex mm-box--flex-direction-column"
+                    class="flex-col flex"
                   >
                     <div
-                      class="mm-box mm-box--display-flex mm-box--justify-content-space-between"
+                      class="justify-between flex"
                     >
                       <div
-                        class="mm-box multichain-account-list-item__account-name mm-box--margin-inline-end-2 mm-box--display-flex mm-box--gap-2 mm-box--align-items-center"
+                        class="gap-2 items-center multichain-account-list-item__account-name flex me-2"
                       >
                         <button
-                          class="mm-box mm-text multichain-account-list-item__account-name__button mm-text--body-md-medium mm-text--ellipsis mm-text--text-align-left mm-box--padding-0 mm-box--width-full mm-box--color-text-default mm-box--background-color-transparent"
+                          class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default truncate multichain-account-list-item__account-name__button p-0 bg-transparent w-full text-left"
+                          type="button"
                         >
                           Account 1
                         </button>
                       </div>
                       <div
-                        class="mm-box mm-text multichain-account-list-item__asset mm-text--body-md mm-text--ellipsis mm-text--text-align-end mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-flex-end mm-box--align-items-center mm-box--color-text-default"
+                        class="flex-row items-center justify-end multichain-account-list-item__asset flex overflow-hidden"
                       >
                         <div
                           class="mm-box currency-display-component mm-box--display-flex mm-box--flex-wrap-wrap mm-box--align-items-center"
@@ -290,20 +291,20 @@ exports[`Connect More Accounts Modal should render correctly 1`] = `
                     </div>
                   </div>
                   <div
-                    class="mm-box mm-box--display-flex mm-box--justify-content-space-between"
+                    class="justify-between flex"
                   >
                     <div
-                      class="mm-box mm-box--display-flex mm-box--align-items-center"
+                      class="items-center flex"
                     >
                       <p
-                        class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
+                        class="text-alternative text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default"
                         data-testid="account-list-address"
                       >
                         0xD5E09...81111
                       </p>
                     </div>
                     <div
-                      class="mm-box network-indicator"
+                      class="network-indicator"
                     >
                       <div
                         class="mm-box"
@@ -396,7 +397,7 @@ exports[`Connect More Accounts Modal should render correctly 1`] = `
                 </div>
               </div>
               <div
-                class="mm-box mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center"
+                class="items-center justify-center flex"
               />
             </div>
           </div>

--- a/ui/pages/permissions-connect/connect-page/__snapshots__/connect-page.test.tsx.snap
+++ b/ui/pages/permissions-connect/connect-page/__snapshots__/connect-page.test.tsx.snap
@@ -98,14 +98,14 @@ exports[`ConnectPage should render correctly 1`] = `
                 style="overflow: auto; max-height: 268px;"
               >
                 <div
-                  class="mm-box multichain-account-list-item items-center mm-box--padding-4 mm-box--display-flex mm-box--background-color-transparent"
+                  class="p-4 bg-transparent multichain-account-list-item flex items-center"
                   data-testid="account-item"
                 >
                   <div
-                    class="mm-box flex w-full gap-2 items-center"
+                    class="flex w-full gap-2 items-center"
                   >
                     <div
-                      class="mm-box mm-box--display-flex mm-box--sm:display-none"
+                      class="flex sm:hidden"
                       data-testid="account-list-item-badge"
                     >
                       <button
@@ -165,7 +165,7 @@ exports[`ConnectPage should render correctly 1`] = `
                       </button>
                     </div>
                     <div
-                      class="mm-box mm-box--display-none mm-box--sm:display-flex"
+                      class="hidden sm:flex"
                     >
                       <div
                         class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
@@ -212,25 +212,26 @@ exports[`ConnectPage should render correctly 1`] = `
                       </div>
                     </div>
                     <div
-                      class="mm-box multichain-account-list-item__content mm-box--display-flex mm-box--flex-direction-column"
+                      class="flex-col multichain-account-list-item__content flex"
                     >
                       <div
-                        class="mm-box mm-box--display-flex mm-box--flex-direction-column"
+                        class="flex-col flex"
                       >
                         <div
-                          class="mm-box mm-box--display-flex mm-box--justify-content-space-between"
+                          class="justify-between flex"
                         >
                           <div
-                            class="mm-box multichain-account-list-item__account-name mm-box--margin-inline-end-2 mm-box--display-flex mm-box--gap-2 mm-box--align-items-center"
+                            class="gap-2 items-center multichain-account-list-item__account-name flex me-2"
                           >
                             <button
-                              class="mm-box mm-text multichain-account-list-item__account-name__button mm-text--body-md-medium mm-text--ellipsis mm-text--text-align-left mm-box--padding-0 mm-box--width-full mm-box--color-text-default mm-box--background-color-transparent"
+                              class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default truncate multichain-account-list-item__account-name__button p-0 bg-transparent w-full text-left"
+                              type="button"
                             >
                               Test Account
                             </button>
                           </div>
                           <div
-                            class="mm-box mm-text multichain-account-list-item__asset mm-text--body-md mm-text--ellipsis mm-text--text-align-end mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-flex-end mm-box--align-items-center mm-box--color-text-default"
+                            class="flex-row items-center justify-end multichain-account-list-item__asset flex overflow-hidden"
                           >
                             <div
                               class="mm-box currency-display-component mm-box--display-flex mm-box--flex-wrap-wrap mm-box--align-items-center"
@@ -253,20 +254,20 @@ exports[`ConnectPage should render correctly 1`] = `
                         </div>
                       </div>
                       <div
-                        class="mm-box mm-box--display-flex mm-box--justify-content-space-between"
+                        class="justify-between flex"
                       >
                         <div
-                          class="mm-box mm-box--display-flex mm-box--align-items-center"
+                          class="items-center flex"
                         >
                           <p
-                            class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
+                            class="text-alternative text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default"
                             data-testid="account-list-address"
                           >
                             0x0DCD5...3E7bc
                           </p>
                         </div>
                         <div
-                          class="mm-box network-indicator"
+                          class="network-indicator"
                         >
                           <div
                             class="mm-box"
@@ -359,7 +360,7 @@ exports[`ConnectPage should render correctly 1`] = `
                     </div>
                   </div>
                   <div
-                    class="mm-box mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center"
+                    class="items-center justify-center flex"
                   />
                 </div>
               </div>
@@ -504,14 +505,14 @@ exports[`ConnectPage should render with defaults from the requested permissions 
                 style="overflow: auto; max-height: 268px;"
               >
                 <div
-                  class="mm-box multichain-account-list-item items-center mm-box--padding-4 mm-box--display-flex mm-box--background-color-transparent"
+                  class="p-4 bg-transparent multichain-account-list-item flex items-center"
                   data-testid="account-item"
                 >
                   <div
-                    class="mm-box flex w-full gap-2 items-center"
+                    class="flex w-full gap-2 items-center"
                   >
                     <div
-                      class="mm-box mm-box--display-flex mm-box--sm:display-none"
+                      class="flex sm:hidden"
                       data-testid="account-list-item-badge"
                     >
                       <button
@@ -571,7 +572,7 @@ exports[`ConnectPage should render with defaults from the requested permissions 
                       </button>
                     </div>
                     <div
-                      class="mm-box mm-box--display-none mm-box--sm:display-flex"
+                      class="hidden sm:flex"
                     >
                       <div
                         class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-lg h-8 w-8"
@@ -618,25 +619,26 @@ exports[`ConnectPage should render with defaults from the requested permissions 
                       </div>
                     </div>
                     <div
-                      class="mm-box multichain-account-list-item__content mm-box--display-flex mm-box--flex-direction-column"
+                      class="flex-col multichain-account-list-item__content flex"
                     >
                       <div
-                        class="mm-box mm-box--display-flex mm-box--flex-direction-column"
+                        class="flex-col flex"
                       >
                         <div
-                          class="mm-box mm-box--display-flex mm-box--justify-content-space-between"
+                          class="justify-between flex"
                         >
                           <div
-                            class="mm-box multichain-account-list-item__account-name mm-box--margin-inline-end-2 mm-box--display-flex mm-box--gap-2 mm-box--align-items-center"
+                            class="gap-2 items-center multichain-account-list-item__account-name flex me-2"
                           >
                             <button
-                              class="mm-box mm-text multichain-account-list-item__account-name__button mm-text--body-md-medium mm-text--ellipsis mm-text--text-align-left mm-box--padding-0 mm-box--width-full mm-box--color-text-default mm-box--background-color-transparent"
+                              class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default truncate multichain-account-list-item__account-name__button p-0 bg-transparent w-full text-left"
+                              type="button"
                             >
                               Test Account
                             </button>
                           </div>
                           <div
-                            class="mm-box mm-text multichain-account-list-item__asset mm-text--body-md mm-text--ellipsis mm-text--text-align-end mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-flex-end mm-box--align-items-center mm-box--color-text-default"
+                            class="flex-row items-center justify-end multichain-account-list-item__asset flex overflow-hidden"
                           >
                             <div
                               class="mm-box currency-display-component mm-box--display-flex mm-box--flex-wrap-wrap mm-box--align-items-center"
@@ -659,20 +661,20 @@ exports[`ConnectPage should render with defaults from the requested permissions 
                         </div>
                       </div>
                       <div
-                        class="mm-box mm-box--display-flex mm-box--justify-content-space-between"
+                        class="justify-between flex"
                       >
                         <div
-                          class="mm-box mm-box--display-flex mm-box--align-items-center"
+                          class="items-center flex"
                         >
                           <p
-                            class="mm-box mm-text mm-text--body-sm mm-box--color-text-alternative"
+                            class="text-alternative text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default"
                             data-testid="account-list-address"
                           >
                             0x0DCD5...3E7bc
                           </p>
                         </div>
                         <div
-                          class="mm-box network-indicator"
+                          class="network-indicator"
                         >
                           <div
                             class="mm-box"
@@ -765,7 +767,7 @@ exports[`ConnectPage should render with defaults from the requested permissions 
                     </div>
                   </div>
                   <div
-                    class="mm-box mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center"
+                    class="items-center justify-center flex"
                   />
                 </div>
               </div>


### PR DESCRIPTION
## **Description**

This change migrates multichain `account-list-item`, `account-list-item-menu`, and the account list item Storybook story from deprecated `component-library` to `@metamask/design-system-react`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1670

## **Manual testing steps**

1. Open the Account Menu in the wallet view and make sure all UI elements are correctly rendered
2. Try to connect to a dapp and make sure all UI elements are correct in the connection flow

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/4501e6fe-bd6e-4815-a3ad-ec689b37af27

https://github.com/user-attachments/assets/e96e7d97-14bb-4405-8844-291736507c27

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> UI refactor of `AccountListItem` and related menu/story introduces new design-system components and classnames, which could cause visual/layout or interaction regressions in account selection and connect flows.
> 
> **Overview**
> **Migrates multichain account list UI to `@metamask/design-system-react`.** `AccountListItem` and `AccountListItemMenu` switch from deprecated `component-library`/legacy design-system constants to the new design-system enums/components, and update layout/styling (new utility classnames, updated `TextVariant` casing, `ButtonIcon` sizing).
> 
> **Adjusts markup for accessibility/structure.** The account name is now rendered via `Text asChild` wrapping an explicit `<button type="button">`, and tag rendering is updated to use `Tag`’s newer `textVariant` API.
> 
> **Updates Storybook and snapshots.** The story uses the new `Checkbox`, and multiple Jest snapshots are refreshed to match the updated DOM/class output in account selectors and connect-account flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ae6be19d4f24d46f7dfde0fcfc12a593cb53be5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->