### PR TITLE
feat: Add camera access error modal content

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -6381,6 +6381,38 @@
     "message": "QR",
     "description": "Hardware device name"
   },
+  "qrCameraAccessBlockedBody": {
+    "message": "To continue, allow camera access in your browser settings.",
+    "description": "Body text when the browser has persistently blocked camera access for the QR hardware wallet scanner (Chromium, Firefox, etc.)."
+  },
+  "qrCameraAccessBlockedChromiumHint": {
+    "message": "Click the camera icon in settings and set to \"Allow\"",
+    "description": "Instruction shown on the Chromium blocked-camera screen for QR scanning."
+  },
+  "qrCameraAccessBlockedFirefoxStep1": {
+    "message": "Go to Settings → Privacy & Security → Permissions → Camera",
+    "description": "Firefox camera recovery step 1."
+  },
+  "qrCameraAccessBlockedFirefoxStep2": {
+    "message": "Look for $1",
+    "description": "$1 is the truncated moz-extension:// origin for this install."
+  },
+  "qrCameraAccessBlockedFirefoxStep3": {
+    "message": "Set to \"Allow\"",
+    "description": "Firefox camera recovery step 3."
+  },
+  "qrCameraAccessBlockedTitle": {
+    "message": "Camera access blocked",
+    "description": "Title when camera access is persistently blocked for QR scanning."
+  },
+  "qrCameraAccessNeededBody": {
+    "message": "MetaMask needs camera access to scan the QR code on your device.",
+    "description": "Body when the user dismissed the camera permission prompt but it can be requested again."
+  },
+  "qrCameraAccessNeededTitle": {
+    "message": "Camera access needed",
+    "description": "Title when the camera permission dialog was dismissed without a choice."
+  },
   "queued": {
     "message": "Queued"
   },
@@ -7776,10 +7808,6 @@
   "showTestnetNetworksDescription": {
     "message": "Select this to show test networks in network list"
   },
-  "sidePanelMigrationToast": {
-    "message": "MetaMask now opens in the side panel by default. $1 (or switch any time from the menu).",
-    "description": "Shown when the extension opens in the side panel after migration. $1 is an inline link to switch back to the popup view."
-  },
   "sign": {
     "message": "Sign"
   },
@@ -8873,9 +8901,6 @@
   },
   "switchBack": {
     "message": "Switch back"
-  },
-  "switchBackToPopup": {
-    "message": "Switch back to popup"
   },
   "switchEthereumChainConfirmationDescription": {
     "message": "This will switch the selected network within MetaMask to a previously added network:"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -7808,6 +7808,10 @@
   "showTestnetNetworksDescription": {
     "message": "Select this to show test networks in network list"
   },
+  "sidePanelMigrationToast": {
+    "message": "MetaMask now opens in the side panel by default. $1 (or switch any time from the menu).",
+    "description": "Shown when the extension opens in the side panel after migration. $1 is an inline link to switch back to the popup view."
+  },
   "sign": {
     "message": "Sign"
   },
@@ -8901,6 +8905,9 @@
   },
   "switchBack": {
     "message": "Switch back"
+  },
+  "switchBackToPopup": {
+    "message": "Switch back to popup"
   },
   "switchEthereumChainConfirmationDescription": {
     "message": "This will switch the selected network within MetaMask to a previously added network:"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -6381,6 +6381,38 @@
     "message": "QR",
     "description": "Hardware device name"
   },
+  "qrCameraAccessBlockedBody": {
+    "message": "To continue, allow camera access in your browser settings.",
+    "description": "Body text when the browser has persistently blocked camera access for the QR hardware wallet scanner (Chromium, Firefox, etc.)."
+  },
+  "qrCameraAccessBlockedChromiumHint": {
+    "message": "Click the camera icon in settings and set to \"Allow\"",
+    "description": "Instruction shown on the Chromium blocked-camera screen for QR scanning."
+  },
+  "qrCameraAccessBlockedFirefoxStep1": {
+    "message": "Go to Settings → Privacy & Security → Permissions → Camera",
+    "description": "Firefox camera recovery step 1."
+  },
+  "qrCameraAccessBlockedFirefoxStep2": {
+    "message": "Look for $1",
+    "description": "$1 is the truncated moz-extension:// origin for this install."
+  },
+  "qrCameraAccessBlockedFirefoxStep3": {
+    "message": "Set to \"Allow\"",
+    "description": "Firefox camera recovery step 3."
+  },
+  "qrCameraAccessBlockedTitle": {
+    "message": "Camera access blocked",
+    "description": "Title when camera access is persistently blocked for QR scanning."
+  },
+  "qrCameraAccessNeededBody": {
+    "message": "MetaMask needs camera access to scan the QR code on your device.",
+    "description": "Body when the user dismissed the camera permission prompt but it can be requested again."
+  },
+  "qrCameraAccessNeededTitle": {
+    "message": "Camera access needed",
+    "description": "Title when the camera permission dialog was dismissed without a choice."
+  },
   "queued": {
     "message": "Queued"
   },
@@ -7776,10 +7808,6 @@
   "showTestnetNetworksDescription": {
     "message": "Select this to show test networks in network list"
   },
-  "sidePanelMigrationToast": {
-    "message": "MetaMask now opens in the side panel by default. $1 (or switch any time from the menu).",
-    "description": "Shown when the extension opens in the side panel after migration. $1 is an inline link to switch back to the popup view."
-  },
   "sign": {
     "message": "Sign"
   },
@@ -8873,9 +8901,6 @@
   },
   "switchBack": {
     "message": "Switch back"
-  },
-  "switchBackToPopup": {
-    "message": "Switch back to popup"
   },
   "switchEthereumChainConfirmationDescription": {
     "message": "This will switch the selected network within MetaMask to a previously added network:"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -7808,6 +7808,10 @@
   "showTestnetNetworksDescription": {
     "message": "Select this to show test networks in network list"
   },
+  "sidePanelMigrationToast": {
+    "message": "MetaMask now opens in the side panel by default. $1 (or switch any time from the menu).",
+    "description": "Shown when the extension opens in the side panel after migration. $1 is an inline link to switch back to the popup view."
+  },
   "sign": {
     "message": "Sign"
   },
@@ -8901,6 +8905,9 @@
   },
   "switchBack": {
     "message": "Switch back"
+  },
+  "switchBackToPopup": {
+    "message": "Switch back to popup"
   },
   "switchEthereumChainConfirmationDescription": {
     "message": "This will switch the selected network within MetaMask to a previously added network:"

--- a/ui/components/app/camera-access-error-content/camera-access-error-content.stories.tsx
+++ b/ui/components/app/camera-access-error-content/camera-access-error-content.stories.tsx
@@ -1,0 +1,141 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import { Box, BoxBackgroundColor } from '@metamask/design-system-react';
+import {
+  CameraAccessErrorContent,
+  CameraAccessErrorContentVariant,
+} from './camera-access-error-content';
+import type {
+  CameraAccessErrorContentBlockedProps,
+  CameraAccessErrorContentNeededProps,
+} from './camera-access-error-content.types';
+
+const MOZ_EXTENSION_DISPLAY_MOCK = 'moz-extension://ab5f75ae…d4aa03';
+
+const meta = {
+  title: 'Components/App/CameraAccessErrorContent',
+  component: CameraAccessErrorContent,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: `
+Locale copy lives inside the component (\`useI18nContext\`).
+
+**Variants**
+- **needed** — User dismissed the permission prompt (Chromium-style flow); primary action retries the prompt.
+- **blocked** — Camera denied / blocked. **Firefox**: numbered steps (step 2 uses \`mozExtensionDisplay\`). **Chromium**: Videocam hint callout, **Open settings**, and primary **Continue**.
+
+**Blocked props (type-level)**
+\`mozExtensionDisplay\` and \`onOpenSettings\` are required for \`blocked\` even though only one branch uses them at runtime (Firefox vs Chromium).
+
+**Optional (both variants)**
+\`continueLoading\` — primary button loading/disabled state.
+\`rootPaddingHorizontal\` / \`rootPaddingBottom\` — outer wrapper padding on the design-system scale (default \`4\` each). Use \`0\` when embedded in a padded container (e.g. \`ModalBody\`).
+`.trim(),
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <Box
+        backgroundColor={BoxBackgroundColor.BackgroundDefault}
+        padding={4}
+        style={{ width: '100%', maxWidth: 400 }}
+      >
+        <Story />
+      </Box>
+    ),
+  ],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: [
+        CameraAccessErrorContentVariant.Needed,
+        CameraAccessErrorContentVariant.Blocked,
+      ],
+      description:
+        '`needed` — prompt dismissed. `blocked` — denied (UI branches on `isFirefox`).',
+    },
+    onContinue: {
+      action: 'onContinue',
+      description: 'Primary button handler. Label is always the `continue` locale string.',
+    },
+    continueLoading: {
+      control: 'boolean',
+      description: 'Disables the primary button and shows a loading state.',
+    },
+    rootPaddingHorizontal: {
+      control: { type: 'number', min: 0, max: 12, step: 1 },
+      description:
+        'Root horizontal padding (0–12). Default 4; use 0 inside padded parents.',
+    },
+    rootPaddingBottom: {
+      control: { type: 'number', min: 0, max: 12, step: 1 },
+      description:
+        'Root bottom padding (0–12). Default 4; use 0 inside padded parents.',
+    },
+    isFirefox: {
+      control: 'boolean',
+      description:
+        '`blocked` only: Firefox steps vs Chromium hint + Open settings.',
+      if: { arg: 'variant', eq: CameraAccessErrorContentVariant.Blocked },
+    },
+    mozExtensionDisplay: {
+      control: 'text',
+      description:
+        '`blocked` only: Firefox step 2; ignored when `isFirefox` is false.',
+      if: { arg: 'variant', eq: CameraAccessErrorContentVariant.Blocked },
+    },
+    onOpenSettings: {
+      action: 'onOpenSettings',
+      description: '`blocked` only: Chromium secondary; not shown for Firefox.',
+      if: { arg: 'variant', eq: CameraAccessErrorContentVariant.Blocked },
+    },
+  } as Meta<typeof CameraAccessErrorContent>['argTypes'],
+} satisfies Meta<typeof CameraAccessErrorContent>;
+
+export default meta;
+
+type Story = StoryObj<typeof CameraAccessErrorContent>;
+
+/** Default “needed” state; use Controls for `continueLoading` and root padding. */
+export const Needed: Story = {
+  args: {
+    variant: CameraAccessErrorContentVariant.Needed,
+    onContinue: () => undefined,
+  } satisfies CameraAccessErrorContentNeededProps,
+};
+
+/** Primary button in a loading state. */
+export const NeededContinueLoading: Story = {
+  storyName: 'Needed (continue loading)',
+  args: {
+    variant: CameraAccessErrorContentVariant.Needed,
+    continueLoading: true,
+    onContinue: () => undefined,
+  } satisfies CameraAccessErrorContentNeededProps,
+};
+
+export const BlockedChromium: Story = {
+  storyName: 'Blocked (Chrome / Chromium)',
+  args: {
+    variant: CameraAccessErrorContentVariant.Blocked,
+    isFirefox: false,
+    mozExtensionDisplay: '',
+    onContinue: () => undefined,
+    onOpenSettings: () => undefined,
+  } satisfies CameraAccessErrorContentBlockedProps,
+};
+
+export const BlockedFirefox: Story = {
+  storyName: 'Blocked (Firefox)',
+  args: {
+    variant: CameraAccessErrorContentVariant.Blocked,
+    isFirefox: true,
+    mozExtensionDisplay: MOZ_EXTENSION_DISPLAY_MOCK,
+    onContinue: () => undefined,
+    onOpenSettings: () => undefined,
+  } satisfies CameraAccessErrorContentBlockedProps,
+};

--- a/ui/components/app/camera-access-error-content/camera-access-error-content.test.tsx
+++ b/ui/components/app/camera-access-error-content/camera-access-error-content.test.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { renderWithLocalization } from '../../../../test/lib/render-helpers';
+import { enLocale as messages, tEn } from '../../../../test/lib/i18n-helpers';
+import {
+  CameraAccessErrorContent,
+  CameraAccessErrorContentVariant,
+} from './camera-access-error-content';
+
+describe('CameraAccessErrorContent', () => {
+  describe('needed variant', () => {
+    it('renders localized title, body, and continue control', async () => {
+      const user = userEvent.setup();
+      const onContinue = jest.fn();
+      renderWithLocalization(
+        <CameraAccessErrorContent
+          variant={CameraAccessErrorContentVariant.Needed}
+          onContinue={onContinue}
+        />,
+      );
+
+      expect(screen.getByTestId('qr-camera-access-needed')).toBeInTheDocument();
+      expect(
+        screen.getByText(messages.qrCameraAccessNeededTitle.message),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(messages.qrCameraAccessNeededBody.message),
+      ).toBeInTheDocument();
+      expect(screen.getByText(messages.continue.message)).toBeInTheDocument();
+      await user.click(screen.getByTestId('qr-camera-access-needed-continue'));
+      expect(onContinue).toHaveBeenCalledTimes(1);
+    });
+
+    it('accepts zero root padding without breaking layout', () => {
+      renderWithLocalization(
+        <CameraAccessErrorContent
+          variant={CameraAccessErrorContentVariant.Needed}
+          onContinue={jest.fn()}
+          rootPaddingHorizontal={0}
+          rootPaddingBottom={0}
+        />,
+      );
+
+      expect(screen.getByTestId('qr-camera-access-needed')).toBeInTheDocument();
+      expect(
+        screen.getByText(messages.qrCameraAccessNeededTitle.message),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('blocked variant', () => {
+    it('shows chromium hint and open settings when not Firefox', () => {
+      const onContinue = jest.fn();
+      const onOpenSettings = jest.fn();
+      renderWithLocalization(
+        <CameraAccessErrorContent
+          variant={CameraAccessErrorContentVariant.Blocked}
+          isFirefox={false}
+          mozExtensionDisplay=""
+          onOpenSettings={onOpenSettings}
+          onContinue={onContinue}
+        />,
+      );
+
+      expect(
+        screen.getByTestId('qr-camera-access-blocked'),
+      ).toBeInTheDocument();
+      expect(screen.getByTestId('qr-camera-chromium-hint')).toHaveTextContent(
+        messages.qrCameraAccessBlockedChromiumHint.message,
+      );
+      expect(
+        screen.getByTestId('qr-camera-chromium-hint-videocam'),
+      ).toBeInTheDocument();
+      expect(screen.getByTestId('qr-camera-open-settings')).toBeInTheDocument();
+      expect(
+        screen.queryByTestId('qr-camera-firefox-instructions'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('shows firefox instructions when Firefox', () => {
+      const mozOrigin = 'moz-extension://abc';
+      renderWithLocalization(
+        <CameraAccessErrorContent
+          variant={CameraAccessErrorContentVariant.Blocked}
+          isFirefox
+          mozExtensionDisplay={mozOrigin}
+          onOpenSettings={jest.fn()}
+          onContinue={jest.fn()}
+        />,
+      );
+
+      expect(
+        screen.getByTestId('qr-camera-firefox-instructions'),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(`1. ${tEn('qrCameraAccessBlockedFirefoxStep1', [])}`),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          `2. ${tEn('qrCameraAccessBlockedFirefoxStep2', [mozOrigin])}`,
+        ),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(`3. ${tEn('qrCameraAccessBlockedFirefoxStep3', [])}`),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByTestId('qr-camera-open-settings'),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/ui/components/app/camera-access-error-content/camera-access-error-content.tsx
+++ b/ui/components/app/camera-access-error-content/camera-access-error-content.tsx
@@ -1,0 +1,218 @@
+import React from 'react';
+import {
+  Box,
+  BoxAlignItems,
+  BoxBackgroundColor,
+  BoxFlexDirection,
+  BoxJustifyContent,
+  Button,
+  ButtonSize,
+  ButtonVariant,
+  FontWeight,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+  Text,
+  TextAlign,
+  TextColor,
+  TextVariant,
+  type BoxSpacing,
+} from '@metamask/design-system-react';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import {
+  CameraAccessErrorContentVariant,
+  type CameraAccessErrorContentProps,
+} from './camera-access-error-content.types';
+
+const DEFAULT_ROOT_PADDING: BoxSpacing = 4;
+
+export const CameraAccessErrorContent = (
+  props: CameraAccessErrorContentProps,
+) => {
+  const t = useI18nContext();
+  const { variant, onContinue, continueLoading = false } = props;
+
+  const rootPaddingHorizontal: BoxSpacing =
+    props.rootPaddingHorizontal ?? DEFAULT_ROOT_PADDING;
+  const rootPaddingBottom: BoxSpacing =
+    props.rootPaddingBottom ?? DEFAULT_ROOT_PADDING;
+
+  const isBlocked = variant === CameraAccessErrorContentVariant.Blocked;
+  const isFirefox = isBlocked && props.isFirefox;
+  const showChromiumActions = isBlocked && !props.isFirefox;
+
+  const rootTestId =
+    variant === CameraAccessErrorContentVariant.Needed
+      ? 'qr-camera-access-needed'
+      : 'qr-camera-access-blocked';
+
+  const title =
+    variant === CameraAccessErrorContentVariant.Needed
+      ? t('qrCameraAccessNeededTitle')
+      : t('qrCameraAccessBlockedTitle');
+
+  let body: string;
+  if (variant === CameraAccessErrorContentVariant.Needed) {
+    body = t('qrCameraAccessNeededBody');
+  } else {
+    body = t('qrCameraAccessBlockedBody');
+  }
+
+  const firefoxSteps =
+    variant === CameraAccessErrorContentVariant.Blocked && isFirefox
+      ? [
+          t('qrCameraAccessBlockedFirefoxStep1'),
+          t('qrCameraAccessBlockedFirefoxStep2', [props.mozExtensionDisplay]),
+          t('qrCameraAccessBlockedFirefoxStep3'),
+        ]
+      : [];
+
+  const chromiumHintText = showChromiumActions
+    ? t('qrCameraAccessBlockedChromiumHint')
+    : '';
+
+  const openSettingsLabel = showChromiumActions ? t('openSettings') : '';
+
+  const handleOpenSettings = showChromiumActions
+    ? props.onOpenSettings
+    : undefined;
+
+  return (
+    <Box
+      data-testid={rootTestId}
+      flexDirection={BoxFlexDirection.Column}
+      paddingHorizontal={rootPaddingHorizontal}
+      paddingBottom={rootPaddingBottom}
+      style={{ width: '100%' }}
+    >
+      <Box
+        flexDirection={BoxFlexDirection.Column}
+        alignItems={BoxAlignItems.Center}
+        paddingBottom={2}
+      >
+        <Icon
+          name={IconName.Camera}
+          color={IconColor.IconDefault}
+          size={IconSize.Xl}
+        />
+      </Box>
+      <Box paddingTop={2} paddingBottom={2}>
+        <Text
+          variant={TextVariant.HeadingMd}
+          fontWeight={FontWeight.Medium}
+          textAlign={TextAlign.Center}
+          color={TextColor.TextDefault}
+        >
+          {title}
+        </Text>
+      </Box>
+      <Box padding={3}>
+        <Text
+          variant={TextVariant.BodyMd}
+          textAlign={TextAlign.Center}
+          color={TextColor.TextDefault}
+        >
+          {body}
+        </Text>
+      </Box>
+      {isBlocked && isFirefox ? (
+        <Box
+          data-testid="qr-camera-firefox-instructions"
+          flexDirection={BoxFlexDirection.Column}
+          gap={2}
+          marginTop={2}
+          padding={3}
+          backgroundColor={BoxBackgroundColor.BackgroundAlternative}
+          style={{ borderRadius: 8 }}
+        >
+          {firefoxSteps.map((step, index) => (
+            <Text
+              key={`firefox-camera-step-${index}`}
+              variant={TextVariant.BodyMd}
+              textAlign={TextAlign.Left}
+              color={TextColor.TextDefault}
+            >
+              {`${index + 1}. ${step}`}
+            </Text>
+          ))}
+        </Box>
+      ) : null}
+      {showChromiumActions ? (
+        <Box
+          data-testid="qr-camera-chromium-hint"
+          flexDirection={BoxFlexDirection.Column}
+          marginTop={2}
+          padding={3}
+          backgroundColor={BoxBackgroundColor.BackgroundAlternative}
+          style={{ borderRadius: 8 }}
+        >
+          <Box
+            flexDirection={BoxFlexDirection.Row}
+            gap={3}
+            alignItems={BoxAlignItems.Center}
+          >
+            <Box
+              data-testid="qr-camera-chromium-hint-videocam"
+              flexDirection={BoxFlexDirection.Row}
+              alignItems={BoxAlignItems.Center}
+              justifyContent={BoxJustifyContent.Center}
+              backgroundColor={BoxBackgroundColor.BackgroundMuted}
+              style={{
+                width: 40,
+                height: 40,
+                borderRadius: 8,
+                flexShrink: 0,
+              }}
+            >
+              <Icon
+                name={IconName.Videocam}
+                color={IconColor.IconDefault}
+                size={IconSize.Md}
+              />
+            </Box>
+            <Box style={{ flex: 1, minWidth: 0 }}>
+              <Text
+                variant={TextVariant.BodyMd}
+                textAlign={TextAlign.Left}
+                color={TextColor.TextDefault}
+              >
+                {chromiumHintText}
+              </Text>
+            </Box>
+          </Box>
+        </Box>
+      ) : null}
+      <Box flexDirection={BoxFlexDirection.Column} gap={3} marginTop={4}>
+        {showChromiumActions && handleOpenSettings ? (
+          <Button
+            size={ButtonSize.Lg}
+            variant={ButtonVariant.Secondary}
+            onClick={handleOpenSettings}
+            data-testid="qr-camera-open-settings"
+            isFullWidth
+          >
+            {openSettingsLabel}
+          </Button>
+        ) : null}
+        <Button
+          size={ButtonSize.Lg}
+          variant={ButtonVariant.Primary}
+          onClick={onContinue}
+          isLoading={continueLoading}
+          isDisabled={continueLoading}
+          data-testid={
+            variant === CameraAccessErrorContentVariant.Needed
+              ? 'qr-camera-access-needed-continue'
+              : 'qr-camera-blocked-continue'
+          }
+          isFullWidth
+        >
+          {t('continue')}
+        </Button>
+      </Box>
+    </Box>
+  );
+};
+
+export { CameraAccessErrorContentVariant } from './camera-access-error-content.types';

--- a/ui/components/app/camera-access-error-content/camera-access-error-content.tsx
+++ b/ui/components/app/camera-access-error-content/camera-access-error-content.tsx
@@ -27,6 +27,172 @@ import {
 
 const DEFAULT_ROOT_PADDING: BoxSpacing = 4;
 
+type TranslateFn = ReturnType<typeof useI18nContext>;
+
+type FirefoxInstructionStep = {
+  id: string;
+  order: number;
+  text: string;
+};
+
+/**
+ * Resolves root test id, title, and body copy for the camera access variant.
+ *
+ * @param variant - Needed vs blocked UI branch.
+ * @param t - i18n `t` from `useI18nContext`.
+ * @returns Root `data-testid` plus localized title and body.
+ */
+function resolveCameraAccessCopy(
+  variant: CameraAccessErrorContentVariant,
+  t: TranslateFn,
+): { rootTestId: string; title: string; body: string } {
+  const isNeeded = variant === CameraAccessErrorContentVariant.Needed;
+  return {
+    rootTestId: isNeeded
+      ? 'qr-camera-access-needed'
+      : 'qr-camera-access-blocked',
+    title: isNeeded
+      ? t('qrCameraAccessNeededTitle')
+      : t('qrCameraAccessBlockedTitle'),
+    body: isNeeded
+      ? t('qrCameraAccessNeededBody')
+      : t('qrCameraAccessBlockedBody'),
+  };
+}
+
+/**
+ * Builds numbered Firefox permission instructions with stable row ids for list keys.
+ *
+ * @param t - i18n `t` from `useI18nContext`.
+ * @param mozExtensionDisplay - Extension origin string shown in Firefox step 2.
+ * @returns Rows for `renderFirefoxCameraInstructions` (`id`, `order`, `text`).
+ */
+function buildFirefoxInstructionSteps(
+  t: TranslateFn,
+  mozExtensionDisplay: string,
+): FirefoxInstructionStep[] {
+  return [
+    {
+      id: 'qr-camera-firefox-step-permissions',
+      order: 1,
+      text: t('qrCameraAccessBlockedFirefoxStep1'),
+    },
+    {
+      id: 'qr-camera-firefox-step-extension-url',
+      order: 2,
+      text: t('qrCameraAccessBlockedFirefoxStep2', [mozExtensionDisplay]),
+    },
+    {
+      id: 'qr-camera-firefox-step-reload',
+      order: 3,
+      text: t('qrCameraAccessBlockedFirefoxStep3'),
+    },
+  ];
+}
+
+/**
+ * Returns the `data-testid` for the primary continue button by variant.
+ *
+ * @param variant - Needed vs blocked UI branch.
+ * @returns Continue button `data-testid` string.
+ */
+function continueButtonTestId(
+  variant: CameraAccessErrorContentVariant,
+): string {
+  return variant === CameraAccessErrorContentVariant.Needed
+    ? 'qr-camera-access-needed-continue'
+    : 'qr-camera-blocked-continue';
+}
+
+/**
+ * Renders the Firefox blocked-state numbered instruction list.
+ *
+ * @param params - List props.
+ * @param params.steps - Instruction rows (`id`, `order`, `text`).
+ */
+function renderFirefoxCameraInstructions(params: {
+  steps: readonly FirefoxInstructionStep[];
+}) {
+  const { steps } = params;
+  return (
+    <Box
+      data-testid="qr-camera-firefox-instructions"
+      flexDirection={BoxFlexDirection.Column}
+      gap={2}
+      marginTop={2}
+      padding={3}
+      backgroundColor={BoxBackgroundColor.BackgroundAlternative}
+      style={{ borderRadius: 8 }}
+    >
+      {steps.map((step) => (
+        <Text
+          key={step.id}
+          variant={TextVariant.BodyMd}
+          textAlign={TextAlign.Left}
+          color={TextColor.TextDefault}
+        >
+          {`${step.order}. ${step.text}`}
+        </Text>
+      ))}
+    </Box>
+  );
+}
+
+/**
+ * Renders the Chromium blocked-state hint callout with videocam icon.
+ *
+ * @param params - Hint props.
+ * @param params.hintText - Localized Chromium blocked-state hint body.
+ */
+function renderChromiumCameraHint(params: { hintText: string }) {
+  const { hintText } = params;
+  return (
+    <Box
+      data-testid="qr-camera-chromium-hint"
+      flexDirection={BoxFlexDirection.Column}
+      marginTop={2}
+      padding={3}
+      backgroundColor={BoxBackgroundColor.BackgroundAlternative}
+      style={{ borderRadius: 8 }}
+    >
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        gap={3}
+        alignItems={BoxAlignItems.Center}
+      >
+        <Box
+          data-testid="qr-camera-chromium-hint-videocam"
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          justifyContent={BoxJustifyContent.Center}
+          backgroundColor={BoxBackgroundColor.BackgroundMuted}
+          style={{
+            width: 40,
+            height: 40,
+            borderRadius: 8,
+            flexShrink: 0,
+          }}
+        >
+          <Icon
+            name={IconName.Videocam}
+            color={IconColor.IconDefault}
+            size={IconSize.Md}
+          />
+        </Box>
+        <Box style={{ flex: 1, minWidth: 0 }}>
+          <Text
+            variant={TextVariant.BodyMd}
+            textAlign={TextAlign.Left}
+            color={TextColor.TextDefault}
+          >
+            {hintText}
+          </Text>
+        </Box>
+      </Box>
+    </Box>
+  );
+}
+
 export const CameraAccessErrorContent = (
   props: CameraAccessErrorContentProps,
 ) => {
@@ -42,30 +208,11 @@ export const CameraAccessErrorContent = (
   const isFirefox = isBlocked && props.isFirefox;
   const showChromiumActions = isBlocked && !props.isFirefox;
 
-  const rootTestId =
-    variant === CameraAccessErrorContentVariant.Needed
-      ? 'qr-camera-access-needed'
-      : 'qr-camera-access-blocked';
-
-  const title =
-    variant === CameraAccessErrorContentVariant.Needed
-      ? t('qrCameraAccessNeededTitle')
-      : t('qrCameraAccessBlockedTitle');
-
-  let body: string;
-  if (variant === CameraAccessErrorContentVariant.Needed) {
-    body = t('qrCameraAccessNeededBody');
-  } else {
-    body = t('qrCameraAccessBlockedBody');
-  }
+  const { rootTestId, title, body } = resolveCameraAccessCopy(variant, t);
 
   const firefoxSteps =
-    variant === CameraAccessErrorContentVariant.Blocked && isFirefox
-      ? [
-          t('qrCameraAccessBlockedFirefoxStep1'),
-          t('qrCameraAccessBlockedFirefoxStep2', [props.mozExtensionDisplay]),
-          t('qrCameraAccessBlockedFirefoxStep3'),
-        ]
+    isBlocked && isFirefox
+      ? buildFirefoxInstructionSteps(t, props.mozExtensionDisplay)
       : [];
 
   const chromiumHintText = showChromiumActions
@@ -116,73 +263,12 @@ export const CameraAccessErrorContent = (
           {body}
         </Text>
       </Box>
-      {isBlocked && isFirefox ? (
-        <Box
-          data-testid="qr-camera-firefox-instructions"
-          flexDirection={BoxFlexDirection.Column}
-          gap={2}
-          marginTop={2}
-          padding={3}
-          backgroundColor={BoxBackgroundColor.BackgroundAlternative}
-          style={{ borderRadius: 8 }}
-        >
-          {firefoxSteps.map((step, index) => (
-            <Text
-              key={`firefox-camera-step-${index}`}
-              variant={TextVariant.BodyMd}
-              textAlign={TextAlign.Left}
-              color={TextColor.TextDefault}
-            >
-              {`${index + 1}. ${step}`}
-            </Text>
-          ))}
-        </Box>
-      ) : null}
-      {showChromiumActions ? (
-        <Box
-          data-testid="qr-camera-chromium-hint"
-          flexDirection={BoxFlexDirection.Column}
-          marginTop={2}
-          padding={3}
-          backgroundColor={BoxBackgroundColor.BackgroundAlternative}
-          style={{ borderRadius: 8 }}
-        >
-          <Box
-            flexDirection={BoxFlexDirection.Row}
-            gap={3}
-            alignItems={BoxAlignItems.Center}
-          >
-            <Box
-              data-testid="qr-camera-chromium-hint-videocam"
-              flexDirection={BoxFlexDirection.Row}
-              alignItems={BoxAlignItems.Center}
-              justifyContent={BoxJustifyContent.Center}
-              backgroundColor={BoxBackgroundColor.BackgroundMuted}
-              style={{
-                width: 40,
-                height: 40,
-                borderRadius: 8,
-                flexShrink: 0,
-              }}
-            >
-              <Icon
-                name={IconName.Videocam}
-                color={IconColor.IconDefault}
-                size={IconSize.Md}
-              />
-            </Box>
-            <Box style={{ flex: 1, minWidth: 0 }}>
-              <Text
-                variant={TextVariant.BodyMd}
-                textAlign={TextAlign.Left}
-                color={TextColor.TextDefault}
-              >
-                {chromiumHintText}
-              </Text>
-            </Box>
-          </Box>
-        </Box>
-      ) : null}
+      {firefoxSteps.length > 0
+        ? renderFirefoxCameraInstructions({ steps: firefoxSteps })
+        : null}
+      {showChromiumActions
+        ? renderChromiumCameraHint({ hintText: chromiumHintText })
+        : null}
       <Box flexDirection={BoxFlexDirection.Column} gap={3} marginTop={4}>
         {showChromiumActions && handleOpenSettings ? (
           <Button
@@ -201,11 +287,7 @@ export const CameraAccessErrorContent = (
           onClick={onContinue}
           isLoading={continueLoading}
           isDisabled={continueLoading}
-          data-testid={
-            variant === CameraAccessErrorContentVariant.Needed
-              ? 'qr-camera-access-needed-continue'
-              : 'qr-camera-blocked-continue'
-          }
+          data-testid={continueButtonTestId(variant)}
           isFullWidth
         >
           {t('continue')}

--- a/ui/components/app/camera-access-error-content/camera-access-error-content.types.ts
+++ b/ui/components/app/camera-access-error-content/camera-access-error-content.types.ts
@@ -1,0 +1,43 @@
+import type { BoxSpacing } from '@metamask/design-system-react';
+
+export enum CameraAccessErrorContentVariant {
+  Needed = 'needed',
+  Blocked = 'blocked',
+}
+
+/** Optional root `Box` padding (design-system spacing scale). Both variants support these. */
+export type CameraAccessErrorContentRootLayoutProps = {
+  /**
+   * Horizontal padding on the outermost wrapper. Default `4`.
+   * Use `0` when a parent already provides horizontal padding (e.g. `ModalBody`).
+   */
+  rootPaddingHorizontal?: BoxSpacing;
+  /**
+   * Bottom padding on the outermost wrapper. Default `4`.
+   * Use `0` when a parent already provides bottom padding.
+   */
+  rootPaddingBottom?: BoxSpacing;
+};
+
+export type CameraAccessErrorContentNeededProps =
+  CameraAccessErrorContentRootLayoutProps & {
+    variant: CameraAccessErrorContentVariant.Needed;
+    onContinue: () => void | Promise<void>;
+    continueLoading?: boolean;
+  };
+
+export type CameraAccessErrorContentBlockedProps =
+  CameraAccessErrorContentRootLayoutProps & {
+    variant: CameraAccessErrorContentVariant.Blocked;
+    isFirefox: boolean;
+    onContinue: () => void | Promise<void>;
+    continueLoading?: boolean;
+    /** Used for Firefox step 2; ignored when `isFirefox` is false. */
+    mozExtensionDisplay: string;
+    /** Used for Chromium “Open settings”; ignored when `isFirefox` is true. */
+    onOpenSettings: () => void;
+  };
+
+export type CameraAccessErrorContentProps =
+  | CameraAccessErrorContentNeededProps
+  | CameraAccessErrorContentBlockedProps;

--- a/ui/components/app/camera-access-error-content/index.ts
+++ b/ui/components/app/camera-access-error-content/index.ts
@@ -1,0 +1,8 @@
+export { CameraAccessErrorContent } from './camera-access-error-content';
+export {
+  CameraAccessErrorContentVariant,
+  type CameraAccessErrorContentProps,
+  type CameraAccessErrorContentNeededProps,
+  type CameraAccessErrorContentBlockedProps,
+  type CameraAccessErrorContentRootLayoutProps,
+} from './camera-access-error-content.types';


### PR DESCRIPTION
## **Description**
This PR adds new component which is used to display specific variations of content required for QR hardware wallet recovery flow and errors related to camera access.

This component will be **shared** and used in **several different places** related to the hardware wallet error modal and base reader (camera QR reading functionality).

This component represents only content for the modals. We're using different approaches for modals where this component will be used and these content boxes (modals) will just use this content. For that reason, this component has no background and other parent elements.

This is split from the other PR which is still WIP: https://github.com/MetaMask/metamask-extension/pull/41612

This PR will not affect anything functional and it is not introducing any changes to the existing code. It is only adding independent UI component.

## **Changelog**
<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**
Fixes: n/a

## **Manual testing steps**
1. Run `yarn storybook`
2. Check `CameraAccessErrorContent` component.

## **Screenshots/Recordings**

### **Before**
This component did not exist before. Nothing to show here.

### **After**
<img width="1032" height="935" alt="Screenshot 2026-04-15 at 00 44 50" src="https://github.com/user-attachments/assets/689ce0e1-26b8-4c8d-91b8-a1620f5d8a58" />
<img width="1034" height="592" alt="Screenshot 2026-04-15 at 01 04 45" src="https://github.com/user-attachments/assets/68127eda-1248-4382-82fa-6dd14008650f" />
<img width="1032" height="623" alt="Screenshot 2026-04-15 at 01 04 28" src="https://github.com/user-attachments/assets/2d2888a8-aca3-4908-94bc-37b932cb6438" />

## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new self-contained UI component plus locale strings, Storybook stories, and unit tests; no existing flows or security/data-handling logic are modified.
> 
> **Overview**
> Adds a new `CameraAccessErrorContent` component to standardize QR scanner camera-permission error messaging, with `needed` (re-request permission) and `blocked` (denied) variants and browser-specific blocked guidance (Firefox steps vs Chromium hint + “Open settings”).
> 
> Introduces new i18n strings for these messages in `en` and `en_GB`, and adds Storybook coverage plus unit tests for rendering and action wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c61caccb374aceb49595f11765d8f9edd1b8ed0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->