### PR TITLE
feat: adds hasMax true for musd convert flow percentage input

### DIFF
--- a/ui/pages/confirmations/components/info/musd-conversion-info/musd-conversion-info.tsx
+++ b/ui/pages/confirmations/components/info/musd-conversion-info/musd-conversion-info.tsx
@@ -99,6 +99,7 @@ export const MusdConversionInfo = () => {
     <CustomAmountInfo
       disablePay={Boolean(existingPayToken)}
       preferredToken={preferredToken}
+      hasMax={true}
       overrideCenterContent={renderOverrideContent}
       overrideBottomContent={<MusdBottomContent />}
     />


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds percentage input to the musd conversion flow

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Adds percentage input to the musd conversion flow

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-126

## **Manual testing steps**

Go through musd conversion flow and use percentage input

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="521" height="461" alt="Screenshot 2026-04-09 at 1 21 10 PM" src="https://github.com/user-attachments/assets/9b2df459-79ff-4660-afe5-b9f610b3c903" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that toggles an existing `CustomAmountInfo` feature flag; no changes to transaction building, quotes, or persistence logic.
> 
> **Overview**
> Enables the *max/percentage input controls* in the mUSD conversion confirmation by passing `hasMax={true}` to `CustomAmountInfo` in `musd-conversion-info.tsx`, allowing users to set the amount via percentage buttons during the convert flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a0f8f624b6c96217f0efcbd4d99817cd83cf8e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->