### PR TITLE
fix: pass env type on emitAppOpenedMetricEvent

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -1262,8 +1262,10 @@ function trackDappView(remotePort) {
 
 /**
  * Emit App Opened event
+ *
+ * @param {string} environmentType - The environment type where the app is opening
  */
-function emitAppOpenedMetricEvent() {
+function emitAppOpenedMetricEvent(environmentType) {
   const { metaMetricsId, participateInMetaMetrics } =
     controller.metaMetricsController.state;
 
@@ -1275,6 +1277,7 @@ function emitAppOpenedMetricEvent() {
   controller.metaMetricsController.trackEvent({
     event: MetaMetricsEventName.AppOpened,
     category: MetaMetricsEventCategory.App,
+    environmentType,
   });
 }
 
@@ -1290,6 +1293,7 @@ function trackAppOpened(environment) {
     ENVIRONMENT_TYPE_POPUP,
     ENVIRONMENT_TYPE_NOTIFICATION,
     ENVIRONMENT_TYPE_FULLSCREEN,
+    ENVIRONMENT_TYPE_SIDEPANEL,
   ];
 
   // Check if any UI instances are currently open
@@ -1302,7 +1306,7 @@ function trackAppOpened(environment) {
 
   // Only emit event if no UI is open and environment is valid
   if (!isAlreadyOpen && environmentTypeList.includes(environment)) {
-    emitAppOpenedMetricEvent();
+    emitAppOpenedMetricEvent(environment);
   }
 }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes a bug where all [App Opened events are emitted with the `environment_type` property `background`](https://mixpanel.com/project/2212883/view/2760759/app/boards#id=10970585&edited-bookmark=LQusY6ng73pt). This is because the environment type was not being passed and therefore it was defaulting to the `background` type. Also adds sidepanel as a relevant environment type for this metric.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Run segment dev server `node development/mock-segment.js`
2. Open MM in different envs: sidepanel, fullscreen, sidepanel, notification (connect to a dapp)
3. See that the `App Opened` event contains the correct `environment_type` value

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only threads the UI `environmentType` through `trackAppOpened` into the `MetaMetricsEventName.AppOpened` payload; no behavioral changes beyond metrics enrichment.
> 
> **Overview**
> Adds `environmentType` to the `MetaMetricsEventName.AppOpened` tracking payload by updating `emitAppOpenedMetricEvent` to accept the environment and passing it from `trackAppOpened`.
> 
> Extends the set of valid tracked environments to include `ENVIRONMENT_TYPE_SIDEPANEL`, so App Opened events can be attributed to sidepanel opens as well.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 526aa22cf877913319223a49c02c4450b98f6a53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->