### PR TITLE
docs(ab-testing): align extension guide with onboarding format

### DIFF
--- a/docs/ab-testing.md
+++ b/docs/ab-testing.md
@@ -11,8 +11,8 @@ example. The rest of the document explains the rules behind that workflow.
 Use this order every time:
 
 1. Create a remote JSON flag named `{teamName}{TICKET}Abtest{TestName}`.
-2. Add a feature-local config module that keeps the flag key, variants, and
-   any analytics mapping together.
+2. Add a single experiment config module in
+   `shared/lib/ab-testing/configs/`.
 3. In the feature, call `useABTest(flagKey, variants)`.
 4. If the feature sends business events through the shared MetaMetrics path,
    register an `ABTestAnalyticsMapping` in background-safe shared code used by
@@ -26,7 +26,8 @@ Use this order every time:
 
 Most A/B tests change only these places:
 
-- A feature-local config module, often something like `abTestConfig.ts`
+- A single background-safe shared experiment config module in
+  `shared/lib/ab-testing/configs/`
 - The feature component or hook that consumes `useABTest`
 - Background-safe shared analytics mapping code used by
   `shared/lib/ab-testing/ab-test-analytics.ts`
@@ -53,8 +54,11 @@ This is the smallest complete pattern for a new extension A/B test.
 
 ### 1. Create the config module
 
-Keep the test definition in one place. This keeps the flag key, variants, and
-analytics mapping in sync.
+Keep the flag key, variants, and analytics mapping together in one
+background-safe shared module, for example
+`shared/lib/ab-testing/configs/swaps-button-color.ts`. This is the standard
+pattern for extension A/B tests because the same config must be safe to import
+from both UI code and background analytics code.
 
 ```typescript
 import type { ABTestAnalyticsMapping } from '../../../shared/lib/ab-testing/ab-test-analytics';
@@ -114,10 +118,13 @@ Important behavior:
 ### 3. Register business-event auto-enrichment
 
 If the feature tracks business events through the shared MetaMetrics path,
-register the mapping in background-safe shared code:
+register the mapping in background-safe shared code and keep existing mappings
+intact:
 
 ```typescript
+// In shared/lib/ab-testing/ab-test-analytics.ts
 export const AB_TEST_ANALYTICS_MAPPINGS: ABTestAnalyticsMapping[] = [
+  // Existing mappings...
   FEATURE_AB_TEST_ANALYTICS_MAPPING,
 ];
 ```
@@ -134,7 +141,8 @@ trackEvent({
 ### 4. Handle bypass paths manually
 
 If an event bypasses the shared MetaMetrics enrichment path, add
-`active_ab_tests` yourself:
+`active_ab_tests` yourself. Do not copy this pattern for `trackEvent(...)`
+calls that already flow through shared enrichment.
 
 ```typescript
 const activeABTests = isActive
@@ -146,12 +154,9 @@ const activeABTests = isActive
     ]
   : undefined;
 
-trackEvent({
-  event: MetaMetricsEventName.TransactionSubmitted,
-  category: MetaMetricsEventCategory.Swaps,
-  properties: {
-    ...(activeABTests && { active_ab_tests: activeABTests }),
-  },
+sendCustomAnalyticsPayload({
+  event: 'Custom Swap Metric',
+  ...(activeABTests && { active_ab_tests: activeABTests }),
 });
 ```
 

--- a/docs/ab-testing.md
+++ b/docs/ab-testing.md
@@ -1,84 +1,175 @@
-# A/B Testing Framework
+# A/B Testing in MetaMask Extension
 
-Generic A/B testing guidance for the MetaMask extension.
+This is the canonical guide for implementing A/B tests in the MetaMask
+extension.
 
-## Current Analytics Standard
+If you are adding a new test, start with the quickstart and the end-to-end
+example. The rest of the document explains the rules behind that workflow.
 
-Use these two mechanisms together:
+## Quickstart
 
-1. Automatic exposure event: `Experiment Viewed`
-2. Business event context: `active_ab_tests`
+Use this order every time:
 
-`ab_tests` is legacy and should not be used for new extension instrumentation.
+1. Create a remote JSON flag named `{teamName}{TICKET}Abtest{TestName}`.
+2. Add a feature-local config module that keeps the flag key, variants, and
+   any analytics mapping together.
+3. In the feature, call `useABTest(flagKey, variants)`.
+4. If the feature sends business events through the shared MetaMetrics path,
+   register an `ABTestAnalyticsMapping` in background-safe shared code used by
+   `shared/lib/ab-testing/ab-test-analytics.ts`.
+5. If the feature uses a custom tracking path that bypasses shared MetaMetrics
+   enrichment, attach `active_ab_tests` manually on that event.
+6. Update targeted tests, the E2E feature-flag registry, and local override
+   guidance when needed.
 
-## References
+## What You Need to Touch
 
-- [Remote feature flags contributor docs](https://github.com/MetaMask/contributor-docs/blob/main/docs/remote-feature-flags.md)
-- `test/e2e/feature-flags/feature-flag-registry.ts`
-- `test/e2e/tests/remote-feature-flag/remote-feature-flag.spec.ts`
+Most A/B tests change only these places:
 
-## Agent Note
+- A feature-local config module, often something like `abTestConfig.ts`
+- The feature component or hook that consumes `useABTest`
+- Background-safe shared analytics mapping code used by
+  `shared/lib/ab-testing/ab-test-analytics.ts`
+- Tests for the feature, analytics enrichment, or hook behavior when behavior
+  or instrumentation changes
+- `test/e2e/feature-flags/feature-flag-registry.ts` for the
+  production-accurate default flag value
 
-Agent workflow lives in `.agents/skills/ab-testing-implementation/SKILL.md`.
-Keep this document focused on human-readable implementation guidance, background behavior, examples, and FAQ.
+## Definition of Done
 
----
+An A/B test is ready when all of these are true:
 
-## How Variant Assignment Works
+- The remote JSON flag exists and uses the threshold-array format shown below
+- The feature reads assignment through `useABTest`
+- The variants object includes a `control` variant
+- Shared MetaMetrics events are registered for auto-enrichment when needed
+- Custom tracker events attach `active_ab_tests` manually when active
+- Relevant tests were added or updated when behavior or analytics wiring changed
+- The E2E feature-flag registry includes the production default value
 
-The extension receives remote feature flags through
-`@metamask/remote-feature-flag-controller`, which fetches flags from the
-client-config API.
+## End-to-End Example
 
-For A/B tests, the controller does client-side bucketing from a JSON array value:
+This is the smallest complete pattern for a new extension A/B test.
 
-1. The remote flag returns an array where each item has `scope.value` from `0` to `1`.
-2. The controller hashes `sha256(metaMetricsId + flagName)` to produce a deterministic threshold.
-3. The controller selects the first array item where `userThreshold <= scope.value`.
-4. The selected assignment is stored in `metamask.remoteFeatureFlags` as `{ name, value }`.
+### 1. Create the config module
 
-Example remote flag value:
-
-```json
-[
-  {
-    "name": "control",
-    "scope": { "type": "threshold", "value": 0.5 }
-  },
-  {
-    "name": "treatment",
-    "scope": { "type": "threshold", "value": 1.0 }
-  }
-]
-```
-
-`useABTest` reads the processed assignment's `name` field and maps it to your
-locally defined `variants` object.
-
-If the user does not have a valid assignment yet, the flag is missing, the
-value is invalid, or the controller did not produce a `{ name, value }`
-assignment, the hook falls back to `control` and reports `isActive: false`.
-
----
-
-## `useABTest` Hook
+Keep the test definition in one place. This keeps the flag key, variants, and
+analytics mapping in sync.
 
 ```typescript
-const quickAmountsTest = useABTest(
-  'swapsSWAPS4135AbtestNumpadQuickAmounts',
+import type { ABTestAnalyticsMapping } from '../../../shared/lib/ab-testing/ab-test-analytics';
+import { MetaMetricsEventName } from '../../../shared/constants/metametrics';
+
+export const FEATURE_AB_TEST_KEY = 'swapsSWAPS4135AbtestButtonColor';
+
+export enum FeatureVariant {
+  Control = 'control',
+  Treatment = 'treatment',
+}
+
+type FeatureVariantConfig = {
+  color: string;
+};
+
+export const FEATURE_VARIANTS: Record<FeatureVariant, FeatureVariantConfig> = {
+  [FeatureVariant.Control]: { color: 'green' },
+  [FeatureVariant.Treatment]: { color: 'blue' },
+};
+
+export const FEATURE_AB_TEST_ANALYTICS_MAPPING: ABTestAnalyticsMapping = {
+  flagKey: FEATURE_AB_TEST_KEY,
+  validVariants: Object.values(FeatureVariant),
+  eventNames: [MetaMetricsEventName.TransactionSubmitted],
+};
+```
+
+### 2. Use `useABTest` in the feature
+
+`useABTest` is the supported way to resolve the assignment in UI code.
+
+```typescript
+const { variant, variantName, isActive } = useABTest(
+  FEATURE_AB_TEST_KEY,
+  FEATURE_VARIANTS,
   {
-    control: { buttons: [25, 50, 75, 'MAX'] },
-    treatment: { buttons: [50, 75, 90, 'MAX'] },
-  },
-  {
-    experimentName: 'Swaps Quick Amounts',
+    experimentName: 'Button Color Test',
     variationNames: {
-      control: 'Control',
-      treatment: 'Larger Presets',
+      control: 'Green button color',
+      treatment: 'Blue button color',
     },
   },
 );
+
+const buttonColor = variant.color;
 ```
+
+Important behavior:
+
+- `control` is the fallback when the flag is missing, invalid, or unresolved
+- `isActive` is `true` only when the remote assignment matches a declared
+  variant
+- `useABTest` automatically emits `Experiment Viewed` once per
+  `experiment_id + variation_id` pair per extension session
+
+### 3. Register business-event auto-enrichment
+
+If the feature tracks business events through the shared MetaMetrics path,
+register the mapping in background-safe shared code:
+
+```typescript
+export const AB_TEST_ANALYTICS_MAPPINGS: ABTestAnalyticsMapping[] = [
+  FEATURE_AB_TEST_ANALYTICS_MAPPING,
+];
+```
+
+After this, shared MetaMetrics events are enriched automatically:
+
+```typescript
+trackEvent({
+  event: MetaMetricsEventName.TransactionSubmitted,
+  category: MetaMetricsEventCategory.Swaps,
+});
+```
+
+### 4. Handle bypass paths manually
+
+If an event bypasses the shared MetaMetrics enrichment path, add
+`active_ab_tests` yourself:
+
+```typescript
+const activeABTests = isActive
+  ? [
+      {
+        key: FEATURE_AB_TEST_KEY,
+        value: variantName,
+      },
+    ]
+  : undefined;
+
+trackEvent({
+  event: MetaMetricsEventName.TransactionSubmitted,
+  category: MetaMetricsEventCategory.Swaps,
+  properties: {
+    ...(activeABTests && { active_ab_tests: activeABTests }),
+  },
+});
+```
+
+## The Rules That Matter
+
+### 1. Use `useABTest`
+
+Do this:
+
+- Call `useABTest(flagKey, variants)` from the feature code
+- Always provide a `control` variant
+- Use the returned `variant`, `variantName`, and `isActive` to drive UI
+  behavior
+
+Do not do this:
+
+- Do not read raw flag values directly in feature code
+- Do not manually emit `Experiment Viewed` when using `useABTest`
 
 API:
 
@@ -97,157 +188,106 @@ function useABTest<T extends { control: unknown } & Record<string, unknown>>(
 };
 ```
 
-Behavior:
+The hook supports both processed controller assignments like `{ name, value }`
+and legacy string assignments for backward compatibility.
 
-- Fallback is always `control`.
-- `isActive` is `true` only when the remote assignment matches a defined variant.
-- The hook supports both processed controller objects like `{ name, value }` and
-  legacy string values for backward compatibility.
-- When active, the hook emits `Experiment Viewed` once per
-  `experiment_id + variation_id` pair per extension session.
+### 2. Use `active_ab_tests` for business events
 
----
+There are two analytics mechanisms, and new tests usually need both:
 
-## Automatic Exposure Event
+1. Exposure event: `Experiment Viewed`
+2. Business-event context: `active_ab_tests`
 
-`useABTest` automatically emits this event for active assignments:
+Events are auto-enriched when:
 
-- `event`: `Experiment Viewed`
-- `category`: `Analytics`
-- required properties:
-  - `experiment_id`
-  - `variation_id`
-- optional properties:
-  - `experiment_name`
-  - `variation_name`
+- the event flows through `MetaMetricsContext.trackEvent` or
+  `MetaMetricsController:trackEvent`
+- and the event name is registered in background-safe shared analytics mapping
+  code
 
-You should not manually fire duplicate exposure events for experiments that use
-`useABTest`.
+If an event bypasses that shared path, attach `active_ab_tests` manually.
 
----
+### 3. Do not add new `ab_tests` payloads
 
-## Business Event Instrumentation
+`ab_tests` is legacy and should not be used for new payload additions.
 
-For page views, clicks, submits, conversions, and any other business events,
-use `active_ab_tests`.
-
-Shape:
+Use this shape instead:
 
 ```typescript
 type ActiveABTest = Array<{ key: string; value: string }>;
 ```
 
-### Shared MetaMetrics auto-enrichment
-
-The extension auto-injects `active_ab_tests` for allowlisted `trackEvent`
-payloads sent through `MetaMetricsContext.trackEvent` or direct
-`MetaMetricsController:trackEvent` callers.
-
-Define these mappings in background-safe shared code so the background
-MetaMetrics controller can import them:
+Correct:
 
 ```typescript
-export type ABTestAnalyticsMapping = {
-  flagKey: string;
-  validVariants: readonly string[];
-  eventNames: readonly string[];
+active_ab_tests: [{ key: FEATURE_AB_TEST_KEY, value: variantName }];
+```
+
+Incorrect:
+
+```typescript
+ab_tests: {
+  swapsSWAPS4135AbtestButtonColor: 'control',
 };
+```
 
-export const AB_TEST_ANALYTICS_MAPPINGS: ABTestAnalyticsMapping[] = [
+## Remote Flag Setup
+
+### Flag naming
+
+Use this format:
+
+`{teamName}{ticketId}Abtest{TestName}`
+
+Example:
+
+`swapsSWAPS4135AbtestButtonColor`
+
+Rules:
+
+- `teamName`: lower camel team token, for example `swaps`
+- `ticketId`: uppercase project key plus number, for example `SWAPS4135`
+- literal segment: exact `Abtest`
+- `TestName`: semantic PascalCase name
+
+### Flag value
+
+Create a JSON flag and use the threshold-array format:
+
+```json
+[
   {
-    flagKey: 'swapsSWAPS4135AbtestNumpadQuickAmounts',
-    validVariants: ['control', 'treatment'],
-    eventNames: ['Unified SwapBridge Page Viewed'],
+    "name": "control",
+    "scope": { "type": "threshold", "value": 0.5 }
   },
-];
+  {
+    "name": "treatment",
+    "scope": { "type": "threshold", "value": 1.0 }
+  }
+]
 ```
 
-When an event name is allowlisted and the current assignment is active, the
-controller injects:
+### How assignment works
 
-```typescript
-active_ab_tests: [{ key: flagKey, value: variantName }];
-```
+The extension receives remote feature flags through
+`@metamask/remote-feature-flag-controller`, which fetches flags from the
+client-config API.
 
-### Manual fallback for bypass paths
+For A/B tests, the controller performs client-side bucketing from the JSON
+array value:
 
-If an event does not flow through the shared MetaMetrics event path, attach
-`active_ab_tests` manually.
+1. The remote flag returns an array where each item has `scope.value` from `0`
+   to `1`.
+2. The controller hashes `sha256(metaMetricsId + flagName)` to produce a
+   deterministic threshold.
+3. The controller selects the first array item where `userThreshold <= scope.value`.
+4. The selected assignment is stored in `metamask.remoteFeatureFlags` as
+   `{ name, value }`.
 
-Single test example:
+`useABTest` reads the processed assignment's `name` field and maps it to the
+locally defined `variants` object.
 
-```typescript
-const quickAmountsTest = useABTest('swapsSWAPS4135AbtestNumpadQuickAmounts', {
-  control: { buttons: [25, 50, 75, 'MAX'] },
-  treatment: { buttons: [50, 75, 90, 'MAX'] },
-});
-
-const activeABTests = quickAmountsTest.isActive
-  ? [
-      {
-        key: 'swapsSWAPS4135AbtestNumpadQuickAmounts',
-        value: quickAmountsTest.variantName,
-      },
-    ]
-  : undefined;
-
-trackEvent({
-  event: MetaMetricsEventName.TransactionSubmitted,
-  category: MetaMetricsEventCategory.Swaps,
-  properties: {
-    ...(activeABTests && { active_ab_tests: activeABTests }),
-  },
-});
-```
-
-Multiple concurrent tests:
-
-```typescript
-const buttonColorTest = useABTest('swapsSWAPS4135AbtestButtonColor', {
-  control: { color: 'green' },
-  treatment: { color: 'blue' },
-});
-
-const ctaTextTest = useABTest('swapsSWAPS4135AbtestCtaText', {
-  control: { text: 'Get Started' },
-  urgent: { text: 'Start Now' },
-});
-
-const activeABTests = [
-  ...(buttonColorTest.isActive
-    ? [
-        {
-          key: 'swapsSWAPS4135AbtestButtonColor',
-          value: buttonColorTest.variantName,
-        },
-      ]
-    : []),
-  ...(ctaTextTest.isActive
-    ? [
-        {
-          key: 'swapsSWAPS4135AbtestCtaText',
-          value: ctaTextTest.variantName,
-        },
-      ]
-    : []),
-];
-
-trackEvent({
-  event: MetaMetricsEventName.TransactionSubmitted,
-  category: MetaMetricsEventCategory.Swaps,
-  properties: {
-    ...(activeABTests.length > 0 && { active_ab_tests: activeABTests }),
-  },
-});
-```
-
-Do not emit per-test nested properties under `ab_tests`.
-Do not create analytics mappings in `ui/` modules that background code cannot
-import.
-
----
-
-## Local Development Overrides
+## Local Overrides and E2E
 
 To force a specific variant locally, override the processed assignment in
 `.manifest-overrides.json`:
@@ -256,10 +296,10 @@ To force a specific variant locally, override the processed assignment in
 {
   "_flags": {
     "remoteFeatureFlags": {
-      "swapsSWAPS4135AbtestNumpadQuickAmounts": {
+      "swapsSWAPS4135AbtestButtonColor": {
         "name": "treatment",
         "value": {
-          "buttons": [50, 75, 90, "MAX"]
+          "color": "blue"
         }
       }
     }
@@ -269,10 +309,6 @@ To force a specific variant locally, override the processed assignment in
 
 This mirrors the post-bucketing shape returned by
 `RemoteFeatureFlagController`, which makes local overrides deterministic.
-
----
-
-## E2E Test Setup
 
 Every new remote A/B test flag should be registered in
 `test/e2e/feature-flags/feature-flag-registry.ts` with its production default.
@@ -286,65 +322,57 @@ test:
 - `manifestFlags: { remoteFeatureFlags: { flagName: { name, value } } }`
 - `FixtureBuilder.withRemoteFeatureFlags({ flagName: { name, value } })`
 
----
+## Testing and Validation
 
-## Naming Convention
+Use risk-based scope:
 
-Use the same experiment key format as mobile:
+- If behavior changed, add or update feature tests
+- If analytics wiring changed, add or update analytics tests
+- If the change is copy-only or config-only, you may skip new tests with a
+  brief rationale
 
-`{teamName}{ticketId}Abtest{TestName}`
+Recommended commands:
 
-Example:
+```bash
+yarn jest <changed-test-file> --collectCoverage=false
+node --import tsx .agents/skills/ab-testing-implementation/scripts/check-ab-testing-compliance.ts --staged
+```
 
-`swapsSWAPS4135AbtestNumpadQuickAmounts`
+If you changed behavior and analytics wiring, run both the relevant feature
+test and the relevant analytics test.
 
-Recommended pattern:
-
-- `teamName`: lower camel team token, for example `swaps`
-- `ticketId`: uppercase project key plus number, for example `SWAPS4135`
-- literal `Abtest`
-- semantic PascalCase test name
-
----
-
-## Implementation Checklist
-
-- [ ] Remote flag created with threshold-array JSON value
-- [ ] `useABTest` added in the feature component
-- [ ] `Experiment Viewed` fires for active assignments
-- [ ] Business events use allowlisted auto-enrichment or manual `active_ab_tests`
-- [ ] E2E feature flag registry updated with production default
-- [ ] Local override path documented for QA if needed
-
----
-
-## FAQ
-
-**Q: What is the fallback variant?**
-`control`.
-
-**Q: When is `isActive` false?**
-When the hook is using the fallback because the assignment is missing, invalid,
-or unresolved.
-
-**Q: Do I manually emit `Experiment Viewed`?**
-No, not when using `useABTest`.
-
-**Q: Should I send both `ab_tests` and `active_ab_tests`?**
-No. Use `active_ab_tests`.
-
-**Q: What if basic functionality or metrics are unavailable?**
-If the extension does not have a usable experiment assignment, `useABTest`
-falls back to `control` and does not emit an exposure event.
-
----
-
-## Related Files
+Helpful existing files:
 
 - `ui/hooks/useABTest.ts`
 - `ui/hooks/useABTest.test.ts`
 - `shared/lib/ab-testing/resolve-ab-test-assignment.ts`
 - `shared/lib/ab-testing/ab-test-analytics.ts`
 - `app/scripts/controllers/metametrics-controller.ts`
-- `ui/selectors/remote-feature-flags.ts`
 - `test/e2e/feature-flags/feature-flag-registry.ts`
+
+## FAQ
+
+**Do I manually emit `Experiment Viewed`?**  
+No. Not when you use `useABTest`.
+
+**Do I manually attach `active_ab_tests` to every event?**  
+No. Register shared-path events for auto-enrichment. Add `active_ab_tests`
+manually only for bypass paths.
+
+**What is the fallback variant?**  
+`control`.
+
+**When is `isActive` false?**  
+When the hook is using the fallback because the assignment is missing, invalid,
+or unresolved.
+
+**Do I need a per-test analytics schema key?**  
+No. Use the shared `active_ab_tests` array of `{ key, value }`.
+
+**Can multiple tests enrich the same event?**  
+Yes. Multiple assignments can be included in the same `active_ab_tests` array.
+
+## References
+
+- [Remote feature flags contributor docs](https://github.com/MetaMask/contributor-docs/blob/main/docs/remote-feature-flags.md)
+- `test/e2e/tests/remote-feature-flag/remote-feature-flag.spec.ts`


### PR DESCRIPTION
## **Description**

This updates the extension A/B testing documentation to match the improved onboarding format recently adopted in mobile, while keeping the extension-specific implementation details intact.

The guide now starts with a quickstart and definition of done, walks through a single end-to-end example, and clarifies the shared-vs-manual analytics paths.
## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

<!-- ## **Manual testing steps** -->
<!-- N/A (documentation-only change) -->

<!-- ## **Screenshots/Recordings** -->
<!-- ### **Before** -->
<!-- N/A -->
<!-- ### **After** -->
<!-- N/A -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
