### PR TITLE
ci: exclude "Process completed with exit code" from Triage and Retry System

### DIFF
--- a/.github/scripts/classify-failures.mts
+++ b/.github/scripts/classify-failures.mts
@@ -422,7 +422,11 @@ function classifyJob(job: Job): JobClassification {
   // No transient pattern matched. Capture the first annotation message or
   // the last few log lines so the dashboard can surface what the actual
   // error was — useful for identifying new patterns to add.
-  const firstAnnotation = annotations.find((a) => a.message?.trim());
+  // Skip the generic "Process completed with exit code N" annotation —
+  // it appears on every failed job and provides no diagnostic value.
+  const firstAnnotation = annotations.find(
+    (a) => a.message?.trim() && !/^Process completed with exit code \d+/.test(a.message.trim()),
+  );
   const fallbackSnippet = firstAnnotation
     ? firstAnnotation.message!.trim().slice(0, 200)
     : logs


### PR DESCRIPTION
## **Description**

The Sentry dashboard for the Triage and Retry System is collecting `Process completed with exit code 1.` errors, which are worthless and should be ignored.

<img width="990" height="270" alt="image" src="https://github.com/user-attachments/assets/0ae6e5fc-4c88-478d-a362-ea2cd7e42c5c" />

## **Changelog**

CHANGELOG entry: null

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**
[skip-e2e]-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts fallback error-snippet selection for CI failure classification/reporting, without changing retry decision logic or external interfaces.
> 
> **Overview**
> Prevents the triage/retry classifier from using the generic GitHub Actions annotation `Process completed with exit code N` as the fallback `errorSnippet` when no transient pattern matches.
> 
> When capturing a representative annotation message, the script now skips this non-diagnostic annotation and falls back to the next meaningful annotation (or log tail) for better Sentry/dashboard signal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bad6bcc96106e6e79bed65c38972fa74b7c6f75e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->