### PR TITLE
fix: tempo disable confirm button until gasless info has finished loading

### DIFF
--- a/ui/pages/confirmations/hooks/gas/useIsGaslessLoading.test.ts
+++ b/ui/pages/confirmations/hooks/gas/useIsGaslessLoading.test.ts
@@ -1,4 +1,6 @@
 import { GasFeeToken } from '@metamask/transaction-controller';
+import { Hex } from '@metamask/utils';
+
 import { renderHookWithConfirmContextProvider } from '../../../../../test/lib/confirmations/render-helpers';
 import { genUnapprovedContractInteractionConfirmation } from '../../../../../test/data/confirmations/contract-interaction';
 import { getMockConfirmStateForTransaction } from '../../../../../test/data/confirmations/helper';
@@ -16,17 +18,23 @@ async function runHook({
   simulationEnabled,
   gaslessSupported,
   insufficientBalance,
+  pending = false,
   gasFeeTokens,
+  selectedGasFeeToken,
+  excludeNativeTokenForFee,
 }: {
   simulationEnabled: boolean;
   gaslessSupported: boolean;
   insufficientBalance: boolean;
+  pending?: boolean;
   gasFeeTokens?: GasFeeToken[];
+  selectedGasFeeToken?: Hex;
+  excludeNativeTokenForFee?: boolean;
 }) {
   mockedUseIsGaslessSupported.mockReturnValue({
     isSupported: gaslessSupported,
     isSmartTransaction: true,
-    pending: false,
+    pending,
   });
   mockedUseHasInsufficientBalance.mockReturnValue({
     hasInsufficientBalance: insufficientBalance,
@@ -38,6 +46,8 @@ async function runHook({
     getMockConfirmStateForTransaction(
       genUnapprovedContractInteractionConfirmation({
         gasFeeTokens,
+        selectedGasFeeToken,
+        excludeNativeTokenForFee,
       }),
       { metamask: { useTransactionSimulations: simulationEnabled } },
     ),
@@ -69,6 +79,17 @@ describe('useIsGaslessLoading', () => {
     });
 
     expect(result.isGaslessLoading).toBe(false);
+  });
+
+  it('returns true if gasless support check is pending', async () => {
+    const result = await runHook({
+      simulationEnabled: true,
+      gaslessSupported: false,
+      insufficientBalance: true,
+      pending: true,
+    });
+
+    expect(result.isGaslessLoading).toBe(true);
   });
 
   it('returns false if there is no insufficient balance', async () => {
@@ -109,6 +130,74 @@ describe('useIsGaslessLoading', () => {
       gaslessSupported: true,
       insufficientBalance: true,
       gasFeeTokens: [],
+    });
+
+    expect(result.isGaslessLoading).toBe(false);
+  });
+
+  it('returns false if gas fee tokens are present and dont match selectedGasFeeToken (non-reg)', async () => {
+    const result = await runHook({
+      simulationEnabled: true,
+      gaslessSupported: true,
+      insufficientBalance: true,
+      gasFeeTokens: [{ tokenAddress: '0x123' }] as unknown as GasFeeToken[],
+      selectedGasFeeToken: '0x456',
+    });
+
+    expect(result.isGaslessLoading).toBe(false);
+  });
+
+  it('returns true if gas fee tokens are present and dont match selectedGasFeeToken with excludeNativeTokenForFee being true (Tempo)', async () => {
+    const result = await runHook({
+      simulationEnabled: true,
+      gaslessSupported: true,
+      insufficientBalance: true,
+      gasFeeTokens: [{ tokenAddress: '0x123' }] as unknown as GasFeeToken[],
+      selectedGasFeeToken: '0x456',
+      excludeNativeTokenForFee: true,
+    });
+
+    expect(result.isGaslessLoading).toBe(true);
+  });
+
+  it('returns false if gas fee tokens are present AND match selectedGasFeeToken with excludeNativeTokenForFee being true (Tempo)', async () => {
+    const result = await runHook({
+      simulationEnabled: true,
+      gaslessSupported: true,
+      insufficientBalance: true,
+      gasFeeTokens: [
+        { tokenAddress: '0x123' },
+        { tokenAddress: '0x789' },
+      ] as unknown as GasFeeToken[],
+      // Matches the first one
+      selectedGasFeeToken: '0x123',
+      excludeNativeTokenForFee: true,
+    });
+
+    expect(result.isGaslessLoading).toBe(false);
+  });
+
+  it('returns false if gas fee tokens are present AND selectedGasFeeToken is undefined with excludeNativeTokenForFee being true (Tempo)', async () => {
+    const result = await runHook({
+      simulationEnabled: true,
+      gaslessSupported: true,
+      insufficientBalance: true,
+      gasFeeTokens: [{ tokenAddress: '0x123' }] as unknown as GasFeeToken[],
+      selectedGasFeeToken: undefined,
+      excludeNativeTokenForFee: true,
+    });
+
+    expect(result.isGaslessLoading).toBe(false);
+  });
+
+  it('returns false if gas fee tokens are empty array with excludeNativeTokenForFee being true (Tempo)', async () => {
+    const result = await runHook({
+      simulationEnabled: true,
+      gaslessSupported: true,
+      insufficientBalance: true,
+      gasFeeTokens: [] as unknown as GasFeeToken[],
+      selectedGasFeeToken: '0x456',
+      excludeNativeTokenForFee: true,
     });
 
     expect(result.isGaslessLoading).toBe(false);

--- a/ui/pages/confirmations/hooks/gas/useIsGaslessLoading.ts
+++ b/ui/pages/confirmations/hooks/gas/useIsGaslessLoading.ts
@@ -1,28 +1,90 @@
 import { useSelector } from 'react-redux';
 import { TransactionMeta } from '@metamask/transaction-controller';
+import { useMemo } from 'react';
 import { useConfirmContext } from '../../context/confirm';
 import { getUseTransactionSimulations } from '../../../../selectors';
 import { useHasInsufficientBalance } from '../useHasInsufficientBalance';
+import { NATIVE_TOKEN_ADDRESS } from '../../../../../shared/constants/transaction';
 import { useIsGaslessSupported } from './useIsGaslessSupported';
 
 export function useIsGaslessLoading() {
   const { currentConfirmation: transactionMeta } =
     useConfirmContext<TransactionMeta>();
 
-  const { gasFeeTokens } = transactionMeta ?? {};
+  const { gasFeeTokens, excludeNativeTokenForFee, selectedGasFeeToken } =
+    transactionMeta ?? {};
 
-  const { isSupported: isGaslessSupported, pending } = useIsGaslessSupported();
+  const {
+    isSupported: isGaslessSupported,
+    pending: isGaslessSupportedPending,
+  } = useIsGaslessSupported();
+
   const isSimulationEnabled = useSelector(getUseTransactionSimulations);
 
   const { hasInsufficientBalance } = useHasInsufficientBalance();
 
-  const isGaslessSupportedFinished = !pending && isGaslessSupported;
-
-  const isGaslessLoading =
-    isSimulationEnabled &&
-    isGaslessSupportedFinished &&
-    hasInsufficientBalance &&
-    !gasFeeTokens;
-
+  const isGaslessLoading = useMemo(() => {
+    if (!isSimulationEnabled) {
+      return false;
+    }
+    // No need for waiting if user doesn't have insufficient balance, unless native is excluded.
+    if (!excludeNativeTokenForFee && !hasInsufficientBalance) {
+      return false;
+    }
+    if (isGaslessSupportedPending) {
+      return true;
+    }
+    if (!isGaslessSupported) {
+      return false;
+    }
+    /*
+     * Sometimes useAutomaticGasFeeTokenSelect needs to have time to run
+     * for the correct available fee token to be assigned.
+     * This is the case on Tempo when we 'suggest' a default fee token
+     * but this is not one of the available token.
+     * Not doing this would fallback on using the native token, which makes it
+     * less painful on other chains, but means tx failure on Tempo.
+     * By using `excludeNativeTokenForFee` as guard, we limit regression risks on
+     * other networks/flows while solving this issue for Tempo.
+     * Without this, clicking too fast on "confirm" while the tx is building would
+     * be possible and would cause a tx failure.
+     */
+    if (excludeNativeTokenForFee) {
+      // `excludeNativeTokenForFee` assumes no native, so we expect gasFeeTokens (empty array [] OK).
+      if (!gasFeeTokens) {
+        return true;
+      }
+      // Empty gasFeeTokens means we finished loading - tx won't be submittable.
+      if (gasFeeTokens.length === 0) {
+        return false;
+      }
+      // If no gas fee token is selected, there might just be none available.
+      if (!selectedGasFeeToken) {
+        return false;
+      }
+      // If a non-native gas fee token is selected but doesn't match the gasFeeTokens list,
+      // then we are in this "wait" situation where useAutomaticGasFeeTokenSelect logic
+      // will execute, auto-selecting the first gas fee token available.
+      // In the meantime we want consider that the state is loading so user won't hit "confirm".
+      const hasSelectedGasFeeTokenInconsistentWithAvailableGasFeeTokens =
+        selectedGasFeeToken !== NATIVE_TOKEN_ADDRESS &&
+        !gasFeeTokens.some(
+          ({ tokenAddress }) =>
+            tokenAddress?.toLocaleLowerCase() ===
+            selectedGasFeeToken?.toLocaleLowerCase(),
+        );
+      return hasSelectedGasFeeTokenInconsistentWithAvailableGasFeeTokens;
+    }
+    // Nominal case: Loading if waiting for gasFeeTokens list while not enough native.
+    return !gasFeeTokens;
+  }, [
+    isGaslessSupportedPending,
+    isGaslessSupported,
+    isSimulationEnabled,
+    hasInsufficientBalance,
+    gasFeeTokens,
+    selectedGasFeeToken,
+    excludeNativeTokenForFee,
+  ]);
   return { isGaslessLoading };
 }

--- a/ui/pages/confirmations/hooks/gas/useIsGaslessLoading.ts
+++ b/ui/pages/confirmations/hooks/gas/useIsGaslessLoading.ts
@@ -1,11 +1,31 @@
 import { useSelector } from 'react-redux';
-import { TransactionMeta } from '@metamask/transaction-controller';
-import { useMemo } from 'react';
+import { GasFeeToken, TransactionMeta } from '@metamask/transaction-controller';
+import { Hex } from '@metamask/utils';
 import { useConfirmContext } from '../../context/confirm';
 import { getUseTransactionSimulations } from '../../../../selectors';
 import { useHasInsufficientBalance } from '../useHasInsufficientBalance';
 import { NATIVE_TOKEN_ADDRESS } from '../../../../../shared/constants/transaction';
 import { useIsGaslessSupported } from './useIsGaslessSupported';
+
+// Chains with no native may have selectedGasFeeToken inconsistent with gasFeeTokens
+function hasWrongSelectedGasFeeToken({
+  gasFeeTokens,
+  selectedGasFeeToken,
+}: {
+  gasFeeTokens: GasFeeToken[];
+  selectedGasFeeToken?: Hex;
+}) {
+  return (
+    gasFeeTokens.length &&
+    selectedGasFeeToken &&
+    selectedGasFeeToken !== NATIVE_TOKEN_ADDRESS &&
+    !gasFeeTokens.some(
+      ({ tokenAddress }) =>
+        tokenAddress?.toLocaleLowerCase() ===
+        selectedGasFeeToken?.toLocaleLowerCase(),
+    )
+  );
+}
 
 export function useIsGaslessLoading() {
   const { currentConfirmation: transactionMeta } =
@@ -23,68 +43,20 @@ export function useIsGaslessLoading() {
 
   const { hasInsufficientBalance } = useHasInsufficientBalance();
 
-  const isGaslessLoading = useMemo(() => {
-    if (!isSimulationEnabled) {
-      return false;
-    }
-    // No need for waiting if user doesn't have insufficient balance, unless native is excluded.
-    if (!excludeNativeTokenForFee && !hasInsufficientBalance) {
-      return false;
-    }
-    if (isGaslessSupportedPending) {
-      return true;
-    }
-    if (!isGaslessSupported) {
-      return false;
-    }
-    /*
-     * Sometimes useAutomaticGasFeeTokenSelect needs to have time to run
-     * for the correct available fee token to be assigned.
-     * This is the case on Tempo when we 'suggest' a default fee token
-     * but this is not one of the available token.
-     * Not doing this would fallback on using the native token, which makes it
-     * less painful on other chains, but means tx failure on Tempo.
-     * By using `excludeNativeTokenForFee` as guard, we limit regression risks on
-     * other networks/flows while solving this issue for Tempo.
-     * Without this, clicking too fast on "confirm" while the tx is building would
-     * be possible and would cause a tx failure.
-     */
-    if (excludeNativeTokenForFee) {
-      // `excludeNativeTokenForFee` assumes no native, so we expect gasFeeTokens (empty array [] OK).
-      if (!gasFeeTokens) {
-        return true;
-      }
-      // Empty gasFeeTokens means we finished loading - tx won't be submittable.
-      if (gasFeeTokens.length === 0) {
-        return false;
-      }
-      // If no gas fee token is selected, there might just be none available.
-      if (!selectedGasFeeToken) {
-        return false;
-      }
-      // If a non-native gas fee token is selected but doesn't match the gasFeeTokens list,
-      // then we are in this "wait" situation where useAutomaticGasFeeTokenSelect logic
-      // will execute, auto-selecting the first gas fee token available.
-      // In the meantime we want consider that the state is loading so user won't hit "confirm".
-      const hasSelectedGasFeeTokenInconsistentWithAvailableGasFeeTokens =
-        selectedGasFeeToken !== NATIVE_TOKEN_ADDRESS &&
-        !gasFeeTokens.some(
-          ({ tokenAddress }) =>
-            tokenAddress?.toLocaleLowerCase() ===
-            selectedGasFeeToken?.toLocaleLowerCase(),
-        );
-      return hasSelectedGasFeeTokenInconsistentWithAvailableGasFeeTokens;
-    }
-    // Nominal case: Loading if waiting for gasFeeTokens list while not enough native.
-    return !gasFeeTokens;
-  }, [
-    isGaslessSupportedPending,
-    isGaslessSupported,
-    isSimulationEnabled,
-    hasInsufficientBalance,
-    gasFeeTokens,
-    selectedGasFeeToken,
-    excludeNativeTokenForFee,
-  ]);
+  const isGaslessSupportedFinished =
+    !isGaslessSupportedPending && isGaslessSupported;
+
+  const hasNoNativeTokenAvailable =
+    excludeNativeTokenForFee || hasInsufficientBalance;
+
+  const isGaslessLoading = Boolean(
+    isSimulationEnabled &&
+      hasNoNativeTokenAvailable &&
+      (isGaslessSupportedPending || isGaslessSupportedFinished) &&
+      (!gasFeeTokens ||
+        (excludeNativeTokenForFee &&
+          hasWrongSelectedGasFeeToken({ gasFeeTokens, selectedGasFeeToken }))),
+  );
+
   return { isGaslessLoading };
 }

--- a/ui/pages/confirmations/hooks/useAutomaticGasFeeTokenSelect.ts
+++ b/ui/pages/confirmations/hooks/useAutomaticGasFeeTokenSelect.ts
@@ -35,7 +35,10 @@ export function useAutomaticGasFeeTokenSelect() {
 
   let firstGasFeeTokenAddress = gasFeeTokens?.[0]?.tokenAddress;
 
-  if (!isSmartTransaction && firstGasFeeTokenAddress === NATIVE_TOKEN_ADDRESS) {
+  if (
+    (!isSmartTransaction || excludeNativeTokenForFee) &&
+    firstGasFeeTokenAddress === NATIVE_TOKEN_ADDRESS
+  ) {
     firstGasFeeTokenAddress = gasFeeTokens?.[1]?.tokenAddress;
   }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The goal of the change is to prevent a premature "enablement" for the Confirm button when a transaction is loading. There are pre-existing race conditions that allowed users to confirm a transaction before everything is fully loaded. Those conditions could make the tx skip gasless flows, falling back to native token for gas payment.

The impact is bigger on Tempo because using a native token is not an option (there is no native token on Tempo), which means that such race condition will always result in a failed tx (the tx won't be sent to the RPC or relayer).

The changes solve the race conditions cases, as well as adds some extra conditions for the loading when on a chain that has no native token.

The PR focuses on the `useIsGaslessLoading` hook, preserving current behavior, adding a different behavior just for Tempo chains. Moved from the `isGaslessLoading` ternary to a "series of if" notation to try to make the logic more explicit but open for feedback.  

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: add new `excludeNativeTokenForFee` (Tempo) specific cases in isGaslessLoading guard to Confirmation button.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/NEB-950?atlOrigin=eyJpIjoiMjc5MmRlOWEwNDFkNGFlZDhiNTQ5ZWYwNmM2MmFlZjIiLCJwIjoiaiJ9

## **Manual testing steps**

<img width="400" alt="image" src="https://github.com/user-attachments/assets/8854e4da-65ef-4dad-867f-50a158495a7b" />

- On Chrome dev tools, throttle your CPU on purpose to slow down the app.
- On Tempo mainnet, find `pathUSD` and click on "Send".
- Set amount to 0.01 and select the account to send to (any account).
- As soon as you clicked on the recipient account, start "spam clicking" on "Confirm" or the location where you know "Confirm" will appear.
- 
<img width="400" alt="image" src="https://github.com/user-attachments/assets/19a8535d-d73b-452b-98c2-d8471000fd48" />

<img width="400" alt="image" src="https://github.com/user-attachments/assets/2846ad13-ba71-4101-b96b-74a86abdc7b7" />

What should be observed is that despite spam-clicking, it should not be possible to "Confirm" the transaction "too soon" and it should always succeed no matter how "early" you click on "Confirm".

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes confirmation gating and fee-token selection logic; mistakes could block confirmations or choose incorrect fee tokens on networks without a native token.
> 
> **Overview**
> Prevents premature enabling of the Confirm action by expanding `useIsGaslessLoading` to treat gasless support checks as *loading* while pending, and to keep loading when `gasFeeTokens` haven’t arrived or (for Tempo via `excludeNativeTokenForFee`) when `selectedGasFeeToken` doesn’t match the available `gasFeeTokens`.
> 
> Updates `useAutomaticGasFeeTokenSelect` to skip the native token as the default fee token not only for non-smart transactions but also when `excludeNativeTokenForFee` is set, and adds targeted unit tests covering the new pending/mismatch/Tempo conditions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81a2d952cd380993b9a3d07c5d712a131f410014. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->