### PR TITLE
chore: Bulk register actions in `PreferencesController`

### DIFF
--- a/app/scripts/controllers/preferences-controller-method-action-types.ts
+++ b/app/scripts/controllers/preferences-controller-method-action-types.ts
@@ -1,0 +1,435 @@
+/**
+ * This file is auto generated.
+ * Do not edit manually.
+ */
+
+import type { PreferencesController } from './preferences-controller';
+
+/**
+ * Sets the {@code forgottenPassword} state property
+ *
+ * @param forgottenPassword - whether or not the user has forgotten their password
+ */
+export type PreferencesControllerSetPasswordForgottenAction = {
+  type: `PreferencesController:setPasswordForgotten`;
+  handler: PreferencesController['setPasswordForgotten'];
+};
+
+/**
+ * Setter for the `usePhishDetect` property
+ *
+ * @param val - Whether or not the user prefers phishing domain protection
+ */
+export type PreferencesControllerSetUsePhishDetectAction = {
+  type: `PreferencesController:setUsePhishDetect`;
+  handler: PreferencesController['setUsePhishDetect'];
+};
+
+/**
+ * Setter for the `useMultiAccountBalanceChecker` property
+ *
+ * @param val - Whether or not the user prefers to turn off/on all security settings
+ */
+export type PreferencesControllerSetUseMultiAccountBalanceCheckerAction = {
+  type: `PreferencesController:setUseMultiAccountBalanceChecker`;
+  handler: PreferencesController['setUseMultiAccountBalanceChecker'];
+};
+
+/**
+ * Setter for the `useSafeChainsListValidation` property
+ *
+ * @param val - Whether or not the user prefers to turn off/on validation for manually adding networks
+ */
+export type PreferencesControllerSetUseSafeChainsListValidationAction = {
+  type: `PreferencesController:setUseSafeChainsListValidation`;
+  handler: PreferencesController['setUseSafeChainsListValidation'];
+};
+
+export type PreferencesControllerToggleExternalServicesAction = {
+  type: `PreferencesController:toggleExternalServices`;
+  handler: PreferencesController['toggleExternalServices'];
+};
+
+/**
+ * Setter for the `useTokenDetection` property
+ *
+ * @param val - Whether or not the user prefers to use the static token list or dynamic token list from the API
+ */
+export type PreferencesControllerSetUseTokenDetectionAction = {
+  type: `PreferencesController:setUseTokenDetection`;
+  handler: PreferencesController['setUseTokenDetection'];
+};
+
+/**
+ * Setter for the `useNftDetection` property
+ *
+ * @param useNftDetection - Whether or not the user prefers to autodetect NFTs.
+ */
+export type PreferencesControllerSetUseNftDetectionAction = {
+  type: `PreferencesController:setUseNftDetection`;
+  handler: PreferencesController['setUseNftDetection'];
+};
+
+/**
+ * Setter for the `use4ByteResolution` property
+ *
+ * @param use4ByteResolution - (Privacy) Whether or not the user prefers to have smart contract name details resolved with 4byte.directory
+ */
+export type PreferencesControllerSetUse4ByteResolutionAction = {
+  type: `PreferencesController:setUse4ByteResolution`;
+  handler: PreferencesController['setUse4ByteResolution'];
+};
+
+/**
+ * Setter for the `useCurrencyRateCheck` property
+ *
+ * @param val - Whether or not the user prefers to use currency rate check for ETH and tokens.
+ */
+export type PreferencesControllerSetUseCurrencyRateCheckAction = {
+  type: `PreferencesController:setUseCurrencyRateCheck`;
+  handler: PreferencesController['setUseCurrencyRateCheck'];
+};
+
+/**
+ * Setter for the `openSeaEnabled` property
+ *
+ * @param openSeaEnabled - Whether or not the user prefers to use the OpenSea API for NFTs data.
+ */
+export type PreferencesControllerSetOpenSeaEnabledAction = {
+  type: `PreferencesController:setOpenSeaEnabled`;
+  handler: PreferencesController['setOpenSeaEnabled'];
+};
+
+/**
+ * Setter for the `securityAlertsEnabled` property
+ *
+ * @param securityAlertsEnabled - Whether or not the user prefers to use the security alerts.
+ */
+export type PreferencesControllerSetSecurityAlertsEnabledAction = {
+  type: `PreferencesController:setSecurityAlertsEnabled`;
+  handler: PreferencesController['setSecurityAlertsEnabled'];
+};
+
+/**
+ * Setter for the `addSnapAccountEnabled` property.
+ *
+ * @param addSnapAccountEnabled - Whether or not the user wants to
+ * enable the "Add Snap accounts" button.
+ */
+export type PreferencesControllerSetAddSnapAccountEnabledAction = {
+  type: `PreferencesController:setAddSnapAccountEnabled`;
+  handler: PreferencesController['setAddSnapAccountEnabled'];
+};
+
+/**
+ * Setter for the `watchEthereumAccountEnabled` property.
+ *
+ * @param watchEthereumAccountEnabled - Whether or not the user wants to
+ * enable the "Watch Ethereum account (Beta)" button.
+ */
+export type PreferencesControllerSetWatchEthereumAccountEnabledAction = {
+  type: `PreferencesController:setWatchEthereumAccountEnabled`;
+  handler: PreferencesController['setWatchEthereumAccountEnabled'];
+};
+
+/**
+ * Setter for the `useExternalNameSources` property
+ *
+ * @param useExternalNameSources - Whether or not to use external name providers in the name controller.
+ */
+export type PreferencesControllerSetUseExternalNameSourcesAction = {
+  type: `PreferencesController:setUseExternalNameSources`;
+  handler: PreferencesController['setUseExternalNameSources'];
+};
+
+/**
+ * Setter for the `useTransactionSimulations` property
+ *
+ * @param useTransactionSimulations - Whether or not to use simulations in the transaction confirmations.
+ */
+export type PreferencesControllerSetUseTransactionSimulationsAction = {
+  type: `PreferencesController:setUseTransactionSimulations`;
+  handler: PreferencesController['setUseTransactionSimulations'];
+};
+
+/**
+ * Setter for the `advancedGasFee` property
+ *
+ * @param options
+ * @param options.chainId - The chainId the advancedGasFees should be set on
+ * @param options.gasFeePreferences - The advancedGasFee options to set
+ */
+export type PreferencesControllerSetAdvancedGasFeeAction = {
+  type: `PreferencesController:setAdvancedGasFee`;
+  handler: PreferencesController['setAdvancedGasFee'];
+};
+
+/**
+ * Setter for the `theme` property
+ *
+ * @param val - 'default' or 'dark' value based on the mode selected by user.
+ */
+export type PreferencesControllerSetThemeAction = {
+  type: `PreferencesController:setTheme`;
+  handler: PreferencesController['setTheme'];
+};
+
+/**
+ * Add new methodData to state, to avoid requesting this information again through Infura
+ *
+ * @param fourBytePrefix - Four-byte method signature
+ * @param methodData - Corresponding data method
+ */
+export type PreferencesControllerAddKnownMethodDataAction = {
+  type: `PreferencesController:addKnownMethodData`;
+  handler: PreferencesController['addKnownMethodData'];
+};
+
+/**
+ * Setter for the `currentLocale` property
+ *
+ * @param key - he preferred language locale key
+ */
+export type PreferencesControllerSetCurrentLocaleAction = {
+  type: `PreferencesController:setCurrentLocale`;
+  handler: PreferencesController['setCurrentLocale'];
+};
+
+/**
+ * Sets a custom label for an account
+ *
+ * @deprecated - Use setAccountName from the AccountsController
+ * @param address - the account to set a label for
+ * @param label - the custom label for the account
+ * @returns the account label
+ */
+export type PreferencesControllerSetAccountLabelAction = {
+  type: `PreferencesController:setAccountLabel`;
+  handler: PreferencesController['setAccountLabel'];
+};
+
+/**
+ * Updates the `featureFlags` property, which is an object. One property within that object will be set to a boolean.
+ *
+ * @param feature - A key that corresponds to a UI feature.
+ * @param activated - Indicates whether or not the UI feature should be displayed
+ * @returns the updated featureFlags object.
+ */
+export type PreferencesControllerSetFeatureFlagAction = {
+  type: `PreferencesController:setFeatureFlag`;
+  handler: PreferencesController['setFeatureFlag'];
+};
+
+/**
+ * Updates the `preferences` property, which is an object. These are user-controlled features
+ * found in the settings page.
+ *
+ * @param preference - The preference to enable or disable.
+ * @param value - Indicates whether or not the preference should be enabled or disabled.
+ * @returns Promises a updated Preferences object.
+ */
+export type PreferencesControllerSetPreferenceAction = {
+  type: `PreferencesController:setPreference`;
+  handler: PreferencesController['setPreference'];
+};
+
+/**
+ * A getter for the `preferences` property
+ *
+ * @returns A map of user-selected preferences.
+ */
+export type PreferencesControllerGetPreferencesAction = {
+  type: `PreferencesController:getPreferences`;
+  handler: PreferencesController['getPreferences'];
+};
+
+/**
+ * A getter for the `ipfsGateway` property
+ *
+ * @returns The current IPFS gateway domain
+ */
+export type PreferencesControllerGetIpfsGatewayAction = {
+  type: `PreferencesController:getIpfsGateway`;
+  handler: PreferencesController['getIpfsGateway'];
+};
+
+/**
+ * A setter for the `ipfsGateway` property
+ *
+ * @param domain - The new IPFS gateway domain
+ * @returns the update IPFS gateway domain
+ */
+export type PreferencesControllerSetIpfsGatewayAction = {
+  type: `PreferencesController:setIpfsGateway`;
+  handler: PreferencesController['setIpfsGateway'];
+};
+
+/**
+ * A setter for the `isIpfsGatewayEnabled` property
+ *
+ * @param enabled - Whether or not IPFS is enabled
+ */
+export type PreferencesControllerSetIsIpfsGatewayEnabledAction = {
+  type: `PreferencesController:setIsIpfsGatewayEnabled`;
+  handler: PreferencesController['setIsIpfsGatewayEnabled'];
+};
+
+/**
+ * A setter for the `useAddressBarEnsResolution` property
+ *
+ * @param useAddressBarEnsResolution - Whether or not user prefers IPFS resolution for domains
+ */
+export type PreferencesControllerSetUseAddressBarEnsResolutionAction = {
+  type: `PreferencesController:setUseAddressBarEnsResolution`;
+  handler: PreferencesController['setUseAddressBarEnsResolution'];
+};
+
+/**
+ * A setter for the `ledgerTransportType` property.
+ *
+ * @deprecated We no longer support specifying a ledger transport type other
+ * than webhid, therefore managing a preference is no longer necessary.
+ * @param ledgerTransportType - 'webhid'
+ * @returns The transport type that was set.
+ */
+export type PreferencesControllerSetLedgerTransportPreferenceAction = {
+  type: `PreferencesController:setLedgerTransportPreference`;
+  handler: PreferencesController['setLedgerTransportPreference'];
+};
+
+/**
+ * A setter for the user preference to dismiss the seed phrase backup reminder
+ *
+ * @param dismissSeedBackUpReminder - User preference for dismissing the back up reminder.
+ */
+export type PreferencesControllerSetDismissSeedBackUpReminderAction = {
+  type: `PreferencesController:setDismissSeedBackUpReminder`;
+  handler: PreferencesController['setDismissSeedBackUpReminder'];
+};
+
+/**
+ * A setter for the user preference to override the Content-Security-Policy header
+ *
+ * @param overrideContentSecurityPolicyHeader - User preference for overriding the Content-Security-Policy header.
+ */
+export type PreferencesControllerSetOverrideContentSecurityPolicyHeaderAction =
+  {
+    type: `PreferencesController:setOverrideContentSecurityPolicyHeader`;
+    handler: PreferencesController['setOverrideContentSecurityPolicyHeader'];
+  };
+
+/**
+ * A setter for the user preference to manage institutional wallets
+ *
+ * @param manageInstitutionalWallets - User preference for managing institutional wallets.
+ */
+export type PreferencesControllerSetManageInstitutionalWalletsAction = {
+  type: `PreferencesController:setManageInstitutionalWallets`;
+  handler: PreferencesController['setManageInstitutionalWallets'];
+};
+
+export type PreferencesControllerSetServiceWorkerKeepAlivePreferenceAction = {
+  type: `PreferencesController:setServiceWorkerKeepAlivePreference`;
+  handler: PreferencesController['setServiceWorkerKeepAlivePreference'];
+};
+
+export type PreferencesControllerSetUseSidePanelAsDefaultAction = {
+  type: `PreferencesController:setUseSidePanelAsDefault`;
+  handler: PreferencesController['setUseSidePanelAsDefault'];
+};
+
+export type PreferencesControllerSetShowDefaultAddressAction = {
+  type: `PreferencesController:setShowDefaultAddress`;
+  handler: PreferencesController['setShowDefaultAddress'];
+};
+
+export type PreferencesControllerSetDefaultAddressScopeAction = {
+  type: `PreferencesController:setDefaultAddressScope`;
+  handler: PreferencesController['setDefaultAddressScope'];
+};
+
+export type PreferencesControllerSetSnapsAddSnapAccountModalDismissedAction = {
+  type: `PreferencesController:setSnapsAddSnapAccountModalDismissed`;
+  handler: PreferencesController['setSnapsAddSnapAccountModalDismissed'];
+};
+
+/**
+ * Resets the preferences state to the default values.
+ * This is used when the wallet is reset during the "Forgot Password" flow.
+ */
+export type PreferencesControllerResetStateAction = {
+  type: `PreferencesController:resetState`;
+  handler: PreferencesController['resetState'];
+};
+
+export type PreferencesControllerAddReferralApprovedAccountAction = {
+  type: `PreferencesController:addReferralApprovedAccount`;
+  handler: PreferencesController['addReferralApprovedAccount'];
+};
+
+export type PreferencesControllerAddReferralPassedAccountAction = {
+  type: `PreferencesController:addReferralPassedAccount`;
+  handler: PreferencesController['addReferralPassedAccount'];
+};
+
+export type PreferencesControllerAddReferralDeclinedAccountAction = {
+  type: `PreferencesController:addReferralDeclinedAccount`;
+  handler: PreferencesController['addReferralDeclinedAccount'];
+};
+
+export type PreferencesControllerRemoveReferralDeclinedAccountAction = {
+  type: `PreferencesController:removeReferralDeclinedAccount`;
+  handler: PreferencesController['removeReferralDeclinedAccount'];
+};
+
+export type PreferencesControllerSetAccountsReferralApprovedAction = {
+  type: `PreferencesController:setAccountsReferralApproved`;
+  handler: PreferencesController['setAccountsReferralApproved'];
+};
+
+/**
+ * Union of all PreferencesController action types.
+ */
+export type PreferencesControllerMethodActions =
+  | PreferencesControllerSetPasswordForgottenAction
+  | PreferencesControllerSetUsePhishDetectAction
+  | PreferencesControllerSetUseMultiAccountBalanceCheckerAction
+  | PreferencesControllerSetUseSafeChainsListValidationAction
+  | PreferencesControllerToggleExternalServicesAction
+  | PreferencesControllerSetUseTokenDetectionAction
+  | PreferencesControllerSetUseNftDetectionAction
+  | PreferencesControllerSetUse4ByteResolutionAction
+  | PreferencesControllerSetUseCurrencyRateCheckAction
+  | PreferencesControllerSetOpenSeaEnabledAction
+  | PreferencesControllerSetSecurityAlertsEnabledAction
+  | PreferencesControllerSetAddSnapAccountEnabledAction
+  | PreferencesControllerSetWatchEthereumAccountEnabledAction
+  | PreferencesControllerSetUseExternalNameSourcesAction
+  | PreferencesControllerSetUseTransactionSimulationsAction
+  | PreferencesControllerSetAdvancedGasFeeAction
+  | PreferencesControllerSetThemeAction
+  | PreferencesControllerAddKnownMethodDataAction
+  | PreferencesControllerSetCurrentLocaleAction
+  | PreferencesControllerSetAccountLabelAction
+  | PreferencesControllerSetFeatureFlagAction
+  | PreferencesControllerSetPreferenceAction
+  | PreferencesControllerGetPreferencesAction
+  | PreferencesControllerGetIpfsGatewayAction
+  | PreferencesControllerSetIpfsGatewayAction
+  | PreferencesControllerSetIsIpfsGatewayEnabledAction
+  | PreferencesControllerSetUseAddressBarEnsResolutionAction
+  | PreferencesControllerSetLedgerTransportPreferenceAction
+  | PreferencesControllerSetDismissSeedBackUpReminderAction
+  | PreferencesControllerSetOverrideContentSecurityPolicyHeaderAction
+  | PreferencesControllerSetManageInstitutionalWalletsAction
+  | PreferencesControllerSetServiceWorkerKeepAlivePreferenceAction
+  | PreferencesControllerSetUseSidePanelAsDefaultAction
+  | PreferencesControllerSetShowDefaultAddressAction
+  | PreferencesControllerSetDefaultAddressScopeAction
+  | PreferencesControllerSetSnapsAddSnapAccountModalDismissedAction
+  | PreferencesControllerResetStateAction
+  | PreferencesControllerAddReferralApprovedAccountAction
+  | PreferencesControllerAddReferralPassedAccountAction
+  | PreferencesControllerAddReferralDeclinedAccountAction
+  | PreferencesControllerRemoveReferralDeclinedAccountAction
+  | PreferencesControllerSetAccountsReferralApprovedAction;

--- a/app/scripts/controllers/preferences-controller.ts
+++ b/app/scripts/controllers/preferences-controller.ts
@@ -20,6 +20,7 @@ import {
 import { type DefaultAddressScope } from '../../../shared/constants/default-address';
 import { DefiReferralPartner } from '../../../shared/constants/defi-referrals';
 import { FALLBACK_LOCALE } from '../../../shared/lib/i18n';
+import { PreferencesControllerMethodActions } from './preferences-controller-method-action-types';
 
 /**
  * Referral status for an account
@@ -43,7 +44,9 @@ export type PreferencesControllerGetStateAction = ControllerGetStateAction<
 /**
  * Actions exposed by the {@link PreferencesController}.
  */
-export type PreferencesControllerActions = PreferencesControllerGetStateAction;
+export type PreferencesControllerActions =
+  | PreferencesControllerGetStateAction
+  | PreferencesControllerMethodActions;
 
 /**
  * Event emitted when the state of the {@link PreferencesController} changes.
@@ -443,6 +446,51 @@ const controllerMetadata: StateMetadata<PreferencesControllerState> = {
   },
 };
 
+const MESSENGER_EXPOSED_METHODS = [
+  'setPasswordForgotten',
+  'setUsePhishDetect',
+  'setUseMultiAccountBalanceChecker',
+  'setUseSafeChainsListValidation',
+  'toggleExternalServices',
+  'setUseTokenDetection',
+  'setUseNftDetection',
+  'setUse4ByteResolution',
+  'setUseCurrencyRateCheck',
+  'setOpenSeaEnabled',
+  'setSecurityAlertsEnabled',
+  'setAddSnapAccountEnabled',
+  'setWatchEthereumAccountEnabled',
+  'setUseExternalNameSources',
+  'setUseTransactionSimulations',
+  'setAdvancedGasFee',
+  'setTheme',
+  'addKnownMethodData',
+  'setCurrentLocale',
+  'setAccountLabel',
+  'setFeatureFlag',
+  'setPreference',
+  'getPreferences',
+  'getIpfsGateway',
+  'setIpfsGateway',
+  'setIsIpfsGatewayEnabled',
+  'setUseAddressBarEnsResolution',
+  'setLedgerTransportPreference',
+  'setDismissSeedBackUpReminder',
+  'setOverrideContentSecurityPolicyHeader',
+  'setManageInstitutionalWallets',
+  'setServiceWorkerKeepAlivePreference',
+  'setUseSidePanelAsDefault',
+  'setShowDefaultAddress',
+  'setDefaultAddressScope',
+  'setSnapsAddSnapAccountModalDismissed',
+  'resetState',
+  'addReferralApprovedAccount',
+  'addReferralPassedAccount',
+  'addReferralDeclinedAccount',
+  'removeReferralDeclinedAccount',
+  'setAccountsReferralApproved',
+] as const;
+
 export class PreferencesController extends BaseController<
   typeof controllerName,
   PreferencesControllerState,
@@ -486,6 +534,11 @@ export class PreferencesController extends BaseController<
     globalThis.setPreference = (key: keyof Preferences, value: boolean) => {
       return this.setFeatureFlag(key, value);
     };
+
+    this.messenger.registerMethodActionHandlers(
+      this,
+      MESSENGER_EXPOSED_METHODS,
+    );
   }
 
   /**

--- a/app/scripts/messenger-client-init/messengers/index.ts
+++ b/app/scripts/messenger-client-init/messengers/index.ts
@@ -310,7 +310,6 @@ export {
 } from './name-controller-messenger';
 export type { OnboardingControllerMessenger } from './onboarding-controller-messenger';
 export { getOnboardingControllerMessenger } from './onboarding-controller-messenger';
-export type { PreferencesControllerMessenger } from './preferences-controller-messenger';
 export { getPreferencesControllerMessenger } from './preferences-controller-messenger';
 export type {
   PermissionControllerMessenger,

--- a/app/scripts/messenger-client-init/messengers/preferences-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/preferences-controller-messenger.ts
@@ -1,11 +1,10 @@
-import { Messenger } from '@metamask/messenger';
-import { AllowedActions } from '../../controllers/preferences-controller';
+import {
+  Messenger,
+  MessengerActions,
+  MessengerEvents,
+} from '@metamask/messenger';
+import { PreferencesControllerMessenger } from '../../controllers/preferences-controller';
 import { RootMessenger } from '../../lib/messenger';
-
-export type PreferencesControllerMessenger = ReturnType<
-  typeof getPreferencesControllerMessenger
->;
-
 /**
  * Create a messenger with delegated actions and events of the
  * preferences controller.
@@ -14,17 +13,16 @@ export type PreferencesControllerMessenger = ReturnType<
  * @returns The controller messenger.
  */
 export function getPreferencesControllerMessenger(
-  messenger: RootMessenger<AllowedActions>,
+  messenger: RootMessenger<
+    MessengerActions<PreferencesControllerMessenger>,
+    MessengerEvents<PreferencesControllerMessenger>
+  >,
 ) {
-  const preferencesControllerMessenger = new Messenger<
-    'PreferencesController',
-    AllowedActions,
-    never,
-    typeof messenger
-  >({
-    namespace: 'PreferencesController',
-    parent: messenger,
-  });
+  const preferencesControllerMessenger: PreferencesControllerMessenger =
+    new Messenger({
+      namespace: 'PreferencesController',
+      parent: messenger,
+    });
   messenger.delegate({
     messenger: preferencesControllerMessenger,
     actions: [

--- a/app/scripts/messenger-client-init/preferences-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/preferences-controller-init.test.ts
@@ -1,11 +1,11 @@
-import { PreferencesController } from '../controllers/preferences-controller';
+import {
+  PreferencesController,
+  PreferencesControllerMessenger,
+} from '../controllers/preferences-controller';
 import { getRootMessenger } from '../lib/messenger';
 import { ControllerInitRequest } from './types';
 import { buildControllerInitRequestMock } from './test/utils';
-import {
-  getPreferencesControllerMessenger,
-  PreferencesControllerMessenger,
-} from './messengers';
+import { getPreferencesControllerMessenger } from './messengers';
 import { PreferencesControllerInit } from './preferences-controller-init';
 
 jest.mock('../controllers/preferences-controller');


### PR DESCRIPTION
## **Description**

This PR updates the `PreferencesController` to use `registerMethodActionHandlers` and `MESSENGER_EXPOSED_METHODS` to register actions.



## **Changelog**

CHANGELOG entry:null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how `PreferencesController` exposes and types messenger actions; a mismatch in the generated action types or `MESSENGER_EXPOSED_METHODS` list could break IPC calls at runtime or during initialization.
> 
> **Overview**
> **Refactors `PreferencesController` messenger action exposure to use bulk registration.** The controller now defines a `MESSENGER_EXPOSED_METHODS` allowlist and calls `messenger.registerMethodActionHandlers` to register handlers in one place.
> 
> Adds an auto-generated `preferences-controller-method-action-types.ts` and expands `PreferencesControllerActions` to include these method action types, updating the preferences controller messenger wiring/types and adjusting the init test imports accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd5065bf92523c2c675e94300fd48e99672a193c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->