### PR TITLE
fix: correct perps tab 24h change color and sign display

### DIFF
--- a/ui/components/app/perps/perps-market-card/perps-market-card.tsx
+++ b/ui/components/app/perps/perps-market-card/perps-market-card.tsx
@@ -12,7 +12,11 @@ import {
   AvatarTokenSize,
 } from '@metamask/design-system-react';
 import { PerpsTokenLogo } from '../perps-token-logo';
-import { getDisplayName } from '../utils';
+import {
+  formatSignedChangePercent,
+  getChangeColor,
+  getDisplayName,
+} from '../utils';
 
 const CARD_STYLES =
   'justify-start rounded-none min-w-0 h-[62px] gap-4 text-left cursor-pointer bg-default pt-2 pb-2 px-4 hover:bg-hover active:bg-pressed';
@@ -38,8 +42,11 @@ export const PerpsMarketCard: React.FC<PerpsMarketCardProps> = ({
 }) => {
   const displaySymbol = getDisplayName(symbol);
   const displayName = name ? getDisplayName(name) : displaySymbol;
-  const isPositiveChange =
-    change24hPercent.startsWith('+') || change24hPercent === '0.00%';
+  const displayChange24hPercent = formatSignedChangePercent(change24hPercent);
+  const changeColor =
+    displayChange24hPercent && /\d/u.test(displayChange24hPercent)
+      ? getChangeColor(displayChange24hPercent)
+      : TextColor.TextAlternative;
 
   return (
     <ButtonBase
@@ -75,13 +82,8 @@ export const PerpsMarketCard: React.FC<PerpsMarketCardProps> = ({
         <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
           {price}
         </Text>
-        <Text
-          variant={TextVariant.BodySm}
-          color={
-            isPositiveChange ? TextColor.SuccessDefault : TextColor.ErrorDefault
-          }
-        >
-          {change24hPercent}
+        <Text variant={TextVariant.BodySm} color={changeColor}>
+          {displayChange24hPercent}
         </Text>
       </Box>
     </ButtonBase>

--- a/ui/components/app/perps/perps-market-card/perps-market-card.tsx
+++ b/ui/components/app/perps/perps-market-card/perps-market-card.tsx
@@ -43,10 +43,7 @@ export const PerpsMarketCard: React.FC<PerpsMarketCardProps> = ({
   const displaySymbol = getDisplayName(symbol);
   const displayName = name ? getDisplayName(name) : displaySymbol;
   const displayChange24hPercent = formatSignedChangePercent(change24hPercent);
-  const changeColor =
-    displayChange24hPercent && /\d/u.test(displayChange24hPercent)
-      ? getChangeColor(displayChange24hPercent)
-      : TextColor.TextAlternative;
+  const changeColor = getChangeColor(displayChange24hPercent);
 
   return (
     <ButtonBase
@@ -82,7 +79,11 @@ export const PerpsMarketCard: React.FC<PerpsMarketCardProps> = ({
         <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
           {price}
         </Text>
-        <Text variant={TextVariant.BodySm} color={changeColor}>
+        <Text
+          variant={TextVariant.BodySm}
+          color={changeColor}
+          data-testid="perps-market-card-change"
+        >
           {displayChange24hPercent}
         </Text>
       </Box>

--- a/ui/components/app/perps/utils.test.ts
+++ b/ui/components/app/perps/utils.test.ts
@@ -157,6 +157,12 @@ describe('Perps Utils', () => {
       expect(getChangeColor('+0%')).toBe(TextColor.SuccessDefault);
       expect(getChangeColor('-0%')).toBe(TextColor.SuccessDefault);
     });
+
+    it('returns TextAlternative for non-numeric fallback values', () => {
+      expect(getChangeColor('N/A')).toBe(TextColor.TextAlternative);
+      expect(getChangeColor('—')).toBe(TextColor.TextAlternative);
+      expect(getChangeColor('')).toBe(TextColor.TextAlternative);
+    });
   });
 
   describe('formatSignedChangePercent', () => {

--- a/ui/components/app/perps/utils.test.ts
+++ b/ui/components/app/perps/utils.test.ts
@@ -6,6 +6,7 @@ import {
   formatStatus,
   getStatusColor,
   formatChangePercent,
+  formatSignedChangePercent,
   getChangeColor,
   getDisplaySymbol,
   getAssetIconUrl,
@@ -155,6 +156,35 @@ describe('Perps Utils', () => {
       expect(getChangeColor('0.00%')).toBe(TextColor.SuccessDefault);
       expect(getChangeColor('+0%')).toBe(TextColor.SuccessDefault);
       expect(getChangeColor('-0%')).toBe(TextColor.SuccessDefault);
+    });
+  });
+
+  describe('formatSignedChangePercent', () => {
+    it('preserves explicit positive prefixes', () => {
+      expect(formatSignedChangePercent('+2.84%')).toBe('+2.84%');
+      expect(formatSignedChangePercent('+2.84')).toBe('+2.84%');
+    });
+
+    it('adds a plus prefix to unsigned positive values', () => {
+      expect(formatSignedChangePercent('2.84%')).toBe('+2.84%');
+      expect(formatSignedChangePercent('2.84')).toBe('+2.84%');
+    });
+
+    it('preserves negative values', () => {
+      expect(formatSignedChangePercent('-1.23%')).toBe('-1.23%');
+      expect(formatSignedChangePercent('-1.23')).toBe('-1.23%');
+    });
+
+    it('preserves zero values without adding a plus prefix', () => {
+      expect(formatSignedChangePercent('0%')).toBe('0%');
+      expect(formatSignedChangePercent('0.00')).toBe('0.00%');
+      expect(formatSignedChangePercent('0.00%')).toBe('0.00%');
+    });
+
+    it('returns non-numeric strings unchanged', () => {
+      expect(formatSignedChangePercent('—')).toBe('—');
+      expect(formatSignedChangePercent('N/A')).toBe('N/A');
+      expect(formatSignedChangePercent('')).toBe('');
     });
   });
 

--- a/ui/components/app/perps/utils.ts
+++ b/ui/components/app/perps/utils.ts
@@ -159,7 +159,8 @@ export const formatSignedChangePercent = (value: string): string => {
 
 /**
  * Get the appropriate text color for a percentage change value
- * Non-negative values (≥ 0) → green, negative → red
+ * Non-negative values (≥ 0) → green, negative → red,
+ * non-numeric / fallback values → alternative text color
  *
  * @param percentString - The percentage string (e.g., "+2.84%", "-1.23%", "0.00%", "2.84%")
  * @returns The appropriate text color
@@ -168,9 +169,13 @@ export const formatSignedChangePercent = (value: string): string => {
  * getChangeColor('2.84%') => TextColor.SuccessDefault
  * getChangeColor('0.00%') => TextColor.SuccessDefault
  * getChangeColor('-1.23%') => TextColor.ErrorDefault
+ * getChangeColor('N/A') => TextColor.TextAlternative
  */
 export const getChangeColor = (percentString: string): TextColor => {
-  const value = parseFloat(percentString.replace('%', ''));
+  const value = Number.parseFloat(percentString.replace('%', ''));
+  if (Number.isNaN(value)) {
+    return TextColor.TextAlternative;
+  }
   if (value < 0) {
     return TextColor.ErrorDefault;
   }

--- a/ui/components/app/perps/utils.ts
+++ b/ui/components/app/perps/utils.ts
@@ -122,6 +122,42 @@ export const formatChangePercent = (value: string): string => {
 };
 
 /**
+ * Normalizes a 24h percentage change string for UI display.
+ * Positive numeric values are always shown with an explicit '+' prefix,
+ * matching mobile behavior. Negative values and zero keep their natural sign.
+ *
+ * Returns the value unchanged if:
+ * - empty / falsy
+ * - contains no digits (e.g. a fallback dash "—" or error string)
+ *
+ * @param value - Raw percentage string, with or without '%' or '+' (e.g., "2.84", "+2.84%", "-1.23%")
+ * @returns The normalized percentage string for display
+ * @example
+ * formatSignedChangePercent('2.84') => '+2.84%'
+ * formatSignedChangePercent('2.84%') => '+2.84%'
+ * formatSignedChangePercent('+2.84%') => '+2.84%'
+ * formatSignedChangePercent('-1.23%') => '-1.23%'
+ * formatSignedChangePercent('0.00%') => '0.00%'
+ */
+export const formatSignedChangePercent = (value: string): string => {
+  const formattedValue = formatChangePercent(value);
+
+  if (!formattedValue || !/\d/u.test(formattedValue)) {
+    return formattedValue;
+  }
+
+  if (
+    formattedValue.startsWith('+') ||
+    formattedValue.startsWith('-') ||
+    Number.parseFloat(formattedValue.replace('%', '')) <= 0
+  ) {
+    return formattedValue;
+  }
+
+  return `+${formattedValue}`;
+};
+
+/**
  * Get the appropriate text color for a percentage change value
  * Non-negative values (≥ 0) → green, negative → red
  *


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes the 24h change display for market rows on the Perps tab landing view, specifically the Watchlist and Explore Markets rows. The issue was that those rows treated a value as positive only when it already included a leading +, so upstream values like 2.50% were incorrectly rendered in red even though they were positive.

The solution normalizes 24h percentage values for display on that surface so positive values always show an explicit +, matching mobile behavior, and moves the color decision into shared perps utilities so it is derived from the numeric value rather than string shape. This makes positive changes render green, negative changes render red, preserves zero correctly, and handles fallback values like N/A with neutral styling.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixes the 24h change display for market rows on the Perps tab landing view

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2944

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
<img width="393" height="528" alt="Screenshot 2026-04-14 at 8 24 38 AM" src="https://github.com/user-attachments/assets/6562173a-2321-4151-bf35-3581998eee93" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change: adjusts formatting and coloring for perps market 24h change values and adds unit coverage; no auth, persistence, or protocol logic touched.
> 
> **Overview**
> Fixes Perps market row 24h change display by **normalizing percent strings** so positive values always show an explicit `+` (via new `formatSignedChangePercent`) and by **deriving the text color from the numeric value** rather than string prefixes.
> 
> Updates `PerpsMarketCard` to use the shared utils for both sign formatting and color, adds a `data-testid` for the change value, and extends utils tests to cover unsigned positives, zero handling, and fallback/non-numeric values (e.g., `N/A`, `—`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 419c3f86d8cc98b50e165af2f917baaefc2561aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->