### PR TITLE
chore: upgrade @metamask/design-system-react to v0.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -318,7 +318,7 @@
     "@metamask/delegation-controller": "^2.0.2",
     "@metamask/delegation-core": "^0.2.0-rc.1",
     "@metamask/delegation-deployments": "^1.0.0",
-    "@metamask/design-system-react": "^0.14.0",
+    "@metamask/design-system-react": "^0.16.0",
     "@metamask/design-system-tailwind-preset": "^0.6.1",
     "@metamask/design-tokens": "^8.3.0",
     "@metamask/eip-5792-middleware": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -402,7 +402,7 @@
     "@metamask/transaction-pay-controller": "^19.0.0",
     "@metamask/tron-wallet-snap": "^1.25.1",
     "@metamask/user-operation-controller": "^41.1.0",
-    "@metamask/utils": "^11.10.0",
+    "@metamask/utils": "^11.11.0",
     "@ngraveio/bc-ur": "^1.1.13",
     "@noble/hashes": "^1.3.3",
     "@popperjs/core": "^2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -34206,7 +34206,7 @@ __metadata:
     "@metamask/transaction-pay-controller": "npm:^19.0.0"
     "@metamask/tron-wallet-snap": "npm:^1.25.1"
     "@metamask/user-operation-controller": "npm:^41.1.0"
-    "@metamask/utils": "npm:^11.10.0"
+    "@metamask/utils": "npm:^11.11.0"
     "@ngraveio/bc-ur": "npm:^1.1.13"
     "@noble/ciphers": "npm:^1.3.0"
     "@noble/curves": "npm:^1.9.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6175,11 +6175,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/design-system-react@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "@metamask/design-system-react@npm:0.14.0"
+"@metamask/design-system-react@npm:^0.16.0":
+  version: 0.16.0
+  resolution: "@metamask/design-system-react@npm:0.16.0"
   dependencies:
-    "@metamask/design-system-shared": "npm:^0.7.0"
+    "@metamask/design-system-shared": "npm:^0.9.0"
     "@metamask/jazzicon": "npm:^2.0.0"
     "@radix-ui/react-slot": "npm:^1.1.0"
     blo: "npm:^2.0.0"
@@ -6190,18 +6190,18 @@ __metadata:
     "@metamask/utils": ^11.11.0
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
-  checksum: 10/17506712e71331f73c9cafa03b4ad7f4bfef3d97df8a71f6e79be8440712740561be765a7f0cdd717c5b366a42a30362e62d8bb205c64a88757e69470be2a322
+  checksum: 10/42b7e5456c1d2d1e820b4f54f9e2e857a839703869a4709b66a80eee88e2a7150b781db82e5cff212b83323b81e6386da61f773887b65dc89e9ded255eb396fb
   languageName: node
   linkType: hard
 
-"@metamask/design-system-shared@npm:^0.7.0":
-  version: 0.7.0
-  resolution: "@metamask/design-system-shared@npm:0.7.0"
+"@metamask/design-system-shared@npm:^0.9.0":
+  version: 0.9.0
+  resolution: "@metamask/design-system-shared@npm:0.9.0"
   dependencies:
     "@metamask/utils": "npm:^11.11.0"
   peerDependencies:
     react: ^17.0.0 || ^18.0.0
-  checksum: 10/6029af5621f4a80a1cdcfea226ab4391fce466ee8c0ed6259c0aa06e4ec4029c7b0049c93e6d53cf0bb0a77e630574c92242f80280d7a10e3fb1fdf0b9656a42
+  checksum: 10/d1c7d54fac099b119b9f4ad6580289abba3fdbc699db13ebceb23c17c1d162987237625e3bf67397bf869e286951cc8edf9879c600f74dfef50f5447b898d61f
   languageName: node
   linkType: hard
 
@@ -34100,7 +34100,7 @@ __metadata:
     "@metamask/delegation-controller": "npm:^2.0.2"
     "@metamask/delegation-core": "npm:^0.2.0-rc.1"
     "@metamask/delegation-deployments": "npm:^1.0.0"
-    "@metamask/design-system-react": "npm:^0.14.0"
+    "@metamask/design-system-react": "npm:^0.16.0"
     "@metamask/design-system-tailwind-preset": "npm:^0.6.1"
     "@metamask/design-tokens": "npm:^8.3.0"
     "@metamask/eip-5792-middleware": "npm:3.0.3"


### PR DESCRIPTION
## **Description**

Upgrades `@metamask/design-system-react` from `^0.13.0` to `^0.16.0` as part of the [MetaMask Design System v31.0.0 release](https://github.com/MetaMask/metamask-design-system/releases/tag/v31.0.0).

Also bumps `@metamask/utils` from `^11.10.0` to `^11.11.0` to satisfy the peer dependency declared by `@metamask/design-system-react@0.16.0`, preventing a duplicate install that could cause identity check or type mismatch issues across package boundaries.

Changes in `@metamask/design-system-react` v0.16.0:
- Updated `BadgeNetwork` type internals; imports from `@metamask/design-system-react` are unchanged — no consumer-facing breaking changes for the extension.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Run `yarn install` — no errors
2. Build the extension — no TypeScript or import errors related to `design-system-react`
3. Smoke test UI components that use `BadgeNetwork`

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-only change; main impact is updated UI component library and its transitive dependencies, which could surface as build/type or minor UI regressions.
> 
> **Overview**
> Upgrades `@metamask/design-system-react` from `^0.14.0` to `^0.16.0`.
> 
> Bumps `@metamask/utils` to `^11.11.0` to satisfy updated peer requirements and updates `yarn.lock` accordingly (including pulling in `@metamask/design-system-shared@^0.9.0`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa7d07e9dfa131efe22ed6cdae27c928878cc9e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->