### PR TITLE
fix: Flip fee is not displayed

### DIFF
--- a/ui/components/app/perps/reverse-position/reverse-position-modal.test.tsx
+++ b/ui/components/app/perps/reverse-position/reverse-position-modal.test.tsx
@@ -81,6 +81,16 @@ jest.mock('../../../../providers/perps', () => ({
   getPerpsStreamManager: () => mockGetPerpsStreamManager(),
 }));
 
+jest.mock('../../../../hooks/useFormatters', () => ({
+  useFormatters: () => ({
+    formatCurrencyWithMinThreshold: (value: number, _currency: string) =>
+      `$${value.toLocaleString('en-US', {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      })}`,
+  }),
+}));
+
 jest.mock('../perps-toast', () => ({
   PERPS_TOAST_KEYS: {
     REVERSE_FAILED: 'perpsToastReverseFailed',
@@ -146,7 +156,7 @@ describe('ReversePositionModal', () => {
       expect(screen.getByText(messages.perpsFees.message)).toBeInTheDocument();
     });
 
-    it('shows Cancel and Save buttons', () => {
+    it('shows Cancel and Confirm buttons', () => {
       renderWithProvider(<ReversePositionModal {...defaultProps} />, mockStore);
 
       expect(
@@ -157,10 +167,11 @@ describe('ReversePositionModal', () => {
       ).toBeInTheDocument();
     });
 
-    it('shows fees placeholder as em-dash', () => {
+    it('shows estimated flip fee', () => {
       renderWithProvider(<ReversePositionModal {...defaultProps} />, mockStore);
 
-      expect(screen.getByText('—')).toBeInTheDocument();
+      // 2 * 2.5 * 2900 * 0.0001 = $1.45
+      expect(screen.getByText('-$1.45')).toBeInTheDocument();
     });
   });
 

--- a/ui/components/app/perps/reverse-position/reverse-position-modal.tsx
+++ b/ui/components/app/perps/reverse-position/reverse-position-modal.tsx
@@ -26,9 +26,11 @@ import {
 } from '../../../../../shared/constants/perps-events';
 import { usePerpsEventTracking } from '../../../../hooks/perps';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
+import { useFormatters } from '../../../../hooks/useFormatters';
 import { submitRequestToBackground } from '../../../../store/background-connection';
 import { getPerpsStreamManager } from '../../../../providers/perps';
 import { getPositionDirection } from '../utils';
+import { PERPS_MARKET_ORDER_FEE_RATE } from '../constants';
 import { handlePerpsError } from '../utils/translate-perps-error';
 import { PERPS_TOAST_KEYS, usePerpsToast } from '../perps-toast';
 import type { Position } from '../types';
@@ -72,7 +74,7 @@ export const ReversePositionModal: React.FC<ReversePositionModalProps> = ({
   isOpen,
   onClose,
   position,
-  currentPrice: _currentPrice,
+  currentPrice,
 }) => {
   const t = useI18nContext();
   const { track } = usePerpsEventTracking();
@@ -87,6 +89,7 @@ export const ReversePositionModal: React.FC<ReversePositionModalProps> = ({
     },
   });
   const { replacePerpsToastByKey } = usePerpsToast();
+  const { formatCurrencyWithMinThreshold } = useFormatters();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -97,6 +100,12 @@ export const ReversePositionModal: React.FC<ReversePositionModalProps> = ({
       : `${t('perpsShort')} → ${t('perpsLong')}`;
   const sizeNum = Math.abs(parseFloat(position.size));
   const estSizeLabel = `${sizeNum.toFixed(2)} ${position.symbol}`;
+
+  // Flip trades 2x position size (close + reopen), matching close-position-modal fee pattern.
+  const estimatedFees = useMemo(
+    () => 2 * sizeNum * currentPrice * PERPS_MARKET_ORDER_FEE_RATE,
+    [sizeNum, currentPrice],
+  );
 
   const positionForFlip = useMemo(
     () => toFlipPositionPayload(position),
@@ -205,8 +214,12 @@ export const ReversePositionModal: React.FC<ReversePositionModalProps> = ({
               >
                 {t('perpsFees')}
               </Text>
-              <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
-                —
+              <Text
+                variant={TextVariant.BodySm}
+                fontWeight={FontWeight.Medium}
+                data-testid="perps-reverse-fee-value"
+              >
+                -{formatCurrencyWithMinThreshold(estimatedFees, 'USD')}
               </Text>
             </Box>
             {error && (
@@ -235,7 +248,7 @@ export const ReversePositionModal: React.FC<ReversePositionModalProps> = ({
           }}
           submitButtonProps={{
             'data-testid': 'perps-reverse-position-modal-save',
-            children: isSubmitting ? t('perpsSubmitting') : t('save'),
+            children: isSubmitting ? t('perpsSubmitting') : t('confirm'),
             disabled: isSubmitting,
           }}
         />


### PR DESCRIPTION
## **Description**

The "Reverse position" modal in perps displayed an em-dash (`—`) for the Fees row instead of the actual estimated fee. The submit button also read "Save" instead of "Confirm". This PR calculates the flip fee as `2 × position size × current price × taker fee rate` (matching the close-position pattern) and changes the button label to "Confirm".

## **Changelog**

CHANGELOG entry: Fixed reverse position modal to display estimated flip fee and use "Confirm" button label

## **Related issues**

Fixes: [TAT-2830](https://consensyssoftware.atlassian.net/browse/TAT-2830)

## **Manual testing steps**

1. Navigate to the Perps tab and open a market with an existing position (e.g. ETH)
2. Click the "Modify" dropdown on the position CTAs
3. Select "Reverse position"
4. Verify the Fees row shows a calculated fee (e.g. `-<$0.01`) instead of `—`
5. Verify the submit button reads "Confirm" instead of "Save"

## **Screenshots/Recordings**

### **Before**

_Evidence available in task artifacts — will be added by reviewer if needed._

### **After**

_Evidence available in task artifacts — will be added by reviewer if needed._

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[TAT-2830]: https://consensyssoftware.atlassian.net/browse/TAT-2830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change: computes and displays an estimated fee in the reverse-position modal and updates related tests; no changes to flip execution logic or backend requests.
> 
> **Overview**
> The perps *Reverse position* modal now computes and displays an **estimated flip fee** (using `2 × position size × current price × PERPS_MARKET_ORDER_FEE_RATE`) instead of an em-dash placeholder, formatted via `useFormatters`.
> 
> The submit button label changes from **Save** to **Confirm**, and the modal test suite is updated to mock formatting and assert the new fee and label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3e4126f28aada7a9cbd4b04a182fca0306294fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->