### PR TITLE
chore: Bulk register actions in `NetworkOrderController`

### DIFF
--- a/app/scripts/controllers/network-order-method-action-types.ts
+++ b/app/scripts/controllers/network-order-method-action-types.ts
@@ -1,0 +1,22 @@
+/**
+ * This file is auto generated.
+ * Do not edit manually.
+ */
+
+import type { NetworkOrderController } from './network-order';
+
+/**
+ * Updates the networks list in the state with the provided list of networks.
+ *
+ * @param networkList - The list of networks to update in the state.
+ */
+export type NetworkOrderControllerUpdateNetworksListAction = {
+  type: `NetworkOrderController:updateNetworksList`;
+  handler: NetworkOrderController['updateNetworksList'];
+};
+
+/**
+ * Union of all NetworkOrderController action types.
+ */
+export type NetworkOrderControllerMethodActions =
+  NetworkOrderControllerUpdateNetworksListAction;

--- a/app/scripts/controllers/network-order-method-action-types.ts
+++ b/app/scripts/controllers/network-order-method-action-types.ts
@@ -6,6 +6,17 @@
 import type { NetworkOrderController } from './network-order';
 
 /**
+ * Handles the state change of the network controller and updates the networks list.
+ *
+ * @param networkControllerState - The state of the network controller.
+ * @param networkControllerState.networkConfigurationsByChainId
+ */
+export type NetworkOrderControllerOnNetworkControllerStateChangeAction = {
+  type: `NetworkOrderController:onNetworkControllerStateChange`;
+  handler: NetworkOrderController['onNetworkControllerStateChange'];
+};
+
+/**
  * Updates the networks list in the state with the provided list of networks.
  *
  * @param networkList - The list of networks to update in the state.
@@ -19,4 +30,5 @@ export type NetworkOrderControllerUpdateNetworksListAction = {
  * Union of all NetworkOrderController action types.
  */
 export type NetworkOrderControllerMethodActions =
-  NetworkOrderControllerUpdateNetworksListAction;
+  | NetworkOrderControllerOnNetworkControllerStateChangeAction
+  | NetworkOrderControllerUpdateNetworksListAction;

--- a/app/scripts/controllers/network-order.ts
+++ b/app/scripts/controllers/network-order.ts
@@ -91,7 +91,10 @@ const metadata: StateMetadata<NetworkOrderControllerState> = {
   },
 };
 
-const MESSENGER_EXPOSED_METHODS = ['updateNetworksList'] as const;
+const MESSENGER_EXPOSED_METHODS = [
+  'onNetworkControllerStateChange',
+  'updateNetworksList',
+] as const;
 
 /**
  * Controller that updates the order of the network list.

--- a/app/scripts/controllers/network-order.ts
+++ b/app/scripts/controllers/network-order.ts
@@ -16,6 +16,7 @@ import type {
   ControllerStateChangeEvent,
 } from '@metamask/base-controller';
 import { TEST_CHAINS } from '../../../shared/constants/network';
+import { NetworkOrderControllerMethodActions } from './network-order-method-action-types';
 
 // Unique name for the controller
 const controllerName = 'NetworkOrderController';
@@ -43,16 +44,15 @@ export type NetworkOrderStateChange = {
   payload: [NetworkOrderControllerState, Patch[]];
 };
 
-// Describes the action for updating the networks list
-export type NetworkOrderControllerUpdateNetworksListAction = {
-  type: `${typeof controllerName}:updateNetworksList`;
-  handler: NetworkOrderController['updateNetworksList'];
-};
+export type NetworkOrderControllerGetStateAction = ControllerGetStateAction<
+  typeof controllerName,
+  NetworkOrderControllerState
+>;
 
 // Union of all possible actions for the messenger
-export type NetworkOrderControllerMessengerActions =
-  | ControllerGetStateAction<typeof controllerName, NetworkOrderControllerState>
-  | NetworkOrderControllerUpdateNetworksListAction;
+export type NetworkOrderControllerActions =
+  | NetworkOrderControllerGetStateAction
+  | NetworkOrderControllerMethodActions;
 
 export type NetworkOrderControllerMessengerEvents =
   | ControllerStateChangeEvent<
@@ -72,7 +72,7 @@ type AllowedEvents =
 // Type for the messenger of NetworkOrderController
 export type NetworkOrderControllerMessenger = Messenger<
   typeof controllerName,
-  NetworkOrderControllerMessengerActions | AllowedActions,
+  NetworkOrderControllerActions | AllowedActions,
   NetworkOrderControllerMessengerEvents | AllowedEvents
 >;
 
@@ -90,6 +90,8 @@ const metadata: StateMetadata<NetworkOrderControllerState> = {
     usedInUi: true,
   },
 };
+
+const MESSENGER_EXPOSED_METHODS = ['updateNetworksList'] as const;
 
 /**
  * Controller that updates the order of the network list.
@@ -129,6 +131,11 @@ export class NetworkOrderController extends BaseController<
       (networkControllerState) => {
         this.onNetworkControllerStateChange(networkControllerState);
       },
+    );
+
+    this.messenger.registerMethodActionHandlers(
+      this,
+      MESSENGER_EXPOSED_METHODS,
     );
   }
 

--- a/app/scripts/messenger-client-init/assets/network-order-controller-init.ts
+++ b/app/scripts/messenger-client-init/assets/network-order-controller-init.ts
@@ -1,8 +1,8 @@
 import {
   NetworkOrderController,
+  NetworkOrderControllerMessenger,
   NetworkOrderControllerState,
 } from '../../controllers/network-order';
-import { NetworkOrderControllerMessenger } from '../messengers/assets';
 import { ControllerInitFunction } from '../types';
 
 const generateDefaultNetworkOrderControllerState =

--- a/app/scripts/messenger-client-init/messengers/assets/index.ts
+++ b/app/scripts/messenger-client-init/messengers/assets/index.ts
@@ -29,7 +29,6 @@ export type {
 } from './assets-contract-controller-messenger';
 
 export { getNetworkOrderControllerMessenger } from './network-order-controller-messenger';
-export type { NetworkOrderControllerMessenger } from './network-order-controller-messenger';
 
 export {
   getNetworkEnablementControllerMessenger,

--- a/app/scripts/messenger-client-init/messengers/assets/network-order-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/assets/network-order-controller-messenger.ts
@@ -1,32 +1,18 @@
-import { Messenger } from '@metamask/messenger';
 import {
-  NetworkControllerGetStateAction,
-  NetworkControllerNetworkRemovedEvent,
-  NetworkControllerSetActiveNetworkAction,
-  NetworkControllerStateChangeEvent,
-} from '@metamask/network-controller';
+  Messenger,
+  MessengerActions,
+  MessengerEvents,
+} from '@metamask/messenger';
 import { RootMessenger } from '../../../lib/messenger';
-
-type Actions =
-  | NetworkControllerGetStateAction
-  | NetworkControllerSetActiveNetworkAction;
-type Events =
-  | NetworkControllerStateChangeEvent
-  | NetworkControllerNetworkRemovedEvent;
-
-export type NetworkOrderControllerMessenger = ReturnType<
-  typeof getNetworkOrderControllerMessenger
->;
+import { NetworkOrderControllerMessenger } from '../../../controllers/network-order';
 
 export function getNetworkOrderControllerMessenger(
-  messenger: RootMessenger<Actions, Events>,
+  messenger: RootMessenger<
+    MessengerActions<NetworkOrderControllerMessenger>,
+    MessengerEvents<NetworkOrderControllerMessenger>
+  >,
 ) {
-  const controllerMessenger = new Messenger<
-    'NetworkOrderController',
-    Actions,
-    Events,
-    typeof messenger
-  >({
+  const controllerMessenger: NetworkOrderControllerMessenger = new Messenger({
     namespace: 'NetworkOrderController',
     parent: messenger,
   });


### PR DESCRIPTION
## **Description**

This PR updates the `NetworkOrderController` to use `registerMethodActionHandlers` and `MESSENGER_EXPOSED_METHODS` to register actions.

## **Changelog**

CHANGELOG entry:null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `NetworkOrderController` exposes/handles messenger method actions, which could break controller messaging if method names/types drift. Otherwise largely a typing and wiring refactor with minimal business-logic impact.
> 
> **Overview**
> Refactors `NetworkOrderController` to bulk-register messenger method actions via `registerMethodActionHandlers` and a `MESSENGER_EXPOSED_METHODS` allowlist, replacing the prior per-action typing.
> 
> Adds an auto-generated `network-order-method-action-types.ts` and updates messenger/type plumbing so `NetworkOrderControllerMessenger` is sourced from the controller module and the assets messenger uses `MessengerActions`/`MessengerEvents` for delegation typing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0267474eeda3942b25bfed8561f65cc633efeea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->