### PR TITLE
chore: Bulk register actions in `DecryptMessageController`

### DIFF
--- a/app/scripts/controllers/decrypt-message-method-action-types.ts
+++ b/app/scripts/controllers/decrypt-message-method-action-types.ts
@@ -1,0 +1,90 @@
+/**
+ * This file is auto generated.
+ * Do not edit manually.
+ */
+
+import type { DecryptMessageController } from './decrypt-message';
+
+/**
+ * Reset the controller state to the initial state.
+ */
+export type DecryptMessageControllerResetStateAction = {
+  type: `DecryptMessageController:resetState`;
+  handler: DecryptMessageController['resetState'];
+};
+
+/**
+ * Clears all unapproved messages from memory.
+ */
+export type DecryptMessageControllerClearUnapprovedAction = {
+  type: `DecryptMessageController:clearUnapproved`;
+  handler: DecryptMessageController['clearUnapproved'];
+};
+
+/**
+ * Called when a dapp uses the eth_decrypt method
+ *
+ * @param messageParams - The params passed to eth_decrypt.
+ * @param req - The original request, containing the origin.
+ * @returns Promise resolving to the raw data of the signature request.
+ */
+export type DecryptMessageControllerNewRequestDecryptMessageAction = {
+  type: `DecryptMessageController:newRequestDecryptMessage`;
+  handler: DecryptMessageController['newRequestDecryptMessage'];
+};
+
+/**
+ * Signifies a user's approval to decrypt a message in queue.
+ * Triggers decrypt, and the callback function from newUnsignedDecryptMessage.
+ *
+ * @param messageParams - The params of the message to decrypt & return to the Dapp.
+ * @returns A full state update.
+ */
+export type DecryptMessageControllerDecryptMessageAction = {
+  type: `DecryptMessageController:decryptMessage`;
+  handler: DecryptMessageController['decryptMessage'];
+};
+
+/**
+ * Only decrypt message and don't touch transaction state
+ *
+ * @param messageParams - The params of the message to decrypt.
+ * @returns A full state update.
+ */
+export type DecryptMessageControllerDecryptMessageInlineAction = {
+  type: `DecryptMessageController:decryptMessageInline`;
+  handler: DecryptMessageController['decryptMessageInline'];
+};
+
+/**
+ * Used to cancel a eth_decrypt type message.
+ *
+ * @param messageId - The ID of the message to cancel.
+ * @returns A full state update.
+ */
+export type DecryptMessageControllerCancelDecryptMessageAction = {
+  type: `DecryptMessageController:cancelDecryptMessage`;
+  handler: DecryptMessageController['cancelDecryptMessage'];
+};
+
+/**
+ * Reject all unapproved messages of any type.
+ *
+ * @param reason - A message to indicate why.
+ */
+export type DecryptMessageControllerRejectUnapprovedAction = {
+  type: `DecryptMessageController:rejectUnapproved`;
+  handler: DecryptMessageController['rejectUnapproved'];
+};
+
+/**
+ * Union of all DecryptMessageController action types.
+ */
+export type DecryptMessageControllerMethodActions =
+  | DecryptMessageControllerResetStateAction
+  | DecryptMessageControllerClearUnapprovedAction
+  | DecryptMessageControllerNewRequestDecryptMessageAction
+  | DecryptMessageControllerDecryptMessageAction
+  | DecryptMessageControllerDecryptMessageInlineAction
+  | DecryptMessageControllerCancelDecryptMessageAction
+  | DecryptMessageControllerRejectUnapprovedAction;

--- a/app/scripts/controllers/decrypt-message.test.ts
+++ b/app/scripts/controllers/decrypt-message.test.ts
@@ -38,6 +38,7 @@ const createKeyringControllerMock = () => ({
 const createMessengerMock = () =>
   ({
     registerActionHandler: jest.fn(),
+    registerMethodActionHandlers: jest.fn(),
     registerInitialEventPayload: jest.fn(),
     subscribe: jest.fn(),
     publish: jest.fn(),

--- a/app/scripts/controllers/decrypt-message.test.ts
+++ b/app/scripts/controllers/decrypt-message.test.ts
@@ -5,7 +5,8 @@ import {
 } from '@metamask/message-manager';
 import type { DecryptMessageManagerMessenger } from '@metamask/message-manager';
 import { MetaMetricsEventCategory } from '../../../shared/constants/metametrics';
-import DecryptMessageController, {
+import {
+  DecryptMessageController,
   DecryptMessageControllerMessenger,
   DecryptMessageControllerOptions,
   getDefaultState,

--- a/app/scripts/controllers/decrypt-message.ts
+++ b/app/scripts/controllers/decrypt-message.ts
@@ -13,7 +13,11 @@ import type {
   DecryptMessageManagerState,
   DecryptMessageManagerUnapprovedMessageAddedEvent,
 } from '@metamask/message-manager';
-import { BaseController, StateMetadata } from '@metamask/base-controller';
+import {
+  BaseController,
+  ControllerGetStateAction,
+  StateMetadata,
+} from '@metamask/base-controller';
 import { Messenger } from '@metamask/messenger';
 import {
   ApprovalControllerAcceptRequestAction,
@@ -29,6 +33,7 @@ import { stripHexPrefix } from '../../../shared/lib/hexstring-utils';
 // This import is only used for the type.
 // eslint-disable-next-line import-x/no-restricted-paths
 import type { MetaMaskReduxState } from '../../../ui/store/store';
+import { DecryptMessageControllerMethodActions } from './decrypt-message-method-action-types';
 
 const controllerName = 'DecryptMessageController';
 
@@ -99,17 +104,19 @@ export type DecryptMessageControllerState = {
   unapprovedDecryptMsgCount: number;
 };
 
-export type GetDecryptMessageControllerState = {
-  type: `${typeof controllerName}:getState`;
-  handler: () => DecryptMessageControllerState;
-};
+export type DecryptMessageControllerGetStateAction = ControllerGetStateAction<
+  typeof controllerName,
+  DecryptMessageControllerState
+>;
 
 export type DecryptMessageControllerStateChange = {
   type: `${typeof controllerName}:stateChange`;
   payload: [DecryptMessageControllerState, Patch[]];
 };
 
-export type DecryptMessageControllerActions = GetDecryptMessageControllerState;
+export type DecryptMessageControllerActions =
+  | DecryptMessageControllerGetStateAction
+  | DecryptMessageControllerMethodActions;
 
 export type DecryptMessageControllerEvents =
   DecryptMessageControllerStateChange;
@@ -145,10 +152,20 @@ export type DecryptMessageControllerOptions = {
   metricsEvent: (payload: any, options?: any) => void;
 };
 
+const MESSENGER_EXPOSED_METHODS = [
+  'resetState',
+  'clearUnapproved',
+  'newRequestDecryptMessage',
+  'decryptMessage',
+  'decryptMessageInline',
+  'cancelDecryptMessage',
+  'rejectUnapproved',
+] as const;
+
 /**
  * Controller for decrypt signing requests requiring user approval.
  */
-export default class DecryptMessageController extends BaseController<
+export class DecryptMessageController extends BaseController<
   typeof controllerName,
   DecryptMessageControllerState,
   DecryptMessageControllerMessenger
@@ -197,6 +214,11 @@ export default class DecryptMessageController extends BaseController<
         state.unapprovedDecryptMsgs = newMessages;
         state.unapprovedDecryptMsgCount = messageCount;
       },
+    );
+
+    this.messenger.registerMethodActionHandlers(
+      this,
+      MESSENGER_EXPOSED_METHODS,
     );
   }
 

--- a/app/scripts/messenger-client-init/confirmations/decrypt-message-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/confirmations/decrypt-message-controller-init.test.ts
@@ -1,9 +1,11 @@
-import DecryptMessageController from '../../controllers/decrypt-message';
+import {
+  DecryptMessageController,
+  DecryptMessageControllerMessenger,
+} from '../../controllers/decrypt-message';
 import { ControllerInitRequest } from '../types';
 import { buildControllerInitRequestMock } from '../test/utils';
 import {
   getDecryptMessageControllerMessenger,
-  DecryptMessageControllerMessenger,
   getDecryptMessageControllerInitMessenger,
 } from '../messengers';
 import { getRootMessenger } from '../../lib/messenger';

--- a/app/scripts/messenger-client-init/confirmations/decrypt-message-controller-init.ts
+++ b/app/scripts/messenger-client-init/confirmations/decrypt-message-controller-init.ts
@@ -1,6 +1,8 @@
-import DecryptMessageController from '../../controllers/decrypt-message';
+import {
+  DecryptMessageController,
+  DecryptMessageControllerMessenger,
+} from '../../controllers/decrypt-message';
 import { ControllerInitFunction } from '../types';
-import { DecryptMessageControllerMessenger } from '../messengers';
 import { DecryptMessageControllerInitMessenger } from '../messengers/decrypt-message-controller-messenger';
 
 /**

--- a/app/scripts/messenger-client-init/controller-list.ts
+++ b/app/scripts/messenger-client-init/controller-list.ts
@@ -105,7 +105,7 @@ import { AccountOrderController } from '../controllers/account-order';
 import { AlertController } from '../controllers/alert-controller';
 import { MetaMetricsDataDeletionController } from '../controllers/metametrics-data-deletion/metametrics-data-deletion';
 import { AppMetadataController } from '../controllers/app-metadata';
-import DecryptMessageController from '../controllers/decrypt-message';
+import { DecryptMessageController } from '../controllers/decrypt-message';
 import EncryptionPublicKeyController from '../controllers/encryption-public-key';
 import { RewardsDataService } from '../controllers/rewards/rewards-data-service';
 import { RewardsController } from '../controllers/rewards/rewards-controller';

--- a/app/scripts/messenger-client-init/messengers/decrypt-message-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/decrypt-message-controller-messenger.ts
@@ -1,14 +1,11 @@
-import { Messenger } from '@metamask/messenger';
 import {
-  AllowedActions,
-  AllowedEvents,
-} from '../../controllers/decrypt-message';
+  Messenger,
+  MessengerActions,
+  MessengerEvents,
+} from '@metamask/messenger';
+import { DecryptMessageControllerMessenger } from '../../controllers/decrypt-message';
 import { MetaMetricsControllerTrackEventAction } from '../../controllers/metametrics-controller';
 import { RootMessenger } from '../../lib/messenger';
-
-export type DecryptMessageControllerMessenger = ReturnType<
-  typeof getDecryptMessageControllerMessenger
->;
 
 /**
  * Create a messenger restricted to the allowed actions and events of the
@@ -18,14 +15,12 @@ export type DecryptMessageControllerMessenger = ReturnType<
  * messenger.
  */
 export function getDecryptMessageControllerMessenger(
-  messenger: RootMessenger<AllowedActions, AllowedEvents>,
+  messenger: RootMessenger<
+    MessengerActions<DecryptMessageControllerMessenger>,
+    MessengerEvents<DecryptMessageControllerMessenger>
+  >,
 ) {
-  const controllerMessenger = new Messenger<
-    'DecryptMessageController',
-    AllowedActions,
-    AllowedEvents,
-    typeof messenger
-  >({
+  const controllerMessenger: DecryptMessageControllerMessenger = new Messenger({
     namespace: 'DecryptMessageController',
     parent: messenger,
   });

--- a/app/scripts/messenger-client-init/messengers/index.ts
+++ b/app/scripts/messenger-client-init/messengers/index.ts
@@ -245,7 +245,6 @@ export {
   getCurrencyRateControllerMessenger,
   getCurrencyRateControllerInitMessenger,
 } from './currency-rate-controller-messenger';
-export type { DecryptMessageControllerMessenger } from './decrypt-message-controller-messenger';
 export {
   getDecryptMessageControllerMessenger,
   getDecryptMessageControllerInitMessenger,


### PR DESCRIPTION
## **Description**

This PR updates the `DecryptMessage` to use `registerMethodActionHandlers` and `MESSENGER_EXPOSED_METHODS` to register actions.

## **Changelog**

CHANGELOG entry:null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `DecryptMessageController` exposes messenger actions by switching to bulk method registration; if the exposed method list or types are wrong, decrypt approvals/cancellation flows could break at runtime.
> 
> **Overview**
> **Updates `DecryptMessageController` to bulk-register its messenger method actions.** The controller now declares `MESSENGER_EXPOSED_METHODS` and calls `messenger.registerMethodActionHandlers`, with a new auto-generated `decrypt-message-method-action-types.ts` used to type the exposed method actions.
> 
> Related wiring is adjusted to match the new export/typing shape: `DecryptMessageController` is now a named export (not default), `getState` action typing is standardized via `ControllerGetStateAction`, messenger init/import sites are updated, and the decrypt-message controller messenger is retyped using `MessengerActions`/`MessengerEvents`. Tests are updated to mock `registerMethodActionHandlers` and new import paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77fa3845131261752c200b2a87009396c4c5f3a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->