### PR TITLE
feat: add updated logic for QR Adapter

### DIFF
--- a/shared/lib/browser-runtime.utils.test.ts
+++ b/shared/lib/browser-runtime.utils.test.ts
@@ -187,4 +187,36 @@ describe('Browser Runtime Utils', () => {
       expect(result).toStrictEqual('Brave');
     });
   });
+
+  describe('isFirefoxBrowser', () => {
+    it('uses window.navigator defaults when called with no arguments', () => {
+      const getParserSpy = jest.spyOn(Bowser, 'getParser');
+      const explicit = BrowserRuntimeUtil.isFirefoxBrowser(
+        Bowser.getParser(window.navigator.userAgent),
+        window.navigator,
+      );
+      getParserSpy.mockClear();
+
+      const implicit = BrowserRuntimeUtil.isFirefoxBrowser();
+
+      expect(getParserSpy).toHaveBeenCalledTimes(1);
+      expect(getParserSpy).toHaveBeenCalledWith(window.navigator.userAgent);
+      expect(implicit).toBe(explicit);
+      getParserSpy.mockRestore();
+    });
+
+    it('returns true for Firefox user agent', () => {
+      const bowser = Bowser.getParser(
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:91.0) Gecko/20100101 Firefox/91.0',
+      );
+      expect(BrowserRuntimeUtil.isFirefoxBrowser(bowser)).toBe(true);
+    });
+
+    it('returns false for Chrome user agent', () => {
+      const bowser = Bowser.getParser(
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+      );
+      expect(BrowserRuntimeUtil.isFirefoxBrowser(bowser)).toBe(false);
+    });
+  });
 });

--- a/shared/lib/browser-runtime.utils.ts
+++ b/shared/lib/browser-runtime.utils.ts
@@ -104,15 +104,13 @@ export function getBrowserName(
 }
 
 /**
- * @param bowser - Optional Bowser parser (defaults from `window.navigator.userAgent`).
- * @param nav - Optional Navigator (defaults to `window.navigator`).
+ * Checks whether the current browser is Firefox.
+ *
+ * @param args - Same optional `[bowser, navigator]` accepted by {@link getBrowserName}.
  * @returns Whether the host browser is Firefox (MV2 extension build).
  */
 export function isFirefoxBrowser(
-  bowser: Bowser.Parser.Parser = Bowser.getParser(
-    globalThis.navigator.userAgent,
-  ),
-  nav: Navigator = globalThis.navigator,
+  ...args: Parameters<typeof getBrowserName>
 ): boolean {
-  return getBrowserName(bowser, nav) === PLATFORM_FIREFOX;
+  return getBrowserName(...args) === PLATFORM_FIREFOX;
 }

--- a/shared/lib/browser-runtime.utils.ts
+++ b/shared/lib/browser-runtime.utils.ts
@@ -6,6 +6,11 @@ import Bowser from 'bowser';
 import browser from 'webextension-polyfill';
 import log from 'loglevel';
 import {
+  PLATFORM_BRAVE,
+  PLATFORM_EDGE,
+  PLATFORM_FIREFOX,
+} from '../constants/app';
+import {
   BROKEN_PRERENDER_BROWSER_VERSIONS,
   FIXED_PRERENDER_BROWSER_VERSIONS,
   // TODO: Remove restricted import
@@ -100,4 +105,16 @@ export function getBrowserName(
   }
 
   return bowser.getBrowserName();
+}
+
+/**
+ * @param bowser - Optional Bowser parser (defaults from `window.navigator.userAgent`).
+ * @param nav - Optional Navigator (defaults to `window.navigator`).
+ * @returns Whether the host browser is Firefox (MV2 extension build).
+ */
+export function isFirefoxBrowser(
+  bowser: Bowser.Parser.Parser = Bowser.getParser(window.navigator.userAgent),
+  nav: Navigator = window.navigator,
+): boolean {
+  return getBrowserName(bowser, nav) === PLATFORM_FIREFOX;
 }

--- a/shared/lib/browser-runtime.utils.ts
+++ b/shared/lib/browser-runtime.utils.ts
@@ -5,11 +5,7 @@
 import Bowser from 'bowser';
 import browser from 'webextension-polyfill';
 import log from 'loglevel';
-import {
-  PLATFORM_BRAVE,
-  PLATFORM_EDGE,
-  PLATFORM_FIREFOX,
-} from '../constants/app';
+import { PLATFORM_FIREFOX } from '../constants/app';
 import {
   BROKEN_PRERENDER_BROWSER_VERSIONS,
   FIXED_PRERENDER_BROWSER_VERSIONS,
@@ -113,8 +109,10 @@ export function getBrowserName(
  * @returns Whether the host browser is Firefox (MV2 extension build).
  */
 export function isFirefoxBrowser(
-  bowser: Bowser.Parser.Parser = Bowser.getParser(window.navigator.userAgent),
-  nav: Navigator = window.navigator,
+  bowser: Bowser.Parser.Parser = Bowser.getParser(
+    globalThis.navigator.userAgent,
+  ),
+  nav: Navigator = globalThis.navigator,
 ): boolean {
   return getBrowserName(bowser, nav) === PLATFORM_FIREFOX;
 }

--- a/ui/contexts/hardware-wallets/adapters/QrAdapter.test.ts
+++ b/ui/contexts/hardware-wallets/adapters/QrAdapter.test.ts
@@ -99,13 +99,13 @@ describe('QrAdapter', () => {
     expect(adapter.isConnected()).toBe(false);
   });
 
-  it('ensureDeviceReady returns true when permission is granted and getUserMedia succeeds', async () => {
+  it('ensureDeviceReady returns true immediately when permission is already granted without opening getUserMedia', async () => {
     mockCheckCameraPermission.mockResolvedValue(CameraPermissionState.Granted);
 
     await expect(adapter.ensureDeviceReady()).resolves.toBe(true);
 
-    expect(mockOpenCameraVideoStream).toHaveBeenCalledTimes(1);
-    expect(mockStopMediaStreamTracks).toHaveBeenCalledWith(mockStream);
+    expect(mockOpenCameraVideoStream).not.toHaveBeenCalled();
+    expect(mockStopMediaStreamTracks).not.toHaveBeenCalled();
   });
 
   it('ensureDeviceReady does not call connect again when already connected', async () => {

--- a/ui/contexts/hardware-wallets/adapters/QrAdapter.test.ts
+++ b/ui/contexts/hardware-wallets/adapters/QrAdapter.test.ts
@@ -1,22 +1,46 @@
 import { ErrorCode, HardwareWalletError } from '@metamask/hw-wallet-sdk';
+import { isFirefoxBrowser } from '../../../../shared/lib/browser-runtime.utils';
 import { CameraPermissionState } from '../constants';
 import { DeviceEvent, type HardwareWalletAdapterOptions } from '../types';
 import * as webConnectionUtils from '../webConnectionUtils';
 import { QrAdapter } from './QrAdapter';
 
+jest.mock('../../../../shared/lib/browser-runtime.utils', () => ({
+  ...jest.requireActual<
+    typeof import('../../../../shared/lib/browser-runtime.utils')
+  >('../../../../shared/lib/browser-runtime.utils'),
+  isFirefoxBrowser: jest.fn(() => false),
+}));
+
 jest.mock('../webConnectionUtils', () => ({
   ...jest.requireActual('../webConnectionUtils'),
   checkCameraPermission: jest.fn(),
+  openCameraVideoStream: jest.fn(),
+  stopMediaStreamTracks: jest.fn(),
 }));
 
 const mockCheckCameraPermission =
   webConnectionUtils.checkCameraPermission as jest.MockedFunction<
     typeof webConnectionUtils.checkCameraPermission
   >;
+const mockOpenCameraVideoStream =
+  webConnectionUtils.openCameraVideoStream as jest.MockedFunction<
+    typeof webConnectionUtils.openCameraVideoStream
+  >;
+const mockStopMediaStreamTracks =
+  webConnectionUtils.stopMediaStreamTracks as jest.MockedFunction<
+    typeof webConnectionUtils.stopMediaStreamTracks
+  >;
+
+const mockIsFirefoxBrowser = jest.mocked(isFirefoxBrowser);
 
 describe('QrAdapter', () => {
   let adapter: QrAdapter;
   let mockOptions: HardwareWalletAdapterOptions;
+
+  const mockStream = {
+    getTracks: () => [{ stop: jest.fn() }],
+  };
 
   const createMockOptions = (): HardwareWalletAdapterOptions => ({
     onDisconnect: jest.fn(),
@@ -28,12 +52,17 @@ describe('QrAdapter', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockIsFirefoxBrowser.mockReturnValue(false);
     mockOptions = createMockOptions();
     adapter = new QrAdapter(mockOptions);
+    mockOpenCameraVideoStream.mockResolvedValue(
+      mockStream as unknown as MediaStream,
+    );
+    mockStopMediaStreamTracks.mockImplementation(() => undefined);
   });
 
   afterEach(() => {
-    jest.resetAllMocks();
+    jest.restoreAllMocks();
     adapter.destroy();
   });
 
@@ -64,9 +93,19 @@ describe('QrAdapter', () => {
     expect(mockOptions.onDisconnect).toHaveBeenCalledWith(handlerError);
   });
 
-  it('ensureDeviceReady returns true when camera permission is granted', async () => {
+  it('destroy clears connected state', async () => {
+    await adapter.connect();
+    adapter.destroy();
+    expect(adapter.isConnected()).toBe(false);
+  });
+
+  it('ensureDeviceReady returns true when permission is granted and getUserMedia succeeds', async () => {
     mockCheckCameraPermission.mockResolvedValue(CameraPermissionState.Granted);
+
     await expect(adapter.ensureDeviceReady()).resolves.toBe(true);
+
+    expect(mockOpenCameraVideoStream).toHaveBeenCalledTimes(1);
+    expect(mockStopMediaStreamTracks).toHaveBeenCalledWith(mockStream);
   });
 
   it('ensureDeviceReady does not call connect again when already connected', async () => {
@@ -80,13 +119,14 @@ describe('QrAdapter', () => {
     connectSpy.mockRestore();
   });
 
-  it('ensureDeviceReady throws PermissionCameraDenied when camera permission is denied', async () => {
+  it('ensureDeviceReady throws PermissionCameraDenied when permission query is denied without calling getUserMedia', async () => {
     mockCheckCameraPermission.mockResolvedValue(CameraPermissionState.Denied);
 
     await expect(adapter.ensureDeviceReady()).rejects.toThrow(
       HardwareWalletError,
     );
 
+    expect(mockOpenCameraVideoStream).not.toHaveBeenCalled();
     expect(mockOptions.onDeviceEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         event: DeviceEvent.ConnectionFailed,
@@ -97,8 +137,124 @@ describe('QrAdapter', () => {
     );
   });
 
-  it('ensureDeviceReady throws PermissionCameraPromptDismissed when camera permission is prompt', async () => {
+  it('ensureDeviceReady returns true when permission is prompt and getUserMedia succeeds', async () => {
     mockCheckCameraPermission.mockResolvedValue(CameraPermissionState.Prompt);
+
+    await expect(adapter.ensureDeviceReady()).resolves.toBe(true);
+
+    expect(mockOpenCameraVideoStream).toHaveBeenCalledTimes(1);
+  });
+
+  it('ensureDeviceReady throws PermissionCameraPromptDismissed when getUserMedia fails with NotAllowedError and permission stays prompt (Chromium)', async () => {
+    mockCheckCameraPermission.mockResolvedValue(CameraPermissionState.Prompt);
+    const notAllowed = new Error('denied');
+    notAllowed.name = 'NotAllowedError';
+    mockOpenCameraVideoStream.mockRejectedValueOnce(notAllowed);
+
+    await expect(adapter.ensureDeviceReady()).rejects.toThrow(
+      HardwareWalletError,
+    );
+
+    expect(mockCheckCameraPermission).toHaveBeenCalledTimes(2);
+    expect(mockOptions.onDeviceEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.objectContaining({
+          code: ErrorCode.PermissionCameraPromptDismissed,
+        }),
+      }),
+    );
+  });
+
+  it('ensureDeviceReady throws PermissionCameraPromptDismissed when getUserMedia fails with NotAllowedError and follow-up permission query throws', async () => {
+    mockCheckCameraPermission
+      .mockResolvedValueOnce(CameraPermissionState.Prompt)
+      .mockRejectedValueOnce(new Error('permissions.query failed'));
+    const notAllowed = new Error('denied');
+    notAllowed.name = 'NotAllowedError';
+    mockOpenCameraVideoStream.mockRejectedValueOnce(notAllowed);
+
+    await expect(adapter.ensureDeviceReady()).rejects.toThrow(
+      HardwareWalletError,
+    );
+
+    expect(mockCheckCameraPermission).toHaveBeenCalledTimes(2);
+    expect(mockOptions.onDeviceEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.objectContaining({
+          code: ErrorCode.PermissionCameraPromptDismissed,
+        }),
+      }),
+    );
+  });
+
+  it('ensureDeviceReady throws PermissionCameraPromptDismissed when getUserMedia fails with NotAllowedError and permission re-query is granted (Chromium)', async () => {
+    mockCheckCameraPermission
+      .mockResolvedValueOnce(CameraPermissionState.Prompt)
+      .mockResolvedValueOnce(CameraPermissionState.Granted);
+    const notAllowed = new Error('denied');
+    notAllowed.name = 'NotAllowedError';
+    mockOpenCameraVideoStream.mockRejectedValueOnce(notAllowed);
+
+    await expect(adapter.ensureDeviceReady()).rejects.toThrow(
+      HardwareWalletError,
+    );
+
+    expect(mockOptions.onDeviceEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.objectContaining({
+          code: ErrorCode.PermissionCameraPromptDismissed,
+        }),
+      }),
+    );
+  });
+
+  it('ensureDeviceReady throws PermissionCameraDenied when getUserMedia fails with NotAllowedError and permission stays prompt on Firefox', async () => {
+    mockIsFirefoxBrowser.mockReturnValue(true);
+    mockCheckCameraPermission.mockResolvedValue(CameraPermissionState.Prompt);
+    const notAllowed = new Error('denied');
+    notAllowed.name = 'NotAllowedError';
+    mockOpenCameraVideoStream.mockRejectedValueOnce(notAllowed);
+
+    await expect(adapter.ensureDeviceReady()).rejects.toThrow(
+      HardwareWalletError,
+    );
+
+    expect(mockCheckCameraPermission).toHaveBeenCalledTimes(2);
+    expect(mockOptions.onDeviceEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.objectContaining({
+          code: ErrorCode.PermissionCameraDenied,
+        }),
+      }),
+    );
+  });
+
+  it('ensureDeviceReady throws PermissionCameraDenied when getUserMedia fails with NotAllowedError and permission becomes denied', async () => {
+    mockCheckCameraPermission
+      .mockResolvedValueOnce(CameraPermissionState.Prompt)
+      .mockResolvedValueOnce(CameraPermissionState.Denied);
+    const notAllowed = new Error('denied');
+    notAllowed.name = 'NotAllowedError';
+    mockOpenCameraVideoStream.mockRejectedValueOnce(notAllowed);
+
+    await expect(adapter.ensureDeviceReady()).rejects.toThrow(
+      HardwareWalletError,
+    );
+
+    expect(mockOptions.onDeviceEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.objectContaining({
+          code: ErrorCode.PermissionCameraDenied,
+        }),
+      }),
+    );
+  });
+
+  it('ensureDeviceReady maps non-NotAllowed errors from openCameraVideoStream to hardware wallet errors', async () => {
+    mockCheckCameraPermission.mockResolvedValue(CameraPermissionState.Prompt);
+    mockOpenCameraVideoStream.mockRejectedValueOnce(
+      new Error('Camera hardware missing'),
+    );
 
     await expect(adapter.ensureDeviceReady()).rejects.toThrow(
       HardwareWalletError,
@@ -108,13 +264,13 @@ describe('QrAdapter', () => {
       expect.objectContaining({
         event: DeviceEvent.ConnectionFailed,
         error: expect.objectContaining({
-          code: ErrorCode.PermissionCameraPromptDismissed,
+          code: ErrorCode.Unknown,
         }),
       }),
     );
   });
 
-  it('maps unexpected errors to hardware wallet errors and emits device event', async () => {
+  it('maps unexpected errors from checkCameraPermission to hardware wallet errors and emits device event', async () => {
     mockCheckCameraPermission.mockRejectedValue(
       new Error('Unable to read camera permission'),
     );

--- a/ui/contexts/hardware-wallets/adapters/QrAdapter.ts
+++ b/ui/contexts/hardware-wallets/adapters/QrAdapter.ts
@@ -1,4 +1,5 @@
 import { ErrorCode, type HardwareWalletError } from '@metamask/hw-wallet-sdk';
+import { isFirefoxBrowser } from '../../../../shared/lib/browser-runtime.utils';
 import { createHardwareWalletError, getDeviceEventForError } from '../errors';
 import { toHardwareWalletError } from '../rpcErrorUtils';
 import {
@@ -9,7 +10,11 @@ import {
   type HardwareWalletAdapterOptions,
 } from '../types';
 import { CameraPermissionState } from '../constants';
-import { checkCameraPermission } from '../webConnectionUtils';
+import {
+  checkCameraPermission,
+  openCameraVideoStream,
+  stopMediaStreamTracks,
+} from '../webConnectionUtils';
 
 /**
  * QR hardware wallet adapter.
@@ -75,11 +80,15 @@ export class QrAdapter implements HardwareWalletAdapter {
   }
 
   /**
-   * Ensures camera permission state allows QR scanning (via Permissions API probe).
-   * Rejects with `HardwareWalletError` when permission is denied, still prompt, or the probe fails.
+   * Ensures the browser allows camera access for QR scanning.
+   *
+   * Uses `permissions.query` first: if `denied`, fails without calling `getUserMedia`.
+   * For `prompt` or `granted`, calls `openCameraVideoStream` (`getUserMedia`);
+   * `NotAllowedError` maps to dismissed vs blocked
+   * after re-querying permission state.
    *
    * @param _options - Reserved for parity with other hardware adapters; ignored for QR.
-   * @returns True when camera permission is granted.
+   * @returns True when a video stream can be acquired.
    */
   async ensureDeviceReady(
     _options?: EnsureDeviceReadyOptions,
@@ -97,10 +106,6 @@ export class QrAdapter implements HardwareWalletAdapter {
       );
     }
 
-    if (permissionState === CameraPermissionState.Granted) {
-      return true;
-    }
-
     if (permissionState === CameraPermissionState.Denied) {
       return this.failEnsureDeviceReady(
         createHardwareWalletError(
@@ -110,11 +115,42 @@ export class QrAdapter implements HardwareWalletAdapter {
       );
     }
 
-    return this.failEnsureDeviceReady(
-      createHardwareWalletError(
-        ErrorCode.PermissionCameraPromptDismissed,
-        HardwareWalletType.Qr,
-      ),
-    );
+    try {
+      const stream = await openCameraVideoStream();
+      stopMediaStreamTracks(stream);
+      return true;
+    } catch (error) {
+      const domError = error as { name?: string };
+      if (domError.name === 'NotAllowedError') {
+        let nextState: PermissionState;
+        try {
+          nextState = await checkCameraPermission();
+        } catch {
+          return this.failEnsureDeviceReady(
+            createHardwareWalletError(
+              ErrorCode.PermissionCameraPromptDismissed,
+              HardwareWalletType.Qr,
+            ),
+          );
+        }
+        if (nextState === CameraPermissionState.Denied || isFirefoxBrowser()) {
+          return this.failEnsureDeviceReady(
+            createHardwareWalletError(
+              ErrorCode.PermissionCameraDenied,
+              HardwareWalletType.Qr,
+            ),
+          );
+        }
+        return this.failEnsureDeviceReady(
+          createHardwareWalletError(
+            ErrorCode.PermissionCameraPromptDismissed,
+            HardwareWalletType.Qr,
+          ),
+        );
+      }
+      return this.failEnsureDeviceReady(
+        toHardwareWalletError(error, HardwareWalletType.Qr),
+      );
+    }
   }
 }

--- a/ui/contexts/hardware-wallets/adapters/QrAdapter.ts
+++ b/ui/contexts/hardware-wallets/adapters/QrAdapter.ts
@@ -133,7 +133,10 @@ export class QrAdapter implements HardwareWalletAdapter {
             ),
           );
         }
-        if (nextState === CameraPermissionState.Denied || isFirefoxBrowser()) {
+        if (
+          nextState === CameraPermissionState.Denied ||
+          (nextState === CameraPermissionState.Prompt && isFirefoxBrowser())
+        ) {
           return this.failEnsureDeviceReady(
             createHardwareWalletError(
               ErrorCode.PermissionCameraDenied,

--- a/ui/contexts/hardware-wallets/adapters/QrAdapter.ts
+++ b/ui/contexts/hardware-wallets/adapters/QrAdapter.ts
@@ -83,12 +83,13 @@ export class QrAdapter implements HardwareWalletAdapter {
    * Ensures the browser allows camera access for QR scanning.
    *
    * Uses `permissions.query` first: if `denied`, fails without calling `getUserMedia`.
-   * For `prompt` or `granted`, calls `openCameraVideoStream` (`getUserMedia`);
-   * `NotAllowedError` maps to dismissed vs blocked
-   * after re-querying permission state.
+   * If already `granted`, returns immediately — the actual camera stream will be
+   * opened later by `EnhancedReader` in the QR scanner popover.
+   * For `prompt`, calls `openCameraVideoStream` to trigger the browser permission
+   * dialog; `NotAllowedError` maps to dismissed vs blocked after re-querying.
    *
    * @param _options - Reserved for parity with other hardware adapters; ignored for QR.
-   * @returns True when a video stream can be acquired.
+   * @returns True when camera access is permitted.
    */
   async ensureDeviceReady(
     _options?: EnsureDeviceReadyOptions,
@@ -113,6 +114,12 @@ export class QrAdapter implements HardwareWalletAdapter {
           HardwareWalletType.Qr,
         ),
       );
+    }
+
+    // Skip getUserMedia when already granted — no need to open/close the camera
+    // just to prove access. The QR scanner will open it when it renders.
+    if (permissionState === CameraPermissionState.Granted) {
+      return true;
     }
 
     try {

--- a/ui/contexts/hardware-wallets/webConnectionUtils.test.ts
+++ b/ui/contexts/hardware-wallets/webConnectionUtils.test.ts
@@ -8,6 +8,8 @@ import {
   isWebHidAvailable,
   isWebUsbAvailable,
   isCameraAvailable,
+  openCameraVideoStream,
+  stopMediaStreamTracks,
   checkHardwareWalletPermission,
   checkWebHidPermission,
   checkWebUsbPermission,
@@ -379,6 +381,40 @@ describe('webConnectionUtils', () => {
     });
   });
 
+  describe('openCameraVideoStream', () => {
+    it('throws when camera APIs are unavailable', async () => {
+      Object.defineProperty(window.navigator, 'mediaDevices', {
+        value: undefined,
+        writable: true,
+        configurable: true,
+      });
+
+      await expect(openCameraVideoStream()).rejects.toThrow(
+        'Camera capture is not available in this context',
+      );
+    });
+
+    it('returns the stream from getUserMedia', async () => {
+      const mockStream = { getTracks: () => [] } as unknown as MediaStream;
+      getMockedMediaDevices().getUserMedia.mockResolvedValue(mockStream);
+
+      await expect(openCameraVideoStream()).resolves.toBe(mockStream);
+      expect(getMockedMediaDevices().getUserMedia).toHaveBeenCalledWith({
+        video: true,
+      });
+    });
+  });
+
+  describe('stopMediaStreamTracks', () => {
+    it('stops every track', () => {
+      const stop = jest.fn();
+      stopMediaStreamTracks({
+        getTracks: () => [{ stop }],
+      } as unknown as MediaStream);
+      expect(stop).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('camera permission helpers', () => {
     it('checkCameraPermissionState returns Granted when camera permission is granted', async () => {
       getMockedPermissions().query.mockResolvedValue({
@@ -397,6 +433,16 @@ describe('webConnectionUtils', () => {
 
       await expect(checkCameraPermissionState()).resolves.toBe(
         HardwareConnectionPermissionState.Denied,
+      );
+    });
+
+    it('checkCameraPermissionState returns Prompt when permission state is prompt', async () => {
+      getMockedPermissions().query.mockResolvedValue({
+        state: CameraPermissionState.Prompt,
+      });
+
+      await expect(checkCameraPermissionState()).resolves.toBe(
+        HardwareConnectionPermissionState.Prompt,
       );
     });
 

--- a/ui/contexts/hardware-wallets/webConnectionUtils.ts
+++ b/ui/contexts/hardware-wallets/webConnectionUtils.ts
@@ -238,20 +238,36 @@ export async function requestHardwareWalletPermission(
 }
 
 /**
+ * Opens a temporary video stream for permission or capability checks.
+ * Call {@link stopMediaStreamTracks} when finished.
+ *
+ * @returns Stream from `getUserMedia({ video: true })`.
+ * @throws When camera APIs are unavailable or `getUserMedia` rejects (e.g. `NotAllowedError`).
+ */
+export async function openCameraVideoStream(): Promise<MediaStream> {
+  if (!isCameraAvailable()) {
+    throw new Error('Camera capture is not available in this context');
+  }
+  const { navigator } = globalThis;
+  return await navigator.mediaDevices.getUserMedia({ video: true });
+}
+
+/**
+ * Stops every track on a media stream (e.g. after a probe or permission request).
+ *
+ * @param stream - Stream returned from {@link openCameraVideoStream}.
+ */
+export function stopMediaStreamTracks(stream: MediaStream): void {
+  stream.getTracks().forEach((track) => track.stop());
+}
+
+/**
  * Request camera permission from the user.
  */
 export async function requestCameraPermission(): Promise<boolean> {
-  if (!isCameraAvailable()) {
-    return false;
-  }
-
   try {
-    const { navigator } = globalThis;
-    const stream = await navigator.mediaDevices.getUserMedia({
-      video: true,
-    });
-
-    stream.getTracks().forEach((track) => track.stop());
+    const stream = await openCameraVideoStream();
+    stopMediaStreamTracks(stream);
     return true;
   } catch {
     return false;


### PR DESCRIPTION
## **Description**
This PR adds updates to QR Adapter and its utilities in order to support better error handling and differences between Chromium browsers and Firefox.

This is split from the other PR which is still WIP: https://github.com/MetaMask/metamask-extension/pull/41612

QR Adapter is not yet in use and will be enabled in another PR: https://github.com/MetaMask/metamask-extension/pull/41612

## **Changelog**
<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**
Fixes: n/a

## **Manual testing steps**
1. Unit tests for files changed should be passing.

## **Screenshots/Recordings**

### **Before**
No UI changes. Nothing to show here.

### **After**
No UI changes. Nothing to show here.

## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates QR camera readiness checks to actively probe `getUserMedia` and map `NotAllowedError` differently across Chromium vs Firefox, which could change when users see denied vs dismissed errors. Also refactors camera permission utilities, so regressions could impact any camera-permission flows relying on these helpers.
> 
> **Overview**
> Improves `QrAdapter.ensureDeviceReady` to **avoid opening the camera when permission is already `granted`**, to **trigger the permission prompt via `getUserMedia` when state is `prompt`**, and to **differentiate blocked vs dismissed outcomes** by re-querying permissions after `NotAllowedError` (treating Firefox `prompt` as *denied*).
> 
> Refactors camera utilities by extracting `openCameraVideoStream` and `stopMediaStreamTracks`, updates `requestCameraPermission` to use them, and adds `BrowserRuntimeUtil.isFirefoxBrowser` to centralize Firefox detection. Tests are expanded to cover the new permission-state matrix and stream helper behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af62c8ae848bd4acc50712511a572667af68804d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->