### PR TITLE
fix: disable gasless gas station for EIP-7702 account downgrades

### DIFF
--- a/ui/pages/confirmations/hooks/gas/useIsGaslessSupported.test.ts
+++ b/ui/pages/confirmations/hooks/gas/useIsGaslessSupported.test.ts
@@ -1,7 +1,9 @@
 import { act } from 'react-dom/test-utils';
+import { AuthorizationList } from '@metamask/transaction-controller';
 import { genUnapprovedContractInteractionConfirmation } from '../../../../../test/data/confirmations/contract-interaction';
 import { getMockConfirmStateForTransaction } from '../../../../../test/data/confirmations/helper';
 import { renderHookWithConfirmContextProvider } from '../../../../../test/lib/confirmations/render-helpers';
+import { EIP_7702_REVOKE_ADDRESS } from '../../../../../shared/lib/eip7702-utils';
 import { isRelaySupported } from '../../../../store/actions';
 import { isHardwareWallet } from '../../../../selectors';
 import { useIsGaslessSupported } from './useIsGaslessSupported';
@@ -22,11 +24,13 @@ jest.mock('../../../../selectors', () => ({
 
 jest.mock('./useGaslessSupportedSmartTransactions');
 
-async function runHook() {
+async function runHook({
+  authorizationList,
+}: { authorizationList?: AuthorizationList } = {}) {
   const { result } = renderHookWithConfirmContextProvider(
     useIsGaslessSupported,
     getMockConfirmStateForTransaction(
-      genUnapprovedContractInteractionConfirmation(),
+      genUnapprovedContractInteractionConfirmation({ authorizationList }),
     ),
   );
 
@@ -189,6 +193,58 @@ describe('useIsGaslessSupported', () => {
       isSupported: false,
       isSmartTransaction: false,
       pending: false,
+    });
+  });
+
+  describe('account downgrade transactions', () => {
+    const downgradeAuthorizationList: AuthorizationList = [
+      { address: EIP_7702_REVOKE_ADDRESS },
+    ];
+
+    it('returns isSupported false for downgrade even when relay is supported', async () => {
+      isRelaySupportedMock.mockResolvedValue(true);
+
+      const result = await runHook({
+        authorizationList: downgradeAuthorizationList,
+      });
+
+      expect(result).toStrictEqual({
+        isSupported: false,
+        isSmartTransaction: false,
+        pending: false,
+      });
+    });
+
+    it('returns isSupported false for downgrade even when smart transactions are supported', async () => {
+      useGaslessSupportedSmartTransactionsMock.mockReturnValue({
+        isSmartTransaction: true,
+        isSupported: true,
+        pending: false,
+      });
+
+      const result = await runHook({
+        authorizationList: downgradeAuthorizationList,
+      });
+
+      expect(result).toStrictEqual({
+        isSupported: false,
+        isSmartTransaction: true,
+        pending: false,
+      });
+    });
+
+    it('still returns isSupported true for upgrade transactions with relay support', async () => {
+      isRelaySupportedMock.mockResolvedValue(true);
+
+      const result = await runHook({
+        authorizationList: [{ address: '0x1234' }],
+      });
+
+      expect(result).toStrictEqual({
+        isSupported: true,
+        isSmartTransaction: false,
+        pending: false,
+      });
     });
   });
 });

--- a/ui/pages/confirmations/hooks/gas/useIsGaslessSupported.ts
+++ b/ui/pages/confirmations/hooks/gas/useIsGaslessSupported.ts
@@ -1,5 +1,6 @@
 import { TransactionMeta } from '@metamask/transaction-controller';
 import { useSelector } from 'react-redux';
+import { EIP_7702_REVOKE_ADDRESS } from '../../../../../shared/lib/eip7702-utils';
 import { useAsyncResult } from '../../../../hooks/useAsync';
 import { isHardwareWallet } from '../../../../selectors';
 import { useConfirmContext } from '../../context/confirm';
@@ -16,6 +17,9 @@ import { useGaslessSupportedSmartTransactions } from './useGaslessSupportedSmart
  * Hardware wallets are excluded from gasless support because they cannot sign
  * EIP-7702 authorization lists. They fall back to the standard "user pay gas" flow.
  *
+ * Account downgrade (revoke delegation) transactions are excluded because gasless
+ * requires an upgraded account, which conflicts with the downgrade intent.
+ *
  * @returns An object containing:
  * - `isSupported`: `true` if gasless transactions are supported via either 7702 or smart transactions with sendBundle.
  * - `isSmartTransaction`: `true` if smart transactions are enabled for the current chain.
@@ -27,6 +31,10 @@ export function useIsGaslessSupported() {
 
   const { chainId } = transactionMeta ?? {};
   const isHardwareWalletAccount = useSelector(isHardwareWallet);
+
+  const isDowngradeTransaction =
+    transactionMeta?.txParams?.authorizationList?.[0]?.address ===
+    EIP_7702_REVOKE_ADDRESS;
 
   const {
     isSmartTransaction,
@@ -56,11 +64,13 @@ export function useIsGaslessSupported() {
 
   const isSupported = Boolean(
     !isHardwareWalletAccount &&
+      !isDowngradeTransaction &&
       (isSmartTransactionAndBundleSupported || is7702Supported),
   );
 
   const isPending =
     !isHardwareWalletAccount &&
+    !isDowngradeTransaction &&
     (smartTransactionPending || (shouldCheck7702Eligibility && relayPending));
 
   return {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Using the 7702 gas station during an account downgrade can prevent the account from actually reverting to an EOA, because gasless flows assume an upgraded account.

This change treats EIP-7702 **revoke delegation** (downgrade) transactions as ineligible for gasless support in the confirmation flow. The hook `useIsGaslessSupported` now returns `isSupported: false` when the current transaction’s first authorization entry is the revoke address (`EIP_7702_REVOKE_ADDRESS`), matching how downgrades are identified elsewhere. That hides gas station–driven UI (e.g. sponsored fee and gas fee token picker) for downgrades while leaving normal and upgrade flows unchanged.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed an issue where the gas station could still be offered when downgrading an EIP-7702 account

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-745

## **Manual testing steps**

- Select the upgraded account on the supported network.
- Open the flow to **downgrade** the account back to a standard EOA (same entry point you use today for “switch account type” / revoke delegation — the confirmation that uses `TransactionType.revokeDelegation` / revoke authorization).
- On the confirmation screen, inspect the **Network fee** row:
   - **Expected after this PR:** Gas station / gasless treatment is **not** offered (no “Paid by MetaMask” / sponsored fee for this path, and no gas fee token picker driven by gasless eligibility for this downgrade).
- Optionally compare with **before** the fix (e.g. `main`): on the same downgrade confirmation, gas station options could still appear when relay supported the chain.
- Sanity check a **non-downgrade** transaction on the same chain (e.g. a normal send or an upgrade) and confirm gasless behavior still works when the chain and account support it.

## **Screenshots/Recordings**

[downgrade.webm](https://github.com/user-attachments/assets/3d29d5e6-a05a-46fd-8f88-64852f0b45df)


<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes gasless-eligibility gating used by the confirmation UI; a mistake could wrongly hide or show sponsored fees/token fee options for certain transactions, but the logic change is small and covered by new tests.
> 
> **Overview**
> Prevents gasless (relay/Smart Transactions) flows from being offered for EIP-7702 *revoke delegation* (account downgrade) confirmations by detecting `txParams.authorizationList[0].address === EIP_7702_REVOKE_ADDRESS` and forcing `isSupported`/`pending` to `false`.
> 
> Updates `useIsGaslessSupported` tests to pass an `authorizationList` into the mocked confirmation and adds coverage ensuring downgrades are always ineligible while non-downgrade authorization lists continue to allow gasless when supported.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93669f83cfdb9da2d919bf405ca1175789c68573. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->