### PR TITLE
fix: cp-13.27.0 add cancel button to malicious site detected warning

### DIFF
--- a/ui/pages/permissions-connect/connection-trust-signal-gate/connection-trust-signal-gate.test.tsx
+++ b/ui/pages/permissions-connect/connection-trust-signal-gate/connection-trust-signal-gate.test.tsx
@@ -102,4 +102,22 @@ describe('ConnectionTrustSignalGate', () => {
     expect(queryByTestId('trust-signal-block-modal')).not.toBeInTheDocument();
     expect(getByText('Child content')).toBeInTheDocument();
   });
+
+  it('calls onCancel when cancel button is clicked in block modal', () => {
+    mockUseOriginTrustSignals.mockReturnValue({
+      state: TrustSignalDisplayState.Malicious,
+      label: null,
+    });
+
+    const onCancel = jest.fn();
+
+    const { getByTestId } = render(
+      <ConnectionTrustSignalGate {...defaultProps} onCancel={onCancel}>
+        <div>Child content</div>
+      </ConnectionTrustSignalGate>,
+    );
+
+    fireEvent.click(getByTestId('trust-signal-block-modal-cancel'));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
 });

--- a/ui/pages/permissions-connect/connection-trust-signal-gate/connection-trust-signal-gate.tsx
+++ b/ui/pages/permissions-connect/connection-trust-signal-gate/connection-trust-signal-gate.tsx
@@ -6,18 +6,24 @@ import { TrustSignalModal } from './trust-signal-modal';
 type ConnectionTrustSignalGateProps = {
   origin: string;
   children: React.ReactNode;
+  onCancel?: () => void;
 };
 
 export function ConnectionTrustSignalGate({
   origin,
   children,
+  onCancel,
 }: ConnectionTrustSignalGateProps) {
   const { state } = useOriginTrustSignals(origin);
   const [dismissed, setDismissed] = useState(false);
 
   if (!dismissed && state === TrustSignalDisplayState.Malicious) {
     return (
-      <TrustSignalModal origin={origin} onContinue={() => setDismissed(true)} />
+      <TrustSignalModal
+        origin={origin}
+        onContinue={() => setDismissed(true)}
+        onCancel={onCancel}
+      />
     );
   }
 

--- a/ui/pages/permissions-connect/connection-trust-signal-gate/trust-signal-modal.test.tsx
+++ b/ui/pages/permissions-connect/connection-trust-signal-gate/trust-signal-modal.test.tsx
@@ -47,4 +47,31 @@ describe('TrustSignalModal', () => {
     fireEvent.click(getByTestId('trust-signal-block-modal-continue'));
     expect(defaultProps.onContinue).toHaveBeenCalledTimes(1);
   });
+
+  it('renders cancel button when onCancel is provided', () => {
+    const onCancel = jest.fn();
+    const { getByTestId } = render(
+      <TrustSignalModal {...defaultProps} onCancel={onCancel} />,
+    );
+
+    expect(getByTestId('trust-signal-block-modal-cancel')).toBeInTheDocument();
+  });
+
+  it('calls onCancel when cancel button is clicked', () => {
+    const onCancel = jest.fn();
+    const { getByTestId } = render(
+      <TrustSignalModal {...defaultProps} onCancel={onCancel} />,
+    );
+
+    fireEvent.click(getByTestId('trust-signal-block-modal-cancel'));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render cancel button when onCancel is not provided', () => {
+    const { queryByTestId } = render(
+      <TrustSignalModal {...defaultProps} />,
+    );
+
+    expect(queryByTestId('trust-signal-block-modal-cancel')).not.toBeInTheDocument();
+  });
 });

--- a/ui/pages/permissions-connect/connection-trust-signal-gate/trust-signal-modal.test.tsx
+++ b/ui/pages/permissions-connect/connection-trust-signal-gate/trust-signal-modal.test.tsx
@@ -8,6 +8,7 @@ const MOCK_I18N: Record<string, string> = {
   trustSignalBlockTitle: messages.trustSignalBlockTitle.message,
   trustSignalBlockDescription: messages.trustSignalBlockDescription.message,
   trustSignalContinueAnyway: messages.trustSignalContinueAnyway.message,
+  cancel: messages.cancel.message,
 };
 
 jest.mock('../../../hooks/useI18nContext', () => ({

--- a/ui/pages/permissions-connect/connection-trust-signal-gate/trust-signal-modal.test.tsx
+++ b/ui/pages/permissions-connect/connection-trust-signal-gate/trust-signal-modal.test.tsx
@@ -69,10 +69,10 @@ describe('TrustSignalModal', () => {
   });
 
   it('does not render cancel button when onCancel is not provided', () => {
-    const { queryByTestId } = render(
-      <TrustSignalModal {...defaultProps} />,
-    );
+    const { queryByTestId } = render(<TrustSignalModal {...defaultProps} />);
 
-    expect(queryByTestId('trust-signal-block-modal-cancel')).not.toBeInTheDocument();
+    expect(
+      queryByTestId('trust-signal-block-modal-cancel'),
+    ).not.toBeInTheDocument();
   });
 });

--- a/ui/pages/permissions-connect/connection-trust-signal-gate/trust-signal-modal.tsx
+++ b/ui/pages/permissions-connect/connection-trust-signal-gate/trust-signal-modal.tsx
@@ -22,11 +22,13 @@ import { useI18nContext } from '../../../hooks/useI18nContext';
 type TrustSignalModalProps = {
   origin: string;
   onContinue: () => void;
+  onCancel?: () => void;
 };
 
 export function TrustSignalModal({
   origin,
   onContinue,
+  onCancel,
 }: TrustSignalModalProps) {
   const t = useI18nContext();
 
@@ -82,6 +84,17 @@ export function TrustSignalModal({
           {t('trustSignalBlockDescription')}
         </Text>
       </Box>
+      {onCancel && (
+        <Button
+          variant={ButtonVariant.Secondary}
+          size={ButtonSize.Lg}
+          className="w-full"
+          onClick={onCancel}
+          data-testid="trust-signal-block-modal-cancel"
+        >
+          {t('cancel')}
+        </Button>
+      )}
       <Button
         variant={ButtonVariant.Primary}
         size={ButtonSize.Lg}

--- a/ui/pages/permissions-connect/permissions-connect.tsx
+++ b/ui/pages/permissions-connect/permissions-connect.tsx
@@ -638,7 +638,10 @@ function PermissionsConnect() {
   );
 
   return (
-    <ConnectionTrustSignalGate origin={origin}>
+    <ConnectionTrustSignalGate
+      origin={origin}
+      onCancel={() => cancelPermissionsRequest(permissionsRequestId || '')}
+    >
       <div className="permissions-connect">
         {!hideTopBar &&
           permissionsRequestId &&

--- a/ui/pages/permissions-connect/permissions-connect.tsx
+++ b/ui/pages/permissions-connect/permissions-connect.tsx
@@ -637,10 +637,15 @@ function PermissionsConnect() {
     (metadata as Record<string, string>)?.origin,
   );
 
+  const cancelFromTrustSignalGate = useCallback(
+    () => cancelPermissionsRequest(permissionsRequestId || ''),
+    [cancelPermissionsRequest, permissionsRequestId],
+  );
+
   return (
     <ConnectionTrustSignalGate
       origin={origin}
-      onCancel={() => cancelPermissionsRequest(permissionsRequestId || '')}
+      onCancel={cancelFromTrustSignalGate}
     >
       <div className="permissions-connect">
         {!hideTopBar &&


### PR DESCRIPTION
## Summary

ticket: [WAPI-1423](https://consensyssoftware.atlassian.net/browse/WAPI-1423)

- Adds a **Cancel** button to the "Malicious site detected" warning modal so users can reject the connection without being forced to click "Connect Anyway"
- Threads an optional `onCancel` prop through `TrustSignalModal` → `ConnectionTrustSignalGate` → `PermissionsConnect`
- Wires cancel to the existing `cancelPermissionsRequest` call (dispatches `rejectPermissionsRequest` + navigates home) — identical behavior to canceling on the normal connect page

### Before
<img width="496" height="1281" alt="image (1)" src="https://github.com/user-attachments/assets/7a4a4a9b-8866-47e2-a49e-9c385e57a55f" />


### After
<img width="1092" height="1952" alt="Screenshot 2026-04-14 at 2 23 18 PM" src="https://github.com/user-attachments/assets/34576b35-cff9-4ec8-b1fd-56fabb3c13bb" />

## Motivation

On v13.23.0 in sidebar mode, the malicious site warning had no dismiss path. "Connect Anyway" was the only available action, making it a mandatory step to recover — and leaving the permissions request dangling if the user navigated away manually.

## Changes

- `trust-signal-modal.tsx` — adds optional `onCancel` prop; renders `ButtonVariant.Secondary` cancel button above the danger button when provided
- `connection-trust-signal-gate.tsx` — adds optional `onCancel` prop; passes it through to the modal
- `permissions-connect.tsx` — passes `() => cancelPermissionsRequest(permissionsRequestId || '')` as `onCancel` to the gate

## Test Plan

- [ ] `yarn jest ui/pages/permissions-connect/connection-trust-signal-gate/ --no-coverage` — 12/12 passing
- [ ] Visit a site flagged as malicious in sidebar mode — confirm Cancel button appears above "Connect Anyway"
- [ ] Click Cancel — confirm the permissions request is rejected and extension navigates home
- [ ] Click "Connect Anyway" — confirm existing behavior is unchanged
- [ ] Non-malicious sites — confirm no cancel button appears on the normal connect flow

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Adds a Cancel button to the "Malicious site detected" warning modal

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the permissions connection flow by introducing a new cancel path that rejects the pending permissions request; low complexity but impacts user-facing approval/rejection behavior.
> 
> **Overview**
> Adds an optional *Cancel* action to the "malicious site detected" trust-signal block modal so users can back out instead of only choosing `Connect Anyway`.
> 
> Threads a new optional `onCancel` callback through `TrustSignalModal` → `ConnectionTrustSignalGate` → `PermissionsConnect`, wiring it to `cancelPermissionsRequest` to reject the active permissions request and exit the flow. Updates unit tests to cover rendering and invocation of the cancel button.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e99aac4aa4c336aa40116579cebec21cb665433f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[WAPI-1423]: https://consensyssoftware.atlassian.net/browse/WAPI-1423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ