### PR TITLE
chore: Bulk register actions in `SubscriptionService`

### DIFF
--- a/app/scripts/messenger-client-init/messengers/subscription/index.ts
+++ b/app/scripts/messenger-client-init/messengers/subscription/index.ts
@@ -1,6 +1,5 @@
 export {
   getSubscriptionControllerMessenger,
-  type SubscriptionControllerMessenger,
   getSubscriptionControllerInitMessenger,
   type SubscriptionControllerInitMessenger,
 } from './subscription-controller-messenger';

--- a/app/scripts/messenger-client-init/messengers/subscription/subscription-service-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/subscription/subscription-service-messenger.ts
@@ -1,8 +1,10 @@
-import { Messenger } from '@metamask/messenger';
-import type { SubscriptionControllerEvents } from '@metamask/subscription-controller';
+import {
+  Messenger,
+  MessengerActions,
+  MessengerEvents,
+} from '@metamask/messenger';
 import {
   SERVICE_NAME,
-  SubscriptionServiceAction,
   SubscriptionServiceMessenger,
 } from '../../../services/subscription/types';
 import { RootMessenger } from '../../../lib/messenger';
@@ -16,16 +18,11 @@ import { RootMessenger } from '../../../lib/messenger';
  */
 export function getSubscriptionServiceMessenger(
   messenger: RootMessenger<
-    SubscriptionServiceAction,
-    SubscriptionControllerEvents
+    MessengerActions<SubscriptionServiceMessenger>,
+    MessengerEvents<SubscriptionServiceMessenger>
   >,
 ): SubscriptionServiceMessenger {
-  const serviceMessenger = new Messenger<
-    'SubscriptionService',
-    SubscriptionServiceAction,
-    SubscriptionControllerEvents,
-    typeof messenger
-  >({
+  const serviceMessenger: SubscriptionServiceMessenger = new Messenger({
     namespace: SERVICE_NAME,
     parent: messenger,
   });

--- a/app/scripts/messenger-client-init/messengers/transaction-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/transaction-controller-messenger.ts
@@ -57,7 +57,7 @@ import {
 } from '@metamask/transaction-pay-controller';
 import { RootMessenger } from '../../lib/messenger';
 import { AppStateControllerGetStateAction } from '../../controllers/app-state-controller';
-import { SubscriptionServiceAction } from '../../services/subscription/types';
+import { SubscriptionServiceSubmitSubscriptionSponsorshipIntentAction } from '../../services/subscription/types';
 import {
   InstitutionalSnapControllerBeforeCheckPendingTransactionHookAction,
   InstitutionalSnapControllerPublishHookAction,
@@ -124,7 +124,7 @@ type InitMessengerActions =
   | NetworkControllerGetNetworkClientByIdAction
   | RemoteFeatureFlagControllerGetStateAction
   | SubscriptionControllerActions
-  | SubscriptionServiceAction
+  | SubscriptionServiceSubmitSubscriptionSponsorshipIntentAction
   | TransactionControllerAddTransactionAction
   | TransactionControllerAddTransactionBatchAction
   | TransactionControllerEstimateGasAction

--- a/app/scripts/messenger-client-init/subscription/subscription-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/subscription/subscription-controller-init.test.ts
@@ -6,13 +6,13 @@ import { ControllerInitRequest } from '../types';
 import {
   getSubscriptionControllerInitMessenger,
   getSubscriptionControllerMessenger,
-  SubscriptionControllerMessenger,
   SubscriptionControllerInitMessenger,
 } from '../messengers/subscription';
 import { getRootMessenger } from '../../lib/messenger';
 import { buildControllerInitRequestMock } from '../test/utils';
 import { ENVIRONMENT } from '../../../../development/build/constants';
 import { SubscriptionControllerInit } from './subscription-controller-init';
+import { SubscriptionControllerMessenger } from '../messengers/subscription/subscription-controller-messenger';
 
 jest.mock('@metamask/subscription-controller');
 

--- a/app/scripts/messenger-client-init/subscription/subscription-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/subscription/subscription-controller-init.test.ts
@@ -11,8 +11,8 @@ import {
 import { getRootMessenger } from '../../lib/messenger';
 import { buildControllerInitRequestMock } from '../test/utils';
 import { ENVIRONMENT } from '../../../../development/build/constants';
-import { SubscriptionControllerInit } from './subscription-controller-init';
 import { SubscriptionControllerMessenger } from '../messengers/subscription/subscription-controller-messenger';
+import { SubscriptionControllerInit } from './subscription-controller-init';
 
 jest.mock('@metamask/subscription-controller');
 

--- a/app/scripts/services/subscription/subscription-service-method-action-types.ts
+++ b/app/scripts/services/subscription/subscription-service-method-action-types.ts
@@ -1,0 +1,60 @@
+/**
+ * This file is auto generated.
+ * Do not edit manually.
+ */
+
+import type { SubscriptionService } from './subscription-service';
+
+export type SubscriptionServiceUpdateSubscriptionCardPaymentMethodAction = {
+  type: `SubscriptionService:updateSubscriptionCardPaymentMethod`;
+  handler: SubscriptionService['updateSubscriptionCardPaymentMethod'];
+};
+
+export type SubscriptionServiceUpdateSubscriptionCryptoPaymentMethodAction = {
+  type: `SubscriptionService:updateSubscriptionCryptoPaymentMethod`;
+  handler: SubscriptionService['updateSubscriptionCryptoPaymentMethod'];
+};
+
+export type SubscriptionServiceStartSubscriptionWithCardAction = {
+  type: `SubscriptionService:startSubscriptionWithCard`;
+  handler: SubscriptionService['startSubscriptionWithCard'];
+};
+
+/**
+ * Handles the shield subscription approval transaction after confirm
+ *
+ * @param txMeta - The transaction metadata.
+ * @returns Promise<void> - resolves when the transaction is submitted successfully.
+ */
+export type SubscriptionServiceHandlePostTransactionAction = {
+  type: `SubscriptionService:handlePostTransaction`;
+  handler: SubscriptionService['handlePostTransaction'];
+};
+
+export type SubscriptionServiceSubmitSubscriptionSponsorshipIntentAction = {
+  type: `SubscriptionService:submitSubscriptionSponsorshipIntent`;
+  handler: SubscriptionService['submitSubscriptionSponsorshipIntent'];
+};
+
+/**
+ * Link the reward to the existing shield subscription.
+ *
+ * @param subscriptionId - Shield subscription ID to link the reward to.
+ * @param rewardPoints - The reward points.
+ * @returns Promise<void> - The reward subscription ID or undefined if the season is not active or the primary account is not opted in to rewards.
+ */
+export type SubscriptionServiceLinkRewardToExistingSubscriptionAction = {
+  type: `SubscriptionService:linkRewardToExistingSubscription`;
+  handler: SubscriptionService['linkRewardToExistingSubscription'];
+};
+
+/**
+ * Union of all SubscriptionService action types.
+ */
+export type SubscriptionServiceMethodActions =
+  | SubscriptionServiceUpdateSubscriptionCardPaymentMethodAction
+  | SubscriptionServiceUpdateSubscriptionCryptoPaymentMethodAction
+  | SubscriptionServiceStartSubscriptionWithCardAction
+  | SubscriptionServiceHandlePostTransactionAction
+  | SubscriptionServiceSubmitSubscriptionSponsorshipIntentAction
+  | SubscriptionServiceLinkRewardToExistingSubscriptionAction;

--- a/app/scripts/services/subscription/subscription-service.ts
+++ b/app/scripts/services/subscription/subscription-service.ts
@@ -43,15 +43,23 @@ import {
   SHIELD_ERROR,
 } from '../../../../shared/lib/shield';
 import {
-  SubscriptionServiceAction,
-  SubscriptionServiceEvent,
   SubscriptionServiceOptions,
   SERVICE_NAME,
   ServiceName,
+  SubscriptionServiceMessenger,
 } from './types';
 
 const SUBSCRIPTION_POLL_INTERVAL = 5 * SECOND;
 const SUBSCRIPTION_POLL_TIMEOUT = 60 * SECOND;
+
+const MESSENGER_EXPOSED_METHODS = [
+  'updateSubscriptionCardPaymentMethod',
+  'updateSubscriptionCryptoPaymentMethod',
+  'startSubscriptionWithCard',
+  'handlePostTransaction',
+  'submitSubscriptionSponsorshipIntent',
+  'linkRewardToExistingSubscription',
+] as const;
 
 export class SubscriptionService {
   // Required for modular initialisation.
@@ -59,11 +67,7 @@ export class SubscriptionService {
 
   state = null;
 
-  #messenger: Messenger<
-    typeof SERVICE_NAME,
-    SubscriptionServiceAction,
-    SubscriptionServiceEvent
-  >;
+  #messenger: SubscriptionServiceMessenger;
 
   #platform: ExtensionPlatform;
 
@@ -78,16 +82,16 @@ export class SubscriptionService {
     this.#platform = platform;
     this.#webAuthenticator = webAuthenticator;
 
-    this.#messenger.registerActionHandler(
-      `${SERVICE_NAME}:submitSubscriptionSponsorshipIntent`,
-      this.submitSubscriptionSponsorshipIntent.bind(this),
+    this.#messenger.registerMethodActionHandlers(
+      this,
+      MESSENGER_EXPOSED_METHODS,
     );
   }
 
   async updateSubscriptionCardPaymentMethod(
     params: Extract<UpdatePaymentMethodOpts, { paymentType: 'card' }>,
     currentTabId?: number,
-  ) {
+  ): Promise<Subscription[]> {
     try {
       const { paymentType } = params;
       if (paymentType !== PAYMENT_TYPES.byCard) {
@@ -144,7 +148,7 @@ export class SubscriptionService {
 
   async updateSubscriptionCryptoPaymentMethod(
     params: Extract<UpdatePaymentMethodOpts, { paymentType: 'crypto' }>,
-  ) {
+  ): Promise<Subscription[]> {
     try {
       const { paymentType } = params;
       if (paymentType !== PAYMENT_TYPES.byCrypto) {

--- a/app/scripts/services/subscription/types.ts
+++ b/app/scripts/services/subscription/types.ts
@@ -37,17 +37,22 @@ import {
   RewardsControllerGetSeasonMetadataAction,
   RewardsControllerGetSeasonStatusAction,
 } from '../../controllers/rewards/rewards-controller-method-action-types';
+import { SubscriptionServiceMethodActions } from './subscription-service-method-action-types';
+
+export type {
+  SubscriptionServiceUpdateSubscriptionCardPaymentMethodAction,
+  SubscriptionServiceUpdateSubscriptionCryptoPaymentMethodAction,
+  SubscriptionServiceStartSubscriptionWithCardAction,
+  SubscriptionServiceHandlePostTransactionAction,
+  SubscriptionServiceSubmitSubscriptionSponsorshipIntentAction,
+  SubscriptionServiceLinkRewardToExistingSubscriptionAction,
+} from './subscription-service-method-action-types';
 
 export const SERVICE_NAME = 'SubscriptionService';
 
 export type ServiceName = typeof SERVICE_NAME;
 
-export type SubscriptionServiceSubmitSubscriptionSponsorshipIntentAction = {
-  type: `${ServiceName}:submitSubscriptionSponsorshipIntent`;
-  handler: (txMeta: TransactionMeta) => Promise<void>;
-};
-
-export type SubscriptionServiceAction =
+type AllowedAction =
   | SubscriptionControllerGetPricingAction
   | SubscriptionControllerStartShieldSubscriptionWithCardAction
   | SubscriptionControllerUpdatePaymentMethodAction
@@ -55,7 +60,6 @@ export type SubscriptionServiceAction =
   | SubscriptionControllerGetCryptoApproveTransactionParamsAction
   | SubscriptionControllerGetBillingPortalUrlAction
   | SubscriptionControllerSubmitSponsorshipIntentsAction
-  | SubscriptionServiceSubmitSubscriptionSponsorshipIntentAction
   | SubscriptionControllerGetStateAction
   | SubscriptionControllerLinkRewardsAction
   | SubscriptionControllerSubmitShieldSubscriptionCryptoApprovalAction
@@ -82,7 +86,7 @@ export type SubscriptionServiceEvent = never;
 
 export type SubscriptionServiceMessenger = Messenger<
   ServiceName,
-  SubscriptionServiceAction,
+  SubscriptionServiceMethodActions | AllowedAction,
   SubscriptionServiceEvent
 >;
 

--- a/app/scripts/services/subscription/types.ts
+++ b/app/scripts/services/subscription/types.ts
@@ -52,7 +52,7 @@ export const SERVICE_NAME = 'SubscriptionService';
 
 export type ServiceName = typeof SERVICE_NAME;
 
-type AllowedAction =
+type AllowedActions =
   | SubscriptionControllerGetPricingAction
   | SubscriptionControllerStartShieldSubscriptionWithCardAction
   | SubscriptionControllerUpdatePaymentMethodAction
@@ -86,7 +86,7 @@ export type SubscriptionServiceEvent = never;
 
 export type SubscriptionServiceMessenger = Messenger<
   ServiceName,
-  SubscriptionServiceMethodActions | AllowedAction,
+  SubscriptionServiceMethodActions | AllowedActions,
   SubscriptionServiceEvent
 >;
 


### PR DESCRIPTION
## **Description**

This PR updates the `SubscriptionService` to use `registerMethodActionHandlers` and `MESSENGER_EXPOSED_METHODS` to register actions.

## **Changelog**

CHANGELOG entry:null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors how `SubscriptionService` action handlers are registered and how its messenger action types are defined, which could break cross-module messaging if any exposed method list/type unions are incomplete or mismatched.
> 
> **Overview**
> Refactors `SubscriptionService` to register its exposed messenger actions via `registerMethodActionHandlers` using a centralized `MESSENGER_EXPOSED_METHODS` list, instead of manually registering individual action handlers.
> 
> Introduces auto-generated `SubscriptionServiceMethodActions` types and updates messenger/type plumbing (`SubscriptionServiceMessenger`, `getSubscriptionServiceMessenger`, and transaction init messenger action unions) to use `MessengerActions`/`MessengerEvents` and the new specific action types; adjusts a test import due to subscription messenger re-exports changing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fa0fec70bd3bcb9299c20fa1b7861c7db077e56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->