### PR TITLE
fix: hide close cancel all and sticky header

### DIFF
--- a/ui/components/app/perps/perps-positions-orders/perps-positions-orders.tsx
+++ b/ui/components/app/perps/perps-positions-orders/perps-positions-orders.tsx
@@ -5,11 +5,7 @@ import {
   BoxJustifyContent,
   BoxAlignItems,
   Text,
-  TextVariant,
-  TextColor,
   FontWeight,
-  ButtonBase,
-  ButtonBaseSize,
 } from '@metamask/design-system-react';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { PositionCard } from '../position-card';
@@ -19,19 +15,21 @@ import type { Position, Order } from '../types';
 export type PerpsPositionsOrdersProps = {
   positions: Position[];
   orders: Order[];
-  onCloseAllPositions?: () => void;
-  onCancelAllOrders?: () => void;
-  isCloseAllPending?: boolean;
-  isCancelAllPending?: boolean;
+  // TODO: TAT-2852 - Unhide when batch close/cancel is implemented
+  // onCloseAllPositions?: () => void;
+  // onCancelAllOrders?: () => void;
+  // isCloseAllPending?: boolean;
+  // isCancelAllPending?: boolean;
 };
 
 export const PerpsPositionsOrders: React.FC<PerpsPositionsOrdersProps> = ({
   positions,
   orders,
-  onCloseAllPositions,
-  onCancelAllOrders,
-  isCloseAllPending = false,
-  isCancelAllPending = false,
+  // TODO: TAT-2852 - Unhide when batch close/cancel is implemented
+  // onCloseAllPositions,
+  // onCancelAllOrders,
+  // isCloseAllPending = false,
+  // isCancelAllPending = false,
 }) => {
   const t = useI18nContext();
   const hasPositions = positions.length > 0;
@@ -63,7 +61,8 @@ export const PerpsPositionsOrders: React.FC<PerpsPositionsOrdersProps> = ({
             marginBottom={2}
           >
             <Text fontWeight={FontWeight.Medium}>{t('perpsPositions')}</Text>
-            <ButtonBase
+            {/* TODO: TAT-2852 - Unhide when batch close/cancel is implemented */}
+            {/* <ButtonBase
               size={ButtonBaseSize.Sm}
               disabled={isCloseAllPending || !onCloseAllPositions}
               onClick={onCloseAllPositions}
@@ -75,7 +74,7 @@ export const PerpsPositionsOrders: React.FC<PerpsPositionsOrdersProps> = ({
               }}
             >
               {t('perpsCloseAll')}
-            </ButtonBase>
+            </ButtonBase> */}
           </Box>
           <Box flexDirection={BoxFlexDirection.Column}>
             {positions.map((position) => (
@@ -101,7 +100,8 @@ export const PerpsPositionsOrders: React.FC<PerpsPositionsOrdersProps> = ({
             marginBottom={2}
           >
             <Text fontWeight={FontWeight.Medium}>{t('perpsOpenOrders')}</Text>
-            <ButtonBase
+            {/* TODO: TAT-2852 - Unhide when batch close/cancel is implemented */}
+            {/* <ButtonBase
               size={ButtonBaseSize.Sm}
               disabled={isCancelAllPending || !onCancelAllOrders}
               onClick={onCancelAllOrders}
@@ -113,7 +113,7 @@ export const PerpsPositionsOrders: React.FC<PerpsPositionsOrdersProps> = ({
               }}
             >
               {t('perpsCancelAllOrders')}
-            </ButtonBase>
+            </ButtonBase> */}
           </Box>
           <Box flexDirection={BoxFlexDirection.Column}>
             {orders.map((order) => (

--- a/ui/components/app/perps/perps-positions-orders/perps-positions-orders.tsx
+++ b/ui/components/app/perps/perps-positions-orders/perps-positions-orders.tsx
@@ -15,21 +15,19 @@ import type { Position, Order } from '../types';
 export type PerpsPositionsOrdersProps = {
   positions: Position[];
   orders: Order[];
-  // TODO: TAT-2852 - Unhide when batch close/cancel is implemented
-  // onCloseAllPositions?: () => void;
-  // onCancelAllOrders?: () => void;
-  // isCloseAllPending?: boolean;
-  // isCancelAllPending?: boolean;
+  onCloseAllPositions?: () => void;
+  onCancelAllOrders?: () => void;
+  isCloseAllPending?: boolean;
+  isCancelAllPending?: boolean;
 };
 
 export const PerpsPositionsOrders: React.FC<PerpsPositionsOrdersProps> = ({
   positions,
   orders,
-  // TODO: TAT-2852 - Unhide when batch close/cancel is implemented
-  // onCloseAllPositions,
-  // onCancelAllOrders,
-  // isCloseAllPending = false,
-  // isCancelAllPending = false,
+  onCloseAllPositions,
+  onCancelAllOrders,
+  isCloseAllPending = false,
+  isCancelAllPending = false,
 }) => {
   const t = useI18nContext();
   const hasPositions = positions.length > 0;

--- a/ui/components/app/perps/perps-view.test.tsx
+++ b/ui/components/app/perps/perps-view.test.tsx
@@ -171,11 +171,13 @@ describe('PerpsView', () => {
       expect(screen.getByText(/open orders/iu)).toBeInTheDocument();
     });
 
-    it('displays close all option in positions section', () => {
+    // TODO: TAT-2852 - Restore when batch close/cancel is implemented
+    it('does not display close all option in positions section while hidden', () => {
       renderWithProvider(<PerpsView />, mockStore);
 
-      const closeAllElements = screen.getAllByText(/close all/iu);
-      expect(closeAllElements.length).toBeGreaterThanOrEqual(1);
+      expect(
+        screen.queryByTestId('perps-close-all-positions'),
+      ).not.toBeInTheDocument();
     });
 
     it('shows Support & Learn section with Learn basics', () => {
@@ -273,8 +275,9 @@ describe('PerpsView', () => {
     });
   });
 
+  // TODO: TAT-2852 - Restore/unskip when batch close/cancel is implemented
   describe('close all and cancel all', () => {
-    it('calls batch close and applies a single positions snapshot', async () => {
+    it.skip('calls batch close and applies a single positions snapshot', async () => {
       const clearAll = jest.fn();
       const pushPositions = jest.fn();
       mockGetPerpsStreamManager.mockReturnValue({
@@ -316,7 +319,7 @@ describe('PerpsView', () => {
       expect(pushPositions).toHaveBeenCalledWith([]);
     });
 
-    it('calls batch cancel and applies a single orders snapshot', async () => {
+    it.skip('calls batch cancel and applies a single orders snapshot', async () => {
       const ordersPush = jest.fn();
       mockGetPerpsStreamManager.mockReturnValue({
         init: jest.fn().mockResolvedValue(undefined),
@@ -390,7 +393,7 @@ describe('PerpsView', () => {
       );
     });
 
-    it('refreshes open orders when cancel all returns success false with no failures', async () => {
+    it.skip('refreshes open orders when cancel all returns success false with no failures', async () => {
       const ordersPush = jest.fn();
       mockGetPerpsStreamManager.mockReturnValue({
         init: jest.fn().mockResolvedValue(undefined),
@@ -430,7 +433,7 @@ describe('PerpsView', () => {
       ).not.toBeInTheDocument();
     });
 
-    it('shows batch error when cancel all reports failures', async () => {
+    it.skip('shows batch error when cancel all reports failures', async () => {
       mockSubmitRequestToBackground.mockImplementation((method: string) => {
         if (method === 'perpsCancelOrders') {
           return Promise.resolve({

--- a/ui/pages/perps/perps-market-detail-page.tsx
+++ b/ui/pages/perps/perps-market-detail-page.tsx
@@ -858,6 +858,7 @@ const PerpsMarketDetailPage: React.FC = () => {
     >
       {/* Header */}
       <Box
+        className="sticky top-0 z-10 bg-background-default"
         flexDirection={BoxFlexDirection.Row}
         alignItems={BoxAlignItems.Center}
         paddingLeft={4}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Two UX improvements to the Perps trading UI:

**1. Hide "Close All" / "Cancel All" batch action buttons**

The "Close All Positions" and "Cancel All Orders" buttons are temporarily hidden while the backend batch-action implementation is being completed (TAT-2852). Displaying non-functional buttons would confuse users, so they are commented out with a TODO referencing the ticket. The underlying handlers, state, and tests are preserved (skipped) so they can be restored with minimal effort once the feature is ready.

**2. Sticky market detail header**

When scrolling through a market detail page (e.g. BTC-USD), the header row — containing the back button, token logo, symbol/price, and favourite toggle — was scrolling out of view. It is now pinned to the top of the viewport (`position: sticky`) so users always have context on which market they are viewing and can navigate back without scrolling.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed the Perps market detail header so it stays visible while scrolling.

## **Related issues**

Fixes: TAT-2852 (batch close/cancel hidden pending backend implementation)

## **Manual testing steps**

**Sticky header:**
1. Open the MetaMask extension and navigate to the Perps tab.
2. Tap any market (e.g. BTC-USD) to open the market detail page.
3. Scroll down past the chart and through the position/order cards.
4. Verify the header row (back arrow, BTC logo, price, and favourite icon) remains pinned at the top throughout scrolling.

**Hidden batch action buttons:**
1. On the Perps tab, ensure you have at least one open position and one open order (use testnet or a fixture).
2. Verify the "Close All" button is **not** visible in the Positions section header.
3. Verify the "Cancel All Orders" button is **not** visible in the Open Orders section header.
4. Verify positions and orders still render correctly without the buttons.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- Header scrolls off-screen; "Close All" and "Cancel All" buttons visible -->

### **After**

<!-- Header stays pinned to top on scroll; batch action buttons removed from UI -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only changes, but several batch-action tests are now skipped which reduces regression coverage until the feature is re-enabled.
> 
> **Overview**
> **Perps batch actions are now hidden in the UI.** The `Close All Positions` and `Cancel All Orders` header buttons in `perps-positions-orders.tsx` are commented out behind a TODO (`TAT-2852`), leaving the underlying props/handlers in place.
> 
> **Tests were updated to match the hidden controls.** `perps-view.test.tsx` now asserts the buttons are absent and skips the batch close/cancel interaction tests until backend support is implemented.
> 
> **Market detail header now stays visible while scrolling.** `perps-market-detail-page.tsx` adds sticky positioning classes to the header container.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43bdb035d3da5c30ae4de9f4a2bca35756c6976b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->