### PR TITLE
chore: Bulk register actions in `DataDeletionService`

### DIFF
--- a/app/scripts/controllers/metametrics-data-deletion/metametrics-data-deletion.test.ts
+++ b/app/scripts/controllers/metametrics-data-deletion/metametrics-data-deletion.test.ts
@@ -21,6 +21,7 @@ describe('MetaMetricsDataDeletionController', () => {
         metaMetricsId: mockMetaMetricsId,
         options: {
           dataDeletionService: {
+            name: 'DataDeletionService' as const,
             createDataDeletionRegulationTask: jest
               .fn()
               .mockResolvedValue(mockTaskId),
@@ -54,6 +55,7 @@ describe('MetaMetricsDataDeletionController', () => {
         metaMetricsId: mockMetaMetricsId,
         options: {
           dataDeletionService: {
+            name: 'DataDeletionService' as const,
             createDataDeletionRegulationTask: jest
               .fn()
               .mockResolvedValue(mockTaskId),
@@ -103,6 +105,7 @@ describe('MetaMetricsDataDeletionController', () => {
         metaMetricsId: mockMetaMetricsId,
         options: {
           dataDeletionService: {
+            name: 'DataDeletionService' as const,
             createDataDeletionRegulationTask: jest
               .fn()
               .mockResolvedValue(mockTaskId),
@@ -270,6 +273,7 @@ function setupController({
   const mockCreateDataDeletionRegulationTaskResponse = 'mockRegulateId';
   const mockFetchDeletionRegulationStatusResponse = 'UNKNOWN';
   const mockDataDeletionService = {
+    name: 'DataDeletionService' as const,
     createDataDeletionRegulationTask: jest
       .fn()
       .mockResolvedValue(mockCreateDataDeletionRegulationTaskResponse),

--- a/app/scripts/messenger-client-init/controller-list.ts
+++ b/app/scripts/messenger-client-init/controller-list.ts
@@ -110,6 +110,7 @@ import EncryptionPublicKeyController from '../controllers/encryption-public-key'
 import { RewardsDataService } from '../controllers/rewards/rewards-data-service';
 import { RewardsController } from '../controllers/rewards/rewards-controller';
 import { StaticAssetsController } from '../controllers/static-assets-controller';
+import { DataDeletionService } from '../services/data-deletion-service';
 
 /**
  * Union of all controllers supporting or required by modular initialization.
@@ -131,6 +132,7 @@ export type Controller =
   | ClaimsController
   | CronjobController
   | CurrencyRateController
+  | DataDeletionService
   | DecryptMessageController
   | DecryptMessageManager
   | DelegationController

--- a/app/scripts/messenger-client-init/data-deletion-service-init.test.ts
+++ b/app/scripts/messenger-client-init/data-deletion-service-init.test.ts
@@ -1,0 +1,33 @@
+import { ControllerInitRequest } from './types';
+import { getRootMessenger } from '../lib/messenger';
+import { buildControllerInitRequestMock } from './test/utils';
+import {
+  DataDeletionService,
+  DataDeletionServiceMessenger,
+} from '../services/data-deletion-service';
+import { DataDeletionServiceInit } from './data-deletion-service-init';
+import { getDataDeletionServiceMessenger } from './messengers/data-deletion-service-messenger';
+
+function buildInitRequestMock(): jest.Mocked<
+  ControllerInitRequest<DataDeletionServiceMessenger>
+> {
+  const baseControllerMessenger = getRootMessenger<never, never>();
+
+  return {
+    ...buildControllerInitRequestMock(),
+    controllerMessenger: getDataDeletionServiceMessenger(
+      baseControllerMessenger,
+    ),
+    initMessenger: undefined,
+  };
+}
+
+describe('DataDeletionServiceInit', () => {
+  it('returns the service instance', () => {
+    const requestMock = buildInitRequestMock();
+
+    expect(DataDeletionServiceInit(requestMock).controller).toBeInstanceOf(
+      DataDeletionService,
+    );
+  });
+});

--- a/app/scripts/messenger-client-init/data-deletion-service-init.test.ts
+++ b/app/scripts/messenger-client-init/data-deletion-service-init.test.ts
@@ -1,10 +1,10 @@
-import { ControllerInitRequest } from './types';
 import { getRootMessenger } from '../lib/messenger';
-import { buildControllerInitRequestMock } from './test/utils';
 import {
   DataDeletionService,
   DataDeletionServiceMessenger,
 } from '../services/data-deletion-service';
+import { ControllerInitRequest } from './types';
+import { buildControllerInitRequestMock } from './test/utils';
 import { DataDeletionServiceInit } from './data-deletion-service-init';
 import { getDataDeletionServiceMessenger } from './messengers/data-deletion-service-messenger';
 

--- a/app/scripts/messenger-client-init/data-deletion-service-init.ts
+++ b/app/scripts/messenger-client-init/data-deletion-service-init.ts
@@ -1,0 +1,20 @@
+import {
+  DataDeletionService,
+  DataDeletionServiceMessenger,
+} from '../services/data-deletion-service';
+import { ControllerInitFunction } from './types';
+
+export const DataDeletionServiceInit: ControllerInitFunction<
+  DataDeletionService,
+  DataDeletionServiceMessenger
+> = ({ controllerMessenger }) => {
+  const service = new DataDeletionService({
+    messenger: controllerMessenger,
+  });
+
+  return {
+    controller: service,
+    memStateKey: null,
+    persistedStateKey: null,
+  };
+};

--- a/app/scripts/messenger-client-init/messengers/data-deletion-service-messenger.test.ts
+++ b/app/scripts/messenger-client-init/messengers/data-deletion-service-messenger.test.ts
@@ -1,0 +1,13 @@
+import { Messenger } from '@metamask/messenger';
+import { getRootMessenger } from '../../lib/messenger';
+import { getDataDeletionServiceMessenger } from './data-deletion-service-messenger';
+
+describe('getDataDeletionServiceMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = getRootMessenger<never, never>();
+    const dataDeletionServiceMessenger =
+      getDataDeletionServiceMessenger(messenger);
+
+    expect(dataDeletionServiceMessenger).toBeInstanceOf(Messenger);
+  });
+});

--- a/app/scripts/messenger-client-init/messengers/data-deletion-service-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/data-deletion-service-messenger.ts
@@ -1,0 +1,27 @@
+import {
+  Messenger,
+  MessengerActions,
+  MessengerEvents,
+} from '@metamask/messenger';
+import { RootMessenger } from '../../lib/messenger';
+import { DataDeletionServiceMessenger } from '../../services/data-deletion-service';
+
+/**
+ * Create a messenger restricted to the allowed actions and events of the Data Deletion Service.
+ *
+ * @param messenger - The base messenger used to create the restricted
+ * messenger.
+ */
+export function getDataDeletionServiceMessenger(
+  messenger: RootMessenger<
+    MessengerActions<DataDeletionServiceMessenger>,
+    MessengerEvents<DataDeletionServiceMessenger>
+  >,
+) {
+  const controllerMessenger: DataDeletionServiceMessenger = new Messenger({
+    namespace: 'DataDeletionService',
+    parent: messenger,
+  });
+
+  return controllerMessenger;
+}

--- a/app/scripts/messenger-client-init/messengers/index.ts
+++ b/app/scripts/messenger-client-init/messengers/index.ts
@@ -209,6 +209,7 @@ import { getProfileMetricsControllerMessenger } from './profile-metrics-controll
 import { getProfileMetricsServiceMessenger } from './profile-metrics-service-messenger';
 import { getStorageServiceMessenger } from './storage-service-messenger';
 import { getPerpsControllerMessenger } from './perps-controller-messenger';
+import { getDataDeletionServiceMessenger } from './data-deletion-service-messenger';
 
 export { getAccountOrderControllerMessenger } from './account-order-controller-messenger';
 export type {
@@ -478,6 +479,10 @@ export const CONTROLLER_MESSENGERS = {
   CurrencyRateController: {
     getMessenger: getCurrencyRateControllerMessenger,
     getInitMessenger: getCurrencyRateControllerInitMessenger,
+  },
+  DataDeletionService: {
+    getMessenger: getDataDeletionServiceMessenger,
+    getInitMessenger: noop,
   },
   DecryptMessageController: {
     getMessenger: getDecryptMessageControllerMessenger,

--- a/app/scripts/messenger-client-init/metametrics-data-deletion-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/metametrics-data-deletion-controller-init.test.ts
@@ -8,6 +8,7 @@ import { ControllerInitRequest } from './types';
 import { buildControllerInitRequestMock } from './test/utils';
 import { getMetaMetricsDataDeletionControllerMessenger } from './messengers';
 import { MetaMetricsDataDeletionControllerInit } from './metametrics-data-deletion-controller-init';
+import { getDataDeletionServiceMessenger } from './messengers/data-deletion-service-messenger';
 
 jest.mock('../controllers/metametrics-data-deletion/metametrics-data-deletion');
 
@@ -22,6 +23,15 @@ function getInitRequestMock(): jest.Mocked<
       getMetaMetricsDataDeletionControllerMessenger(baseMessenger),
     initMessenger: undefined,
   };
+
+  // @ts-expect-error: Partial implementation.
+  requestMock.getController.mockImplementation((controllerName: string) => {
+    if (controllerName === 'DataDeletionService') {
+      return new DataDeletionService({
+        messenger: getDataDeletionServiceMessenger(baseMessenger),
+      });
+    }
+  });
 
   return requestMock;
 }

--- a/app/scripts/messenger-client-init/metametrics-data-deletion-controller-init.ts
+++ b/app/scripts/messenger-client-init/metametrics-data-deletion-controller-init.ts
@@ -2,7 +2,7 @@ import {
   MetaMetricsDataDeletionController,
   MetaMetricsDataDeletionControllerMessenger,
 } from '../controllers/metametrics-data-deletion/metametrics-data-deletion';
-import { DataDeletionService } from '../services/data-deletion-service';
+import type { DataDeletionService } from '../services/data-deletion-service';
 import { ControllerInitFunction } from './types';
 
 /**
@@ -12,13 +12,17 @@ import { ControllerInitFunction } from './types';
  * @param request.controllerMessenger - The messenger to use for the controller.
  * @param request.persistedState - The persisted state to use for the
  * controller.
+ * @param request.getController - The function to get other controllers.
  * @returns The initialized controller.
  */
 export const MetaMetricsDataDeletionControllerInit: ControllerInitFunction<
   MetaMetricsDataDeletionController,
   MetaMetricsDataDeletionControllerMessenger
-> = ({ controllerMessenger, persistedState }) => {
-  const dataDeletionService = new DataDeletionService();
+> = ({ controllerMessenger, persistedState, getController }) => {
+  const dataDeletionService = getController(
+    'DataDeletionService',
+  ) as DataDeletionService;
+
   const controller = new MetaMetricsDataDeletionController({
     messenger: controllerMessenger,
     state: persistedState.MetaMetricsDataDeletionController,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -444,6 +444,7 @@ import { MessengerSubscriptions } from './lib/MessengerSubscriptions';
 import { ProfileMetricsControllerInit } from './messenger-client-init/profile-metrics-controller-init';
 import { ProfileMetricsServiceInit } from './messenger-client-init/profile-metrics-service-init';
 import { getAddTransactionSendCallExtraOptions } from './lib/transaction/tempo-tx-utils';
+import { DataDeletionServiceInit } from './messenger-client-init/data-deletion-service-init';
 
 export const METAMASK_CONTROLLER_EVENTS = {
   // Fired after state changes that impact the extension badge (unapproved msg count)
@@ -602,6 +603,7 @@ export default class MetamaskController extends EventEmitter {
       RemoteFeatureFlagController: RemoteFeatureFlagControllerInit,
       NetworkController: NetworkControllerInit,
       MetaMetricsController: MetaMetricsControllerInit,
+      DataDeletionService: DataDeletionServiceInit,
       MetaMetricsDataDeletionController: MetaMetricsDataDeletionControllerInit,
       GasFeeController: GasFeeControllerInit,
       UserOperationController: UserOperationControllerInit,
@@ -721,6 +723,7 @@ export default class MetamaskController extends EventEmitter {
     this.appStateController = controllersByName.AppStateController;
     this.networkController = controllersByName.NetworkController;
     this.metaMetricsController = controllersByName.MetaMetricsController;
+    this.dataDeletionService = controllersByName.DataDeletionService;
     this.metaMetricsDataDeletionController =
       controllersByName.MetaMetricsDataDeletionController;
     this.remoteFeatureFlagController =

--- a/app/scripts/services/data-deletion-service-method-action-types.ts
+++ b/app/scripts/services/data-deletion-service-method-action-types.ts
@@ -1,0 +1,40 @@
+/**
+ * This file is auto generated.
+ * Do not edit manually.
+ */
+
+import type { DataDeletionService } from './data-deletion-service';
+
+/**
+ * Submit a deletion request.
+ *
+ * We use Segment for this request. Segment calls this deletion request a "regulation", and
+ * returns a "regulation ID" to keep track of this request and get status updates for it.
+ * https://docs.segmentapis.com/tag/Deletion-and-Suppression#operation/createSourceRegulation
+ *
+ * @param metaMetricsId - The ID associated with the analytics data that we will be deleting.
+ * @returns The regulation ID for the deletion request.
+ */
+export type DataDeletionServiceCreateDataDeletionRegulationTaskAction = {
+  type: `DataDeletionService:createDataDeletionRegulationTask`;
+  handler: DataDeletionService['createDataDeletionRegulationTask'];
+};
+
+/**
+ * Fetch the status of the given deletion request.
+ * https://docs.segmentapis.com/tag/Deletion-and-Suppression#operation/getRegulation
+ *
+ * @param deleteRegulationId - The Segment "regulation ID" for the deletion request to check.
+ * @returns The status of the given deletion request.
+ */
+export type DataDeletionServiceFetchDeletionRegulationStatusAction = {
+  type: `DataDeletionService:fetchDeletionRegulationStatus`;
+  handler: DataDeletionService['fetchDeletionRegulationStatus'];
+};
+
+/**
+ * Union of all DataDeletionService action types.
+ */
+export type DataDeletionServiceMethodActions =
+  | DataDeletionServiceCreateDataDeletionRegulationTaskAction
+  | DataDeletionServiceFetchDeletionRegulationStatusAction;

--- a/app/scripts/services/data-deletion-service.test.ts
+++ b/app/scripts/services/data-deletion-service.test.ts
@@ -1,9 +1,17 @@
 import nock from 'nock';
 
 import {
+  Messenger,
+  MessengerActions,
+  MessengerEvents,
+  MOCK_ANY_NAMESPACE,
+  MockAnyNamespace,
+} from '@metamask/messenger';
+import {
   DataDeletionService,
   RETRIES,
   MAX_CONSECUTIVE_FAILURES,
+  DataDeletionServiceMessenger,
 } from './data-deletion-service';
 
 // We're not customizing the default max delay
@@ -1194,6 +1202,22 @@ function mockDataDeletionStatusInterceptor(
   );
 }
 
+type RootMessenger = Messenger<
+  MockAnyNamespace,
+  MessengerActions<DataDeletionServiceMessenger>,
+  MessengerEvents<DataDeletionServiceMessenger>
+>;
+
+function getMessenger(): DataDeletionServiceMessenger {
+  const rootMessenger: RootMessenger = new Messenger({
+    namespace: MOCK_ANY_NAMESPACE,
+  });
+  return new Messenger({
+    namespace: 'DataDeletionService',
+    parent: rootMessenger,
+  });
+}
+
 /**
  * Get default options for the DataDeletionService.
  *
@@ -1206,5 +1230,6 @@ function getDefaultOptions(): ConstructorParameters<
     analyticsDataDeletionEndpoint: mockAnalyticsDataDeletionEndpoint,
     analyticsDataDeletionSourceId: mockSourceId,
     timeout: defaultTimeout,
+    messenger: getMessenger(),
   };
 }

--- a/app/scripts/services/data-deletion-service.ts
+++ b/app/scripts/services/data-deletion-service.ts
@@ -9,8 +9,14 @@ import {
   wrap,
   CircuitState,
 } from 'cockatiel';
+import { Messenger } from '@metamask/messenger';
 import getFetchWithTimeout from '../../../shared/lib/fetch-with-timeout';
 import { DeleteRegulationStatus } from '../../../shared/constants/metametrics';
+import { DataDeletionServiceMethodActions } from './data-deletion-service-method-action-types';
+
+export const SERVICE_NAME = 'DataDeletionService';
+
+type ServiceName = typeof SERVICE_NAME;
 
 const inTest = process.env.IN_TEST;
 const fallbackSourceId = 'test';
@@ -47,6 +53,15 @@ const DEFAULT_CIRCUIT_BREAK_DURATION = 30 * 60 * 1000;
  * The threshold (in milliseconds) for when a successful request is considered "degraded".
  */
 const DEFAULT_DEGRADED_THRESHOLD = 5_000;
+
+/**
+ * The messenger for the DataDeletionService.
+ */
+export type DataDeletionServiceMessenger = Messenger<
+  ServiceName,
+  DataDeletionServiceMethodActions,
+  never
+>;
 
 /**
  * Type guard for Fetch network responses with a `statusCode` property.
@@ -139,10 +154,19 @@ function createRetryPolicy({
   return wrap(retryPolicy, circuitBreakerPolicy);
 }
 
+const MESSENGER_EXPOSED_METHODS = [
+  'createDataDeletionRegulationTask',
+  'fetchDeletionRegulationStatus',
+] as const;
+
 /**
  * A serivce for requesting the deletion of analytics data.
  */
 export class DataDeletionService {
+  name: ServiceName = SERVICE_NAME;
+
+  #messenger: DataDeletionServiceMessenger;
+
   #analyticsDataDeletionEndpoint: string;
 
   #analyticsDataDeletionSourceId: string;
@@ -168,8 +192,10 @@ export class DataDeletionService {
    * @param options.onDegraded - An event handler for when the circuit remains closed, but requests
    * are failing or resolving too slowly (i.e. resolving more slowly than the `degradedThreshold`).
    * @param options.timeout - The timeout allowed for network calls before they are aborted.
+   * @param options.messenger - The service messenger.
    */
   constructor({
+    messenger,
     analyticsDataDeletionEndpoint = DEFAULT_ANALYTICS_DATA_DELETION_ENDPOINT,
     analyticsDataDeletionSourceId = DEFAULT_ANALYTICS_DATA_DELETION_SOURCE_ID,
     circuitBreakDuration = DEFAULT_CIRCUIT_BREAK_DURATION,
@@ -178,6 +204,7 @@ export class DataDeletionService {
     onDegraded,
     timeout,
   }: {
+    messenger: DataDeletionServiceMessenger;
     analyticsDataDeletionEndpoint?: string;
     analyticsDataDeletionSourceId?: string;
     circuitBreakDuration?: number;
@@ -185,12 +212,13 @@ export class DataDeletionService {
     onBreak?: () => void;
     onDegraded?: () => void;
     timeout?: number;
-  } = {}) {
+  }) {
     if (!analyticsDataDeletionEndpoint) {
       throw new Error('Missing ANALYTICS_DATA_DELETION_ENDPOINT');
     } else if (!analyticsDataDeletionSourceId) {
       throw new Error('Missing ANALYTICS_DATA_DELETION_SOURCE_ID');
     }
+    this.#messenger = messenger;
     this.#fetchWithTimeout = getFetchWithTimeout(timeout);
     this.#analyticsDataDeletionEndpoint = analyticsDataDeletionEndpoint;
     this.#analyticsDataDeletionSourceId = analyticsDataDeletionSourceId;
@@ -210,6 +238,11 @@ export class DataDeletionService {
       onDegraded,
       retries: RETRIES,
     });
+
+    this.#messenger.registerMethodActionHandlers(
+      this,
+      MESSENGER_EXPOSED_METHODS,
+    );
   }
 
   /**


### PR DESCRIPTION
## **Description**

This PR updates the `DataDeletionService` to have a messenger and use `registerMethodActionHandlers` and `MESSENGER_EXPOSED_METHODS` to register actions.

In order to get a messenger, the service is now registered through the controller init system.

## **Changelog**

CHANGELOG entry:null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes `DataDeletionService` construction to require a messenger and wires it into the global controller init graph; misconfiguration could break analytics deletion flows at runtime.
> 
> **Overview**
> **Refactors `DataDeletionService` to be a messenger-aware service** by adding a dedicated `DataDeletionServiceMessenger`, `SERVICE_NAME`, and bulk action registration via `registerMethodActionHandlers` for `createDataDeletionRegulationTask`/`fetchDeletionRegulationStatus`.
> 
> **Moves service instantiation into the modular controller init system**: adds `DataDeletionServiceInit` plus a restricted messenger factory, registers `DataDeletionService` in controller lists/messenger maps, and updates `MetaMetricsDataDeletionControllerInit` to retrieve the service via `getController('DataDeletionService')` instead of constructing it directly. Tests are updated/added to reflect the new messenger requirement and initialization wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad22ccfbac5fb7057db95f6e8db7a4f4c225614c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->