### PR TITLE
feat: improve Perps deposit confirmation footer and amount display

### DIFF
--- a/ui/pages/confirmations/components/confirm/footer/footer.test.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/footer.test.tsx
@@ -1205,6 +1205,27 @@ describe('ConfirmFooter', () => {
     expect(queryByText(messages.cancel.message)).not.toBeInTheDocument();
   });
 
+  it('renders SingleActionFooter for perpsDeposit transaction type', () => {
+    jest.spyOn(confirmContext, 'useConfirmContext').mockReturnValue({
+      currentConfirmation: {
+        ...genUnapprovedContractInteractionConfirmation(),
+        type: TransactionType.perpsDeposit,
+      },
+      isScrollToBottomCompleted: true,
+      setIsScrollToBottomCompleted: () => undefined,
+    } as unknown as ReturnType<typeof confirmContext.useConfirmContext>);
+
+    const { getByTestId, queryByText } = render(
+      getMockContractInteractionConfirmState(),
+    );
+
+    expect(getByTestId('confirm-footer-button')).toBeInTheDocument();
+    expect(getByTestId('confirm-footer-button')).toHaveTextContent(
+      messages.addFunds.message,
+    );
+    expect(queryByText(messages.cancel.message)).not.toBeInTheDocument();
+  });
+
   describe('goBackTo navigation', () => {
     it('does not call navigateNext when cancel is clicked and goBackTo is defined', async () => {
       const navigateNextMock = jest.fn();

--- a/ui/pages/confirmations/components/confirm/footer/footer.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/footer.tsx
@@ -51,7 +51,10 @@ import ShieldFooterAgreement from './shield-footer-agreement';
 import ShieldFooterCoverageIndicator from './shield-footer-coverage-indicator/shield-footer-coverage-indicator';
 import { SingleActionFooter } from './single-action-footer';
 
-const SINGLE_ACTION_FOOTER_TYPES = [TransactionType.musdConversion];
+const SINGLE_ACTION_FOOTER_TYPES = [
+  TransactionType.musdConversion,
+  TransactionType.perpsDeposit,
+];
 
 export type OnCancelHandler = ({
   location,

--- a/ui/pages/confirmations/components/confirm/footer/single-action-footer.test.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/single-action-footer.test.tsx
@@ -27,8 +27,14 @@ function genMusdConversion() {
   return { ...base, type: TransactionType.musdConversion, origin: 'metamask' };
 }
 
+function genPerpsDeposit() {
+  const base = genUnapprovedContractInteractionConfirmation({ chainId: '0x1' });
+  return { ...base, type: TransactionType.perpsDeposit, origin: 'metamask' };
+}
+
 function render({
   isGaslessLoading = false,
+  confirmation = genMusdConversion(),
   alerts = [] as {
     key: string;
     severity: string;
@@ -37,6 +43,9 @@ function render({
   }[],
 }: {
   isGaslessLoading?: boolean;
+  confirmation?:
+    | ReturnType<typeof genMusdConversion>
+    | ReturnType<typeof genPerpsDeposit>;
   alerts?: {
     key: string;
     severity: string;
@@ -44,7 +53,6 @@ function render({
     isBlocking?: boolean;
   }[];
 } = {}) {
-  const confirmation = genMusdConversion();
   const baseState = getMockConfirmStateForTransaction(
     confirmation,
   ) as DefaultRootState;
@@ -144,5 +152,11 @@ describe('<SingleActionFooter />', () => {
     const { getByTestId } = render();
 
     expect(getByTestId('confirm-footer-button')).toBeDisabled();
+  });
+
+  it('shows Add funds label for perpsDeposit transaction type', () => {
+    const { getByTestId } = render({ confirmation: genPerpsDeposit() });
+
+    expect(getByTestId('confirm-footer-button')).toHaveTextContent('Add funds');
   });
 });

--- a/ui/pages/confirmations/components/confirm/footer/single-action-footer.test.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/single-action-footer.test.tsx
@@ -5,6 +5,7 @@ import { DefaultRootState } from 'react-redux';
 import { getMockConfirmStateForTransaction } from '../../../../../../test/data/confirmations/helper';
 import { genUnapprovedContractInteractionConfirmation } from '../../../../../../test/data/confirmations/contract-interaction';
 import { renderWithConfirmContextProvider } from '../../../../../../test/lib/confirmations/render-helpers';
+import { enLocale as messages } from '../../../../../../test/lib/i18n-helpers';
 import configureStore from '../../../../../store/store';
 import { Severity } from '../../../../../helpers/constants/design-system';
 import {
@@ -129,7 +130,7 @@ describe('<SingleActionFooter />', () => {
 
     const button = getByTestId('confirm-footer-button');
     expect(button).toBeDisabled();
-    expect(button).toHaveTextContent('Convert');
+    expect(button).toHaveTextContent(messages.musdConvert.message);
   });
 
   it('disables button when amount is zero', () => {
@@ -157,6 +158,8 @@ describe('<SingleActionFooter />', () => {
   it('shows Add funds label for perpsDeposit transaction type', () => {
     const { getByTestId } = render({ confirmation: genPerpsDeposit() });
 
-    expect(getByTestId('confirm-footer-button')).toHaveTextContent('Add funds');
+    expect(getByTestId('confirm-footer-button')).toHaveTextContent(
+      messages.addFunds.message,
+    );
   });
 });

--- a/ui/pages/confirmations/components/confirm/footer/single-action-footer.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/single-action-footer.tsx
@@ -21,6 +21,7 @@ type ButtonState = {
 
 const BUTTON_TEXT_BY_TYPE: Partial<Record<TransactionType, string>> = {
   [TransactionType.musdConversion]: 'musdConvert',
+  [TransactionType.perpsDeposit]: 'addFunds',
 };
 
 function useSingleActionButtonState(isGaslessLoading: boolean): ButtonState {

--- a/ui/pages/confirmations/components/confirm/info/perps-deposit-info/perps-deposit-info.tsx
+++ b/ui/pages/confirmations/components/confirm/info/perps-deposit-info/perps-deposit-info.tsx
@@ -11,5 +11,7 @@ export const PerpsDepositInfo = () => {
     tokenAddress: ARBITRUM_USDC.address,
   });
 
-  return <CustomAmountInfo currency={PERPS_CURRENCY} hasMax />;
+  return (
+    <CustomAmountInfo currency={PERPS_CURRENCY} hasMax hidePayTokenAmount />
+  );
 };

--- a/ui/pages/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/ui/pages/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -90,6 +90,7 @@ const DEFAULT_ALERTS_HOOK_RETURN = {
 function render({
   hasMax = false,
   disablePay = false,
+  hidePayTokenAmount = false,
   availableTokens = [MOCK_AVAILABLE_TOKEN],
   customAmountHookReturn = DEFAULT_CUSTOM_AMOUNT_HOOK_RETURN,
   payTokenHookReturn = DEFAULT_PAY_TOKEN_HOOK_RETURN,
@@ -101,6 +102,7 @@ function render({
 }: {
   hasMax?: boolean;
   disablePay?: boolean;
+  hidePayTokenAmount?: boolean;
   availableTokens?: (typeof MOCK_AVAILABLE_TOKEN)[];
   customAmountHookReturn?: typeof DEFAULT_CUSTOM_AMOUNT_HOOK_RETURN;
   payTokenHookReturn?: typeof DEFAULT_PAY_TOKEN_HOOK_RETURN;
@@ -162,7 +164,11 @@ function render({
   const state = getMockConfirmStateForTransaction(MOCK_TRANSACTION_META);
 
   return renderWithConfirmContextProvider(
-    <CustomAmountInfo hasMax={hasMax} disablePay={disablePay} />,
+    <CustomAmountInfo
+      hasMax={hasMax}
+      disablePay={disablePay}
+      hidePayTokenAmount={hidePayTokenAmount}
+    />,
     mockStore(state),
   );
 }
@@ -185,6 +191,15 @@ describe('CustomAmountInfo', () => {
   it('does not render pay token amount when disablePay is true', () => {
     const { queryByTestId } = render({ disablePay: true });
     expect(queryByTestId('pay-token-amount')).not.toBeInTheDocument();
+  });
+
+  it('does not render pay token amount when hidePayTokenAmount is true', () => {
+    const { queryByTestId, getByTestId } = render({
+      hidePayTokenAmount: true,
+      disablePay: false,
+    });
+    expect(queryByTestId('pay-token-amount')).not.toBeInTheDocument();
+    expect(getByTestId('pay-with-row')).toBeInTheDocument();
   });
 
   it('renders pay with row when tokens available and disablePay is false', () => {

--- a/ui/pages/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/ui/pages/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -50,6 +50,7 @@ export type CustomAmountInfoProps = {
   currency?: string;
   disablePay?: boolean;
   hasMax?: boolean;
+  hidePayTokenAmount?: boolean;
   preferredToken?: SetPayTokenRequest;
   overrideBottomContent?: ReactNode;
   overrideCenterContent?: (amountHuman: string) => ReactNode;
@@ -61,6 +62,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = React.memo(
     currency,
     disablePay,
     hasMax,
+    hidePayTokenAmount,
     overrideBottomContent,
     overrideCenterContent,
     preferredToken,
@@ -117,6 +119,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = React.memo(
           disablePay={disablePay}
           hasMax={hasMax && !isNativePayToken}
           hasTokens={hasTokens}
+          hidePayTokenAmount={hidePayTokenAmount}
           onAmountChange={handleAmountChange}
           onPercentageClick={handlePercentageClick}
           overrideCenterContent={overrideCenterContent}
@@ -150,6 +153,7 @@ type CenterContainerProps = {
   disablePay?: boolean;
   hasMax?: boolean;
   hasTokens: boolean;
+  hidePayTokenAmount?: boolean;
   onAmountChange: (value: string) => void;
   onPercentageClick: (percentage: number) => void;
   overrideCenterContent?: (amountHuman: string) => ReactNode;
@@ -163,6 +167,7 @@ function CenterContainer({
   disablePay,
   hasMax,
   hasTokens,
+  hidePayTokenAmount,
   onAmountChange,
   onPercentageClick,
   overrideCenterContent,
@@ -192,7 +197,7 @@ function CenterContainer({
           alignItems={AlignItems.center}
           gap={3}
         >
-          {disablePay !== true && (
+          {disablePay !== true && !hidePayTokenAmount && (
             <PayTokenAmount amountHuman={amountHuman} disabled={!hasTokens} />
           )}
           {children}


### PR DESCRIPTION
…ooter and related components

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**


Perps deposit confirmations previously used the standard two-button footer (Cancel + Confirm), showed a pay-token line (for example “0 MUSD”) under the fiat amount, and allowed Confirm with a zero amount.
This change routes `TransactionType.perpsDeposit` through the same single-action footer pattern as mUSD conversion: one primary CTA labeled **Add funds** using the existing `addFunds` locale. The shared `SingleActionFooter` logic disables that CTA until the pay flow has a non-zero required amount, so users cannot confirm without entering an amount. The secondary pay-token amount line under the hero fiat input is hidden for Perps deposit only via a new `hidePayTokenAmount` prop on `CustomAmountInfo`, without removing the “Pay with” row or pay-token selection.


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updated the Perps deposit confirmation screen to use a single “Add funds” button that stays disabled until an amount is entered, and removed the extra token amount line below the fiat total.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1177 https://consensyssoftware.atlassian.net/browse/CONF-1178

## **Manual testing steps**

1. Ensure a dev build includes Perps at compile time: set `PERPS_ENABLED='true'` in `.metamaskrc` (see `.metamaskrc.dist`).
2. Ensure the remote Perps rollout allows your build: override `perpsEnabledVersion` (for example via `MANIFEST_OVERRIDES` pointing at a `.manifest-overrides.json` that sets `remoteFeatureFlags.perpsEnabledVersion` to `{ "enabled": true, "minimumVersion": "0.0.0" }`), or use your team’s usual LaunchDarkly / test setup.
3. Build and load the extension (`yarn start` or your usual command), unlock the wallet, and open the Perps deposit confirmation (product flow that opens **Deposit funds to Perps**, or the confirmations **developer** option that triggers a Perps deposit confirmation if available in your build).
4. Confirm the header still shows **Deposit funds to Perps** (or equivalent localized title).
5. With **$0** (or empty) fiat input, confirm there is a **single** footer button **Add funds**, that it is **disabled**, and that there is **no** secondary line like “0 MUSD” directly under the large fiat amount (the **Pay with** row should still appear when applicable).
6. Enter a positive fiat amount (or use percentage / Max if enabled) and confirm **Add funds** becomes **enabled** and still submits the deposit flow as before.
7. Optional: compare with **mUSD conversion** confirmation — single primary CTA pattern should feel consistent.


## **Screenshots/Recordings**

[perps.webm](https://github.com/user-attachments/assets/4b26f488-46f0-4250-8340-373b4a7a3bf6)


<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Perps deposit confirmation CTA logic and display, including disabling submission until a non-zero amount is present, which could affect deposit UX/flow if pay-token data is missing or miscomputed.
> 
> **Overview**
> Routes `TransactionType.perpsDeposit` confirmations through the existing `SingleActionFooter` flow (single primary CTA) and labels the action **Add funds**, removing the secondary Cancel button for this type.
> 
> Extends `SingleActionFooter` to map `perpsDeposit` to the `addFunds` locale key and keeps the CTA disabled when pay-token requirements indicate a zero/empty amount (or blocking alerts).
> 
> Adds a `hidePayTokenAmount` option to `CustomAmountInfo` and uses it for Perps deposits to suppress the extra pay-token amount line under the input while retaining the *Pay with* row, with updated/added unit tests covering these behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9eae9a30533d54043c825b37bb674362b5440165. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->