### PR TITLE
[Draft] [Bug]: NFTs in Send flow overlapping

### DIFF
--- a/ui/pages/confirmations/components/UI/asset/asset.test.tsx
+++ b/ui/pages/confirmations/components/UI/asset/asset.test.tsx
@@ -200,4 +200,18 @@ describe('NFTAsset', () => {
 
     expect(getByText('Native SegWit')).toBeInTheDocument();
   });
+
+  it('renders NftDefaultImage when both asset image and collection imageUrl are missing', () => {
+    const assetWithoutAnyImage = {
+      ...mockNFTERC721Asset,
+      image: undefined,
+      collection: {
+        ...mockNFTERC721Asset.collection,
+        imageUrl: undefined,
+      },
+    };
+    mockUseNftImageUrl.mockReturnValue('');
+    const { getByTestId } = render(<Asset asset={assetWithoutAnyImage} />);
+    expect(getByTestId('nft-default-image')).toBeInTheDocument();
+  });
 });

--- a/ui/pages/confirmations/components/UI/asset/asset.tsx
+++ b/ui/pages/confirmations/components/UI/asset/asset.tsx
@@ -28,6 +28,7 @@ import { accountTypeLabel } from '../../../constants/network';
 import { useFormatters } from '../../../../../hooks/useFormatters';
 import { AccountTypeLabel } from '../account-type-label';
 import { getAvatarTokenSrc } from '../../../../../components/app/assets/asset-list/cells/asset-cell-badge';
+import NftDefaultImage from '../../../../../components/app/assets/nfts/nft-default-image/nft-default-image';
 
 type AssetProps = {
   asset: AssetType;
@@ -90,7 +91,16 @@ const NftAsset = ({ asset, onClick, isSelected }: AssetProps) => {
                 objectFit: 'cover',
               }}
             />
-          ) : null}
+          ) : (
+            <Box
+              style={{
+                width: 32,
+                height: 32,
+              }}
+            >
+              <NftDefaultImage className="nft-asset__default-image" />
+            </Box>
+          )}
         </BadgeWrapper>
       </Box>
       <Box


### PR DESCRIPTION
## Summary

Perfect! I have successfully implemented the fix for the NFT overlapping issue in the MetaMask send flow. Here's the summary:



The fix addresses the root cause by ensuring that when NFTs don't have images (both `image` and `collection.imageUrl` are unavailable), the component renders a proper `NftDefaultImage` placeholder instead of `null`. This maintains the layout spacing and prevents the overlapping issue described in the bug report.

**Source:** https://github.com/MetaMask/metamask-extension/issues/40669

## Changes

| Metric | Value |
|--------|-------|
| Files changed | 2 |
| Lines added | +25 |
| Lines removed | -1 |

**Files:**
- `ui/pages/confirmations/components/UI/asset/asset.test.tsx`
- `ui/pages/confirmations/components/UI/asset/asset.tsx`

## Validation

**Status:** Passed
- lint: passed

## Review

**Status:** approved (high confidence)

## Agent Chain

| Step | Status | Duration | Attempt |
|------|--------|----------|---------|
| triage | passed | 15s | 1 |
| plan | passed | 84s | 1 |
| execute | passed | 91s | 1 |
| validate | passed | 21s | 1 |
| review | passed | 39s | 1 |
| __meta | passed | - | 0 |

## Metadata

- **Run ID:** `fcdfc706-ba6a-4d52-9a50-d261ec603ff4`
- **Total cost:** $0.7487
- **Evidence:** complete

---
*This PR was created by the MetaMask Autonomous Engineering Platform.*