### PR TITLE
fix: tempo useHasInsufficientBalance return false non-7702 cp-13.27.0

### DIFF
--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -1361,7 +1361,7 @@
       "React: Act warnings (component updates not wrapped)": 1
     },
     "ui/pages/confirmations/hooks/useHasInsufficientBalance.test.ts": {
-      "MetaMask: Background connection not initialized": 30,
+      "MetaMask: Background connection not initialized": 54,
       "Reselect: Identity function warnings": 3
     },
     "ui/pages/confirmations/hooks/useLedgerConnection.test.ts": {

--- a/ui/pages/confirmations/hooks/useHasInsufficientBalance.test.ts
+++ b/ui/pages/confirmations/hooks/useHasInsufficientBalance.test.ts
@@ -34,12 +34,14 @@ function buildState({
   transaction = TRANSACTION_MOCK,
   selectedNetworkClientId,
   chainId,
+  excludeNativeTokenForFee,
 }: {
   balance?: number;
   currentConfirmation?: Partial<TransactionMeta>;
   transaction?: Partial<TransactionMeta>;
   selectedNetworkClientId?: string;
   chainId?: string;
+  excludeNativeTokenForFee?: boolean;
 } = {}) {
   const accountAddress = transaction?.txParams?.from as string;
 
@@ -64,7 +66,15 @@ function buildState({
           },
         },
       },
-      transactions: transaction ? [transaction] : [],
+      transactions: transaction
+        ? [
+            {
+              ...transaction,
+              ...(excludeNativeTokenForFee ? { excludeNativeTokenForFee } : {}),
+              ...(chainId ? { chainId } : {}),
+            },
+          ]
+        : [],
     },
   });
 }
@@ -123,5 +133,43 @@ describe('useHasInsufficientBalance', () => {
   it('returns 0x0 if balance missing', () => {
     const result = runHook({ balance: undefined });
     expect(result.hasInsufficientBalance).toBe(true);
+  });
+
+  it('always return true for Tempo if `excludeNativeTokenForFee` is true', () => {
+    const result = runHook({
+      balance: 0,
+      chainId: '0x1079',
+      excludeNativeTokenForFee: true,
+    });
+    expect(result.hasInsufficientBalance).toBe(true);
+    expect(result.nativeCurrency).toBe('pathUSD');
+  });
+
+  it('always return true for Tempo Testnet if `excludeNativeTokenForFee` is true', () => {
+    const result = runHook({
+      balance: 0,
+      chainId: '0xa5bf',
+      excludeNativeTokenForFee: true,
+    });
+    expect(result.hasInsufficientBalance).toBe(true);
+    expect(result.nativeCurrency).toBe('pathUSD');
+  });
+
+  it('always return false for Tempo if `excludeNativeTokenForFee` is unset', () => {
+    const result = runHook({
+      balance: 0,
+      chainId: '0x1079',
+    });
+    expect(result.hasInsufficientBalance).toBe(false);
+    expect(result.nativeCurrency).toBe('pathUSD');
+  });
+
+  it('always return false for Tempo Testnet if `excludeNativeTokenForFee` is unset', () => {
+    const result = runHook({
+      balance: 0,
+      chainId: '0xa5bf',
+    });
+    expect(result.hasInsufficientBalance).toBe(false);
+    expect(result.nativeCurrency).toBe('pathUSD');
   });
 });

--- a/ui/pages/confirmations/hooks/useHasInsufficientBalance.ts
+++ b/ui/pages/confirmations/hooks/useHasInsufficientBalance.ts
@@ -44,35 +44,20 @@ export function useHasInsufficientBalance(): {
   );
 
   const { nativeCurrencySymbol } = useNativeCurrencySymbol(chainId);
-
-  let hasInsufficientBalance;
+  const hasNoNativeAsset = NO_NATIVE_ASSET_CHAIN_IDS.has(chainId);
   /**
-   * Specific cases for chains with no native asset like Tempo.
-   * - On normal Tempo 7702 flows, there is never enough native balance because there is no native.
-   * - However, in some conditions we want to force-disable 7702 (like for with HW), causing Tempo to fall
-   * into a degraded "legacy" flow. In this flow (detected when `excludeNativeTokenForFee` is false on a Tempo chain)
-   * the old version of MetaMask used to read the RPC `getbalance` with a big number 424242424242...
-   * This made MetaMask assume that the user had enough native token at all times, allowing the user to
-   * be able to try to interact with the chain. The newest version of MetaMask sets "0" for Tempo native balance
-   * which means that this "legacy flow" won't work anymore because MetaMask "sees" that there is not enough native token.
-   * The line below restores the old "has enough balance no matter what" behavior that we had previously,
-   * in the specific cases where 7702 is disabled for Tempo.
-   * This should be a temporary solution until gasless/7702 is supported by hardware wallets.
+   * Tempo (7702) special case: Force "enough native balance" in legacy flow
+   * (when `excludeNativeTokenForFee` is false) to restore old MetaMask behavior.
+   * New MM reports "0" balance, breaking legacy flow. Temporary fix until HW
+   * supports gasless/7702.
    */
-  if (NO_NATIVE_ASSET_CHAIN_IDS.has(chainId)) {
-    /**
-     * In Tempo:
-     * - When `excludeNativeTokenForFee` is `true`, we are in the 7702 flow (force no native token).
-     * - When `excludeNativeTokenForFee` is unset, we are in a non-7702 fallback (assume unlimited native token).
-     */
-    hasInsufficientBalance = Boolean(excludeNativeTokenForFee);
-  } else {
-    hasInsufficientBalance = !isBalanceSufficient({
-      amount: totalValue,
-      gasTotal: maxFeeHex,
-      balance,
-    });
-  }
+  const hasInsufficientBalance = hasNoNativeAsset
+    ? Boolean(excludeNativeTokenForFee)
+    : !isBalanceSufficient({
+        amount: totalValue,
+        gasTotal: maxFeeHex,
+        balance,
+      });
 
   return {
     hasInsufficientBalance,

--- a/ui/pages/confirmations/hooks/useHasInsufficientBalance.ts
+++ b/ui/pages/confirmations/hooks/useHasInsufficientBalance.ts
@@ -9,6 +9,8 @@ import { isBalanceSufficient } from '../send-utils/send.utils';
 import { useFeeCalculations } from '../components/confirm/info/hooks/useFeeCalculations';
 import { useNativeCurrencySymbol } from '../components/confirm/info/hooks/useNativeCurrencySymbol';
 
+const NO_NATIVE_ASSET_CHAIN_IDS = new Set(['0x1079', '0xa5bf']);
+
 const ZERO_HEX_FALLBACK = '0x0';
 
 export function useHasInsufficientBalance(): {
@@ -18,6 +20,7 @@ export function useHasInsufficientBalance(): {
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
   const {
     chainId,
+    excludeNativeTokenForFee,
     txParams: { value = ZERO_HEX_FALLBACK, from: fromAddress = '' } = {},
   } = currentConfirmation ?? {};
 
@@ -41,14 +44,38 @@ export function useHasInsufficientBalance(): {
   );
 
   const { nativeCurrencySymbol } = useNativeCurrencySymbol(chainId);
-  const insufficientBalance = !isBalanceSufficient({
-    amount: totalValue,
-    gasTotal: maxFeeHex,
-    balance,
-  });
+
+  let hasInsufficientBalance;
+  /**
+   * Specific cases for chains with no native asset like Tempo.
+   * - On normal Tempo 7702 flows, there is never enough native balance because there is no native.
+   * - However, in some conditions we want to force-disable 7702 (like for with HW), causing Tempo to fall
+   * into a degraded "legacy" flow. In this flow (detected when `excludeNativeTokenForFee` is false on a Tempo chain)
+   * the old version of MetaMask used to read the RPC `getbalance` with a big number 424242424242...
+   * This made MetaMask assume that the user had enough native token at all times, allowing the user to
+   * be able to try to interact with the chain. The newest version of MetaMask sets "0" for Tempo native balance
+   * which means that this "legacy flow" won't work anymore because MetaMask "sees" that there is not enough native token.
+   * The line below restores the old "has enough balance no matter what" behavior that we had previously,
+   * in the specific cases where 7702 is disabled for Tempo.
+   * This should be a temporary solution until gasless/7702 is supported by hardware wallets.
+   */
+  if (NO_NATIVE_ASSET_CHAIN_IDS.has(chainId)) {
+    /**
+     * In Tempo:
+     * - When `excludeNativeTokenForFee` is `true`, we are in the 7702 flow (force no native token).
+     * - When `excludeNativeTokenForFee` is unset, we are in a non-7702 fallback (assume unlimited native token).
+     */
+    hasInsufficientBalance = Boolean(excludeNativeTokenForFee);
+  } else {
+    hasInsufficientBalance = !isBalanceSufficient({
+      amount: totalValue,
+      gasTotal: maxFeeHex,
+      balance,
+    });
+  }
 
   return {
-    hasInsufficientBalance: insufficientBalance,
+    hasInsufficientBalance,
     nativeCurrency: nativeCurrencySymbol,
   };
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

When signing a tx on Tempo:
- Before the recent Tempo changes, MetaMask assumed that the native token supply was unlimited (RPC returning a balance of ``424242424242...`, which resulted in a degraded - but working in the right conditions - transaction UX.
- Now that we’ve defined “no native token for Tempo,” native balance is always seen as `0`, since we using a 7702 gasless flow, this has only positive impact on UX.
- However, since Hardware Wallets aren't supported in our gasless flow, we make those fallback to "normal transactions", which is a problem because MetaMask now sees the native balance as always `0` throwing an error.

The issue is that some hardware wallet users may have already interacted with Tempo before the recent changes. On the current Extension release, those users may not be able to transact on Tempo anymore, making it a regression.

This PR introduces a quick fix, strictly scoped to Hardware Wallets on Tempo chains so it doesn't affect other flows. It modifies `useHasInsufficientBalance` hook to override balance checks on Tempo, and instead do:
- If gasless/7702 flow, assume no native balance.
- If "normal flow" (forced when using a Hardware Wallet), assume unlimited balance (retro-compatibility with how it was before).

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: useHasInsufficientBalance to skip native balance checks on Tempo

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

Use Extension on Tempo using an Hardware Wallet.
Transactions should be optimistic, showing an estimate of `pathUSD` gas fees, regardless of user `pathUSD` balance.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces chain-specific branching in `useHasInsufficientBalance` for Tempo networks, which can affect transaction confirmation gating on those chains if the `excludeNativeTokenForFee` flag is set incorrectly.
> 
> **Overview**
> Adjusts `useHasInsufficientBalance` to special-case Tempo mainnet/testnet (`0x1079`, `0xa5bf`) by bypassing the normal native balance + max-fee sufficiency check when the chain has *no native asset*.
> 
> For these chains, the hook now returns **insufficient balance only when** `excludeNativeTokenForFee` is `true` (gasless/7702), and returns **sufficient balance** when the flag is unset (legacy/hardware-wallet flow). Tests are updated to cover these behaviors and the Jest console baseline is updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe6aa2c0b1fb9c8fd84db87c643ca7bfa26e719f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->