### PR TITLE
chore: Bulk register actions in `MetametricsDataDeletionController`

### DIFF
--- a/app/scripts/controllers/metametrics-data-deletion/metametrics-data-deletion-method-action-types.ts
+++ b/app/scripts/controllers/metametrics-data-deletion/metametrics-data-deletion-method-action-types.ts
@@ -1,0 +1,32 @@
+/**
+ * This file is auto generated.
+ * Do not edit manually.
+ */
+
+import type { MetaMetricsDataDeletionController } from './metametrics-data-deletion';
+
+/**
+ * Creating the delete regulation using source regulation
+ *
+ */
+export type MetaMetricsDataDeletionControllerCreateMetaMetricsDataDeletionTaskAction =
+  {
+    type: `MetaMetricsDataDeletionController:createMetaMetricsDataDeletionTask`;
+    handler: MetaMetricsDataDeletionController['createMetaMetricsDataDeletionTask'];
+  };
+
+/**
+ * To check the status of the current delete regulation.
+ */
+export type MetaMetricsDataDeletionControllerUpdateDataDeletionTaskStatusAction =
+  {
+    type: `MetaMetricsDataDeletionController:updateDataDeletionTaskStatus`;
+    handler: MetaMetricsDataDeletionController['updateDataDeletionTaskStatus'];
+  };
+
+/**
+ * Union of all MetaMetricsDataDeletionController action types.
+ */
+export type MetaMetricsDataDeletionControllerMethodActions =
+  | MetaMetricsDataDeletionControllerCreateMetaMetricsDataDeletionTaskAction
+  | MetaMetricsDataDeletionControllerUpdateDataDeletionTaskStatusAction;

--- a/app/scripts/controllers/metametrics-data-deletion/metametrics-data-deletion.ts
+++ b/app/scripts/controllers/metametrics-data-deletion/metametrics-data-deletion.ts
@@ -9,6 +9,7 @@ import { PublicInterface } from '@metamask/utils';
 import type { DataDeletionService } from '../../services/data-deletion-service';
 import { DeleteRegulationStatus } from '../../../../shared/constants/metametrics';
 import { MetaMetricsControllerGetStateAction } from '../metametrics-controller';
+import { MetaMetricsDataDeletionControllerMethodActions } from './metametrics-data-deletion-method-action-types';
 
 // Unique name for the controller
 const controllerName = 'MetaMetricsDataDeletionController';
@@ -63,26 +64,18 @@ const metadata: StateMetadata<MetaMetricsDataDeletionState> = {
   },
 };
 
-// Describes the action creating the delete regulation task
-export type CreateMetaMetricsDataDeletionTaskAction = {
-  type: `${typeof controllerName}:createMetaMetricsDataDeletionTask`;
-  handler: MetaMetricsDataDeletionController['createMetaMetricsDataDeletionTask'];
-};
+const MESSENGER_EXPOSED_METHODS = [
+  'createMetaMetricsDataDeletionTask',
+  'updateDataDeletionTaskStatus',
+] as const;
 
-// Describes the action to check the existing regulation status
-export type UpdateDataDeletionTaskStatusAction = {
-  type: `${typeof controllerName}:updateDataDeletionTaskStatus`;
-  handler: MetaMetricsDataDeletionController['updateDataDeletionTaskStatus'];
-};
+export type MetaMetricsDataDeletionControllerGetStateAction =
+  ControllerGetStateAction<typeof controllerName, MetaMetricsDataDeletionState>;
 
 // Union of all possible actions for the messenger
 export type MetaMetricsDataDeletionControllerMessengerActions =
-  | ControllerGetStateAction<
-      typeof controllerName,
-      MetaMetricsDataDeletionState
-    >
-  | CreateMetaMetricsDataDeletionTaskAction
-  | UpdateDataDeletionTaskStatusAction;
+  | MetaMetricsDataDeletionControllerGetStateAction
+  | MetaMetricsDataDeletionControllerMethodActions;
 
 export type MetaMetricsDataDeletionControllerMessengerEvents =
   ControllerStateChangeEvent<
@@ -143,22 +136,9 @@ export class MetaMetricsDataDeletionController extends BaseController<
       state: { ...getDefaultState(), ...state },
     });
     this.#dataDeletionService = dataDeletionService;
-    this.#registerMessageHandlers();
-  }
-
-  /**
-   * Constructor helper for registering this controller's messaging system
-   * actions.
-   */
-  #registerMessageHandlers(): void {
-    this.messenger.registerActionHandler(
-      `${controllerName}:createMetaMetricsDataDeletionTask`,
-      this.createMetaMetricsDataDeletionTask.bind(this),
-    );
-
-    this.messenger.registerActionHandler(
-      `${controllerName}:updateDataDeletionTaskStatus`,
-      this.updateDataDeletionTaskStatus.bind(this),
+    this.messenger.registerMethodActionHandlers(
+      this,
+      MESSENGER_EXPOSED_METHODS,
     );
   }
 

--- a/app/scripts/messenger-client-init/messengers/index.ts
+++ b/app/scripts/messenger-client-init/messengers/index.ts
@@ -295,7 +295,6 @@ export type { LoggingControllerMessenger } from './logging-controller-messenger'
 export { getLoggingControllerMessenger } from './logging-controller-messenger';
 export type { MetaMetricsControllerMessenger } from './metametrics-controller-messenger';
 export { getMetaMetricsControllerMessenger } from './metametrics-controller-messenger';
-export type { MetaMetricsDataDeletionControllerMessenger } from './metametrics-data-deletion-controller-messenger';
 export { getMetaMetricsDataDeletionControllerMessenger } from './metametrics-data-deletion-controller-messenger';
 export type { NetworkControllerInitMessenger } from './network-controller-messenger';
 export {

--- a/app/scripts/messenger-client-init/messengers/metametrics-data-deletion-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/metametrics-data-deletion-controller-messenger.ts
@@ -1,13 +1,10 @@
-import { Messenger } from '@metamask/messenger';
 import {
-  AllowedActions,
-  AllowedEvents,
-} from '../../controllers/metametrics-data-deletion/metametrics-data-deletion';
+  Messenger,
+  MessengerActions,
+  MessengerEvents,
+} from '@metamask/messenger';
 import { RootMessenger } from '../../lib/messenger';
-
-export type MetaMetricsDataDeletionControllerMessenger = ReturnType<
-  typeof getMetaMetricsDataDeletionControllerMessenger
->;
+import { MetaMetricsDataDeletionControllerMessenger } from '../../controllers/metametrics-data-deletion/metametrics-data-deletion';
 
 /**
  * Create a messenger restricted to the allowed actions and events of the
@@ -17,17 +14,16 @@ export type MetaMetricsDataDeletionControllerMessenger = ReturnType<
  * messenger.
  */
 export function getMetaMetricsDataDeletionControllerMessenger(
-  messenger: RootMessenger<AllowedActions, AllowedEvents>,
+  messenger: RootMessenger<
+    MessengerActions<MetaMetricsDataDeletionControllerMessenger>,
+    MessengerEvents<MetaMetricsDataDeletionControllerMessenger>
+  >,
 ) {
-  const metaMetricsDataDeletionControllerMessenger = new Messenger<
-    'MetaMetricsDataDeletionController',
-    AllowedActions,
-    AllowedEvents,
-    RootMessenger<AllowedActions, AllowedEvents>
-  >({
-    namespace: 'MetaMetricsDataDeletionController',
-    parent: messenger,
-  });
+  const metaMetricsDataDeletionControllerMessenger: MetaMetricsDataDeletionControllerMessenger =
+    new Messenger({
+      namespace: 'MetaMetricsDataDeletionController',
+      parent: messenger,
+    });
   messenger.delegate({
     messenger: metaMetricsDataDeletionControllerMessenger,
     actions: ['MetaMetricsController:getState'],

--- a/app/scripts/messenger-client-init/metametrics-data-deletion-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/metametrics-data-deletion-controller-init.test.ts
@@ -1,12 +1,12 @@
-import { MetaMetricsDataDeletionController } from '../controllers/metametrics-data-deletion/metametrics-data-deletion';
+import {
+  MetaMetricsDataDeletionController,
+  MetaMetricsDataDeletionControllerMessenger,
+} from '../controllers/metametrics-data-deletion/metametrics-data-deletion';
 import { DataDeletionService } from '../services/data-deletion-service';
 import { getRootMessenger } from '../lib/messenger';
 import { ControllerInitRequest } from './types';
 import { buildControllerInitRequestMock } from './test/utils';
-import {
-  getMetaMetricsDataDeletionControllerMessenger,
-  MetaMetricsDataDeletionControllerMessenger,
-} from './messengers';
+import { getMetaMetricsDataDeletionControllerMessenger } from './messengers';
 import { MetaMetricsDataDeletionControllerInit } from './metametrics-data-deletion-controller-init';
 
 jest.mock('../controllers/metametrics-data-deletion/metametrics-data-deletion');

--- a/app/scripts/messenger-client-init/metametrics-data-deletion-controller-init.ts
+++ b/app/scripts/messenger-client-init/metametrics-data-deletion-controller-init.ts
@@ -1,7 +1,9 @@
-import { MetaMetricsDataDeletionController } from '../controllers/metametrics-data-deletion/metametrics-data-deletion';
+import {
+  MetaMetricsDataDeletionController,
+  MetaMetricsDataDeletionControllerMessenger,
+} from '../controllers/metametrics-data-deletion/metametrics-data-deletion';
 import { DataDeletionService } from '../services/data-deletion-service';
 import { ControllerInitFunction } from './types';
-import { MetaMetricsDataDeletionControllerMessenger } from './messengers';
 
 /**
  * Initialize the MetaMetrics data deletion controller.


### PR DESCRIPTION
## **Description**

This PR updates the `MetametricsDataDeletionController` to use `registerMethodActionHandlers` and `MESSENGER_EXPOSED_METHODS` to register actions.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a refactor of messenger action registration and TypeScript typing; runtime behavior should be unchanged aside from potential wiring/typing mistakes in action exposure.
> 
> **Overview**
> Refactors `MetaMetricsDataDeletionController` to register its messenger actions via `registerMethodActionHandlers` using a `MESSENGER_EXPOSED_METHODS` allowlist, replacing per-method `registerActionHandler` calls.
> 
> Adds an auto-generated `metametrics-data-deletion-method-action-types.ts` file to define the typed method action union, and updates the controller messenger/init wiring to use the controller-exported `MetaMetricsDataDeletionControllerMessenger` type and newer `@metamask/messenger` generics (dropping the re-exported messenger type from `messengers/index.ts`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a2346b6f832d15780bf6080f4c12ae75e6ff009. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->