### PR TITLE
fix(perps): sort Explore Markets by 24h trading volume descending

### DIFF
--- a/ui/components/app/perps/constants.ts
+++ b/ui/components/app/perps/constants.ts
@@ -40,6 +40,9 @@ export const PERPS_CONSTANTS = {
 
   RECENT_ACTIVITY_LIMIT: 3,
   FILLS_LOOKBACK_MS: 90 * 24 * 60 * 60 * 1000, // 3 months in milliseconds
+
+  /** Max markets shown in the explore section (aligned with mobile). */
+  EXPLORE_MARKETS_LIMIT: 8,
 } as const;
 
 /**

--- a/ui/components/app/perps/perps-explore-markets/perps-explore-markets.tsx
+++ b/ui/components/app/perps/perps-explore-markets/perps-explore-markets.tsx
@@ -59,7 +59,7 @@ export const PerpsExploreMarkets: React.FC<PerpsExploreMarketsProps> = ({
         />
       </ButtonBase>
       <Box flexDirection={BoxFlexDirection.Column}>
-        {markets.map((market) => (
+        {markets.slice(0, 10).map((market) => (
           <PerpsMarketCard
             key={market.symbol}
             symbol={market.symbol}

--- a/ui/components/app/perps/perps-explore-markets/perps-explore-markets.tsx
+++ b/ui/components/app/perps/perps-explore-markets/perps-explore-markets.tsx
@@ -17,6 +17,7 @@ import {
   PERPS_MARKET_LIST_ROUTE,
 } from '../../../../helpers/constants/routes';
 import { PerpsMarketCard } from '../perps-market-card';
+import { PERPS_CONSTANTS } from '../constants';
 import type { PerpsMarketData } from '../types';
 
 export type PerpsExploreMarketsProps = {
@@ -59,18 +60,20 @@ export const PerpsExploreMarkets: React.FC<PerpsExploreMarketsProps> = ({
         />
       </ButtonBase>
       <Box flexDirection={BoxFlexDirection.Column}>
-        {markets.slice(0, 10).map((market) => (
-          <PerpsMarketCard
-            key={market.symbol}
-            symbol={market.symbol}
-            name={market.name}
-            price={market.price}
-            change24hPercent={market.change24hPercent}
-            volume={market.volume}
-            onClick={handleMarketClick}
-            data-testid={`explore-markets-${market.symbol.replace(/:/gu, '-')}`}
-          />
-        ))}
+        {markets
+          .slice(0, PERPS_CONSTANTS.EXPLORE_MARKETS_LIMIT)
+          .map((market) => (
+            <PerpsMarketCard
+              key={market.symbol}
+              symbol={market.symbol}
+              name={market.name}
+              price={market.price}
+              change24hPercent={market.change24hPercent}
+              volume={market.volume}
+              onClick={handleMarketClick}
+              data-testid={`explore-markets-${market.symbol.replaceAll(':', '-')}`}
+            />
+          ))}
       </Box>
     </Box>
   );

--- a/ui/components/app/perps/perps-explore-markets/perps-explore-markets.tsx
+++ b/ui/components/app/perps/perps-explore-markets/perps-explore-markets.tsx
@@ -20,13 +20,11 @@ import { PerpsMarketCard } from '../perps-market-card';
 import type { PerpsMarketData } from '../types';
 
 export type PerpsExploreMarketsProps = {
-  cryptoMarkets: PerpsMarketData[];
-  hip3Markets: PerpsMarketData[];
+  markets: PerpsMarketData[];
 };
 
 export const PerpsExploreMarkets: React.FC<PerpsExploreMarketsProps> = ({
-  cryptoMarkets,
-  hip3Markets,
+  markets,
 }) => {
   const t = useI18nContext();
   const navigate = useNavigate();
@@ -61,7 +59,7 @@ export const PerpsExploreMarkets: React.FC<PerpsExploreMarketsProps> = ({
         />
       </ButtonBase>
       <Box flexDirection={BoxFlexDirection.Column}>
-        {cryptoMarkets.map((market) => (
+        {markets.map((market) => (
           <PerpsMarketCard
             key={market.symbol}
             symbol={market.symbol}
@@ -70,19 +68,7 @@ export const PerpsExploreMarkets: React.FC<PerpsExploreMarketsProps> = ({
             change24hPercent={market.change24hPercent}
             volume={market.volume}
             onClick={handleMarketClick}
-            data-testid={`explore-crypto-${market.symbol}`}
-          />
-        ))}
-        {hip3Markets.map((market) => (
-          <PerpsMarketCard
-            key={market.symbol}
-            symbol={market.symbol}
-            name={market.name}
-            price={market.price}
-            change24hPercent={market.change24hPercent}
-            volume={market.volume}
-            onClick={handleMarketClick}
-            data-testid={`explore-hip3-${market.symbol.replace(/:/gu, '-')}`}
+            data-testid={`explore-markets-${market.symbol.replace(/:/gu, '-')}`}
           />
         ))}
       </Box>

--- a/ui/components/app/perps/perps-view.tsx
+++ b/ui/components/app/perps/perps-view.tsx
@@ -74,11 +74,8 @@ export const PerpsView: React.FC = () => {
     usePerpsLivePositions();
   const { orders: allOrders, isInitialLoading: ordersLoading } =
     usePerpsLiveOrders();
-  const {
-    cryptoMarkets: allCryptoMarkets,
-    hip3Markets: allHip3Markets,
-    isInitialLoading: marketsLoading,
-  } = usePerpsLiveMarketData();
+  const { markets: allMarkets, isInitialLoading: marketsLoading } =
+    usePerpsLiveMarketData();
 
   const {
     transactions: allRecentActivityTransactions,
@@ -197,15 +194,6 @@ export const PerpsView: React.FC = () => {
     }
   }, [dispatch, isFirstTimeUser, isLoading, isTestnet, tutorialCompleted]);
 
-  // Limit markets to 5 for explore sections
-  const cryptoMarkets = useMemo(() => {
-    return allCryptoMarkets.slice(0, 5);
-  }, [allCryptoMarkets]);
-
-  const hip3Markets = useMemo(() => {
-    return allHip3Markets.slice(0, 5);
-  }, [allHip3Markets]);
-
   // Show loading state while initial stream data is being fetched.
   // Transaction history loads in parallel; Recent Activity skeleton is included here
   // so the section is represented before the main view mounts.
@@ -259,10 +247,7 @@ export const PerpsView: React.FC = () => {
       <PerpsWatchlist />
 
       {/* Explore markets */}
-      <PerpsExploreMarkets
-        cryptoMarkets={cryptoMarkets}
-        hip3Markets={hip3Markets}
-      />
+      <PerpsExploreMarkets markets={allMarkets} />
 
       {/* Recent Activity */}
       <PerpsRecentActivity

--- a/ui/components/app/perps/utils.test.ts
+++ b/ui/components/app/perps/utils.test.ts
@@ -15,6 +15,7 @@ import {
   filterTransactionsByType,
   getTransactionStatusColor,
   getTransactionAmountColor,
+  parseVolume,
   hasVolume,
 } from './utils';
 import { HYPERLIQUID_ASSET_ICONS_BASE_URL } from './constants';
@@ -517,6 +518,51 @@ describe('Perps Utils', () => {
     it('returns TextDefault for amounts without prefix', () => {
       expect(getTransactionAmountColor('100.00')).toBe(TextColor.TextDefault);
       expect(getTransactionAmountColor('0')).toBe(TextColor.TextDefault);
+    });
+  });
+
+  describe('parseVolume', () => {
+    it('parses suffixed volume strings into numeric values', () => {
+      expect(parseVolume('$500K')).toBe(500_000);
+      expect(parseVolume('$1.2M')).toBe(1_200_000);
+      expect(parseVolume('$850M')).toBe(850_000_000);
+      expect(parseVolume('$2.3B')).toBe(2_300_000_000);
+      expect(parseVolume('$1.5T')).toBe(1_500_000_000_000);
+    });
+
+    it('parses plain numeric strings without suffix', () => {
+      expect(parseVolume('$100')).toBe(100);
+      expect(parseVolume('$0')).toBe(0);
+      expect(parseVolume('$0.5')).toBe(0.5);
+    });
+
+    it('strips commas from formatted numbers', () => {
+      expect(parseVolume('$1,234')).toBe(1234);
+      expect(parseVolume('$1,234,567')).toBe(1_234_567);
+    });
+
+    it('handles strings without $ prefix', () => {
+      expect(parseVolume('500K')).toBe(500_000);
+      expect(parseVolume('1.2M')).toBe(1_200_000);
+      expect(parseVolume('100')).toBe(100);
+    });
+
+    it('returns 0.5 for the "$<1" special case', () => {
+      expect(parseVolume('$<1')).toBe(0.5);
+    });
+
+    it('returns -1 for the fallback display "--"', () => {
+      expect(parseVolume('--')).toBe(-1);
+    });
+
+    it('returns -1 for undefined or empty input', () => {
+      expect(parseVolume(undefined)).toBe(-1);
+      expect(parseVolume('')).toBe(-1);
+    });
+
+    it('returns -1 for non-numeric strings', () => {
+      expect(parseVolume('abc')).toBe(-1);
+      expect(parseVolume('N/A')).toBe(-1);
     });
   });
 

--- a/ui/components/app/perps/utils.ts
+++ b/ui/components/app/perps/utils.ts
@@ -1,13 +1,12 @@
 import { TextColor } from '@metamask/design-system-react';
 import { formatDateWithYearContext } from '../../../helpers/utils/util';
-import { parseVolume } from '../../../pages/perps/utils/sortMarkets';
 import type {
   Order,
   PerpsMarketData,
   PerpsTransaction,
   PerpsTransactionFilter,
 } from './types';
-import { HYPERLIQUID_ASSET_ICONS_BASE_URL } from './constants';
+import { HYPERLIQUID_ASSET_ICONS_BASE_URL, PERPS_CONSTANTS } from './constants';
 
 /**
  * Extract display name from symbol (strips DEX prefix for HIP-3 markets)
@@ -416,6 +415,59 @@ export const isHip3Market = (
  */
 export const isCryptoMarket = (market: PerpsMarketData): boolean => {
   return !market.marketSource;
+};
+
+const volumeMultipliers: Record<string, number> = {
+  K: 1e3,
+  M: 1e6,
+  B: 1e9,
+  T: 1e12,
+} as const;
+
+const VOLUME_SUFFIX_REGEX = /\$?([\d.,]+)([KMBT])?/u;
+
+const removeCommas = (str: string): string => {
+  let result = '';
+  for (const char of str) {
+    if (char !== ',') {
+      result += char;
+    }
+  }
+  return result;
+};
+
+/**
+ * Parse volume strings with magnitude suffixes (e.g., '$1.2B', '$850M')
+ * Returns numeric value for sorting
+ *
+ * @param volumeStr - The volume string to parse
+ * @returns Numeric value for sorting
+ */
+export const parseVolume = (volumeStr: string | undefined): number => {
+  if (!volumeStr) {
+    return -1;
+  }
+
+  if (volumeStr === PERPS_CONSTANTS.FALLBACK_PRICE_DISPLAY) {
+    return -1;
+  }
+  if (volumeStr === '$<1') {
+    return 0.5;
+  }
+
+  const suffixMatch = VOLUME_SUFFIX_REGEX.exec(volumeStr);
+  if (suffixMatch) {
+    const [, numberPart, suffix] = suffixMatch;
+    const baseValue = Number.parseFloat(removeCommas(numberPart));
+
+    if (Number.isNaN(baseValue)) {
+      return -1;
+    }
+
+    return suffix ? baseValue * volumeMultipliers[suffix] : baseValue;
+  }
+
+  return -1;
 };
 
 /**

--- a/ui/hooks/perps/stream/usePerpsLiveMarketData.test.ts
+++ b/ui/hooks/perps/stream/usePerpsLiveMarketData.test.ts
@@ -245,4 +245,49 @@ describe('usePerpsLiveMarketData', () => {
     expect(result.current.hip3Markets).toHaveLength(1);
     expect(result.current.hip3Markets[0].symbol).toBe('xyz:TSLA');
   });
+
+  it('sorts cryptoMarkets and hip3Markets by 24h volume descending', () => {
+    const allMarkets = [
+      createMockMarket({ symbol: 'DOGE', volume: '$50M' }),
+      createMockMarket({ symbol: 'BTC', volume: '$1.2B' }),
+      createMockMarket({ symbol: 'ETH', volume: '$850M' }),
+      createMockMarket({
+        symbol: 'xyz:GOOG',
+        volume: '$80M',
+        marketSource: 'xyz',
+      }),
+      createMockMarket({
+        symbol: 'xyz:TSLA',
+        volume: '$30M',
+        marketSource: 'xyz',
+      }),
+      createMockMarket({
+        symbol: 'xyz:NVDA',
+        volume: '$200M',
+        marketSource: 'xyz',
+      }),
+    ];
+
+    const { streamManager } = createMockStreamManager(allMarkets);
+
+    usePerpsStreamManagerMock.mockReturnValue({
+      streamManager,
+      isInitializing: false,
+      error: null,
+      selectedAddress: '0x123',
+    });
+
+    const { result } = renderHook(() => usePerpsLiveMarketData());
+
+    expect(result.current.cryptoMarkets.map((m) => m.symbol)).toEqual([
+      'BTC',
+      'ETH',
+      'DOGE',
+    ]);
+    expect(result.current.hip3Markets.map((m) => m.symbol)).toEqual([
+      'xyz:NVDA',
+      'xyz:GOOG',
+      'xyz:TSLA',
+    ]);
+  });
 });

--- a/ui/hooks/perps/stream/usePerpsLiveMarketData.ts
+++ b/ui/hooks/perps/stream/usePerpsLiveMarketData.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import type { PerpsMarketData } from '@metamask/perps-controller';
 import { hasVolume } from '../../../components/app/perps/utils';
+import { parseVolume } from '../../../pages/perps/utils/sortMarkets';
 import { usePerpsStreamManager } from './usePerpsStreamManager';
 
 /**
@@ -107,14 +108,21 @@ export function usePerpsLiveMarketData(
   // Filter out markets with no trading volume (inactive/delisted)
   const activeMarkets = useMemo(() => markets.filter(hasVolume), [markets]);
 
-  // Derive crypto and HIP-3 markets from active markets only
+  const compareByVolumeDesc = useCallback(
+    (a: PerpsMarketData, b: PerpsMarketData) =>
+      parseVolume(b.volume) - parseVolume(a.volume),
+    [],
+  );
+
+  // Derive crypto and HIP-3 markets from active markets, sorted by 24h volume descending
   const cryptoMarkets = useMemo(
-    () => activeMarkets.filter((m) => !m.marketSource),
-    [activeMarkets],
+    () =>
+      activeMarkets.filter((m) => !m.marketSource).sort(compareByVolumeDesc),
+    [activeMarkets, compareByVolumeDesc],
   );
   const hip3Markets = useMemo(
-    () => activeMarkets.filter((m) => m.marketSource),
-    [activeMarkets],
+    () => activeMarkets.filter((m) => m.marketSource).sort(compareByVolumeDesc),
+    [activeMarkets, compareByVolumeDesc],
   );
 
   // Manual refresh function

--- a/ui/hooks/perps/stream/usePerpsLiveMarketData.ts
+++ b/ui/hooks/perps/stream/usePerpsLiveMarketData.ts
@@ -1,7 +1,6 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import type { PerpsMarketData } from '@metamask/perps-controller';
-import { hasVolume } from '../../../components/app/perps/utils';
-import { parseVolume } from '../../../pages/perps/utils/sortMarkets';
+import { hasVolume, parseVolume } from '../../../components/app/perps/utils';
 import { usePerpsStreamManager } from './usePerpsStreamManager';
 
 /**

--- a/ui/hooks/perps/stream/usePerpsLiveMarketData.ts
+++ b/ui/hooks/perps/stream/usePerpsLiveMarketData.ts
@@ -105,24 +105,25 @@ export function usePerpsLiveMarketData(
     return true;
   });
 
-  // Filter out markets with no trading volume (inactive/delisted)
-  const activeMarkets = useMemo(() => markets.filter(hasVolume), [markets]);
-
   const compareByVolumeDesc = useCallback(
     (a: PerpsMarketData, b: PerpsMarketData) =>
       parseVolume(b.volume) - parseVolume(a.volume),
     [],
   );
 
+  // Filter out markets with no trading volume (inactive/delisted)
+  const activeMarkets = useMemo(() => {
+    return markets.filter(hasVolume).sort(compareByVolumeDesc);
+  }, [markets, compareByVolumeDesc]);
+
   // Derive crypto and HIP-3 markets from active markets, sorted by 24h volume descending
   const cryptoMarkets = useMemo(
-    () =>
-      activeMarkets.filter((m) => !m.marketSource).sort(compareByVolumeDesc),
-    [activeMarkets, compareByVolumeDesc],
+    () => activeMarkets.filter((m) => !m.marketSource),
+    [activeMarkets],
   );
   const hip3Markets = useMemo(
-    () => activeMarkets.filter((m) => m.marketSource).sort(compareByVolumeDesc),
-    [activeMarkets, compareByVolumeDesc],
+    () => activeMarkets.filter((m) => m.marketSource),
+    [activeMarkets],
   );
 
   // Manual refresh function

--- a/ui/pages/perps/utils/index.ts
+++ b/ui/pages/perps/utils/index.ts
@@ -1,2 +1,3 @@
-export { sortMarkets, parseVolume } from './sortMarkets';
+export { sortMarkets } from './sortMarkets';
+export { parseVolume } from '../../../components/app/perps/utils';
 export type { SortField, SortDirection } from './sortMarkets';

--- a/ui/pages/perps/utils/sortMarkets.ts
+++ b/ui/pages/perps/utils/sortMarkets.ts
@@ -1,8 +1,6 @@
 import type { PerpsMarketData } from '../../../components/app/perps/types';
-import {
-  MARKET_SORTING_CONFIG,
-  PERPS_CONSTANTS,
-} from '../../../components/app/perps/constants';
+import { MARKET_SORTING_CONFIG } from '../../../components/app/perps/constants';
+import { parseVolume } from '../../../components/app/perps/utils';
 
 export type SortField =
   | 'volume'
@@ -10,63 +8,6 @@ export type SortField =
   | 'fundingRate'
   | 'openInterest';
 export type SortDirection = 'asc' | 'desc';
-
-const multipliers: Record<string, number> = {
-  K: 1e3,
-  M: 1e6,
-  B: 1e9,
-  T: 1e12,
-} as const;
-
-// Pre-compiled regex for better performance
-const VOLUME_SUFFIX_REGEX = /\$?([\d.,]+)([KMBT])?/u;
-
-// Helper function to remove commas
-const removeCommas = (str: string): string => {
-  let result = '';
-  for (const char of str) {
-    if (char !== ',') {
-      result += char;
-    }
-  }
-  return result;
-};
-
-/**
- * Parse volume strings with magnitude suffixes (e.g., '$1.2B', '$850M')
- * Returns numeric value for sorting
- *
- * @param volumeStr - The volume string to parse
- * @returns Numeric value for sorting
- */
-export const parseVolume = (volumeStr: string | undefined): number => {
-  if (!volumeStr) {
-    return -1;
-  }
-
-  // Handle special cases
-  if (volumeStr === PERPS_CONSTANTS.FALLBACK_PRICE_DISPLAY) {
-    return -1;
-  }
-  if (volumeStr === '$<1') {
-    return 0.5;
-  }
-
-  // Handle suffixed values (e.g., "$1.5M", "$2.3B", "$500K")
-  const suffixMatch = VOLUME_SUFFIX_REGEX.exec(volumeStr);
-  if (suffixMatch) {
-    const [, numberPart, suffix] = suffixMatch;
-    const baseValue = Number.parseFloat(removeCommas(numberPart));
-
-    if (Number.isNaN(baseValue)) {
-      return -1;
-    }
-
-    return suffix ? baseValue * multipliers[suffix] : baseValue;
-  }
-
-  return -1;
-};
 
 type SortMarketsParams = {
   markets: PerpsMarketData[];


### PR DESCRIPTION
## **Description**

The "Explore Markets" section on the Perps home tab (`/perps`) displayed markets in an arbitrary order determined by the stream data arrival order. When the view sliced the first 5 markets for display, users saw a random assortment rather than the most actively traded markets.

This PR sorts both `cryptoMarkets` and `hip3Markets` by 24h trading volume (highest first) inside the `usePerpsLiveMarketData` hook. This ensures that when `PerpsView` takes `.slice(0, 5)`, the top 5 by volume are shown — matching the expected behavior described in the bug report.

The sort reuses the existing `parseVolume` utility from `sortMarkets.ts`, which already handles formatted volume strings like `$1.2B`, `$850M`, `$500K`.

## **Changelog**

CHANGELOG entry: Fixed Explore Markets section on the Perps tab to display markets ranked by highest 24h trading volume

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2789

## **Manual testing steps**

Feature: Perps Explore Markets sorting

Scenario: Markets are sorted by 24h volume descending
  Given the wallet is unlocked
  And the user navigates to the Perps tab (`/perps`)
  When the Explore Markets section loads
  Then markets should be ordered by 24h trading volume, highest first
  And the top 5 crypto markets and top 5 HIP-3 markets displayed should be the highest-volume ones

## **Screenshots/Recordings**

### **Before**
![image](https://github.com/user-attachments/assets/46c27926-9eb0-4cf4-88b2-a848ce5b3a73)

### **After**
<img width="456" height="592" alt="Screenshot 2026-04-09 at 14 06 00" src="https://github.com/user-attachments/assets/ec656386-52e4-4111-aecd-9c6fdf8ee21f" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes market ordering logic used by the perps home experience by sorting live market data based on parsed volume strings; any parsing or sort edge cases could affect which markets appear first. Scope is UI/data-presentation only with added unit coverage.
> 
> **Overview**
> **Explore Markets on `/perps` is now volume-ranked instead of stream-order.** `usePerpsLiveMarketData` filters to active markets and sorts them by parsed 24h `volume` descending before deriving `cryptoMarkets`/`hip3Markets`, with a new unit test covering the ordering.
> 
> **Explore list rendering was simplified and capped.** `PerpsExploreMarkets` now takes a single `markets` prop and shows the top `PERPS_CONSTANTS.EXPLORE_MARKETS_LIMIT` (new constant set to `8`), and `PerpsView` now passes the unified `allMarkets` list.
> 
> **Volume parsing was centralized.** `parseVolume` was moved into `ui/components/app/perps/utils.ts` (and re-exported from `ui/pages/perps/utils`), with new unit tests validating suffixes, commas, `$<1`, and fallback handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 435a03ab787e3fe982b4178cd2161c370c06f50f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->