### PR TITLE
feat: automatic upgrade for enforced simulations

### DIFF
--- a/app/scripts/lib/transaction/containers/enforced-simulations.test.ts
+++ b/app/scripts/lib/transaction/containers/enforced-simulations.test.ts
@@ -1,6 +1,7 @@
 import {
   SimulationData,
   SimulationTokenStandard,
+  TransactionControllerIsAtomicBatchSupportedAction,
   TransactionMeta,
   TransactionParams,
 } from '@metamask/transaction-controller';
@@ -59,12 +60,17 @@ describe('Enforced Simulations Utils', () => {
     DelegationControllerSignDelegationAction['handler']
   > = jest.fn();
 
+  const isAtomicBatchSupportedMock: jest.MockedFn<
+    TransactionControllerIsAtomicBatchSupportedAction['handler']
+  > = jest.fn();
+
   beforeEach(() => {
     jest.resetAllMocks();
 
     const baseMessenger = new Messenger<
       MockAnyNamespace,
-      DelegationControllerSignDelegationAction,
+      | DelegationControllerSignDelegationAction
+      | TransactionControllerIsAtomicBatchSupportedAction,
       never
     >({
       namespace: MOCK_ANY_NAMESPACE,
@@ -75,9 +81,15 @@ describe('Enforced Simulations Utils', () => {
       signDelegationMock,
     );
 
+    baseMessenger.registerActionHandler(
+      'TransactionController:isAtomicBatchSupported',
+      isAtomicBatchSupportedMock,
+    );
+
     messenger = new Messenger<
       'TransactionControllerInitMessenger',
-      DelegationControllerSignDelegationAction,
+      | DelegationControllerSignDelegationAction
+      | TransactionControllerIsAtomicBatchSupportedAction,
       never,
       typeof baseMessenger
     >({
@@ -86,7 +98,10 @@ describe('Enforced Simulations Utils', () => {
     });
     baseMessenger.delegate({
       messenger,
-      actions: ['DelegationController:signDelegation'],
+      actions: [
+        'DelegationController:signDelegation',
+        'TransactionController:isAtomicBatchSupported',
+      ],
     });
 
     signDelegationMock.mockResolvedValue(DELEGATION_SIGNATURE_MOCK);
@@ -300,6 +315,46 @@ describe('Enforced Simulations Utils', () => {
         expect(newTransaction.txParams.data).not.toStrictEqual(
           expect.stringContaining(remove0x(toHex(90000)).toLowerCase()),
         );
+      });
+    });
+
+    describe('with non-upgraded account', () => {
+      const UPGRADE_CONTRACT_ADDRESS_MOCK =
+        '0x1234567890123456789012345678901234567890' as Hex;
+
+      beforeEach(() => {
+        options.transactionMeta = cloneDeep({
+          ...TRANSACTION_META_MOCK,
+          delegationAddress: undefined,
+        }) as TransactionMeta;
+
+        isAtomicBatchSupportedMock.mockResolvedValue([
+          {
+            chainId: CHAIN_ID_MOCK,
+            isSupported: false,
+            upgradeContractAddress: UPGRADE_CONTRACT_ADDRESS_MOCK,
+          },
+        ]);
+      });
+
+      it('sets transaction type to setCode', async () => {
+        const { updateTransaction } = await enforceSimulations(options);
+
+        const newTransaction = cloneDeep(options.transactionMeta);
+        updateTransaction?.(newTransaction);
+
+        expect(newTransaction.txParams.type).toBe('0x4');
+      });
+
+      it('sets minimal authorization list with upgrade contract address', async () => {
+        const { updateTransaction } = await enforceSimulations(options);
+
+        const newTransaction = cloneDeep(options.transactionMeta);
+        updateTransaction?.(newTransaction);
+
+        expect(newTransaction.txParams.authorizationList).toEqual([
+          { address: UPGRADE_CONTRACT_ADDRESS_MOCK },
+        ]);
       });
     });
   });

--- a/app/scripts/lib/transaction/containers/enforced-simulations.test.ts
+++ b/app/scripts/lib/transaction/containers/enforced-simulations.test.ts
@@ -39,8 +39,12 @@ const TX_PARAMS_MOCK: TransactionParams = {
   to: '0xabcdef1234567890abcdef1234567890abcdef12' as Hex,
 };
 
+const DELEGATION_ADDRESS_MOCK =
+  '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B' as Hex;
+
 const TRANSACTION_META_MOCK: TransactionMeta = {
   chainId: CHAIN_ID_MOCK,
+  delegationAddress: DELEGATION_ADDRESS_MOCK,
   id: '123-456',
   simulationData: SIMULATION_DATA_MOCK,
   txParams: TX_PARAMS_MOCK,

--- a/app/scripts/lib/transaction/containers/enforced-simulations.ts
+++ b/app/scripts/lib/transaction/containers/enforced-simulations.ts
@@ -54,15 +54,19 @@ export async function enforceSimulations({
     slippage,
   );
 
-  const { data, to } = await convertTransactionToRedeemDelegations({
-    transaction: transactionMeta,
-    messenger: messenger as DelegationMessenger,
-    caveats,
-    delegatee: from,
-    delegationSignature: useRealSignature
-      ? undefined
-      : MOCK_DELEGATION_SIGNATURE,
-  });
+  const { authorizationList, data, to, type } =
+    await convertTransactionToRedeemDelegations({
+      transaction: transactionMeta,
+      messenger: messenger as DelegationMessenger,
+      caveats,
+      delegatee: from,
+      delegationSignature: useRealSignature
+        ? undefined
+        : MOCK_DELEGATION_SIGNATURE,
+      authorization: transactionMeta.delegationAddress
+        ? undefined
+        : { minimal: true },
+    });
 
   log('Data', data);
 
@@ -71,6 +75,11 @@ export async function enforceSimulations({
       transaction.txParams.data = data;
       transaction.txParams.to = to;
       transaction.txParams.value = '0x0';
+      transaction.txParams.type = type;
+
+      if (authorizationList) {
+        transaction.txParams.authorizationList = authorizationList;
+      }
     },
   };
 }

--- a/app/scripts/lib/transaction/containers/util.ts
+++ b/app/scripts/lib/transaction/containers/util.ts
@@ -63,11 +63,20 @@ export async function applyTransactionContainers({
       transaction.containerTypes = types;
 
       // Only update the fields modified by container wrapping.
-      // Preserves gas fees, nonce, gasLimit, type, chainId,
-      // authorizationList, and other fields set by the approval flow.
+      // Preserves gas fees, nonce, gasLimit, chainId,
+      // and other fields set by the approval flow.
       transaction.txParams.data = finalMetadata.txParams.data;
       transaction.txParams.to = finalMetadata.txParams.to;
       transaction.txParams.value = finalMetadata.txParams.value;
+
+      if (finalMetadata.txParams.type) {
+        transaction.txParams.type = finalMetadata.txParams.type;
+      }
+
+      if (finalMetadata.txParams.authorizationList) {
+        transaction.txParams.authorizationList =
+          finalMetadata.txParams.authorizationList;
+      }
 
       if (newGas) {
         transaction.txParams.gas = newGas;

--- a/app/scripts/lib/transaction/delegation.test.ts
+++ b/app/scripts/lib/transaction/delegation.test.ts
@@ -7,6 +7,7 @@ import { DelegationControllerSignDelegationAction } from '@metamask/delegation-c
 import { KeyringControllerSignEip7702AuthorizationAction } from '@metamask/keyring-controller';
 import {
   TransactionControllerGetNonceLockAction,
+  TransactionControllerIsAtomicBatchSupportedAction,
   TransactionMeta,
 } from '@metamask/transaction-controller';
 import {
@@ -107,6 +108,10 @@ describe('delegation', () => {
     TransactionControllerGetNonceLockAction['handler']
   > = jest.fn();
 
+  const isAtomicBatchSupportedMock: jest.MockedFn<
+    TransactionControllerIsAtomicBatchSupportedAction['handler']
+  > = jest.fn();
+
   let messenger: DelegationMessenger;
   let addCaveatMock: jest.Mock;
   let buildCaveatMock: jest.Mock;
@@ -118,7 +123,8 @@ describe('delegation', () => {
       MockAnyNamespace,
       | DelegationControllerSignDelegationAction
       | KeyringControllerSignEip7702AuthorizationAction
-      | TransactionControllerGetNonceLockAction,
+      | TransactionControllerGetNonceLockAction
+      | TransactionControllerIsAtomicBatchSupportedAction,
       never
     >({
       namespace: MOCK_ANY_NAMESPACE,
@@ -128,7 +134,8 @@ describe('delegation', () => {
       'TestDelegation',
       | DelegationControllerSignDelegationAction
       | KeyringControllerSignEip7702AuthorizationAction
-      | TransactionControllerGetNonceLockAction,
+      | TransactionControllerGetNonceLockAction
+      | TransactionControllerIsAtomicBatchSupportedAction,
       never,
       typeof baseMessenger
     >({
@@ -142,6 +149,7 @@ describe('delegation', () => {
         'DelegationController:signDelegation',
         'KeyringController:signEip7702Authorization',
         'TransactionController:getNonceLock',
+        'TransactionController:isAtomicBatchSupported',
       ] as never,
     });
 
@@ -158,6 +166,11 @@ describe('delegation', () => {
     baseMessenger.registerActionHandler(
       'TransactionController:getNonceLock',
       getNonceLockMock,
+    );
+
+    baseMessenger.registerActionHandler(
+      'TransactionController:isAtomicBatchSupported',
+      isAtomicBatchSupportedMock,
     );
 
     messenger = childMessenger as DelegationMessenger;
@@ -485,20 +498,8 @@ describe('delegation', () => {
       expect(signEip7702AuthorizationMock).not.toHaveBeenCalled();
     });
 
-    it('throws when authorization has no upgradeContractAddress and no isAtomicBatchSupported', async () => {
-      await expect(
-        convertTransactionToRedeemDelegations({
-          transaction: TRANSACTION_META_MOCK,
-          messenger,
-          authorization: {
-            upgradeContractAddress: undefined,
-          },
-        }),
-      ).rejects.toThrow('Upgrade contract address not found');
-    });
-
-    it('resolves authorization via isAtomicBatchSupported when that variant is used', async () => {
-      const isAtomicBatchSupported = jest.fn().mockResolvedValue([
+    it('resolves authorization via messenger isAtomicBatchSupported', async () => {
+      isAtomicBatchSupportedMock.mockResolvedValue([
         {
           chainId: '0x1',
           isSupported: false,
@@ -509,12 +510,10 @@ describe('delegation', () => {
       await convertTransactionToRedeemDelegations({
         transaction: TRANSACTION_META_MOCK,
         messenger,
-        authorization: {
-          isAtomicBatchSupported,
-        },
+        authorization: {},
       });
 
-      expect(isAtomicBatchSupported).toHaveBeenCalledWith({
+      expect(isAtomicBatchSupportedMock).toHaveBeenCalledWith({
         address: TRANSACTION_META_MOCK.txParams.from,
         chainIds: ['0x1'],
       });
@@ -523,47 +522,47 @@ describe('delegation', () => {
     });
 
     it('throws when isAtomicBatchSupported returns no upgradeContractAddress', async () => {
+      isAtomicBatchSupportedMock.mockResolvedValue([
+        { chainId: '0x1', isSupported: false },
+      ] as never);
+
       await expect(
         convertTransactionToRedeemDelegations({
           transaction: TRANSACTION_META_MOCK,
           messenger,
-          authorization: {
-            isAtomicBatchSupported: jest
-              .fn()
-              .mockResolvedValue([{ chainId: '0x1', isSupported: false }]),
-          },
+          authorization: {},
         }),
       ).rejects.toThrow('Upgrade contract address not found');
     });
 
     it('throws when chain is not in isAtomicBatchSupported result', async () => {
+      isAtomicBatchSupportedMock.mockResolvedValue([
+        { chainId: '0x999', isSupported: false },
+      ] as never);
+
       await expect(
         convertTransactionToRedeemDelegations({
           transaction: TRANSACTION_META_MOCK,
           messenger,
-          authorization: {
-            isAtomicBatchSupported: jest
-              .fn()
-              .mockResolvedValue([{ chainId: '0x999', isSupported: false }]),
-          },
+          authorization: {},
         }),
       ).rejects.toThrow('Chain does not support EIP-7702');
     });
 
     it('skips authorization when already upgraded and isSupported', async () => {
+      isAtomicBatchSupportedMock.mockResolvedValue([
+        {
+          chainId: '0x1',
+          isSupported: true,
+          delegationAddress: '0xexisting',
+          upgradeContractAddress: UPGRADE_CONTRACT_ADDRESS_MOCK,
+        },
+      ]);
+
       const result = await convertTransactionToRedeemDelegations({
         transaction: TRANSACTION_META_MOCK,
         messenger,
-        authorization: {
-          isAtomicBatchSupported: jest.fn().mockResolvedValue([
-            {
-              chainId: '0x1',
-              isSupported: true,
-              delegationAddress: '0xexisting',
-              upgradeContractAddress: UPGRADE_CONTRACT_ADDRESS_MOCK,
-            },
-          ]),
-        },
+        authorization: {},
       });
 
       expect(result.authorizationList).toBeUndefined();
@@ -571,19 +570,20 @@ describe('delegation', () => {
     });
 
     it('throws when upgraded to different address and upgradeExistingDelegation is false', async () => {
+      isAtomicBatchSupportedMock.mockResolvedValue([
+        {
+          chainId: '0x1',
+          isSupported: false,
+          delegationAddress: '0xdifferent',
+          upgradeContractAddress: UPGRADE_CONTRACT_ADDRESS_MOCK,
+        },
+      ]);
+
       await expect(
         convertTransactionToRedeemDelegations({
           transaction: TRANSACTION_META_MOCK,
           messenger,
           authorization: {
-            isAtomicBatchSupported: jest.fn().mockResolvedValue([
-              {
-                chainId: '0x1',
-                isSupported: false,
-                delegationAddress: '0xdifferent',
-                upgradeContractAddress: UPGRADE_CONTRACT_ADDRESS_MOCK,
-              },
-            ]),
             upgradeExistingDelegation: false,
           },
         }),
@@ -593,19 +593,19 @@ describe('delegation', () => {
     });
 
     it('overwrites delegation when upgraded to different address by default', async () => {
+      isAtomicBatchSupportedMock.mockResolvedValue([
+        {
+          chainId: '0x1',
+          isSupported: false,
+          delegationAddress: '0xdifferent',
+          upgradeContractAddress: UPGRADE_CONTRACT_ADDRESS_MOCK,
+        },
+      ]);
+
       const result = await convertTransactionToRedeemDelegations({
         transaction: TRANSACTION_META_MOCK,
         messenger,
-        authorization: {
-          isAtomicBatchSupported: jest.fn().mockResolvedValue([
-            {
-              chainId: '0x1',
-              isSupported: false,
-              delegationAddress: '0xdifferent',
-              upgradeContractAddress: UPGRADE_CONTRACT_ADDRESS_MOCK,
-            },
-          ]),
-        },
+        authorization: {},
       });
 
       expect(result.authorizationList).toBeDefined();
@@ -613,18 +613,19 @@ describe('delegation', () => {
     });
 
     it('overwrites delegation when upgraded to different address and upgradeExistingDelegation is true', async () => {
+      isAtomicBatchSupportedMock.mockResolvedValue([
+        {
+          chainId: '0x1',
+          isSupported: false,
+          delegationAddress: '0xdifferent',
+          upgradeContractAddress: UPGRADE_CONTRACT_ADDRESS_MOCK,
+        },
+      ]);
+
       const result = await convertTransactionToRedeemDelegations({
         transaction: TRANSACTION_META_MOCK,
         messenger,
         authorization: {
-          isAtomicBatchSupported: jest.fn().mockResolvedValue([
-            {
-              chainId: '0x1',
-              isSupported: false,
-              delegationAddress: '0xdifferent',
-              upgradeContractAddress: UPGRADE_CONTRACT_ADDRESS_MOCK,
-            },
-          ]),
           upgradeExistingDelegation: true,
         },
       });
@@ -636,17 +637,16 @@ describe('delegation', () => {
 
   describe('getDelegationTransaction', () => {
     it('adds value 0x0 to converted delegation transaction', async () => {
-      const result = await getDelegationTransaction(
+      isAtomicBatchSupportedMock.mockResolvedValue([
         {
-          messenger,
-          isAtomicBatchSupported: jest.fn().mockResolvedValue([
-            {
-              chainId: '0x1',
-              isSupported: false,
-              upgradeContractAddress: UPGRADE_CONTRACT_ADDRESS_MOCK,
-            },
-          ]),
+          chainId: '0x1',
+          isSupported: false,
+          upgradeContractAddress: UPGRADE_CONTRACT_ADDRESS_MOCK,
         },
+      ]);
+
+      const result = await getDelegationTransaction(
+        { messenger },
         TRANSACTION_META_MOCK,
       );
 
@@ -659,8 +659,8 @@ describe('delegation', () => {
       );
     });
 
-    it('passes isAtomicBatchSupported through to authorization', async () => {
-      const isAtomicBatchSupported = jest.fn().mockResolvedValue([
+    it('calls isAtomicBatchSupported via messenger', async () => {
+      isAtomicBatchSupportedMock.mockResolvedValue([
         {
           chainId: '0x1',
           isSupported: false,
@@ -668,15 +668,9 @@ describe('delegation', () => {
         },
       ]);
 
-      await getDelegationTransaction(
-        {
-          messenger,
-          isAtomicBatchSupported,
-        },
-        TRANSACTION_META_MOCK,
-      );
+      await getDelegationTransaction({ messenger }, TRANSACTION_META_MOCK);
 
-      expect(isAtomicBatchSupported).toHaveBeenCalledWith({
+      expect(isAtomicBatchSupportedMock).toHaveBeenCalledWith({
         address: TRANSACTION_META_MOCK.txParams.from,
         chainIds: ['0x1'],
       });

--- a/app/scripts/lib/transaction/delegation.test.ts
+++ b/app/scripts/lib/transaction/delegation.test.ts
@@ -498,6 +498,54 @@ describe('delegation', () => {
       expect(signEip7702AuthorizationMock).not.toHaveBeenCalled();
     });
 
+    it('returns minimal authorization list with only address when minimal is true', async () => {
+      isAtomicBatchSupportedMock.mockResolvedValue([
+        {
+          chainId: '0x1',
+          isSupported: false,
+          upgradeContractAddress: UPGRADE_CONTRACT_ADDRESS_MOCK,
+        },
+      ]);
+
+      const result = await convertTransactionToRedeemDelegations({
+        transaction: TRANSACTION_META_MOCK,
+        messenger,
+        authorization: { minimal: true },
+      });
+
+      expect(result.authorizationList).toEqual([
+        { address: UPGRADE_CONTRACT_ADDRESS_MOCK },
+      ]);
+      expect(getNonceLockMock).not.toHaveBeenCalled();
+      expect(signEip7702AuthorizationMock).not.toHaveBeenCalled();
+    });
+
+    it('returns setCode transaction type when authorization list is present', async () => {
+      const result = await convertTransactionToRedeemDelegations({
+        transaction: TRANSACTION_META_MOCK,
+        messenger,
+        authorization: {
+          upgradeContractAddress: UPGRADE_CONTRACT_ADDRESS_MOCK,
+        },
+      });
+
+      expect(result.type).toBe('0x4');
+    });
+
+    it('returns original transaction type when no authorization list', async () => {
+      const transaction = {
+        ...TRANSACTION_META_MOCK,
+        txParams: { ...TRANSACTION_META_MOCK.txParams, type: '0x2' },
+      } as unknown as TransactionMeta;
+
+      const result = await convertTransactionToRedeemDelegations({
+        transaction,
+        messenger,
+      });
+
+      expect(result.type).toBe('0x2');
+    });
+
     it('resolves authorization via messenger isAtomicBatchSupported', async () => {
       isAtomicBatchSupportedMock.mockResolvedValue([
         {

--- a/app/scripts/lib/transaction/delegation.ts
+++ b/app/scripts/lib/transaction/delegation.ts
@@ -1,15 +1,17 @@
 import {
   AuthorizationList,
-  IsAtomicBatchSupportedRequest,
-  IsAtomicBatchSupportedResult,
+  TransactionEnvelopeType,
   TransactionMeta,
+} from '@metamask/transaction-controller';
+import type {
+  TransactionControllerIsAtomicBatchSupportedAction,
+  TransactionControllerGetNonceLockAction,
 } from '@metamask/transaction-controller';
 import { Hex, add0x, createProjectLogger } from '@metamask/utils';
 import { toHex } from '@metamask/controller-utils';
 import type { Messenger } from '@metamask/messenger';
 import type { DelegationControllerSignDelegationAction } from '@metamask/delegation-controller';
 import type { KeyringControllerSignEip7702AuthorizationAction } from '@metamask/keyring-controller';
-import type { TransactionControllerGetNonceLockAction } from '@metamask/transaction-controller';
 import {
   BATCH_DEFAULT_MODE,
   Caveat,
@@ -38,7 +40,8 @@ export const PRIMARY_TYPE_DELEGATION = 'Delegation';
 type DelegationMessengerActions =
   | DelegationControllerSignDelegationAction
   | KeyringControllerSignEip7702AuthorizationAction
-  | TransactionControllerGetNonceLockAction;
+  | TransactionControllerGetNonceLockAction
+  | TransactionControllerIsAtomicBatchSupportedAction;
 
 export type DelegationMessenger = Messenger<
   string,
@@ -47,9 +50,7 @@ export type DelegationMessenger = Messenger<
 >;
 
 type AuthorizationRequest = {
-  isAtomicBatchSupported?: (
-    request: IsAtomicBatchSupportedRequest,
-  ) => Promise<IsAtomicBatchSupportedResult>;
+  minimal?: boolean;
 
   upgradeContractAddress?: Hex;
 
@@ -102,13 +103,10 @@ type ConvertTransactionToRedeemDelegationsResult = {
   authorizationList?: AuthorizationList;
   data: Hex;
   to: Hex;
+  type: TransactionEnvelopeType;
 };
 
 type GetDelegationTransactionRequest = {
-  isAtomicBatchSupported: (
-    request: IsAtomicBatchSupportedRequest,
-  ) => Promise<IsAtomicBatchSupportedResult>;
-
   messenger: DelegationMessenger;
 };
 
@@ -116,6 +114,7 @@ type DelegationTransactionResult = {
   authorizationList?: AuthorizationList;
   data: Hex;
   to: Hex;
+  type: TransactionEnvelopeType;
   value: Hex;
 };
 
@@ -179,6 +178,9 @@ export async function convertTransactionToRedeemDelegations(
     authorizationList,
     data,
     to: environment.DelegationManager as Hex,
+    type: authorizationList
+      ? TransactionEnvelopeType.setCode
+      : (transaction.txParams.type as TransactionEnvelopeType),
   };
 }
 
@@ -186,19 +188,18 @@ export async function getDelegationTransaction(
   request: GetDelegationTransactionRequest,
   transaction: TransactionMeta,
 ): Promise<DelegationTransactionResult> {
-  const { data, to, authorizationList } =
+  const { authorizationList, data, to, type } =
     await convertTransactionToRedeemDelegations({
       transaction,
       messenger: request.messenger,
-      authorization: {
-        isAtomicBatchSupported: request.isAtomicBatchSupported,
-      },
+      authorization: {},
     });
 
   return {
     authorizationList,
     data,
     to,
+    type,
     value: '0x0',
   };
 }
@@ -350,22 +351,22 @@ function decodeAuthorizationSignature(signature: Hex) {
 
 async function resolveUpgradeContractAddress(
   transaction: TransactionMeta,
+  messenger: DelegationMessenger,
   authorization: AuthorizationRequest,
 ): Promise<Hex | undefined> {
   if (authorization.upgradeContractAddress) {
     return authorization.upgradeContractAddress;
   }
 
-  if (!authorization.isAtomicBatchSupported) {
-    throw new Error('Upgrade contract address not found');
-  }
-
   const { chainId, txParams } = transaction;
 
-  const atomicBatchResult = await authorization.isAtomicBatchSupported({
-    address: txParams.from as Hex,
-    chainIds: [chainId],
-  });
+  const atomicBatchResult = await messenger.call(
+    'TransactionController:isAtomicBatchSupported',
+    {
+      address: txParams.from as Hex,
+      chainIds: [chainId],
+    },
+  );
 
   const chainResult = atomicBatchResult.find(
     (r) => r.chainId.toLowerCase() === chainId.toLowerCase(),
@@ -410,11 +411,16 @@ async function buildAuthorizationList(
 ): Promise<AuthorizationList | undefined> {
   const upgradeContractAddress = await resolveUpgradeContractAddress(
     transaction,
+    messenger,
     authorization,
   );
 
   if (!upgradeContractAddress) {
     return undefined;
+  }
+
+  if (authorization.minimal) {
+    return [{ address: upgradeContractAddress }];
   }
 
   const { chainId, txParams, networkClientId } = transaction;

--- a/app/scripts/lib/transaction/hooks/delegation-7702-publish.test.ts
+++ b/app/scripts/lib/transaction/hooks/delegation-7702-publish.test.ts
@@ -9,8 +9,8 @@ import {
   KeyringControllerSignTypedMessageAction,
 } from '@metamask/keyring-controller';
 import {
-  TransactionController,
   TransactionControllerGetNonceLockAction,
+  TransactionControllerIsAtomicBatchSupportedAction,
   TransactionControllerUpdateTransactionAction,
   TransactionMeta,
   TransactionType,
@@ -76,7 +76,7 @@ describe('Delegation 7702 Publish Hook', () => {
   > = jest.fn();
 
   const isAtomicBatchSupportedMock: jest.MockedFn<
-    TransactionController['isAtomicBatchSupported']
+    TransactionControllerIsAtomicBatchSupportedAction['handler']
   > = jest.fn();
 
   const getNonceLockMock: jest.MockedFn<
@@ -103,6 +103,7 @@ describe('Delegation 7702 Publish Hook', () => {
       | KeyringControllerSignEip7702AuthorizationAction
       | KeyringControllerSignTypedMessageAction
       | TransactionControllerGetNonceLockAction
+      | TransactionControllerIsAtomicBatchSupportedAction
       | TransactionControllerUpdateTransactionAction,
       never
     >({
@@ -115,6 +116,7 @@ describe('Delegation 7702 Publish Hook', () => {
       | KeyringControllerSignEip7702AuthorizationAction
       | KeyringControllerSignTypedMessageAction
       | TransactionControllerGetNonceLockAction
+      | TransactionControllerIsAtomicBatchSupportedAction
       | TransactionControllerUpdateTransactionAction,
       never,
       typeof baseMessenger
@@ -129,6 +131,7 @@ describe('Delegation 7702 Publish Hook', () => {
         'KeyringController:signTypedMessage',
         'DelegationController:signDelegation',
         'TransactionController:getNonceLock',
+        'TransactionController:isAtomicBatchSupported',
         'TransactionController:updateTransaction',
       ] as never,
     });
@@ -158,8 +161,12 @@ describe('Delegation 7702 Publish Hook', () => {
       getNonceLockMock,
     );
 
+    baseMessenger.registerActionHandler(
+      'TransactionController:isAtomicBatchSupported',
+      isAtomicBatchSupportedMock,
+    );
+
     hookClass = new Delegation7702PublishHook({
-      isAtomicBatchSupported: isAtomicBatchSupportedMock,
       messenger,
     });
 

--- a/app/scripts/lib/transaction/hooks/delegation-7702-publish.ts
+++ b/app/scripts/lib/transaction/hooks/delegation-7702-publish.ts
@@ -2,8 +2,6 @@ import { Interface } from '@ethersproject/abi';
 import { abiERC20 } from '@metamask/metamask-eth-abis';
 import {
   GasFeeToken,
-  IsAtomicBatchSupportedRequest,
-  IsAtomicBatchSupportedResult,
   PublishHook,
   PublishHookResult,
   TransactionMeta,
@@ -39,22 +37,13 @@ const EMPTY_RESULT = {
 const log = createProjectLogger('delegation-7702-publish-hook');
 
 export class Delegation7702PublishHook {
-  #isAtomicBatchSupported: (
-    request: IsAtomicBatchSupportedRequest,
-  ) => Promise<IsAtomicBatchSupportedResult>;
-
   #messenger: TransactionControllerInitMessenger;
 
   constructor({
-    isAtomicBatchSupported,
     messenger,
   }: {
-    isAtomicBatchSupported: (
-      request: IsAtomicBatchSupportedRequest,
-    ) => Promise<IsAtomicBatchSupportedResult>;
     messenger: TransactionControllerInitMessenger;
   }) {
-    this.#isAtomicBatchSupported = isAtomicBatchSupported;
     this.#messenger = messenger;
   }
 
@@ -83,10 +72,13 @@ export class Delegation7702PublishHook {
 
     const { from } = txParams;
 
-    const atomicBatchSupport = await this.#isAtomicBatchSupported({
-      address: from as Hex,
-      chainIds: [chainId],
-    });
+    const atomicBatchSupport = await this.#messenger.call(
+      'TransactionController:isAtomicBatchSupported',
+      {
+        address: from as Hex,
+        chainIds: [chainId],
+      },
+    );
 
     const atomicBatchChainSupport = findAtomicBatchSupportForChain(
       atomicBatchSupport,

--- a/app/scripts/messenger-client-init/confirmations/transaction-controller-init.ts
+++ b/app/scripts/messenger-client-init/confirmations/transaction-controller-init.ts
@@ -23,6 +23,7 @@ import { hasTransactionType } from '../../../../shared/lib/transactions.utils';
 import { getIsSmartTransaction } from '../../../../shared/lib/selectors';
 import { getShieldGatewayConfig } from '../../../../shared/lib/shield';
 import { isEnforcedSimulationsEligible } from '../../../../shared/lib/transaction/enforced-simulations';
+import { getEip7702SupportedChains } from '../../../../shared/lib/eip7702-support-utils';
 import { TransactionMetricsRequest } from '../../../../shared/types/metametrics';
 import {
   getSmartTransactionCommonParams,
@@ -199,10 +200,12 @@ export const TransactionControllerInit: MessengerClientInitFunction<
       beforeSign: new EnforceSimulationHook({
         messenger: initMessenger,
         isEligible: (transactionMeta) =>
-          isEnforcedSimulationsEligible(
-            transactionMeta,
-            initMessenger.call('AppStateController:getState'),
-          ),
+          isEnforcedSimulationsEligible(transactionMeta, {
+            ...initMessenger.call('AppStateController:getState'),
+            eip7702SupportedChains: getEip7702SupportedChains(
+              initMessenger.call('RemoteFeatureFlagController:getState'),
+            ),
+          }),
       }).getBeforeSignHook(),
       beforeCheckPendingTransactions: (transactionMeta: TransactionMeta) => {
         const response = initMessenger.call(
@@ -450,9 +453,6 @@ export async function publishHook({
     (!isSmartTransaction || !sendBundleSupport || isExternalSign)
   ) {
     const hook = new Delegation7702PublishHook({
-      isAtomicBatchSupported: transactionController.isAtomicBatchSupported.bind(
-        transactionController,
-      ),
       messenger: initMessenger,
     }).getHook();
 

--- a/app/scripts/messenger-client-init/messengers/transaction-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/transaction-controller-messenger.ts
@@ -37,6 +37,7 @@ import {
   TransactionControllerEstimateGasAction,
   TransactionControllerGetNonceLockAction,
   TransactionControllerGetStateAction,
+  TransactionControllerIsAtomicBatchSupportedAction,
   TransactionControllerMessenger,
   TransactionControllerPostTransactionBalanceUpdatedEvent,
   TransactionControllerStateChangeEvent,
@@ -130,6 +131,7 @@ type InitMessengerActions =
   | TransactionControllerEstimateGasAction
   | TransactionControllerGetNonceLockAction
   | TransactionControllerGetStateAction
+  | TransactionControllerIsAtomicBatchSupportedAction
   | TransactionControllerUpdateTransactionAction
   | TransactionPayControllerGetStateAction
   | TransactionPayControllerGetStrategyAction;
@@ -207,6 +209,7 @@ export function getTransactionControllerInitMessenger(
       'TransactionController:estimateGas',
       'TransactionController:getNonceLock',
       'TransactionController:getState',
+      'TransactionController:isAtomicBatchSupported',
       'TransactionController:updateTransaction',
       'TransactionPayController:getState',
       'TransactionPayController:getStrategy',

--- a/app/scripts/messenger-client-init/transaction-pay-controller-init.ts
+++ b/app/scripts/messenger-client-init/transaction-pay-controller-init.ts
@@ -3,10 +3,7 @@ import {
   TransactionPayControllerMessenger,
   TransactionPayStrategy,
 } from '@metamask/transaction-pay-controller';
-import type {
-  TransactionController,
-  TransactionMeta,
-} from '@metamask/transaction-controller';
+import type { TransactionMeta } from '@metamask/transaction-controller';
 import {
   type DelegationMessenger,
   getDelegationTransaction,
@@ -24,20 +21,11 @@ export const TransactionPayControllerInit: MessengerClientInitFunction<
 > = (request) => {
   const { controllerMessenger, initMessenger, persistedState } = request;
 
-  const getTransactionController = () =>
-    request.getMessengerClient(
-      'TransactionController',
-    ) as TransactionController;
-
   const getDelegationTransactionCallback: (request: {
     transaction: TransactionMeta;
   }) => ReturnType<typeof getDelegationTransaction> = ({ transaction }) =>
     getDelegationTransaction(
       {
-        isAtomicBatchSupported:
-          getTransactionController().isAtomicBatchSupported.bind(
-            getTransactionController(),
-          ),
         messenger: initMessenger as DelegationMessenger,
       },
       transaction,

--- a/shared/lib/transaction/enforced-simulations.test.ts
+++ b/shared/lib/transaction/enforced-simulations.test.ts
@@ -50,16 +50,21 @@ function buildCacheEntry(resultType: ResultType) {
   };
 }
 
-function buildState(resultType: ResultType): EnforcedSimulationsState {
+function buildState(
+  resultType: ResultType,
+  eip7702SupportedChains = [ETHEREUM_CHAIN_ID],
+): EnforcedSimulationsState {
   return {
     addressSecurityAlertResponses: {
       [CACHE_KEY]: buildCacheEntry(resultType),
     },
+    eip7702SupportedChains,
   };
 }
 
 function buildStateForAddresses(
   entries: Record<string, ResultType>,
+  eip7702SupportedChains = [ETHEREUM_CHAIN_ID],
 ): EnforcedSimulationsState {
   const responses: Record<string, CachedScanAddressResponse> = {};
 
@@ -68,7 +73,10 @@ function buildStateForAddresses(
     responses[key] = buildCacheEntry(resultType);
   }
 
-  return { addressSecurityAlertResponses: responses };
+  return {
+    addressSecurityAlertResponses: responses,
+    eip7702SupportedChains,
+  };
 }
 
 describe('enforced-simulations', () => {
@@ -87,8 +95,13 @@ describe('enforced-simulations', () => {
       delete process.env.ENABLE_ENFORCED_SIMULATIONS;
     });
 
-    it('returns true when all conditions are met and no state provided', () => {
-      expect(isEnforcedSimulationsEligible(BASE_TRANSACTION_META)).toBe(true);
+    it('returns true when all conditions are met', () => {
+      expect(
+        isEnforcedSimulationsEligible(
+          BASE_TRANSACTION_META,
+          buildState(ResultType.Benign),
+        ),
+      ).toBe(true);
     });
 
     it('returns false when env flag is not set', () => {
@@ -115,50 +128,65 @@ describe('enforced-simulations', () => {
       ).toBe(false);
     });
 
-    it('returns false when delegation address is missing', () => {
+    it('returns false when chain is not in eip7702 supported chains', () => {
       expect(
-        isEnforcedSimulationsEligible({
-          ...BASE_TRANSACTION_META,
-          delegationAddress: undefined,
-        }),
+        isEnforcedSimulationsEligible(
+          { ...BASE_TRANSACTION_META, chainId: UNSUPPORTED_CHAIN_ID },
+          buildState(ResultType.Benign),
+        ),
       ).toBe(false);
+    });
+
+    it('returns true when delegation address is missing but chain is supported', () => {
+      expect(
+        isEnforcedSimulationsEligible(
+          { ...BASE_TRANSACTION_META, delegationAddress: undefined },
+          buildState(ResultType.Benign),
+        ),
+      ).toBe(true);
     });
 
     it('returns false when simulation data is undefined', () => {
       expect(
-        isEnforcedSimulationsEligible({
-          ...BASE_TRANSACTION_META,
-          simulationData: undefined,
-        }),
+        isEnforcedSimulationsEligible(
+          { ...BASE_TRANSACTION_META, simulationData: undefined },
+          buildState(ResultType.Benign),
+        ),
       ).toBe(false);
     });
 
     it('returns false when simulation data has no balance changes', () => {
       expect(
-        isEnforcedSimulationsEligible({
-          ...BASE_TRANSACTION_META,
-          simulationData: { tokenBalanceChanges: [] },
-        }),
+        isEnforcedSimulationsEligible(
+          {
+            ...BASE_TRANSACTION_META,
+            simulationData: { tokenBalanceChanges: [] },
+          },
+          buildState(ResultType.Benign),
+        ),
       ).toBe(false);
     });
 
     it('returns true when simulation data has only token balance changes', () => {
       expect(
-        isEnforcedSimulationsEligible({
-          ...BASE_TRANSACTION_META,
-          simulationData: {
-            tokenBalanceChanges: [
-              {
-                address: '0xabc' as const,
-                standard: SimulationTokenStandard.erc20,
-                difference: '0x1' as const,
-                isDecrease: true,
-                previousBalance: '0x2' as const,
-                newBalance: '0x1' as const,
-              },
-            ],
+        isEnforcedSimulationsEligible(
+          {
+            ...BASE_TRANSACTION_META,
+            simulationData: {
+              tokenBalanceChanges: [
+                {
+                  address: '0xabc' as const,
+                  standard: SimulationTokenStandard.erc20,
+                  difference: '0x1' as const,
+                  isDecrease: true,
+                  previousBalance: '0x2' as const,
+                  newBalance: '0x1' as const,
+                },
+              ],
+            },
           },
-        }),
+          buildState(ResultType.Benign),
+        ),
       ).toBe(true);
     });
 
@@ -203,6 +231,7 @@ describe('enforced-simulations', () => {
         expect(
           isEnforcedSimulationsEligible(BASE_TRANSACTION_META, {
             addressSecurityAlertResponses: {},
+            eip7702SupportedChains: [ETHEREUM_CHAIN_ID],
           }),
         ).toBe(false);
       });
@@ -210,19 +239,22 @@ describe('enforced-simulations', () => {
       it('returns true when chain is not supported by trust signals', () => {
         expect(
           isEnforcedSimulationsEligible(
-            { ...BASE_TRANSACTION_META, chainId: UNSUPPORTED_CHAIN_ID },
-            buildState(ResultType.Benign),
+            {
+              ...BASE_TRANSACTION_META,
+              chainId: UNSUPPORTED_CHAIN_ID,
+            },
+            buildState(ResultType.Benign, [UNSUPPORTED_CHAIN_ID]),
           ),
         ).toBe(true);
       });
 
-      it('returns true when chainId is undefined', () => {
+      it('returns false when chainId is undefined', () => {
         expect(
           isEnforcedSimulationsEligible(
             { ...BASE_TRANSACTION_META, chainId: undefined as never },
             buildState(ResultType.Benign),
           ),
-        ).toBe(true);
+        ).toBe(false);
       });
 
       it('uses txParamsOriginal.to when container wrapping changed txParams.to', () => {
@@ -247,6 +279,7 @@ describe('enforced-simulations', () => {
                 [CACHE_KEY]: buildCacheEntry(ResultType.Benign),
                 [trustedCacheKey]: buildCacheEntry(ResultType.Trusted),
               },
+              eip7702SupportedChains: [ETHEREUM_CHAIN_ID],
             },
           ),
         ).toBe(true);

--- a/shared/lib/transaction/enforced-simulations.test.ts
+++ b/shared/lib/transaction/enforced-simulations.test.ts
@@ -4,6 +4,7 @@ import {
   TransactionMeta,
   TransactionStatus,
 } from '@metamask/transaction-controller';
+import { Hex } from '@metamask/utils';
 import { CachedScanAddressResponse, ResultType } from '../trust-signals';
 import {
   EnforcedSimulationsState,
@@ -11,8 +12,8 @@ import {
   isEnforcedSimulationsEligible,
 } from './enforced-simulations';
 
-const ETHEREUM_CHAIN_ID = '0x1';
-const UNSUPPORTED_CHAIN_ID = '0xdeadbeef';
+const ETHEREUM_CHAIN_ID: Hex = '0x1';
+const UNSUPPORTED_CHAIN_ID: Hex = '0xdeadbeef';
 const TO_ADDRESS = '0xRecipientAddress';
 const NESTED_ADDRESS_A = '0xNestedAddressA';
 const NESTED_ADDRESS_B = '0xNestedAddressB';

--- a/shared/lib/transaction/enforced-simulations.ts
+++ b/shared/lib/transaction/enforced-simulations.ts
@@ -3,6 +3,7 @@ import {
   TransactionMeta,
 } from '@metamask/transaction-controller';
 import { ORIGIN_METAMASK } from '@metamask/controller-utils';
+import { Hex } from '@metamask/utils';
 import {
   CachedScanAddressResponse,
   createCacheKey,
@@ -17,6 +18,7 @@ const DEFAULT_ENFORCED_SIMULATIONS_SLIPPAGE = 10;
  */
 export type EnforcedSimulationsState = {
   addressSecurityAlertResponses: Record<string, CachedScanAddressResponse>;
+  eip7702SupportedChains: Hex[];
 };
 
 /**
@@ -46,7 +48,7 @@ export function isEnforcedSimulationsEligible(
   transactionMeta: TransactionMeta,
   state?: EnforcedSimulationsState,
 ): boolean {
-  const { delegationAddress, origin, simulationData } = transactionMeta;
+  const { chainId, origin, simulationData } = transactionMeta;
 
   if (!process.env.ENABLE_ENFORCED_SIMULATIONS) {
     return false;
@@ -56,7 +58,11 @@ export function isEnforcedSimulationsEligible(
     return false;
   }
 
-  if (!delegationAddress) {
+  if (
+    !state?.eip7702SupportedChains?.some(
+      (supported) => supported.toLowerCase() === chainId?.toLowerCase(),
+    )
+  ) {
     return false;
   }
 

--- a/ui/pages/confirmations/hooks/useIsEnforcedSimulationsEligible.test.ts
+++ b/ui/pages/confirmations/hooks/useIsEnforcedSimulationsEligible.test.ts
@@ -66,7 +66,10 @@ describe('useIsEnforcedSimulationsEligible', () => {
 
     expect(getIsEnforcedSimulationsEligibleMock).toHaveBeenCalledWith(
       expect.objectContaining({ id: expect.any(String) }),
-      { addressSecurityAlertResponses: alertResponses },
+      {
+        addressSecurityAlertResponses: alertResponses,
+        eip7702SupportedChains: [],
+      },
     );
   });
 });

--- a/ui/pages/confirmations/hooks/useIsEnforcedSimulationsEligible.ts
+++ b/ui/pages/confirmations/hooks/useIsEnforcedSimulationsEligible.ts
@@ -1,9 +1,11 @@
 import { TransactionMeta } from '@metamask/transaction-controller';
+import type { RemoteFeatureFlagControllerState } from '@metamask/remote-feature-flag-controller';
 import { useSelector } from 'react-redux';
 import {
   EnforcedSimulationsState,
   isEnforcedSimulationsEligible,
 } from '../../../../shared/lib/transaction/enforced-simulations';
+import { getEip7702SupportedChains } from '../../../../shared/lib/eip7702-support-utils';
 import { useConfirmContext } from '../context/confirm';
 
 const EMPTY_RESPONSES: EnforcedSimulationsState['addressSecurityAlertResponses'] =
@@ -17,11 +19,17 @@ export function useIsEnforcedSimulationsEligible(): boolean {
       state.metamask.addressSecurityAlertResponses ?? EMPTY_RESPONSES,
   );
 
+  const eip7702SupportedChains = useSelector(
+    (state: { metamask: RemoteFeatureFlagControllerState }) =>
+      getEip7702SupportedChains(state.metamask),
+  );
+
   if (!currentConfirmation) {
     return false;
   }
 
   return isEnforcedSimulationsEligible(currentConfirmation, {
     addressSecurityAlertResponses,
+    eip7702SupportedChains,
   });
 }


### PR DESCRIPTION
## **Description**

Enforced simulations currently requires the account to already be 7702-upgraded (`delegationAddress` present). This PR removes that requirement and instead:

1. **Eligibility**: Replaces `delegationAddress` check with `eip7702SupportedChains` from remote feature flags — any account on a supported chain is eligible
2. **Auto-upgrade**: Includes a minimal (unsigned) authorization list for non-upgraded accounts, deferring signing to the TransactionController at confirmation time
3. **Messenger cleanup**: Encapsulates `isAtomicBatchSupported` in `DelegationMessenger` instead of threading callbacks through callers (enforced-simulations container, delegation-7702-publish hook, transaction-pay-controller-init)
4. **Type encapsulation**: `convertTransactionToRedeemDelegations` now returns `type` so callers don't need to derive `setCode` from auth list presence

Companion core PR needed for `@metamask/transaction-controller` gas estimation changes (broadened `isUpgradeWithData` condition + `to: from` fix for upgrade-only estimation).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Enable enforced simulations feature flag
2. Use a non-upgraded EOA on a supported chain (e.g., mainnet)
3. Initiate a transaction — should see enforced simulations applied with authorization list
4. Gas estimation should succeed (split upgrade + execution estimation)
5. Confirm transaction — TC should sign the minimal authorization list

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how enforced simulations and delegation transactions build EIP-7702 `authorizationList` and `txParams.type`, and wires new messenger calls to determine upgrade support; mistakes here could produce invalid type-4 transactions or broken gas/approval flows.
> 
> **Overview**
> **Enforced simulations no longer requires a pre-existing `delegationAddress`.** Eligibility is now gated by a new `eip7702SupportedChains` list (sourced from remote feature flags) instead of “already upgraded” checks.
> 
> When enforced simulations run on a non-upgraded account, the transaction wrapping now **auto-prepares an upgrade** by attaching a *minimal* EIP-7702 `authorizationList` (address-only) and setting `txParams.type` to `setCode` (`0x4`), deferring signature generation to later in the approval flow.
> 
> Delegation utilities were updated to **centralize `isAtomicBatchSupported` behind the messenger** (removing callback threading) and to have `convertTransactionToRedeemDelegations` return the computed envelope `type`, with container wrapping selectively propagating `type` and `authorizationList` into the final tx params. Tests were updated to cover minimal authorization behavior and the new eligibility inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e3dc9aca3849757250c399662d8cd74b2550e5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->