### PR TITLE
chore: add hover background style on default address component in account list and app header

### DIFF
--- a/ui/components/multichain-accounts/multichain-account-cell-default-address/multichain-account-cell-default-address.tsx
+++ b/ui/components/multichain-accounts/multichain-account-cell-default-address/multichain-account-cell-default-address.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import classnames from 'clsx';
 import { type AccountGroupId } from '@metamask/account-api';
 import {
   Box,
@@ -88,7 +89,9 @@ export const MultichainAccountCellDefaultAddress = ({
           paddingVertical={1}
           paddingHorizontal={2}
           gap={1}
-          className="rounded-lg h-6 min-w-0"
+          className={classnames('rounded-lg h-6 min-w-0', {
+            'hover:bg-muted-hover': !addressCopied,
+          })}
           data-testid="default-address-container"
         >
           <Text

--- a/ui/components/multichain-accounts/multichain-account-network-group-with-copy-icon/multichain-account-network-group-with-copy-icon.tsx
+++ b/ui/components/multichain-accounts/multichain-account-network-group-with-copy-icon/multichain-account-network-group-with-copy-icon.tsx
@@ -61,10 +61,10 @@ export const MultichainAccountNetworkGroupWithCopyIcon = ({
       }
       padding={1}
       gap={1}
-      className={classnames(
-        'rounded-lg h-6',
-        displayDefaultAddress && 'cursor-pointer',
-      )}
+      className={classnames('rounded-lg h-6', {
+        'cursor-pointer': displayDefaultAddress,
+        'hover:bg-muted-hover': !addressCopied,
+      })}
       data-testid="network-group-with-copy-icon"
     >
       <MultichainAccountNetworkGroup

--- a/ui/components/multichain/app-header/__snapshots__/app-header.test.js.snap
+++ b/ui/components/multichain/app-header/__snapshots__/app-header.test.js.snap
@@ -142,7 +142,7 @@ exports[`App Header unlocked state matches snapshot: unlocked 1`] = `
               class=""
             >
               <div
-                class="flex flex-row gap-1 items-center p-1 bg-muted rounded-lg h-6"
+                class="flex flex-row gap-1 items-center p-1 bg-muted rounded-lg h-6 hover:bg-muted-hover"
                 data-testid="network-group-with-copy-icon"
               >
                 <div


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Small change to add a hover state on the app header and account list where the default address component is. Note there is no hover when the address is copied as that has its own success background colour.

https://github.com/user-attachments/assets/7e1452e7-e200-4f63-9bb8-5d417d14547c


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: add hover state styles to default address component in account list and app header

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds a hover background style to clickable default-address elements, without altering copy behavior or data handling.
> 
> **Overview**
> Adds a `hover:bg-muted-hover` state to the default-address copy UI in the account list (`MultichainAccountCellDefaultAddress`) and the app header network/address chip (`MultichainAccountNetworkGroupWithCopyIcon`), but suppresses the hover style while `addressCopied` is true.
> 
> Updates the app header Jest snapshot to reflect the new hover class.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8010a63342a58e37fcb367039b49dbbe1a617b5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->