### PR TITLE
perf(6672): remove 7 identity wrappers in selectors.js and audit createDeepEqualSelector usage

### DIFF
--- a/ui/components/app/snaps/snap-home-page/snap-home-renderer.js
+++ b/ui/components/app/snaps/snap-home-page/snap-home-renderer.js
@@ -6,8 +6,8 @@ import { Box, Text } from '../../../component-library';
 import { SnapUIRenderer } from '../snap-ui-renderer';
 import {
   getSnapMetadata,
-  getMemoizedUnapprovedConfirmations,
-  getMemoizedUnapprovedTemplatedConfirmations,
+  getUnapprovedConfirmations,
+  getUnapprovedTemplatedConfirmations,
 } from '../../../../selectors';
 import { SnapDelineator } from '../snap-delineator';
 import { DelineatorType } from '../../../../helpers/constants/snaps';
@@ -33,11 +33,9 @@ export const SnapHomeRenderer = ({ snapId }) => {
   );
 
   const unapprovedTemplatedConfirmations = useSelector(
-    getMemoizedUnapprovedTemplatedConfirmations,
+    getUnapprovedTemplatedConfirmations,
   );
-  const unapprovedConfirmations = useSelector(
-    getMemoizedUnapprovedConfirmations,
-  );
+  const unapprovedConfirmations = useSelector(getUnapprovedConfirmations);
   const navigate = useNavigate();
 
   const { data, error, loading } = useSnapHome({ snapId });

--- a/ui/components/app/snaps/snap-ui-renderer/snap-ui-renderer.js
+++ b/ui/components/app/snaps/snap-ui-renderer/snap-ui-renderer.js
@@ -8,7 +8,7 @@ import { MuiPickersUtilsProvider } from '@material-ui/pickers';
 import LuxonUtils from '@date-io/luxon';
 import { ThemeProvider } from '@material-ui/core/styles';
 import MetaMaskTemplateRenderer from '../../metamask-template-renderer/metamask-template-renderer';
-import { getMemoizedInterface } from '../../../../selectors';
+import { getInterface } from '../../../../selectors';
 import { Box } from '../../../component-library';
 
 import { SnapInterfaceContextProvider } from '../../../../contexts/snaps';
@@ -63,7 +63,7 @@ const SnapUIRendererComponent = ({
   const locale = useSelector(getIntlLocale);
 
   const interfaceState = useSelector(
-    (state) => getMemoizedInterface(state, interfaceId),
+    (state) => getInterface(state, interfaceId),
     // We only want to update the state if the content has changed.
     // We do this to avoid useless re-renders.
     (oldState, newState) => isEqual(oldState.content, newState.content),

--- a/ui/components/app/wallet-overview/hooks/useHandleSendNonEvm.ts
+++ b/ui/components/app/wallet-overview/hooks/useHandleSendNonEvm.ts
@@ -5,7 +5,7 @@ import { useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import { sendMultichainTransaction } from '../../../../store/actions';
 import {
-  getMemoizedUnapprovedTemplatedConfirmations,
+  getUnapprovedTemplatedConfirmations,
   getSelectedInternalAccount,
 } from '../../../../selectors';
 import { getSelectedMultichainNetworkConfiguration } from '../../../../selectors/multichain/networks';
@@ -30,7 +30,7 @@ export const useHandleSendNonEvm = (caipAssetType?: CaipAssetType) => {
   const navigate = useNavigate();
 
   const unapprovedTemplatedConfirmations = useSelector(
-    getMemoizedUnapprovedTemplatedConfirmations,
+    getUnapprovedTemplatedConfirmations,
   );
 
   useEffect(() => {

--- a/ui/pages/confirmations/components/send/loader/loader.tsx
+++ b/ui/pages/confirmations/components/send/loader/loader.tsx
@@ -8,13 +8,13 @@ import {
   TRON_WALLET_SNAP_ID,
 } from '../../../../../../shared/lib/accounts';
 import LoadingScreen from '../../../../../components/ui/loading-screen';
-import { getMemoizedUnapprovedTemplatedConfirmations } from '../../../../../selectors';
+import { getUnapprovedTemplatedConfirmations } from '../../../../../selectors';
 import { CONFIRMATION_V_NEXT_ROUTE } from '../../../../../helpers/constants/routes';
 
 export const Loader = () => {
   const navigate = useNavigate();
   const unapprovedTemplatedConfirmations = useSelector(
-    getMemoizedUnapprovedTemplatedConfirmations,
+    getUnapprovedTemplatedConfirmations,
   );
 
   useEffect(() => {

--- a/ui/pages/confirmations/confirmation/alerts/TemplateAlertContext.tsx
+++ b/ui/pages/confirmations/confirmation/alerts/TemplateAlertContext.tsx
@@ -13,7 +13,7 @@ import useAlerts from '../../../../hooks/useAlerts';
 import { AlertActionHandlerProvider } from '../../../../components/app/alert-system/contexts/alertActionHandler';
 import { AlertMetricsProvider } from '../../../../components/app/alert-system/contexts/alertMetricsContext';
 import { MultipleAlertModal } from '../../../../components/app/alert-system/multiple-alert-modal';
-import { getMemoizedUnapprovedConfirmations } from '../../../../selectors';
+import { getUnapprovedConfirmations } from '../../../../selectors';
 import { useTemplateConfirmationAlerts } from './useTemplateConfirmationAlerts';
 import { useAlertsActions } from './useAlertsActions';
 
@@ -33,7 +33,7 @@ export const TemplateAlertContextProvider: React.FC<{
   confirmationId: string;
   onSubmit: () => void;
 }> = ({ children, confirmationId, onSubmit }) => {
-  const pendingConfirmations = useSelector(getMemoizedUnapprovedConfirmations);
+  const pendingConfirmations = useSelector(getUnapprovedConfirmations);
 
   const pendingConfirmation =
     pendingConfirmations?.find(

--- a/ui/pages/confirmations/confirmation/confirmation.js
+++ b/ui/pages/confirmations/confirmation/confirmation.js
@@ -35,7 +35,7 @@ import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 import {
-  getMemoizedUnapprovedTemplatedConfirmations,
+  getUnapprovedTemplatedConfirmations,
   getUnapprovedTxCount,
   getApprovalFlows,
   getTotalUnapprovedCount,
@@ -234,9 +234,7 @@ export default function ConfirmationPage({
   const { trackEvent } = useContext(MetaMetricsContext);
   const dispatch = useDispatch();
   const navigate = useNavigate();
-  const pendingConfirmations = useSelector(
-    getMemoizedUnapprovedTemplatedConfirmations,
-  );
+  const pendingConfirmations = useSelector(getUnapprovedTemplatedConfirmations);
   const unapprovedTxsCount = useSelector(getUnapprovedTxCount);
   const approvalFlows = useSelector(getApprovalFlows, isEqual);
   const totalUnapprovedCount = useSelector(getTotalUnapprovedCount);

--- a/ui/selectors/nft.ts
+++ b/ui/selectors/nft.ts
@@ -1,7 +1,9 @@
 import { Nft, NftContract } from '@metamask/assets-controllers';
 import { createSelector } from 'reselect';
-import { NetworkState } from '../../shared/lib/selectors/networks';
-import { getMemoizedCurrentChainId } from './selectors';
+import {
+  getCurrentChainId,
+  NetworkState,
+} from '../../shared/lib/selectors/networks';
 import { EMPTY_OBJECT } from './shared';
 
 type NftState = {
@@ -67,7 +69,7 @@ export const getNftContractsByAddressByChain = createSelector(
 );
 
 export const getNftContractsByAddressOnCurrentChain = createSelector(
-  (state: NftState & NetworkState) => getMemoizedCurrentChainId(state),
+  (state: NftState & NetworkState) => getCurrentChainId(state),
   getNftContractsByAddressByChain,
   (currentChainId, nftContractsByAddressByChain) => {
     return nftContractsByAddressByChain[currentChainId] ?? {};

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -1408,12 +1408,13 @@ export const getUnapprovedConfirmations = createDeepEqualSelector(
   (pendingApprovals) => Object.values(pendingApprovals),
 );
 
-function getUnapprovedTemplatedConfirmations(state) {
-  const unapprovedConfirmations = getUnapprovedConfirmations(state);
-  return unapprovedConfirmations.filter((approval) =>
-    TEMPLATED_CONFIRMATION_APPROVAL_TYPES.includes(approval.type),
-  );
-}
+export const getUnapprovedTemplatedConfirmations = createDeepEqualSelector(
+  getUnapprovedConfirmations,
+  (unapprovedConfirmations) =>
+    unapprovedConfirmations.filter((approval) =>
+      TEMPLATED_CONFIRMATION_APPROVAL_TYPES.includes(approval.type),
+    ),
+);
 
 export function getSuggestedTokens(state) {
   return (
@@ -1522,12 +1523,9 @@ export function getUseExternalNameSources(state) {
   return state.metamask.useExternalNameSources;
 }
 
-export const getTokenSortConfig = createDeepEqualSelector(
-  getPreferences,
-  ({ tokenSortConfig }) => {
-    return tokenSortConfig;
-  },
-);
+export function getTokenSortConfig(state) {
+  return state.metamask.preferences?.tokenSortConfig;
+}
 
 /**
  * Returns an object indicating which networks
@@ -1814,27 +1812,6 @@ export const getHideSnapBranding = createDeepEqualSelector(
 );
 
 /**
- * Get a memoized version of the target subject metadata.
- */
-
-/**
- * Get a memoized version of the unapproved confirmations.
- */
-export const getMemoizedUnapprovedConfirmations = createDeepEqualSelector(
-  getUnapprovedConfirmations,
-  (confirmations) => confirmations,
-);
-
-/**
- * Get a memoized version of the unapproved templated confirmations.
- */
-export const getMemoizedUnapprovedTemplatedConfirmations =
-  createDeepEqualSelector(
-    getUnapprovedTemplatedConfirmations,
-    (confirmations) => confirmations,
-  );
-
-/**
  * Get the Snap interfaces from the redux state.
  *
  * @param state - Redux state object.
@@ -1852,27 +1829,11 @@ const getInterfaces = (state) => state.metamask.interfaces;
 const selectInterfaceId = (_state, interfaceId) => interfaceId;
 
 /**
- * Get a memoized version of the Snap interfaces.
- */
-const getMemoizedInterfaces = createDeepEqualSelector(
-  getInterfaces,
-  (interfaces) => interfaces,
-);
-
-/**
  * Get a Snap Interface with a given ID.
  */
 export const getInterface = createSelector(
-  [getMemoizedInterfaces, selectInterfaceId],
+  [getInterfaces, selectInterfaceId],
   (interfaces, id) => interfaces[id],
-);
-
-/**
- * Get a memoized version of a Snap interface with a given ID
- */
-export const getMemoizedInterface = createDeepEqualSelector(
-  getInterface,
-  (snapInterface) => snapInterface,
 );
 
 /**
@@ -2116,10 +2077,9 @@ export function getNativeCurrencyForChain(chainId) {
   return CHAIN_ID_TOKEN_IMAGE_MAP[chainId] ?? undefined;
 }
 
-export const selectERC20TokensByChain = createDeepEqualSelector(
-  (state) => state.metamask.tokensChainsCache,
-  (erc20TokensByChain) => erc20TokensByChain,
-);
+export function selectERC20TokensByChain(state) {
+  return state.metamask.tokensChainsCache;
+}
 
 const selectERC20Tokens = createDeepEqualSelector(
   getCurrentChainId,
@@ -2288,11 +2248,6 @@ export const getConnectedSitesList = createDeepEqualSelector(
     });
     return sitesList;
   },
-);
-
-export const getMemoizedCurrentChainId = createDeepEqualSelector(
-  getCurrentChainId,
-  (chainId) => chainId,
 );
 
 export function getSnaps(state) {

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -163,6 +163,7 @@ import { createDeepEqualSelector } from '../../shared/lib/selectors/util';
 import {
   createParameterizedSelector,
   createParameterizedShallowEqualSelector,
+  createResultEqualSelector,
 } from '../../shared/lib/selectors/selector-creators';
 import { isSnapIgnoredInProd } from '../helpers/utils/snaps';
 import {
@@ -1408,7 +1409,7 @@ export const getUnapprovedConfirmations = createDeepEqualSelector(
   (pendingApprovals) => Object.values(pendingApprovals),
 );
 
-export const getUnapprovedTemplatedConfirmations = createDeepEqualSelector(
+export const getUnapprovedTemplatedConfirmations = createResultEqualSelector(
   getUnapprovedConfirmations,
   (unapprovedConfirmations) =>
     unapprovedConfirmations.filter((approval) =>


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- Avoid unnecessary deep equality on selector outputs where referential stability from input selectors is enough.
- Remove 7 redundant identity wrapper selectors from `ui/selectors/selectors.js`. These use createDeepEqualSelector to compensate for upstream instability. After P0 fixes, they become unnecessary overhead.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/6672

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because selector memoization/equality behavior changes for confirmations, snap interfaces, and token/NFT selectors, which could affect rerender frequency and edge-case UI updates if referential stability assumptions are wrong.
> 
> **Overview**
> **Reduces selector overhead by removing redundant deep-equality “identity wrapper” selectors** and updating call sites to use the non-memoized selectors directly (e.g., confirmations and Snap UI flows now use `getUnapprovedConfirmations` / `getUnapprovedTemplatedConfirmations` / `getInterface`).
> 
> **Reworks selector implementations for stability/perf:** `getUnapprovedTemplatedConfirmations` is now a `createResultEqualSelector` (stable output when filtered set is unchanged), while a few selectors (`getTokenSortConfig`, `selectERC20TokensByChain`) are simplified to plain state reads. NFT selectors also switch from a UI-level `getMemoizedCurrentChainId` wrapper to `getCurrentChainId` from shared network selectors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 835c764155eb1aa239ee892456b06bde8c88e1f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->