### PR TITLE
chore: Bulk register actions in `OnboardingController`

### DIFF
--- a/app/scripts/controllers/onboarding-method-action-types.ts
+++ b/app/scripts/controllers/onboarding-method-action-types.ts
@@ -1,0 +1,75 @@
+/**
+ * This file is auto generated.
+ * Do not edit manually.
+ */
+
+import type { OnboardingController } from './onboarding';
+
+/**
+ * Setter for the `seedPhraseBackedUp` property
+ *
+ * @param newSeedPhraseBackUpState - Indicates if the seedphrase is backup by the user or not
+ */
+export type OnboardingControllerSetSeedPhraseBackedUpAction = {
+  type: `OnboardingController:setSeedPhraseBackedUp`;
+  handler: OnboardingController['setSeedPhraseBackedUp'];
+};
+
+/**
+ * Sets the completedOnboarding state to true, indicating that the user has completed the
+ * onboarding process.
+ */
+export type OnboardingControllerCompleteOnboardingAction = {
+  type: `OnboardingController:completeOnboarding`;
+  handler: OnboardingController['completeOnboarding'];
+};
+
+/**
+ * Setter for the `firstTimeFlowType` property
+ *
+ * @param type - Indicates the type of first time flow - create or import - the user wishes to follow
+ */
+export type OnboardingControllerSetFirstTimeFlowTypeAction = {
+  type: `OnboardingController:setFirstTimeFlowType`;
+  handler: OnboardingController['setFirstTimeFlowType'];
+};
+
+/**
+ * Registering a site as having initiated onboarding
+ *
+ * @param location - The location of the site registering
+ * @param tabId - The id of the tab registering
+ */
+export type OnboardingControllerRegisterOnboardingAction = {
+  type: `OnboardingController:registerOnboarding`;
+  handler: OnboardingController['registerOnboarding'];
+};
+
+/**
+ * Check if the user onboarding flow is Social login flow or not.
+ *
+ * @returns true if the user onboarding flow is Social loing flow, otherwise false.
+ */
+export type OnboardingControllerGetIsSocialLoginFlowAction = {
+  type: `OnboardingController:getIsSocialLoginFlow`;
+  handler: OnboardingController['getIsSocialLoginFlow'];
+};
+
+/**
+ * Reset the onboarding controller state.
+ */
+export type OnboardingControllerResetOnboardingAction = {
+  type: `OnboardingController:resetOnboarding`;
+  handler: OnboardingController['resetOnboarding'];
+};
+
+/**
+ * Union of all OnboardingController action types.
+ */
+export type OnboardingControllerMethodActions =
+  | OnboardingControllerSetSeedPhraseBackedUpAction
+  | OnboardingControllerCompleteOnboardingAction
+  | OnboardingControllerSetFirstTimeFlowTypeAction
+  | OnboardingControllerRegisterOnboardingAction
+  | OnboardingControllerGetIsSocialLoginFlowAction
+  | OnboardingControllerResetOnboardingAction;

--- a/app/scripts/controllers/onboarding.test.ts
+++ b/app/scripts/controllers/onboarding.test.ts
@@ -7,7 +7,8 @@ import {
   MockAnyNamespace,
 } from '@metamask/messenger';
 import { FirstTimeFlowType } from '../../../shared/constants/onboarding';
-import OnboardingController, {
+import {
+  OnboardingController,
   OnboardingControllerMessenger,
   getDefaultOnboardingControllerState,
 } from './onboarding';

--- a/app/scripts/controllers/onboarding.ts
+++ b/app/scripts/controllers/onboarding.ts
@@ -8,6 +8,7 @@ import type { Messenger } from '@metamask/messenger';
 import log from 'loglevel';
 import { FirstTimeFlowType } from '../../../shared/constants/onboarding';
 import { getIsSeedlessOnboardingFeatureEnabled } from '../../../shared/lib/environment';
+import { OnboardingControllerMethodActions } from './onboarding-method-action-types';
 
 // Unique name for the controller
 const controllerName = 'OnboardingController';
@@ -80,7 +81,9 @@ export type OnboardingControllerGetStateAction = ControllerGetStateAction<
 /**
  * Actions exposed by the {@link OnboardingController}.
  */
-export type OnboardingControllerActions = OnboardingControllerGetStateAction;
+export type OnboardingControllerActions =
+  | OnboardingControllerGetStateAction
+  | OnboardingControllerMethodActions;
 
 /**
  * Event emitted when the state of the {@link OnboardingController} changes.
@@ -115,11 +118,20 @@ export type OnboardingControllerMessenger = Messenger<
   OnboardingControllerControllerEvents | AllowedEvents
 >;
 
+const MESSENGER_EXPOSED_METHODS = [
+  'setSeedPhraseBackedUp',
+  'completeOnboarding',
+  'setFirstTimeFlowType',
+  'registerOnboarding',
+  'getIsSocialLoginFlow',
+  'resetOnboarding',
+] as const;
+
 /**
  * Controller responsible for maintaining
  * state related to onboarding
  */
-export default class OnboardingController extends BaseController<
+export class OnboardingController extends BaseController<
   typeof controllerName,
   OnboardingControllerState,
   OnboardingControllerMessenger
@@ -150,6 +162,11 @@ export default class OnboardingController extends BaseController<
         ...defaultTransientState,
       },
     });
+
+    this.messenger.registerMethodActionHandlers(
+      this,
+      MESSENGER_EXPOSED_METHODS,
+    );
   }
 
   /**
@@ -191,10 +208,7 @@ export default class OnboardingController extends BaseController<
    * @param location - The location of the site registering
    * @param tabId - The id of the tab registering
    */
-  registerOnboarding = async (
-    location: string,
-    tabId: string,
-  ): Promise<void> => {
+  async registerOnboarding(location: string, tabId: string): Promise<void> {
     if (this.state.completedOnboarding) {
       log.debug('Ignoring registerOnboarding; user already onboarded');
       return;
@@ -216,7 +230,7 @@ export default class OnboardingController extends BaseController<
         };
       });
     }
-  };
+  }
 
   /**
    * Check if the user onboarding flow is Social login flow or not.

--- a/app/scripts/messenger-client-init/controller-list.ts
+++ b/app/scripts/messenger-client-init/controller-list.ts
@@ -91,7 +91,7 @@ import {
   ProfileMetricsService,
 } from '@metamask/profile-metrics-controller';
 import { PerpsController } from '@metamask/perps-controller';
-import OnboardingController from '../controllers/onboarding';
+import { OnboardingController } from '../controllers/onboarding';
 import { PreferencesController } from '../controllers/preferences-controller';
 import { InstitutionalSnapController } from '../controllers/institutional-snap/InstitutionalSnapController';
 import { NetworkOrderController } from '../controllers/network-order';

--- a/app/scripts/messenger-client-init/messengers/index.ts
+++ b/app/scripts/messenger-client-init/messengers/index.ts
@@ -308,7 +308,6 @@ export {
   getNameControllerMessenger,
   getNameControllerInitMessenger,
 } from './name-controller-messenger';
-export type { OnboardingControllerMessenger } from './onboarding-controller-messenger';
 export { getOnboardingControllerMessenger } from './onboarding-controller-messenger';
 export type { PreferencesControllerMessenger } from './preferences-controller-messenger';
 export { getPreferencesControllerMessenger } from './preferences-controller-messenger';

--- a/app/scripts/messenger-client-init/messengers/onboarding-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/onboarding-controller-messenger.ts
@@ -1,9 +1,10 @@
-import { Messenger } from '@metamask/messenger';
+import {
+  Messenger,
+  MessengerActions,
+  MessengerEvents,
+} from '@metamask/messenger';
 import { RootMessenger } from '../../lib/messenger';
-
-export type OnboardingControllerMessenger = ReturnType<
-  typeof getOnboardingControllerMessenger
->;
+import { OnboardingControllerMessenger } from '../../controllers/onboarding';
 
 /**
  * Create a messenger restricted to the allowed actions and events of the
@@ -12,9 +13,17 @@ export type OnboardingControllerMessenger = ReturnType<
  * @param messenger - The base messenger used to create the restricted
  * messenger.
  */
-export function getOnboardingControllerMessenger(messenger: RootMessenger) {
-  return new Messenger({
-    namespace: 'OnboardingController',
-    parent: messenger,
-  });
+export function getOnboardingControllerMessenger(
+  messenger: RootMessenger<
+    MessengerActions<OnboardingControllerMessenger>,
+    MessengerEvents<OnboardingControllerMessenger>
+  >,
+) {
+  const onboardingControllerMessenger: OnboardingControllerMessenger =
+    new Messenger({
+      namespace: 'OnboardingController',
+      parent: messenger,
+    });
+
+  return onboardingControllerMessenger;
 }

--- a/app/scripts/messenger-client-init/onboarding-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/onboarding-controller-init.test.ts
@@ -1,11 +1,11 @@
-import OnboardingController from '../controllers/onboarding';
+import {
+  OnboardingController,
+  OnboardingControllerMessenger,
+} from '../controllers/onboarding';
 import { getRootMessenger } from '../lib/messenger';
 import { ControllerInitRequest } from './types';
 import { buildControllerInitRequestMock } from './test/utils';
-import {
-  getOnboardingControllerMessenger,
-  OnboardingControllerMessenger,
-} from './messengers';
+import { getOnboardingControllerMessenger } from './messengers';
 import { OnboardingControllerInit } from './onboarding-controller-init';
 
 jest.mock('../controllers/onboarding');

--- a/app/scripts/messenger-client-init/onboarding-controller-init.ts
+++ b/app/scripts/messenger-client-init/onboarding-controller-init.ts
@@ -1,5 +1,7 @@
-import OnboardingController from '../controllers/onboarding';
-import { OnboardingControllerMessenger } from './messengers';
+import {
+  OnboardingController,
+  OnboardingControllerMessenger,
+} from '../controllers/onboarding';
 import { ControllerInitFunction } from './types';
 
 /**

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -7348,7 +7348,9 @@ export default class MetamaskController extends EventEmitter {
       engine.push(
         createOnboardingMiddleware({
           location: sender.url,
-          registerOnboarding: this.onboardingController.registerOnboarding,
+          registerOnboarding: this.onboardingController.registerOnboarding.bind(
+            this.onboardingController,
+          ),
         }),
       );
     }
@@ -7810,7 +7812,9 @@ export default class MetamaskController extends EventEmitter {
       engine.push(
         createOnboardingMiddleware({
           location: sender.url,
-          registerOnboarding: this.onboardingController.registerOnboarding,
+          registerOnboarding: this.onboardingController.registerOnboarding.bind(
+            this.onboardingController,
+          ),
         }),
       );
     }


### PR DESCRIPTION
## **Description**

This PR updates the `OnboardingController` to use `registerMethodActionHandlers` and `MESSENGER_EXPOSED_METHODS` to register actions.

## **Changelog**

CHANGELOG entry:null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches controller-to-messenger wiring for `OnboardingController` and changes how methods are registered/bound, which could break onboarding RPC/middleware calls if action types or `this` binding are incorrect. No state shape changes or sensitive data-handling logic added.
> 
> **Overview**
> **Refactors `OnboardingController` action exposure to be bulk-registered via the messenger.** The controller now defines `MESSENGER_EXPOSED_METHODS` and calls `registerMethodActionHandlers`, backed by a new auto-generated `onboarding-method-action-types.ts` union that adds method actions to `OnboardingControllerActions`.
> 
> Updates imports/exports and typing around onboarding messenger creation/initialization to use the controller’s exported `OnboardingController` class (no default export) and `OnboardingControllerMessenger` type, and ensures `registerOnboarding` is passed with correct `this` binding in `metamask-controller.js`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6cfd9a74c90cce54d70b654c257155a51fb8795. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->