### PR TITLE
refactor(stores): replace segment hooks with EventEmitter

### DIFF
--- a/app/scripts/lib/setup-initial-state-hooks.js
+++ b/app/scripts/lib/setup-initial-state-hooks.js
@@ -34,12 +34,14 @@ function createLocalStore() {
 const localStore = createLocalStore();
 
 // Single PersistenceManager per context: one in background, one per UI context.
-export const persistenceManager = new PersistenceManager({
-  localStore,
-  segmentHooks: {
-    onVaultCorruptionEvent: trackVaultCorruptionEvent,
-    onEarlySegmentEvent: trackEarlySegmentEvent,
-  },
+export const persistenceManager = new PersistenceManager({ localStore });
+
+persistenceManager.events.on('vaultCorruptionEventToTrack', (args) => {
+  trackVaultCorruptionEvent(args.backup, args.event, args.corruptionType);
+});
+
+persistenceManager.events.on('earlySegmentEventToTrack', (args) => {
+  trackEarlySegmentEvent(args);
 });
 
 /**

--- a/app/scripts/lib/setup-initial-state-hooks.js
+++ b/app/scripts/lib/setup-initial-state-hooks.js
@@ -38,9 +38,7 @@ function createLocalStore() {
 const localStore = createLocalStore();
 
 // Single PersistenceManager per context: one in background, one per UI context.
-export const persistenceManager = new PersistenceManager({ localStore });
-
-persistenceManager
+export const persistenceManager = new PersistenceManager({ localStore })
   .on('vaultCorruptionDetected', (payload) => {
     trackVaultCorruptionEvent(
       payload.backup,

--- a/app/scripts/lib/setup-initial-state-hooks.js
+++ b/app/scripts/lib/setup-initial-state-hooks.js
@@ -6,6 +6,10 @@ import ExtensionPlatform from '../platforms/extension';
 import { SENTRY_BACKGROUND_STATE } from '../constants/sentry-state';
 import { FixtureExtensionStore } from '../../../shared/lib/stores/fixture-extension-store';
 import ExtensionStore from '../../../shared/lib/stores/extension-store';
+import {
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
+} from '../../../shared/constants/metametrics';
 import { PersistenceManager } from '../../../shared/lib/stores/persistence-manager';
 import { trackVaultCorruptionEvent } from './state-corruption/track-vault-corruption';
 import { trackEarlySegmentEvent } from './segment/early-segment-tracking';
@@ -36,13 +40,28 @@ const localStore = createLocalStore();
 // Single PersistenceManager per context: one in background, one per UI context.
 export const persistenceManager = new PersistenceManager({ localStore });
 
-persistenceManager.events.on('vaultCorruptionEventToTrack', (args) => {
-  trackVaultCorruptionEvent(args.backup, args.event, args.corruptionType);
-});
-
-persistenceManager.events.on('earlySegmentEventToTrack', (args) => {
-  trackEarlySegmentEvent(args);
-});
+persistenceManager
+  .on('vaultCorruptionDetected', (payload) => {
+    trackVaultCorruptionEvent(
+      payload.backup,
+      MetaMetricsEventName.VaultCorruptionDetected,
+      payload.corruptionType,
+    );
+  })
+  .on('splitStateMigrationSucceeded', (payload) => {
+    trackEarlySegmentEvent({
+      state: payload.state,
+      event: MetaMetricsEventName.StateMigrationSucceeded,
+      category: MetaMetricsEventCategory.StateMigration,
+    });
+  })
+  .on('splitStateMigrationFailed', (payload) => {
+    trackEarlySegmentEvent({
+      state: payload.state,
+      event: MetaMetricsEventName.StateMigrationFailed,
+      category: MetaMetricsEventCategory.StateMigration,
+    });
+  });
 
 /**
  * Get the persisted wallet state.

--- a/app/scripts/lib/setup-initial-state-hooks.test.ts
+++ b/app/scripts/lib/setup-initial-state-hooks.test.ts
@@ -3,6 +3,7 @@ import type { PersistenceManager as PersistenceManagerType } from '../../../shar
 const mockGet = jest.fn();
 const mockGetBackup = jest.fn();
 const mockCleanUpMostRecentRetrievedState = jest.fn();
+const mockPersistenceOn = jest.fn();
 let mockMostRecentRetrievedState: unknown = null;
 
 jest.mock('../platforms/extension', () => {
@@ -36,6 +37,10 @@ jest.mock('../../../shared/lib/stores/persistence-manager', () => ({
     get: mockGet,
     getBackup: mockGetBackup,
     cleanUpMostRecentRetrievedState: mockCleanUpMostRecentRetrievedState,
+    events: {
+      on: mockPersistenceOn,
+      off: jest.fn(),
+    },
     get mostRecentRetrievedState() {
       return mockMostRecentRetrievedState;
     },
@@ -69,6 +74,7 @@ describe('setup-initial-state-hooks', () => {
     jest.resetModules();
     mockMostRecentRetrievedState = null;
     mockCleanUpMostRecentRetrievedState.mockClear();
+    mockPersistenceOn.mockClear();
     globalThis.stateHooks = {} as typeof stateHooks;
   });
 
@@ -174,6 +180,21 @@ describe('setup-initial-state-hooks', () => {
 
       expect(persistenceManager).toBeDefined();
       expect(persistenceManager.get).toBeDefined();
+    });
+
+    it('registers persistence lifecycle event listeners for analytics wiring', async () => {
+      setSelfHref('chrome-extension://abc123/home.html');
+      await importFresh();
+
+      expect(mockPersistenceOn).toHaveBeenCalledTimes(2);
+      expect(mockPersistenceOn).toHaveBeenCalledWith(
+        'vaultCorruptionEventToTrack',
+        expect.any(Function),
+      );
+      expect(mockPersistenceOn).toHaveBeenCalledWith(
+        'earlySegmentEventToTrack',
+        expect.any(Function),
+      );
     });
   });
 

--- a/app/scripts/lib/setup-initial-state-hooks.test.ts
+++ b/app/scripts/lib/setup-initial-state-hooks.test.ts
@@ -33,18 +33,22 @@ jest.mock('../../../shared/lib/stores/fixture-extension-store', () => ({
 }));
 
 jest.mock('../../../shared/lib/stores/persistence-manager', () => ({
-  PersistenceManager: jest.fn().mockImplementation(() => ({
-    get: mockGet,
-    getBackup: mockGetBackup,
-    cleanUpMostRecentRetrievedState: mockCleanUpMostRecentRetrievedState,
-    events: {
-      on: mockPersistenceOn,
+  PersistenceManager: jest.fn().mockImplementation(() => {
+    const instance = {
+      get: mockGet,
+      getBackup: mockGetBackup,
+      cleanUpMostRecentRetrievedState: mockCleanUpMostRecentRetrievedState,
+      on: (...args: unknown[]) => {
+        mockPersistenceOn(...args);
+        return instance;
+      },
       off: jest.fn(),
-    },
-    get mostRecentRetrievedState() {
-      return mockMostRecentRetrievedState;
-    },
-  })),
+      get mostRecentRetrievedState() {
+        return mockMostRecentRetrievedState;
+      },
+    };
+    return instance;
+  }),
 }));
 
 /**
@@ -186,13 +190,17 @@ describe('setup-initial-state-hooks', () => {
       setSelfHref('chrome-extension://abc123/home.html');
       await importFresh();
 
-      expect(mockPersistenceOn).toHaveBeenCalledTimes(2);
+      expect(mockPersistenceOn).toHaveBeenCalledTimes(3);
       expect(mockPersistenceOn).toHaveBeenCalledWith(
-        'vaultCorruptionEventToTrack',
+        'vaultCorruptionDetected',
         expect.any(Function),
       );
       expect(mockPersistenceOn).toHaveBeenCalledWith(
-        'earlySegmentEventToTrack',
+        'splitStateMigrationSucceeded',
+        expect.any(Function),
+      );
+      expect(mockPersistenceOn).toHaveBeenCalledWith(
+        'splitStateMigrationFailed',
         expect.any(Function),
       );
     });

--- a/shared/lib/stores/persistence-manager.test.ts
+++ b/shared/lib/stores/persistence-manager.test.ts
@@ -50,6 +50,17 @@ describe('PersistenceManager', () => {
     manager = new PersistenceManager({ localStore: new ExtensionStore() });
   });
 
+  describe('events', () => {
+    it('supports SafeEventEmitter on and off without throwing', () => {
+      const listener = jest.fn();
+      expect(() => {
+        manager.events.on('earlySegmentEventToTrack', listener);
+        manager.events.off('earlySegmentEventToTrack', listener);
+        manager.events.off('vaultCorruptionEventToTrack', listener);
+      }).not.toThrow();
+    });
+  });
+
   describe('set', () => {
     beforeEach(() => {
       manager.storageKind = 'data';

--- a/shared/lib/stores/persistence-manager.test.ts
+++ b/shared/lib/stores/persistence-manager.test.ts
@@ -51,12 +51,12 @@ describe('PersistenceManager', () => {
   });
 
   describe('events', () => {
-    it('supports SafeEventEmitter on and off without throwing', () => {
+    it('supports EventEmitter on and off without throwing', () => {
       const listener = jest.fn();
       expect(() => {
-        manager.events.on('earlySegmentEventToTrack', listener);
-        manager.events.off('earlySegmentEventToTrack', listener);
-        manager.events.off('vaultCorruptionEventToTrack', listener);
+        manager.on('splitStateMigrationSucceeded', listener);
+        manager.off('splitStateMigrationSucceeded', listener);
+        manager.off('vaultCorruptionDetected', listener);
       }).not.toThrow();
     });
   });

--- a/shared/lib/stores/persistence-manager.ts
+++ b/shared/lib/stores/persistence-manager.ts
@@ -1,5 +1,6 @@
 import log from 'loglevel';
 import { isEmpty } from 'lodash';
+import SafeEventEmitter from '@metamask/safe-event-emitter';
 import { RuntimeObject, hasProperty, isObject } from '@metamask/utils';
 import { captureException, captureMessage } from '../sentry';
 import { MISSING_VAULT_ERROR } from '../../constants/errors';
@@ -42,25 +43,27 @@ export const backedUpStateKeys = [
 
 export type BackedUpStateKey = (typeof backedUpStateKeys)[number];
 
-/**
- * Optional hooks for emitting Segment events.
- */
-export type PersistenceManagerSegmentHooks = {
-  onVaultCorruptionEvent?: (
-    backup: Backup | null,
-    eventName: MetaMetricsEventName,
-    corruptionType: VaultCorruptionType,
-  ) => void;
-  onEarlySegmentEvent?: (args: {
-    state: MetaMaskStateType;
-    event: MetaMetricsEventName;
-    category: MetaMetricsEventCategory;
-  }) => void;
+export type VaultCorruptionEventToTrackPayload = {
+  backup: Backup | null;
+  event: MetaMetricsEventName;
+  corruptionType: VaultCorruptionType;
 };
+
+export type EarlySegmentEventToTrackPayload = {
+  state: MetaMaskStateType;
+  event: MetaMetricsEventName;
+  category: MetaMetricsEventCategory;
+};
+
+export type PersistenceManagerEventMap = {
+  vaultCorruptionEventToTrack: VaultCorruptionEventToTrackPayload;
+  earlySegmentEventToTrack: EarlySegmentEventToTrackPayload;
+};
+
+export type PersistenceManagerEventName = keyof PersistenceManagerEventMap;
 
 export type PersistenceManagerOptions = {
   localStore: BaseStore;
-  segmentHooks?: PersistenceManagerSegmentHooks;
 };
 
 /**
@@ -232,11 +235,10 @@ export class PersistenceManager {
    */
   #errorTypeBeforeCallbackRegistered: StorageWriteErrorType | null = null;
 
-  #segmentHooks?: PersistenceManagerSegmentHooks;
+  readonly events = new SafeEventEmitter();
 
-  constructor({ localStore, segmentHooks }: PersistenceManagerOptions) {
+  constructor({ localStore }: PersistenceManagerOptions) {
     this.#localStore = localStore;
-    this.#segmentHooks = segmentHooks;
   }
 
   /**
@@ -743,11 +745,11 @@ export class PersistenceManager {
               const corruptionType = localStoreError
                 ? VaultCorruptionType.InaccessibleDatabase
                 : VaultCorruptionType.MissingVaultInDatabase;
-              this.#segmentHooks?.onVaultCorruptionEvent?.(
+              this.events.emit('vaultCorruptionEventToTrack', {
                 backup,
-                MetaMetricsEventName.VaultCorruptionDetected,
+                event: MetaMetricsEventName.VaultCorruptionDetected,
                 corruptionType,
-              );
+              });
 
               // We've got some data (we haven't checked for a vault, as the
               // background+UI are responsible for determining what happens now).
@@ -946,14 +948,14 @@ export class PersistenceManager {
       );
 
       if (migrationStatus === 'succeeded') {
-        this.#segmentHooks?.onEarlySegmentEvent?.({
+        this.events.emit('earlySegmentEventToTrack', {
           state,
           event: MetaMetricsEventName.StateMigrationSucceeded,
           category: MetaMetricsEventCategory.StateMigration,
         });
       }
     } catch (error) {
-      this.#segmentHooks?.onEarlySegmentEvent?.({
+      this.events.emit('earlySegmentEventToTrack', {
         state,
         event: MetaMetricsEventName.StateMigrationFailed,
         category: MetaMetricsEventCategory.StateMigration,

--- a/shared/lib/stores/persistence-manager.ts
+++ b/shared/lib/stores/persistence-manager.ts
@@ -58,8 +58,6 @@ export type PersistenceManagerEventMap = {
   splitStateMigrationFailed: [SplitStateMigrationFailedEvent];
 };
 
-export type PersistenceManagerEventName = keyof PersistenceManagerEventMap;
-
 export type PersistenceManagerOptions = {
   localStore: BaseStore;
 };

--- a/shared/lib/stores/persistence-manager.ts
+++ b/shared/lib/stores/persistence-manager.ts
@@ -1,15 +1,11 @@
+import EventEmitter from 'events';
 import log from 'loglevel';
 import { isEmpty } from 'lodash';
-import SafeEventEmitter from '@metamask/safe-event-emitter';
 import { RuntimeObject, hasProperty, isObject } from '@metamask/utils';
 import { captureException, captureMessage } from '../sentry';
 import { MISSING_VAULT_ERROR } from '../../constants/errors';
 import { getManifestFlags } from '../manifestFlags';
 import { VaultCorruptionType } from '../../constants/state-corruption';
-import {
-  MetaMetricsEventCategory,
-  MetaMetricsEventName,
-} from '../../constants/metametrics';
 import { StorageWriteErrorType } from '../../constants/app-state';
 import { IndexedDBStore } from './indexeddb-store';
 import type {
@@ -43,21 +39,23 @@ export const backedUpStateKeys = [
 
 export type BackedUpStateKey = (typeof backedUpStateKeys)[number];
 
-export type VaultCorruptionEventToTrackPayload = {
-  backup: Backup | null;
-  event: MetaMetricsEventName;
+export type VaultCorruptionDetectedEvent = {
+  backup: Backup;
   corruptionType: VaultCorruptionType;
 };
 
-export type EarlySegmentEventToTrackPayload = {
+export type SplitStateMigrationSucceededEvent = {
   state: MetaMaskStateType;
-  event: MetaMetricsEventName;
-  category: MetaMetricsEventCategory;
+};
+
+export type SplitStateMigrationFailedEvent = {
+  state: MetaMaskStateType;
 };
 
 export type PersistenceManagerEventMap = {
-  vaultCorruptionEventToTrack: VaultCorruptionEventToTrackPayload;
-  earlySegmentEventToTrack: EarlySegmentEventToTrackPayload;
+  vaultCorruptionDetected: [VaultCorruptionDetectedEvent];
+  splitStateMigrationSucceeded: [SplitStateMigrationSucceededEvent];
+  splitStateMigrationFailed: [SplitStateMigrationFailedEvent];
 };
 
 export type PersistenceManagerEventName = keyof PersistenceManagerEventMap;
@@ -178,7 +176,7 @@ const STATE_LOCK = 'state-lock';
  * implementation of the `BaseStore` class (`ExtensionStore`). It provides methods for setting and retrieving
  * state, managing metadata, and handling cleanup tasks.
  */
-export class PersistenceManager {
+export class PersistenceManager extends EventEmitter<PersistenceManagerEventMap> {
   /**
    * DefaultStorageKind is a static property that defines the default storage
    * kind to be used by the PersistenceManager. It checks if the code is running
@@ -235,9 +233,8 @@ export class PersistenceManager {
    */
   #errorTypeBeforeCallbackRegistered: StorageWriteErrorType | null = null;
 
-  readonly events = new SafeEventEmitter();
-
   constructor({ localStore }: PersistenceManagerOptions) {
+    super();
     this.#localStore = localStore;
   }
 
@@ -745,9 +742,8 @@ export class PersistenceManager {
               const corruptionType = localStoreError
                 ? VaultCorruptionType.InaccessibleDatabase
                 : VaultCorruptionType.MissingVaultInDatabase;
-              this.events.emit('vaultCorruptionEventToTrack', {
+              this.emit('vaultCorruptionDetected', {
                 backup,
-                event: MetaMetricsEventName.VaultCorruptionDetected,
                 corruptionType,
               });
 
@@ -948,18 +944,10 @@ export class PersistenceManager {
       );
 
       if (migrationStatus === 'succeeded') {
-        this.events.emit('earlySegmentEventToTrack', {
-          state,
-          event: MetaMetricsEventName.StateMigrationSucceeded,
-          category: MetaMetricsEventCategory.StateMigration,
-        });
+        this.emit('splitStateMigrationSucceeded', { state });
       }
     } catch (error) {
-      this.events.emit('earlySegmentEventToTrack', {
-        state,
-        event: MetaMetricsEventName.StateMigrationFailed,
-        category: MetaMetricsEventCategory.StateMigration,
-      });
+      this.emit('splitStateMigrationFailed', { state });
 
       throw error;
     }


### PR DESCRIPTION
## **Description**

This PR replaces hook with event emitter, in answer to this comment: https://github.com/MetaMask/metamask-extension/pull/41408#discussion_r3045878489

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: 

## **Manual testing steps**

NA

## **Screenshots/Recordings**

NA

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core persistence initialization and state migration/vault-corruption signaling by changing `PersistenceManager` to an `EventEmitter`, which could affect analytics wiring or event ordering if consumers aren’t updated correctly.
> 
> **Overview**
> Refactors `PersistenceManager` to **emit typed lifecycle events** (`vaultCorruptionDetected`, `splitStateMigrationSucceeded`, `splitStateMigrationFailed`) instead of accepting `segmentHooks` callbacks in its constructor.
> 
> Updates `setup-initial-state-hooks` to register analytics handlers via `.on(...)` for those events (tracking vault corruption and split-state migration success/failure), and adjusts tests to mock/verify event listener registration and ensure `.on/.off` are supported.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f883c4d0ce379de6ad23b459624daefbb84bcef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->