### PR TITLE
chore: update default address styles

### DIFF
--- a/ui/components/multichain-accounts/multichain-account-cell-default-address/multichain-account-cell-default-address.tsx
+++ b/ui/components/multichain-accounts/multichain-account-cell-default-address/multichain-account-cell-default-address.tsx
@@ -68,7 +68,7 @@ export const MultichainAccountCellDefaultAddress = ({
           size={ButtonIconSize.Sm}
           variant={ButtonIconVariant.Filled}
           iconProps={{
-            size: IconSize.Sm,
+            size: IconSize.Xs,
           }}
           ariaLabel={t('openMultichainAccountAddressMenu')}
           className="text-icon-alternative rounded-lg"
@@ -94,7 +94,7 @@ export const MultichainAccountCellDefaultAddress = ({
           <Text
             ellipsis
             variant={TextVariant.BodySm}
-            fontWeight={FontWeight.Medium}
+            fontWeight={FontWeight.Regular}
             color={
               addressCopied
                 ? TextColor.SuccessDefault
@@ -108,7 +108,7 @@ export const MultichainAccountCellDefaultAddress = ({
           </Text>
           <Icon
             name={addressCopied ? IconName.CopySuccess : IconName.Copy}
-            size={IconSize.Sm}
+            size={IconSize.Xs}
             color={
               addressCopied
                 ? IconColor.SuccessDefault


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Tiny adjustment to default address font weight and icon sizes. See [Figma](https://www.figma.com/design/IVt20ztP5OpMtBpIzGX0Q4/Adding-default-address-toggle-for-home-address-and-account-list?node-id=1223-25924&p=f&m=dev)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Tiny adjustment to default address font weight and icon sizes

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="736" height="333" alt="image" src="https://github.com/user-attachments/assets/b8238b8d-549d-4233-ac77-f4208c079b19" />


### **After**

<img width="298" height="348" alt="image" src="https://github.com/user-attachments/assets/62206148-31c6-4429-964a-1320e4ad5f65" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only tweaks (icon sizing and font weight) with no changes to data flow or address/copy behavior.
> 
> **Overview**
> Updates `MultichainAccountCellDefaultAddress` styling to better match design specs.
> 
> Reduces the dropdown arrow and copy icon sizes from `Sm` to `Xs`, and changes the displayed default address text weight from `Medium` to `Regular`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 816ebd0a612901fa2dbd6a6b02a5484423a525fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->