### PR TITLE
fix: audit follow-redirects

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -77,3 +77,4 @@ npmPreapprovedPackages:
   - 'lavamoat-node'
   - 'lavamoat'
   - 'extension-port-stream'
+  - 'follow-redirects' # CVE GHSA-r4q5-vmmm-2653: bump to 1.16.0

--- a/package.json
+++ b/package.json
@@ -158,6 +158,7 @@
     "yarn-binary:hydrate": "corepack hydrate .yarn/yarn-corepack.tgz --activate"
   },
   "resolutions": {
+    "follow-redirects": "^1.16.0",
     "@unrs/resolver-binding-wasm32-wasi": "npm:npm-empty-package@1.0.0",
     "jest-clean-console-reporter/chalk": "^4.1.2",
     "napi-postinstall": "npm:npm-empty-package@1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -27187,13 +27187,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.14.0, follow-redirects@npm:^1.14.9, follow-redirects@npm:^1.15.11":
-  version: 1.15.11
-  resolution: "follow-redirects@npm:1.15.11"
+"follow-redirects@npm:^1.16.0":
+  version: 1.16.0
+  resolution: "follow-redirects@npm:1.16.0"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: 10/07372fd74b98c78cf4d417d68d41fdaa0be4dcacafffb9e67b1e3cf090bc4771515e65020651528faab238f10f9b9c0d9707d6c1574a6c0387c5de1042cde9ba
+  checksum: 10/3fbe3d80b3b544c22705d837aa5d4a0d07a740d913534a2620b0a004c610af4148e3b58723536dd099aaa1c9d3a155964bde9665d6e5cb331460809a1fc572fd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

Forces `follow-redirects` to `^1.16.0` via a Yarn resolution to address the moderate-severity advisory [GHSA-r4q5-vmmm-2653](https://github.com/advisories/GHSA-r4q5-vmmm-2653) (auth header leakage on cross-domain redirects). The vulnerable version `1.15.11` is brought in transitively by `axios`.

Because `1.16.0` was published less than 3 days ago it was blocked by the project's `npmMinimalAgeGate`. `follow-redirects` is added to `npmPreapprovedPackages` in `.yarnrc.yml` so the resolution can be installed immediately.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A (security advisory GHSA-r4q5-vmmm-2653)

## **Manual testing steps**

1. Check out the branch and run `yarn install`.
2. Verify the resolved version: `cat node_modules/follow-redirects/package.json | grep '"version"'` — should print `"version": "1.16.0"`.
3. Run `yarn npm audit` and confirm no `follow-redirects` advisories are reported.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

* I've followed MetaMask Contributor Docs and MetaMask Extension Coding Standards.
* I've completed the PR template to the best of my ability
* I've included tests if applicable
* I've documented my code using JSDoc format if applicable
* I've applied the right labels on the PR (see labeling guidelines). Not required for external contributors.