### PR TITLE
fix: positon roe calculation

### DIFF
--- a/ui/__mocks__/perps/perps-controller/index.ts
+++ b/ui/__mocks__/perps/perps-controller/index.ts
@@ -861,7 +861,7 @@ export type Position = {
   };
   liquidationPrice: string | null; // Liquidation price (null if no risk)
   maxLeverage: number; // Maximum allowed leverage for this asset
-  returnOnEquity: string; // ROE percentage
+  returnOnEquity: string; // ROE as decimal ratio (e.g. 0.1579 for 15.79%)
   cumulativeFunding: {
     // Funding payments history
     allTime: string; // Total funding since account opening

--- a/ui/components/app/perps/mocks.ts
+++ b/ui/components/app/perps/mocks.ts
@@ -51,7 +51,7 @@ export const mockPositions: Position[] = [
     },
     liquidationPrice: '2400.00',
     maxLeverage: 20,
-    returnOnEquity: '15.79',
+    returnOnEquity: '0.1579',
     cumulativeFunding: {
       allTime: '12.50',
       sinceOpen: '8.30',
@@ -75,7 +75,7 @@ export const mockPositions: Position[] = [
     },
     liquidationPrice: '48000.00',
     maxLeverage: 20,
-    returnOnEquity: '-16.67',
+    returnOnEquity: '-0.1667',
     cumulativeFunding: {
       allTime: '-5.20',
       sinceOpen: '-3.10',
@@ -100,7 +100,7 @@ export const mockPositions: Position[] = [
     },
     liquidationPrice: '85.00',
     maxLeverage: 20,
-    returnOnEquity: '26.32',
+    returnOnEquity: '0.2632',
     cumulativeFunding: {
       allTime: '2.50',
       sinceOpen: '1.80',
@@ -124,7 +124,7 @@ export const mockPositions: Position[] = [
     },
     liquidationPrice: '1.08',
     maxLeverage: 20,
-    returnOnEquity: '-41.67',
+    returnOnEquity: '-0.4167',
     cumulativeFunding: {
       allTime: '-1.20',
       sinceOpen: '-0.80',
@@ -149,7 +149,7 @@ export const mockPositions: Position[] = [
     },
     liquidationPrice: '0.80',
     maxLeverage: 20,
-    returnOnEquity: '26.67',
+    returnOnEquity: '0.2667',
     cumulativeFunding: {
       allTime: '3.50',
       sinceOpen: '2.20',
@@ -175,7 +175,7 @@ export const mockPositions: Position[] = [
     },
     liquidationPrice: '216.00',
     maxLeverage: 10,
-    returnOnEquity: '22.92',
+    returnOnEquity: '0.2292',
     cumulativeFunding: {
       allTime: '4.80',
       sinceOpen: '2.40',
@@ -199,7 +199,7 @@ export const mockPositions: Position[] = [
     },
     liquidationPrice: '528.00',
     maxLeverage: 10,
-    returnOnEquity: '-10.42',
+    returnOnEquity: '-0.1042',
     cumulativeFunding: {
       allTime: '-2.10',
       sinceOpen: '-1.50',
@@ -225,7 +225,7 @@ export const mockPositions: Position[] = [
     },
     liquidationPrice: '1930.00',
     maxLeverage: 20,
-    returnOnEquity: '15.27',
+    returnOnEquity: '0.1527',
     cumulativeFunding: {
       allTime: '1.20',
       sinceOpen: '0.80',
@@ -250,7 +250,7 @@ export const mockPositions: Position[] = [
     },
     liquidationPrice: '1.0600',
     maxLeverage: 20,
-    returnOnEquity: '13.86',
+    returnOnEquity: '0.1386',
     cumulativeFunding: {
       allTime: '8.50',
       sinceOpen: '5.20',

--- a/ui/components/app/perps/position-card/position-card.test.tsx
+++ b/ui/components/app/perps/position-card/position-card.test.tsx
@@ -13,6 +13,8 @@ jest.mock('../../../../hooks/useFormatters', () => ({
         minimumFractionDigits: 2,
         maximumFractionDigits: 2,
       })}`,
+    formatPercentWithMinThreshold: (value: number) =>
+      `${(value * 100).toFixed(2)}%`,
   }),
 }));
 
@@ -36,7 +38,7 @@ const createMockPosition = (overrides: Partial<Position> = {}): Position => ({
   },
   liquidationPrice: '2400.00',
   maxLeverage: 20,
-  returnOnEquity: '15.79',
+  returnOnEquity: '0.1579',
   cumulativeFunding: {
     allTime: '12.50',
     sinceOpen: '8.30',
@@ -150,5 +152,42 @@ describe('PositionCard', () => {
     renderWithProvider(<PositionCard position={position} />, mockStore);
 
     expect(screen.getByText('+$0.00')).toBeInTheDocument();
+  });
+
+  it('displays ROE percentage for a profitable position', () => {
+    const position = createMockPosition({
+      symbol: 'ETH',
+      returnOnEquity: '0.1579',
+    });
+    renderWithProvider(<PositionCard position={position} />, mockStore);
+
+    expect(screen.getByTestId('position-card-roe-ETH')).toHaveTextContent(
+      '(15.79%)',
+    );
+  });
+
+  it('displays ROE percentage for a losing position', () => {
+    const position = createMockPosition({
+      symbol: 'BTC',
+      unrealizedPnl: '-250.00',
+      returnOnEquity: '-0.1667',
+    });
+    renderWithProvider(<PositionCard position={position} />, mockStore);
+
+    expect(screen.getByTestId('position-card-roe-BTC')).toHaveTextContent(
+      '(-16.67%)',
+    );
+  });
+
+  it('does not render ROE when returnOnEquity is not a number', () => {
+    const position = createMockPosition({
+      symbol: 'ETH',
+      returnOnEquity: 'not-a-number',
+    });
+    renderWithProvider(<PositionCard position={position} />, mockStore);
+
+    expect(
+      screen.queryByTestId('position-card-roe-ETH'),
+    ).not.toBeInTheDocument();
   });
 });

--- a/ui/components/app/perps/position-card/position-card.tsx
+++ b/ui/components/app/perps/position-card/position-card.tsx
@@ -37,7 +37,8 @@ export const PositionCard: React.FC<PositionCardProps> = ({
   onClick,
 }) => {
   const navigate = useNavigate();
-  const { formatCurrencyWithMinThreshold } = useFormatters();
+  const { formatCurrencyWithMinThreshold, formatPercentWithMinThreshold } =
+    useFormatters();
   const direction = getPositionDirection(position.size);
   const pnlNum = parseFloat(position.unrealizedPnl);
   const isProfit = pnlNum >= 0;
@@ -45,6 +46,10 @@ export const PositionCard: React.FC<PositionCardProps> = ({
   const displayName = getDisplayName(position.symbol);
   const pnlPrefix = isProfit ? '+' : '-';
   const formattedPnl = `${pnlPrefix}${formatCurrencyWithMinThreshold(Math.abs(pnlNum), 'USD')}`;
+  const roeNum = Number.parseFloat(position.returnOnEquity);
+  const formattedRoe = Number.isNaN(roeNum)
+    ? null
+    : formatPercentWithMinThreshold(roeNum);
 
   const handleClick = useCallback(() => {
     if (onClick) {
@@ -113,12 +118,29 @@ export const PositionCard: React.FC<PositionCardProps> = ({
             'USD',
           )}
         </Text>
-        <Text
-          variant={TextVariant.BodySm}
-          color={isProfit ? TextColor.SuccessDefault : TextColor.ErrorDefault}
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Baseline}
+          gap={1}
         >
-          {formattedPnl}
-        </Text>
+          <Text
+            variant={TextVariant.BodySm}
+            color={isProfit ? TextColor.SuccessDefault : TextColor.ErrorDefault}
+          >
+            {formattedPnl}
+          </Text>
+          {formattedRoe !== null && (
+            <Text
+              variant={TextVariant.BodySm}
+              color={
+                isProfit ? TextColor.SuccessDefault : TextColor.ErrorDefault
+              }
+              data-testid={`position-card-roe-${position.symbol}`}
+            >
+              ({formattedRoe})
+            </Text>
+          )}
+        </Box>
       </Box>
     </ButtonBase>
   );

--- a/ui/components/app/perps/utils.ts
+++ b/ui/components/app/perps/utils.ts
@@ -508,12 +508,12 @@ export const hasVolume = (market: PerpsMarketData): boolean => {
  * cannot be determined.
  *
  * Primary: unrealizedPnl / marginUsed.
- * Fallback: returnOnEquity (percent) converted to a ratio.
+ * Fallback: returnOnEquity, which is already a ratio (e.g. 0.1579 for 15.79%).
  *
  * @param position - Position values used to compute the PnL ratio.
  * @param position.unrealizedPnl - Unrealized profit and loss as a string.
  * @param position.marginUsed - Margin used as a string.
- * @param position.returnOnEquity - Return on equity percentage as a string.
+ * @param position.returnOnEquity - Return on equity as a decimal ratio string (e.g. "0.1579").
  * @returns The PnL ratio (e.g. 0.15 for +15 %) or `undefined`.
  */
 export const getPositionPnlRatio = (position: {
@@ -534,8 +534,8 @@ export const getPositionPnlRatio = (position: {
 
   const returnOnEquity = parseFloat(position.returnOnEquity);
   if (!Number.isNaN(returnOnEquity)) {
-    // Controller/mobile ROE is a percent value (e.g. 15.79); formatter expects a ratio.
-    return returnOnEquity / 100;
+    // position.returnOnEquity is a decimal ratio (e.g. 0.1579); pass directly to formatter.
+    return returnOnEquity;
   }
 
   return undefined;

--- a/ui/pages/perps/perps-market-detail-page.tsx
+++ b/ui/pages/perps/perps-market-detail-page.tsx
@@ -1156,9 +1156,9 @@ const PerpsMarketDetailPage: React.FC = () => {
                         : TextColor.ErrorDefault
                     }
                   >
-                    {/* Controller/mobile ROE is percent (e.g. 15.79), formatter expects ratio. */}
+                    {/* Controller/mobile ROE is a ratio (e.g. 0.1579), same as what the formatter expects. */}
                     {formatPercentWithMinThreshold(
-                      Number.parseFloat(position.returnOnEquity) / 100,
+                      Number.parseFloat(position.returnOnEquity),
                     )}
                   </Text>
                 </Box>

--- a/ui/pages/perps/perps-order-entry-page.test.tsx
+++ b/ui/pages/perps/perps-order-entry-page.test.tsx
@@ -741,7 +741,7 @@ describe('PerpsOrderEntryPage', () => {
       });
     });
 
-    it('converts ROE percent values for close subtitle fallback', async () => {
+    it('uses ROE ratio for close subtitle fallback', async () => {
       mockSearchParams.set('mode', 'close');
       mockLivePositions.mockReturnValue({
         positions: [
@@ -749,7 +749,7 @@ describe('PerpsOrderEntryPage', () => {
             ...mockPositions[0],
             marginUsed: '0',
             unrealizedPnl: 'not-a-number',
-            returnOnEquity: '0.8',
+            returnOnEquity: '0.008',
           },
         ],
         isInitialLoading: false,


### PR DESCRIPTION
## **Description**

Position ROE (Return on Equity) was displaying values 100× too small (e.g. `0.48%` instead of `48%`).

**Root cause:** `position.returnOnEquity` from the HyperLiquid API is a **decimal ratio** (e.g. `0.1579` for 15.79%). The `adaptPositionFromSDK` adapter passes it through unchanged. However, the UI was incorrectly dividing it by 100 before passing it to `formatPercentWithMinThreshold` — which already expects a ratio — making the displayed value 100× too small.

Note: the account-level `returnOnEquity` (from `adaptAccountStateFromSDK`) is correctly multiplied by 100 before being stored, so dividing by 100 in the balance dropdown is right. The per-position value has no such transformation and was being double-converted.

**Changes:**
- Removed the erroneous `/ 100` from the Return card in `perps-market-detail-page.tsx`
- Fixed `getPositionPnlRatio` fallback in `utils.ts` to return the ratio directly (also used for the close-position toast PnL%)
- Added the ROE% to position rows in `PositionCard`, displayed alongside the USD P&L (e.g. `+$375.00 (15.79%)`)
- Updated mock `returnOnEquity` values in `mocks.ts` and tests from percent-style strings to ratio-style strings to match real HyperLiquid data

## **Changelog**

CHANGELOG entry: Fixed a bug that was causing the position Return on Equity (ROE) percentage to display 100× too small. Added ROE% display to position rows.

## **Related issues**

Fixes: TAT-2911

## **Manual testing steps**

1. Open MetaMask and navigate to the Perps section
2. Ensure you have at least one open position
3. On the main Perps screen, observe the position row — confirm it now shows both the USD P&L and the ROE% (e.g. `+$375.00 (15.79%)`)
4. Tap on the position to open the market detail page
5. In the **Position** section, check the **Return** card — confirm the percentage is now correct (e.g. `15.79%` instead of `0.16%`)
6. Close a position and verify the success toast PnL% is also correct


## **Screenshots/Recordings**

### **Before**
<img width="443" height="400" alt="Screenshot 2026-04-13 at 16 13 12" src="https://github.com/user-attachments/assets/5d896ada-359a-4118-a7c2-c46108ca285e" />

### **After**
<img width="448" height="375" alt="Screenshot 2026-04-13 at 16 18 29" src="https://github.com/user-attachments/assets/c077d952-baa0-4f83-95cf-ceba8d986862" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates are isolated to perps UI formatting/math for ROE and adjusts mocks/tests accordingly, with minimal impact outside display and toast copy.
> 
> **Overview**
> Fixes per-position `returnOnEquity` handling by treating it as a *decimal ratio* throughout the perps UI (removing erroneous `/ 100` in the market detail Return card and returning the ratio directly in `getPositionPnlRatio` fallback), preventing ROE from displaying 100× too small.
> 
> Enhances the positions list UI by showing ROE% next to USD P&L in `PositionCard` (with safe handling for non-numeric ROE), and updates perps mocks/types and related tests (including close-position toast fallback) to use ratio-style `returnOnEquity` values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a42bdb9817055cd30d25ee78d7f78e5fa87f8f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->