### PR TITLE
[Draft] [Bug]: NFTs in Send flow overlapping

### DIFF
--- a/ui/pages/confirmations/components/UI/asset/asset.scss
+++ b/ui/pages/confirmations/components/UI/asset/asset.scss
@@ -1,0 +1,12 @@
+.nft-asset-default-image {
+  width: 32px;
+  height: 32px;
+  min-width: 32px;
+  min-height: 32px;
+  border-radius: 8px;
+  padding: 0;
+
+  // Override the padding-top: 100% from the base nft-default class
+  // since we need fixed dimensions for the Send flow layout
+  padding-top: 0 !important;
+}

--- a/ui/pages/confirmations/components/UI/asset/asset.test.tsx
+++ b/ui/pages/confirmations/components/UI/asset/asset.test.tsx
@@ -200,4 +200,22 @@ describe('NFTAsset', () => {
 
     expect(getByText('Native SegWit')).toBeInTheDocument();
   });
+
+  it('renders NftDefaultImage when no image or collection imageUrl is provided', () => {
+    mockUseNftImageUrl.mockReturnValue('');
+    const assetWithoutAnyImage = {
+      ...mockNFTERC721Asset,
+      image: undefined,
+      collection: {
+        name: 'Test Collection',
+        imageUrl: undefined,
+      },
+    };
+    const { getByTestId } = render(<Asset asset={assetWithoutAnyImage} />);
+
+    expect(getByTestId('nft-default-image')).toBeInTheDocument();
+    expect(getByTestId('nft-default-image')).toHaveClass(
+      'nft-asset-default-image',
+    );
+  });
 });

--- a/ui/pages/confirmations/components/UI/asset/asset.tsx
+++ b/ui/pages/confirmations/components/UI/asset/asset.tsx
@@ -10,6 +10,7 @@ import {
   Text,
   AvatarTokenSize,
 } from '../../../../../components/component-library';
+import NftDefaultImage from '../../../../../components/app/assets/nfts/nft-default-image/nft-default-image';
 import {
   AlignItems,
   BackgroundColor,
@@ -18,6 +19,7 @@ import {
   TextColor,
   TextVariant,
 } from '../../../../../helpers/constants/design-system';
+import './asset.scss';
 import {
   type Asset as AssetType,
   AssetStandard,
@@ -90,7 +92,12 @@ const NftAsset = ({ asset, onClick, isSelected }: AssetProps) => {
                 objectFit: 'cover',
               }}
             />
-          ) : null}
+          ) : (
+            <NftDefaultImage
+              className="nft-asset-default-image"
+              clickable={false}
+            />
+          )}
         </BadgeWrapper>
       </Box>
       <Box


### PR DESCRIPTION
## Summary

Step execute completed with 61 messages.

**Source:** https://github.com/MetaMask/metamask-extension/issues/40669

## Changes

| Metric | Value |
|--------|-------|
| Files changed | 3 |
| Lines added | +38 |
| Lines removed | -1 |

**Files:**
- `ui/pages/confirmations/components/UI/asset/asset.scss`
- `ui/pages/confirmations/components/UI/asset/asset.test.tsx`
- `ui/pages/confirmations/components/UI/asset/asset.tsx`

## Validation

**Status:** Passed
- lint: passed

## Review

**Status:** approved (high confidence)

**Findings:**
- [medium] Use of !important in CSS is generally discouraged, but the comment explains it's needed to override base nft-default class padding-top: 100%
- [low] Fixed dimensions (32x32px) are hardcoded in CSS rather than using design system tokens

## Agent Chain

| Step | Status | Duration | Attempt |
|------|--------|----------|---------|
| triage | passed | 12s | 1 |
| plan | passed | 138s | 1 |
| execute | passed | 96s | 1 |
| validate | failed | 21s | 1 |
| fix | passed | 21s | 1 |
| validate | passed | 18s | 2 |
| review | passed | 41s | 1 |
| __meta | passed | - | 0 |

## Metadata

- **Run ID:** `6d6befb8-3916-4c2b-a905-bb0840ab94c8`
- **Total cost:** $1.1021
- **Evidence:** complete

---
*This PR was created by the MetaMask Autonomous Engineering Platform.*