### PR TITLE
fix: No restriction on order size above available margin

### DIFF
--- a/ui/pages/perps/perps-order-entry-page.test.tsx
+++ b/ui/pages/perps/perps-order-entry-page.test.tsx
@@ -570,6 +570,41 @@ describe('PerpsOrderEntryPage', () => {
         screen.getByTestId('limit-price-liquidation-warning'),
       ).toBeInTheDocument();
     });
+
+    it('disables submit and shows Insufficient funds when order exceeds available balance', () => {
+      const store = mockStore(createMockState());
+      renderWithProvider(<PerpsOrderEntryPage />, store);
+
+      const amountContainer = screen.getByTestId('amount-input-field');
+      const amountInput = amountContainer.querySelector('input');
+      // availableBalance is 10125, default leverage is 3, so max amount = 30375
+      // Enter 50000 which requires margin of 50000/3 ≈ 16666 > 10125
+      fireEvent.change(amountInput as HTMLInputElement, {
+        target: { value: '50000' },
+      });
+
+      expect(screen.getByTestId('submit-order-button')).toBeDisabled();
+      expect(screen.getByTestId('submit-order-button')).toHaveTextContent(
+        messages.insufficientFundsSend.message,
+      );
+    });
+
+    it('does not disable submit when order is within available balance', () => {
+      const store = mockStore(createMockState());
+      renderWithProvider(<PerpsOrderEntryPage />, store);
+
+      const amountContainer = screen.getByTestId('amount-input-field');
+      const amountInput = amountContainer.querySelector('input');
+      // Enter 100 which requires margin of 100/3 ≈ 33 < 10125
+      fireEvent.change(amountInput as HTMLInputElement, {
+        target: { value: '100' },
+      });
+
+      expect(screen.getByTestId('submit-order-button')).not.toBeDisabled();
+      expect(screen.getByTestId('submit-order-button')).not.toHaveTextContent(
+        messages.insufficientFundsSend.message,
+      );
+    });
   });
 
   describe('order submission', () => {

--- a/ui/pages/perps/perps-order-entry-page.tsx
+++ b/ui/pages/perps/perps-order-entry-page.tsx
@@ -472,6 +472,19 @@ const PerpsOrderEntryPage: React.FC = () => {
     return tpInvalid || slInvalid;
   }, [orderFormState, orderType, currentPrice]);
 
+  const isInsufficientFunds = useMemo(() => {
+    if (!orderFormState || orderMode === 'close') {
+      return false;
+    }
+    const amount =
+      Number.parseFloat(orderFormState.amount.replace(/,/gu, '')) || 0;
+    if (amount <= 0 || orderFormState.leverage <= 0) {
+      return false;
+    }
+    const marginRequired = amount / orderFormState.leverage;
+    return marginRequired > availableBalance;
+  }, [orderFormState, orderMode, availableBalance]);
+
   const isSubmitDisabled =
     !isEligible ||
     !selectedAddress ||
@@ -480,6 +493,7 @@ const PerpsOrderEntryPage: React.FC = () => {
     isLimitPriceUnfavorable ||
     isNearLiquidation ||
     hasInvalidTPSL ||
+    isInsufficientFunds ||
     currentPrice <= 0;
 
   const maxLeverage = useMemo(() => {
@@ -1046,6 +1060,10 @@ const PerpsOrderEntryPage: React.FC = () => {
     }
   })();
 
+  const resolvedButtonText = isInsufficientFunds
+    ? t('insufficientFundsSend')
+    : submitButtonText;
+
   return (
     <Box
       className="main-container asset__container"
@@ -1177,7 +1195,7 @@ const PerpsOrderEntryPage: React.FC = () => {
           )}
           data-testid="submit-order-button"
         >
-          {isOrderPending ? t('perpsSubmitting') : submitButtonText}
+          {isOrderPending ? t('perpsSubmitting') : resolvedButtonText}
         </Button>
       </Box>
     </Box>


### PR DESCRIPTION
## **Description**

The perps order entry page allowed submitting orders of any size regardless of available balance. Added a margin-vs-balance check: when `amount / leverage` exceeds `availableBalance`, the submit button is disabled and shows "Insufficient funds" — matching mobile's `usePerpsOrderValidation`.

## **Changelog**

CHANGELOG entry: Fixed a bug where perps order entry did not restrict order size above available margin

## **Related issues**

Fixes: [TAT-2893](https://consensyssoftware.atlassian.net/browse/TAT-2893)

## **Manual testing steps**

1. Navigate to perps order entry (e.g. ETH Long)
2. Enter a very large dollar amount (e.g. 999999999) that exceeds available balance
3. Verify the submit button is disabled and reads "Insufficient funds"
4. Change the amount to a small value (e.g. 1)
5. Verify the submit button is enabled and reads "Open Long ETH"

## **Screenshots/Recordings**

Order entry now disables submit + shows 'Insufficient funds' when margin exceeds available balance.

### Oversized order — button disabled with Insufficient funds
$999M order requires $333M margin vs <!-- Evidence will be added by the gateway from evidence-manifest.json -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

5 available — button disabled.
| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/fixes/41697/before.mp4" alt="Oversized order — button disabled with Insufficient funds before" width="360" /> | <img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/fixes/41697/after-ac1-button-disabled.png" alt="Oversized order — button disabled with Insufficient funds after" width="360" /> |

### Normal order — button enabled with Open Long ETH
<img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/fixes/41697/after-ac3-button-enabled.png" alt="Normal order — button enabled with Open Long ETH" width="360" />


### Video
before.mp4 shows recipe failing at button-disabled check (bug present). after.mp4 shows 12/12 pass.
_Uploaded artifact links below; replace with manual GitHub video attachments if you want inline playback._
- Before video: [before.mp4](https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/fixes/41697/before.mp4)
- After video: [after.mp4](https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/fixes/41697/after.mp4)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[TAT-2893]: https://consensyssoftware.atlassian.net/browse/TAT-2893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new pre-submit margin validation that can block order placement; risk is limited to perps order-entry UX/validation but could incorrectly disable trading if the calculation or inputs differ from controller expectations.
> 
> **Overview**
> Prevents creating/increasing perps orders when required margin exceeds the account’s available balance by computing `amount / leverage` and treating it as an **insufficient funds** state.
> 
> When insufficient funds is detected (excluding `close` mode), the submit button is disabled and its label changes to `insufficientFundsSend`.
> 
> Adds unit tests covering both over-balance (disabled + text) and within-balance (enabled) scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1caa5fad9d0ba636950ff2137d2ff43128f8bb74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->