### PR TITLE
chore: Bulk register actions in `AppStateController`

### DIFF
--- a/app/scripts/controllers/app-state-controller-method-action-types.ts
+++ b/app/scripts/controllers/app-state-controller-method-action-types.ts
@@ -1,0 +1,675 @@
+/**
+ * This file is auto generated.
+ * Do not edit manually.
+ */
+
+import type { AppStateController } from './app-state-controller';
+
+/**
+ * Get a Promise that resolves when the extension is unlocked.
+ * This Promise will never reject.
+ *
+ * @param shouldShowUnlockRequest - Whether the extension notification
+ * popup should be opened.
+ * @returns A promise that resolves when the extension is
+ * unlocked, or immediately if the extension is already unlocked.
+ */
+export type AppStateControllerGetUnlockPromiseAction = {
+  type: `AppStateController:getUnlockPromise`;
+  handler: AppStateController['getUnlockPromise'];
+};
+
+/**
+ * Sets the default home tab
+ *
+ * @param defaultHomeActiveTabName - the tab name
+ */
+export type AppStateControllerSetDefaultHomeActiveTabNameAction = {
+  type: `AppStateController:setDefaultHomeActiveTabName`;
+  handler: AppStateController['setDefaultHomeActiveTabName'];
+};
+
+/**
+ * Record that the user has seen the connected status info popover
+ */
+export type AppStateControllerSetConnectedStatusPopoverHasBeenShownAction = {
+  type: `AppStateController:setConnectedStatusPopoverHasBeenShown`;
+  handler: AppStateController['setConnectedStatusPopoverHasBeenShown'];
+};
+
+/**
+ * Record that the user has been shown the recovery phrase reminder.
+ */
+export type AppStateControllerSetRecoveryPhraseReminderHasBeenShownAction = {
+  type: `AppStateController:setRecoveryPhraseReminderHasBeenShown`;
+  handler: AppStateController['setRecoveryPhraseReminderHasBeenShown'];
+};
+
+export type AppStateControllerSetSurveyLinkLastClickedOrClosedAction = {
+  type: `AppStateController:setSurveyLinkLastClickedOrClosed`;
+  handler: AppStateController['setSurveyLinkLastClickedOrClosed'];
+};
+
+export type AppStateControllerSetOnboardingDateAction = {
+  type: `AppStateController:setOnboardingDate`;
+  handler: AppStateController['setOnboardingDate'];
+};
+
+export type AppStateControllerSetLastViewedUserSurveyAction = {
+  type: `AppStateController:setLastViewedUserSurvey`;
+  handler: AppStateController['setLastViewedUserSurvey'];
+};
+
+export type AppStateControllerSetRampCardClosedAction = {
+  type: `AppStateController:setRampCardClosed`;
+  handler: AppStateController['setRampCardClosed'];
+};
+
+export type AppStateControllerSetNewPrivacyPolicyToastClickedOrClosedAction = {
+  type: `AppStateController:setNewPrivacyPolicyToastClickedOrClosed`;
+  handler: AppStateController['setNewPrivacyPolicyToastClickedOrClosed'];
+};
+
+export type AppStateControllerSetNewPrivacyPolicyToastShownDateAction = {
+  type: `AppStateController:setNewPrivacyPolicyToastShownDate`;
+  handler: AppStateController['setNewPrivacyPolicyToastShownDate'];
+};
+
+export type AppStateControllerSetPna25AcknowledgedAction = {
+  type: `AppStateController:setPna25Acknowledged`;
+  handler: AppStateController['setPna25Acknowledged'];
+};
+
+export type AppStateControllerSetShieldPausedToastLastClickedOrClosedAction = {
+  type: `AppStateController:setShieldPausedToastLastClickedOrClosed`;
+  handler: AppStateController['setShieldPausedToastLastClickedOrClosed'];
+};
+
+export type AppStateControllerSetShieldEndingToastLastClickedOrClosedAction = {
+  type: `AppStateController:setShieldEndingToastLastClickedOrClosed`;
+  handler: AppStateController['setShieldEndingToastLastClickedOrClosed'];
+};
+
+/**
+ * Sets a generic shield API error.
+ * When set to a non-null object, a toast is shown on the homepage with the error.
+ * Setting to null clears/dismisses the error.
+ *
+ * @param error - The error object with message and optional code, or null to clear
+ */
+export type AppStateControllerSetShieldSubscriptionErrorAction = {
+  type: `AppStateController:setShieldSubscriptionError`;
+  handler: AppStateController['setShieldSubscriptionError'];
+};
+
+/**
+ * Sets the storage write error type, which controls whether to show the storage error toast.
+ * When errorType is not null, the toast will be shown with the appropriate message.
+ * This is called when set operations fail (storage.local or IndexedDB).
+ *
+ * @param errorType - The type of storage write error, or null to hide the toast
+ */
+export type AppStateControllerSetStorageWriteErrorTypeAction = {
+  type: `AppStateController:setStorageWriteErrorType`;
+  handler: AppStateController['setStorageWriteErrorType'];
+};
+
+/**
+ * Replaces slides in state with new slides. If a slide with the same id
+ * already exists, it will be merged with the new slide.
+ *
+ * @param slides - Array of new slides
+ */
+export type AppStateControllerUpdateSlidesAction = {
+  type: `AppStateController:updateSlides`;
+  handler: AppStateController['updateSlides'];
+};
+
+/**
+ * Marks a slide as dismissed by ID
+ *
+ * @param id - ID of the slide to dismiss
+ */
+export type AppStateControllerRemoveSlideAction = {
+  type: `AppStateController:removeSlide`;
+  handler: AppStateController['removeSlide'];
+};
+
+/**
+ * Record the timestamp of the last time the user has seen the recovery phrase reminder
+ *
+ * @param lastShown - timestamp when user was last shown the reminder.
+ */
+export type AppStateControllerSetRecoveryPhraseReminderLastShownAction = {
+  type: `AppStateController:setRecoveryPhraseReminderLastShown`;
+  handler: AppStateController['setRecoveryPhraseReminderLastShown'];
+};
+
+/**
+ * Record the timestamp of the last time the user has acceoted the terms of use
+ *
+ * @param lastAgreed - timestamp when user last accepted the terms of use
+ */
+export type AppStateControllerSetTermsOfUseLastAgreedAction = {
+  type: `AppStateController:setTermsOfUseLastAgreed`;
+  handler: AppStateController['setTermsOfUseLastAgreed'];
+};
+
+/**
+ * Record if popover for snaps privacy warning has been shown
+ * on the first install of a snap.
+ *
+ * @param shown - shown status
+ */
+export type AppStateControllerSetSnapsInstallPrivacyWarningShownStatusAction = {
+  type: `AppStateController:setSnapsInstallPrivacyWarningShownStatus`;
+  handler: AppStateController['setSnapsInstallPrivacyWarningShownStatus'];
+};
+
+/**
+ * Record the timestamp of the last time the user has seen the outdated browser warning
+ *
+ * @param lastShown - Timestamp (in milliseconds) of when the user was last shown the warning.
+ */
+export type AppStateControllerSetOutdatedBrowserWarningLastShownAction = {
+  type: `AppStateController:setOutdatedBrowserWarningLastShown`;
+  handler: AppStateController['setOutdatedBrowserWarningLastShown'];
+};
+
+/**
+ * Sets the last active time to the current time.
+ */
+export type AppStateControllerSetLastActiveTimeAction = {
+  type: `AppStateController:setLastActiveTime`;
+  handler: AppStateController['setLastActiveTime'];
+};
+
+/**
+ * Set the version of the pending extension update, or null when no update is available or after update is applied.
+ *
+ * @param version - Version string of the available update, or null to clear.
+ */
+export type AppStateControllerSetPendingExtensionVersionAction = {
+  type: `AppStateController:setPendingExtensionVersion`;
+  handler: AppStateController['setPendingExtensionVersion'];
+};
+
+/**
+ * Record the timestamp of the last time the user has dismissed the update modal
+ *
+ * @param updateModalLastDismissedAt - timestamp of the last time the user has dismissed the update modal.
+ */
+export type AppStateControllerSetUpdateModalLastDismissedAtAction = {
+  type: `AppStateController:setUpdateModalLastDismissedAt`;
+  handler: AppStateController['setUpdateModalLastDismissedAt'];
+};
+
+/**
+ * Record the timestamp of the last time the user has updated
+ *
+ * @param lastUpdatedAt - timestamp of the last time the user has updated
+ */
+export type AppStateControllerSetLastUpdatedAtAction = {
+  type: `AppStateController:setLastUpdatedAt`;
+  handler: AppStateController['setLastUpdatedAt'];
+};
+
+/**
+ * Record the previous version the user updated from
+ *
+ * @param fromVersion - the version the user updated from
+ */
+export type AppStateControllerSetLastUpdatedFromVersionAction = {
+  type: `AppStateController:setLastUpdatedFromVersion`;
+  handler: AppStateController['setLastUpdatedFromVersion'];
+};
+
+/**
+ * Sets the current browser and OS environment
+ *
+ * @param os
+ * @param browser
+ */
+export type AppStateControllerSetBrowserEnvironmentAction = {
+  type: `AppStateController:setBrowserEnvironment`;
+  handler: AppStateController['setBrowserEnvironment'];
+};
+
+/**
+ * Adds a pollingToken for a given environmentType
+ *
+ * @param pollingToken
+ * @param pollingTokenType
+ */
+export type AppStateControllerAddPollingTokenAction = {
+  type: `AppStateController:addPollingToken`;
+  handler: AppStateController['addPollingToken'];
+};
+
+/**
+ * removes a pollingToken for a given environmentType
+ *
+ * @param pollingToken
+ * @param pollingTokenType
+ */
+export type AppStateControllerRemovePollingTokenAction = {
+  type: `AppStateController:removePollingToken`;
+  handler: AppStateController['removePollingToken'];
+};
+
+/**
+ * clears all pollingTokens
+ */
+export type AppStateControllerClearPollingTokensAction = {
+  type: `AppStateController:clearPollingTokens`;
+  handler: AppStateController['clearPollingTokens'];
+};
+
+/**
+ * Sets whether the testnet dismissal link should be shown in the network dropdown
+ *
+ * @param showTestnetMessageInDropdown
+ */
+export type AppStateControllerSetShowTestnetMessageInDropdownAction = {
+  type: `AppStateController:setShowTestnetMessageInDropdown`;
+  handler: AppStateController['setShowTestnetMessageInDropdown'];
+};
+
+/**
+ * Sets whether the beta notification heading on the home page
+ *
+ * @param showBetaHeader
+ */
+export type AppStateControllerSetShowBetaHeaderAction = {
+  type: `AppStateController:setShowBetaHeader`;
+  handler: AppStateController['setShowBetaHeader'];
+};
+
+/**
+ * Sets whether the permissions tour should be shown to the user
+ *
+ * @param showPermissionsTour
+ */
+export type AppStateControllerSetShowPermissionsTourAction = {
+  type: `AppStateController:setShowPermissionsTour`;
+  handler: AppStateController['setShowPermissionsTour'];
+};
+
+/**
+ * Sets whether the multichain intro modal has been shown to the user
+ *
+ * @param hasShown - Whether the modal has been shown
+ */
+export type AppStateControllerSetHasShownMultichainAccountsIntroModalAction = {
+  type: `AppStateController:setHasShownMultichainAccountsIntroModal`;
+  handler: AppStateController['setHasShownMultichainAccountsIntroModal'];
+};
+
+/**
+ * Sets whether the mUSD conversion education screen has been seen.
+ *
+ * @param value - Whether the education screen has been seen
+ */
+export type AppStateControllerSetMusdConversionEducationSeenAction = {
+  type: `AppStateController:setMusdConversionEducationSeen`;
+  handler: AppStateController['setMusdConversionEducationSeen'];
+};
+
+/**
+ * Adds a dismissed mUSD asset-detail CTA key (chainId-tokenAddress format).
+ * Used to hide the CTA for that token on that chain once dismissed.
+ *
+ * @param key - Key in format "chainId-tokenAddress" (e.g. "0x1-0xa0b86991...")
+ */
+export type AppStateControllerAddMusdConversionDismissedCtaKeyAction = {
+  type: `AppStateController:addMusdConversionDismissedCtaKey`;
+  handler: AppStateController['addMusdConversionDismissedCtaKey'];
+};
+
+/**
+ * Sets the product tour to be shown to the user
+ *
+ * @param productTour - Tour name to show (e.g., 'accountIcon') or empty string to hide
+ */
+export type AppStateControllerSetProductTourAction = {
+  type: `AppStateController:setProductTour`;
+  handler: AppStateController['setProductTour'];
+};
+
+/**
+ * Sets whether the Network Banner should be shown
+ *
+ * @param showNetworkBanner
+ */
+export type AppStateControllerSetShowNetworkBannerAction = {
+  type: `AppStateController:setShowNetworkBanner`;
+  handler: AppStateController['setShowNetworkBanner'];
+};
+
+/**
+ * Updates the network connection banner state
+ *
+ * @param networkConnectionBanner - The new banner state
+ */
+export type AppStateControllerUpdateNetworkConnectionBannerAction = {
+  type: `AppStateController:updateNetworkConnectionBanner`;
+  handler: AppStateController['updateNetworkConnectionBanner'];
+};
+
+/**
+ * Sets whether the Account Banner should be shown
+ *
+ * @param showAccountBanner
+ */
+export type AppStateControllerSetShowAccountBannerAction = {
+  type: `AppStateController:setShowAccountBanner`;
+  handler: AppStateController['setShowAccountBanner'];
+};
+
+/**
+ * Sets a unique ID for the current extension popup
+ *
+ * @param currentExtensionPopupId
+ */
+export type AppStateControllerSetCurrentExtensionPopupIdAction = {
+  type: `AppStateController:setCurrentExtensionPopupId`;
+  handler: AppStateController['setCurrentExtensionPopupId'];
+};
+
+/**
+ * Sets a property indicating the model of the user's Trezor hardware wallet
+ *
+ * @param trezorModel - The Trezor model.
+ */
+export type AppStateControllerSetTrezorModelAction = {
+  type: `AppStateController:setTrezorModel`;
+  handler: AppStateController['setTrezorModel'];
+};
+
+/**
+ * A setter for the `nftsDropdownState` property
+ *
+ * @param nftsDropdownState
+ */
+export type AppStateControllerUpdateNftDropDownStateAction = {
+  type: `AppStateController:updateNftDropDownState`;
+  handler: AppStateController['updateNftDropDownState'];
+};
+
+export type AppStateControllerGetSignatureSecurityAlertResponseAction = {
+  type: `AppStateController:getSignatureSecurityAlertResponse`;
+  handler: AppStateController['getSignatureSecurityAlertResponse'];
+};
+
+export type AppStateControllerAddSignatureSecurityAlertResponseAction = {
+  type: `AppStateController:addSignatureSecurityAlertResponse`;
+  handler: AppStateController['addSignatureSecurityAlertResponse'];
+};
+
+/**
+ * A setter for the currentPopupId which indicates the id of popup window that's currently active
+ *
+ * @param currentPopupId
+ */
+export type AppStateControllerSetCurrentPopupIdAction = {
+  type: `AppStateController:setCurrentPopupId`;
+  handler: AppStateController['setCurrentPopupId'];
+};
+
+/**
+ * The function returns information about the last confirmation user interacted with
+ */
+export type AppStateControllerGetLastInteractedConfirmationInfoAction = {
+  type: `AppStateController:getLastInteractedConfirmationInfo`;
+  handler: AppStateController['getLastInteractedConfirmationInfo'];
+};
+
+/**
+ * Update the information about the last confirmation user interacted with
+ *
+ * @param lastInteractedConfirmationInfo
+ */
+export type AppStateControllerSetLastInteractedConfirmationInfoAction = {
+  type: `AppStateController:setLastInteractedConfirmationInfo`;
+  handler: AppStateController['setLastInteractedConfirmationInfo'];
+};
+
+/**
+ * A getter to retrieve currentPopupId saved in the appState
+ */
+export type AppStateControllerGetCurrentPopupIdAction = {
+  type: `AppStateController:getCurrentPopupId`;
+  handler: AppStateController['getCurrentPopupId'];
+};
+
+export type AppStateControllerGetThrottledOriginStateAction = {
+  type: `AppStateController:getThrottledOriginState`;
+  handler: AppStateController['getThrottledOriginState'];
+};
+
+export type AppStateControllerUpdateThrottledOriginStateAction = {
+  type: `AppStateController:updateThrottledOriginState`;
+  handler: AppStateController['updateThrottledOriginState'];
+};
+
+/**
+ * Completes a QR code scan by resolving the promise with the scanned data.
+ *
+ * @param scannedData - The data that was scanned from the QR code.
+ * @throws If no QR code scan is in progress.
+ */
+export type AppStateControllerCompleteQrCodeScanAction = {
+  type: `AppStateController:completeQrCodeScan`;
+  handler: AppStateController['completeQrCodeScan'];
+};
+
+/**
+ * Cancels the current QR code scan, if one is in progress.
+ * This will reject the promise with an error.
+ *
+ * @param error - The error to reject the promise with.
+ * @throws If no QR code scan is in progress.
+ */
+export type AppStateControllerCancelQrCodeScanAction = {
+  type: `AppStateController:cancelQrCodeScan`;
+  handler: AppStateController['cancelQrCodeScan'];
+};
+
+/**
+ * Requests a QR code scan and returns a promise that resolves with the scanned data.
+ * If a scan is already in progress, it returns the existing promise.
+ *
+ * @param request - The QR code scan request.
+ * @returns The scanned QR code data.
+ */
+export type AppStateControllerRequestQrCodeScanAction = {
+  type: `AppStateController:requestQrCodeScan`;
+  handler: AppStateController['requestQrCodeScan'];
+};
+
+/**
+ * Sets the active tab information
+ *
+ * @param tabData - The active tab data
+ */
+export type AppStateControllerSetAppActiveTabAction = {
+  type: `AppStateController:setAppActiveTab`;
+  handler: AppStateController['setAppActiveTab'];
+};
+
+/**
+ * Clears the active tab information by setting appActiveTab to undefined.
+ */
+export type AppStateControllerClearAppActiveTabAction = {
+  type: `AppStateController:clearAppActiveTab`;
+  handler: AppStateController['clearAppActiveTab'];
+};
+
+export type AppStateControllerSetShowShieldEntryModalOnceAction = {
+  type: `AppStateController:setShowShieldEntryModalOnce`;
+  handler: AppStateController['setShowShieldEntryModalOnce'];
+};
+
+/**
+ * Sets the pending redirect route to be applied after the default page is loaded.
+ *
+ * @param route - The pending redirect route.
+ */
+export type AppStateControllerSetPendingRedirectRouteAction = {
+  type: `AppStateController:setPendingRedirectRoute`;
+  handler: AppStateController['setPendingRedirectRoute'];
+};
+
+export type AppStateControllerSetPendingShieldCohortAction = {
+  type: `AppStateController:setPendingShieldCohort`;
+  handler: AppStateController['setPendingShieldCohort'];
+};
+
+export type AppStateControllerSetCanTrackWalletFundsObtainedAction = {
+  type: `AppStateController:setCanTrackWalletFundsObtained`;
+  handler: AppStateController['setCanTrackWalletFundsObtained'];
+};
+
+export type AppStateControllerSetIsWalletResetInProgressAction = {
+  type: `AppStateController:setIsWalletResetInProgress`;
+  handler: AppStateController['setIsWalletResetInProgress'];
+};
+
+export type AppStateControllerGetIsWalletResetInProgressAction = {
+  type: `AppStateController:getIsWalletResetInProgress`;
+  handler: AppStateController['getIsWalletResetInProgress'];
+};
+
+export type AppStateControllerSetDefaultSubscriptionPaymentOptionsAction = {
+  type: `AppStateController:setDefaultSubscriptionPaymentOptions`;
+  handler: AppStateController['setDefaultSubscriptionPaymentOptions'];
+};
+
+/**
+ * Update the Shield subscription metrics properties which are not accessible in the background directly.
+ *
+ * @param shieldSubscriptionMetricsProps - The Shield subscription metrics properties.
+ */
+export type AppStateControllerSetShieldSubscriptionMetricsPropsAction = {
+  type: `AppStateController:setShieldSubscriptionMetricsProps`;
+  handler: AppStateController['setShieldSubscriptionMetricsProps'];
+};
+
+export type AppStateControllerDeleteDappSwapComparisonDataAction = {
+  type: `AppStateController:deleteDappSwapComparisonData`;
+  handler: AppStateController['deleteDappSwapComparisonData'];
+};
+
+export type AppStateControllerSetDappSwapComparisonDataAction = {
+  type: `AppStateController:setDappSwapComparisonData`;
+  handler: AppStateController['setDappSwapComparisonData'];
+};
+
+export type AppStateControllerGetDappSwapComparisonDataAction = {
+  type: `AppStateController:getDappSwapComparisonData`;
+  handler: AppStateController['getDappSwapComparisonData'];
+};
+
+/**
+ * Updates state with deferred deep link data.
+ *
+ * @param deferredDeepLink - Deferred deep link data.
+ */
+export type AppStateControllerSetDeferredDeepLinkAction = {
+  type: `AppStateController:setDeferredDeepLink`;
+  handler: AppStateController['setDeferredDeepLink'];
+};
+
+/**
+ * Removes deferred deep link data.
+ */
+export type AppStateControllerRemoveDeferredDeepLinkAction = {
+  type: `AppStateController:removeDeferredDeepLink`;
+  handler: AppStateController['removeDeferredDeepLink'];
+};
+
+export type AppStateControllerAddAddressSecurityAlertResponseAction = {
+  type: `AppStateController:addAddressSecurityAlertResponse`;
+  handler: AppStateController['addAddressSecurityAlertResponse'];
+};
+
+export type AppStateControllerGetAddressSecurityAlertResponseAction = {
+  type: `AppStateController:getAddressSecurityAlertResponse`;
+  handler: AppStateController['getAddressSecurityAlertResponse'];
+};
+
+/**
+ * Union of all AppStateController action types.
+ */
+export type AppStateControllerMethodActions =
+  | AppStateControllerGetUnlockPromiseAction
+  | AppStateControllerSetDefaultHomeActiveTabNameAction
+  | AppStateControllerSetConnectedStatusPopoverHasBeenShownAction
+  | AppStateControllerSetRecoveryPhraseReminderHasBeenShownAction
+  | AppStateControllerSetSurveyLinkLastClickedOrClosedAction
+  | AppStateControllerSetOnboardingDateAction
+  | AppStateControllerSetLastViewedUserSurveyAction
+  | AppStateControllerSetRampCardClosedAction
+  | AppStateControllerSetNewPrivacyPolicyToastClickedOrClosedAction
+  | AppStateControllerSetNewPrivacyPolicyToastShownDateAction
+  | AppStateControllerSetPna25AcknowledgedAction
+  | AppStateControllerSetShieldPausedToastLastClickedOrClosedAction
+  | AppStateControllerSetShieldEndingToastLastClickedOrClosedAction
+  | AppStateControllerSetShieldSubscriptionErrorAction
+  | AppStateControllerSetStorageWriteErrorTypeAction
+  | AppStateControllerUpdateSlidesAction
+  | AppStateControllerRemoveSlideAction
+  | AppStateControllerSetRecoveryPhraseReminderLastShownAction
+  | AppStateControllerSetTermsOfUseLastAgreedAction
+  | AppStateControllerSetSnapsInstallPrivacyWarningShownStatusAction
+  | AppStateControllerSetOutdatedBrowserWarningLastShownAction
+  | AppStateControllerSetLastActiveTimeAction
+  | AppStateControllerSetPendingExtensionVersionAction
+  | AppStateControllerSetUpdateModalLastDismissedAtAction
+  | AppStateControllerSetLastUpdatedAtAction
+  | AppStateControllerSetLastUpdatedFromVersionAction
+  | AppStateControllerSetBrowserEnvironmentAction
+  | AppStateControllerAddPollingTokenAction
+  | AppStateControllerRemovePollingTokenAction
+  | AppStateControllerClearPollingTokensAction
+  | AppStateControllerSetShowTestnetMessageInDropdownAction
+  | AppStateControllerSetShowBetaHeaderAction
+  | AppStateControllerSetShowPermissionsTourAction
+  | AppStateControllerSetHasShownMultichainAccountsIntroModalAction
+  | AppStateControllerSetMusdConversionEducationSeenAction
+  | AppStateControllerAddMusdConversionDismissedCtaKeyAction
+  | AppStateControllerSetProductTourAction
+  | AppStateControllerSetShowNetworkBannerAction
+  | AppStateControllerUpdateNetworkConnectionBannerAction
+  | AppStateControllerSetShowAccountBannerAction
+  | AppStateControllerSetCurrentExtensionPopupIdAction
+  | AppStateControllerSetTrezorModelAction
+  | AppStateControllerUpdateNftDropDownStateAction
+  | AppStateControllerGetSignatureSecurityAlertResponseAction
+  | AppStateControllerAddSignatureSecurityAlertResponseAction
+  | AppStateControllerSetCurrentPopupIdAction
+  | AppStateControllerGetLastInteractedConfirmationInfoAction
+  | AppStateControllerSetLastInteractedConfirmationInfoAction
+  | AppStateControllerGetCurrentPopupIdAction
+  | AppStateControllerGetThrottledOriginStateAction
+  | AppStateControllerUpdateThrottledOriginStateAction
+  | AppStateControllerCompleteQrCodeScanAction
+  | AppStateControllerCancelQrCodeScanAction
+  | AppStateControllerRequestQrCodeScanAction
+  | AppStateControllerSetAppActiveTabAction
+  | AppStateControllerClearAppActiveTabAction
+  | AppStateControllerSetShowShieldEntryModalOnceAction
+  | AppStateControllerSetPendingRedirectRouteAction
+  | AppStateControllerSetPendingShieldCohortAction
+  | AppStateControllerSetCanTrackWalletFundsObtainedAction
+  | AppStateControllerSetIsWalletResetInProgressAction
+  | AppStateControllerGetIsWalletResetInProgressAction
+  | AppStateControllerSetDefaultSubscriptionPaymentOptionsAction
+  | AppStateControllerSetShieldSubscriptionMetricsPropsAction
+  | AppStateControllerDeleteDappSwapComparisonDataAction
+  | AppStateControllerSetDappSwapComparisonDataAction
+  | AppStateControllerGetDappSwapComparisonDataAction
+  | AppStateControllerSetDeferredDeepLinkAction
+  | AppStateControllerRemoveDeferredDeepLinkAction
+  | AppStateControllerAddAddressSecurityAlertResponseAction
+  | AppStateControllerGetAddressSecurityAlertResponseAction;

--- a/app/scripts/controllers/app-state-controller.ts
+++ b/app/scripts/controllers/app-state-controller.ts
@@ -68,6 +68,7 @@ import type {
   PreferencesControllerGetStateAction,
   PreferencesControllerStateChangeEvent,
 } from './preferences-controller';
+import { AppStateControllerMethodActions } from './app-state-controller-method-action-types';
 
 export type DappSwapComparisonData = {
   quotes?: QuoteResponse[];
@@ -193,47 +194,12 @@ export type AppStateControllerGetStateAction = ControllerGetStateAction<
   AppStateControllerState
 >;
 
-export type AppStateControllerGetUnlockPromiseAction = {
-  type: 'AppStateController:getUnlockPromise';
-  handler: (shouldShowUnlockRequest: boolean) => Promise<void>;
-};
-
-export type AppStateControllerRequestQrCodeScanAction = {
-  type: 'AppStateController:requestQrCodeScan';
-  handler: (request: QrScanRequest) => Promise<SerializedUR>;
-};
-
-export type AppStateControllerSetCanTrackWalletFundsObtainedAction = {
-  type: 'AppStateController:setCanTrackWalletFundsObtained';
-  handler: AppStateController['setCanTrackWalletFundsObtained'];
-};
-
-export type AppStateControllerSetPendingShieldCohortAction = {
-  type: 'AppStateController:setPendingShieldCohort';
-  handler: AppStateController['setPendingShieldCohort'];
-};
-
-export type AppStateControllerSetPendingRedirectRouteAction = {
-  type: 'AppStateController:setPendingRedirectRoute';
-  handler: AppStateController['setPendingRedirectRoute'];
-};
-
-export type AppStateControllerSetShieldSubscriptionErrorAction = {
-  type: 'AppStateController:setShieldSubscriptionError';
-  handler: AppStateController['setShieldSubscriptionError'];
-};
-
 /**
  * Actions exposed by the {@link AppStateController}.
  */
 export type AppStateControllerActions =
   | AppStateControllerGetStateAction
-  | AppStateControllerGetUnlockPromiseAction
-  | AppStateControllerRequestQrCodeScanAction
-  | AppStateControllerSetCanTrackWalletFundsObtainedAction
-  | AppStateControllerSetPendingShieldCohortAction
-  | AppStateControllerSetPendingRedirectRouteAction
-  | AppStateControllerSetShieldSubscriptionErrorAction;
+  | AppStateControllerMethodActions;
 
 /**
  * Actions that this controller is allowed to call.
@@ -754,6 +720,80 @@ const controllerMetadata: StateMetadata<AppStateControllerState> = {
   },
 };
 
+const MESSENGER_EXPOSED_METHODS = [
+  'addAddressSecurityAlertResponse',
+  'addMusdConversionDismissedCtaKey',
+  'addPollingToken',
+  'addSignatureSecurityAlertResponse',
+  'cancelQrCodeScan',
+  'clearAppActiveTab',
+  'clearPollingTokens',
+  'completeQrCodeScan',
+  'deleteDappSwapComparisonData',
+  'getAddressSecurityAlertResponse',
+  'getCurrentPopupId',
+  'getDappSwapComparisonData',
+  'getIsWalletResetInProgress',
+  'getLastInteractedConfirmationInfo',
+  'getSignatureSecurityAlertResponse',
+  'getThrottledOriginState',
+  'getUnlockPromise',
+  'removeDeferredDeepLink',
+  'removePollingToken',
+  'removeSlide',
+  'requestQrCodeScan',
+  'setAppActiveTab',
+  'setBrowserEnvironment',
+  'setCanTrackWalletFundsObtained',
+  'setConnectedStatusPopoverHasBeenShown',
+  'setCurrentExtensionPopupId',
+  'setCurrentPopupId',
+  'setDappSwapComparisonData',
+  'setDefaultHomeActiveTabName',
+  'setDefaultSubscriptionPaymentOptions',
+  'setDeferredDeepLink',
+  'setHasShownMultichainAccountsIntroModal',
+  'setIsWalletResetInProgress',
+  'setLastActiveTime',
+  'setLastInteractedConfirmationInfo',
+  'setLastUpdatedAt',
+  'setLastUpdatedFromVersion',
+  'setLastViewedUserSurvey',
+  'setMusdConversionEducationSeen',
+  'setNewPrivacyPolicyToastClickedOrClosed',
+  'setNewPrivacyPolicyToastShownDate',
+  'setOnboardingDate',
+  'setOutdatedBrowserWarningLastShown',
+  'setPendingExtensionVersion',
+  'setPendingRedirectRoute',
+  'setPendingShieldCohort',
+  'setPna25Acknowledged',
+  'setProductTour',
+  'setRampCardClosed',
+  'setRecoveryPhraseReminderHasBeenShown',
+  'setRecoveryPhraseReminderLastShown',
+  'setShieldEndingToastLastClickedOrClosed',
+  'setShieldPausedToastLastClickedOrClosed',
+  'setShieldSubscriptionError',
+  'setShieldSubscriptionMetricsProps',
+  'setShowAccountBanner',
+  'setShowBetaHeader',
+  'setShowNetworkBanner',
+  'setShowPermissionsTour',
+  'setShowShieldEntryModalOnce',
+  'setShowTestnetMessageInDropdown',
+  'setSnapsInstallPrivacyWarningShownStatus',
+  'setStorageWriteErrorType',
+  'setSurveyLinkLastClickedOrClosed',
+  'setTermsOfUseLastAgreed',
+  'setTrezorModel',
+  'setUpdateModalLastDismissedAt',
+  'updateNetworkConnectionBanner',
+  'updateNftDropDownState',
+  'updateSlides',
+  'updateThrottledOriginState',
+] as const;
+
 export class AppStateController extends BaseController<
   typeof controllerName,
   AppStateControllerState,
@@ -819,34 +859,9 @@ export class AppStateController extends BaseController<
       this.#setInactiveTimeout(preferences.autoLockTimeLimit);
     }
 
-    this.messenger.registerActionHandler(
-      'AppStateController:getUnlockPromise',
-      this.getUnlockPromise.bind(this),
-    );
-
-    this.messenger.registerActionHandler(
-      'AppStateController:requestQrCodeScan',
-      this.#requestQrCodeScan.bind(this),
-    );
-
-    this.messenger.registerActionHandler(
-      'AppStateController:setCanTrackWalletFundsObtained',
-      this.setCanTrackWalletFundsObtained.bind(this),
-    );
-
-    this.messenger.registerActionHandler(
-      'AppStateController:setPendingShieldCohort',
-      this.setPendingShieldCohort.bind(this),
-    );
-
-    this.messenger.registerActionHandler(
-      'AppStateController:setPendingRedirectRoute',
-      this.setPendingRedirectRoute.bind(this),
-    );
-
-    this.messenger.registerActionHandler(
-      'AppStateController:setShieldSubscriptionError',
-      this.setShieldSubscriptionError.bind(this),
+    this.messenger.registerMethodActionHandlers(
+      this,
+      MESSENGER_EXPOSED_METHODS,
     );
 
     this.#approvalRequestId = null;
@@ -1665,7 +1680,7 @@ export class AppStateController extends BaseController<
    * @param request - The QR code scan request.
    * @returns The scanned QR code data.
    */
-  #requestQrCodeScan(request: QrScanRequest): Promise<SerializedUR> {
+  requestQrCodeScan(request: QrScanRequest): Promise<SerializedUR> {
     if (this.#qrCodeScanPromise) {
       return this.#qrCodeScanPromise.promise;
     }

--- a/app/scripts/controllers/permissions/snaps/specifications.ts
+++ b/app/scripts/controllers/permissions/snaps/specifications.ts
@@ -31,7 +31,7 @@ import {
 } from '../../../../../shared/constants/snaps/permissions';
 import { PreferencesControllerGetStateAction } from '../../preferences-controller';
 import { KeyringType } from '../../../../../shared/constants/keyring';
-import { AppStateControllerGetUnlockPromiseAction } from '../../app-state-controller';
+import { AppStateControllerGetUnlockPromiseAction } from '../../app-state-controller-method-action-types';
 import { RootMessenger } from '../../../lib/messenger';
 import { getMnemonic, getMnemonicSeed } from './utils';
 

--- a/app/scripts/lib/WalletFundsObtainedMonitor.ts
+++ b/app/scripts/lib/WalletFundsObtainedMonitor.ts
@@ -13,7 +13,7 @@ import log from 'loglevel';
 import { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
 import { AssetsControllerGetStateAction } from '@metamask/assets-controller';
 import type { MetaMetricsControllerTrackEventAction } from '../controllers/metametrics-controller';
-import type { AppStateControllerSetCanTrackWalletFundsObtainedAction } from '../controllers/app-state-controller';
+import type { AppStateControllerSetCanTrackWalletFundsObtainedAction } from '../controllers/app-state-controller-method-action-types';
 import type { OnboardingControllerGetStateAction } from '../controllers/onboarding';
 import {
   hasNonZeroTokenBalance,

--- a/app/scripts/messenger-client-init/app-state-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/app-state-controller-init.test.ts
@@ -1,11 +1,11 @@
-import { AppStateController } from '../controllers/app-state-controller';
+import {
+  AppStateController,
+  AppStateControllerMessenger,
+} from '../controllers/app-state-controller';
 import { getRootMessenger } from '../lib/messenger';
 import { ControllerInitRequest } from './types';
 import { buildControllerInitRequestMock } from './test/utils';
-import {
-  getAppStateControllerMessenger,
-  AppStateControllerMessenger,
-} from './messengers';
+import { getAppStateControllerMessenger } from './messengers';
 import { AppStateControllerInit } from './app-state-controller-init';
 
 jest.mock('../controllers/app-state-controller');

--- a/app/scripts/messenger-client-init/keyring-controller-init.ts
+++ b/app/scripts/messenger-client-init/keyring-controller-init.ts
@@ -60,7 +60,6 @@ export const KeyringControllerInit: ControllerInitFunction<
       keyringOverrides?.qrBridge || QrKeyringScannerBridge,
       {
         requestScan: async (request) =>
-          // @ts-expect-error type mismatch
           initMessenger.call('AppStateController:requestQrCodeScan', request),
       },
     ),

--- a/app/scripts/messenger-client-init/keyring-controller-init.ts
+++ b/app/scripts/messenger-client-init/keyring-controller-init.ts
@@ -60,6 +60,7 @@ export const KeyringControllerInit: ControllerInitFunction<
       keyringOverrides?.qrBridge || QrKeyringScannerBridge,
       {
         requestScan: async (request) =>
+          // @ts-expect-error type mismatch
           initMessenger.call('AppStateController:requestQrCodeScan', request),
       },
     ),

--- a/app/scripts/messenger-client-init/messengers/app-state-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/app-state-controller-messenger.ts
@@ -1,13 +1,10 @@
-import { Messenger } from '@metamask/messenger';
 import {
-  AllowedActions,
-  AllowedEvents,
-} from '../../controllers/app-state-controller';
+  Messenger,
+  MessengerActions,
+  MessengerEvents,
+} from '@metamask/messenger';
+import { AppStateControllerMessenger } from '../../controllers/app-state-controller';
 import { RootMessenger } from '../../lib/messenger';
-
-export type AppStateControllerMessenger = ReturnType<
-  typeof getAppStateControllerMessenger
->;
 
 /**
  * Create a messenger restricted to the allowed actions and events of the
@@ -16,16 +13,17 @@ export type AppStateControllerMessenger = ReturnType<
  * @param messenger - The base messenger used to create the restricted
  * messenger.
  */
-export function getAppStateControllerMessenger(messenger: RootMessenger) {
-  const appStateControllerMessenger = new Messenger<
-    'AppStateController',
-    AllowedActions,
-    AllowedEvents,
-    RootMessenger
-  >({
-    namespace: 'AppStateController',
-    parent: messenger,
-  });
+export function getAppStateControllerMessenger(
+  messenger: RootMessenger<
+    MessengerActions<AppStateControllerMessenger>,
+    MessengerEvents<AppStateControllerMessenger>
+  >,
+) {
+  const appStateControllerMessenger: AppStateControllerMessenger =
+    new Messenger({
+      namespace: 'AppStateController',
+      parent: messenger,
+    });
   messenger.delegate({
     messenger: appStateControllerMessenger,
     actions: [

--- a/app/scripts/messenger-client-init/messengers/index.ts
+++ b/app/scripts/messenger-client-init/messengers/index.ts
@@ -230,7 +230,6 @@ export type { AnnouncementControllerMessenger } from './announcement-controller-
 export { getAnnouncementControllerMessenger } from './announcement-controller-messenger';
 export type { AppMetadataControllerMessenger } from './app-metadata-controller-messenger';
 export { getAppMetadataControllerMessenger } from './app-metadata-controller-messenger';
-export type { AppStateControllerMessenger } from './app-state-controller-messenger';
 export { getAppStateControllerMessenger } from './app-state-controller-messenger';
 export type { ApprovalControllerMessenger } from './approval-controller-messenger';
 export { getApprovalControllerMessenger } from './approval-controller-messenger';

--- a/app/scripts/messenger-client-init/messengers/keyring-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/keyring-controller-messenger.ts
@@ -1,5 +1,5 @@
 import { Messenger } from '@metamask/messenger';
-import { AppStateControllerRequestQrCodeScanAction } from '../../controllers/app-state-controller';
+import { AppStateControllerRequestQrCodeScanAction } from '../../controllers/app-state-controller-method-action-types';
 import { RootMessenger } from '../../lib/messenger';
 
 export type KeyringControllerMessenger = ReturnType<

--- a/app/scripts/services/subscription/types.ts
+++ b/app/scripts/services/subscription/types.ts
@@ -25,12 +25,12 @@ import { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feat
 import ExtensionPlatform from '../../platforms/extension';
 import { WebAuthenticator } from '../oauth/types';
 import { PreferencesControllerGetStateAction } from '../../controllers/preferences-controller';
+import { AppStateControllerGetStateAction } from '../../controllers/app-state-controller';
 import {
-  AppStateControllerGetStateAction,
   AppStateControllerSetPendingShieldCohortAction,
   AppStateControllerSetPendingRedirectRouteAction,
   AppStateControllerSetShieldSubscriptionErrorAction,
-} from '../../controllers/app-state-controller';
+} from '../../controllers/app-state-controller-method-action-types';
 import { MetaMetricsControllerTrackEventAction } from '../../controllers/metametrics-controller';
 import {
   RewardsControllerGetHasAccountOptedInAction,


### PR DESCRIPTION
## **Description**

This PR updates the `AppStateController` to use `registerMethodActionHandlers` and `MESSENGER_EXPOSED_METHODS` to register actions.

It also exposes all the missing public methods that are used across the codebase as messenger actions.

## **Changelog**

CHANGELOG entry:null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the controller-messenger boundary and the list of exposed actions, so misregistration or naming mismatches could break cross-module calls at runtime, but behavior is otherwise largely a refactor.
> 
> **Overview**
> Refactors `AppStateController` to expose its public methods over the messenger via `registerMethodActionHandlers` and a centralized `MESSENGER_EXPOSED_METHODS` allowlist, replacing several ad-hoc `registerActionHandler` calls.
> 
> Adds an auto-generated `app-state-controller-method-action-types.ts` defining the full union of method action types, updates `AppStateControllerActions` to use this union, and adjusts dependent modules (Snaps permissions, keyring init messenger, subscription service, and `WalletFundsObtainedMonitor`) to import the moved action types. Also promotes `#requestQrCodeScan` to the public `requestQrCodeScan` method so it can be registered and called via the messenger, and tightens `getAppStateControllerMessenger` typing to use `MessengerActions`/`MessengerEvents`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 054259379af1ec77b0eaf795468aa78f78008b4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->