### PR TITLE
fix: cp-13.26.0 duplicate toast notifications

### DIFF
--- a/ui/helpers/constants/transactions.js
+++ b/ui/helpers/constants/transactions.js
@@ -36,6 +36,8 @@ export const TOAST_EXCLUDED_TRANSACTION_TYPES = new Set([
   TransactionType.bridgeApproval,
   TransactionType.bridge,
   TransactionType.shieldSubscriptionApprove,
+  TransactionType.musdConversion,
+  TransactionType.musdClaim,
 ]);
 
 // Non-EVM transaction types excluded from toast notifications.

--- a/ui/selectors/toast.test.ts
+++ b/ui/selectors/toast.test.ts
@@ -142,6 +142,118 @@ describe('toast selectors', () => {
       );
       expect(results).toStrictEqual([]);
     });
+
+    it('excludes transactions listed as requiredTransactionIds of another tx', () => {
+      const primary = {
+        id: 'primary',
+        time: 1,
+        type: TransactionType.swap,
+        requiredTransactionIds: ['satellite-id'],
+      };
+      const satellite = {
+        id: 'satellite-id',
+        time: 2,
+        type: TransactionType.simpleSend,
+      };
+      const state = {
+        metamask: {
+          transactions: [primary, satellite],
+        },
+      } as unknown as SelectorState;
+
+      const results = selectEvmTransactionsForToast(state);
+
+      expect(results).toStrictEqual([primary]);
+    });
+
+    it('excludes transactions whose hash matches a required transaction hash', () => {
+      const sharedHash = '0xdeadbeef';
+      const satellite = {
+        id: 'satellite-id',
+        time: 1,
+        type: TransactionType.simpleSend,
+        hash: sharedHash,
+      };
+      const primary = {
+        id: 'primary',
+        time: 2,
+        type: TransactionType.swap,
+        requiredTransactionIds: ['satellite-id'],
+      };
+      const duplicateHashDifferentId = {
+        id: 'other-id',
+        time: 3,
+        type: TransactionType.simpleSend,
+        hash: sharedHash,
+      };
+      const state = {
+        metamask: {
+          transactions: [satellite, primary, duplicateHashDifferentId],
+        },
+      } as unknown as SelectorState;
+
+      const results = selectEvmTransactionsForToast(state);
+
+      expect(results).toStrictEqual([primary]);
+    });
+
+    it('excludes Merkl musdClaim and attached gasPayment from toast eligibility', () => {
+      const gasPaymentSatellite = {
+        id: 'gas-payment-tx-id',
+        time: 1,
+        type: TransactionType.gasPayment,
+      };
+      const merklClaimPrimary = {
+        id: 'merkl-claim-tx-id',
+        time: 2,
+        type: TransactionType.musdClaim,
+        requiredTransactionIds: ['gas-payment-tx-id'],
+      };
+      const state = {
+        metamask: {
+          transactions: [gasPaymentSatellite, merklClaimPrimary],
+        },
+      } as unknown as SelectorState;
+
+      const results = selectEvmTransactionsForToast(state);
+
+      expect(results).toStrictEqual([]);
+    });
+
+    it('excludes gasPayment Merkl satellite by hash when id differs (claim flow)', () => {
+      const claimHash = '0xclaimgas';
+      const gasPaymentSatellite = {
+        id: 'gas-payment-tx-id',
+        time: 1,
+        type: TransactionType.gasPayment,
+        hash: claimHash,
+      };
+      const merklClaimPrimary = {
+        id: 'merkl-claim-tx-id',
+        time: 2,
+        type: TransactionType.musdClaim,
+        requiredTransactionIds: ['gas-payment-tx-id'],
+      };
+      const duplicateGasByHash = {
+        id: 'stale-local-gas-entry',
+        time: 3,
+        type: TransactionType.gasPayment,
+        hash: claimHash,
+      };
+      const state = {
+        metamask: {
+          transactions: [
+            gasPaymentSatellite,
+            merklClaimPrimary,
+            duplicateGasByHash,
+          ],
+        },
+      } as unknown as SelectorState;
+
+      const results = selectEvmTransactionsForToast(state);
+
+      expect(results).toStrictEqual([]);
+    });
   });
 
   describe('selectNonEvmTransactionsForToast', () => {

--- a/ui/selectors/toast.ts
+++ b/ui/selectors/toast.ts
@@ -6,6 +6,10 @@ import {
   TOAST_EXCLUDED_NON_EVM_TRANSACTION_TYPES,
 } from '../helpers/constants/transactions';
 import { EMPTY_ARRAY, EMPTY_OBJECT } from './shared';
+import {
+  selectRequiredTransactionHashes,
+  selectRequiredTransactionIds,
+} from './transactionController';
 
 const selectTransactions = (state: MetaMaskReduxState) =>
   state.metamask?.transactions ?? EMPTY_ARRAY;
@@ -57,7 +61,15 @@ export const selectEvmTransactionsForToast = createSelector(
   selectTransactions,
   selectBridgeApprovalTxIds,
   selectCrossChainBridgeSourceTxIds,
-  (rawTransactions, bridgeApprovalIds, crossChainBridgeIds) => {
+  selectRequiredTransactionIds,
+  selectRequiredTransactionHashes,
+  (
+    rawTransactions,
+    bridgeApprovalIds,
+    crossChainBridgeIds,
+    requiredTransactionIds,
+    requiredTransactionHashes,
+  ) => {
     if (!rawTransactions?.length) {
       return EMPTY_ARRAY;
     }
@@ -79,7 +91,12 @@ export const selectEvmTransactionsForToast = createSelector(
         Boolean(type) &&
         !TOAST_EXCLUDED_TRANSACTION_TYPES.has(type) &&
         !bridgeApprovalIds.has(transaction.id?.toLowerCase()) &&
-        !crossChainBridgeIds.has(transaction.id)
+        !crossChainBridgeIds.has(transaction.id) &&
+        !requiredTransactionIds.has(transaction.id) &&
+        !(
+          transaction.hash &&
+          requiredTransactionHashes.has(transaction.hash.toLowerCase())
+        )
       );
     });
   },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

mUSD conversion and Merkl reward claim flows already show dedicated toasts (MusdConversionToast, MerklClaimToast). The global EVM transaction toast listener was still treating the same flows as normal sends, so users could see duplicate “Transaction confirmed” toasts from react-hot-toast.

Problem

Primary txs with types musdConversion and musdClaim were not excluded from the generic toast pipeline.
Satellite / prerequisite transactions (e.g. relayDeposit, approvals, batch, gasPayment) linked via requiredTransactionIds are hidden from the unified activity list but were still eligible for generic toasts because selectEvmTransactionsForToast did not mirror that linking logic.

Solution

Add TransactionType.musdConversion and TransactionType.musdClaim to TOAST_EXCLUDED_TRANSACTION_TYPES in [ui/helpers/constants/transactions.js]
Extend [ui/selectors/toast.ts] so selectEvmTransactionsForToast also excludes:
any transaction whose id appears in another transaction’s requiredTransactionIds (selectRequiredTransactionIds), and
any transaction whose hash matches a required prerequisite’s hash (selectRequiredTransactionHashes),
matching the activity list behavior in ui/selectors/transactionController.ts

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: n/a

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MN-202
Fixes: https://github.com/MetaMask/metamask-extension/issues/41478

## **Manual testing steps**

Create a musdConversion tx by clicking an MUSD convert cta and converting. There should be toasts custom to musd conversion only.

Create a musdClaim tx by clicking an MUSD claim cta and claiming. There should be toasts custom to musd claim only.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://www.loom.com/share/0da23489ac72408ebb81c059f7333b9d

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit e50d66aa6e2778870cdf42b7741699a6bc9732b8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->