### PR TITLE
chore: Bulk register actions in`RewardController` and `RewardsDataService`

### DIFF
--- a/app/scripts/controllers/rewards/rewards-controller-method-action-types.ts
+++ b/app/scripts/controllers/rewards/rewards-controller-method-action-types.ts
@@ -1,0 +1,189 @@
+/**
+ * This file is auto generated.
+ * Do not edit manually.
+ */
+
+import type { RewardsController } from './rewards-controller';
+
+/**
+ * Reset controller state to default
+ */
+export type RewardsControllerResetStateAction = {
+  type: `RewardsController:resetState`;
+  handler: RewardsController['resetState'];
+};
+
+/**
+ * Get the actual subscription ID for a given CAIP account ID
+ *
+ * @param account - The CAIP account ID to check
+ * @returns The subscription ID or null if not found
+ */
+export type RewardsControllerGetActualSubscriptionIdAction = {
+  type: `RewardsController:getActualSubscriptionId`;
+  handler: RewardsController['getActualSubscriptionId'];
+};
+
+/**
+ * Check if an internal account supports opt-in for rewards.
+ *
+ * @param account - The internal account to check
+ * @returns boolean - True if the account supports silent opt-in, false otherwise
+ */
+export type RewardsControllerIsOptInSupportedAction = {
+  type: `RewardsController:isOptInSupported`;
+  handler: RewardsController['isOptInSupported'];
+};
+
+/**
+ * Check if the given account (caip-10 format) has opted in to rewards
+ *
+ * @param account - The account address in CAIP-10 format
+ * @returns Promise<boolean> - True if the account has opted in, false otherwise
+ */
+export type RewardsControllerGetHasAccountOptedInAction = {
+  type: `RewardsController:getHasAccountOptedIn`;
+  handler: RewardsController['getHasAccountOptedIn'];
+};
+
+/**
+ * Get opt-in status for multiple addresses with feature flag check
+ *
+ * @param params - The request parameters containing addresses
+ * @returns Promise<OptInStatusDto> - The opt-in status response
+ */
+export type RewardsControllerGetOptInStatusAction = {
+  type: `RewardsController:getOptInStatus`;
+  handler: RewardsController['getOptInStatus'];
+};
+
+/**
+ * Estimate points for a given activity
+ *
+ * @param request - The estimate points request containing activity type and context
+ * @returns Promise<EstimatedPointsDto> - The estimated points and bonus information
+ */
+export type RewardsControllerEstimatePointsAction = {
+  type: `RewardsController:estimatePoints`;
+  handler: RewardsController['estimatePoints'];
+};
+
+/**
+ * Check if the rewards feature is enabled via feature flag
+ *
+ * @returns boolean - True if rewards feature is enabled, false otherwise
+ */
+export type RewardsControllerIsRewardsFeatureEnabledAction = {
+  type: `RewardsController:isRewardsFeatureEnabled`;
+  handler: RewardsController['isRewardsFeatureEnabled'];
+};
+
+/**
+ * Get season metadata with caching. This fetches and caches the season metadata including id, name, dates, and tiers.
+ *
+ * @param type - The type of season to get
+ * @returns Promise<SeasonDtoState> - The season metadata
+ */
+export type RewardsControllerGetSeasonMetadataAction = {
+  type: `RewardsController:getSeasonMetadata`;
+  handler: RewardsController['getSeasonMetadata'];
+};
+
+/**
+ * Get season status with caching
+ *
+ * @param subscriptionId - The subscription ID for authentication
+ * @param seasonId - The ID of the season to get status for
+ * @returns Promise<SeasonStatusState> - The season status data
+ */
+export type RewardsControllerGetSeasonStatusAction = {
+  type: `RewardsController:getSeasonStatus`;
+  handler: RewardsController['getSeasonStatus'];
+};
+
+/**
+ * Perform the complete opt-in process for rewards
+ *
+ * @param accounts - The accounts to opt in
+ * @param referralCode - Optional referral code
+ */
+export type RewardsControllerOptInAction = {
+  type: `RewardsController:optIn`;
+  handler: RewardsController['optIn'];
+};
+
+/**
+ * Get geo rewards metadata including location and opt-in support status
+ *
+ * @returns Promise<GeoRewardsMetadata> - The geo rewards metadata
+ */
+export type RewardsControllerGetGeoRewardsMetadataAction = {
+  type: `RewardsController:getGeoRewardsMetadata`;
+  handler: RewardsController['getGeoRewardsMetadata'];
+};
+
+/**
+ * Validate a referral code
+ *
+ * @param code - The referral code to validate
+ * @returns Promise<boolean> - True if the code is valid, false otherwise
+ */
+export type RewardsControllerValidateReferralCodeAction = {
+  type: `RewardsController:validateReferralCode`;
+  handler: RewardsController['validateReferralCode'];
+};
+
+/**
+ * Get candidate subscription ID with fallback logic
+ *
+ * @param primaryWalletGroupAccounts - Optional list of internal accounts from the primary account group of the active wallet
+ * @returns Promise<string | null> - The subscription ID or null if none found
+ */
+export type RewardsControllerGetCandidateSubscriptionIdAction = {
+  type: `RewardsController:getCandidateSubscriptionId`;
+  handler: RewardsController['getCandidateSubscriptionId'];
+};
+
+/**
+ * Link an account to a subscription via mobile join
+ *
+ * @param account - The account to link to the subscription
+ * @param invalidateRelatedData - Whether to invalidate related cache data
+ * @param primaryWalletGroupAccounts - Optional list of internal accounts from the primary account group of the active wallet
+ * @returns Promise<boolean> - The updated subscription information
+ */
+export type RewardsControllerLinkAccountToSubscriptionCandidateAction = {
+  type: `RewardsController:linkAccountToSubscriptionCandidate`;
+  handler: RewardsController['linkAccountToSubscriptionCandidate'];
+};
+
+/**
+ * Link multiple accounts to a subscription candidate
+ *
+ * @param accounts - Array of accounts to link to the subscription
+ * @param primaryWalletGroupAccounts - Optional list of internal accounts from the primary account group of the active wallet
+ */
+export type RewardsControllerLinkAccountsToSubscriptionCandidateAction = {
+  type: `RewardsController:linkAccountsToSubscriptionCandidate`;
+  handler: RewardsController['linkAccountsToSubscriptionCandidate'];
+};
+
+/**
+ * Union of all RewardsController action types.
+ */
+export type RewardsControllerMethodActions =
+  | RewardsControllerResetStateAction
+  | RewardsControllerGetActualSubscriptionIdAction
+  | RewardsControllerIsOptInSupportedAction
+  | RewardsControllerGetHasAccountOptedInAction
+  | RewardsControllerGetOptInStatusAction
+  | RewardsControllerEstimatePointsAction
+  | RewardsControllerIsRewardsFeatureEnabledAction
+  | RewardsControllerGetSeasonMetadataAction
+  | RewardsControllerGetSeasonStatusAction
+  | RewardsControllerOptInAction
+  | RewardsControllerGetGeoRewardsMetadataAction
+  | RewardsControllerValidateReferralCodeAction
+  | RewardsControllerGetCandidateSubscriptionIdAction
+  | RewardsControllerLinkAccountToSubscriptionCandidateAction
+  | RewardsControllerLinkAccountsToSubscriptionCandidateAction;

--- a/app/scripts/controllers/rewards/rewards-controller.test.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.test.ts
@@ -27,17 +27,17 @@ import {
   RecurringInterval,
 } from '@metamask/subscription-controller';
 import { HardwareKeyringType } from '../../../../shared/constants/hardware-wallets';
-import {
-  RewardsControllerActions,
-  RewardsControllerEvents,
-  RewardsControllerMessenger,
-} from '../../messenger-client-init/messengers';
 import { getRootMessenger } from '../../lib/messenger';
 import {
   EstimatedPointsDto,
   EstimatePointsDto,
   SeasonDtoState,
 } from '../../../../shared/types/rewards';
+import {
+  RewardsControllerActions,
+  RewardsControllerEvents,
+  RewardsControllerMessenger,
+} from './rewards-controller.types';
 import {
   RewardsController,
   getRewardsControllerDefaultState,
@@ -74,7 +74,7 @@ import {
   RewardsDataServiceGenerateChallengeAction,
   RewardsDataServiceSiweLoginAction,
   RewardsDataServiceSiweJoinAction,
-} from './rewards-data-service-types';
+} from './rewards-data-service-method-action-types';
 
 type AllActions = MessengerActions<RewardsControllerMessenger>;
 

--- a/app/scripts/controllers/rewards/rewards-controller.test.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.test.ts
@@ -2835,7 +2835,7 @@ describe('RewardsController', () => {
   describe('getGeoRewardsMetadata', () => {
     it('should return unknown location when rewards are disabled', async () => {
       await withController({ isDisabled: true }, async ({ controller }) => {
-        const result = await controller.getRewardsGeoMetadata();
+        const result = await controller.getGeoRewardsMetadata();
 
         expect(result).toEqual({
           geoLocation: 'UNKNOWN',
@@ -2855,7 +2855,7 @@ describe('RewardsController', () => {
             return undefined;
           });
 
-          const result = await controller.getRewardsGeoMetadata();
+          const result = await controller.getGeoRewardsMetadata();
 
           expect(result).toEqual({
             geoLocation: 'US',
@@ -2863,7 +2863,7 @@ describe('RewardsController', () => {
           });
 
           // Verify caching - second call should not fetch again
-          const cachedResult = await controller.getRewardsGeoMetadata();
+          const cachedResult = await controller.getGeoRewardsMetadata();
           expect(cachedResult).toEqual(result);
         },
       );
@@ -2880,7 +2880,7 @@ describe('RewardsController', () => {
             return undefined;
           });
 
-          const result = await controller.getRewardsGeoMetadata();
+          const result = await controller.getGeoRewardsMetadata();
 
           expect(result).toEqual({
             geoLocation: 'UK',
@@ -5122,7 +5122,7 @@ describe('Additional RewardsController edge cases', () => {
             return undefined;
           });
 
-          const result = await controller.getRewardsGeoMetadata();
+          const result = await controller.getGeoRewardsMetadata();
 
           expect(result).toEqual({
             geoLocation: 'UNKNOWN',

--- a/app/scripts/controllers/rewards/rewards-controller.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.ts
@@ -11,7 +11,6 @@ import {
 import { base58, isAddress as isEvmAddress } from 'ethers/lib/utils';
 import { SnapControllerHandleRequestAction } from '@metamask/snaps-controllers';
 import { detectSIWE } from '@metamask/controller-utils';
-import { RewardsControllerMessenger } from '../../messenger-client-init/messengers/rewards-controller-messenger';
 import {
   isBtcMainnetAddress,
   isBtcTestnetAddress,
@@ -40,6 +39,7 @@ import {
   SeasonMetadataDto,
   DiscoverSeasonsDto,
   ChallengeDto,
+  RewardsControllerMessenger,
 } from './rewards-controller.types';
 import {
   AccountAlreadyRegisteredError,
@@ -226,6 +226,24 @@ export async function wrapWithCache<T>({
 
   return freshValue;
 }
+
+const MESSENGER_EXPOSED_METHODS = [
+  'getHasAccountOptedIn',
+  'estimatePoints',
+  'isRewardsFeatureEnabled',
+  'getSeasonMetadata',
+  'getSeasonStatus',
+  'optIn',
+  'getGeoRewardsMetadata',
+  'validateReferralCode',
+  'linkAccountToSubscriptionCandidate',
+  'linkAccountsToSubscriptionCandidate',
+  'getCandidateSubscriptionId',
+  'getOptInStatus',
+  'isOptInSupported',
+  'getActualSubscriptionId',
+  'resetState',
+] as const;
 
 /**
  * Controller for managing user rewards and campaigns
@@ -502,73 +520,14 @@ export class RewardsController extends BaseController<
       },
     });
 
-    this.#registerActionHandlers();
+    this.messenger.registerMethodActionHandlers(
+      this,
+      MESSENGER_EXPOSED_METHODS,
+    );
     this.#initializeEventSubscriptions();
     this.#isDisabled = isDisabled;
     this.#isBitcoinDisabled = isBitcoinDisabled;
     this.#isTronDisabled = isTronDisabled;
-  }
-
-  /**
-   * Register action handlers for this controller
-   */
-  #registerActionHandlers(): void {
-    this.messenger.registerActionHandler(
-      'RewardsController:getHasAccountOptedIn',
-      this.getHasAccountOptedIn.bind(this),
-    );
-    this.messenger.registerActionHandler(
-      'RewardsController:estimatePoints',
-      this.estimatePoints.bind(this),
-    );
-    this.messenger.registerActionHandler(
-      'RewardsController:isRewardsFeatureEnabled',
-      this.isRewardsFeatureEnabled.bind(this),
-    );
-    this.messenger.registerActionHandler(
-      'RewardsController:getSeasonMetadata',
-      this.getSeasonMetadata.bind(this),
-    );
-    this.messenger.registerActionHandler(
-      'RewardsController:getSeasonStatus',
-      this.getSeasonStatus.bind(this),
-    );
-    this.messenger.registerActionHandler(
-      'RewardsController:optIn',
-      this.optIn.bind(this),
-    );
-    this.messenger.registerActionHandler(
-      'RewardsController:getGeoRewardsMetadata',
-      this.getRewardsGeoMetadata.bind(this),
-    );
-    this.messenger.registerActionHandler(
-      'RewardsController:validateReferralCode',
-      this.validateReferralCode.bind(this),
-    );
-    this.messenger.registerActionHandler(
-      'RewardsController:linkAccountToSubscriptionCandidate',
-      this.linkAccountToSubscriptionCandidate.bind(this),
-    );
-    this.messenger.registerActionHandler(
-      'RewardsController:linkAccountsToSubscriptionCandidate',
-      this.linkAccountsToSubscriptionCandidate.bind(this),
-    );
-    this.messenger.registerActionHandler(
-      'RewardsController:getCandidateSubscriptionId',
-      this.getCandidateSubscriptionId.bind(this),
-    );
-    this.messenger.registerActionHandler(
-      'RewardsController:getOptInStatus',
-      this.getOptInStatus.bind(this),
-    );
-    this.messenger.registerActionHandler(
-      'RewardsController:isOptInSupported',
-      this.isOptInSupported.bind(this),
-    );
-    this.messenger.registerActionHandler(
-      'RewardsController:getActualSubscriptionId',
-      this.getActualSubscriptionId.bind(this),
-    );
   }
 
   /**
@@ -1929,7 +1888,7 @@ export class RewardsController extends BaseController<
    *
    * @returns Promise<GeoRewardsMetadata> - The geo rewards metadata
    */
-  async getRewardsGeoMetadata(): Promise<RewardsGeoMetadata> {
+  async getGeoRewardsMetadata(): Promise<RewardsGeoMetadata> {
     const rewardsEnabled = this.isRewardsFeatureEnabled();
     if (!rewardsEnabled) {
       return {

--- a/app/scripts/controllers/rewards/rewards-controller.types.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.types.ts
@@ -1,18 +1,44 @@
 import { CaipAccountId, CaipAssetType } from '@metamask/utils';
 import { InternalAccount } from '@metamask/keyring-internal-api';
+import { ControllerGetStateAction } from '@metamask/base-controller';
+import type { SnapControllerHandleRequestAction } from '@metamask/snaps-controllers';
 import {
-  EstimatedPointsDto,
+  AccountsControllerGetSelectedMultichainAccountAction,
+  AccountsControllerListMultichainAccountsAction,
+} from '@metamask/accounts-controller';
+import {
+  AccountTreeControllerGetAccountsFromSelectedAccountGroupAction,
+  AccountTreeControllerSelectedAccountGroupChangeEvent,
+} from '@metamask/account-tree-controller';
+import {
+  KeyringControllerSignPersonalMessageAction,
+  KeyringControllerUnlockEvent,
+} from '@metamask/keyring-controller';
+import { Messenger } from '@metamask/messenger';
+import {
   EstimatePerpsContextDto,
-  EstimatePointsDto,
   EstimateShieldContextDto,
-  OptInStatusDto,
-  OptInStatusInputDto,
   PointsEventEarnType,
-  RewardsGeoMetadata,
   SeasonDtoState,
   SeasonRewardType,
   SeasonStatusState,
 } from '../../../../shared/types/rewards';
+import {
+  RewardsDataServiceGetOptInStatusAction,
+  RewardsDataServiceEstimatePointsAction,
+  RewardsDataServiceGetSeasonStatusAction,
+  RewardsDataServiceLoginAction,
+  RewardsDataServiceSiweLoginAction,
+  RewardsDataServiceMobileJoinAction,
+  RewardsDataServiceSiweJoinAction,
+  RewardsDataServiceMobileOptinAction,
+  RewardsDataServiceValidateReferralCodeAction,
+  RewardsDataServiceFetchGeoLocationAction,
+  RewardsDataServiceGetSeasonMetadataAction,
+  RewardsDataServiceGetDiscoverSeasonsAction,
+  RewardsDataServiceGenerateChallengeAction,
+} from './rewards-data-service-types';
+import { RewardsControllerMethodActions } from './rewards-controller-method-action-types';
 
 export type LoginResponseDto = {
   sessionId: string;
@@ -800,117 +826,57 @@ export type PerpsDiscountData = {
 };
 
 /**
- * Action for getting opt-in status of multiple addresses with feature flag check
+ * Events that can be emitted by the RewardsController
  */
-export type RewardsControllerGetOptInStatusAction = {
-  type: 'RewardsController:getOptInStatus';
-  handler: (params: OptInStatusInputDto) => Promise<OptInStatusDto>;
-};
+export type RewardsControllerEvents =
+  | {
+      type: 'RewardsController:stateChange';
+      payload: [RewardsControllerState, Patch[]];
+    }
+  | RewardsControllerAccountLinkedEvent;
 
 /**
- * Action for estimating points for a given activity
+ * Action for getting the current state of the RewardsController
  */
-export type RewardsControllerEstimatePointsAction = {
-  type: 'RewardsController:estimatePoints';
-  handler: (request: EstimatePointsDto) => Promise<EstimatedPointsDto>;
-};
+export type RewardsControllerGetStateAction = ControllerGetStateAction<
+  'RewardsController',
+  RewardsControllerState
+>;
 
 /**
- * Action for checking if rewards feature is enabled via feature flag
+ * Actions that can be performed by the RewardsController
  */
-export type RewardsControllerIsRewardsFeatureEnabledAction = {
-  type: 'RewardsController:isRewardsFeatureEnabled';
-  handler: () => boolean;
-};
+export type RewardsControllerActions =
+  | RewardsControllerGetStateAction
+  | RewardsControllerMethodActions;
 
-/**
- * Action for validating referral codes
- */
-export type RewardsControllerValidateReferralCodeAction = {
-  type: 'RewardsController:validateReferralCode';
-  handler: (code: string) => Promise<boolean>;
-};
+// Don't reexport as per guidelines
+type AllowedActions =
+  | AccountsControllerGetSelectedMultichainAccountAction
+  | AccountsControllerListMultichainAccountsAction
+  | KeyringControllerSignPersonalMessageAction
+  | RewardsDataServiceLoginAction
+  | RewardsDataServiceSiweLoginAction
+  | RewardsDataServiceEstimatePointsAction
+  | RewardsDataServiceGetSeasonStatusAction
+  | RewardsDataServiceFetchGeoLocationAction
+  | RewardsDataServiceMobileOptinAction
+  | RewardsDataServiceValidateReferralCodeAction
+  | RewardsDataServiceMobileJoinAction
+  | RewardsDataServiceSiweJoinAction
+  | RewardsDataServiceGetOptInStatusAction
+  | RewardsDataServiceGetSeasonMetadataAction
+  | RewardsDataServiceGetDiscoverSeasonsAction
+  | RewardsDataServiceGenerateChallengeAction
+  | AccountTreeControllerGetAccountsFromSelectedAccountGroupAction
+  | SnapControllerHandleRequestAction;
 
-/**
- * Action for checking if an account supports opt-in
- */
-export type RewardsControllerIsOptInSupportedAction = {
-  type: 'RewardsController:isOptInSupported';
-  handler: (account: InternalAccount) => boolean;
-};
+type AllowedEvents =
+  | KeyringControllerUnlockEvent
+  | AccountTreeControllerSelectedAccountGroupChangeEvent;
 
-/**
- * Action for linking an account to a subscription
- */
-export type RewardsControllerLinkAccountToSubscriptionAction = {
-  type: 'RewardsController:linkAccountToSubscriptionCandidate';
-  handler: (
-    account: InternalAccount,
-    invalidateRelatedData?: boolean,
-    primaryWalletGroupAccounts?: InternalAccount[],
-  ) => Promise<boolean>;
-};
-
-/**
- * Action for linking multiple accounts to a subscription candidate
- */
-export type RewardsControllerLinkAccountsToSubscriptionCandidateAction = {
-  type: 'RewardsController:linkAccountsToSubscriptionCandidate';
-  handler: (
-    accounts: InternalAccount[],
-    primaryWalletGroupAccounts?: InternalAccount[],
-  ) => Promise<{ account: InternalAccount; success: boolean }[]>;
-};
-
-/**
- * Action for getting geo rewards metadata
- */
-export type RewardsControllerGetGeoRewardsMetadataAction = {
-  type: 'RewardsController:getGeoRewardsMetadata';
-  handler: () => Promise<RewardsGeoMetadata>;
-};
-
-/**
- * Action for getting candidate subscription ID
- */
-export type RewardsControllerGetCandidateSubscriptionIdAction = {
-  type: 'RewardsController:getCandidateSubscriptionId';
-  handler: (
-    primaryWalletGroupAccounts?: InternalAccount[],
-  ) => Promise<string | null>;
-};
-
-/**
- * Action for getting whether the account (caip-10 format) has opted in
- */
-export type RewardsControllerGetHasAccountOptedInAction = {
-  type: 'RewardsController:getHasAccountOptedIn';
-  handler: (account: CaipAccountId) => Promise<boolean>;
-};
-
-/**
- * Action for getting the actual subscription ID for an account
- */
-export type RewardsControllerGetActualSubscriptionIdAction = {
-  type: 'RewardsController:getActualSubscriptionId';
-  handler: (account: CaipAccountId) => string | null;
-};
-
-/**
- * Action for getting season metadata
- */
-export type RewardsControllerGetSeasonMetadataAction = {
-  type: 'RewardsController:getSeasonMetadata';
-  handler: (type?: 'current' | 'next') => Promise<SeasonDtoState>;
-};
-
-/**
- * Action for getting season status
- */
-export type RewardsControllerGetSeasonStatusAction = {
-  type: 'RewardsController:getSeasonStatus';
-  handler: (
-    subscriptionId: string,
-    seasonId: string,
-  ) => Promise<SeasonStatusState | null>;
-};
+export type RewardsControllerMessenger = Messenger<
+  'RewardsController',
+  RewardsControllerActions | AllowedActions,
+  RewardsControllerEvents | AllowedEvents
+>;

--- a/app/scripts/controllers/rewards/rewards-controller.types.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.types.ts
@@ -37,7 +37,7 @@ import {
   RewardsDataServiceGetSeasonMetadataAction,
   RewardsDataServiceGetDiscoverSeasonsAction,
   RewardsDataServiceGenerateChallengeAction,
-} from './rewards-data-service-types';
+} from './rewards-data-service-method-action-types';
 import { RewardsControllerMethodActions } from './rewards-controller-method-action-types';
 
 export type LoginResponseDto = {

--- a/app/scripts/controllers/rewards/rewards-controller.types.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.types.ts
@@ -1,5 +1,4 @@
 import { CaipAccountId, CaipAssetType } from '@metamask/utils';
-import { InternalAccount } from '@metamask/keyring-internal-api';
 import { ControllerGetStateAction } from '@metamask/base-controller';
 import type { SnapControllerHandleRequestAction } from '@metamask/snaps-controllers';
 import {
@@ -784,17 +783,6 @@ export type Patch = {
   op: 'replace' | 'add' | 'remove';
   path: string[];
   value?: unknown;
-};
-
-/**
- * Action for updating state with opt-in response
- */
-export type RewardsControllerOptInAction = {
-  type: 'RewardsController:optIn';
-  handler: (
-    accounts: InternalAccount[],
-    referralCode?: string,
-  ) => Promise<string | null>;
 };
 
 /**

--- a/app/scripts/controllers/rewards/rewards-data-service-method-action-types.ts
+++ b/app/scripts/controllers/rewards/rewards-data-service-method-action-types.ts
@@ -1,0 +1,176 @@
+/**
+ * This file is auto generated.
+ * Do not edit manually.
+ */
+
+import type { RewardsDataService } from './rewards-data-service';
+
+/**
+ * Perform login via signature for the current account.
+ *
+ * @param body - The login request body containing account, timestamp, and signature.
+ * @param body.account
+ * @param body.timestamp
+ * @param body.signature
+ * @returns The login response DTO.
+ */
+export type RewardsDataServiceLoginAction = {
+  type: `RewardsDataService:login`;
+  handler: RewardsDataService['login'];
+};
+
+/**
+ * Perform login via SIWE (Sign-In with Ethereum) signature.
+ *
+ * @param body - The SIWE login request body containing challengeId, signature, and optional referralCode.
+ * @param body.challengeId - The unique identifier of the challenge
+ * @param body.signature - The signature of the SIWE message
+ * @param body.referralCode - Optional referral code provided by referrer
+ * @returns The login response DTO.
+ */
+export type RewardsDataServiceSiweLoginAction = {
+  type: `RewardsDataService:siweLogin`;
+  handler: RewardsDataService['siweLogin'];
+};
+
+/**
+ * Estimate points for a given activity.
+ *
+ * @param body - The estimate points request body.
+ * @returns The estimated points response DTO.
+ */
+export type RewardsDataServiceEstimatePointsAction = {
+  type: `RewardsDataService:estimatePoints`;
+  handler: RewardsDataService['estimatePoints'];
+};
+
+/**
+ * Perform optin via signature for the current account.
+ *
+ * @param body - The login request body containing account, timestamp, signature and referral code.
+ * @returns The login response DTO.
+ */
+export type RewardsDataServiceMobileOptinAction = {
+  type: `RewardsDataService:mobileOptin`;
+  handler: RewardsDataService['mobileOptin'];
+};
+
+/**
+ * Get season state for a specific season.
+ *
+ * @param seasonId - The ID of the season to get state for.
+ * @param subscriptionToken - The subscription token for authentication.
+ * @returns The season state DTO.
+ */
+export type RewardsDataServiceGetSeasonStatusAction = {
+  type: `RewardsDataService:getSeasonStatus`;
+  handler: RewardsDataService['getSeasonStatus'];
+};
+
+/**
+ * Fetch geolocation information from MetaMask's geolocation service.
+ * Returns location in Country or Country-Region format (e.g., 'US', 'CA-ON', 'FR').
+ *
+ * @returns Promise<string> - The geolocation string or 'UNKNOWN' on failure.
+ */
+export type RewardsDataServiceFetchGeoLocationAction = {
+  type: `RewardsDataService:fetchGeoLocation`;
+  handler: RewardsDataService['fetchGeoLocation'];
+};
+
+/**
+ * Validate a referral code.
+ *
+ * @param code - The referral code to validate.
+ * @returns Promise<{valid: boolean}> - Object indicating if the code is valid.
+ */
+export type RewardsDataServiceValidateReferralCodeAction = {
+  type: `RewardsDataService:validateReferralCode`;
+  handler: RewardsDataService['validateReferralCode'];
+};
+
+/**
+ * Join an account to a subscription via mobile login.
+ *
+ * @param body - The mobile login request body containing account, timestamp, and signature.
+ * @param subscriptionToken - The subscription token to join the account to.
+ * @returns Promise<SubscriptionDto> - The updated subscription information.
+ */
+export type RewardsDataServiceMobileJoinAction = {
+  type: `RewardsDataService:mobileJoin`;
+  handler: RewardsDataService['mobileJoin'];
+};
+
+/**
+ * Join an account to a subscription via SIWE (Sign-In with Ethereum) signature.
+ *
+ * @param body - The SIWE join request body containing challengeId and signature.
+ * @param subscriptionToken - The subscription token to join the account to.
+ * @returns Promise<SubscriptionDto> - The updated subscription information.
+ */
+export type RewardsDataServiceSiweJoinAction = {
+  type: `RewardsDataService:siweJoin`;
+  handler: RewardsDataService['siweJoin'];
+};
+
+/**
+ * Get opt-in status for multiple addresses.
+ *
+ * @param body - The request body containing addresses to check.
+ * @returns Promise<OptInStatusDto> - The opt-in status for each address.
+ */
+export type RewardsDataServiceGetOptInStatusAction = {
+  type: `RewardsDataService:getOptInStatus`;
+  handler: RewardsDataService['getOptInStatus'];
+};
+
+/**
+ * Get discover seasons information (current and next season).
+ *
+ * @returns The discover seasons DTO with current and next season information.
+ */
+export type RewardsDataServiceGetDiscoverSeasonsAction = {
+  type: `RewardsDataService:getDiscoverSeasons`;
+  handler: RewardsDataService['getDiscoverSeasons'];
+};
+
+/**
+ * Get season metadata for a specific season.
+ *
+ * @param seasonId - The ID of the season to get metadata for.
+ * @returns The season metadata DTO.
+ */
+export type RewardsDataServiceGetSeasonMetadataAction = {
+  type: `RewardsDataService:getSeasonMetadata`;
+  handler: RewardsDataService['getSeasonMetadata'];
+};
+
+/**
+ * Generate a challenge for SIWE (Sign-In with Ethereum) authentication.
+ *
+ * @param body - The challenge generation request body containing address.
+ * @param body.address
+ * @returns The challenge DTO.
+ */
+export type RewardsDataServiceGenerateChallengeAction = {
+  type: `RewardsDataService:generateChallenge`;
+  handler: RewardsDataService['generateChallenge'];
+};
+
+/**
+ * Union of all RewardsDataService action types.
+ */
+export type RewardsDataServiceMethodActions =
+  | RewardsDataServiceLoginAction
+  | RewardsDataServiceSiweLoginAction
+  | RewardsDataServiceEstimatePointsAction
+  | RewardsDataServiceMobileOptinAction
+  | RewardsDataServiceGetSeasonStatusAction
+  | RewardsDataServiceFetchGeoLocationAction
+  | RewardsDataServiceValidateReferralCodeAction
+  | RewardsDataServiceMobileJoinAction
+  | RewardsDataServiceSiweJoinAction
+  | RewardsDataServiceGetOptInStatusAction
+  | RewardsDataServiceGetDiscoverSeasonsAction
+  | RewardsDataServiceGetSeasonMetadataAction
+  | RewardsDataServiceGenerateChallengeAction;

--- a/app/scripts/controllers/rewards/rewards-data-service-types.ts
+++ b/app/scripts/controllers/rewards/rewards-data-service-types.ts
@@ -1,86 +1,16 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import type { RewardsDataService } from './rewards-data-service';
+import { Messenger } from '@metamask/messenger';
+import { PreferencesControllerGetStateAction } from '../preferences-controller';
+import { RewardsDataServiceMethodActions } from './rewards-data-service-method-action-types';
 
 const SERVICE_NAME = 'RewardsDataService';
 
-// Auth endpoint action types
+export type RewardsDataServiceMessenger = Messenger<
+  typeof SERVICE_NAME,
+  Actions | AllowedActions,
+  never
+>;
 
-export interface RewardsDataServiceLoginAction {
-  type: `${typeof SERVICE_NAME}:login`;
-  handler: RewardsDataService['login'];
-}
+export type Actions = RewardsDataServiceMethodActions;
 
-export interface RewardsDataServiceSiweLoginAction {
-  type: `${typeof SERVICE_NAME}:siweLogin`;
-  handler: RewardsDataService['siweLogin'];
-}
-
-export interface RewardsDataServiceEstimatePointsAction {
-  type: `${typeof SERVICE_NAME}:estimatePoints`;
-  handler: RewardsDataService['estimatePoints'];
-}
-
-export interface RewardsDataServiceMobileOptinAction {
-  type: `${typeof SERVICE_NAME}:mobileOptin`;
-  handler: RewardsDataService['mobileOptin'];
-}
-
-export interface RewardsDataServiceGetSeasonStatusAction {
-  type: `${typeof SERVICE_NAME}:getSeasonStatus`;
-  handler: RewardsDataService['getSeasonStatus'];
-}
-
-export interface RewardsDataServiceFetchGeoLocationAction {
-  type: `${typeof SERVICE_NAME}:fetchGeoLocation`;
-  handler: RewardsDataService['fetchGeoLocation'];
-}
-
-export interface RewardsDataServiceValidateReferralCodeAction {
-  type: `${typeof SERVICE_NAME}:validateReferralCode`;
-  handler: RewardsDataService['validateReferralCode'];
-}
-
-export interface RewardsDataServiceMobileJoinAction {
-  type: `${typeof SERVICE_NAME}:mobileJoin`;
-  handler: RewardsDataService['mobileJoin'];
-}
-
-export interface RewardsDataServiceSiweJoinAction {
-  type: `${typeof SERVICE_NAME}:siweJoin`;
-  handler: RewardsDataService['siweJoin'];
-}
-
-export interface RewardsDataServiceGetOptInStatusAction {
-  type: `${typeof SERVICE_NAME}:getOptInStatus`;
-  handler: RewardsDataService['getOptInStatus'];
-}
-
-export interface RewardsDataServiceGetSeasonMetadataAction {
-  type: `${typeof SERVICE_NAME}:getSeasonMetadata`;
-  handler: RewardsDataService['getSeasonMetadata'];
-}
-
-export interface RewardsDataServiceGetDiscoverSeasonsAction {
-  type: `${typeof SERVICE_NAME}:getDiscoverSeasons`;
-  handler: RewardsDataService['getDiscoverSeasons'];
-}
-
-export interface RewardsDataServiceGenerateChallengeAction {
-  type: `${typeof SERVICE_NAME}:generateChallenge`;
-  handler: RewardsDataService['generateChallenge'];
-}
-
-export type RewardsDataServiceActions =
-  | RewardsDataServiceLoginAction
-  | RewardsDataServiceSiweLoginAction
-  | RewardsDataServiceEstimatePointsAction
-  | RewardsDataServiceGetSeasonStatusAction
-  | RewardsDataServiceFetchGeoLocationAction
-  | RewardsDataServiceMobileOptinAction
-  | RewardsDataServiceValidateReferralCodeAction
-  | RewardsDataServiceMobileJoinAction
-  | RewardsDataServiceSiweJoinAction
-  | RewardsDataServiceGetOptInStatusAction
-  | RewardsDataServiceGetSeasonMetadataAction
-  | RewardsDataServiceGetDiscoverSeasonsAction
-  | RewardsDataServiceGenerateChallengeAction;
+type AllowedActions = PreferencesControllerGetStateAction;

--- a/app/scripts/controllers/rewards/rewards-data-service.test.ts
+++ b/app/scripts/controllers/rewards/rewards-data-service.test.ts
@@ -6,7 +6,6 @@ import {
   MockAnyNamespace,
 } from '@metamask/messenger';
 import { ENVIRONMENT } from '../../../../development/build/constants';
-import { RewardsDataServiceMessenger } from '../../messenger-client-init/messengers/reward-data-service-messenger';
 import { REWARDS_API_URL } from '../../../../shared/constants/rewards';
 import {
   EstimatePointsDto,
@@ -28,6 +27,7 @@ import type {
   SiweJoinDto,
   ChallengeDto,
 } from './rewards-controller.types';
+import { RewardsDataServiceMessenger } from './rewards-data-service-types';
 
 // Mock ExtensionPlatform
 jest.mock('../../platforms/extension', () => {

--- a/app/scripts/controllers/rewards/rewards-data-service.ts
+++ b/app/scripts/controllers/rewards/rewards-data-service.ts
@@ -8,7 +8,6 @@ import {
   REWARDS_API_URL,
   REWARDS_ERROR_MESSAGES,
 } from '../../../../shared/constants/rewards';
-import type { RewardsDataServiceMessenger } from '../../messenger-client-init/messengers/reward-data-service-messenger';
 import { FALLBACK_LOCALE } from '../../../../shared/lib/i18n';
 import {
   EstimatePointsDto,
@@ -28,6 +27,8 @@ import type {
   SiweLoginDto,
   SiweJoinDto,
 } from './rewards-controller.types';
+import { RewardsDataServiceMethodActions } from './rewards-data-service-method-action-types';
+import { RewardsDataServiceMessenger } from './rewards-data-service-types';
 
 /**
  * Custom error for invalid timestamps
@@ -65,6 +66,24 @@ export class SeasonNotFoundError extends Error {
     this.name = 'SeasonNotFoundError';
   }
 }
+
+const MESSENGER_EXPOSED_METHODS = [
+  'login',
+  'siweLogin',
+  'estimatePoints',
+  'mobileOptin',
+  'getSeasonStatus',
+  'fetchGeoLocation',
+  'validateReferralCode',
+  'mobileJoin',
+  'siweJoin',
+  'getOptInStatus',
+  'getSeasonMetadata',
+  'getDiscoverSeasons',
+  'generateChallenge',
+] as const;
+
+export type RewardsDataServiceActions = RewardsDataServiceMethodActions;
 
 /**
  * Custom error for account already registered (409 conflict)
@@ -121,58 +140,9 @@ export class RewardsDataService {
     this.#fetch = fetchFunction;
     this.#rewardsApiUrl = this.getRewardsApiBaseUrl();
 
-    // Register all action handlers
-    this.#messenger.registerActionHandler(
-      `${SERVICE_NAME}:login`,
-      this.login.bind(this),
-    );
-    this.#messenger.registerActionHandler(
-      `${SERVICE_NAME}:siweLogin`,
-      this.siweLogin.bind(this),
-    );
-    this.#messenger.registerActionHandler(
-      `${SERVICE_NAME}:estimatePoints`,
-      this.estimatePoints.bind(this),
-    );
-    this.#messenger.registerActionHandler(
-      `${SERVICE_NAME}:mobileOptin`,
-      this.mobileOptin.bind(this),
-    );
-    this.#messenger.registerActionHandler(
-      `${SERVICE_NAME}:getSeasonStatus`,
-      this.getSeasonStatus.bind(this),
-    );
-    this.#messenger.registerActionHandler(
-      `${SERVICE_NAME}:fetchGeoLocation`,
-      this.fetchGeoLocation.bind(this),
-    );
-    this.#messenger.registerActionHandler(
-      `${SERVICE_NAME}:validateReferralCode`,
-      this.validateReferralCode.bind(this),
-    );
-    this.#messenger.registerActionHandler(
-      `${SERVICE_NAME}:mobileJoin`,
-      this.mobileJoin.bind(this),
-    );
-    this.#messenger.registerActionHandler(
-      `${SERVICE_NAME}:siweJoin`,
-      this.siweJoin.bind(this),
-    );
-    this.#messenger.registerActionHandler(
-      `${SERVICE_NAME}:getOptInStatus`,
-      this.getOptInStatus.bind(this),
-    );
-    this.#messenger.registerActionHandler(
-      `${SERVICE_NAME}:getSeasonMetadata`,
-      this.getSeasonMetadata.bind(this),
-    );
-    this.#messenger.registerActionHandler(
-      `${SERVICE_NAME}:getDiscoverSeasons`,
-      this.getDiscoverSeasons.bind(this),
-    );
-    this.#messenger.registerActionHandler(
-      `${SERVICE_NAME}:generateChallenge`,
-      this.generateChallenge.bind(this),
+    this.#messenger.registerMethodActionHandlers(
+      this,
+      MESSENGER_EXPOSED_METHODS,
     );
   }
 

--- a/app/scripts/messenger-client-init/messengers/index.ts
+++ b/app/scripts/messenger-client-init/messengers/index.ts
@@ -350,11 +350,6 @@ export {
 } from './signature-controller-messenger';
 export type { SubjectMetadataControllerMessenger } from './subject-metadata-controller-messenger';
 export { getSubjectMetadataControllerMessenger } from './subject-metadata-controller-messenger';
-export type {
-  RewardsControllerMessenger,
-  RewardsControllerActions,
-  RewardsControllerEvents,
-} from './rewards-controller-messenger';
 export { getRewardsControllerMessenger } from './rewards-controller-messenger';
 export type {
   TokenBalancesControllerMessenger,

--- a/app/scripts/messenger-client-init/messengers/reward-data-service-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/reward-data-service-messenger.ts
@@ -1,18 +1,6 @@
-import { Messenger } from '@metamask/messenger';
-import { PreferencesControllerGetStateAction } from '../../controllers/preferences-controller';
-import type { RewardsDataServiceActions } from '../../controllers/rewards/rewards-data-service-types';
+import { Messenger, MessengerActions } from '@metamask/messenger';
 import { RootMessenger } from '../../lib/messenger';
-
-type AllowedActions =
-  | RewardsDataServiceActions
-  | PreferencesControllerGetStateAction;
-
-type AllowedEvents = never;
-
-export type RewardsDataServiceMessenger = ReturnType<
-  typeof getRewardsDataServiceMessenger
->;
-
+import { RewardsDataServiceMessenger } from '../../controllers/rewards/rewards-data-service-types';
 /**
  * Get a messenger restricted to the actions and events that the
  * rewards data service is allowed to handle.
@@ -21,14 +9,12 @@ export type RewardsDataServiceMessenger = ReturnType<
  * @returns The restricted controller messenger.
  */
 export function getRewardsDataServiceMessenger(
-  messenger: RootMessenger<AllowedActions, AllowedEvents>,
+  messenger: RootMessenger<
+    MessengerActions<RewardsDataServiceMessenger>,
+    never
+  >,
 ) {
-  const serviceMessenger = new Messenger<
-    'RewardsDataService',
-    AllowedActions,
-    AllowedEvents,
-    typeof messenger
-  >({
+  const serviceMessenger: RewardsDataServiceMessenger = new Messenger({
     namespace: 'RewardsDataService',
     parent: messenger,
   });

--- a/app/scripts/messenger-client-init/messengers/rewards-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/rewards-controller-messenger.ts
@@ -1,137 +1,24 @@
-import { ControllerGetStateAction } from '@metamask/base-controller';
 import {
   Messenger,
   MessengerActions,
   MessengerEvents,
 } from '@metamask/messenger';
 
-import {
-  AccountsControllerGetSelectedMultichainAccountAction,
-  AccountsControllerListMultichainAccountsAction,
-} from '@metamask/accounts-controller';
-import {
-  AccountTreeControllerGetAccountsFromSelectedAccountGroupAction,
-  AccountTreeControllerSelectedAccountGroupChangeEvent,
-} from '@metamask/account-tree-controller';
-import {
-  KeyringControllerSignPersonalMessageAction,
-  KeyringControllerUnlockEvent,
-} from '@metamask/keyring-controller';
 import { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
-import type { SnapControllerHandleRequestAction } from '@metamask/snaps-controllers';
+
 import { PreferencesControllerGetStateAction } from '../../controllers/preferences-controller';
-import {
-  RewardsDataServiceGetOptInStatusAction,
-  RewardsDataServiceEstimatePointsAction,
-  RewardsDataServiceGetSeasonStatusAction,
-  RewardsDataServiceLoginAction,
-  RewardsDataServiceSiweLoginAction,
-  RewardsDataServiceMobileJoinAction,
-  RewardsDataServiceSiweJoinAction,
-  RewardsDataServiceMobileOptinAction,
-  RewardsDataServiceValidateReferralCodeAction,
-  RewardsDataServiceFetchGeoLocationAction,
-  RewardsDataServiceGetSeasonMetadataAction,
-  RewardsDataServiceGetDiscoverSeasonsAction,
-  RewardsDataServiceGenerateChallengeAction,
-} from '../../controllers/rewards/rewards-data-service-types';
-import {
-  RewardsControllerState,
-  Patch,
-  RewardsControllerAccountLinkedEvent,
-  RewardsControllerOptInAction,
-  RewardsControllerGetOptInStatusAction,
-  RewardsControllerEstimatePointsAction,
-  RewardsControllerIsRewardsFeatureEnabledAction,
-  RewardsControllerValidateReferralCodeAction,
-  RewardsControllerIsOptInSupportedAction,
-  RewardsControllerLinkAccountToSubscriptionAction,
-  RewardsControllerLinkAccountsToSubscriptionCandidateAction,
-  RewardsControllerGetGeoRewardsMetadataAction,
-  RewardsControllerGetCandidateSubscriptionIdAction,
-  RewardsControllerGetHasAccountOptedInAction,
-  RewardsControllerGetActualSubscriptionIdAction,
-  RewardsControllerGetSeasonMetadataAction,
-  RewardsControllerGetSeasonStatusAction,
-} from '../../controllers/rewards/rewards-controller.types';
+
 import { RootMessenger } from '../../lib/messenger';
-
-const name = 'RewardsController';
-
-/**
- * Events that can be emitted by the RewardsController
- */
-export type RewardsControllerEvents =
-  | {
-      type: 'RewardsController:stateChange';
-      payload: [RewardsControllerState, Patch[]];
-    }
-  | RewardsControllerAccountLinkedEvent;
-
-/**
- * Actions that can be performed by the RewardsController
- */
-export type RewardsControllerActions =
-  | ControllerGetStateAction<'RewardsController', RewardsControllerState>
-  | RewardsControllerGetOptInStatusAction
-  | RewardsControllerEstimatePointsAction
-  | RewardsControllerIsRewardsFeatureEnabledAction
-  | RewardsControllerOptInAction
-  | RewardsControllerGetGeoRewardsMetadataAction
-  | RewardsControllerValidateReferralCodeAction
-  | RewardsControllerIsOptInSupportedAction
-  | RewardsControllerLinkAccountToSubscriptionAction
-  | RewardsControllerLinkAccountsToSubscriptionCandidateAction
-  | RewardsControllerGetCandidateSubscriptionIdAction
-  | RewardsControllerGetHasAccountOptedInAction
-  | RewardsControllerGetActualSubscriptionIdAction
-  | RewardsControllerGetSeasonMetadataAction
-  | RewardsControllerGetSeasonStatusAction;
-
-// Don't reexport as per guidelines
-type AllowedActions =
-  | AccountsControllerGetSelectedMultichainAccountAction
-  | AccountsControllerListMultichainAccountsAction
-  | KeyringControllerSignPersonalMessageAction
-  | RewardsDataServiceLoginAction
-  | RewardsDataServiceSiweLoginAction
-  | RewardsDataServiceEstimatePointsAction
-  | RewardsDataServiceGetSeasonStatusAction
-  | RewardsDataServiceFetchGeoLocationAction
-  | RewardsDataServiceMobileOptinAction
-  | RewardsDataServiceValidateReferralCodeAction
-  | RewardsDataServiceMobileJoinAction
-  | RewardsDataServiceSiweJoinAction
-  | RewardsDataServiceGetOptInStatusAction
-  | RewardsDataServiceGetSeasonMetadataAction
-  | RewardsDataServiceGetDiscoverSeasonsAction
-  | RewardsDataServiceGenerateChallengeAction
-  | AccountTreeControllerGetAccountsFromSelectedAccountGroupAction
-  | SnapControllerHandleRequestAction;
-
-type AllowedEvents =
-  | KeyringControllerUnlockEvent
-  | AccountTreeControllerSelectedAccountGroupChangeEvent;
-
-export type RewardsControllerMessenger = Messenger<
-  typeof name,
-  RewardsControllerActions | AllowedActions,
-  RewardsControllerEvents | AllowedEvents
->;
+import { RewardsControllerMessenger } from '../../controllers/rewards/rewards-controller.types';
 
 export function getRewardsControllerMessenger(
   messenger: RootMessenger<
-    RewardsControllerActions | AllowedActions,
-    RewardsControllerEvents | AllowedEvents
+    MessengerActions<RewardsControllerMessenger>,
+    MessengerEvents<RewardsControllerMessenger>
   >,
 ): RewardsControllerMessenger {
-  const controllerMessenger = new Messenger<
-    typeof name,
-    MessengerActions<RewardsControllerMessenger>,
-    MessengerEvents<RewardsControllerMessenger>,
-    typeof messenger
-  >({
-    namespace: name,
+  const controllerMessenger: RewardsControllerMessenger = new Messenger({
+    namespace: 'RewardsController',
     parent: messenger,
   });
   messenger.delegate({

--- a/app/scripts/messenger-client-init/rewards-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/rewards-controller-init.test.ts
@@ -1,6 +1,9 @@
 import { RewardsController } from '../controllers/rewards/rewards-controller';
 import { getManifestFlags } from '../../../shared/lib/manifestFlags';
-import { RewardsControllerState } from '../controllers/rewards/rewards-controller.types';
+import {
+  RewardsControllerMessenger,
+  RewardsControllerState,
+} from '../controllers/rewards/rewards-controller.types';
 import { getRootMessenger } from '../lib/messenger';
 import {
   getRewardsControllerMessenger,
@@ -8,10 +11,7 @@ import {
 } from './messengers/rewards-controller-messenger';
 import { buildControllerInitRequestMock } from './test/utils';
 import { RewardsControllerInit } from './rewards-controller-init';
-import type {
-  RewardsControllerInitMessenger,
-  RewardsControllerMessenger,
-} from './messengers/rewards-controller-messenger';
+import type { RewardsControllerInitMessenger } from './messengers/rewards-controller-messenger';
 import type { ControllerInitRequest } from './types';
 
 jest.mock('../controllers/rewards/rewards-controller');

--- a/app/scripts/messenger-client-init/rewards-controller-init.ts
+++ b/app/scripts/messenger-client-init/rewards-controller-init.ts
@@ -7,10 +7,8 @@ import {
   validatedVersionGatedFeatureFlag,
   VersionGatedFeatureFlag,
 } from '../../../shared/lib/feature-flags/version-gating';
-import {
-  RewardsControllerInitMessenger,
-  RewardsControllerMessenger,
-} from './messengers/rewards-controller-messenger';
+import { RewardsControllerMessenger } from '../controllers/rewards/rewards-controller.types';
+import { RewardsControllerInitMessenger } from './messengers/rewards-controller-messenger';
 import { ControllerInitFunction } from './types';
 
 /**

--- a/app/scripts/messenger-client-init/rewards-data-service-init.test.ts
+++ b/app/scripts/messenger-client-init/rewards-data-service-init.test.ts
@@ -5,11 +5,9 @@ import {
 } from '@metamask/messenger';
 import type { PreferencesControllerGetStateAction } from '../controllers/preferences-controller';
 import { RewardsDataService } from '../controllers/rewards/rewards-data-service';
+import { RewardsDataServiceMessenger } from '../controllers/rewards/rewards-data-service-types';
 import { ControllerInitRequest } from './types';
-import {
-  getRewardsDataServiceMessenger,
-  RewardsDataServiceMessenger,
-} from './messengers/reward-data-service-messenger';
+import { getRewardsDataServiceMessenger } from './messengers/reward-data-service-messenger';
 import { RewardsDataServiceInit } from './rewards-data-service-init';
 import { buildControllerInitRequestMock } from './test/utils';
 

--- a/app/scripts/messenger-client-init/rewards-data-service-init.ts
+++ b/app/scripts/messenger-client-init/rewards-data-service-init.ts
@@ -1,5 +1,5 @@
 import { RewardsDataService } from '../controllers/rewards/rewards-data-service';
-import type { RewardsDataServiceMessenger } from './messengers/reward-data-service-messenger';
+import { RewardsDataServiceMessenger } from '../controllers/rewards/rewards-data-service-types';
 import { ControllerInitFunction } from './types';
 
 /**

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2772,7 +2772,7 @@ export default class MetamaskController extends EventEmitter {
         this.rewardsController.validateReferralCode.bind(
           this.rewardsController,
         ),
-      getRewardsGeoMetadata: this.rewardsController.getRewardsGeoMetadata.bind(
+      getRewardsGeoMetadata: this.rewardsController.getGeoRewardsMetadata.bind(
         this.rewardsController,
       ),
       rewardsOptIn: this.rewardsController.optIn.bind(this.rewardsController),

--- a/app/scripts/services/subscription/types.ts
+++ b/app/scripts/services/subscription/types.ts
@@ -36,7 +36,7 @@ import {
   RewardsControllerGetHasAccountOptedInAction,
   RewardsControllerGetSeasonMetadataAction,
   RewardsControllerGetSeasonStatusAction,
-} from '../../controllers/rewards/rewards-controller.types';
+} from '../../controllers/rewards/rewards-controller-method-action-types';
 
 export const SERVICE_NAME = 'SubscriptionService';
 


### PR DESCRIPTION
## **Description**

This PR updates the `RewardsController` and `RewardsDataService` to use `registerMethodActionHandlers` and `MESSENGER_EXPOSED_METHODS` to register actions.

## **Changelog**

CHANGELOG entry:null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly a wiring/type refactor, but it changes how action handlers are registered; any mismatch in the exposed method list or action type strings could break rewards-related messenger calls at runtime.
> 
> **Overview**
> Refactors `RewardsController` and `RewardsDataService` to **bulk register messenger action handlers** via `registerMethodActionHandlers` and an explicit `MESSENGER_EXPOSED_METHODS` allowlist, replacing many per-action `registerActionHandler` calls.
> 
> Moves/centralizes rewards messenger typing by introducing auto-generated `*-method-action-types.ts` files and updating controller/service messenger types and init wiring to import from these new definitions. Also renames `getRewardsGeoMetadata` to `getGeoRewardsMetadata` and updates all call sites/tests accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc571f7a0356d165e83310e2dd4a851be6fa0a7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->