### PR TITLE
fix: enable gasless sends and swaps for hardware wallets via sendBundle

### DIFF
--- a/ui/pages/confirmations/hooks/gas/useGaslessSupportedSmartTransactions.test.ts
+++ b/ui/pages/confirmations/hooks/gas/useGaslessSupportedSmartTransactions.test.ts
@@ -150,16 +150,17 @@ describe('useGaslessSupportedSmartTransactions', () => {
     });
   });
 
-  it('returns isSupported false for hardware wallets even when smart transactions and sendBundle are supported', async () => {
+  it('returns isSupported true for hardware wallets when smart transactions and sendBundle are supported', async () => {
     isHardwareWalletMock.mockReturnValue(true);
     getIsSmartTransactionMock.mockReturnValue(true);
     isSendBundleSupportedMock.mockResolvedValue(true);
 
     const result = await runHook();
 
+    // Hardware wallets support the sendBundle path (standard EIP-1559 signing only)
     expect(result).toStrictEqual({
       isSmartTransaction: true,
-      isSupported: false,
+      isSupported: true,
       pending: false,
     });
   });

--- a/ui/pages/confirmations/hooks/gas/useGaslessSupportedSmartTransactions.ts
+++ b/ui/pages/confirmations/hooks/gas/useGaslessSupportedSmartTransactions.ts
@@ -7,7 +7,6 @@ import {
 } from '../../../../../shared/lib/selectors';
 import { useAsyncResult } from '../../../../hooks/useAsync';
 import { isSendBundleSupported } from '../../../../store/actions';
-import { isHardwareWallet } from '../../../../selectors';
 import { useConfirmContext } from '../../context/confirm';
 
 export function useGaslessSupportedSmartTransactions(): {
@@ -19,7 +18,6 @@ export function useGaslessSupportedSmartTransactions(): {
     useConfirmContext<TransactionMeta>();
 
   const { chainId } = transactionMeta ?? {};
-  const isHardwareWalletAccount = useSelector(isHardwareWallet);
   const isSmartTransaction = useSelector((state: SmartTransactionsState) =>
     getIsSmartTransaction(state, chainId),
   );
@@ -31,9 +29,10 @@ export function useGaslessSupportedSmartTransactions(): {
 
   return {
     isSmartTransaction: Boolean(isSmartTransaction),
-    isSupported: Boolean(
-      !isHardwareWalletAccount && isSmartTransaction && sendBundleSupported,
-    ),
-    pending: !isHardwareWalletAccount && pending,
+    // sendBundle requires only standard EIP-1559 signing, which all account
+    // types (including hardware wallets) support. Hardware wallets are only
+    // excluded from the EIP-7702 relay path (see useIsGaslessSupported).
+    isSupported: Boolean(isSmartTransaction && sendBundleSupported),
+    pending,
   };
 }

--- a/ui/pages/confirmations/hooks/gas/useIsGaslessSupported.test.ts
+++ b/ui/pages/confirmations/hooks/gas/useIsGaslessSupported.test.ts
@@ -160,7 +160,7 @@ describe('useIsGaslessSupported', () => {
     });
   });
 
-  it('returns isSupported false for hardware wallets even when smart transactions are supported', async () => {
+  it('returns isSupported true for hardware wallets when smart transactions with sendBundle are supported', async () => {
     isHardwareWalletMock.mockReturnValue(true);
     useGaslessSupportedSmartTransactionsMock.mockReturnValue({
       isSmartTransaction: true,
@@ -170,19 +170,21 @@ describe('useIsGaslessSupported', () => {
 
     const result = await runHook();
 
+    // Hardware wallets can use the sendBundle path (standard EIP-1559 signing only)
     expect(result).toStrictEqual({
-      isSupported: false,
+      isSupported: true,
       isSmartTransaction: true,
       pending: false,
     });
   });
 
-  it('returns isSupported false for hardware wallets even when relay is supported', async () => {
+  it('returns isSupported false for hardware wallets when only relay (7702) is supported but not sendBundle', async () => {
     isHardwareWalletMock.mockReturnValue(true);
     isRelaySupportedMock.mockResolvedValue(true);
 
     const result = await runHook();
 
+    // Relay (7702) check must NOT be made for hardware wallets
     expect(isRelaySupportedMock).not.toHaveBeenCalled();
 
     expect(result).toStrictEqual({

--- a/ui/pages/confirmations/hooks/gas/useIsGaslessSupported.ts
+++ b/ui/pages/confirmations/hooks/gas/useIsGaslessSupported.ts
@@ -10,14 +10,15 @@ import { useGaslessSupportedSmartTransactions } from './useGaslessSupportedSmart
  * Hook to determine if gasless transactions are supported for the current confirmation context.
  *
  * Gasless support can be enabled in two ways:
- * - Via 7702: Supported when the current account is upgraded, the chain supports atomic batch, relay is available, and the transaction is not a contract deployment.
- * - Via Smart Transactions: Supported when smart transactions are enabled and sendBundle is supported for the chain.
- *
- * Hardware wallets are excluded from gasless support because they cannot sign
- * EIP-7702 authorization lists. They fall back to the standard "user pay gas" flow.
+ * - Via Smart Transactions (sendBundle): Supported when smart transactions are enabled and
+ *   sendBundle is supported for the chain. Works for all account types including hardware wallets,
+ *   since only standard EIP-1559 signing is required.
+ * - Via 7702 relay: Supported when the current account is upgraded, the chain supports atomic
+ *   batch, relay is available, and the transaction is not a contract deployment. Hardware wallets
+ *   are excluded from this path because they cannot sign EIP-7702 authorization lists.
  *
  * @returns An object containing:
- * - `isSupported`: `true` if gasless transactions are supported via either 7702 or smart transactions with sendBundle.
+ * - `isSupported`: `true` if gasless transactions are supported via either sendBundle or 7702.
  * - `isSmartTransaction`: `true` if smart transactions are enabled for the current chain.
  * - `pending`: `true` if the support check is still in progress.
  */
@@ -54,14 +55,15 @@ export function useIsGaslessSupported() {
       transactionMeta?.txParams?.to !== undefined,
   );
 
+  // sendBundle is open to all account types; is7702Supported already gates HW wallets
   const isSupported = Boolean(
-    !isHardwareWalletAccount &&
-      (isSmartTransactionAndBundleSupported || is7702Supported),
+    isSmartTransactionAndBundleSupported || is7702Supported,
   );
 
+  // sendBundle pending state applies to all account types; 7702 pending stays HW-gated
   const isPending =
-    !isHardwareWalletAccount &&
-    (smartTransactionPending || (shouldCheck7702Eligibility && relayPending));
+    smartTransactionPending ||
+    (!isHardwareWalletAccount && shouldCheck7702Eligibility && relayPending);
 
   return {
     isSupported,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Summary

  Hardware wallet users (Ledger, Trezor, Lattice, OneKey, QR/Keystone) were completely excluded from gasless transaction flows — both the EIP-7702 relay path and the sendBundle/Smart Transactions path. While the
  7702 exclusion is technically correct, the sendBundle exclusion was overly broad. The sendBundle path only requires a standard EIP-1559 transaction signature, which all hardware wallets support natively.

  This fix restores gasless support for hardware wallets on the sendBundle path for both sends and swaps, while keeping the EIP-7702 relay path correctly blocked.

  Background

  PR #40915 introduced a blanket !isHardwareWalletAccount gate across both gasless paths to fix hardware wallets erroring when they attempted to use EIP-7702 on chains like Monad and Sei (signing an authorization
  list is not supported by hardware wallet firmware). That fix was correct for 7702, but it over-blocked the sendBundle path which was working cleanly for hardware wallets in v13.21.0 before the gasless feature
  launched.

  How gasless via sendBundle works

  The sendBundle path submits a signed transaction to the Sentinel API which bundles it and pays the gas on behalf of the user. The only signing required is a standard eth_signTransaction (EIP-1559) call —
  identical to what hardware wallets already sign for every normal transaction. No additional signing (no typed data, no authorization lists) is needed.

  What changed

  Two UI hooks had an overly broad !isHardwareWalletAccount guard that blocked hardware wallets from the sendBundle path:

  useGaslessSupportedSmartTransactions.ts — Removed the !isHardwareWalletAccount condition from isSupported and pending. The sendBundle eligibility check is now account-type agnostic:
  // Before
  isSupported: Boolean(!isHardwareWalletAccount && isSmartTransaction && sendBundleSupported)

  // After
  isSupported: Boolean(isSmartTransaction && sendBundleSupported)

  useIsGaslessSupported.ts — Updated isSupported and isPending to allow hardware wallets through the sendBundle branch. The 7702 branch (is7702Supported) retains its own !isHardwareWalletAccount guard and is
  untouched:
  // Before — blanket HW exclusion
  const isSupported = Boolean(!isHardwareWalletAccount && (isSmartTransactionAndBundleSupported || is7702Supported))

  // After — sendBundle open to all; 7702 stays gated via is7702Supported
  const isSupported = Boolean(isSmartTransactionAndBundleSupported || is7702Supported)

  What was NOT changed

  The following files already handle the sendBundle/7702 distinction correctly and needed no changes:

  ```
┌─────────────────────────────────────────────────────────────┬────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
  │                            File                             │                                                 Why unchanged                                                  │
  ├─────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ useGasIncluded7702.ts                                       │ Already returns false for hardware wallets — gates only the 7702 quote request                                 │
  ├─────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ bridge/selectors.ts                                         │ Already allows gasIncluded (sendBundle flag) for hardware wallets; only gates gasIncluded7702 and gasSponsored │
  ├─────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ bridge-status-controller-init.ts                            │ isGasFeeIncluded is used only by the 7702 delegation hook, not sendBundle                                      │
  ├─────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ transaction-controller-init.ts publishHook                  │ Routes to STX based on isSmartTransaction && sendBundleSupport with no hardware wallet check                   │
  ├─────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ transaction-controller-init.ts isEIP7702GasFeeTokensEnabled │ Already returns false for hardware wallets via accountSupports7702()                                           │
  ├─────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
  │ All keyring packages                                        │ sendBundle uses standard EIP-1559 signing — no keyring changes needed                                          │
  └─────────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```

  Affected wallets

  All 5 supported hardware wallet types benefit equally: Ledger, Trezor, Lattice (GridPlus), OneKey, and QR hardware wallets (Keystone, AirGap, CoolWallet, etc.)

  ---
  QA Steps

  ▎ Prerequisites for all tests:
  ▎ - ETH mainnet (sendBundle is supported here)
  ▎ - An ERC-20 token balance (e.g. USDC, DAI) in the hardware wallet account with zero or insufficient ETH for gas
  ▎ - For swaps: have a token balance to swap from with no ETH for gas

  ---
  Ledger

  Setup: Connect Ledger via USB. Open the Ethereum app. Enable blind signing (Settings → Blind signing → Enabled) — required for contract interactions.

  Gasless send:
  1. Go to Send, enter a recipient and an ERC-20 token amount (e.g. 10 USDC)
  2. On the confirmation screen, verify the Network fee row shows gas as free/sponsored (not a gas fee token selector)
  3. Click Confirm — Ledger device prompts for a standard transaction signature
  4. Approve on device
  5. Verify the transaction lands on-chain without the user spending ETH

  Gasless swap:
  1. Go to Swap/Bridge, select a token pair (e.g. USDC → DAI)
  2. Verify the quote shows "Gas included" in the fee breakdown (no ETH gas fee shown)
  3. If an ERC-20 approval is required, confirm that approval on the Ledger first
  4. Confirm the swap on the Ledger — device shows a standard contract interaction
  5. Verify the swap completes without ETH spent on gas

  Regression — 7702 path remains blocked:
  1. On a chain where 7702 is the only gasless path (no sendBundle support), verify the UI shows the normal gas fee UI — no gasless option, no gas fee token selector

  ---
  Trezor

  Setup: Connect Trezor via USB. Enter PIN on device.

  Gasless send:
  1. Go to Send, enter a recipient and an ERC-20 token amount with zero ETH in account
  2. Confirm the Network fee shows as free/sponsored
  3. Click Confirm — Trezor prompts for a standard transaction confirmation (shows to/value/data on device screen)
  4. Approve on device
  5. Verify the transaction lands without ETH gas spent

  Gasless swap:
  1. Go to Swap/Bridge, select a token pair
  2. Verify "Gas included" is shown in the fee breakdown
  3. If approval needed: confirm the approval transaction on Trezor
  4. Confirm the swap on Trezor
  5. Verify swap completes without ETH gas spent

  ---
  QR Hardware Wallet (Keystone / AirGap)

  Setup: Connect via camera QR scanning. Ensure camera permissions granted.

  Gasless send:
  1. Go to Send, enter recipient and ERC-20 amount with zero ETH
  2. Confirm Network fee shows as free/sponsored
  3. Click Confirm — MetaMask displays a QR code for the unsigned transaction
  4. Scan the QR code on the hardware wallet device, sign on device, scan the signature QR back into MetaMask
  5. Verify transaction lands without ETH gas spent

  Gasless swap:
  1. Go to Swap/Bridge, select a token pair
  2. Verify "Gas included" in the fee breakdown
  3. If approval needed: complete the QR signing flow for the approval
  4. Complete the QR signing flow for the swap
  5. Verify swap completes without ETH gas spent

  ▎ Note for QR wallets: Because signing requires two QR scanning interactions per transaction (one to send the unsigned tx to the device, one to return the signature), the batch flow for swaps (approval + swap)
  ▎ will require completing the QR flow twice in sequence.

  ---
  Lattice (GridPlus)

  Setup: Lattice connected via network (GridPlus pairing).

  Gasless send:
  1. Go to Send, enter recipient and ERC-20 amount with zero ETH
  2. Confirm Network fee shows as free/sponsored
  3. Click Confirm — Lattice device shows the transaction for approval
  4. Approve on device touchscreen
  5. Verify transaction lands without ETH gas spent

  Gasless swap:
  1. Go to Swap/Bridge, select a token pair
  2. Verify "Gas included" in the fee breakdown
  3. Confirm approval and swap transactions on Lattice
  4. Verify swap completes without ETH gas spent

  ---
  OneKey

  Setup: Connect OneKey via USB.

  Steps identical to Ledger above. OneKey uses the same WebHID transport and Ethereum app structure.

  ---
  Cross-wallet regression checks

  These should pass for all hardware wallet types:

  
```┌──────────────────────────────────────────────────────────────────────────────────────────────────────────┬───────────────────────────────────────────────────────────────────────────────────┐
  │                                                 Scenario                                                 │                                  Expected result                                  │
  ├──────────────────────────────────────────────────────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────┤
  │ Chain with sendBundle support (ETH mainnet), insufficient ETH                                            │ Gasless option shown, gas free                                                    │
  ├──────────────────────────────────────────────────────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────┤
  │ Chain without sendBundle support (any chain where Sentinel doesn't support sendBundle), insufficient ETH │ Normal gas fee UI shown, no gasless option                                        │
  ├──────────────────────────────────────────────────────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────┤
  │ Chain where 7702 is the only gasless path, hardware wallet                                               │ Normal gas fee UI shown — 7702 path correctly blocked                             │
  ├──────────────────────────────────────────────────────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────┤
  │ Software wallet (HD/simple) on ETH mainnet                                                               │ Behaviour unchanged — both sendBundle and 7702 paths available as before          │
  ├──────────────────────────────────────────────────────────────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────────────────────┤
  │ Hardware wallet with sufficient ETH for gas                                                              │ Normal gas fee UI shown — gasless only activates when ETH balance is insufficient │
  └──────────────────────────────────────────────────────────────────────────────────────────────────────────┴───────────────────────────────────────────────────────────────────────────────────┘
```

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes gasless-eligibility gating so hardware wallets can be treated as supported via the `sendBundle` smart-transactions path; this impacts transaction routing and pending-state behavior but keeps EIP-7702 relay explicitly hardware-wallet gated.
> 
> **Overview**
> Enables hardware-wallet accounts to be considered gasless-supported when Smart Transactions `sendBundle` is available, instead of blanket-excluding hardware wallets.
> 
> Updates `useGaslessSupportedSmartTransactions` and `useIsGaslessSupported` to remove hardware-wallet gating for the `sendBundle` path while keeping hardware wallets excluded from the EIP-7702 relay path, and adjusts pending-state handling accordingly. Tests are updated to assert the new hardware-wallet behavior for both paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edbc2a37cf12b70ade5a76e2b097ee35d4f0c19b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->