### PR TITLE
fix: fullscreen settings hover and active state

### DIFF
--- a/ui/pages/settings-v2/tab-bar.tsx
+++ b/ui/pages/settings-v2/tab-bar.tsx
@@ -50,7 +50,7 @@ const TabBar = ({
       const active = isActive(key, content);
 
       const activeClass =
-        active && !removeFullscreenStyles ? 'sm:bg-background-muted' : '';
+        active && !removeFullscreenStyles ? 'sm:bg-pressed' : '';
 
       const caretClass = removeFullscreenStyles
         ? 'rtl:rotate-180'
@@ -64,7 +64,7 @@ const TabBar = ({
           iconColor={IconColor.IconAlternative}
           iconSize={IconSize.Lg}
           textVariant={TextVariant.BodyMd}
-          className={`!rounded-none focus:outline-none focus:[outline:none] focus-visible:outline-none focus-visible:[outline:none] focus:shadow-none ${activeClass}`}
+          className={`!rounded-none hover:bg-hover focus:outline-none focus:[outline:none] focus-visible:outline-none focus-visible:[outline:none] focus:shadow-none ${activeClass}`}
           data-testid={dataTestId}
           onClick={
             onTabClick


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Uses the semi transparent overlays `bg-hover` and `bg-pressed` to indicate hover and active states on fullscreen settings (which do not use the default background colour).

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Tweaked hover and active styles on fullscreen Settings view

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CEUX-992

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

Preferences and display active, security hovered
<img width="704" height="724" alt="image" src="https://github.com/user-attachments/assets/c77e76a1-328c-4eca-a173-e40d33a9512a" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change to tab styling; main risk is minor visual regression from updated CSS utility classes.
> 
> **Overview**
> Updates Settings V2 tab styling to use semi-transparent overlay classes for fullscreen states: active tabs now use `sm:bg-pressed` and tabs get a `hover:bg-hover` background. This improves hover/active visibility on fullscreen settings where the default background color isn’t used.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23c900f1a18ffc7515fd9bab717397b8be9fb31d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->