### PR TITLE
fix: cp-13.26.0 temporarily add token eagerly for mUSD conversion new user single wallet

### DIFF
--- a/ui/components/app/musd/utils/ensure-musd-token-imported.test.ts
+++ b/ui/components/app/musd/utils/ensure-musd-token-imported.test.ts
@@ -1,0 +1,73 @@
+import type { Hex } from '@metamask/utils';
+import { CHAIN_IDS } from '../../../../../shared/constants/network';
+import { MUSD_TOKEN_ADDRESS } from '../constants';
+import { ensureMusdTokenImportedForChain } from './ensure-musd-token-imported';
+
+const mockFindNetworkClientIdByChainId = jest.fn();
+const mockAddImportedTokens = jest.fn();
+
+jest.mock('../../../../store/actions', () => ({
+  addImportedTokens: (...args: unknown[]) => mockAddImportedTokens(...args),
+  findNetworkClientIdByChainId: (...args: unknown[]) =>
+    mockFindNetworkClientIdByChainId(...args),
+}));
+
+describe('ensureMusdTokenImportedForChain', () => {
+  const mockDispatch = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFindNetworkClientIdByChainId.mockResolvedValue('mainnet');
+    mockAddImportedTokens.mockImplementation(
+      () => async () => Promise.resolve(),
+    );
+    mockDispatch.mockImplementation((action: unknown) => {
+      if (typeof action === 'function') {
+        return (
+          action as (
+            d: typeof mockDispatch,
+            getState: () => unknown,
+          ) => Promise<unknown>
+        )(mockDispatch, () => ({}));
+      }
+      return undefined;
+    });
+  });
+
+  it('does nothing when chain has no mUSD mapping', async () => {
+    await ensureMusdTokenImportedForChain('0x9999' as Hex, mockDispatch);
+
+    expect(mockFindNetworkClientIdByChainId).not.toHaveBeenCalled();
+    expect(mockAddImportedTokens).not.toHaveBeenCalled();
+  });
+
+  it('imports mUSD for a supported chain', async () => {
+    await ensureMusdTokenImportedForChain(CHAIN_IDS.MAINNET, mockDispatch);
+
+    expect(mockFindNetworkClientIdByChainId).toHaveBeenCalledWith(
+      CHAIN_IDS.MAINNET,
+    );
+    expect(mockAddImportedTokens).toHaveBeenCalledWith(
+      [
+        {
+          address: MUSD_TOKEN_ADDRESS,
+          symbol: 'MUSD',
+          decimals: 6,
+        },
+      ],
+      'mainnet',
+    );
+  });
+
+  it('logs and resolves when import fails', async () => {
+    jest.spyOn(console, 'warn').mockImplementation();
+    mockFindNetworkClientIdByChainId.mockRejectedValue(new Error('network'));
+
+    await expect(
+      ensureMusdTokenImportedForChain(CHAIN_IDS.MAINNET, mockDispatch),
+    ).resolves.toBeUndefined();
+
+    expect(console.warn).toHaveBeenCalled();
+    (console.warn as jest.Mock).mockRestore();
+  });
+});

--- a/ui/components/app/musd/utils/ensure-musd-token-imported.test.ts
+++ b/ui/components/app/musd/utils/ensure-musd-token-imported.test.ts
@@ -59,6 +59,22 @@ describe('ensureMusdTokenImportedForChain', () => {
     );
   });
 
+  it('imports mUSD when chain id uses non-canonical hex casing', async () => {
+    await ensureMusdTokenImportedForChain('0X1' as Hex, mockDispatch);
+
+    expect(mockFindNetworkClientIdByChainId).toHaveBeenCalledWith('0x1');
+    expect(mockAddImportedTokens).toHaveBeenCalledWith(
+      [
+        {
+          address: MUSD_TOKEN_ADDRESS,
+          symbol: 'MUSD',
+          decimals: 6,
+        },
+      ],
+      'mainnet',
+    );
+  });
+
   it('logs and resolves when import fails', async () => {
     jest.spyOn(console, 'warn').mockImplementation();
     mockFindNetworkClientIdByChainId.mockRejectedValue(new Error('network'));

--- a/ui/components/app/musd/utils/ensure-musd-token-imported.ts
+++ b/ui/components/app/musd/utils/ensure-musd-token-imported.ts
@@ -1,5 +1,5 @@
 import type { Hex } from '@metamask/utils';
-import { MUSD_TOKEN, MUSD_TOKEN_ADDRESS_BY_CHAIN } from '../constants';
+import { MUSD_TOKEN, getMusdTokenAddressForChain } from '../constants';
 import {
   addImportedTokens,
   findNetworkClientIdByChainId,
@@ -19,13 +19,15 @@ export async function ensureMusdTokenImportedForChain(
   chainId: Hex,
   dispatch: MetaMaskReduxDispatch,
 ): Promise<void> {
-  const musdAddress = MUSD_TOKEN_ADDRESS_BY_CHAIN[chainId];
+  const musdAddress = getMusdTokenAddressForChain(chainId);
   if (!musdAddress) {
     return;
   }
 
   try {
-    const networkClientId = await findNetworkClientIdByChainId(chainId);
+    const networkClientId = await findNetworkClientIdByChainId(
+      chainId.toLowerCase(),
+    );
     await Promise.resolve(
       dispatch(
         addImportedTokens(

--- a/ui/components/app/musd/utils/ensure-musd-token-imported.ts
+++ b/ui/components/app/musd/utils/ensure-musd-token-imported.ts
@@ -1,0 +1,46 @@
+import type { Hex } from '@metamask/utils';
+import { MUSD_TOKEN, MUSD_TOKEN_ADDRESS_BY_CHAIN } from '../constants';
+import {
+  addImportedTokens,
+  findNetworkClientIdByChainId,
+} from '../../../../store/actions';
+import type { MetaMaskReduxDispatch } from '../../../../store/store';
+
+/**
+ * Ensures mUSD is present in the user's imported token list for `chainId` so
+ * account-group asset selectors include it before the conversion confirm screen.
+ *
+ * Errors are logged and swallowed so the conversion flow can continue if import fails.
+ *
+ * @param chainId - EVM chain for the conversion (must be a supported mUSD chain).
+ * @param dispatch - Redux dispatch (thunk-capable).
+ */
+export async function ensureMusdTokenImportedForChain(
+  chainId: Hex,
+  dispatch: MetaMaskReduxDispatch,
+): Promise<void> {
+  const musdAddress = MUSD_TOKEN_ADDRESS_BY_CHAIN[chainId];
+  if (!musdAddress) {
+    return;
+  }
+
+  try {
+    const networkClientId = await findNetworkClientIdByChainId(chainId);
+    await Promise.resolve(
+      dispatch(
+        addImportedTokens(
+          [
+            {
+              address: musdAddress,
+              symbol: MUSD_TOKEN.symbol,
+              decimals: MUSD_TOKEN.decimals,
+            },
+          ],
+          networkClientId,
+        ),
+      ),
+    );
+  } catch (err) {
+    console.warn('[MUSD] Failed to add mUSD token to token list:', err);
+  }
+}

--- a/ui/components/app/musd/utils/index.ts
+++ b/ui/components/app/musd/utils/index.ts
@@ -23,3 +23,6 @@ export type {
   MusdTransferDetails,
   TransactionControllerCallbacks,
 } from './transaction-utils';
+
+/** Ensures mUSD is imported for a chain before conversion confirm UI (token list / assets). */
+export { ensureMusdTokenImportedForChain } from './ensure-musd-token-imported';

--- a/ui/hooks/musd/useMusdConversion.test.ts
+++ b/ui/hooks/musd/useMusdConversion.test.ts
@@ -34,6 +34,9 @@ jest.mock('../../selectors/transactions', () => ({
 const mockAddTransaction = jest.fn();
 const mockFindNetworkClientIdByChainId = jest.fn();
 const mockSetMusdConversionEducationSeen = jest.fn();
+const mockEnsureMusdTokenImportedForChain = jest.fn(
+  (_chainId: unknown, _dispatch: unknown) => Promise.resolve(),
+);
 
 jest.mock('../../store/actions', () => ({
   addTransaction: (...args: unknown[]) => mockAddTransaction(...args),
@@ -58,6 +61,8 @@ jest.mock('../../components/app/musd/utils', () => ({
     mockBuildMusdConversionTx(...args),
   isMatchingMusdConversion: (...args: unknown[]) =>
     mockIsMatchingMusdConversion(...args),
+  ensureMusdTokenImportedForChain: (chainId: unknown, dispatch: unknown) =>
+    mockEnsureMusdTokenImportedForChain(chainId, dispatch),
 }));
 
 jest.mock('../../components/app/musd/constants', () => ({
@@ -306,6 +311,32 @@ describe('useMusdConversion', () => {
           pathname: '/confirm-transaction/existing-tx-id',
         }),
       );
+    });
+
+    it('adds mUSD token to token list before navigating', async () => {
+      const invocationOrder: string[] = [];
+
+      mockEnsureMusdTokenImportedForChain.mockImplementationOnce(async () => {
+        invocationOrder.push('ensureMusdToken');
+      });
+
+      mockNavigate.mockImplementationOnce(() => {
+        invocationOrder.push('navigate');
+      });
+
+      const { result } = renderHook(() => useMusdConversion());
+
+      await act(async () => {
+        await result.current.startConversionFlow({
+          preferredToken: MOCK_PREFERRED_TOKEN,
+        });
+      });
+
+      expect(mockEnsureMusdTokenImportedForChain).toHaveBeenCalledWith(
+        '0x1',
+        mockDispatch,
+      );
+      expect(invocationOrder).toEqual(['ensureMusdToken', 'navigate']);
     });
 
     it('creates a new transaction and navigates to confirm', async () => {

--- a/ui/hooks/musd/useMusdConversion.ts
+++ b/ui/hooks/musd/useMusdConversion.ts
@@ -29,8 +29,10 @@ import {
   findNetworkClientIdByChainId,
   setMusdConversionEducationSeen,
 } from '../../store/actions';
+import type { MetaMaskReduxDispatch } from '../../store/store';
 import {
   buildMusdConversionTx,
+  ensureMusdTokenImportedForChain,
   isMatchingMusdConversion,
 } from '../../components/app/musd/utils';
 import { CONFIRM_TRANSACTION_ROUTE } from '../../helpers/constants/routes';
@@ -124,7 +126,7 @@ function findExistingPendingMusdConversion(params: {
  * @returns Object with state and actions for mUSD conversion
  */
 export function useMusdConversion(): UseMusdConversionResult {
-  const dispatch = useDispatch();
+  const dispatch = useDispatch<MetaMaskReduxDispatch>();
   const navigate = useNavigate();
   const location = useLocation();
   const [error, setError] = useState<string | null>(null);
@@ -201,6 +203,11 @@ export function useMusdConversion(): UseMusdConversionResult {
       try {
         setError(null);
 
+        const ensureMusdTokenPromise = ensureMusdTokenImportedForChain(
+          chainId,
+          dispatch,
+        );
+
         const existing = findExistingPendingMusdConversion({
           unapprovedTransactions: unapprovedTransactions as Record<
             string,
@@ -268,6 +275,8 @@ export function useMusdConversion(): UseMusdConversionResult {
           tags: navTraceTags,
         });
 
+        await ensureMusdTokenPromise;
+
         navigate({
           pathname: `${CONFIRM_TRANSACTION_ROUTE}/${txId}`,
           search: new URLSearchParams({
@@ -298,6 +307,7 @@ export function useMusdConversion(): UseMusdConversionResult {
       }
     },
     [
+      dispatch,
       isFeatureEnabled,
       isUserGeoBlocked,
       educationSeen,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

mUSD conversion relies on pay-with / asset data that comes from tracked tokens. If mUSD was never added to the token list for any account in the wallet, the conversion flow could fail on the confirm screen. Adding mUSD manually fixed it. Having mUSD in another account group could also make conversion work for a group that didn’t list mUSD.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: n/a

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-620
Fixes: https://github.com/MetaMask/metamask-extension/issues/41619

## **Manual testing steps**

Use a  new single wallet with no mUSD to attempt to convert a stablecoin to mUSD

You will need ETH and a stablecoin sent to a new address

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://www.loom.com/share/c143235412e04b97b72e07f0e9237288

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes the mUSD conversion start flow to mutate imported-token state before navigation; failures are swallowed but timing/order changes could affect conversion UX and token lists on supported chains.
> 
> **Overview**
> Prevents mUSD conversion from failing for wallets that have never imported mUSD by **eagerly adding mUSD to the user’s imported token list** for the selected conversion `chainId` before navigating to the confirm screen.
> 
> Introduces `ensureMusdTokenImportedForChain` (exported from `ui/components/app/musd/utils`) which resolves the `networkClientId`, dispatches `addImportedTokens` for the mUSD contract (case-normalizing `chainId`), and **logs/swallows errors** to avoid blocking the flow. Updates `useMusdConversion` to use a typed `dispatch` and to `await` this import prior to `navigate`, with new unit tests covering supported/unsupported chains, casing, failure handling, and the import-before-navigation ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39ff999b76b3af2662740e5465db9ecf2d581c60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->