### PR TITLE
fix: ordering of events in metametrics setting

### DIFF
--- a/ui/pages/settings-v2/privacy-tab/metametrics-item.test.tsx
+++ b/ui/pages/settings-v2/privacy-tab/metametrics-item.test.tsx
@@ -133,4 +133,27 @@ describe('MetametricsToggleItem', () => {
     const toggle = screen.getByTestId('participate-in-meta-metrics-input');
     expect(toggle.closest('.toggle-button--disabled')).toBeInTheDocument();
   });
+
+  it('fires TurnOffMetaMetrics event when toggled off', async () => {
+    const mockTrackEvent = jest.fn();
+    const mockStore = createMockStore({ participateInMetaMetrics: true });
+
+    renderWithProvider(
+      <MetametricsToggleItem />,
+      mockStore,
+      '/',
+      undefined,
+      () => mockTrackEvent,
+    );
+
+    fireEvent.click(screen.getByTestId('participate-in-meta-metrics-input'));
+
+    await waitFor(() => {
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: 'MetaMetrics Turned Off',
+        }),
+      );
+    });
+  });
 });

--- a/ui/pages/settings-v2/privacy-tab/metametrics-item.tsx
+++ b/ui/pages/settings-v2/privacy-tab/metametrics-item.tsx
@@ -65,7 +65,6 @@ export const MetametricsToggleItem = () => {
         dispatch(setDataCollectionForMarketing(false));
       }
 
-      await disableMetametrics();
       trackEvent({
         category: MetaMetricsEventCategory.Settings,
         event: MetaMetricsEventName.TurnOffMetaMetrics,
@@ -86,6 +85,8 @@ export const MetametricsToggleItem = () => {
           location: 'Settings',
         },
       });
+
+      await disableMetametrics();
     }
   };
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Mirrors [this fix here](https://github.com/MetaMask/metamask-extension/pull/41343) where MetaMetrics Turned Off and Analytics Preference Selected events are placed before the actual call to disable metametrics, meaning we receive the events before it's disabled.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to Settings > Privacy > Participate in Metametrics
2. Turn off and see the `MetaMetrics Turned Off` and `Analytics Preference Selected` events in the network tab

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small UI-side reordering to ensure telemetry opt-out events are sent before analytics is disabled, plus a focused unit test to prevent regression.
> 
> **Overview**
> Ensures the **MetaMetrics opt-out flow** tracks `MetaMetrics Turned Off` and `Analytics Preference Selected` *before* calling `disableMetametrics()`, so those events aren’t dropped when the user turns metrics off.
> 
> Adds a unit test asserting the Turn Off event is fired when the settings toggle is switched off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e80c046fc26d2e0ba14cf8be476ecce9881be48a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->