### PR TITLE
feat: disable post-transaction toast cp-13.26.0

### DIFF
--- a/test/e2e/page-objects/pages/bridge/quote-page.ts
+++ b/test/e2e/page-objects/pages/bridge/quote-page.ts
@@ -64,6 +64,9 @@ class BridgeQuotePage {
 
   private noOptionAvailable = '[data-testid="bridge-no-options-available"]';
 
+  private statusPageCloseButton =
+    '[data-testid="smart-transaction-status-page-footer-close-button"]';
+
   private moreETHneededForGas =
     '[data-testid="bridge-insufficient-gas-for-quote"]';
 
@@ -229,6 +232,11 @@ class BridgeQuotePage {
 
   submitQuote = async () => {
     await this.driver.clickElement(this.submitButton);
+    await this.dismissStatusPage();
+  };
+
+  dismissStatusPage = async () => {
+    await this.driver.clickElement(this.statusPageCloseButton);
   };
 
   confirmBridgeTransaction = async () => {

--- a/test/e2e/page-objects/pages/bridge/quote-page.ts
+++ b/test/e2e/page-objects/pages/bridge/quote-page.ts
@@ -230,9 +230,11 @@ class BridgeQuotePage {
     await this.driver.waitForSelector(this.submitButton, { timeout: 30000 });
   };
 
-  submitQuote = async () => {
+  submitQuote = async ({ dismissStatusPage = true } = {}) => {
     await this.driver.clickElement(this.submitButton);
-    await this.dismissStatusPage();
+    if (dismissStatusPage) {
+      await this.dismissStatusPage();
+    }
   };
 
   dismissStatusPage = async () => {

--- a/test/e2e/tests/bridge/bridge-L2-tests.spec.ts
+++ b/test/e2e/tests/bridge/bridge-L2-tests.spec.ts
@@ -27,6 +27,7 @@ describe('Bridge tests', function (this: Suite) {
           },
           expectedTransactionsCount: 1,
           expectedDestAmount: '0.991',
+          dismissStatusPage: true,
         });
 
         await bridgeTransaction({
@@ -40,6 +41,7 @@ describe('Bridge tests', function (this: Suite) {
           },
           expectedTransactionsCount: 2,
           expectedDestAmount: '0.991',
+          dismissStatusPage: true,
         });
 
         await bridgeTransaction({
@@ -53,6 +55,7 @@ describe('Bridge tests', function (this: Suite) {
           },
           expectedTransactionsCount: 4,
           expectedDestAmount: '9.905',
+          dismissStatusPage: true,
         });
 
         await bridgeTransaction({
@@ -66,6 +69,7 @@ describe('Bridge tests', function (this: Suite) {
           },
           expectedTransactionsCount: 6,
           expectedDestAmount: '9.67',
+          dismissStatusPage: true,
         });
       },
     );

--- a/test/e2e/tests/bridge/bridge-positive-cases.spec.ts
+++ b/test/e2e/tests/bridge/bridge-positive-cases.spec.ts
@@ -38,6 +38,7 @@ describe('Bridge tests', function (this: Suite) {
           },
           expectedTransactionsCount: 2,
           expectedDestAmount: '0.0157',
+          dismissStatusPage: true,
         });
 
         await bridgeTransaction({
@@ -51,6 +52,7 @@ describe('Bridge tests', function (this: Suite) {
           },
           expectedTransactionsCount: 3,
           expectedDestAmount: '1,642',
+          dismissStatusPage: true,
         });
         await bridgeTransaction({
           driver,
@@ -63,6 +65,7 @@ describe('Bridge tests', function (this: Suite) {
           },
           expectedTransactionsCount: 4,
           expectedDestAmount: '0.991',
+          dismissStatusPage: true,
         });
 
         await homePage.checkPageIsLoaded();
@@ -81,6 +84,7 @@ describe('Bridge tests', function (this: Suite) {
           },
           expectedTransactionsCount: 6,
           expectedDestAmount: '9.9',
+          dismissStatusPage: true,
         });
       },
     );
@@ -154,6 +158,7 @@ describe('Bridge tests', function (this: Suite) {
           },
           expectedTransactionsCount: 2,
           expectedDestAmount: '9.9',
+          dismissStatusPage: true,
         });
         const finalQuoteRequestTimestamp = Date.now();
         const bridgePage = new BridgeQuotePage(driver);

--- a/test/e2e/tests/bridge/bridge-test-utils.ts
+++ b/test/e2e/tests/bridge/bridge-test-utils.ts
@@ -106,6 +106,7 @@ export class BridgePage {
  * @param testParams.expectedDestAmount - The expected quoted destination amounts in the quote page
  * @param testParams.submitDelay - The delay to wait before submitting the transaction, must be less than the refresh interval of the stream
  * @param testParams.expectedStatus - The expected state of the transaction
+ * @param testParams.dismissStatusPage - Whether to dismiss the status page after submitting
  */
 export const bridgeTransaction = async ({
   driver,
@@ -116,6 +117,7 @@ export const bridgeTransaction = async ({
   expectedSwapTokens,
   expectedDestAmount,
   submitDelay,
+  dismissStatusPage = false,
 }: {
   driver: Driver;
   quote: BridgeQuote;
@@ -125,6 +127,7 @@ export const bridgeTransaction = async ({
   expectedSwapTokens?: Pick<BridgeQuote, 'tokenFrom' | 'tokenTo'>;
   expectedDestAmount: string;
   submitDelay?: number;
+  dismissStatusPage?: boolean;
 }) => {
   // Navigate to Bridge page
   const homePage = new HomePage(driver);
@@ -140,7 +143,7 @@ export const bridgeTransaction = async ({
   if (expectedDestAmount) {
     await bridgePage.checkDestAmount(expectedDestAmount);
   }
-  await bridgePage.submitQuote();
+  await bridgePage.submitQuote({ dismissStatusPage });
 
   await homePage.goToActivityList();
 

--- a/test/e2e/tests/bridge/swap-positive-cases.spec.ts
+++ b/test/e2e/tests/bridge/swap-positive-cases.spec.ts
@@ -37,6 +37,7 @@ describe('Swap tests', function (this: Suite) {
           },
           submitDelay: 10000,
           expectedDestAmount: '3,839',
+          dismissStatusPage: true,
         });
 
         const events = await getEventPayloads(driver, mockedEndpoints);

--- a/test/e2e/tests/btc/btc-swap.spec.ts
+++ b/test/e2e/tests/btc/btc-swap.spec.ts
@@ -158,7 +158,7 @@ describe('BTC Account - Swap (Bridge)', function (this: Suite) {
         await bridgePage.checkExpectedNetworkFeeIsDisplayed();
 
         // Submit the swap quote
-        await bridgePage.submitQuote();
+        await bridgePage.submitQuote({ dismissStatusPage: false });
 
         // Navigate to activity list and verify the bridge transaction
         await homePage.goToActivityList();

--- a/test/e2e/tests/metrics/bridge.spec.ts
+++ b/test/e2e/tests/metrics/bridge.spec.ts
@@ -48,6 +48,7 @@ describe('Bridge tests', function (this: Suite) {
           quote,
           expectedTransactionsCount: 2,
           expectedDestAmount: '0.0157',
+          dismissStatusPage: true,
         });
 
         const inputChangesCount1 = await checkInputChangedEvents(

--- a/test/e2e/tests/smart-transactions/smart-transactions.spec.ts
+++ b/test/e2e/tests/smart-transactions/smart-transactions.spec.ts
@@ -144,6 +144,9 @@ describe('Smart Transactions', function () {
         await swapPage.checkQuoteIsGasIncluded();
         await swapPage.submitSwap();
 
+        await swapPage.waitForSmartTransactionToComplete();
+        await swapPage.clickViewActivity();
+
         await homePage.checkPageIsLoaded();
         await homePage.goToActivityList();
 
@@ -174,6 +177,9 @@ describe('Smart Transactions', function () {
         await swapPage.waitForQuote();
         await swapPage.checkQuoteIsGasIncluded();
         await swapPage.submitSwap();
+
+        await swapPage.waitForSmartTransactionToComplete();
+        await swapPage.clickViewActivity();
 
         await homePage.checkPageIsLoaded();
         await homePage.goToActivityList();

--- a/test/e2e/tests/swaps/swap-erc20-with-loaded-state.spec.ts
+++ b/test/e2e/tests/swaps/swap-erc20-with-loaded-state.spec.ts
@@ -48,6 +48,7 @@ describe('Swap', function () {
             quote: testCase.quote,
             expectedTransactionsCount: testCase.expectedTransactionsCount,
             expectedDestAmount: testCase.expectedDestAmount,
+            dismissStatusPage: true,
           });
         },
       );

--- a/ui/pages/bridge/hooks/useSubmitBridgeTransaction.test.tsx
+++ b/ui/pages/bridge/hooks/useSubmitBridgeTransaction.test.tsx
@@ -207,7 +207,7 @@ describe('ui/pages/bridge/hooks/useSubmitBridgeTransaction', () => {
       expect(mockUseNavigate.mock.calls).toMatchInlineSnapshot(`
         [
           [
-            "/",
+            "/?tab=activity",
             {
               "replace": true,
               "state": {
@@ -260,7 +260,7 @@ describe('ui/pages/bridge/hooks/useSubmitBridgeTransaction', () => {
       expect(mockUseNavigate.mock.calls).toMatchInlineSnapshot(`
         [
           [
-            "/",
+            "/?tab=activity",
             {
               "replace": true,
               "state": {
@@ -311,7 +311,7 @@ describe('ui/pages/bridge/hooks/useSubmitBridgeTransaction', () => {
             },
           ],
           [
-            "/",
+            "/?tab=activity",
             {
               "replace": true,
               "state": {
@@ -389,12 +389,15 @@ describe('ui/pages/bridge/hooks/useSubmitBridgeTransaction', () => {
         accountAddress: expect.any(String),
       });
       expect(submitTxSpy).not.toHaveBeenCalled();
-      expect(mockUseNavigate).toHaveBeenCalledWith(DEFAULT_ROUTE, {
-        replace: true,
-        state: {
-          stayOnHomePage: true,
+      expect(mockUseNavigate).toHaveBeenCalledWith(
+        `${DEFAULT_ROUTE}?tab=activity`,
+        {
+          replace: true,
+          state: {
+            stayOnHomePage: true,
+          },
         },
-      });
+      );
       expect(resetBridgeStoreSpy).not.toHaveBeenCalled();
       expect(mockResetState).not.toHaveBeenCalled();
     });
@@ -429,21 +432,24 @@ describe('ui/pages/bridge/hooks/useSubmitBridgeTransaction', () => {
         );
       });
 
-      expect(mockUseNavigate).toHaveBeenCalledWith(DEFAULT_ROUTE, {
-        replace: true,
-        state: {
-          stayOnHomePage: true,
+      expect(mockUseNavigate).toHaveBeenCalledWith(
+        `${DEFAULT_ROUTE}?tab=activity`,
+        {
+          replace: true,
+          state: {
+            stayOnHomePage: true,
+          },
         },
-      });
+      );
       expect(resetBridgeStoreSpy).not.toHaveBeenCalled();
       expect(mockResetState).not.toHaveBeenCalled();
       expect(consoleErrorSpy.mock.calls).toMatchInlineSnapshot(`
-      [
-        [
-          [Error: submit failed],
-        ],
-      ]
-    `);
+              [
+                [
+                  [Error: submit failed],
+                ],
+              ]
+          `);
     });
 
     it('routes hardware-wallet intent quotes to default route after submit', async () => {
@@ -477,12 +483,16 @@ describe('ui/pages/bridge/hooks/useSubmitBridgeTransaction', () => {
         `${CROSS_CHAIN_SWAP_ROUTE}${AWAITING_SIGNATURES_ROUTE}`,
         { state: {} },
       );
-      expect(mockUseNavigate).toHaveBeenNthCalledWith(2, DEFAULT_ROUTE, {
-        replace: true,
-        state: {
-          stayOnHomePage: true,
+      expect(mockUseNavigate).toHaveBeenNthCalledWith(
+        2,
+        `${DEFAULT_ROUTE}?tab=activity`,
+        {
+          replace: true,
+          state: {
+            stayOnHomePage: true,
+          },
         },
-      });
+      );
       expect(resetBridgeStoreSpy).not.toHaveBeenCalled();
       expect(mockResetState).not.toHaveBeenCalled();
     });

--- a/ui/pages/bridge/hooks/useSubmitBridgeTransaction.ts
+++ b/ui/pages/bridge/hooks/useSubmitBridgeTransaction.ts
@@ -159,7 +159,7 @@ export default function useSubmitBridgeTransaction() {
       setIsSubmitting(false);
     }
 
-    navigate(DEFAULT_ROUTE, {
+    navigate(`${DEFAULT_ROUTE}?tab=activity`, {
       state: { stayOnHomePage: true },
       replace: true,
     });

--- a/ui/pages/confirmations/confirmation/templates/smart-transaction-status-page.js
+++ b/ui/pages/confirmations/confirmation/templates/smart-transaction-status-page.js
@@ -2,11 +2,6 @@
 function getValues(pendingApproval, t, actions, _navigate) {
   const { id, requestState } = pendingApproval;
   return {
-    // Skip the full-screen page; the transaction continues in the background
-    // and the toast listener provides status feedback.
-    onLoad: () => {
-      actions.resolvePendingApproval(id, true);
-    },
     content: [
       {
         element: 'SmartTransactionStatusPage',

--- a/ui/pages/confirmations/hooks/send/useSendActions.test.ts
+++ b/ui/pages/confirmations/hooks/send/useSendActions.test.ts
@@ -130,7 +130,7 @@ describe('useSendQueryParams', () => {
 
     await waitFor(() => {
       expect(mockSubmitNonEvmTransaction).toHaveBeenCalled();
-      expect(mockUseNavigate).toHaveBeenCalledWith('/');
+      expect(mockUseNavigate).toHaveBeenCalledWith('/?tab=activity');
     });
   });
 

--- a/ui/pages/confirmations/hooks/send/useSendActions.ts
+++ b/ui/pages/confirmations/hooks/send/useSendActions.ts
@@ -98,7 +98,7 @@ export const useSendActions = () => {
         }
 
         // Success
-        navigate(DEFAULT_ROUTE);
+        navigate(`${DEFAULT_ROUTE}?tab=activity`);
       } catch (error) {
         // Check for user rejection using error code (4001) - this is language-independent
         const errorCode = (error as { code?: number })?.code;

--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -105,7 +105,6 @@ import {
   ENVIRONMENT_TYPE_SIDEPANEL,
   SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES,
 } from '../../../shared/constants/app';
-import { isInteractiveUI } from '../../../shared/lib/environment-type';
 // TODO: Remove restricted import
 // eslint-disable-next-line import-x/no-restricted-paths
 import { getEnvironmentType } from '../../../app/scripts/lib/util';
@@ -135,7 +134,6 @@ import { contactsRoutes } from '../contacts';
 import RequireBasicFunctionality from '../../helpers/higher-order-components/require-basic-functionality/require-basic-functionality';
 import { getCurrencyRateControllerCurrentCurrency } from '../../../shared/lib/selectors/assets-migration';
 import { Toaster } from '../../components/ui/toast/toast';
-import { ToastListener } from '../../app/toast-listener/toast-listener';
 import { getConnectingLabel, setTheme } from './utils';
 import { ConfirmationHandler } from './confirmation-handler';
 import { Modals } from './modals';
@@ -691,7 +689,6 @@ export default function Routes() {
       dir={textDirection}
     >
       <ConfirmationHandler />
-      {isInteractiveUI() && <ToastListener />}
 
       <QRHardwarePopover />
       <Modal />

--- a/ui/pages/smart-transactions/smart-transaction-status-page/smart-transaction-status-page.tsx
+++ b/ui/pages/smart-transactions/smart-transaction-status-page/smart-transaction-status-page.tsx
@@ -230,7 +230,7 @@ const ViewActivityButton = ({
       width={BlockSize.Full}
       marginTop={3}
     >
-      {t('backToHome')}
+      {t('viewActivity')}
     </ButtonSecondary>
   );
 };

--- a/ui/pages/smart-transactions/smart-transaction-status-page/smart-transaction-status-page.tsx
+++ b/ui/pages/smart-transactions/smart-transaction-status-page/smart-transaction-status-page.tsx
@@ -230,7 +230,7 @@ const ViewActivityButton = ({
       width={BlockSize.Full}
       marginTop={3}
     >
-      {t('viewActivity')}
+      {t('backToHome')}
     </ButtonSecondary>
   );
 };

--- a/ui/pages/swaps/awaiting-swap/awaiting-swap.js
+++ b/ui/pages/swaps/awaiting-swap/awaiting-swap.js
@@ -50,6 +50,7 @@ import {
   OFFLINE_FOR_MAINTENANCE,
 } from '../../../../shared/constants/swaps';
 import { CHAINID_DEFAULT_BLOCK_EXPLORER_URL_MAP } from '../../../../shared/constants/common';
+import { isSwapsDefaultTokenSymbol } from '../../../../shared/lib/swaps.utils';
 import PulseLoader from '../../../components/ui/pulse-loader';
 import { isFlask, isBeta } from '../../../../shared/lib/build-types';
 
@@ -338,6 +339,11 @@ export default function AwaitingSwap({
             );
           } else if (errorKey) {
             await dispatch(navigateBackToPrepareSwap(navigate));
+          } else if (
+            isSwapsDefaultTokenSymbol(destinationTokenSymbol, chainId) ||
+            swapComplete
+          ) {
+            navigate(`${DEFAULT_ROUTE}?tab=activity`);
           } else {
             navigate(DEFAULT_ROUTE);
           }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Revert the post-transaction toast  feature

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**


https://github.com/user-attachments/assets/f1047cc3-3526-4619-bc68-bedf641df9dc


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes post-transaction navigation and disables the toast listener, which can affect user flow after swaps/bridges/sends and may surface regressions in transaction feedback. Also updates e2e behavior around the smart transaction status page, which may introduce test or UI flakiness if the status page timing differs.
> 
> **Overview**
> Disables the post-transaction toast flow by removing the global `ToastListener` mount and stopping `SmartTransactionStatusPage` from auto-resolving on load.
> 
> Updates post-submit navigation to go directly to `/?tab=activity` after bridge submissions (`useSubmitBridgeTransaction`), non-EVM sends (`useSendActions`), and certain swap completion paths (`awaiting-swap`).
> 
> Adjusts e2e bridge/swap tests to handle the smart transaction status page explicitly (adds a close button selector, makes `submitQuote` optionally dismiss the status page, and threads a `dismissStatusPage` flag through test helpers/cases).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ad5544c7bd59525396178187e766da9fb19a183. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->