### PR TITLE
fix: move metamask fee in tx fee tooltip in MM Pay

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -4160,6 +4160,10 @@
     "message": "Bonus details",
     "description": "Accessible name for the info control that opens the mUSD conversion bonus explanation popover"
   },
+  "musdConversionFeeTooltipDescription": {
+    "message": "mUSD conversion fees include network costs and may include provider fees. No MetaMask fee applies when you convert to mUSD.",
+    "description": "Body text shown above the fee breakdown in the transaction fee tooltip for mUSD conversion"
+  },
   "musdConversionTitle": {
     "message": "Converted to mUSD",
     "description": "Title shown in the transaction details modal for mUSD conversion transactions"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -4160,6 +4160,10 @@
     "message": "Bonus details",
     "description": "Accessible name for the info control that opens the mUSD conversion bonus explanation popover"
   },
+  "musdConversionFeeTooltipDescription": {
+    "message": "mUSD conversion fees include network costs and may include provider fees. No MetaMask fee applies when you convert to mUSD.",
+    "description": "Body text shown above the fee breakdown in the transaction fee tooltip for mUSD conversion"
+  },
   "musdConversionTitle": {
     "message": "Converted to mUSD",
     "description": "Title shown in the transaction details modal for mUSD conversion transactions"

--- a/ui/components/app/confirm/info/row/row.tsx
+++ b/ui/components/app/confirm/info/row/row.tsx
@@ -51,12 +51,28 @@ export type ConfirmInfoRowProps = {
   onClick?: () => void;
   rowVariant?: ConfirmInfoRowSize;
   style?: React.CSSProperties;
-  tooltip?: string;
+  tooltip?: string | React.ReactNode;
   tooltipIcon?: IconName;
   tooltipIconColor?: IconColor;
   variant?: ConfirmInfoRowVariant;
   labelChildrenStyleOverride?: React.CSSProperties;
 };
+
+type TooltipDisplayProps = { html?: React.ReactNode; title?: string };
+
+function getConfirmInfoRowTooltipProps(
+  tooltip: string | React.ReactNode,
+): TooltipDisplayProps {
+  if (typeof tooltip !== 'string') {
+    return { html: tooltip };
+  }
+  if (tooltip.includes('\n')) {
+    return {
+      html: <span style={{ whiteSpace: 'pre-line' }}>{tooltip}</span>,
+    };
+  }
+  return { title: tooltip };
+}
 
 const BACKGROUND_COLORS = {
   [ConfirmInfoRowVariant.Default]: undefined,
@@ -194,34 +210,29 @@ export const ConfirmInfoRow: React.FC<ConfirmInfoRowProps> = ({
               </Text>
             )}
             {labelChildren}
-            {!labelChildren && tooltip?.length && (
-              <Tooltip
-                position="bottom"
-                {...(tooltip.includes('\n')
-                  ? {
-                      html: (
-                        <span style={{ whiteSpace: 'pre-line' }}>
-                          {tooltip}
-                        </span>
-                      ),
+            {!labelChildren &&
+              tooltip !== undefined &&
+              tooltip !== null &&
+              (typeof tooltip !== 'string' || tooltip.length > 0) && (
+                <Tooltip
+                  position="bottom"
+                  {...getConfirmInfoRowTooltipProps(tooltip)}
+                  style={{ display: 'flex' }}
+                >
+                  <Icon
+                    name={tooltipIcon ?? TOOLTIP_ICONS[variant]}
+                    marginLeft={1}
+                    color={
+                      tooltipIconColor ??
+                      (TOOLTIP_ICON_COLORS[variant] as unknown as IconColor)
                     }
-                  : { title: tooltip })}
-                style={{ display: 'flex' }}
-              >
-                <Icon
-                  name={tooltipIcon ?? TOOLTIP_ICONS[variant]}
-                  marginLeft={1}
-                  color={
-                    tooltipIconColor ??
-                    (TOOLTIP_ICON_COLORS[variant] as unknown as IconColor)
-                  }
-                  size={IconSize.Sm}
-                  {...(dataTestId
-                    ? { 'data-testid': `${dataTestId}-tooltip` }
-                    : {})}
-                />
-              </Tooltip>
-            )}
+                    size={IconSize.Sm}
+                    {...(dataTestId
+                      ? { 'data-testid': `${dataTestId}-tooltip` }
+                      : {})}
+                  />
+                </Tooltip>
+              )}
           </Box>
         </Box>
         {expanded &&

--- a/ui/pages/confirmations/components/info/musd-conversion-info/musd-conversion-info.tsx
+++ b/ui/pages/confirmations/components/info/musd-conversion-info/musd-conversion-info.tsx
@@ -15,6 +15,7 @@ import {
   useIsTransactionPayLoading,
   useTransactionPayQuotes,
 } from '../../../hooks/pay/useTransactionPayData';
+import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { BridgeFeeRow } from '../../rows/bridge-fee-row/bridge-fee-row';
 import { ClaimableBonusRow } from '../../rows/claimable-bonus-row/claimable-bonus-row';
 import { TotalRow } from '../../rows/total-row/total-row';
@@ -22,6 +23,7 @@ import { useMusdConversionQuoteTrace } from '../../../hooks/musd/useMusdConversi
 import { MusdOverrideContent } from './musd-override-content';
 
 const MusdBottomContent = () => {
+  const t = useI18nContext();
   const quotes = useTransactionPayQuotes();
   const isQuotesLoading = useIsTransactionPayLoading();
   const { hideResults } = useTransactionCustomAmountAlerts();
@@ -34,7 +36,10 @@ const MusdBottomContent = () => {
 
   return (
     <Box flexDirection={BoxFlexDirection.Column} gap={2} paddingBottom={4}>
-      <BridgeFeeRow variant={ConfirmInfoRowSize.Small} />
+      <BridgeFeeRow
+        variant={ConfirmInfoRowSize.Small}
+        tooltipDescription={t('musdConversionFeeTooltipDescription')}
+      />
       <ClaimableBonusRow rowVariant={ConfirmInfoRowSize.Small} />
       <TotalRow variant={ConfirmInfoRowSize.Small} />
     </Box>

--- a/ui/pages/confirmations/components/rows/bridge-fee-row/bridge-fee-row.test.tsx
+++ b/ui/pages/confirmations/components/rows/bridge-fee-row/bridge-fee-row.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { userEvent } from '@testing-library/user-event';
 import configureMockStore from 'redux-mock-store';
 import type {
   TransactionPayQuote,
@@ -62,35 +63,87 @@ describe('BridgeFeeRow', () => {
     expect(getByText(messages.transactionFee.message)).toBeInTheDocument();
   });
 
-  it('renders full skeletons without labels when loading (Small variant)', () => {
+  it('renders bridge fee skeleton only when loading (Small variant)', () => {
     useIsTransactionPayLoadingMock.mockReturnValue(true);
 
-    const { getByTestId, queryByText } = render({
+    const { getByTestId, queryByTestId, queryByText } = render({
       variant: ConfirmInfoRowSize.Small,
     });
 
     expect(getByTestId('bridge-fee-row-skeleton')).toBeInTheDocument();
-    expect(getByTestId('metamask-fee-row-skeleton')).toBeInTheDocument();
+    expect(queryByTestId('metamask-fee-row-skeleton')).not.toBeInTheDocument();
     expect(
       queryByText(messages.transactionFee.message),
     ).not.toBeInTheDocument();
     expect(queryByText(messages.metamaskFee.message)).not.toBeInTheDocument();
   });
 
-  it('does not render metamask fee with Default variant', () => {
+  it('does not render metamask fee body row (Default variant)', () => {
     const { getByTestId, queryByTestId } = render();
 
     expect(getByTestId('bridge-fee-row')).toBeInTheDocument();
     expect(queryByTestId('metamask-fee-row')).not.toBeInTheDocument();
   });
 
-  it('renders metamask fee with Small variant when quotes exist', () => {
-    const { getByTestId } = render({
+  it('does not render metamask fee body row (Small variant)', () => {
+    const { getByTestId, queryByTestId } = render({
       variant: ConfirmInfoRowSize.Small,
     });
 
     expect(getByTestId('bridge-fee-row')).toBeInTheDocument();
-    expect(getByTestId('metamask-fee-row')).toBeInTheDocument();
+    expect(queryByTestId('metamask-fee-row')).not.toBeInTheDocument();
+  });
+
+  it('renders tooltip with network and bridge fee only for Default variant (no MetaMask row)', async () => {
+    const user = userEvent.setup();
+    const { getByTestId, findByText } = render();
+
+    await user.hover(getByTestId('bridge-fee-row-tooltip'));
+
+    const tooltip = await findByText((content) =>
+      content.includes(`${messages.networkFee.message}:`),
+    );
+    expect(
+      tooltip.textContent?.startsWith(`${messages.networkFee.message}:`),
+    ).toBe(true);
+    expect(tooltip.textContent).toContain(`${messages.bridgeFee.message}:`);
+    expect(tooltip.textContent).not.toContain(
+      `${messages.metamaskFee.message}:`,
+    );
+  });
+
+  it('renders tooltip with network, bridge, and metamask fee for Small variant', async () => {
+    const user = userEvent.setup();
+    const { getByTestId, findByText } = render({
+      variant: ConfirmInfoRowSize.Small,
+    });
+
+    await user.hover(getByTestId('bridge-fee-row-tooltip'));
+
+    const tooltip = await findByText((content) =>
+      content.includes(`${messages.networkFee.message}:`),
+    );
+    expect(tooltip.textContent).toContain(`${messages.bridgeFee.message}:`);
+    expect(tooltip.textContent).toContain(`${messages.metamaskFee.message}:`);
+  });
+
+  it('renders rich tooltip with description and fee labels when tooltipDescription is set', async () => {
+    const user = userEvent.setup();
+    const { getByTestId, findByText } = render({
+      variant: ConfirmInfoRowSize.Small,
+      tooltipDescription: messages.musdConversionFeeTooltipDescription.message,
+    });
+
+    await user.hover(getByTestId('bridge-fee-row-tooltip'));
+
+    const tooltip = await findByText((content) =>
+      content.includes(messages.musdConversionFeeTooltipDescription.message),
+    );
+    expect(tooltip.textContent).toContain(
+      `${messages.musdConversionFeeTooltipDescription.message}\n\n${messages.networkFee.message}:`,
+    );
+    expect(tooltip.textContent).toContain(`${messages.bridgeFee.message}:`);
+    expect(tooltip.textContent).toContain(`${messages.metamaskFee.message}:`);
   });
 
   it('does not render metamask fee if no quotes (Small variant)', () => {
@@ -102,6 +155,15 @@ describe('BridgeFeeRow', () => {
 
     expect(getByTestId('bridge-fee-row')).toBeInTheDocument();
     expect(queryByTestId('metamask-fee-row')).not.toBeInTheDocument();
+  });
+
+  it('does not render a transaction fee tooltip when there are no quotes', () => {
+    useTransactionPayQuotesMock.mockReturnValue([]);
+
+    const { getByTestId, queryByTestId } = render();
+
+    expect(getByTestId('bridge-fee-row')).toBeInTheDocument();
+    expect(queryByTestId('bridge-fee-row-tooltip')).not.toBeInTheDocument();
   });
 
   it('renders fee value with ConfirmInfoRowText for Default variant', () => {

--- a/ui/pages/confirmations/components/rows/bridge-fee-row/bridge-fee-row.tsx
+++ b/ui/pages/confirmations/components/rows/bridge-fee-row/bridge-fee-row.tsx
@@ -22,11 +22,17 @@ import { useFiatFormatter } from '../../../../../hooks/useFiatFormatter';
 
 export type BridgeFeeRowProps = {
   variant?: ConfirmInfoRowSize;
+  /**
+   * When set, this text is shown first in the tooltip, then newline-separated fee lines
+   * (e.g. mUSD conversion copy from the parent).
+   */
+  tooltipDescription?: string;
 };
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export function BridgeFeeRow({
   variant = ConfirmInfoRowSize.Default,
+  tooltipDescription,
 }: BridgeFeeRowProps) {
   const t = useI18nContext();
   const formatFiat = useFiatFormatter();
@@ -53,77 +59,92 @@ export function BridgeFeeRow({
 
   if (isLoading) {
     return (
-      <>
-        <ConfirmInfoRowSkeleton
-          data-testid="bridge-fee-row-skeleton"
-          label={t('transactionFee')}
-          rowVariant={variant}
-        />
-        {isSmall && (
-          <ConfirmInfoRowSkeleton
-            data-testid="metamask-fee-row-skeleton"
-            label={t('metamaskFee')}
-            rowVariant={variant}
-          />
-        )}
-      </>
+      <ConfirmInfoRowSkeleton
+        data-testid="bridge-fee-row-skeleton"
+        label={t('transactionFee')}
+        rowVariant={variant}
+      />
     );
   }
 
   const hasQuotes = Boolean(quotes?.length);
 
+  let tooltipContent: string | undefined;
+  if (hasQuotes && totals) {
+    tooltipContent = renderTooltipContent({
+      description: tooltipDescription,
+      t,
+      totals,
+      formatFiat,
+      metamaskFeeFormatted: metamaskFeeUsd,
+      /** Matches prior behavior: MetaMask fee was only shown for Small variant (body row). */
+      includeMetamaskFee: isSmall,
+    });
+  }
+
   return (
-    <>
-      <ConfirmInfoRow
-        data-testid="bridge-fee-row"
-        label={t('transactionFee')}
-        rowVariant={variant}
-        tooltip={
-          hasQuotes && totals
-            ? renderTooltipContent(t, totals, formatFiat)
-            : undefined
-        }
-      >
-        {isSmall ? (
-          <Text
-            variant={textVariant}
-            color={TextColor.textAlternative}
-            data-testid="transaction-fee-value"
-          >
-            {feeTotalUsd}
-          </Text>
-        ) : (
-          <ConfirmInfoRowText
-            text={feeTotalUsd}
-            data-testid="transaction-fee-value"
-          />
-        )}
-      </ConfirmInfoRow>
-      {hasQuotes && isSmall && (
-        <ConfirmInfoRow
-          data-testid="metamask-fee-row"
-          label={t('metamaskFee')}
-          rowVariant={variant}
+    <ConfirmInfoRow
+      data-testid="bridge-fee-row"
+      label={t('transactionFee')}
+      rowVariant={variant}
+      tooltip={tooltipContent}
+    >
+      {isSmall ? (
+        <Text
+          variant={textVariant}
+          color={TextColor.textAlternative}
+          data-testid="transaction-fee-value"
         >
-          <Text variant={textVariant} color={TextColor.textAlternative}>
-            {metamaskFeeUsd}
-          </Text>
-        </ConfirmInfoRow>
+          {feeTotalUsd}
+        </Text>
+      ) : (
+        <ConfirmInfoRowText
+          text={feeTotalUsd}
+          data-testid="transaction-fee-value"
+        />
       )}
-    </>
+    </ConfirmInfoRow>
   );
 }
 
-function renderTooltipContent(
-  t: ReturnType<typeof useI18nContext>,
-  totals: TransactionPayTotals,
-  formatFiat: ReturnType<typeof useFiatFormatter>,
-): string {
+type RenderTooltipContentArgs = {
+  description: string | undefined;
+  t: ReturnType<typeof useI18nContext>;
+  totals: TransactionPayTotals;
+  formatFiat: ReturnType<typeof useFiatFormatter>;
+  metamaskFeeFormatted: string;
+  includeMetamaskFee: boolean;
+};
+
+function renderTooltipContent({
+  description,
+  t,
+  totals,
+  formatFiat,
+  metamaskFeeFormatted,
+  includeMetamaskFee,
+}: RenderTooltipContentArgs): string {
   const networkFee = new BigNumber(totals.fees.sourceNetwork.estimate.usd).plus(
     totals.fees.targetNetwork.usd,
   );
 
-  const providerFee = new BigNumber(totals.fees.provider.usd);
+  const bridgeFeeUsd = new BigNumber(totals.fees.provider.usd);
 
-  return `${t('networkFee')}: ${formatFiat(networkFee.toNumber())}\n${t('bridgeFee')}: ${formatFiat(providerFee.toNumber())}`;
+  const lines: string[] = [];
+
+  if (description) {
+    lines.push(description);
+    lines.push('');
+  }
+
+  lines.push(
+    `${t('networkFee')}: ${formatFiat(networkFee.toNumber())}`,
+    `${t('bridgeFee')}: ${formatFiat(bridgeFeeUsd.toNumber())}`,
+  );
+
+  if (includeMetamaskFee) {
+    lines.push(`${t('metamaskFee')}: ${metamaskFeeFormatted}`);
+  }
+
+  return lines.join('\n');
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- moves metamask fee in tx fee tooltip in MM Pay
- adds generic tooltip description option to the bridge fee row component

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updates metamask fee to be in tx bridge fee tooltip in MM Pay

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUSD-639
Related: https://consensyssoftware.atlassian.net/browse/CONF-1114

## **Manual testing steps**

Go to mUSD convert flow and enter an amount

There should be no metamask fee in the quote rows, but when hovering over Transaction fee info icon you see mUSD specific copy and the metamask fee

The metamask fee shows in the same cases it did before

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
<img width="525" height="369" alt="Screenshot 2026-04-09 at 11 28 02 PM" src="https://github.com/user-attachments/assets/eadb90dd-ebb2-48e6-a456-ad3457763d52" />
<img width="506" height="225" alt="Screenshot 2026-04-09 at 11 27 34 PM" src="https://github.com/user-attachments/assets/c797f58b-2495-4606-bdf0-7f9b7357579e" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that reworks fee display and tooltip rendering; main risk is regressions in confirmation fee breakdown visibility across variants/locales.
> 
> **Overview**
> Moves the **MetaMask fee** out of the separate fee row in MM Pay confirmations and into the `Transaction fee` tooltip (shown for the small/quote view), while keeping the default view free of the MetaMask fee line.
> 
> Adds a `tooltipDescription` option to `BridgeFeeRow` to prepend contextual copy (used by mUSD conversion), introduces a new i18n string (`musdConversionFeeTooltipDescription`), and updates `ConfirmInfoRow` tooltips to accept either strings (including newline formatting) or rich `ReactNode` content. Tests are updated to assert the new tooltip behavior and the removal of the MetaMask fee row/skeleton.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fa504c01409848b1993ebe64976b3b1616332b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->