### PR TITLE
chore: Bulk register actions in `AppMetadataController`

### DIFF
--- a/app/scripts/controllers/app-metadata-method-action-types.ts
+++ b/app/scripts/controllers/app-metadata-method-action-types.ts
@@ -1,0 +1,24 @@
+/**
+ * This file is auto generated.
+ * Do not edit manually.
+ */
+
+import type { AppMetadataController } from './app-metadata';
+
+/**
+ * Records the first time info if it hasn't been set yet.
+ * This captures the version and date when MetaMask was first installed.
+ * Once set, this value never changes.
+ *
+ * @param version - The current MetaMask version
+ */
+export type AppMetadataControllerMaybeRecordFirstTimeInfoAction = {
+  type: `AppMetadataController:maybeRecordFirstTimeInfo`;
+  handler: AppMetadataController['maybeRecordFirstTimeInfo'];
+};
+
+/**
+ * Union of all AppMetadataController action types.
+ */
+export type AppMetadataControllerMethodActions =
+  AppMetadataControllerMaybeRecordFirstTimeInfoAction;

--- a/app/scripts/controllers/app-metadata.test.ts
+++ b/app/scripts/controllers/app-metadata.test.ts
@@ -6,7 +6,8 @@ import {
   Messenger,
   MockAnyNamespace,
 } from '@metamask/messenger';
-import AppMetadataController, {
+import {
+  AppMetadataController,
   getDefaultAppMetadataControllerState,
   type AppMetadataControllerOptions,
 } from './app-metadata';

--- a/app/scripts/controllers/app-metadata.ts
+++ b/app/scripts/controllers/app-metadata.ts
@@ -240,5 +240,3 @@ export class AppMetadataController extends BaseController<
     }
   }
 }
-
-export default AppMetadataController;

--- a/app/scripts/controllers/app-metadata.ts
+++ b/app/scripts/controllers/app-metadata.ts
@@ -5,6 +5,7 @@ import {
   StateMetadata,
 } from '@metamask/base-controller';
 import type { Messenger } from '@metamask/messenger';
+import { AppMetadataControllerMethodActions } from './app-metadata-method-action-types';
 
 // Unique name for the controller
 const controllerName = 'AppMetadataController';
@@ -65,7 +66,9 @@ export type AppMetadataControllerGetStateAction = ControllerGetStateAction<
 /**
  * Actions exposed by the {@link AppMetadataController}.
  */
-export type AppMetadataControllerActions = AppMetadataControllerGetStateAction;
+export type AppMetadataControllerActions =
+  | AppMetadataControllerGetStateAction
+  | AppMetadataControllerMethodActions;
 
 /**
  * Event emitted when the state of the {@link AppMetadataController} changes.
@@ -90,7 +93,7 @@ type AllowedEvents = never;
 /**
  * Messenger type for the {@link AppMetadataController}.
  */
-type AppMetadataControllerMessenger = Messenger<
+export type AppMetadataControllerMessenger = Messenger<
   typeof controllerName,
   AppMetadataControllerActions | AllowedActions,
   AppMetadataControllerEvents | AllowedEvents
@@ -137,6 +140,11 @@ const controllerMetadata: StateMetadata<AppMetadataControllerState> = {
 };
 
 /**
+ * Methods exposed by the {@link AlertController} messenger.
+ */
+const MESSENGER_EXPOSED_METHODS = ['maybeRecordFirstTimeInfo'] as const;
+
+/**
  * The AppMetadata controller stores metadata about the current extension instance,
  * including the currently and previously installed versions, and the most recently
  * run migration.
@@ -175,6 +183,11 @@ export default class AppMetadataController extends BaseController<
     this.#maybeUpdateAppVersion(currentAppVersion);
 
     this.#maybeUpdateMigrationVersion(currentMigrationVersion);
+
+    this.messenger.registerMethodActionHandlers(
+      this,
+      MESSENGER_EXPOSED_METHODS,
+    );
   }
 
   /**

--- a/app/scripts/controllers/app-metadata.ts
+++ b/app/scripts/controllers/app-metadata.ts
@@ -150,7 +150,7 @@ const MESSENGER_EXPOSED_METHODS = ['maybeRecordFirstTimeInfo'] as const;
  * run migration.
  *
  */
-export default class AppMetadataController extends BaseController<
+export class AppMetadataController extends BaseController<
   typeof controllerName,
   AppMetadataControllerState,
   AppMetadataControllerMessenger
@@ -240,3 +240,5 @@ export default class AppMetadataController extends BaseController<
     }
   }
 }
+
+export default AppMetadataController;

--- a/app/scripts/messenger-client-init/app-metadata-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/app-metadata-controller-init.test.ts
@@ -1,11 +1,10 @@
-import AppMetadataController from '../controllers/app-metadata';
+import AppMetadataController, {
+  AppMetadataControllerMessenger,
+} from '../controllers/app-metadata';
 import { getRootMessenger } from '../lib/messenger';
 import { ControllerInitRequest } from './types';
 import { buildControllerInitRequestMock } from './test/utils';
-import {
-  getAppMetadataControllerMessenger,
-  AppMetadataControllerMessenger,
-} from './messengers';
+import { getAppMetadataControllerMessenger } from './messengers';
 import { AppMetadataControllerInit } from './app-metadata-controller-init';
 
 jest.mock('../controllers/app-metadata');

--- a/app/scripts/messenger-client-init/app-metadata-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/app-metadata-controller-init.test.ts
@@ -1,4 +1,5 @@
-import AppMetadataController, {
+import {
+  AppMetadataController,
   AppMetadataControllerMessenger,
 } from '../controllers/app-metadata';
 import { getRootMessenger } from '../lib/messenger';

--- a/app/scripts/messenger-client-init/app-metadata-controller-init.ts
+++ b/app/scripts/messenger-client-init/app-metadata-controller-init.ts
@@ -1,4 +1,5 @@
-import AppMetadataController, {
+import {
+  AppMetadataController,
   AppMetadataControllerMessenger,
 } from '../controllers/app-metadata';
 import { ControllerInitFunction } from './types';

--- a/app/scripts/messenger-client-init/app-metadata-controller-init.ts
+++ b/app/scripts/messenger-client-init/app-metadata-controller-init.ts
@@ -1,6 +1,7 @@
-import AppMetadataController from '../controllers/app-metadata';
+import AppMetadataController, {
+  AppMetadataControllerMessenger,
+} from '../controllers/app-metadata';
 import { ControllerInitFunction } from './types';
-import { AppMetadataControllerMessenger } from './messengers';
 
 /**
  * Initialize the appMetadata controller.

--- a/app/scripts/messenger-client-init/controller-list.ts
+++ b/app/scripts/messenger-client-init/controller-list.ts
@@ -104,7 +104,7 @@ import { SubscriptionService } from '../services/subscription/subscription-servi
 import { AccountOrderController } from '../controllers/account-order';
 import { AlertController } from '../controllers/alert-controller';
 import { MetaMetricsDataDeletionController } from '../controllers/metametrics-data-deletion/metametrics-data-deletion';
-import AppMetadataController from '../controllers/app-metadata';
+import { AppMetadataController } from '../controllers/app-metadata';
 import DecryptMessageController from '../controllers/decrypt-message';
 import EncryptionPublicKeyController from '../controllers/encryption-public-key';
 import { RewardsDataService } from '../controllers/rewards/rewards-data-service';

--- a/app/scripts/messenger-client-init/messengers/app-metadata-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/app-metadata-controller-messenger.ts
@@ -1,9 +1,10 @@
-import { Messenger } from '@metamask/messenger';
+import {
+  Messenger,
+  MessengerActions,
+  MessengerEvents,
+} from '@metamask/messenger';
 import { RootMessenger } from '../../lib/messenger';
-
-export type AppMetadataControllerMessenger = ReturnType<
-  typeof getAppMetadataControllerMessenger
->;
+import { AppMetadataControllerMessenger } from '../../controllers/app-metadata';
 
 /**
  * Create a messenger restricted to the allowed actions and events of the
@@ -12,9 +13,16 @@ export type AppMetadataControllerMessenger = ReturnType<
  * @param messenger - The base messenger used to create the restricted
  * messenger.
  */
-export function getAppMetadataControllerMessenger(messenger: RootMessenger) {
-  return new Messenger({
+export function getAppMetadataControllerMessenger(
+  messenger: RootMessenger<
+    MessengerActions<AppMetadataControllerMessenger>,
+    MessengerEvents<AppMetadataControllerMessenger>
+  >,
+) {
+  const appMetadataMessenger: AppMetadataControllerMessenger = new Messenger({
     namespace: 'AppMetadataController',
     parent: messenger,
   });
+
+  return appMetadataMessenger;
 }

--- a/app/scripts/messenger-client-init/messengers/index.ts
+++ b/app/scripts/messenger-client-init/messengers/index.ts
@@ -228,7 +228,6 @@ export type { AlertControllerMessenger } from './alert-controller-messenger';
 export { getAlertControllerMessenger } from './alert-controller-messenger';
 export type { AnnouncementControllerMessenger } from './announcement-controller-messenger';
 export { getAnnouncementControllerMessenger } from './announcement-controller-messenger';
-export type { AppMetadataControllerMessenger } from './app-metadata-controller-messenger';
 export { getAppMetadataControllerMessenger } from './app-metadata-controller-messenger';
 export type { AppStateControllerMessenger } from './app-state-controller-messenger';
 export { getAppStateControllerMessenger } from './app-state-controller-messenger';


### PR DESCRIPTION
## **Description**

This PR updates the `AppMetadataController` to use `registerMethodActionHandlers` and `MESSENGER_EXPOSED_METHODS` to register actions.

## **Changelog**

CHANGELOG entry:null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily typing and wiring changes around messenger action registration with limited behavioral impact; risk is mainly mis-registration or type mismatches breaking controller initialization/messaging.
> 
> **Overview**
> `AppMetadataController` now bulk-registers its exposed messenger methods via `registerMethodActionHandlers` and a `MESSENGER_EXPOSED_METHODS` allowlist, with action typing generated into the new `app-metadata-method-action-types.ts` and included in `AppMetadataControllerActions`.
> 
> This refactors exports/imports to use a named `AppMetadataController` class and exported `AppMetadataControllerMessenger` type, and updates the app-metadata messenger factory and init/tests to use the new typing and imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f35ea9576045c9e06204c5949ebc26f35cd249e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->