### PR TITLE
chore: Bulk register actions in `AlertController`

### DIFF
--- a/app/scripts/controllers/alert-controller-method-action-types.ts
+++ b/app/scripts/controllers/alert-controller-method-action-types.ts
@@ -1,0 +1,64 @@
+/**
+ * This file is auto generated.
+ * Do not edit manually.
+ */
+
+import type { AlertController } from './alert-controller';
+
+export type AlertControllerSetAlertEnablednessAction = {
+  type: `AlertController:setAlertEnabledness`;
+  handler: AlertController['setAlertEnabledness'];
+};
+
+/**
+ * Sets the "switch to connected" alert as shown for the given origin
+ *
+ * @param origin - The origin the alert has been shown for
+ */
+export type AlertControllerSetUnconnectedAccountAlertShownAction = {
+  type: `AlertController:setUnconnectedAccountAlertShown`;
+  handler: AlertController['setUnconnectedAccountAlertShown'];
+};
+
+/**
+ * Gets the web3 shim usage state for the given origin.
+ *
+ * @param origin - The origin to get the web3 shim usage state for.
+ * @returns The web3 shim usage state for the given
+ * origin, or undefined.
+ */
+export type AlertControllerGetWeb3ShimUsageStateAction = {
+  type: `AlertController:getWeb3ShimUsageState`;
+  handler: AlertController['getWeb3ShimUsageState'];
+};
+
+/**
+ * Sets the web3 shim usage state for the given origin to RECORDED.
+ *
+ * @param origin - The origin the that used the web3 shim.
+ */
+export type AlertControllerSetWeb3ShimUsageRecordedAction = {
+  type: `AlertController:setWeb3ShimUsageRecorded`;
+  handler: AlertController['setWeb3ShimUsageRecorded'];
+};
+
+/**
+ * Sets the web3 shim usage state for the given origin to DISMISSED.
+ *
+ * @param origin - The origin that the web3 shim notification was
+ * dismissed for.
+ */
+export type AlertControllerSetWeb3ShimUsageAlertDismissedAction = {
+  type: `AlertController:setWeb3ShimUsageAlertDismissed`;
+  handler: AlertController['setWeb3ShimUsageAlertDismissed'];
+};
+
+/**
+ * Union of all AlertController action types.
+ */
+export type AlertControllerMethodActions =
+  | AlertControllerSetAlertEnablednessAction
+  | AlertControllerSetUnconnectedAccountAlertShownAction
+  | AlertControllerGetWeb3ShimUsageStateAction
+  | AlertControllerSetWeb3ShimUsageRecordedAction
+  | AlertControllerSetWeb3ShimUsageAlertDismissedAction;

--- a/app/scripts/controllers/alert-controller.ts
+++ b/app/scripts/controllers/alert-controller.ts
@@ -13,6 +13,7 @@ import {
   TOGGLEABLE_ALERT_TYPES,
   Web3ShimUsageAlertStates,
 } from '../../../shared/constants/alerts';
+import type { AlertControllerMethodActions } from './alert-controller-method-action-types';
 
 const controllerName = 'AlertController';
 
@@ -27,7 +28,9 @@ export type AlertControllerGetStateAction = ControllerGetStateAction<
 /**
  * Actions exposed by the {@link AlertController}.
  */
-export type AlertControllerActions = AlertControllerGetStateAction;
+export type AlertControllerActions =
+  | AlertControllerGetStateAction
+  | AlertControllerMethodActions;
 
 /**
  * Event emitted when the state of the {@link AlertController} changes.
@@ -128,6 +131,17 @@ const controllerMetadata: StateMetadata<AlertControllerState> = {
 };
 
 /**
+ * Methods exposed by the {@link AlertController} messenger.
+ */
+const MESSENGER_EXPOSED_METHODS = [
+  'setAlertEnabledness',
+  'setUnconnectedAccountAlertShown',
+  'getWeb3ShimUsageState',
+  'setWeb3ShimUsageRecorded',
+  'setWeb3ShimUsageAlertDismissed',
+] as const;
+
+/**
  * Controller responsible for maintaining alert-related state.
  */
 export class AlertController extends BaseController<
@@ -166,6 +180,11 @@ export class AlertController extends BaseController<
           });
         }
       },
+    );
+
+    this.messenger.registerMethodActionHandlers(
+      this,
+      MESSENGER_EXPOSED_METHODS,
     );
   }
 

--- a/app/scripts/messenger-client-init/alert-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/alert-controller-init.test.ts
@@ -1,11 +1,11 @@
-import { AlertController } from '../controllers/alert-controller';
+import {
+  AlertController,
+  AlertControllerMessenger,
+} from '../controllers/alert-controller';
 import { getRootMessenger } from '../lib/messenger';
 import { ControllerInitRequest } from './types';
 import { buildControllerInitRequestMock } from './test/utils';
-import {
-  getAlertControllerMessenger,
-  AlertControllerMessenger,
-} from './messengers';
+import { getAlertControllerMessenger } from './messengers';
 import { AlertControllerInit } from './alert-controller-init';
 
 jest.mock('../controllers/alert-controller');

--- a/app/scripts/messenger-client-init/alert-controller-init.ts
+++ b/app/scripts/messenger-client-init/alert-controller-init.ts
@@ -1,6 +1,8 @@
-import { AlertController } from '../controllers/alert-controller';
+import {
+  AlertController,
+  AlertControllerMessenger,
+} from '../controllers/alert-controller';
 import { ControllerInitFunction } from './types';
-import { AlertControllerMessenger } from './messengers';
 
 /**
  * Initialize the alert controller.

--- a/app/scripts/messenger-client-init/messengers/alert-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/alert-controller-messenger.ts
@@ -1,13 +1,10 @@
-import { Messenger } from '@metamask/messenger';
 import {
-  AllowedActions,
-  AllowedEvents,
-} from '../../controllers/alert-controller';
-import { RootMessenger } from '../../lib/messenger';
-
-export type AlertControllerMessenger = ReturnType<
-  typeof getAlertControllerMessenger
->;
+  Messenger,
+  MessengerActions,
+  MessengerEvents,
+} from '@metamask/messenger';
+import type { RootMessenger } from '../../lib/messenger';
+import type { AlertControllerMessenger } from '../../controllers/alert-controller';
 
 /**
  * Create a messenger restricted to the allowed actions and events of the
@@ -16,13 +13,13 @@ export type AlertControllerMessenger = ReturnType<
  * @param messenger - The base messenger used to create the restricted
  * messenger.
  */
-export function getAlertControllerMessenger(messenger: RootMessenger) {
-  const alertControlerMessenger = new Messenger<
-    'AlertController',
-    AllowedActions,
-    AllowedEvents,
-    typeof messenger
-  >({
+export function getAlertControllerMessenger(
+  messenger: RootMessenger<
+    MessengerActions<AlertControllerMessenger>,
+    MessengerEvents<AlertControllerMessenger>
+  >,
+) {
+  const alertControlerMessenger: AlertControllerMessenger = new Messenger({
     namespace: 'AlertController',
     parent: messenger,
   });

--- a/app/scripts/messenger-client-init/messengers/index.ts
+++ b/app/scripts/messenger-client-init/messengers/index.ts
@@ -224,7 +224,6 @@ export type { AccountsControllerMessenger } from './accounts-controller-messenge
 export { getAccountsControllerMessenger } from './accounts-controller-messenger';
 export type { AddressBookControllerMessenger } from './address-book-controller-messenger';
 export { getAddressBookControllerMessenger } from './address-book-controller-messenger';
-export type { AlertControllerMessenger } from './alert-controller-messenger';
 export { getAlertControllerMessenger } from './alert-controller-messenger';
 export type { AnnouncementControllerMessenger } from './announcement-controller-messenger';
 export { getAnnouncementControllerMessenger } from './announcement-controller-messenger';


### PR DESCRIPTION
## **Description**

This PR updates the`AlertController` to use `registerMethodActionHandlers` and `MESSENGER_EXPOSED_METHODS` to register actions.

## **Changelog**

CHANGELOG entry:null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly type plumbing and action registration refactoring with no new business logic; main risk is mis-registration or typing mismatches causing runtime messenger call failures.
> 
> **Overview**
> `AlertController` now bulk-registers its public messenger actions using `registerMethodActionHandlers` and a new `MESSENGER_EXPOSED_METHODS` allowlist, instead of relying solely on state actions.
> 
> Adds an auto-generated `alert-controller-method-action-types.ts` defining typed method action unions, expands `AlertControllerActions` accordingly, and updates messenger init/messenger factory typing + exports to reference the controller-defined `AlertControllerMessenger` type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd5036adc47341771ec11a0c68559b19370f1781. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->