### PR TITLE
feat: erc-8213

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -7655,6 +7655,24 @@
   "showHexDataDescription": {
     "message": "Select this to show the hex data field on the send screen"
   },
+  "showERC8213Digests": {
+    "message": "Show ERC-8213 digests"
+  },
+  "showERC8213DigestsDescription": {
+    "message": "Display Calldata Digest and EIP-712 Digest on transaction and signature confirmations for independent verification"
+  },
+  "calldataDigest": {
+    "message": "Calldata Digest"
+  },
+  "eip712Digest": {
+    "message": "EIP-712 Digest"
+  },
+  "domainHash": {
+    "message": "Domain Hash"
+  },
+  "messageHash": {
+    "message": "Message Hash"
+  },
   "showLess": {
     "message": "Show less"
   },

--- a/app/scripts/controllers/preferences-controller.ts
+++ b/app/scripts/controllers/preferences-controller.ts
@@ -86,6 +86,7 @@ export type Preferences = {
   privacyMode: boolean;
   showConfirmationAdvancedDetails: boolean;
   showDefaultAddress: boolean;
+  showERC8213Digests: boolean;
   showExtensionInFullSizeView: boolean;
   showFiatInTestnets: boolean;
   showMultiRpcModal: boolean;
@@ -181,6 +182,7 @@ export const getDefaultPreferencesControllerState =
       privacyMode: false,
       showConfirmationAdvancedDetails: false,
       showDefaultAddress: true,
+      showERC8213Digests: false,
       defaultAddressScope: 'eip155',
       showExtensionInFullSizeView: false,
       showFiatInTestnets: false,

--- a/shared/lib/digest.test.ts
+++ b/shared/lib/digest.test.ts
@@ -1,0 +1,70 @@
+import { computeCalldataDigest, computeEIP712Digest } from './digest';
+
+describe('ERC-8213 Digest Functions', () => {
+  describe('computeCalldataDigest', () => {
+    it('matches the ERC-8213 test vector for ERC-20 transfer', () => {
+      // ERC-20 transfer(address,uint256) calldata from the ERC spec
+      const calldata =
+        '0xa9059cbb0000000000000000000000004675c7e5baafbffbca748158becba61ef3b0a2630000000000000000000000000000000000000000000000000de0b6b3a7640000';
+
+      const digest = computeCalldataDigest(calldata);
+
+      expect(digest).toBe(
+        '0x812cee5d9cc7461c04bbcd7b70af9c28b243ac5d74d3453b008b93b7dac69985',
+      );
+    });
+
+    it('produces different digests for different calldata', () => {
+      const calldata1 = '0xabcdef';
+      const calldata2 = '0xabcdef00';
+
+      const digest1 = computeCalldataDigest(calldata1);
+      const digest2 = computeCalldataDigest(calldata2);
+
+      expect(digest1).not.toBe(digest2);
+    });
+
+    it('handles minimal calldata', () => {
+      const calldata = '0x12345678';
+      const digest = computeCalldataDigest(calldata);
+
+      expect(digest).toMatch(/^0x[0-9a-f]{64}$/u);
+    });
+  });
+
+  describe('computeEIP712Digest', () => {
+    it('produces a valid 32-byte digest', () => {
+      const domainSeparator =
+        '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef';
+      const messageHash =
+        '0xfedcba0987654321fedcba0987654321fedcba0987654321fedcba0987654321';
+
+      const digest = computeEIP712Digest(domainSeparator, messageHash);
+
+      expect(digest).toMatch(/^0x[0-9a-f]{64}$/u);
+    });
+
+    it('accepts hex strings without 0x prefix', () => {
+      const domainSeparator =
+        '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef';
+      const messageHash =
+        'fedcba0987654321fedcba0987654321fedcba0987654321fedcba0987654321';
+
+      const digest = computeEIP712Digest(domainSeparator, messageHash);
+
+      expect(digest).toMatch(/^0x[0-9a-f]{64}$/u);
+    });
+
+    it('produces consistent results for same inputs', () => {
+      const domainSeparator =
+        '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef';
+      const messageHash =
+        '0xfedcba0987654321fedcba0987654321fedcba0987654321fedcba0987654321';
+
+      const digest1 = computeEIP712Digest(domainSeparator, messageHash);
+      const digest2 = computeEIP712Digest(domainSeparator, messageHash);
+
+      expect(digest1).toBe(digest2);
+    });
+  });
+});

--- a/shared/lib/digest.ts
+++ b/shared/lib/digest.ts
@@ -1,0 +1,51 @@
+import { keccak, toBuffer } from 'ethereumjs-util';
+import { add0x, type Hex } from '@metamask/utils';
+
+/**
+ * Computes the Calldata Digest per ERC-8213.
+ *
+ * Calldata Digest = keccak256(uint256(len(calldata)) || calldata)
+ *
+ * The length prefix is a big-endian uint256 (32 bytes) to prevent
+ * ambiguity between calldata of different lengths sharing a prefix.
+ *
+ * @param calldata - The raw calldata hex string (0x-prefixed).
+ * @returns The 0x-prefixed Calldata Digest hex string.
+ */
+export function computeCalldataDigest(calldata: Hex): Hex {
+  const calldataBuffer = toBuffer(calldata);
+  const lengthBuffer = Buffer.alloc(32);
+  lengthBuffer.writeUInt32BE(calldataBuffer.length, 28);
+
+  const preimage = Buffer.concat([lengthBuffer, calldataBuffer]);
+  return add0x(keccak(preimage).toString('hex'));
+}
+
+/**
+ * Computes the EIP-712 Digest per ERC-8213.
+ *
+ * EIP-712 Digest = keccak256("\x19\x01" || domainSeparator || messageHash)
+ *
+ * @param domainSeparatorHex - The domain separator hash as a hex string.
+ * @param messageHashHex - The message struct hash as a hex string.
+ * @returns The 0x-prefixed EIP-712 Digest hex string.
+ */
+export function computeEIP712Digest(
+  domainSeparatorHex: string,
+  messageHashHex: string,
+): Hex {
+  const prefix = Buffer.from('1901', 'hex');
+  const domainSeparator = toBuffer(
+    domainSeparatorHex.startsWith('0x')
+      ? domainSeparatorHex
+      : `0x${domainSeparatorHex}`,
+  );
+  const messageHash = toBuffer(
+    messageHashHex.startsWith('0x')
+      ? messageHashHex
+      : `0x${messageHashHex}`,
+  );
+
+  const preimage = Buffer.concat([prefix, domainSeparator, messageHash]);
+  return add0x(keccak(preimage).toString('hex'));
+}

--- a/ui/helpers/constants/settings.js
+++ b/ui/helpers/constants/settings.js
@@ -172,7 +172,7 @@ const SETTINGS_CONSTANTS = [
     icon: 'fas fa-sliders-h',
     hidden: getBrowserName() !== PLATFORM_FIREFOX,
   },
-  // advanced settingsRefs[11]
+  // advanced settingsRefs[10]
   {
     tabMessage: (t) => t('advanced'),
     sectionMessage: (t) => t('showERC8213Digests'),

--- a/ui/helpers/constants/settings.js
+++ b/ui/helpers/constants/settings.js
@@ -172,6 +172,14 @@ const SETTINGS_CONSTANTS = [
     icon: 'fas fa-sliders-h',
     hidden: getBrowserName() !== PLATFORM_FIREFOX,
   },
+  // advanced settingsRefs[11]
+  {
+    tabMessage: (t) => t('advanced'),
+    sectionMessage: (t) => t('showERC8213Digests'),
+    descriptionMessage: (t) => t('showERC8213DigestsDescription'),
+    route: `${ADVANCED_ROUTE}#show-erc8213-digests`,
+    icon: 'fas fa-sliders-h',
+  },
   {
     tabMessage: (t) => t('backupAndSync'),
     sectionMessage: (t) => t('backupAndSyncEnable'),

--- a/ui/pages/confirmations/components/confirm/info/shared/transaction-data/transaction-data.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/transaction-data/transaction-data.tsx
@@ -1,6 +1,7 @@
 // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
 /* eslint-disable @typescript-eslint/naming-convention */
-import React from 'react';
+import React, { useMemo } from 'react';
+import { useSelector } from 'react-redux';
 import { TransactionMeta } from '@metamask/transaction-controller';
 import { hexStripZeros } from '@ethersproject/bytes';
 import _ from 'lodash';
@@ -37,6 +38,8 @@ import { useDappSwapContext } from '../../../../../context/dapp-swap';
 import { hasTransactionData } from '../../../../../../../../shared/lib/transaction.utils';
 import { renderShortTokenId } from '../../../../../../../components/app/assets/nfts/nft-details/utils';
 import { BatchedApprovalFunction } from '../batched-approval-function/batched-approval-function';
+import { computeCalldataDigest } from '../../../../../../../../shared/lib/digest';
+import { selectShowERC8213Digests } from '../../../../../selectors/preferences';
 
 export const TransactionData = ({
   data,
@@ -84,6 +87,7 @@ export const TransactionData = ({
     return (
       <Container noPadding={noPadding} transactionData={transactionData}>
         <RawDataRow transactionData={transactionData} />
+        <CalldataDigestRow transactionData={transactionData} />
       </Container>
     );
   }
@@ -123,6 +127,7 @@ export const TransactionData = ({
             </React.Fragment>
           );
         })}
+        <CalldataDigestRow transactionData={transactionData} />
       </>
     </Container>
   );
@@ -159,6 +164,33 @@ export function Container({
         {children}
       </ConfirmInfoSection>
     </>
+  );
+}
+
+function CalldataDigestRow({ transactionData }: { transactionData: string }) {
+  const t = useI18nContext();
+  const showDigests = useSelector(selectShowERC8213Digests);
+
+  const digest = useMemo(() => {
+    if (!showDigests || !transactionData) {
+      return null;
+    }
+    return computeCalldataDigest(transactionData as Hex);
+  }, [showDigests, transactionData]);
+
+  if (!digest) {
+    return null;
+  }
+
+  return (
+    <ConfirmInfoRow
+      label={t('calldataDigest')}
+      copyEnabled
+      copyText={digest}
+      data-testid="calldata-digest-row"
+    >
+      <ConfirmInfoRowText text={digest} />
+    </ConfirmInfoRow>
   );
 }
 

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign.tsx
@@ -1,7 +1,12 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { isValidAddress } from 'ethereumjs-util';
+import { useSelector } from 'react-redux';
 
 import { isSnapId } from '@metamask/snaps-utils';
+import {
+  TypedDataUtils,
+  SignTypedDataVersion,
+} from '@metamask/eth-sig-util';
 import { ConfirmInfoAlertRow } from '../../../../../../components/app/confirm/info/row/alert-row/alert-row';
 import { parseTypedDataMessage } from '../../../../../../../shared/lib/transaction.utils';
 import { RowAlertKey } from '../../../../../../components/app/confirm/info/row/constants';
@@ -9,9 +14,11 @@ import {
   ConfirmInfoRow,
   ConfirmInfoRowAddress,
   ConfirmInfoRowDivider,
+  ConfirmInfoRowText,
   ConfirmInfoRowUrl,
 } from '../../../../../../components/app/confirm/info/row';
 import { ConfirmInfoSection } from '../../../../../../components/app/confirm/info/row/section';
+import { ConfirmInfoExpandableRow } from '../../../../../../components/app/confirm/info/row/expandable-row';
 import { useI18nContext } from '../../../../../../hooks/useI18nContext';
 import { SignatureRequestType } from '../../../../types/confirm';
 import { useGetTokenStandardAndDetails } from '../../../../hooks/useGetTokenStandardAndDetails';
@@ -25,6 +32,8 @@ import { ConfirmInfoRowTypedSignData } from '../../row/typed-sign-data/typedSign
 import { NetworkRow } from '../shared/network-row/network-row';
 import { SigningInWithRow } from '../shared/sign-in-with-row/sign-in-with-row';
 import { TypedSignV4Simulation } from './typed-sign-v4-simulation';
+import { computeEIP712Digest } from '../../../../../../../shared/lib/digest';
+import { selectShowERC8213Digests } from '../../../../selectors/preferences';
 
 const useTokenContract = () => {
   const { currentConfirmation } = useConfirmContext<SignatureRequestType>();
@@ -44,6 +53,89 @@ const useTokenContract = () => {
   const chainId = currentConfirmation.chainId as string;
 
   return { tokenContract, verifyingContract, spender, isPermit, chainId };
+};
+
+const EIP712DigestSection: React.FC = () => {
+  const t = useI18nContext();
+  const showDigests = useSelector(selectShowERC8213Digests);
+  const { currentConfirmation } = useConfirmContext<SignatureRequestType>();
+
+  const digests = useMemo(() => {
+    if (!showDigests || !currentConfirmation?.msgParams?.data) {
+      return null;
+    }
+
+    try {
+      const msgData = currentConfirmation.msgParams.data as string;
+      const parsedData = parseTypedDataMessage(msgData);
+
+      const sanitizedData = TypedDataUtils.sanitizeData(
+        parsedData as Parameters<typeof TypedDataUtils.sanitizeData>[0],
+      );
+
+      const domainSeparatorHex = TypedDataUtils.hashStruct(
+        'EIP712Domain',
+        sanitizedData.domain,
+        sanitizedData.types,
+        SignTypedDataVersion.V4,
+      ).toString('hex');
+
+      const messageHashHex = TypedDataUtils.hashStruct(
+        sanitizedData.primaryType as string,
+        sanitizedData.message,
+        sanitizedData.types,
+        SignTypedDataVersion.V4,
+      ).toString('hex');
+
+      const eip712Digest = computeEIP712Digest(
+        domainSeparatorHex,
+        messageHashHex,
+      );
+
+      return {
+        eip712Digest,
+        domainHash: `0x${domainSeparatorHex}`,
+        messageHash: `0x${messageHashHex}`,
+      };
+    } catch {
+      return null;
+    }
+  }, [showDigests, currentConfirmation]);
+
+  if (!digests) {
+    return null;
+  }
+
+  return (
+    <ConfirmInfoSection data-testid="eip712-digest-section">
+      <ConfirmInfoRow
+        label={t('eip712Digest')}
+        copyEnabled
+        copyText={digests.eip712Digest}
+        data-testid="eip712-digest-row"
+      >
+        <ConfirmInfoRowText text={digests.eip712Digest} />
+      </ConfirmInfoRow>
+      <ConfirmInfoExpandableRow
+        label={t('domainHash')}
+        copyEnabled
+        copyText={digests.domainHash}
+        data-testid="eip712-domain-hash-row"
+        content={
+          <ConfirmInfoRow
+            label={t('messageHash')}
+            copyEnabled
+            copyText={digests.messageHash}
+            data-testid="eip712-message-hash-row"
+          >
+            <ConfirmInfoRowText text={digests.messageHash} />
+          </ConfirmInfoRow>
+        }
+      >
+        <ConfirmInfoRowText text={digests.domainHash} />
+      </ConfirmInfoExpandableRow>
+    </ConfirmInfoSection>
+  );
 };
 
 const TypedSignInfo: React.FC = () => {
@@ -120,6 +212,7 @@ const TypedSignInfo: React.FC = () => {
           />
         </ConfirmInfoRow>
       </ConfirmInfoSection>
+      <EIP712DigestSection />
     </>
   );
 };

--- a/ui/pages/confirmations/selectors/preferences.ts
+++ b/ui/pages/confirmations/selectors/preferences.ts
@@ -4,6 +4,7 @@ export type RootState = {
     preferences?: {
       showConfirmationAdvancedDetails?: boolean;
       dismissSmartAccountSuggestionEnabled?: boolean;
+      showERC8213Digests?: boolean;
     };
   };
 };
@@ -19,4 +20,9 @@ export function selectConfirmationAdvancedDetailsOpen(state: RootState) {
 export function getDismissSmartAccountSuggestionEnabled(state: RootState) {
   const { metamask } = state;
   return Boolean(metamask.preferences?.dismissSmartAccountSuggestionEnabled);
+}
+
+export function selectShowERC8213Digests(state: RootState) {
+  const { metamask } = state;
+  return Boolean(metamask.preferences?.showERC8213Digests);
 }

--- a/ui/pages/settings-v2/search-config.ts
+++ b/ui/pages/settings-v2/search-config.ts
@@ -43,6 +43,7 @@ export const TRANSACTION_ITEMS = {
   'smart-account-requests-from-dapps': 'smartAccountRequestsFromDapps',
   'proposed-nicknames': 'externalNameSourcesSetting',
   'show-hex-data': 'showHexData',
+  'show-erc8213-digests': 'showERC8213Digests',
 } as const;
 
 export const PREFERENCES_ITEMS = {

--- a/ui/pages/settings-v2/transactions-tab/transactions-tab.tsx
+++ b/ui/pages/settings-v2/transactions-tab/transactions-tab.tsx
@@ -22,6 +22,7 @@ import {
   setDismissSmartAccountSuggestionEnabled,
   setFeatureFlag,
   setSecurityAlertsEnabled,
+  setShowERC8213Digests,
   setSmartTransactionsPreferenceEnabled,
   setUseExternalNameSources,
   setUseTransactionSimulations,
@@ -134,6 +135,16 @@ const ShowHexDataItem = createToggleItem({
   },
 });
 
+const ShowERC8213DigestsItem = createToggleItem({
+  name: 'ShowERC8213DigestsItem',
+  titleKey: TRANSACTION_ITEMS['show-erc8213-digests'],
+  descriptionKey: 'showERC8213DigestsDescription',
+  selector: (state: MetaMaskReduxState) =>
+    Boolean(getPreferences(state)?.showERC8213Digests),
+  action: setShowERC8213Digests,
+  dataTestId: 'transactions-show-erc8213-digests-toggle',
+});
+
 const TRANSACTION_SETTING_ITEMS: SettingItemConfig[] = [
   { id: 'estimate-balance-changes', component: TransactionSimulationsItem },
   { id: 'security-alerts', component: SecurityAlertsItem },
@@ -144,6 +155,7 @@ const TRANSACTION_SETTING_ITEMS: SettingItemConfig[] = [
   },
   { id: 'proposed-nicknames', component: ProposedNicknamesItem },
   { id: 'show-hex-data', component: ShowHexDataItem, hasDividerBefore: true },
+  { id: 'show-erc8213-digests', component: ShowERC8213DigestsItem },
 ];
 
 const TransactionsTab = () => <SettingsTab items={TRANSACTION_SETTING_ITEMS} />;

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.js
@@ -61,6 +61,8 @@ export default class AdvancedTab extends PureComponent {
     setManageInstitutionalWallets: PropTypes.func.isRequired,
     dismissSmartAccountSuggestionEnabled: PropTypes.bool.isRequired,
     setDismissSmartAccountSuggestionEnabled: PropTypes.func.isRequired,
+    showERC8213Digests: PropTypes.bool,
+    setShowERC8213Digests: PropTypes.func.isRequired,
   };
 
   state = {
@@ -631,6 +633,38 @@ export default class AdvancedTab extends PureComponent {
     );
   }
 
+  renderShowERC8213Digests() {
+    const { t } = this.context;
+    const { showERC8213Digests, setShowERC8213Digests } = this.props;
+
+    return (
+      <Box
+        ref={this.settingsRefs[11]}
+        className="settings-page__content-row"
+        display={Display.Flex}
+        flexDirection={FlexDirection.Row}
+        justifyContent={JustifyContent.spaceBetween}
+        gap={[null, 4]}
+        data-testid="advanced-setting-show-erc8213-digests"
+      >
+        <div className="settings-page__content-item">
+          <span>{t('showERC8213Digests')}</span>
+          <div className="settings-page__content-description">
+            {t('showERC8213DigestsDescription')}
+          </div>
+        </div>
+        <div className="settings-page__content-item-col">
+          <ToggleButton
+            value={showERC8213Digests}
+            onToggle={(value) => setShowERC8213Digests(!value)}
+            offLabel={t('off')}
+            onLabel={t('on')}
+          />
+        </div>
+      </Box>
+    );
+  }
+
   render() {
     const { errorInSettings } = this.props;
     // When adding/removing/editing the order of renders, double-check the order of the settingsRefs. This affects settings-search.js
@@ -651,6 +685,7 @@ export default class AdvancedTab extends PureComponent {
         {this.renderAutoLockTimeLimit()}
         {this.renderUserDataBackup()}
         {this.renderDismissSeedBackupReminderControl()}
+        {this.renderShowERC8213Digests()}
       </div>
     );
   }

--- a/ui/pages/settings/advanced-tab/advanced-tab.component.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.component.js
@@ -639,7 +639,6 @@ export default class AdvancedTab extends PureComponent {
 
     return (
       <Box
-        ref={this.settingsRefs[11]}
         className="settings-page__content-row"
         display={Display.Flex}
         flexDirection={FlexDirection.Row}

--- a/ui/pages/settings/advanced-tab/advanced-tab.container.js
+++ b/ui/pages/settings/advanced-tab/advanced-tab.container.js
@@ -13,6 +13,7 @@ import {
   setSmartTransactionsPreferenceEnabled,
   showModal,
   setManageInstitutionalWallets,
+  setShowERC8213Digests,
 } from '../../../store/actions';
 import { getSmartTransactionsPreferenceEnabled } from '../../../../shared/lib/selectors';
 import {
@@ -37,6 +38,7 @@ export const mapStateToProps = (state) => {
     showExtensionInFullSizeView,
     autoLockTimeLimit = DEFAULT_AUTO_LOCK_TIME_LIMIT,
     dismissSmartAccountSuggestionEnabled,
+    showERC8213Digests,
   } = getPreferences(state);
 
   return {
@@ -50,6 +52,7 @@ export const mapStateToProps = (state) => {
     dismissSeedBackUpReminder,
     manageInstitutionalWallets,
     dismissSmartAccountSuggestionEnabled,
+    showERC8213Digests,
   };
 };
 
@@ -86,6 +89,9 @@ export const mapDispatchToProps = (dispatch) => {
     },
     setDismissSmartAccountSuggestionEnabled: (value) => {
       return dispatch(setDismissSmartAccountSuggestionEnabled(value));
+    },
+    setShowERC8213Digests: (value) => {
+      return dispatch(setShowERC8213Digests(value));
     },
   };
 };

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -4383,6 +4383,10 @@ export function setDismissSmartAccountSuggestionEnabled(
   };
 }
 
+export function setShowERC8213Digests(value: boolean) {
+  return setPreference('showERC8213Digests', value, false);
+}
+
 export function setTokenSortConfig(value: SortCriteria) {
   return setPreference('tokenSortConfig', value, false);
 }


### PR DESCRIPTION
## **Description**

Implements [ERC-8213: Wallet Signature and Calldata Digest Display](https://github.com/ethereum/ERCs/pull/1639) in MetaMask.

ERC-8213 standardizes the display of cryptographic digests in wallets for both EIP-712 signed data and transaction calldata. Recent exchange hacks (Bybit $1.4B, WazirX $200M, Radiant Capital $50M) demonstrate the need for wallet-based verification independent of potentially compromised websites. Displaying compact digests gives security-conscious signers a way to independently verify what they are signing without comparing hundreds of hex characters.

This PR adds an opt-in setting ("Show ERC-8213 digests") under Settings > Transactions that, when enabled, displays:

- **Calldata Digest** on transaction confirmations — `keccak256(uint256(len(calldata)) || calldata)` shown after the transaction data
- **EIP-712 Digest** on typed data signature requests — `keccak256("\x19\x01" || domainSeparator || hashStruct(message))` with expandable Domain Hash and Message Hash

All values are displayed as copyable `0x`-prefixed hex strings using the exact terminology defined in the ERC. No core dependency updates were needed — all crypto primitives (`keccak` from `ethereumjs-util`, `TypedDataUtils` from `@metamask/eth-sig-util`) were already available.

## **Changelog**

CHANGELOG entry: Added ERC-8213 digest display for transaction calldata and EIP-712 signatures, enabled via Settings > Transactions

## **Related issues**

Fixes: N/A — implements [ERC-8213](https://github.com/ethereum/ERCs/pull/1639)

## **Manual testing steps**

1. Go to Settings > Transactions and assets > Transactions
2. Enable "Show ERC-8213 digests" toggle
3. Trigger a transaction with calldata (e.g. token swap or ERC-20 transfer on a test dapp)
4. Open Advanced Details on the confirmation screen — verify "Calldata Digest" row appears with a `0x`-prefixed hash after the transaction data
5. Trigger an `eth_signTypedData_v4` request (e.g. a Permit signature on a test dapp)
6. Verify "EIP-712 Digest" section appears at the bottom of the signature confirmation
7. Click the expand arrow on "Domain Hash" to reveal "Message Hash"
8. Verify all three digest values are copyable
9. Disable the toggle and repeat steps 3-5 — verify digests no longer appear

## **Screenshots/Recordings**

https://youtu.be/S9hrEWh-JTw

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


# Video

https://youtu.be/S9hrEWh-JTw

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new cryptographic digest computations and surfaces them in transaction/signature confirmation UIs behind a preference toggle; risk is mainly around correctness of hashing/display and potential UI regressions in critical confirmation flows.
> 
> **Overview**
> Adds an opt-in `showERC8213Digests` preference (default off) with new settings toggles/search support and i18n strings for ERC-8213 terminology.
> 
> When enabled, transaction confirmations now show a copyable **Calldata Digest** row computed from the raw calldata, and typed-signature confirmations add an **EIP-712 Digest** section with expandable/copyable `Domain Hash` and `Message Hash`.
> 
> Introduces `shared/lib/digest.ts` (with unit tests) implementing ERC-8213 `computeCalldataDigest` and `computeEIP712Digest`, and wires these into the confirmation components via a new `selectShowERC8213Digests` selector and `setShowERC8213Digests` action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a998dd346d366231cfcfdc39bdf621730b59eed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->