### PR TITLE
fix: Flip fee is not displayed

### DIFF
--- a/ui/components/app/perps/reverse-position/reverse-position-modal.test.tsx
+++ b/ui/components/app/perps/reverse-position/reverse-position-modal.test.tsx
@@ -7,6 +7,16 @@ import { enLocale as messages } from '../../../../../test/lib/i18n-helpers';
 import { mockPositions } from '../mocks';
 import { ReversePositionModal } from './reverse-position-modal';
 
+jest.mock('../../../../hooks/useFormatters', () => ({
+  useFormatters: () => ({
+    formatCurrencyWithMinThreshold: (value: number, _currency: string) =>
+      `$${value.toLocaleString('en-US', {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      })}`,
+  }),
+}));
+
 jest.mock('@metamask/perps-controller', () => ({
   PERPS_ERROR_CODES: {
     CLIENT_NOT_INITIALIZED: 'CLIENT_NOT_INITIALIZED',
@@ -146,7 +156,7 @@ describe('ReversePositionModal', () => {
       expect(screen.getByText(messages.perpsFees.message)).toBeInTheDocument();
     });
 
-    it('shows Cancel and Save buttons', () => {
+    it('shows Cancel and Confirm buttons', () => {
       renderWithProvider(<ReversePositionModal {...defaultProps} />, mockStore);
 
       expect(
@@ -157,10 +167,20 @@ describe('ReversePositionModal', () => {
       ).toBeInTheDocument();
     });
 
-    it('shows fees placeholder as em-dash', () => {
+    it('shows estimated flip fee', () => {
       renderWithProvider(<ReversePositionModal {...defaultProps} />, mockStore);
 
-      expect(screen.getByText('—')).toBeInTheDocument();
+      // ETH: 2 * 2.5 * 2900 * 0.0001 = 1.45 → displayed as -$1.45
+      expect(screen.getByText('-$1.45')).toBeInTheDocument();
+    });
+
+    it('shows Confirm button text instead of Save', () => {
+      renderWithProvider(<ReversePositionModal {...defaultProps} />, mockStore);
+
+      const submitBtn = screen.getByTestId(
+        'perps-reverse-position-modal-save',
+      );
+      expect(submitBtn).toHaveTextContent(messages.confirm.message);
     });
   });
 

--- a/ui/components/app/perps/reverse-position/reverse-position-modal.tsx
+++ b/ui/components/app/perps/reverse-position/reverse-position-modal.tsx
@@ -26,11 +26,13 @@ import {
 } from '../../../../../shared/constants/perps-events';
 import { usePerpsEventTracking } from '../../../../hooks/perps';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
+import { useFormatters } from '../../../../hooks/useFormatters';
 import { submitRequestToBackground } from '../../../../store/background-connection';
 import { getPerpsStreamManager } from '../../../../providers/perps';
 import { getPositionDirection } from '../utils';
 import { handlePerpsError } from '../utils/translate-perps-error';
 import { PERPS_TOAST_KEYS, usePerpsToast } from '../perps-toast';
+import { PERPS_MARKET_ORDER_FEE_RATE } from '../constants';
 import type { Position } from '../types';
 
 export type ReversePositionModalProps = {
@@ -72,9 +74,10 @@ export const ReversePositionModal: React.FC<ReversePositionModalProps> = ({
   isOpen,
   onClose,
   position,
-  currentPrice: _currentPrice,
+  currentPrice,
 }) => {
   const t = useI18nContext();
+  const { formatCurrencyWithMinThreshold } = useFormatters();
   const { track } = usePerpsEventTracking();
   usePerpsEventTracking({
     eventName: MetaMetricsEventName.PerpsScreenViewed,
@@ -97,6 +100,11 @@ export const ReversePositionModal: React.FC<ReversePositionModalProps> = ({
       : `${t('perpsShort')} → ${t('perpsLong')}`;
   const sizeNum = Math.abs(parseFloat(position.size));
   const estSizeLabel = `${sizeNum.toFixed(2)} ${position.symbol}`;
+
+  const estimatedFees = useMemo(
+    () => 2 * sizeNum * currentPrice * PERPS_MARKET_ORDER_FEE_RATE,
+    [sizeNum, currentPrice],
+  );
 
   const positionForFlip = useMemo(
     () => toFlipPositionPayload(position),
@@ -206,7 +214,7 @@ export const ReversePositionModal: React.FC<ReversePositionModalProps> = ({
                 {t('perpsFees')}
               </Text>
               <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
-                —
+                -{formatCurrencyWithMinThreshold(estimatedFees, 'USD')}
               </Text>
             </Box>
             {error && (
@@ -235,7 +243,7 @@ export const ReversePositionModal: React.FC<ReversePositionModalProps> = ({
           }}
           submitButtonProps={{
             'data-testid': 'perps-reverse-position-modal-save',
-            children: isSubmitting ? t('perpsSubmitting') : t('save'),
+            children: isSubmitting ? t('perpsSubmitting') : t('confirm'),
             disabled: isSubmitting,
           }}
         />


### PR DESCRIPTION
## **Description**

The "Reverse position" modal in perps displayed an em-dash (—) for fees instead of the estimated flip fee. The submit button also read "Save" instead of "Confirm". This fix computes the fee using `2 × size × price × PERPS_MARKET_ORDER_FEE_RATE` (matching the close-position pattern) and changes the button label to "Confirm".

## **Changelog**

CHANGELOG entry: Fixed reverse position modal to display estimated flip fee and use "Confirm" button text

## **Related issues**

Fixes: [TAT-2830](https://consensyssoftware.atlassian.net/browse/TAT-2830)

## **Manual testing steps**

1. Open a perps position on any market (e.g. ETH)
2. On the market detail page, click "Modify" → "Reverse position"
3. Verify the Fees row shows a dollar amount (e.g. `-$0.05`) instead of "—"
4. Verify the submit button reads "Confirm" instead of "Save"

## **Screenshots/Recordings**

_Evidence available in task artifacts — will be added by reviewer if needed._

### **Before**

<!-- Fees row shows em-dash, button says "Save" -->

### **After**

<!-- Fees row shows estimated fee amount, button says "Confirm" -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[TAT-2830]: https://consensyssoftware.atlassian.net/browse/TAT-2830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that computes and displays an estimated fee and updates button labeling; main risk is incorrect fee estimation/formatting due to price/size inputs.
> 
> **Overview**
> The perps "Reverse position" modal now computes and displays an **estimated flip fee** (using `2 × size × price × PERPS_MARKET_ORDER_FEE_RATE`) instead of an em-dash placeholder, formatting it via `useFormatters`.
> 
> The submit CTA label is updated from *Save* to **Confirm**, and the unit tests are updated to mock the formatter and assert the displayed fee and new button text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7947632332e78b4c306d96d348d4ec74c844a07c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->