### PR TITLE
test: migrate more specs to FixtureBuilderV2 (gas, simulations...)

### DIFF
--- a/test/e2e/tests/account/snap-account-signatures.spec.ts
+++ b/test/e2e/tests/account/snap-account-signatures.spec.ts
@@ -3,7 +3,7 @@ import { Mockttp } from 'mockttp';
 import { Driver } from '../../webdriver/driver';
 import { DAPP_PATH, WINDOW_TITLES } from '../../constants';
 import { withFixtures } from '../../helpers';
-import FixtureBuilder from '../../fixtures/fixture-builder';
+import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import ExperimentalSettings from '../../page-objects/pages/settings/experimental-settings';
 import HeaderNavbar from '../../page-objects/pages/header-navbar';
 import SettingsPage from '../../page-objects/pages/settings/settings-page';
@@ -37,7 +37,9 @@ describe('Snap Account Signatures', function (this: Suite) {
             numberOfTestDapps: 1,
             customDappPaths: [DAPP_PATH.SNAP_SIMPLE_KEYRING_SITE],
           },
-          fixtures: new FixtureBuilder().build(),
+          fixtures: new FixtureBuilderV2()
+            .withSnapsPrivacyWarningAlreadyShown()
+            .build(),
           testSpecificMock: async (mockServer: Mockttp) => {
             const snapMocks = await mockSnapSimpleKeyringAndSite(
               mockServer,

--- a/test/e2e/tests/account/snap-account-transfers.spec.ts
+++ b/test/e2e/tests/account/snap-account-transfers.spec.ts
@@ -10,7 +10,6 @@ import { withFixtures } from '../../helpers';
 import { Driver } from '../../webdriver/driver';
 import AccountListPage from '../../page-objects/pages/account-list-page';
 import ActivityListPage from '../../page-objects/pages/home/activity-list';
-import FixtureBuilder from '../../fixtures/fixture-builder';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import HeaderNavbar from '../../page-objects/pages/header-navbar';
 import HomePage from '../../page-objects/pages/home/homepage';
@@ -39,9 +38,12 @@ describe.skip('Snap Account Transfers', function (this: Suite) {
         dappOptions: {
           customDappPaths: [DAPP_PATH.SNAP_SIMPLE_KEYRING_SITE],
         },
-        fixtures: new FixtureBuilder()
-          .withPreferencesControllerShowNativeTokenAsMainBalanceDisabled()
-          .withShowFiatTestnetEnabled()
+        fixtures: new FixtureBuilderV2()
+          .withSnapsPrivacyWarningAlreadyShown()
+          .withShowNativeTokenAsMainBalanceDisabled()
+          .withPreferencesController({
+            preferences: { showFiatInTestnets: true },
+          })
           .withEnabledNetworks({ eip155: { '0x1': true } })
           .build(),
         testSpecificMock: async (mockServer: Mockttp) => {
@@ -100,9 +102,12 @@ describe.skip('Snap Account Transfers', function (this: Suite) {
   it('can import a private key and transfer 1 ETH (async flow approve)', async function () {
     await withFixtures(
       {
-        fixtures: new FixtureBuilder()
-          .withPreferencesControllerShowNativeTokenAsMainBalanceDisabled()
-          .withShowFiatTestnetEnabled()
+        fixtures: new FixtureBuilderV2()
+          .withSnapsPrivacyWarningAlreadyShown()
+          .withShowNativeTokenAsMainBalanceDisabled()
+          .withPreferencesController({
+            preferences: { showFiatInTestnets: true },
+          })
           .withEnabledNetworks({ eip155: { '0x1': true } })
           .build(),
         testSpecificMock: async (mockServer: Mockttp) => {

--- a/test/e2e/tests/confirmations/helpers.ts
+++ b/test/e2e/tests/confirmations/helpers.ts
@@ -78,7 +78,6 @@ export function withSignatureFixtures(
           participateInMetaMetrics: true,
         })
         .build(),
-      localNodeOptions: {},
       testSpecificMock: mocks,
       title,
     },

--- a/test/e2e/tests/confirmations/helpers.ts
+++ b/test/e2e/tests/confirmations/helpers.ts
@@ -1,5 +1,5 @@
 import { TransactionEnvelopeType } from '@metamask/transaction-controller';
-import FixtureBuilder from '../../fixtures/fixture-builder';
+import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { withFixtures } from '../../helpers';
 import { MockedEndpoint, Mockttp } from '../../mock-e2e';
 import { SMART_CONTRACTS } from '../../seeder/smart-contracts';
@@ -39,7 +39,7 @@ export function withTransactionEnvelopeTypeFixtures(
     {
       dappOptions: { numberOfTestDapps: 1 },
       driverOptions: { timeOut: 20000 },
-      fixtures: new FixtureBuilder()
+      fixtures: new FixtureBuilderV2()
         .withPermissionControllerConnectedToTestDapp()
         .withMetaMetricsController({
           metaMetricsId: MOCK_META_METRICS_ID,
@@ -71,7 +71,7 @@ export function withSignatureFixtures(
     {
       dappOptions: { numberOfTestDapps: 1 },
       driverOptions: { timeOut: 20000 },
-      fixtures: new FixtureBuilder()
+      fixtures: new FixtureBuilderV2()
         .withPermissionControllerConnectedToTestDapp()
         .withMetaMetricsController({
           metaMetricsId: MOCK_META_METRICS_ID,

--- a/test/e2e/tests/confirmations/transactions/gas-fee-tokens-eip-7702-sponsored.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/gas-fee-tokens-eip-7702-sponsored.spec.ts
@@ -1,10 +1,9 @@
-import { CHAIN_IDS } from '@metamask/transaction-controller';
 import { Suite } from 'mocha';
 import { MockttpServer } from 'mockttp';
 import { RelayStatus } from '../../../../../app/scripts/lib/transaction/transaction-relay';
 import { TX_SENTINEL_URL } from '../../../../../shared/constants/transaction';
 import { DEFAULT_FIXTURE_ACCOUNT, WINDOW_TITLES } from '../../../constants';
-import FixtureBuilder from '../../../fixtures/fixture-builder';
+import FixtureBuilderV2 from '../../../fixtures/fixture-builder-v2';
 import { convertETHToHexGwei, withFixtures } from '../../../helpers';
 import { login } from '../../../page-objects/flows/login.flow';
 import { createDappTransaction } from '../../../page-objects/flows/transaction';
@@ -23,13 +22,11 @@ describe('Gas Fee Tokens - EIP-7702 - Sponsored', function (this: Suite) {
     await withFixtures(
       {
         dappOptions: { numberOfTestDapps: 1 },
-        fixtures: new FixtureBuilder({ inputChainId: CHAIN_IDS.MAINNET })
-          .withPermissionControllerConnectedToTestDapp()
-          .withPreferencesControllerSmartTransactionsOptedOut()
+        fixtures: new FixtureBuilderV2()
+          .withEnabledNetworks({ eip155: { '0x1': true } })
+          .withPermissionControllerConnectedToTestDapp({ chainIds: [1] })
+          .withSmartTransactionsOptedOut()
           .build(),
-        manifestFlags: {
-          testing: { disableSmartTransactionsOverride: true },
-        },
         localNodeOptions: {
           loadState:
             './test/e2e/seeder/network-states/eip7702-state/withUpgradedAccount.json',
@@ -86,9 +83,9 @@ describe('Gas Fee Tokens - EIP-7702 - Sponsored', function (this: Suite) {
     await withFixtures(
       {
         dappOptions: { numberOfTestDapps: 1 },
-        fixtures: new FixtureBuilder({ inputChainId: CHAIN_IDS.MAINNET })
-          .withPermissionControllerConnectedToTestDapp()
-          .withNetworkControllerOnMainnet()
+        fixtures: new FixtureBuilderV2()
+          .withEnabledNetworks({ eip155: { '0x1': true } })
+          .withPermissionControllerConnectedToTestDapp({ chainIds: [1] })
           .build(),
         localNodeOptions: {
           loadState:

--- a/test/e2e/tests/confirmations/transactions/gas-fee-tokens-eip-7702.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/gas-fee-tokens-eip-7702.spec.ts
@@ -1,11 +1,10 @@
-import { CHAIN_IDS } from '@metamask/transaction-controller';
 import { Anvil } from '@viem/anvil';
 import { Suite } from 'mocha';
 import { MockttpServer } from 'mockttp';
 import { RelayStatus } from '../../../../../app/scripts/lib/transaction/transaction-relay';
 import { TX_SENTINEL_URL } from '../../../../../shared/constants/transaction';
 import { decimalToHex } from '../../../../../shared/lib/conversion.utils';
-import FixtureBuilder from '../../../fixtures/fixture-builder';
+import FixtureBuilderV2 from '../../../fixtures/fixture-builder-v2';
 import { WINDOW_TITLES } from '../../../constants';
 import { withFixtures } from '../../../helpers';
 import { createDappTransaction } from '../../../page-objects/flows/transaction';
@@ -27,15 +26,12 @@ describe('Gas Fee Tokens - EIP-7702', function (this: Suite) {
     await withFixtures(
       {
         dappOptions: { numberOfTestDapps: 1 },
-        fixtures: new FixtureBuilder({ inputChainId: CHAIN_IDS.MAINNET })
-          .withPermissionControllerConnectedToTestDapp()
-          .withPreferencesControllerSmartTransactionsOptedOut()
+        fixtures: new FixtureBuilderV2()
+          .withEnabledNetworks({ eip155: { '0x1': true } })
+          .withPermissionControllerConnectedToTestDapp({ chainIds: [1] })
+          .withSmartTransactionsOptedOut()
           .build(),
-        manifestFlags: {
-          testing: { disableSmartTransactionsOverride: true },
-        },
         localNodeOptions: {
-          hardfork: 'prague',
           loadState:
             './test/e2e/seeder/network-states/eip7702-state/withUpgradedAccount.json',
         },
@@ -100,12 +96,11 @@ describe('Gas Fee Tokens - EIP-7702', function (this: Suite) {
     await withFixtures(
       {
         dappOptions: { numberOfTestDapps: 1 },
-        fixtures: new FixtureBuilder({ inputChainId: CHAIN_IDS.MAINNET })
-          .withPermissionControllerConnectedToTestDapp()
-          .withNetworkControllerOnMainnet()
+        fixtures: new FixtureBuilderV2()
+          .withEnabledNetworks({ eip155: { '0x1': true } })
+          .withPermissionControllerConnectedToTestDapp({ chainIds: [1] })
           .build(),
         localNodeOptions: {
-          hardfork: 'prague',
           loadState:
             './test/e2e/seeder/network-states/eip7702-state/withUpgradedAccount.json',
         },

--- a/test/e2e/tests/confirmations/transactions/gas-fee-tokens-smart-transactions.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/gas-fee-tokens-smart-transactions.spec.ts
@@ -1,10 +1,9 @@
-import { CHAIN_IDS } from '@metamask/transaction-controller';
 import { Anvil } from '@viem/anvil';
 import { Suite } from 'mocha';
 import { MockttpServer } from 'mockttp';
 import { TX_SENTINEL_URL } from '../../../../../shared/constants/transaction';
 import { decimalToHex } from '../../../../../shared/lib/conversion.utils';
-import FixtureBuilder from '../../../fixtures/fixture-builder';
+import FixtureBuilderV2 from '../../../fixtures/fixture-builder-v2';
 import { WINDOW_TITLES } from '../../../constants';
 import { withFixtures } from '../../../helpers';
 import { mockMultiNetworkBalancePolling } from '../../../mock-balance-polling/mock-balance-polling';
@@ -29,23 +28,10 @@ describe('Gas Fee Tokens - Smart Transactions', function (this: Suite) {
     await withFixtures(
       {
         dappOptions: { numberOfTestDapps: 1 },
-        fixtures: new FixtureBuilder({ inputChainId: CHAIN_IDS.MAINNET })
-          .withPermissionControllerConnectedToTestDapp()
-          .withNetworkControllerOnMainnet()
-          .withTokenBalancesController({
-            tokenBalances: {
-              '0x5cfe73b6021e818b776b421b1c4db2474086a7e1': {
-                '0x1': {
-                  '0x0000000000000000000000000000000000000000':
-                    '0x15af1d78b58c40000', // 25 ETH
-                },
-              },
-            },
-          })
+        fixtures: new FixtureBuilderV2()
+          .withEnabledNetworks({ eip155: { '0x1': true } })
+          .withPermissionControllerConnectedToTestDapp({ chainIds: [1] })
           .build(),
-        localNodeOptions: {
-          hardfork: 'london',
-        },
         testSpecificMock: async (mockServer: MockttpServer) => {
           await mockMultiNetworkBalancePolling(mockServer);
           mockSimulationResponse(mockServer);
@@ -110,13 +96,10 @@ describe('Gas Fee Tokens - Smart Transactions', function (this: Suite) {
     await withFixtures(
       {
         dappOptions: { numberOfTestDapps: 1 },
-        fixtures: new FixtureBuilder({ inputChainId: CHAIN_IDS.MAINNET })
-          .withPermissionControllerConnectedToTestDapp()
-          .withNetworkControllerOnMainnet()
+        fixtures: new FixtureBuilderV2()
+          .withEnabledNetworks({ eip155: { '0x1': true } })
+          .withPermissionControllerConnectedToTestDapp({ chainIds: [1] })
           .build(),
-        localNodeOptions: {
-          hardfork: 'london',
-        },
         testSpecificMock: async (mockServer: MockttpServer) => {
           await mockSimulationResponse(mockServer);
           await mockSmartTransactionBatchRequests(mockServer, {

--- a/test/e2e/tests/hardware-wallets/ledger/ledger-swap.spec.ts
+++ b/test/e2e/tests/hardware-wallets/ledger/ledger-swap.spec.ts
@@ -24,9 +24,6 @@ describe.skip('Ledger Swap', function () {
         localNodeOptions: {
           loadState: './test/e2e/seeder/network-states/with50Dai.json',
         },
-        manifestFlags: {
-          testing: { disableSmartTransactionsOverride: true },
-        },
         title: this.test?.fullTitle(),
         testSpecificMock: mockLedgerTransactionRequests,
       },

--- a/test/e2e/tests/multichain-accounts/common.ts
+++ b/test/e2e/tests/multichain-accounts/common.ts
@@ -1,6 +1,5 @@
 import { Mockttp } from 'mockttp';
 import { Driver } from '../../webdriver/driver';
-import FixtureBuilder from '../../fixtures/fixture-builder';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { withFixtures } from '../../helpers';
 import AccountListPage from '../../page-objects/pages/account-list-page';
@@ -52,9 +51,9 @@ export async function withMultichainAccountsDesignEnabled(
         .build();
       break;
     default:
-      fixture = new FixtureBuilder()
+      fixture = new FixtureBuilderV2()
         .withKeyringControllerMultiSRP()
-        .withPreferencesControllerShowNativeTokenAsMainBalanceDisabled()
+        .withShowNativeTokenAsMainBalanceDisabled()
         .withEnabledNetworks({ eip155: { '0x1': true } })
         .withCurrencyController({
           currencyRates: {

--- a/test/e2e/tests/multichain-accounts/common.ts
+++ b/test/e2e/tests/multichain-accounts/common.ts
@@ -53,6 +53,7 @@ export async function withMultichainAccountsDesignEnabled(
     default:
       fixture = new FixtureBuilderV2()
         .withKeyringControllerMultiSRP()
+        .withSnapsPrivacyWarningAlreadyShown()
         .withShowNativeTokenAsMainBalanceDisabled()
         .withEnabledNetworks({ eip155: { '0x1': true } })
         .withCurrencyController({

--- a/test/e2e/tests/notifications/enable-notifications.spec.ts
+++ b/test/e2e/tests/notifications/enable-notifications.spec.ts
@@ -1,6 +1,6 @@
 import { Mockttp } from 'mockttp';
 import { withFixtures } from '../../helpers';
-import FixtureBuilder from '../../fixtures/fixture-builder';
+import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { getProductionRemoteFlagApiResponse } from '../../feature-flags';
 import { Driver } from '../../webdriver/driver';
 import {
@@ -66,9 +66,7 @@ describe('Enable Notifications - Without Accounts Syncing', function () {
       const triggerServer = new MockttpNotificationTriggerServer();
       await withFixtures(
         {
-          fixtures: new FixtureBuilder({ onboarding: true })
-            .withMetaMetricsController()
-            .build(),
+          fixtures: new FixtureBuilderV2({ onboarding: true }).build(),
           title: this.test?.fullTitle(),
           testSpecificMock: async (server: Mockttp) => {
             await mockNotificationServices(server, triggerServer);
@@ -99,7 +97,7 @@ describe('Enable Notifications - Without Accounts Syncing', function () {
 
       await withFixtures(
         {
-          fixtures: new FixtureBuilder({ onboarding: true }).build(),
+          fixtures: new FixtureBuilderV2({ onboarding: true }).build(),
           title: this.test?.fullTitle(),
           testSpecificMock: async (server: Mockttp) => {
             await mockNotificationServices(server, triggerServer);

--- a/test/e2e/tests/petnames/petnames-signatures.spec.ts
+++ b/test/e2e/tests/petnames/petnames-signatures.spec.ts
@@ -97,6 +97,7 @@ describe('Petnames - Signatures', function (this: Suite) {
         },
         fixtures: new FixtureBuilderV2()
           .withPermissionControllerConnectedToTestDapp({ chainIds: [1] })
+          .withSnapsPrivacyWarningAlreadyShown()
           .withNoNames()
           .withEnabledNetworks({ eip155: { '0x1': true } })
           .build(),

--- a/test/e2e/tests/petnames/petnames-signatures.spec.ts
+++ b/test/e2e/tests/petnames/petnames-signatures.spec.ts
@@ -6,7 +6,7 @@ import TestDapp from '../../page-objects/pages/test-dapp';
 import { openTestSnapClickButtonAndInstall } from '../../page-objects/flows/install-test-snap.flow';
 import { DAPP_ONE_URL, DAPP_PATH, WINDOW_TITLES } from '../../constants';
 import { withFixtures } from '../../helpers';
-import FixtureBuilder from '../../fixtures/fixture-builder';
+import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { mockLookupSnap } from '../../mock-response-data/snaps/snap-binary-mocks';
 import Confirmation from '../../page-objects/pages/confirmations/confirmation';
 
@@ -95,10 +95,10 @@ describe('Petnames - Signatures', function (this: Suite) {
           customDappPaths: [DAPP_PATH.TEST_SNAPS],
           numberOfTestDapps: 1,
         },
-        fixtures: new FixtureBuilder()
-          .withPermissionControllerConnectedToTestDapp()
+        fixtures: new FixtureBuilderV2()
+          .withPermissionControllerConnectedToTestDapp({ chainIds: [1] })
           .withNoNames()
-          .withNetworkControllerOnMainnet()
+          .withEnabledNetworks({ eip155: { '0x1': true } })
           .build(),
         testSpecificMock: mockLookupSnap,
         title: this.test?.fullTitle(),

--- a/test/e2e/tests/send/send-eth-advanced.spec.ts
+++ b/test/e2e/tests/send/send-eth-advanced.spec.ts
@@ -12,7 +12,6 @@ import { SMART_CONTRACTS } from '../../seeder/smart-contracts';
 import { login } from '../../page-objects/flows/login.flow';
 import { WINDOW_TITLES } from '../../constants';
 import { withFixtures } from '../../helpers';
-import FixtureBuilder from '../../fixtures/fixture-builder';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { mockSpotPrices } from '../tokens/utils/mocks';
 import { Driver } from '../../webdriver/driver';
@@ -27,10 +26,9 @@ import { createInternalTransaction } from '../../page-objects/flows/transaction'
 
 const PREFERENCES_STATE_MOCK = {
   preferences: {
+    showConfirmationAdvancedDetails: true,
     showFiatInTestnets: true,
   },
-  // Enables advanced details due to migration 123
-  useNonceField: true,
 };
 
 describe('Send ETH - Advanced', function () {
@@ -85,7 +83,7 @@ describe('Send ETH - Advanced', function () {
       await withFixtures(
         {
           dappOptions: { numberOfTestDapps: 1 },
-          fixtures: new FixtureBuilder()
+          fixtures: new FixtureBuilderV2()
             .withPermissionControllerConnectedToTestDapp()
             .withPreferencesController(PREFERENCES_STATE_MOCK)
             .build(),
@@ -147,7 +145,7 @@ describe('Send ETH - Advanced', function () {
       await withFixtures(
         {
           dappOptions: { numberOfTestDapps: 1 },
-          fixtures: new FixtureBuilder()
+          fixtures: new FixtureBuilderV2()
             .withPermissionControllerConnectedToTestDapp()
             .withPreferencesController(PREFERENCES_STATE_MOCK)
             .build(),
@@ -212,7 +210,7 @@ describe('Send ETH - Advanced', function () {
     it('renders correct recipient with ERC20 transfer signature in hex data', async function () {
       await withFixtures(
         {
-          fixtures: new FixtureBuilder()
+          fixtures: new FixtureBuilderV2()
             .withPreferencesController({
               featureFlags: {
                 sendHexData: true,

--- a/test/e2e/tests/simulation-details/simulation-details.spec.ts
+++ b/test/e2e/tests/simulation-details/simulation-details.spec.ts
@@ -2,7 +2,7 @@ import { hexToNumber } from '@metamask/utils';
 import { Mockttp, MockttpServer } from 'mockttp';
 import { CHAIN_IDS } from '../../../../shared/constants/network';
 import { TX_SENTINEL_URL } from '../../../../shared/constants/transaction';
-import FixtureBuilder from '../../fixtures/fixture-builder';
+import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { Fixtures, withFixtures } from '../../helpers';
 import { DAPP_URL, WINDOW_TITLES } from '../../constants';
 import { login } from '../../page-objects/flows/login.flow';
@@ -56,14 +56,20 @@ async function withFixturesForSimulationDetails(
 ) {
   await withFixtures(
     {
-      fixtures: new FixtureBuilder({ inputChainId })
-        .withPermissionControllerConnectedToTestDapp()
+      fixtures: new FixtureBuilderV2()
+        .withEnabledNetworks({
+          eip155: {
+            [inputChainId]: true,
+          },
+        })
+        .withPermissionControllerConnectedToTestDapp({
+          chainIds: [hexToNumber(inputChainId)],
+        })
         .build(),
       title,
       testSpecificMock: mockRequests,
       dappOptions: { numberOfTestDapps: 1 },
       localNodeOptions: {
-        hardfork: 'london',
         chainId: hexToNumber(inputChainId),
       },
     },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Migrate more specs to use FixtureBuilderV2 and cleanup code.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. All tests should continue to pass

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="3097" height="1541" alt="image" src="https://github.com/user-attachments/assets/614099da-0f6c-4a0d-b252-8ebe407cb1c4" />


### **After**

<img width="3118" height="1541" alt="image" src="https://github.com/user-attachments/assets/ee1cf601-648c-4f6a-9ea4-6a8df9f8d7c9" />



<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to e2e test setup, primarily swapping fixture builders and adjusting test-only configuration to match the new builder APIs.
> 
> **Overview**
> Migrates a set of e2e specs (snap accounts, confirmations/gas-fee-token flows, simulation details, notifications, multichain accounts, and send-ETH advanced) from `FixtureBuilder` to `FixtureBuilderV2`, updating fixture composition calls accordingly (e.g., enabled networks, connected chainIds, smart-transactions opt-out, and snaps privacy warning state).
> 
> Cleans up test configuration by removing now-unneeded `manifestFlags`/hardfork overrides in several fixtures, and updates preference setup in `send-eth-advanced` to use `showConfirmationAdvancedDetails` instead of relying on a migration flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd51fec015faad066f32ea2cf6df92e1d750ba64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->