### PR TITLE
ci: help close the Pattern Gap in the Merge Queue Retry system

### DIFF
--- a/.github/rules/retry-config.jsonc
+++ b/.github/rules/retry-config.jsonc
@@ -68,6 +68,7 @@
     "429 Too Many Requests",
     "502 Bad Gateway",
     "503 Service Unavailable",
+    "API rate limit exceeded",
     "Anvil exited: Error: Address already in use",
     "Authentication failed for",
     "Could not resolve host",
@@ -80,6 +81,7 @@
     "ETIMEDOUT",
     "Exceeded timeout of \\d+ ms for a test",
     "fatal: unable to access",
+    "git.* failed with exit code 128",
     "heap out of memory",
     "JavaScript heap out of memory",
     "net::ERR_",
@@ -93,5 +95,19 @@
     "VulkanError.cpp",
     "write EPIPE",
     "Yarn is terminating due to an unexpected empty event loop"
+  ],
+
+  // Patterns that indicate deterministic failures — errors that will never
+  // self-heal on retry (code errors, policy mismatches, snapshot drift).
+  // Checked against annotations + log tail when no transient pattern matched
+  // and the structural annotation check did not fire.
+  "deterministicErrorPatterns": [
+    "BASELINE VIOLATIONS DETECTED",
+    "Code style issues found",
+    "NEW FILES \\(not in baseline\\)",
+    "Test Suites:.*failed",
+    "Working tree dirty",
+    "snapshots? failed",
+    "✖ \\d+ problems? \\("
   ]
 }

--- a/.github/scripts/classify-failures.mts
+++ b/.github/scripts/classify-failures.mts
@@ -70,6 +70,8 @@ interface Job {
 interface Annotation {
   message?: string;
   title?: string;
+  path?: string;
+  start_line?: number;
 }
 
 type Category = 'alwaysRetryable' | 'retryableOnTransientError' | 'optional';
@@ -82,6 +84,7 @@ interface JobClassification {
   reason: string;
   errorSnippet?: string;
   unmatched?: boolean;
+  deterministic?: boolean;
 }
 
 interface CategoryConfig {
@@ -92,6 +95,7 @@ interface RetryConfig {
   jobClassification: Record<Category, CategoryConfig>;
   blockerPatterns: string[];
   transientErrorPatterns: string[];
+  deterministicErrorPatterns: string[];
   defaults: { unmatchedCategory: Category };
 }
 
@@ -246,6 +250,9 @@ const compiledPatterns = Object.fromEntries(
   ]),
 ) as Record<Category, RegExp[]>;
 const transientErrorRegexes = config.transientErrorPatterns.map(
+  (p) => new RegExp(p, 'i'),
+);
+const deterministicErrorRegexes = config.deterministicErrorPatterns.map(
   (p) => new RegExp(p, 'i'),
 );
 
@@ -420,18 +427,92 @@ function classifyJob(job: Job): JobClassification {
   }
 
   // No transient pattern matched. Capture the first annotation message or
-  // the last few log lines so the dashboard can surface what the actual
+  // a meaningful log line so the dashboard can surface what the actual
   // error was — useful for identifying new patterns to add.
   // Skip the generic "Process completed with exit code N" annotation —
   // it appears on every failed job and provides no diagnostic value.
   const firstAnnotation = annotations.find(
-    (a) => a.message?.trim() && !/^Process completed with exit code \d+/.test(a.message.trim()),
+    (a) =>
+      a.message?.trim() &&
+      !/^Process completed with exit code \d+/.test(a.message.trim()),
   );
-  const fallbackSnippet = firstAnnotation
-    ? firstAnnotation.message!.trim().slice(0, 200)
-    : logs
-      ? logs.trim().split('\n').slice(-3).join(' | ').slice(0, 200)
-      : undefined;
+  let fallbackSnippet: string | undefined;
+  if (firstAnnotation) {
+    fallbackSnippet = firstAnnotation.message!.trim().slice(0, 200);
+  } else if (logs) {
+    // Scan from the bottom for a line that looks like an actual error.
+    // The last few lines are often just the checkout/cleanup step —
+    // the real error is usually a few lines above.
+    const errorLineRe =
+      /\b(?:error|ERR!|FATAL|fatal|failed|FAILED|Error:|Cannot |Unable to )/i;
+    const lines = logs.trim().split('\n');
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const line = lines[i].trim();
+      // Strip the GHA timestamp prefix (e.g. "2026-04-09T20:48:51.437Z ")
+      const stripped = line.replace(/^\d{4}-\d{2}-\d{2}T[\d:.]+Z\s*/, '');
+      if (
+        stripped &&
+        errorLineRe.test(stripped) &&
+        !/Process completed with exit code \d+/.test(stripped) &&
+        !/^\[command\]/.test(stripped)
+      ) {
+        fallbackSnippet = stripped.slice(0, 200);
+        break;
+      }
+    }
+    // Last resort: use the last 3 lines if no error-like line was found
+    if (!fallbackSnippet) {
+      fallbackSnippet = lines.slice(-3).join(' | ').slice(0, 200);
+    }
+  }
+
+  // Check for deterministic (non-transient) failure signals.
+  //
+  // STRUCTURAL: If any annotation references a source file (has a real
+  // path + line number), this is a compiler/linter error — deterministic
+  // by nature. This catches ALL TypeScript, ESLint, and Stylelint errors
+  // without needing to enumerate every possible error message.
+  const sourceFileAnnotation = annotations.find(
+    (a) =>
+      a.path &&
+      a.path !== '.github' &&
+      a.start_line != null &&
+      a.start_line > 0 &&
+      a.message?.trim() &&
+      !/^Process completed with exit code \d+/.test(a.message.trim()),
+  );
+  if (sourceFileAnnotation) {
+    return {
+      jobName,
+      jobId,
+      category,
+      jobRetryable: false,
+      reason: `Deterministic: code error in ${sourceFileAnnotation.path}:${sourceFileAnnotation.start_line}`,
+      errorSnippet:
+        fallbackSnippet ?? sourceFileAnnotation.message!.trim().slice(0, 200),
+      unmatched,
+      deterministic: true,
+    };
+  }
+
+  // Log-only deterministic signals (no source-file annotation).
+  // Patterns live in retry-config.jsonc → deterministicErrorPatterns.
+  const combinedText = [annotationText, logs ?? ''].join('\n');
+  for (const re of deterministicErrorRegexes) {
+    const deterministicMatch = re.exec(combinedText);
+    if (deterministicMatch) {
+      return {
+        jobName,
+        jobId,
+        category,
+        jobRetryable: false,
+        reason: `Deterministic: ${deterministicMatch[0]}`,
+        errorSnippet: fallbackSnippet ?? deterministicMatch[0],
+        unmatched,
+        deterministic: true,
+      };
+    }
+  }
 
   return {
     jobName,
@@ -958,6 +1039,7 @@ if (Sentry) {
       'ci.job.reason': job.reason,
       ...(job.errorSnippet ? { 'ci.job.errorSnippet': job.errorSnippet } : {}),
       ...(job.unmatched ? { 'ci.job.unmatched': true } : {}),
+      ...(job.deterministic ? { 'ci.job.deterministic': true } : {}),
     });
   }
 


### PR DESCRIPTION
## **Description**

We've been collecting retry decision Pattern Gaps in this Sentry dashboard: https://metamask.sentry.io/dashboard/521041/?project=4510302346608640

I went through all known Pattern Gaps and closed the gaps.  Then I validated against 50 consecutive failed workflow runs.

### DETAILS

Adds two layers of deterministic failure detection so the retry system won't waste Sentry pattern-gap events on failures that can never self-heal:
- **Structural annotation check:** Any GHA annotation with a real source file path + line number is a compiler/linter error — catches all TS, ESLint, and Stylelint errors without enumerating messages
- **Config-driven patterns:** New `deterministicErrorPatterns` in retry-config.jsonc catches log-only signals (Prettier violations, Jest snapshot/suite failures, baseline drift, LavaMoat policy mismatch)
- **Smart log scan:** Bottom-up search for error-like lines instead of blindly grabbing last 3 lines, improving snippet quality
- Deterministic jobs emit `ci.job.deterministic: true` to Sentry for dashboard filtering


## **Changelog**

CHANGELOG entry: null

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**
[skip-e2e]-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the CI retry decision logic to classify more failures as non-retryable using new heuristics and patterns; mistakes could reduce automatic retries for genuinely transient failures or affect merge-queue throughput.
> 
> **Overview**
> Improves merge-queue retry triage by adding explicit **deterministic failure detection** so non-transient failures are marked non-retryable instead of generating pattern-gap noise.
> 
> Extends `retry-config.jsonc` with `deterministicErrorPatterns` (and adds a few new transient patterns), updates `classify-failures.mts` to (1) treat source-file annotations (`path` + `start_line`) as deterministic code errors, (2) match log/annotation text against deterministic patterns, (3) extract better `errorSnippet` via a bottom-up error-line scan, and (4) emit `ci.job.deterministic=true` to Sentry for filtering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 365e1e62b5b3a32d22bc873d4d9d450dfb51c603. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->