### PR TITLE
fix: toast message after wallet import

### DIFF
--- a/ui/components/app/toast-master/selectors.ts
+++ b/ui/components/app/toast-master/selectors.ts
@@ -144,13 +144,13 @@ export function selectShowConnectAccountGroupToast(
 }
 
 /**
- * Retrieves user preference to see the "New SRP Added" toast
+ * Retrieves the wallet number for the "New SRP Added" toast, or false if hidden.
  *
  * @param state - Redux state object.
- * @returns Boolean preference value
+ * @returns The new wallet number to display, or false if the toast should be hidden.
  */
-export function selectNewSrpAdded(state: Pick<State, 'appState'>): boolean {
-  return Boolean(state.appState.showNewSrpAddedToast);
+export function selectNewSrpAdded(state: Pick<State, 'appState'>): number | false {
+  return state.appState.showNewSrpAddedToast || false;
 }
 
 /**

--- a/ui/components/app/toast-master/selectors.ts
+++ b/ui/components/app/toast-master/selectors.ts
@@ -149,7 +149,9 @@ export function selectShowConnectAccountGroupToast(
  * @param state - Redux state object.
  * @returns The new wallet number to display, or false if the toast should be hidden.
  */
-export function selectNewSrpAdded(state: Pick<State, 'appState'>): number | false {
+export function selectNewSrpAdded(
+  state: Pick<State, 'appState'>,
+): number | false {
   return state.appState.showNewSrpAddedToast || false;
 }
 

--- a/ui/components/app/toast-master/toast-master.js
+++ b/ui/components/app/toast-master/toast-master.js
@@ -31,7 +31,6 @@ import { useI18nContext } from '../../../hooks/useI18nContext';
 import { usePrevious } from '../../../hooks/usePrevious';
 import {
   getCurrentNetwork,
-  getMetaMaskHdKeyrings,
   getOriginOfCurrentTab,
   getPermissions,
   getUseNftDetection,
@@ -414,11 +413,8 @@ function NewSrpAddedToast() {
   const t = useI18nContext();
   const dispatch = useDispatch();
 
-  const showNewSrpAddedToast = useSelector(selectNewSrpAdded);
+  const walletNumber = useSelector(selectNewSrpAdded);
   const autoHideDelay = 5 * SECOND;
-
-  const hdKeyrings = useSelector(getMetaMaskHdKeyrings);
-  const latestHdKeyringNumber = hdKeyrings.length;
 
   // This will close the toast if the user clicks the account menu.
   useEffect(() => {
@@ -438,10 +434,10 @@ function NewSrpAddedToast() {
   }, [dispatch]);
 
   return (
-    showNewSrpAddedToast && (
+    walletNumber && (
       <Toast
         key="new-srp-added-toast"
-        text={t('importWalletSuccess', [latestHdKeyringNumber])}
+        text={t('importWalletSuccess', [walletNumber])}
         startAdornment={
           <Icon name={IconName.CheckBold} color={IconColor.iconDefault} />
         }

--- a/ui/components/app/toast-master/toast-master.test.ts
+++ b/ui/components/app/toast-master/toast-master.test.ts
@@ -33,7 +33,7 @@ const createMockPrivacyPolicyState = (
 });
 
 const createMockAppState = (
-  showNewSrpAddedToast?: boolean,
+  showNewSrpAddedToast?: number | false,
   showCopyAddressToast?: boolean,
 ) => ({
   appState: {
@@ -236,10 +236,16 @@ describe('#getShowPrivacyPolicyToast', () => {
 });
 
 describe('#getShowNewSrpAddedToast', () => {
-  it('returns true if the user has not seen the toast', () => {
-    const mockStateData = createMockAppState(true);
+  it('returns the wallet number when set', () => {
+    const mockStateData = createMockAppState(2);
     const result = selectNewSrpAdded(mockStateData);
-    expect(result).toBe(true);
+    expect(result).toBe(2);
+  });
+
+  it('returns false when not set', () => {
+    const mockStateData = createMockAppState(false);
+    const result = selectNewSrpAdded(mockStateData);
+    expect(result).toBe(false);
   });
 });
 

--- a/ui/components/app/toast-master/utils.ts
+++ b/ui/components/app/toast-master/utils.ts
@@ -71,7 +71,7 @@ export function submitRequestToBackgroundAndCatch(
   });
 }
 
-export function setShowNewSrpAddedToast(value: boolean) {
+export function setShowNewSrpAddedToast(value: number | false) {
   return {
     type: SET_SHOW_NEW_SRP_ADDED_TOAST,
     payload: value,

--- a/ui/ducks/app/app.ts
+++ b/ui/ducks/app/app.ts
@@ -129,7 +129,7 @@ type AppState = {
   isMultiRpcOnboarding: boolean;
   isAccessedFromDappConnectedSitePopover: boolean;
   errorInSettings: string | null;
-  showNewSrpAddedToast: boolean;
+  showNewSrpAddedToast: number | false;
   showPasswordChangeToast: PasswordChangeToastType | null;
   showCopyAddressToast: boolean;
   showClaimSubmitToast: ClaimSubmitToastType | null;

--- a/ui/pages/multi-srp/import-srp/import-srp.test.tsx
+++ b/ui/pages/multi-srp/import-srp/import-srp.test.tsx
@@ -24,10 +24,12 @@ jest.mock('../../../store/actions', () => ({
 }));
 
 jest.mock('../../../components/app/toast-master/utils', () => ({
-  setShowNewSrpAddedToast: jest.fn().mockImplementation((value: number | false) => ({
-    type: 'SET_SHOW_NEW_SRP_ADDED_TOAST',
-    payload: value,
-  })),
+  setShowNewSrpAddedToast: jest
+    .fn()
+    .mockImplementation((value: number | false) => ({
+      type: 'SET_SHOW_NEW_SRP_ADDED_TOAST',
+      payload: value,
+    })),
 }));
 
 const mockNavigate = jest.fn();

--- a/ui/pages/multi-srp/import-srp/import-srp.test.tsx
+++ b/ui/pages/multi-srp/import-srp/import-srp.test.tsx
@@ -24,7 +24,7 @@ jest.mock('../../../store/actions', () => ({
 }));
 
 jest.mock('../../../components/app/toast-master/utils', () => ({
-  setShowNewSrpAddedToast: jest.fn().mockImplementation((value: boolean) => ({
+  setShowNewSrpAddedToast: jest.fn().mockImplementation((value: number | false) => ({
     type: 'SET_SHOW_NEW_SRP_ADDED_TOAST',
     payload: value,
   })),
@@ -99,7 +99,7 @@ describe('ImportSrp', () => {
       expect(importMnemonicToVault).toHaveBeenCalledWith(VALID_SEED);
       // Verify that navigation happened after import
       expect(mockNavigate).toHaveBeenCalledWith(DEFAULT_ROUTE);
-      expect(setShowNewSrpAddedToast).toHaveBeenCalledWith(true);
+      expect(setShowNewSrpAddedToast).toHaveBeenCalledWith(2);
     });
   });
 

--- a/ui/pages/multi-srp/import-srp/import-srp.tsx
+++ b/ui/pages/multi-srp/import-srp/import-srp.tsx
@@ -19,7 +19,7 @@ import {
 import { setShowNewSrpAddedToast } from '../../../components/app/toast-master/utils';
 import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
 import { Header, Page } from '../../../components/multichain/pages/page';
-import { getIsSocialLoginFlow } from '../../../selectors';
+import { getIsSocialLoginFlow, getMetaMaskHdKeyrings } from '../../../selectors';
 import { getIsSeedlessPasswordOutdated } from '../../../ducks/metamask/metamask';
 import PasswordOutdatedModal from '../../../components/app/password-outdated-modal';
 import { MetaMaskReduxDispatch } from '../../../store/store';
@@ -35,6 +35,7 @@ export const ImportSrp = () => {
   const [secretRecoveryPhrase, setSecretRecoveryPhrase] = useState('');
   const isSocialLoginEnabled = useSelector(getIsSocialLoginFlow);
   const isSeedlessPasswordOutdated = useSelector(getIsSeedlessPasswordOutdated);
+  const hdKeyrings = useSelector(getMetaMaskHdKeyrings);
   const { trackEvent } = useContext(MetaMetricsContext);
 
   // Providing duplicate SRP throws an error in metamask-controller, which results in a warning in the UI
@@ -71,7 +72,7 @@ export const ImportSrp = () => {
       await dispatch(importMnemonicToVault(secretRecoveryPhrase));
 
       navigate(DEFAULT_ROUTE);
-      dispatch(setShowNewSrpAddedToast(true));
+      dispatch(setShowNewSrpAddedToast(hdKeyrings.length + 1));
     } catch (error) {
       switch ((error as Error)?.message) {
         case 'KeyringController - The account you are trying to import is a duplicate':

--- a/ui/pages/multi-srp/import-srp/import-srp.tsx
+++ b/ui/pages/multi-srp/import-srp/import-srp.tsx
@@ -19,7 +19,10 @@ import {
 import { setShowNewSrpAddedToast } from '../../../components/app/toast-master/utils';
 import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
 import { Header, Page } from '../../../components/multichain/pages/page';
-import { getIsSocialLoginFlow, getMetaMaskHdKeyrings } from '../../../selectors';
+import {
+  getIsSocialLoginFlow,
+  getMetaMaskHdKeyrings,
+} from '../../../selectors';
 import { getIsSeedlessPasswordOutdated } from '../../../ducks/metamask/metamask';
 import PasswordOutdatedModal from '../../../components/app/password-outdated-modal';
 import { MetaMaskReduxDispatch } from '../../../store/store';

--- a/ui/store/actions.test.js
+++ b/ui/store/actions.test.js
@@ -4618,7 +4618,6 @@ describe('Actions', () => {
         { type: 'SHOW_LOADING_INDICATION', payload: undefined },
         { type: 'HIDE_LOADING_INDICATION' },
         { type: 'HIDE_WARNING' },
-        { type: 'SET_SHOW_NEW_SRP_ADDED_TOAST', payload: true },
       ];
 
       await store.dispatch(actions.importMnemonicToVault(mnemonic));

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -180,7 +180,6 @@ import {
 import { SortCriteria } from '../components/app/assets/util/sort';
 import { NOTIFICATIONS_EXPIRATION_DELAY } from '../helpers/constants/notifications';
 import { getDismissSmartAccountSuggestionEnabled } from '../pages/confirmations/selectors/preferences';
-import { setShowNewSrpAddedToast } from '../components/app/toast-master/utils';
 import { stripWalletTypePrefixFromWalletId } from '../hooks/multichain-accounts/utils';
 import {
   ClaimSubmitToastType,
@@ -1107,7 +1106,6 @@ export function importMnemonicToVault(
       .then(async (result) => {
         dispatch(hideLoadingIndication());
         dispatch(hideWarning());
-        dispatch(setShowNewSrpAddedToast(true));
         return result;
       })
       .catch((err) => {


### PR DESCRIPTION
## **Description**

When importing an SRP, the toast message briefly shows "Wallet 1 imported" before updating to the correct number (e.g. "Wallet 2 imported"). This happens because background state updates are debounced (200ms, max 1s), so `hdKeyrings.length` is stale when the toast first renders.

- Changed `showNewSrpAddedToast` from a `boolean` to `number | false`, storing the wallet number directly
- The import component now computes `hdKeyrings.length + 1` before the import and passes it to the toast state
- The toast reads the number from state instead of deriving it from the (lagging) keyrings selector
- Removed a duplicate `setShowNewSrpAddedToast` dispatch from `importMnemonicToVault`

## **Changelog**

CHANGELOG entry: Fixed a bug that was causing the wallet imported toast to momentarily show the wrong wallet added.

## **Related issues**

Fixes #40944 

## **Manual testing steps**

1. Build from this branch
2. Import an SRP, the toast should immediately show the correct wallet number (e.g. "Wallet 2 imported")

## **Screenshots/Recordings**

### **Before**

See issue: https://github.com/MetaMask/metamask-extension/issues/40944

### **After**

https://github.com/user-attachments/assets/52978cc1-053c-496a-965b-b4b9bc8a988f

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Redux `appState.showNewSrpAddedToast` type from boolean to `number | false` and updates dispatch/selector usage; any remaining call sites assuming a boolean could break or hide the toast incorrectly.
> 
> **Overview**
> Fixes the “New SRP Added” toast briefly showing the wrong wallet number after importing an SRP by **storing the wallet number in Redux** instead of a boolean.
> 
> `selectNewSrpAdded`/`setShowNewSrpAddedToast` now use `number | false`, the import flow dispatches the computed next wallet number (`hdKeyrings.length + 1`), and `ToastMaster` renders the message directly from that stored number. A redundant `setShowNewSrpAddedToast(true)` dispatch inside `importMnemonicToVault` was removed, and related unit tests were updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d9bad21184fd5062e0eeeab1c44312b11e9cc79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->