### PR TITLE
fix: Flip fee is not displayed

### DIFF
--- a/ui/components/app/perps/reverse-position/reverse-position-modal.test.tsx
+++ b/ui/components/app/perps/reverse-position/reverse-position-modal.test.tsx
@@ -165,7 +165,7 @@ describe('ReversePositionModal', () => {
       const feeValue = screen.getByTestId('perps-reverse-fee-value');
       expect(feeValue).toBeInTheDocument();
       // Fee = 2 * 2.5 * 2900 * 0.0001 = $1.45
-      expect(feeValue.textContent).toMatch(/\$/u);
+      expect(feeValue.textContent).toBe('-$1.45');
     });
   });
 

--- a/ui/components/app/perps/reverse-position/reverse-position-modal.test.tsx
+++ b/ui/components/app/perps/reverse-position/reverse-position-modal.test.tsx
@@ -146,21 +146,26 @@ describe('ReversePositionModal', () => {
       expect(screen.getByText(messages.perpsFees.message)).toBeInTheDocument();
     });
 
-    it('shows Cancel and Save buttons', () => {
+    it('shows Cancel and Confirm buttons', () => {
       renderWithProvider(<ReversePositionModal {...defaultProps} />, mockStore);
 
       expect(
         screen.getByTestId('perps-reverse-position-modal-cancel'),
       ).toBeInTheDocument();
-      expect(
-        screen.getByTestId('perps-reverse-position-modal-save'),
-      ).toBeInTheDocument();
+      const confirmButton = screen.getByTestId(
+        'perps-reverse-position-modal-save',
+      );
+      expect(confirmButton).toBeInTheDocument();
+      expect(confirmButton).toHaveTextContent(messages.confirm.message);
     });
 
-    it('shows fees placeholder as em-dash', () => {
+    it('shows estimated fees as a formatted currency value', () => {
       renderWithProvider(<ReversePositionModal {...defaultProps} />, mockStore);
 
-      expect(screen.getByText('—')).toBeInTheDocument();
+      const feeValue = screen.getByTestId('perps-reverse-fee-value');
+      expect(feeValue).toBeInTheDocument();
+      // Fee = 2 * 2.5 * 2900 * 0.0001 = $1.45
+      expect(feeValue.textContent).toMatch(/\$/u);
     });
   });
 

--- a/ui/components/app/perps/reverse-position/reverse-position-modal.tsx
+++ b/ui/components/app/perps/reverse-position/reverse-position-modal.tsx
@@ -26,10 +26,12 @@ import {
 } from '../../../../../shared/constants/perps-events';
 import { usePerpsEventTracking } from '../../../../hooks/perps';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
+import { useFormatters } from '../../../../hooks/useFormatters';
 import { submitRequestToBackground } from '../../../../store/background-connection';
 import { getPerpsStreamManager } from '../../../../providers/perps';
 import { getPositionDirection } from '../utils';
 import { handlePerpsError } from '../utils/translate-perps-error';
+import { PERPS_MARKET_ORDER_FEE_RATE } from '../constants';
 import { PERPS_TOAST_KEYS, usePerpsToast } from '../perps-toast';
 import type { Position } from '../types';
 
@@ -72,7 +74,7 @@ export const ReversePositionModal: React.FC<ReversePositionModalProps> = ({
   isOpen,
   onClose,
   position,
-  currentPrice: _currentPrice,
+  currentPrice,
 }) => {
   const t = useI18nContext();
   const { track } = usePerpsEventTracking();
@@ -87,6 +89,7 @@ export const ReversePositionModal: React.FC<ReversePositionModalProps> = ({
     },
   });
   const { replacePerpsToastByKey } = usePerpsToast();
+  const { formatCurrencyWithMinThreshold } = useFormatters();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -97,6 +100,13 @@ export const ReversePositionModal: React.FC<ReversePositionModalProps> = ({
       : `${t('perpsShort')} → ${t('perpsLong')}`;
   const sizeNum = Math.abs(parseFloat(position.size));
   const estSizeLabel = `${sizeNum.toFixed(2)} ${position.symbol}`;
+
+  // A flip places a 2x order (close current + open opposite direction).
+  // Fee is charged on the full 2x notional, matching mobile's calculation.
+  const estimatedFees = useMemo(
+    () => 2 * sizeNum * currentPrice * PERPS_MARKET_ORDER_FEE_RATE,
+    [sizeNum, currentPrice],
+  );
 
   const positionForFlip = useMemo(
     () => toFlipPositionPayload(position),
@@ -205,8 +215,12 @@ export const ReversePositionModal: React.FC<ReversePositionModalProps> = ({
               >
                 {t('perpsFees')}
               </Text>
-              <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
-                —
+              <Text
+                variant={TextVariant.BodySm}
+                fontWeight={FontWeight.Medium}
+                data-testid="perps-reverse-fee-value"
+              >
+                -{formatCurrencyWithMinThreshold(estimatedFees, 'USD')}
               </Text>
             </Box>
             {error && (
@@ -235,7 +249,7 @@ export const ReversePositionModal: React.FC<ReversePositionModalProps> = ({
           }}
           submitButtonProps={{
             'data-testid': 'perps-reverse-position-modal-save',
-            children: isSubmitting ? t('perpsSubmitting') : t('save'),
+            children: isSubmitting ? t('perpsSubmitting') : t('confirm'),
             disabled: isSubmitting,
           }}
         />


### PR DESCRIPTION
## **Description**

The Reverse Position modal displayed a hardcoded em-dash for the fee value and used "Save" as the submit button label. This calculates the flip fee as `2 × size × price × feeRate` (matching mobile and the close-position modal) and changes the button text to "Confirm".

## **Changelog**

CHANGELOG entry: Fixed reverse position modal to display calculated flip fee and use "Confirm" button label

## **Related issues**

Fixes: [TAT-2830](https://consensyssoftware.atlassian.net/browse/TAT-2830)

## **Manual testing steps**

1. Open perps tab, navigate to a market with an open position (e.g. ETH)
2. Click Modify → Reverse Position
3. Verify the Fees row shows a calculated dollar value (not an em-dash)
4. Verify the submit button says "Confirm" (not "Save")

## **Screenshots/Recordings**

Reverse position modal now shows calculated flip fee and Confirm button.

### Reverse position modal — fee visible and Confirm label

<img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/fixes/41684/after-ac1-fee-displayed.png" alt="Reverse position modal showing calculated fee and Confirm label" width="360" />

_This screenshot proves both the fee display fix and the Confirm button label._

### Video

_Uploaded artifact links below; replace with manual GitHub video attachments if you want inline playback._
- After video: [after.mp4](https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/fixes/41684/after.mp4)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[TAT-2830]: https://consensyssoftware.atlassian.net/browse/TAT-2830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI change: adds a deterministic fee estimate calculation/display and updates the submit button label, with corresponding test updates.
> 
> **Overview**
> The Reverse Position (flip) modal now **calculates and displays an estimated fee** instead of showing a placeholder, using `2 × size × price × PERPS_MARKET_ORDER_FEE_RATE` and formatting it as a USD currency value.
> 
> The primary action button label is updated from **"Save" to "Confirm"**, and tests are adjusted to assert the new label and the rendered fee value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70466d912e9b662ba5bfca7e3872608c04e14654. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->