### PR TITLE
fix: Flip fee is not displayed

### DIFF
--- a/ui/components/app/perps/reverse-position/reverse-position-modal.test.tsx
+++ b/ui/components/app/perps/reverse-position/reverse-position-modal.test.tsx
@@ -391,7 +391,7 @@ describe('ReversePositionModal', () => {
 
       await waitFor(() => {
         expect(
-          screen.getByText(\"We couldn't load this page.\"),
+          screen.getByText("We couldn't load this page."),
         ).toBeInTheDocument();
       });
 
@@ -423,7 +423,7 @@ describe('ReversePositionModal', () => {
 
       await waitFor(() => {
         expect(
-          screen.getByText(\"We couldn't load this page.\"),
+          screen.getByText("We couldn't load this page."),
         ).toBeInTheDocument();
       });
       expect(onClose).not.toHaveBeenCalled();

--- a/ui/components/app/perps/reverse-position/reverse-position-modal.test.tsx
+++ b/ui/components/app/perps/reverse-position/reverse-position-modal.test.tsx
@@ -7,6 +7,28 @@ import { enLocale as messages } from '../../../../../test/lib/i18n-helpers';
 import { mockPositions } from '../mocks';
 import { ReversePositionModal } from './reverse-position-modal';
 
+const mockUsePerpsOrderFees = jest.fn();
+const mockUsePerpsEligibility = jest.fn(() => ({ isEligible: true }));
+
+jest.mock('../../../../hooks/perps/usePerpsOrderFees', () => ({
+  usePerpsOrderFees: () => mockUsePerpsOrderFees(),
+}));
+
+jest.mock('../../../../hooks/perps', () => ({
+  usePerpsEligibility: () => mockUsePerpsEligibility(),
+  usePerpsEventTracking: () => ({ track: jest.fn() }),
+}));
+
+jest.mock('../../../../hooks/useFormatters', () => ({
+  useFormatters: () => ({
+    formatCurrencyWithMinThreshold: (value: number, _currency: string) =>
+      `$${value.toLocaleString('en-US', {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      })}`,
+  }),
+}));
+
 jest.mock('@metamask/perps-controller', () => ({
   PERPS_ERROR_CODES: {
     CLIENT_NOT_INITIALIZED: 'CLIENT_NOT_INITIALIZED',
@@ -81,11 +103,6 @@ jest.mock('../../../../providers/perps', () => ({
   getPerpsStreamManager: () => mockGetPerpsStreamManager(),
 }));
 
-const mockUsePerpsEligibility = jest.fn(() => ({ isEligible: true }));
-jest.mock('../../../../hooks/perps/usePerpsEligibility', () => ({
-  usePerpsEligibility: () => mockUsePerpsEligibility(),
-}));
-
 jest.mock('../perps-toast', () => ({
   PERPS_TOAST_KEYS: {
     REVERSE_FAILED: 'perpsToastReverseFailed',
@@ -103,8 +120,8 @@ const mockStore = configureStore({
   },
 });
 
-const longPosition = mockPositions[0]; // ETH: size=2.5 (long), leverage.value=3
-const shortPosition = mockPositions[1]; // BTC: size=-0.5 (short), leverage.value=15
+const longPosition = mockPositions[0];
+const shortPosition = mockPositions[1];
 
 const defaultProps = {
   isOpen: true,
@@ -117,6 +134,11 @@ describe('ReversePositionModal', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUsePerpsEligibility.mockReturnValue({ isEligible: true });
+    mockUsePerpsOrderFees.mockReturnValue({
+      feeRate: 0.0001,
+      isLoading: false,
+      hasError: false,
+    });
     mockSubmitRequestToBackground.mockImplementation((method: string) => {
       if (method === 'perpsFlipPosition') {
         return Promise.resolve({ success: true });
@@ -152,21 +174,52 @@ describe('ReversePositionModal', () => {
       expect(screen.getByText(messages.perpsFees.message)).toBeInTheDocument();
     });
 
-    it('shows Cancel and Save buttons', () => {
+    it('shows Cancel and Confirm buttons', () => {
       renderWithProvider(<ReversePositionModal {...defaultProps} />, mockStore);
 
       expect(
         screen.getByTestId('perps-reverse-position-modal-cancel'),
       ).toBeInTheDocument();
-      expect(
-        screen.getByTestId('perps-reverse-position-modal-save'),
-      ).toBeInTheDocument();
+      const submitButton = screen.getByTestId(
+        'perps-reverse-position-modal-save',
+      );
+      expect(submitButton).toBeInTheDocument();
+      expect(submitButton).toHaveTextContent(messages.confirm.message);
     });
 
-    it('shows fees placeholder as em-dash', () => {
+    it('shows computed estimated fee', () => {
       renderWithProvider(<ReversePositionModal {...defaultProps} />, mockStore);
 
-      expect(screen.getByText('—')).toBeInTheDocument();
+      const feeElement = screen.getByTestId('perps-reverse-fee-value');
+      expect(feeElement).toHaveTextContent('$1.45');
+    });
+
+    it('shows fee placeholder while fees are unavailable', () => {
+      mockUsePerpsOrderFees.mockReturnValue({
+        feeRate: undefined,
+        isLoading: true,
+        hasError: false,
+      });
+
+      renderWithProvider(<ReversePositionModal {...defaultProps} />, mockStore);
+
+      expect(screen.getByTestId('perps-reverse-fee-value')).toHaveTextContent(
+        '--',
+      );
+    });
+
+    it('shows fee placeholder when fee lookup fails', () => {
+      mockUsePerpsOrderFees.mockReturnValue({
+        feeRate: undefined,
+        isLoading: false,
+        hasError: true,
+      });
+
+      renderWithProvider(<ReversePositionModal {...defaultProps} />, mockStore);
+
+      expect(screen.getByTestId('perps-reverse-fee-value')).toHaveTextContent(
+        '--',
+      );
     });
   });
 
@@ -399,7 +452,6 @@ describe('ReversePositionModal', () => {
 
   describe('toast emission', () => {
     it('emits reverse in-progress toast on submit', () => {
-      // Never resolve so we can assert the in-progress toast fires
       mockSubmitRequestToBackground.mockImplementation(
         () => new Promise(() => undefined),
       );

--- a/ui/components/app/perps/reverse-position/reverse-position-modal.test.tsx
+++ b/ui/components/app/perps/reverse-position/reverse-position-modal.test.tsx
@@ -190,8 +190,9 @@ describe('ReversePositionModal', () => {
     it('shows computed estimated fee', () => {
       renderWithProvider(<ReversePositionModal {...defaultProps} />, mockStore);
 
-      const feeElement = screen.getByTestId('perps-reverse-fee-value');
-      expect(feeElement).toHaveTextContent('$1.45');
+      expect(screen.getByTestId('perps-reverse-fee-value')).toHaveTextContent(
+        '$1.45',
+      );
     });
 
     it('shows fee placeholder while fees are unavailable', () => {
@@ -390,7 +391,7 @@ describe('ReversePositionModal', () => {
 
       await waitFor(() => {
         expect(
-          screen.getByText("We couldn't load this page."),
+          screen.getByText(\"We couldn't load this page.\"),
         ).toBeInTheDocument();
       });
 
@@ -422,7 +423,7 @@ describe('ReversePositionModal', () => {
 
       await waitFor(() => {
         expect(
-          screen.getByText("We couldn't load this page."),
+          screen.getByText(\"We couldn't load this page.\"),
         ).toBeInTheDocument();
       });
       expect(onClose).not.toHaveBeenCalled();

--- a/ui/components/app/perps/reverse-position/reverse-position-modal.tsx
+++ b/ui/components/app/perps/reverse-position/reverse-position-modal.tsx
@@ -46,13 +46,6 @@ export type ReversePositionModalProps = {
   currentPrice: number;
 };
 
-/**
- * Builds a position payload for `perpsFlipPosition`. The controller expects
- * `leverage.value`; normalize when the stream sent a primitive leverage.
- *
- * @param pos - UI position from props
- * @returns Position safe to pass to the background flip RPC
- */
 function toFlipPositionPayload(pos: Position): Position {
   if (typeof pos.leverage === 'object' && pos.leverage !== null) {
     return pos;
@@ -64,16 +57,6 @@ function toFlipPositionPayload(pos: Position): Position {
   };
 }
 
-/**
- * Modal to reverse a position (Long -> Short or Short -> Long).
- * Shows Direction, Est. size, Fees and Cancel/Save.
- * Save calls `perpsFlipPosition` (single venue order via PerpsController; not close+open).
- * @param options0
- * @param options0.isOpen
- * @param options0.onClose
- * @param options0.position
- * @param options0.currentPrice
- */
 export const ReversePositionModal: React.FC<ReversePositionModalProps> = ({
   isOpen,
   onClose,
@@ -123,8 +106,6 @@ export const ReversePositionModal: React.FC<ReversePositionModalProps> = ({
     orderType: 'market',
   });
 
-  // A flip places one order of 2x position size (1x close + 1x open opposite).
-  // Fee is charged on the full 2x notional.
   const estimatedFees = useMemo(
     () =>
       feeRate === undefined ? undefined : 2 * sizeNum * currentPrice * feeRate,

--- a/ui/components/app/perps/reverse-position/reverse-position-modal.tsx
+++ b/ui/components/app/perps/reverse-position/reverse-position-modal.tsx
@@ -29,12 +29,14 @@ import {
   usePerpsEventTracking,
 } from '../../../../hooks/perps';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
+import { useFormatters } from '../../../../hooks/useFormatters';
 import { submitRequestToBackground } from '../../../../store/background-connection';
 import { getPerpsStreamManager } from '../../../../providers/perps';
 import { getPositionDirection } from '../utils';
 import { handlePerpsError } from '../utils/translate-perps-error';
 import { PERPS_TOAST_KEYS, usePerpsToast } from '../perps-toast';
 import { PerpsGeoBlockModal } from '../perps-geo-block-modal';
+import { usePerpsOrderFees } from '../../../../hooks/perps/usePerpsOrderFees';
 import type { Position } from '../types';
 
 export type ReversePositionModalProps = {
@@ -76,10 +78,11 @@ export const ReversePositionModal: React.FC<ReversePositionModalProps> = ({
   isOpen,
   onClose,
   position,
-  currentPrice: _currentPrice,
+  currentPrice,
 }) => {
   const t = useI18nContext();
   const { isEligible } = usePerpsEligibility();
+  const { formatCurrencyWithMinThreshold } = useFormatters();
   const { track } = usePerpsEventTracking();
   const [isGeoBlockModalOpen, setIsGeoBlockModalOpen] = useState(false);
 
@@ -111,6 +114,26 @@ export const ReversePositionModal: React.FC<ReversePositionModalProps> = ({
   const sizeNum = Math.abs(parseFloat(position.size));
   const estSizeLabel = `${sizeNum.toFixed(2)} ${position.symbol}`;
 
+  const {
+    feeRate,
+    isLoading: isFeeLoading,
+    hasError: hasFeeError,
+  } = usePerpsOrderFees({
+    symbol: position.symbol,
+    orderType: 'market',
+  });
+
+  // A flip places one order of 2x position size (1x close + 1x open opposite).
+  // Fee is charged on the full 2x notional.
+  const estimatedFees = useMemo(
+    () =>
+      feeRate === undefined ? undefined : 2 * sizeNum * currentPrice * feeRate,
+    [sizeNum, currentPrice, feeRate],
+  );
+
+  const shouldShowFeePlaceholder =
+    isFeeLoading || hasFeeError || estimatedFees === undefined;
+
   const positionForFlip = useMemo(
     () => toFlipPositionPayload(position),
     [position],
@@ -121,6 +144,7 @@ export const ReversePositionModal: React.FC<ReversePositionModalProps> = ({
       setIsGeoBlockModalOpen(true);
       return;
     }
+
     setIsSubmitting(true);
     setError(null);
 
@@ -235,8 +259,11 @@ export const ReversePositionModal: React.FC<ReversePositionModalProps> = ({
                 <Text
                   variant={TextVariant.BodySm}
                   fontWeight={FontWeight.Medium}
+                  data-testid="perps-reverse-fee-value"
                 >
-                  —
+                  {shouldShowFeePlaceholder
+                    ? '--'
+                    : formatCurrencyWithMinThreshold(estimatedFees, 'USD')}
                 </Text>
               </Box>
               {error && (
@@ -265,7 +292,7 @@ export const ReversePositionModal: React.FC<ReversePositionModalProps> = ({
             }}
             submitButtonProps={{
               'data-testid': 'perps-reverse-position-modal-save',
-              children: isSubmitting ? t('perpsSubmitting') : t('save'),
+              children: isSubmitting ? t('perpsSubmitting') : t('confirm'),
               disabled: isSubmitting,
             }}
           />

--- a/ui/components/app/perps/reverse-position/reverse-position-modal.tsx
+++ b/ui/components/app/perps/reverse-position/reverse-position-modal.tsx
@@ -177,7 +177,6 @@ export const ReversePositionModal: React.FC<ReversePositionModalProps> = ({
   ]);
 
   return (
-<<<<<<< HEAD
     <>
       <Modal
         isOpen={isOpen}
@@ -191,70 +190,6 @@ export const ReversePositionModal: React.FC<ReversePositionModalProps> = ({
           </ModalHeader>
           <ModalBody>
             <Box flexDirection={BoxFlexDirection.Column} gap={4}>
-=======
-    <Modal
-      isOpen={isOpen}
-      onClose={onClose}
-      data-testid="perps-reverse-position-modal"
-    >
-      <ModalOverlay />
-      <ModalContent size={ModalContentSize.Sm}>
-        <ModalHeader onClose={onClose}>{t('perpsReversePosition')}</ModalHeader>
-        <ModalBody>
-          <Box flexDirection={BoxFlexDirection.Column} gap={4}>
-            <Box
-              flexDirection={BoxFlexDirection.Row}
-              justifyContent={BoxJustifyContent.Between}
-              alignItems={BoxAlignItems.Center}
-            >
-              <Text
-                variant={TextVariant.BodySm}
-                color={TextColor.TextAlternative}
-              >
-                {t('perpsDirection')}
-              </Text>
-              <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
-                {directionLabel}
-              </Text>
-            </Box>
-            <Box
-              flexDirection={BoxFlexDirection.Row}
-              justifyContent={BoxJustifyContent.Between}
-              alignItems={BoxAlignItems.Center}
-            >
-              <Text
-                variant={TextVariant.BodySm}
-                color={TextColor.TextAlternative}
-              >
-                {t('perpsEstSize')}
-              </Text>
-              <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
-                {estSizeLabel}
-              </Text>
-            </Box>
-            <Box
-              flexDirection={BoxFlexDirection.Row}
-              justifyContent={BoxJustifyContent.Between}
-              alignItems={BoxAlignItems.Center}
-            >
-              <Text
-                variant={TextVariant.BodySm}
-                color={TextColor.TextAlternative}
-              >
-                {t('perpsFees')}
-              </Text>
-              <Text
-                variant={TextVariant.BodySm}
-                fontWeight={FontWeight.Medium}
-                data-testid="perps-reverse-fee-value"
-              >
-                {estimatedFees !== undefined
-                  ? formatCurrencyWithMinThreshold(estimatedFees, 'USD')
-                  : '--'}
-              </Text>
-            </Box>
-            {error && (
->>>>>>> b96b80b3c2 (fix: show -- instead of $0.00 when fee rate is loading)
               <Box
                 flexDirection={BoxFlexDirection.Row}
                 justifyContent={BoxJustifyContent.Between}

--- a/ui/components/app/perps/reverse-position/reverse-position-modal.tsx
+++ b/ui/components/app/perps/reverse-position/reverse-position-modal.tsx
@@ -177,6 +177,7 @@ export const ReversePositionModal: React.FC<ReversePositionModalProps> = ({
   ]);
 
   return (
+<<<<<<< HEAD
     <>
       <Modal
         isOpen={isOpen}
@@ -190,6 +191,70 @@ export const ReversePositionModal: React.FC<ReversePositionModalProps> = ({
           </ModalHeader>
           <ModalBody>
             <Box flexDirection={BoxFlexDirection.Column} gap={4}>
+=======
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      data-testid="perps-reverse-position-modal"
+    >
+      <ModalOverlay />
+      <ModalContent size={ModalContentSize.Sm}>
+        <ModalHeader onClose={onClose}>{t('perpsReversePosition')}</ModalHeader>
+        <ModalBody>
+          <Box flexDirection={BoxFlexDirection.Column} gap={4}>
+            <Box
+              flexDirection={BoxFlexDirection.Row}
+              justifyContent={BoxJustifyContent.Between}
+              alignItems={BoxAlignItems.Center}
+            >
+              <Text
+                variant={TextVariant.BodySm}
+                color={TextColor.TextAlternative}
+              >
+                {t('perpsDirection')}
+              </Text>
+              <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
+                {directionLabel}
+              </Text>
+            </Box>
+            <Box
+              flexDirection={BoxFlexDirection.Row}
+              justifyContent={BoxJustifyContent.Between}
+              alignItems={BoxAlignItems.Center}
+            >
+              <Text
+                variant={TextVariant.BodySm}
+                color={TextColor.TextAlternative}
+              >
+                {t('perpsEstSize')}
+              </Text>
+              <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
+                {estSizeLabel}
+              </Text>
+            </Box>
+            <Box
+              flexDirection={BoxFlexDirection.Row}
+              justifyContent={BoxJustifyContent.Between}
+              alignItems={BoxAlignItems.Center}
+            >
+              <Text
+                variant={TextVariant.BodySm}
+                color={TextColor.TextAlternative}
+              >
+                {t('perpsFees')}
+              </Text>
+              <Text
+                variant={TextVariant.BodySm}
+                fontWeight={FontWeight.Medium}
+                data-testid="perps-reverse-fee-value"
+              >
+                {estimatedFees !== undefined
+                  ? formatCurrencyWithMinThreshold(estimatedFees, 'USD')
+                  : '--'}
+              </Text>
+            </Box>
+            {error && (
+>>>>>>> b96b80b3c2 (fix: show -- instead of $0.00 when fee rate is loading)
               <Box
                 flexDirection={BoxFlexDirection.Row}
                 justifyContent={BoxJustifyContent.Between}

--- a/ui/pages/perps/perps-market-detail-page.test.tsx
+++ b/ui/pages/perps/perps-market-detail-page.test.tsx
@@ -155,6 +155,14 @@ jest.mock('../../store/background-connection', () => ({
     mockSubmitRequestToBackground(...args),
 }));
 
+jest.mock('../../hooks/perps/usePerpsOrderFees', () => ({
+  usePerpsOrderFees: () => ({
+    feeRate: 0.0001,
+    isLoading: false,
+    hasError: false,
+  }),
+}));
+
 jest.mock('../../selectors/accounts', () => ({
   ...jest.requireActual('../../selectors/accounts'),
   getSelectedInternalAccount: () => ({ address: '0x123' }),


### PR DESCRIPTION
## **Description**

The "Reverse position" modal in perps trading hardcoded the fee as `—` and the submit button as "Save". This PR computes the estimated flip fee (`2 * size * price * feeRate`) to match mobile's logic and changes the button label to "Confirm".

## **Changelog**

CHANGELOG entry: Fixed reverse position modal to display computed flip fee and use "Confirm" button label

## **Related issues**

Fixes: [TAT-2830](https://consensyssoftware.atlassian.net/browse/TAT-2830)

## **Manual testing steps**

1. Navigate to a perps market detail page (e.g. ETH) with an open position
2. Click "Modify" > "Reverse position"
3. Verify the Fees row shows a dollar amount (e.g. `$0.22`), not `—`
4. Verify the submit button reads "Confirm", not "Save"

## **Screenshots/Recordings**

Reverse position modal now shows computed fee and Confirm button.

### Reverse position modal — fee visible and Confirm label
Before: Fees showed '—' and button said 'Save'. After: Fees shows '$0.22' and button says 'Confirm'.
| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/fixes/41685/before-ac1-fee-visible.png" alt="Reverse position modal — fee visible and Confirm label before" width="360" /> | <img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/fixes/41685/after-ac1-fee-visible.png" alt="Reverse position modal — fee visible and Confirm label after" width="360" /> |

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[TAT-2830]: https://consensyssoftware.atlassian.net/browse/TAT-2830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> User-facing perps trading modal now derives and displays estimated flip fees from live fee rates and price; incorrect inputs (price/feeRate/loading) could mislead users even though it does not change order execution.
> 
> **Overview**
> Fixes the perps **Reverse Position** modal to show a computed estimated flip fee instead of a hardcoded em-dash by fetching the market fee rate via `usePerpsOrderFees` and calculating `2 * size * price * feeRate`, formatting the result for display (falls back to `--` while loading or on error).
> 
> Updates the modal submit CTA label from *Save* to *Confirm* and expands/adjusts tests to cover fee rendering, placeholder states, and the new button text (including mocking `usePerpsOrderFees` in affected test suites).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd9a5c142bd817f7838c944fc12c3ef683f38456. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

