### PR TITLE
feat(perps): enable PERPS_ENABLED in main build type

### DIFF
--- a/.metamaskrc.dist
+++ b/.metamaskrc.dist
@@ -10,8 +10,8 @@ SEEDLESS_ONBOARDING_ENABLED='false'
 ; Set this to `true` to enable Metamask Shield
 METAMASK_SHIELD_ENABLED='false'
 
-; Set to `true` to include PerpsController and perps features (matches experimental channel when true).
-; Set to `false` to match main/beta/flask builds that omit perps at compile time.
+; Set to `true` to include PerpsController and perps features.
+; main and experimental builds have this enabled by default; beta and flask do not.
 PERPS_ENABLED='true'
 
 ; Set to `true` to enable AssetsController unified state population.

--- a/builds.yml
+++ b/builds.yml
@@ -37,6 +37,7 @@ buildTypes:
       - APPLE_PROD_CLIENT_ID
       - GOOGLE_CLIENT_ID_REF: GOOGLE_PROD_CLIENT_ID
       - APPLE_CLIENT_ID_REF: APPLE_PROD_CLIENT_ID
+      - PERPS_ENABLED: true
     # Main build uses the default browser manifest
     manifestOverrides: false
     # Build name used in multiple user-readable places


### PR DESCRIPTION
Promotes the perps compile-time gate from experimental-only to the main build type. Updates the .metamaskrc.dist comment to reflect that main and experimental both ship with perps enabled.

Made-with: Cursor

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables perps codepaths in the `main` build type at compile time, which could surface unfinished/region-restricted functionality or increase bundle/behavior differences for production users.
> 
> **Overview**
> **Perps is now compiled into `main` builds by default.** This sets `PERPS_ENABLED: true` under the `buildTypes.main` env in `builds.yml`, promoting the perps compile-time gate beyond experimental.
> 
> Updates `.metamaskrc.dist` comments to clarify that `main` and `experimental` ship with perps enabled by default, while `beta` and `flask` do not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4671eba5a57eff6dd41f158be8380818117b00e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->