### PR TITLE
chore: Bulk register actions in `EncryptionPublicKeyController`

### DIFF
--- a/app/scripts/controllers/encryption-public-key-method-action-types.ts
+++ b/app/scripts/controllers/encryption-public-key-method-action-types.ts
@@ -1,0 +1,75 @@
+/**
+ * This file is auto generated.
+ * Do not edit manually.
+ */
+
+import type { EncryptionPublicKeyController } from './encryption-public-key';
+
+/**
+ * Reset the controller state to the initial state.
+ */
+export type EncryptionPublicKeyControllerResetStateAction = {
+  type: `EncryptionPublicKeyController:resetState`;
+  handler: EncryptionPublicKeyController['resetState'];
+};
+
+/**
+ * Called when a Dapp uses the eth_getEncryptionPublicKey method, to request user approval.
+ *
+ * @param address - The address from the encryption public key will be extracted.
+ * @param [req] - The original request, containing the origin.
+ */
+export type EncryptionPublicKeyControllerNewRequestEncryptionPublicKeyAction = {
+  type: `EncryptionPublicKeyController:newRequestEncryptionPublicKey`;
+  handler: EncryptionPublicKeyController['newRequestEncryptionPublicKey'];
+};
+
+/**
+ * Signifies a user's approval to receiving encryption public key in queue.
+ *
+ * @param msgParams - The params of the message to receive & return to the Dapp.
+ * @returns A full state update.
+ */
+export type EncryptionPublicKeyControllerEncryptionPublicKeyAction = {
+  type: `EncryptionPublicKeyController:encryptionPublicKey`;
+  handler: EncryptionPublicKeyController['encryptionPublicKey'];
+};
+
+/**
+ * Used to cancel a message submitted via eth_getEncryptionPublicKey.
+ *
+ * @param msgId - The id of the message to cancel.
+ */
+export type EncryptionPublicKeyControllerCancelEncryptionPublicKeyAction = {
+  type: `EncryptionPublicKeyController:cancelEncryptionPublicKey`;
+  handler: EncryptionPublicKeyController['cancelEncryptionPublicKey'];
+};
+
+/**
+ * Reject all unapproved messages of any type.
+ *
+ * @param reason - A message to indicate why.
+ */
+export type EncryptionPublicKeyControllerRejectUnapprovedAction = {
+  type: `EncryptionPublicKeyController:rejectUnapproved`;
+  handler: EncryptionPublicKeyController['rejectUnapproved'];
+};
+
+/**
+ * Clears all unapproved messages from memory.
+ */
+export type EncryptionPublicKeyControllerClearUnapprovedAction = {
+  type: `EncryptionPublicKeyController:clearUnapproved`;
+  handler: EncryptionPublicKeyController['clearUnapproved'];
+};
+
+/**
+ * Union of all EncryptionPublicKeyController action types.
+ */
+export type EncryptionPublicKeyControllerMethodActions =
+  | EncryptionPublicKeyControllerResetStateAction
+  | EncryptionPublicKeyControllerNewRequestEncryptionPublicKeyAction
+  | EncryptionPublicKeyControllerEncryptionPublicKeyAction
+  | EncryptionPublicKeyControllerCancelEncryptionPublicKeyAction
+  | EncryptionPublicKeyControllerRejectUnapprovedAction
+  | EncryptionPublicKeyControllerClearUnapprovedAction;

--- a/app/scripts/controllers/encryption-public-key.test.ts
+++ b/app/scripts/controllers/encryption-public-key.test.ts
@@ -46,6 +46,7 @@ const requestMock = {
 const createMessengerMock = () =>
   ({
     registerActionHandler: jest.fn(),
+    registerMethodActionHandlers: jest.fn(),
     publish: jest.fn(),
     subscribe: jest.fn(),
     call: jest.fn(),

--- a/app/scripts/controllers/encryption-public-key.test.ts
+++ b/app/scripts/controllers/encryption-public-key.test.ts
@@ -7,7 +7,8 @@ import {
 } from '@metamask/message-manager';
 import { KeyringType } from '../../../shared/constants/keyring';
 import { MetaMetricsEventCategory } from '../../../shared/constants/metametrics';
-import EncryptionPublicKeyController, {
+import {
+  EncryptionPublicKeyController,
   EncryptionPublicKeyControllerMessenger,
   EncryptionPublicKeyControllerOptions,
 } from './encryption-public-key';

--- a/app/scripts/controllers/encryption-public-key.ts
+++ b/app/scripts/controllers/encryption-public-key.ts
@@ -23,6 +23,7 @@ import {
 import { MetaMetricsEventCategory } from '../../../shared/constants/metametrics';
 import { KeyringType } from '../../../shared/constants/keyring';
 import { ORIGIN_METAMASK } from '../../../shared/constants/app';
+import type { EncryptionPublicKeyControllerMethodActions } from './encryption-public-key-method-action-types';
 
 const controllerName = 'EncryptionPublicKeyController';
 const methodNameGetEncryptionPublicKey = 'eth_getEncryptionPublicKey';
@@ -65,7 +66,7 @@ export type EncryptionPublicKeyControllerState = {
   unapprovedEncryptionPublicKeyMsgCount: number;
 };
 
-export type EncryptionPublicKeyControllerGetState = {
+export type EncryptionPublicKeyControllerGetStateAction = {
   type: `${typeof controllerName}:getState`;
   handler: () => EncryptionPublicKeyControllerState;
 };
@@ -76,7 +77,8 @@ export type EncryptionPublicKeyControllerStateChange = {
 };
 
 export type EncryptionPublicKeyControllerActions =
-  EncryptionPublicKeyControllerGetState;
+  | EncryptionPublicKeyControllerGetStateAction
+  | EncryptionPublicKeyControllerMethodActions;
 
 export type EncryptionPublicKeyControllerEvents =
   EncryptionPublicKeyControllerStateChange;
@@ -116,10 +118,19 @@ export type EncryptionPublicKeyControllerOptions = {
   manager: EncryptionPublicKeyManager;
 };
 
+const MESSENGER_EXPOSED_METHODS = [
+  'cancelEncryptionPublicKey',
+  'clearUnapproved',
+  'encryptionPublicKey',
+  'newRequestEncryptionPublicKey',
+  'rejectUnapproved',
+  'resetState',
+] as const;
+
 /**
  * Controller for requesting encryption public key requests requiring user approval.
  */
-export default class EncryptionPublicKeyController extends BaseController<
+export class EncryptionPublicKeyController extends BaseController<
   typeof controllerName,
   EncryptionPublicKeyControllerState,
   EncryptionPublicKeyControllerMessenger
@@ -181,6 +192,11 @@ export default class EncryptionPublicKeyController extends BaseController<
         state.unapprovedEncryptionPublicKeyMsgs = newMessages;
         state.unapprovedEncryptionPublicKeyMsgCount = messageCount;
       },
+    );
+
+    this.messenger.registerMethodActionHandlers(
+      this,
+      MESSENGER_EXPOSED_METHODS,
     );
   }
 

--- a/app/scripts/messenger-client-init/confirmations/encryption-public-key-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/confirmations/encryption-public-key-controller-init.test.ts
@@ -1,9 +1,11 @@
-import EncryptionPublicKeyController from '../../controllers/encryption-public-key';
+import {
+  EncryptionPublicKeyController,
+  EncryptionPublicKeyControllerMessenger,
+} from '../../controllers/encryption-public-key';
 import { ControllerInitRequest } from '../types';
 import { buildControllerInitRequestMock } from '../test/utils';
 import {
   getEncryptionPublicKeyControllerMessenger,
-  EncryptionPublicKeyControllerMessenger,
   getEncryptionPublicKeyControllerInitMessenger,
   EncryptionPublicKeyControllerInitMessenger,
 } from '../messengers';

--- a/app/scripts/messenger-client-init/confirmations/encryption-public-key-controller-init.ts
+++ b/app/scripts/messenger-client-init/confirmations/encryption-public-key-controller-init.ts
@@ -1,9 +1,9 @@
-import EncryptionPublicKeyController from '../../controllers/encryption-public-key';
-import { ControllerInitFunction } from '../types';
 import {
+  EncryptionPublicKeyController,
   EncryptionPublicKeyControllerMessenger,
-  EncryptionPublicKeyControllerInitMessenger,
-} from '../messengers';
+} from '../../controllers/encryption-public-key';
+import { ControllerInitFunction } from '../types';
+import { EncryptionPublicKeyControllerInitMessenger } from '../messengers';
 
 /**
  * Initialize the encryption public key controller.

--- a/app/scripts/messenger-client-init/controller-list.ts
+++ b/app/scripts/messenger-client-init/controller-list.ts
@@ -106,7 +106,7 @@ import { AlertController } from '../controllers/alert-controller';
 import { MetaMetricsDataDeletionController } from '../controllers/metametrics-data-deletion/metametrics-data-deletion';
 import { AppMetadataController } from '../controllers/app-metadata';
 import { DecryptMessageController } from '../controllers/decrypt-message';
-import EncryptionPublicKeyController from '../controllers/encryption-public-key';
+import { EncryptionPublicKeyController } from '../controllers/encryption-public-key';
 import { RewardsDataService } from '../controllers/rewards/rewards-data-service';
 import { RewardsController } from '../controllers/rewards/rewards-controller';
 import { StaticAssetsController } from '../controllers/static-assets-controller';

--- a/app/scripts/messenger-client-init/messengers/encryption-public-key-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/encryption-public-key-controller-messenger.ts
@@ -1,15 +1,12 @@
-import { Messenger } from '@metamask/messenger';
-import { KeyringControllerGetEncryptionPublicKeyAction } from '@metamask/keyring-controller';
 import {
-  AllowedActions,
-  AllowedEvents,
-} from '../../controllers/encryption-public-key';
+  Messenger,
+  MessengerActions,
+  MessengerEvents,
+} from '@metamask/messenger';
+import { KeyringControllerGetEncryptionPublicKeyAction } from '@metamask/keyring-controller';
+import { EncryptionPublicKeyControllerMessenger } from '../../controllers/encryption-public-key';
 import { MetaMetricsControllerTrackEventAction } from '../../controllers/metametrics-controller';
 import { RootMessenger } from '../../lib/messenger';
-
-export type EncryptionPublicKeyControllerMessenger = ReturnType<
-  typeof getEncryptionPublicKeyControllerMessenger
->;
 
 /**
  * Create a messenger restricted to the allowed actions and events of the
@@ -19,17 +16,16 @@ export type EncryptionPublicKeyControllerMessenger = ReturnType<
  * messenger.
  */
 export function getEncryptionPublicKeyControllerMessenger(
-  messenger: RootMessenger<AllowedActions, AllowedEvents>,
+  messenger: RootMessenger<
+    MessengerActions<EncryptionPublicKeyControllerMessenger>,
+    MessengerEvents<EncryptionPublicKeyControllerMessenger>
+  >,
 ) {
-  const controllerMessenger = new Messenger<
-    'EncryptionPublicKeyController',
-    AllowedActions,
-    AllowedEvents,
-    typeof messenger
-  >({
-    namespace: 'EncryptionPublicKeyController',
-    parent: messenger,
-  });
+  const controllerMessenger: EncryptionPublicKeyControllerMessenger =
+    new Messenger({
+      namespace: 'EncryptionPublicKeyController',
+      parent: messenger,
+    });
   messenger.delegate({
     messenger: controllerMessenger,
     actions: [

--- a/app/scripts/messenger-client-init/messengers/index.ts
+++ b/app/scripts/messenger-client-init/messengers/index.ts
@@ -251,10 +251,7 @@ export {
 } from './decrypt-message-controller-messenger';
 export type { DecryptMessageManagerMessenger } from './decrypt-message-manager-messenger';
 export { getDecryptMessageManagerMessenger } from './decrypt-message-manager-messenger';
-export type {
-  EncryptionPublicKeyControllerMessenger,
-  EncryptionPublicKeyControllerInitMessenger,
-} from './encryption-public-key-controller-messenger';
+export type { EncryptionPublicKeyControllerInitMessenger } from './encryption-public-key-controller-messenger';
 export {
   getEncryptionPublicKeyControllerMessenger,
   getEncryptionPublicKeyControllerInitMessenger,


### PR DESCRIPTION
## **Description**

This PR updates the `EncryptionPublicKeyController` to use `registerMethodActionHandlers` and `MESSENGER_EXPOSED_METHODS` to register actions.

## **Changelog**

CHANGELOG entry:null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly a refactor of `EncryptionPublicKeyController` messenger wiring; risk is moderate because incorrect method exposure/typing could break `eth_getEncryptionPublicKey` approval flows at runtime.
> 
> **Overview**
> Refactors `EncryptionPublicKeyController` to register its public action methods via `registerMethodActionHandlers` using a new `MESSENGER_EXPOSED_METHODS` allowlist, and introduces an auto-generated `encryption-public-key-method-action-types.ts` to type those method actions.
> 
> Updates exports/imports to use a named `EncryptionPublicKeyController` class (instead of default export) and adjusts the controller messenger typing/creation to use `MessengerActions`/`MessengerEvents`, with corresponding test and init wiring updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e48449b9b3e863b618daf1d2f4a41f826efa77e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->