### PR TITLE
fix: change confirmations returnTo to goBackTo and set in context

### DIFF
--- a/test/lib/confirmations/render-helpers.tsx
+++ b/test/lib/confirmations/render-helpers.tsx
@@ -82,6 +82,7 @@ export function renderWithConfirmContext(
     currentConfirmation,
     isScrollToBottomCompleted: true,
     setIsScrollToBottomCompleted: () => undefined,
+    goBackTo: undefined,
   });
 }
 

--- a/ui/components/app/musd/hooks/useMerklClaim.test.ts
+++ b/ui/components/app/musd/hooks/useMerklClaim.test.ts
@@ -139,7 +139,7 @@ describe('useMerklClaim', () => {
     expect(txParams.data).toBe(expectedData);
   });
 
-  it('navigates to confirmation page with returnTo param', async () => {
+  it('navigates to confirmation page with goBackTo param', async () => {
     const { result } = renderHook(() =>
       useMerklClaim({
         tokenAddress: MOCK_TOKEN_ADDRESS,
@@ -153,7 +153,7 @@ describe('useMerklClaim', () => {
 
     expect(mockNavigate).toHaveBeenCalledWith({
       pathname: `/confirm-transaction/${MOCK_TX_ID}`,
-      search: 'returnTo=%2Fasset%2F0x1%2F0xtest',
+      search: 'goBackTo=%2Fasset%2F0x1%2F0xtest',
     });
   });
 

--- a/ui/components/app/musd/hooks/useMerklClaim.ts
+++ b/ui/components/app/musd/hooks/useMerklClaim.ts
@@ -123,7 +123,7 @@ export const useMerklClaim = ({
       navigate({
         pathname: `${CONFIRM_TRANSACTION_ROUTE}/${transactionMeta.id}`,
         search: new URLSearchParams({
-          returnTo: location.pathname + location.search,
+          goBackTo: location.pathname + location.search,
         }).toString(),
       });
     } catch (e) {

--- a/ui/components/app/perps/hooks/usePerpsDepositConfirmation.test.ts
+++ b/ui/components/app/perps/hooks/usePerpsDepositConfirmation.test.ts
@@ -51,7 +51,7 @@ describe('usePerpsDepositConfirmation', () => {
     expect(triggerResult).toStrictEqual({ transactionId: 'tx-123' });
   });
 
-  it('includes returnTo param when triggered from a non-root route', async () => {
+  it('includes goBackTo param when triggered from a non-root route', async () => {
     mockCreatePerpsDepositTransaction.mockResolvedValue({
       transactionId: 'tx-return',
     });
@@ -68,7 +68,7 @@ describe('usePerpsDepositConfirmation', () => {
 
     expect(mockNavigate).toHaveBeenCalledWith({
       pathname: `${CONFIRM_TRANSACTION_ROUTE}/tx-return`,
-      search: `loader=${ConfirmationLoader.CustomAmount}&returnTo=%2Fperps%2Ftrade%2FBTC`,
+      search: `loader=${ConfirmationLoader.CustomAmount}&goBackTo=%2Fperps%2Ftrade%2FBTC`,
     });
   });
 

--- a/ui/components/app/perps/hooks/usePerpsDepositConfirmation.ts
+++ b/ui/components/app/perps/hooks/usePerpsDepositConfirmation.ts
@@ -63,9 +63,9 @@ export function usePerpsDepositConfirmation(
           loader: ConfirmationLoader.CustomAmount,
         });
 
-        const returnTo = location.pathname + location.search;
-        if (returnTo && returnTo !== '/') {
-          params.set('returnTo', returnTo);
+        const goBackTo = location.pathname + location.search;
+        if (goBackTo && goBackTo !== '/') {
+          params.set('goBackTo', goBackTo);
         }
 
         navigate({

--- a/ui/hooks/musd/useMusdConversion.test.ts
+++ b/ui/hooks/musd/useMusdConversion.test.ts
@@ -330,7 +330,7 @@ describe('useMusdConversion', () => {
       expect(mockNavigate).toHaveBeenCalledWith(
         expect.objectContaining({
           pathname: `/confirm-transaction/${MOCK_TX_ID}`,
-          search: 'loader=customAmount&returnTo=%2Fasset%2F0x1%2F0xtest',
+          search: 'loader=customAmount&goBackTo=%2Fasset%2F0x1%2F0xtest',
         }),
       );
     });

--- a/ui/hooks/musd/useMusdConversion.ts
+++ b/ui/hooks/musd/useMusdConversion.ts
@@ -272,7 +272,7 @@ export function useMusdConversion(): UseMusdConversionResult {
           pathname: `${CONFIRM_TRANSACTION_ROUTE}/${txId}`,
           search: new URLSearchParams({
             loader: ConfirmationLoader.CustomAmount,
-            returnTo: location.pathname + location.search,
+            goBackTo: location.pathname + location.search,
           }).toString(),
         });
 

--- a/ui/pages/confirmations/components/confirm/footer/footer.test.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/footer.test.tsx
@@ -39,10 +39,7 @@ import { useOriginThrottling } from '../../../hooks/useOriginThrottling';
 import { useIsGaslessSupported } from '../../../hooks/gas/useIsGaslessSupported';
 import { useInsufficientBalanceAlerts } from '../../../hooks/alerts/transactions/useInsufficientBalanceAlerts';
 import { useIsGaslessLoading } from '../../../hooks/gas/useIsGaslessLoading';
-import {
-  useConfirmationNavigation,
-  useConfirmationNavigationOptions,
-} from '../../../hooks/useConfirmationNavigation';
+import { useConfirmationNavigation } from '../../../hooks/useConfirmationNavigation';
 import { useAddEthereumChain } from '../../../hooks/useAddEthereumChain';
 import { useUserSubscriptions } from '../../../../../hooks/subscription/useSubscription';
 import Footer from './footer';
@@ -102,10 +99,6 @@ jest.mock('../../../hooks/useConfirmationNavigation', () => ({
   useConfirmationNavigation: jest.fn(() => ({
     navigateNext: mockNavigateNext,
     navigateToId: mockNavigateToId,
-  })),
-  useConfirmationNavigationOptions: jest.fn(() => ({
-    loader: 'default',
-    returnTo: undefined,
   })),
 }));
 jest.mock(
@@ -1211,22 +1204,20 @@ describe('ConfirmFooter', () => {
     expect(queryByText(messages.cancel.message)).not.toBeInTheDocument();
   });
 
-  describe('returnTo navigation', () => {
-    const useConfirmationNavigationOptionsMock = jest.mocked(
-      useConfirmationNavigationOptions,
-    );
-
-    it('does not call navigateNext when cancel is clicked and returnTo is defined', async () => {
+  describe('goBackTo navigation', () => {
+    it('does not call navigateNext when cancel is clicked and goBackTo is defined', async () => {
       const navigateNextMock = jest.fn();
       useConfirmationNavigationMock.mockReturnValue({
         navigateNext: navigateNextMock,
         navigateToId: jest.fn(),
       } as unknown as ReturnType<typeof useConfirmationNavigation>);
 
-      useConfirmationNavigationOptionsMock.mockReturnValue({
-        loader: undefined,
-        returnTo: '/asset/0x123',
-      });
+      jest.spyOn(confirmContext, 'useConfirmContext').mockReturnValue({
+        currentConfirmation: genUnapprovedContractInteractionConfirmation(),
+        isScrollToBottomCompleted: true,
+        setIsScrollToBottomCompleted: () => undefined,
+        goBackTo: '/asset/0x123',
+      } as unknown as ReturnType<typeof confirmContext.useConfirmContext>);
 
       const { getAllByRole } = render();
       const cancelButton = getAllByRole('button')[0];
@@ -1243,21 +1234,23 @@ describe('ConfirmFooter', () => {
         expect(rejectSpy).toHaveBeenCalled();
       });
 
-      // Should NOT call navigateNext when returnTo is defined (early return)
+      // Should NOT call navigateNext when goBackTo is defined (early return)
       expect(navigateNextMock).not.toHaveBeenCalled();
     });
 
-    it('calls navigateNext when cancel is clicked and returnTo is undefined', async () => {
+    it('calls navigateNext when cancel is clicked and goBackTo is undefined', async () => {
       const navigateNextMock = jest.fn();
       useConfirmationNavigationMock.mockReturnValue({
         navigateNext: navigateNextMock,
         navigateToId: jest.fn(),
       } as unknown as ReturnType<typeof useConfirmationNavigation>);
 
-      useConfirmationNavigationOptionsMock.mockReturnValue({
-        loader: undefined,
-        returnTo: undefined,
-      });
+      jest.spyOn(confirmContext, 'useConfirmContext').mockReturnValue({
+        currentConfirmation: genUnapprovedContractInteractionConfirmation(),
+        isScrollToBottomCompleted: true,
+        setIsScrollToBottomCompleted: () => undefined,
+        goBackTo: undefined,
+      } as unknown as ReturnType<typeof confirmContext.useConfirmContext>);
 
       const { getAllByRole } = render();
       const cancelButton = getAllByRole('button')[0];
@@ -1274,7 +1267,7 @@ describe('ConfirmFooter', () => {
         expect(rejectSpy).toHaveBeenCalled();
       });
 
-      // Should call navigateNext when returnTo is undefined
+      // Should call navigateNext when goBackTo is undefined
       await waitFor(() => {
         expect(navigateNextMock).toHaveBeenCalled();
       });

--- a/ui/pages/confirmations/components/confirm/footer/footer.test.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/footer.test.tsx
@@ -96,6 +96,7 @@ jest.mock('../../../../../store/background-connection', () => ({
   submitRequestToBackground: jest.fn(() => Promise.resolve()),
 }));
 jest.mock('../../../hooks/useConfirmationNavigation', () => ({
+  ...jest.requireActual('../../../hooks/useConfirmationNavigation'),
   useConfirmationNavigation: jest.fn(() => ({
     navigateNext: mockNavigateNext,
     navigateToId: mockNavigateToId,

--- a/ui/pages/confirmations/components/confirm/footer/footer.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/footer.tsx
@@ -26,10 +26,7 @@ import {
 import { DEFAULT_ROUTE } from '../../../../../helpers/constants/routes';
 import useAlerts from '../../../../../hooks/useAlerts';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
-import {
-  useConfirmationNavigation,
-  useConfirmationNavigationOptions,
-} from '../../../hooks/useConfirmationNavigation';
+import { useConfirmationNavigation } from '../../../hooks/useConfirmationNavigation';
 import { resolvePendingApproval } from '../../../../../store/actions';
 import { useConfirmContext } from '../../../context/confirm';
 import { useIsGaslessLoading } from '../../../hooks/gas/useIsGaslessLoading';
@@ -239,7 +236,7 @@ const Footer = () => {
   const { navigateNext } = useConfirmationNavigation();
   const { onSubmit: onAddEthereumChain } = useAddEthereumChain();
 
-  const { currentConfirmation, isScrollToBottomCompleted } =
+  const { currentConfirmation, isScrollToBottomCompleted, goBackTo } =
     useConfirmContext<TransactionMeta>();
   const currentConfirmationId = currentConfirmation?.id;
   const t = useI18nContext();
@@ -249,7 +246,6 @@ const Footer = () => {
   const { shouldThrottleOrigin } = useOriginThrottling();
   const [showOriginThrottleModal, setShowOriginThrottleModal] = useState(false);
   const { onCancel, resetTransactionState } = useConfirmActions();
-  const { returnTo } = useConfirmationNavigationOptions();
   const { hasUnconfirmedDangerAlerts } = useAlerts(
     currentConfirmation?.id ?? '',
   );
@@ -395,13 +391,13 @@ const Footer = () => {
 
     await onCancel({
       location: MetaMetricsEventLocation.Confirmation,
-      navigateBackToPreviousPage: Boolean(returnTo),
+      navigateBackToPreviousPage: Boolean(goBackTo),
     });
 
     onDappSwapCompleted();
     dismissErrorModal();
 
-    if (returnTo) {
+    if (goBackTo) {
       return;
     }
 
@@ -416,7 +412,7 @@ const Footer = () => {
   }, [
     navigateNext,
     onCancel,
-    returnTo,
+    goBackTo,
     shouldThrottleOrigin,
     currentConfirmationId,
     isAddEthereumChain,

--- a/ui/pages/confirmations/components/confirm/info/info.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/info.test.tsx
@@ -209,6 +209,7 @@ describe('Info', () => {
         currentConfirmation: undefined as never,
         isScrollToBottomCompleted: true,
         setIsScrollToBottomCompleted: jest.fn(),
+        goBackTo: undefined,
       };
     });
 

--- a/ui/pages/confirmations/components/rows/bridge-time-row/bridge-time-row.test.tsx
+++ b/ui/pages/confirmations/components/rows/bridge-time-row/bridge-time-row.test.tsx
@@ -47,6 +47,7 @@ describe('BridgeTimeRow', () => {
       },
       isScrollToBottomCompleted: true,
       setIsScrollToBottomCompleted: jest.fn(),
+      goBackTo: undefined,
     } as ReturnType<typeof useConfirmContext>);
 
     useIsTransactionPayLoadingMock.mockReturnValue(false);

--- a/ui/pages/confirmations/components/smart-transactions-banner-alert/smart-transactions-banner-alert.test.tsx
+++ b/ui/pages/confirmations/components/smart-transactions-banner-alert/smart-transactions-banner-alert.test.tsx
@@ -16,6 +16,7 @@ type TestConfirmContextValue = {
   currentConfirmation: Confirmation;
   isScrollToBottomCompleted: boolean;
   setIsScrollToBottomCompleted: (isScrollToBottomCompleted: boolean) => void;
+  goBackTo: string | undefined;
 };
 
 jest.mock('../../../../hooks/useI18nContext', () => ({
@@ -40,6 +41,7 @@ const renderWithConfirmContext = (
     } as SignatureRequestType,
     isScrollToBottomCompleted: true,
     setIsScrollToBottomCompleted: () => undefined,
+    goBackTo: undefined,
   },
 ) => {
   return renderWithProvider(
@@ -266,6 +268,7 @@ describe('SmartTransactionsBannerAlert', () => {
       } as SignatureRequestType,
       isScrollToBottomCompleted: true,
       setIsScrollToBottomCompleted: () => undefined,
+      goBackTo: undefined,
     };
 
     renderWithConfirmContext(

--- a/ui/pages/confirmations/context/confirm/index.test.tsx
+++ b/ui/pages/confirmations/context/confirm/index.test.tsx
@@ -9,16 +9,16 @@ import { ConfirmContextProvider, useConfirmContext } from '.';
 
 const mockNavigate = jest.fn();
 
-let mockSearchParams = new URLSearchParams('');
+let mockWindowSearch = '';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useNavigate: () => mockNavigate,
-  useSearchParams: () => [mockSearchParams, jest.fn()],
+  useSearchParams: () => [new URLSearchParams(mockWindowSearch), jest.fn()],
   useParams: () => ({}),
   useLocation: () => ({
     pathname: '/confirm-transaction',
-    search: '',
+    search: mockWindowSearch,
     hash: '',
     state: null,
     key: 'test',
@@ -72,11 +72,12 @@ function renderContextProvider(store: ReturnType<typeof createStore>) {
 describe('ConfirmContextProvider', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockSearchParams = new URLSearchParams('');
+    mockWindowSearch = '';
+    window.history.replaceState({}, '', '/');
     mockCurrentConfirmation = { id: 'test-id', type: 'transaction' };
   });
 
-  it('navigates to DEFAULT_ROUTE when confirmation disappears and no returnTo', () => {
+  it('navigates to DEFAULT_ROUTE when confirmation disappears and no goBackTo', () => {
     const store = createStore();
     const { rerender } = renderContextProvider(store);
 
@@ -86,8 +87,9 @@ describe('ConfirmContextProvider', () => {
     expect(mockNavigate).toHaveBeenCalledWith(DEFAULT_ROUTE, { replace: true });
   });
 
-  it('navigates to returnTo when confirmation disappears and returnTo is present', () => {
-    mockSearchParams = new URLSearchParams('returnTo=/perps/trade/BTC');
+  it('navigates to goBackTo when confirmation disappears and goBackTo is present', () => {
+    mockWindowSearch = '?goBackTo=/perps/trade/BTC';
+    window.history.replaceState({}, '', '/?goBackTo=/perps/trade/BTC');
     const store = createStore();
     const { rerender } = renderContextProvider(store);
 
@@ -134,9 +136,12 @@ describe('ConfirmContextProvider', () => {
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
-  it('ignores unsafe returnTo values (absolute URLs)', () => {
-    mockSearchParams = new URLSearchParams(
-      'returnTo=https://evil.com/phishing',
+  it('ignores unsafe goBackTo values (absolute URLs)', () => {
+    mockWindowSearch = '?goBackTo=https%3A%2F%2Fevil.com%2Fphishing';
+    window.history.replaceState(
+      {},
+      '',
+      '/?goBackTo=https%3A%2F%2Fevil.com%2Fphishing',
     );
     const store = createStore();
     const { rerender } = renderContextProvider(store);
@@ -145,5 +150,18 @@ describe('ConfirmContextProvider', () => {
     rerender();
 
     expect(mockNavigate).toHaveBeenCalledWith(DEFAULT_ROUTE, { replace: true });
+  });
+
+  it('keeps goBackTo from initial URL when location search is cleared after mount', () => {
+    mockWindowSearch = '?goBackTo=/asset/keep';
+    window.history.replaceState({}, '', '/?goBackTo=/asset/keep');
+    const store = createStore();
+    const { result, rerender } = renderContextProvider(store);
+
+    expect(result.current.goBackTo).toBe('/asset/keep');
+    mockWindowSearch = '';
+    window.history.replaceState({}, '', '/');
+    rerender();
+    expect(result.current.goBackTo).toBe('/asset/keep');
   });
 });

--- a/ui/pages/confirmations/context/confirm/index.tsx
+++ b/ui/pages/confirmations/context/confirm/index.tsx
@@ -10,18 +10,20 @@ import React, {
 import { useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 
-import { DEFAULT_ROUTE } from '../../../../helpers/constants/routes';
 import { usePrevious } from '../../../../hooks/usePrevious';
 import { getIsHardwareWalletErrorModalVisible } from '../../../../selectors';
 import useCurrentConfirmation from '../../hooks/useCurrentConfirmation';
 import { useConfirmationNavigationOptions } from '../../hooks/useConfirmationNavigation';
 import useSyncConfirmPath from '../../hooks/useSyncConfirmPath';
+import { DEFAULT_ROUTE } from '../../../../helpers/constants/routes';
 import { Confirmation } from '../../types/confirm';
 
 export type ConfirmContextType = {
   currentConfirmation: Confirmation;
   isScrollToBottomCompleted: boolean;
   setIsScrollToBottomCompleted: (isScrollToBottomCompleted: boolean) => void;
+  /** Route to use for cancel / reject / auto-exit; captured once from URL on mount. */
+  goBackTo: string | undefined;
 };
 
 export const ConfirmContext = createContext<ConfirmContextType | undefined>(
@@ -34,6 +36,8 @@ export const ConfirmContextProvider: React.FC<{
   /** When provided, injects this as currentConfirmation (e.g. for gas modal opened from cancel-speedup). Skips route sync and navigation. */
   currentConfirmationOverride?: Confirmation;
 }> = ({ children, confirmationId, currentConfirmationOverride }) => {
+  const { goBackTo: goBackFromUrl } = useConfirmationNavigationOptions();
+  const [goBackTo] = useState(goBackFromUrl);
   const [isScrollToBottomCompleted, setIsScrollToBottomCompleted] =
     useState(true);
   const { currentConfirmation: currentConfirmationFromHook } =
@@ -50,7 +54,6 @@ export const ConfirmContextProvider: React.FC<{
   const isHardwareWalletErrorModalVisible = useSelector(
     getIsHardwareWalletErrorModalVisible,
   );
-  const { returnTo } = useConfirmationNavigationOptions();
 
   /**
    * The hook below takes care of navigating to the home page when the confirmation not acted on by user
@@ -67,14 +70,14 @@ export const ConfirmContextProvider: React.FC<{
 
     if (shouldNavigateHomeRef.current && !isHardwareWalletErrorModalVisible) {
       shouldNavigateHomeRef.current = false;
-      navigate(returnTo ?? DEFAULT_ROUTE, { replace: true });
+      navigate(goBackTo ?? DEFAULT_ROUTE, { replace: true });
     }
   }, [
     currentConfirmationOverride,
     previousConfirmation,
     currentConfirmation,
     navigate,
-    returnTo,
+    goBackTo,
     isHardwareWalletErrorModalVisible,
   ]);
 
@@ -83,11 +86,13 @@ export const ConfirmContextProvider: React.FC<{
       currentConfirmation,
       isScrollToBottomCompleted,
       setIsScrollToBottomCompleted,
+      goBackTo,
     }),
     [
       currentConfirmation,
       isScrollToBottomCompleted,
       setIsScrollToBottomCompleted,
+      goBackTo,
     ],
   );
 
@@ -107,5 +112,6 @@ export const useConfirmContext = <CurrentConfirmation = Confirmation,>() => {
     currentConfirmation: CurrentConfirmation;
     isScrollToBottomCompleted: boolean;
     setIsScrollToBottomCompleted: (isScrollToBottomCompleted: boolean) => void;
+    goBackTo: string | undefined;
   };
 };

--- a/ui/pages/confirmations/hooks/useConfirmActions.test.ts
+++ b/ui/pages/confirmations/hooks/useConfirmActions.test.ts
@@ -8,7 +8,6 @@ import { useConfirmActions } from './useConfirmActions';
 
 const mockDispatch = jest.fn();
 const mockNavigate = jest.fn();
-const mockReturnTo = jest.fn<string | undefined, []>(() => undefined);
 
 jest.mock('react-redux', () => {
   const actual = jest.requireActual('react-redux');
@@ -23,14 +22,7 @@ jest.mock('react-router-dom', () => ({
   useNavigate: () => mockNavigate,
 }));
 
-jest.mock('./useConfirmationNavigation', () => ({
-  ...jest.requireActual('./useConfirmationNavigation'),
-  useConfirmationNavigationOptions: () => ({
-    returnTo: mockReturnTo(),
-  }),
-}));
-
-function renderHook() {
+function renderHook(pathname = '/') {
   const transactionMeta = genUnapprovedTokenTransferConfirmation({
     amountHex:
       '0000000000000000000000000000000000000000000000000000000000011170',
@@ -39,6 +31,7 @@ function renderHook() {
   const { result } = renderHookWithConfirmContextProvider(
     () => useConfirmActions(),
     getMockConfirmStateForTransaction(transactionMeta),
+    pathname,
   );
   return result.current;
 }
@@ -88,10 +81,9 @@ describe('useConfirmActions', () => {
     expect(mockNavigateBackIfSend).not.toHaveBeenCalled();
   });
 
-  it('navigates to returnTo when navigateBackToPreviousPage is true', async () => {
-    mockReturnTo.mockReturnValue('/asset/0x1/0xabc');
+  it('navigates to goBackTo when navigateBackToPreviousPage is true', async () => {
     mockDispatch.mockResolvedValue(undefined);
-    const result = renderHook();
+    const result = renderHook('/?goBackTo=%2Fasset%2F0x1%2F0xabc');
     await result.onCancel({
       location: 'dummy',
       navigateBackToPreviousPage: true,
@@ -99,8 +91,7 @@ describe('useConfirmActions', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/asset/0x1/0xabc');
   });
 
-  it('navigates to DEFAULT_ROUTE when navigateBackToPreviousPage is true but no returnTo', async () => {
-    mockReturnTo.mockReturnValue(undefined);
+  it('navigates to DEFAULT_ROUTE when navigateBackToPreviousPage is true but no goBackTo', async () => {
     mockDispatch.mockResolvedValue(undefined);
     const result = renderHook();
     await result.onCancel({
@@ -111,9 +102,8 @@ describe('useConfirmActions', () => {
   });
 
   it('does not navigate back by default', async () => {
-    mockReturnTo.mockReturnValue('/some-page');
     mockDispatch.mockResolvedValue(undefined);
-    const result = renderHook();
+    const result = renderHook('/?goBackTo=%2Fsome-page');
     await result.onCancel({ location: 'dummy' });
     expect(mockNavigate).not.toHaveBeenCalled();
   });

--- a/ui/pages/confirmations/hooks/useConfirmActions.ts
+++ b/ui/pages/confirmations/hooks/useConfirmActions.ts
@@ -13,15 +13,14 @@ import {
   updateCustomNonce,
 } from '../../../store/actions';
 import { useConfirmContext } from '../context/confirm';
-import { useConfirmationNavigationOptions } from './useConfirmationNavigation';
 import { useConfirmSendNavigation } from './useConfirmSendNavigation';
 
 export const useConfirmActions = () => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
-  const { currentConfirmation } = useConfirmContext<TransactionMeta>();
+  const { currentConfirmation, goBackTo } =
+    useConfirmContext<TransactionMeta>();
   const { navigateBackIfSend } = useConfirmSendNavigation();
-  const { returnTo } = useConfirmationNavigationOptions();
   const { id: currentConfirmationId } = currentConfirmation || {};
 
   const rejectApproval = useCallback(
@@ -66,7 +65,7 @@ export const useConfirmActions = () => {
       await rejectApproval({ location });
       resetTransactionState();
       if (navigateBackToPreviousPage) {
-        navigate(returnTo || DEFAULT_ROUTE);
+        navigate(goBackTo ?? DEFAULT_ROUTE);
       }
     },
     [
@@ -75,7 +74,7 @@ export const useConfirmActions = () => {
       navigateBackIfSend,
       rejectApproval,
       resetTransactionState,
-      returnTo,
+      goBackTo,
     ],
   );
 

--- a/ui/pages/confirmations/hooks/useConfirmationAlertActions.test.ts
+++ b/ui/pages/confirmations/hooks/useConfirmationAlertActions.test.ts
@@ -51,6 +51,7 @@ describe('useConfirmationAlertActions', () => {
       },
       isScrollToBottomCompleted: true,
       setIsScrollToBottomCompleted: jest.fn(),
+      goBackTo: undefined,
     });
 
     // @ts-expect-error mocking platform
@@ -84,6 +85,7 @@ describe('useConfirmationAlertActions', () => {
       },
       isScrollToBottomCompleted: true,
       setIsScrollToBottomCompleted: jest.fn(),
+      goBackTo: undefined,
     });
 
     processAlertActionKey(AlertActionKey.ShowAdvancedGasFeeModal);

--- a/ui/pages/confirmations/hooks/useConfirmationNavigation.test.ts
+++ b/ui/pages/confirmations/hooks/useConfirmationNavigation.test.ts
@@ -388,32 +388,32 @@ describe('useConfirmationNavigation', () => {
       });
     });
 
-    it('navigates with only returnTo param when no loader provided', () => {
+    it('navigates with only goBackTo param when no loader provided', () => {
       const result = renderHook(ApprovalType.Transaction);
 
       result.navigateToTransaction('tx-100', {
-        returnTo: '/asset/0x1/0xabc',
+        goBackTo: '/asset/0x1/0xabc',
       });
 
       expect(mockUseNavigate).toHaveBeenCalledTimes(1);
       expect(mockUseNavigate).toHaveBeenCalledWith({
         pathname: `${CONFIRM_TRANSACTION_ROUTE}/tx-100`,
-        search: 'returnTo=%2Fasset%2F0x1%2F0xabc',
+        search: 'goBackTo=%2Fasset%2F0x1%2F0xabc',
       });
     });
 
-    it('navigates with both loader and returnTo params', () => {
+    it('navigates with both loader and goBackTo params', () => {
       const result = renderHook(ApprovalType.Transaction);
 
       result.navigateToTransaction('tx-200', {
         loader: ConfirmationLoader.CustomAmount,
-        returnTo: '/home?tab=tokens',
+        goBackTo: '/home?tab=tokens',
       });
 
       expect(mockUseNavigate).toHaveBeenCalledTimes(1);
       expect(mockUseNavigate).toHaveBeenCalledWith({
         pathname: `${CONFIRM_TRANSACTION_ROUTE}/tx-200`,
-        search: 'loader=customAmount&returnTo=%2Fhome%3Ftab%3Dtokens',
+        search: 'loader=customAmount&goBackTo=%2Fhome%3Ftab%3Dtokens',
       });
     });
   });
@@ -459,31 +459,31 @@ describe('useConfirmationNavigationOptions', () => {
     expect(result.loader).toBe(ConfirmationLoader.Default);
   });
 
-  it('returns sanitized returnTo from search params', () => {
+  it('returns sanitized goBackTo from search params', () => {
     const searchParams = new URLSearchParams({
-      returnTo: '/asset/0x1/0xabc',
+      goBackTo: '/asset/0x1/0xabc',
     });
 
     const result = renderOptionsHook(searchParams);
 
-    expect(result.returnTo).toBe('/asset/0x1/0xabc');
+    expect(result.goBackTo).toBe('/asset/0x1/0xabc');
   });
 
-  it('returns undefined returnTo when not present in search params', () => {
+  it('returns undefined goBackTo when not present in search params', () => {
     const searchParams = new URLSearchParams();
 
     const result = renderOptionsHook(searchParams);
 
-    expect(result.returnTo).toBeUndefined();
+    expect(result.goBackTo).toBeUndefined();
   });
 
-  it('rejects unsafe returnTo values', () => {
+  it('rejects unsafe goBackTo values', () => {
     const searchParams = new URLSearchParams({
-      returnTo: 'https://evil.com',
+      goBackTo: 'https://evil.com',
     });
 
     const result = renderOptionsHook(searchParams);
 
-    expect(result.returnTo).toBeUndefined();
+    expect(result.goBackTo).toBeUndefined();
   });
 });

--- a/ui/pages/confirmations/hooks/useConfirmationNavigation.ts
+++ b/ui/pages/confirmations/hooks/useConfirmationNavigation.ts
@@ -39,7 +39,7 @@ const CONNECT_APPROVAL_TYPES = [
 
 export type ConfirmationNavigationOptions = {
   loader?: ConfirmationLoader;
-  returnTo?: string;
+  goBackTo?: string;
 };
 
 export function useConfirmationNavigation() {
@@ -105,8 +105,8 @@ export function useConfirmationNavigation() {
         params.set('loader', options.loader);
       }
 
-      if (options.returnTo) {
-        params.set('returnTo', options.returnTo);
+      if (options.goBackTo) {
+        params.set('goBackTo', options.goBackTo);
       }
 
       navigate({
@@ -207,10 +207,10 @@ export function useConfirmationNavigationOptions(): ConfirmationNavigationOption
     (searchParams.get('loader') as ConfirmationLoader) ??
     ConfirmationLoader.Default;
 
-  const returnTo = sanitizeRedirectUrl(searchParams.get('returnTo'));
+  const goBackTo = sanitizeRedirectUrl(searchParams.get('goBackTo'));
 
   return {
     loader,
-    returnTo,
+    goBackTo,
   };
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

### Context

The confirmation flow accepts a URL search parameter (returnTo) to tell the UI where to navigate on cancel/reject. This was read on-demand from the URL every time it was needed.

### Problem

Certain user actions inside the confirmation flow (e.g. switching the payment token via useMusdPaymentToken) trigger internal navigation or cause the URL search string to be replaced, silently dropping the returnTo param. From that point on, cancel/reject would fall back to the default transaction-list route instead of the caller's intended destination.

### Solution

- Renamed the URL parameter and context field from returnTo to goBackTo to make it clear this covers only the cancel/reject/auto-exit action, not post-completion navigation.
- Captured goBackTo once on mount inside ConfirmContextProvider using useState(initialValue) and exposed it through the context. Any subsequent URL changes cannot overwrite it.
- Updated consumers (useConfirmActions, footer.tsx) to read goBackTo from context instead of re-reading the URL on every render.
- Updated entry points (useMusdConversion, useMerklClaim, usePerpsDepositConfirmation) to set the renamed goBackTo search param when navigating into the confirmation flow.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: n/a

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-329

## **Manual testing steps**

```
Feature: Stable go-back destination in the confirmation flow

  Background:
    Given the user has navigated to the confirmation screen from an asset page
    And the URL contains "goBackTo=/asset/0x1/0xabc"

  Scenario: Go-back destination survives a payment-token switch
    When the user switches the payment token inside the confirmation screen
    And the URL no longer contains the "goBackTo" parameter
    And the user clicks Cancel
    Then the user is navigated to "/asset/0x1/0xabc"
    And the user is NOT navigated to the default transaction list

  Scenario: No go-back destination set — fallback to default route
    Given the URL does not contain "goBackTo"
    When the user clicks Cancel
    Then the user is navigated to the default transaction list route "/"
```

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://www.loom.com/share/dd5abdc2cb3f430d951a283178ea5b64

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes confirmation-flow routing on cancel/reject/auto-exit and renames a URL parameter, which could break callers or deep links still using `returnTo`. The logic is straightforward and covered by updated tests, but incorrect propagation could strand users on the wrong route.
> 
> **Overview**
> **Confirmation cancel/exit navigation is now driven by a persistent `goBackTo` value instead of a mutable `returnTo` query param.**
> 
> The PR renames the confirmations URL/search parameter from `returnTo` to `goBackTo`, updates entry points that open confirmations (mUSD conversion, Merkl claim, Perps deposit) to set `goBackTo`, and updates `useConfirmationNavigation` helpers accordingly.
> 
> `ConfirmContextProvider` now captures `goBackTo` once on mount and exposes it via context, and cancel/reject handling in `Footer` and `useConfirmActions` uses this context value so internal URL changes during the flow can’t drop the intended back destination. Tests across confirmations were updated/added to validate the new param name, safe-redirect sanitization, and persistence behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b06265a2336c1e97f8131d8be46acf486acd5c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->