### PR TITLE
refactor: migrate multi-srp UI to design-system-react

### DIFF
--- a/ui/components/multichain/multi-srp/select-srp/select-srp.tsx
+++ b/ui/components/multichain/multi-srp/select-srp/select-srp.tsx
@@ -54,9 +54,11 @@ export const SelectSrp = ({
           <Icon name={IconName.ArrowRight} size={IconSize.Sm} />
         </Box>
       </Card>
-      <Text variant={TextVariant.BodySm}>
-        {t('srpListSelectionDescription')}
-      </Text>
+      <Box marginTop={1}>
+        <Text variant={TextVariant.BodySm}>
+          {t('srpListSelectionDescription')}
+        </Text>
+      </Box>
     </Box>
   );
 };

--- a/ui/components/multichain/multi-srp/select-srp/select-srp.tsx
+++ b/ui/components/multichain/multi-srp/select-srp/select-srp.tsx
@@ -1,21 +1,18 @@
 import React from 'react';
-import Card from '../../../ui/card';
 import {
   Box,
-  IconName,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxJustifyContent,
   Icon,
-  Text,
+  IconName,
   IconSize,
-  Label,
-} from '../../../component-library';
-import {
-  JustifyContent,
-  Display,
+  Text,
   TextColor,
-  FlexDirection,
-  AlignItems,
   TextVariant,
-} from '../../../../helpers/constants/design-system';
+} from '@metamask/design-system-react';
+import Card from '../../../ui/card';
+import { Label } from '../../../component-library';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 
 export type SelectSrpProps = {
@@ -42,14 +39,13 @@ export const SelectSrp = ({
         data-testid={`select-srp-${srpName}`}
       >
         <Box
-          display={Display.Flex}
-          flexDirection={FlexDirection.Row}
-          alignItems={AlignItems.center}
-          justifyContent={JustifyContent.spaceBetween}
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          justifyContent={BoxJustifyContent.Between}
         >
           <Box>
             <Text>{srpName}</Text>
-            <Text variant={TextVariant.bodySm} color={TextColor.textMuted}>
+            <Text variant={TextVariant.BodySm} color={TextColor.TextMuted}>
               {srpAccounts > 1
                 ? t('srpListNumberOfAccounts', [srpAccounts])
                 : t('srpListSingleOrZero', [srpAccounts])}
@@ -58,7 +54,7 @@ export const SelectSrp = ({
           <Icon name={IconName.ArrowRight} size={IconSize.Sm} />
         </Box>
       </Card>
-      <Text variant={TextVariant.bodySm} marginTop={1}>
+      <Text variant={TextVariant.BodySm} className="mt-1">
         {t('srpListSelectionDescription')}
       </Text>
     </Box>

--- a/ui/components/multichain/multi-srp/select-srp/select-srp.tsx
+++ b/ui/components/multichain/multi-srp/select-srp/select-srp.tsx
@@ -54,7 +54,7 @@ export const SelectSrp = ({
           <Icon name={IconName.ArrowRight} size={IconSize.Sm} />
         </Box>
       </Card>
-      <Text variant={TextVariant.BodySm} className="mt-1">
+      <Text variant={TextVariant.BodySm}>
         {t('srpListSelectionDescription')}
       </Text>
     </Box>

--- a/ui/components/multichain/multi-srp/srp-list/srp-card.tsx
+++ b/ui/components/multichain/multi-srp/srp-list/srp-card.tsx
@@ -1,6 +1,20 @@
 import React, { useState, useContext, useCallback } from 'react';
 import type { AccountWalletId } from '@metamask/account-api';
 
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxJustifyContent,
+  FontWeight,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react';
 import { MetaMetricsContext } from '../../../../contexts/metametrics';
 import { useWalletInfo } from '../../../../hooks/multichain-accounts/useWalletInfo';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
@@ -11,23 +25,6 @@ import {
 } from '../../../../../shared/constants/metametrics';
 
 import Card from '../../../ui/card';
-import {
-  Box,
-  IconName,
-  Icon,
-  Text,
-  IconSize,
-} from '../../../component-library';
-import {
-  JustifyContent,
-  Display,
-  TextColor,
-  FlexDirection,
-  AlignItems,
-  BlockSize,
-  TextVariant,
-  IconColor,
-} from '../../../../helpers/constants/design-system';
 import { SrpListItem } from './srp-list-item';
 
 /**
@@ -92,19 +89,18 @@ export const SrpCard = ({
       marginBottom={3}
     >
       <Box
-        display={Display.Flex}
-        flexDirection={FlexDirection.Row}
-        alignItems={AlignItems.center}
-        justifyContent={JustifyContent.spaceBetween}
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        justifyContent={BoxJustifyContent.Between}
       >
         <Box>
-          <Text variant={TextVariant.bodyMdMedium}>
+          <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
             {t('srpListName', [index + 1])}
           </Text>
           {!hideShowAccounts && (
             <Text
-              variant={TextVariant.bodySm}
-              color={TextColor.primaryDefault}
+              variant={TextVariant.BodySm}
+              color={TextColor.PrimaryDefault}
               className="srp-list__show-accounts"
               data-testid={`srp-list-show-accounts-${index}`}
               onClick={(event: React.MouseEvent) => {
@@ -125,14 +121,19 @@ export const SrpCard = ({
             </Text>
           )}
         </Box>
-        <Box display={Display.Flex} alignItems={AlignItems.center} gap={1}>
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          gap={1}
+        >
           {isSettingsPage && (
             <Text
-              variant={TextVariant.bodyMdMedium}
+              variant={TextVariant.BodyMd}
+              fontWeight={FontWeight.Medium}
               color={
                 shouldTriggerBackup
-                  ? TextColor.errorDefault
-                  : TextColor.textAlternative
+                  ? TextColor.ErrorDefault
+                  : TextColor.TextAlternative
               }
             >
               {shouldTriggerBackup
@@ -145,8 +146,8 @@ export const SrpCard = ({
             size={IconSize.Sm}
             color={
               shouldTriggerBackup && isSettingsPage
-                ? IconColor.errorDefault
-                : IconColor.iconAlternative
+                ? IconColor.ErrorDefault
+                : IconColor.IconAlternative
             }
           />
         </Box>
@@ -154,8 +155,7 @@ export const SrpCard = ({
       {showAccounts && (
         <Box>
           <Box
-            width={BlockSize.Full}
-            className="srp-list__divider"
+            className="srp-list__divider w-full"
             marginTop={2}
             marginBottom={2}
           />

--- a/ui/components/multichain/multi-srp/srp-list/srp-card.tsx
+++ b/ui/components/multichain/multi-srp/srp-list/srp-card.tsx
@@ -156,10 +156,7 @@ export const SrpCard = ({
       </Box>
       {showAccounts && (
         <Box>
-          <Box
-            marginTop={2}
-            marginBottom={2}
-          />
+          <Box marginTop={2} marginBottom={2} />
           {multichainAccounts.map((group) => {
             return (
               <SrpListItem

--- a/ui/components/multichain/multi-srp/srp-list/srp-card.tsx
+++ b/ui/components/multichain/multi-srp/srp-list/srp-card.tsx
@@ -12,6 +12,8 @@ import {
   IconName,
   IconSize,
   Text,
+  TextButton,
+  TextButtonSize,
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react';
@@ -98,8 +100,8 @@ export const SrpCard = ({
             {t('srpListName', [index + 1])}
           </Text>
           {!hideShowAccounts && (
-            <Text
-              variant={TextVariant.BodySm}
+            <TextButton
+              size={TextButtonSize.BodySm}
               color={TextColor.PrimaryDefault}
               className="srp-list__show-accounts"
               data-testid={`srp-list-show-accounts-${index}`}
@@ -118,7 +120,7 @@ export const SrpCard = ({
               }}
             >
               {showHideText(multichainAccounts.length)}
-            </Text>
+            </TextButton>
           )}
         </Box>
         <Box

--- a/ui/components/multichain/multi-srp/srp-list/srp-card.tsx
+++ b/ui/components/multichain/multi-srp/srp-list/srp-card.tsx
@@ -157,7 +157,6 @@ export const SrpCard = ({
       {showAccounts && (
         <Box>
           <Box
-            className="srp-list__divider w-full"
             marginTop={2}
             marginBottom={2}
           />

--- a/ui/components/multichain/multi-srp/srp-list/srp-list-item.tsx
+++ b/ui/components/multichain/multi-srp/srp-list/srp-list-item.tsx
@@ -1,17 +1,17 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { type AccountGroupId } from '@metamask/account-api';
-import { AvatarAccountSize } from '@metamask/design-system-react';
-import { PreferredAvatar } from '../../../app/preferred-avatar';
 import {
-  Display,
-  FlexDirection,
-  AlignItems,
-  JustifyContent,
+  AvatarAccountSize,
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxJustifyContent,
+  Text,
   TextVariant,
-} from '../../../../helpers/constants/design-system';
+} from '@metamask/design-system-react';
+import { PreferredAvatar } from '../../../app/preferred-avatar';
 import { getIconSeedAddressByAccountGroupId } from '../../../../selectors/multichain-accounts/account-tree';
-import { Text, Box } from '../../../component-library';
 
 type SrpListItemProps = {
   accountId: AccountGroupId;
@@ -31,15 +31,13 @@ export const SrpListItem = ({
   return (
     <Box
       key={accountId}
-      display={Display.Flex}
-      flexDirection={FlexDirection.Row}
-      alignItems={AlignItems.center}
-      justifyContent={JustifyContent.spaceBetween}
+      flexDirection={BoxFlexDirection.Row}
+      alignItems={BoxAlignItems.Center}
+      justifyContent={BoxJustifyContent.Between}
     >
       <Box
-        display={Display.Flex}
-        flexDirection={FlexDirection.Row}
-        alignItems={AlignItems.center}
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
       >
         <PreferredAvatar
           address={seedAddress}
@@ -47,15 +45,14 @@ export const SrpListItem = ({
           data-testid="avatar"
         />
         <Text
-          className="srp-list__account-name"
-          variant={TextVariant.bodySm}
+          className="srp-list__account-name ps-5"
+          variant={TextVariant.BodySm}
           ellipsis
-          paddingInlineStart={5}
         >
           {accountName}
         </Text>
       </Box>
-      <Text variant={TextVariant.bodySm}>{balance}</Text>
+      <Text variant={TextVariant.BodySm}>{balance}</Text>
     </Box>
   );
 };

--- a/ui/components/multichain/multi-srp/srp-list/srp-list-item.tsx
+++ b/ui/components/multichain/multi-srp/srp-list/srp-list-item.tsx
@@ -45,7 +45,7 @@ export const SrpListItem = ({
           data-testid="avatar"
         />
         <Text
-          className="srp-list__account-name ps-5"
+          className="srp-list__account-name"
           variant={TextVariant.BodySm}
           ellipsis
         >

--- a/ui/components/multichain/multi-srp/srp-list/srp-list-item.tsx
+++ b/ui/components/multichain/multi-srp/srp-list/srp-list-item.tsx
@@ -38,6 +38,7 @@ export const SrpListItem = ({
       <Box
         flexDirection={BoxFlexDirection.Row}
         alignItems={BoxAlignItems.Center}
+        gap={2}
       >
         <PreferredAvatar
           address={seedAddress}

--- a/ui/components/multichain/multi-srp/srp-list/srp-list.tsx
+++ b/ui/components/multichain/multi-srp/srp-list/srp-list.tsx
@@ -3,9 +3,9 @@ import { useSelector } from 'react-redux';
 import classnames from 'clsx';
 import { AccountWalletType } from '@metamask/account-api';
 
+import { Box } from '@metamask/design-system-react';
 import { getWalletIdsByType } from '../../../../selectors/multichain-accounts/account-tree';
 import { getIsPrimarySeedPhraseBackedUp } from '../../../../ducks/metamask/metamask';
-import { Box } from '../../../component-library';
 import { SrpCard } from './srp-card';
 
 export const SrpList = ({


### PR DESCRIPTION
## **Description**

Migrates multi-SRP UI (`srp-card`, `srp-list`, `srp-list-item`, `select-srp`) from deprecated `component-library` `Box`, `Text`, `Icon`, and related enums to `@metamask/design-system-react`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1672

## **Manual testing steps**

1. Go to settings > Security and password > Manage wallet recovery
2. Make sure all UI elements are properly rendered and navigation works

## **Screenshots/Recordings**

<img width="492" height="775" alt="Screenshot 2026-04-10 at 3 00 54 PM" src="https://github.com/user-attachments/assets/25194c8b-85c2-4b18-a82d-f813ccc54657" />

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI refactor with minimal logic changes, but could introduce minor layout/styling regressions due to component/token migrations and a switch from `Text` to `TextButton` for the show/hide control.
> 
> **Overview**
> Migrates multi-SRP UI components (`select-srp`, `srp-card`, `srp-list`, `srp-list-item`) from the deprecated `component-library` and legacy design-system constants to `@metamask/design-system-react` (Box/Text/Icon tokens and enum casing updates).
> 
> Includes small presentation tweaks such as rendering the show/hide accounts control as a `TextButton`, updating divider sizing via CSS classes (replacing `BlockSize.Full`), and wrapping helper copy under the select card in a spaced `Box`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 326aa748bfd9d11f73c748373dcc7a5631007a14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->