### PR TITLE
fix(perps): use correct copy for margin toasts

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5851,8 +5851,8 @@
     "description": "$1 is the formatted PnL percentage for a closed position"
   },
   "perpsToastMarginAddSuccess": {
-    "message": "Added $1 $2 margin",
-    "description": "$1 is the amount and $2 is the asset symbol for successful margin addition"
+    "message": "Added $1 margin to $2 position",
+    "description": "$1 is the dollar-prefixed amount (e.g. $100) and $2 is the asset symbol for successful margin addition"
   },
   "perpsToastMarginAdjustmentFailed": {
     "message": "Margin adjustment failed",
@@ -5863,8 +5863,8 @@
     "description": "Fallback description shown when margin adjustment fails without a usable error message."
   },
   "perpsToastMarginRemoveSuccess": {
-    "message": "Removed $1 $2 margin",
-    "description": "$1 is the amount and $2 is the asset symbol for successful margin removal"
+    "message": "Removed $1 margin from $2 position",
+    "description": "$1 is the dollar-prefixed amount (e.g. $100) and $2 is the asset symbol for successful margin removal"
   },
   "perpsToastOrderFailed": {
     "message": "Order failed",

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -5851,8 +5851,8 @@
     "description": "$1 is the formatted PnL percentage for a closed position"
   },
   "perpsToastMarginAddSuccess": {
-    "message": "Added $1 $2 margin",
-    "description": "$1 is the amount and $2 is the asset symbol for successful margin addition"
+    "message": "Added $1 margin to $2 position",
+    "description": "$1 is the dollar-prefixed amount (e.g. $100) and $2 is the asset symbol for successful margin addition"
   },
   "perpsToastMarginAdjustmentFailed": {
     "message": "Margin adjustment failed",
@@ -5863,8 +5863,8 @@
     "description": "Fallback description shown when margin adjustment fails without a usable error message."
   },
   "perpsToastMarginRemoveSuccess": {
-    "message": "Removed $1 $2 margin",
-    "description": "$1 is the amount and $2 is the asset symbol for successful margin removal"
+    "message": "Removed $1 margin from $2 position",
+    "description": "$1 is the dollar-prefixed amount (e.g. $100) and $2 is the asset symbol for successful margin removal"
   },
   "perpsToastOrderFailed": {
     "message": "Order failed",

--- a/ui/components/app/perps/edit-margin/edit-margin-expandable.test.tsx
+++ b/ui/components/app/perps/edit-margin/edit-margin-expandable.test.tsx
@@ -192,7 +192,7 @@ describe('EditMarginExpandable', () => {
       });
       expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith({
         key: 'perpsToastMarginAddSuccess',
-        messageParams: ['100', 'ETH'],
+        messageParams: ['$100', 'ETH'],
       });
     });
 
@@ -246,7 +246,7 @@ describe('EditMarginExpandable', () => {
 
       expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith({
         key: 'perpsToastMarginRemoveSuccess',
-        messageParams: ['50', 'ETH'],
+        messageParams: ['$50', 'ETH'],
       });
     });
   });

--- a/ui/components/app/perps/edit-margin/edit-margin-modal-content.tsx
+++ b/ui/components/app/perps/edit-margin/edit-margin-modal-content.tsx
@@ -282,7 +282,7 @@ export const EditMarginModalContent: React.FC<EditMarginModalContentProps> = ({
           marginMode === 'add'
             ? PERPS_TOAST_KEYS.MARGIN_ADD_SUCCESS
             : PERPS_TOAST_KEYS.MARGIN_REMOVE_SUCCESS,
-        messageParams: [marginAmount, displaySymbol],
+        messageParams: [`$${marginAmount}`, displaySymbol],
       });
 
       setMarginAmount('');

--- a/ui/components/app/perps/perps-toast/perps-toast-provider.test.tsx
+++ b/ui/components/app/perps/perps-toast/perps-toast-provider.test.tsx
@@ -580,14 +580,18 @@ describe('PerpsToastProvider', () => {
     fireEvent.click(
       screen.getByRole('button', { name: 'Show Key Margin Add Success' }),
     );
-    expect(screen.getByText('Added $100 margin to ETH position')).toBeInTheDocument();
+    expect(
+      screen.getByText('Added $100 margin to ETH position'),
+    ).toBeInTheDocument();
     expectSuccessToastIcon();
 
     act(() => {
       jest.advanceTimersByTime(3000);
     });
 
-    expect(screen.queryByText('Added $100 margin to ETH position')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Added $100 margin to ETH position'),
+    ).not.toBeInTheDocument();
   });
 
   it('maps margin remove success key to success variant with auto-hide', () => {
@@ -603,14 +607,18 @@ describe('PerpsToastProvider', () => {
     fireEvent.click(
       screen.getByRole('button', { name: 'Show Key Margin Remove Success' }),
     );
-    expect(screen.getByText('Removed $50 margin from ETH position')).toBeInTheDocument();
+    expect(
+      screen.getByText('Removed $50 margin from ETH position'),
+    ).toBeInTheDocument();
     expectSuccessToastIcon();
 
     act(() => {
       jest.advanceTimersByTime(3000);
     });
 
-    expect(screen.queryByText('Removed $50 margin from ETH position')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Removed $50 margin from ETH position'),
+    ).not.toBeInTheDocument();
   });
 
   it('maps margin adjustment failed key to error variant with auto-hide', () => {

--- a/ui/components/app/perps/perps-toast/perps-toast-provider.test.tsx
+++ b/ui/components/app/perps/perps-toast/perps-toast-provider.test.tsx
@@ -122,7 +122,7 @@ const ToastHarness = () => {
         onClick={() => {
           replacePerpsToastByKey({
             key: PERPS_TOAST_KEYS.MARGIN_ADD_SUCCESS,
-            messageParams: ['100', 'ETH'],
+            messageParams: ['$100', 'ETH'],
           });
         }}
       >
@@ -144,7 +144,7 @@ const ToastHarness = () => {
         onClick={() => {
           replacePerpsToastByKey({
             key: PERPS_TOAST_KEYS.MARGIN_REMOVE_SUCCESS,
-            messageParams: ['50', 'ETH'],
+            messageParams: ['$50', 'ETH'],
           });
         }}
       >
@@ -580,14 +580,14 @@ describe('PerpsToastProvider', () => {
     fireEvent.click(
       screen.getByRole('button', { name: 'Show Key Margin Add Success' }),
     );
-    expect(screen.getByText('Added 100 ETH margin')).toBeInTheDocument();
+    expect(screen.getByText('Added $100 margin to ETH position')).toBeInTheDocument();
     expectSuccessToastIcon();
 
     act(() => {
       jest.advanceTimersByTime(3000);
     });
 
-    expect(screen.queryByText('Added 100 ETH margin')).not.toBeInTheDocument();
+    expect(screen.queryByText('Added $100 margin to ETH position')).not.toBeInTheDocument();
   });
 
   it('maps margin remove success key to success variant with auto-hide', () => {
@@ -603,14 +603,14 @@ describe('PerpsToastProvider', () => {
     fireEvent.click(
       screen.getByRole('button', { name: 'Show Key Margin Remove Success' }),
     );
-    expect(screen.getByText('Removed 50 ETH margin')).toBeInTheDocument();
+    expect(screen.getByText('Removed $50 margin from ETH position')).toBeInTheDocument();
     expectSuccessToastIcon();
 
     act(() => {
       jest.advanceTimersByTime(3000);
     });
 
-    expect(screen.queryByText('Removed 50 ETH margin')).not.toBeInTheDocument();
+    expect(screen.queryByText('Removed $50 margin from ETH position')).not.toBeInTheDocument();
   });
 
   it('maps margin adjustment failed key to error variant with auto-hide', () => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Update toast copy to match metamask-mobile

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: update margin toast copy

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2867

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/503a7a59-f5db-4dd6-8d24-df4c71dfc3d4



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates localized toast strings and the parameters passed to them (adding a `$` prefix and rewording text), with corresponding test updates.
> 
> **Overview**
> Updates perps margin adjustment success toasts to use new copy: **“Added/Removed $amount margin to/from SYMBOL position”** (in `en` and `en_GB`).
> 
> Adjusts margin toast calls to pass dollar-prefixed amounts (e.g. `$100`) and updates related unit tests to match the new message format.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fbf9e22ee91e5fdaa25fcaa315a1ea17a164c13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->