### PR TITLE
fix: missing % on percent change

### DIFF
--- a/ui/components/app/perps/utils.test.ts
+++ b/ui/components/app/perps/utils.test.ts
@@ -5,6 +5,7 @@ import {
   formatOrderType,
   formatStatus,
   getStatusColor,
+  formatChangePercent,
   getChangeColor,
   getDisplaySymbol,
   getAssetIconUrl,
@@ -106,6 +107,24 @@ describe('Perps Utils', () => {
       expect(getStatusColor('open')).toBe(TextColor.TextAlternative);
       expect(getStatusColor('queued')).toBe(TextColor.TextAlternative);
       expect(getStatusColor('triggered')).toBe(TextColor.TextAlternative);
+    });
+  });
+
+  describe('formatChangePercent', () => {
+    it('returns the value unchanged when it already includes %', () => {
+      expect(formatChangePercent('+2.84%')).toBe('+2.84%');
+      expect(formatChangePercent('-1.23%')).toBe('-1.23%');
+      expect(formatChangePercent('0.00%')).toBe('0.00%');
+    });
+
+    it('appends % when the value does not include it', () => {
+      expect(formatChangePercent('+2.84')).toBe('+2.84%');
+      expect(formatChangePercent('-1.23')).toBe('-1.23%');
+      expect(formatChangePercent('0.00')).toBe('0.00%');
+    });
+
+    it('returns empty string unchanged', () => {
+      expect(formatChangePercent('')).toBe('');
     });
   });
 

--- a/ui/components/app/perps/utils.test.ts
+++ b/ui/components/app/perps/utils.test.ts
@@ -126,6 +126,12 @@ describe('Perps Utils', () => {
     it('returns empty string unchanged', () => {
       expect(formatChangePercent('')).toBe('');
     });
+
+    it('returns non-numeric strings unchanged', () => {
+      expect(formatChangePercent('—')).toBe('—');
+      expect(formatChangePercent('-')).toBe('-');
+      expect(formatChangePercent('N/A')).toBe('N/A');
+    });
   });
 
   describe('getChangeColor', () => {

--- a/ui/components/app/perps/utils.ts
+++ b/ui/components/app/perps/utils.ts
@@ -101,18 +101,24 @@ export const getStatusColor = (status: Order['status']): TextColor => {
  * Normalizes a 24h percentage change string to always include the '%' suffix.
  * The live price stream may omit '%' while market data always includes it.
  *
+ * Returns the value unchanged if:
+ * - empty / falsy
+ * - already contains '%'
+ * - contains no digits (e.g. a fallback dash "—" or error string)
+ *
  * @param value - Raw percentage string, with or without '%' (e.g., "+2.84" or "+2.84%")
  * @returns The normalized percentage string with '%' appended if missing
  * @example
  * formatChangePercent('+2.84')  => '+2.84%'
  * formatChangePercent('+2.84%') => '+2.84%'
  * formatChangePercent('')       => ''
+ * formatChangePercent('—')      => '—'
  */
 export const formatChangePercent = (value: string): string => {
-  if (!value) {
+  if (!value || value.includes('%') || !/\d/u.test(value)) {
     return value;
   }
-  return value.includes('%') ? value : `${value}%`;
+  return `${value}%`;
 };
 
 /**

--- a/ui/components/app/perps/utils.ts
+++ b/ui/components/app/perps/utils.ts
@@ -98,6 +98,24 @@ export const getStatusColor = (status: Order['status']): TextColor => {
 };
 
 /**
+ * Normalizes a 24h percentage change string to always include the '%' suffix.
+ * The live price stream may omit '%' while market data always includes it.
+ *
+ * @param value - Raw percentage string, with or without '%' (e.g., "+2.84" or "+2.84%")
+ * @returns The normalized percentage string with '%' appended if missing
+ * @example
+ * formatChangePercent('+2.84')  => '+2.84%'
+ * formatChangePercent('+2.84%') => '+2.84%'
+ * formatChangePercent('')       => ''
+ */
+export const formatChangePercent = (value: string): string => {
+  if (!value) {
+    return value;
+  }
+  return value.includes('%') ? value : `${value}%`;
+};
+
+/**
  * Get the appropriate text color for a percentage change value
  * Non-negative values (≥ 0) → green, negative → red
  *

--- a/ui/pages/perps/perps-market-detail-page.test.tsx
+++ b/ui/pages/perps/perps-market-detail-page.test.tsx
@@ -452,6 +452,30 @@ describe('PerpsMarketDetailPage', () => {
       });
     });
 
+    it('appends % to live percentChange24h when the stream omits it', async () => {
+      const store = mockStore(createMockState(true));
+      const { getByTestId } = await renderPage(store);
+
+      await waitFor(() => {
+        expect(mockPriceSubscribe).toHaveBeenCalled();
+      });
+
+      act(() => {
+        latestPriceSubscriber?.([
+          {
+            symbol: 'ETH',
+            percentChange24h: '+9.99',
+          },
+        ]);
+      });
+
+      await waitFor(() => {
+        expect(getByTestId('perps-market-detail-change')).toHaveTextContent(
+          '+9.99%',
+        );
+      });
+    });
+
     it('displays candlestick chart', async () => {
       const store = mockStore(createMockState(true));
 

--- a/ui/pages/perps/perps-market-detail-page.tsx
+++ b/ui/pages/perps/perps-market-detail-page.tsx
@@ -79,6 +79,7 @@ import {
   getDisplayName,
   safeDecodeURIComponent,
   getChangeColor,
+  formatChangePercent,
 } from '../../components/app/perps/utils';
 import { transformFillsToTransactions } from '../../components/app/perps/utils/transactionTransforms';
 import { normalizeMarketDetailsOrders } from '../../components/app/perps/utils/orderUtils';
@@ -510,8 +511,9 @@ const PerpsMarketDetailPage: React.FC = () => {
   }, [chartCurrentPrice, market, formatNumber]);
 
   // 24h change prefers live stream updates when available, with market-data fallback.
-  const displayChange =
-    livePrice?.percentChange24h ?? market?.change24hPercent ?? '';
+  const displayChange = formatChangePercent(
+    livePrice?.percentChange24h ?? market?.change24hPercent ?? '',
+  );
 
   // Build price lines for chart overlay (current price + TP, Entry, SL)
   // Current price line is always shown; TP/Entry/SL only when position exists.

--- a/ui/pages/perps/perps-order-entry-page.tsx
+++ b/ui/pages/perps/perps-order-entry-page.tsx
@@ -77,6 +77,7 @@ import {
   getPositionPnlRatio,
   normalizeTpslPrices,
   safeDecodeURIComponent,
+  formatChangePercent,
 } from '../../components/app/perps/utils';
 import {
   isLimitPriceUnfavorable as checkLimitPriceUnfavorable,
@@ -480,8 +481,10 @@ const PerpsOrderEntryPage: React.FC = () => {
     return market?.price ?? '$0.00';
   }, [chartCurrentPrice, market?.price, formatNumber]);
 
-  const displayChange =
-    livePrice?.percentChange24h ?? market?.change24hPercent ?? '';
+  // 24h change prefers live stream updates when available, with market-data fallback.
+  const displayChange = formatChangePercent(
+    livePrice?.percentChange24h ?? market?.change24hPercent ?? '',
+  );
 
   const handleBackClick = useCallback(
     (perpsToastKey?: PerpsToastKey, perpsToastDescription?: string) => {


### PR DESCRIPTION
## **Description**

The 24h price change percentage on the perps market header loses its `%` sign after the first render.

**Root cause:** `displayChange` falls back to `market?.change24hPercent` on first render (pre-formatted with `%`, e.g. `+2.5%`). Once the live price stream activates, `livePrice.percentChange24h` takes over — but this value arrives from the stream without a `%` suffix (e.g. `+2.5`), causing it to disappear.

**Solution:** Introduced a `formatChangePercent` utility in the shared perps `utils.ts` that normalises any percentage string to always include `%`, handling both formats gracefully. This utility is now used in `perps-market-detail-page.tsx` and `perps-order-entry-page.tsx` to replace the duplicated inline logic that previously existed in both files.

## **Changelog**

CHANGELOG entry: Fixed a bug that was causing the 24h price change percentage to lose its `%` symbol on the perps market header after the first render.

## **Related issues**

Fixes: TAT-2914

## **Manual testing steps**

1. Open MetaMask and navigate to the Perps section
2. Tap on any market (e.g. BTC-USD) to open the market detail page
3. Observe the 24h price change value in the header (next to the current price)
4. Wait a couple of seconds for the live price stream to activate
5. Confirm the `%` symbol remains visible after the live data kicks in
6. Repeat on the order entry page (tap Long or Short from the market detail page)

## **Screenshots/Recordings**

### **Before**

### **After**
<img width="270" height="89" alt="Screenshot 2026-04-13 at 16 27 51" src="https://github.com/user-attachments/assets/166122f2-3185-44ff-b147-5d0ad24b038f" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that standardizes formatting of a displayed value; main risk is minor formatting edge cases for unexpected percent strings.
> 
> **Overview**
> Fixes a perps header display bug where the live `percentChange24h` stream could drop the `%` suffix after initial render.
> 
> Introduces `formatChangePercent` in `perps/utils.ts` and applies it to the market detail and order entry headers so both live and fallback market data render consistently, with new unit tests and a page test covering the missing-`%` stream case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e396f0de97025515ad1a1d7b57d62ab014f41dcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->