### PR TITLE
feat: add gas fees sponsored tx in token details page

### DIFF
--- a/ui/components/multichain/activity-v2/helpers.test.ts
+++ b/ui/components/multichain/activity-v2/helpers.test.ts
@@ -231,17 +231,16 @@ describe('matchesLocalTransaction', () => {
     ).toBe(false);
   });
 
-  it('matches a batched swap when a nested transaction targets the token contract', () => {
+  it('matches a batched send when a nested transaction targets the token contract', () => {
     const group = makeLocalGroup({
       time: 1000,
-      type: TransactionType.swap,
+      type: TransactionType.tokenMethodTransfer,
       txParams: {
         to: '0xUSER',
         nonce: '0x0',
       } as TransactionMeta['txParams'],
       nestedTransactions: [
-        { to: '0xTokenContract' as `0x${string}`, data: '0x095ea7b3' as `0x${string}`, type: TransactionType.swapApproval },
-        { to: '0xSwapRouter' as `0x${string}`, data: '0x5f575529' as `0x${string}`, type: TransactionType.swap },
+        { to: '0xTokenContract' as `0x${string}`, data: '0xa9059cbb' as `0x${string}` },
       ],
     });
     expect(
@@ -252,17 +251,16 @@ describe('matchesLocalTransaction', () => {
     ).toBe(true);
   });
 
-  it('does not match a batched swap when no nested transaction targets the token', () => {
+  it('does not match a batched send when no nested transaction targets the token', () => {
     const group = makeLocalGroup({
       time: 1000,
-      type: TransactionType.swap,
+      type: TransactionType.tokenMethodTransfer,
       txParams: {
         to: '0xUSER',
         nonce: '0x0',
       } as TransactionMeta['txParams'],
       nestedTransactions: [
-        { to: '0xOtherToken' as `0x${string}`, data: '0x095ea7b3' as `0x${string}`, type: TransactionType.swapApproval },
-        { to: '0xSwapRouter' as `0x${string}`, data: '0x5f575529' as `0x${string}`, type: TransactionType.swap },
+        { to: '0xOtherToken' as `0x${string}`, data: '0xa9059cbb' as `0x${string}` },
       ],
     });
     expect(
@@ -276,7 +274,7 @@ describe('matchesLocalTransaction', () => {
   it('returns false for token scope when txParams.to differs and there are no nested transactions', () => {
     const group = makeLocalGroup({
       time: 1000,
-      type: TransactionType.swap,
+      type: TransactionType.tokenMethodTransfer,
       txParams: {
         to: '0xUSER',
         nonce: '0x0',

--- a/ui/components/multichain/activity-v2/helpers.test.ts
+++ b/ui/components/multichain/activity-v2/helpers.test.ts
@@ -230,6 +230,65 @@ describe('matchesLocalTransaction', () => {
       matchesLocalTransaction(group, { kind: 'token', tokenAddress: '0x123' }),
     ).toBe(false);
   });
+
+  it('matches a batched swap when a nested transaction targets the token contract', () => {
+    const group = makeLocalGroup({
+      time: 1000,
+      type: TransactionType.swap,
+      txParams: {
+        to: '0xUSER',
+        nonce: '0x0',
+      } as TransactionMeta['txParams'],
+      nestedTransactions: [
+        { to: '0xTokenContract' as `0x${string}`, data: '0x095ea7b3' as `0x${string}`, type: TransactionType.swapApproval },
+        { to: '0xSwapRouter' as `0x${string}`, data: '0x5f575529' as `0x${string}`, type: TransactionType.swap },
+      ],
+    });
+    expect(
+      matchesLocalTransaction(group, {
+        kind: 'token',
+        tokenAddress: '0xtokencontract',
+      }),
+    ).toBe(true);
+  });
+
+  it('does not match a batched swap when no nested transaction targets the token', () => {
+    const group = makeLocalGroup({
+      time: 1000,
+      type: TransactionType.swap,
+      txParams: {
+        to: '0xUSER',
+        nonce: '0x0',
+      } as TransactionMeta['txParams'],
+      nestedTransactions: [
+        { to: '0xOtherToken' as `0x${string}`, data: '0x095ea7b3' as `0x${string}`, type: TransactionType.swapApproval },
+        { to: '0xSwapRouter' as `0x${string}`, data: '0x5f575529' as `0x${string}`, type: TransactionType.swap },
+      ],
+    });
+    expect(
+      matchesLocalTransaction(group, {
+        kind: 'token',
+        tokenAddress: '0xUnrelatedToken',
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false for token scope when txParams.to differs and there are no nested transactions', () => {
+    const group = makeLocalGroup({
+      time: 1000,
+      type: TransactionType.swap,
+      txParams: {
+        to: '0xUSER',
+        nonce: '0x0',
+      } as TransactionMeta['txParams'],
+    });
+    expect(
+      matchesLocalTransaction(group, {
+        kind: 'token',
+        tokenAddress: '0xSomeToken',
+      }),
+    ).toBe(false);
+  });
 });
 
 describe('matchesNonEvmTransaction', () => {

--- a/ui/components/multichain/activity-v2/helpers.test.ts
+++ b/ui/components/multichain/activity-v2/helpers.test.ts
@@ -240,7 +240,10 @@ describe('matchesLocalTransaction', () => {
         nonce: '0x0',
       } as TransactionMeta['txParams'],
       nestedTransactions: [
-        { to: '0xTokenContract' as `0x${string}`, data: '0xa9059cbb' as `0x${string}` },
+        {
+          to: '0xTokenContract' as `0x${string}`,
+          data: '0xa9059cbb' as `0x${string}`,
+        },
       ],
     });
     expect(
@@ -260,7 +263,10 @@ describe('matchesLocalTransaction', () => {
         nonce: '0x0',
       } as TransactionMeta['txParams'],
       nestedTransactions: [
-        { to: '0xOtherToken' as `0x${string}`, data: '0xa9059cbb' as `0x${string}` },
+        {
+          to: '0xOtherToken' as `0x${string}`,
+          data: '0xa9059cbb' as `0x${string}`,
+        },
       ],
     });
     expect(

--- a/ui/components/multichain/activity-v2/helpers.ts
+++ b/ui/components/multichain/activity-v2/helpers.ts
@@ -225,10 +225,18 @@ export function matchesLocalTransaction(
       txType === TransactionType.incoming
     );
   }
-  return (
-    group.initialTransaction.txParams?.to?.toLowerCase() ===
-    scope.tokenAddress.toLowerCase()
-  );
+  const addr = scope.tokenAddress.toLowerCase();
+  if (group.initialTransaction.txParams?.to?.toLowerCase() === addr) {
+    return true;
+  }
+  // For batched/delegated transactions (EIP-7702),
+  // txParams.to points to the user's own address. Check nestedTransactions
+  // to see if any inner call targets the token contract.
+  const nested = group.initialTransaction.nestedTransactions;
+  if (nested?.length) {
+    return nested.some((call) => call.to?.toLowerCase() === addr);
+  }
+  return false;
 }
 
 /**


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This pull request improves the logic for matching local token transactions, especially for batched or delegated transactions, and adds comprehensive tests to cover these scenarios. The changes ensure that transactions using nested calls (such as those following EIP-7702 patterns) are correctly identified.

**Enhancements to transaction matching logic:**

* Updated `matchesLocalTransaction` in `helpers.ts` to check for token contract addresses not only in `txParams.to`, but also within `nestedTransactions`, allowing accurate matching for batched/delegated transactions (EIP-7702).

**Expanded test coverage:**

* Added new test cases in `helpers.test.ts` to verify correct behavior for:
  - Batched sends where a nested transaction targets the token contract.
  - Batched sends where no nested transaction targets the token.
  - Cases where `txParams.to` does not match and there are no nested transactions.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: add gas fees sponsored tx in token details page

## **Related issues**

Fixes:

## **Manual testing steps**

1. Make send or swap transactions on Monad network
2. Go to the transaction list from the selected token detail page

## **Screenshots/Recordings**
MON token on MONAD network:
<img width="461" height="459" alt="ext MON" src="https://github.com/user-attachments/assets/aa8cfc91-d6e2-4973-b9e7-cfd8fccc1fb0" />

WMON ERC20 token on MONAD network:
<img width="472" height="600" alt="ext WMON" src="https://github.com/user-attachments/assets/18cb80cd-f5ef-47a6-aef1-c0552b3741c4" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes token-scoped filtering for local activity items by inspecting `nestedTransactions`, which could alter which transactions appear in token details/activity views. Risk is moderate because it impacts transaction classification/visibility but is localized and covered by new tests.
> 
> **Overview**
> Local activity filtering for token scopes now matches batched/delegated (EIP-7702-style) transactions by checking `initialTransaction.nestedTransactions` when `txParams.to` points at the user address.
> 
> Tests were expanded to cover matching/non-matching nested token calls and the fallback behavior when no nested transactions exist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b35fa69b89117abc9fc3b2cc0451b1343c7dccb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->