### PR TITLE
fix: Error state: Long/Short button not disabled when user has no perps funds

### DIFF
--- a/ui/pages/perps/perps-order-entry-page.test.tsx
+++ b/ui/pages/perps/perps-order-entry-page.test.tsx
@@ -570,6 +570,42 @@ describe('PerpsOrderEntryPage', () => {
         screen.getByTestId('limit-price-liquidation-warning'),
       ).toBeInTheDocument();
     });
+
+    it('disables submit when available balance is zero in new order mode', () => {
+      mockLiveAccount.mockReturnValue({
+        account: {
+          ...mockAccountState,
+          availableBalance: '0',
+          totalBalance: '0',
+        },
+        isInitialLoading: false,
+      });
+      const store = mockStore(createMockState());
+      renderWithProvider(<PerpsOrderEntryPage />, store);
+
+      expect(screen.getByTestId('submit-order-button')).toBeDisabled();
+    });
+
+    it('does not disable submit for zero balance in close mode', () => {
+      mockSearchParams.set('mode', 'close');
+      mockSearchParams.set('direction', 'long');
+      mockLivePositions.mockReturnValue({
+        positions: mockPositions,
+        isInitialLoading: false,
+      });
+      mockLiveAccount.mockReturnValue({
+        account: {
+          ...mockAccountState,
+          availableBalance: '0',
+          totalBalance: '0',
+        },
+        isInitialLoading: false,
+      });
+      const store = mockStore(createMockState());
+      renderWithProvider(<PerpsOrderEntryPage />, store);
+
+      expect(screen.getByTestId('submit-order-button')).not.toBeDisabled();
+    });
   });
 
   describe('order submission', () => {

--- a/ui/pages/perps/perps-order-entry-page.tsx
+++ b/ui/pages/perps/perps-order-entry-page.tsx
@@ -430,6 +430,8 @@ const PerpsOrderEntryPage: React.FC = () => {
     orderCalculations,
   ]);
 
+  const hasNoBalance = orderMode === 'new' && availableBalance <= 0;
+
   const isSubmitDisabled =
     !isEligible ||
     !selectedAddress ||
@@ -437,6 +439,7 @@ const PerpsOrderEntryPage: React.FC = () => {
     isLimitPriceInvalid ||
     isLimitPriceUnfavorable ||
     isNearLiquidation ||
+    hasNoBalance ||
     currentPrice <= 0;
 
   const maxLeverage = useMemo(() => {


### PR DESCRIPTION
## **Description**

The submit button ("Open Long/Short") on the perps order entry page was enabled even when the user had zero perps balance. Added an `availableBalance <= 0` check to `isSubmitDisabled`, gated to new-order mode only so close/modify operations remain unaffected.

## **Changelog**

CHANGELOG entry: Fixed perps order entry submit button remaining enabled when user has no perps funds

## **Related issues**

Fixes: [TAT-2831](https://consensyssoftware.atlassian.net/browse/TAT-2831)

## **Manual testing steps**

1. Open extension, unlock wallet
2. Ensure the perps account has zero balance (no deposited funds)
3. Navigate to Perps tab, then open a market order entry (e.g., /perps/trade/ETH)
4. Observe: the "Open Long ETH" button is now disabled
5. Deposit funds via the Add Funds icon next to "Available to trade"
6. Observe: the button becomes enabled once balance > 0

## **Screenshots/Recordings**

### **Before**

_Evidence available in task artifacts — will be added by reviewer if needed._

### **After**

_Evidence available in task artifacts — will be added by reviewer if needed._

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[TAT-2831]: https://consensyssoftware.atlassian.net/browse/TAT-2831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ