### PR TITLE
fix: hide long/short and auto close when modify or close

### DIFF
--- a/ui/components/app/perps/order-entry/components/direction-tabs/direction-tabs.test.tsx
+++ b/ui/components/app/perps/order-entry/components/direction-tabs/direction-tabs.test.tsx
@@ -1,0 +1,59 @@
+import { screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+
+import mockState from '../../../../../../../test/data/mock-state.json';
+import { enLocale as messages } from '../../../../../../../test/lib/i18n-helpers';
+import { renderWithProvider } from '../../../../../../../test/lib/render-helpers-navigate';
+import configureStore from '../../../../../../store/store';
+import { DirectionTabs } from './direction-tabs';
+
+const mockStore = configureStore({
+  metamask: {
+    ...mockState.metamask,
+  },
+});
+
+describe('DirectionTabs', () => {
+  const defaultProps = {
+    direction: 'long' as const,
+    onDirectionChange: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('rendering', () => {
+    it('renders Long and Short tabs', () => {
+      renderWithProvider(<DirectionTabs {...defaultProps} />, mockStore);
+
+      expect(screen.getByText(messages.perpsLong.message)).toBeInTheDocument();
+      expect(screen.getByText(messages.perpsShort.message)).toBeInTheDocument();
+    });
+
+    it('renders both tabs with correct test ids', () => {
+      renderWithProvider(<DirectionTabs {...defaultProps} />, mockStore);
+
+      expect(screen.getByTestId('direction-tab-long')).toBeInTheDocument();
+      expect(screen.getByTestId('direction-tab-short')).toBeInTheDocument();
+    });
+  });
+
+  describe('direction switching', () => {
+    it('calls onDirectionChange when the inactive tab is clicked', () => {
+      renderWithProvider(<DirectionTabs {...defaultProps} />, mockStore);
+
+      fireEvent.click(screen.getByTestId('direction-tab-short'));
+
+      expect(defaultProps.onDirectionChange).toHaveBeenCalledWith('short');
+    });
+
+    it('does not call onDirectionChange when the active tab is clicked', () => {
+      renderWithProvider(<DirectionTabs {...defaultProps} />, mockStore);
+
+      fireEvent.click(screen.getByTestId('direction-tab-long'));
+
+      expect(defaultProps.onDirectionChange).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/ui/components/app/perps/order-entry/order-entry.test.tsx
+++ b/ui/components/app/perps/order-entry/order-entry.test.tsx
@@ -295,7 +295,7 @@ describe('OrderEntry', () => {
       expect(screen.getByTestId('leverage-slider')).toBeInTheDocument();
     });
 
-    it('auto-expands auto-close section when TP/SL exists', () => {
+    it('does not show auto-close section when TP/SL exists in modify mode', () => {
       renderWithProvider(
         <OrderEntry
           {...defaultProps}
@@ -305,9 +305,10 @@ describe('OrderEntry', () => {
         mockStore,
       );
 
-      // Should show TP/SL inputs because existing position has TP/SL
-      expect(screen.getByTestId('tp-price-input')).toBeInTheDocument();
-      expect(screen.getByTestId('sl-price-input')).toBeInTheDocument();
+      // Auto-close is hidden in modify mode — existing TP/SL carries over untouched
+      expect(screen.queryByTestId('auto-close-toggle')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('tp-price-input')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('sl-price-input')).not.toBeInTheDocument();
     });
   });
 
@@ -399,6 +400,19 @@ describe('OrderEntry', () => {
         <OrderEntry
           {...defaultProps}
           mode="close"
+          existingPosition={existingPosition}
+        />,
+        mockStore,
+      );
+
+      expect(screen.queryByTestId('auto-close-toggle')).not.toBeInTheDocument();
+    });
+
+    it('hides auto-close section in modify mode', () => {
+      renderWithProvider(
+        <OrderEntry
+          {...defaultProps}
+          mode="modify"
           existingPosition={existingPosition}
         />,
         mockStore,

--- a/ui/components/app/perps/order-entry/order-entry.test.tsx
+++ b/ui/components/app/perps/order-entry/order-entry.test.tsx
@@ -97,6 +97,20 @@ describe('OrderEntry', () => {
         'Open Short BTC',
       );
     });
+
+    it('strips the dex prefix from HIP-3 symbols in the submit button label', () => {
+      renderWithProvider(
+        <OrderEntry {...defaultProps} asset="xyz:BRENTOIL" />,
+        mockStore,
+      );
+
+      expect(screen.getByTestId('order-entry-submit-button')).toHaveTextContent(
+        'Open Long BRENTOIL',
+      );
+      expect(
+        screen.getByTestId('order-entry-submit-button'),
+      ).not.toHaveTextContent('xyz:BRENTOIL');
+    });
   });
 
   describe('amount input', () => {

--- a/ui/components/app/perps/order-entry/order-entry.test.tsx
+++ b/ui/components/app/perps/order-entry/order-entry.test.tsx
@@ -97,20 +97,6 @@ describe('OrderEntry', () => {
         'Open Short BTC',
       );
     });
-
-    it('strips the dex prefix from HIP-3 symbols in the submit button label', () => {
-      renderWithProvider(
-        <OrderEntry {...defaultProps} asset="xyz:BRENTOIL" />,
-        mockStore,
-      );
-
-      expect(screen.getByTestId('order-entry-submit-button')).toHaveTextContent(
-        'Open Long BRENTOIL',
-      );
-      expect(
-        screen.getByTestId('order-entry-submit-button'),
-      ).not.toHaveTextContent('xyz:BRENTOIL');
-    });
   });
 
   describe('amount input', () => {

--- a/ui/components/app/perps/order-entry/order-entry.tsx
+++ b/ui/components/app/perps/order-entry/order-entry.tsx
@@ -341,8 +341,8 @@ export const OrderEntry: React.FC<OrderEntryProps> = ({
           />
         )}
 
-        {/* New/Modify Modes: Show Auto Close (TP/SL) Section */}
-        {mode !== 'close' && (
+        {/* New Mode Only: Show Auto Close (TP/SL) Section */}
+        {mode === 'new' && (
           <AutoCloseSection
             enabled={formState.autoCloseEnabled}
             onEnabledChange={handleAutoCloseEnabledChange}

--- a/ui/components/app/perps/order-entry/order-entry.tsx
+++ b/ui/components/app/perps/order-entry/order-entry.tsx
@@ -352,21 +352,8 @@ export const OrderEntry: React.FC<OrderEntryProps> = ({
             onStopLossPriceChange={handleStopLossPriceChange}
             direction={formState.direction}
             currentPrice={currentPrice}
-            leverage={
-              mode === 'modify' && existingPosition?.leverage
-                ? existingPosition.leverage
-                : formState.leverage
-            }
-            entryPrice={
-              mode === 'modify' && existingPosition?.entryPrice
-                ? (() => {
-                    const p = parseFloat(
-                      existingPosition.entryPrice.replace(/,/gu, ''),
-                    );
-                    return Number.isNaN(p) ? undefined : p;
-                  })()
-                : undefined
-            }
+            leverage={formState.leverage}
+            entryPrice={undefined}
             estimatedSize={estimatedSize}
             orderType={formState.type}
             limitPrice={formState.limitPrice}

--- a/ui/pages/perps/perps-order-entry-page.test.tsx
+++ b/ui/pages/perps/perps-order-entry-page.test.tsx
@@ -341,6 +341,42 @@ describe('PerpsOrderEntryPage', () => {
       expect(screen.getByText(messages.perpsLong.message)).toBeInTheDocument();
       expect(screen.getByText(messages.perpsShort.message)).toBeInTheDocument();
     });
+
+    it('does not render direction tabs in modify mode', () => {
+      mockSearchParams.set('mode', 'modify');
+      mockLivePositions.mockReturnValue({
+        positions: mockPositions,
+        isInitialLoading: false,
+      });
+      const store = mockStore(createMockState());
+      renderWithProvider(<PerpsOrderEntryPage />, store);
+
+      expect(screen.queryByTestId('direction-tabs')).not.toBeInTheDocument();
+    });
+
+    it('does not render direction tabs in close mode', () => {
+      mockSearchParams.set('mode', 'close');
+      mockLivePositions.mockReturnValue({
+        positions: mockPositions,
+        isInitialLoading: false,
+      });
+      const store = mockStore(createMockState());
+      renderWithProvider(<PerpsOrderEntryPage />, store);
+
+      expect(screen.queryByTestId('direction-tabs')).not.toBeInTheDocument();
+    });
+
+    it('hides the auto-close section in modify mode', () => {
+      mockSearchParams.set('mode', 'modify');
+      mockLivePositions.mockReturnValue({
+        positions: mockPositions,
+        isInitialLoading: false,
+      });
+      const store = mockStore(createMockState());
+      renderWithProvider(<PerpsOrderEntryPage />, store);
+
+      expect(screen.queryByTestId('auto-close-toggle')).not.toBeInTheDocument();
+    });
   });
 
   describe('redirects', () => {
@@ -1093,7 +1129,7 @@ describe('PerpsOrderEntryPage', () => {
       });
     });
 
-    it('submits normalized TP/SL values when modified', async () => {
+    it('submits existing position TP/SL values unchanged in modify mode', async () => {
       mockSearchParams.set('mode', 'modify');
       mockLivePositions.mockReturnValue({
         positions: mockPositions,
@@ -1103,20 +1139,12 @@ describe('PerpsOrderEntryPage', () => {
       const store = mockStore(createMockState());
       renderWithProvider(<PerpsOrderEntryPage />, store);
 
-      const tpContainer = screen.getByTestId('tp-price-input');
-      const tpInput = tpContainer.querySelector('input');
-      fireEvent.change(tpInput as HTMLInputElement, {
-        target: { value: '3300.1' },
-      });
-      fireEvent.blur(tpInput as HTMLInputElement);
+      // Auto-close section is hidden in modify mode; TP/SL inputs are not accessible
+      expect(screen.queryByTestId('tp-price-input')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('sl-price-input')).not.toBeInTheDocument();
 
-      const slContainer = screen.getByTestId('sl-price-input');
-      const slInput = slContainer.querySelector('input');
-      fireEvent.change(slInput as HTMLInputElement, {
-        target: { value: '2500' },
-      });
-      fireEvent.blur(slInput as HTMLInputElement);
-
+      // Submitting with no additional amount calls perpsUpdatePositionTPSL
+      // with the pre-loaded TP/SL values from the existing position
       await act(async () => {
         fireEvent.click(screen.getByTestId('submit-order-button'));
       });
@@ -1126,54 +1154,11 @@ describe('PerpsOrderEntryPage', () => {
         [
           expect.objectContaining({
             symbol: 'ETH',
-            takeProfitPrice: '3300.1',
-            stopLossPrice: '2500',
+            takeProfitPrice: mockPositions[0].takeProfitPrice,
+            stopLossPrice: mockPositions[0].stopLossPrice,
           }),
         ],
       );
-    });
-
-    it('submits undefined TP/SL values when fields are cleared', async () => {
-      mockSearchParams.set('mode', 'modify');
-      mockLivePositions.mockReturnValue({
-        positions: mockPositions,
-        isInitialLoading: false,
-      });
-
-      const store = mockStore(createMockState());
-      renderWithProvider(<PerpsOrderEntryPage />, store);
-
-      const tpContainer = screen.getByTestId('tp-price-input');
-      const tpInput = tpContainer.querySelector('input');
-      fireEvent.change(tpInput as HTMLInputElement, {
-        target: { value: '' },
-      });
-      fireEvent.blur(tpInput as HTMLInputElement);
-
-      const slContainer = screen.getByTestId('sl-price-input');
-      const slInput = slContainer.querySelector('input');
-      fireEvent.change(slInput as HTMLInputElement, {
-        target: { value: '' },
-      });
-      fireEvent.blur(slInput as HTMLInputElement);
-
-      await act(async () => {
-        fireEvent.click(screen.getByTestId('submit-order-button'));
-      });
-
-      const updateCall = mockSubmitRequestToBackground.mock.calls.find(
-        ([method]) => method === 'perpsUpdatePositionTPSL',
-      );
-      expect(updateCall).toBeDefined();
-
-      const payload = updateCall?.[1]?.[0] as {
-        symbol?: string;
-        takeProfitPrice?: string;
-        stopLossPrice?: string;
-      };
-      expect(payload.symbol).toBe('ETH');
-      expect(payload.takeProfitPrice).toBeUndefined();
-      expect(payload.stopLossPrice).toBeUndefined();
     });
 
     it('does not submit when currentPrice is 0', async () => {

--- a/ui/pages/perps/perps-order-entry-page.test.tsx
+++ b/ui/pages/perps/perps-order-entry-page.test.tsx
@@ -1161,6 +1161,28 @@ describe('PerpsOrderEntryPage', () => {
       );
     });
 
+    it('does not disable submit in modify mode when pre-loaded TP has crossed market price', async () => {
+      mockSearchParams.set('mode', 'modify');
+      // Market has run above the existing TP ($3,200) — stale TP is now on the wrong
+      // side of the current price for a long, which previously silently blocked submit.
+      mockLiveMarketData.mockReturnValue({
+        markets: mockCryptoMarkets.map((m) =>
+          m.symbol === 'ETH' ? { ...m, price: '$3,500.00' } : m,
+        ),
+        isInitialLoading: false,
+      });
+      mockLivePositions.mockReturnValue({
+        positions: mockPositions,
+        isInitialLoading: false,
+      });
+
+      const store = mockStore(createMockState());
+      renderWithProvider(<PerpsOrderEntryPage />, store);
+
+      const submitButton = screen.getByTestId('submit-order-button');
+      expect(submitButton).not.toBeDisabled();
+    });
+
     it('does not submit when currentPrice is 0', async () => {
       mockLiveMarketData.mockReturnValue({
         markets: mockCryptoMarkets.map((m) => ({

--- a/ui/pages/perps/perps-order-entry-page.tsx
+++ b/ui/pages/perps/perps-order-entry-page.tsx
@@ -490,7 +490,9 @@ const PerpsOrderEntryPage: React.FC = () => {
   ]);
 
   const hasInvalidTPSL = useMemo(() => {
-    if (!orderFormState?.autoCloseEnabled) {
+    // In modify mode the TP/SL section is hidden and values carry over untouched,
+    // so stale prices that crossed the current market should not block submission.
+    if (!orderFormState?.autoCloseEnabled || orderMode === 'modify') {
       return false;
     }
 
@@ -524,7 +526,7 @@ const PerpsOrderEntryPage: React.FC = () => {
     );
 
     return tpInvalid || slInvalid;
-  }, [orderFormState, orderType, currentPrice]);
+  }, [orderFormState, orderType, currentPrice, orderMode]);
 
   const isInsufficientFunds = useMemo(() => {
     if (!orderFormState || orderMode === 'close') {

--- a/ui/pages/perps/perps-order-entry-page.tsx
+++ b/ui/pages/perps/perps-order-entry-page.tsx
@@ -1292,10 +1292,12 @@ const PerpsOrderEntryPage: React.FC = () => {
           isOrderPending && 'pointer-events-none opacity-50',
         )}
       >
-        <DirectionTabs
-          direction={orderDirection}
-          onDirectionChange={handleDirectionChange}
-        />
+        {orderMode === 'new' && (
+          <DirectionTabs
+            direction={orderDirection}
+            onDirectionChange={handleDirectionChange}
+          />
+        )}
         <OrderEntry
           asset={decodedSymbol}
           currentPrice={currentPrice}


### PR DESCRIPTION
## **Description**

Fixes a bug (TAT-2856) where the "Increase Exposure" flow (modify mode) on the perps order entry screen incorrectly showed:

1. **Long/Short direction tabs** — the user could flip direction while adding to an existing position, which is wrong. Direction is already determined by the open position.
2. **Auto-close (TP/SL) toggle** — the existing position's TP/SL should carry over untouched; exposing the controls implied the user needed to re-configure them.

The fix scopes both controls to `mode === 'new'` only:
- `DirectionTabs` is conditionally rendered only in new-order mode (also correctly hidden in close mode).
- `AutoCloseSection` render guard changed from `mode !== 'close'` to `mode === 'new'`.
- In modify mode, the existing position's TP/SL values are pre-loaded into form state via `deriveModifyFields` and submitted unchanged.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: TAT-2856

## **Manual testing steps**

1. Open the MetaMask extension and navigate to the Perps section.
2. Open or simulate an existing position (e.g. Long ETH).
3. Tap the **Modify** button and select **Increase Exposure**.
4. Verify the **Long/Short direction tabs are not shown** on the order entry screen.
5. Verify the **Auto-close (TP/SL) toggle is not shown**.
6. Enter an additional margin amount and submit — confirm the order is placed successfully.
7. Submit with no additional amount — confirm the existing TP/SL values are carried over (no change to the position's TP/SL).
8. Repeat steps 3–7 for a Short position to confirm parity.
9. Open a **new** position from the market detail page — confirm Long/Short tabs and Auto-close are still visible as expected.
10. Open the **Close** position flow — confirm Long/Short tabs are also not shown there.


## **Screenshots/Recordings**

### **Before**

### **After**
<img width="808" height="490" alt="Screenshot 2026-04-15 at 15 12 36" src="https://github.com/user-attachments/assets/b9b8d387-eb71-41bc-b9cd-5129dc3b5555" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes conditional rendering and submission validation in perps trading flows; mistakes could hide required inputs or incorrectly allow/deny order submission in modify mode.
> 
> **Overview**
> **Perps order entry now hides direction selection and TP/SL controls outside new orders.** `DirectionTabs` only render for `mode === 'new'`, preventing long/short flips during *modify* or *close* flows.
> 
> **Auto-close (TP/SL) UI is now new-order only.** `OrderEntry` renders `AutoCloseSection` only in new mode and simplifies the props passed to it.
> 
> **Modify-mode submit validation no longer blocks on stale TP/SL.** `PerpsOrderEntryPage` skips the `hasInvalidTPSL` guard when `orderMode === 'modify'`, and tests were updated/added to assert hidden UI, unchanged TP/SL submission, and the crossed-market-price regression case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9510e751bfbff0c219548607cbb36bab53899cf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->