### PR TITLE
fix: Margin modification slider for non-us locale

### DIFF
--- a/ui/components/app/perps/edit-margin/edit-margin-modal-content.tsx
+++ b/ui/components/app/perps/edit-margin/edit-margin-modal-content.tsx
@@ -186,15 +186,6 @@ export const EditMarginModalContent: React.FC<EditMarginModalContentProps> = ({
     locale,
   ]);
 
-  const formatAmount = useCallback(
-    (value: number): string =>
-      formatNumber(value, {
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2,
-      }),
-    [formatNumber],
-  );
-
   const marginPercent = useMemo(() => {
     if (maxAmount <= 0) {
       return 0;
@@ -236,9 +227,9 @@ export const EditMarginModalContent: React.FC<EditMarginModalContentProps> = ({
         setMarginAmount('');
         return;
       }
-      setMarginAmount(formatAmount(floored));
+      setMarginAmount(floored.toFixed(2));
     },
-    [maxAmount, formatAmount],
+    [maxAmount],
   );
 
   const handleSaveMargin = useCallback(async () => {
@@ -429,7 +420,7 @@ export const EditMarginModalContent: React.FC<EditMarginModalContentProps> = ({
               disabled={maxAmount <= 0 || isSaving}
             />
           </Box>
-          <Box className="w-[5.5rem] shrink-0">
+          <Box className="shrink-0">
             <TextField
               size={TextFieldSize.Md}
               value={marginAmount}
@@ -438,9 +429,8 @@ export const EditMarginModalContent: React.FC<EditMarginModalContentProps> = ({
               borderRadius={BorderRadius.MD}
               borderWidth={0}
               backgroundColor={BackgroundColor.backgroundMuted}
-              className="w-full"
               disabled={isSaving}
-              inputProps={{ inputMode: 'decimal' }}
+              inputProps={{ inputMode: 'decimal', size: 10 }}
               startAccessory={
                 <Text
                   variant={TextVariant.BodyMd}


### PR DESCRIPTION
## **Description**

The margin slider was broken for users with a non-English locale (e.g. French). When the slider was moved, formatNumber would produce a locale-formatted string (e.g. "50,00") and store it in state. Downstream parsing code then stripped commas assuming they were thousands separators, turning "50,00" into 5000 — causing marginPercent to always clamp to 100%.

Fix: handleSliderChange now stores the amount using floored.toFixed(2), which always produces a locale-neutral decimal string (e.g. "50.00"), making all downstream parseFloat calls correct regardless of locale.

Also removed the now-unused formatAmount callback and increased the margin text input width to prevent value truncation.

## **Changelog**

CHANGELOG entry: Fix broken add margin slider

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2848

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/fe3a6124-9726-4919-955b-4f454c2ec589

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI fix that changes how the margin amount string is formatted when set via the slider; primary risk is unintended formatting/rounding differences in edge locales.
> 
> **Overview**
> Fixes the perps margin slider for non-English locales by **storing slider-driven amounts as locale-neutral decimals** (`toFixed(2)`) instead of locale-formatted output, preventing downstream parsing from misinterpreting commas.
> 
> Cleans up the now-unused `formatAmount` callback and tweaks the amount input sizing (removes fixed width class, sets `inputProps.size`) to avoid truncation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a36d751f1d136b761f498336d7e790179c4db67e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->