### PR TITLE
fix: TAT-2913 display asset symbol

### DIFF
--- a/ui/components/app/perps/order-entry/components/amount-input/amount-input.test.tsx
+++ b/ui/components/app/perps/order-entry/components/amount-input/amount-input.test.tsx
@@ -226,6 +226,18 @@ describe('AmountInput', () => {
     });
   });
 
+  describe('HIP-3 symbol display', () => {
+    it('strips the dex prefix from HIP-3 asset symbols in the token input label', () => {
+      renderWithProvider(
+        <AmountInput {...defaultProps} asset="xyz:BRENTOIL" />,
+        mockStore,
+      );
+
+      expect(screen.getByText('BRENTOIL')).toBeInTheDocument();
+      expect(screen.queryByText('xyz:BRENTOIL')).not.toBeInTheDocument();
+    });
+  });
+
   describe('token display', () => {
     it('displays token amount as size divided by price (not multiplied by leverage)', () => {
       renderWithProvider(

--- a/ui/components/app/perps/order-entry/components/amount-input/amount-input.tsx
+++ b/ui/components/app/perps/order-entry/components/amount-input/amount-input.tsx
@@ -21,6 +21,7 @@ import { useFormatters } from '../../../../../../hooks/useFormatters';
 import { useI18nContext } from '../../../../../../hooks/useI18nContext';
 import { TextField, TextFieldSize } from '../../../../../component-library';
 import { PerpsSlider } from '../../../perps-slider';
+import { getDisplaySymbol } from '../../../utils';
 import type { AmountInputProps } from '../../order-entry.types';
 import { isDigitsOnlyInput, isUnsignedDecimalInput } from '../../utils';
 
@@ -322,7 +323,7 @@ export const AmountInput: React.FC<AmountInputProps> = ({
                 variant={TextVariant.BodyMd}
                 color={TextColor.TextAlternative}
               >
-                {asset}
+                {getDisplaySymbol(asset)}
               </Text>
             }
           />

--- a/ui/components/app/perps/order-entry/components/close-amount-section/close-amount-section.test.tsx
+++ b/ui/components/app/perps/order-entry/components/close-amount-section/close-amount-section.test.tsx
@@ -122,6 +122,18 @@ describe('CloseAmountSection', () => {
     });
   });
 
+  describe('HIP-3 symbol display', () => {
+    it('strips the dex prefix from HIP-3 asset symbols in the position size display', () => {
+      renderWithProvider(
+        <CloseAmountSection {...defaultProps} asset="xyz:BRENTOIL" />,
+        mockStore,
+      );
+
+      expect(screen.getByText(/2\.5.*BRENTOIL/u)).toBeInTheDocument();
+      expect(screen.queryByText(/xyz:BRENTOIL/u)).not.toBeInTheDocument();
+    });
+  });
+
   describe('edge cases', () => {
     it('handles zero position size', () => {
       renderWithProvider(

--- a/ui/components/app/perps/order-entry/components/close-amount-section/close-amount-section.tsx
+++ b/ui/components/app/perps/order-entry/components/close-amount-section/close-amount-section.tsx
@@ -12,6 +12,7 @@ import {
   BoxAlignItems,
 } from '@metamask/design-system-react';
 import { PerpsSlider } from '../../../perps-slider';
+import { getDisplaySymbol } from '../../../utils';
 import { useI18nContext } from '../../../../../../hooks/useI18nContext';
 import { useFormatters } from '../../../../../../hooks/useFormatters';
 import type { CloseAmountSectionProps } from '../../order-entry.types';
@@ -70,7 +71,7 @@ export const CloseAmountSection: React.FC<CloseAmountSectionProps> = ({
           {t('perpsAvailableToClose')}
         </Text>
         <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
-          {formatTokenQuantity(totalPositionSize, asset)}
+          {formatTokenQuantity(totalPositionSize, getDisplaySymbol(asset))}
         </Text>
       </Box>
 

--- a/ui/components/app/perps/order-entry/order-entry.test.tsx
+++ b/ui/components/app/perps/order-entry/order-entry.test.tsx
@@ -97,6 +97,20 @@ describe('OrderEntry', () => {
         'Open Short BTC',
       );
     });
+
+    it('strips the dex prefix from HIP-3 symbols in the submit button label', () => {
+      renderWithProvider(
+        <OrderEntry {...defaultProps} asset="xyz:BRENTOIL" />,
+        mockStore,
+      );
+
+      expect(
+        screen.getByTestId('order-entry-submit-button'),
+      ).toHaveTextContent('Open Long BRENTOIL');
+      expect(
+        screen.getByTestId('order-entry-submit-button'),
+      ).not.toHaveTextContent('xyz:BRENTOIL');
+    });
   });
 
   describe('amount input', () => {

--- a/ui/components/app/perps/order-entry/order-entry.test.tsx
+++ b/ui/components/app/perps/order-entry/order-entry.test.tsx
@@ -104,9 +104,9 @@ describe('OrderEntry', () => {
         mockStore,
       );
 
-      expect(
-        screen.getByTestId('order-entry-submit-button'),
-      ).toHaveTextContent('Open Long BRENTOIL');
+      expect(screen.getByTestId('order-entry-submit-button')).toHaveTextContent(
+        'Open Long BRENTOIL',
+      );
       expect(
         screen.getByTestId('order-entry-submit-button'),
       ).not.toHaveTextContent('xyz:BRENTOIL');

--- a/ui/components/app/perps/order-entry/order-entry.tsx
+++ b/ui/components/app/perps/order-entry/order-entry.tsx
@@ -18,6 +18,7 @@ import {
   BorderRadius,
   TextColor,
 } from '../../../../helpers/constants/design-system';
+import { getDisplaySymbol } from '../utils';
 import type { OrderEntryProps, OrderCalculations } from './order-entry.types';
 
 import { AmountInput } from './components/amount-input';
@@ -170,8 +171,8 @@ export const OrderEntry: React.FC<OrderEntryProps> = ({
           : t('perpsConfirmCloseShort');
       default:
         return isLong
-          ? t('perpsOpenLong', [asset])
-          : t('perpsOpenShort', [asset]);
+          ? t('perpsOpenLong', [getDisplaySymbol(asset)])
+          : t('perpsOpenShort', [getDisplaySymbol(asset)]);
     }
   }, [mode, isLong, asset, t]);
 

--- a/ui/hooks/perps/usePerpsOrderForm.ts
+++ b/ui/hooks/perps/usePerpsOrderForm.ts
@@ -13,6 +13,7 @@ import type {
 } from '../../components/app/perps/order-entry/order-entry.types';
 import { useFormatters } from '../useFormatters';
 import { formatPerpsPrice } from '../../../shared/lib/perps-formatters';
+import { getDisplaySymbol } from '../../components/app/perps/utils';
 import { getIntlLocale } from '../../ducks/locale/locale';
 
 /**
@@ -329,7 +330,7 @@ export function usePerpsOrderForm({
       const estimatedFees = closeValueUsd * (feeRate ?? 0);
 
       return {
-        positionSize: formatTokenQuantity(closeAmount, asset),
+        positionSize: formatTokenQuantity(closeAmount, getDisplaySymbol(asset)),
         marginRequired: null, // Not relevant for closing
         liquidationPrice: null, // Not relevant for closing
         liquidationPriceRaw: null,
@@ -402,7 +403,7 @@ export function usePerpsOrderForm({
     );
 
     return {
-      positionSize: formatTokenQuantity(positionSize, asset),
+      positionSize: formatTokenQuantity(positionSize, getDisplaySymbol(asset)),
       marginRequired: formatCurrencyWithMinThreshold(marginRequired, 'USD'),
       liquidationPrice:
         liquidationPriceValue > 0


### PR DESCRIPTION
## **Description**

HIP-3 markets use a `dex:SYMBOL` format for their internal identifier (e.g. `xyz:BRENTOIL`). The raw symbol was being passed directly to display contexts in the order entry flow, causing the full `xyz:BRENTOIL` string to appear in the UI instead of the user-facing `BRENTOIL`.

Applied `getDisplaySymbol` (which strips the `dex:` prefix, and is a no-op for regular symbols like `BTC`) at every display point in the order entry flow:

- **Token input end-accessory** (`amount-input.tsx`) — the label next to the size input
- **Submit button label** (`order-entry.tsx`) — "Open Long / Open Short" button
- **Available to close quantity** (`close-amount-section.tsx`) — position size shown before the slider
- **Order summary position size** (`usePerpsOrderForm.ts`) — the formatted token quantity in the order summary

Backend / API calls continue to receive the full raw symbol unchanged.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [TAT-2913](https://consensyssoftware.atlassian.net/browse/TAT-2913)

## **Manual testing steps**

1. Open a HIP-3 market (e.g. Brent Oil / `xyz:BRENTOIL`) in the perps order entry screen.
2. Verify the token input end-accessory shows `BRENTOIL` (not `xyz:BRENTOIL`).
3. Verify the submit button reads "Open Long BRENTOIL" / "Open Short BRENTOIL".
4. Open the close position flow and verify the available-to-close quantity shows e.g. `2.5 BRENTOIL`.
5. Verify the order summary position size shows `BRENTOIL` without prefix.
6. Confirm a regular asset (e.g. `BTC`) is unaffected — all labels still show `BTC`.


## **Screenshots/Recordings**

### **Before**

### **After**
<img width="491" height="511" alt="Screenshot 2026-04-15 at 13 54 43" src="https://github.com/user-attachments/assets/68107c78-9905-4c99-b6c5-7babbadd5418" />



## **Pre-merge author checklist**

* I've followed MetaMask Contributor Docs and MetaMask Extension Coding Standards.
* I've completed the PR template to the best of my ability
* I've included tests if applicable
* I've documented my code using JSDoc format if applicable
* I've applied the right labels on the PR (see labeling guidelines). Not required for external contributors.

[TAT-2913]: https://consensyssoftware.atlassian.net/browse/TAT-2913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts displayed labels by normalizing symbols via `getDisplaySymbol`, with added unit tests to prevent regressions.
> 
> **Overview**
> Fixes perps order-entry UI to display HIP-3 market symbols without the `dex:` prefix (e.g. `xyz:BRENTOIL` -> `BRENTOIL`) by applying `getDisplaySymbol` in the size token label, submit button text, available-to-close quantity, and order-summary position size formatting.
> 
> Adds focused tests covering HIP-3 symbol rendering in `AmountInput`, `CloseAmountSection`, and `OrderEntry` to ensure prefixed symbols are stripped while normal symbols remain unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e68c9194a1f7ff0ca6f603e09a86707de86bde7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->