### PR TITLE
fix: Error state: Long/Short button not disabled when user has no perps funds

### DIFF
--- a/ui/pages/perps/perps-market-detail-page.test.tsx
+++ b/ui/pages/perps/perps-market-detail-page.test.tsx
@@ -202,6 +202,13 @@ jest.mock('../../components/app/perps/perps-toast', () => {
 const mockUsePerpsMarketFills = jest
   .fn()
   .mockReturnValue({ fills: [], isInitialLoading: false });
+const mockTriggerDeposit = jest.fn().mockResolvedValue({
+  transactionId: 'perps-deposit-tx',
+});
+const mockLiveAccount = jest.fn(() => ({
+  account: mockAccountState,
+  isInitialLoading: false,
+}));
 
 jest.mock('../../hooks/perps', () => ({
   usePerpsEligibility: () => ({ isEligible: true }),
@@ -212,6 +219,15 @@ jest.mock('../../hooks/perps', () => ({
   usePerpsMarginCalculations: jest.fn(),
   usePerpsMarketFills: (...args: unknown[]) => mockUsePerpsMarketFills(...args),
 }));
+jest.mock(
+  '../../components/app/perps/hooks/usePerpsDepositConfirmation',
+  () => ({
+    usePerpsDepositConfirmation: () => ({
+      trigger: mockTriggerDeposit,
+      isLoading: false,
+    }),
+  }),
+);
 
 // Mock the perps stream hooks
 jest.mock('../../hooks/perps/stream', () => ({
@@ -223,10 +239,7 @@ jest.mock('../../hooks/perps/stream', () => ({
     orders: mockOrders,
     isInitialLoading: false,
   }),
-  usePerpsLiveAccount: () => ({
-    account: mockAccountState,
-    isInitialLoading: false,
-  }),
+  usePerpsLiveAccount: () => mockLiveAccount(),
   usePerpsLiveMarketData: () => ({
     markets: [...mockCryptoMarkets, ...mockHip3Markets],
     isInitialLoading: false,
@@ -322,6 +335,11 @@ describe('PerpsMarketDetailPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockReplacePerpsToastByKey.mockReset();
+    mockTriggerDeposit.mockClear();
+    mockLiveAccount.mockReturnValue({
+      account: mockAccountState,
+      isInitialLoading: false,
+    });
     mockUsePerpsMarketFills.mockReturnValue({
       fills: [],
       isInitialLoading: false,
@@ -1033,6 +1051,49 @@ describe('PerpsMarketDetailPage', () => {
       ).not.toBeInTheDocument();
     });
 
+    it('shows an add funds CTA instead of Long/Short when balance is zero', async () => {
+      mockUseParams.mockReturnValue({ symbol: 'xyz:AAPL' });
+      mockLiveAccount.mockReturnValue({
+        account: {
+          ...mockAccountState,
+          availableBalance: '0',
+          totalBalance: '0',
+        },
+        isInitialLoading: false,
+      });
+      const store = mockStore(createMockState(true));
+
+      await renderPage(store);
+
+      expect(
+        screen.queryByTestId('perps-trade-cta-buttons'),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByTestId('perps-add-funds-cta-button'),
+      ).toHaveTextContent(messages.addFunds.message);
+    });
+
+    it('starts deposit flow from add funds CTA when balance is zero', async () => {
+      mockUseParams.mockReturnValue({ symbol: 'xyz:AAPL' });
+      mockLiveAccount.mockReturnValue({
+        account: {
+          ...mockAccountState,
+          availableBalance: '0',
+          totalBalance: '0',
+        },
+        isInitialLoading: false,
+      });
+      const store = mockStore(createMockState(true));
+
+      await renderPage(store);
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('perps-add-funds-cta-button'));
+      });
+
+      expect(mockTriggerDeposit).toHaveBeenCalledTimes(1);
+    });
+
     it('navigates to order entry when Long button is clicked', async () => {
       mockUseParams.mockReturnValue({ symbol: 'xyz:AAPL' });
       const store = mockStore(createMockState(true));
@@ -1074,6 +1135,20 @@ describe('PerpsMarketDetailPage', () => {
       expect(
         screen.queryByText(messages.perpsPosition.message),
       ).not.toBeInTheDocument();
+    });
+
+    it('keeps trade buttons disabled while account state is loading', async () => {
+      mockUseParams.mockReturnValue({ symbol: 'xyz:AAPL' });
+      mockLiveAccount.mockReturnValue({
+        account: mockAccountState,
+        isInitialLoading: true,
+      });
+      const store = mockStore(createMockState(true));
+
+      await renderPage(store);
+
+      expect(screen.getByTestId('perps-long-cta-button')).toBeDisabled();
+      expect(screen.getByTestId('perps-short-cta-button')).toBeDisabled();
     });
   });
 

--- a/ui/pages/perps/perps-market-detail-page.tsx
+++ b/ui/pages/perps/perps-market-detail-page.tsx
@@ -92,6 +92,7 @@ import { ReversePositionModal } from '../../components/app/perps/reverse-positio
 import { UpdateTPSLModal } from '../../components/app/perps/update-tpsl';
 import { ClosePositionModal } from '../../components/app/perps/close-position';
 import { CancelOrderModal } from '../../components/app/perps/cancel-order';
+import { usePerpsDepositConfirmation } from '../../components/app/perps/hooks/usePerpsDepositConfirmation';
 import type { Order } from '../../components/app/perps/types';
 import {
   PERPS_TOAST_KEYS,
@@ -293,9 +294,11 @@ const PerpsMarketDetailPage: React.FC = () => {
   // Use stream hooks for real-time data
   const { positions: allPositions } = usePerpsLivePositions();
   const { orders: allOrders } = usePerpsLiveOrders();
-  const { account } = usePerpsLiveAccount();
+  const { account, isInitialLoading: isLoadingAccount } = usePerpsLiveAccount();
   const { markets: allMarkets, isInitialLoading: marketsLoading } =
     usePerpsLiveMarketData();
+  const { trigger: triggerDeposit, isLoading: isDepositLoading } =
+    usePerpsDepositConfirmation();
 
   // Safely decode the symbol from URL
   const decodedSymbol = useMemo(() => {
@@ -385,6 +388,8 @@ const PerpsMarketDetailPage: React.FC = () => {
       (pos) => pos.symbol.toLowerCase() === decodedSymbol.toLowerCase(),
     );
   }, [decodedSymbol, allPositions]);
+  const hasNoAvailableBalance =
+    !position && !isLoadingAccount && !hasPerpBalance;
 
   // Ref to track current position - avoids stale data in callbacks
   // This follows mobile's pattern (currentPositionRef) to ensure we always
@@ -641,7 +646,7 @@ const PerpsMarketDetailPage: React.FC = () => {
 
   const handleOpenOrder = useCallback(
     (direction: 'long' | 'short') => {
-      if (!isEligible || !decodedSymbol) {
+      if (!isEligible || !decodedSymbol || isLoadingAccount) {
         return;
       }
       track(MetaMetricsEventName.PerpsUiInteraction, {
@@ -656,8 +661,40 @@ const PerpsMarketDetailPage: React.FC = () => {
       });
       navigate(buildOrderEntryUrl(direction, 'new'));
     },
-    [isEligible, decodedSymbol, navigate, buildOrderEntryUrl, track],
+    [
+      isEligible,
+      decodedSymbol,
+      isLoadingAccount,
+      navigate,
+      buildOrderEntryUrl,
+      track,
+    ],
   );
+
+  const handleAddFunds = useCallback(() => {
+    if (!isEligible || !selectedAddress || isDepositLoading) {
+      return;
+    }
+
+    track(MetaMetricsEventName.PerpsUiInteraction, {
+      [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
+        PERPS_EVENT_VALUE.INTERACTION_TYPE.BUTTON_CLICKED,
+      [PERPS_EVENT_PROPERTY.BUTTON_TYPE]:
+        PERPS_EVENT_VALUE.BUTTON_CLICKED.DEPOSIT,
+      [PERPS_EVENT_PROPERTY.BUTTON_LOCATION]:
+        PERPS_EVENT_VALUE.BUTTON_LOCATION.ASSET_DETAILS,
+      ...(decodedSymbol && { [PERPS_EVENT_PROPERTY.ASSET]: decodedSymbol }),
+    });
+
+    triggerDeposit();
+  }, [
+    decodedSymbol,
+    isDepositLoading,
+    isEligible,
+    selectedAddress,
+    track,
+    triggerDeposit,
+  ]);
 
   const handleClosePosition = useCallback(() => {
     if (!isEligible || !position) {
@@ -1793,7 +1830,21 @@ const PerpsMarketDetailPage: React.FC = () => {
         )}
 
         {/* Without Position: Show Long and Short buttons */}
-        {!position && (
+        {!position && hasNoAvailableBalance && (
+          <Button
+            variant={ButtonVariant.Primary}
+            size={ButtonSize.Lg}
+            onClick={handleAddFunds}
+            disabled={!isEligible || !selectedAddress || isDepositLoading}
+            title={isEligible ? undefined : t('perpsGeoBlockedTooltip')}
+            className="w-full"
+            data-testid="perps-add-funds-cta-button"
+          >
+            {t('addFunds')}
+          </Button>
+        )}
+
+        {!position && !hasNoAvailableBalance && (
           <Box
             flexDirection={BoxFlexDirection.Row}
             gap={3}
@@ -1804,7 +1855,7 @@ const PerpsMarketDetailPage: React.FC = () => {
               variant={ButtonVariant.Primary}
               size={ButtonSize.Lg}
               onClick={() => handleOpenOrder('long')}
-              disabled={!isEligible}
+              disabled={!isEligible || isLoadingAccount}
               title={isEligible ? undefined : t('perpsGeoBlockedTooltip')}
               className="flex-1"
               data-testid="perps-long-cta-button"
@@ -1817,7 +1868,7 @@ const PerpsMarketDetailPage: React.FC = () => {
               variant={ButtonVariant.Primary}
               size={ButtonSize.Lg}
               onClick={() => handleOpenOrder('short')}
-              disabled={!isEligible}
+              disabled={!isEligible || isLoadingAccount}
               title={isEligible ? undefined : t('perpsGeoBlockedTooltip')}
               className="flex-1"
               data-testid="perps-short-cta-button"

--- a/ui/pages/perps/perps-order-entry-page.test.tsx
+++ b/ui/pages/perps/perps-order-entry-page.test.tsx
@@ -440,6 +440,24 @@ describe('PerpsOrderEntryPage', () => {
       expect(screen.getByTestId('submit-order-button')).toBeDisabled();
     });
 
+    it('disables submit and prompts to add funds when new order balance is zero', () => {
+      mockLiveAccount.mockReturnValue({
+        account: {
+          ...mockAccountState,
+          availableBalance: '0',
+          totalBalance: '0',
+        },
+        isInitialLoading: false,
+      });
+      const store = mockStore(createMockState());
+      renderWithProvider(<PerpsOrderEntryPage />, store);
+
+      expect(screen.getByTestId('submit-order-button')).toBeDisabled();
+      expect(screen.getByTestId('submit-order-button')).toHaveTextContent(
+        'Add funds',
+      );
+    });
+
     it('disables submit when selected account address is missing', async () => {
       const state = createMockState();
       state.metamask.internalAccounts = {

--- a/ui/pages/perps/perps-order-entry-page.test.tsx
+++ b/ui/pages/perps/perps-order-entry-page.test.tsx
@@ -454,7 +454,7 @@ describe('PerpsOrderEntryPage', () => {
 
       expect(screen.getByTestId('submit-order-button')).toBeDisabled();
       expect(screen.getByTestId('submit-order-button')).toHaveTextContent(
-        'Add funds',
+        messages.addFunds.message,
       );
     });
 

--- a/ui/pages/perps/perps-order-entry-page.test.tsx
+++ b/ui/pages/perps/perps-order-entry-page.test.tsx
@@ -113,6 +113,9 @@ jest.mock('../../store/background-connection', () => ({
 
 const mockReplacePerpsToastByKey = jest.fn();
 const mockHidePerpsToast = jest.fn();
+const mockTriggerDeposit = jest.fn().mockResolvedValue({
+  transactionId: 'perps-deposit-tx',
+});
 jest.mock('../../components/app/perps/perps-toast', () => {
   const { PERPS_TOAST_KEYS } = jest.requireActual(
     '../../components/app/perps/perps-toast/perps-toast-provider',
@@ -131,6 +134,15 @@ jest.mock('../../providers/perps', () => {
     getPerpsStreamManager: () => mockGetPerpsStreamManager(),
   };
 });
+jest.mock(
+  '../../components/app/perps/hooks/usePerpsDepositConfirmation',
+  () => ({
+    usePerpsDepositConfirmation: () => ({
+      trigger: mockTriggerDeposit,
+      isLoading: false,
+    }),
+  }),
+);
 
 const mockLivePositions = jest.fn<
   { positions: Position[]; isInitialLoading: boolean },
@@ -257,6 +269,7 @@ describe('PerpsOrderEntryPage', () => {
     mockIsNearLiquidationPrice.mockImplementation(realIsNearLiquidation);
     mockReplacePerpsToastByKey.mockReset();
     mockHidePerpsToast.mockReset();
+    mockTriggerDeposit.mockClear();
     mockUseParams.mockReturnValue({ symbol: 'ETH' });
     mockSearchParams.delete('direction');
     mockSearchParams.delete('mode');
@@ -440,7 +453,7 @@ describe('PerpsOrderEntryPage', () => {
       expect(screen.getByTestId('submit-order-button')).toBeDisabled();
     });
 
-    it('disables submit and prompts to add funds when new order balance is zero', () => {
+    it('shows an add funds CTA when new order balance is zero', async () => {
       mockLiveAccount.mockReturnValue({
         account: {
           ...mockAccountState,
@@ -452,10 +465,31 @@ describe('PerpsOrderEntryPage', () => {
       const store = mockStore(createMockState());
       renderWithProvider(<PerpsOrderEntryPage />, store);
 
+      const submitButton = screen.getByTestId('submit-order-button');
+
+      expect(submitButton).not.toBeDisabled();
+      expect(submitButton).toHaveTextContent(messages.addFunds.message);
+
+      await act(async () => {
+        fireEvent.click(submitButton);
+      });
+
+      expect(mockTriggerDeposit).toHaveBeenCalledTimes(1);
+    });
+
+    it('disables submit while account state is still loading for a new order', () => {
+      mockLiveAccount.mockReturnValue({
+        account: {
+          ...mockAccountState,
+          availableBalance: '0',
+          totalBalance: '0',
+        },
+        isInitialLoading: true,
+      });
+      const store = mockStore(createMockState());
+      renderWithProvider(<PerpsOrderEntryPage />, store);
+
       expect(screen.getByTestId('submit-order-button')).toBeDisabled();
-      expect(screen.getByTestId('submit-order-button')).toHaveTextContent(
-        messages.addFunds.message,
-      );
     });
 
     it('disables submit when selected account address is missing', async () => {
@@ -622,6 +656,29 @@ describe('PerpsOrderEntryPage', () => {
       expect(screen.getByTestId('submit-order-button')).not.toHaveTextContent(
         messages.insufficientFundsSend.message,
       );
+    });
+
+    it('disables submit when auto-close take profit is invalid', async () => {
+      const store = mockStore(createMockState());
+      renderWithProvider(<PerpsOrderEntryPage />, store);
+
+      const amountContainer = screen.getByTestId('amount-input-field');
+      const amountInput = amountContainer.querySelector('input');
+      fireEvent.change(amountInput as HTMLInputElement, {
+        target: { value: '100' },
+      });
+
+      fireEvent.click(screen.getByTestId('auto-close-toggle'));
+
+      const tpContainer = screen.getByTestId('tp-price-input');
+      const tpInput = tpContainer.querySelector('input');
+      fireEvent.change(tpInput as HTMLInputElement, {
+        target: { value: '1000' },
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('submit-order-button')).toBeDisabled();
+      });
     });
   });
 

--- a/ui/pages/perps/perps-order-entry-page.tsx
+++ b/ui/pages/perps/perps-order-entry-page.tsx
@@ -195,7 +195,8 @@ const PerpsOrderEntryPage: React.FC = () => {
   trackRef.current = track;
   const tradeConfigurations = useSelector(selectPerpsTradeConfigurations);
   const isTestnet = useSelector(selectPerpsIsTestnet);
-  const { trigger: triggerDeposit } = usePerpsDepositConfirmation();
+  const { trigger: triggerDeposit, isLoading: isDepositLoading } =
+    usePerpsDepositConfirmation();
   const { formatPercentWithMinThreshold } = useFormatters();
   const { replacePerpsToastByKey, hidePerpsToast } = usePerpsToast();
 
@@ -408,6 +409,7 @@ const PerpsOrderEntryPage: React.FC = () => {
     : 0;
   const hasNoAvailableBalance =
     orderMode === 'new' && !isLoadingAccount && availableBalance <= 0;
+  const isPrimaryTradeAction = orderMode !== 'new' || !hasNoAvailableBalance;
 
   const isLimitPriceUnfavorable = useMemo(() => {
     if (orderType !== 'limit' || !orderFormState) {
@@ -488,16 +490,18 @@ const PerpsOrderEntryPage: React.FC = () => {
   }, [orderFormState, orderMode, availableBalance]);
 
   const isSubmitDisabled =
-    hasNoAvailableBalance ||
     !isEligible ||
     !selectedAddress ||
+    isDepositLoading ||
     isOrderPending ||
-    isLimitPriceInvalid ||
-    isLimitPriceUnfavorable ||
-    isNearLiquidation ||
-    hasInvalidTPSL ||
-    isInsufficientFunds ||
-    currentPrice <= 0;
+    (orderMode === 'new' && isLoadingAccount) ||
+    (isPrimaryTradeAction &&
+      (isLimitPriceInvalid ||
+        isLimitPriceUnfavorable ||
+        isNearLiquidation ||
+        hasInvalidTPSL ||
+        isInsufficientFunds ||
+        currentPrice <= 0));
 
   const maxLeverage = useMemo(() => {
     if (!market) {
@@ -971,6 +975,26 @@ const PerpsOrderEntryPage: React.FC = () => {
     t,
   ]);
 
+  const handlePrimaryAction = useCallback(async () => {
+    if (hasNoAvailableBalance) {
+      if (!isEligible || !selectedAddress || isDepositLoading) {
+        return;
+      }
+
+      await triggerDeposit();
+      return;
+    }
+
+    await handleOrderSubmit();
+  }, [
+    handleOrderSubmit,
+    hasNoAvailableBalance,
+    isDepositLoading,
+    isEligible,
+    selectedAddress,
+    triggerDeposit,
+  ]);
+
   useEffect(() => {
     if (!pendingOrderSymbol) {
       return;
@@ -1067,7 +1091,7 @@ const PerpsOrderEntryPage: React.FC = () => {
     }
   })();
 
-  const resolvedButtonText = isInsufficientFunds
+  const resolvedButtonText = isPrimaryTradeAction && isInsufficientFunds
     ? t('insufficientFundsSend')
     : submitButtonText;
 
@@ -1193,7 +1217,7 @@ const PerpsOrderEntryPage: React.FC = () => {
         <Button
           variant={ButtonVariant.Primary}
           size={ButtonSize.Lg}
-          onClick={handleOrderSubmit}
+          onClick={handlePrimaryAction}
           disabled={isSubmitDisabled}
           title={isEligible ? undefined : t('perpsGeoBlockedTooltip')}
           className={twMerge(

--- a/ui/pages/perps/perps-order-entry-page.tsx
+++ b/ui/pages/perps/perps-order-entry-page.tsx
@@ -1091,9 +1091,10 @@ const PerpsOrderEntryPage: React.FC = () => {
     }
   })();
 
-  const resolvedButtonText = isPrimaryTradeAction && isInsufficientFunds
-    ? t('insufficientFundsSend')
-    : submitButtonText;
+  const resolvedButtonText =
+    isPrimaryTradeAction && isInsufficientFunds
+      ? t('insufficientFundsSend')
+      : submitButtonText;
 
   return (
     <Box

--- a/ui/pages/perps/perps-order-entry-page.tsx
+++ b/ui/pages/perps/perps-order-entry-page.tsx
@@ -200,7 +200,7 @@ const PerpsOrderEntryPage: React.FC = () => {
   const { replacePerpsToastByKey, hidePerpsToast } = usePerpsToast();
 
   const { positions: allPositions } = usePerpsLivePositions();
-  const { account } = usePerpsLiveAccount();
+  const { account, isInitialLoading: isLoadingAccount } = usePerpsLiveAccount();
   const { markets: allMarkets, isInitialLoading: marketsLoading } =
     usePerpsLiveMarketData();
 
@@ -406,6 +406,8 @@ const PerpsOrderEntryPage: React.FC = () => {
   const availableBalance = account
     ? Number.parseFloat(account.availableBalance)
     : 0;
+  const hasNoAvailableBalance =
+    orderMode === 'new' && !isLoadingAccount && availableBalance <= 0;
 
   const isLimitPriceUnfavorable = useMemo(() => {
     if (orderType !== 'limit' || !orderFormState) {
@@ -486,6 +488,7 @@ const PerpsOrderEntryPage: React.FC = () => {
   }, [orderFormState, orderMode, availableBalance]);
 
   const isSubmitDisabled =
+    hasNoAvailableBalance ||
     !isEligible ||
     !selectedAddress ||
     isOrderPending ||
@@ -1046,6 +1049,10 @@ const PerpsOrderEntryPage: React.FC = () => {
   const displayName = getDisplayName(market.symbol);
   const isLong = orderDirection === 'long';
   const submitButtonText = (() => {
+    if (hasNoAvailableBalance) {
+      return t('addFunds');
+    }
+
     switch (orderMode) {
       case 'modify':
         return t('perpsModifyPosition');


### PR DESCRIPTION
## **Description**

Prevents the perps order-entry screen from showing an enabled trade CTA when the account has no available perps funds. New orders now surface a disabled `Add funds` CTA instead of leaving the user on an enabled `Open Long/Short` action that cannot complete successfully.

## **Changelog**

CHANGELOG entry: Fixed a bug where zero-balance perps order entry showed an enabled trade CTA instead of prompting users to add funds

## **Related issues**

Fixes: [TAT-2831](https://consensyssoftware.atlassian.net/browse/TAT-2831)

## **Manual testing steps**

1. Open the extension, unlock the wallet, and navigate to a perps market order-entry screen such as `/perps/trade/BTC?direction=long&mode=new`.
2. Ensure the perps account state has zero available balance.
3. Confirm the primary CTA is disabled and reads `Add funds` instead of showing an enabled `Open Long/Short` action.

## **Screenshots/Recordings**

Zero-balance perps order entry now presents a disabled deposit-oriented CTA instead of an enabled trade action.

### Perps order entry zero-balance CTA
Before the fix the zero-balance screen still showed an enabled Open Long CTA; after the fix it shows a disabled Add funds CTA.

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/fixes/41692/before-ac1-disabled-add-funds.png" alt="Perps order entry zero-balance CTA before" width="360" /> | <img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/fixes/41692/after-ac1-disabled-add-funds.png" alt="Perps order entry zero-balance CTA after" width="360" /> |

### Video
Videos capture the full recipe run before and after the fix.
_Uploaded artifact links below; replace with manual GitHub video attachments if you want inline playback._
- Before video: [before.mp4](https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/fixes/41692/before.mp4)
- After video: [after.mp4](https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/fixes/41692/after.mp4)

## **Validation Recipe**

<details><summary>recipe.json</summary>

```json
{
  "title": "TAT-2831 - disable perps submit CTA when no funds are available",
  "validate": {
    "workflow": {
      "pre_conditions": [
        "wallet.unlocked",
        "perps.feature_enabled",
        "perps.ready_to_trade"
      ],
      "setup": [
        {
          "id": "setup-prime-perps-state",
          "action": "call",
          "ref": "perps/prime-perps-state"
        },
        {
          "id": "setup-navigate-market-detail",
          "action": "call",
          "ref": "perps/navigate-to-market-detail",
          "params": {
            "symbol": "BTC"
          }
        },
        {
          "id": "setup-wait-open-long-cta",
          "action": "wait_for",
          "test_id": "perps-long-cta-button",
          "timeout_ms": 10000
        },
        {
          "id": "setup-open-order-entry",
          "action": "press",
          "test_id": "perps-long-cta-button"
        },
        {
          "id": "setup-wait-order-entry",
          "action": "wait_for",
          "test_id": "perps-order-entry-page",
          "timeout_ms": 10000
        },
        {
          "id": "setup-inject-zero-balance-account",
          "action": "eval_sync",
          "expression": "(()=>{const sm=stateHooks.getPerpsStreamManager();const current=sm.account.getCachedData()??{};const injected={...current,availableBalance:'0',totalBalance:'0',marginUsed:'0',unrealizedPnl:'0',returnOnEquity:'0',subAccountBreakdown:{'':{availableBalance:'0',totalBalance:'0'}}};sm.account.pushData(injected);const next=sm.account.getCachedData();return JSON.stringify({availableBalance:next?.availableBalance??null,totalBalance:next?.totalBalance??null})})()",
          "assert": {
            "operator": "eq",
            "field": "availableBalance",
            "value": "0"
          }
        }
      ],
      "teardown": [
        {
          "id": "teardown-restore-live-account",
          "action": "eval_async",
          "expression": "(async()=>{const sm=stateHooks.getPerpsStreamManager();const live=await stateHooks.submitRequestToBackground('perpsGetAccountState',[]);sm.account.pushData(live??null);const next=sm.account.getCachedData();return JSON.stringify({restored:!!next,availableBalance:next?.availableBalance??null})})()",
          "assert": {
            "operator": "truthy",
            "field": "restored"
          }
        }
      ],
      "entry": "ac1-wait-submit-disabled",
      "nodes": {
        "ac1-wait-submit-disabled": {
          "action": "wait_for",
          "expression": "(()=>{const submit=document.querySelector('[data-testid=\"submit-order-button\"]');return JSON.stringify({exists:!!submit,disabled:!!submit&&(submit.hasAttribute('disabled')||submit.getAttribute('aria-disabled')==='true')})})()",
          "assert": {
            "operator": "eq",
            "field": "disabled",
            "value": true
          },
          "timeout_ms": 5000,
          "poll_ms": 250,
          "next": "ac1-assert-submit-label"
        },
        "ac1-assert-submit-label": {
          "action": "eval_sync",
          "expression": "(()=>{const submit=document.querySelector('[data-testid=\"submit-order-button\"]');return JSON.stringify({label:submit?.textContent?.trim()??null})})()",
          "assert": {
            "operator": "eq",
            "field": "label",
            "value": "Add funds"
          },
          "next": "ac1-screenshot-disabled-submit"
        },
        "ac1-screenshot-disabled-submit": {
          "action": "screenshot",
          "filename": "evidence-ac1-disabled-add-funds.png",
          "next": "done"
        },
        "done": {
          "action": "end",
          "status": "pass"
        }
      }
    }
  }
}
```

</details>

## **Recipe Workflow**

<details><summary>Mermaid workflow</summary>

```mermaid
flowchart TD
  %% TAT-2831 - disable perps submit CTA when no funds are available
  __entry__(["ENTRY"]) --> node_ac1_wait_submit_disabled
  node_ac1_wait_submit_disabled["ac1-wait-submit-disabled<br/>wait_for"]
  node_ac1_assert_submit_label["ac1-assert-submit-label<br/>eval_sync"]
  node_ac1_screenshot_disabled_submit["ac1-screenshot-disabled-submit<br/>screenshot"]
  node_done(["done<br/>PASS"])
  node_ac1_wait_submit_disabled --> node_ac1_assert_submit_label
  node_ac1_assert_submit_label --> node_ac1_screenshot_disabled_submit
  node_ac1_screenshot_disabled_submit --> node_done
```

</details>

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[TAT-2831]: https://consensyssoftware.atlassian.net/browse/TAT-2831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the primary perps CTAs on both market detail and order entry screens, including triggering the deposit flow when balances are zero; mistakes here could block trading or send users into the wrong flow. Scope is UI-only but impacts a key trading path.
> 
> **Overview**
> Prevents users from initiating perps trades while the live account state is still loading, and avoids showing actionable trade CTAs when the perps available balance is zero.
> 
> On `PerpsMarketDetailPage`, replaces the Long/Short footer with a single **`Add funds`** CTA (wired to `usePerpsDepositConfirmation().trigger`) when there is no position and no available balance; otherwise Long/Short are now disabled while account data loads.
> 
> On `PerpsOrderEntryPage`, the submit button now becomes an **`Add funds`** primary action for *new* orders with zero balance (triggering the deposit flow), and is disabled during account loading and while a deposit is in progress; submit validation is adjusted so trade-only constraints (e.g., insufficient funds label/disabled logic) don’t override the deposit CTA.
> 
> Adds/updates unit tests to cover the new zero-balance `Add funds` behavior, deposit triggering, and loading-state disabling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f65bb0a1550d9cc596ae21b78fb945e7560ed65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

