### PR TITLE
fix: cp-13.27.0 add back in 'fit-content' style to app header avatar container

### DIFF
--- a/ui/components/multichain/app-header/app-header-unlocked-content.tsx
+++ b/ui/components/multichain/app-header/app-header-unlocked-content.tsx
@@ -184,6 +184,7 @@ export const AppHeaderUnlockedContent = ({
           <BoxDeprecated
             marginTop={1}
             marginLeft={2}
+            style={{ width: 'fit-content' }}
             data-testid="networks-subtitle-test-id"
           >
             <MultichainTriggeredAddressRowsList


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

A style was lost in the default address changes that keeps the width of the avatar icons + copy button fitted to the content. The issue is seen when the default address feature is toggled off in Settings or off in LD.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixes the container width on the app header hoverable network icons

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/41691

## **Manual testing steps**

Go to app home page
View app header with Default address setting toggled off

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="243" height="74" alt="image" src="https://github.com/user-attachments/assets/9f08cb38-e9b9-48ed-b2a6-c5d252fd1ebc" />

### **After**

<img width="237" height="79" alt="image" src="https://github.com/user-attachments/assets/f27f1ce4-2ee0-4314-bb36-8b1c4d77fe23" />

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts layout styling for the app header address subtitle without affecting data flow or business logic.
> 
> **Overview**
> Restores `style={{ width: 'fit-content' }}` on the app header's multichain address subtitle container (`networks-subtitle-test-id`) so the address rows list sizes to its contents instead of stretching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc9d9318cceb632cc1836022f377acb4898bdd58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->