### PR TITLE
refactor: rename controller to messengerClient in init files

### DIFF
--- a/app/scripts/messenger-client-init/account-order-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/account-order-controller-init.test.ts
@@ -25,13 +25,13 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('AccountOrderControllerInit', () => {
-  it('initializes the messengerClient', () => {
+  it('initializes the controller', () => {
     const { messengerClient } =
       AccountOrderControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(AccountOrderController);
   });
 
-  it('passes the proper arguments to the messengerClient', () => {
+  it('passes the proper arguments to the controller', () => {
     AccountOrderControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(AccountOrderController);

--- a/app/scripts/messenger-client-init/account-order-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/account-order-controller-init.test.ts
@@ -25,12 +25,13 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('AccountOrderControllerInit', () => {
-  it('initializes the controller', () => {
-    const { controller } = AccountOrderControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(AccountOrderController);
+  it('initializes the messengerClient', () => {
+    const { messengerClient } =
+      AccountOrderControllerInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(AccountOrderController);
   });
 
-  it('passes the proper arguments to the controller', () => {
+  it('passes the proper arguments to the messengerClient', () => {
     AccountOrderControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(AccountOrderController);

--- a/app/scripts/messenger-client-init/account-order-controller-init.ts
+++ b/app/scripts/messenger-client-init/account-order-controller-init.ts
@@ -17,12 +17,12 @@ export const AccountOrderControllerInit: MessengerClientInitFunction<
   AccountOrderController,
   AccountOrderControllerMessenger
 > = ({ controllerMessenger, persistedState }) => {
-  const controller = new AccountOrderController({
+  const messengerClient = new AccountOrderController({
     messenger: controllerMessenger,
     state: persistedState.AccountOrderController,
   });
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/account-tracker-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/account-tracker-controller-init.test.ts
@@ -89,12 +89,13 @@ function getInitRequestMock(
 }
 
 describe('AccountTrackerControllerInit', () => {
-  it('initializes the controller', () => {
-    const { controller } = AccountTrackerControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(AccountTrackerController);
+  it('initializes the messengerClient', () => {
+    const { messengerClient } =
+      AccountTrackerControllerInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(AccountTrackerController);
   });
 
-  it('passes the proper arguments to the controller', () => {
+  it('passes the proper arguments to the messengerClient', () => {
     AccountTrackerControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(AccountTrackerController);

--- a/app/scripts/messenger-client-init/account-tracker-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/account-tracker-controller-init.test.ts
@@ -89,13 +89,13 @@ function getInitRequestMock(
 }
 
 describe('AccountTrackerControllerInit', () => {
-  it('initializes the messengerClient', () => {
+  it('initializes the controller', () => {
     const { messengerClient } =
       AccountTrackerControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(AccountTrackerController);
   });
 
-  it('passes the proper arguments to the messengerClient', () => {
+  it('passes the proper arguments to the controller', () => {
     AccountTrackerControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(AccountTrackerController);

--- a/app/scripts/messenger-client-init/account-tracker-controller-init.ts
+++ b/app/scripts/messenger-client-init/account-tracker-controller-init.ts
@@ -10,15 +10,15 @@ export const AccountTrackerControllerInit: MessengerClientInitFunction<
   AccountTrackerController,
   AccountTrackerControllerMessenger,
   AccountTrackerControllerInitMessenger
-> = ({ controllerMessenger, initMessenger, getController }) => {
+> = ({ controllerMessenger, initMessenger, getMessengerClient }) => {
   const getAssetsContractController = () =>
-    getController('AssetsContractController');
+    getMessengerClient('AssetsContractController');
 
-  const onboardingController = () => getController('OnboardingController');
+  const onboardingController = () => getMessengerClient('OnboardingController');
 
   // TODO: Fix AccountTrackerControllerMessenger type - add AccountTrackerControllerActions & AccountTrackerControllerEvents
   // TODO: Bump @metamask/network-controller, @metamask/accounts-controller to match assets-controllers
-  const controller = new AccountTrackerController({
+  const messengerClient = new AccountTrackerController({
     messenger: controllerMessenger,
     getStakedBalanceForChain: (
       addresses: string[],
@@ -57,6 +57,6 @@ export const AccountTrackerControllerInit: MessengerClientInitFunction<
   return {
     persistedStateKey: null,
     memStateKey: null,
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/accounts-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/accounts-controller-init.test.ts
@@ -25,12 +25,12 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('AccountsControllerInit', () => {
-  it('initializes the controller', () => {
-    const { controller } = AccountsControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(AccountsController);
+  it('initializes the messengerClient', () => {
+    const { messengerClient } = AccountsControllerInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(AccountsController);
   });
 
-  it('passes the proper arguments to the controller', () => {
+  it('passes the proper arguments to the messengerClient', () => {
     AccountsControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(AccountsController);

--- a/app/scripts/messenger-client-init/accounts-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/accounts-controller-init.test.ts
@@ -25,12 +25,12 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('AccountsControllerInit', () => {
-  it('initializes the messengerClient', () => {
+  it('initializes the controller', () => {
     const { messengerClient } = AccountsControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(AccountsController);
   });
 
-  it('passes the proper arguments to the messengerClient', () => {
+  it('passes the proper arguments to the controller', () => {
     AccountsControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(AccountsController);

--- a/app/scripts/messenger-client-init/accounts-controller-init.ts
+++ b/app/scripts/messenger-client-init/accounts-controller-init.ts
@@ -15,13 +15,13 @@ export const AccountsControllerInit: MessengerClientInitFunction<
   AccountsController,
   AccountsControllerMessenger
 > = ({ controllerMessenger, persistedState }) => {
-  const controller = new AccountsController({
+  const messengerClient = new AccountsController({
     messenger: controllerMessenger,
     // @ts-expect-error: Accounts controller does not accept partial state.
     state: persistedState.AccountsController,
   });
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/accounts/account-tree-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/accounts/account-tree-controller-init.test.ts
@@ -40,9 +40,9 @@ describe('AccountTreeControllerInit', () => {
 
   it('returns controller instance', () => {
     const requestMock = buildInitRequestMock();
-    expect(AccountTreeControllerInit(requestMock).controller).toBeInstanceOf(
-      AccountTreeController,
-    );
+    expect(
+      AccountTreeControllerInit(requestMock).messengerClient,
+    ).toBeInstanceOf(AccountTreeController);
   });
 
   it('initializes with correct messenger and state', () => {

--- a/app/scripts/messenger-client-init/accounts/account-tree-controller-init.ts
+++ b/app/scripts/messenger-client-init/accounts/account-tree-controller-init.ts
@@ -23,7 +23,7 @@ export const AccountTreeControllerInit: MessengerClientInitFunction<
   AccountTreeControllerMessenger,
   AccountTreeControllerInitMessenger
 > = ({ controllerMessenger, persistedState, initMessenger }) => {
-  const controller = new AccountTreeController({
+  const messengerClient = new AccountTreeController({
     messenger: controllerMessenger,
     state: persistedState.AccountTreeController,
     config: {
@@ -84,5 +84,5 @@ export const AccountTreeControllerInit: MessengerClientInitFunction<
   // the `AccountsController.updateAccounts` method and re-construct the tree at the
   // same time.
 
-  return { controller };
+  return { messengerClient };
 };

--- a/app/scripts/messenger-client-init/accounts/snap-keyring-builder-init.ts
+++ b/app/scripts/messenger-client-init/accounts/snap-keyring-builder-init.ts
@@ -40,6 +40,6 @@ export const SnapKeyringBuilderInit: MessengerClientInitFunction<
   return {
     persistedStateKey: null,
     memStateKey: null,
-    controller: builder,
+    messengerClient: builder,
   };
 };

--- a/app/scripts/messenger-client-init/alert-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/alert-controller-init.test.ts
@@ -25,12 +25,12 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('AlertControllerInit', () => {
-  it('initializes the controller', () => {
-    const { controller } = AlertControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(AlertController);
+  it('initializes the messengerClient', () => {
+    const { messengerClient } = AlertControllerInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(AlertController);
   });
 
-  it('passes the proper arguments to the controller', () => {
+  it('passes the proper arguments to the messengerClient', () => {
     AlertControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(AlertController);

--- a/app/scripts/messenger-client-init/alert-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/alert-controller-init.test.ts
@@ -25,12 +25,12 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('AlertControllerInit', () => {
-  it('initializes the messengerClient', () => {
+  it('initializes the controller', () => {
     const { messengerClient } = AlertControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(AlertController);
   });
 
-  it('passes the proper arguments to the messengerClient', () => {
+  it('passes the proper arguments to the controller', () => {
     AlertControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(AlertController);

--- a/app/scripts/messenger-client-init/alert-controller-init.ts
+++ b/app/scripts/messenger-client-init/alert-controller-init.ts
@@ -17,12 +17,12 @@ export const AlertControllerInit: MessengerClientInitFunction<
   AlertController,
   AlertControllerMessenger
 > = ({ controllerMessenger, persistedState }) => {
-  const controller = new AlertController({
+  const messengerClient = new AlertController({
     state: persistedState.AlertController,
     messenger: controllerMessenger,
   });
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/announcement-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/announcement-controller-init.test.ts
@@ -26,13 +26,13 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('AnnouncementControllerInit', () => {
-  it('initializes the messengerClient', () => {
+  it('initializes the controller', () => {
     const { messengerClient } =
       AnnouncementControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(AnnouncementController);
   });
 
-  it('passes the proper arguments to the messengerClient', () => {
+  it('passes the proper arguments to the controller', () => {
     AnnouncementControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(AnnouncementController);

--- a/app/scripts/messenger-client-init/announcement-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/announcement-controller-init.test.ts
@@ -26,12 +26,13 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('AnnouncementControllerInit', () => {
-  it('initializes the controller', () => {
-    const { controller } = AnnouncementControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(AnnouncementController);
+  it('initializes the messengerClient', () => {
+    const { messengerClient } =
+      AnnouncementControllerInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(AnnouncementController);
   });
 
-  it('passes the proper arguments to the controller', () => {
+  it('passes the proper arguments to the messengerClient', () => {
     AnnouncementControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(AnnouncementController);

--- a/app/scripts/messenger-client-init/announcement-controller-init.ts
+++ b/app/scripts/messenger-client-init/announcement-controller-init.ts
@@ -16,7 +16,7 @@ export const AnnouncementControllerInit: MessengerClientInitFunction<
   AnnouncementController,
   AnnouncementControllerMessenger
 > = ({ controllerMessenger, persistedState }) => {
-  const controller = new AnnouncementController({
+  const messengerClient = new AnnouncementController({
     messenger: controllerMessenger,
     allAnnouncements: UI_NOTIFICATIONS,
     // @ts-expect-error: Announcement controller does not accept partial state.
@@ -24,6 +24,6 @@ export const AnnouncementControllerInit: MessengerClientInitFunction<
   });
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/app-metadata-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/app-metadata-controller-init.test.ts
@@ -25,12 +25,12 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('AppMetadataControllerInit', () => {
-  it('initializes the messengerClient', () => {
+  it('initializes the controller', () => {
     const { messengerClient } = AppMetadataControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(AppMetadataController);
   });
 
-  it('passes the proper arguments to the messengerClient', () => {
+  it('passes the proper arguments to the controller', () => {
     AppMetadataControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(AppMetadataController);

--- a/app/scripts/messenger-client-init/app-metadata-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/app-metadata-controller-init.test.ts
@@ -25,12 +25,12 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('AppMetadataControllerInit', () => {
-  it('initializes the controller', () => {
-    const { controller } = AppMetadataControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(AppMetadataController);
+  it('initializes the messengerClient', () => {
+    const { messengerClient } = AppMetadataControllerInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(AppMetadataController);
   });
 
-  it('passes the proper arguments to the controller', () => {
+  it('passes the proper arguments to the messengerClient', () => {
     AppMetadataControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(AppMetadataController);

--- a/app/scripts/messenger-client-init/app-metadata-controller-init.ts
+++ b/app/scripts/messenger-client-init/app-metadata-controller-init.ts
@@ -18,7 +18,7 @@ export const AppMetadataControllerInit: MessengerClientInitFunction<
   AppMetadataController,
   AppMetadataControllerMessenger
 > = ({ controllerMessenger, persistedState, currentMigrationVersion }) => {
-  const controller = new AppMetadataController({
+  const messengerClient = new AppMetadataController({
     state: persistedState.AppMetadataController,
     messenger: controllerMessenger,
     currentAppVersion: process.env.METAMASK_VERSION,
@@ -26,6 +26,6 @@ export const AppMetadataControllerInit: MessengerClientInitFunction<
   });
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/app-state-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/app-state-controller-init.test.ts
@@ -25,12 +25,12 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('AppStateControllerInit', () => {
-  it('initializes the controller', () => {
-    const { controller } = AppStateControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(AppStateController);
+  it('initializes the messengerClient', () => {
+    const { messengerClient } = AppStateControllerInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(AppStateController);
   });
 
-  it('passes the proper arguments to the controller', () => {
+  it('passes the proper arguments to the messengerClient', () => {
     AppStateControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(AppStateController);

--- a/app/scripts/messenger-client-init/app-state-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/app-state-controller-init.test.ts
@@ -25,12 +25,12 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('AppStateControllerInit', () => {
-  it('initializes the messengerClient', () => {
+  it('initializes the controller', () => {
     const { messengerClient } = AppStateControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(AppStateController);
   });
 
-  it('passes the proper arguments to the messengerClient', () => {
+  it('passes the proper arguments to the controller', () => {
     AppStateControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(AppStateController);

--- a/app/scripts/messenger-client-init/app-state-controller-init.ts
+++ b/app/scripts/messenger-client-init/app-state-controller-init.ts
@@ -18,7 +18,7 @@ export const AppStateControllerInit: MessengerClientInitFunction<
   AppStateController,
   AppStateControllerMessenger
 > = ({ controllerMessenger, persistedState, setLocked, extension }) => {
-  const controller = new AppStateController({
+  const messengerClient = new AppStateController({
     messenger: controllerMessenger,
     state: persistedState.AppStateController,
     onInactiveTimeout: () => setLocked(),
@@ -26,6 +26,6 @@ export const AppStateControllerInit: MessengerClientInitFunction<
   });
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/assets/assets-contract-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/assets/assets-contract-controller-init.test.ts
@@ -80,9 +80,9 @@ describe('AssetsContractControllerInit', () => {
 
   it('returns controller instance', () => {
     const requestMock = buildInitRequestMock();
-    expect(AssetsContractControllerInit(requestMock).controller).toBeInstanceOf(
-      AssetsContractController,
-    );
+    expect(
+      AssetsContractControllerInit(requestMock).messengerClient,
+    ).toBeInstanceOf(AssetsContractController);
   });
 
   it('initializes with correct messenger and state', () => {

--- a/app/scripts/messenger-client-init/assets/assets-contract-controller-init.ts
+++ b/app/scripts/messenger-client-init/assets/assets-contract-controller-init.ts
@@ -21,13 +21,13 @@ export const AssetsContractControllerInit: MessengerClientInitFunction<
 > = ({ controllerMessenger, initMessenger }) => {
   // TODO: Fix AssetsContractControllerMessenger type - add AssetsContractControllerActions
   // TODO: Bump @metamask/network-controller to match assets-controllers
-  const controller = new AssetsContractController({
+  const messengerClient = new AssetsContractController({
     messenger: controllerMessenger,
     chainId: getGlobalChainId(initMessenger),
   });
 
   return {
-    controller,
+    messengerClient,
     memStateKey: null,
     persistedStateKey: null,
   };

--- a/app/scripts/messenger-client-init/assets/assets-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/assets/assets-controller-init.test.ts
@@ -62,7 +62,7 @@ function getInitRequestMock(
   };
 
   // Mock getController for RemoteFeatureFlagController
-  requestMock.getController.mockImplementation((controllerName) => {
+  requestMock.getMessengerClient.mockImplementation((controllerName) => {
     if (controllerName === 'RemoteFeatureFlagController') {
       return {
         state: {
@@ -73,7 +73,7 @@ function getInitRequestMock(
             },
           },
         },
-      } as unknown as ReturnType<typeof requestMock.getController>;
+      } as unknown as ReturnType<typeof requestMock.getMessengerClient>;
     }
     throw new Error(`Unexpected controller name: ${controllerName}`);
   });
@@ -98,8 +98,8 @@ describe('AssetsControllerInit', () => {
   });
 
   it('initializes the controller', () => {
-    const { controller } = AssetsControllerInit(getInitRequestMock());
-    expect(controller).toBeDefined();
+    const { messengerClient } = AssetsControllerInit(getInitRequestMock());
+    expect(messengerClient).toBeDefined();
   });
 
   it('creates AssetsController with correct parameters', () => {
@@ -261,13 +261,13 @@ describe('AssetsControllerInit', () => {
         initMessenger: getAssetsControllerInitMessenger(baseMessenger),
       };
 
-      requestMock.getController.mockImplementation((controllerName) => {
+      requestMock.getMessengerClient.mockImplementation((controllerName) => {
         if (controllerName === 'RemoteFeatureFlagController') {
           return {
             state: {
               remoteFeatureFlags: {},
             },
-          } as unknown as ReturnType<typeof requestMock.getController>;
+          } as unknown as ReturnType<typeof requestMock.getMessengerClient>;
         }
         throw new Error(`Unexpected controller name: ${controllerName}`);
       });
@@ -293,7 +293,7 @@ describe('AssetsControllerInit', () => {
       expect(isEnabled()).toBe(false);
     });
 
-    it('returns false when getController throws an error', () => {
+    it('returns false when getMessengerClient throws an error', () => {
       jest.mocked(isAssetsUnifyStateFeatureEnabled).mockReturnValue(false);
 
       const baseMessenger = getRootMessenger<never, never>();
@@ -304,7 +304,7 @@ describe('AssetsControllerInit', () => {
         initMessenger: getAssetsControllerInitMessenger(baseMessenger),
       };
 
-      requestMock.getController.mockImplementation(() => {
+      requestMock.getMessengerClient.mockImplementation(() => {
         throw new Error('Controller not found');
       });
 

--- a/app/scripts/messenger-client-init/assets/assets-controller-init.ts
+++ b/app/scripts/messenger-client-init/assets/assets-controller-init.ts
@@ -104,14 +104,19 @@ function getApiClient(
  * @param request.controllerMessenger - The messenger to use for the controller.
  * @param request.persistedState - The persisted state of the extension.
  * @param request.initMessenger - The init messenger to use for the controller.
- * @param request.getController - Function to get a controller by name.
+ * @param request.getMessengerClient - Function to get a controller by name.
  * @returns The initialized controller.
  */
 export const AssetsControllerInit: MessengerClientInitFunction<
   AssetsController,
   AssetsControllerMessenger,
   AssetsControllerInitMessenger
-> = ({ controllerMessenger, persistedState, initMessenger, getController }) => {
+> = ({
+  controllerMessenger,
+  persistedState,
+  initMessenger,
+  getMessengerClient,
+}) => {
   /**
    * Check if the AssetsController feature is enabled based on the remote feature flag.
    *
@@ -119,7 +124,7 @@ export const AssetsControllerInit: MessengerClientInitFunction<
    */
   const isEnabled = (): boolean => {
     try {
-      const remoteFeatureFlagController = getController(
+      const remoteFeatureFlagController = getMessengerClient(
         'RemoteFeatureFlagController',
       );
       const featureFlag = remoteFeatureFlagController.state.remoteFeatureFlags[
@@ -159,7 +164,7 @@ export const AssetsControllerInit: MessengerClientInitFunction<
 
   // Create the controller - it now creates all data sources internally.
   // queryApiClient is cast to the package's type to avoid duplicate @metamask/core-backend type conflicts.
-  const controller = new AssetsController({
+  const messengerClient = new AssetsController({
     messenger: controllerMessenger,
     state: persistedState.AssetsController,
     isEnabled,
@@ -181,5 +186,5 @@ export const AssetsControllerInit: MessengerClientInitFunction<
     trace: traceAsControllerCallback,
   });
 
-  return { controller };
+  return { messengerClient };
 };

--- a/app/scripts/messenger-client-init/assets/client-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/assets/client-controller-init.test.ts
@@ -16,7 +16,7 @@ describe('ClientControllerInit', () => {
 
     const result = ClientControllerInit(request);
 
-    expect(result.controller).toBeInstanceOf(ClientController);
+    expect(result.messengerClient).toBeInstanceOf(ClientController);
   });
 
   it('initializes with persisted state when provided', () => {
@@ -32,6 +32,6 @@ describe('ClientControllerInit', () => {
 
     const result = ClientControllerInit(request);
 
-    expect(result.controller.state.isUiOpen).toBe(true);
+    expect(result.messengerClient.state.isUiOpen).toBe(true);
   });
 });

--- a/app/scripts/messenger-client-init/assets/client-controller-init.ts
+++ b/app/scripts/messenger-client-init/assets/client-controller-init.ts
@@ -17,12 +17,12 @@ export const ClientControllerInit: MessengerClientInitFunction<
 > = (request) => {
   const { controllerMessenger, persistedState } = request;
 
-  const controller = new ClientController({
+  const messengerClient = new ClientController({
     messenger: controllerMessenger,
     state: persistedState.ClientController,
   });
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/assets/network-enablement-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/assets/network-enablement-controller-init.test.ts
@@ -40,7 +40,7 @@ function getInitRequestMock(
   };
 
   // @ts-expect-error: Partial mock.
-  requestMock.getController.mockImplementation((controllerName) => {
+  requestMock.getMessengerClient.mockImplementation((controllerName) => {
     if (controllerName === 'MultichainNetworkController') {
       return {
         state: {
@@ -65,17 +65,17 @@ function getInitRequestMock(
       };
     }
 
-    throw new Error(`Unexpected controller name: ${controllerName}`);
+    throw new Error(`Unexpected messengerClient name: ${controllerName}`);
   });
 
   return requestMock;
 }
 
 describe('NetworkEnablementControllerInit', () => {
-  it('initializes the controller', () => {
-    const { controller } =
+  it('initializes the messengerClient', () => {
+    const { messengerClient } =
       NetworkEnablementControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(NetworkEnablementController);
+    expect(messengerClient).toBeInstanceOf(NetworkEnablementController);
   });
 
   it('enables the Solana network when `AccountsController:selectedAccountChange` is emitted', () => {
@@ -87,16 +87,16 @@ describe('NetworkEnablementControllerInit', () => {
       namespace: MOCK_ANY_NAMESPACE,
     });
     const request = getInitRequestMock(messenger);
-    const { controller } = NetworkEnablementControllerInit(request);
+    const { messengerClient } = NetworkEnablementControllerInit(request);
 
-    expect(controller.enableNetworkInNamespace).not.toHaveBeenCalled();
+    expect(messengerClient.enableNetworkInNamespace).not.toHaveBeenCalled();
 
     // @ts-expect-error: Partial mock.
     messenger.publish('AccountsController:selectedAccountChange', {
       type: SolAccountType.DataAccount,
     });
 
-    expect(controller.enableNetworkInNamespace).toHaveBeenCalledWith(
+    expect(messengerClient.enableNetworkInNamespace).toHaveBeenCalledWith(
       'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
       'solana',
     );
@@ -117,16 +117,16 @@ describe('NetworkEnablementControllerInit', () => {
     );
 
     const request = getInitRequestMock(messenger);
-    const { controller } = NetworkEnablementControllerInit(request);
+    const { messengerClient } = NetworkEnablementControllerInit(request);
 
-    controller.state = {
+    messengerClient.state = {
       enabledNetworkMap: {
         solana: { [SolScope.Mainnet]: true },
       },
       nativeAssetIdentifiers: {},
     };
 
-    expect(controller.enableNetwork).not.toHaveBeenCalled();
+    expect(messengerClient.enableNetwork).not.toHaveBeenCalled();
 
     messenger.publish(
       'AccountTreeController:selectedAccountGroupChange',
@@ -134,7 +134,7 @@ describe('NetworkEnablementControllerInit', () => {
       '',
     );
 
-    expect(controller.enableNetwork).toHaveBeenCalledWith('0x1');
+    expect(messengerClient.enableNetwork).toHaveBeenCalledWith('0x1');
   });
 
   it('enables the Ethereum network when `AccountTreeController:selectedAccountGroupChange` is emitted, the current chain ID is Bitcoin mainnet, and there are no Bitcoin accounts', () => {
@@ -152,16 +152,16 @@ describe('NetworkEnablementControllerInit', () => {
     );
 
     const request = getInitRequestMock(messenger);
-    const { controller } = NetworkEnablementControllerInit(request);
+    const { messengerClient } = NetworkEnablementControllerInit(request);
 
-    controller.state = {
+    messengerClient.state = {
       enabledNetworkMap: {
         bitcoin: { [BtcScope.Mainnet]: true },
       },
       nativeAssetIdentifiers: {},
     };
 
-    expect(controller.enableNetwork).not.toHaveBeenCalled();
+    expect(messengerClient.enableNetwork).not.toHaveBeenCalled();
 
     messenger.publish(
       'AccountTreeController:selectedAccountGroupChange',
@@ -169,7 +169,7 @@ describe('NetworkEnablementControllerInit', () => {
       '',
     );
 
-    expect(controller.enableNetwork).toHaveBeenCalledWith('0x1');
+    expect(messengerClient.enableNetwork).toHaveBeenCalledWith('0x1');
   });
 
   it('does not enable the Ethereum network when `AccountTreeController:selectedAccountGroupChange` is emitted and there are accounts', () => {
@@ -186,16 +186,16 @@ describe('NetworkEnablementControllerInit', () => {
     );
 
     const request = getInitRequestMock(messenger);
-    const { controller } = NetworkEnablementControllerInit(request);
+    const { messengerClient } = NetworkEnablementControllerInit(request);
 
-    controller.state = {
+    messengerClient.state = {
       enabledNetworkMap: {
         solana: { [SolScope.Mainnet]: true },
       },
       nativeAssetIdentifiers: {},
     };
 
-    expect(controller.enableNetwork).not.toHaveBeenCalled();
+    expect(messengerClient.enableNetwork).not.toHaveBeenCalled();
 
     messenger.publish(
       'AccountTreeController:selectedAccountGroupChange',
@@ -203,7 +203,7 @@ describe('NetworkEnablementControllerInit', () => {
       '',
     );
 
-    expect(controller.enableNetwork).not.toHaveBeenCalled();
+    expect(messengerClient.enableNetwork).not.toHaveBeenCalled();
   });
 
   it('does not enable the Ethereum network when `AccountTreeController:selectedAccountGroupChange` is emitted and multiple networks are enabled', () => {
@@ -219,9 +219,9 @@ describe('NetworkEnablementControllerInit', () => {
     );
 
     const request = getInitRequestMock(messenger);
-    const { controller } = NetworkEnablementControllerInit(request);
+    const { messengerClient } = NetworkEnablementControllerInit(request);
 
-    controller.state = {
+    messengerClient.state = {
       enabledNetworkMap: {
         solana: { [SolScope.Mainnet]: true },
         bitcoin: { [BtcScope.Mainnet]: true },
@@ -229,7 +229,7 @@ describe('NetworkEnablementControllerInit', () => {
       nativeAssetIdentifiers: {},
     };
 
-    expect(controller.enableNetwork).not.toHaveBeenCalled();
+    expect(messengerClient.enableNetwork).not.toHaveBeenCalled();
 
     messenger.publish(
       'AccountTreeController:selectedAccountGroupChange',
@@ -237,10 +237,10 @@ describe('NetworkEnablementControllerInit', () => {
       '',
     );
 
-    expect(controller.enableNetwork).not.toHaveBeenCalled();
+    expect(messengerClient.enableNetwork).not.toHaveBeenCalled();
   });
 
-  it('initialises the controller with the correct networks for prod environment', () => {
+  it('initialises the messengerClient with the correct networks for prod environment', () => {
     process.env.METAMASK_DEBUG = '';
     process.env.METAMASK_ENVIRONMENT = 'production';
     process.env.IN_TEST = '';
@@ -270,7 +270,7 @@ describe('NetworkEnablementControllerInit', () => {
     });
   });
 
-  it('initialises the controller with the correct networks for IN_TEST environment', () => {
+  it('initialises the messengerClient with the correct networks for IN_TEST environment', () => {
     process.env.IN_TEST = 'true';
 
     NetworkEnablementControllerInit(getInitRequestMock());
@@ -298,7 +298,7 @@ describe('NetworkEnablementControllerInit', () => {
     });
   });
 
-  it('initialises the controller with the correct networks for DEBUG environment', () => {
+  it('initialises the messengerClient with the correct networks for DEBUG environment', () => {
     process.env.METAMASK_DEBUG = 'true';
     process.env.METAMASK_ENVIRONMENT = 'production';
     process.env.IN_TEST = '';
@@ -328,7 +328,7 @@ describe('NetworkEnablementControllerInit', () => {
     });
   });
 
-  it('initialises the controller with the correct networks for test environment', () => {
+  it('initialises the messengerClient with the correct networks for test environment', () => {
     process.env.METAMASK_DEBUG = '';
     process.env.METAMASK_ENVIRONMENT = 'test';
     process.env.IN_TEST = '';

--- a/app/scripts/messenger-client-init/assets/network-enablement-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/assets/network-enablement-controller-init.test.ts
@@ -72,7 +72,7 @@ function getInitRequestMock(
 }
 
 describe('NetworkEnablementControllerInit', () => {
-  it('initializes the messengerClient', () => {
+  it('initializes the controller', () => {
     const { messengerClient } =
       NetworkEnablementControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(NetworkEnablementController);
@@ -240,7 +240,7 @@ describe('NetworkEnablementControllerInit', () => {
     expect(messengerClient.enableNetwork).not.toHaveBeenCalled();
   });
 
-  it('initialises the messengerClient with the correct networks for prod environment', () => {
+  it('initialises the controller with the correct networks for prod environment', () => {
     process.env.METAMASK_DEBUG = '';
     process.env.METAMASK_ENVIRONMENT = 'production';
     process.env.IN_TEST = '';
@@ -270,7 +270,7 @@ describe('NetworkEnablementControllerInit', () => {
     });
   });
 
-  it('initialises the messengerClient with the correct networks for IN_TEST environment', () => {
+  it('initialises the controller with the correct networks for IN_TEST environment', () => {
     process.env.IN_TEST = 'true';
 
     NetworkEnablementControllerInit(getInitRequestMock());
@@ -298,7 +298,7 @@ describe('NetworkEnablementControllerInit', () => {
     });
   });
 
-  it('initialises the messengerClient with the correct networks for DEBUG environment', () => {
+  it('initialises the controller with the correct networks for DEBUG environment', () => {
     process.env.METAMASK_DEBUG = 'true';
     process.env.METAMASK_ENVIRONMENT = 'production';
     process.env.IN_TEST = '';
@@ -328,7 +328,7 @@ describe('NetworkEnablementControllerInit', () => {
     });
   });
 
-  it('initialises the messengerClient with the correct networks for test environment', () => {
+  it('initialises the controller with the correct networks for test environment', () => {
     process.env.METAMASK_DEBUG = '';
     process.env.METAMASK_ENVIRONMENT = 'test';
     process.env.IN_TEST = '';

--- a/app/scripts/messenger-client-init/assets/network-enablement-controller-init.ts
+++ b/app/scripts/messenger-client-init/assets/network-enablement-controller-init.ts
@@ -137,14 +137,19 @@ export const NetworkEnablementControllerInit: MessengerClientInitFunction<
   NetworkEnablementController,
   NetworkEnablementControllerMessenger,
   NetworkEnablementControllerInitMessenger
-> = ({ controllerMessenger, initMessenger, persistedState, getController }) => {
-  const multichainNetworkControllerState = getController(
+> = ({
+  controllerMessenger,
+  initMessenger,
+  persistedState,
+  getMessengerClient,
+}) => {
+  const multichainNetworkControllerState = getMessengerClient(
     'MultichainNetworkController',
   ).state;
 
-  const networkControllerState = getController('NetworkController').state;
+  const networkControllerState = getMessengerClient('NetworkController').state;
 
-  const controller = new NetworkEnablementController({
+  const messengerClient = new NetworkEnablementController({
     messenger: controllerMessenger,
     state: {
       ...generateDefaultNetworkEnablementControllerState(
@@ -159,14 +164,14 @@ export const NetworkEnablementControllerInit: MessengerClientInitFunction<
   // This reads from NetworkController and MultichainNetworkController to populate
   // the nativeAssetIdentifiers state with CAIP-19-like identifiers for each network.
   // We intentionally don't await this - it will complete in the background.
-  controller.init();
+  messengerClient.init();
 
   // TODO: Remove this after BIP-44 rollout.
   initMessenger.subscribe(
     'AccountsController:selectedAccountChange',
     (account) => {
       if (account.type === SolAccountType.DataAccount) {
-        controller.enableNetworkInNamespace(
+        messengerClient.enableNetworkInNamespace(
           SolScope.Mainnet,
           KnownCaipNamespace.Solana,
         );
@@ -198,7 +203,9 @@ export const NetworkEnablementControllerInit: MessengerClientInitFunction<
 
       const allEnabledNetworks = {};
 
-      for (const network of Object.values(controller.state.enabledNetworkMap)) {
+      for (const network of Object.values(
+        messengerClient.state.enabledNetworkMap,
+      )) {
         Object.assign(allEnabledNetworks, network);
       }
 
@@ -216,13 +223,13 @@ export const NetworkEnablementControllerInit: MessengerClientInitFunction<
           shouldEnableMainnetNetworks = true;
         }
         if (shouldEnableMainnetNetworks) {
-          controller.enableNetwork('0x1');
+          messengerClient.enableNetwork('0x1');
         }
       }
     },
   );
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/assets/network-order-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/assets/network-order-controller-init.test.ts
@@ -26,7 +26,7 @@ function buildInitRequestMock() {
       baseControllerMessenger,
     ),
     initMessenger: undefined,
-    getController: jest.fn(),
+    getMessengerClient: jest.fn(),
   };
 }
 
@@ -52,7 +52,7 @@ describe('NetworkOrderControllerInit', () => {
     };
 
     // Happy path: network controller with some featured networks configured
-    requestMock.getController.mockReturnValue({
+    requestMock.getMessengerClient.mockReturnValue({
       state: mockNetworkConfigState,
     } as MockVar);
 
@@ -80,7 +80,7 @@ describe('NetworkOrderControllerInit', () => {
     const requestMock = buildInitRequestMock();
     const result = NetworkOrderControllerInit(requestMock);
 
-    expect(result.controller).toBeInstanceOf(NetworkOrderController);
+    expect(result.messengerClient).toBeInstanceOf(NetworkOrderController);
   });
 
   it('initializes controller with correct messenger and merged state', () => {

--- a/app/scripts/messenger-client-init/assets/network-order-controller-init.ts
+++ b/app/scripts/messenger-client-init/assets/network-order-controller-init.ts
@@ -26,7 +26,7 @@ export const NetworkOrderControllerInit: MessengerClientInitFunction<
   NetworkOrderController,
   NetworkOrderControllerMessenger
 > = ({ controllerMessenger, persistedState }) => {
-  const controller = new NetworkOrderController({
+  const messengerClient = new NetworkOrderController({
     messenger: controllerMessenger,
     state: {
       ...generateDefaultNetworkOrderControllerState(),
@@ -35,6 +35,6 @@ export const NetworkOrderControllerInit: MessengerClientInitFunction<
   });
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/assets/nft-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/assets/nft-controller-init.test.ts
@@ -35,7 +35,7 @@ describe('NftControllerInit', () => {
 
   it('returns controller instance', () => {
     const requestMock = buildInitRequestMock();
-    expect(NftControllerInit(requestMock).controller).toBeInstanceOf(
+    expect(NftControllerInit(requestMock).messengerClient).toBeInstanceOf(
       NftController,
     );
   });

--- a/app/scripts/messenger-client-init/assets/nft-controller-init.ts
+++ b/app/scripts/messenger-client-init/assets/nft-controller-init.ts
@@ -24,7 +24,7 @@ export const NftControllerInit: MessengerClientInitFunction<
   NftControllerMessenger,
   NftControllerInitMessenger
 > = ({ controllerMessenger, initMessenger, persistedState }) => {
-  const controller = new NftController({
+  const messengerClient = new NftController({
     state: persistedState.NftController,
     messenger: controllerMessenger,
     onNftAdded: ({ address, symbol, tokenId, standard, source }) =>
@@ -53,6 +53,6 @@ export const NftControllerInit: MessengerClientInitFunction<
   });
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/assets/nft-detection-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/assets/nft-detection-controller-init.test.ts
@@ -45,7 +45,7 @@ function buildInitRequestMock(): jest.Mocked<
     initMessenger: undefined,
   };
   // @ts-expect-error Incomplete mock, just includes properties used by code-under-test.
-  requestMock.getController.mockReturnValue(buildControllerMock());
+  requestMock.getMessengerClient.mockReturnValue(buildControllerMock());
 
   return requestMock;
 }
@@ -59,9 +59,9 @@ describe('NftDetectionControllerInit', () => {
 
   it('returns controller instance', () => {
     const requestMock = buildInitRequestMock();
-    expect(NftDetectionControllerInit(requestMock).controller).toBeInstanceOf(
-      NftDetectionController,
-    );
+    expect(
+      NftDetectionControllerInit(requestMock).messengerClient,
+    ).toBeInstanceOf(NftDetectionController);
   });
 
   it('initializes with correct messenger and state', () => {

--- a/app/scripts/messenger-client-init/assets/nft-detection-controller-init.ts
+++ b/app/scripts/messenger-client-init/assets/nft-detection-controller-init.ts
@@ -7,19 +7,20 @@ import { NftDetectionControllerMessenger } from '../messengers/assets';
  *
  * @param request - The request object.
  * @param request.controllerMessenger - The messenger to use for the controller.
- * @param request.getController - The function to get the controller.
+ * @param request.getMessengerClient - The function to get the controller.
  * @returns The initialized controller.
  */
 export const NftDetectionControllerInit: MessengerClientInitFunction<
   NftDetectionController,
   NftDetectionControllerMessenger
 > = (request) => {
-  const { controllerMessenger, getController } = request;
+  const { controllerMessenger, getMessengerClient } = request;
 
-  const preferencesController = () => getController('PreferencesController');
-  const nftController = () => getController('NftController');
+  const preferencesController = () =>
+    getMessengerClient('PreferencesController');
+  const nftController = () => getMessengerClient('NftController');
 
-  const controller = new NftDetectionController({
+  const messengerClient = new NftDetectionController({
     messenger: controllerMessenger,
     addNfts: (...args) => nftController().addNfts(...args),
     getNftState: () => nftController().state,
@@ -28,7 +29,7 @@ export const NftDetectionControllerInit: MessengerClientInitFunction<
   });
 
   return {
-    controller,
+    messengerClient,
     persistedStateKey: null,
   };
 };

--- a/app/scripts/messenger-client-init/assets/token-rates-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/assets/token-rates-controller-init.test.ts
@@ -79,7 +79,7 @@ function buildInitRequestMock(): jest.Mocked<
   };
 
   // @ts-expect-error Incomplete mock, just includes properties used by code-under-test.
-  requestMock.getController.mockReturnValue(buildControllerMock());
+  requestMock.getMessengerClient.mockReturnValue(buildControllerMock());
 
   return requestMock;
 }
@@ -93,9 +93,9 @@ describe('TokenRatesControllerInit', () => {
 
   it('returns controller instance', () => {
     const requestMock = buildInitRequestMock();
-    expect(TokenRatesControllerInit(requestMock).controller).toBeInstanceOf(
-      TokenRatesController,
-    );
+    expect(
+      TokenRatesControllerInit(requestMock).messengerClient,
+    ).toBeInstanceOf(TokenRatesController);
   });
 
   it('initializes with correct messenger and state', () => {

--- a/app/scripts/messenger-client-init/assets/token-rates-controller-init.ts
+++ b/app/scripts/messenger-client-init/assets/token-rates-controller-init.ts
@@ -25,7 +25,7 @@ export const TokenRatesControllerInit: MessengerClientInitFunction<
   const { controllerMessenger, initMessenger, persistedState } = request;
   const preferencesState = initMessenger.call('PreferencesController:getState');
 
-  const controller = new TokenRatesController({
+  const messengerClient = new TokenRatesController({
     messenger: controllerMessenger,
     state: persistedState.TokenRatesController,
     tokenPricesService: new CodefiTokenPricesServiceV2(),
@@ -38,9 +38,9 @@ export const TokenRatesControllerInit: MessengerClientInitFunction<
       const { useCurrencyRateCheck: prevUseCurrencyRateCheck } = prevState;
       const { useCurrencyRateCheck: currUseCurrencyRateCheck } = currState;
       if (currUseCurrencyRateCheck && !prevUseCurrencyRateCheck) {
-        controller.enable();
+        messengerClient.enable();
       } else if (!currUseCurrencyRateCheck && prevUseCurrencyRateCheck) {
-        controller.disable();
+        messengerClient.disable();
       }
 
       return true;
@@ -48,6 +48,6 @@ export const TokenRatesControllerInit: MessengerClientInitFunction<
   );
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/bridge-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/bridge-controller-init.test.ts
@@ -42,12 +42,12 @@ describe('BridgeControllerInit', () => {
     process.env.METAMASK_VERSION = 'MOCK_VERSION';
   });
 
-  it('initializes the messengerClient', () => {
+  it('initializes the controller', () => {
     const { messengerClient } = BridgeControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(BridgeController);
   });
 
-  it('passes the proper arguments to the messengerClient', () => {
+  it('passes the proper arguments to the controller', () => {
     BridgeControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(BridgeController);

--- a/app/scripts/messenger-client-init/bridge-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/bridge-controller-init.test.ts
@@ -42,12 +42,12 @@ describe('BridgeControllerInit', () => {
     process.env.METAMASK_VERSION = 'MOCK_VERSION';
   });
 
-  it('initializes the controller', () => {
-    const { controller } = BridgeControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(BridgeController);
+  it('initializes the messengerClient', () => {
+    const { messengerClient } = BridgeControllerInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(BridgeController);
   });
 
-  it('passes the proper arguments to the controller', () => {
+  it('passes the proper arguments to the messengerClient', () => {
     BridgeControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(BridgeController);

--- a/app/scripts/messenger-client-init/bridge-controller-init.ts
+++ b/app/scripts/messenger-client-init/bridge-controller-init.ts
@@ -20,15 +20,15 @@ import { BridgeControllerInitMessenger } from './messengers';
  * @param request - The request object.
  * @param request.controllerMessenger - The messenger to use for the controller.
  * @param request.initMessenger - The messenger to use for initialization.
- * @param request.getController
+ * @param request.getMessengerClient
  * @returns The initialized controller.
  */
 export const BridgeControllerInit: MessengerClientInitFunction<
   BridgeController,
   BridgeControllerMessenger,
   BridgeControllerInitMessenger
-> = ({ controllerMessenger, initMessenger, getController }) => {
-  const transactionController = getController(
+> = ({ controllerMessenger, initMessenger, getMessengerClient }) => {
+  const transactionController = getMessengerClient(
     'TransactionController',
   ) as TransactionController;
 
@@ -38,7 +38,7 @@ export const BridgeControllerInit: MessengerClientInitFunction<
     );
   }
 
-  const controller = new BridgeController({
+  const messengerClient = new BridgeController({
     messenger: controllerMessenger,
     clientId: BridgeClientId.EXTENSION,
     clientVersion: process.env.METAMASK_VERSION,
@@ -109,6 +109,6 @@ export const BridgeControllerInit: MessengerClientInitFunction<
   return {
     persistedStateKey: null,
     memStateKey: null,
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/bridge-status-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/bridge-status-controller-init.test.ts
@@ -27,12 +27,13 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('BridgeStatusControllerInit', () => {
-  it('initializes the controller', () => {
-    const { controller } = BridgeStatusControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(BridgeStatusController);
+  it('initializes the messengerClient', () => {
+    const { messengerClient } =
+      BridgeStatusControllerInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(BridgeStatusController);
   });
 
-  it('passes the proper arguments to the controller', () => {
+  it('passes the proper arguments to the messengerClient', () => {
     BridgeStatusControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(BridgeStatusController);
@@ -65,7 +66,7 @@ describe('BridgeStatusControllerInit', () => {
               : undefined,
           ),
         );
-      requestMock.getController.mockImplementation(((
+      requestMock.getMessengerClient.mockImplementation(((
         name: MessengerClientName,
       ) => {
         if (name === 'TransactionController') {
@@ -80,7 +81,7 @@ describe('BridgeStatusControllerInit', () => {
           return { getKeyringForAccount: mockGetKeyringForAccount };
         }
         return undefined;
-      }) as unknown as MessengerClientInitRequest<BridgeStatusControllerMessenger>['getController']);
+      }) as unknown as MessengerClientInitRequest<BridgeStatusControllerMessenger>['getMessengerClient']);
 
       BridgeStatusControllerInit(requestMock);
 

--- a/app/scripts/messenger-client-init/bridge-status-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/bridge-status-controller-init.test.ts
@@ -27,13 +27,13 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('BridgeStatusControllerInit', () => {
-  it('initializes the messengerClient', () => {
+  it('initializes the controller', () => {
     const { messengerClient } =
       BridgeStatusControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(BridgeStatusController);
   });
 
-  it('passes the proper arguments to the messengerClient', () => {
+  it('passes the proper arguments to the controller', () => {
     BridgeStatusControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(BridgeStatusController);

--- a/app/scripts/messenger-client-init/bridge-status-controller-init.ts
+++ b/app/scripts/messenger-client-init/bridge-status-controller-init.ts
@@ -14,18 +14,18 @@ import { MessengerClientInitFunction } from './types';
  *
  * @param request - The request object.
  * @param request.controllerMessenger - The messenger to use for the controller.
- * @param request.getController - Function to get other initialized controllers.
+ * @param request.getMessengerClient - Function to get other initialized controllers.
  * @param request.persistedState - The persisted state for the controller.
  * @returns The initialized controller.
  */
 export const BridgeStatusControllerInit: MessengerClientInitFunction<
   BridgeStatusController,
   BridgeStatusControllerMessenger
-> = ({ controllerMessenger, persistedState, getController }) => {
-  const transactionController = getController('TransactionController');
-  const keyringController = getController('KeyringController');
+> = ({ controllerMessenger, persistedState, getMessengerClient }) => {
+  const transactionController = getMessengerClient('TransactionController');
+  const keyringController = getMessengerClient('KeyringController');
 
-  const controller = new BridgeStatusController({
+  const messengerClient = new BridgeStatusController({
     messenger: controllerMessenger,
     state: persistedState.BridgeStatusController,
     clientId: BridgeClientId.EXTENSION,
@@ -64,6 +64,6 @@ export const BridgeStatusControllerInit: MessengerClientInitFunction<
   });
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/claims/claims-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/claims/claims-controller-init.test.ts
@@ -34,7 +34,9 @@ describe('ClaimsControllerInit', () => {
     const request = buildInitRequestMock();
     const controllerInitResult = ClaimsControllerInit(request);
     expect(controllerInitResult).toBeDefined();
-    expect(controllerInitResult.controller).toBeInstanceOf(ClaimsController);
+    expect(controllerInitResult.messengerClient).toBeInstanceOf(
+      ClaimsController,
+    );
   });
 
   it('should initialize with correct messenger and state', () => {

--- a/app/scripts/messenger-client-init/claims/claims-controller-init.ts
+++ b/app/scripts/messenger-client-init/claims/claims-controller-init.ts
@@ -11,11 +11,11 @@ export const ClaimsControllerInit: MessengerClientInitFunction<
   ClaimsControllerInitMessenger
 > = (request) => {
   const { controllerMessenger, persistedState } = request;
-  const controller = new ClaimsController({
+  const messengerClient = new ClaimsController({
     messenger: controllerMessenger,
     state: persistedState.ClaimsController,
   });
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/claims/claims-service-init.test.ts
+++ b/app/scripts/messenger-client-init/claims/claims-service-init.test.ts
@@ -29,7 +29,7 @@ describe('ClaimsServiceInit', () => {
 
   it('should return Service instance', () => {
     const requestMock = buildInitRequestMock();
-    expect(ClaimsServiceInit(requestMock).controller).toBeInstanceOf(
+    expect(ClaimsServiceInit(requestMock).messengerClient).toBeInstanceOf(
       ClaimsService,
     );
   });

--- a/app/scripts/messenger-client-init/claims/claims-service-init.ts
+++ b/app/scripts/messenger-client-init/claims/claims-service-init.ts
@@ -18,7 +18,7 @@ export const ClaimsServiceInit: MessengerClientInitFunction<
   });
 
   return {
-    controller: service,
+    messengerClient: service,
     memStateKey: null,
     persistedStateKey: null,
   };

--- a/app/scripts/messenger-client-init/claims/claims-service-init.ts
+++ b/app/scripts/messenger-client-init/claims/claims-service-init.ts
@@ -11,14 +11,14 @@ export const ClaimsServiceInit: MessengerClientInitFunction<
 
   const { claimsEnv } = loadShieldConfig();
 
-  const service = new ClaimsService({
+  const messengerClient = new ClaimsService({
     messenger: controllerMessenger,
     env: claimsEnv,
     fetchFunction: fetch.bind(globalThis),
   });
 
   return {
-    messengerClient: service,
+    messengerClient,
     memStateKey: null,
     persistedStateKey: null,
   };

--- a/app/scripts/messenger-client-init/confirmations/address-book-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/confirmations/address-book-controller-init.test.ts
@@ -25,12 +25,12 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('AddressBookControllerInit', () => {
-  it('initializes the controller', () => {
-    const { controller } = AddressBookControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(AddressBookController);
+  it('initializes the messengerClient', () => {
+    const { messengerClient } = AddressBookControllerInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(AddressBookController);
   });
 
-  it('passes the proper arguments to the controller', () => {
+  it('passes the proper arguments to the messengerClient', () => {
     AddressBookControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(AddressBookController);

--- a/app/scripts/messenger-client-init/confirmations/address-book-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/confirmations/address-book-controller-init.test.ts
@@ -25,12 +25,12 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('AddressBookControllerInit', () => {
-  it('initializes the messengerClient', () => {
+  it('initializes the controller', () => {
     const { messengerClient } = AddressBookControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(AddressBookController);
   });
 
-  it('passes the proper arguments to the messengerClient', () => {
+  it('passes the proper arguments to the controller', () => {
     AddressBookControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(AddressBookController);

--- a/app/scripts/messenger-client-init/confirmations/address-book-controller-init.ts
+++ b/app/scripts/messenger-client-init/confirmations/address-book-controller-init.ts
@@ -14,12 +14,12 @@ export const AddressBookControllerInit: MessengerClientInitFunction<
   AddressBookController,
   AddressBookControllerMessenger
 > = ({ controllerMessenger, persistedState }) => {
-  const controller = new AddressBookController({
+  const messengerClient = new AddressBookController({
     messenger: controllerMessenger,
     state: persistedState.AddressBookController,
   });
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/confirmations/approval-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/confirmations/approval-controller-init.test.ts
@@ -25,12 +25,12 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('ApprovalControllerInit', () => {
-  it('initializes the controller', () => {
-    const { controller } = ApprovalControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(ApprovalController);
+  it('initializes the messengerClient', () => {
+    const { messengerClient } = ApprovalControllerInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(ApprovalController);
   });
 
-  it('passes the proper arguments to the controller', () => {
+  it('passes the proper arguments to the messengerClient', () => {
     ApprovalControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(ApprovalController);

--- a/app/scripts/messenger-client-init/confirmations/approval-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/confirmations/approval-controller-init.test.ts
@@ -25,12 +25,12 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('ApprovalControllerInit', () => {
-  it('initializes the messengerClient', () => {
+  it('initializes the controller', () => {
     const { messengerClient } = ApprovalControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(ApprovalController);
   });
 
-  it('passes the proper arguments to the messengerClient', () => {
+  it('passes the proper arguments to the controller', () => {
     ApprovalControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(ApprovalController);

--- a/app/scripts/messenger-client-init/confirmations/approval-controller-init.ts
+++ b/app/scripts/messenger-client-init/confirmations/approval-controller-init.ts
@@ -17,7 +17,7 @@ export const ApprovalControllerInit: MessengerClientInitFunction<
   ApprovalController,
   ApprovalControllerMessenger
 > = ({ controllerMessenger, showUserConfirmation }) => {
-  const controller = new ApprovalController({
+  const messengerClient = new ApprovalController({
     messenger: controllerMessenger,
     showApprovalRequest: showUserConfirmation,
     typesExcludedFromRateLimiting: [
@@ -40,6 +40,6 @@ export const ApprovalControllerInit: MessengerClientInitFunction<
   return {
     persistedStateKey: null,
     memStateKey: null,
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/confirmations/decrypt-message-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/confirmations/decrypt-message-controller-init.test.ts
@@ -32,13 +32,13 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('DecryptMessageControllerInit', () => {
-  it('initializes the messengerClient', () => {
+  it('initializes the controller', () => {
     const { messengerClient } =
       DecryptMessageControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(DecryptMessageController);
   });
 
-  it('passes the proper arguments to the messengerClient', () => {
+  it('passes the proper arguments to the controller', () => {
     const manager = {};
     const request = getInitRequestMock();
 

--- a/app/scripts/messenger-client-init/confirmations/decrypt-message-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/confirmations/decrypt-message-controller-init.test.ts
@@ -32,17 +32,18 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('DecryptMessageControllerInit', () => {
-  it('initializes the controller', () => {
-    const { controller } = DecryptMessageControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(DecryptMessageController);
+  it('initializes the messengerClient', () => {
+    const { messengerClient } =
+      DecryptMessageControllerInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(DecryptMessageController);
   });
 
-  it('passes the proper arguments to the controller', () => {
+  it('passes the proper arguments to the messengerClient', () => {
     const manager = {};
     const request = getInitRequestMock();
 
     // @ts-expect-error: Partial mock.
-    request.getController.mockReturnValue(manager);
+    request.getMessengerClient.mockReturnValue(manager);
 
     DecryptMessageControllerInit(request);
 

--- a/app/scripts/messenger-client-init/confirmations/decrypt-message-controller-init.ts
+++ b/app/scripts/messenger-client-init/confirmations/decrypt-message-controller-init.ts
@@ -11,7 +11,7 @@ import { DecryptMessageControllerInitMessenger } from '../messengers/decrypt-mes
  * @param request - The request object.
  * @param request.controllerMessenger - The messenger to use for the controller.
  * @param request.initMessenger - The messenger to use for initialization.
- * @param request.getController - Function to get other initialized controllers.
+ * @param request.getMessengerClient - Function to get other initialized controllers.
  * @param request.getUIState - Function to get the UI state.
  * @returns The initialized controller.
  */
@@ -19,10 +19,15 @@ export const DecryptMessageControllerInit: MessengerClientInitFunction<
   DecryptMessageController,
   DecryptMessageControllerMessenger,
   DecryptMessageControllerInitMessenger
-> = ({ controllerMessenger, initMessenger, getController, getUIState }) => {
-  const manager = getController('DecryptMessageManager');
+> = ({
+  controllerMessenger,
+  initMessenger,
+  getMessengerClient,
+  getUIState,
+}) => {
+  const manager = getMessengerClient('DecryptMessageManager');
 
-  const controller = new DecryptMessageController({
+  const messengerClient = new DecryptMessageController({
     messenger: controllerMessenger,
     manager,
     getState: getUIState,
@@ -35,6 +40,6 @@ export const DecryptMessageControllerInit: MessengerClientInitFunction<
   return {
     persistedStateKey: null,
     memStateKey: null,
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/confirmations/decrypt-message-manager-init.test.ts
+++ b/app/scripts/messenger-client-init/confirmations/decrypt-message-manager-init.test.ts
@@ -26,8 +26,8 @@ function getInitRequestMock(): jest.Mocked<
 
 describe('DecryptMessageManagerInit', () => {
   it('initializes the controller', () => {
-    const { controller } = DecryptMessageManagerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(DecryptMessageManager);
+    const { messengerClient } = DecryptMessageManagerInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(DecryptMessageManager);
   });
 
   it('passes the proper arguments to the controller', () => {

--- a/app/scripts/messenger-client-init/confirmations/decrypt-message-manager-init.ts
+++ b/app/scripts/messenger-client-init/confirmations/decrypt-message-manager-init.ts
@@ -13,7 +13,7 @@ export const DecryptMessageManagerInit: MessengerClientInitFunction<
   DecryptMessageManager,
   DecryptMessageManagerMessenger
 > = ({ controllerMessenger }) => {
-  const controller = new DecryptMessageManager({
+  const messengerClient = new DecryptMessageManager({
     additionalFinishStatuses: ['decrypted'],
     messenger: controllerMessenger,
   });
@@ -21,6 +21,6 @@ export const DecryptMessageManagerInit: MessengerClientInitFunction<
   return {
     persistedStateKey: null,
     memStateKey: null,
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/confirmations/encryption-public-key-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/confirmations/encryption-public-key-controller-init.test.ts
@@ -33,18 +33,18 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('EncryptionPublicKeyControllerInit', () => {
-  it('initializes the controller', () => {
-    const { controller } =
+  it('initializes the messengerClient', () => {
+    const { messengerClient } =
       EncryptionPublicKeyControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(EncryptionPublicKeyController);
+    expect(messengerClient).toBeInstanceOf(EncryptionPublicKeyController);
   });
 
-  it('passes the proper arguments to the controller', () => {
+  it('passes the proper arguments to the messengerClient', () => {
     const manager = {};
     const request = getInitRequestMock();
 
     // @ts-expect-error: Partial mock.
-    request.getController.mockReturnValue(manager);
+    request.getMessengerClient.mockReturnValue(manager);
 
     EncryptionPublicKeyControllerInit(request);
 

--- a/app/scripts/messenger-client-init/confirmations/encryption-public-key-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/confirmations/encryption-public-key-controller-init.test.ts
@@ -33,13 +33,13 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('EncryptionPublicKeyControllerInit', () => {
-  it('initializes the messengerClient', () => {
+  it('initializes the controller', () => {
     const { messengerClient } =
       EncryptionPublicKeyControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(EncryptionPublicKeyController);
   });
 
-  it('passes the proper arguments to the messengerClient', () => {
+  it('passes the proper arguments to the controller', () => {
     const manager = {};
     const request = getInitRequestMock();
 

--- a/app/scripts/messenger-client-init/confirmations/encryption-public-key-controller-init.ts
+++ b/app/scripts/messenger-client-init/confirmations/encryption-public-key-controller-init.ts
@@ -11,7 +11,7 @@ import { EncryptionPublicKeyControllerInitMessenger } from '../messengers';
  * @param request - The request object.
  * @param request.controllerMessenger - The messenger to use for the controller.
  * @param request.initMessenger - The messenger to use for initialization.
- * @param request.getController - Function to get other initialized controllers.
+ * @param request.getMessengerClient - Function to get other initialized controllers.
  * @param request.getUIState - Function to get the UI state.
  * @returns The initialized controller.
  */
@@ -19,11 +19,16 @@ export const EncryptionPublicKeyControllerInit: MessengerClientInitFunction<
   EncryptionPublicKeyController,
   EncryptionPublicKeyControllerMessenger,
   EncryptionPublicKeyControllerInitMessenger
-> = ({ controllerMessenger, initMessenger, getController, getUIState }) => {
-  const manager = getController('EncryptionPublicKeyManager');
-  const keyringController = getController('KeyringController');
+> = ({
+  controllerMessenger,
+  initMessenger,
+  getMessengerClient,
+  getUIState,
+}) => {
+  const manager = getMessengerClient('EncryptionPublicKeyManager');
+  const keyringController = getMessengerClient('KeyringController');
 
-  const controller = new EncryptionPublicKeyController({
+  const messengerClient = new EncryptionPublicKeyController({
     messenger: controllerMessenger,
     manager,
     getState: getUIState,
@@ -45,6 +50,6 @@ export const EncryptionPublicKeyControllerInit: MessengerClientInitFunction<
   return {
     persistedStateKey: null,
     memStateKey: null,
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/confirmations/encryption-public-key-message-manager-init.test.ts
+++ b/app/scripts/messenger-client-init/confirmations/encryption-public-key-message-manager-init.test.ts
@@ -26,8 +26,9 @@ function getInitRequestMock(): jest.Mocked<
 
 describe('EncryptionPublicKeyManagerInit', () => {
   it('initializes the controller', () => {
-    const { controller } = EncryptionPublicKeyManagerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(EncryptionPublicKeyManager);
+    const { messengerClient } =
+      EncryptionPublicKeyManagerInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(EncryptionPublicKeyManager);
   });
 
   it('passes the proper arguments to the controller', () => {

--- a/app/scripts/messenger-client-init/confirmations/encryption-public-key-message-manager-init.ts
+++ b/app/scripts/messenger-client-init/confirmations/encryption-public-key-message-manager-init.ts
@@ -13,7 +13,7 @@ export const EncryptionPublicKeyManagerInit: MessengerClientInitFunction<
   EncryptionPublicKeyManager,
   EncryptionPublicKeyManagerMessenger
 > = ({ controllerMessenger }) => {
-  const controller = new EncryptionPublicKeyManager({
+  const messengerClient = new EncryptionPublicKeyManager({
     additionalFinishStatuses: ['received'],
     messenger: controllerMessenger,
   });
@@ -21,6 +21,6 @@ export const EncryptionPublicKeyManagerInit: MessengerClientInitFunction<
   return {
     persistedStateKey: null,
     memStateKey: null,
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/confirmations/ens-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/confirmations/ens-controller-init.test.ts
@@ -27,12 +27,12 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('EnsControllerInit', () => {
-  it('initializes the messengerClient', () => {
+  it('initializes the controller', () => {
     const { messengerClient } = EnsControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(EnsController);
   });
 
-  it('passes the proper arguments to the messengerClient', () => {
+  it('passes the proper arguments to the controller', () => {
     EnsControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(EnsController);

--- a/app/scripts/messenger-client-init/confirmations/ens-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/confirmations/ens-controller-init.test.ts
@@ -27,12 +27,12 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('EnsControllerInit', () => {
-  it('initializes the controller', () => {
-    const { controller } = EnsControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(EnsController);
+  it('initializes the messengerClient', () => {
+    const { messengerClient } = EnsControllerInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(EnsController);
   });
 
-  it('passes the proper arguments to the controller', () => {
+  it('passes the proper arguments to the messengerClient', () => {
     EnsControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(EnsController);

--- a/app/scripts/messenger-client-init/confirmations/ens-controller-init.ts
+++ b/app/scripts/messenger-client-init/confirmations/ens-controller-init.ts
@@ -18,7 +18,7 @@ export const EnsControllerInit: MessengerClientInitFunction<
   EnsControllerMessenger,
   EnsControllerInitMessenger
 > = ({ controllerMessenger, initMessenger }) => {
-  const controller = new EnsController({
+  const messengerClient = new EnsController({
     messenger: controllerMessenger,
     onNetworkDidChange: (listener) =>
       initMessenger.subscribe('NetworkController:networkDidChange', listener),
@@ -26,6 +26,6 @@ export const EnsControllerInit: MessengerClientInitFunction<
 
   return {
     persistedStateKey: null,
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/confirmations/gas-fee-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/confirmations/gas-fee-controller-init.test.ts
@@ -30,12 +30,12 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('GasFeeControllerInit', () => {
-  it('initializes the controller', () => {
-    const { controller } = GasFeeControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(GasFeeController);
+  it('initializes the messengerClient', () => {
+    const { messengerClient } = GasFeeControllerInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(GasFeeController);
   });
 
-  it('passes the proper arguments to the controller', () => {
+  it('passes the proper arguments to the messengerClient', () => {
     GasFeeControllerInit(getInitRequestMock());
 
     expect(GasFeeController).toHaveBeenCalledWith(

--- a/app/scripts/messenger-client-init/confirmations/gas-fee-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/confirmations/gas-fee-controller-init.test.ts
@@ -30,12 +30,12 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('GasFeeControllerInit', () => {
-  it('initializes the messengerClient', () => {
+  it('initializes the controller', () => {
     const { messengerClient } = GasFeeControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(GasFeeController);
   });
 
-  it('passes the proper arguments to the messengerClient', () => {
+  it('passes the proper arguments to the controller', () => {
     GasFeeControllerInit(getInitRequestMock());
 
     expect(GasFeeController).toHaveBeenCalledWith(

--- a/app/scripts/messenger-client-init/confirmations/gas-fee-controller-init.ts
+++ b/app/scripts/messenger-client-init/confirmations/gas-fee-controller-init.ts
@@ -30,7 +30,7 @@ export const GasFeeControllerInit: MessengerClientInitFunction<
   GasFeeControllerMessenger,
   GasFeeControllerInitMessenger
 > = ({ controllerMessenger, initMessenger, persistedState }) => {
-  const controller = new GasFeeController({
+  const messengerClient = new GasFeeController({
     // @ts-expect-error: `GasFeeController` does not accept a partial state.
     state: persistedState.GasFeeController,
     messenger: controllerMessenger,
@@ -72,6 +72,6 @@ export const GasFeeControllerInit: MessengerClientInitFunction<
   });
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/confirmations/name-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/confirmations/name-controller-init.test.ts
@@ -27,7 +27,7 @@ function getInitRequestMock(): jest.Mocked<
   };
 
   // @ts-expect-error: Partial mock.
-  requestMock.getController.mockImplementation((name: string) => {
+  requestMock.getMessengerClient.mockImplementation((name: string) => {
     if (name === 'EnsController') {
       return {
         reverseResolveAddress: jest.fn(),
@@ -45,12 +45,12 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('NameControllerInit', () => {
-  it('initializes the controller', () => {
-    const { controller } = NameControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(NameController);
+  it('initializes the messengerClient', () => {
+    const { messengerClient } = NameControllerInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(NameController);
   });
 
-  it('passes the proper arguments to the controller', () => {
+  it('passes the proper arguments to the messengerClient', () => {
     NameControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(NameController);

--- a/app/scripts/messenger-client-init/confirmations/name-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/confirmations/name-controller-init.test.ts
@@ -45,12 +45,12 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('NameControllerInit', () => {
-  it('initializes the messengerClient', () => {
+  it('initializes the controller', () => {
     const { messengerClient } = NameControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(NameController);
   });
 
-  it('passes the proper arguments to the messengerClient', () => {
+  it('passes the proper arguments to the controller', () => {
     NameControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(NameController);

--- a/app/scripts/messenger-client-init/confirmations/name-controller-init.ts
+++ b/app/scripts/messenger-client-init/confirmations/name-controller-init.ts
@@ -18,21 +18,26 @@ import { MessengerClientInitFunction } from '../types';
  * @param request.controllerMessenger - The messenger to use for the controller.
  * @param request.persistedState - The persisted state of the extension.
  * @param request.initMessenger
- * @param request.getController
+ * @param request.getMessengerClient
  * @returns The initialized controller.
  */
 export const NameControllerInit: MessengerClientInitFunction<
   NameController,
   NameControllerMessenger,
   NameControllerInitMessenger
-> = ({ controllerMessenger, initMessenger, persistedState, getController }) => {
-  const ensController = getController('EnsController');
-  const snapsNameProvider = getController('SnapsNameProvider');
+> = ({
+  controllerMessenger,
+  initMessenger,
+  persistedState,
+  getMessengerClient,
+}) => {
+  const ensController = getMessengerClient('EnsController');
+  const snapsNameProvider = getMessengerClient('SnapsNameProvider');
 
   const isExternalNameSourcesEnabled = () =>
     initMessenger.call('PreferencesController:getState').useExternalNameSources;
 
-  const controller = new NameController({
+  const messengerClient = new NameController({
     messenger: controllerMessenger,
     state: persistedState.NameController,
     providers: [
@@ -52,6 +57,6 @@ export const NameControllerInit: MessengerClientInitFunction<
   });
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/confirmations/ppom-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/confirmations/ppom-controller-init.test.ts
@@ -102,7 +102,7 @@ function buildInitRequestMock(): jest.Mocked<
     initMessenger: getPPOMControllerInitMessenger(baseControllerMessenger),
   };
 
-  requestMock.getController.mockReturnValue(buildControllerMock());
+  requestMock.getMessengerClient.mockReturnValue(buildControllerMock());
 
   return requestMock;
 }
@@ -125,7 +125,7 @@ describe('PPOM Controller Init', () => {
   ): PPOMControllerOptions[T] {
     const requestMock = buildInitRequestMock();
 
-    requestMock.getController.mockReturnValue(
+    requestMock.getMessengerClient.mockReturnValue(
       buildControllerMock(dependencyProperties),
     );
 
@@ -140,7 +140,7 @@ describe('PPOM Controller Init', () => {
 
   it('returns controller instance', () => {
     const requestMock = buildInitRequestMock();
-    expect(PPOMControllerInit(requestMock).controller).toBeInstanceOf(
+    expect(PPOMControllerInit(requestMock).messengerClient).toBeInstanceOf(
       PPOMController,
     );
   });

--- a/app/scripts/messenger-client-init/confirmations/ppom-controller-init.ts
+++ b/app/scripts/messenger-client-init/confirmations/ppom-controller-init.ts
@@ -13,15 +13,20 @@ export const PPOMControllerInit: MessengerClientInitFunction<
   PPOMControllerMessenger,
   PPOMControllerInitMessenger
 > = (request) => {
-  const { controllerMessenger, initMessenger, getController, persistedState } =
-    request;
+  const {
+    controllerMessenger,
+    initMessenger,
+    getMessengerClient,
+    persistedState,
+  } = request;
 
-  const preferencesController = () => getController('PreferencesController');
+  const preferencesController = () =>
+    getMessengerClient('PreferencesController');
 
   const { provider } =
     initMessenger.call('NetworkController:getSelectedNetworkClient') ?? {};
 
-  const controller = new PPOMController({
+  const messengerClient = new PPOMController({
     messenger: controllerMessenger,
     storageBackend: new IndexedDBPPOMStorage('PPOMDB', 1),
     // @ts-expect-error: PPOMController expects `provider` to be defined, but it
@@ -47,6 +52,6 @@ export const PPOMControllerInit: MessengerClientInitFunction<
   });
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/confirmations/signature-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/confirmations/signature-controller-init.test.ts
@@ -37,8 +37,8 @@ function getInitRequestMock(): jest.Mocked<
 
 describe('SignatureControllerInit', () => {
   it('initializes the controller', () => {
-    const { controller } = SignatureControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(Object);
+    const { messengerClient } = SignatureControllerInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(Object);
   });
 
   it('passes the proper arguments to the controller', () => {

--- a/app/scripts/messenger-client-init/confirmations/signature-controller-init.ts
+++ b/app/scripts/messenger-client-init/confirmations/signature-controller-init.ts
@@ -20,7 +20,7 @@ export const SignatureControllerInit: MessengerClientInitFunction<
   SignatureControllerMessenger,
   SignatureControllerInitMessenger
 > = ({ controllerMessenger, initMessenger }) => {
-  const controller = new SignatureController({
+  const messengerClient = new SignatureController({
     messenger: controllerMessenger,
     decodingApiUrl: process.env.DECODING_API_URL,
     isDecodeSignatureRequestEnabled: () => {
@@ -32,20 +32,23 @@ export const SignatureControllerInit: MessengerClientInitFunction<
     trace,
   });
 
-  controller.hub.on('cancelWithReason', ({ metadata: message, reason }) => {
-    initMessenger.call('MetaMetricsController:trackEvent', {
-      event: reason,
-      category: MetaMetricsEventCategory.Transactions,
-      properties: {
-        action: 'Sign Request',
-        type: message.type,
-      },
-    });
-  });
+  messengerClient.hub.on(
+    'cancelWithReason',
+    ({ metadata: message, reason }) => {
+      initMessenger.call('MetaMetricsController:trackEvent', {
+        event: reason,
+        category: MetaMetricsEventCategory.Transactions,
+        properties: {
+          action: 'Sign Request',
+          type: message.type,
+        },
+      });
+    },
+  );
 
   return {
     persistedStateKey: null,
     memStateKey: null,
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/confirmations/transaction-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/confirmations/transaction-controller-init.test.ts
@@ -77,7 +77,7 @@ function buildInitRequestMock(): jest.Mocked<
     ),
   };
 
-  requestMock.getController.mockReturnValue(buildControllerMock());
+  requestMock.getMessengerClient.mockReturnValue(buildControllerMock());
 
   return requestMock;
 }
@@ -104,7 +104,7 @@ describe('Transaction Controller Init', () => {
   ): TransactionControllerOptions[T] {
     const requestMock = buildInitRequestMock();
 
-    requestMock.getController.mockReturnValue(
+    requestMock.getMessengerClient.mockReturnValue(
       buildControllerMock(dependencyProperties),
     );
 
@@ -154,9 +154,9 @@ describe('Transaction Controller Init', () => {
 
   it('returns controller instance', () => {
     const requestMock = buildInitRequestMock();
-    expect(TransactionControllerInit(requestMock).controller).toBeInstanceOf(
-      TransactionController,
-    );
+    expect(
+      TransactionControllerInit(requestMock).messengerClient,
+    ).toBeInstanceOf(TransactionController);
   });
 
   it('retrieves saved gas fees from preferences', () => {
@@ -438,7 +438,7 @@ describe('Transaction Controller Init', () => {
 
     it('skips Delegation7702PublishHook for hardware wallet accounts', async () => {
       const requestMock = buildInitRequestMock();
-      requestMock.getController.mockImplementation(((
+      requestMock.getMessengerClient.mockImplementation(((
         name: MessengerClientName,
       ) => {
         if (name === 'KeyringController') {
@@ -452,7 +452,7 @@ describe('Transaction Controller Init', () => {
       }) as unknown as MessengerClientInitRequest<
         TransactionControllerMessenger,
         TransactionControllerInitMessenger
-      >['getController']);
+      >['getMessengerClient']);
 
       TransactionControllerInit(requestMock);
 
@@ -465,7 +465,7 @@ describe('Transaction Controller Init', () => {
 
     it('calls Delegation7702PublishHook for HD keyring accounts', async () => {
       const requestMock = buildInitRequestMock();
-      requestMock.getController.mockImplementation(((
+      requestMock.getMessengerClient.mockImplementation(((
         name: MessengerClientName,
       ) => {
         if (name === 'KeyringController') {
@@ -479,7 +479,7 @@ describe('Transaction Controller Init', () => {
       }) as unknown as MessengerClientInitRequest<
         TransactionControllerMessenger,
         TransactionControllerInitMessenger
-      >['getController']);
+      >['getMessengerClient']);
 
       TransactionControllerInit(requestMock);
 

--- a/app/scripts/messenger-client-init/confirmations/transaction-controller-init.ts
+++ b/app/scripts/messenger-client-init/confirmations/transaction-controller-init.ts
@@ -94,7 +94,7 @@ export const TransactionControllerInit: MessengerClientInitFunction<
     smartTransactionsController,
   } = getControllers(request);
 
-  const controller: TransactionController = new TransactionController({
+  const messengerClient: TransactionController = new TransactionController({
     getCurrentNetworkEIP1559Compatibility: () =>
       // @ts-expect-error Controller type does not support undefined return value
       initMessenger.call('NetworkController:getEIP1559Compatibility'),
@@ -221,12 +221,12 @@ export const TransactionControllerInit: MessengerClientInitFunction<
           keyringController,
           signedTx,
           smartTransactionsController: smartTransactionsController(),
-          transactionController: controller,
+          transactionController: messengerClient,
           transactionMeta,
         }),
       publishBatch: async (_request: PublishBatchHookRequest) => {
         const result = await publishBatchHook({
-          transactionController: controller,
+          transactionController: messengerClient,
           smartTransactionsController: smartTransactionsController(),
           hookControllerMessenger:
             initMessenger as SmartTransactionHookMessenger,
@@ -268,34 +268,37 @@ export const TransactionControllerInit: MessengerClientInitFunction<
     getTransactionMetricsRequest,
   );
 
-  const api = getApi(controller);
+  const api = getApi(messengerClient);
 
-  return { controller, api, memStateKey: 'TxController' };
+  return { messengerClient, api, memStateKey: 'TxController' };
 };
 
 function getApi(
-  controller: TransactionController,
+  messengerClient: TransactionController,
 ): MessengerClientInitResult<TransactionController>['api'] {
   return {
     abortTransactionSigning:
-      controller.abortTransactionSigning.bind(controller),
-    getLayer1GasFee: controller.getLayer1GasFee.bind(controller),
-    getTransactions: controller.getTransactions.bind(controller),
-    isAtomicBatchSupported: controller.isAtomicBatchSupported.bind(controller),
+      messengerClient.abortTransactionSigning.bind(messengerClient),
+    getLayer1GasFee: messengerClient.getLayer1GasFee.bind(messengerClient),
+    getTransactions: messengerClient.getTransactions.bind(messengerClient),
+    isAtomicBatchSupported:
+      messengerClient.isAtomicBatchSupported.bind(messengerClient),
     startIncomingTransactionPolling:
-      controller.startIncomingTransactionPolling.bind(controller),
+      messengerClient.startIncomingTransactionPolling.bind(messengerClient),
     stopIncomingTransactionPolling:
-      controller.stopIncomingTransactionPolling.bind(controller),
-    updateAtomicBatchData: controller.updateAtomicBatchData.bind(controller),
+      messengerClient.stopIncomingTransactionPolling.bind(messengerClient),
+    updateAtomicBatchData:
+      messengerClient.updateAtomicBatchData.bind(messengerClient),
     updateBatchTransactions:
-      controller.updateBatchTransactions.bind(controller),
-    updateEditableParams: controller.updateEditableParams.bind(controller),
+      messengerClient.updateBatchTransactions.bind(messengerClient),
+    updateEditableParams:
+      messengerClient.updateEditableParams.bind(messengerClient),
     updatePreviousGasParams:
-      controller.updatePreviousGasParams.bind(controller),
+      messengerClient.updatePreviousGasParams.bind(messengerClient),
     updateSelectedGasFeeToken:
-      controller.updateSelectedGasFeeToken.bind(controller),
+      messengerClient.updateSelectedGasFeeToken.bind(messengerClient),
     updateTransactionGasFees:
-      controller.updateTransactionGasFees.bind(controller),
+      messengerClient.updateTransactionGasFees.bind(messengerClient),
   };
 }
 
@@ -306,15 +309,17 @@ function getControllers(
   >,
 ) {
   return {
-    gasFeeController: () => request.getController('GasFeeController'),
-    keyringController: () => request.getController('KeyringController'),
-    networkController: () => request.getController('NetworkController'),
-    onboardingController: () => request.getController('OnboardingController'),
-    preferencesController: () => request.getController('PreferencesController'),
+    gasFeeController: () => request.getMessengerClient('GasFeeController'),
+    keyringController: () => request.getMessengerClient('KeyringController'),
+    networkController: () => request.getMessengerClient('NetworkController'),
+    onboardingController: () =>
+      request.getMessengerClient('OnboardingController'),
+    preferencesController: () =>
+      request.getMessengerClient('PreferencesController'),
     smartTransactionsController: () =>
-      request.getController('SmartTransactionsController'),
+      request.getMessengerClient('SmartTransactionsController'),
     institutionalSnapController: () =>
-      request.getController('InstitutionalSnapController'),
+      request.getMessengerClient('InstitutionalSnapController'),
   };
 }
 

--- a/app/scripts/messenger-client-init/confirmations/user-operation-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/confirmations/user-operation-controller-init.test.ts
@@ -33,7 +33,7 @@ function getInitRequestMock(): jest.Mocked<
   };
 
   // @ts-expect-error: Partial mock.
-  requestMock.getController.mockImplementation((name: string) => {
+  requestMock.getMessengerClient.mockImplementation((name: string) => {
     if (name === 'GasFeeController') {
       return {
         fetchGasFeeEstimates: jest.fn(),
@@ -47,8 +47,9 @@ function getInitRequestMock(): jest.Mocked<
 
 describe('UserOperationControllerInit', () => {
   it('initializes the controller', () => {
-    const { controller } = UserOperationControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(Object);
+    const { messengerClient } =
+      UserOperationControllerInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(Object);
   });
 
   it('passes the proper arguments to the controller', () => {

--- a/app/scripts/messenger-client-init/confirmations/user-operation-controller-init.ts
+++ b/app/scripts/messenger-client-init/confirmations/user-operation-controller-init.ts
@@ -12,17 +12,22 @@ import {
  * @param request.controllerMessenger - The messenger to use for the controller.
  * @param request.initMessenger - The messenger to use for initialization.
  * @param request.persistedState - The persisted state.
- * @param request.getController - Function to get other controllers.
+ * @param request.getMessengerClient - Function to get other controllers.
  * @returns The initialized controller.
  */
 export const UserOperationControllerInit: MessengerClientInitFunction<
   UserOperationController,
   UserOperationControllerMessenger,
   UserOperationControllerInitMessenger
-> = ({ controllerMessenger, initMessenger, persistedState, getController }) => {
-  const gasFeeController = getController('GasFeeController');
+> = ({
+  controllerMessenger,
+  initMessenger,
+  persistedState,
+  getMessengerClient,
+}) => {
+  const gasFeeController = getMessengerClient('GasFeeController');
 
-  const controller = new UserOperationController({
+  const messengerClient = new UserOperationController({
     messenger: controllerMessenger,
     state: persistedState.UserOperationController,
     // @ts-expect-error: `UserOperationController` does not accept `undefined`.
@@ -31,13 +36,13 @@ export const UserOperationControllerInit: MessengerClientInitFunction<
       gasFeeController.fetchGasFeeEstimates(...args),
   });
 
-  controller.hub.on('user-operation-added', (userOperationMeta) =>
+  messengerClient.hub.on('user-operation-added', (userOperationMeta) =>
     initMessenger.call(
       'TransactionController:emulateNewTransaction',
       userOperationMeta.id,
     ),
   );
-  controller.hub.on('transaction-updated', (transactionMeta) =>
+  messengerClient.hub.on('transaction-updated', (transactionMeta) =>
     initMessenger.call(
       'TransactionController:emulateTransactionUpdate',
       transactionMeta,
@@ -45,6 +50,6 @@ export const UserOperationControllerInit: MessengerClientInitFunction<
   );
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/connectivity/connectivity-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/connectivity/connectivity-controller-init.test.ts
@@ -41,14 +41,14 @@ describe('ConnectivityControllerInit', () => {
     const requestMock = buildInitRequestMock();
     const result = ConnectivityControllerInit(requestMock);
 
-    expect(result.controller).toBeInstanceOf(ConnectivityController);
+    expect(result.messengerClient).toBeInstanceOf(ConnectivityController);
   });
 
   it('initializes with online status by default', () => {
     const requestMock = buildInitRequestMock();
     const result = ConnectivityControllerInit(requestMock);
 
-    expect(result.controller.state.connectivityStatus).toBe('online');
+    expect(result.messengerClient.state.connectivityStatus).toBe('online');
   });
 
   it('uses default memStateKey (controller name)', () => {
@@ -78,24 +78,24 @@ describe('ConnectivityControllerInit', () => {
   it('API setConnectivityStatus updates controller state via service', () => {
     const requestMock = buildInitRequestMock();
     const result = ConnectivityControllerInit(requestMock);
-    const { controller } = result;
+    const { messengerClient } = result;
 
-    expect(controller.state.connectivityStatus).toBe('online');
+    expect(messengerClient.state.connectivityStatus).toBe('online');
 
     result.api?.setConnectivityStatus('offline');
 
-    expect(controller.state.connectivityStatus).toBe('offline');
+    expect(messengerClient.state.connectivityStatus).toBe('offline');
   });
 
   it('API setConnectivityStatus handles online status', () => {
     const requestMock = buildInitRequestMock();
     const result = ConnectivityControllerInit(requestMock);
-    const { controller } = result;
+    const { messengerClient } = result;
 
     result.api?.setConnectivityStatus('offline');
-    expect(controller.state.connectivityStatus).toBe('offline');
+    expect(messengerClient.state.connectivityStatus).toBe('offline');
 
     result.api?.setConnectivityStatus('online');
-    expect(controller.state.connectivityStatus).toBe('online');
+    expect(messengerClient.state.connectivityStatus).toBe('online');
   });
 });

--- a/app/scripts/messenger-client-init/connectivity/connectivity-controller-init.ts
+++ b/app/scripts/messenger-client-init/connectivity/connectivity-controller-init.ts
@@ -30,13 +30,13 @@ export const ConnectivityControllerInit: MessengerClientInitFunction<
   // - MV2: Background page directly (app/scripts/background.js)
   const connectivityAdapter = new ExtensionConnectivityAdapter();
 
-  const controller = new ConnectivityController({
+  const messengerClient = new ConnectivityController({
     messenger: controllerMessenger,
     connectivityAdapter,
   });
 
   return {
-    controller,
+    messengerClient,
     api: {
       setConnectivityStatus: (status: 'online' | 'offline') =>
         connectivityAdapter.setStatus(status),

--- a/app/scripts/messenger-client-init/core-backend/account-activity-service-init.test.ts
+++ b/app/scripts/messenger-client-init/core-backend/account-activity-service-init.test.ts
@@ -31,8 +31,9 @@ describe('AccountActivityServiceInit', () => {
   });
 
   it('initializes the controller', () => {
-    const { controller } = AccountActivityServiceInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(AccountActivityService);
+    const { messengerClient } =
+      AccountActivityServiceInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(AccountActivityService);
   });
 
   it('passes the messenger and traceFn to the controller', () => {
@@ -53,9 +54,10 @@ describe('AccountActivityServiceInit', () => {
   });
 
   it('returns the controller instance', () => {
-    const { controller } = AccountActivityServiceInit(getInitRequestMock());
+    const { messengerClient } =
+      AccountActivityServiceInit(getInitRequestMock());
 
-    expect(controller).toBeDefined();
-    expect(controller).toBeInstanceOf(AccountActivityService);
+    expect(messengerClient).toBeDefined();
+    expect(messengerClient).toBeInstanceOf(AccountActivityService);
   });
 });

--- a/app/scripts/messenger-client-init/core-backend/account-activity-service-init.ts
+++ b/app/scripts/messenger-client-init/core-backend/account-activity-service-init.ts
@@ -16,7 +16,7 @@ export const AccountActivityServiceInit: MessengerClientInitFunction<
   AccountActivityService,
   AccountActivityServiceMessenger
 > = ({ controllerMessenger }) => {
-  const controller = new AccountActivityService({
+  const messengerClient = new AccountActivityService({
     messenger: controllerMessenger,
     // @ts-expect-error: Types of `TraceRequest` are not the same.
     traceFn: trace,
@@ -25,6 +25,6 @@ export const AccountActivityServiceInit: MessengerClientInitFunction<
   return {
     memStateKey: null,
     persistedStateKey: null,
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/core-backend/backend-websocket-service-init.test.ts
+++ b/app/scripts/messenger-client-init/core-backend/backend-websocket-service-init.test.ts
@@ -59,8 +59,9 @@ describe('BackendWebSocketServiceInit', () => {
   });
 
   it('initializes the controller', () => {
-    const { controller } = BackendWebSocketServiceInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(BackendWebSocketService);
+    const { messengerClient } =
+      BackendWebSocketServiceInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(BackendWebSocketService);
   });
 
   it('passes the proper arguments to the controller', () => {

--- a/app/scripts/messenger-client-init/core-backend/backend-websocket-service-init.ts
+++ b/app/scripts/messenger-client-init/core-backend/backend-websocket-service-init.ts
@@ -27,7 +27,7 @@ export const BackendWebSocketServiceInit: MessengerClientInitFunction<
   BackendWebSocketServiceMessenger,
   BackendWebSocketServiceInitMessenger
 > = ({ controllerMessenger, initMessenger }) => {
-  const controller = new BackendWebSocketService({
+  const messengerClient = new BackendWebSocketService({
     messenger: controllerMessenger,
     url:
       process.env.MM_BACKEND_WEBSOCKET_URL ||
@@ -69,6 +69,6 @@ export const BackendWebSocketServiceInit: MessengerClientInitFunction<
   return {
     memStateKey: null,
     persistedStateKey: null,
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/currency-rate-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/currency-rate-controller-init.test.ts
@@ -48,7 +48,7 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('CurrencyRateControllerInit', () => {
-  it('initializes the messengerClient', () => {
+  it('initializes the controller', () => {
     const { messengerClient } =
       CurrencyRateControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(CurrencyRateController);

--- a/app/scripts/messenger-client-init/currency-rate-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/currency-rate-controller-init.test.ts
@@ -48,8 +48,9 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('CurrencyRateControllerInit', () => {
-  it('initializes the controller', () => {
-    const { controller } = CurrencyRateControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(CurrencyRateController);
+  it('initializes the messengerClient', () => {
+    const { messengerClient } =
+      CurrencyRateControllerInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(CurrencyRateController);
   });
 });

--- a/app/scripts/messenger-client-init/currency-rate-controller-init.ts
+++ b/app/scripts/messenger-client-init/currency-rate-controller-init.ts
@@ -24,7 +24,7 @@ export const CurrencyRateControllerInit: MessengerClientInitFunction<
 > = ({ controllerMessenger, initMessenger, persistedState }) => {
   // TODO: Fix CurrencyRateControllerMessenger type - add CurrencyRateControllerActions & CurrencyRateControllerEvents
   // TODO: Bump @metamask/network-controller to match assets-controllers
-  const controller = new CurrencyRateController({
+  const messengerClient = new CurrencyRateController({
     // @ts-expect-error - CurrencyRateController is persisted as 'CurrencyController' but init pattern expects 'CurrencyRateController'
     state: persistedState.CurrencyController,
     messenger: controllerMessenger,
@@ -37,6 +37,6 @@ export const CurrencyRateControllerInit: MessengerClientInitFunction<
   return {
     memStateKey: 'CurrencyController',
     persistedStateKey: 'CurrencyController',
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/data-deletion-service-init.test.ts
+++ b/app/scripts/messenger-client-init/data-deletion-service-init.test.ts
@@ -26,7 +26,7 @@ describe('DataDeletionServiceInit', () => {
   it('returns the service instance', () => {
     const requestMock = buildInitRequestMock();
 
-    expect(DataDeletionServiceInit(requestMock).controller).toBeInstanceOf(
+    expect(DataDeletionServiceInit(requestMock).messengerClient).toBeInstanceOf(
       DataDeletionService,
     );
   });

--- a/app/scripts/messenger-client-init/data-deletion-service-init.ts
+++ b/app/scripts/messenger-client-init/data-deletion-service-init.ts
@@ -13,7 +13,7 @@ export const DataDeletionServiceInit: MessengerClientInitFunction<
   });
 
   return {
-    controller: service,
+    messengerClient: service,
     memStateKey: null,
     persistedStateKey: null,
   };

--- a/app/scripts/messenger-client-init/data-deletion-service-init.ts
+++ b/app/scripts/messenger-client-init/data-deletion-service-init.ts
@@ -8,12 +8,12 @@ export const DataDeletionServiceInit: MessengerClientInitFunction<
   DataDeletionService,
   DataDeletionServiceMessenger
 > = ({ controllerMessenger }) => {
-  const service = new DataDeletionService({
+  const messengerClient = new DataDeletionService({
     messenger: controllerMessenger,
   });
 
   return {
-    messengerClient: service,
+    messengerClient,
     memStateKey: null,
     persistedStateKey: null,
   };

--- a/app/scripts/messenger-client-init/defi-positions/defi-positions-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/defi-positions/defi-positions-controller-init.test.ts
@@ -42,9 +42,9 @@ describe('DefiPositionsControllerInit', () => {
 
   it('returns controller instance', () => {
     const requestMock = buildInitRequestMock();
-    expect(DeFiPositionsControllerInit(requestMock).controller).toBeInstanceOf(
-      DeFiPositionsController,
-    );
+    expect(
+      DeFiPositionsControllerInit(requestMock).messengerClient,
+    ).toBeInstanceOf(DeFiPositionsController);
   });
 
   it('initializes with correct messenger and state', () => {

--- a/app/scripts/messenger-client-init/defi-positions/defi-positions-controller-init.ts
+++ b/app/scripts/messenger-client-init/defi-positions/defi-positions-controller-init.ts
@@ -13,11 +13,13 @@ export const DeFiPositionsControllerInit: MessengerClientInitFunction<
   DeFiPositionsController,
   DeFiPositionsControllerMessenger,
   DeFiPositionsControllerInitMessenger
-> = ({ initMessenger, controllerMessenger, getController }) => {
-  const getPreferencesController = () => getController('PreferencesController');
-  const getOnboardingController = () => getController('OnboardingController');
+> = ({ initMessenger, controllerMessenger, getMessengerClient }) => {
+  const getPreferencesController = () =>
+    getMessengerClient('PreferencesController');
+  const getOnboardingController = () =>
+    getMessengerClient('OnboardingController');
 
-  const controller = new DeFiPositionsController({
+  const messengerClient = new DeFiPositionsController({
     messenger: controllerMessenger,
     isEnabled: () => {
       const {
@@ -46,7 +48,7 @@ export const DeFiPositionsControllerInit: MessengerClientInitFunction<
   });
 
   return {
-    controller,
+    messengerClient,
     persistedStateKey: null,
   };
 };

--- a/app/scripts/messenger-client-init/delegation/delegation-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/delegation/delegation-controller-init.test.ts
@@ -51,9 +51,9 @@ describe('DelegationControllerInit', () => {
 
   it('returns controller instance', () => {
     const requestMock = buildInitRequestMock();
-    expect(DelegationControllerInit(requestMock).controller).toBeInstanceOf(
-      DelegationController,
-    );
+    expect(
+      DelegationControllerInit(requestMock).messengerClient,
+    ).toBeInstanceOf(DelegationController);
   });
 
   it('initializes with correct messenger and state', () => {
@@ -86,7 +86,7 @@ describe('DelegationControllerInit', () => {
 
 describe('DelegationController:awaitDeleteDelegationEntry', () => {
   const mockHash = '0x123' as Hex;
-  let controller: DelegationController;
+  let messengerClient: DelegationController;
   let initMessenger: DelegationControllerInitMessenger;
   let subscribeHandler:
     | ((event: { transactionMeta: TransactionMeta }) => void)
@@ -111,7 +111,7 @@ describe('DelegationController:awaitDeleteDelegationEntry', () => {
   });
 
   beforeEach(() => {
-    controller = new DelegationController({
+    messengerClient = new DelegationController({
       messenger: getDelegationControllerMessenger(getRootMessenger()),
       state: {},
       hashDelegation: () => '0x123' as Hex,
@@ -136,7 +136,7 @@ describe('DelegationController:awaitDeleteDelegationEntry', () => {
   it('subscribes to transaction status updates', () => {
     const txMeta = createMockTransactionMeta({});
 
-    awaitDeleteDelegationEntry(controller, initMessenger, {
+    awaitDeleteDelegationEntry(messengerClient, initMessenger, {
       hash: mockHash,
       txMeta,
     });
@@ -149,9 +149,9 @@ describe('DelegationController:awaitDeleteDelegationEntry', () => {
 
   it('deletes delegation when transaction is confirmed', () => {
     const txMeta = createMockTransactionMeta({});
-    const deleteSpy = jest.spyOn(controller, 'delete');
+    const deleteSpy = jest.spyOn(messengerClient, 'delete');
 
-    awaitDeleteDelegationEntry(controller, initMessenger, {
+    awaitDeleteDelegationEntry(messengerClient, initMessenger, {
       hash: mockHash,
       txMeta,
     });
@@ -169,9 +169,9 @@ describe('DelegationController:awaitDeleteDelegationEntry', () => {
 
   it('unsubscribes when transaction is dropped', () => {
     const txMeta = createMockTransactionMeta({});
-    const deleteSpy = jest.spyOn(controller, 'delete');
+    const deleteSpy = jest.spyOn(messengerClient, 'delete');
 
-    awaitDeleteDelegationEntry(controller, initMessenger, {
+    awaitDeleteDelegationEntry(messengerClient, initMessenger, {
       hash: mockHash,
       txMeta,
     });
@@ -189,9 +189,9 @@ describe('DelegationController:awaitDeleteDelegationEntry', () => {
 
   it('follows transaction chain when replaced', () => {
     const txMeta = createMockTransactionMeta({});
-    const deleteSpy = jest.spyOn(controller, 'delete');
+    const deleteSpy = jest.spyOn(messengerClient, 'delete');
 
-    awaitDeleteDelegationEntry(controller, initMessenger, {
+    awaitDeleteDelegationEntry(messengerClient, initMessenger, {
       hash: mockHash,
       txMeta,
     });
@@ -220,9 +220,9 @@ describe('DelegationController:awaitDeleteDelegationEntry', () => {
 
   it('unsubscribes when transaction is cancelled', () => {
     const txMeta = createMockTransactionMeta({});
-    const deleteSpy = jest.spyOn(controller, 'delete');
+    const deleteSpy = jest.spyOn(messengerClient, 'delete');
 
-    awaitDeleteDelegationEntry(controller, initMessenger, {
+    awaitDeleteDelegationEntry(messengerClient, initMessenger, {
       hash: mockHash,
       txMeta,
     });

--- a/app/scripts/messenger-client-init/delegation/delegation-controller-init.ts
+++ b/app/scripts/messenger-client-init/delegation/delegation-controller-init.ts
@@ -34,7 +34,7 @@ export const DelegationControllerInit: MessengerClientInitFunction<
   DelegationControllerMessenger,
   DelegationControllerInitMessenger
 > = ({ controllerMessenger, persistedState, initMessenger }) => {
-  const controller = new DelegationController({
+  const messengerClient = new DelegationController({
     messenger: controllerMessenger,
     state: persistedState.DelegationController,
     hashDelegation: getDelegationHashOffchain,
@@ -43,21 +43,21 @@ export const DelegationControllerInit: MessengerClientInitFunction<
 
   controllerMessenger.registerActionHandler(
     'DelegationController:signDelegation',
-    controller.signDelegation.bind(controller),
+    messengerClient.signDelegation.bind(messengerClient),
   );
 
   return {
-    controller,
+    messengerClient,
     api: {
-      signDelegation: controller.signDelegation.bind(controller),
-      storeDelegationEntry: controller.store.bind(controller),
-      listDelegationEntries: controller.list.bind(controller),
-      getDelegationEntry: controller.retrieve.bind(controller),
-      getDelegationEntryChain: controller.chain.bind(controller),
-      deleteDelegationEntry: controller.delete.bind(controller),
+      signDelegation: messengerClient.signDelegation.bind(messengerClient),
+      storeDelegationEntry: messengerClient.store.bind(messengerClient),
+      listDelegationEntries: messengerClient.list.bind(messengerClient),
+      getDelegationEntry: messengerClient.retrieve.bind(messengerClient),
+      getDelegationEntryChain: messengerClient.chain.bind(messengerClient),
+      deleteDelegationEntry: messengerClient.delete.bind(messengerClient),
       awaitDeleteDelegationEntry: awaitDeleteDelegationEntry.bind(
         null,
-        controller,
+        messengerClient,
         initMessenger,
       ),
     },
@@ -68,7 +68,7 @@ export const DelegationControllerInit: MessengerClientInitFunction<
  * Awaits for the transaction with txMeta to be confirmed, then
  * deletes the delegation entry with `hash`.
  *
- * @param controller - The DelegationController.
+ * @param messengerClient - The DelegationController.
  * @param initMessenger - The initialization messenger for the controller.
  * @param options
  * @param options.hash - The hash of the delegation entry to delete.
@@ -76,7 +76,7 @@ export const DelegationControllerInit: MessengerClientInitFunction<
  * @param options.entryToStore - The delegation entry to store.
  */
 export async function awaitDeleteDelegationEntry(
-  controller: DelegationController,
+  messengerClient: DelegationController,
   initMessenger: DelegationControllerInitMessenger,
   {
     hash,
@@ -135,9 +135,9 @@ export async function awaitDeleteDelegationEntry(
     }
 
     if (action === 'delete') {
-      controller.delete(hash);
+      messengerClient.delete(hash);
       if (entryToStore) {
-        controller.store({ entry: entryToStore });
+        messengerClient.store({ entry: entryToStore });
       }
     }
 

--- a/app/scripts/messenger-client-init/gator-permissions/gator-permissions-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/gator-permissions/gator-permissions-controller-init.test.ts
@@ -58,7 +58,7 @@ describe('GatorPermissionsControllerInit', () => {
   it('returns controller instance', () => {
     const requestMock = buildInitRequestMock();
     expect(
-      GatorPermissionsControllerInit(requestMock).controller,
+      GatorPermissionsControllerInit(requestMock).messengerClient,
     ).toBeInstanceOf(GatorPermissionsController);
   });
 

--- a/app/scripts/messenger-client-init/gator-permissions/gator-permissions-controller-init.ts
+++ b/app/scripts/messenger-client-init/gator-permissions/gator-permissions-controller-init.ts
@@ -42,20 +42,21 @@ export const GatorPermissionsControllerInit: MessengerClientInitFunction<
   GatorPermissionsController,
   GatorPermissionsControllerMessenger
 > = ({ controllerMessenger, persistedState }) => {
-  const controller = new GatorPermissionsController({
+  const messengerClient = new GatorPermissionsController({
     messenger: controllerMessenger,
     config: createGatorPermissionsConfig(),
     state: persistedState.GatorPermissionsController,
   });
 
   return {
-    controller,
+    messengerClient,
     api: {
       fetchAndUpdateGatorPermissions:
-        controller.fetchAndUpdateGatorPermissions.bind(controller),
-      addPendingRevocation: controller.addPendingRevocation.bind(controller),
+        messengerClient.fetchAndUpdateGatorPermissions.bind(messengerClient),
+      addPendingRevocation:
+        messengerClient.addPendingRevocation.bind(messengerClient),
       submitDirectRevocation:
-        controller.submitDirectRevocation.bind(controller),
+        messengerClient.submitDirectRevocation.bind(messengerClient),
     },
   };
 };

--- a/app/scripts/messenger-client-init/identity/authentication-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/identity/authentication-controller-init.test.ts
@@ -43,9 +43,9 @@ describe('AuthenticationControllerInit', () => {
 
   it('returns controller instance', () => {
     const requestMock = buildInitRequestMock();
-    expect(AuthenticationControllerInit(requestMock).controller).toBeInstanceOf(
-      AuthenticationController,
-    );
+    expect(
+      AuthenticationControllerInit(requestMock).messengerClient,
+    ).toBeInstanceOf(AuthenticationController);
   });
 
   it('initializes with correct messenger and state', () => {

--- a/app/scripts/messenger-client-init/identity/authentication-controller-init.ts
+++ b/app/scripts/messenger-client-init/identity/authentication-controller-init.ts
@@ -25,7 +25,7 @@ export const AuthenticationControllerInit: MessengerClientInitFunction<
   AuthenticationControllerInitMessenger
 > = ({ controllerMessenger, initMessenger, persistedState }) => {
   const env = loadAuthenticationConfig();
-  const controller = new AuthenticationController({
+  const messengerClient = new AuthenticationController({
     messenger: controllerMessenger,
     state:
       persistedState.AuthenticationController as AuthenticationControllerState,
@@ -42,6 +42,6 @@ export const AuthenticationControllerInit: MessengerClientInitFunction<
   });
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/identity/user-storage-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/identity/user-storage-controller-init.test.ts
@@ -47,9 +47,9 @@ describe('UserStorageControllerInit', () => {
 
   it('returns controller instance', () => {
     const requestMock = buildInitRequestMock();
-    expect(UserStorageControllerInit(requestMock).controller).toBeInstanceOf(
-      UserStorageController,
-    );
+    expect(
+      UserStorageControllerInit(requestMock).messengerClient,
+    ).toBeInstanceOf(UserStorageController);
   });
 
   it('initializes with correct messenger and state', () => {

--- a/app/scripts/messenger-client-init/identity/user-storage-controller-init.ts
+++ b/app/scripts/messenger-client-init/identity/user-storage-controller-init.ts
@@ -29,7 +29,7 @@ export const UserStorageControllerInit: MessengerClientInitFunction<
   // The environment must be the same used by AuthenticationController.
   const env = loadAuthenticationConfig();
   const { controllerMessenger, initMessenger, persistedState } = request;
-  const controller = new UserStorageController({
+  const messengerClient = new UserStorageController({
     messenger: controllerMessenger,
     state: persistedState.UserStorageController as UserStorageControllerState,
     // @ts-expect-error Controller uses string for names rather than enum
@@ -98,6 +98,6 @@ export const UserStorageControllerInit: MessengerClientInitFunction<
   });
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/institutional-snap/institutional-snap-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/institutional-snap/institutional-snap-controller-init.test.ts
@@ -36,7 +36,7 @@ describe('InstitutionalSnapControllerInit', () => {
   it('returns controller instance', () => {
     const requestMock = buildInitRequestMock();
     expect(
-      InstitutionalSnapControllerInit(requestMock).controller,
+      InstitutionalSnapControllerInit(requestMock).messengerClient,
     ).toBeInstanceOf(InstitutionalSnapController);
   });
 

--- a/app/scripts/messenger-client-init/institutional-snap/institutional-snap-controller-init.ts
+++ b/app/scripts/messenger-client-init/institutional-snap/institutional-snap-controller-init.ts
@@ -6,12 +6,12 @@ export const InstitutionalSnapControllerInit: MessengerClientInitFunction<
   InstitutionalSnapController,
   InstitutionalSnapControllerMessenger
 > = (request) => {
-  const controller = new InstitutionalSnapController({
+  const messengerClient = new InstitutionalSnapController({
     messenger: request.controllerMessenger,
   });
 
   return {
-    controller,
+    messengerClient,
     persistedStateKey: null,
   };
 };

--- a/app/scripts/messenger-client-init/keyring-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/keyring-controller-init.test.ts
@@ -53,12 +53,12 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('KeyringControllerInit', () => {
-  it('initializes the messengerClient', () => {
+  it('initializes the controller', () => {
     const { messengerClient } = KeyringControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(KeyringController);
   });
 
-  it('passes the proper arguments to the messengerClient', () => {
+  it('passes the proper arguments to the controller', () => {
     KeyringControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(KeyringController);

--- a/app/scripts/messenger-client-init/keyring-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/keyring-controller-init.test.ts
@@ -53,12 +53,12 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('KeyringControllerInit', () => {
-  it('initializes the controller', () => {
-    const { controller } = KeyringControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(KeyringController);
+  it('initializes the messengerClient', () => {
+    const { messengerClient } = KeyringControllerInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(KeyringController);
   });
 
-  it('passes the proper arguments to the controller', () => {
+  it('passes the proper arguments to the messengerClient', () => {
     KeyringControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(KeyringController);

--- a/app/scripts/messenger-client-init/keyring-controller-init.ts
+++ b/app/scripts/messenger-client-init/keyring-controller-init.ts
@@ -39,7 +39,7 @@ import {
  * @param request.keyringOverrides - Optional overrides for keyring classes and
  * bridges.
  * @param request.encryptor - Optional encryptor to use for the controller.
- * @param request.getController - Function to get other controllers.
+ * @param request.getMessengerClient - Function to get other controllers.
  * @returns The initialized controller.
  */
 export const KeyringControllerInit: MessengerClientInitFunction<
@@ -52,7 +52,7 @@ export const KeyringControllerInit: MessengerClientInitFunction<
   initMessenger,
   keyringOverrides,
   encryptor,
-  getController,
+  getMessengerClient,
 }) => {
   const additionalKeyrings = [
     qrKeyringBuilderFactory(
@@ -102,12 +102,12 @@ export const KeyringControllerInit: MessengerClientInitFunction<
     );
   }
 
-  const snapKeyringBuilder = getController('SnapKeyringBuilder');
+  const snapKeyringBuilder = getMessengerClient('SnapKeyringBuilder');
 
   // @ts-expect-error: `addAccounts` is missing in `SnapKeyring` type.
   additionalKeyrings.push(snapKeyringBuilder);
 
-  const controller = new KeyringController({
+  const messengerClient = new KeyringController({
     state: persistedState.KeyringController,
     messenger: controllerMessenger,
     keyringBuilders: additionalKeyrings,
@@ -115,6 +115,6 @@ export const KeyringControllerInit: MessengerClientInitFunction<
   });
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/logging-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/logging-controller-init.test.ts
@@ -33,12 +33,12 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('LoggingControllerInit', () => {
-  it('initializes the controller', () => {
-    const { controller } = LoggingControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(LoggingController);
+  it('initializes the messengerClient', () => {
+    const { messengerClient } = LoggingControllerInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(LoggingController);
   });
 
-  it('passes the proper arguments to the controller', () => {
+  it('passes the proper arguments to the messengerClient', () => {
     LoggingControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(LoggingController);
@@ -50,20 +50,20 @@ describe('LoggingControllerInit', () => {
 
   it('logs the previous and current version when the client is updated', () => {
     const request = getInitRequestMock();
-    const { controller } = LoggingControllerInit(request);
+    const { messengerClient } = LoggingControllerInit(request);
 
-    expect(controller.add).not.toHaveBeenCalled();
+    expect(messengerClient.add).not.toHaveBeenCalled();
 
     const listener = jest.mocked(
       request.extension.runtime.onInstalled.addListener,
     ).mock.calls[0][0];
 
     listener({ reason: 'install', temporary: false });
-    expect(controller.add).not.toHaveBeenCalled();
+    expect(messengerClient.add).not.toHaveBeenCalled();
 
     listener({ reason: 'update', previousVersion: '1.0.0', temporary: false });
 
-    expect(controller.add).toHaveBeenCalledWith({
+    expect(messengerClient.add).toHaveBeenCalledWith({
       type: LogType.GenericLog,
       data: {
         event: 'Extension version update',

--- a/app/scripts/messenger-client-init/logging-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/logging-controller-init.test.ts
@@ -33,12 +33,12 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('LoggingControllerInit', () => {
-  it('initializes the messengerClient', () => {
+  it('initializes the controller', () => {
     const { messengerClient } = LoggingControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(LoggingController);
   });
 
-  it('passes the proper arguments to the messengerClient', () => {
+  it('passes the proper arguments to the controller', () => {
     LoggingControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(LoggingController);

--- a/app/scripts/messenger-client-init/logging-controller-init.ts
+++ b/app/scripts/messenger-client-init/logging-controller-init.ts
@@ -17,14 +17,14 @@ export const LoggingControllerInit: MessengerClientInitFunction<
   LoggingController,
   LoggingControllerMessenger
 > = ({ controllerMessenger, persistedState, extension }) => {
-  const controller = new LoggingController({
+  const messengerClient = new LoggingController({
     messenger: controllerMessenger,
     state: persistedState.LoggingController,
   });
 
   extension.runtime.onInstalled.addListener((details) => {
     if (details.reason === 'update') {
-      controller.add({
+      messengerClient.add({
         type: LogType.GenericLog,
         data: {
           event: LOG_EVENT.VERSION_UPDATE,
@@ -36,6 +36,6 @@ export const LoggingControllerInit: MessengerClientInitFunction<
   });
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/metametrics-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/metametrics-controller-init.test.ts
@@ -25,12 +25,12 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('MetaMetricsControllerInit', () => {
-  it('initializes the controller', () => {
-    const { controller } = MetaMetricsControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(MetaMetricsController);
+  it('initializes the messengerClient', () => {
+    const { messengerClient } = MetaMetricsControllerInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(MetaMetricsController);
   });
 
-  it('passes the proper arguments to the controller', () => {
+  it('passes the proper arguments to the messengerClient', () => {
     MetaMetricsControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(MetaMetricsController);

--- a/app/scripts/messenger-client-init/metametrics-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/metametrics-controller-init.test.ts
@@ -25,12 +25,12 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('MetaMetricsControllerInit', () => {
-  it('initializes the messengerClient', () => {
+  it('initializes the controller', () => {
     const { messengerClient } = MetaMetricsControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(MetaMetricsController);
   });
 
-  it('passes the proper arguments to the messengerClient', () => {
+  it('passes the proper arguments to the controller', () => {
     MetaMetricsControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(MetaMetricsController);

--- a/app/scripts/messenger-client-init/metametrics-controller-init.ts
+++ b/app/scripts/messenger-client-init/metametrics-controller-init.ts
@@ -19,7 +19,7 @@ export const MetaMetricsControllerInit: MessengerClientInitFunction<
   MetaMetricsController,
   MetaMetricsControllerMessenger
 > = ({ controllerMessenger, extension, persistedState }) => {
-  const controller = new MetaMetricsController({
+  const messengerClient = new MetaMetricsController({
     state: persistedState.MetaMetricsController,
     messenger: controllerMessenger,
     version: process.env.METAMASK_VERSION as string,
@@ -30,6 +30,6 @@ export const MetaMetricsControllerInit: MessengerClientInitFunction<
   });
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/metametrics-data-deletion-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/metametrics-data-deletion-controller-init.test.ts
@@ -39,13 +39,13 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('MetaMetricsDataDeletionControllerInit', () => {
-  it('initializes the messengerClient', () => {
+  it('initializes the controller', () => {
     const { messengerClient } =
       MetaMetricsDataDeletionControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(MetaMetricsDataDeletionController);
   });
 
-  it('passes the proper arguments to the messengerClient', () => {
+  it('passes the proper arguments to the controller', () => {
     MetaMetricsDataDeletionControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(MetaMetricsDataDeletionController);

--- a/app/scripts/messenger-client-init/metametrics-data-deletion-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/metametrics-data-deletion-controller-init.test.ts
@@ -24,14 +24,16 @@ function getInitRequestMock(): jest.Mocked<
     initMessenger: undefined,
   };
 
-  // @ts-expect-error: Partial implementation.
-  requestMock.getController.mockImplementation((controllerName: string) => {
-    if (controllerName === 'DataDeletionService') {
-      return new DataDeletionService({
-        messenger: getDataDeletionServiceMessenger(baseMessenger),
-      });
-    }
-  });
+  requestMock.getMessengerClient.mockImplementation(
+    // @ts-expect-error: Partial implementation.
+    (controllerName: string) => {
+      if (controllerName === 'DataDeletionService') {
+        return new DataDeletionService({
+          messenger: getDataDeletionServiceMessenger(baseMessenger),
+        });
+      }
+    },
+  );
 
   return requestMock;
 }

--- a/app/scripts/messenger-client-init/metametrics-data-deletion-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/metametrics-data-deletion-controller-init.test.ts
@@ -37,13 +37,13 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('MetaMetricsDataDeletionControllerInit', () => {
-  it('initializes the controller', () => {
-    const { controller } =
+  it('initializes the messengerClient', () => {
+    const { messengerClient } =
       MetaMetricsDataDeletionControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(MetaMetricsDataDeletionController);
+    expect(messengerClient).toBeInstanceOf(MetaMetricsDataDeletionController);
   });
 
-  it('passes the proper arguments to the controller', () => {
+  it('passes the proper arguments to the messengerClient', () => {
     MetaMetricsDataDeletionControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(MetaMetricsDataDeletionController);

--- a/app/scripts/messenger-client-init/metametrics-data-deletion-controller-init.ts
+++ b/app/scripts/messenger-client-init/metametrics-data-deletion-controller-init.ts
@@ -12,24 +12,24 @@ import { MessengerClientInitFunction } from './types';
  * @param request.controllerMessenger - The messenger to use for the controller.
  * @param request.persistedState - The persisted state to use for the
  * controller.
- * @param request.getController - The function to get other controllers.
+ * @param request.getMessengerClient - The function to get other messenger clients.
  * @returns The initialized controller.
  */
 export const MetaMetricsDataDeletionControllerInit: MessengerClientInitFunction<
   MetaMetricsDataDeletionController,
   MetaMetricsDataDeletionControllerMessenger
-> = ({ controllerMessenger, persistedState, getController }) => {
-  const dataDeletionService = getController(
+> = ({ controllerMessenger, persistedState, getMessengerClient }) => {
+  const dataDeletionService = getMessengerClient(
     'DataDeletionService',
   ) as DataDeletionService;
 
-  const controller = new MetaMetricsDataDeletionController({
+  const messengerClient = new MetaMetricsDataDeletionController({
     messenger: controllerMessenger,
     state: persistedState.MetaMetricsDataDeletionController,
     dataDeletionService,
   });
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/multichain/multichain-account-service-init.test.ts
+++ b/app/scripts/messenger-client-init/multichain/multichain-account-service-init.test.ts
@@ -62,7 +62,7 @@ describe('MultichainAccountServiceInit', () => {
       const requestMock = buildInitRequestMock();
       const result = MultichainAccountServiceInit(requestMock);
 
-      expect(result.controller).toBeInstanceOf(MultichainAccountService);
+      expect(result.messengerClient).toBeInstanceOf(MultichainAccountService);
     });
 
     it('returns null memStateKey and persistedStateKey', () => {
@@ -155,7 +155,7 @@ describe('MultichainAccountServiceInit', () => {
 
       const result = MultichainAccountServiceInit(requestMock);
       const setBasicFunctionalitySpy = jest
-        .spyOn(result.controller, 'setBasicFunctionality')
+        .spyOn(result.messengerClient, 'setBasicFunctionality')
         .mockResolvedValue(undefined as never);
 
       const handler = subscribeSpy.mock.calls.find(
@@ -176,7 +176,7 @@ describe('MultichainAccountServiceInit', () => {
 
       const result = MultichainAccountServiceInit(requestMock);
       const setBasicFunctionalitySpy = jest
-        .spyOn(result.controller, 'setBasicFunctionality')
+        .spyOn(result.messengerClient, 'setBasicFunctionality')
         .mockResolvedValue(undefined as never);
 
       const handler = subscribeSpy.mock.calls.find(

--- a/app/scripts/messenger-client-init/multichain/multichain-account-service-init.ts
+++ b/app/scripts/messenger-client-init/multichain/multichain-account-service-init.ts
@@ -46,7 +46,7 @@ export const MultichainAccountServiceInit: MessengerClientInitFunction<
     },
   };
 
-  const controller = new MultichainAccountService({
+  const messengerClient = new MultichainAccountService({
     messenger: controllerMessenger,
     providerConfigs: {
       [SOL_ACCOUNT_PROVIDER_NAME]: {
@@ -76,7 +76,7 @@ export const MultichainAccountServiceInit: MessengerClientInitFunction<
       if (prevUseExternalServices !== currUseExternalServices) {
         // Set basic functionality and trigger alignment when enabled
         // This single call handles both provider disable/enable and alignment.
-        controller
+        messengerClient
           .setBasicFunctionality(currUseExternalServices)
           .catch((error) => {
             console.error(
@@ -93,6 +93,6 @@ export const MultichainAccountServiceInit: MessengerClientInitFunction<
   return {
     memStateKey: null,
     persistedStateKey: null,
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/multichain/multichain-assets-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/multichain/multichain-assets-controller-init.test.ts
@@ -36,7 +36,7 @@ describe('MultichainAssetsControllerInit', () => {
   it('returns controller instance', () => {
     const requestMock = buildInitRequestMock();
     expect(
-      MultichainAssetsControllerInit(requestMock).controller,
+      MultichainAssetsControllerInit(requestMock).messengerClient,
     ).toBeInstanceOf(MultichainAssetsController);
   });
 

--- a/app/scripts/messenger-client-init/multichain/multichain-assets-controller-init.ts
+++ b/app/scripts/messenger-client-init/multichain/multichain-assets-controller-init.ts
@@ -16,12 +16,12 @@ export const MultichainAssetsControllerInit: MessengerClientInitFunction<
   MultichainAssetsController,
   MultichainAssetsControllerMessenger
 > = ({ controllerMessenger, persistedState }) => {
-  const controller = new MultichainAssetsController({
+  const messengerClient = new MultichainAssetsController({
     messenger: controllerMessenger,
     state: persistedState.MultichainAssetsController,
   });
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/multichain/multichain-balances-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/multichain/multichain-balances-controller-init.test.ts
@@ -36,7 +36,7 @@ describe('MultichainBalancesControllerInit', () => {
   it('returns controller instance', () => {
     const requestMock = buildInitRequestMock();
     expect(
-      MultichainBalancesControllerInit(requestMock).controller,
+      MultichainBalancesControllerInit(requestMock).messengerClient,
     ).toBeInstanceOf(MultichainBalancesController);
   });
 

--- a/app/scripts/messenger-client-init/multichain/multichain-balances-controller-init.ts
+++ b/app/scripts/messenger-client-init/multichain/multichain-balances-controller-init.ts
@@ -14,10 +14,10 @@ export const MultichainBalancesControllerInit: MessengerClientInitFunction<
   MultichainBalancesController,
   MultichainBalancesControllerMessenger
 > = ({ controllerMessenger, persistedState }) => {
-  const controller = new MultichainBalancesController({
+  const messengerClient = new MultichainBalancesController({
     messenger: controllerMessenger,
     state: persistedState.MultichainBalancesController,
   });
 
-  return { controller };
+  return { messengerClient };
 };

--- a/app/scripts/messenger-client-init/multichain/multichain-network-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/multichain/multichain-network-controller-init.test.ts
@@ -42,7 +42,7 @@ describe('MultichainNetworkControllerInit', () => {
   it('returns controller instance', () => {
     const requestMock = buildInitRequestMock();
     expect(
-      MultichainNetworkControllerInit(requestMock).controller,
+      MultichainNetworkControllerInit(requestMock).messengerClient,
     ).toBeInstanceOf(MultichainNetworkController);
   });
 

--- a/app/scripts/messenger-client-init/multichain/multichain-network-controller-init.ts
+++ b/app/scripts/messenger-client-init/multichain/multichain-network-controller-init.ts
@@ -27,13 +27,13 @@ export const MultichainNetworkControllerInit = ({
 > => {
   const networkService = MultichainNetworkServiceInit();
 
-  const controller = new MultichainNetworkController({
+  const messengerClient = new MultichainNetworkController({
     messenger: controllerMessenger,
     state: persistedState.MultichainNetworkController,
     networkService,
   });
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/multichain/multichain-network-service-init.test.ts
+++ b/app/scripts/messenger-client-init/multichain/multichain-network-service-init.test.ts
@@ -14,8 +14,8 @@ describe('MultichainNetworkServiceControllerInit', () => {
   });
 
   it('returns controller instance', () => {
-    const controller = MultichainNetworkServiceInit();
-    expect(controller).toBeInstanceOf(MultichainNetworkService);
+    const messengerClient = MultichainNetworkServiceInit();
+    expect(messengerClient).toBeInstanceOf(MultichainNetworkService);
   });
 
   it('initializes with window.fetch', () => {

--- a/app/scripts/messenger-client-init/multichain/multichain-rates-assets-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/multichain/multichain-rates-assets-controller-init.test.ts
@@ -36,7 +36,7 @@ describe('MultichainAssetsRatesControllerInit', () => {
   it('returns controller instance', () => {
     const requestMock = buildInitRequestMock();
     expect(
-      MultichainAssetsRatesControllerInit(requestMock).controller,
+      MultichainAssetsRatesControllerInit(requestMock).messengerClient,
     ).toBeInstanceOf(MultichainAssetsRatesController);
   });
 

--- a/app/scripts/messenger-client-init/multichain/multichain-rates-assets-controller-init.ts
+++ b/app/scripts/messenger-client-init/multichain/multichain-rates-assets-controller-init.ts
@@ -14,13 +14,13 @@ export const MultichainAssetsRatesControllerInit: MessengerClientInitFunction<
   MultichainAssetsRatesController,
   MultichainAssetsRatesControllerMessenger
 > = ({ controllerMessenger, persistedState }) => {
-  const controller = new MultichainAssetsRatesController({
+  const messengerClient = new MultichainAssetsRatesController({
     messenger: controllerMessenger,
     state: persistedState.MultichainAssetsRatesController,
     interval: 1000 * 60 * 3, // 3 mins
   });
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/multichain/multichain-transactions-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/multichain/multichain-transactions-controller-init.test.ts
@@ -36,7 +36,7 @@ describe('MultichainTransactionsControllerInit', () => {
   it('returns controller instance', () => {
     const requestMock = buildInitRequestMock();
     expect(
-      MultichainTransactionsControllerInit(requestMock).controller,
+      MultichainTransactionsControllerInit(requestMock).messengerClient,
     ).toBeInstanceOf(MultichainTransactionsController);
   });
 

--- a/app/scripts/messenger-client-init/multichain/multichain-transactions-controller-init.ts
+++ b/app/scripts/messenger-client-init/multichain/multichain-transactions-controller-init.ts
@@ -14,12 +14,12 @@ export const MultichainTransactionsControllerInit: MessengerClientInitFunction<
   MultichainTransactionsController,
   MultichainTransactionsControllerMessenger
 > = ({ controllerMessenger, persistedState }) => {
-  const controller = new MultichainTransactionsController({
+  const messengerClient = new MultichainTransactionsController({
     messenger: controllerMessenger,
     state: persistedState.MultichainTransactionsController,
   });
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/network-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/network-controller-init.test.ts
@@ -80,8 +80,8 @@ describe('NetworkControllerInit', () => {
   });
 
   it('initializes the controller', () => {
-    const { controller } = NetworkControllerInit(getInitRequestMock());
-    expect(controller).toStrictEqual({
+    const { messengerClient } = NetworkControllerInit(getInitRequestMock());
+    expect(messengerClient).toStrictEqual({
       initializeProvider: expect.any(Function),
       enableRpcFailover: expect.any(Function),
       disableRpcFailover: expect.any(Function),
@@ -343,8 +343,8 @@ describe('NetworkControllerInit', () => {
 
     const request = getInitRequestMock(messenger);
 
-    const { controller } = NetworkControllerInit(request);
-    expect(controller.enableRpcFailover).not.toHaveBeenCalled();
+    const { messengerClient } = NetworkControllerInit(request);
+    expect(messengerClient.enableRpcFailover).not.toHaveBeenCalled();
 
     messenger.publish(
       'RemoteFeatureFlagController:stateChange',
@@ -357,7 +357,7 @@ describe('NetworkControllerInit', () => {
       [],
     );
 
-    expect(controller.enableRpcFailover).toHaveBeenCalled();
+    expect(messengerClient.enableRpcFailover).toHaveBeenCalled();
   });
 
   it('disables RPC failover when the `walletFrameworkRpcFailoverEnabled` feature flag is disabled', () => {
@@ -372,8 +372,8 @@ describe('NetworkControllerInit', () => {
 
     const request = getInitRequestMock(messenger);
 
-    const { controller } = NetworkControllerInit(request);
-    expect(controller.disableRpcFailover).not.toHaveBeenCalled();
+    const { messengerClient } = NetworkControllerInit(request);
+    expect(messengerClient.disableRpcFailover).not.toHaveBeenCalled();
 
     messenger.publish(
       'RemoteFeatureFlagController:stateChange',
@@ -386,6 +386,6 @@ describe('NetworkControllerInit', () => {
       [],
     );
 
-    expect(controller.disableRpcFailover).toHaveBeenCalled();
+    expect(messengerClient.disableRpcFailover).toHaveBeenCalled();
   });
 });

--- a/app/scripts/messenger-client-init/network-controller-init.ts
+++ b/app/scripts/messenger-client-init/network-controller-init.ts
@@ -254,7 +254,7 @@ export const NetworkControllerInit: MessengerClientInitFunction<
     };
   };
 
-  const controller = new NetworkController({
+  const messengerClient = new NetworkController({
     messenger: controllerMessenger,
     state: initialState,
     infuraProjectId,
@@ -319,10 +319,10 @@ export const NetworkControllerInit: MessengerClientInitFunction<
     (isRpcFailoverEnabled) => {
       if (isRpcFailoverEnabled) {
         console.log('Enabling RPC failover.');
-        controller.enableRpcFailover();
+        messengerClient.enableRpcFailover();
       } else {
         console.log('Disabling RPC failover.');
-        controller.disableRpcFailover();
+        messengerClient.disableRpcFailover();
       }
     },
     getIsRpcFailoverEnabled,
@@ -330,9 +330,9 @@ export const NetworkControllerInit: MessengerClientInitFunction<
 
   // Delay lookupNetwork until after onboarding to prevent network requests before the user can
   // update their RPC endpoints.
-  controller.initializeProvider({ lookupNetwork: false });
+  messengerClient.initializeProvider({ lookupNetwork: false });
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/notifications/notification-services-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/notifications/notification-services-controller-init.test.ts
@@ -48,7 +48,9 @@ describe('NotificationServicesControllerInit', () => {
   it('returns controller instance', () => {
     const { requestMock } = arrange();
     const result = NotificationServicesControllerInit(requestMock);
-    expect(result.controller).toBeInstanceOf(NotificationServicesController);
+    expect(result.messengerClient).toBeInstanceOf(
+      NotificationServicesController,
+    );
   });
 
   it('initializes with correct messenger and state', () => {

--- a/app/scripts/messenger-client-init/notifications/notification-services-controller-init.ts
+++ b/app/scripts/messenger-client-init/notifications/notification-services-controller-init.ts
@@ -11,8 +11,8 @@ const getNormalisedLocale = (locale: string): string =>
 export const NotificationServicesControllerInit: MessengerClientInitFunction<
   NotificationServicesController,
   NotificationServicesControllerMessenger
-> = ({ controllerMessenger, persistedState, getController }) => {
-  const controller = new NotificationServicesController({
+> = ({ controllerMessenger, persistedState, getMessengerClient }) => {
+  const messengerClient = new NotificationServicesController({
     messenger: controllerMessenger,
     state: persistedState.NotificationServicesController,
     env: {
@@ -24,12 +24,12 @@ export const NotificationServicesControllerInit: MessengerClientInitFunction<
       },
       locale: () =>
         getNormalisedLocale(
-          getController('PreferencesController').state.currentLocale,
+          getMessengerClient('PreferencesController').state.currentLocale,
         ),
     },
   });
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/notifications/notification-services-push-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/notifications/notification-services-push-controller-init.test.ts
@@ -58,7 +58,7 @@ describe('NotificationServicesPushControllerInit', () => {
   it('returns controller instance', () => {
     const { requestMock } = arrange();
     const result = NotificationServicesPushControllerInit(requestMock);
-    expect(result.controller).toBeInstanceOf(
+    expect(result.messengerClient).toBeInstanceOf(
       NotificationServicesPushController,
     );
   });

--- a/app/scripts/messenger-client-init/notifications/notification-services-push-controller-init.ts
+++ b/app/scripts/messenger-client-init/notifications/notification-services-push-controller-init.ts
@@ -36,8 +36,13 @@ export const NotificationServicesPushControllerInit: MessengerClientInitFunction
   NotificationServicesPushController,
   NotificationServicesPushControllerMessenger,
   NotificationServicesPushControllerInitMessenger
-> = ({ controllerMessenger, initMessenger, persistedState, getController }) => {
-  const controller = new NotificationServicesPushController({
+> = ({
+  controllerMessenger,
+  initMessenger,
+  persistedState,
+  getMessengerClient,
+}) => {
+  const messengerClient = new NotificationServicesPushController({
     messenger: controllerMessenger,
     state: {
       ...defaultState,
@@ -69,7 +74,7 @@ export const NotificationServicesPushControllerInit: MessengerClientInitFunction
       },
       getLocale: () =>
         getNormalisedLocale(
-          getController('PreferencesController').state.currentLocale,
+          getMessengerClient('PreferencesController').state.currentLocale,
         ),
     },
   });
@@ -128,6 +133,6 @@ export const NotificationServicesPushControllerInit: MessengerClientInitFunction
   );
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/onboarding-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/onboarding-controller-init.test.ts
@@ -25,12 +25,12 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('OnboardingControllerInit', () => {
-  it('initializes the messengerClient', () => {
+  it('initializes the controller', () => {
     const { messengerClient } = OnboardingControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(OnboardingController);
   });
 
-  it('passes the proper arguments to the messengerClient', () => {
+  it('passes the proper arguments to the controller', () => {
     OnboardingControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(OnboardingController);

--- a/app/scripts/messenger-client-init/onboarding-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/onboarding-controller-init.test.ts
@@ -25,12 +25,12 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('OnboardingControllerInit', () => {
-  it('initializes the controller', () => {
-    const { controller } = OnboardingControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(OnboardingController);
+  it('initializes the messengerClient', () => {
+    const { messengerClient } = OnboardingControllerInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(OnboardingController);
   });
 
-  it('passes the proper arguments to the controller', () => {
+  it('passes the proper arguments to the messengerClient', () => {
     OnboardingControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(OnboardingController);

--- a/app/scripts/messenger-client-init/onboarding-controller-init.ts
+++ b/app/scripts/messenger-client-init/onboarding-controller-init.ts
@@ -16,12 +16,12 @@ export const OnboardingControllerInit: MessengerClientInitFunction<
   OnboardingController,
   OnboardingControllerMessenger
 > = ({ controllerMessenger, persistedState }) => {
-  const controller = new OnboardingController({
+  const messengerClient = new OnboardingController({
     state: persistedState.OnboardingController,
     messenger: controllerMessenger,
   });
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/permission-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/permission-controller-init.test.ts
@@ -66,12 +66,12 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('PermissionControllerInit', () => {
-  it('initializes the messengerClient', () => {
+  it('initializes the controller', () => {
     const { messengerClient } = PermissionControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(PermissionController);
   });
 
-  it('passes the proper arguments to the messengerClient', () => {
+  it('passes the proper arguments to the controller', () => {
     PermissionControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(PermissionController);

--- a/app/scripts/messenger-client-init/permission-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/permission-controller-init.test.ts
@@ -44,32 +44,34 @@ function getInitRequestMock(): jest.Mocked<
     initMessenger: getPermissionControllerInitMessenger(baseMessenger),
   };
 
-  requestMock.getController.mockImplementation((name: MessengerClientName) => {
-    if (name === 'ApprovalController') {
-      return {
-        addAndShowApprovalRequest: jest.fn(),
-      } as unknown as MessengerClientByName['ApprovalController'];
-    }
+  requestMock.getMessengerClient.mockImplementation(
+    (name: MessengerClientName) => {
+      if (name === 'ApprovalController') {
+        return {
+          addAndShowApprovalRequest: jest.fn(),
+        } as unknown as MessengerClientByName['ApprovalController'];
+      }
 
-    if (name === 'KeyringController') {
-      return {
-        addNewKeyring: jest.fn(),
-      } as unknown as MessengerClientByName['KeyringController'];
-    }
+      if (name === 'KeyringController') {
+        return {
+          addNewKeyring: jest.fn(),
+        } as unknown as MessengerClientByName['KeyringController'];
+      }
 
-    throw new Error(`Controller "${String(name)}" not found.`);
-  });
+      throw new Error(`Controller "${String(name)}" not found.`);
+    },
+  );
 
   return requestMock;
 }
 
 describe('PermissionControllerInit', () => {
-  it('initializes the controller', () => {
-    const { controller } = PermissionControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(PermissionController);
+  it('initializes the messengerClient', () => {
+    const { messengerClient } = PermissionControllerInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(PermissionController);
   });
 
-  it('passes the proper arguments to the controller', () => {
+  it('passes the proper arguments to the messengerClient', () => {
     PermissionControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(PermissionController);

--- a/app/scripts/messenger-client-init/permission-controller-init.ts
+++ b/app/scripts/messenger-client-init/permission-controller-init.ts
@@ -22,7 +22,7 @@ import { MessengerClientInitFunction } from './types';
  * @param request.controllerMessenger - The messenger to use for the controller.
  * @param request.persistedState - The persisted state of the extension.
  * @param request.initMessenger
- * @param request.getController
+ * @param request.getMessengerClient
  * @returns The initialized controller.
  */
 export const PermissionControllerInit: MessengerClientInitFunction<
@@ -32,11 +32,16 @@ export const PermissionControllerInit: MessengerClientInitFunction<
   >,
   PermissionControllerMessenger,
   PermissionControllerInitMessenger
-> = ({ controllerMessenger, persistedState, initMessenger, getController }) => {
-  const approvalController = getController('ApprovalController');
-  const keyringController = getController('KeyringController');
+> = ({
+  controllerMessenger,
+  persistedState,
+  initMessenger,
+  getMessengerClient,
+}) => {
+  const approvalController = getMessengerClient('ApprovalController');
+  const keyringController = getMessengerClient('KeyringController');
 
-  const controller = new PermissionController({
+  const messengerClient = new PermissionController({
     state: persistedState.PermissionController,
     // @ts-expect-error PermissionController messenger parameter type is incompatible with our messenger alias (handler unions).
     messenger: controllerMessenger,
@@ -73,6 +78,6 @@ export const PermissionControllerInit: MessengerClientInitFunction<
   });
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/permission-log-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/permission-log-controller-init.test.ts
@@ -25,12 +25,13 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('PermissionLogControllerInit', () => {
-  it('initializes the controller', () => {
-    const { controller } = PermissionLogControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(PermissionLogController);
+  it('initializes the messengerClient', () => {
+    const { messengerClient } =
+      PermissionLogControllerInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(PermissionLogController);
   });
 
-  it('passes the proper arguments to the controller', () => {
+  it('passes the proper arguments to the messengerClient', () => {
     PermissionLogControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(PermissionLogController);

--- a/app/scripts/messenger-client-init/permission-log-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/permission-log-controller-init.test.ts
@@ -25,13 +25,13 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('PermissionLogControllerInit', () => {
-  it('initializes the messengerClient', () => {
+  it('initializes the controller', () => {
     const { messengerClient } =
       PermissionLogControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(PermissionLogController);
   });
 
-  it('passes the proper arguments to the messengerClient', () => {
+  it('passes the proper arguments to the controller', () => {
     PermissionLogControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(PermissionLogController);

--- a/app/scripts/messenger-client-init/permission-log-controller-init.ts
+++ b/app/scripts/messenger-client-init/permission-log-controller-init.ts
@@ -15,13 +15,13 @@ export const PermissionLogControllerInit: MessengerClientInitFunction<
   PermissionLogController,
   PermissionLogControllerMessenger
 > = ({ controllerMessenger, persistedState }) => {
-  const controller = new PermissionLogController({
+  const messengerClient = new PermissionLogController({
     messenger: controllerMessenger,
     state: persistedState.PermissionLogController,
     restrictedMethods: new Set(Object.keys(RestrictedMethods)),
   });
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/perps-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/perps-controller-init.test.ts
@@ -158,7 +158,7 @@ describe('PerpsControllerInit', () => {
       const request = getInitRequestMock();
       const result = PerpsControllerInit(request);
 
-      expect(result.controller).toBeDefined();
+      expect(result.messengerClient).toBeDefined();
       expect(result.api).toBeDefined();
     });
 
@@ -482,13 +482,13 @@ describe('PerpsControllerInit', () => {
     ];
 
     for (const [apiMethod, controllerMethod] of apiToController) {
-      it(`${apiMethod} delegates to controller.${controllerMethod}`, async () => {
-        const { api, controller } = initWithApi();
+      it(`${apiMethod} delegates to messengerClient.${controllerMethod}`, async () => {
+        const { api, messengerClient } = initWithApi();
 
         await (api as Record<string, CallableFunction>)[apiMethod]();
 
         expect(
-          (controller as unknown as Record<string, jest.Mock>)[
+          (messengerClient as unknown as Record<string, jest.Mock>)[
             controllerMethod
           ],
         ).toHaveBeenCalled();
@@ -496,40 +496,40 @@ describe('PerpsControllerInit', () => {
     }
 
     it('perpsDepositWithConfirmation returns lastDepositTransactionId', async () => {
-      const { api, controller } = initWithApi();
+      const { api, messengerClient } = initWithApi();
       (
-        controller.state as unknown as Record<string, string>
+        messengerClient.state as unknown as Record<string, string>
       ).lastDepositTransactionId = 'tx-123';
 
       const result = await api.perpsDepositWithConfirmation(
         ...([] as unknown as Parameters<
-          typeof controller.depositWithConfirmation
+          typeof messengerClient.depositWithConfirmation
         >),
       );
 
-      expect(controller.depositWithConfirmation).toHaveBeenCalled();
+      expect(messengerClient.depositWithConfirmation).toHaveBeenCalled();
       expect(result).toBe('tx-123');
     });
 
     it('perpsGetUserHistory calls provider.getUserHistory', async () => {
-      const { api, controller } = initWithApi();
+      const { api, messengerClient } = initWithApi();
       const params = { startTime: 0 };
 
       await api.perpsGetUserHistory(params);
 
       expect(
-        controller.getActiveProvider().getUserHistory,
+        messengerClient.getActiveProvider().getUserHistory,
       ).toHaveBeenCalledWith(params);
     });
 
     it('perpsGetUserNonFundingLedgerUpdates calls provider.getUserNonFundingLedgerUpdates', async () => {
-      const { api, controller } = initWithApi();
+      const { api, messengerClient } = initWithApi();
       const params = { startTime: 0 };
 
       await api.perpsGetUserNonFundingLedgerUpdates(params);
 
       expect(
-        controller.getActiveProvider().getUserNonFundingLedgerUpdates,
+        messengerClient.getActiveProvider().getUserNonFundingLedgerUpdates,
       ).toHaveBeenCalledWith(params);
     });
   });

--- a/app/scripts/messenger-client-init/perps-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/perps-controller-init.test.ts
@@ -536,46 +536,46 @@ describe('PerpsControllerInit', () => {
 
   describe('withAutoInit recovery', () => {
     it('retries after CLIENT_NOT_INITIALIZED and succeeds', async () => {
-      const { api, controller } = initWithApi();
-      const getPositions = controller.getPositions as jest.Mock;
+      const { api, messengerClient } = initWithApi();
+      const getPositions = messengerClient.getPositions as jest.Mock;
       getPositions
         .mockRejectedValueOnce(new Error('CLIENT_NOT_INITIALIZED'))
         .mockResolvedValueOnce([{ symbol: 'ETH' }]);
 
       const result = await api.perpsGetPositions();
 
-      expect(controller.init).toHaveBeenCalledTimes(1);
+      expect(messengerClient.init).toHaveBeenCalledTimes(1);
       expect(getPositions).toHaveBeenCalledTimes(2);
       expect(result).toEqual([{ symbol: 'ETH' }]);
     });
 
     it('retries after CLIENT_REINITIALIZING and succeeds', async () => {
-      const { api, controller } = initWithApi();
-      const getMarkets = controller.getMarkets as jest.Mock;
+      const { api, messengerClient } = initWithApi();
+      const getMarkets = messengerClient.getMarkets as jest.Mock;
       getMarkets
         .mockRejectedValueOnce(new Error('CLIENT_REINITIALIZING'))
         .mockResolvedValueOnce([{ market: 'BTC' }]);
 
       const result = await api.perpsGetMarkets();
 
-      expect(controller.init).toHaveBeenCalledTimes(1);
+      expect(messengerClient.init).toHaveBeenCalledTimes(1);
       expect(getMarkets).toHaveBeenCalledTimes(2);
       expect(result).toEqual([{ market: 'BTC' }]);
     });
 
     it('does not retry for unrelated errors', async () => {
-      const { api, controller } = initWithApi();
-      const getPositions = controller.getPositions as jest.Mock;
+      const { api, messengerClient } = initWithApi();
+      const getPositions = messengerClient.getPositions as jest.Mock;
       getPositions.mockRejectedValueOnce(new Error('NETWORK_ERROR'));
 
       await expect(api.perpsGetPositions()).rejects.toThrow('NETWORK_ERROR');
-      expect(controller.init).not.toHaveBeenCalled();
+      expect(messengerClient.init).not.toHaveBeenCalled();
       expect(getPositions).toHaveBeenCalledTimes(1);
     });
 
     it('does not wrap lifecycle methods (perpsInit)', async () => {
-      const { api, controller } = initWithApi();
-      const init = controller.init as jest.Mock;
+      const { api, messengerClient } = initWithApi();
+      const init = messengerClient.init as jest.Mock;
       init.mockRejectedValueOnce(new Error('CLIENT_NOT_INITIALIZED'));
 
       // perpsInit should NOT auto-retry — it IS the init
@@ -584,24 +584,24 @@ describe('PerpsControllerInit', () => {
     });
 
     it('does not wrap preference methods (perpsSaveTradeConfiguration)', async () => {
-      const { api, controller } = initWithApi();
-      const save = controller.saveTradeConfiguration as jest.Mock;
+      const { api, messengerClient } = initWithApi();
+      const save = messengerClient.saveTradeConfiguration as jest.Mock;
       save.mockRejectedValueOnce(new Error('CLIENT_NOT_INITIALIZED'));
 
       // Preferences are state-only — should NOT auto-retry
       await expect(
         api.perpsSaveTradeConfiguration(
           ...([] as unknown as Parameters<
-            typeof controller.saveTradeConfiguration
+            typeof messengerClient.saveTradeConfiguration
           >),
         ),
       ).rejects.toThrow('CLIENT_NOT_INITIALIZED');
-      expect(controller.init).not.toHaveBeenCalled();
+      expect(messengerClient.init).not.toHaveBeenCalled();
     });
 
     it('recovers provider passthrough (perpsGetUserHistory)', async () => {
-      const { api, controller } = initWithApi();
-      const getUserHistory = controller.getActiveProvider()
+      const { api, messengerClient } = initWithApi();
+      const getUserHistory = messengerClient.getActiveProvider()
         .getUserHistory as jest.Mock;
       getUserHistory
         .mockRejectedValueOnce(new Error('CLIENT_NOT_INITIALIZED'))
@@ -609,22 +609,22 @@ describe('PerpsControllerInit', () => {
 
       const result = await api.perpsGetUserHistory({ startTime: 0 });
 
-      expect(controller.init).toHaveBeenCalledTimes(1);
+      expect(messengerClient.init).toHaveBeenCalledTimes(1);
       expect(result).toEqual([{ id: 'h1' }]);
     });
 
     it('recovers trading mutations (perpsPlaceOrder)', async () => {
-      const { api, controller } = initWithApi();
-      const placeOrder = controller.placeOrder as jest.Mock;
+      const { api, messengerClient } = initWithApi();
+      const placeOrder = messengerClient.placeOrder as jest.Mock;
       placeOrder
         .mockRejectedValueOnce(new Error('CLIENT_NOT_INITIALIZED'))
         .mockResolvedValueOnce({ orderId: '123' });
 
       const result = await api.perpsPlaceOrder(
-        ...([] as unknown as Parameters<typeof controller.placeOrder>),
+        ...([] as unknown as Parameters<typeof messengerClient.placeOrder>),
       );
 
-      expect(controller.init).toHaveBeenCalledTimes(1);
+      expect(messengerClient.init).toHaveBeenCalledTimes(1);
       expect(placeOrder).toHaveBeenCalledTimes(2);
       expect(result).toEqual({ orderId: '123' });
     });

--- a/app/scripts/messenger-client-init/perps-controller-init.ts
+++ b/app/scripts/messenger-client-init/perps-controller-init.ts
@@ -59,7 +59,7 @@ export const PerpsControllerInit: MessengerClientInitFunction<
   const useExternalServices =
     persistedState.PreferencesController?.useExternalServices ?? false;
 
-  const controller = new PerpsController({
+  const messengerClient = new PerpsController({
     // TODO: Remove cast once @metamask/perps-controller adds
     // MetaMetricsController:trackEvent to its allowed-actions union.
     // The extension messenger is a superset of the package messenger type;
@@ -82,9 +82,9 @@ export const PerpsControllerInit: MessengerClientInitFunction<
     deferEligibilityCheck: !completedOnboarding || !useExternalServices,
   });
 
-  const api = getApi(controller);
+  const api = getApi(messengerClient);
 
-  return { controller, api };
+  return { messengerClient, api };
 };
 
 /**
@@ -218,112 +218,137 @@ function withAutoInit<TArgs extends unknown[], TResult>(
   };
 }
 
-function getApi(controller: PerpsController): PerpsBackgroundApi {
+function getApi(messengerClient: PerpsController): PerpsBackgroundApi {
   const guard = <TArgs extends unknown[], TResult>(
     fn: (...args: TArgs) => TResult,
-  ) => withAutoInit(controller, fn);
+  ) => withAutoInit(messengerClient, fn);
 
   return {
     // -- Lifecycle (no guard — IS the init itself) --
-    perpsInit: controller.init.bind(controller),
-    perpsDisconnect: controller.disconnect.bind(controller),
+    perpsInit: messengerClient.init.bind(messengerClient),
+    perpsDisconnect: messengerClient.disconnect.bind(messengerClient),
 
     // -- Trading mutations (guarded) --
-    perpsPlaceOrder: guard(controller.placeOrder.bind(controller)),
-    perpsClosePosition: guard(controller.closePosition.bind(controller)),
-    perpsClosePositions: guard(controller.closePositions.bind(controller)),
-    perpsEditOrder: guard(controller.editOrder.bind(controller)),
-    perpsCancelOrder: guard(controller.cancelOrder.bind(controller)),
-    perpsCancelOrders: guard(controller.cancelOrders.bind(controller)),
+    perpsPlaceOrder: guard(messengerClient.placeOrder.bind(messengerClient)),
+    perpsClosePosition: guard(
+      messengerClient.closePosition.bind(messengerClient),
+    ),
+    perpsClosePositions: guard(
+      messengerClient.closePositions.bind(messengerClient),
+    ),
+    perpsEditOrder: guard(messengerClient.editOrder.bind(messengerClient)),
+    perpsCancelOrder: guard(messengerClient.cancelOrder.bind(messengerClient)),
+    perpsCancelOrders: guard(
+      messengerClient.cancelOrders.bind(messengerClient),
+    ),
     perpsUpdatePositionTPSL: guard(
-      controller.updatePositionTPSL.bind(controller),
+      messengerClient.updatePositionTPSL.bind(messengerClient),
     ),
-    perpsUpdateMargin: guard(controller.updateMargin.bind(controller)),
-    perpsFlipPosition: guard(controller.flipPosition.bind(controller)),
-    perpsWithdraw: guard(controller.withdraw.bind(controller)),
+    perpsUpdateMargin: guard(
+      messengerClient.updateMargin.bind(messengerClient),
+    ),
+    perpsFlipPosition: guard(
+      messengerClient.flipPosition.bind(messengerClient),
+    ),
+    perpsWithdraw: guard(messengerClient.withdraw.bind(messengerClient)),
     perpsValidateWithdrawal: guard(
-      controller.validateWithdrawal.bind(controller),
+      messengerClient.validateWithdrawal.bind(messengerClient),
     ),
-    perpsGetWithdrawalRoutes: controller.getWithdrawalRoutes.bind(controller),
+    perpsGetWithdrawalRoutes:
+      messengerClient.getWithdrawalRoutes.bind(messengerClient),
     perpsUpdateWithdrawalStatus: guard(
-      controller.updateWithdrawalStatus.bind(controller),
+      messengerClient.updateWithdrawalStatus.bind(messengerClient),
     ),
     perpsUpdateWithdrawalProgress: guard(
-      controller.updateWithdrawalProgress.bind(controller),
+      messengerClient.updateWithdrawalProgress.bind(messengerClient),
     ),
     perpsGetWithdrawalProgress:
-      controller.getWithdrawalProgress.bind(controller),
+      messengerClient.getWithdrawalProgress.bind(messengerClient),
     perpsDepositWithConfirmation: guard(
       async (
-        ...args: Parameters<typeof controller.depositWithConfirmation>
+        ...args: Parameters<typeof messengerClient.depositWithConfirmation>
       ) => {
-        await controller.depositWithConfirmation(...args);
+        await messengerClient.depositWithConfirmation(...args);
         // TODO: depositWithConfirmation should return the transaction ID
         // directly — that requires a controller package change.
-        return controller.state.lastDepositTransactionId;
+        return messengerClient.state.lastDepositTransactionId;
       },
     ),
 
     // -- Data fetches (guarded) --
-    perpsGetPositions: guard(controller.getPositions.bind(controller)),
-    perpsGetMarkets: guard(controller.getMarkets.bind(controller)),
-    perpsGetMarketDataWithPrices: guard(
-      controller.getMarketDataWithPrices.bind(controller),
+    perpsGetPositions: guard(
+      messengerClient.getPositions.bind(messengerClient),
     ),
-    perpsGetOrderFills: guard(controller.getOrderFills.bind(controller)),
-    perpsGetOrders: guard(controller.getOrders.bind(controller)),
-    perpsGetOpenOrders: guard(controller.getOpenOrders.bind(controller)),
-    perpsGetFunding: guard(controller.getFunding.bind(controller)),
-    perpsGetAccountState: guard(controller.getAccountState.bind(controller)),
+    perpsGetMarkets: guard(messengerClient.getMarkets.bind(messengerClient)),
+    perpsGetMarketDataWithPrices: guard(
+      messengerClient.getMarketDataWithPrices.bind(messengerClient),
+    ),
+    perpsGetOrderFills: guard(
+      messengerClient.getOrderFills.bind(messengerClient),
+    ),
+    perpsGetOrders: guard(messengerClient.getOrders.bind(messengerClient)),
+    perpsGetOpenOrders: guard(
+      messengerClient.getOpenOrders.bind(messengerClient),
+    ),
+    perpsGetFunding: guard(messengerClient.getFunding.bind(messengerClient)),
+    perpsGetAccountState: guard(
+      messengerClient.getAccountState.bind(messengerClient),
+    ),
     perpsGetHistoricalPortfolio: guard(
-      controller.getHistoricalPortfolio.bind(controller),
+      messengerClient.getHistoricalPortfolio.bind(messengerClient),
     ),
     perpsFetchHistoricalCandles: guard(
-      controller.fetchHistoricalCandles.bind(controller),
+      messengerClient.fetchHistoricalCandles.bind(messengerClient),
     ),
-    perpsCalculateFees: guard(controller.calculateFees.bind(controller)),
-    perpsGetAvailableDexs: guard(controller.getAvailableDexs.bind(controller)),
+    perpsCalculateFees: guard(
+      messengerClient.calculateFees.bind(messengerClient),
+    ),
+    perpsGetAvailableDexs: guard(
+      messengerClient.getAvailableDexs.bind(messengerClient),
+    ),
 
     // -- Eligibility (no guard — state-only) --
-    perpsRefreshEligibility: controller.refreshEligibility.bind(controller),
+    perpsRefreshEligibility:
+      messengerClient.refreshEligibility.bind(messengerClient),
     perpsStartEligibilityMonitoring:
-      controller.startEligibilityMonitoring.bind(controller),
+      messengerClient.startEligibilityMonitoring.bind(messengerClient),
     perpsStopEligibilityMonitoring:
-      controller.stopEligibilityMonitoring.bind(controller),
+      messengerClient.stopEligibilityMonitoring.bind(messengerClient),
 
     // -- Toggle (no guard — handled by bridge) --
-    perpsToggleTestnet: controller.toggleTestnet.bind(controller),
+    perpsToggleTestnet: messengerClient.toggleTestnet.bind(messengerClient),
 
     // -- Preferences (no guard — never call getActiveProvider) --
     perpsSaveTradeConfiguration:
-      controller.saveTradeConfiguration.bind(controller),
+      messengerClient.saveTradeConfiguration.bind(messengerClient),
     perpsGetTradeConfiguration:
-      controller.getTradeConfiguration.bind(controller),
+      messengerClient.getTradeConfiguration.bind(messengerClient),
     perpsSavePendingTradeConfiguration:
-      controller.savePendingTradeConfiguration.bind(controller),
+      messengerClient.savePendingTradeConfiguration.bind(messengerClient),
     perpsGetPendingTradeConfiguration:
-      controller.getPendingTradeConfiguration.bind(controller),
+      messengerClient.getPendingTradeConfiguration.bind(messengerClient),
     perpsClearPendingTradeConfiguration:
-      controller.clearPendingTradeConfiguration.bind(controller),
+      messengerClient.clearPendingTradeConfiguration.bind(messengerClient),
     perpsSaveMarketFilterPreferences:
-      controller.saveMarketFilterPreferences.bind(controller),
+      messengerClient.saveMarketFilterPreferences.bind(messengerClient),
     perpsGetMarketFilterPreferences:
-      controller.getMarketFilterPreferences.bind(controller),
+      messengerClient.getMarketFilterPreferences.bind(messengerClient),
     perpsSetSelectedPaymentToken:
-      controller.setSelectedPaymentToken.bind(controller),
+      messengerClient.setSelectedPaymentToken.bind(messengerClient),
     perpsResetSelectedPaymentToken:
-      controller.resetSelectedPaymentToken.bind(controller),
+      messengerClient.resetSelectedPaymentToken.bind(messengerClient),
     perpsMarkTutorialCompleted:
-      controller.markTutorialCompleted.bind(controller),
+      messengerClient.markTutorialCompleted.bind(messengerClient),
     perpsMarkFirstOrderCompleted:
-      controller.markFirstOrderCompleted.bind(controller),
+      messengerClient.markFirstOrderCompleted.bind(messengerClient),
     perpsResetFirstTimeUserState:
-      controller.resetFirstTimeUserState.bind(controller),
+      messengerClient.resetFirstTimeUserState.bind(messengerClient),
     perpsClearPendingTransactionRequests:
-      controller.clearPendingTransactionRequests.bind(controller),
+      messengerClient.clearPendingTransactionRequests.bind(messengerClient),
     perpsSaveOrderBookGrouping:
-      controller.saveOrderBookGrouping.bind(controller),
-    perpsGetOrderBookGrouping: controller.getOrderBookGrouping.bind(controller),
+      messengerClient.saveOrderBookGrouping.bind(messengerClient),
+    perpsGetOrderBookGrouping:
+      messengerClient.getOrderBookGrouping.bind(messengerClient),
 
     // -- Provider passthrough (guarded) --
     perpsGetUserHistory: guard(
@@ -332,7 +357,7 @@ function getApi(controller: PerpsController): PerpsBackgroundApi {
         endTime?: number;
         accountId?: `${string}:${string}:${string}`;
       }) => {
-        return controller.getActiveProvider().getUserHistory(params);
+        return messengerClient.getActiveProvider().getUserHistory(params);
       },
     ),
     perpsGetUserNonFundingLedgerUpdates: guard(
@@ -341,22 +366,28 @@ function getApi(controller: PerpsController): PerpsBackgroundApi {
         endTime?: number;
         accountId?: string;
       }) => {
-        return controller
+        return messengerClient
           .getActiveProvider()
           .getUserNonFundingLedgerUpdates(params);
       },
     ),
 
     // -- Misc (no guard — state-only) --
-    perpsClearDepositResult: controller.clearDepositResult.bind(controller),
-    perpsClearWithdrawResult: controller.clearWithdrawResult.bind(controller),
-    perpsGetBlockExplorerUrl: controller.getBlockExplorerUrl.bind(controller),
-    perpsGetCurrentNetwork: controller.getCurrentNetwork.bind(controller),
+    perpsClearDepositResult:
+      messengerClient.clearDepositResult.bind(messengerClient),
+    perpsClearWithdrawResult:
+      messengerClient.clearWithdrawResult.bind(messengerClient),
+    perpsGetBlockExplorerUrl:
+      messengerClient.getBlockExplorerUrl.bind(messengerClient),
+    perpsGetCurrentNetwork:
+      messengerClient.getCurrentNetwork.bind(messengerClient),
     perpsIsFirstTimeUserOnCurrentNetwork:
-      controller.isFirstTimeUserOnCurrentNetwork.bind(controller),
-    perpsGetWatchlistMarkets: controller.getWatchlistMarkets.bind(controller),
+      messengerClient.isFirstTimeUserOnCurrentNetwork.bind(messengerClient),
+    perpsGetWatchlistMarkets:
+      messengerClient.getWatchlistMarkets.bind(messengerClient),
     perpsToggleWatchlistMarket:
-      controller.toggleWatchlistMarket.bind(controller),
-    perpsIsWatchlistMarket: controller.isWatchlistMarket.bind(controller),
+      messengerClient.toggleWatchlistMarket.bind(messengerClient),
+    perpsIsWatchlistMarket:
+      messengerClient.isWatchlistMarket.bind(messengerClient),
   };
 }

--- a/app/scripts/messenger-client-init/phishing-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/phishing-controller-init.test.ts
@@ -25,12 +25,12 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('PhishingControllerInit', () => {
-  it('initializes the messengerClient', () => {
+  it('initializes the controller', () => {
     const { messengerClient } = PhishingControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(PhishingController);
   });
 
-  it('passes the proper arguments to the messengerClient', () => {
+  it('passes the proper arguments to the controller', () => {
     PhishingControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(PhishingController);

--- a/app/scripts/messenger-client-init/phishing-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/phishing-controller-init.test.ts
@@ -25,12 +25,12 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('PhishingControllerInit', () => {
-  it('initializes the controller', () => {
-    const { controller } = PhishingControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(PhishingController);
+  it('initializes the messengerClient', () => {
+    const { messengerClient } = PhishingControllerInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(PhishingController);
   });
 
-  it('passes the proper arguments to the controller', () => {
+  it('passes the proper arguments to the messengerClient', () => {
     PhishingControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(PhishingController);

--- a/app/scripts/messenger-client-init/phishing-controller-init.ts
+++ b/app/scripts/messenger-client-init/phishing-controller-init.ts
@@ -16,7 +16,7 @@ export const PhishingControllerInit: MessengerClientInitFunction<
   PhishingController,
   PhishingControllerMessenger
 > = ({ controllerMessenger, persistedState }) => {
-  const controller = new PhishingController({
+  const messengerClient = new PhishingController({
     messenger: controllerMessenger,
     state: persistedState.PhishingController,
     hotlistRefreshInterval: process.env.IN_TEST
@@ -28,6 +28,6 @@ export const PhishingControllerInit: MessengerClientInitFunction<
   });
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/preferences-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/preferences-controller-init.test.ts
@@ -26,12 +26,12 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('PreferencesControllerInit', () => {
-  it('initializes the controller', () => {
-    const { controller } = PreferencesControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(PreferencesController);
+  it('initializes the messengerClient', () => {
+    const { messengerClient } = PreferencesControllerInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(PreferencesController);
   });
 
-  it('passes the proper arguments to the controller', () => {
+  it('passes the proper arguments to the messengerClient', () => {
     PreferencesControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(PreferencesController);

--- a/app/scripts/messenger-client-init/preferences-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/preferences-controller-init.test.ts
@@ -26,12 +26,12 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('PreferencesControllerInit', () => {
-  it('initializes the messengerClient', () => {
+  it('initializes the controller', () => {
     const { messengerClient } = PreferencesControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(PreferencesController);
   });
 
-  it('passes the proper arguments to the messengerClient', () => {
+  it('passes the proper arguments to the controller', () => {
     PreferencesControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(PreferencesController);

--- a/app/scripts/messenger-client-init/preferences-controller-init.ts
+++ b/app/scripts/messenger-client-init/preferences-controller-init.ts
@@ -17,7 +17,7 @@ export const PreferencesControllerInit: MessengerClientInitFunction<
   PreferencesController,
   PreferencesControllerMessenger
 > = ({ controllerMessenger, persistedState, initLangCode }) => {
-  const controller = new PreferencesController({
+  const messengerClient = new PreferencesController({
     state: {
       currentLocale: initLangCode ?? '',
       ...persistedState.PreferencesController,
@@ -26,6 +26,6 @@ export const PreferencesControllerInit: MessengerClientInitFunction<
   });
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/profile-metrics-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/profile-metrics-controller-init.test.ts
@@ -25,12 +25,13 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('ProfileMetricsControllerInit', () => {
-  it('initializes the controller', () => {
-    const { controller } = ProfileMetricsControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(ProfileMetricsController);
+  it('initializes the messengerClient', () => {
+    const { messengerClient } =
+      ProfileMetricsControllerInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(ProfileMetricsController);
   });
 
-  it('passes the proper arguments to the controller', () => {
+  it('passes the proper arguments to the messengerClient', () => {
     ProfileMetricsControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(ProfileMetricsController);

--- a/app/scripts/messenger-client-init/profile-metrics-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/profile-metrics-controller-init.test.ts
@@ -25,13 +25,13 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('ProfileMetricsControllerInit', () => {
-  it('initializes the messengerClient', () => {
+  it('initializes the controller', () => {
     const { messengerClient } =
       ProfileMetricsControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(ProfileMetricsController);
   });
 
-  it('passes the proper arguments to the messengerClient', () => {
+  it('passes the proper arguments to the controller', () => {
     ProfileMetricsControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(ProfileMetricsController);

--- a/app/scripts/messenger-client-init/profile-metrics-controller-init.ts
+++ b/app/scripts/messenger-client-init/profile-metrics-controller-init.ts
@@ -15,25 +15,25 @@ const initialDelayDuration = isTestEnvironment ? 1000 : 10 * 60 * 1000;
  * @param request.controllerMessenger - The messenger to use for the controller.
  * @param request.persistedState - The persisted state to use for the
  * controller.
- * @param request.getController - A function to get other initialized controllers.
+ * @param request.getMessengerClient - A function to get other initialized controllers.
  * @returns The initialized controller.
  */
 export const ProfileMetricsControllerInit: MessengerClientInitFunction<
   ProfileMetricsController,
   ProfileMetricsControllerMessenger
-> = ({ controllerMessenger, persistedState, getController }) => {
-  const remoteFeatureFlagController = getController(
+> = ({ controllerMessenger, persistedState, getMessengerClient }) => {
+  const remoteFeatureFlagController = getMessengerClient(
     'RemoteFeatureFlagController',
   );
-  const metaMetricsController = getController('MetaMetricsController');
-  const appStateController = getController('AppStateController');
+  const metaMetricsController = getMessengerClient('MetaMetricsController');
+  const appStateController = getMessengerClient('AppStateController');
   const assertUserOptedIn = () =>
     remoteFeatureFlagController.state.remoteFeatureFlags.extensionUxPna25 ===
       true &&
     appStateController.state.pna25Acknowledged === true &&
     metaMetricsController.state.participateInMetaMetrics === true;
 
-  const controller = new ProfileMetricsController({
+  const messengerClient = new ProfileMetricsController({
     messenger: controllerMessenger,
     state: persistedState.ProfileMetricsController,
     interval: isTestEnvironment ? 1000 : 10 * 1000,
@@ -43,6 +43,6 @@ export const ProfileMetricsControllerInit: MessengerClientInitFunction<
   });
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/profile-metrics-service-init.test.ts
+++ b/app/scripts/messenger-client-init/profile-metrics-service-init.test.ts
@@ -27,8 +27,8 @@ function getInitRequestMock(): jest.Mocked<
 
 describe('ProfileMetricsServiceInit', () => {
   it('initializes the service', () => {
-    const { controller } = ProfileMetricsServiceInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(ProfileMetricsService);
+    const { messengerClient } = ProfileMetricsServiceInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(ProfileMetricsService);
   });
 
   it('passes the proper arguments to the controller', () => {

--- a/app/scripts/messenger-client-init/profile-metrics-service-init.ts
+++ b/app/scripts/messenger-client-init/profile-metrics-service-init.ts
@@ -19,7 +19,7 @@ export const ProfileMetricsServiceInit: MessengerClientInitFunction<
   // The environment must be the same used by AuthenticationController.
   const env = loadAuthenticationConfig();
 
-  const controller = new ProfileMetricsService({
+  const messengerClient = new ProfileMetricsService({
     messenger: controllerMessenger,
     fetch: fetch.bind(globalThis),
     env,
@@ -28,6 +28,6 @@ export const ProfileMetricsServiceInit: MessengerClientInitFunction<
   return {
     persistedStateKey: null,
     memStateKey: null,
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/rates-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/rates-controller-init.test.ts
@@ -25,12 +25,12 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('RatesControllerInit', () => {
-  it('initializes the messengerClient', () => {
+  it('initializes the controller', () => {
     const { messengerClient } = RatesControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(RatesController);
   });
 
-  it('passes the proper arguments to the messengerClient', () => {
+  it('passes the proper arguments to the controller', () => {
     RatesControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(RatesController);

--- a/app/scripts/messenger-client-init/rates-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/rates-controller-init.test.ts
@@ -25,12 +25,12 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('RatesControllerInit', () => {
-  it('initializes the controller', () => {
-    const { controller } = RatesControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(RatesController);
+  it('initializes the messengerClient', () => {
+    const { messengerClient } = RatesControllerInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(RatesController);
   });
 
-  it('passes the proper arguments to the controller', () => {
+  it('passes the proper arguments to the messengerClient', () => {
     RatesControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(RatesController);

--- a/app/scripts/messenger-client-init/rates-controller-init.ts
+++ b/app/scripts/messenger-client-init/rates-controller-init.ts
@@ -14,7 +14,7 @@ export const RatesControllerInit: MessengerClientInitFunction<
   RatesController,
   RatesControllerMessenger
 > = ({ controllerMessenger, persistedState }) => {
-  const controller = new RatesController({
+  const messengerClient = new RatesController({
     // @ts-expect-error: `RatesController` is persisted as
     // `MultichainRatesController`, but the controller init pattern doesn't
     // allow this in the type of `persistedState`.
@@ -26,6 +26,6 @@ export const RatesControllerInit: MessengerClientInitFunction<
   return {
     memStateKey: 'MultichainRatesController',
     persistedStateKey: 'MultichainRatesController',
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/remote-feature-flag-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/remote-feature-flag-controller-init.test.ts
@@ -101,13 +101,13 @@ describe('getConfigForRemoteFeatureFlagRequest', () => {
 });
 
 describe('RemoteFeatureFlagControllerInit', () => {
-  it('initializes the controller', () => {
-    const { controller } =
+  it('initializes the messengerClient', () => {
+    const { messengerClient } =
       RemoteFeatureFlagControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(RemoteFeatureFlagController);
+    expect(messengerClient).toBeInstanceOf(RemoteFeatureFlagController);
   });
 
-  it('passes the proper arguments to the controller', () => {
+  it('passes the proper arguments to the messengerClient', () => {
     RemoteFeatureFlagControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(RemoteFeatureFlagController);

--- a/app/scripts/messenger-client-init/remote-feature-flag-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/remote-feature-flag-controller-init.test.ts
@@ -101,13 +101,13 @@ describe('getConfigForRemoteFeatureFlagRequest', () => {
 });
 
 describe('RemoteFeatureFlagControllerInit', () => {
-  it('initializes the messengerClient', () => {
+  it('initializes the controller', () => {
     const { messengerClient } =
       RemoteFeatureFlagControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(RemoteFeatureFlagController);
   });
 
-  it('passes the proper arguments to the messengerClient', () => {
+  it('passes the proper arguments to the controller', () => {
     RemoteFeatureFlagControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(RemoteFeatureFlagController);

--- a/app/scripts/messenger-client-init/remote-feature-flag-controller-init.ts
+++ b/app/scripts/messenger-client-init/remote-feature-flag-controller-init.ts
@@ -85,7 +85,7 @@ export const RemoteFeatureFlagControllerInit: MessengerClientInitFunction<
   const getIsDisabled = () =>
     !hasCompletedOnboarding || !canUseExternalServices;
 
-  const controller = new RemoteFeatureFlagController({
+  const messengerClient = new RemoteFeatureFlagController({
     state: persistedState.RemoteFeatureFlagController,
     messenger: controllerMessenger,
     fetchInterval: 15 * 60 * 1000, // 15 minutes in milliseconds
@@ -111,10 +111,10 @@ export const RemoteFeatureFlagControllerInit: MessengerClientInitFunction<
   function toggle() {
     const shouldBeDisabled = getIsDisabled();
     if (shouldBeDisabled) {
-      controller.disable();
+      messengerClient.disable();
     } else {
-      controller.enable();
-      controller.updateRemoteFeatureFlags().catch((error) => {
+      messengerClient.enable();
+      messengerClient.updateRemoteFeatureFlags().catch((error) => {
         console.error('Failed to update remote feature flags:', error);
       });
     }
@@ -161,6 +161,6 @@ export const RemoteFeatureFlagControllerInit: MessengerClientInitFunction<
   );
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/rewards-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/rewards-controller-init.test.ts
@@ -69,7 +69,7 @@ describe('RewardsControllerInit', () => {
       const requestMock = buildInitRequestMock();
       const result = RewardsControllerInit(requestMock);
 
-      expect(result.controller).toBeInstanceOf(RewardsController);
+      expect(result.messengerClient).toBeInstanceOf(RewardsController);
     });
 
     it('initializes with correct messenger', () => {

--- a/app/scripts/messenger-client-init/rewards-controller-init.ts
+++ b/app/scripts/messenger-client-init/rewards-controller-init.ts
@@ -42,7 +42,7 @@ export const RewardsControllerInit: MessengerClientInitFunction<
   const rewardsControllerState =
     persistedState.RewardsController ?? defaultRewardsControllerState;
 
-  const controller = new RewardsController({
+  const messengerClient = new RewardsController({
     messenger: controllerMessenger,
     state: rewardsControllerState,
     isDisabled: () => {
@@ -107,5 +107,5 @@ export const RewardsControllerInit: MessengerClientInitFunction<
     },
   });
 
-  return { controller };
+  return { messengerClient };
 };

--- a/app/scripts/messenger-client-init/rewards-data-service-init.test.ts
+++ b/app/scripts/messenger-client-init/rewards-data-service-init.test.ts
@@ -44,7 +44,7 @@ describe('RewardsDataServiceInit', () => {
 
   it('should return controller instance', () => {
     const requestMock = buildInitRequestMock();
-    expect(RewardsDataServiceInit(requestMock).controller).toBeInstanceOf(
+    expect(RewardsDataServiceInit(requestMock).messengerClient).toBeInstanceOf(
       RewardsDataService,
     );
   });

--- a/app/scripts/messenger-client-init/rewards-data-service-init.ts
+++ b/app/scripts/messenger-client-init/rewards-data-service-init.ts
@@ -16,13 +16,13 @@ export const RewardsDataServiceInit: MessengerClientInitFunction<
   RewardsDataService,
   RewardsDataServiceMessenger
 > = ({ controllerMessenger }) => {
-  const controller = new RewardsDataService({
+  const messengerClient = new RewardsDataService({
     messenger: controllerMessenger,
     fetch: fetch.bind(globalThis),
   });
 
   return {
-    controller,
+    messengerClient,
     persistedStateKey: null,
   };
 };

--- a/app/scripts/messenger-client-init/seedless-onboarding/oauth-service-init.test.ts
+++ b/app/scripts/messenger-client-init/seedless-onboarding/oauth-service-init.test.ts
@@ -23,7 +23,7 @@ describe('OAuthServiceInit', () => {
     const requestMock = buildInitRequestMock();
 
     // @ts-expect-error: Partial mock for testing.
-    requestMock.getController.mockImplementation(() => {
+    requestMock.getMessengerClient.mockImplementation(() => {
       return {
         bufferedTrace: jest.fn(),
         bufferedEndTrace: jest.fn(),
@@ -33,7 +33,7 @@ describe('OAuthServiceInit', () => {
       };
     });
 
-    expect(OAuthServiceInit(requestMock).controller).toBeInstanceOf(
+    expect(OAuthServiceInit(requestMock).messengerClient).toBeInstanceOf(
       OAuthService,
     );
   });

--- a/app/scripts/messenger-client-init/seedless-onboarding/oauth-service-init.ts
+++ b/app/scripts/messenger-client-init/seedless-onboarding/oauth-service-init.ts
@@ -8,9 +8,9 @@ export const OAuthServiceInit: MessengerClientInitFunction<
   OAuthService,
   OAuthServiceMessenger
 > = (request) => {
-  const { controllerMessenger, getController } = request;
+  const { controllerMessenger, getMessengerClient } = request;
 
-  const metaMetricsController = getController(
+  const metaMetricsController = getMessengerClient(
     'MetaMetricsController',
   ) as MetaMetricsController;
 
@@ -42,7 +42,7 @@ export const OAuthServiceInit: MessengerClientInitFunction<
   });
 
   return {
-    controller: service,
+    messengerClient: service,
     memStateKey: null,
     persistedStateKey: null,
   };

--- a/app/scripts/messenger-client-init/seedless-onboarding/oauth-service-init.ts
+++ b/app/scripts/messenger-client-init/seedless-onboarding/oauth-service-init.ts
@@ -14,7 +14,7 @@ export const OAuthServiceInit: MessengerClientInitFunction<
     'MetaMetricsController',
   ) as MetaMetricsController;
 
-  const service = new OAuthService({
+  const messengerClient = new OAuthService({
     messenger: controllerMessenger,
     env: {
       googleClientId: process.env.GOOGLE_CLIENT_ID ?? '',
@@ -42,7 +42,7 @@ export const OAuthServiceInit: MessengerClientInitFunction<
   });
 
   return {
-    messengerClient: service,
+    messengerClient,
     memStateKey: null,
     persistedStateKey: null,
   };

--- a/app/scripts/messenger-client-init/seedless-onboarding/seedless-onboarding-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/seedless-onboarding/seedless-onboarding-controller-init.test.ts
@@ -51,7 +51,7 @@ describe('SeedlessOnboardingControllerInit', () => {
   it('should return controller instance', () => {
     const requestMock = buildInitRequestMock();
     expect(
-      SeedlessOnboardingControllerInit(requestMock).controller,
+      SeedlessOnboardingControllerInit(requestMock).messengerClient,
     ).toBeInstanceOf(SeedlessOnboardingController);
   });
 

--- a/app/scripts/messenger-client-init/seedless-onboarding/seedless-onboarding-controller-init.ts
+++ b/app/scripts/messenger-client-init/seedless-onboarding/seedless-onboarding-controller-init.ts
@@ -24,7 +24,7 @@ export const SeedlessOnboardingControllerInit: MessengerClientInitFunction<
 
   const network = loadWeb3AuthNetwork();
 
-  const controller = new SeedlessOnboardingController<
+  const messengerClient = new SeedlessOnboardingController<
     CryptoKey | EncryptionKey
   >({
     messenger: controllerMessenger,
@@ -47,6 +47,6 @@ export const SeedlessOnboardingControllerInit: MessengerClientInitFunction<
   });
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/selected-network-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/selected-network-controller-init.test.ts
@@ -26,12 +26,13 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('SelectedNetworkControllerInit', () => {
-  it('initializes the controller', () => {
-    const { controller } = SelectedNetworkControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(SelectedNetworkController);
+  it('initializes the messengerClient', () => {
+    const { messengerClient } =
+      SelectedNetworkControllerInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(SelectedNetworkController);
   });
 
-  it('passes the proper arguments to the controller', () => {
+  it('passes the proper arguments to the messengerClient', () => {
     SelectedNetworkControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(SelectedNetworkController);

--- a/app/scripts/messenger-client-init/selected-network-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/selected-network-controller-init.test.ts
@@ -26,13 +26,13 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('SelectedNetworkControllerInit', () => {
-  it('initializes the messengerClient', () => {
+  it('initializes the controller', () => {
     const { messengerClient } =
       SelectedNetworkControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(SelectedNetworkController);
   });
 
-  it('passes the proper arguments to the messengerClient', () => {
+  it('passes the proper arguments to the controller', () => {
     SelectedNetworkControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(SelectedNetworkController);

--- a/app/scripts/messenger-client-init/selected-network-controller-init.ts
+++ b/app/scripts/messenger-client-init/selected-network-controller-init.ts
@@ -15,7 +15,7 @@ export const SelectedNetworkControllerInit: MessengerClientInitFunction<
   SelectedNetworkController,
   SelectedNetworkControllerMessenger
 > = ({ controllerMessenger, persistedState }) => {
-  const controller = new SelectedNetworkController({
+  const messengerClient = new SelectedNetworkController({
     // @ts-expect-error: `SelectedNetworkController` expects the full state, but
     // the persisted state may be partial.
     state: persistedState.SelectedNetworkController,
@@ -24,6 +24,6 @@ export const SelectedNetworkControllerInit: MessengerClientInitFunction<
   });
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/shield/shield-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/shield/shield-controller-init.test.ts
@@ -35,7 +35,9 @@ describe('ShieldControllerInit', () => {
     const request = buildInitRequestMock();
     const controllerInitResult = ShieldControllerInit(request);
     expect(controllerInitResult).toBeDefined();
-    expect(controllerInitResult.controller).toBeInstanceOf(ShieldController);
+    expect(controllerInitResult.messengerClient).toBeInstanceOf(
+      ShieldController,
+    );
   });
 
   it('initializes with correct messenger, state and normalizeSignatureRequest function', () => {

--- a/app/scripts/messenger-client-init/shield/shield-controller-init.ts
+++ b/app/scripts/messenger-client-init/shield/shield-controller-init.ts
@@ -62,7 +62,7 @@ export const ShieldControllerInit: MessengerClientInitFunction<
   const getAccessToken = () =>
     initMessenger.call('AuthenticationController:getBearerToken');
 
-  const controller = new ShieldController({
+  const messengerClient = new ShieldController({
     messenger: controllerMessenger,
     state: persistedState.ShieldController,
     normalizeSignatureRequest,
@@ -80,6 +80,6 @@ export const ShieldControllerInit: MessengerClientInitFunction<
   });
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/smart-transactions/smart-transactions-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/smart-transactions/smart-transactions-controller-init.test.ts
@@ -122,7 +122,7 @@ describe('SmartTransactionsController Init', () => {
       initMessenger: getSmartTransactionsControllerInitMessenger(
         mocks.baseControllerMessenger,
       ),
-      getController: jest.fn((name: string) => {
+      getMessengerClient: jest.fn((name: string) => {
         switch (name) {
           case 'AccountsController':
             return mocks.accountsController;
@@ -222,7 +222,7 @@ describe('SmartTransactionsController Init', () => {
     const { fullRequest } = buildInitRequest();
     const result = SmartTransactionsControllerInit(fullRequest);
 
-    expect(result.controller).toBeInstanceOf(SmartTransactionsController);
+    expect(result.messengerClient).toBeInstanceOf(SmartTransactionsController);
   });
 
   it('initializes with correct supported chain IDs', () => {

--- a/app/scripts/messenger-client-init/smart-transactions/smart-transactions-controller-init.ts
+++ b/app/scripts/messenger-client-init/smart-transactions/smart-transactions-controller-init.ts
@@ -109,6 +109,6 @@ export const SmartTransactionsControllerInit: MessengerClientInitFunction<
   });
 
   return {
-    controller: smartTransactionsController,
+    messengerClient: smartTransactionsController,
   };
 };

--- a/app/scripts/messenger-client-init/snaps/cronjob-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/snaps/cronjob-controller-init.test.ts
@@ -30,8 +30,8 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('CronjobControllerInit', () => {
-  it('initializes the controller', () => {
-    const { controller } = CronjobControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(CronjobController);
+  it('initializes the messengerClient', () => {
+    const { messengerClient } = CronjobControllerInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(CronjobController);
   });
 });

--- a/app/scripts/messenger-client-init/snaps/cronjob-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/snaps/cronjob-controller-init.test.ts
@@ -30,7 +30,7 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('CronjobControllerInit', () => {
-  it('initializes the messengerClient', () => {
+  it('initializes the controller', () => {
     const { messengerClient } = CronjobControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(CronjobController);
   });

--- a/app/scripts/messenger-client-init/snaps/cronjob-controller-init.ts
+++ b/app/scripts/messenger-client-init/snaps/cronjob-controller-init.ts
@@ -22,7 +22,7 @@ export const CronjobControllerInit: MessengerClientInitFunction<
   persistedState,
   getCronjobControllerStorageManager,
 }) => {
-  const controller = new CronjobController({
+  const messengerClient = new CronjobController({
     // @ts-expect-error: `persistedState.CronjobController` is not compatible
     // with the expected type.
     // TODO: Look into the type mismatch.
@@ -33,7 +33,7 @@ export const CronjobControllerInit: MessengerClientInitFunction<
   });
 
   return {
-    controller,
+    messengerClient,
     persistedStateKey: null,
   };
 };

--- a/app/scripts/messenger-client-init/snaps/execution-service-init.test.ts
+++ b/app/scripts/messenger-client-init/snaps/execution-service-init.test.ts
@@ -30,8 +30,8 @@ function getInitRequestMock(): jest.Mocked<
 
 describe('ExecutionServiceInit', () => {
   it('initializes the iframe execution service if `chrome.offscreen` is not available', () => {
-    const { controller } = ExecutionServiceInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(IframeExecutionService);
+    const { messengerClient } = ExecutionServiceInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(IframeExecutionService);
   });
 
   it('does not store state', () => {
@@ -49,8 +49,8 @@ describe('ExecutionServiceInit', () => {
       },
     });
 
-    const { controller } = ExecutionServiceInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(OffscreenExecutionService);
+    const { messengerClient } = ExecutionServiceInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(OffscreenExecutionService);
   });
 
   it('passes the proper arguments to the service', () => {

--- a/app/scripts/messenger-client-init/snaps/execution-service-init.ts
+++ b/app/scripts/messenger-client-init/snaps/execution-service-init.ts
@@ -69,7 +69,7 @@ export const ExecutionServiceInit: MessengerClientInitFunction<
     return {
       memStateKey: null,
       persistedStateKey: null,
-      controller: new OffscreenExecutionService({
+      messengerClient: new OffscreenExecutionService({
         messenger: controllerMessenger,
         setupSnapProvider,
         offscreenPromise,
@@ -83,7 +83,7 @@ export const ExecutionServiceInit: MessengerClientInitFunction<
   return {
     memStateKey: null,
     persistedStateKey: null,
-    controller: new IframeExecutionService({
+    messengerClient: new IframeExecutionService({
       messenger: controllerMessenger,
       iframeUrl: new URL(iframeUrl),
       setupSnapProvider,

--- a/app/scripts/messenger-client-init/snaps/multichain-routing-service-init.test.ts
+++ b/app/scripts/messenger-client-init/snaps/multichain-routing-service-init.test.ts
@@ -26,8 +26,9 @@ function getInitRequestMock(): jest.Mocked<
 
 describe('MultichainRoutingServiceInit', () => {
   it('initializes the multichain router', () => {
-    const { controller } = MultichainRoutingServiceInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(MultichainRoutingService);
+    const { messengerClient } =
+      MultichainRoutingServiceInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(MultichainRoutingService);
   });
 
   it('does not store state', () => {

--- a/app/scripts/messenger-client-init/snaps/multichain-routing-service-init.ts
+++ b/app/scripts/messenger-client-init/snaps/multichain-routing-service-init.ts
@@ -11,15 +11,15 @@ import { KeyringType } from '../../../../shared/constants/keyring';
  *
  * @param request - The request object.
  * @param request.controllerMessenger - The messenger to use for the service.
- * @param request.getController
+ * @param request.getMessengerClient
  * @returns The initialized service.
  */
 export const MultichainRoutingServiceInit: MessengerClientInitFunction<
   MultichainRoutingService,
   MultichainRoutingServiceMessenger
-> = ({ controllerMessenger, getController }) => {
-  const keyringController = getController('KeyringController');
-  const appStateController = getController('AppStateController');
+> = ({ controllerMessenger, getMessengerClient }) => {
+  const keyringController = getMessengerClient('KeyringController');
+  const appStateController = getMessengerClient('AppStateController');
 
   const getSnapKeyring = async (): Promise<SnapKeyring> => {
     // Ensure the client is unlocked before attempting to access keyrings.
@@ -55,7 +55,7 @@ export const MultichainRoutingServiceInit: MessengerClientInitFunction<
     return operation({ keyring });
   };
 
-  const controller = new MultichainRoutingService({
+  const messengerClient = new MultichainRoutingService({
     messenger: controllerMessenger,
     withSnapKeyring,
   });
@@ -63,6 +63,6 @@ export const MultichainRoutingServiceInit: MessengerClientInitFunction<
   return {
     memStateKey: null,
     persistedStateKey: null,
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/snaps/rate-limit-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/snaps/rate-limit-controller-init.test.ts
@@ -30,9 +30,9 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('RateLimitController', () => {
-  it('initializes the controller', () => {
-    const { controller } = RateLimitControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(RateLimitController);
+  it('initializes the messengerClient', () => {
+    const { messengerClient } = RateLimitControllerInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(RateLimitController);
   });
 
   it('does not store state', () => {
@@ -43,7 +43,7 @@ describe('RateLimitController', () => {
     expect(persistedStateKey).toBeNull();
   });
 
-  it('passes the proper arguments to the controller', () => {
+  it('passes the proper arguments to the messengerClient', () => {
     RateLimitControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(RateLimitController);

--- a/app/scripts/messenger-client-init/snaps/rate-limit-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/snaps/rate-limit-controller-init.test.ts
@@ -30,7 +30,7 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('RateLimitController', () => {
-  it('initializes the messengerClient', () => {
+  it('initializes the controller', () => {
     const { messengerClient } = RateLimitControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(RateLimitController);
   });
@@ -43,7 +43,7 @@ describe('RateLimitController', () => {
     expect(persistedStateKey).toBeNull();
   });
 
-  it('passes the proper arguments to the messengerClient', () => {
+  it('passes the proper arguments to the controller', () => {
     RateLimitControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(RateLimitController);

--- a/app/scripts/messenger-client-init/snaps/rate-limit-controller-init.ts
+++ b/app/scripts/messenger-client-init/snaps/rate-limit-controller-init.ts
@@ -33,7 +33,7 @@ export const RateLimitControllerInit: MessengerClientInitFunction<
   persistedState,
   showNotification,
 }) => {
-  const controller = new RateLimitController({
+  const messengerClient = new RateLimitController({
     state: persistedState.RateLimitController,
     messenger: controllerMessenger,
 
@@ -99,7 +99,7 @@ export const RateLimitControllerInit: MessengerClientInitFunction<
   });
 
   return {
-    controller,
+    messengerClient,
     memStateKey: null,
     persistedStateKey: null,
   };

--- a/app/scripts/messenger-client-init/snaps/snap-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/snaps/snap-controller-init.test.ts
@@ -46,12 +46,12 @@ describe('SnapControllerInit', () => {
     jest.clearAllMocks();
   });
 
-  it('initializes the messengerClient', () => {
+  it('initializes the controller', () => {
     const { messengerClient } = SnapControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(SnapController);
   });
 
-  it('passes the proper arguments to the messengerClient', () => {
+  it('passes the proper arguments to the controller', () => {
     SnapControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(SnapController);

--- a/app/scripts/messenger-client-init/snaps/snap-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/snaps/snap-controller-init.test.ts
@@ -46,12 +46,12 @@ describe('SnapControllerInit', () => {
     jest.clearAllMocks();
   });
 
-  it('initializes the controller', () => {
-    const { controller } = SnapControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(SnapController);
+  it('initializes the messengerClient', () => {
+    const { messengerClient } = SnapControllerInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(SnapController);
   });
 
-  it('passes the proper arguments to the controller', () => {
+  it('passes the proper arguments to the messengerClient', () => {
     SnapControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(SnapController);

--- a/app/scripts/messenger-client-init/snaps/snap-controller-init.ts
+++ b/app/scripts/messenger-client-init/snaps/snap-controller-init.ts
@@ -99,7 +99,7 @@ export const SnapControllerInit: MessengerClientInitFunction<
     await promise;
   }
 
-  const controller = new SnapController({
+  const messengerClient = new SnapController({
     environmentEndowmentPermissions: Object.values(EndowmentPermissions),
     excludedPermissions: {
       ...ExcludedSnapPermissions,
@@ -150,6 +150,6 @@ export const SnapControllerInit: MessengerClientInitFunction<
   });
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/snaps/snap-insights-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/snaps/snap-insights-controller-init.test.ts
@@ -25,12 +25,13 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('SnapInsightsControllerInit', () => {
-  it('initializes the controller', () => {
-    const { controller } = SnapInsightsControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(SnapInsightsController);
+  it('initializes the messengerClient', () => {
+    const { messengerClient } =
+      SnapInsightsControllerInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(SnapInsightsController);
   });
 
-  it('passes the proper arguments to the controller', () => {
+  it('passes the proper arguments to the messengerClient', () => {
     SnapInsightsControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(SnapInsightsController);

--- a/app/scripts/messenger-client-init/snaps/snap-insights-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/snaps/snap-insights-controller-init.test.ts
@@ -25,13 +25,13 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('SnapInsightsControllerInit', () => {
-  it('initializes the messengerClient', () => {
+  it('initializes the controller', () => {
     const { messengerClient } =
       SnapInsightsControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(SnapInsightsController);
   });
 
-  it('passes the proper arguments to the messengerClient', () => {
+  it('passes the proper arguments to the controller', () => {
     SnapInsightsControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(SnapInsightsController);

--- a/app/scripts/messenger-client-init/snaps/snap-insights-controller-init.ts
+++ b/app/scripts/messenger-client-init/snaps/snap-insights-controller-init.ts
@@ -16,7 +16,7 @@ export const SnapInsightsControllerInit: MessengerClientInitFunction<
   SnapInsightsController,
   SnapInsightsControllerMessenger
 > = ({ controllerMessenger, persistedState }) => {
-  const controller = new SnapInsightsController({
+  const messengerClient = new SnapInsightsController({
     // @ts-expect-error: `persistedState.SnapInsightsController` is not
     // compatible with the expected type.
     // TODO: Look into the type mismatch.
@@ -25,6 +25,6 @@ export const SnapInsightsControllerInit: MessengerClientInitFunction<
   });
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/snaps/snap-interface-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/snaps/snap-interface-controller-init.test.ts
@@ -25,12 +25,13 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('SnapInterfaceControllerInit', () => {
-  it('initializes the controller', () => {
-    const { controller } = SnapInterfaceControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(SnapInterfaceController);
+  it('initializes the messengerClient', () => {
+    const { messengerClient } =
+      SnapInterfaceControllerInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(SnapInterfaceController);
   });
 
-  it('passes the proper arguments to the controller', () => {
+  it('passes the proper arguments to the messengerClient', () => {
     SnapInterfaceControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(SnapInterfaceController);

--- a/app/scripts/messenger-client-init/snaps/snap-interface-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/snaps/snap-interface-controller-init.test.ts
@@ -25,13 +25,13 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('SnapInterfaceControllerInit', () => {
-  it('initializes the messengerClient', () => {
+  it('initializes the controller', () => {
     const { messengerClient } =
       SnapInterfaceControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(SnapInterfaceController);
   });
 
-  it('passes the proper arguments to the messengerClient', () => {
+  it('passes the proper arguments to the controller', () => {
     SnapInterfaceControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(SnapInterfaceController);

--- a/app/scripts/messenger-client-init/snaps/snap-interface-controller-init.ts
+++ b/app/scripts/messenger-client-init/snaps/snap-interface-controller-init.ts
@@ -16,7 +16,7 @@ export const SnapInterfaceControllerInit: MessengerClientInitFunction<
   SnapInterfaceController,
   SnapInterfaceControllerMessenger
 > = ({ controllerMessenger, persistedState }) => {
-  const controller = new SnapInterfaceController({
+  const messengerClient = new SnapInterfaceController({
     // @ts-expect-error: `persistedState.SnapInterfaceController` is not compatible
     // with the expected type.
     // TODO: Look into the type mismatch.
@@ -25,6 +25,6 @@ export const SnapInterfaceControllerInit: MessengerClientInitFunction<
   });
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/snaps/snap-registry-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/snaps/snap-registry-controller-init.test.ts
@@ -34,12 +34,13 @@ describe('SnapRegistryControllerInit', () => {
     process.env.METAMASK_VERSION = metamaskVersion;
   });
 
-  it('initializes the controller', () => {
-    const { controller } = SnapRegistryControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(SnapRegistryController);
+  it('initializes the messengerClient', () => {
+    const { messengerClient } =
+      SnapRegistryControllerInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(SnapRegistryController);
   });
 
-  it('passes the proper arguments to the controller', () => {
+  it('passes the proper arguments to the messengerClient', () => {
     SnapRegistryControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(SnapRegistryController);

--- a/app/scripts/messenger-client-init/snaps/snap-registry-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/snaps/snap-registry-controller-init.test.ts
@@ -34,13 +34,13 @@ describe('SnapRegistryControllerInit', () => {
     process.env.METAMASK_VERSION = metamaskVersion;
   });
 
-  it('initializes the messengerClient', () => {
+  it('initializes the controller', () => {
     const { messengerClient } =
       SnapRegistryControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(SnapRegistryController);
   });
 
-  it('passes the proper arguments to the messengerClient', () => {
+  it('passes the proper arguments to the controller', () => {
     SnapRegistryControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(SnapRegistryController);

--- a/app/scripts/messenger-client-init/snaps/snap-registry-controller-init.ts
+++ b/app/scripts/messenger-client-init/snaps/snap-registry-controller-init.ts
@@ -30,7 +30,7 @@ export const SnapRegistryControllerInit: MessengerClientInitFunction<
       : originalVersion
   ) as SemVerVersion;
 
-  const controller = new SnapRegistryController({
+  const messengerClient = new SnapRegistryController({
     // @ts-expect-error: `persistedState.SnapRegistryController` is not
     // compatible with the expected type.
     // TODO: Look into the type mismatch.
@@ -44,6 +44,6 @@ export const SnapRegistryControllerInit: MessengerClientInitFunction<
   });
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/snaps/snaps-name-provider-init.test.ts
+++ b/app/scripts/messenger-client-init/snaps/snaps-name-provider-init.test.ts
@@ -26,7 +26,7 @@ function getInitRequestMock(): jest.Mocked<
 
 describe('SnapsNameProvider', () => {
   it('initializes the provider', () => {
-    const { controller } = SnapsNameProviderInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(SnapsNameProvider);
+    const { messengerClient } = SnapsNameProviderInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(SnapsNameProvider);
   });
 });

--- a/app/scripts/messenger-client-init/snaps/snaps-name-provider-init.ts
+++ b/app/scripts/messenger-client-init/snaps/snaps-name-provider-init.ts
@@ -15,13 +15,13 @@ export const SnapsNameProviderInit: MessengerClientInitFunction<
   SnapsNameProvider,
   SnapsNameProviderMessenger
 > = ({ controllerMessenger }) => {
-  const controller = new SnapsNameProvider({
+  const messengerClient = new SnapsNameProvider({
     messenger: controllerMessenger,
   });
 
   return {
     persistedStateKey: null,
     memStateKey: null,
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/snaps/websocket-service-init.test.ts
+++ b/app/scripts/messenger-client-init/snaps/websocket-service-init.test.ts
@@ -24,7 +24,7 @@ function getInitRequestMock(): jest.Mocked<
 
 describe('WebSocketServiceInit', () => {
   it('initializes the controller', () => {
-    const { controller } = WebSocketServiceInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(WebSocketService);
+    const { messengerClient } = WebSocketServiceInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(WebSocketService);
   });
 });

--- a/app/scripts/messenger-client-init/snaps/websocket-service-init.ts
+++ b/app/scripts/messenger-client-init/snaps/websocket-service-init.ts
@@ -15,13 +15,13 @@ export const WebSocketServiceInit: MessengerClientInitFunction<
   WebSocketService,
   WebSocketServiceMessenger
 > = ({ controllerMessenger }) => {
-  const controller = new WebSocketService({
+  const messengerClient = new WebSocketService({
     messenger: controllerMessenger,
   });
 
   return {
     memStateKey: null,
     persistedStateKey: null,
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/static-assets-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/static-assets-controller-init.test.ts
@@ -30,12 +30,13 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('StaticAssetsControllerInit', () => {
-  it('initializes the controller', () => {
-    const { controller } = StaticAssetsControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(StaticAssetsController);
+  it('initializes the messengerClient', () => {
+    const { messengerClient } =
+      StaticAssetsControllerInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(StaticAssetsController);
   });
 
-  it('passes the proper arguments to the controller', () => {
+  it('passes the proper arguments to the messengerClient', () => {
     StaticAssetsControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(StaticAssetsController);

--- a/app/scripts/messenger-client-init/static-assets-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/static-assets-controller-init.test.ts
@@ -30,13 +30,13 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('StaticAssetsControllerInit', () => {
-  it('initializes the messengerClient', () => {
+  it('initializes the controller', () => {
     const { messengerClient } =
       StaticAssetsControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(StaticAssetsController);
   });
 
-  it('passes the proper arguments to the messengerClient', () => {
+  it('passes the proper arguments to the controller', () => {
     StaticAssetsControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(StaticAssetsController);

--- a/app/scripts/messenger-client-init/static-assets-controller-init.ts
+++ b/app/scripts/messenger-client-init/static-assets-controller-init.ts
@@ -24,7 +24,7 @@ export const StaticAssetsControllerInit: MessengerClientInitFunction<
   StaticAssetsControllerMessenger,
   StaticAssetsControllerInitMessenger
 > = ({ controllerMessenger, initMessenger }) => {
-  const controller = new StaticAssetsController({
+  const messengerClient = new StaticAssetsController({
     messenger: controllerMessenger,
     getSupportedChains: (): Set<Hex> => {
       const supportedChains =
@@ -44,6 +44,6 @@ export const StaticAssetsControllerInit: MessengerClientInitFunction<
     },
   });
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/storage-service-init.test.ts
+++ b/app/scripts/messenger-client-init/storage-service-init.test.ts
@@ -32,8 +32,8 @@ describe('StorageServiceInit', () => {
   });
 
   it('initializes the service', () => {
-    const { controller } = StorageServiceInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(StorageService);
+    const { messengerClient } = StorageServiceInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(StorageService);
   });
 
   it('passes the proper arguments to the service', () => {

--- a/app/scripts/messenger-client-init/storage-service-init.ts
+++ b/app/scripts/messenger-client-init/storage-service-init.ts
@@ -17,13 +17,13 @@ export const StorageServiceInit: MessengerClientInitFunction<
   StorageService,
   StorageServiceMessenger
 > = ({ controllerMessenger }) => {
-  const controller = new StorageService({
+  const messengerClient = new StorageService({
     messenger: controllerMessenger,
     storage: new BrowserStorageAdapter(),
   });
 
   return {
-    controller,
+    messengerClient,
     // StorageService is stateless - no persisted or mem state
     persistedStateKey: null,
     memStateKey: null,

--- a/app/scripts/messenger-client-init/subject-metadata-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/subject-metadata-controller-init.test.ts
@@ -25,12 +25,13 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('SubjectMetadataControllerInit', () => {
-  it('initializes the controller', () => {
-    const { controller } = SubjectMetadataControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(SubjectMetadataController);
+  it('initializes the messengerClient', () => {
+    const { messengerClient } =
+      SubjectMetadataControllerInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(SubjectMetadataController);
   });
 
-  it('passes the proper arguments to the controller', () => {
+  it('passes the proper arguments to the messengerClient', () => {
     SubjectMetadataControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(SubjectMetadataController);

--- a/app/scripts/messenger-client-init/subject-metadata-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/subject-metadata-controller-init.test.ts
@@ -25,13 +25,13 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('SubjectMetadataControllerInit', () => {
-  it('initializes the messengerClient', () => {
+  it('initializes the controller', () => {
     const { messengerClient } =
       SubjectMetadataControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(SubjectMetadataController);
   });
 
-  it('passes the proper arguments to the messengerClient', () => {
+  it('passes the proper arguments to the controller', () => {
     SubjectMetadataControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(SubjectMetadataController);

--- a/app/scripts/messenger-client-init/subject-metadata-controller-init.ts
+++ b/app/scripts/messenger-client-init/subject-metadata-controller-init.ts
@@ -14,13 +14,13 @@ export const SubjectMetadataControllerInit: MessengerClientInitFunction<
   SubjectMetadataController,
   SubjectMetadataControllerMessenger
 > = ({ controllerMessenger, persistedState }) => {
-  const controller = new SubjectMetadataController({
+  const messengerClient = new SubjectMetadataController({
     state: persistedState.SubjectMetadataController,
     messenger: controllerMessenger,
     subjectCacheLimit: 100,
   });
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/subscription/subscription-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/subscription/subscription-controller-init.test.ts
@@ -48,9 +48,9 @@ describe('SubscriptionControllerInit', () => {
 
   it('should return controller instance', () => {
     const requestMock = buildInitRequestMock();
-    expect(SubscriptionControllerInit(requestMock).controller).toBeInstanceOf(
-      SubscriptionController,
-    );
+    expect(
+      SubscriptionControllerInit(requestMock).messengerClient,
+    ).toBeInstanceOf(SubscriptionController);
   });
 
   it('initializes with correct messenger and state', () => {

--- a/app/scripts/messenger-client-init/subscription/subscription-controller-init.ts
+++ b/app/scripts/messenger-client-init/subscription/subscription-controller-init.ts
@@ -26,13 +26,13 @@ export const SubscriptionControllerInit: MessengerClientInitFunction<
     captureException: captureExceptionWithSentry,
   });
 
-  const controller = new SubscriptionController({
+  const messengerClient = new SubscriptionController({
     messenger: controllerMessenger,
     state: persistedState.SubscriptionController,
     subscriptionService,
   });
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/subscription/subscription-service-init.test.ts
+++ b/app/scripts/messenger-client-init/subscription/subscription-service-init.test.ts
@@ -27,7 +27,7 @@ describe('SubscriptionServiceInit', () => {
 
   it('should return controller instance', () => {
     const requestMock = buildInitRequestMock();
-    expect(SubscriptionServiceInit(requestMock).controller).toBeInstanceOf(
+    expect(SubscriptionServiceInit(requestMock).messengerClient).toBeInstanceOf(
       SubscriptionService,
     );
   });

--- a/app/scripts/messenger-client-init/subscription/subscription-service-init.ts
+++ b/app/scripts/messenger-client-init/subscription/subscription-service-init.ts
@@ -16,7 +16,7 @@ export const SubscriptionServiceInit: MessengerClientInitFunction<
   });
 
   return {
-    controller: service,
+    messengerClient: service,
     memStateKey: null,
     persistedStateKey: null,
   };

--- a/app/scripts/messenger-client-init/subscription/subscription-service-init.ts
+++ b/app/scripts/messenger-client-init/subscription/subscription-service-init.ts
@@ -9,14 +9,14 @@ export const SubscriptionServiceInit: MessengerClientInitFunction<
 > = (request) => {
   const { controllerMessenger, platform } = request;
 
-  const service = new SubscriptionService({
+  const messengerClient = new SubscriptionService({
     messenger: controllerMessenger,
     platform,
     webAuthenticator: webAuthenticatorFactory(),
   });
 
   return {
-    messengerClient: service,
+    messengerClient,
     memStateKey: null,
     persistedStateKey: null,
   };

--- a/app/scripts/messenger-client-init/test/utils.ts
+++ b/app/scripts/messenger-client-init/test/utils.ts
@@ -22,7 +22,7 @@ export function buildControllerInitRequestMock(): jest.Mocked<
     extension: {},
     platform: new ExtensionPlatform(),
     getCronjobControllerStorageManager: jest.fn(),
-    getController: jest.fn(),
+    getMessengerClient: jest.fn(),
     getFlatState: jest.fn(),
     getPermittedAccounts: jest.fn(),
     getProvider: jest.fn(),

--- a/app/scripts/messenger-client-init/token-balances-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/token-balances-controller-init.test.ts
@@ -64,12 +64,13 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('TokenBalancesControllerInit', () => {
-  it('initializes the controller', () => {
-    const { controller } = TokenBalancesControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(TokenBalancesController);
+  it('initializes the messengerClient', () => {
+    const { messengerClient } =
+      TokenBalancesControllerInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(TokenBalancesController);
   });
 
-  it('passes the proper arguments to the controller', () => {
+  it('passes the proper arguments to the messengerClient', () => {
     TokenBalancesControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(TokenBalancesController);

--- a/app/scripts/messenger-client-init/token-balances-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/token-balances-controller-init.test.ts
@@ -64,13 +64,13 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('TokenBalancesControllerInit', () => {
-  it('initializes the messengerClient', () => {
+  it('initializes the controller', () => {
     const { messengerClient } =
       TokenBalancesControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(TokenBalancesController);
   });
 
-  it('passes the proper arguments to the messengerClient', () => {
+  it('passes the proper arguments to the controller', () => {
     TokenBalancesControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(TokenBalancesController);

--- a/app/scripts/messenger-client-init/token-balances-controller-init.ts
+++ b/app/scripts/messenger-client-init/token-balances-controller-init.ts
@@ -18,7 +18,7 @@ export const TokenBalancesControllerInit: MessengerClientInitFunction<
     ) as unknown as PreferencesControllerState;
   const { useMultiAccountBalanceChecker } = getRetypedPrefState();
 
-  const controller = new TokenBalancesController({
+  const messengerClient = new TokenBalancesController({
     messenger: controllerMessenger,
     state: persistedState.TokenBalancesController,
     queryMultipleAccounts: Boolean(useMultiAccountBalanceChecker),
@@ -45,6 +45,6 @@ export const TokenBalancesControllerInit: MessengerClientInitFunction<
   });
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/token-detection-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/token-detection-controller-init.test.ts
@@ -30,12 +30,13 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('TokenDetectionControllerInit', () => {
-  it('initializes the controller', () => {
-    const { controller } = TokenDetectionControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(TokenDetectionController);
+  it('initializes the messengerClient', () => {
+    const { messengerClient } =
+      TokenDetectionControllerInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(TokenDetectionController);
   });
 
-  it('passes the proper arguments to the controller', () => {
+  it('passes the proper arguments to the messengerClient', () => {
     TokenDetectionControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(TokenDetectionController);

--- a/app/scripts/messenger-client-init/token-detection-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/token-detection-controller-init.test.ts
@@ -30,13 +30,13 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('TokenDetectionControllerInit', () => {
-  it('initializes the messengerClient', () => {
+  it('initializes the controller', () => {
     const { messengerClient } =
       TokenDetectionControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(TokenDetectionController);
   });
 
-  it('passes the proper arguments to the messengerClient', () => {
+  it('passes the proper arguments to the controller', () => {
     TokenDetectionControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(TokenDetectionController);

--- a/app/scripts/messenger-client-init/token-detection-controller-init.ts
+++ b/app/scripts/messenger-client-init/token-detection-controller-init.ts
@@ -17,7 +17,7 @@ export const TokenDetectionControllerInit: MessengerClientInitFunction<
       'PreferencesController:getState',
     ) as unknown as PreferencesControllerState;
 
-  const controller = new TokenDetectionController({
+  const messengerClient = new TokenDetectionController({
     messenger: controllerMessenger,
     disabled: false,
     getBalancesInSingleCall: (...args) =>
@@ -35,6 +35,6 @@ export const TokenDetectionControllerInit: MessengerClientInitFunction<
   return {
     memStateKey: null,
     persistedStateKey: null,
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/token-list-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/token-list-controller-init.test.ts
@@ -85,12 +85,12 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('TokenListControllerInit', () => {
-  it('initializes the controller', () => {
-    const { controller } = TokenListControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(TokenListController);
+  it('initializes the messengerClient', () => {
+    const { messengerClient } = TokenListControllerInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(TokenListController);
   });
 
-  it('passes the proper arguments to the controller', () => {
+  it('passes the proper arguments to the messengerClient', () => {
     TokenListControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(TokenListController);

--- a/app/scripts/messenger-client-init/token-list-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/token-list-controller-init.test.ts
@@ -85,12 +85,12 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('TokenListControllerInit', () => {
-  it('initializes the messengerClient', () => {
+  it('initializes the controller', () => {
     const { messengerClient } = TokenListControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(TokenListController);
   });
 
-  it('passes the proper arguments to the messengerClient', () => {
+  it('passes the proper arguments to the controller', () => {
     TokenListControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(TokenListController);

--- a/app/scripts/messenger-client-init/token-list-controller-init.ts
+++ b/app/scripts/messenger-client-init/token-list-controller-init.ts
@@ -13,7 +13,7 @@ export const TokenListControllerInit: MessengerClientInitFunction<
 > = ({ controllerMessenger, initMessenger, persistedState }) => {
   // TODO: Fix TokenListControllerMessenger type - add TokenListControllerActions & TokenListControllerEvents
   // TODO: Bump @metamask/network-controller to match assets-controllers
-  const controller = new TokenListController({
+  const messengerClient = new TokenListController({
     messenger: controllerMessenger,
     state: persistedState.TokenListController,
     chainId: getGlobalChainId(initMessenger),
@@ -22,7 +22,7 @@ export const TokenListControllerInit: MessengerClientInitFunction<
   // Initialize the controller to load cached token lists from storage.
   // This is a fire-and-forget operation - if it fails, the controller will
   // self-heal by fetching token lists on demand when needed.
-  controller.initialize().catch((error: Error) => {
+  messengerClient.initialize().catch((error: Error) => {
     console.error(
       'TokenListController: Failed to initialize from storage:',
       error,
@@ -30,6 +30,6 @@ export const TokenListControllerInit: MessengerClientInitFunction<
   });
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/tokens-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/tokens-controller-init.test.ts
@@ -79,12 +79,12 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('TokensControllerInit', () => {
-  it('initializes the messengerClient', () => {
+  it('initializes the controller', () => {
     const { messengerClient } = TokensControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(TokensController);
   });
 
-  it('passes the proper arguments to the messengerClient', () => {
+  it('passes the proper arguments to the controller', () => {
     TokensControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(TokensController);

--- a/app/scripts/messenger-client-init/tokens-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/tokens-controller-init.test.ts
@@ -79,12 +79,12 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('TokensControllerInit', () => {
-  it('initializes the controller', () => {
-    const { controller } = TokensControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(TokensController);
+  it('initializes the messengerClient', () => {
+    const { messengerClient } = TokensControllerInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(TokensController);
   });
 
-  it('passes the proper arguments to the controller', () => {
+  it('passes the proper arguments to the messengerClient', () => {
     TokensControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(TokensController);

--- a/app/scripts/messenger-client-init/tokens-controller-init.ts
+++ b/app/scripts/messenger-client-init/tokens-controller-init.ts
@@ -18,7 +18,7 @@ export const TokensControllerInit: MessengerClientInitFunction<
 
   // TODO: Fix TokensControllerMessenger type - add TokensControllerActions & TokensControllerEvents
   // TODO: Bump @metamask/network-controller, @metamask/accounts-controller, @metamask/keyring-controller to match assets-controllers
-  const controller = new TokensController({
+  const messengerClient = new TokensController({
     messenger: controllerMessenger,
     state: persistedState.TokensController,
     provider,
@@ -26,6 +26,6 @@ export const TokensControllerInit: MessengerClientInitFunction<
   });
 
   return {
-    controller,
+    messengerClient,
   };
 };

--- a/app/scripts/messenger-client-init/transaction-pay-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/transaction-pay-controller-init.test.ts
@@ -32,12 +32,13 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('TransactionPayControllerInit', () => {
-  it('initializes the controller', () => {
-    const { controller } = TransactionPayControllerInit(getInitRequestMock());
-    expect(controller).toBeInstanceOf(TransactionPayController);
+  it('initializes the messengerClient', () => {
+    const { messengerClient } =
+      TransactionPayControllerInit(getInitRequestMock());
+    expect(messengerClient).toBeInstanceOf(TransactionPayController);
   });
 
-  it('passes the proper arguments to the controller', () => {
+  it('passes the proper arguments to the messengerClient', () => {
     TransactionPayControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(TransactionPayController);

--- a/app/scripts/messenger-client-init/transaction-pay-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/transaction-pay-controller-init.test.ts
@@ -32,13 +32,13 @@ function getInitRequestMock(): jest.Mocked<
 }
 
 describe('TransactionPayControllerInit', () => {
-  it('initializes the messengerClient', () => {
+  it('initializes the controller', () => {
     const { messengerClient } =
       TransactionPayControllerInit(getInitRequestMock());
     expect(messengerClient).toBeInstanceOf(TransactionPayController);
   });
 
-  it('passes the proper arguments to the messengerClient', () => {
+  it('passes the proper arguments to the controller', () => {
     TransactionPayControllerInit(getInitRequestMock());
 
     const controllerMock = jest.mocked(TransactionPayController);

--- a/app/scripts/messenger-client-init/transaction-pay-controller-init.ts
+++ b/app/scripts/messenger-client-init/transaction-pay-controller-init.ts
@@ -25,7 +25,9 @@ export const TransactionPayControllerInit: MessengerClientInitFunction<
   const { controllerMessenger, initMessenger, persistedState } = request;
 
   const getTransactionController = () =>
-    request.getController('TransactionController') as TransactionController;
+    request.getMessengerClient(
+      'TransactionController',
+    ) as TransactionController;
 
   const getDelegationTransactionCallback: (request: {
     transaction: TransactionMeta;
@@ -41,32 +43,32 @@ export const TransactionPayControllerInit: MessengerClientInitFunction<
       transaction,
     );
 
-  const controller = new TransactionPayController({
+  const messengerClient = new TransactionPayController({
     getDelegationTransaction: getDelegationTransactionCallback,
     getStrategy,
     messenger: controllerMessenger,
     state: persistedState.TransactionPayController,
   });
 
-  const api = getApi(controller);
+  const api = getApi(messengerClient);
 
-  return { controller, api };
+  return { messengerClient, api };
 };
 
 function getApi(
-  controller: TransactionPayController,
+  messengerClient: TransactionPayController,
 ): MessengerClientInitResult<TransactionPayController>['api'] {
   return {
     setTransactionPayIsMaxAmount: (
       transactionId: string,
       isMaxAmount: boolean,
     ) => {
-      controller.setTransactionConfig(transactionId, (config) => {
+      messengerClient.setTransactionConfig(transactionId, (config) => {
         config.isMaxAmount = isMaxAmount;
       });
     },
     updateTransactionPaymentToken:
-      controller.updatePaymentToken.bind(controller),
+      messengerClient.updatePaymentToken.bind(messengerClient),
   };
 }
 

--- a/app/scripts/messenger-client-init/types.ts
+++ b/app/scripts/messenger-client-init/types.ts
@@ -106,7 +106,7 @@ export type MessengerClientInitRequest<
    *
    * @param name - The name of the messenger client to retrieve.
    */
-  getController<Name extends MessengerClientName>(
+  getMessengerClient<Name extends MessengerClientName>(
     name: Name,
   ): MessengerClientByName[Name];
 
@@ -266,7 +266,7 @@ export type MessengerClientInitResult<
   /**
    * The initialized messenger client instance.
    */
-  controller: MessengerClientType;
+  messengerClient: MessengerClientType;
 
   /**
    * The background API methods available for the messenger client.

--- a/app/scripts/messenger-client-init/utils.test.ts
+++ b/app/scripts/messenger-client-init/utils.test.ts
@@ -31,7 +31,7 @@ function buildControllerInitResultMock({
   memStateKey?: string | null;
 } = {}) {
   return {
-    controller: buildControllerMock(name),
+    messengerClient: buildControllerMock(name),
     api,
     persistedStateKey,
     memStateKey,
@@ -100,7 +100,7 @@ describe('Messenger Client Init Utils', () => {
       expect(init2Mock).toHaveBeenCalledTimes(1);
     });
 
-    describe('provides getController method', () => {
+    describe('provides getMessengerClient method', () => {
       it('that returns initialized controller', () => {
         const requestMock = buildControllerInitRequestMock();
         const initMock = buildControllerFunctionMock();
@@ -113,10 +113,10 @@ describe('Messenger Client Init Utils', () => {
           initRequest: requestMock,
         });
 
-        const { getController } = initMock.mock.calls[0][0];
+        const { getMessengerClient } = initMock.mock.calls[0][0];
 
         expect(
-          getController(CONTROLLER_NAME_MOCK as MessengerClientName),
+          getMessengerClient(CONTROLLER_NAME_MOCK as MessengerClientName),
         ).toStrictEqual({ name: CONTROLLER_NAME_MOCK });
       });
 
@@ -132,10 +132,10 @@ describe('Messenger Client Init Utils', () => {
           initRequest: requestMock,
         });
 
-        const { getController } = initMock.mock.calls[0][0];
+        const { getMessengerClient } = initMock.mock.calls[0][0];
 
         expect(() =>
-          getController('InvalidController' as MessengerClientName),
+          getMessengerClient('InvalidController' as MessengerClientName),
         ).toThrow(
           'Messenger client requested before it was initialized: InvalidController',
         );

--- a/app/scripts/messenger-client-init/utils.ts
+++ b/app/scripts/messenger-client-init/utils.ts
@@ -92,7 +92,7 @@ export function initMessengerClients({
   initFunctions: InitFunctions;
   initRequest: Omit<
     BaseMessengerClientInitRequest,
-    'controllerMessenger' | 'getController' | 'initMessenger'
+    'controllerMessenger' | 'getMessengerClient' | 'initMessenger'
   >;
 }): InitMessengerClientsResult {
   log('Initializing messenger clients', Object.keys(initFunctions).length);
@@ -103,7 +103,7 @@ export function initMessengerClients({
   const controllerMemState: Record<string, MessengerClient> = {};
   let messengerClientApi = {};
 
-  const getController = <Name extends MessengerClientName>(
+  const getMessengerClient = <Name extends MessengerClientName>(
     name: Name,
   ): MessengerClientByName[Name] =>
     getMessengerClientOrThrow(
@@ -131,7 +131,7 @@ export function initMessengerClients({
     const finalInitRequest: BaseMessengerClientInitRequest = {
       ...initRequest,
       controllerMessenger,
-      getController,
+      getMessengerClient,
       initMessenger,
     };
 
@@ -141,7 +141,7 @@ export function initMessengerClients({
     });
 
     const {
-      controller,
+      messengerClient,
       persistedStateKey: persistedStateKeyRaw,
       memStateKey: memStateKeyRaw,
     } = result;
@@ -159,7 +159,7 @@ export function initMessengerClients({
         : (memStateKeyRaw ?? messengerClientName);
 
     // @ts-expect-error: Union too complex.
-    partialMessengerClientsByName[messengerClientName] = controller;
+    partialMessengerClientsByName[messengerClientName] = messengerClient;
 
     messengerClientApi = {
       ...messengerClientApi,
@@ -167,11 +167,11 @@ export function initMessengerClients({
     };
 
     if (persistedStateKey) {
-      controllerPersistedState[persistedStateKey] = controller;
+      controllerPersistedState[persistedStateKey] = messengerClient;
     }
 
     if (memStateKey) {
-      controllerMemState[memStateKey] = controller;
+      controllerMemState[memStateKey] = messengerClient;
     }
 
     log('Initialized messenger client', messengerClientName, {

--- a/app/scripts/metamask-controller.actions.test.js
+++ b/app/scripts/metamask-controller.actions.test.js
@@ -29,7 +29,7 @@ const mockIsUserRejectedHardwareWalletError = jest.fn().mockReturnValue(false);
 
 jest.mock('./messenger-client-init/perps-controller-init', () => ({
   PerpsControllerInit: jest.fn().mockReturnValue({
-    controller: {
+    messengerClient: {
       state: {},
       name: 'PerpsController',
     },

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -88,7 +88,7 @@ import MetaMaskController from './metamask-controller';
 
 jest.mock('./messenger-client-init/perps-controller-init', () => ({
   PerpsControllerInit: jest.fn().mockReturnValue({
-    controller: {
+    messengerClient: {
       state: {},
       name: 'PerpsController',
     },

--- a/ui/store/actions.test.js
+++ b/ui/store/actions.test.js
@@ -39,7 +39,7 @@ jest.mock(
   '../../app/scripts/messenger-client-init/perps-controller-init',
   () => ({
     PerpsControllerInit: jest.fn().mockReturnValue({
-      controller: {
+      messengerClient: {
         state: {},
         name: 'PerpsController',
       },


### PR DESCRIPTION
## **Description**

Rename the `controller` property in `MessengerClientInitResult` to `messengerClient` and the `getController` method in `MessengerClientInitRequest` to `getMessengerClient`. Update all ~95 init files and ~95 test files accordingly.

**Changes in `types.ts`:**
- `MessengerClientInitResult.controller` → `.messengerClient`
- `MessengerClientInitRequest.getController()` → `.getMessengerClient()`

**Changes in all init files:**
- `const controller = new SomeController(...)` → `const messengerClient = new SomeController(...)`
- `return { controller }` → `return { messengerClient }`
- `controller.someMethod(...)` → `messengerClient.someMethod(...)`
- `request.getController(...)` → `request.getMessengerClient(...)`

**Changes in all test files:**
- `const { controller }` → `const { messengerClient }`
- `result.controller` → `result.messengerClient`
- Updated assertions and variable references

This is **PR 5 of 5** in a series that updates the init system API to use "messenger client" terminology:
- ~~PR 1: Directory rename + import path updates (#41556)~~
- ~~PR 2: Core type renames (`Controller` → `MessengerClient`, `ControllerInitFunction` → `MessengerClientInitFunction`, etc.). (#41573))~~
- ~~PR 3: `CONTROLLER_MESSENGERS` → `MESSENGER_FACTORIES` (#41595)~~
- ~~PR 4: `initControllers` → `initMessengerClients` + utils/metamask-controller renames (#41597)~~
- **PR 5 (this):**  Property renames (`controller` → `messengerClient`, `getController` → `getMessengerClient`) in all init files + tests

## **Changelog**

CHANGELOG entry: null

## **Related issues**

- https://consensyssoftware.atlassian.net/browse/WPC-915

## **Manual testing steps**

1. Verify the extension builds successfully
2. Verify TypeScript compilation passes (`tsc --noEmit`)
3. Run unit tests: `yarn test:unit:coverage --shard=4/6`

## **Screenshots/Recordings**

N/A — no UI changes.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad mechanical rename across many init functions/tests may cause missed references or integration breakage despite no intended behavior change. Risk is mainly around bootstrapping wiring via `getMessengerClient` and returned init results.
> 
> **Overview**
> Renames the messenger-client init API to consistently use **messenger client** terminology: `MessengerClientInitResult.controller` becomes `messengerClient`, and `MessengerClientInitRequest.getController()` becomes `getMessengerClient()`.
> 
> Updates a large set of init modules and their tests to return/access `messengerClient` (including API bindings and event listeners) and to fetch dependencies via `getMessengerClient`, with no intended runtime behavior changes beyond the renamed interfaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd74a83ac4f535c6be4dd0965ca7d22e90debf56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->