### PR TITLE
feat: Extension AgenticService (mobile parity)

### DIFF
--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -324,13 +324,15 @@ type StateHooks = {
    */
   resetWebVitalsMetrics?: () => void;
 
-  // Agentic dev hooks (METAMASK_DEBUG only) — expose internals for CDP automation
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  store?: any;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  submitRequestToBackground?: (method: string, args?: any[]) => Promise<any>;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  getPerpsStreamManager?: () => any;
+  // Agentic dev hooks (METAMASK_DEBUG only) — expose internals for CDP automation.
+  // Typed as `unknown` because these are untyped debug-only entry points consumed
+  // by CDP automation scripts that perform their own runtime checks.
+  store?: unknown;
+  submitRequestToBackground?: (
+    method: string,
+    args?: unknown[],
+  ) => Promise<unknown>;
+  getPerpsStreamManager?: () => unknown;
 };
 
 export declare global {

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -323,6 +323,14 @@ type StateHooks = {
    * Useful for clearing metrics between benchmark runs.
    */
   resetWebVitalsMetrics?: () => void;
+
+  // Agentic dev hooks (METAMASK_DEBUG only) — expose internals for CDP automation
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  store?: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  submitRequestToBackground?: (method: string, args?: any[]) => Promise<any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  getPerpsStreamManager?: () => any;
 };
 
 export declare global {

--- a/ui/index.js
+++ b/ui/index.js
@@ -441,9 +441,10 @@ function setupStateHooks(store) {
 
   // Agentic dev hooks — expose internals for CDP automation
   if (process.env.METAMASK_DEBUG) {
-    window.stateHooks.store = store;
-    window.stateHooks.submitRequestToBackground = submitRequestToBackground;
-    window.stateHooks.getPerpsStreamManager = getPerpsStreamManager;
+    globalThis.stateHooks.store = store;
+    globalThis.stateHooks.submitRequestToBackground =
+      submitRequestToBackground;
+    globalThis.stateHooks.getPerpsStreamManager = getPerpsStreamManager;
   }
 }
 

--- a/ui/index.js
+++ b/ui/index.js
@@ -442,8 +442,7 @@ function setupStateHooks(store) {
   // Agentic dev hooks — expose internals for CDP automation
   if (process.env.METAMASK_DEBUG) {
     globalThis.stateHooks.store = store;
-    globalThis.stateHooks.submitRequestToBackground =
-      submitRequestToBackground;
+    globalThis.stateHooks.submitRequestToBackground = submitRequestToBackground;
     globalThis.stateHooks.getPerpsStreamManager = getPerpsStreamManager;
   }
 }

--- a/ui/index.js
+++ b/ui/index.js
@@ -50,7 +50,10 @@ import {
 } from './ducks/metamask/metamask';
 import Root from './pages';
 import txHelper from './helpers/utils/tx-helper';
-import { setBackgroundConnection } from './store/background-connection';
+import {
+  setBackgroundConnection,
+  submitRequestToBackground,
+} from './store/background-connection';
 import { getStartupTraceTags } from './helpers/utils/tags';
 import { SEEDLESS_PASSWORD_OUTDATED_CHECK_INTERVAL_MS } from './constants';
 import { initWebVitals } from './helpers/utils/web-vitals';
@@ -434,6 +437,13 @@ function setupStateHooks(store) {
   // Expose metrics APIs for E2E benchmark harness
   if (process.env.IN_TEST || process.env.METAMASK_DEBUG) {
     exposeLongTaskMetricsForTesting();
+  }
+
+  // Agentic dev hooks — expose internals for CDP automation
+  if (process.env.METAMASK_DEBUG) {
+    window.stateHooks.store = store;
+    window.stateHooks.submitRequestToBackground = submitRequestToBackground;
+    window.stateHooks.getPerpsStreamManager = getPerpsStreamManager;
   }
 }
 


### PR DESCRIPTION
## **Description**

Exposes 3 dev-only hooks on `window.stateHooks` gated behind `process.env.METAMASK_DEBUG`, giving CDP automation full read/write access to the extension's internals:

- **`stateHooks.store`** — live Redux store (read state, dispatch actions)
- **`stateHooks.submitRequestToBackground(method, args)`** — generic background RPC proxy. Combined with the existing `messengerCall` API, this provides access to ANY controller method (`AccountsController:listAccounts`, `PerpsController:getAccountState`, etc.) without manual mapping
- **`stateHooks.getPerpsStreamManager()`** — live perps stream singleton (positions, orders, account data that bypasses the Redux gap)

This closes the gap with mobile's `globalThis.__AGENTIC__` bridge. Mobile exposes `Engine.context.*` for direct controller access; extension can't do that due to LavaMoat, but `submitRequestToBackground('messengerCall', [action, args])` is functionally equivalent.

**Zero prod impact** — all 3 hooks are behind `process.env.METAMASK_DEBUG` which is stripped from production builds.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [TAT-2902](https://consensyssoftware.atlassian.net/browse/TAT-2902)

## **Manual testing steps**

1. Build extension in dev mode (`yarn start`)
2. Open `home.html` in browser, open DevTools console
3. Verify hooks exist:
   ```js
   typeof stateHooks.store // 'object'
   typeof stateHooks.submitRequestToBackground // 'function'
   typeof stateHooks.getPerpsStreamManager // 'function'
   ```
4. Test generic controller call:
   ```js
   await stateHooks.submitRequestToBackground('messengerCall', ['AccountsController:listAccounts', []])
   // Returns array of accounts
   ```
5. Test Redux store access:
   ```js
   Object.keys(stateHooks.store.getState().metamask.internalAccounts.accounts)
   // Returns account IDs
   ```
6. Test stream manager:
   ```js
   stateHooks.getPerpsStreamManager().positions.getCachedData()
   // Returns cached positions array
   ```
7. Verify NOT available in production build (`yarn build:prod` → hooks are undefined)

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/b8ccb1c6-9ebb-432e-91e9-eddf707d9ff5


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## **Validation Recipe**

<details>
<summary>recipe.json — 9-node validation workflow (all pass)</summary>

```json
{
  "title": "Validate AgenticService dev hooks on window.stateHooks",
  "validate": {
    "workflow": {
      "pre_conditions": ["wallet.unlocked"],
      "entry": "ac1-store-exists",
      "nodes": {
        "ac1-store-exists": {
          "id": "ac1-store-exists",
          "action": "eval_sync",
          "expression": "typeof window.stateHooks.store === 'object' && typeof window.stateHooks.store.getState === 'function'",
          "assert": { "operator": "eq", "value": true },
          "next": "ac1-store-has-metamask"
        },
        "ac1-store-has-metamask": {
          "id": "ac1-store-has-metamask",
          "action": "eval_sync",
          "expression": "typeof window.stateHooks.store.getState().metamask === 'object'",
          "assert": { "operator": "eq", "value": true },
          "next": "ac2-submit-request-exists"
        },
        "ac2-submit-request-exists": {
          "id": "ac2-submit-request-exists",
          "action": "eval_sync",
          "expression": "typeof window.stateHooks.submitRequestToBackground === 'function'",
          "assert": { "operator": "eq", "value": true },
          "next": "ac2-messenger-call-works"
        },
        "ac2-messenger-call-works": {
          "id": "ac2-messenger-call-works",
          "action": "eval_async",
          "expression": "window.stateHooks.submitRequestToBackground('messengerCall', ['AccountsController:listAccounts', []]).then(a => Array.isArray(a))",
          "assert": { "operator": "eq", "value": true },
          "next": "ac3-stream-manager-exists"
        },
        "ac3-stream-manager-exists": {
          "id": "ac3-stream-manager-exists",
          "action": "eval_sync",
          "expression": "typeof window.stateHooks.getPerpsStreamManager === 'function'",
          "assert": { "operator": "eq", "value": true },
          "next": "ac3-stream-manager-has-channels"
        },
        "ac3-stream-manager-has-channels": {
          "id": "ac3-stream-manager-has-channels",
          "action": "eval_sync",
          "expression": "(function() { var m = window.stateHooks.getPerpsStreamManager(); return typeof m.positions === 'object' && typeof m.orders === 'object' && typeof m.account === 'object'; })()",
          "assert": { "operator": "eq", "value": true },
          "next": "ac4-accounts-via-store"
        },
        "ac4-accounts-via-store": {
          "id": "ac4-accounts-via-store",
          "action": "eval_sync",
          "expression": "Object.keys(window.stateHooks.store.getState().metamask.internalAccounts.accounts).length > 0",
          "assert": { "operator": "eq", "value": true },
          "next": "ac5-perps-controller-call"
        },
        "ac5-perps-controller-call": {
          "id": "ac5-perps-controller-call",
          "action": "eval_async",
          "expression": "window.stateHooks.submitRequestToBackground('perpsGetAccountState', []).then(r => r !== undefined).catch(() => true)",
          "assert": { "operator": "eq", "value": true },
          "next": "ac6-screenshot-evidence"
        },
        "ac6-screenshot-evidence": {
          "id": "ac6-screenshot-evidence",
          "action": "screenshot",
          "filename": "evidence-agentic-hooks-validated.png",
          "next": "done"
        },
        "done": {
          "id": "done",
          "action": "end",
          "status": "pass",
          "message": "All agentic dev hooks validated: store, submitRequestToBackground, getPerpsStreamManager"
        }
      }
    }
  }
}
```

</details>

[TAT-2902]: https://consensyssoftware.atlassian.net/browse/TAT-2902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds debug-only global access to the live Redux store, a generic background RPC proxy, and the perps stream manager; risk is mainly accidental exposure if build-time `METAMASK_DEBUG` gating is misconfigured.
> 
> **Overview**
> Exposes **dev-only CDP automation hooks** on `window.stateHooks` when `process.env.METAMASK_DEBUG` is enabled, including the live Redux `store`, `submitRequestToBackground(method, args)` for generic background RPC calls, and `getPerpsStreamManager()`.
> 
> Updates global TypeScript declarations (`types/global.d.ts`) and wires the new assignments during UI startup (`ui/index.js`), while keeping production behavior unchanged via the debug gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c666500420e05e16ef41a423476cee40f1f3136. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



