### PR TITLE
fix: use portal with popover and create candle interval modal

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5407,6 +5407,18 @@
   "perpsActivity": {
     "message": "Activity"
   },
+  "perpsCandleIntervals": {
+    "message": "Candle intervals"
+  },
+  "perpsCandlePeriodDays": {
+    "message": "Days"
+  },
+  "perpsCandlePeriodHours": {
+    "message": "Hours"
+  },
+  "perpsCandlePeriodMinutes": {
+    "message": "Minutes"
+  },
   "perpsAddExposure": {
     "message": "Add exposure"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5407,18 +5407,6 @@
   "perpsActivity": {
     "message": "Activity"
   },
-  "perpsCandleIntervals": {
-    "message": "Candle intervals"
-  },
-  "perpsCandlePeriodDays": {
-    "message": "Days"
-  },
-  "perpsCandlePeriodHours": {
-    "message": "Hours"
-  },
-  "perpsCandlePeriodMinutes": {
-    "message": "Minutes"
-  },
   "perpsAddExposure": {
     "message": "Add exposure"
   },
@@ -5477,6 +5465,18 @@
   },
   "perpsCancelOrder": {
     "message": "Cancel order"
+  },
+  "perpsCandleIntervals": {
+    "message": "Candle intervals"
+  },
+  "perpsCandlePeriodDays": {
+    "message": "Days"
+  },
+  "perpsCandlePeriodHours": {
+    "message": "Hours"
+  },
+  "perpsCandlePeriodMinutes": {
+    "message": "Minutes"
   },
   "perpsCloseAll": {
     "message": "Close all"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -5466,6 +5466,18 @@
   "perpsCancelOrder": {
     "message": "Cancel order"
   },
+  "perpsCandleIntervals": {
+    "message": "Candle intervals"
+  },
+  "perpsCandlePeriodDays": {
+    "message": "Days"
+  },
+  "perpsCandlePeriodHours": {
+    "message": "Hours"
+  },
+  "perpsCandlePeriodMinutes": {
+    "message": "Minutes"
+  },
   "perpsCloseAll": {
     "message": "Close all"
   },

--- a/ui/components/app/perps/constants/chartConfig.ts
+++ b/ui/components/app/perps/constants/chartConfig.ts
@@ -53,20 +53,6 @@ export const DEFAULT_CANDLE_PERIODS = [
   { label: '15min', value: CandlePeriod.FifteenMinutes },
 ] as const;
 
-// More periods shown in the dropdown (not in default row)
-export const MORE_CANDLE_PERIODS = [
-  { label: '30min', value: CandlePeriod.ThirtyMinutes },
-  { label: '1h', value: CandlePeriod.OneHour },
-  { label: '2h', value: CandlePeriod.TwoHours },
-  { label: '4h', value: CandlePeriod.FourHours },
-  { label: '8h', value: CandlePeriod.EightHours },
-  { label: '12h', value: CandlePeriod.TwelveHours },
-  { label: '1D', value: CandlePeriod.OneDay },
-  { label: '3D', value: CandlePeriod.ThreeDays },
-  { label: '1W', value: CandlePeriod.OneWeek },
-  { label: '1M', value: CandlePeriod.OneMonth },
-] as const;
-
 // Candle count configuration
 export const CANDLE_COUNT = {
   MIN: 10, // Minimum candles visible when zoomed in

--- a/ui/components/app/perps/perps-candle-period-selector/index.ts
+++ b/ui/components/app/perps/perps-candle-period-selector/index.ts
@@ -1,2 +1,4 @@
 export { default as PerpsCandlePeriodSelector } from './perps-candle-period-selector';
 export type { PerpsCandlePeriodSelectorProps } from './perps-candle-period-selector';
+export { default as PerpsCandlePeriodModal } from './perps-candle-period-modal';
+export type { PerpsCandlePeriodModalProps } from './perps-candle-period-modal';

--- a/ui/components/app/perps/perps-candle-period-selector/perps-candle-period-modal.test.tsx
+++ b/ui/components/app/perps/perps-candle-period-selector/perps-candle-period-modal.test.tsx
@@ -63,8 +63,6 @@ describe('PerpsCandlePeriodModal', () => {
 
     expect(screen.getByRole('dialog')).toHaveStyle({
       width: '100%',
-      maxWidth: '360px',
-      borderRadius: '20px',
     });
     expect(screen.getByRole('dialog')).not.toHaveStyle({
       marginTop: 'auto',

--- a/ui/components/app/perps/perps-candle-period-selector/perps-candle-period-modal.test.tsx
+++ b/ui/components/app/perps/perps-candle-period-selector/perps-candle-period-modal.test.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import {
+  ENVIRONMENT_TYPE_FULLSCREEN,
+  ENVIRONMENT_TYPE_POPUP,
+  ENVIRONMENT_TYPE_SIDEPANEL,
+} from '../../../../../shared/constants/app';
+import { CandlePeriod } from '../constants/chartConfig';
+import { PerpsCandlePeriodModal } from './perps-candle-period-modal';
+
+const mockT = jest.fn((key: string) => key);
+
+jest.mock('../../../../hooks/useI18nContext', () => ({
+  useI18nContext: () => mockT,
+}));
+
+const mockGetEnvironmentType = jest.fn();
+
+jest.mock('../../../../../shared/lib/environment-type', () => ({
+  getEnvironmentType: () => mockGetEnvironmentType(),
+}));
+
+describe('PerpsCandlePeriodModal', () => {
+  const defaultProps = {
+    isOpen: true,
+    selectedPeriod: CandlePeriod.FiveMinutes,
+    onClose: jest.fn(),
+    onPeriodChange: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetEnvironmentType.mockReturnValue(ENVIRONMENT_TYPE_POPUP);
+  });
+
+  it('renders as a bottom sheet in popup mode', () => {
+    render(<PerpsCandlePeriodModal {...defaultProps} />);
+
+    expect(screen.getByRole('dialog')).toHaveStyle({
+      marginTop: 'auto',
+      width: '100%',
+      maxWidth: '100%',
+      borderBottomLeftRadius: '0',
+      borderBottomRightRadius: '0',
+    });
+  });
+
+  it('renders as a bottom sheet in sidepanel mode', () => {
+    mockGetEnvironmentType.mockReturnValue(ENVIRONMENT_TYPE_SIDEPANEL);
+
+    render(<PerpsCandlePeriodModal {...defaultProps} />);
+
+    expect(screen.getByRole('dialog')).toHaveStyle({
+      marginTop: 'auto',
+      maxWidth: '100%',
+    });
+  });
+
+  it('renders as a centered modal in fullscreen mode', () => {
+    mockGetEnvironmentType.mockReturnValue(ENVIRONMENT_TYPE_FULLSCREEN);
+
+    render(<PerpsCandlePeriodModal {...defaultProps} />);
+
+    expect(screen.getByRole('dialog')).toHaveStyle({
+      width: '100%',
+      maxWidth: '360px',
+      borderRadius: '20px',
+    });
+    expect(screen.getByRole('dialog')).not.toHaveStyle({
+      marginTop: 'auto',
+      borderBottomLeftRadius: '0',
+    });
+  });
+
+  it('selects a period and closes the modal', () => {
+    render(<PerpsCandlePeriodModal {...defaultProps} />);
+
+    fireEvent.click(screen.getByTestId('perps-candle-period-modal-30m'));
+
+    expect(defaultProps.onPeriodChange).toHaveBeenCalledWith(
+      CandlePeriod.ThirtyMinutes,
+    );
+    expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+
+  it('only marks 1M as selected when the monthly period is selected', () => {
+    render(
+      <PerpsCandlePeriodModal
+        {...defaultProps}
+        selectedPeriod={CandlePeriod.OneMonth}
+      />,
+    );
+
+    expect(screen.getByTestId('perps-candle-period-modal-1M')).toHaveClass(
+      'bg-overlay-inverse',
+    );
+    expect(screen.getByTestId('perps-candle-period-modal-1m')).not.toHaveClass(
+      'bg-overlay-inverse',
+    );
+  });
+
+  it('closes when the close button is clicked', () => {
+    render(<PerpsCandlePeriodModal {...defaultProps} />);
+
+    fireEvent.click(screen.getByLabelText(mockT('close')));
+
+    expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+});

--- a/ui/components/app/perps/perps-candle-period-selector/perps-candle-period-modal.tsx
+++ b/ui/components/app/perps/perps-candle-period-selector/perps-candle-period-modal.tsx
@@ -32,7 +32,7 @@ import { CandlePeriod, CANDLE_PERIODS } from '../constants/chartConfig';
 import { isMatchingPeriod } from './perps-candle-period-utils';
 
 type CandlePeriodSection = {
-  title: string;
+  titleKey: string;
   periods: readonly {
     label: string;
     value: CandlePeriod;
@@ -41,7 +41,7 @@ type CandlePeriodSection = {
 
 const CANDLE_PERIOD_MODAL_SECTIONS: CandlePeriodSection[] = [
   {
-    title: 'Minutes',
+    titleKey: 'perpsCandlePeriodMinutes',
     periods: CANDLE_PERIODS.filter((period) =>
       [
         CandlePeriod.OneMinute,
@@ -53,7 +53,7 @@ const CANDLE_PERIOD_MODAL_SECTIONS: CandlePeriodSection[] = [
     ),
   },
   {
-    title: 'Hours',
+    titleKey: 'perpsCandlePeriodHours',
     periods: CANDLE_PERIODS.filter((period) =>
       [
         CandlePeriod.OneHour,
@@ -65,7 +65,7 @@ const CANDLE_PERIOD_MODAL_SECTIONS: CandlePeriodSection[] = [
     ),
   },
   {
-    title: 'Days',
+    titleKey: 'perpsCandlePeriodDays',
     periods: CANDLE_PERIODS.filter((period) =>
       [
         CandlePeriod.OneDay,
@@ -110,8 +110,6 @@ export const PerpsCandlePeriodModal: React.FC<PerpsCandlePeriodModalProps> = ({
           marginTop: 'auto',
           width: '100%',
           maxWidth: '100%',
-          borderBottomLeftRadius: 0,
-          borderBottomRightRadius: 0,
           borderTopLeftRadius: '20px',
           borderTopRightRadius: '20px',
           borderBottomLeftRadius: 0,
@@ -126,7 +124,6 @@ export const PerpsCandlePeriodModal: React.FC<PerpsCandlePeriodModalProps> = ({
           width: '100%',
           maxWidth: '360px',
           borderRadius: '20px',
-          overflow: 'hidden',
         },
       };
 
@@ -155,7 +152,7 @@ export const PerpsCandlePeriodModal: React.FC<PerpsCandlePeriodModalProps> = ({
               fontWeight={FontWeight.Bold}
               className="text-center"
             >
-              Candle intervals
+              {t('perpsCandleIntervals')}
             </Text>
             <ButtonIcon
               iconName={IconName.Close}
@@ -170,7 +167,7 @@ export const PerpsCandlePeriodModal: React.FC<PerpsCandlePeriodModalProps> = ({
         <Box className="flex flex-col gap-2 px-4 pt-1 pb-5">
           {CANDLE_PERIOD_MODAL_SECTIONS.map((section, sectionIndex) => (
             <Box
-              key={section.title}
+              key={section.titleKey}
               className={twMerge(
                 'flex flex-col gap-2',
                 sectionIndex > 0 && 'pt-5',
@@ -181,7 +178,7 @@ export const PerpsCandlePeriodModal: React.FC<PerpsCandlePeriodModalProps> = ({
                 color={TextColor.TextAlternative}
                 fontWeight={FontWeight.Medium}
               >
-                {section.title}
+                {t(section.titleKey)}
               </Text>
 
               <div className="grid grid-cols-5 gap-2">

--- a/ui/components/app/perps/perps-candle-period-selector/perps-candle-period-modal.tsx
+++ b/ui/components/app/perps/perps-candle-period-selector/perps-candle-period-modal.tsx
@@ -112,6 +112,11 @@ export const PerpsCandlePeriodModal: React.FC<PerpsCandlePeriodModalProps> = ({
           maxWidth: '100%',
           borderBottomLeftRadius: 0,
           borderBottomRightRadius: 0,
+          borderTopLeftRadius: '20px',
+          borderTopRightRadius: '20px',
+          borderBottomLeftRadius: 0,
+          borderBottomRightRadius: 0,
+          overflow: 'hidden',
         },
       }
     : {
@@ -121,6 +126,7 @@ export const PerpsCandlePeriodModal: React.FC<PerpsCandlePeriodModalProps> = ({
           width: '100%',
           maxWidth: '360px',
           borderRadius: '20px',
+          overflow: 'hidden',
         },
       };
 

--- a/ui/components/app/perps/perps-candle-period-selector/perps-candle-period-modal.tsx
+++ b/ui/components/app/perps/perps-candle-period-selector/perps-candle-period-modal.tsx
@@ -2,7 +2,10 @@ import React from 'react';
 import {
   Box,
   ButtonBase,
+  ButtonIcon,
+  ButtonIconSize,
   FontWeight,
+  IconName,
   Text,
   TextColor,
   TextVariant,
@@ -13,9 +16,6 @@ import {
   ModalContent,
   ModalOverlay,
   ModalContentSize,
-  ButtonIcon,
-  ButtonIconSize,
-  IconName,
 } from '../../../component-library';
 import {
   AlignItems,

--- a/ui/components/app/perps/perps-candle-period-selector/perps-candle-period-modal.tsx
+++ b/ui/components/app/perps/perps-candle-period-selector/perps-candle-period-modal.tsx
@@ -1,0 +1,219 @@
+import React from 'react';
+import {
+  Box,
+  ButtonBase,
+  FontWeight,
+  Text,
+  TextColor,
+  TextVariant,
+  twMerge,
+} from '@metamask/design-system-react';
+import {
+  Modal,
+  ModalContent,
+  ModalOverlay,
+  ModalContentSize,
+  ButtonIcon,
+  ButtonIconSize,
+  IconName,
+} from '../../../component-library';
+import {
+  AlignItems,
+  Display,
+  JustifyContent,
+} from '../../../../helpers/constants/design-system';
+import { useI18nContext } from '../../../../hooks/useI18nContext';
+import { getEnvironmentType } from '../../../../../shared/lib/environment-type';
+import {
+  ENVIRONMENT_TYPE_POPUP,
+  ENVIRONMENT_TYPE_SIDEPANEL,
+} from '../../../../../shared/constants/app';
+import { CandlePeriod, CANDLE_PERIODS } from '../constants/chartConfig';
+import { isMatchingPeriod } from './perps-candle-period-utils';
+
+type CandlePeriodSection = {
+  title: string;
+  periods: readonly {
+    label: string;
+    value: CandlePeriod;
+  }[];
+};
+
+const CANDLE_PERIOD_MODAL_SECTIONS: CandlePeriodSection[] = [
+  {
+    title: 'Minutes',
+    periods: CANDLE_PERIODS.filter((period) =>
+      [
+        CandlePeriod.OneMinute,
+        CandlePeriod.ThreeMinutes,
+        CandlePeriod.FiveMinutes,
+        CandlePeriod.FifteenMinutes,
+        CandlePeriod.ThirtyMinutes,
+      ].includes(period.value),
+    ),
+  },
+  {
+    title: 'Hours',
+    periods: CANDLE_PERIODS.filter((period) =>
+      [
+        CandlePeriod.OneHour,
+        CandlePeriod.TwoHours,
+        CandlePeriod.FourHours,
+        CandlePeriod.EightHours,
+        CandlePeriod.TwelveHours,
+      ].includes(period.value),
+    ),
+  },
+  {
+    title: 'Days',
+    periods: CANDLE_PERIODS.filter((period) =>
+      [
+        CandlePeriod.OneDay,
+        CandlePeriod.ThreeDays,
+        CandlePeriod.OneWeek,
+        CandlePeriod.OneMonth,
+      ].includes(period.value),
+    ),
+  },
+];
+
+export type PerpsCandlePeriodModalProps = {
+  isOpen: boolean;
+  selectedPeriod: CandlePeriod | string;
+  onClose: () => void;
+  onPeriodChange?: (period: CandlePeriod) => void;
+};
+
+export const PerpsCandlePeriodModal: React.FC<PerpsCandlePeriodModalProps> = ({
+  isOpen,
+  selectedPeriod,
+  onClose,
+  onPeriodChange,
+}) => {
+  const t = useI18nContext();
+
+  const handlePeriodSelect = (period: CandlePeriod) => {
+    onPeriodChange?.(period);
+    onClose();
+  };
+
+  const environmentType = getEnvironmentType();
+  const isCompactSheet =
+    environmentType === ENVIRONMENT_TYPE_POPUP ||
+    environmentType === ENVIRONMENT_TYPE_SIDEPANEL;
+
+  const modalLayoutProps = isCompactSheet
+    ? {
+        justifyContent: JustifyContent.flexEnd,
+        alignItems: AlignItems.stretch,
+        dialogStyle: {
+          marginTop: 'auto',
+          width: '100%',
+          maxWidth: '100%',
+          borderBottomLeftRadius: 0,
+          borderBottomRightRadius: 0,
+        },
+      }
+    : {
+        justifyContent: JustifyContent.center,
+        alignItems: AlignItems.center,
+        dialogStyle: {
+          width: '100%',
+          maxWidth: '360px',
+          borderRadius: '20px',
+        },
+      };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      data-testid="perps-candle-period-modal"
+    >
+      <ModalOverlay />
+      <ModalContent
+        size={ModalContentSize.Sm}
+        display={Display.Flex}
+        justifyContent={modalLayoutProps.justifyContent}
+        alignItems={modalLayoutProps.alignItems}
+        padding={0}
+        modalDialogProps={{
+          padding: 0,
+          style: modalLayoutProps.dialogStyle,
+        }}
+      >
+        <div className="px-4 pb-4 pt-3">
+          <div className="relative flex min-h-8 items-center justify-center">
+            <Text
+              variant={TextVariant.HeadingSm}
+              fontWeight={FontWeight.Bold}
+              className="text-center"
+            >
+              Candle intervals
+            </Text>
+            <ButtonIcon
+              iconName={IconName.Close}
+              ariaLabel={t('close')}
+              size={ButtonIconSize.Md}
+              onClick={onClose}
+              className="absolute right-0 top-1/2 -translate-y-1/2"
+            />
+          </div>
+        </div>
+
+        <Box className="flex flex-col gap-2 px-4 pt-1 pb-5">
+          {CANDLE_PERIOD_MODAL_SECTIONS.map((section, sectionIndex) => (
+            <Box
+              key={section.title}
+              className={twMerge(
+                'flex flex-col gap-2',
+                sectionIndex > 0 && 'pt-5',
+              )}
+            >
+              <Text
+                variant={TextVariant.BodySm}
+                color={TextColor.TextAlternative}
+                fontWeight={FontWeight.Medium}
+              >
+                {section.title}
+              </Text>
+
+              <div className="grid grid-cols-5 gap-2">
+                {section.periods.map((period) => {
+                  const isSelected = isMatchingPeriod(
+                    selectedPeriod,
+                    period.value,
+                  );
+
+                  return (
+                    <ButtonBase
+                      key={period.value}
+                      className={twMerge(
+                        'h-9 min-w-0 rounded-xl bg-muted px-0 py-0 transition-colors hover:bg-muted-hover active:bg-muted-pressed',
+                        isSelected &&
+                          'bg-overlay-inverse hover:bg-overlay-inverse active:bg-overlay-inverse',
+                      )}
+                      onClick={() => handlePeriodSelect(period.value)}
+                      data-testid={`perps-candle-period-modal-${period.value}`}
+                    >
+                      <Text
+                        variant={TextVariant.BodySm}
+                        fontWeight={FontWeight.Medium}
+                        className={isSelected ? 'text-icon-inverse' : undefined}
+                        color={isSelected ? undefined : TextColor.TextDefault}
+                      >
+                        {period.label}
+                      </Text>
+                    </ButtonBase>
+                  );
+                })}
+              </div>
+            </Box>
+          ))}
+        </Box>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default PerpsCandlePeriodModal;

--- a/ui/components/app/perps/perps-candle-period-selector/perps-candle-period-selector.tsx
+++ b/ui/components/app/perps/perps-candle-period-selector/perps-candle-period-selector.tsx
@@ -42,7 +42,7 @@ const PerpsCandlePeriodSelector: React.FC<PerpsCandlePeriodSelectorProps> = ({
   const [isMoreModalOpen, setIsMoreModalOpen] = useState(false);
 
   const isMorePeriodSelected = !DEFAULT_CANDLE_PERIODS.some((period) =>
-    isMatchingPeriod(period.value, selectedPeriod),
+    isMatchingPeriod(selectedPeriod, period.value),
   );
 
   const emitPeriodChange = useCallback(

--- a/ui/components/app/perps/perps-candle-period-selector/perps-candle-period-selector.tsx
+++ b/ui/components/app/perps/perps-candle-period-selector/perps-candle-period-selector.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import {
   twMerge,
   Box,
@@ -18,24 +18,15 @@ import {
   PERPS_EVENT_PROPERTY,
   PERPS_EVENT_VALUE,
 } from '../../../../../shared/constants/perps-events';
-import { Popover, PopoverPosition } from '../../../component-library';
 import { MetaMetricsEventName } from '../../../../../shared/constants/metametrics';
 import { usePerpsEventTracking } from '../../../../hooks/perps';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
+import { CandlePeriod, DEFAULT_CANDLE_PERIODS } from '../constants/chartConfig';
+import { PerpsCandlePeriodModal } from './perps-candle-period-modal';
 import {
-  CandlePeriod,
-  CANDLE_PERIODS,
-  DEFAULT_CANDLE_PERIODS,
-  MORE_CANDLE_PERIODS,
-} from '../constants/chartConfig';
-
-// Helper function to get the display label for a candle period
-const getCandlePeriodLabel = (period: CandlePeriod | string): string => {
-  const candlePeriod = CANDLE_PERIODS.find(
-    (p) => p.value?.toLowerCase() === period?.toLowerCase(),
-  );
-  return candlePeriod?.label || period;
-};
+  getCandlePeriodLabel,
+  isMatchingPeriod,
+} from './perps-candle-period-utils';
 
 export type PerpsCandlePeriodSelectorProps = {
   selectedPeriod: CandlePeriod | string;
@@ -48,12 +39,10 @@ const PerpsCandlePeriodSelector: React.FC<PerpsCandlePeriodSelectorProps> = ({
 }) => {
   const t = useI18nContext();
   const { track } = usePerpsEventTracking();
-  const [isMoreOpen, setIsMoreOpen] = useState(false);
-  const moreButtonRef = useRef<HTMLButtonElement>(null);
+  const [isMoreModalOpen, setIsMoreModalOpen] = useState(false);
 
-  // Check if the selected period is in the "More" category (not in default periods)
-  const isMorePeriodSelected = !DEFAULT_CANDLE_PERIODS.some(
-    (period) => period.value?.toLowerCase() === selectedPeriod?.toLowerCase(),
+  const isMorePeriodSelected = !DEFAULT_CANDLE_PERIODS.some((period) =>
+    isMatchingPeriod(period.value, selectedPeriod),
   );
 
   const emitPeriodChange = useCallback(
@@ -68,122 +57,80 @@ const PerpsCandlePeriodSelector: React.FC<PerpsCandlePeriodSelectorProps> = ({
     [onPeriodChange, track],
   );
 
-  const handleMorePeriodSelect = (period: CandlePeriod) => {
-    emitPeriodChange(period);
-    setIsMoreOpen(false);
-  };
-
   return (
-    <Box
-      flexDirection={BoxFlexDirection.Row}
-      alignItems={BoxAlignItems.Center}
-      justifyContent={BoxJustifyContent.Center}
-      gap={1}
-      paddingTop={2}
-      paddingBottom={2}
-      paddingLeft={4}
-      paddingRight={4}
-      data-testid="perps-candle-period-selector"
-    >
-      {/* Default Candle Period Buttons */}
-      {DEFAULT_CANDLE_PERIODS.map((period) => {
-        const isSelected =
-          selectedPeriod?.toLowerCase() === period.value?.toLowerCase();
+    <>
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        justifyContent={BoxJustifyContent.Center}
+        gap={1}
+        paddingTop={2}
+        paddingBottom={2}
+        paddingLeft={4}
+        paddingRight={4}
+        data-testid="perps-candle-period-selector"
+      >
+        {DEFAULT_CANDLE_PERIODS.map((period) => {
+          const isSelected = isMatchingPeriod(selectedPeriod, period.value);
 
-        return (
-          <ButtonBase
-            key={period.value}
-            className={twMerge(
-              '!py-1.5 h-auto !min-w-12 rounded-lg bg-transparent hover:bg-hover active:bg-pressed',
-              isSelected && 'bg-muted',
-            )}
-            onClick={() => {
-              emitPeriodChange(period.value);
-            }}
-            data-testid={`perps-candle-period-${period.value}`}
-          >
-            <Text
-              variant={TextVariant.BodySm}
-              color={
-                isSelected ? TextColor.TextDefault : TextColor.TextAlternative
-              }
+          return (
+            <ButtonBase
+              key={period.value}
+              className={twMerge(
+                'py-1.5 h-auto min-w-12 rounded-lg bg-transparent hover:bg-hover active:bg-pressed',
+                isSelected && 'bg-muted',
+              )}
+              onClick={() => emitPeriodChange(period.value)}
+              data-testid={`perps-candle-period-${period.value}`}
             >
-              {period.label}
-            </Text>
-          </ButtonBase>
-        );
-      })}
-
-      {/* More Button with Popover */}
-      <ButtonBase
-        ref={moreButtonRef}
-        className={twMerge(
-          '!py-1.5 h-auto !min-w-12 rounded-lg flex items-center gap-1 bg-transparent hover:bg-hover active:bg-pressed',
-          isMorePeriodSelected && 'bg-muted',
-        )}
-        onClick={() => setIsMoreOpen(!isMoreOpen)}
-        data-testid="perps-candle-period-more"
-      >
-        <Text
-          variant={TextVariant.BodySm}
-          color={
-            isMorePeriodSelected
-              ? TextColor.TextDefault
-              : TextColor.TextAlternative
-          }
-        >
-          {isMorePeriodSelected
-            ? getCandlePeriodLabel(selectedPeriod)
-            : t('perpsMore')}
-        </Text>
-        <Icon
-          name={IconName.ArrowDown}
-          size={IconSize.Xs}
-          color={IconColor.IconAlternative}
-          className="shrink-0"
-        />
-      </ButtonBase>
-
-      <Popover
-        isOpen={isMoreOpen}
-        position={PopoverPosition.BottomEnd}
-        referenceElement={moreButtonRef.current}
-        onClickOutside={() => setIsMoreOpen(false)}
-        onPressEscKey={() => setIsMoreOpen(false)}
-        padding={0}
-        className="rounded-lg bg-default"
-      >
-        <Box flexDirection={BoxFlexDirection.Column} padding={2} gap={1}>
-          {MORE_CANDLE_PERIODS.map((period) => {
-            const isSelected =
-              selectedPeriod?.toLowerCase() === period.value?.toLowerCase();
-
-            return (
-              <ButtonBase
-                key={period.value}
-                className={twMerge(
-                  '!px-2 !py-1.5 h-auto !min-w-16 rounded-lg text-left bg-transparent hover:bg-hover active:bg-pressed',
-                  isSelected && 'bg-muted',
-                )}
-                onClick={() => handleMorePeriodSelect(period.value)}
-                data-testid={`perps-candle-period-more-${period.value}`}
+              <Text
+                variant={TextVariant.BodySm}
+                color={
+                  isSelected ? TextColor.TextDefault : TextColor.TextAlternative
+                }
               >
-                <Text
-                  variant={TextVariant.BodySm}
-                  color={
-                    isSelected
-                      ? TextColor.TextDefault
-                      : TextColor.TextAlternative
-                  }
-                >
-                  {period.label}
-                </Text>
-              </ButtonBase>
-            );
-          })}
-        </Box>
-      </Popover>
-    </Box>
+                {period.label}
+              </Text>
+            </ButtonBase>
+          );
+        })}
+
+        <ButtonBase
+          className={twMerge(
+            'py-1.5 h-auto min-w-12 rounded-lg flex items-center gap-1 bg-transparent hover:bg-hover active:bg-pressed',
+            isMorePeriodSelected && 'bg-muted',
+          )}
+          onClick={() => setIsMoreModalOpen(true)}
+          data-testid="perps-candle-period-more"
+        >
+          <Text
+            variant={TextVariant.BodySm}
+            color={
+              isMorePeriodSelected
+                ? TextColor.TextDefault
+                : TextColor.TextAlternative
+            }
+          >
+            {isMorePeriodSelected
+              ? getCandlePeriodLabel(selectedPeriod)
+              : t('perpsMore')}
+          </Text>
+          <Icon
+            name={IconName.ArrowDown}
+            size={IconSize.Xs}
+            color={IconColor.IconAlternative}
+            className="shrink-0"
+          />
+        </ButtonBase>
+      </Box>
+
+      <PerpsCandlePeriodModal
+        isOpen={isMoreModalOpen}
+        selectedPeriod={selectedPeriod}
+        onClose={() => setIsMoreModalOpen(false)}
+        onPeriodChange={emitPeriodChange}
+      />
+    </>
   );
 };
 

--- a/ui/components/app/perps/perps-candle-period-selector/perps-candle-period-utils.ts
+++ b/ui/components/app/perps/perps-candle-period-selector/perps-candle-period-utils.ts
@@ -1,0 +1,14 @@
+import { CandlePeriod, CANDLE_PERIODS } from '../constants/chartConfig';
+
+export const isMatchingPeriod = (
+  periodA: CandlePeriod | string | undefined,
+  periodB: CandlePeriod | string | undefined,
+) => periodA === periodB;
+
+export const getCandlePeriodLabel = (period: CandlePeriod | string): string => {
+  const candlePeriod = CANDLE_PERIODS.find((candidate) =>
+    isMatchingPeriod(candidate.value, period),
+  );
+
+  return candlePeriod?.label || period;
+};

--- a/ui/pages/perps/perps-market-detail-page.test.tsx
+++ b/ui/pages/perps/perps-market-detail-page.test.tsx
@@ -778,7 +778,7 @@ describe('PerpsMarketDetailPage', () => {
       await renderPage(store);
 
       fireEvent.click(screen.getByTestId('perps-candle-period-more'));
-      fireEvent.click(screen.getByLabelText('Close'));
+      fireEvent.click(screen.getByLabelText(messages.close.message));
 
       expect(
         screen.queryByTestId('perps-candle-period-modal'),

--- a/ui/pages/perps/perps-market-detail-page.test.tsx
+++ b/ui/pages/perps/perps-market-detail-page.test.tsx
@@ -729,10 +729,18 @@ describe('PerpsMarketDetailPage', () => {
       expect(
         screen.getByTestId('perps-candle-period-modal'),
       ).toBeInTheDocument();
-      expect(screen.getByText('Candle intervals')).toBeInTheDocument();
-      expect(screen.getByText('Minutes')).toBeInTheDocument();
-      expect(screen.getByText('Hours')).toBeInTheDocument();
-      expect(screen.getByText('Days')).toBeInTheDocument();
+      expect(
+        screen.getByText(messages.perpsCandleIntervals.message),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(messages.perpsCandlePeriodMinutes.message),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(messages.perpsCandlePeriodHours.message),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(messages.perpsCandlePeriodDays.message),
+      ).toBeInTheDocument();
 
       const morePeriodOption = screen.getByTestId(
         'perps-candle-period-modal-30m',
@@ -745,6 +753,23 @@ describe('PerpsMarketDetailPage', () => {
       expect(
         screen.queryByTestId('perps-candle-period-modal'),
       ).not.toBeInTheDocument();
+    });
+
+    it('does not mark 1min as selected after selecting 1M from the modal', async () => {
+      const store = mockStore(createMockState(true));
+
+      await renderPage(store);
+
+      fireEvent.click(screen.getByTestId('perps-candle-period-more'));
+      fireEvent.click(screen.getByTestId('perps-candle-period-modal-1M'));
+
+      expect(screen.getByText('1M')).toBeInTheDocument();
+      expect(screen.getByTestId('perps-candle-period-more')).toHaveClass(
+        'bg-muted',
+      );
+      expect(screen.getByTestId('perps-candle-period-1m')).not.toHaveClass(
+        'bg-muted',
+      );
     });
 
     it('closes the candle period modal when the close button is clicked', async () => {

--- a/ui/pages/perps/perps-market-detail-page.test.tsx
+++ b/ui/pages/perps/perps-market-detail-page.test.tsx
@@ -734,9 +734,27 @@ describe('PerpsMarketDetailPage', () => {
       expect(screen.getByText('Hours')).toBeInTheDocument();
       expect(screen.getByText('Days')).toBeInTheDocument();
 
-      fireEvent.click(screen.getByTestId('perps-candle-period-modal-30m'));
+      const morePeriodOption = screen.getByTestId(
+        'perps-candle-period-modal-30m',
+      );
+      expect(morePeriodOption).toBeInTheDocument();
+
+      fireEvent.click(morePeriodOption);
 
       expect(screen.getByText('30min')).toBeInTheDocument();
+      expect(
+        screen.queryByTestId('perps-candle-period-modal'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('closes the candle period modal when the close button is clicked', async () => {
+      const store = mockStore(createMockState(true));
+
+      await renderPage(store);
+
+      fireEvent.click(screen.getByTestId('perps-candle-period-more'));
+      fireEvent.click(screen.getByLabelText('Close'));
+
       expect(
         screen.queryByTestId('perps-candle-period-modal'),
       ).not.toBeInTheDocument();

--- a/ui/pages/perps/perps-market-detail-page.test.tsx
+++ b/ui/pages/perps/perps-market-detail-page.test.tsx
@@ -593,7 +593,9 @@ describe('PerpsMarketDetailPage', () => {
 
       fireEvent.click(screen.getByTestId('perps-modify-cta-button'));
 
-      expect(screen.getByTestId('perps-modify-menu')).toBeInTheDocument();
+      const modifyMenu = screen.getByTestId('perps-modify-menu');
+      expect(modifyMenu).toBeInTheDocument();
+      expect(modifyMenu.parentElement).toBe(document.body);
       expect(
         screen.getByTestId('perps-modify-menu-add-exposure'),
       ).toBeInTheDocument();
@@ -620,7 +622,9 @@ describe('PerpsMarketDetailPage', () => {
       await renderPage(store);
 
       fireEvent.click(screen.getByTestId('perps-margin-card'));
-      expect(screen.getByTestId('perps-margin-menu')).toBeInTheDocument();
+      const marginMenu = screen.getByTestId('perps-margin-menu');
+      expect(marginMenu).toBeInTheDocument();
+      expect(marginMenu.parentElement).toBe(document.body);
       expect(
         screen.getByText(messages.perpsAddMargin.message),
       ).toBeInTheDocument();
@@ -713,6 +717,29 @@ describe('PerpsMarketDetailPage', () => {
       expect(
         screen.getByTestId('perps-decrease-margin-modal'),
       ).toBeInTheDocument();
+    });
+
+    it('updates the selected candle period from the More menu', async () => {
+      const store = mockStore(createMockState(true));
+
+      await renderPage(store);
+
+      fireEvent.click(screen.getByTestId('perps-candle-period-more'));
+
+      expect(
+        screen.getByTestId('perps-candle-period-modal'),
+      ).toBeInTheDocument();
+      expect(screen.getByText('Candle intervals')).toBeInTheDocument();
+      expect(screen.getByText('Minutes')).toBeInTheDocument();
+      expect(screen.getByText('Hours')).toBeInTheDocument();
+      expect(screen.getByText('Days')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId('perps-candle-period-modal-30m'));
+
+      expect(screen.getByText('30min')).toBeInTheDocument();
+      expect(
+        screen.queryByTestId('perps-candle-period-modal'),
+      ).not.toBeInTheDocument();
     });
 
     it('displays Close Long button text for long position', async () => {

--- a/ui/pages/perps/perps-market-detail-page.tsx
+++ b/ui/pages/perps/perps-market-detail-page.tsx
@@ -1224,12 +1224,15 @@ const PerpsMarketDetailPage: React.FC = () => {
                   <Popover
                     referenceElement={marginMenuRef.current}
                     isOpen={isMarginMenuOpen}
+                    isPortal
                     onClickOutside={() => setIsMarginMenuOpen(false)}
                     onPressEscKey={() => setIsMarginMenuOpen(false)}
                     position={PopoverPosition.Top}
+                    preventOverflow
+                    flip
                     offset={[0, 8]}
                     padding={0}
-                    className="min-w-[220px] rounded-lg"
+                    className="min-w-[220px] rounded-lg z-[1050]"
                     data-testid="perps-margin-menu"
                   >
                     <Box flexDirection={BoxFlexDirection.Column}>
@@ -1714,12 +1717,16 @@ const PerpsMarketDetailPage: React.FC = () => {
               <Popover
                 referenceElement={modifyMenuRef.current}
                 isOpen={isModifyMenuOpen}
+                isPortal
                 onClickOutside={() => setIsModifyMenuOpen(false)}
                 onPressEscKey={() => setIsModifyMenuOpen(false)}
                 position={PopoverPosition.Top}
+                preventOverflow
+                flip
+                offset={[0, 8]}
                 padding={0}
                 matchWidth
-                className="rounded-lg"
+                className="rounded-lg z-[1050]"
                 data-testid="perps-modify-menu"
               >
                 <Box flexDirection={BoxFlexDirection.Column}>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes the perps position card dropdown and interval selection issues in the extension.

The change was needed because several perps menus were rendering with the wrong layering and interaction behavior. The Modify and margin menus could overlap the chart or nearby controls, making options like Add Exposure appear broken or untappable. The chart timeframe More menu also did not work well as a dropdown in compact extension layouts and had a selection bug where choosing 1M could incorrectly also mark 1min as selected.

  The solution is twofold. First, the affected perps action menus were updated so they render above surrounding UI reliably and remain tappable. Second, the chart timeframe More control was redesigned from a dropdown into a modal surface modeled on the mobile/Figma pattern, with responsive presentation across popup, side panel, and fullscreen modes. The timeframe selection logic was also corrected to use exact candle-period matching, which fixes the 1m versus 1M collision. Together, these changes make the perps controls visually correct, consistent across extension surfaces, and reliable to interact with.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixes the perps position card dropdown and interval selection issues in the extension

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2791

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/5fab9b2b-dbe9-408b-8835-150861057d8e



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes perps trading UI interaction surfaces (position action popovers and candle period selection), which could affect usability/regress selection behavior across extension layouts. Scope is contained to UI/components with added tests and no sensitive data/auth logic.
> 
> **Overview**
> Fixes perps UI layering and interval selection issues in the extension.
> 
> Position card `Modify` and `Margin` popovers are updated to render via portal with overflow/flip handling and higher z-index so menus appear above nearby UI reliably.
> 
> Replaces the candle period “More” popover with a responsive `PerpsCandlePeriodModal` (bottom sheet in popup/sidepanel, centered modal in fullscreen), adds i18n strings for section headers, and introduces exact period matching/utilities to avoid the `1m` vs `1M` selection collision; includes new/updated tests covering modal behavior and selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 521522fb73a12f2901feba2fc66dc6b2c26bb3ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->