### PR TITLE
feat(perps): add "See All" button to market detail recent activity

### DIFF
--- a/ui/pages/perps/perps-activity-page.test.tsx
+++ b/ui/pages/perps/perps-activity-page.test.tsx
@@ -126,13 +126,13 @@ describe('PerpsActivityPage', () => {
     ).toBeInTheDocument();
   });
 
-  it('back button navigates to DEFAULT_ROUTE', () => {
+  it('back button navigates to previous page', () => {
     renderWithProvider(<PerpsActivityPage />, createMockStore());
 
     const backButton = screen.getByTestId('perps-activity-back-button');
     fireEvent.click(backButton);
 
-    expect(mockNavigate).toHaveBeenCalledWith(DEFAULT_ROUTE);
+    expect(mockNavigate).toHaveBeenCalledWith(-1);
   });
 
   it('redirects when perps experience is unavailable', () => {

--- a/ui/pages/perps/perps-activity-page.tsx
+++ b/ui/pages/perps/perps-activity-page.tsx
@@ -88,7 +88,7 @@ const PerpsActivityPage: React.FC = () => {
 
   // Navigation handlers
   const handleBackClick = useCallback(() => {
-    navigate(DEFAULT_ROUTE);
+    navigate(-1);
   }, [navigate]);
 
   // Navigate to the market detail page when an order transaction is clicked

--- a/ui/pages/perps/perps-market-detail-page.test.tsx
+++ b/ui/pages/perps/perps-market-detail-page.test.tsx
@@ -137,13 +137,17 @@ jest.mock('../../components/app/perps/perps-toast', () => {
   };
 });
 
+const mockUsePerpsMarketFills = jest
+  .fn()
+  .mockReturnValue({ fills: [], isInitialLoading: false });
+
 jest.mock('../../hooks/perps', () => ({
   usePerpsEligibility: () => ({ isEligible: true }),
   usePerpsOrderForm: jest.fn(),
   useUserHistory: jest.fn(),
   usePerpsTransactionHistory: jest.fn(),
   usePerpsMarginCalculations: jest.fn(),
-  usePerpsMarketFills: () => ({ fills: [], isInitialLoading: false }),
+  usePerpsMarketFills: (...args: unknown[]) => mockUsePerpsMarketFills(...args),
 }));
 
 // Mock the perps stream hooks
@@ -245,6 +249,10 @@ describe('PerpsMarketDetailPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockReplacePerpsToastByKey.mockReset();
+    mockUsePerpsMarketFills.mockReturnValue({
+      fills: [],
+      isInitialLoading: false,
+    });
     mockUseParams.mockReturnValue({ symbol: 'ETH' });
     latestPriceSubscriber = undefined;
     mockUseLocation.mockReturnValue({
@@ -492,6 +500,50 @@ describe('PerpsMarketDetailPage', () => {
       expect(
         getByText(messages.perpsRecentActivity.message),
       ).toBeInTheDocument();
+    });
+
+    it('does not show View All button when there are no fills', () => {
+      const store = mockStore(createMockState(true));
+
+      renderWithProvider(<PerpsMarketDetailPage />, store);
+
+      expect(
+        screen.queryByTestId('perps-market-detail-view-all-activity'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('shows View All button when there are fills and navigates to activity page', () => {
+      mockUsePerpsMarketFills.mockReturnValue({
+        fills: [
+          {
+            orderId: 'fill-1',
+            symbol: 'ETH',
+            side: 'buy',
+            size: '1.0',
+            price: '2500.00',
+            pnl: '0',
+            direction: 'Open Long',
+            fee: '0.50',
+            feeToken: 'USDC',
+            timestamp: Date.now(),
+          },
+        ],
+        isInitialLoading: false,
+      });
+      const store = mockStore(createMockState(true));
+
+      renderWithProvider(<PerpsMarketDetailPage />, store);
+
+      const viewAllButton = screen.getByTestId(
+        'perps-market-detail-view-all-activity',
+      );
+      expect(viewAllButton).toBeInTheDocument();
+      expect(
+        screen.getByText(messages.perpsSeeAll.message),
+      ).toBeInTheDocument();
+
+      fireEvent.click(viewAllButton);
+      expect(mockUseNavigate).toHaveBeenCalledWith('/perps/activity');
     });
 
     it('displays learn section', () => {

--- a/ui/pages/perps/perps-market-detail-page.test.tsx
+++ b/ui/pages/perps/perps-market-detail-page.test.tsx
@@ -13,6 +13,7 @@ import {
   mockHip3Markets,
   mockTransactions,
 } from '../../components/app/perps/mocks';
+import { PERPS_ACTIVITY_ROUTE } from '../../helpers/constants/routes';
 
 // Mock lightweight-charts to prevent DOM rendering issues in tests
 const mockPriceLine = { options: jest.fn() };
@@ -543,7 +544,7 @@ describe('PerpsMarketDetailPage', () => {
       ).toBeInTheDocument();
 
       fireEvent.click(viewAllButton);
-      expect(mockUseNavigate).toHaveBeenCalledWith('/perps/activity');
+      expect(mockUseNavigate).toHaveBeenCalledWith(PERPS_ACTIVITY_ROUTE);
     });
 
     it('displays learn section', () => {

--- a/ui/pages/perps/perps-market-detail-page.tsx
+++ b/ui/pages/perps/perps-market-detail-page.tsx
@@ -29,6 +29,7 @@ import {
   Button,
   ButtonVariant,
   ButtonSize,
+  ButtonBase,
 } from '@metamask/design-system-react';
 import { brandColor } from '@metamask/design-tokens';
 import type { Position, PriceUpdate, Order } from '@metamask/perps-controller';
@@ -39,6 +40,7 @@ import { useI18nContext } from '../../hooks/useI18nContext';
 import {
   DEFAULT_ROUTE,
   PERPS_ORDER_ENTRY_ROUTE,
+  PERPS_ACTIVITY_ROUTE,
 } from '../../helpers/constants/routes';
 import {
   usePerpsLivePositions,
@@ -1510,13 +1512,33 @@ const PerpsMarketDetailPage: React.FC = () => {
 
         {/* Recent Activity Section - always visible */}
         <Box paddingLeft={4} paddingRight={4}>
-          <Box paddingTop={4} paddingBottom={2}>
+          <Box
+            flexDirection={BoxFlexDirection.Row}
+            justifyContent={BoxJustifyContent.Between}
+            alignItems={BoxAlignItems.Center}
+            paddingTop={4}
+            paddingBottom={2}
+          >
             <Text
               variant={TextVariant.HeadingSm}
               fontWeight={FontWeight.Medium}
             >
               {t('perpsRecentActivity')}
             </Text>
+            {recentActivityTransactions.length > 0 && (
+              <ButtonBase
+                onClick={() => navigate(PERPS_ACTIVITY_ROUTE)}
+                className="bg-transparent hover:bg-transparent active:bg-transparent p-0 min-w-0 h-auto"
+                data-testid="perps-market-detail-view-all-activity"
+              >
+                <Text
+                  variant={TextVariant.BodySm}
+                  color={TextColor.TextAlternative}
+                >
+                  {t('perpsSeeAll')}
+                </Text>
+              </ButtonBase>
+            )}
           </Box>
           {renderRecentActivityContent()}
 


### PR DESCRIPTION
## **Description**

The Recent Activity section on the perps market detail page (`/perps/market/:symbol`) was missing a navigational affordance to view the full activity history. Additionally, the activity page's back button always redirected to the asset list instead of returning to the previous screen.

**Changes:**

1. **"See All" button on market detail page** — Adds a "See All" link inline with the "Recent Activity" heading (right-aligned) that navigates to `/perps/activity`. The button only renders when there are transactions to display, consistent with the existing `PerpsRecentActivity` component on the perps home tab. Reuses the `perpsSeeAll` i18n key and `ButtonBase` visual pattern.

2. **Activity page back navigation** — Changes the back button on `/perps/activity` from `navigate(DEFAULT_ROUTE)` to `navigate(-1)` so users return to whichever page they came from (e.g., the market detail page) instead of always landing on the asset list.

## **Changelog**

CHANGELOG entry: Added a "See All" button to the Recent Activity section on the perps market detail page and fixed the activity page back button to return to the previous screen

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2829

## **Manual testing steps**

Feature: See All button on perps market detail Recent Activity

Scenario: See All button appears when there is recent activity
  Given the user has unlocked their wallet
  And navigated to the Perps tab
  When the user taps on a market with recent trade fills (e.g. ETH)
  And scrolls to the "Recent Activity" section
  Then a "See All" button is visible on the right side of the "Recent Activity" heading
  And tapping it navigates to `/perps/activity`

Scenario: See All button is hidden when there is no activity
  Given the user has unlocked their wallet
  And navigated to the Perps tab
  When the user taps on a market with no recent fills
  Then the "Recent Activity" heading is shown without a "See All" button

Scenario: Activity page back button returns to market detail
  Given the user is on a market detail page (e.g. `/perps/market/ETH`)
  When the user taps "See All" to open the activity page
  And then taps the back button on the activity page
  Then the user is returned to the market detail page they came from

## **Screenshots/Recordings**

### **Before**

### **After**
<img width="452" height="780" alt="Screenshot 2026-04-08 at 10 37 49" src="https://github.com/user-attachments/assets/7cefb090-1659-4d7b-9f73-c6412a5d8a54" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI navigation change: adds a conditional link to the activity page and updates the activity page back button to use browser history, with unit tests covering both behaviors.
> 
> **Overview**
> Adds a right-aligned **"See all"** action in the Perps market detail *Recent Activity* header that conditionally appears when recent fills exist and navigates to `PERPS_ACTIVITY_ROUTE`.
> 
> Updates the Perps Activity page back button to `navigate(-1)` (history back) instead of always routing to `DEFAULT_ROUTE`, and adjusts/extends tests to validate the new navigation behavior and the conditional rendering of the new button.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee898ad558ee31fbb714d74ab1cb692374855d01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->