### PR TITLE
fix: use correct percentage for reduce percentage

### DIFF
--- a/ui/components/app/perps/order-entry/order-entry.mocks.ts
+++ b/ui/components/app/perps/order-entry/order-entry.mocks.ts
@@ -11,6 +11,7 @@ import type { OrderFormState } from './order-entry.types';
 export const mockOrderFormDefaults: OrderFormState = {
   asset: 'BTC',
   direction: 'long',
+  closePercent: 100,
   amount: '',
   leverage: 3,
   balancePercent: 0,

--- a/ui/components/app/perps/order-entry/order-entry.types.ts
+++ b/ui/components/app/perps/order-entry/order-entry.types.ts
@@ -50,6 +50,8 @@ export type OrderFormState = {
   asset: string;
   /** Order direction - long or short */
   direction: OrderDirection;
+  /** Percentage of the existing position to close in close mode */
+  closePercent: number;
   /** USD amount to trade (string for input handling) */
   amount: string;
   /** Leverage multiplier (1-50x typically) */

--- a/ui/hooks/perps/usePerpsOrderForm.ts
+++ b/ui/hooks/perps/usePerpsOrderForm.ts
@@ -194,9 +194,6 @@ export function usePerpsOrderForm({
   const { formatCurrencyWithMinThreshold, formatTokenQuantity } =
     useFormatters();
 
-  // Close percentage state (for 'close' mode, defaults to 100%)
-  const [closePercent, setClosePercent] = useState<number>(100);
-
   /**
    * Compute TP/SL and leverage from an existing position for modify mode.
    * Amount is left empty so the user enters the size INCREASE (additional margin
@@ -295,8 +292,6 @@ export function usePerpsOrderForm({
       initialLeverage,
     };
 
-    setClosePercent(100);
-
     const pos = existingPositionRef.current;
     const typeForReset = orderTypeRef.current;
     if (mode === 'modify' && pos) {
@@ -328,7 +323,7 @@ export function usePerpsOrderForm({
     // For close mode, calculate based on close amount
     if (mode === 'close' && existingPosition) {
       const positionSize = Math.abs(parseFloat(existingPosition.size)) || 0;
-      const closeAmount = (positionSize * closePercent) / 100;
+      const closeAmount = (positionSize * formState.closePercent) / 100;
       const closeValueUsd = closeAmount * currentPrice;
 
       const estimatedFees = closeValueUsd * (feeRate ?? 0);
@@ -426,7 +421,7 @@ export function usePerpsOrderForm({
     currentPrice,
     mode,
     existingPosition,
-    closePercent,
+    formState.closePercent,
     asset,
     maxLeverage,
     szDecimals,
@@ -473,7 +468,7 @@ export function usePerpsOrderForm({
 
   // Close percent change handler (for close mode)
   const handleClosePercentChange = useCallback((percent: number) => {
-    setClosePercent(percent);
+    setFormState((prev) => ({ ...prev, closePercent: percent }));
   }, []);
 
   // Limit price change handler (for limit order mode)
@@ -492,7 +487,7 @@ export function usePerpsOrderForm({
 
   return {
     formState,
-    closePercent,
+    closePercent: formState.closePercent,
     calculations,
     handleAmountChange,
     handleBalancePercentChange,

--- a/ui/pages/perps/perps-order-entry-page.test.tsx
+++ b/ui/pages/perps/perps-order-entry-page.test.tsx
@@ -823,6 +823,7 @@ describe('PerpsOrderEntryPage', () => {
       );
       expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith({
         key: 'perpsToastCloseInProgress',
+        description: expect.stringMatching(/^Long [^ ]+ ETH$/u),
       });
       expect(mockUseNavigate).toHaveBeenCalledWith('/perps/market/ETH', {
         state: expect.objectContaining({
@@ -878,7 +879,7 @@ describe('PerpsOrderEntryPage', () => {
       });
     });
 
-    it('does not add a close subtitle when close PnL cannot be calculated', async () => {
+    it('falls back to close subtitle when close PnL cannot be calculated', async () => {
       mockSearchParams.set('mode', 'close');
       mockLivePositions.mockReturnValue({
         positions: [
@@ -900,9 +901,10 @@ describe('PerpsOrderEntryPage', () => {
       });
 
       expect(mockUseNavigate).toHaveBeenCalledWith('/perps/market/ETH', {
-        state: {
+        state: expect.objectContaining({
           perpsToastKey: 'perpsToastTradeSuccess',
-        },
+          perpsToastDescription: expect.stringMatching(/^Long [^ ]+ ETH$/u),
+        }),
       });
     });
 
@@ -1360,6 +1362,9 @@ describe('PerpsOrderEntryPage', () => {
         key: 'perpsToastPartialCloseFailed',
         description: 'Your position is still active',
       });
+      expect(screen.getByTestId('perps-order-submit-error')).toHaveTextContent(
+        "We couldn't load this page.",
+      );
     });
 
     it('shows update failure toast when updatePositionTPSL fails', async () => {

--- a/ui/pages/perps/perps-order-entry-page.test.tsx
+++ b/ui/pages/perps/perps-order-entry-page.test.tsx
@@ -3,7 +3,7 @@ import type {
   Position,
   PerpsMarketData,
 } from '@metamask/perps-controller';
-import { screen, fireEvent, act, waitFor } from '@testing-library/react';
+import { screen, fireEvent, act, waitFor, within } from '@testing-library/react';
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
@@ -808,10 +808,11 @@ describe('PerpsOrderEntryPage', () => {
       expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
         'perpsClosePosition',
         [
-          expect.objectContaining({
+          {
             symbol: 'ETH',
             orderType: 'market',
-          }),
+            currentPrice: 3025.5,
+          },
         ],
       );
       expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith(
@@ -828,6 +829,39 @@ describe('PerpsOrderEntryPage', () => {
           ),
         }),
       });
+    });
+
+    it('calls closePosition with size for partial close mode', async () => {
+      mockSearchParams.set('mode', 'close');
+      mockLivePositions.mockReturnValue({
+        positions: mockPositions,
+        isInitialLoading: false,
+      });
+
+      const store = mockStore(createMockState());
+      renderWithProvider(<PerpsOrderEntryPage />, store);
+
+      const slider = within(
+        screen.getByTestId('close-amount-slider'),
+      ).getByRole('slider');
+      slider.focus();
+      fireEvent.keyDown(slider, { key: 'ArrowLeft' });
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('submit-order-button'));
+      });
+
+      expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+        'perpsClosePosition',
+        [
+          expect.objectContaining({
+            symbol: 'ETH',
+            orderType: 'market',
+            currentPrice: 3025.5,
+            size: expect.any(String),
+          }),
+        ],
+      );
     });
 
     it('falls back to close subtitle when close PnL cannot be calculated', async () => {

--- a/ui/pages/perps/perps-order-entry-page.test.tsx
+++ b/ui/pages/perps/perps-order-entry-page.test.tsx
@@ -25,6 +25,8 @@ import {
 } from '../../components/app/perps/mocks';
 import PerpsOrderEntryPage from './perps-order-entry-page';
 
+const mockUsePerpsMarketInfo = jest.fn(() => undefined);
+
 jest.mock('@metamask/perps-controller', () => ({
   PERPS_ERROR_CODES: {
     CLIENT_NOT_INITIALIZED: 'CLIENT_NOT_INITIALIZED',
@@ -91,7 +93,7 @@ jest.mock('../../hooks/perps/usePerpsEligibility', () => ({
 }));
 
 jest.mock('../../hooks/perps/usePerpsMarketInfo', () => ({
-  usePerpsMarketInfo: () => undefined,
+  usePerpsMarketInfo: () => mockUsePerpsMarketInfo(),
 }));
 
 jest.mock('../../hooks/perps/usePerpsOrderFees', () => ({
@@ -292,6 +294,7 @@ describe('PerpsOrderEntryPage', () => {
       positions: [],
       isInitialLoading: false,
     });
+    mockUsePerpsMarketInfo.mockReturnValue(undefined);
     mockLiveAccount.mockReturnValue({
       account: mockAccountState,
       isInitialLoading: false,
@@ -869,7 +872,7 @@ describe('PerpsOrderEntryPage', () => {
       expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith(
         expect.objectContaining({
           key: 'perpsToastPartialCloseInProgress',
-          description: expect.stringMatching(/^long [^ ]+ ETH$/u),
+          description: expect.stringMatching(/^Long [^ ]+ ETH$/u),
         }),
       );
       expect(mockUseNavigate).toHaveBeenCalledWith('/perps/market/ETH', {
@@ -904,6 +907,40 @@ describe('PerpsOrderEntryPage', () => {
         state: expect.objectContaining({
           perpsToastKey: 'perpsToastTradeSuccess',
           perpsToastDescription: expect.stringMatching(/^Long [^ ]+ ETH$/u),
+        }),
+      });
+    });
+
+    it('uses the actual short position direction for full close toasts', async () => {
+      mockSearchParams.set('mode', 'close');
+      mockLivePositions.mockReturnValue({
+        positions: [
+          {
+            ...mockPositions[0],
+            size: '-4.95',
+            marginUsed: '0',
+            unrealizedPnl: 'not-a-number',
+            returnOnEquity: 'not-a-number',
+          },
+        ],
+        isInitialLoading: false,
+      });
+
+      const store = mockStore(createMockState());
+      renderWithProvider(<PerpsOrderEntryPage />, store);
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('submit-order-button'));
+      });
+
+      expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith({
+        key: 'perpsToastCloseInProgress',
+        description: expect.stringMatching(/^Short [^ ]+ ETH$/u),
+      });
+      expect(mockUseNavigate).toHaveBeenCalledWith('/perps/market/ETH', {
+        state: expect.objectContaining({
+          perpsToastKey: 'perpsToastTradeSuccess',
+          perpsToastDescription: expect.stringMatching(/^Short [^ ]+ ETH$/u),
         }),
       });
     });

--- a/ui/pages/perps/perps-order-entry-page.test.tsx
+++ b/ui/pages/perps/perps-order-entry-page.test.tsx
@@ -3,7 +3,13 @@ import type {
   Position,
   PerpsMarketData,
 } from '@metamask/perps-controller';
-import { screen, fireEvent, act, waitFor, within } from '@testing-library/react';
+import {
+  screen,
+  fireEvent,
+  act,
+  waitFor,
+  within,
+} from '@testing-library/react';
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
@@ -420,7 +426,7 @@ describe('PerpsOrderEntryPage', () => {
       renderWithProvider(<PerpsOrderEntryPage />, store);
 
       expect(screen.getByTestId('submit-order-button')).toHaveTextContent(
-        'Close Long',
+        'Close position',
       );
     });
 
@@ -815,12 +821,9 @@ describe('PerpsOrderEntryPage', () => {
           },
         ],
       );
-      expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith(
-        expect.objectContaining({
-          key: 'perpsToastCloseInProgress',
-          description: expect.stringMatching(/^Long [^ ]+ ETH$/u),
-        }),
-      );
+      expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith({
+        key: 'perpsToastCloseInProgress',
+      });
       expect(mockUseNavigate).toHaveBeenCalledWith('/perps/market/ETH', {
         state: expect.objectContaining({
           perpsToastKey: 'perpsToastTradeSuccess',
@@ -862,9 +865,20 @@ describe('PerpsOrderEntryPage', () => {
           }),
         ],
       );
+      expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'perpsToastPartialCloseInProgress',
+          description: expect.stringMatching(/^long [^ ]+ ETH$/u),
+        }),
+      );
+      expect(mockUseNavigate).toHaveBeenCalledWith('/perps/market/ETH', {
+        state: expect.objectContaining({
+          perpsToastKey: 'perpsToastPartialCloseSuccess',
+        }),
+      });
     });
 
-    it('falls back to close subtitle when close PnL cannot be calculated', async () => {
+    it('does not add a close subtitle when close PnL cannot be calculated', async () => {
       mockSearchParams.set('mode', 'close');
       mockLivePositions.mockReturnValue({
         positions: [
@@ -886,10 +900,9 @@ describe('PerpsOrderEntryPage', () => {
       });
 
       expect(mockUseNavigate).toHaveBeenCalledWith('/perps/market/ETH', {
-        state: expect.objectContaining({
+        state: {
           perpsToastKey: 'perpsToastTradeSuccess',
-          perpsToastDescription: expect.stringMatching(/^Long [^ ]+ ETH$/u),
-        }),
+        },
       });
     });
 
@@ -1313,6 +1326,39 @@ describe('PerpsOrderEntryPage', () => {
       expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith({
         key: 'perpsToastCloseFailed',
         description: "We couldn't load this page.",
+      });
+    });
+
+    it('shows partial close failure toast when partial closePosition fails', async () => {
+      mockSearchParams.set('mode', 'close');
+      mockLivePositions.mockReturnValue({
+        positions: mockPositions,
+        isInitialLoading: false,
+      });
+      mockSubmitRequestToBackground.mockImplementation((method: string) => {
+        if (method === 'perpsClosePosition') {
+          return Promise.resolve({ success: false, error: 'Close failed' });
+        }
+        return Promise.resolve({ success: true });
+      });
+
+      const store = mockStore(createMockState());
+      renderWithProvider(<PerpsOrderEntryPage />, store);
+
+      const slider = within(
+        screen.getByTestId('close-amount-slider'),
+      ).getByRole('slider');
+      slider.focus();
+      fireEvent.keyDown(slider, { key: 'ArrowLeft' });
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('submit-order-button'));
+      });
+
+      expect(mockHidePerpsToast).toHaveBeenCalledTimes(1);
+      expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith({
+        key: 'perpsToastPartialCloseFailed',
+        description: 'Your position is still active',
       });
     });
 

--- a/ui/pages/perps/perps-order-entry-page.tsx
+++ b/ui/pages/perps/perps-order-entry-page.tsx
@@ -1042,7 +1042,9 @@ const PerpsOrderEntryPage: React.FC = () => {
         if (isPartialClose) {
           setSubmitError(translatedError ?? t('somethingWentWrong'));
         }
-        replacePerpsToastByKey(getCloseFailureToastConfig(translatedError));
+        replacePerpsToastByKey(
+          getCloseFailureToastConfig(translatedError ?? undefined),
+        );
       } else {
         const failedToastDescription =
           translatedError ??

--- a/ui/pages/perps/perps-order-entry-page.tsx
+++ b/ui/pages/perps/perps-order-entry-page.tsx
@@ -767,7 +767,6 @@ const PerpsOrderEntryPage: React.FC = () => {
         ? closePartialToastDescription
         : undefined;
     }
-
     if (inProgressToastKey !== undefined) {
       replacePerpsToastByKey({
         key: inProgressToastKey,

--- a/ui/pages/perps/perps-order-entry-page.tsx
+++ b/ui/pages/perps/perps-order-entry-page.tsx
@@ -281,6 +281,7 @@ const PerpsOrderEntryPage: React.FC = () => {
   );
   const [pendingOrderToastDescription, setPendingOrderToastDescription] =
     useState<string | null>(null);
+  const [submitError, setSubmitError] = useState<string | null>(null);
 
   const isOrderPending = isSubmitting || pendingOrderSymbol !== null;
 
@@ -711,6 +712,7 @@ const PerpsOrderEntryPage: React.FC = () => {
   );
 
   const handleFormStateChange = useCallback((formState: OrderFormState) => {
+    setSubmitError(null);
     setOrderFormState(formState);
   }, []);
 
@@ -748,10 +750,12 @@ const PerpsOrderEntryPage: React.FC = () => {
 
     setIsSubmitting(true);
     setPendingOrderToastDescription(null);
+    setSubmitError(null);
 
     const tradeActionToastDescription = getTradeActionToastDescription();
     const closePartialToastDescription = getClosePartialToastDescription();
-    const closeSuccessToastDescription = getCloseSuccessToastDescription();
+    const closeSuccessToastDescription =
+      getCloseSuccessToastDescription() ?? tradeActionToastDescription;
     const closePercent = orderFormState.closePercent ?? FULL_CLOSE_PERCENT;
     const isPartialClose =
       orderMode === 'close' && closePercent < FULL_CLOSE_PERCENT;
@@ -765,7 +769,7 @@ const PerpsOrderEntryPage: React.FC = () => {
         : PERPS_TOAST_KEYS.CLOSE_IN_PROGRESS;
       inProgressToastDescription = isPartialClose
         ? closePartialToastDescription
-        : undefined;
+        : tradeActionToastDescription;
     }
     if (inProgressToastKey !== undefined) {
       replacePerpsToastByKey({
@@ -1016,6 +1020,9 @@ const PerpsOrderEntryPage: React.FC = () => {
         t as (key: string) => string,
       );
       if (orderMode === 'close') {
+        if (isPartialClose) {
+          setSubmitError(translatedError ?? t('somethingWentWrong'));
+        }
         replacePerpsToastByKey(getCloseFailureToastConfig(translatedError));
       } else {
         const failedToastDescription =
@@ -1300,6 +1307,15 @@ const PerpsOrderEntryPage: React.FC = () => {
             estimatedFees={orderCalculations.estimatedFees}
             liquidationPrice={orderCalculations.liquidationPrice}
           />
+        )}
+        {submitError && (
+          <Text
+            variant={TextVariant.BodySm}
+            color={TextColor.ErrorDefault}
+            data-testid="perps-order-submit-error"
+          >
+            {submitError}
+          </Text>
         )}
         <Button
           variant={ButtonVariant.Primary}

--- a/ui/pages/perps/perps-order-entry-page.tsx
+++ b/ui/pages/perps/perps-order-entry-page.tsx
@@ -32,6 +32,7 @@ import {
   ButtonSize,
 } from '@metamask/design-system-react';
 import type {
+  ClosePositionParams,
   OrderType,
   OrderParams,
   PriceUpdate,
@@ -173,6 +174,25 @@ function formStateToOrderParams(
   }
 
   return params;
+}
+
+const FULL_CLOSE_PERCENT = 100;
+
+function buildClosePositionParams(
+  formState: OrderFormState,
+  currentPrice: number,
+  existingPositionSize: string,
+): ClosePositionParams {
+  const closePercent = formState.closePercent ?? FULL_CLOSE_PERCENT;
+  const positionSize = Math.abs(Number.parseFloat(existingPositionSize)) || 0;
+  const closeSize = ((positionSize * closePercent) / 100).toString();
+
+  return {
+    symbol: formState.asset,
+    orderType: 'market',
+    currentPrice,
+    ...(closePercent >= FULL_CLOSE_PERCENT ? {} : { size: closeSize }),
+  };
 }
 
 /**
@@ -519,7 +539,9 @@ const PerpsOrderEntryPage: React.FC = () => {
         isNearLiquidation ||
         hasInvalidTPSL ||
         isInsufficientFunds ||
-        currentPrice <= 0));
+        currentPrice <= 0 ||
+        (orderMode === 'close' &&
+          (orderFormState?.closePercent ?? FULL_CLOSE_PERCENT) <= 0)));
 
   const maxLeverage = useMemo(() => {
     if (!market) {
@@ -596,52 +618,59 @@ const PerpsOrderEntryPage: React.FC = () => {
       return undefined;
     }
 
-    const directionLabel = (() => {
-      if (orderMode === 'close' && position?.size) {
-        return Number.parseFloat(position.size) >= 0
-          ? t('perpsLong')
-          : t('perpsShort');
-      }
-      return orderFormState.direction === 'long'
-        ? t('perpsLong')
-        : t('perpsShort');
-    })();
-
+    const directionLabel =
+      orderFormState.direction === 'long' ? t('perpsLong') : t('perpsShort');
     const rawAssetSymbol = orderFormState.asset;
     const displayAssetSymbol = getDisplayName(rawAssetSymbol);
-
     const formattedPositionSize = orderCalculations?.positionSize?.trim();
-    if (formattedPositionSize) {
-      const rawAmount = formattedPositionSize.endsWith(` ${rawAssetSymbol}`)
-        ? formattedPositionSize.slice(0, -` ${rawAssetSymbol}`.length).trimEnd()
-        : formattedPositionSize;
-
-      if (rawAmount) {
-        return t('perpsToastOrderPlacementSubtitle', [
-          directionLabel,
-          rawAmount,
-          displayAssetSymbol,
-        ]);
-      }
-    }
-
-    if (orderMode !== 'close' || !position?.size) {
+    if (!formattedPositionSize) {
       return undefined;
     }
 
-    const absoluteSize = Math.abs(Number.parseFloat(position.size));
-    if (Number.isNaN(absoluteSize)) {
+    const rawAmount = formattedPositionSize.endsWith(` ${rawAssetSymbol}`)
+      ? formattedPositionSize.slice(0, -` ${rawAssetSymbol}`.length).trimEnd()
+      : formattedPositionSize;
+
+    if (!rawAmount) {
       return undefined;
     }
-
-    const rawAmount = absoluteSize.toString();
 
     return t('perpsToastOrderPlacementSubtitle', [
       directionLabel,
       rawAmount,
       displayAssetSymbol,
     ]);
-  }, [orderCalculations, orderFormState, orderMode, position, t]);
+  }, [orderCalculations, orderFormState, orderMode, t]);
+
+  const getClosePartialToastDescription = useCallback(() => {
+    if (orderMode !== 'close' || !orderFormState || !position?.size) {
+      return undefined;
+    }
+
+    const closePercent = orderFormState.closePercent ?? FULL_CLOSE_PERCENT;
+    if (closePercent >= FULL_CLOSE_PERCENT) {
+      return undefined;
+    }
+
+    const positionSize = Math.abs(Number.parseFloat(position.size));
+    if (Number.isNaN(positionSize)) {
+      return undefined;
+    }
+
+    const closeSize = (positionSize * closePercent) / 100;
+    const directionLabel = t(
+      Number.parseFloat(position.size) >= 0 ? 'perpsLong' : 'perpsShort',
+    ).toLowerCase();
+
+    return t('perpsToastOrderPlacementSubtitle', [
+      directionLabel,
+      formatNumber(closeSize, {
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 4,
+      }),
+      getDisplayName(orderFormState.asset),
+    ]);
+  }, [formatNumber, orderFormState, orderMode, position, t]);
 
   const getCloseSuccessToastDescription = useCallback(() => {
     if (orderMode !== 'close' || !position) {
@@ -660,6 +689,26 @@ const PerpsOrderEntryPage: React.FC = () => {
 
     return t('perpsToastClosePnlSubtitle', [formattedPnl]);
   }, [formatPercentWithMinThreshold, orderMode, position, t]);
+
+  const getCloseFailureToastConfig = useCallback(
+    (translatedError?: string) => {
+      const closePercent = orderFormState?.closePercent ?? FULL_CLOSE_PERCENT;
+      const isPartialClose = closePercent < FULL_CLOSE_PERCENT;
+
+      if (isPartialClose) {
+        return {
+          key: PERPS_TOAST_KEYS.PARTIAL_CLOSE_FAILED,
+          description: t('perpsToastPositionStillActive'),
+        };
+      }
+
+      return {
+        key: PERPS_TOAST_KEYS.CLOSE_FAILED,
+        description: translatedError ?? t('somethingWentWrong'),
+      };
+    },
+    [orderFormState?.closePercent, t],
+  );
 
   const handleFormStateChange = useCallback((formState: OrderFormState) => {
     setOrderFormState(formState);
@@ -701,15 +750,25 @@ const PerpsOrderEntryPage: React.FC = () => {
     setPendingOrderToastDescription(null);
 
     const tradeActionToastDescription = getTradeActionToastDescription();
-    const closeSuccessToastDescription =
-      getCloseSuccessToastDescription() ?? tradeActionToastDescription;
+    const closePartialToastDescription = getClosePartialToastDescription();
+    const closeSuccessToastDescription = getCloseSuccessToastDescription();
+    const closePercent = orderFormState.closePercent ?? FULL_CLOSE_PERCENT;
+    const isPartialClose =
+      orderMode === 'close' && closePercent < FULL_CLOSE_PERCENT;
 
-    const inProgressToastKey = ORDER_MODE_TOAST_KEYS[orderMode].inProgress;
-    const inProgressToastDescription =
-      inProgressToastKey === PERPS_TOAST_KEYS.SUBMIT_IN_PROGRESS
-        ? undefined
-        : tradeActionToastDescription;
-    if (inProgressToastKey) {
+    let inProgressToastKey = ORDER_MODE_TOAST_KEYS[orderMode].inProgress;
+    let inProgressToastDescription: string | undefined;
+
+    if (orderMode === 'close') {
+      inProgressToastKey = isPartialClose
+        ? PERPS_TOAST_KEYS.PARTIAL_CLOSE_IN_PROGRESS
+        : PERPS_TOAST_KEYS.CLOSE_IN_PROGRESS;
+      inProgressToastDescription = isPartialClose
+        ? closePartialToastDescription
+        : undefined;
+    }
+
+    if (inProgressToastKey !== undefined) {
       replacePerpsToastByKey({
         key: inProgressToastKey,
         ...(inProgressToastDescription
@@ -766,15 +825,18 @@ const PerpsOrderEntryPage: React.FC = () => {
 
     try {
       if (orderMode === 'close' && position) {
+        const closePercentage = closePercent;
         const closeNotionalUsd =
-          Math.abs(parseFloat(position.size)) * currentPrice;
+          Math.abs(Number.parseFloat(position.size)) *
+          currentPrice *
+          (closePercentage / 100);
         const closeEstimatedFees = closeNotionalUsd * (closeFeeRate ?? 0);
 
-        const closeParams = {
-          symbol: orderFormState.asset,
-          orderType: 'market' as const,
+        const closeParams = buildClosePositionParams(
+          orderFormState,
           currentPrice,
-        };
+          position.size,
+        );
         const result = await submitRequestToBackground<PerpsBackgroundResult>(
           'perpsClosePosition',
           [closeParams],
@@ -785,7 +847,7 @@ const PerpsOrderEntryPage: React.FC = () => {
             MetaMetricsEventName.PerpsPositionCloseTransaction,
             message,
             {
-              [PERPS_EVENT_PROPERTY.PERCENTAGE_CLOSED]: 100,
+              [PERPS_EVENT_PROPERTY.PERCENTAGE_CLOSED]: closePercentage,
               [PERPS_EVENT_PROPERTY.SIZE]: String(closeNotionalUsd),
               [PERPS_EVENT_PROPERTY.METAMASK_FEE]: String(closeEstimatedFees),
             },
@@ -795,12 +857,14 @@ const PerpsOrderEntryPage: React.FC = () => {
         track(MetaMetricsEventName.PerpsPositionCloseTransaction, {
           [PERPS_EVENT_PROPERTY.ASSET]: orderFormState.asset,
           [PERPS_EVENT_PROPERTY.STATUS]: PERPS_EVENT_VALUE.STATUS.SUCCESS,
-          [PERPS_EVENT_PROPERTY.PERCENTAGE_CLOSED]: 100,
+          [PERPS_EVENT_PROPERTY.PERCENTAGE_CLOSED]: closePercentage,
           [PERPS_EVENT_PROPERTY.SIZE]: String(closeNotionalUsd),
           [PERPS_EVENT_PROPERTY.METAMASK_FEE]: String(closeEstimatedFees),
         });
         handleBackClick(
-          PERPS_TOAST_KEYS.TRADE_SUCCESS,
+          isPartialClose
+            ? PERPS_TOAST_KEYS.PARTIAL_CLOSE_SUCCESS
+            : PERPS_TOAST_KEYS.TRADE_SUCCESS,
           closeSuccessToastDescription,
         );
         return;
@@ -952,16 +1016,20 @@ const PerpsOrderEntryPage: React.FC = () => {
         error,
         t as (key: string) => string,
       );
-      const failedToastDescription =
-        translatedError ??
-        (failedToastKey === PERPS_TOAST_KEYS.ORDER_FAILED
-          ? t('perpsToastOrderFailedDescriptionFallback')
-          : t('somethingWentWrong'));
+      if (orderMode === 'close') {
+        replacePerpsToastByKey(getCloseFailureToastConfig(translatedError));
+      } else {
+        const failedToastDescription =
+          translatedError ??
+          (failedToastKey === PERPS_TOAST_KEYS.ORDER_FAILED
+            ? t('perpsToastOrderFailedDescriptionFallback')
+            : t('somethingWentWrong'));
 
-      replacePerpsToastByKey({
-        key: failedToastKey,
-        description: failedToastDescription,
-      });
+        replacePerpsToastByKey({
+          key: failedToastKey,
+          description: failedToastDescription,
+        });
+      }
       if (!specificFailureTracked) {
         const errMsg =
           error instanceof Error ? error.message : 'An unknown error occurred';
@@ -984,7 +1052,9 @@ const PerpsOrderEntryPage: React.FC = () => {
     selectedAddress,
     currentPrice,
     getTradeActionToastDescription,
+    getClosePartialToastDescription,
     getCloseSuccessToastDescription,
+    getCloseFailureToastConfig,
     handleBackClick,
     track,
     hidePerpsToast,
@@ -1099,9 +1169,7 @@ const PerpsOrderEntryPage: React.FC = () => {
       case 'modify':
         return t('perpsModifyPosition');
       case 'close':
-        return isLong
-          ? t('perpsConfirmCloseLong')
-          : t('perpsConfirmCloseShort');
+        return t('perpsClosePosition');
       default:
         return isLong
           ? t('perpsOpenLong', [displayName])

--- a/ui/pages/perps/perps-order-entry-page.tsx
+++ b/ui/pages/perps/perps-order-entry-page.tsx
@@ -64,6 +64,7 @@ import {
   TimeDuration,
 } from '../../components/app/perps/constants/chartConfig';
 import { usePerpsEligibility, usePerpsEventTracking } from '../../hooks/perps';
+import { usePerpsMarketInfo } from '../../hooks/perps/usePerpsMarketInfo';
 import { usePerpsOrderFees } from '../../hooks/perps/usePerpsOrderFees';
 import { useFormatters } from '../../hooks/useFormatters';
 import { translatePerpsError } from '../../components/app/perps/utils/translate-perps-error';
@@ -104,6 +105,7 @@ import {
   type PerpsToastRouteState,
   usePerpsToast,
 } from '../../components/app/perps/perps-toast';
+import { calculatePositionSize } from '../../components/app/perps/order-entry/order-entry.mocks';
 
 const ORDER_MODE_TOAST_KEYS: Record<
   OrderMode,
@@ -182,10 +184,16 @@ function buildClosePositionParams(
   formState: OrderFormState,
   currentPrice: number,
   existingPositionSize: string,
+  szDecimals?: number,
 ): ClosePositionParams {
   const closePercent = formState.closePercent ?? FULL_CLOSE_PERCENT;
   const positionSize = Math.abs(Number.parseFloat(existingPositionSize)) || 0;
-  const closeSize = ((positionSize * closePercent) / 100).toString();
+  const closeNotionalUsd = positionSize * currentPrice * (closePercent / 100);
+  const closeSize = calculatePositionSize(
+    closeNotionalUsd,
+    currentPrice,
+    szDecimals,
+  ).toString();
 
   return {
     symbol: formState.asset,
@@ -308,6 +316,7 @@ const PerpsOrderEntryPage: React.FC = () => {
       (m) => m.symbol.toLowerCase() === decodedSymbol.toLowerCase(),
     );
   }, [decodedSymbol, allMarkets]);
+  const marketInfo = usePerpsMarketInfo(decodedSymbol ?? '');
 
   useEffect(() => {
     if (!orderTypeInteractionSkippedRef.current) {
@@ -619,8 +628,15 @@ const PerpsOrderEntryPage: React.FC = () => {
       return undefined;
     }
 
-    const directionLabel =
+    let directionLabel =
       orderFormState.direction === 'long' ? t('perpsLong') : t('perpsShort');
+
+    if (orderMode === 'close' && position?.size) {
+      directionLabel =
+        Number.parseFloat(position.size) >= 0
+          ? t('perpsLong')
+          : t('perpsShort');
+    }
     const rawAssetSymbol = orderFormState.asset;
     const displayAssetSymbol = getDisplayName(rawAssetSymbol);
     const formattedPositionSize = orderCalculations?.positionSize?.trim();
@@ -641,7 +657,7 @@ const PerpsOrderEntryPage: React.FC = () => {
       rawAmount,
       displayAssetSymbol,
     ]);
-  }, [orderCalculations, orderFormState, orderMode, t]);
+  }, [orderCalculations, orderFormState, orderMode, position, t]);
 
   const getClosePartialToastDescription = useCallback(() => {
     if (orderMode !== 'close' || !orderFormState || !position?.size) {
@@ -661,7 +677,7 @@ const PerpsOrderEntryPage: React.FC = () => {
     const closeSize = (positionSize * closePercent) / 100;
     const directionLabel = t(
       Number.parseFloat(position.size) >= 0 ? 'perpsLong' : 'perpsShort',
-    ).toLowerCase();
+    );
 
     return t('perpsToastOrderPlacementSubtitle', [
       directionLabel,
@@ -699,6 +715,8 @@ const PerpsOrderEntryPage: React.FC = () => {
       if (isPartialClose) {
         return {
           key: PERPS_TOAST_KEYS.PARTIAL_CLOSE_FAILED,
+          // Match mobile toast copy for partial-close failures; detailed errors
+          // are shown separately in the page-level submit error.
           description: t('perpsToastPositionStillActive'),
         };
       }
@@ -839,6 +857,7 @@ const PerpsOrderEntryPage: React.FC = () => {
           orderFormState,
           currentPrice,
           position.size,
+          marketInfo?.szDecimals,
         );
         const result = await submitRequestToBackground<PerpsBackgroundResult>(
           'perpsClosePosition',
@@ -1067,6 +1086,7 @@ const PerpsOrderEntryPage: React.FC = () => {
     replacePerpsToastByKey,
     t,
     closeFeeRate,
+    marketInfo?.szDecimals,
   ]);
 
   const handlePrimaryAction = useCallback(async () => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes the Reduce exposure flow in the perps order entry page so partial closes behave correctly and match the existing mobile close experience more closely.

Why
The existing flow could treat reduce-exposure actions like full closes, which could close the entire position instead of only the selected percentage.

The full-page close UX also diverged from mobile in its CTA/toast copy and failure handling, which made the behavior harder to understand.

Solution
1. The selected close percentage is now kept in form state and used when building the close request: 100% continues to submit a full close, while smaller percentages submit an explicit partial close size, rounded using the same size-precision rules as the rest of the order-entry flow.
2. The full-page close flow now uses mobile parity close copy for the CTA and toasts.
3. Full close in progress and success fallback subtitle behavior has been restored, and full close toast direction now uses the actual position direction.
4. Partial close failures keep the mobile style generic toast while still preserving actionable error feedback inline on the page.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixes the Reduce exposure flow in the perps order entry page

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2842

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/cd4801e7-2144-4803-819c-e953f57333d0



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes perps close submission logic to optionally send a partial `size` and alters close-mode toast/CTA behavior, which could affect real trading outcomes if incorrect. Covered by updated/added unit tests but touches core order execution paths.
> 
> **Overview**
> Fixes the perps **reduce exposure / close** flow to respect the user-selected close percentage end-to-end.
> 
> The close percentage is now stored in `OrderFormState` (defaulting to 100%) and used to compute close-mode calculations and to build `perpsClosePosition` params: full close submits without `size`, while partial close submits an explicit rounded `size` using market `szDecimals`.
> 
> Close-mode UX is adjusted for mobile parity: CTA text becomes generic “Close position”, in-progress/success/failure toasts are split for full vs partial close, toast direction is derived from the actual position sign, and partial-close failures show a generic toast plus an inline page error message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bbb8c9121148e9c715510da7d144fe5a699b84d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->