### PR TITLE
chore: Bulk register actions in `AccountOrderController`

### DIFF
--- a/app/scripts/controllers/account-order-method-action-types.ts
+++ b/app/scripts/controllers/account-order-method-action-types.ts
@@ -1,0 +1,33 @@
+/**
+ * This file is auto generated.
+ * Do not edit manually.
+ */
+
+import type { AccountOrderController } from './account-order';
+
+/**
+ * Updates the accounts list in the state with the provided list of accounts.
+ *
+ * @param accountList - The list of accounts to update in the state.
+ */
+export type AccountOrderControllerUpdateAccountsListAction = {
+  type: `AccountOrderController:updateAccountsList`;
+  handler: AccountOrderController['updateAccountsList'];
+};
+
+/**
+ * Hides the accounts list in the state with the provided list of accounts.
+ *
+ * @param accountList - The list of accounts to hide in the state.
+ */
+export type AccountOrderControllerUpdateHiddenAccountsListAction = {
+  type: `AccountOrderController:updateHiddenAccountsList`;
+  handler: AccountOrderController['updateHiddenAccountsList'];
+};
+
+/**
+ * Union of all AccountOrderController action types.
+ */
+export type AccountOrderControllerMethodActions =
+  | AccountOrderControllerUpdateAccountsListAction
+  | AccountOrderControllerUpdateHiddenAccountsListAction;

--- a/app/scripts/controllers/account-order.ts
+++ b/app/scripts/controllers/account-order.ts
@@ -5,6 +5,7 @@ import {
   StateMetadata,
 } from '@metamask/base-controller';
 import type { Messenger } from '@metamask/messenger';
+import { AccountOrderControllerMethodActions } from './account-order-method-action-types';
 
 // Unique name for the controller
 const controllerName = 'AccountOrderController';
@@ -20,29 +21,20 @@ export type AccountOrderControllerState = {
   hiddenAccountList: AccountAddress[];
 };
 
-export type AccountOrderControllerGetStateAction = {
-  type: 'AccountOrderController:getState';
-  handler: () => AccountOrderControllerState;
-};
+export type AccountOrderControllerGetStateAction = ControllerGetStateAction<
+  typeof controllerName,
+  AccountOrderControllerState
+>;
 
-// Describes the action for updating the accounts list
-export type AccountOrderControllerupdateAccountsListAction = {
-  type: `${typeof controllerName}:updateAccountsList`;
-  handler: AccountOrderController['updateAccountsList'];
-};
-
-// Describes the action for updating the accounts list
-export type AccountOrderControllerhideAccountsListAction = {
-  type: `${typeof controllerName}:updateHiddenAccountsList`;
-  handler: AccountOrderController['updateHiddenAccountsList'];
-};
+const MESSENGER_EXPOSED_METHODS = [
+  'updateAccountsList',
+  'updateHiddenAccountsList',
+] as const;
 
 // Union of all possible actions for the messenger
 export type AccountOrderControllerMessengerActions =
-  | ControllerGetStateAction<typeof controllerName, AccountOrderControllerState>
-  | AccountOrderControllerupdateAccountsListAction
-  | AccountOrderControllerhideAccountsListAction
-  | AccountOrderControllerGetStateAction;
+  | AccountOrderControllerGetStateAction
+  | AccountOrderControllerMethodActions;
 
 export type AccountOrderControllerMessengerEvents = ControllerStateChangeEvent<
   typeof controllerName,
@@ -109,6 +101,11 @@ export class AccountOrderController extends BaseController<
       name: controllerName,
       state: { ...defaultState, ...state },
     });
+
+    this.messenger.registerMethodActionHandlers(
+      this,
+      MESSENGER_EXPOSED_METHODS,
+    );
   }
 
   /**

--- a/app/scripts/messenger-client-init/account-order-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/account-order-controller-init.test.ts
@@ -1,11 +1,11 @@
-import { AccountOrderController } from '../controllers/account-order';
+import {
+  AccountOrderController,
+  AccountOrderControllerMessenger,
+} from '../controllers/account-order';
 import { getRootMessenger } from '../lib/messenger';
 import { ControllerInitRequest } from './types';
 import { buildControllerInitRequestMock } from './test/utils';
-import {
-  getAccountOrderControllerMessenger,
-  AccountOrderControllerMessenger,
-} from './messengers';
+import { getAccountOrderControllerMessenger } from './messengers';
 import { AccountOrderControllerInit } from './account-order-controller-init';
 
 jest.mock('../controllers/account-order');

--- a/app/scripts/messenger-client-init/account-order-controller-init.ts
+++ b/app/scripts/messenger-client-init/account-order-controller-init.ts
@@ -1,6 +1,8 @@
-import { AccountOrderController } from '../controllers/account-order';
+import {
+  AccountOrderController,
+  AccountOrderControllerMessenger,
+} from '../controllers/account-order';
 import { ControllerInitFunction } from './types';
-import { AccountOrderControllerMessenger } from './messengers';
 
 /**
  * Initialize the accountOrder controller.

--- a/app/scripts/messenger-client-init/messengers/index.ts
+++ b/app/scripts/messenger-client-init/messengers/index.ts
@@ -210,7 +210,6 @@ import { getProfileMetricsServiceMessenger } from './profile-metrics-service-mes
 import { getStorageServiceMessenger } from './storage-service-messenger';
 import { getPerpsControllerMessenger } from './perps-controller-messenger';
 
-export type { AccountOrderControllerMessenger } from './account-order-controller-messenger';
 export { getAccountOrderControllerMessenger } from './account-order-controller-messenger';
 export type {
   AccountTrackerControllerMessenger,


### PR DESCRIPTION
## **Description**

This PR updates the`AccountOrderController` to use `registerMethodActionHandlers` and `MESSENGER_EXPOSED_METHODS` to register actions.

## **Changelog**

CHANGELOG entry:null
## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type/refactor-only changes to messenger action registration; behavior should be unchanged aside from potential misconfiguration of the exposed method list.
> 
> **Overview**
> Refactors `AccountOrderController` to bulk-register its messenger method handlers via `registerMethodActionHandlers` using a new `MESSENGER_EXPOSED_METHODS` allowlist, replacing the prior manually-declared per-method action types.
> 
> Adds an auto-generated `account-order-method-action-types.ts` that defines the method action union, updates init code/tests to import `AccountOrderControllerMessenger` from the controller, and removes the re-exported `AccountOrderControllerMessenger` type from `messengers/index.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d023063821f8b1ef1933e01762f674c068461a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->