### PR TITLE
chore: Bulk register actions in `OAuthService`

### DIFF
--- a/app/scripts/messenger-client-init/controller-list.ts
+++ b/app/scripts/messenger-client-init/controller-list.ts
@@ -95,7 +95,7 @@ import OnboardingController from '../controllers/onboarding';
 import { PreferencesController } from '../controllers/preferences-controller';
 import { InstitutionalSnapController } from '../controllers/institutional-snap/InstitutionalSnapController';
 import { NetworkOrderController } from '../controllers/network-order';
-import OAuthService from '../services/oauth/oauth-service';
+import { OAuthService } from '../services/oauth/oauth-service';
 import MetaMetricsController from '../controllers/metametrics-controller';
 import { SnapsNameProvider } from '../lib/SnapsNameProvider';
 import { AppStateController } from '../controllers/app-state-controller';

--- a/app/scripts/messenger-client-init/messengers/seedless-onboarding/index.ts
+++ b/app/scripts/messenger-client-init/messengers/seedless-onboarding/index.ts
@@ -1,5 +1,4 @@
 export { getOAuthServiceMessenger } from './oauth-service-messenger';
-export type { OAuthServiceMessenger } from './oauth-service-messenger';
 export {
   getSeedlessOnboardingControllerMessenger,
   getSeedlessOnboardingControllerInitMessenger,

--- a/app/scripts/messenger-client-init/messengers/seedless-onboarding/oauth-service-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/seedless-onboarding/oauth-service-messenger.ts
@@ -1,11 +1,10 @@
-import { Messenger } from '@metamask/messenger';
-import { OAuthServiceAction } from '../../../services/oauth/types';
+import {
+  Messenger,
+  MessengerActions,
+  MessengerEvents,
+} from '@metamask/messenger';
+import { OAuthServiceMessenger } from '../../../services/oauth/types';
 import { RootMessenger } from '../../../lib/messenger';
-import { OnboardingControllerGetStateAction } from '../../../controllers/onboarding';
-
-type AllowedActions = OAuthServiceAction | OnboardingControllerGetStateAction;
-
-export type OAuthServiceMessenger = ReturnType<typeof getOAuthServiceMessenger>;
 
 /**
  * Get a restricted messenger for the OAuthService. This is scoped to the
@@ -15,14 +14,12 @@ export type OAuthServiceMessenger = ReturnType<typeof getOAuthServiceMessenger>;
  * @returns The restricted messenger.
  */
 export function getOAuthServiceMessenger(
-  messenger: RootMessenger<AllowedActions, never>,
+  messenger: RootMessenger<
+    MessengerActions<OAuthServiceMessenger>,
+    MessengerEvents<OAuthServiceMessenger>
+  >,
 ) {
-  const oauthMessenger = new Messenger<
-    'OAuthService',
-    AllowedActions,
-    never,
-    typeof messenger
-  >({
+  const oauthMessenger: OAuthServiceMessenger = new Messenger({
     namespace: 'OAuthService',
     parent: messenger,
   });

--- a/app/scripts/messenger-client-init/seedless-onboarding/oauth-service-init.test.ts
+++ b/app/scripts/messenger-client-init/seedless-onboarding/oauth-service-init.test.ts
@@ -1,12 +1,10 @@
 import { ControllerInitRequest } from '../types';
-import {
-  getOAuthServiceMessenger,
-  OAuthServiceMessenger,
-} from '../messengers/seedless-onboarding';
+import { getOAuthServiceMessenger } from '../messengers/seedless-onboarding';
 import { getRootMessenger } from '../../lib/messenger';
 import { buildControllerInitRequestMock } from '../test/utils';
-import OAuthService from '../../services/oauth/oauth-service';
+import { OAuthService } from '../../services/oauth/oauth-service';
 import { OAuthServiceInit } from './oauth-service-init';
+import { OAuthServiceMessenger } from '../../services/oauth/types';
 
 function buildInitRequestMock(): jest.Mocked<
   ControllerInitRequest<OAuthServiceMessenger>

--- a/app/scripts/messenger-client-init/seedless-onboarding/oauth-service-init.test.ts
+++ b/app/scripts/messenger-client-init/seedless-onboarding/oauth-service-init.test.ts
@@ -3,8 +3,8 @@ import { getOAuthServiceMessenger } from '../messengers/seedless-onboarding';
 import { getRootMessenger } from '../../lib/messenger';
 import { buildControllerInitRequestMock } from '../test/utils';
 import { OAuthService } from '../../services/oauth/oauth-service';
-import { OAuthServiceInit } from './oauth-service-init';
 import { OAuthServiceMessenger } from '../../services/oauth/types';
+import { OAuthServiceInit } from './oauth-service-init';
 
 function buildInitRequestMock(): jest.Mocked<
   ControllerInitRequest<OAuthServiceMessenger>

--- a/app/scripts/messenger-client-init/seedless-onboarding/oauth-service-init.ts
+++ b/app/scripts/messenger-client-init/seedless-onboarding/oauth-service-init.ts
@@ -1,8 +1,8 @@
 import { ControllerInitFunction } from '../types';
-import OAuthService from '../../services/oauth/oauth-service';
-import { OAuthServiceMessenger } from '../messengers/seedless-onboarding';
+import { OAuthService } from '../../services/oauth/oauth-service';
 import { webAuthenticatorFactory } from '../../services/oauth/web-authenticator-factory';
 import MetaMetricsController from '../../controllers/metametrics-controller';
+import { OAuthServiceMessenger } from '../../services/oauth/types';
 
 export const OAuthServiceInit: ControllerInitFunction<
   OAuthService,

--- a/app/scripts/services/oauth/oauth-service-method-action-types.ts
+++ b/app/scripts/services/oauth/oauth-service-method-action-types.ts
@@ -1,0 +1,63 @@
+/**
+ * This file is auto generated.
+ * Do not edit manually.
+ */
+
+import type { OAuthService } from './oauth-service';
+
+/**
+ * Start the OAuth login process for the given social login type.
+ *
+ * @param authConnection - The social login type to login with.
+ * @returns The login result.
+ */
+export type OAuthServiceStartOAuthLoginAction = {
+  type: `OAuthService:startOAuthLogin`;
+  handler: OAuthService['startOAuthLogin'];
+};
+
+/**
+ * Get a new refresh token from the Web3Auth Authentication Server.
+ *
+ * @param options - The options for the get new refresh token.
+ * @param options.connection - The social login type to login with.
+ * @param options.refreshToken - The refresh token to authenticate the refresh request.
+ * @returns The new refresh token.
+ */
+export type OAuthServiceGetNewRefreshTokenAction = {
+  type: `OAuthService:getNewRefreshToken`;
+  handler: OAuthService['getNewRefreshToken'];
+};
+
+/**
+ * Renew the refresh token - get a new refresh token and revoke token.
+ *
+ * @param options - The options for the revoke and get new refresh token.
+ * @param options.connection - The social login type to login with.
+ * @param options.revokeToken - The revoke token to authenticate the request.
+ * @returns The new refresh token and revoke token.
+ */
+export type OAuthServiceRenewRefreshTokenAction = {
+  type: `OAuthService:renewRefreshToken`;
+  handler: OAuthService['renewRefreshToken'];
+};
+
+export type OAuthServiceRevokeRefreshTokenAction = {
+  type: `OAuthService:revokeRefreshToken`;
+  handler: OAuthService['revokeRefreshToken'];
+};
+
+export type OAuthServiceGetMarketingConsentAction = {
+  type: `OAuthService:getMarketingConsent`;
+  handler: OAuthService['getMarketingConsent'];
+};
+
+/**
+ * Union of all OAuthService action types.
+ */
+export type OAuthServiceMethodActions =
+  | OAuthServiceStartOAuthLoginAction
+  | OAuthServiceGetNewRefreshTokenAction
+  | OAuthServiceRenewRefreshTokenAction
+  | OAuthServiceRevokeRefreshTokenAction
+  | OAuthServiceGetMarketingConsentAction;

--- a/app/scripts/services/oauth/oauth-service-method-action-types.ts
+++ b/app/scripts/services/oauth/oauth-service-method-action-types.ts
@@ -47,6 +47,11 @@ export type OAuthServiceRevokeRefreshTokenAction = {
   handler: OAuthService['revokeRefreshToken'];
 };
 
+export type OAuthServiceSetMarketingConsentAction = {
+  type: `OAuthService:setMarketingConsent`;
+  handler: OAuthService['setMarketingConsent'];
+};
+
 export type OAuthServiceGetMarketingConsentAction = {
   type: `OAuthService:getMarketingConsent`;
   handler: OAuthService['getMarketingConsent'];
@@ -60,4 +65,5 @@ export type OAuthServiceMethodActions =
   | OAuthServiceGetNewRefreshTokenAction
   | OAuthServiceRenewRefreshTokenAction
   | OAuthServiceRevokeRefreshTokenAction
+  | OAuthServiceSetMarketingConsentAction
   | OAuthServiceGetMarketingConsentAction;

--- a/app/scripts/services/oauth/oauth-service.test.ts
+++ b/app/scripts/services/oauth/oauth-service.test.ts
@@ -9,7 +9,7 @@ import {
 import { OAuthErrorMessages } from '../../../../shared/lib/error';
 import { ENVIRONMENT } from '../../../../development/build/constants';
 import { OAuthServiceMessenger, WebAuthenticator } from './types';
-import OAuthService from './oauth-service';
+import { OAuthService } from './oauth-service';
 import { createLoginHandler } from './create-login-handler';
 import { loadOAuthConfig } from './config';
 

--- a/app/scripts/services/oauth/oauth-service.ts
+++ b/app/scripts/services/oauth/oauth-service.ts
@@ -33,7 +33,15 @@ import { loadOAuthConfig } from './config';
 const AUTH_SERVER_MARKETING_OPT_IN_STATUS_PATH =
   '/api/v1/oauth/marketing_opt_in_status';
 
-export default class OAuthService {
+const MESSENGER_EXPOSED_METHODS = [
+  'startOAuthLogin',
+  'getNewRefreshToken',
+  'revokeRefreshToken',
+  'renewRefreshToken',
+  'getMarketingConsent',
+] as const;
+
+export class OAuthService {
   // Required for modular initialisation.
   name: ServiceName = SERVICE_NAME;
 
@@ -79,24 +87,9 @@ export default class OAuthService {
     this.#addEventBeforeMetricsOptIn = addEventBeforeMetricsOptIn;
     this.#getParticipateInMetaMetrics = getParticipateInMetaMetrics;
 
-    this.#messenger.registerActionHandler(
-      `${SERVICE_NAME}:startOAuthLogin`,
-      this.startOAuthLogin.bind(this),
-    );
-
-    this.#messenger.registerActionHandler(
-      `${SERVICE_NAME}:getNewRefreshToken`,
-      this.getNewRefreshToken.bind(this),
-    );
-
-    this.#messenger.registerActionHandler(
-      `${SERVICE_NAME}:revokeRefreshToken`,
-      this.revokeRefreshToken.bind(this),
-    );
-
-    this.#messenger.registerActionHandler(
-      `${SERVICE_NAME}:renewRefreshToken`,
-      this.renewRefreshToken.bind(this),
+    this.#messenger.registerMethodActionHandlers(
+      this,
+      MESSENGER_EXPOSED_METHODS,
     );
   }
 

--- a/app/scripts/services/oauth/oauth-service.ts
+++ b/app/scripts/services/oauth/oauth-service.ts
@@ -39,6 +39,7 @@ const MESSENGER_EXPOSED_METHODS = [
   'revokeRefreshToken',
   'renewRefreshToken',
   'getMarketingConsent',
+  'setMarketingConsent',
 ] as const;
 
 export class OAuthService {

--- a/app/scripts/services/oauth/types.ts
+++ b/app/scripts/services/oauth/types.ts
@@ -14,60 +14,25 @@ import type {
   EndTraceRequest,
 } from '../../../../shared/lib/trace';
 import type { OnboardingControllerGetStateAction } from '../../controllers/onboarding';
+import { OAuthServiceMethodActions } from './oauth-service-method-action-types';
 
 export const SERVICE_NAME = 'OAuthService';
 
 export type ServiceName = typeof SERVICE_NAME;
 
-/**
- * Start the OAuth login process for the given social login type.
- */
-export type OAuthServiceStartOAuthLoginAction = {
-  type: `${ServiceName}:startOAuthLogin`;
-  handler: (authConnection: AuthConnection) => Promise<OAuthLoginResult>;
-};
-
-/**
- * Get a new refresh token from the Web3Auth Authentication Server.
- */
-export type OAuthServiceGetNewRefreshTokenAction = {
-  type: `${ServiceName}:getNewRefreshToken`;
-  handler: (options: {
-    connection: AuthConnection;
-    refreshToken: string;
-  }) => Promise<OAuthRefreshTokenResult>;
-};
-
-/**
- * Revoke the current refresh token and get a new refresh token.
- */
-export type OAuthServiceRevokeRefreshTokenAction = {
-  type: `${ServiceName}:revokeRefreshToken`;
-  handler: (options: {
-    connection: AuthConnection;
-    revokeToken: string;
-  }) => Promise<void>;
-};
-
-/**
- * Revoke the current refresh token and get a new refresh token.
- */
-export type OAuthServiceRenewRefreshTokenAction = {
-  type: `${ServiceName}:renewRefreshToken`;
-  handler: (options: {
-    connection: AuthConnection;
-    revokeToken: string;
-  }) => Promise<{ newRevokeToken: string; newRefreshToken: string }>;
-};
+export type {
+  OAuthServiceStartOAuthLoginAction,
+  OAuthServiceGetNewRefreshTokenAction,
+  OAuthServiceRenewRefreshTokenAction,
+  OAuthServiceRevokeRefreshTokenAction,
+  OAuthServiceGetMarketingConsentAction,
+} from './oauth-service-method-action-types';
 
 /**
  * All possible actions for the OAuthService.
  */
 export type OAuthServiceAction =
-  | OAuthServiceStartOAuthLoginAction
-  | OAuthServiceGetNewRefreshTokenAction
-  | OAuthServiceRevokeRefreshTokenAction
-  | OAuthServiceRenewRefreshTokenAction
+  | OAuthServiceMethodActions
   | SeedlessOnboardingControllerGetStateAction
   | SeedlessOnboardingControllerGetAccessTokenAction
   | OnboardingControllerGetStateAction;

--- a/app/scripts/services/oauth/types.ts
+++ b/app/scripts/services/oauth/types.ts
@@ -26,6 +26,7 @@ export type {
   OAuthServiceRenewRefreshTokenAction,
   OAuthServiceRevokeRefreshTokenAction,
   OAuthServiceGetMarketingConsentAction,
+  OAuthServiceSetMarketingConsentAction,
 } from './oauth-service-method-action-types';
 
 /**


### PR DESCRIPTION
## **Description**

This PR updates the `OAuthService` to use `registerMethodActionHandlers` and `MESSENGER_EXPOSED_METHODS` to register actions.

## **Changelog**

CHANGELOG entry:null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches `OAuthService` action registration and exported types in a login/token-flow area; mistakes could break messenger wiring for OAuth calls at runtime. No business logic changes to token exchange itself, so impact is mostly around initialization/type safety.
> 
> **Overview**
> Refactors `OAuthService` to bulk-register its messenger actions via `registerMethodActionHandlers` using a single `MESSENGER_EXPOSED_METHODS` allowlist instead of per-method `registerActionHandler` calls.
> 
> Introduces an auto-generated `oauth-service-method-action-types.ts` and updates `types.ts`, seedless onboarding messenger setup, and init/tests to use the new method-action types plus a named `OAuthService` export (removing the old default export and redundant messenger type re-exports).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b3c3a8232c0ee7cb7f2593da88a0795fe75bb63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->