### PR TITLE
feat: migration reset native balance to 0 on tempo chains

### DIFF
--- a/app/scripts/migrations/206.test.ts
+++ b/app/scripts/migrations/206.test.ts
@@ -1,0 +1,247 @@
+import { cloneDeep } from 'lodash';
+import { zeroAddress } from 'ethereumjs-util';
+import { migrate, version } from './206';
+
+const VERSION = version;
+const OLD_VERSION = VERSION - 1;
+
+const ZERO_ADDRESS = zeroAddress();
+
+describe(`migration #${VERSION}`, () => {
+  it('migrate balances to 0x0 ONLY for native, ONLY for Tempo chains and FOR ALL accounts', async () => {
+    const oldStorage = {
+      meta: { version: OLD_VERSION },
+      data: {
+        TokenBalancesController: {
+          tokenBalances: {
+            '0xbf4ed7b27f1d666546861667caba0eecca747d7d': {
+              '0x1': {
+                [ZERO_ADDRESS]: '0x42',
+              },
+              '0x1079': {
+                [ZERO_ADDRESS]: '0x0',
+                '0x20c000000000000000000000b9537d11c60e8b50': '0x123',
+              },
+              '0xa5bf': {
+                [ZERO_ADDRESS]: '0x0',
+                '0x20c000000000000000000000b9537d11c60e8b50': '0x123',
+              },
+            },
+            '0x13b7e6EBcd40777099E4c45d407745aB2de1D1F8': {
+              '0x1': {
+                [ZERO_ADDRESS]: '0x42',
+              },
+              '0x1079': {
+                [ZERO_ADDRESS]:
+                  '0x9612084f0316e0ebd5182f398e5195a51b5ca47667d4c9b26c9b26c9b26c9b2',
+                '0x20c000000000000000000000b9537d11c60e8b50': '0x123',
+              },
+              '0xa5bf': {
+                [ZERO_ADDRESS]: '0x0',
+                '0x20c000000000000000000000b9537d11c60e8b50': '0x123',
+              },
+            },
+            '0xd8da6bf26964af9d7eed9e03e53415d37aa96045': {
+              '0x1': {
+                [ZERO_ADDRESS]: '0x42',
+              },
+              '0x1079': {
+                [ZERO_ADDRESS]:
+                  '0x9612084f0316e0ebd5182f398e5195a51b5ca47667d4c9b26c9b26c9b26c9b2',
+                '0x20c000000000000000000000b9537d11c60e8b50': '0x123',
+              },
+              '0xa5bf': {
+                [ZERO_ADDRESS]:
+                  '0x9612084f0316e0ebd5182f398e5195a51b5ca47667d4c9b26c9b26c9b26c9b2',
+                '0x20c000000000000000000000b9537d11c60e8b50': '0x123',
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const versionedData = cloneDeep(oldStorage);
+    const changedControllers = new Set<string>();
+
+    await migrate(versionedData, changedControllers);
+
+    expect(versionedData.meta.version).toBe(VERSION);
+    expect(versionedData.data.TokenBalancesController).toStrictEqual({
+      tokenBalances: {
+        '0xbf4ed7b27f1d666546861667caba0eecca747d7d': {
+          '0x1': {
+            [ZERO_ADDRESS]: '0x42',
+          },
+          '0x1079': {
+            [ZERO_ADDRESS]: '0x0',
+            '0x20c000000000000000000000b9537d11c60e8b50': '0x123',
+          },
+          '0xa5bf': {
+            [ZERO_ADDRESS]: '0x0',
+            '0x20c000000000000000000000b9537d11c60e8b50': '0x123',
+          },
+        },
+        '0x13b7e6EBcd40777099E4c45d407745aB2de1D1F8': {
+          '0x1': {
+            [ZERO_ADDRESS]: '0x42',
+          },
+          '0x1079': {
+            // Migrated
+            [ZERO_ADDRESS]: '0x0',
+            '0x20c000000000000000000000b9537d11c60e8b50': '0x123',
+          },
+          '0xa5bf': {
+            [ZERO_ADDRESS]: '0x0',
+            '0x20c000000000000000000000b9537d11c60e8b50': '0x123',
+          },
+        },
+        '0xd8da6bf26964af9d7eed9e03e53415d37aa96045': {
+          '0x1': {
+            [ZERO_ADDRESS]: '0x42',
+          },
+          '0x1079': {
+            // Migrated
+            [ZERO_ADDRESS]: '0x0',
+            '0x20c000000000000000000000b9537d11c60e8b50': '0x123',
+          },
+          '0xa5bf': {
+            // Migrated
+            [ZERO_ADDRESS]: '0x0',
+            '0x20c000000000000000000000b9537d11c60e8b50': '0x123',
+          },
+        },
+      },
+    });
+    expect(changedControllers).toStrictEqual(
+      new Set(['TokenBalancesController']),
+    );
+  });
+
+  it('does not mark the controller as migrated if no change happened', async () => {
+    const oldStorage = {
+      meta: { version: OLD_VERSION },
+      data: {
+        TokenBalancesController: {
+          tokenBalances: {
+            '0xbf4ed7b27f1d666546861667caba0eecca747d7d': {
+              '0x1': {
+                [ZERO_ADDRESS]: '0x42',
+              },
+              '0x1079': {
+                [ZERO_ADDRESS]: '0x0',
+                '0x20c000000000000000000000b9537d11c60e8b50': '0x123',
+              },
+              '0xa5bf': {
+                [ZERO_ADDRESS]: '0x0',
+                '0x20c000000000000000000000b9537d11c60e8b50': '0x123',
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const versionedData = cloneDeep(oldStorage);
+    const changedControllers = new Set<string>();
+
+    await migrate(versionedData, changedControllers);
+
+    expect(versionedData.meta.version).toBe(VERSION);
+    // Same same
+    expect(versionedData.data.TokenBalancesController).toStrictEqual({
+      tokenBalances: {
+        '0xbf4ed7b27f1d666546861667caba0eecca747d7d': {
+          '0x1': {
+            [ZERO_ADDRESS]: '0x42',
+          },
+          '0x1079': {
+            [ZERO_ADDRESS]: '0x0',
+            '0x20c000000000000000000000b9537d11c60e8b50': '0x123',
+          },
+          '0xa5bf': {
+            [ZERO_ADDRESS]: '0x0',
+            '0x20c000000000000000000000b9537d11c60e8b50': '0x123',
+          },
+        },
+      },
+    });
+    expect(changedControllers).toStrictEqual(new Set([]));
+  });
+
+  it('does nothing when TokenBalancesController is missing', async () => {
+    const oldStorage = {
+      meta: { version: OLD_VERSION },
+      data: {
+        SomeOtherController: {},
+      },
+    };
+
+    const versionedData = cloneDeep(oldStorage);
+    const changedControllers = new Set<string>();
+
+    await migrate(versionedData, changedControllers);
+
+    expect(versionedData.meta.version).toBe(VERSION);
+    expect(versionedData.data).toStrictEqual(oldStorage.data);
+    expect(changedControllers.size).toBe(0);
+  });
+
+  it('does nothing when TokenBalancesController is of incorrect type', async () => {
+    const oldStorage = {
+      meta: { version: OLD_VERSION },
+      data: {
+        TokenBalancesController: 'I am not an object',
+      },
+    };
+
+    const versionedData = cloneDeep(oldStorage);
+    const changedControllers = new Set<string>();
+
+    await migrate(versionedData, changedControllers);
+
+    expect(versionedData.meta.version).toBe(VERSION);
+    expect(versionedData.data).toStrictEqual(oldStorage.data);
+    expect(changedControllers.size).toBe(0);
+  });
+
+  it('does nothing when tokenBalances object is missing', async () => {
+    const oldStorage = {
+      meta: { version: OLD_VERSION },
+      data: {
+        TokenBalancesController: {
+          iamNotTheTokenBalanceObject: {},
+        },
+      },
+    };
+
+    const versionedData = cloneDeep(oldStorage);
+    const changedControllers = new Set<string>();
+
+    await migrate(versionedData, changedControllers);
+
+    expect(versionedData.meta.version).toBe(VERSION);
+    expect(versionedData.data).toStrictEqual(oldStorage.data);
+    expect(changedControllers.size).toBe(0);
+  });
+
+  it('does nothing when tokenBalances is of incorrect type', async () => {
+    const oldStorage = {
+      meta: { version: OLD_VERSION },
+      data: {
+        TokenBalancesController: {
+          tokenBalances: 'I am not an object.',
+        },
+      },
+    };
+
+    const versionedData = cloneDeep(oldStorage);
+    const changedControllers = new Set<string>();
+
+    await migrate(versionedData, changedControllers);
+
+    expect(versionedData.meta.version).toBe(VERSION);
+    expect(versionedData.data).toStrictEqual(oldStorage.data);
+    expect(changedControllers.size).toBe(0);
+  });
+});

--- a/app/scripts/migrations/206.ts
+++ b/app/scripts/migrations/206.ts
@@ -1,0 +1,79 @@
+import { hasProperty, isObject } from '@metamask/utils';
+import { zeroAddress } from 'ethereumjs-util';
+import type { Migrate } from './types';
+
+export const version = 206;
+
+const CHAINS_TO_MIGRATE_NATIVE_BALANCE_TO_ZERO = [
+  '0x1079', // Tempo Mainnet
+  '0xa5bf', // Tempo Testnet Moderato
+];
+
+const ZERO_ADDRESS = zeroAddress();
+const ZERO_BALANCE = '0x0';
+
+/**
+ *
+ * On Tempo, there is no native token.
+ * However Tempo's RPC returns '0x9612084f0316e0ebd5182f398e5195a51b5ca47667d4c9b26c9b26c9b26c9b2'
+ * as balance to `getbalance` causing a huge number to be displayed in MetaMask.
+ *
+ * The newest version of MetaMask hide this "non-existing native token" from everywhere in the UI.
+ * It also prevents that huge balance to be stored in the state.
+ * HOWEVER, if a user used Tempo before the latest version, their Tempo native balance may remain
+ * "cached" in `TokenBalancesController.tokenBalances`, causing the "total USD amount" (aggregated)
+ * to still show that huge number forever - since the native balance of the user will never change,
+ * it would never refresh.
+ *
+ * This one-time migration resets the native balance to 0 (`0x0`) on Tempo chains.
+ * Since the "hidding native" behavior is already in this version of MetaMask, the
+ * migration should only need to run once for those users that already used Tempo before.
+ *
+ * @param versionedData - The versioned data object to migrate.
+ * @param changedControllers - A set used to record controllers that were modified.
+ */
+export const migrate = (async (versionedData, changedControllers) => {
+  versionedData.meta.version = version;
+
+  if (
+    !hasProperty(versionedData.data, 'TokenBalancesController') ||
+    !isObject(versionedData.data.TokenBalancesController)
+  ) {
+    return;
+  }
+
+  const { TokenBalancesController } = versionedData.data;
+
+  if (
+    !hasProperty(TokenBalancesController, 'tokenBalances') ||
+    !isObject(TokenBalancesController.tokenBalances)
+  ) {
+    return;
+  }
+
+  const { tokenBalances } = TokenBalancesController;
+
+  let hasBeenMutatedAtLeastOnce = false;
+
+  Object.values(tokenBalances).forEach((balancesPerChain) => {
+    if (!isObject(balancesPerChain)) {
+      return;
+    }
+    CHAINS_TO_MIGRATE_NATIVE_BALANCE_TO_ZERO.forEach((chainId) => {
+      if (
+        chainId in balancesPerChain &&
+        isObject(balancesPerChain[chainId]) &&
+        balancesPerChain[chainId][ZERO_ADDRESS] &&
+        balancesPerChain[chainId][ZERO_ADDRESS] !== ZERO_BALANCE
+      ) {
+        // Assigns '0x0' (zero balance) if entry exists. We want balance to always be zero for those chains.
+        balancesPerChain[chainId][ZERO_ADDRESS] = ZERO_BALANCE;
+        hasBeenMutatedAtLeastOnce = true;
+      }
+    });
+  });
+
+  if (hasBeenMutatedAtLeastOnce) {
+    changedControllers.add('TokenBalancesController');
+  }
+}) satisfies Migrate;

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -241,6 +241,7 @@ const migrations = [
   require('./203'),
   require('./204'),
   require('./205'),
+  require('./206'),
 ];
 
 export default migrations;

--- a/test/e2e/fixtures/default-fixture.json
+++ b/test/e2e/fixtures/default-fixture.json
@@ -174,7 +174,7 @@
       "announcements": {}
     },
     "AppMetadataController": {
-      "currentMigrationVersion": 205,
+      "currentMigrationVersion": 206,
       "firstTimeInfo": {},
       "previousAppVersion": "",
       "previousMigrationVersion": 0
@@ -1080,6 +1080,6 @@
   },
   "meta": {
     "storageKind": "split",
-    "version": 205
+    "version": 206
   }
 }

--- a/test/e2e/fixtures/onboarding-fixture.json
+++ b/test/e2e/fixtures/onboarding-fixture.json
@@ -40,7 +40,7 @@
       "announcements": {}
     },
     "AppMetadataController": {
-      "currentMigrationVersion": 205,
+      "currentMigrationVersion": 206,
       "firstTimeInfo": {
         "date": 0,
         "version": "13.17.0"
@@ -2253,6 +2253,6 @@
   },
   "meta": {
     "storageKind": "split",
-    "version": 205
+    "version": 206
   }
 }

--- a/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
@@ -305,5 +305,5 @@
     },
     "config": "object"
   },
-  "meta": { "storageKind": "split", "version": 205 }
+  "meta": { "storageKind": "split", "version": 206 }
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

On Tempo, there is no native token.

However Tempo's RPC returns '0x9612084f0316e0ebd5182f398e5195a51b5ca47667d4c9b26c9b26c9b26c9b2'
as balance to `getbalance` causing a huge number to be displayed in MetaMask.

The newest version of MetaMask hide this "non-existing native token" from everywhere in the UI.
It also prevents that huge balance to be stored in the state.
HOWEVER, if a user used Tempo before the latest version, their Tempo native balance may remain
"cached" in `TokenBalancesController.tokenBalances`, causing the "total USD amount" (aggregated)
to still show that huge number forever - since the native balance of the user will never change,
it would never refresh.

This one-time migration resets the native balance to 0 (`0x0`) on Tempo chains.
Since the "hidding native" behavior is already in this version of MetaMask, the
migration should only need to run once for those users that already used Tempo before.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: migration to reset native balance to 0 on tempo chains

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/NEB-948?atlOrigin=eyJpIjoiZGU4NWEzNmJiNGVhNGY0YjkxMzdhNmUwMjQwZDBkODgiLCJwIjoiaiJ9
Fixes: https://github.com/MetaMask/metamask-extension/issues/41304

## **Manual testing steps**

1. Use version prior to v13-26-0.
2. Add Tempo chain, observe huge "total aggregated balance" at the top + presence of the `USD` token with huge balance.
3. Use latest version v13-27-0.
4. Observe that glitched `USD` is gone, but "total aggregated balance" still shows with a huge value at the top.
5. Use THIS PR version.
6. Observe that the "total aggregated balance" now shows a correct value.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="400" alt="image" src="https://github.com/user-attachments/assets/ac82a331-68a4-4d17-9c69-35cd839ea060" />


<!-- [screenshots/recordings] -->

### **After**
<img width="400" alt="image" src="https://github.com/user-attachments/assets/3ce14b5d-5a98-4b03-aebd-1212c3b42f47" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Includes a state migration that mutates persisted balance cache data; while tightly scoped to specific chain IDs and the native balance key, mistakes could affect displayed balances for Tempo users.
> 
> **Overview**
> Adds migration `206` that scans `TokenBalancesController.tokenBalances` for Tempo chain IDs (`0x1079`, `0xa5bf`) and resets any non-zero cached *native* balance (zero-address entry) to `0x0`, marking `TokenBalancesController` as changed only when a mutation occurs.
> 
> Registers the new migration, adds unit coverage for mutation/no-op and malformed state cases, and bumps e2e fixture/state snapshot migration versions from `205` to `206`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86c696ab3c1af9b296367648de28cb70d1755021. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->