### PR TITLE
Fix E2E test flakiness

### DIFF
--- a/test/e2e/fixtures/default-fixture.json
+++ b/test/e2e/fixtures/default-fixture.json
@@ -229,7 +229,7 @@
           "eip155:1/slip44:60": {
             "amount": "25"
           },
-          "eip155:1337/slip44:60": {
+          "eip155:1337/slip44:1": {
             "amount": "25"
           },
           "eip155:42161/slip44:60": {
@@ -249,11 +249,19 @@
           "symbol": "ETH",
           "type": "native"
         },
-        "eip155:1337/slip44:60": {
+        "eip155:1337/slip44:1": {
           "aggregators": [],
           "decimals": 18,
           "image": "https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/slip44/60.png",
           "name": "Ethereum",
+          "symbol": "ETH",
+          "type": "native"
+        },
+        "eip155:10/slip44:60": {
+          "aggregators": [],
+          "decimals": 18,
+          "image": "https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/10/slip44/60.png",
+          "name": "Ether",
           "symbol": "ETH",
           "type": "native"
         },
@@ -288,7 +296,7 @@
           "price": 2047.51,
           "usdPrice": 2047.51
         },
-        "eip155:1337/slip44:60": {
+        "eip155:1337/slip44:1": {
           "assetPriceType": "fungible",
           "id": "ethereum",
           "price": 2047.51,

--- a/test/e2e/fixtures/fixture-builder-v2.ts
+++ b/test/e2e/fixtures/fixture-builder-v2.ts
@@ -1029,10 +1029,10 @@ class FixtureBuilderV2 {
     return this.withAssetsController({
       assetsBalance: {
         'd5e45e4a-3b04-4a09-a5e1-39762e5c6be4': {
-          'eip155:1337/slip44:60': { amount: '25' },
+          'eip155:1337/slip44:1': { amount: '25' },
         },
         [HARDWARE_WALLET_ACCOUNT_ID]: {
-          'eip155:1337/slip44:60': { amount: '100' },
+          'eip155:1337/slip44:1': { amount: '100' },
         },
       },
     })

--- a/test/e2e/fixtures/fixture-builder.js
+++ b/test/e2e/fixtures/fixture-builder.js
@@ -1756,10 +1756,10 @@ class FixtureBuilder {
     return this.withAssetsController({
       assetsBalance: {
         'd5e45e4a-3b04-4a09-a5e1-39762e5c6be4': {
-          'eip155:1337/slip44:60': { amount: '25' },
+          'eip155:1337/slip44:1': { amount: '25' },
         },
         '221ecb67-0d29-4c04-83b2-dff07c263634': {
-          'eip155:1337/slip44:60': { amount: '100' },
+          'eip155:1337/slip44:1': { amount: '100' },
         },
       },
     })

--- a/test/e2e/mock-e2e.js
+++ b/test/e2e/mock-e2e.js
@@ -1261,12 +1261,18 @@ async function setupMocking(
         decimals: 18,
       });
 
-      pushIf(assetIds.includes('eip155:1337/slip44:60'), {
-        assetId: 'eip155:1337/slip44:60',
-        name: 'Ethereum',
-        symbol: 'ETH',
-        decimals: 18,
-      });
+      // Chain 1337 uses slip44:1 per nativeAssetIdentifiers in the fixture.
+      // Support both slip44:1 and slip44:60 requests for backward compat.
+      pushIf(
+        assetIds.includes('eip155:1337/slip44:1') ||
+          assetIds.includes('eip155:1337/slip44:60'),
+        {
+          assetId: 'eip155:1337/slip44:1',
+          name: 'Ethereum',
+          symbol: 'ETH',
+          decimals: 18,
+        },
+      );
 
       const usdcMainnet =
         'eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
@@ -1343,6 +1349,10 @@ async function setupMocking(
         typeof unifiedEvmAccountsApiBalances.mainnetNativeEthHuman === 'string'
           ? unifiedEvmAccountsApiBalances.mainnetNativeEthHuman
           : null;
+      const defaultNativeOverride =
+        typeof unifiedEvmAccountsApiBalances.nativeBalance === 'string'
+          ? unifiedEvmAccountsApiBalances.nativeBalance
+          : null;
       const mainnetAdditional = Array.isArray(
         unifiedEvmAccountsApiBalances.mainnetAdditionalBalances,
       )
@@ -1359,11 +1369,15 @@ async function setupMocking(
         const nativeBalance =
           chainRef === '1' && mainnetNativeOverride !== null
             ? mainnetNativeOverride
-            : '25';
+            : defaultNativeOverride !== null
+              ? defaultNativeOverride
+              : '25';
 
+        // Chain 1337 uses slip44:1 per nativeAssetIdentifiers; all others use slip44:60.
+        const slip44 = chainRef === '1337' ? '1' : '60';
         balances.push({
           accountId: id,
-          assetId: `eip155:${chainRef}/slip44:60`,
+          assetId: `eip155:${chainRef}/slip44:${slip44}`,
           balance: nativeBalance,
         });
 

--- a/test/e2e/page-objects/pages/onboarding/onboarding-complete-page.ts
+++ b/test/e2e/page-objects/pages/onboarding/onboarding-complete-page.ts
@@ -35,12 +35,12 @@ class OnboardingCompletePage {
     this.driver = driver;
   }
 
-  async checkPageIsLoaded(): Promise<void> {
+  async checkPageIsLoaded(timeout: number = 30000): Promise<void> {
     try {
-      await this.driver.waitForMultipleSelectors([
-        this.manageDefaultSettingsButton,
-        this.onboardingCompleteDoneButton,
-      ]);
+      await this.driver.waitForMultipleSelectors(
+        [this.manageDefaultSettingsButton, this.onboardingCompleteDoneButton],
+        { timeout },
+      );
     } catch (e) {
       console.log(
         'Timeout while waiting for onboarding wallet creation complete page to be loaded',

--- a/test/e2e/page-objects/pages/permission/site-permission-page.ts
+++ b/test/e2e/page-objects/pages/permission/site-permission-page.ts
@@ -168,10 +168,13 @@ class SitePermissionPage {
    */
   async checkConnectedNetworksNumber(number: number): Promise<void> {
     console.log(`Check that the number of connected networks is: ${number}`);
-    await this.driver.waitForSelector({
-      text: `${number} networks connected`,
-      tag: 'span',
-    });
+    await this.driver.waitForSelector(
+      {
+        text: `${number} networks connected`,
+        tag: 'span',
+      },
+      { timeout: 20000 },
+    );
   }
 }
 

--- a/test/e2e/snaps/test-snap-namelookup.spec.ts
+++ b/test/e2e/snaps/test-snap-namelookup.spec.ts
@@ -40,7 +40,8 @@ describe('Name lookup', function () {
         await driver.switchToWindowWithTitle(
           WINDOW_TITLES.ExtensionInFullScreenView,
         );
-        // Navigate to the extension home page and validate the recipient address in the send flow
+        await homePage.checkPageIsLoaded();
+
         await homePage.startSendFlow();
 
         await sendPage.selectToken('0x1', 'ETH');

--- a/test/e2e/tests/account-activity/websocket-balance-resilience.spec.ts
+++ b/test/e2e/tests/account-activity/websocket-balance-resilience.spec.ts
@@ -19,7 +19,7 @@ import { Anvil } from '../../seeder/anvil';
 
 const FIFTY_ETH_WEI = '0x2b5e3af16b1880000';
 const THIRTY_FIVE_ETH_WEI = '0x1e5b8fa8fe2ac0000';
-const BALANCE_POLL_TIMEOUT = 150_000;
+const BALANCE_POLL_TIMEOUT = 180_000;
 const RECONNECT_TIMEOUT = 60_000;
 
 async function waitForAccountActivityWsConnections(
@@ -55,7 +55,7 @@ async function waitForBalanceUpdate(
 describe('Account Activity WebSocket Balance Resilience', function (this: Suite) {
   describe('REST Polling Fallback', function () {
     it('balance updates continue via REST polling when WebSocket disconnects', async function () {
-      this.timeout(180_000);
+      this.timeout(210_000);
 
       // Mutable object passed to the global mock in mock-e2e.js.
       // The mock reads defaultNativeEthHuman on every poll, so flipping it
@@ -107,7 +107,7 @@ describe('Account Activity WebSocket Balance Resilience', function (this: Suite)
 
   describe('Reconnection', function () {
     it('WebSocket reconnects and real-time updates resume after server recovery', async function () {
-      this.timeout(180_000);
+      this.timeout(210_000);
 
       const balanceOverride: { nativeBalance: string } = {
         nativeBalance: '25',

--- a/test/e2e/tests/account-activity/websocket-balance-resilience.spec.ts
+++ b/test/e2e/tests/account-activity/websocket-balance-resilience.spec.ts
@@ -1,6 +1,4 @@
-import { strict as assert } from 'assert';
 import { Suite } from 'mocha';
-import { Mockttp } from 'mockttp';
 import { Driver } from '../../webdriver/driver';
 import WebSocketRegistry from '../../websocket/registry';
 import { withFixtures } from '../../helpers';
@@ -58,11 +56,19 @@ describe('Account Activity WebSocket Balance Resilience', function (this: Suite)
   describe('REST Polling Fallback', function () {
     it('balance updates continue via REST polling when WebSocket disconnects', async function () {
       this.timeout(180_000);
+
+      // Mutable object passed to the global mock in mock-e2e.js.
+      // The mock reads defaultNativeEthHuman on every poll, so flipping it
+      // mid-test changes what the next Accounts API response returns.
+      const balanceOverride: { nativeBalance: string } = {
+        nativeBalance: '25',
+      };
+
       await withFixtures(
         {
           fixtures: new FixtureBuilderV2().build(),
           title: this.test?.fullTitle(),
-          // testSpecificMock: mockAccountsApiV5With50Eth,
+          unifiedEvmAccountsApiBalances: balanceOverride,
         },
         async ({
           driver,
@@ -90,6 +96,9 @@ describe('Account Activity WebSocket Balance Resilience', function (this: Suite)
             FIFTY_ETH_WEI,
           );
 
+          // Switch the Accounts API response so the next REST poll returns 50 ETH
+          balanceOverride.nativeBalance = '50';
+
           await waitForBalanceUpdate(homepage, driver, '50');
         },
       );
@@ -103,7 +112,6 @@ describe('Account Activity WebSocket Balance Resilience', function (this: Suite)
         {
           fixtures: new FixtureBuilderV2().build(),
           title: this.test?.fullTitle(),
-          // testSpecificMock: mockAccountsApiV5With35Eth,
         },
         async ({
           driver,
@@ -153,7 +161,7 @@ describe('Account Activity WebSocket Balance Resilience', function (this: Suite)
               {
                 asset: {
                   fungible: true,
-                  type: 'eip155:1337/slip44:60',
+                  type: 'eip155:1337/slip44:1',
                   unit: 'ETH',
                   decimals: 18,
                 },

--- a/test/e2e/tests/account-activity/websocket-balance-resilience.spec.ts
+++ b/test/e2e/tests/account-activity/websocket-balance-resilience.spec.ts
@@ -108,10 +108,16 @@ describe('Account Activity WebSocket Balance Resilience', function (this: Suite)
   describe('Reconnection', function () {
     it('WebSocket reconnects and real-time updates resume after server recovery', async function () {
       this.timeout(180_000);
+
+      const balanceOverride: { nativeBalance: string } = {
+        nativeBalance: '25',
+      };
+
       await withFixtures(
         {
           fixtures: new FixtureBuilderV2().build(),
           title: this.test?.fullTitle(),
+          unifiedEvmAccountsApiBalances: balanceOverride,
         },
         async ({
           driver,
@@ -151,6 +157,8 @@ describe('Account Activity WebSocket Balance Resilience', function (this: Suite)
             DEFAULT_FIXTURE_ACCOUNT,
             THIRTY_FIVE_ETH_WEI,
           );
+
+          balanceOverride.nativeBalance = '35';
 
           const notification = createBalanceUpdateNotification({
             subscriptionId: newSubId,

--- a/test/e2e/tests/btc/mocks/tokens-api.ts
+++ b/test/e2e/tests/btc/mocks/tokens-api.ts
@@ -103,7 +103,7 @@ export const mockTokensV3Assets = (mockServer: Mockttp) =>
 
       if (assetIds.includes('eip155:1337')) {
         results.push({
-          assetId: 'eip155:1337/slip44:60',
+          assetId: 'eip155:1337/slip44:1',
           name: 'Ethereum',
           symbol: 'ETH',
           decimals: 18,

--- a/test/e2e/tests/multichain-accounts/add-wallet.spec.ts
+++ b/test/e2e/tests/multichain-accounts/add-wallet.spec.ts
@@ -95,11 +95,11 @@ describe('Add wallet', function () {
       },
       async (driver: Driver) => {
         const accountListPage = new AccountListPage(driver);
-        await accountListPage.checkPageIsLoaded();
+        await accountListPage.checkPageIsLoaded(20000);
         await accountListPage.startImportSecretPhrase(E2E_SRP);
         const headerNavbar = new HeaderNavbar(driver);
         await headerNavbar.openAccountMenu();
-        await accountListPage.checkPageIsLoaded();
+        await accountListPage.checkPageIsLoaded(20000);
         await accountListPage.checkNumberOfAvailableAccounts(3);
       },
     );

--- a/test/e2e/tests/multichain-accounts/common.ts
+++ b/test/e2e/tests/multichain-accounts/common.ts
@@ -56,10 +56,13 @@ export async function withMultichainAccountsDesignEnabled(
           assetsBalance: {
             [DEFAULT_FIXTURE_ACCOUNT_ID]: {
               'eip155:1/slip44:60': { amount: '0' },
+              'eip155:1337/slip44:1': { amount: '0' },
+              'eip155:42161/slip44:60': { amount: '0' },
+              'eip155:59144/slip44:60': { amount: '0' },
             },
             [HARDWARE_WALLET_ACCOUNT_ID]: {
               'eip155:1/slip44:60': { amount: '0' },
-              'eip155:1337/slip44:60': { amount: '0' },
+              'eip155:1337/slip44:1': { amount: '0' },
             },
           },
         })
@@ -102,6 +105,9 @@ export async function withMultichainAccountsDesignEnabled(
       },
       title,
       dappOptions,
+      ...(accountType === AccountType.HardwareWallet && {
+        unifiedEvmAccountsApiBalances: { nativeBalance: '0' },
+      }),
     },
     async ({ driver }: { driver: Driver; mockServer: Mockttp }) => {
       if (accountType === AccountType.HardwareWallet) {

--- a/test/e2e/tests/privacy/onboarding-infura-call-privacy.spec.ts
+++ b/test/e2e/tests/privacy/onboarding-infura-call-privacy.spec.ts
@@ -182,7 +182,7 @@ describe('MetaMask onboarding', function () {
           await driver.wait(async () => {
             const isPending = await mockedEndpoint.isPending();
             return isPending === false;
-          }, driver.timeout);
+          }, 20000);
 
           const requests = await mockedEndpoint.getSeenRequests();
           assert.equal(

--- a/test/e2e/tests/privacy/onboarding-infura-call-privacy.spec.ts
+++ b/test/e2e/tests/privacy/onboarding-infura-call-privacy.spec.ts
@@ -174,7 +174,8 @@ describe('MetaMask onboarding', function () {
         await handleSidepanelPostOnboarding(driver);
 
         const homePage = new HomePage(driver);
-        await homePage.checkPageIsLoaded();
+        await homePage.waitForNonEvmAccountsLoaded();
+        await homePage.checkPageIsLoaded()
 
         // requests happen here
         for (const mockedEndpoint of mockedEndpoints) {

--- a/test/e2e/tests/profile-metrics/profile-metrics.spec.ts
+++ b/test/e2e/tests/profile-metrics/profile-metrics.spec.ts
@@ -146,6 +146,11 @@ describe('Profile Metrics', function () {
         }) => {
           await login(driver);
 
+          const [authCall] = mockedEndpoint;
+
+          // Wait for the initial 2 PUT requests before creating a new account
+          await waitForEndpointToBeCalled(driver, authCall, 2);
+
           const headerNavbar = new HeaderNavbar(driver);
           await headerNavbar.openAccountMenu();
           const accountListPage = new AccountListPage(driver);
@@ -153,13 +158,9 @@ describe('Profile Metrics', function () {
           await accountListPage.addMultichainAccount();
           await accountListPage.checkAccountDisplayedInAccountList('Account 2');
           await accountListPage.closeMultichainAccountsPage();
-          const [authCall] = mockedEndpoint;
 
-          // There are 3 PUT requests:
-          // 1. One for default EVM Account 1 alone
-          // 2. One for default Solana Account 1 (which is generated after the EVM Account is added)
-          // 3. One for Account 2 (Solana + EVM Accounts in one request)
-          await waitForEndpointToBeCalled(driver, authCall, 3);
+          // 3rd PUT request for the newly created Account 2
+          await waitForEndpointToBeCalled(driver, authCall, 3, 10000);
 
           const requests = await authCall.getSeenRequests();
           assert.equal(

--- a/test/e2e/tests/send/send-edit.spec.ts
+++ b/test/e2e/tests/send/send-edit.spec.ts
@@ -42,7 +42,7 @@ describe('Send - Edit Transaction', function () {
           .withAssetsController({
             assetsPrice: {
               'eip155:1/slip44:60': E2E_ETH_NATIVE_ASSETS_PRICE_USD_1700,
-              'eip155:1337/slip44:60': E2E_ETH_NATIVE_ASSETS_PRICE_USD_1700,
+              'eip155:1337/slip44:1': E2E_ETH_NATIVE_ASSETS_PRICE_USD_1700,
             },
           })
           .build(),
@@ -104,7 +104,7 @@ describe('Send - Edit Transaction', function () {
           .withAssetsController({
             assetsPrice: {
               'eip155:1/slip44:60': E2E_ETH_NATIVE_ASSETS_PRICE_USD_1700,
-              'eip155:1337/slip44:60': E2E_ETH_NATIVE_ASSETS_PRICE_USD_1700,
+              'eip155:1337/slip44:1': E2E_ETH_NATIVE_ASSETS_PRICE_USD_1700,
             },
           })
           .build(),

--- a/test/e2e/tests/send/send-eth-max.spec.ts
+++ b/test/e2e/tests/send/send-eth-max.spec.ts
@@ -59,11 +59,11 @@ const ASSETS_PRICE_ETH_1700 = {
 const ASSETS_CONTROLLER_ETH_1700 = {
   assetsInfo: {
     'eip155:1/slip44:60': ETH_NATIVE_INFO,
-    'eip155:1337/slip44:60': ETH_NATIVE_INFO,
+    'eip155:1337/slip44:1': ETH_NATIVE_INFO,
   },
   assetsPrice: {
     'eip155:1/slip44:60': ASSETS_PRICE_ETH_1700,
-    'eip155:1337/slip44:60': ASSETS_PRICE_ETH_1700,
+    'eip155:1337/slip44:1': ASSETS_PRICE_ETH_1700,
   },
 };
 

--- a/test/e2e/tests/settings/state-logs.json
+++ b/test/e2e/tests/settings/state-logs.json
@@ -149,34 +149,19336 @@
     "networkName": "string",
     "state": "string"
   },
+  "localeMessages": {
+    "current": {
+      "CSS_loadingTakingTooLongActionText": {
+        "description": "string",
+        "message": "string"
+      },
+      "CSS_loadingTakingTooLongMessageText": {
+        "description": "string",
+        "message": "string"
+      },
+      "QRHardwareInvalidTransactionTitle": {
+        "message": "string"
+      },
+      "QRHardwareMismatchedSignId": {
+        "message": "string"
+      },
+      "QRHardwarePubkeyAccountOutOfRange": {
+        "message": "string"
+      },
+      "QRHardwareScanInstructions": {
+        "message": "string"
+      },
+      "QRHardwareSignRequestCancel": {
+        "message": "string"
+      },
+      "QRHardwareSignRequestDescription": {
+        "message": "string"
+      },
+      "QRHardwareSignRequestGetSignature": {
+        "message": "string"
+      },
+      "QRHardwareSignRequestSubtitle": {
+        "message": "string"
+      },
+      "QRHardwareSignRequestTitle": {
+        "message": "string"
+      },
+      "QRHardwareUnknownQRCodeTitle": {
+        "message": "string"
+      },
+      "QRHardwareUnknownWalletQRCode": {
+        "message": "string"
+      },
+      "QRHardwareWalletImporterTitle": {
+        "message": "string"
+      },
+      "QRHardwareWalletSteps1Description": {
+        "message": "string"
+      },
+      "QRHardwareWalletSteps1Title": {
+        "message": "string"
+      },
+      "QRHardwareWalletSteps2Description": {
+        "message": "string"
+      },
+      "SrpListHideAccounts": {
+        "description": "string",
+        "message": "string"
+      },
+      "SrpListHideSingleAccount": {
+        "message": "string"
+      },
+      "SrpListShowAccounts": {
+        "description": "string",
+        "message": "string"
+      },
+      "SrpListShowSingleAccount": {
+        "message": "string"
+      },
+      "about": {
+        "message": "string"
+      },
+      "aboutMetaMask": {
+        "message": "string"
+      },
+      "accept": {
+        "message": "string"
+      },
+      "acceptAndClose": {
+        "message": "string"
+      },
+      "acceptTermsOfUse": {
+        "description": "string",
+        "message": "string"
+      },
+      "accessingYourCamera": {
+        "message": "string"
+      },
+      "account": {
+        "message": "string"
+      },
+      "accountActivity": {
+        "message": "string"
+      },
+      "accountActivityText": {
+        "message": "string"
+      },
+      "accountAlreadyExistsLogin": {
+        "message": "string"
+      },
+      "accountAlreadyExistsLoginDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "accountAlreadyExistsTitle": {
+        "message": "string"
+      },
+      "accountDetails": {
+        "message": "string"
+      },
+      "accountDetailsSrpBackUpMessage": {
+        "description": "string",
+        "message": "string"
+      },
+      "accountIdenticon": {
+        "message": "string"
+      },
+      "accountIdenticonDescription": {
+        "message": "string"
+      },
+      "accountIsntConnectedToastText": {
+        "message": "string"
+      },
+      "accountName": {
+        "message": "string"
+      },
+      "accountNameAlreadyInUse": {
+        "description": "string",
+        "message": "string"
+      },
+      "accountNameDuplicate": {
+        "description": "string",
+        "message": "string"
+      },
+      "accountNameReserved": {
+        "description": "string",
+        "message": "string"
+      },
+      "accountNotFoundCreateOne": {
+        "message": "string"
+      },
+      "accountNotFoundDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "accountNotFoundTitle": {
+        "message": "string"
+      },
+      "accountOptions": {
+        "message": "string"
+      },
+      "accountPermissionToast": {
+        "message": "string"
+      },
+      "accountSelectionRequired": {
+        "message": "string"
+      },
+      "accountSmallCase": {
+        "message": "string"
+      },
+      "accountTypeNotSupported": {
+        "message": "string"
+      },
+      "accounts": {
+        "message": "string"
+      },
+      "accountsConnected": {
+        "message": "string"
+      },
+      "accountsPermissionsTitle": {
+        "message": "string"
+      },
+      "accountsSmallCase": {
+        "message": "string"
+      },
+      "actionUnavailable": {
+        "message": "string"
+      },
+      "active": {
+        "message": "string"
+      },
+      "activity": {
+        "message": "string"
+      },
+      "activityEmptyDescription": {
+        "message": "string"
+      },
+      "add": {
+        "message": "string"
+      },
+      "addACustomNetwork": {
+        "message": "string"
+      },
+      "addAHardwareWallet": {
+        "message": "string"
+      },
+      "addANetwork": {
+        "message": "string"
+      },
+      "addANickname": {
+        "message": "string"
+      },
+      "addAUrl": {
+        "message": "string"
+      },
+      "addAccount": {
+        "message": "string"
+      },
+      "addAccountFromNetwork": {
+        "description": "string",
+        "message": "string"
+      },
+      "addAccountOrWallet": {
+        "message": "string"
+      },
+      "addAcquiredTokens": {
+        "message": "string"
+      },
+      "addAlias": {
+        "message": "string"
+      },
+      "addBitcoinAccountLabel": {
+        "message": "string"
+      },
+      "addBlockExplorer": {
+        "message": "string"
+      },
+      "addBlockExplorerUrl": {
+        "message": "string"
+      },
+      "addContact": {
+        "message": "string"
+      },
+      "addCustomNetwork": {
+        "message": "string"
+      },
+      "addEthereumChainWarningModalHeader": {
+        "description": "string",
+        "message": "string"
+      },
+      "addEthereumChainWarningModalHeaderPartTwo": {
+        "message": "string"
+      },
+      "addEthereumChainWarningModalListHeader": {
+        "message": "string"
+      },
+      "addEthereumChainWarningModalListPointOne": {
+        "message": "string"
+      },
+      "addEthereumChainWarningModalListPointThree": {
+        "message": "string"
+      },
+      "addEthereumChainWarningModalListPointTwo": {
+        "message": "string"
+      },
+      "addEthereumChainWarningModalTitle": {
+        "message": "string"
+      },
+      "addEthereumWatchOnlyAccount": {
+        "message": "string"
+      },
+      "addFriendsAndAddresses": {
+        "message": "string"
+      },
+      "addFunds": {
+        "message": "string"
+      },
+      "addFundsModalBuyCrypto": {
+        "message": "string"
+      },
+      "addFundsModalReceiveTokens": {
+        "message": "string"
+      },
+      "addFundsModalSwapTokens": {
+        "message": "string"
+      },
+      "addHardwareWalletLabel": {
+        "message": "string"
+      },
+      "addIPFSGateway": {
+        "message": "string"
+      },
+      "addMemo": {
+        "message": "string"
+      },
+      "addNetwork": {
+        "message": "string"
+      },
+      "addNetworkConfirmationTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "addNetworkDescription": {
+        "message": "string"
+      },
+      "addNewAccount": {
+        "message": "string"
+      },
+      "addNewEthereumAccountLabel": {
+        "message": "string"
+      },
+      "addNewSolanaAccountLabel": {
+        "message": "string"
+      },
+      "addNewTronAccountLabel": {
+        "message": "string"
+      },
+      "addNft": {
+        "message": "string"
+      },
+      "addNfts": {
+        "message": "string"
+      },
+      "addNonEvmAccount": {
+        "description": "string",
+        "message": "string"
+      },
+      "addNonEvmAccountFromNetworkPicker": {
+        "description": "string",
+        "message": "string"
+      },
+      "addRpcUrl": {
+        "message": "string"
+      },
+      "addSnapAccountToggle": {
+        "message": "string"
+      },
+      "addSnapAccountsDescription": {
+        "message": "string"
+      },
+      "addSuggestedNFTs": {
+        "message": "string"
+      },
+      "addSuggestedTokens": {
+        "message": "string"
+      },
+      "addToken": {
+        "message": "string"
+      },
+      "addUrl": {
+        "message": "string"
+      },
+      "addWallet": {
+        "message": "string"
+      },
+      "addedProtectionDescription": {
+        "message": "string"
+      },
+      "addedProtectionOptionalBadge": {
+        "message": "string"
+      },
+      "addedProtectionTitle": {
+        "message": "string"
+      },
+      "addedProtectionTooltip": {
+        "message": "string"
+      },
+      "additionalNetworks": {
+        "message": "string"
+      },
+      "address": {
+        "message": "string"
+      },
+      "addressCopied": {
+        "message": "string"
+      },
+      "addressLabel": {
+        "description": "string",
+        "message": "string"
+      },
+      "addressMismatch": {
+        "message": "string"
+      },
+      "addressMismatchOriginal": {
+        "description": "string",
+        "message": "string"
+      },
+      "addressMismatchPunycode": {
+        "description": "string",
+        "message": "string"
+      },
+      "addressQrCodeModalDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "addressQrCodeModalHeading": {
+        "description": "string",
+        "message": "string"
+      },
+      "addressQrCodeModalTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "addresses": {
+        "description": "string",
+        "message": "string"
+      },
+      "addressesLabel": {
+        "description": "string",
+        "message": "string"
+      },
+      "advanced": {
+        "message": "string"
+      },
+      "advancedDetailsDataDesc": {
+        "message": "string"
+      },
+      "advancedDetailsHexDesc": {
+        "message": "string"
+      },
+      "advancedDetailsNonceDesc": {
+        "message": "string"
+      },
+      "advancedDetailsNonceTooltip": {
+        "message": "string"
+      },
+      "advancedEIP1559ModalTitle": {
+        "message": "string"
+      },
+      "advancedGasPriceModalTitle": {
+        "message": "string"
+      },
+      "advancedGasPriceTitle": {
+        "message": "string"
+      },
+      "advancedPermissionSmallCase": {
+        "message": "string"
+      },
+      "advancedPermissionsSmallCase": {
+        "message": "string"
+      },
+      "airDropPatternDescription": {
+        "message": "string"
+      },
+      "airDropPatternTitle": {
+        "message": "string"
+      },
+      "airgapVault": {
+        "message": "string"
+      },
+      "alert": {
+        "message": "string"
+      },
+      "alertAccountTypeUpgradeMessage": {
+        "message": "string"
+      },
+      "alertAccountTypeUpgradeTitle": {
+        "message": "string"
+      },
+      "alertActionBurnAddress": {
+        "message": "string"
+      },
+      "alertActionBuyWithNativeCurrency": {
+        "message": "string"
+      },
+      "alertActionEditNetworkFee": {
+        "message": "string"
+      },
+      "alertActionUpdateGas": {
+        "message": "string"
+      },
+      "alertActionUpdateGasFee": {
+        "message": "string"
+      },
+      "alertActionUpdateGasFeeLevel": {
+        "message": "string"
+      },
+      "alertContentMultipleApprovals": {
+        "message": "string"
+      },
+      "alertDisableTooltip": {
+        "message": "string"
+      },
+      "alertInsufficientPayTokenBalance": {
+        "message": "string"
+      },
+      "alertInsufficientPayTokenBalanceFeesNoTarget": {
+        "message": "string"
+      },
+      "alertInsufficientPayTokenNative": {
+        "description": "string",
+        "message": "string"
+      },
+      "alertMessageAddressMismatchWarning": {
+        "message": "string"
+      },
+      "alertMessageAddressTrustSignal": {
+        "message": "string"
+      },
+      "alertMessageAddressTrustSignalMalicious": {
+        "message": "string"
+      },
+      "alertMessageBurnAddress": {
+        "message": "string"
+      },
+      "alertMessageChangeInSimulationResults": {
+        "message": "string"
+      },
+      "alertMessageFirstTimeInteraction": {
+        "message": "string"
+      },
+      "alertMessageGasEstimateFailed": {
+        "message": "string"
+      },
+      "alertMessageGasFeeLow": {
+        "message": "string"
+      },
+      "alertMessageGasTooLow": {
+        "message": "string"
+      },
+      "alertMessageInsufficientBalanceWithNativeCurrency": {
+        "message": "string"
+      },
+      "alertMessageNoGasPrice": {
+        "message": "string"
+      },
+      "alertMessageOriginTrustSignalMalicious": {
+        "message": "string"
+      },
+      "alertMessageOriginTrustSignalWarning": {
+        "message": "string"
+      },
+      "alertMessageSignInDomainMismatch": {
+        "message": "string"
+      },
+      "alertMessageSignInWrongAccount": {
+        "message": "string"
+      },
+      "alertMessageSuggestedGasFeeHigh": {
+        "message": "string"
+      },
+      "alertMessageTokenTrustSignalMalicious": {
+        "message": "string"
+      },
+      "alertMessageTokenTrustSignalWarning": {
+        "message": "string"
+      },
+      "alertModalAcknowledge": {
+        "message": "string"
+      },
+      "alertModalDetails": {
+        "message": "string"
+      },
+      "alertModalReviewAllAlerts": {
+        "message": "string"
+      },
+      "alertNoPayTokenQuotesMessage": {
+        "message": "string"
+      },
+      "alertNoPayTokenQuotesTitle": {
+        "message": "string"
+      },
+      "alertPayHardwareAccountMessage": {
+        "message": "string"
+      },
+      "alertPayHardwareAccountTitle": {
+        "message": "string"
+      },
+      "alertReasonChangeInSimulationResults": {
+        "message": "string"
+      },
+      "alertReasonFirstTimeInteraction": {
+        "message": "string"
+      },
+      "alertReasonGasEstimateFailed": {
+        "message": "string"
+      },
+      "alertReasonGasFeeLow": {
+        "message": "string"
+      },
+      "alertReasonGasSponsorshipUnavailable": {
+        "message": "string"
+      },
+      "alertReasonGasTooLow": {
+        "message": "string"
+      },
+      "alertReasonInsufficientBalance": {
+        "message": "string"
+      },
+      "alertReasonMultipleApprovals": {
+        "message": "string"
+      },
+      "alertReasonNoGasPrice": {
+        "message": "string"
+      },
+      "alertReasonOriginTrustSignalMalicious": {
+        "message": "string"
+      },
+      "alertReasonOriginTrustSignalVerified": {
+        "message": "string"
+      },
+      "alertReasonOriginTrustSignalWarning": {
+        "message": "string"
+      },
+      "alertReasonPendingTransactions": {
+        "message": "string"
+      },
+      "alertReasonSignIn": {
+        "message": "string"
+      },
+      "alertReasonSuggestedGasFeeHigh": {
+        "message": "string"
+      },
+      "alertReasonTokenTrustSignalMalicious": {
+        "message": "string"
+      },
+      "alertReasonTokenTrustSignalWarning": {
+        "message": "string"
+      },
+      "alertReasonWrongAccount": {
+        "message": "string"
+      },
+      "alertSelectedAccountWarning": {
+        "message": "string"
+      },
+      "alerts": {
+        "message": "string"
+      },
+      "all": {
+        "message": "string"
+      },
+      "allNetworks": {
+        "message": "string"
+      },
+      "allPermissions": {
+        "message": "string"
+      },
+      "allPopularNetworks": {
+        "message": "string"
+      },
+      "allTimeHigh": {
+        "message": "string"
+      },
+      "allTimeLow": {
+        "message": "string"
+      },
+      "allTokens": {
+        "message": "string"
+      },
+      "allowAddRpc": {
+        "message": "string"
+      },
+      "allowAddRpcDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "allowNotifications": {
+        "message": "string"
+      },
+      "amount": {
+        "message": "string"
+      },
+      "amountReceived": {
+        "message": "string"
+      },
+      "amountSent": {
+        "message": "string"
+      },
+      "andForListItems": {
+        "description": "string",
+        "message": "string"
+      },
+      "andForTwoItems": {
+        "description": "string",
+        "message": "string"
+      },
+      "annual": {
+        "message": "string"
+      },
+      "appDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "appName": {
+        "description": "string",
+        "message": "string"
+      },
+      "appNameBeta": {
+        "description": "string",
+        "message": "string"
+      },
+      "appNameFlask": {
+        "description": "string",
+        "message": "string"
+      },
+      "apply": {
+        "message": "string"
+      },
+      "approve": {
+        "message": "string"
+      },
+      "approveButtonText": {
+        "message": "string"
+      },
+      "approveIncreaseAllowance": {
+        "description": "string",
+        "message": "string"
+      },
+      "approveSpendingCap": {
+        "description": "string",
+        "message": "string"
+      },
+      "approveToken": {
+        "description": "string",
+        "message": "string"
+      },
+      "approved": {
+        "message": "string"
+      },
+      "approvedOn": {
+        "description": "string",
+        "message": "string"
+      },
+      "approvedOnForAccounts": {
+        "description": "string",
+        "message": "string"
+      },
+      "areYouSure": {
+        "message": "string"
+      },
+      "asset": {
+        "message": "string"
+      },
+      "assetChartNoHistoricalPrices": {
+        "message": "string"
+      },
+      "assetOptions": {
+        "message": "string"
+      },
+      "assets": {
+        "message": "string"
+      },
+      "assetsDescription": {
+        "message": "string"
+      },
+      "asterdexReferralSubtitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "attemptToCancelSwapForFree": {
+        "message": "string"
+      },
+      "attributes": {
+        "message": "string"
+      },
+      "attributions": {
+        "message": "string"
+      },
+      "authorizedPermissions": {
+        "message": "string"
+      },
+      "autoDetectTokens": {
+        "message": "string"
+      },
+      "autoDetectTokensDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "autoDetectTokensDescriptionV2": {
+        "message": "string"
+      },
+      "autoLock": {
+        "message": "string"
+      },
+      "autoLockAfter15Seconds": {
+        "message": "string"
+      },
+      "autoLockAfter1Minute": {
+        "message": "string"
+      },
+      "autoLockAfter30Seconds": {
+        "message": "string"
+      },
+      "autoLockAfter5Minutes": {
+        "message": "string"
+      },
+      "autoLockAfterMinutes": {
+        "message": "string"
+      },
+      "autoLockNever": {
+        "message": "string"
+      },
+      "autoLockTimeLimit": {
+        "message": "string"
+      },
+      "autoLockTimeLimitDescription": {
+        "message": "string"
+      },
+      "available": {
+        "message": "string"
+      },
+      "average": {
+        "message": "string"
+      },
+      "back": {
+        "message": "string"
+      },
+      "backToHome": {
+        "message": "string"
+      },
+      "backUpIncomplete": {
+        "message": "string"
+      },
+      "backup": {
+        "message": "string"
+      },
+      "backupAndSync": {
+        "message": "string"
+      },
+      "backupAndSyncBasicFunctionalityNameMention": {
+        "message": "string"
+      },
+      "backupAndSyncEnable": {
+        "message": "string"
+      },
+      "backupAndSyncEnableConfirmation": {
+        "description": "string",
+        "message": "string"
+      },
+      "backupAndSyncEnableDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "backupAndSyncEnableDescriptionUpdatePreferences": {
+        "description": "string",
+        "message": "string"
+      },
+      "backupAndSyncEnableDescriptionUpdatePreferencesPath": {
+        "message": "string"
+      },
+      "backupAndSyncFeatureAccounts": {
+        "message": "string"
+      },
+      "backupAndSyncFeatureContacts": {
+        "message": "string"
+      },
+      "backupAndSyncManageWhatYouSync": {
+        "message": "string"
+      },
+      "backupAndSyncManageWhatYouSyncDescription": {
+        "message": "string"
+      },
+      "backupAndSyncPrivacyLink": {
+        "message": "string"
+      },
+      "backupApprovalInfo": {
+        "message": "string"
+      },
+      "backupApprovalNotice": {
+        "message": "string"
+      },
+      "backupKeyringSnapReminder": {
+        "message": "string"
+      },
+      "backupNow": {
+        "message": "string"
+      },
+      "balance": {
+        "message": "string"
+      },
+      "balanceOutdated": {
+        "message": "string"
+      },
+      "baseFee": {
+        "message": "string"
+      },
+      "basic": {
+        "message": "string"
+      },
+      "basicConfigurationDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "basicConfigurationDescriptionV2": {
+        "description": "string",
+        "message": "string"
+      },
+      "basicConfigurationLabel": {
+        "message": "string"
+      },
+      "basicConfigurationModalCheckbox": {
+        "message": "string"
+      },
+      "basicConfigurationModalDisclaimerOffPart1": {
+        "message": "string"
+      },
+      "basicConfigurationModalDisclaimerOffPart2": {
+        "message": "string"
+      },
+      "basicConfigurationModalDisclaimerOn": {
+        "message": "string"
+      },
+      "basicConfigurationModalHeadingOff": {
+        "message": "string"
+      },
+      "basicConfigurationModalHeadingOn": {
+        "message": "string"
+      },
+      "basicFunctionalityRequired_description": {
+        "message": "string"
+      },
+      "basicFunctionalityRequired_goToHome": {
+        "message": "string"
+      },
+      "basicFunctionalityRequired_openCreateSnapAccountPage": {
+        "message": "string"
+      },
+      "basicFunctionalityRequired_openDefiPage": {
+        "message": "string"
+      },
+      "basicFunctionalityRequired_openMusdConversionPage": {
+        "message": "string"
+      },
+      "basicFunctionalityRequired_openNotificationsPage": {
+        "message": "string"
+      },
+      "basicFunctionalityRequired_openPerpsPage": {
+        "message": "string"
+      },
+      "basicFunctionalityRequired_openRewardsPage": {
+        "message": "string"
+      },
+      "basicFunctionalityRequired_openSnapsPage": {
+        "message": "string"
+      },
+      "basicFunctionalityRequired_openSwapsPage": {
+        "message": "string"
+      },
+      "basicFunctionalityRequired_openTransactionShieldPage": {
+        "message": "string"
+      },
+      "basicFunctionalityRequired_reviewInSettings": {
+        "message": "string"
+      },
+      "basicFunctionalityRequired_title": {
+        "message": "string"
+      },
+      "basicFunctionalityRequired_toggleLabel": {
+        "message": "string"
+      },
+      "bestQuote": {
+        "message": "string"
+      },
+      "bestQuoteTooltip": {
+        "message": "string"
+      },
+      "beta": {
+        "message": "string"
+      },
+      "betaMetamaskVersion": {
+        "message": "string"
+      },
+      "betaTerms": {
+        "message": "string"
+      },
+      "blockExplorerAccountAction": {
+        "description": "string",
+        "message": "string"
+      },
+      "blockExplorerAssetAction": {
+        "description": "string",
+        "message": "string"
+      },
+      "blockExplorerSwapAction": {
+        "description": "string",
+        "message": "string"
+      },
+      "blockExplorerUrl": {
+        "message": "string"
+      },
+      "blockExplorerUrlDefinition": {
+        "message": "string"
+      },
+      "blockExplorerView": {
+        "description": "string",
+        "message": "string"
+      },
+      "blockaid": {
+        "message": "string"
+      },
+      "blockaidAlertDescriptionBlur": {
+        "message": "string"
+      },
+      "blockaidAlertDescriptionMalicious": {
+        "message": "string"
+      },
+      "blockaidAlertDescriptionOpenSea": {
+        "message": "string"
+      },
+      "blockaidAlertDescriptionOthers": {
+        "message": "string"
+      },
+      "blockaidAlertDescriptionTokenTransfer": {
+        "message": "string"
+      },
+      "blockaidAlertDescriptionWithdraw": {
+        "message": "string"
+      },
+      "blockaidDescriptionApproveFarming": {
+        "message": "string"
+      },
+      "blockaidDescriptionBlurFarming": {
+        "message": "string"
+      },
+      "blockaidDescriptionErrored": {
+        "message": "string"
+      },
+      "blockaidDescriptionMaliciousDomain": {
+        "message": "string"
+      },
+      "blockaidDescriptionMightLoseAssets": {
+        "message": "string"
+      },
+      "blockaidDescriptionSeaportFarming": {
+        "message": "string"
+      },
+      "blockaidDescriptionTransferFarming": {
+        "message": "string"
+      },
+      "blockaidMessage": {
+        "message": "string"
+      },
+      "blockaidTitleDeceptive": {
+        "message": "string"
+      },
+      "blockaidTitleMayNotBeSafe": {
+        "message": "string"
+      },
+      "blockaidTitleSuspicious": {
+        "message": "string"
+      },
+      "blockies": {
+        "message": "string"
+      },
+      "borrowed": {
+        "message": "string"
+      },
+      "boughtFor": {
+        "message": "string"
+      },
+      "bridge": {
+        "message": "string"
+      },
+      "bridgeAllowSwappingOf": {
+        "description": "string",
+        "message": "string"
+      },
+      "bridgeApproval": {
+        "description": "string",
+        "message": "string"
+      },
+      "bridgeApprovalWarning": {
+        "message": "string"
+      },
+      "bridgeApprovalWarningForHardware": {
+        "message": "string"
+      },
+      "bridgeBlockExplorerLinkCopied": {
+        "message": "string"
+      },
+      "bridgeConfirmTwoTransactions": {
+        "message": "string"
+      },
+      "bridgeCreateSolanaAccount": {
+        "message": "string"
+      },
+      "bridgeCreateSolanaAccountDescription": {
+        "message": "string"
+      },
+      "bridgeCreateSolanaAccountTitle": {
+        "message": "string"
+      },
+      "bridgeDetailsTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "bridgeEnterAmount": {
+        "message": "string"
+      },
+      "bridgeExplorerLinkViewOn": {
+        "message": "string"
+      },
+      "bridgeFee": {
+        "message": "string"
+      },
+      "bridgeFromTo": {
+        "description": "string",
+        "message": "string"
+      },
+      "bridgeGasFeesSplit": {
+        "message": "string"
+      },
+      "bridgeGetNewQuote": {
+        "message": "string"
+      },
+      "bridgeLowestCost": {
+        "message": "string"
+      },
+      "bridgeMarketClosedAction": {
+        "message": "string"
+      },
+      "bridgeMarketClosedDescription": {
+        "message": "string"
+      },
+      "bridgeMarketClosedModalDescription": {
+        "message": "string"
+      },
+      "bridgeMarketClosedModalLearnMore": {
+        "message": "string"
+      },
+      "bridgeMarketClosedModalTitle": {
+        "message": "string"
+      },
+      "bridgeMarketClosedTitle": {
+        "message": "string"
+      },
+      "bridgeNoMMFee": {
+        "message": "string"
+      },
+      "bridgePoints": {
+        "description": "string",
+        "message": "string"
+      },
+      "bridgePoints_couldntLoad": {
+        "description": "string",
+        "message": "string"
+      },
+      "bridgePoints_error": {
+        "description": "string",
+        "message": "string"
+      },
+      "bridgePoints_error_content": {
+        "description": "string",
+        "message": "string"
+      },
+      "bridgePoints_tooltip": {
+        "description": "string",
+        "message": "string"
+      },
+      "bridgePoints_tooltip_content_1": {
+        "description": "string",
+        "message": "string"
+      },
+      "bridgePoints_tooltip_content_2": {
+        "description": "string",
+        "message": "string"
+      },
+      "bridgePriceImpact": {
+        "message": "string"
+      },
+      "bridgePriceImpactFiatAlert": {
+        "message": "string"
+      },
+      "bridgePriceImpactHigh": {
+        "message": "string"
+      },
+      "bridgePriceImpactHighDescription": {
+        "message": "string"
+      },
+      "bridgePriceImpactNormalDescription": {
+        "message": "string"
+      },
+      "bridgePriceImpactTooltipTitle": {
+        "message": "string"
+      },
+      "bridgePriceImpactVeryHigh": {
+        "message": "string"
+      },
+      "bridgePriceImpactVeryHighDescription": {
+        "message": "string"
+      },
+      "bridgePriceImpactWarningAriaLabel": {
+        "message": "string"
+      },
+      "bridgePriceImpactWarningTitle": {
+        "message": "string"
+      },
+      "bridgeQuoteStreamCompleteAmountTooHigh": {
+        "message": "string"
+      },
+      "bridgeQuoteStreamCompleteAmountTooLow": {
+        "message": "string"
+      },
+      "bridgeQuoteStreamCompleteRetry": {
+        "message": "string"
+      },
+      "bridgeQuoteStreamCompleteRwaGeoRestricted": {
+        "message": "string"
+      },
+      "bridgeQuoteStreamCompleteRwaMarketUnavailable": {
+        "message": "string"
+      },
+      "bridgeQuoteStreamCompleteRwaNativeTokenUnsupported": {
+        "message": "string"
+      },
+      "bridgeQuoteStreamCompleteSlippageTooHigh": {
+        "message": "string"
+      },
+      "bridgeQuoteStreamCompleteSlippageTooLow": {
+        "message": "string"
+      },
+      "bridgeQuoteStreamCompleteTokenNotSupported": {
+        "message": "string"
+      },
+      "bridgeQuotesSortedByCost": {
+        "message": "string"
+      },
+      "bridgeReceive": {
+        "description": "string",
+        "message": "string"
+      },
+      "bridgeReceiveLoading": {
+        "message": "string"
+      },
+      "bridgeSelectDestinationAccount": {
+        "message": "string"
+      },
+      "bridgeSelectDifferentQuote": {
+        "message": "string"
+      },
+      "bridgeSelectNetwork": {
+        "message": "string"
+      },
+      "bridgeSelectQuote": {
+        "message": "string"
+      },
+      "bridgeSelectTokenAmountAndAccount": {
+        "message": "string"
+      },
+      "bridgeSelectTokenAndAmount": {
+        "message": "string"
+      },
+      "bridgeSend": {
+        "description": "string",
+        "message": "string"
+      },
+      "bridgeSendLoading": {
+        "message": "string"
+      },
+      "bridgeSolanaAccountCreated": {
+        "message": "string"
+      },
+      "bridgeStatusComplete": {
+        "description": "string",
+        "message": "string"
+      },
+      "bridgeStatusFailed": {
+        "description": "string",
+        "message": "string"
+      },
+      "bridgeStatusInProgress": {
+        "description": "string",
+        "message": "string"
+      },
+      "bridgeStepActionBridgeComplete": {
+        "description": "string",
+        "message": "string"
+      },
+      "bridgeStepActionBridgePending": {
+        "description": "string",
+        "message": "string"
+      },
+      "bridgeStepActionSwapComplete": {
+        "description": "string",
+        "message": "string"
+      },
+      "bridgeStepActionSwapPending": {
+        "description": "string",
+        "message": "string"
+      },
+      "bridgeTo": {
+        "message": "string"
+      },
+      "bridgeTokenNotFound": {
+        "message": "string"
+      },
+      "bridgeTransactionProgress": {
+        "message": "string"
+      },
+      "bridgeTxDetailsBridged": {
+        "message": "string"
+      },
+      "bridgeTxDetailsBridging": {
+        "message": "string"
+      },
+      "bridgeTxDetailsDelayedDescription": {
+        "message": "string"
+      },
+      "bridgeTxDetailsDelayedDescriptionSupport": {
+        "message": "string"
+      },
+      "bridgeTxDetailsDelayedTitle": {
+        "message": "string"
+      },
+      "bridgeTxDetailsNonce": {
+        "message": "string"
+      },
+      "bridgeTxDetailsStatus": {
+        "message": "string"
+      },
+      "bridgeTxDetailsSwapped": {
+        "message": "string"
+      },
+      "bridgeTxDetailsSwapping": {
+        "message": "string"
+      },
+      "bridgeTxDetailsTimestamp": {
+        "message": "string"
+      },
+      "bridgeTxDetailsTimestampValue": {
+        "description": "string",
+        "message": "string"
+      },
+      "bridgeTxDetailsTokenAmountOnChain": {
+        "description": "string",
+        "message": "string"
+      },
+      "bridgeTxDetailsTotalGasFee": {
+        "message": "string"
+      },
+      "bridgeTxDetailsYouReceived": {
+        "message": "string"
+      },
+      "bridgeTxDetailsYouSent": {
+        "message": "string"
+      },
+      "bridgeValidationInsufficientGasMessage": {
+        "message": "string"
+      },
+      "bridgeValidationInsufficientGasTitle": {
+        "message": "string"
+      },
+      "bridged": {
+        "message": "string"
+      },
+      "bridgedToChain": {
+        "message": "string"
+      },
+      "bridging": {
+        "message": "string"
+      },
+      "browserNotSupported": {
+        "message": "string"
+      },
+      "builtAroundTheWorld": {
+        "message": "string"
+      },
+      "busy": {
+        "message": "string"
+      },
+      "buy": {
+        "message": "string"
+      },
+      "buyMoreAsset": {
+        "description": "string",
+        "message": "string"
+      },
+      "buyNow": {
+        "message": "string"
+      },
+      "buyTabOpenedToastDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "buyTabOpenedToastText": {
+        "description": "string",
+        "message": "string"
+      },
+      "bytes": {
+        "message": "string"
+      },
+      "canToggleInSettings": {
+        "message": "string"
+      },
+      "cancel": {
+        "message": "string"
+      },
+      "cancelSpeedupAlreadyConfirmedDescription": {
+        "message": "string"
+      },
+      "cancelSpeedupFailedDescription": {
+        "message": "string"
+      },
+      "cancelTransactionDescription": {
+        "message": "string"
+      },
+      "cancelTransactionFailed": {
+        "message": "string"
+      },
+      "cancelTransactionTitle": {
+        "message": "string"
+      },
+      "cancelled": {
+        "message": "string"
+      },
+      "carouselAllCaughtUp": {
+        "description": "string",
+        "message": "string"
+      },
+      "chainId": {
+        "message": "string"
+      },
+      "chainIdDefinition": {
+        "message": "string"
+      },
+      "chainIdExistsErrorMsg": {
+        "message": "string"
+      },
+      "chainListReturnedDifferentTickerSymbol": {
+        "message": "string"
+      },
+      "changeInSettings": {
+        "message": "string"
+      },
+      "changePasswordDetailsSocial": {
+        "message": "string"
+      },
+      "changePasswordLoading": {
+        "message": "string"
+      },
+      "changePasswordLoadingNote": {
+        "message": "string"
+      },
+      "changePasswordWarning": {
+        "message": "string"
+      },
+      "changePasswordWarningDescription": {
+        "message": "string"
+      },
+      "checkNetworkConnectivity": {
+        "message": "string"
+      },
+      "checkNetworkConnectivityOr": {
+        "description": "string",
+        "message": "string"
+      },
+      "chooseYourNetwork": {
+        "message": "string"
+      },
+      "chooseYourNetworkDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "chooseYourNetworkDescriptionCallToAction": {
+        "message": "string"
+      },
+      "chromeRequiredForHardwareWallets": {
+        "message": "string"
+      },
+      "circulatingSupply": {
+        "message": "string"
+      },
+      "clear": {
+        "message": "string"
+      },
+      "clearActivity": {
+        "message": "string"
+      },
+      "clearActivityButton": {
+        "message": "string"
+      },
+      "clearActivityDescription": {
+        "message": "string"
+      },
+      "clearFilters": {
+        "message": "string"
+      },
+      "click": {
+        "message": "string"
+      },
+      "clickToConnectLedgerViaWebHID": {
+        "description": "string",
+        "message": "string"
+      },
+      "close": {
+        "message": "string"
+      },
+      "closeSlide": {
+        "description": "string",
+        "message": "string"
+      },
+      "closeWindowAnytime": {
+        "message": "string"
+      },
+      "coingecko": {
+        "message": "string"
+      },
+      "collectionName": {
+        "message": "string"
+      },
+      "comboNoOptions": {
+        "description": "string",
+        "message": "string"
+      },
+      "communityContributedLanguagesSectionTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "completed": {
+        "message": "string"
+      },
+      "concentratedSupplyDistributionDescription": {
+        "message": "string"
+      },
+      "concentratedSupplyDistributionTitle": {
+        "message": "string"
+      },
+      "configureSnapPopupDescription": {
+        "message": "string"
+      },
+      "configureSnapPopupInstallDescription": {
+        "message": "string"
+      },
+      "configureSnapPopupInstallTitle": {
+        "message": "string"
+      },
+      "configureSnapPopupLink": {
+        "message": "string"
+      },
+      "configureSnapPopupTitle": {
+        "message": "string"
+      },
+      "confirm": {
+        "message": "string"
+      },
+      "confirmAccountTypeSmartContract": {
+        "message": "string"
+      },
+      "confirmAccountTypeStandard": {
+        "message": "string"
+      },
+      "confirmAlertModalAcknowledgeMultiple": {
+        "message": "string"
+      },
+      "confirmAlertModalAcknowledgeSingle": {
+        "message": "string"
+      },
+      "confirmFieldAllowance": {
+        "message": "string"
+      },
+      "confirmFieldAvailablePerDay": {
+        "message": "string"
+      },
+      "confirmFieldExpiration": {
+        "message": "string"
+      },
+      "confirmFieldFrequency": {
+        "message": "string"
+      },
+      "confirmFieldInitialAllowance": {
+        "message": "string"
+      },
+      "confirmFieldMaxAllowance": {
+        "message": "string"
+      },
+      "confirmFieldNeverExpires": {
+        "message": "string"
+      },
+      "confirmFieldPaymaster": {
+        "message": "string"
+      },
+      "confirmFieldPeriodDurationBiWeekly": {
+        "message": "string"
+      },
+      "confirmFieldPeriodDurationDaily": {
+        "message": "string"
+      },
+      "confirmFieldPeriodDurationHourly": {
+        "message": "string"
+      },
+      "confirmFieldPeriodDurationMonthly": {
+        "message": "string"
+      },
+      "confirmFieldPeriodDurationSeconds": {
+        "description": "string",
+        "message": "string"
+      },
+      "confirmFieldPeriodDurationWeekly": {
+        "message": "string"
+      },
+      "confirmFieldPeriodDurationYearly": {
+        "message": "string"
+      },
+      "confirmFieldStartDate": {
+        "message": "string"
+      },
+      "confirmFieldStreamRate": {
+        "message": "string"
+      },
+      "confirmFieldTooltipJustification": {
+        "message": "string"
+      },
+      "confirmFieldTooltipPaymaster": {
+        "message": "string"
+      },
+      "confirmFieldTotalExposure": {
+        "message": "string"
+      },
+      "confirmGasFeeTokenBalance": {
+        "message": "string"
+      },
+      "confirmGasFeeTokenInsufficientBalance": {
+        "message": "string"
+      },
+      "confirmGasFeeTokenMetaMaskFee": {
+        "message": "string"
+      },
+      "confirmGasFeeTokenModalNativeToggleMetaMask": {
+        "message": "string"
+      },
+      "confirmGasFeeTokenModalNativeToggleWallet": {
+        "message": "string"
+      },
+      "confirmGasFeeTokenModalPayETH": {
+        "message": "string"
+      },
+      "confirmGasFeeTokenModalPayToken": {
+        "message": "string"
+      },
+      "confirmGasFeeTokenModalTitle": {
+        "message": "string"
+      },
+      "confirmGasFeeTokenToast": {
+        "message": "string"
+      },
+      "confirmGasFeeTokenTooltip": {
+        "message": "string"
+      },
+      "confirmInfoAccountNow": {
+        "message": "string"
+      },
+      "confirmInfoSwitchingTo": {
+        "message": "string"
+      },
+      "confirmNestedTransactionTitle": {
+        "message": "string"
+      },
+      "confirmPassword": {
+        "message": "string"
+      },
+      "confirmRecoveryPhrase": {
+        "message": "string"
+      },
+      "confirmRecoveryPhraseDetails": {
+        "message": "string"
+      },
+      "confirmRecoveryPhraseTitle": {
+        "message": "string"
+      },
+      "confirmRecoveryPhraseTitleSettings": {
+        "message": "string"
+      },
+      "confirmSimulationApprove": {
+        "message": "string"
+      },
+      "confirmSrpErrorDescription": {
+        "message": "string"
+      },
+      "confirmSrpErrorTitle": {
+        "message": "string"
+      },
+      "confirmSrpSuccessDescription": {
+        "message": "string"
+      },
+      "confirmSrpSuccessTitle": {
+        "message": "string"
+      },
+      "confirmTitleAccountTypeSwitch": {
+        "message": "string"
+      },
+      "confirmTitleApproveTransactionNFT": {
+        "message": "string"
+      },
+      "confirmTitleDeployContract": {
+        "message": "string"
+      },
+      "confirmTitleDescApproveTransaction": {
+        "message": "string"
+      },
+      "confirmTitleDescDelegationRevoke": {
+        "message": "string"
+      },
+      "confirmTitleDescDelegationUpgrade": {
+        "message": "string"
+      },
+      "confirmTitleDescDeployContract": {
+        "message": "string"
+      },
+      "confirmTitleDescERC20ApproveTransaction": {
+        "message": "string"
+      },
+      "confirmTitleDescERC20Revocation": {
+        "message": "string"
+      },
+      "confirmTitleDescPermission": {
+        "message": "string"
+      },
+      "confirmTitleDescPermitSignature": {
+        "message": "string"
+      },
+      "confirmTitleDescSIWESignature": {
+        "message": "string"
+      },
+      "confirmTitleDescSign": {
+        "message": "string"
+      },
+      "confirmTitlePermission": {
+        "message": "string"
+      },
+      "confirmTitlePermitTokens": {
+        "message": "string"
+      },
+      "confirmTitleRevokeApproveTransaction": {
+        "message": "string"
+      },
+      "confirmTitleSIWESignature": {
+        "message": "string"
+      },
+      "confirmTitleSending": {
+        "message": "string"
+      },
+      "confirmTitleSetApprovalForAllRevokeTransaction": {
+        "message": "string"
+      },
+      "confirmTitleSignature": {
+        "message": "string"
+      },
+      "confirmTitleTransaction": {
+        "message": "string"
+      },
+      "confirmationAlertDetails": {
+        "message": "string"
+      },
+      "confirmationAlertModalTitleDescription": {
+        "message": "string"
+      },
+      "confirmed": {
+        "message": "string"
+      },
+      "confusableCharacterTooltip": {
+        "message": "string"
+      },
+      "confusableUnicode": {
+        "message": "string"
+      },
+      "confusableZeroWidthUnicode": {
+        "message": "string"
+      },
+      "confusingEnsDomain": {
+        "message": "string"
+      },
+      "connect": {
+        "message": "string"
+      },
+      "connectAccount": {
+        "message": "string"
+      },
+      "connectAccounts": {
+        "message": "string"
+      },
+      "connectAnAccountHeader": {
+        "message": "string"
+      },
+      "connectHardwareDevice": {
+        "description": "string",
+        "message": "string"
+      },
+      "connectManually": {
+        "message": "string"
+      },
+      "connectMoreAccounts": {
+        "message": "string"
+      },
+      "connectSnap": {
+        "description": "string",
+        "message": "string"
+      },
+      "connectWithMetaMask": {
+        "message": "string"
+      },
+      "connectedAccountsDescriptionPlural": {
+        "description": "string",
+        "message": "string"
+      },
+      "connectedAccountsDescriptionSingular": {
+        "message": "string"
+      },
+      "connectedAccountsEmptyDescription": {
+        "message": "string"
+      },
+      "connectedAccountsListTooltip": {
+        "description": "string",
+        "message": "string"
+      },
+      "connectedSites": {
+        "message": "string"
+      },
+      "connectedSitesAndSnaps": {
+        "message": "string"
+      },
+      "connectedSitesDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "connectedSitesEmptyDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "connectedSnapAndNoAccountDescription": {
+        "message": "string"
+      },
+      "connectedSnaps": {
+        "message": "string"
+      },
+      "connectedWithAccount": {
+        "description": "string",
+        "message": "string"
+      },
+      "connectedWithAccountName": {
+        "description": "string",
+        "message": "string"
+      },
+      "connectedWithNetwork": {
+        "description": "string",
+        "message": "string"
+      },
+      "connectedWithNetworkName": {
+        "description": "string",
+        "message": "string"
+      },
+      "connecting": {
+        "message": "string"
+      },
+      "connectingTo": {
+        "message": "string"
+      },
+      "connectingToGoerli": {
+        "message": "string"
+      },
+      "connectingToLineaGoerli": {
+        "message": "string"
+      },
+      "connectingToLineaMainnet": {
+        "message": "string"
+      },
+      "connectingToLineaSepolia": {
+        "message": "string"
+      },
+      "connectingToMainnet": {
+        "message": "string"
+      },
+      "connectingToSepolia": {
+        "message": "string"
+      },
+      "connectionDescription": {
+        "message": "string"
+      },
+      "connectionFailed": {
+        "message": "string"
+      },
+      "connectionFailedDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "connectionPopoverDescription": {
+        "message": "string"
+      },
+      "connectionRequest": {
+        "message": "string"
+      },
+      "connectionsRemovedModalDescription": {
+        "message": "string"
+      },
+      "connectionsRemovedModalTitle": {
+        "message": "string"
+      },
+      "contactDeleted": {
+        "message": "string"
+      },
+      "contactDetails": {
+        "message": "string"
+      },
+      "contactUpdated": {
+        "message": "string"
+      },
+      "contactUs": {
+        "message": "string"
+      },
+      "contacts": {
+        "message": "string"
+      },
+      "contentFromSnap": {
+        "description": "string",
+        "message": "string"
+      },
+      "continue": {
+        "message": "string"
+      },
+      "contract": {
+        "message": "string"
+      },
+      "contractAddress": {
+        "message": "string"
+      },
+      "contractAddressError": {
+        "message": "string"
+      },
+      "contractDeployment": {
+        "message": "string"
+      },
+      "contractInteraction": {
+        "message": "string"
+      },
+      "convertTokenToNFTDescription": {
+        "message": "string"
+      },
+      "convertTokenToNFTExistDescription": {
+        "message": "string"
+      },
+      "coolWallet": {
+        "message": "string"
+      },
+      "copiedExclamation": {
+        "message": "string"
+      },
+      "copiedToClipboard": {
+        "message": "string"
+      },
+      "copyAddress": {
+        "message": "string"
+      },
+      "copyAddressShort": {
+        "message": "string"
+      },
+      "copyPrivateKey": {
+        "message": "string"
+      },
+      "copyToClipboard": {
+        "message": "string"
+      },
+      "copyTransactionId": {
+        "message": "string"
+      },
+      "correct": {
+        "message": "string"
+      },
+      "create": {
+        "message": "string"
+      },
+      "createMultichainAccountButton": {
+        "description": "string",
+        "message": "string"
+      },
+      "createMultichainAccountButtonLoading": {
+        "description": "string",
+        "message": "string"
+      },
+      "createNewAccountHeader": {
+        "message": "string"
+      },
+      "createPassword": {
+        "message": "string"
+      },
+      "createPasswordCreate": {
+        "message": "string"
+      },
+      "createPasswordDetails": {
+        "message": "string"
+      },
+      "createPasswordDetailsSocial": {
+        "description": "string",
+        "message": "string"
+      },
+      "createPasswordDetailsSocialReset": {
+        "message": "string"
+      },
+      "createPasswordMarketing": {
+        "message": "string"
+      },
+      "createSnapAccountDescription": {
+        "message": "string"
+      },
+      "createSnapAccountTitle": {
+        "message": "string"
+      },
+      "createSolanaAccount": {
+        "message": "string"
+      },
+      "creatorAddress": {
+        "message": "string"
+      },
+      "cryptoCompare": {
+        "message": "string"
+      },
+      "currencyConversion": {
+        "message": "string"
+      },
+      "currencyRateCheckToggle": {
+        "message": "string"
+      },
+      "currencyRateCheckToggleDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "currencySymbol": {
+        "message": "string"
+      },
+      "currencySymbolDefinition": {
+        "message": "string"
+      },
+      "current": {
+        "message": "string"
+      },
+      "currentAccountNotConnected": {
+        "message": "string"
+      },
+      "currentEstimatedBaseFee": {
+        "message": "string"
+      },
+      "currentEstimatedPriorityFeeRange": {
+        "message": "string"
+      },
+      "currentExtension": {
+        "message": "string"
+      },
+      "currentHistoricalBaseFeeRange": {
+        "message": "string"
+      },
+      "currentHistoricalPriorityFeeRange": {
+        "message": "string"
+      },
+      "currentLanguage": {
+        "message": "string"
+      },
+      "currentNetwork": {
+        "description": "string",
+        "message": "string"
+      },
+      "currentQuestion": {
+        "message": "string"
+      },
+      "currentlyUnavailable": {
+        "message": "string"
+      },
+      "curveHighGasEstimate": {
+        "message": "string"
+      },
+      "curveLowGasEstimate": {
+        "message": "string"
+      },
+      "curveMediumGasEstimate": {
+        "message": "string"
+      },
+      "custom": {
+        "message": "string"
+      },
+      "customGasSettingToolTipMessage": {
+        "description": "string",
+        "message": "string"
+      },
+      "customNetworks": {
+        "message": "string"
+      },
+      "customSlippage": {
+        "message": "string"
+      },
+      "customToken": {
+        "message": "string"
+      },
+      "customTokenWarningInTokenDetectionNetwork": {
+        "message": "string"
+      },
+      "customerSupport": {
+        "message": "string"
+      },
+      "customizeYourNotifications": {
+        "message": "string"
+      },
+      "customizeYourNotificationsText": {
+        "message": "string"
+      },
+      "dappConnections": {
+        "message": "string"
+      },
+      "dappScanMaliciousTitle": {
+        "message": "string"
+      },
+      "dappScanMaliciousWarning": {
+        "message": "string"
+      },
+      "dappSuggested": {
+        "message": "string"
+      },
+      "dappSuggestedGasSettingToolTipMessage": {
+        "description": "string",
+        "message": "string"
+      },
+      "dappSuggestedHigh": {
+        "message": "string"
+      },
+      "dappSwapAdvantage": {
+        "message": "string"
+      },
+      "dappSwapAdvantageSaveOnly": {
+        "message": "string"
+      },
+      "dappSwapBenefits": {
+        "message": "string"
+      },
+      "dappSwapQuoteDifference": {
+        "message": "string"
+      },
+      "dappSwapRewardText": {
+        "message": "string"
+      },
+      "darkTheme": {
+        "message": "string"
+      },
+      "data": {
+        "message": "string"
+      },
+      "dataCollectionForMarketing": {
+        "message": "string"
+      },
+      "dataCollectionForMarketingDescription": {
+        "message": "string"
+      },
+      "dataCollectionForMarketingDescriptionSocialLogin": {
+        "message": "string"
+      },
+      "dataCollectionWarningPopoverButton": {
+        "message": "string"
+      },
+      "dataCollectionWarningPopoverDescription": {
+        "message": "string"
+      },
+      "dataUnavailable": {
+        "message": "string"
+      },
+      "date": {
+        "message": "string"
+      },
+      "dateCreated": {
+        "message": "string"
+      },
+      "dcent": {
+        "message": "string"
+      },
+      "debitCreditPurchaseOptions": {
+        "message": "string"
+      },
+      "debug": {
+        "message": "string"
+      },
+      "decimal": {
+        "message": "string"
+      },
+      "decimalsMustZerotoTen": {
+        "message": "string"
+      },
+      "decrypt": {
+        "message": "string"
+      },
+      "decryptCopy": {
+        "message": "string"
+      },
+      "decryptInlineError": {
+        "description": "string",
+        "message": "string"
+      },
+      "decryptMessageNotice": {
+        "description": "string",
+        "message": "string"
+      },
+      "decryptMetamask": {
+        "message": "string"
+      },
+      "decryptRequest": {
+        "message": "string"
+      },
+      "deepLink_Caution": {
+        "message": "string"
+      },
+      "deepLink_Continue": {
+        "message": "string"
+      },
+      "deepLink_ContinueDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "deepLink_DontRemindMeAgain": {
+        "message": "string"
+      },
+      "deepLink_Error404Description": {
+        "message": "string"
+      },
+      "deepLink_Error404Title": {
+        "message": "string"
+      },
+      "deepLink_Error404_CTA": {
+        "description": "string",
+        "message": "string"
+      },
+      "deepLink_Error404_CTA_LinkText": {
+        "description": "string",
+        "message": "string"
+      },
+      "deepLink_ErrorMissingUrl": {
+        "message": "string"
+      },
+      "deepLink_ErrorOtherDescription": {
+        "message": "string"
+      },
+      "deepLink_ErrorOtherTitle": {
+        "message": "string"
+      },
+      "deepLink_GoToTheHomePageButton": {
+        "message": "string"
+      },
+      "deepLink_RedirectingToMetaMask": {
+        "message": "string"
+      },
+      "deepLink_ThirdPartyDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "deepLink_theAssetPage": {
+        "message": "string"
+      },
+      "deepLink_theBuyPage": {
+        "message": "string"
+      },
+      "deepLink_theCardOnboardingPage": {
+        "message": "string"
+      },
+      "deepLink_theHomePage": {
+        "message": "string"
+      },
+      "deepLink_theMusdEducationPage": {
+        "message": "string"
+      },
+      "deepLink_theNFTsPage": {
+        "message": "string"
+      },
+      "deepLink_theNotificationsPage": {
+        "message": "string"
+      },
+      "deepLink_theOnboardingPage": {
+        "message": "string"
+      },
+      "deepLink_thePerpsMarketDetailPage": {
+        "message": "string"
+      },
+      "deepLink_thePerpsMarketListPage": {
+        "message": "string"
+      },
+      "deepLink_thePerpsPage": {
+        "message": "string"
+      },
+      "deepLink_thePredictPage": {
+        "message": "string"
+      },
+      "deepLink_theRewardsPage": {
+        "message": "string"
+      },
+      "deepLink_theSellPage": {
+        "message": "string"
+      },
+      "deepLink_theSwapsPage": {
+        "message": "string"
+      },
+      "deepLink_theSwapsRampsPage": {
+        "message": "string"
+      },
+      "deepLink_theTransactionShieldPage": {
+        "message": "string"
+      },
+      "default": {
+        "message": "string"
+      },
+      "defaultRpcUrl": {
+        "message": "string"
+      },
+      "defaultSettingsSubTitle": {
+        "message": "string"
+      },
+      "defaultSettingsTitle": {
+        "message": "string"
+      },
+      "defi": {
+        "message": "string"
+      },
+      "defiEmptyDescription": {
+        "message": "string"
+      },
+      "defiReferralCheckboxLabel": {
+        "description": "string",
+        "message": "string"
+      },
+      "defiReferralTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "defiTabErrorContent": {
+        "message": "string"
+      },
+      "defiTabErrorTitle": {
+        "message": "string"
+      },
+      "delete": {
+        "message": "string"
+      },
+      "deleteActivityAndNonceData": {
+        "message": "string"
+      },
+      "deleteMetaMetricsData": {
+        "message": "string"
+      },
+      "deleteMetaMetricsDataDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "deleteMetaMetricsDataDescriptionV2": {
+        "description": "string",
+        "message": "string"
+      },
+      "deleteMetaMetricsDataErrorDesc": {
+        "message": "string"
+      },
+      "deleteMetaMetricsDataErrorTitle": {
+        "message": "string"
+      },
+      "deleteMetaMetricsDataErrorToast": {
+        "message": "string"
+      },
+      "deleteMetaMetricsDataModalDesc": {
+        "message": "string"
+      },
+      "deleteMetaMetricsDataModalTitle": {
+        "message": "string"
+      },
+      "deleteMetaMetricsDataRequestedDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "deleteMetaMetricsDataToast": {
+        "message": "string"
+      },
+      "deleteNetworkIntro": {
+        "message": "string"
+      },
+      "deleteNetworkTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "depositCrypto": {
+        "message": "string"
+      },
+      "deprecatedNetwork": {
+        "message": "string"
+      },
+      "deprecatedNetworkButtonMsg": {
+        "message": "string"
+      },
+      "deprecatedNetworkDescription": {
+        "message": "string"
+      },
+      "description": {
+        "message": "string"
+      },
+      "descriptionFromSnap": {
+        "description": "string",
+        "message": "string"
+      },
+      "destinationAccountPickerNoEligible": {
+        "message": "string"
+      },
+      "destinationAccountPickerNoMatching": {
+        "message": "string"
+      },
+      "destinationAccountPickerSearchPlaceholderToMainnet": {
+        "message": "string"
+      },
+      "destinationAccountPickerSearchPlaceholderToSolana": {
+        "message": "string"
+      },
+      "destinationTransactionIdLabel": {
+        "description": "string",
+        "message": "string"
+      },
+      "details": {
+        "message": "string"
+      },
+      "developerOptions": {
+        "message": "string"
+      },
+      "developerTools": {
+        "message": "string"
+      },
+      "disabledGasOptionToolTipMessage": {
+        "description": "string",
+        "message": "string"
+      },
+      "disconnect": {
+        "message": "string"
+      },
+      "disconnectAllAccounts": {
+        "message": "string"
+      },
+      "disconnectAllAccountsConfirmationDescription": {
+        "message": "string"
+      },
+      "disconnectAllAccountsText": {
+        "message": "string"
+      },
+      "disconnectAllDescriptionText": {
+        "message": "string"
+      },
+      "disconnectAllSites": {
+        "message": "string"
+      },
+      "disconnectAllSitesDescriptionText": {
+        "message": "string"
+      },
+      "disconnectAllSitesError": {
+        "message": "string"
+      },
+      "disconnectAllSitesSuccess": {
+        "message": "string"
+      },
+      "disconnectAllSnapsText": {
+        "message": "string"
+      },
+      "disconnectMessage": {
+        "message": "string"
+      },
+      "disconnectPrompt": {
+        "message": "string"
+      },
+      "disconnectThisAccount": {
+        "message": "string"
+      },
+      "discover": {
+        "message": "string"
+      },
+      "discoverSnaps": {
+        "description": "string",
+        "message": "string"
+      },
+      "dismiss": {
+        "message": "string"
+      },
+      "dismissReminderDescriptionField": {
+        "message": "string"
+      },
+      "dismissReminderField": {
+        "message": "string"
+      },
+      "displayNftMedia": {
+        "message": "string"
+      },
+      "displayNftMediaDescription": {
+        "message": "string"
+      },
+      "displayNftMediaDescriptionV2": {
+        "message": "string"
+      },
+      "doNotShare": {
+        "message": "string"
+      },
+      "domain": {
+        "message": "string"
+      },
+      "done": {
+        "message": "string"
+      },
+      "dontShowThisAgain": {
+        "message": "string"
+      },
+      "download": {
+        "message": "string"
+      },
+      "downloadAppDescription": {
+        "message": "string"
+      },
+      "downloadAppTitle": {
+        "message": "string"
+      },
+      "downloadGoogleChrome": {
+        "message": "string"
+      },
+      "downloadMetaMaskMobileDescription": {
+        "message": "string"
+      },
+      "downloadMetaMaskMobileQrNote": {
+        "message": "string"
+      },
+      "downloadMetaMaskMobileTitle": {
+        "message": "string"
+      },
+      "downloadNow": {
+        "message": "string"
+      },
+      "downloadStateLogs": {
+        "message": "string"
+      },
+      "dropped": {
+        "message": "string"
+      },
+      "duplicateContactTooltip": {
+        "message": "string"
+      },
+      "duplicateContactWarning": {
+        "message": "string"
+      },
+      "durationSuffixDay": {
+        "description": "string",
+        "message": "string"
+      },
+      "durationSuffixHour": {
+        "description": "string",
+        "message": "string"
+      },
+      "durationSuffixMillisecond": {
+        "description": "string",
+        "message": "string"
+      },
+      "durationSuffixMinute": {
+        "description": "string",
+        "message": "string"
+      },
+      "durationSuffixMonth": {
+        "description": "string",
+        "message": "string"
+      },
+      "durationSuffixSecond": {
+        "description": "string",
+        "message": "string"
+      },
+      "durationSuffixWeek": {
+        "description": "string",
+        "message": "string"
+      },
+      "durationSuffixYear": {
+        "description": "string",
+        "message": "string"
+      },
+      "earn": {
+        "message": "string"
+      },
+      "edit": {
+        "message": "string"
+      },
+      "editANickname": {
+        "message": "string"
+      },
+      "editAccounts": {
+        "message": "string"
+      },
+      "editAddressNickname": {
+        "message": "string"
+      },
+      "editContact": {
+        "message": "string"
+      },
+      "editGasFeeModalTitle": {
+        "message": "string"
+      },
+      "editGasLimitOutOfBounds": {
+        "message": "string"
+      },
+      "editGasMaxFeeHigh": {
+        "message": "string"
+      },
+      "editGasMaxFeeLow": {
+        "message": "string"
+      },
+      "editGasMaxFeePriorityImbalance": {
+        "message": "string"
+      },
+      "editGasMaxPriorityFeeBelowMinimum": {
+        "message": "string"
+      },
+      "editGasMaxPriorityFeeHigh": {
+        "message": "string"
+      },
+      "editGasMaxPriorityFeeLow": {
+        "message": "string"
+      },
+      "editGasPriceTooLow": {
+        "message": "string"
+      },
+      "editGasTooLow": {
+        "message": "string"
+      },
+      "editInPortfolio": {
+        "message": "string"
+      },
+      "editNetwork": {
+        "message": "string"
+      },
+      "editNetworkLink": {
+        "message": "string"
+      },
+      "editNetworksTitle": {
+        "message": "string"
+      },
+      "editNonceField": {
+        "message": "string"
+      },
+      "editNonceMessage": {
+        "message": "string"
+      },
+      "editPermissions": {
+        "message": "string"
+      },
+      "editSpendingCap": {
+        "message": "string"
+      },
+      "editSpendingCapAccountBalance": {
+        "message": "string"
+      },
+      "editSpendingCapDesc": {
+        "message": "string"
+      },
+      "editSpendingCapError": {
+        "message": "string"
+      },
+      "editSpendingCapSpecialCharError": {
+        "message": "string"
+      },
+      "enableAutoDetect": {
+        "message": "string"
+      },
+      "enableFromSettings": {
+        "message": "string"
+      },
+      "enableSmartContractAccount": {
+        "message": "string"
+      },
+      "enableSmartContractAccountDescription": {
+        "message": "string"
+      },
+      "enableSnap": {
+        "message": "string"
+      },
+      "enableToken": {
+        "description": "string",
+        "message": "string"
+      },
+      "enabled": {
+        "message": "string"
+      },
+      "enabledNetworks": {
+        "message": "string"
+      },
+      "encryptionPublicKeyNotice": {
+        "description": "string",
+        "message": "string"
+      },
+      "encryptionPublicKeyRequest": {
+        "message": "string"
+      },
+      "endpointReturnedDifferentChainId": {
+        "description": "string",
+        "message": "string"
+      },
+      "enhancedTokenDetectionAlertMessage": {
+        "message": "string"
+      },
+      "ensDomainsSettingDescriptionIntroduction": {
+        "message": "string"
+      },
+      "ensDomainsSettingDescriptionOutroduction": {
+        "message": "string"
+      },
+      "ensDomainsSettingDescriptionPart1": {
+        "message": "string"
+      },
+      "ensDomainsSettingDescriptionPart2": {
+        "message": "string"
+      },
+      "ensDomainsSettingTitle": {
+        "message": "string"
+      },
+      "ensUnknownError": {
+        "message": "string"
+      },
+      "enterANameToIdentifyTheUrl": {
+        "message": "string"
+      },
+      "enterChainId": {
+        "message": "string"
+      },
+      "enterNetworkName": {
+        "message": "string"
+      },
+      "enterOptionalPassword": {
+        "message": "string"
+      },
+      "enterPasswordContinue": {
+        "message": "string"
+      },
+      "enterPasswordCurrent": {
+        "message": "string"
+      },
+      "enterRpcUrl": {
+        "message": "string"
+      },
+      "enterSymbol": {
+        "message": "string"
+      },
+      "enterTokenNameOrAddress": {
+        "message": "string"
+      },
+      "enterYourPassword": {
+        "message": "string"
+      },
+      "enterYourPasswordContinue": {
+        "message": "string"
+      },
+      "enterYourPasswordSocialLoginFlow": {
+        "message": "string"
+      },
+      "errorCode": {
+        "description": "string",
+        "message": "string"
+      },
+      "errorDetails": {
+        "description": "string",
+        "message": "string"
+      },
+      "errorGettingSafeChainList": {
+        "message": "string"
+      },
+      "errorLegalTextFirstInfo": {
+        "message": "string"
+      },
+      "errorLegalTextNoPersonalInfo": {
+        "message": "string"
+      },
+      "errorLegalTextSecondInfo": {
+        "message": "string"
+      },
+      "errorLegalTextSummary": {
+        "message": "string"
+      },
+      "errorMessage": {
+        "description": "string",
+        "message": "string"
+      },
+      "errorName": {
+        "description": "string",
+        "message": "string"
+      },
+      "errorPageContactSupport": {
+        "description": "string",
+        "message": "string"
+      },
+      "errorPageDescribeUsWhatHappened": {
+        "description": "string",
+        "message": "string"
+      },
+      "errorPageInfo": {
+        "description": "string",
+        "message": "string"
+      },
+      "errorPageMessageTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "errorPageSentryFormTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "errorPageSentryMessagePlaceholder": {
+        "description": "string",
+        "message": "string"
+      },
+      "errorPageSentrySuccessMessageText": {
+        "description": "string",
+        "message": "string"
+      },
+      "errorPageTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "errorPageTryAgain": {
+        "description": "string",
+        "message": "string"
+      },
+      "errorStack": {
+        "description": "string",
+        "message": "string"
+      },
+      "errorWhileConnectingToRPC": {
+        "message": "string"
+      },
+      "errorWithSnap": {
+        "description": "string",
+        "message": "string"
+      },
+      "estimatedChanges": {
+        "message": "string"
+      },
+      "estimatedFee": {
+        "message": "string"
+      },
+      "estimatedFeeTooltip": {
+        "message": "string"
+      },
+      "estimatedPointsRow": {
+        "message": "string"
+      },
+      "estimatedTime": {
+        "message": "string"
+      },
+      "ethGasPriceFetchWarning": {
+        "message": "string"
+      },
+      "ethereumAndEvms": {
+        "message": "string"
+      },
+      "ethereumProviderAccess": {
+        "description": "string",
+        "message": "string"
+      },
+      "etherscan": {
+        "message": "string"
+      },
+      "etherscanView": {
+        "message": "string"
+      },
+      "etherscanViewOn": {
+        "message": "string"
+      },
+      "existingChainId": {
+        "message": "string"
+      },
+      "experimental": {
+        "message": "string"
+      },
+      "exploreDefi": {
+        "message": "string"
+      },
+      "exportYourData": {
+        "message": "string"
+      },
+      "exportYourDataButton": {
+        "message": "string"
+      },
+      "exportYourDataDescription": {
+        "message": "string"
+      },
+      "extendWalletWithSnaps": {
+        "description": "string",
+        "message": "string"
+      },
+      "externalAccount": {
+        "message": "string"
+      },
+      "externalExtension": {
+        "message": "string"
+      },
+      "externalNameSourcesSetting": {
+        "message": "string"
+      },
+      "externalNameSourcesSettingDescription": {
+        "message": "string"
+      },
+      "externalNameSourcesSettingDescriptionV2": {
+        "message": "string"
+      },
+      "failed": {
+        "message": "string"
+      },
+      "failedToFetchChainId": {
+        "message": "string"
+      },
+      "failover": {
+        "message": "string"
+      },
+      "failoverRpcUrl": {
+        "message": "string"
+      },
+      "failureMessage": {
+        "message": "string"
+      },
+      "fast": {
+        "message": "string"
+      },
+      "fieldRequired": {
+        "message": "string"
+      },
+      "fileImportFail": {
+        "description": "string",
+        "message": "string"
+      },
+      "fileUploaderDescription": {
+        "message": "string"
+      },
+      "fileUploaderInvalidFileTypeError": {
+        "message": "string"
+      },
+      "fileUploaderMaxFileSizeError": {
+        "description": "string",
+        "message": "string"
+      },
+      "flaskWelcomeUninstall": {
+        "description": "string",
+        "message": "string"
+      },
+      "flaskWelcomeWarning1": {
+        "description": "string",
+        "message": "string"
+      },
+      "flaskWelcomeWarning2": {
+        "description": "string",
+        "message": "string"
+      },
+      "flaskWelcomeWarning3": {
+        "description": "string",
+        "message": "string"
+      },
+      "flaskWelcomeWarning4": {
+        "description": "string",
+        "message": "string"
+      },
+      "flaskWelcomeWarningAcceptButton": {
+        "description": "string",
+        "message": "string"
+      },
+      "floatAmountToken": {
+        "message": "string"
+      },
+      "forbiddenIpfsGateway": {
+        "message": "string"
+      },
+      "forgetDevice": {
+        "message": "string"
+      },
+      "forgotPassword": {
+        "message": "string"
+      },
+      "forgotPasswordModalButton": {
+        "message": "string"
+      },
+      "forgotPasswordModalButtonLink": {
+        "message": "string"
+      },
+      "forgotPasswordModalContactSupport": {
+        "description": "string",
+        "message": "string"
+      },
+      "forgotPasswordModalContactSupportLink": {
+        "message": "string"
+      },
+      "forgotPasswordModalDescription1": {
+        "message": "string"
+      },
+      "forgotPasswordModalDescription2": {
+        "message": "string"
+      },
+      "forgotPasswordModalTitle": {
+        "message": "string"
+      },
+      "forgotPasswordSocialDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "forgotPasswordSocialStep1": {
+        "description": "string",
+        "message": "string"
+      },
+      "forgotPasswordSocialStep1Biometrics": {
+        "message": "string"
+      },
+      "forgotPasswordSocialStep2": {
+        "description": "string",
+        "message": "string"
+      },
+      "form": {
+        "message": "string"
+      },
+      "freeTrialDays": {
+        "description": "string",
+        "message": "string"
+      },
+      "from": {
+        "message": "string"
+      },
+      "function": {
+        "message": "string"
+      },
+      "fundYourWallet": {
+        "description": "string",
+        "message": "string"
+      },
+      "gas": {
+        "message": "string"
+      },
+      "gasLimit": {
+        "message": "string"
+      },
+      "gasLimitTooLow": {
+        "message": "string"
+      },
+      "gasPrice": {
+        "message": "string"
+      },
+      "gasPriceExcessive": {
+        "message": "string"
+      },
+      "gasPriceFetchFailed": {
+        "message": "string"
+      },
+      "gasSponsorshipReserveBalanceWarning": {
+        "description": "string",
+        "message": "string"
+      },
+      "gasTimingHoursShort": {
+        "description": "string",
+        "message": "string"
+      },
+      "gasTimingLow": {
+        "message": "string"
+      },
+      "gasTimingMinutesShort": {
+        "description": "string",
+        "message": "string"
+      },
+      "gasTimingSecondsShort": {
+        "description": "string",
+        "message": "string"
+      },
+      "gasUsed": {
+        "message": "string"
+      },
+      "gatorPermissionAnnualFrequency": {
+        "description": "string",
+        "message": "string"
+      },
+      "gatorPermissionCustomFrequency": {
+        "description": "string",
+        "message": "string"
+      },
+      "gatorPermissionDailyFrequency": {
+        "description": "string",
+        "message": "string"
+      },
+      "gatorPermissionFortnightlyFrequency": {
+        "description": "string",
+        "message": "string"
+      },
+      "gatorPermissionMonthlyFrequency": {
+        "description": "string",
+        "message": "string"
+      },
+      "gatorPermissionNoExpiration": {
+        "description": "string",
+        "message": "string"
+      },
+      "gatorPermissionTokenPeriodicFrequencyLabel": {
+        "description": "string",
+        "message": "string"
+      },
+      "gatorPermissionTokenStreamFrequencyLabel": {
+        "description": "string",
+        "message": "string"
+      },
+      "gatorPermissionWeeklyFrequency": {
+        "description": "string",
+        "message": "string"
+      },
+      "gatorPermissionsExpirationDate": {
+        "description": "string",
+        "message": "string"
+      },
+      "gatorPermissionsHideDetails": {
+        "description": "string",
+        "message": "string"
+      },
+      "gatorPermissionsInitialAllowance": {
+        "description": "string",
+        "message": "string"
+      },
+      "gatorPermissionsJustification": {
+        "description": "string",
+        "message": "string"
+      },
+      "gatorPermissionsMaxAllowance": {
+        "description": "string",
+        "message": "string"
+      },
+      "gatorPermissionsRevocationPending": {
+        "description": "string",
+        "message": "string"
+      },
+      "gatorPermissionsRevoke": {
+        "description": "string",
+        "message": "string"
+      },
+      "gatorPermissionsShowDetails": {
+        "description": "string",
+        "message": "string"
+      },
+      "gatorPermissionsStartDate": {
+        "description": "string",
+        "message": "string"
+      },
+      "gatorPermissionsStreamRate": {
+        "description": "string",
+        "message": "string"
+      },
+      "gatorPermissionsStreamingAmountLabel": {
+        "description": "string",
+        "message": "string"
+      },
+      "general": {
+        "message": "string"
+      },
+      "generalCameraError": {
+        "message": "string"
+      },
+      "generalCameraErrorTitle": {
+        "message": "string"
+      },
+      "generalDescription": {
+        "message": "string"
+      },
+      "genericExplorerView": {
+        "message": "string"
+      },
+      "getDollarMore": {
+        "message": "string"
+      },
+      "getTheNewestFeatures": {
+        "message": "string"
+      },
+      "getYourWalletReadyToUseWeb3": {
+        "description": "string",
+        "message": "string"
+      },
+      "gmxReferralSubtitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "goToSite": {
+        "message": "string"
+      },
+      "goerli": {
+        "message": "string"
+      },
+      "gotIt": {
+        "message": "string"
+      },
+      "grantExactAccess": {
+        "message": "string"
+      },
+      "gwei": {
+        "message": "string"
+      },
+      "hardware": {
+        "message": "string"
+      },
+      "hardwareWalletConnected": {
+        "message": "string"
+      },
+      "hardwareWalletErrorContinueButton": {
+        "message": "string"
+      },
+      "hardwareWalletErrorReconnectButton": {
+        "message": "string"
+      },
+      "hardwareWalletErrorRecoveryConnection1": {
+        "message": "string"
+      },
+      "hardwareWalletErrorRecoveryConnection2": {
+        "message": "string"
+      },
+      "hardwareWalletErrorRecoveryConnection3": {
+        "message": "string"
+      },
+      "hardwareWalletErrorRecoveryConnection4": {
+        "description": "string",
+        "message": "string"
+      },
+      "hardwareWalletErrorRecoveryTitle": {
+        "message": "string"
+      },
+      "hardwareWalletErrorRecoveryUnlock1": {
+        "description": "string",
+        "message": "string"
+      },
+      "hardwareWalletErrorRecoveryUnlock2": {
+        "message": "string"
+      },
+      "hardwareWalletErrorTitleBlindSignNotSupported": {
+        "message": "string"
+      },
+      "hardwareWalletErrorTitleBlindSignNotSupportedInstruction1": {
+        "message": "string"
+      },
+      "hardwareWalletErrorTitleBlindSignNotSupportedInstruction2": {
+        "message": "string"
+      },
+      "hardwareWalletErrorTitleConnectYourDevice": {
+        "description": "string",
+        "message": "string"
+      },
+      "hardwareWalletErrorTitleDeviceLocked": {
+        "description": "string",
+        "message": "string"
+      },
+      "hardwareWalletErrorUnknownErrorDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "hardwareWalletErrorUnknownErrorTitle": {
+        "message": "string"
+      },
+      "hardwareWalletEthAppNotOpenDescription": {
+        "message": "string"
+      },
+      "hardwareWalletLegacyDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "hardwareWalletLookingForDevice": {
+        "description": "string",
+        "message": "string"
+      },
+      "hardwareWalletSubmissionWarningStep1": {
+        "message": "string"
+      },
+      "hardwareWalletSubmissionWarningStep2": {
+        "message": "string"
+      },
+      "hardwareWalletSubmissionWarningTitle": {
+        "message": "string"
+      },
+      "hardwareWalletSupportLinkConversion": {
+        "message": "string"
+      },
+      "hardwareWalletTitleEthAppNotOpen": {
+        "message": "string"
+      },
+      "hardwareWalletTypeConnected": {
+        "description": "string",
+        "message": "string"
+      },
+      "hardwareWallets": {
+        "message": "string"
+      },
+      "hardwareWalletsInfo": {
+        "message": "string"
+      },
+      "hardwareWalletsMsg": {
+        "message": "string"
+      },
+      "helpAndSettings": {
+        "message": "string"
+      },
+      "here": {
+        "description": "string",
+        "message": "string"
+      },
+      "hexData": {
+        "message": "string"
+      },
+      "hexDataPlaceholder": {
+        "message": "string"
+      },
+      "hidden": {
+        "message": "string"
+      },
+      "hide": {
+        "message": "string"
+      },
+      "hideAccount": {
+        "message": "string"
+      },
+      "hideAdvancedDetails": {
+        "message": "string"
+      },
+      "hideSentitiveInfo": {
+        "message": "string"
+      },
+      "hideTokenPrompt": {
+        "message": "string"
+      },
+      "hideTokenSymbol": {
+        "description": "string",
+        "message": "string"
+      },
+      "hideZeroBalanceTokens": {
+        "message": "string"
+      },
+      "high": {
+        "message": "string"
+      },
+      "highGasSettingToolTipMessage": {
+        "description": "string",
+        "message": "string"
+      },
+      "highLowercase": {
+        "message": "string"
+      },
+      "highestCurrentBid": {
+        "message": "string"
+      },
+      "highestFloorPrice": {
+        "message": "string"
+      },
+      "history": {
+        "message": "string"
+      },
+      "holdToRevealContent1": {
+        "description": "string",
+        "message": "string"
+      },
+      "holdToRevealContent2": {
+        "description": "string",
+        "message": "string"
+      },
+      "holdToRevealContent3": {
+        "description": "string",
+        "message": "string"
+      },
+      "holdToRevealContent4": {
+        "description": "string",
+        "message": "string"
+      },
+      "holdToRevealContent5": {
+        "description": "string",
+        "message": "string"
+      },
+      "holdToRevealContentPrivateKey1": {
+        "description": "string",
+        "message": "string"
+      },
+      "holdToRevealContentPrivateKey2": {
+        "description": "string",
+        "message": "string"
+      },
+      "holdToRevealLockedLabel": {
+        "message": "string"
+      },
+      "holdToRevealPrivateKey": {
+        "message": "string"
+      },
+      "holdToRevealPrivateKeyTitle": {
+        "message": "string"
+      },
+      "holdToRevealSRP": {
+        "message": "string"
+      },
+      "holdToRevealSRPTitle": {
+        "message": "string"
+      },
+      "holdToRevealUnlockedLabel": {
+        "message": "string"
+      },
+      "honeypotDescription": {
+        "message": "string"
+      },
+      "honeypotTitle": {
+        "message": "string"
+      },
+      "hyperliquidReferralSubtitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "iUnderstand": {
+        "message": "string"
+      },
+      "id": {
+        "message": "string"
+      },
+      "imToken": {
+        "message": "string"
+      },
+      "import": {
+        "description": "string",
+        "message": "string"
+      },
+      "importAWallet": {
+        "message": "string"
+      },
+      "importAccountError": {
+        "message": "string"
+      },
+      "importAccountErrorIsSRP": {
+        "message": "string"
+      },
+      "importAccountErrorNotAValidPrivateKey": {
+        "message": "string"
+      },
+      "importAccountErrorNotHexadecimal": {
+        "message": "string"
+      },
+      "importAccountJsonLoading1": {
+        "message": "string"
+      },
+      "importAccountJsonLoading2": {
+        "message": "string"
+      },
+      "importAccountMsg": {
+        "message": "string"
+      },
+      "importAccountWithSocialMsg": {
+        "message": "string"
+      },
+      "importAccountWithSocialMsgLearnMore": {
+        "description": "string",
+        "message": "string"
+      },
+      "importAnAccount": {
+        "message": "string"
+      },
+      "importNFT": {
+        "message": "string"
+      },
+      "importNFTAddressToolTip": {
+        "message": "string"
+      },
+      "importNFTPage": {
+        "message": "string"
+      },
+      "importNFTTokenIdToolTip": {
+        "message": "string"
+      },
+      "importPrivateKey": {
+        "message": "string"
+      },
+      "importSecretRecoveryPhrase": {
+        "message": "string"
+      },
+      "importTokenQuestion": {
+        "message": "string"
+      },
+      "importTokenWarning": {
+        "message": "string"
+      },
+      "importTokensCamelCase": {
+        "message": "string"
+      },
+      "importTokensError": {
+        "message": "string"
+      },
+      "importWalletOrAccountHeader": {
+        "message": "string"
+      },
+      "importWalletSuccess": {
+        "description": "string",
+        "message": "string"
+      },
+      "imported": {
+        "description": "string",
+        "message": "string"
+      },
+      "includesXTransactions": {
+        "message": "string"
+      },
+      "incorrect": {
+        "message": "string"
+      },
+      "infuraBlockedNotification": {
+        "description": "string",
+        "message": "string"
+      },
+      "insights": {
+        "message": "string"
+      },
+      "insightsFromSnap": {
+        "description": "string",
+        "message": "string"
+      },
+      "install": {
+        "message": "string"
+      },
+      "installOrigin": {
+        "message": "string"
+      },
+      "installRequest": {
+        "message": "string"
+      },
+      "installedOn": {
+        "description": "string",
+        "message": "string"
+      },
+      "insufficientBalance": {
+        "message": "string"
+      },
+      "insufficientBalanceToCoverFees": {
+        "message": "string"
+      },
+      "insufficientFunds": {
+        "message": "string"
+      },
+      "insufficientFundsSend": {
+        "message": "string"
+      },
+      "insufficientLockedLiquidityDescription": {
+        "message": "string"
+      },
+      "insufficientLockedLiquidityTitle": {
+        "message": "string"
+      },
+      "insufficientTokens": {
+        "message": "string"
+      },
+      "interactWithSmartContract": {
+        "message": "string"
+      },
+      "interactingWith": {
+        "message": "string"
+      },
+      "interactingWithTransactionDescription": {
+        "message": "string"
+      },
+      "interaction": {
+        "message": "string"
+      },
+      "invalidAddress": {
+        "message": "string"
+      },
+      "invalidAddressRecipient": {
+        "message": "string"
+      },
+      "invalidAssetType": {
+        "message": "string"
+      },
+      "invalidChainIdTooBig": {
+        "message": "string"
+      },
+      "invalidCustomNetworkAlertContent1": {
+        "description": "string",
+        "message": "string"
+      },
+      "invalidCustomNetworkAlertContent2": {
+        "message": "string"
+      },
+      "invalidCustomNetworkAlertContent3": {
+        "description": "string",
+        "message": "string"
+      },
+      "invalidCustomNetworkAlertTitle": {
+        "message": "string"
+      },
+      "invalidHexData": {
+        "message": "string"
+      },
+      "invalidHexNumber": {
+        "message": "string"
+      },
+      "invalidHexNumberLeadingZeros": {
+        "message": "string"
+      },
+      "invalidIpfsGateway": {
+        "message": "string"
+      },
+      "invalidNumber": {
+        "message": "string"
+      },
+      "invalidNumberLeadingZeros": {
+        "message": "string"
+      },
+      "invalidRPC": {
+        "message": "string"
+      },
+      "invalidSeedPhrase": {
+        "message": "string"
+      },
+      "invalidSeedPhraseCaseSensitive": {
+        "message": "string"
+      },
+      "invalidSeedPhraseNotFound": {
+        "message": "string"
+      },
+      "invalidValue": {
+        "message": "string"
+      },
+      "ipfsGateway": {
+        "message": "string"
+      },
+      "ipfsGatewayDescription": {
+        "message": "string"
+      },
+      "ipfsGatewayDescriptionV2": {
+        "message": "string"
+      },
+      "ipfsToggleModalDescriptionOne": {
+        "message": "string"
+      },
+      "ipfsToggleModalDescriptionTwo": {
+        "description": "string",
+        "message": "string"
+      },
+      "ipfsToggleModalSettings": {
+        "message": "string"
+      },
+      "isSigningOrSubmitting": {
+        "message": "string"
+      },
+      "isSigningOrSubmittingPayToken": {
+        "message": "string"
+      },
+      "jazzicons": {
+        "message": "string"
+      },
+      "jsonFile": {
+        "description": "string",
+        "message": "string"
+      },
+      "keycardShell": {
+        "message": "string"
+      },
+      "keyringAccountName": {
+        "message": "string"
+      },
+      "keyringAccountPublicAddress": {
+        "message": "string"
+      },
+      "keyringSnapRemovalResult1": {
+        "description": "string",
+        "message": "string"
+      },
+      "keyringSnapRemovalResultNotSuccessful": {
+        "description": "string",
+        "message": "string"
+      },
+      "keyringSnapRemoveConfirmation": {
+        "description": "string",
+        "message": "string"
+      },
+      "keystone": {
+        "message": "string"
+      },
+      "knownAddressRecipient": {
+        "message": "string"
+      },
+      "knownTokenWarning": {
+        "message": "string"
+      },
+      "language": {
+        "message": "string"
+      },
+      "lastSold": {
+        "message": "string"
+      },
+      "lattice": {
+        "description": "string",
+        "message": "string"
+      },
+      "lavaDomeCopyWarning": {
+        "message": "string"
+      },
+      "learnHow": {
+        "message": "string"
+      },
+      "learnMore": {
+        "message": "string"
+      },
+      "learnMoreAboutGas": {
+        "description": "string",
+        "message": "string"
+      },
+      "learnMoreAboutPrivacy": {
+        "message": "string"
+      },
+      "learnMoreKeystone": {
+        "message": "string"
+      },
+      "learnMoreUpperCase": {
+        "message": "string"
+      },
+      "learnMoreUpperCaseWithDot": {
+        "message": "string"
+      },
+      "learnScamRisk": {
+        "message": "string"
+      },
+      "leaveMetaMask": {
+        "message": "string"
+      },
+      "leaveMetaMaskDesc": {
+        "message": "string"
+      },
+      "ledger": {
+        "description": "string",
+        "message": "string"
+      },
+      "ledgerAccountRestriction": {
+        "message": "string"
+      },
+      "ledgerConnectionInstructionCloseOtherApps": {
+        "message": "string"
+      },
+      "ledgerConnectionInstructionHeader": {
+        "message": "string"
+      },
+      "ledgerConnectionInstructionStepFour": {
+        "message": "string"
+      },
+      "ledgerConnectionInstructionStepThree": {
+        "message": "string"
+      },
+      "ledgerDeviceOpenFailureMessage": {
+        "message": "string"
+      },
+      "ledgerErrorConnectionIssue": {
+        "message": "string"
+      },
+      "ledgerErrorDevicedLocked": {
+        "message": "string"
+      },
+      "ledgerErrorEthAppNotOpen": {
+        "message": "string"
+      },
+      "ledgerErrorTransactionDataNotPadded": {
+        "message": "string"
+      },
+      "ledgerEthAppNftNotSupportedNotification": {
+        "message": "string"
+      },
+      "ledgerFirefoxNotSupportedDescription1": {
+        "message": "string"
+      },
+      "ledgerFirefoxNotSupportedDescription2": {
+        "message": "string"
+      },
+      "ledgerFirefoxNotSupportedDescription3": {
+        "message": "string"
+      },
+      "ledgerFirefoxNotSupportedLink": {
+        "message": "string"
+      },
+      "ledgerFirefoxNotSupportedTitle": {
+        "message": "string"
+      },
+      "ledgerLiveApp": {
+        "message": "string"
+      },
+      "ledgerLocked": {
+        "message": "string"
+      },
+      "ledgerMultipleDevicesUnsupportedInfoDescription": {
+        "message": "string"
+      },
+      "ledgerMultipleDevicesUnsupportedInfoTitle": {
+        "message": "string"
+      },
+      "ledgerTimeout": {
+        "message": "string"
+      },
+      "ledgerWebHIDNotConnectedErrorMessage": {
+        "description": "string",
+        "message": "string"
+      },
+      "lightTheme": {
+        "message": "string"
+      },
+      "likeToImportToken": {
+        "message": "string"
+      },
+      "likeToImportTokens": {
+        "message": "string"
+      },
+      "lineaGoerli": {
+        "message": "string"
+      },
+      "lineaMainnet": {
+        "message": "string"
+      },
+      "lineaSepolia": {
+        "message": "string"
+      },
+      "link": {
+        "message": "string"
+      },
+      "linkCentralizedExchanges": {
+        "message": "string"
+      },
+      "links": {
+        "message": "string"
+      },
+      "loading": {
+        "message": "string"
+      },
+      "loadingScreenSnapMessage": {
+        "message": "string"
+      },
+      "loadingTokenList": {
+        "message": "string"
+      },
+      "localCurrency": {
+        "message": "string"
+      },
+      "localhost": {
+        "message": "string"
+      },
+      "lock": {
+        "message": "string"
+      },
+      "lockMetaMaskLoadingMessage": {
+        "message": "string"
+      },
+      "lockTimeInvalid": {
+        "message": "string"
+      },
+      "logOut": {
+        "message": "string"
+      },
+      "loginErrorConnectButton": {
+        "message": "string"
+      },
+      "loginErrorConnectDescription": {
+        "message": "string"
+      },
+      "loginErrorConnectTitle": {
+        "message": "string"
+      },
+      "loginErrorGenericButton": {
+        "message": "string"
+      },
+      "loginErrorGenericDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "loginErrorGenericSupport": {
+        "message": "string"
+      },
+      "loginErrorGenericTitle": {
+        "message": "string"
+      },
+      "loginErrorResetWalletDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "loginErrorSessionExpiredButton": {
+        "message": "string"
+      },
+      "loginErrorSessionExpiredDescription": {
+        "message": "string"
+      },
+      "loginErrorSessionExpiredTitle": {
+        "message": "string"
+      },
+      "logo": {
+        "description": "string",
+        "message": "string"
+      },
+      "low": {
+        "message": "string"
+      },
+      "lowGasSettingToolTipMessage": {
+        "description": "string",
+        "message": "string"
+      },
+      "lowLowercase": {
+        "message": "string"
+      },
+      "mainnet": {
+        "message": "string"
+      },
+      "mainnetToken": {
+        "message": "string"
+      },
+      "makeAnotherSwap": {
+        "message": "string"
+      },
+      "makeSmartContractsEasier": {
+        "message": "string"
+      },
+      "makeSmartContractsEasierDescription": {
+        "message": "string"
+      },
+      "manage": {
+        "message": "string"
+      },
+      "manageDefaultSettings": {
+        "message": "string"
+      },
+      "manageInstitutionalWallets": {
+        "message": "string"
+      },
+      "manageInstitutionalWalletsDescription": {
+        "message": "string"
+      },
+      "manageNetworksMenuHeading": {
+        "message": "string"
+      },
+      "managePermissions": {
+        "message": "string"
+      },
+      "manageWalletRecovery": {
+        "message": "string"
+      },
+      "marketCap": {
+        "message": "string"
+      },
+      "marketCapFDV": {
+        "message": "string"
+      },
+      "marketDetails": {
+        "message": "string"
+      },
+      "marketRate": {
+        "message": "string"
+      },
+      "maskicons": {
+        "message": "string"
+      },
+      "max": {
+        "message": "string"
+      },
+      "maxBaseFee": {
+        "message": "string"
+      },
+      "maxBaseFeeMustBeGreaterThanPriorityFee": {
+        "message": "string"
+      },
+      "maxFee": {
+        "message": "string"
+      },
+      "maxFeeTooltip": {
+        "message": "string"
+      },
+      "medium": {
+        "message": "string"
+      },
+      "mediumGasSettingToolTipMessage": {
+        "description": "string",
+        "message": "string"
+      },
+      "memo": {
+        "message": "string"
+      },
+      "merklRewardsClaimBonus": {
+        "description": "string",
+        "message": "string"
+      },
+      "merklRewardsToastFailed": {
+        "description": "string",
+        "message": "string"
+      },
+      "merklRewardsToastInProgress": {
+        "description": "string",
+        "message": "string"
+      },
+      "merklRewardsToastSuccess": {
+        "description": "string",
+        "message": "string"
+      },
+      "merklRewardsUnexpectedError": {
+        "description": "string",
+        "message": "string"
+      },
+      "message": {
+        "message": "string"
+      },
+      "metaMaskConnectStatusParagraphOne": {
+        "message": "string"
+      },
+      "metaMaskConnectStatusParagraphThree": {
+        "message": "string"
+      },
+      "metaMaskConnectStatusParagraphTwo": {
+        "message": "string"
+      },
+      "metaMetricsIdNotAvailableError": {
+        "message": "string"
+      },
+      "metadataModalSourceTooltip": {
+        "description": "string",
+        "message": "string"
+      },
+      "metamaskFee": {
+        "message": "string"
+      },
+      "metamaskNotificationsAreOff": {
+        "message": "string"
+      },
+      "metamaskSwap": {
+        "message": "string"
+      },
+      "metamaskSwapsOfflineDescription": {
+        "message": "string"
+      },
+      "metamaskVersion": {
+        "message": "string"
+      },
+      "methodData": {
+        "message": "string"
+      },
+      "methodDataTransactionDesc": {
+        "message": "string"
+      },
+      "methodNotSupported": {
+        "message": "string"
+      },
+      "metrics": {
+        "message": "string"
+      },
+      "minimumReceivedExplanation": {
+        "message": "string"
+      },
+      "minimumReceivedExplanationTitle": {
+        "message": "string"
+      },
+      "minimumReceivedLabel": {
+        "message": "string"
+      },
+      "minute": {
+        "message": "string"
+      },
+      "mismatchedChainLinkText": {
+        "description": "string",
+        "message": "string"
+      },
+      "mismatchedChainRecommendation": {
+        "description": "string",
+        "message": "string"
+      },
+      "mismatchedNetworkName": {
+        "message": "string"
+      },
+      "mismatchedNetworkSymbol": {
+        "message": "string"
+      },
+      "mismatchedRpcChainId": {
+        "message": "string"
+      },
+      "mismatchedRpcUrl": {
+        "message": "string"
+      },
+      "missingSetting": {
+        "message": "string"
+      },
+      "missingSettingRequest": {
+        "message": "string"
+      },
+      "month": {
+        "message": "string"
+      },
+      "monthly": {
+        "message": "string"
+      },
+      "more": {
+        "message": "string"
+      },
+      "moreAccounts": {
+        "description": "string",
+        "message": "string"
+      },
+      "moreCapital": {
+        "message": "string"
+      },
+      "moreNetworks": {
+        "description": "string",
+        "message": "string"
+      },
+      "moreQuotes": {
+        "message": "string"
+      },
+      "multichainAccountAddressCopied": {
+        "description": "string",
+        "message": "string"
+      },
+      "multichainAccountIntroLearnMore": {
+        "description": "string",
+        "message": "string"
+      },
+      "multichainAccountIntroSameAddressDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "multichainAccountIntroSameAddressTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "multichainAccountIntroSettingUp": {
+        "description": "string",
+        "message": "string"
+      },
+      "multichainAccountIntroViewAccounts": {
+        "description": "string",
+        "message": "string"
+      },
+      "multichainAccountIntroWhatDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "multichainAccountIntroWhatTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "multichainAccountPrivateKeyCopied": {
+        "description": "string",
+        "message": "string"
+      },
+      "multichainAccountsIntroductionModalTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "multichainAddEthereumChainConfirmationDescription": {
+        "message": "string"
+      },
+      "multichainAddressViewAll": {
+        "message": "string"
+      },
+      "multichainProviderAccess": {
+        "description": "string",
+        "message": "string"
+      },
+      "multichainQuoteCardRateExplanation": {
+        "message": "string"
+      },
+      "multichainQuoteCardRateLabel": {
+        "message": "string"
+      },
+      "multipleSnapConnectionWarning": {
+        "description": "string",
+        "message": "string"
+      },
+      "musdBonusExplanation": {
+        "description": "string",
+        "message": "string"
+      },
+      "musdBonusPoweredByRelay": {
+        "description": "string",
+        "message": "string"
+      },
+      "musdBoostDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "musdBoostTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "musdBuyMusd": {
+        "message": "string"
+      },
+      "musdClaimSendingTo": {
+        "description": "string",
+        "message": "string"
+      },
+      "musdClaimSendingToWallet": {
+        "description": "string",
+        "message": "string"
+      },
+      "musdClaimTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "musdClaimableBonus": {
+        "description": "string",
+        "message": "string"
+      },
+      "musdClaimableBonusTooltip": {
+        "description": "string",
+        "message": "string"
+      },
+      "musdClaimableBonusTooltipAria": {
+        "description": "string",
+        "message": "string"
+      },
+      "musdConversionActivityTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "musdConversionBonusTooltipAria": {
+        "description": "string",
+        "message": "string"
+      },
+      "musdConversionFeeTooltipDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "musdConversionTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "musdConversionToastFailed": {
+        "message": "string"
+      },
+      "musdConversionToastInProgress": {
+        "description": "string",
+        "message": "string"
+      },
+      "musdConversionToastSuccess": {
+        "message": "string"
+      },
+      "musdConversionToastSuccessDescription": {
+        "message": "string"
+      },
+      "musdConvert": {
+        "message": "string"
+      },
+      "musdConvertAndGetBonus": {
+        "description": "string",
+        "message": "string"
+      },
+      "musdEarnBonusPercentage": {
+        "description": "string",
+        "message": "string"
+      },
+      "musdEducationGetStarted": {
+        "message": "string"
+      },
+      "musdEducationHeadline": {
+        "description": "string",
+        "message": "string"
+      },
+      "musdEducationNotNow": {
+        "message": "string"
+      },
+      "musdGetBonusPercentage": {
+        "description": "string",
+        "message": "string"
+      },
+      "musdGetMusd": {
+        "message": "string"
+      },
+      "musdMetaMaskUsd": {
+        "description": "string",
+        "message": "string"
+      },
+      "musdTermsApply": {
+        "message": "string"
+      },
+      "mustSelectOne": {
+        "message": "string"
+      },
+      "name": {
+        "message": "string"
+      },
+      "nameAddressLabel": {
+        "description": "string",
+        "message": "string"
+      },
+      "nameAlreadyInUse": {
+        "message": "string"
+      },
+      "nameFooterTrustWarning": {
+        "description": "string",
+        "message": "string"
+      },
+      "nameInstructionsMalicious": {
+        "description": "string",
+        "message": "string"
+      },
+      "nameInstructionsNew": {
+        "description": "string",
+        "message": "string"
+      },
+      "nameInstructionsRecognized": {
+        "description": "string",
+        "message": "string"
+      },
+      "nameInstructionsSaved": {
+        "description": "string",
+        "message": "string"
+      },
+      "nameInstructionsWarning": {
+        "description": "string",
+        "message": "string"
+      },
+      "nameLabel": {
+        "description": "string",
+        "message": "string"
+      },
+      "nameModalMaybeProposedName": {
+        "description": "string",
+        "message": "string"
+      },
+      "nameModalTitleMalicious": {
+        "description": "string",
+        "message": "string"
+      },
+      "nameModalTitleNew": {
+        "description": "string",
+        "message": "string"
+      },
+      "nameModalTitleRecognized": {
+        "description": "string",
+        "message": "string"
+      },
+      "nameModalTitleSaved": {
+        "description": "string",
+        "message": "string"
+      },
+      "nameModalTitleVerified": {
+        "description": "string",
+        "message": "string"
+      },
+      "nameModalTitleWarning": {
+        "description": "string",
+        "message": "string"
+      },
+      "nameProviderProposedBy": {
+        "description": "string",
+        "message": "string"
+      },
+      "nameProvider_ens": {
+        "message": "string"
+      },
+      "nameProvider_etherscan": {
+        "message": "string"
+      },
+      "nameProvider_lens": {
+        "message": "string"
+      },
+      "nameProvider_token": {
+        "message": "string"
+      },
+      "nameResolutionFailedError": {
+        "message": "string"
+      },
+      "nameResolutionZeroAddressError": {
+        "message": "string"
+      },
+      "nameSetPlaceholder": {
+        "description": "string",
+        "message": "string"
+      },
+      "nameSetPlaceholderSuggested": {
+        "description": "string",
+        "message": "string"
+      },
+      "nativeNetworkPermissionRequestDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "nativeTokenScamWarningConversion": {
+        "message": "string"
+      },
+      "nativeTokenScamWarningDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "nativeTokenScamWarningDescriptionExpectedTokenFallback": {
+        "description": "string",
+        "message": "string"
+      },
+      "nativeTokenScamWarningTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "needHelp": {
+        "description": "string",
+        "message": "string"
+      },
+      "needHelpFeedback": {
+        "message": "string"
+      },
+      "needHelpLinkText": {
+        "message": "string"
+      },
+      "needHelpSubmitTicket": {
+        "message": "string"
+      },
+      "needImportFile": {
+        "description": "string",
+        "message": "string"
+      },
+      "negativeOrZeroAmountToken": {
+        "message": "string"
+      },
+      "negativeValuesNotAllowed": {
+        "message": "string"
+      },
+      "network": {
+        "message": "string"
+      },
+      "networkChanged": {
+        "message": "string"
+      },
+      "networkChangedMessage": {
+        "description": "string",
+        "message": "string"
+      },
+      "networkDetails": {
+        "message": "string"
+      },
+      "networkFee": {
+        "message": "string"
+      },
+      "networkFeeExplanation": {
+        "message": "string"
+      },
+      "networkFeeExplanationTitle": {
+        "message": "string"
+      },
+      "networkMenu": {
+        "message": "string"
+      },
+      "networkMenuHeading": {
+        "message": "string"
+      },
+      "networkName": {
+        "message": "string"
+      },
+      "networkNameBitcoin": {
+        "message": "string"
+      },
+      "networkNameBitcoinSegwit": {
+        "message": "string"
+      },
+      "networkNameDefinition": {
+        "message": "string"
+      },
+      "networkNameEthereum": {
+        "message": "string"
+      },
+      "networkNameGoerli": {
+        "message": "string"
+      },
+      "networkNamePolygon": {
+        "message": "string"
+      },
+      "networkNameSolana": {
+        "message": "string"
+      },
+      "networkNameTron": {
+        "message": "string"
+      },
+      "networkOptions": {
+        "message": "string"
+      },
+      "networkPermissionToast": {
+        "message": "string"
+      },
+      "networkProvider": {
+        "message": "string"
+      },
+      "networkStatus": {
+        "message": "string"
+      },
+      "networkStatusBaseFeeTooltip": {
+        "description": "string",
+        "message": "string"
+      },
+      "networkStatusPriorityFeeTooltip": {
+        "message": "string"
+      },
+      "networkStatusStabilityFeeTooltip": {
+        "description": "string",
+        "message": "string"
+      },
+      "networkSuggested": {
+        "message": "string"
+      },
+      "networkTabCustom": {
+        "message": "string"
+      },
+      "networkTabPopular": {
+        "message": "string"
+      },
+      "networkURL": {
+        "message": "string"
+      },
+      "networkURLDefinition": {
+        "message": "string"
+      },
+      "networkUrlErrorWarning": {
+        "description": "string",
+        "message": "string"
+      },
+      "networks": {
+        "message": "string"
+      },
+      "networksSmallCase": {
+        "message": "string"
+      },
+      "nevermind": {
+        "message": "string"
+      },
+      "new": {
+        "message": "string"
+      },
+      "newAccount": {
+        "message": "string"
+      },
+      "newAccountIconMessage": {
+        "description": "string",
+        "message": "string"
+      },
+      "newAccountIconTitle": {
+        "message": "string"
+      },
+      "newAccountNumberName": {
+        "description": "string",
+        "message": "string"
+      },
+      "newContract": {
+        "message": "string"
+      },
+      "newNFTDetectedInImportNFTsMessageStrongText": {
+        "message": "string"
+      },
+      "newNFTDetectedInImportNFTsMsg": {
+        "description": "string",
+        "message": "string"
+      },
+      "newNFTDetectedInNFTsTabMessage": {
+        "message": "string"
+      },
+      "newNFTsAutodetected": {
+        "message": "string"
+      },
+      "newNetworkAdded": {
+        "message": "string"
+      },
+      "newNetworkEdited": {
+        "message": "string"
+      },
+      "newNftAddedMessage": {
+        "message": "string"
+      },
+      "newPassword": {
+        "message": "string"
+      },
+      "newPasswordCreate": {
+        "message": "string"
+      },
+      "newPrivacyPolicyActionButton": {
+        "message": "string"
+      },
+      "newPrivacyPolicyTitle": {
+        "message": "string"
+      },
+      "newRpcUrl": {
+        "message": "string"
+      },
+      "newTokensImportedMessage": {
+        "description": "string",
+        "message": "string"
+      },
+      "newTokensImportedTitle": {
+        "message": "string"
+      },
+      "next": {
+        "message": "string"
+      },
+      "nftAddFailedMessage": {
+        "message": "string"
+      },
+      "nftAddressError": {
+        "description": "string",
+        "message": "string"
+      },
+      "nftAlreadyAdded": {
+        "message": "string"
+      },
+      "nftAutoDetectionEnabled": {
+        "message": "string"
+      },
+      "nftBought": {
+        "message": "string"
+      },
+      "nftEmptyDescription": {
+        "message": "string"
+      },
+      "nftMinted": {
+        "message": "string"
+      },
+      "nftOptions": {
+        "message": "string"
+      },
+      "nftTokenIdPlaceholder": {
+        "message": "string"
+      },
+      "nftWarningContent": {
+        "description": "string",
+        "message": "string"
+      },
+      "nftWarningContentBold": {
+        "description": "string",
+        "message": "string"
+      },
+      "nftWarningContentGrey": {
+        "message": "string"
+      },
+      "nfts": {
+        "message": "string"
+      },
+      "nftsPreviouslyOwned": {
+        "message": "string"
+      },
+      "nickname": {
+        "message": "string"
+      },
+      "no": {
+        "message": "string"
+      },
+      "noAccountsFound": {
+        "message": "string"
+      },
+      "noConnectionDescription": {
+        "message": "string"
+      },
+      "noDefaultAddress": {
+        "description": "string",
+        "message": "string"
+      },
+      "noDomainResolution": {
+        "message": "string"
+      },
+      "noHardwareWalletOrSnapsSupport": {
+        "message": "string"
+      },
+      "noMMFeeSwapping": {
+        "message": "string"
+      },
+      "noNetworkFee": {
+        "message": "string"
+      },
+      "noNetworksAvailable": {
+        "message": "string"
+      },
+      "noNetworksFound": {
+        "message": "string"
+      },
+      "noNetworksSelected": {
+        "message": "string"
+      },
+      "noOptionsAvailableMessage": {
+        "message": "string"
+      },
+      "noSnaps": {
+        "message": "string"
+      },
+      "noTokensMatchingYourFilters": {
+        "message": "string"
+      },
+      "noWebcamFound": {
+        "message": "string"
+      },
+      "noWebcamFoundTitle": {
+        "message": "string"
+      },
+      "noZeroValue": {
+        "message": "string"
+      },
+      "nonContractAddressAlertDesc": {
+        "message": "string"
+      },
+      "nonContractAddressAlertTitle": {
+        "message": "string"
+      },
+      "nonce": {
+        "message": "string"
+      },
+      "none": {
+        "message": "string"
+      },
+      "notBusy": {
+        "message": "string"
+      },
+      "notCurrentAccount": {
+        "message": "string"
+      },
+      "notEnoughGas": {
+        "message": "string"
+      },
+      "notificationDetail": {
+        "message": "string"
+      },
+      "notificationDetailBaseFee": {
+        "message": "string"
+      },
+      "notificationDetailGasLimit": {
+        "message": "string"
+      },
+      "notificationDetailGasUsed": {
+        "message": "string"
+      },
+      "notificationDetailMaxFee": {
+        "message": "string"
+      },
+      "notificationDetailNetwork": {
+        "message": "string"
+      },
+      "notificationDetailNetworkFee": {
+        "message": "string"
+      },
+      "notificationDetailPriorityFee": {
+        "message": "string"
+      },
+      "notificationItemCheckBlockExplorer": {
+        "message": "string"
+      },
+      "notificationItemCollection": {
+        "message": "string"
+      },
+      "notificationItemConfirmed": {
+        "message": "string"
+      },
+      "notificationItemError": {
+        "message": "string"
+      },
+      "notificationItemFrom": {
+        "message": "string"
+      },
+      "notificationItemLidoStakeReadyToBeWithdrawn": {
+        "message": "string"
+      },
+      "notificationItemLidoStakeReadyToBeWithdrawnMessage": {
+        "message": "string"
+      },
+      "notificationItemLidoWithdrawalRequestedMessage": {
+        "message": "string"
+      },
+      "notificationItemNFTReceivedFrom": {
+        "message": "string"
+      },
+      "notificationItemNFTSentTo": {
+        "message": "string"
+      },
+      "notificationItemNetwork": {
+        "message": "string"
+      },
+      "notificationItemRate": {
+        "message": "string"
+      },
+      "notificationItemReceived": {
+        "message": "string"
+      },
+      "notificationItemReceivedFrom": {
+        "message": "string"
+      },
+      "notificationItemSent": {
+        "message": "string"
+      },
+      "notificationItemSentTo": {
+        "message": "string"
+      },
+      "notificationItemStakeCompleted": {
+        "message": "string"
+      },
+      "notificationItemStaked": {
+        "message": "string"
+      },
+      "notificationItemStakingProvider": {
+        "message": "string"
+      },
+      "notificationItemStatus": {
+        "message": "string"
+      },
+      "notificationItemSwapped": {
+        "message": "string"
+      },
+      "notificationItemSwappedFor": {
+        "message": "string"
+      },
+      "notificationItemTo": {
+        "message": "string"
+      },
+      "notificationItemTransactionId": {
+        "message": "string"
+      },
+      "notificationItemUnStakeCompleted": {
+        "message": "string"
+      },
+      "notificationItemUnStaked": {
+        "message": "string"
+      },
+      "notificationItemUnStakingRequested": {
+        "message": "string"
+      },
+      "notificationTransactionFailedMessage": {
+        "description": "string",
+        "message": "string"
+      },
+      "notificationTransactionFailedTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "notificationTransactionSuccessMessage": {
+        "description": "string",
+        "message": "string"
+      },
+      "notificationTransactionSuccessTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "notificationTransactionSuccessView": {
+        "description": "string",
+        "message": "string"
+      },
+      "notifications": {
+        "message": "string"
+      },
+      "notificationsFeatureToggle": {
+        "description": "string",
+        "message": "string"
+      },
+      "notificationsFeatureToggleDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "notificationsMarkAllAsRead": {
+        "message": "string"
+      },
+      "notificationsPageEmptyTitle": {
+        "message": "string"
+      },
+      "notificationsPageErrorContent": {
+        "message": "string"
+      },
+      "notificationsPageErrorTitle": {
+        "message": "string"
+      },
+      "notificationsPageNoNotificationsContent": {
+        "message": "string"
+      },
+      "notificationsSettingsBoxError": {
+        "message": "string"
+      },
+      "notificationsSettingsPageAllowNotifications": {
+        "message": "string"
+      },
+      "notificationsSettingsPageAllowNotificationsLink": {
+        "message": "string"
+      },
+      "numberOfTokens": {
+        "message": "string"
+      },
+      "ofTextNofM": {
+        "message": "string"
+      },
+      "off": {
+        "message": "string"
+      },
+      "offlineForMaintenance": {
+        "message": "string"
+      },
+      "ok": {
+        "message": "string"
+      },
+      "on": {
+        "message": "string"
+      },
+      "onboardedMetametricsAccept": {
+        "message": "string"
+      },
+      "onboardedMetametricsDisagree": {
+        "message": "string"
+      },
+      "onboardedMetametricsKey1": {
+        "message": "string"
+      },
+      "onboardedMetametricsKey2": {
+        "message": "string"
+      },
+      "onboardedMetametricsKey3": {
+        "message": "string"
+      },
+      "onboardedMetametricsLink": {
+        "message": "string"
+      },
+      "onboardedMetametricsParagraph1": {
+        "description": "string",
+        "message": "string"
+      },
+      "onboardedMetametricsParagraph2": {
+        "message": "string"
+      },
+      "onboardedMetametricsParagraph3": {
+        "message": "string"
+      },
+      "onboardedMetametricsTitle": {
+        "message": "string"
+      },
+      "onboardingAdvancedPrivacyIPFSDescription": {
+        "message": "string"
+      },
+      "onboardingAdvancedPrivacyIPFSInvalid": {
+        "message": "string"
+      },
+      "onboardingAdvancedPrivacyIPFSTitle": {
+        "message": "string"
+      },
+      "onboardingAdvancedPrivacyIPFSValid": {
+        "message": "string"
+      },
+      "onboardingAdvancedPrivacyNetworkDescription": {
+        "message": "string"
+      },
+      "onboardingAdvancedPrivacyNetworkDescriptionCallToAction": {
+        "message": "string"
+      },
+      "onboardingAdvancedPrivacyNetworkTitle": {
+        "message": "string"
+      },
+      "onboardingContinueWith": {
+        "description": "string",
+        "message": "string"
+      },
+      "onboardingCreateWallet": {
+        "message": "string"
+      },
+      "onboardingImportWallet": {
+        "message": "string"
+      },
+      "onboardingLoginFooter": {
+        "message": "string"
+      },
+      "onboardingLoginFooterPrivacyNotice": {
+        "message": "string"
+      },
+      "onboardingLoginFooterTermsOfUse": {
+        "message": "string"
+      },
+      "onboardingMetametricCheckboxDescriptionOne": {
+        "message": "string"
+      },
+      "onboardingMetametricCheckboxDescriptionOneUpdated": {
+        "message": "string"
+      },
+      "onboardingMetametricCheckboxDescriptionTwo": {
+        "message": "string"
+      },
+      "onboardingMetametricCheckboxTitleOne": {
+        "message": "string"
+      },
+      "onboardingMetametricCheckboxTitleTwo": {
+        "message": "string"
+      },
+      "onboardingMetametricsContinue": {
+        "message": "string"
+      },
+      "onboardingMetametricsDescription": {
+        "message": "string"
+      },
+      "onboardingMetametricsTitle": {
+        "message": "string"
+      },
+      "onboardingOptionIcon": {
+        "description": "string",
+        "message": "string"
+      },
+      "onboardingSignInWith": {
+        "description": "string",
+        "message": "string"
+      },
+      "onboardingSrpCreate": {
+        "message": "string"
+      },
+      "onboardingSrpImport": {
+        "message": "string"
+      },
+      "onboardingSrpImportError": {
+        "message": "string"
+      },
+      "onboardingSrpInputClearAll": {
+        "message": "string"
+      },
+      "onboardingSrpInputPlaceholder": {
+        "message": "string"
+      },
+      "oneKey": {
+        "description": "string",
+        "message": "string"
+      },
+      "only": {
+        "message": "string"
+      },
+      "onlyConnectTrust": {
+        "description": "string",
+        "message": "string"
+      },
+      "onlyIntegersAllowed": {
+        "message": "string"
+      },
+      "onlyNumbersAllowed": {
+        "message": "string"
+      },
+      "openFullScreen": {
+        "message": "string"
+      },
+      "openFullScreenForLedgerWebHid": {
+        "description": "string",
+        "message": "string"
+      },
+      "openInBlockExplorer": {
+        "message": "string"
+      },
+      "openMultichainAccountAddressMenu": {
+        "message": "string"
+      },
+      "openSettings": {
+        "message": "string"
+      },
+      "openWallet": {
+        "message": "string"
+      },
+      "options": {
+        "message": "string"
+      },
+      "or": {
+        "message": "string"
+      },
+      "origin": {
+        "message": "string"
+      },
+      "originChanged": {
+        "message": "string"
+      },
+      "originChangedMessage": {
+        "description": "string",
+        "message": "string"
+      },
+      "osTheme": {
+        "message": "string"
+      },
+      "other": {
+        "message": "string"
+      },
+      "otherPermissionsOnSiteDescription": {
+        "message": "string"
+      },
+      "otherPermissionsOnSiteTitle": {
+        "message": "string"
+      },
+      "otherSnaps": {
+        "description": "string",
+        "message": "string"
+      },
+      "others": {
+        "message": "string"
+      },
+      "outdatedBrowserNotification": {
+        "message": "string"
+      },
+      "overrideContentSecurityPolicyHeader": {
+        "message": "string"
+      },
+      "overrideContentSecurityPolicyHeaderDescription": {
+        "message": "string"
+      },
+      "padlock": {
+        "message": "string"
+      },
+      "paidByMetaMask": {
+        "message": "string"
+      },
+      "paidWith": {
+        "message": "string"
+      },
+      "participateInMetaMetrics": {
+        "message": "string"
+      },
+      "participateInMetaMetricsDescription": {
+        "message": "string"
+      },
+      "password": {
+        "message": "string"
+      },
+      "passwordChangedRecently": {
+        "message": "string"
+      },
+      "passwordChangedRecentlyDescription": {
+        "message": "string"
+      },
+      "passwordNotLongEnough": {
+        "message": "string"
+      },
+      "passwordTermsWarning": {
+        "message": "string"
+      },
+      "passwordTermsWarningSocial": {
+        "message": "string"
+      },
+      "passwordToggleHide": {
+        "message": "string"
+      },
+      "passwordToggleShow": {
+        "message": "string"
+      },
+      "passwordsDontMatch": {
+        "message": "string"
+      },
+      "paste": {
+        "message": "string"
+      },
+      "pastePrivateKey": {
+        "description": "string",
+        "message": "string"
+      },
+      "payWith": {
+        "description": "string",
+        "message": "string"
+      },
+      "payWithModalTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "pending": {
+        "message": "string"
+      },
+      "pendingConfirmationAddNetworkAlertMessage": {
+        "description": "string",
+        "message": "string"
+      },
+      "pendingConfirmationSwitchNetworkAlertMessage": {
+        "description": "string",
+        "message": "string"
+      },
+      "pendingTransactionAlertMessage": {
+        "description": "string",
+        "message": "string"
+      },
+      "pendingTransactionAlertMessageHyperlink": {
+        "description": "string",
+        "message": "string"
+      },
+      "perSecond": {
+        "message": "string"
+      },
+      "percentChange": {
+        "message": "string"
+      },
+      "permissionFor": {
+        "message": "string"
+      },
+      "permissionFrom": {
+        "message": "string"
+      },
+      "permissionRequested": {
+        "message": "string"
+      },
+      "permissionRequestedForAccounts": {
+        "description": "string",
+        "message": "string"
+      },
+      "permissionRevoked": {
+        "message": "string"
+      },
+      "permissionRevokedForAccounts": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_accessNamedSnap": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_accessNetwork": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_accessNetworkDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_accessSnap": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_accessSnapDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_assets": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_assetsDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_cronjob": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_cronjobDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_dialog": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_dialogDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_ethereumAccounts": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_ethereumProvider": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_ethereumProviderDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_getEntropy": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_getEntropyDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_getLocale": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_getLocaleDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_getPreferences": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_getPreferencesDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_homePage": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_homePageDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_keyring": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_keyringDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_lifecycleHooks": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_lifecycleHooksDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_manageAccounts": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_manageAccountsDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_manageBip32Keys": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_manageBip44AndBip32KeysDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_manageBip44Keys": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_manageState": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_manageStateDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_multichainProvider": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_multichainProviderDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_nameLookup": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_nameLookupDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_notifications": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_notificationsDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_protocol": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_protocolDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_rpc": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_rpcDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_rpcDescriptionOriginList": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_signatureInsight": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_signatureInsightDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_signatureInsightOrigin": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_signatureInsightOriginDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_transactionInsight": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_transactionInsightDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_transactionInsightOrigin": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_transactionInsightOriginDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_unknown": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_viewBip32PublicKeys": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_viewBip32PublicKeysDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_viewNamedBip32PublicKeys": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_walletSwitchEthereumChain": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_webAssembly": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_webAssemblyDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permissions": {
+        "message": "string"
+      },
+      "permissionsPageEmptyDescription": {
+        "message": "string"
+      },
+      "permitSimulationChange_approve": {
+        "message": "string"
+      },
+      "permitSimulationChange_bidding": {
+        "message": "string"
+      },
+      "permitSimulationChange_listing": {
+        "message": "string"
+      },
+      "permitSimulationChange_nft_listing": {
+        "message": "string"
+      },
+      "permitSimulationChange_receive": {
+        "message": "string"
+      },
+      "permitSimulationChange_revoke2": {
+        "message": "string"
+      },
+      "permitSimulationChange_transfer": {
+        "message": "string"
+      },
+      "permitSimulationDetailInfo": {
+        "message": "string"
+      },
+      "permittedChainToastUpdate": {
+        "message": "string"
+      },
+      "perps": {
+        "message": "string"
+      },
+      "perps24hVolume": {
+        "message": "string"
+      },
+      "perpsActivity": {
+        "message": "string"
+      },
+      "perpsAddExposure": {
+        "message": "string"
+      },
+      "perpsAddExposureDescriptionLong": {
+        "message": "string"
+      },
+      "perpsAddExposureDescriptionShort": {
+        "message": "string"
+      },
+      "perpsAddFunds": {
+        "message": "string"
+      },
+      "perpsAddFundsDescription": {
+        "message": "string"
+      },
+      "perpsAddMargin": {
+        "message": "string"
+      },
+      "perpsAddMarginDescription": {
+        "message": "string"
+      },
+      "perpsAddToFavorites": {
+        "message": "string"
+      },
+      "perpsAutoClose": {
+        "message": "string"
+      },
+      "perpsAvailable": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsAvailableBalance": {
+        "message": "string"
+      },
+      "perpsAvailableToAdd": {
+        "message": "string"
+      },
+      "perpsAvailableToClose": {
+        "message": "string"
+      },
+      "perpsAvailableToSubtract": {
+        "message": "string"
+      },
+      "perpsAvailableToTrade": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsBatchCancelFailed": {
+        "message": "string"
+      },
+      "perpsBatchCloseFailed": {
+        "message": "string"
+      },
+      "perpsCancelAllOrders": {
+        "message": "string"
+      },
+      "perpsCancelOrder": {
+        "message": "string"
+      },
+      "perpsCandleIntervals": {
+        "message": "string"
+      },
+      "perpsCandlePeriodDays": {
+        "message": "string"
+      },
+      "perpsCandlePeriodHours": {
+        "message": "string"
+      },
+      "perpsCandlePeriodMinutes": {
+        "message": "string"
+      },
+      "perpsCloseAll": {
+        "message": "string"
+      },
+      "perpsCloseAmount": {
+        "message": "string"
+      },
+      "perpsCloseLong": {
+        "message": "string"
+      },
+      "perpsClosePartialMinNotional": {
+        "message": "string"
+      },
+      "perpsClosePosition": {
+        "message": "string"
+      },
+      "perpsCloseShort": {
+        "message": "string"
+      },
+      "perpsConfirmCloseLong": {
+        "message": "string"
+      },
+      "perpsConfirmCloseShort": {
+        "message": "string"
+      },
+      "perpsConnectionTimeout": {
+        "message": "string"
+      },
+      "perpsContactSupport": {
+        "message": "string"
+      },
+      "perpsDateToday": {
+        "message": "string"
+      },
+      "perpsDateYesterday": {
+        "message": "string"
+      },
+      "perpsDepositActivityTitle": {
+        "message": "string"
+      },
+      "perpsDepositFailed": {
+        "message": "string"
+      },
+      "perpsDepositFundsTitle": {
+        "message": "string"
+      },
+      "perpsDepositTitle": {
+        "message": "string"
+      },
+      "perpsDeposits": {
+        "message": "string"
+      },
+      "perpsDetails": {
+        "message": "string"
+      },
+      "perpsDirection": {
+        "message": "string"
+      },
+      "perpsDisclaimer": {
+        "message": "string"
+      },
+      "perpsEmptyDescription": {
+        "message": "string"
+      },
+      "perpsEntryPrice": {
+        "message": "string"
+      },
+      "perpsEstSize": {
+        "message": "string"
+      },
+      "perpsEstimatedPnlAtStopLoss": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsEstimatedPnlAtTakeProfit": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsExploreMarkets": {
+        "message": "string"
+      },
+      "perpsFees": {
+        "message": "string"
+      },
+      "perpsFilterAll": {
+        "message": "string"
+      },
+      "perpsFilterCommodities": {
+        "message": "string"
+      },
+      "perpsFilterCrypto": {
+        "message": "string"
+      },
+      "perpsFilterForex": {
+        "message": "string"
+      },
+      "perpsFilterNew": {
+        "message": "string"
+      },
+      "perpsFilterStocks": {
+        "message": "string"
+      },
+      "perpsFunding": {
+        "message": "string"
+      },
+      "perpsFundingPayments": {
+        "message": "string"
+      },
+      "perpsFundingRate": {
+        "message": "string"
+      },
+      "perpsFundingRateTooltip": {
+        "message": "string"
+      },
+      "perpsGeoBlockedDescription": {
+        "message": "string"
+      },
+      "perpsGeoBlockedTitle": {
+        "message": "string"
+      },
+      "perpsGiveFeedback": {
+        "message": "string"
+      },
+      "perpsIncludesPnl": {
+        "message": "string"
+      },
+      "perpsInsufficientMargin": {
+        "message": "string"
+      },
+      "perpsLearnBasics": {
+        "message": "string"
+      },
+      "perpsLearnMore": {
+        "message": "string"
+      },
+      "perpsLeverage": {
+        "message": "string"
+      },
+      "perpsLimit": {
+        "message": "string"
+      },
+      "perpsLimitPrice": {
+        "message": "string"
+      },
+      "perpsLimitPriceAboveCurrentPrice": {
+        "message": "string"
+      },
+      "perpsLimitPriceBelowCurrentPrice": {
+        "message": "string"
+      },
+      "perpsLimitPriceNearLiquidation": {
+        "message": "string"
+      },
+      "perpsLiquidationDistance": {
+        "message": "string"
+      },
+      "perpsLiquidationPrice": {
+        "message": "string"
+      },
+      "perpsLong": {
+        "message": "string"
+      },
+      "perpsMargin": {
+        "message": "string"
+      },
+      "perpsMarginRiskWarning": {
+        "message": "string"
+      },
+      "perpsMarket": {
+        "message": "string"
+      },
+      "perpsMarketNotFound": {
+        "message": "string"
+      },
+      "perpsMarketNotFoundDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsMarkets": {
+        "message": "string"
+      },
+      "perpsMid": {
+        "message": "string"
+      },
+      "perpsModify": {
+        "message": "string"
+      },
+      "perpsModifyPosition": {
+        "message": "string"
+      },
+      "perpsMore": {
+        "message": "string"
+      },
+      "perpsNetworkError": {
+        "message": "string"
+      },
+      "perpsNoMarketsFound": {
+        "message": "string"
+      },
+      "perpsNoTransactions": {
+        "message": "string"
+      },
+      "perpsOpenInterest": {
+        "message": "string"
+      },
+      "perpsOpenInterestTooltip": {
+        "message": "string"
+      },
+      "perpsOpenLong": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsOpenOrders": {
+        "message": "string"
+      },
+      "perpsOpenShort": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsOraclePrice": {
+        "message": "string"
+      },
+      "perpsOraclePriceTooltip": {
+        "message": "string"
+      },
+      "perpsOrderDate": {
+        "message": "string"
+      },
+      "perpsOrderFailed": {
+        "message": "string"
+      },
+      "perpsOrderOriginalSize": {
+        "message": "string"
+      },
+      "perpsOrderRejected": {
+        "message": "string"
+      },
+      "perpsOrderStatus": {
+        "message": "string"
+      },
+      "perpsOrderValue": {
+        "message": "string"
+      },
+      "perpsOrders": {
+        "message": "string"
+      },
+      "perpsPnl": {
+        "message": "string"
+      },
+      "perpsPosition": {
+        "message": "string"
+      },
+      "perpsPositions": {
+        "message": "string"
+      },
+      "perpsRateLimitExceeded": {
+        "message": "string"
+      },
+      "perpsRecentActivity": {
+        "message": "string"
+      },
+      "perpsReduceExposure": {
+        "message": "string"
+      },
+      "perpsReduceExposureDescriptionLong": {
+        "message": "string"
+      },
+      "perpsReduceExposureDescriptionShort": {
+        "message": "string"
+      },
+      "perpsReduceOnly": {
+        "message": "string"
+      },
+      "perpsRemoveFromFavorites": {
+        "message": "string"
+      },
+      "perpsRemoveMargin": {
+        "message": "string"
+      },
+      "perpsRemoveMarginDescription": {
+        "message": "string"
+      },
+      "perpsReturn": {
+        "message": "string"
+      },
+      "perpsReversePosition": {
+        "message": "string"
+      },
+      "perpsReversePositionDescriptionLong": {
+        "message": "string"
+      },
+      "perpsReversePositionDescriptionShort": {
+        "message": "string"
+      },
+      "perpsSaveChanges": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsSearchMarkets": {
+        "message": "string"
+      },
+      "perpsSeeAll": {
+        "message": "string"
+      },
+      "perpsServiceUnavailable": {
+        "message": "string"
+      },
+      "perpsShort": {
+        "message": "string"
+      },
+      "perpsSize": {
+        "message": "string"
+      },
+      "perpsSlippageExceeded": {
+        "message": "string"
+      },
+      "perpsSortByFundingRate": {
+        "message": "string"
+      },
+      "perpsSortByHighToLow": {
+        "message": "string"
+      },
+      "perpsSortByLowToHigh": {
+        "message": "string"
+      },
+      "perpsSortByOpenInterest": {
+        "message": "string"
+      },
+      "perpsSortByPriceChange": {
+        "message": "string"
+      },
+      "perpsSortBySection": {
+        "message": "string"
+      },
+      "perpsSortByTitle": {
+        "message": "string"
+      },
+      "perpsSortByVolume": {
+        "message": "string"
+      },
+      "perpsStartNewTrade": {
+        "message": "string"
+      },
+      "perpsStartTrading": {
+        "message": "string"
+      },
+      "perpsStats": {
+        "message": "string"
+      },
+      "perpsStatusCanceled": {
+        "message": "string"
+      },
+      "perpsStatusCompleted": {
+        "message": "string"
+      },
+      "perpsStatusFilled": {
+        "message": "string"
+      },
+      "perpsStatusOpen": {
+        "message": "string"
+      },
+      "perpsStatusQueued": {
+        "message": "string"
+      },
+      "perpsStatusRejected": {
+        "message": "string"
+      },
+      "perpsStatusTriggered": {
+        "message": "string"
+      },
+      "perpsStopLoss": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsStopLossInvalidPrice": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsSubmitting": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsTakeProfit": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsTakeProfitInvalidPrice": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastCancelOrderFailed": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastCancelOrderSuccess": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastCloseFailed": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastCloseInProgress": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastClosePnlSubtitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastMarginAddSuccess": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastMarginAdjustmentFailed": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastMarginAdjustmentFailedDescriptionFallback": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastMarginRemoveSuccess": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastOrderFailed": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastOrderFailedDescriptionFallback": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastOrderFilled": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastOrderPlaced": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastOrderPlacementSubtitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastOrderSubmitted": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastPartialCloseFailed": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastPartialCloseInProgress": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastPartialCloseSuccess": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastPositionStillActive": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastReverseFailed": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastReverseInProgress": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastReverseSuccess": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastSubmitInProgress": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastTradeSuccess": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastUpdateFailed": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastUpdateInProgress": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastUpdateSuccess": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsTotalBalance": {
+        "message": "string"
+      },
+      "perpsTradePerps": {
+        "message": "string"
+      },
+      "perpsTrades": {
+        "message": "string"
+      },
+      "perpsTutorialChooseLeverageDescription": {
+        "message": "string"
+      },
+      "perpsTutorialChooseLeverageTitle": {
+        "message": "string"
+      },
+      "perpsTutorialCloseAnytimeDescription": {
+        "message": "string"
+      },
+      "perpsTutorialCloseAnytimeTitle": {
+        "message": "string"
+      },
+      "perpsTutorialContinue": {
+        "message": "string"
+      },
+      "perpsTutorialGoLongShortDescription": {
+        "message": "string"
+      },
+      "perpsTutorialGoLongShortSubtitle": {
+        "message": "string"
+      },
+      "perpsTutorialGoLongShortTitle": {
+        "message": "string"
+      },
+      "perpsTutorialLetsGo": {
+        "message": "string"
+      },
+      "perpsTutorialReadyToTradeDescription": {
+        "message": "string"
+      },
+      "perpsTutorialReadyToTradeTitle": {
+        "message": "string"
+      },
+      "perpsTutorialSkip": {
+        "message": "string"
+      },
+      "perpsTutorialWatchLiquidationDescription": {
+        "message": "string"
+      },
+      "perpsTutorialWatchLiquidationTitle": {
+        "message": "string"
+      },
+      "perpsTutorialWhatArePerpsDescription": {
+        "message": "string"
+      },
+      "perpsTutorialWhatArePerpsSubtitle": {
+        "message": "string"
+      },
+      "perpsTutorialWhatArePerpsTitle": {
+        "message": "string"
+      },
+      "perpsUnrealizedPnl": {
+        "message": "string"
+      },
+      "perpsWatchlist": {
+        "message": "string"
+      },
+      "perpsWithdraw": {
+        "message": "string"
+      },
+      "perpsWithdrawEstimatedTime": {
+        "message": "string"
+      },
+      "perpsWithdrawFailed": {
+        "message": "string"
+      },
+      "perpsWithdrawFee": {
+        "message": "string"
+      },
+      "perpsWithdrawFundsTitle": {
+        "message": "string"
+      },
+      "perpsWithdrawInsufficient": {
+        "message": "string"
+      },
+      "perpsWithdrawInvalidAddress": {
+        "message": "string"
+      },
+      "perpsWithdrawInvalidAmount": {
+        "message": "string"
+      },
+      "perpsWithdrawMinNotice": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsWithdrawMinutesApprox": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsWithdrawNoAccount": {
+        "message": "string"
+      },
+      "perpsWithdrawReceive": {
+        "message": "string"
+      },
+      "perpsWithdrawRoutesError": {
+        "message": "string"
+      },
+      "perpsWithdrawToastErrorTitle": {
+        "message": "string"
+      },
+      "perpsWithdrawToastSuccessDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsWithdrawToastSuccessTitle": {
+        "message": "string"
+      },
+      "perpsYouReceive": {
+        "message": "string"
+      },
+      "perpsYouWillReceive": {
+        "message": "string"
+      },
+      "personalAddressDetected": {
+        "message": "string"
+      },
+      "pin": {
+        "description": "string",
+        "message": "string"
+      },
+      "pinMetaMask": {
+        "message": "string"
+      },
+      "pinMetaMaskDescription": {
+        "message": "string"
+      },
+      "pinToTop": {
+        "message": "string"
+      },
+      "pinned": {
+        "message": "string"
+      },
+      "pleaseConfirm": {
+        "message": "string"
+      },
+      "pna25ModalBlogPostLink": {
+        "message": "string"
+      },
+      "pna25ModalBody1": {
+        "message": "string"
+      },
+      "pna25ModalBody2": {
+        "message": "string"
+      },
+      "pna25ModalBody3": {
+        "message": "string"
+      },
+      "pna25ModalTitle": {
+        "message": "string"
+      },
+      "popularNetworkAddToolTip": {
+        "description": "string",
+        "message": "string"
+      },
+      "popularNetworks": {
+        "message": "string"
+      },
+      "preferencesAndDisplay": {
+        "message": "string"
+      },
+      "prev": {
+        "message": "string"
+      },
+      "price": {
+        "message": "string"
+      },
+      "priceUnavailable": {
+        "message": "string"
+      },
+      "primaryType": {
+        "message": "string"
+      },
+      "priority": {
+        "message": "string"
+      },
+      "priorityFee": {
+        "message": "string"
+      },
+      "priorityFeeProperCase": {
+        "message": "string"
+      },
+      "priorityFeeTooHigh": {
+        "message": "string"
+      },
+      "privacy": {
+        "message": "string"
+      },
+      "privacyMsg": {
+        "message": "string"
+      },
+      "privateKey": {
+        "description": "string",
+        "message": "string"
+      },
+      "privateKeyCopyWarning": {
+        "description": "string",
+        "message": "string"
+      },
+      "privateKeyHidden": {
+        "description": "string",
+        "message": "string"
+      },
+      "privateKeyShow": {
+        "description": "string",
+        "message": "string"
+      },
+      "privateKeyShown": {
+        "description": "string",
+        "message": "string"
+      },
+      "privateKeyWarning": {
+        "message": "string"
+      },
+      "privateKeys": {
+        "description": "string",
+        "message": "string"
+      },
+      "privateNetwork": {
+        "message": "string"
+      },
+      "proceed": {
+        "message": "string"
+      },
+      "proceedWithTransaction": {
+        "message": "string"
+      },
+      "productAnnouncements": {
+        "message": "string"
+      },
+      "provide": {
+        "message": "string"
+      },
+      "publicAddress": {
+        "message": "string"
+      },
+      "pushNotificationLimitOrderFilledDescriptionLong": {
+        "description": "string",
+        "message": "string"
+      },
+      "pushNotificationLimitOrderFilledDescriptionShort": {
+        "description": "string",
+        "message": "string"
+      },
+      "pushNotificationLimitOrderFilledTitle": {
+        "message": "string"
+      },
+      "pushNotificationPositionLiquidatedDescriptionLong": {
+        "description": "string",
+        "message": "string"
+      },
+      "pushNotificationPositionLiquidatedDescriptionShort": {
+        "description": "string",
+        "message": "string"
+      },
+      "pushNotificationPositionLiquidatedTitle": {
+        "message": "string"
+      },
+      "pushNotificationShieldClaimCreatedDescriptionShort": {
+        "message": "string"
+      },
+      "pushNotificationShieldClaimCreatedTitle": {
+        "message": "string"
+      },
+      "pushNotificationShieldClaimStatusUpdatedDescriptionShort": {
+        "message": "string"
+      },
+      "pushNotificationShieldClaimStatusUpdatedTitle": {
+        "message": "string"
+      },
+      "pushNotificationShieldLearnMoreCta": {
+        "message": "string"
+      },
+      "pushNotificationShieldSubscriptionCreatedDescriptionShort": {
+        "message": "string"
+      },
+      "pushNotificationShieldSubscriptionPaymentFailedDescriptionShort": {
+        "message": "string"
+      },
+      "pushNotificationShieldSubscriptionTitle": {
+        "message": "string"
+      },
+      "pushNotificationShieldUpdatePaymentCta": {
+        "message": "string"
+      },
+      "pushNotificationStopLossTriggeredDescriptionLong": {
+        "description": "string",
+        "message": "string"
+      },
+      "pushNotificationStopLossTriggeredDescriptionShort": {
+        "description": "string",
+        "message": "string"
+      },
+      "pushNotificationStopLossTriggeredTitle": {
+        "message": "string"
+      },
+      "pushNotificationTakeProfitTriggeredDescriptionLong": {
+        "description": "string",
+        "message": "string"
+      },
+      "pushNotificationTakeProfitTriggeredDescriptionShort": {
+        "description": "string",
+        "message": "string"
+      },
+      "pushNotificationTakeProfitTriggeredTitle": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsFundsReceivedDescription": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsFundsReceivedDescriptionDefault": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsFundsReceivedTitle": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsFundsSentDescription": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsFundsSentDescriptionDefault": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsFundsSentTitle": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsNftReceivedDescription": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsNftReceivedTitle": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsNftSentDescription": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsNftSentTitle": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsStakingLidoStakeCompletedDescription": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsStakingLidoStakeCompletedTitle": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsStakingLidoStakeReadyToBeWithdrawnDescription": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsStakingLidoStakeReadyToBeWithdrawnTitle": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsStakingLidoWithdrawalCompletedDescription": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsStakingLidoWithdrawalCompletedTitle": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsStakingLidoWithdrawalRequestedDescription": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsStakingLidoWithdrawalRequestedTitle": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsStakingRocketpoolStakeCompletedDescription": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsStakingRocketpoolStakeCompletedTitle": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsStakingRocketpoolUnstakeCompletedDescription": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsStakingRocketpoolUnstakeCompletedTitle": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsSwapCompletedDescription": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsSwapCompletedTitle": {
+        "message": "string"
+      },
+      "qr": {
+        "description": "string",
+        "message": "string"
+      },
+      "queued": {
+        "message": "string"
+      },
+      "quizIntroduction": {
+        "message": "string"
+      },
+      "quotedTotalCost": {
+        "message": "string"
+      },
+      "rank": {
+        "message": "string"
+      },
+      "rateIncludesMMFee": {
+        "message": "string"
+      },
+      "readdToken": {
+        "message": "string"
+      },
+      "receive": {
+        "message": "string"
+      },
+      "receiveCrypto": {
+        "message": "string"
+      },
+      "received": {
+        "message": "string"
+      },
+      "receivingAddress": {
+        "description": "string",
+        "message": "string"
+      },
+      "recipient": {
+        "message": "string"
+      },
+      "recipientAddressPlaceholderNew": {
+        "message": "string"
+      },
+      "recipientEditAriaLabel": {
+        "message": "string"
+      },
+      "recipientPlaceholderText": {
+        "message": "string"
+      },
+      "recoveryPhraseReminderBackupStart": {
+        "message": "string"
+      },
+      "recoveryPhraseReminderConfirm": {
+        "message": "string"
+      },
+      "recoveryPhraseReminderSubText": {
+        "message": "string"
+      },
+      "recoveryPhraseReminderTitle": {
+        "message": "string"
+      },
+      "redeposit": {
+        "message": "string"
+      },
+      "refreshList": {
+        "message": "string"
+      },
+      "reject": {
+        "message": "string"
+      },
+      "rejectAll": {
+        "message": "string"
+      },
+      "rejected": {
+        "message": "string"
+      },
+      "remove": {
+        "message": "string"
+      },
+      "removeAccount": {
+        "message": "string"
+      },
+      "removeAccountModalBannerDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "removeAccountModalBannerTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "removeAll": {
+        "message": "string"
+      },
+      "removeKeyringSnap": {
+        "message": "string"
+      },
+      "removeKeyringSnapToolTip": {
+        "message": "string"
+      },
+      "removeNFT": {
+        "message": "string"
+      },
+      "removeNftErrorMessage": {
+        "message": "string"
+      },
+      "removeNftMessage": {
+        "message": "string"
+      },
+      "removeSnap": {
+        "message": "string"
+      },
+      "removeSnapAccountDescription": {
+        "message": "string"
+      },
+      "removeSnapAccountTitle": {
+        "message": "string"
+      },
+      "removeSnapConfirmation": {
+        "description": "string",
+        "message": "string"
+      },
+      "removeSnapDescription": {
+        "message": "string"
+      },
+      "rename": {
+        "description": "string",
+        "message": "string"
+      },
+      "replace": {
+        "message": "string"
+      },
+      "reportIssue": {
+        "message": "string"
+      },
+      "reportThisError": {
+        "message": "string"
+      },
+      "requestFrom": {
+        "message": "string"
+      },
+      "requestFromInfo": {
+        "message": "string"
+      },
+      "requestFromInfoSnap": {
+        "message": "string"
+      },
+      "requestFromTransactionDescription": {
+        "message": "string"
+      },
+      "requestingFor": {
+        "message": "string"
+      },
+      "requestingForAccount": {
+        "description": "string",
+        "message": "string"
+      },
+      "requestingForNetwork": {
+        "description": "string",
+        "message": "string"
+      },
+      "required": {
+        "message": "string"
+      },
+      "requiredToken": {
+        "description": "string",
+        "message": "string"
+      },
+      "reset": {
+        "message": "string"
+      },
+      "resetWallet": {
+        "message": "string"
+      },
+      "resetWalletBoldTextOne": {
+        "message": "string"
+      },
+      "resetWalletBoldTextTwo": {
+        "message": "string"
+      },
+      "resetWalletButton": {
+        "message": "string"
+      },
+      "resetWalletDescriptionOne": {
+        "message": "string"
+      },
+      "resetWalletDescriptionTwo": {
+        "description": "string",
+        "message": "string"
+      },
+      "resetWalletTitle": {
+        "message": "string"
+      },
+      "resolutionProtocol": {
+        "description": "string",
+        "message": "string"
+      },
+      "restartMetamask": {
+        "message": "string"
+      },
+      "restore": {
+        "message": "string"
+      },
+      "restoreUserData": {
+        "message": "string"
+      },
+      "restoreWalletDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "resultPageError": {
+        "message": "string"
+      },
+      "resultPageErrorDefaultMessage": {
+        "message": "string"
+      },
+      "resultPageSuccess": {
+        "message": "string"
+      },
+      "resultPageSuccessDefaultMessage": {
+        "message": "string"
+      },
+      "retryTransaction": {
+        "message": "string"
+      },
+      "reusedTokenNameWarning": {
+        "message": "string"
+      },
+      "revealMultichainPrivateKeysBannerDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "revealMultichainPrivateKeysBannerTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "revealSecretRecoveryPhrase": {
+        "message": "string"
+      },
+      "revealSecretRecoveryPhraseSettings": {
+        "message": "string"
+      },
+      "revealSeedWords": {
+        "message": "string"
+      },
+      "revealSeedWordsDescription1": {
+        "description": "string",
+        "message": "string"
+      },
+      "revealSeedWordsQR": {
+        "message": "string"
+      },
+      "revealSeedWordsSRPName": {
+        "message": "string"
+      },
+      "revealSeedWordsText": {
+        "message": "string"
+      },
+      "revealSeedWordsWarning": {
+        "message": "string"
+      },
+      "revealSensitiveContent": {
+        "message": "string"
+      },
+      "review": {
+        "message": "string"
+      },
+      "reviewAlert": {
+        "message": "string"
+      },
+      "reviewAlerts": {
+        "message": "string"
+      },
+      "reviewPendingTransactions": {
+        "message": "string"
+      },
+      "reviewPermissions": {
+        "message": "string"
+      },
+      "revokePermission": {
+        "message": "string"
+      },
+      "revokePermissionTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "revokeSimulationDetailsDesc": {
+        "message": "string"
+      },
+      "revokeTokenApprovals": {
+        "message": "string"
+      },
+      "reward": {
+        "message": "string"
+      },
+      "rewardsAuthFailDescription": {
+        "message": "string"
+      },
+      "rewardsAuthFailTitle": {
+        "message": "string"
+      },
+      "rewardsErrorMessagesAccountAlreadyRegistered": {
+        "message": "string"
+      },
+      "rewardsErrorMessagesFailedToClaimReward": {
+        "message": "string"
+      },
+      "rewardsErrorMessagesRequestRejected": {
+        "message": "string"
+      },
+      "rewardsErrorMessagesServiceNotAvailable": {
+        "message": "string"
+      },
+      "rewardsErrorMessagesSomethingWentWrong": {
+        "message": "string"
+      },
+      "rewardsLinkAccount": {
+        "message": "string"
+      },
+      "rewardsLinkAccountError": {
+        "message": "string"
+      },
+      "rewardsOnboardingIntroDescription": {
+        "message": "string"
+      },
+      "rewardsOnboardingIntroGeoCheckFailedDescription": {
+        "message": "string"
+      },
+      "rewardsOnboardingIntroGeoCheckFailedTitle": {
+        "message": "string"
+      },
+      "rewardsOnboardingIntroGeoCheckRetry": {
+        "message": "string"
+      },
+      "rewardsOnboardingIntroRewardsAuthFailRetry": {
+        "message": "string"
+      },
+      "rewardsOnboardingIntroStepConfirm": {
+        "message": "string"
+      },
+      "rewardsOnboardingIntroStepConfirmLoadingEligibility": {
+        "message": "string"
+      },
+      "rewardsOnboardingIntroStepConfirmLoadingRegion": {
+        "message": "string"
+      },
+      "rewardsOnboardingIntroStepSkip": {
+        "message": "string"
+      },
+      "rewardsOnboardingIntroTitle": {
+        "message": "string"
+      },
+      "rewardsOnboardingIntroUnsupportedRegionDescription": {
+        "message": "string"
+      },
+      "rewardsOnboardingIntroUnsupportedRegionTitle": {
+        "message": "string"
+      },
+      "rewardsOnboardingStep1Description": {
+        "message": "string"
+      },
+      "rewardsOnboardingStep1Title": {
+        "message": "string"
+      },
+      "rewardsOnboardingStep2Description": {
+        "message": "string"
+      },
+      "rewardsOnboardingStep2Title": {
+        "message": "string"
+      },
+      "rewardsOnboardingStep3Description": {
+        "message": "string"
+      },
+      "rewardsOnboardingStep3Title": {
+        "message": "string"
+      },
+      "rewardsOnboardingStep4LegalDisclaimer": {
+        "description": "string",
+        "message": "string"
+      },
+      "rewardsOnboardingStep4LegalDisclaimerLearnMoreLink": {
+        "message": "string"
+      },
+      "rewardsOnboardingStep4LegalDisclaimerTermsLink": {
+        "message": "string"
+      },
+      "rewardsOnboardingStep4OptInError": {
+        "message": "string"
+      },
+      "rewardsOnboardingStep4ReferralCodeError": {
+        "message": "string"
+      },
+      "rewardsOnboardingStep4ReferralCodeInput": {
+        "message": "string"
+      },
+      "rewardsOnboardingStep4ReferralCodePlaceholder": {
+        "message": "string"
+      },
+      "rewardsOnboardingStep4ReferralCodeUnknownError": {
+        "message": "string"
+      },
+      "rewardsOnboardingStep4ReferralCodeUnknownErrorDescription": {
+        "message": "string"
+      },
+      "rewardsOnboardingStep4Title": {
+        "message": "string"
+      },
+      "rewardsOnboardingStep4TitleWithReferralCode": {
+        "message": "string"
+      },
+      "rewardsOnboardingStepConfirm": {
+        "message": "string"
+      },
+      "rewardsOnboardingStepOptIn": {
+        "message": "string"
+      },
+      "rewardsOptInVerifyingReferralCode": {
+        "description": "string",
+        "message": "string"
+      },
+      "rewardsPointsBalance": {
+        "description": "string",
+        "message": "string"
+      },
+      "rewardsPointsBalance_couldntLoad": {
+        "description": "string",
+        "message": "string"
+      },
+      "rewardsPointsIcon": {
+        "description": "string",
+        "message": "string"
+      },
+      "rewardsQRCodeDescription": {
+        "message": "string"
+      },
+      "rewardsQRCodeTitle": {
+        "message": "string"
+      },
+      "rewardsSignInFailed": {
+        "description": "string",
+        "message": "string"
+      },
+      "rewardsSignInToViewPoints": {
+        "description": "string",
+        "message": "string"
+      },
+      "rewardsSignUp": {
+        "message": "string"
+      },
+      "rewardsSigningIn": {
+        "description": "string",
+        "message": "string"
+      },
+      "rpcNameOptional": {
+        "message": "string"
+      },
+      "rpcUrl": {
+        "message": "string"
+      },
+      "safeTransferFrom": {
+        "message": "string"
+      },
+      "save": {
+        "message": "string"
+      },
+      "scanInstructions": {
+        "message": "string"
+      },
+      "scanQrCode": {
+        "message": "string"
+      },
+      "scrollDown": {
+        "message": "string"
+      },
+      "search": {
+        "message": "string"
+      },
+      "searchAnAcccountOrContact": {
+        "message": "string"
+      },
+      "searchForAnAssetToSend": {
+        "message": "string"
+      },
+      "searchNetworks": {
+        "message": "string"
+      },
+      "searchNfts": {
+        "message": "string"
+      },
+      "searchTokens": {
+        "message": "string"
+      },
+      "searchTokensByNameOrAddress": {
+        "message": "string"
+      },
+      "searchYourAccounts": {
+        "description": "string",
+        "message": "string"
+      },
+      "second": {
+        "message": "string"
+      },
+      "secretRecoveryPhrase": {
+        "message": "string"
+      },
+      "secretRecoveryPhrasePlusNumber": {
+        "description": "string",
+        "message": "string"
+      },
+      "secureWallet": {
+        "message": "string"
+      },
+      "secureWalletRemindLaterButton": {
+        "message": "string"
+      },
+      "security": {
+        "message": "string"
+      },
+      "securityAlert": {
+        "message": "string"
+      },
+      "securityAlerts": {
+        "message": "string"
+      },
+      "securityAlertsDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "securityAlertsDescriptionV2": {
+        "message": "string"
+      },
+      "securityAndPassword": {
+        "message": "string"
+      },
+      "securityAndPrivacy": {
+        "message": "string"
+      },
+      "securityChangePassword": {
+        "message": "string"
+      },
+      "securityChangePasswordDescription": {
+        "message": "string"
+      },
+      "securityChangePasswordTitle": {
+        "message": "string"
+      },
+      "securityChangePasswordToastError": {
+        "message": "string"
+      },
+      "securityChangePasswordToastSuccess": {
+        "message": "string"
+      },
+      "securityDefaultSettingsSocialLogin": {
+        "message": "string"
+      },
+      "securityDescription": {
+        "message": "string"
+      },
+      "securityLoginWithSocial": {
+        "description": "string",
+        "message": "string"
+      },
+      "securityLoginWithSrpBackedUp": {
+        "message": "string"
+      },
+      "securityLoginWithSrpNotBackedUp": {
+        "message": "string"
+      },
+      "securityMessageLinkForNetworks": {
+        "message": "string"
+      },
+      "securityProviderPoweredBy": {
+        "description": "string",
+        "message": "string"
+      },
+      "securitySocialLoginDefaultSettingsDescription": {
+        "message": "string"
+      },
+      "securitySocialLoginEnabled": {
+        "message": "string"
+      },
+      "securitySocialLoginEnabledDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "securitySocialLoginLabel": {
+        "description": "string",
+        "message": "string"
+      },
+      "securitySrpDescription": {
+        "message": "string"
+      },
+      "securitySrpLabel": {
+        "message": "string"
+      },
+      "securitySrpWalletRecovery": {
+        "message": "string"
+      },
+      "seeAllPermissions": {
+        "description": "string",
+        "message": "string"
+      },
+      "seeDetails": {
+        "message": "string"
+      },
+      "seedPhraseReq": {
+        "message": "string"
+      },
+      "seedPhraseReviewDetails": {
+        "description": "string",
+        "message": "string"
+      },
+      "seedPhraseReviewTitle": {
+        "message": "string"
+      },
+      "seedPhraseReviewTitleSettings": {
+        "message": "string"
+      },
+      "select": {
+        "message": "string"
+      },
+      "selectAccountToConnect": {
+        "message": "string"
+      },
+      "selectAll": {
+        "message": "string"
+      },
+      "selectAnAccount": {
+        "message": "string"
+      },
+      "selectAnAccountAlreadyConnected": {
+        "message": "string"
+      },
+      "selectEnableDisplayMediaPrivacyPreference": {
+        "message": "string"
+      },
+      "selectHdPath": {
+        "message": "string"
+      },
+      "selectNFTPrivacyPreference": {
+        "message": "string"
+      },
+      "selectNetworkToFilter": {
+        "message": "string"
+      },
+      "selectPathHelp": {
+        "message": "string"
+      },
+      "selectRecipient": {
+        "message": "string"
+      },
+      "selectRpcUrl": {
+        "message": "string"
+      },
+      "selectSecretRecoveryPhrase": {
+        "message": "string"
+      },
+      "selectType": {
+        "message": "string"
+      },
+      "selectedAccountMismatch": {
+        "message": "string"
+      },
+      "send": {
+        "message": "string"
+      },
+      "sendBugReport": {
+        "message": "string"
+      },
+      "sendSelectReceiveAsset": {
+        "message": "string"
+      },
+      "sendSelectSendAsset": {
+        "message": "string"
+      },
+      "sendingAsset": {
+        "message": "string"
+      },
+      "sendingDisabled": {
+        "message": "string"
+      },
+      "sendingNativeAsset": {
+        "description": "string",
+        "message": "string"
+      },
+      "sent": {
+        "message": "string"
+      },
+      "sentSpecifiedTokens": {
+        "description": "string",
+        "message": "string"
+      },
+      "sentTokenAsToken": {
+        "description": "string",
+        "message": "string"
+      },
+      "sepolia": {
+        "message": "string"
+      },
+      "setApprovalForAll": {
+        "message": "string"
+      },
+      "setApprovalForAllRedesignedTitle": {
+        "message": "string"
+      },
+      "setApprovalForAllTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "setUp": {
+        "description": "string",
+        "message": "string"
+      },
+      "settingAddSnapAccount": {
+        "message": "string"
+      },
+      "settings": {
+        "message": "string"
+      },
+      "settingsSearchCantFindSetting": {
+        "description": "string",
+        "message": "string"
+      },
+      "settingsSearchMatchingNotFound": {
+        "message": "string"
+      },
+      "settingsSearchRequestHere": {
+        "message": "string"
+      },
+      "shieldClaim": {
+        "message": "string"
+      },
+      "shieldClaimChainNotSupported": {
+        "message": "string"
+      },
+      "shieldClaimDeleteDraft": {
+        "message": "string"
+      },
+      "shieldClaimDeleteDraftDescription": {
+        "message": "string"
+      },
+      "shieldClaimDeletedDraft": {
+        "message": "string"
+      },
+      "shieldClaimDescription": {
+        "message": "string"
+      },
+      "shieldClaimDescriptionPlaceholder": {
+        "message": "string"
+      },
+      "shieldClaimDetails": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldClaimDetailsViewClaims": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldClaimDraftDeleteFailed": {
+        "message": "string"
+      },
+      "shieldClaimDraftDeleteFailedDescription": {
+        "message": "string"
+      },
+      "shieldClaimDraftSaveFailed": {
+        "message": "string"
+      },
+      "shieldClaimDraftSaveFailedDescription": {
+        "message": "string"
+      },
+      "shieldClaimDraftSaved": {
+        "message": "string"
+      },
+      "shieldClaimDraftSavedDescription": {
+        "message": "string"
+      },
+      "shieldClaimDuplicateClaimExists": {
+        "message": "string"
+      },
+      "shieldClaimEmail": {
+        "message": "string"
+      },
+      "shieldClaimEmailHelpText": {
+        "message": "string"
+      },
+      "shieldClaimFileErrorCountExceeded": {
+        "message": "string"
+      },
+      "shieldClaimFileErrorInvalidType": {
+        "message": "string"
+      },
+      "shieldClaimFileErrorSizeExceeded": {
+        "message": "string"
+      },
+      "shieldClaimFileUploader": {
+        "message": "string"
+      },
+      "shieldClaimFileUploaderAcceptText": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldClaimFileUploaderHelpText": {
+        "message": "string"
+      },
+      "shieldClaimGroupActive": {
+        "message": "string"
+      },
+      "shieldClaimGroupActiveNote": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldClaimGroupCompleted": {
+        "message": "string"
+      },
+      "shieldClaimGroupDrafts": {
+        "message": "string"
+      },
+      "shieldClaimGroupNoCompletedClaims": {
+        "message": "string"
+      },
+      "shieldClaimGroupNoCompletedClaimsDescription": {
+        "message": "string"
+      },
+      "shieldClaimGroupNoOpenClaims": {
+        "message": "string"
+      },
+      "shieldClaimGroupNoOpenClaimsDescription": {
+        "message": "string"
+      },
+      "shieldClaimGroupRejected": {
+        "message": "string"
+      },
+      "shieldClaimImpactedTxHash": {
+        "message": "string"
+      },
+      "shieldClaimImpactedTxHashHelpText": {
+        "message": "string"
+      },
+      "shieldClaimImpactedTxHashHelpTextLink": {
+        "message": "string"
+      },
+      "shieldClaimImpactedTxHashNotEligible": {
+        "message": "string"
+      },
+      "shieldClaimImpactedWalletAddress": {
+        "message": "string"
+      },
+      "shieldClaimIncidentDetails": {
+        "message": "string"
+      },
+      "shieldClaimInvalidChainId": {
+        "message": "string"
+      },
+      "shieldClaimInvalidEmail": {
+        "message": "string"
+      },
+      "shieldClaimInvalidRequired": {
+        "message": "string"
+      },
+      "shieldClaimInvalidTxHash": {
+        "message": "string"
+      },
+      "shieldClaimInvalidWalletAddress": {
+        "message": "string"
+      },
+      "shieldClaimMaxClaimsLimitExceeded": {
+        "message": "string"
+      },
+      "shieldClaimMaxDraftsReached": {
+        "message": "string"
+      },
+      "shieldClaimNetwork": {
+        "message": "string"
+      },
+      "shieldClaimPersonalDetails": {
+        "message": "string"
+      },
+      "shieldClaimReimbursementWalletAddress": {
+        "message": "string"
+      },
+      "shieldClaimReimbursementWalletAddressHelpText": {
+        "message": "string"
+      },
+      "shieldClaimSameWalletAddressesError": {
+        "message": "string"
+      },
+      "shieldClaimSaveAsDraft": {
+        "message": "string"
+      },
+      "shieldClaimSelectAccount": {
+        "message": "string"
+      },
+      "shieldClaimSelectNetwork": {
+        "message": "string"
+      },
+      "shieldClaimSignatureCoverageNotCovered": {
+        "message": "string"
+      },
+      "shieldClaimSubmissionWindowExpired": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldClaimSubmit": {
+        "message": "string"
+      },
+      "shieldClaimSubmitError": {
+        "message": "string"
+      },
+      "shieldClaimSubmitSuccess": {
+        "message": "string"
+      },
+      "shieldClaimSubmitSuccessDescription": {
+        "message": "string"
+      },
+      "shieldClaimTransactionNotFound": {
+        "message": "string"
+      },
+      "shieldClaimTransactionNotFromWalletAddress": {
+        "message": "string"
+      },
+      "shieldClaimTransactionNotSuccessful": {
+        "message": "string"
+      },
+      "shieldClaimViewGuidelines": {
+        "message": "string"
+      },
+      "shieldClaimWalletOwnershipValidationFailed": {
+        "message": "string"
+      },
+      "shieldClaimsLastEdited": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldClaimsListTitle": {
+        "message": "string"
+      },
+      "shieldClaimsNumber": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldClaimsTabHistory": {
+        "message": "string"
+      },
+      "shieldClaimsTabPending": {
+        "message": "string"
+      },
+      "shieldConfirmMembership": {
+        "message": "string"
+      },
+      "shieldCoverageAlertCovered": {
+        "message": "string"
+      },
+      "shieldCoverageAlertHighRiskTransaction": {
+        "message": "string"
+      },
+      "shieldCoverageAlertMessageChainNotSupported": {
+        "message": "string"
+      },
+      "shieldCoverageAlertMessageLearnHowCoverageWorks": {
+        "message": "string"
+      },
+      "shieldCoverageAlertMessagePaused": {
+        "message": "string"
+      },
+      "shieldCoverageAlertMessagePausedAcknowledgeButton": {
+        "message": "string"
+      },
+      "shieldCoverageAlertMessagePotentialRisks": {
+        "message": "string"
+      },
+      "shieldCoverageAlertMessageSignatureNotSupported": {
+        "message": "string"
+      },
+      "shieldCoverageAlertMessageTitle": {
+        "message": "string"
+      },
+      "shieldCoverageAlertMessageTitleCovered": {
+        "message": "string"
+      },
+      "shieldCoverageAlertMessageTitlePaused": {
+        "message": "string"
+      },
+      "shieldCoverageAlertMessageTitleSignatureRequest": {
+        "message": "string"
+      },
+      "shieldCoverageAlertMessageTitleSignatureRequestCovered": {
+        "message": "string"
+      },
+      "shieldCoverageAlertMessageTokenTrustSignalWarning": {
+        "message": "string"
+      },
+      "shieldCoverageAlertMessageTxTypeNotSupported": {
+        "message": "string"
+      },
+      "shieldCoverageAlertMessageUnknown": {
+        "message": "string"
+      },
+      "shieldCoverageEnding": {
+        "message": "string"
+      },
+      "shieldCoverageEndingAction": {
+        "message": "string"
+      },
+      "shieldCoverageEndingDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldCovered": {
+        "message": "string"
+      },
+      "shieldEntryModalGetStarted": {
+        "message": "string"
+      },
+      "shieldEntryModalSubtitleA": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldEntryModalSubtitleB": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldEntryModalTitleA": {
+        "message": "string"
+      },
+      "shieldEntryModalTitleB": {
+        "message": "string"
+      },
+      "shieldErrorPayerAddressAlreadyUsed": {
+        "message": "string"
+      },
+      "shieldEstimatedChangesMonthlyTooltipText": {
+        "message": "string"
+      },
+      "shieldFooterAgreement": {
+        "message": "string"
+      },
+      "shieldManagePlan": {
+        "message": "string"
+      },
+      "shieldNotCovered": {
+        "message": "string"
+      },
+      "shieldPastPlansTitle": {
+        "message": "string"
+      },
+      "shieldPaused": {
+        "message": "string"
+      },
+      "shieldPaymentPaused": {
+        "message": "string"
+      },
+      "shieldPaymentPausedActionCardPayment": {
+        "message": "string"
+      },
+      "shieldPaymentPausedActionCryptoPayment": {
+        "message": "string"
+      },
+      "shieldPaymentPausedActionUnexpectedError": {
+        "message": "string"
+      },
+      "shieldPaymentPausedDescriptionCardPayment": {
+        "message": "string"
+      },
+      "shieldPaymentPausedDescriptionCryptoPayment": {
+        "message": "string"
+      },
+      "shieldPaymentPausedDescriptionUnexpectedError": {
+        "message": "string"
+      },
+      "shieldPlanAnnual": {
+        "message": "string"
+      },
+      "shieldPlanAnnualPrice": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldPlanBillingDate": {
+        "message": "string"
+      },
+      "shieldPlanCard": {
+        "message": "string"
+      },
+      "shieldPlanCryptoMonthlyNote": {
+        "message": "string"
+      },
+      "shieldPlanDetails": {
+        "message": "string"
+      },
+      "shieldPlanDetails1": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldPlanDetails2": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldPlanDetails3": {
+        "message": "string"
+      },
+      "shieldPlanDetailsRewards": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldPlanDetailsRewardsDescription": {
+        "message": "string"
+      },
+      "shieldPlanDetailsRewardsTitle": {
+        "message": "string"
+      },
+      "shieldPlanErrorText": {
+        "message": "string"
+      },
+      "shieldPlanFooterNoteMonthly": {
+        "message": "string"
+      },
+      "shieldPlanFooterNoteYearly": {
+        "message": "string"
+      },
+      "shieldPlanMonthly": {
+        "message": "string"
+      },
+      "shieldPlanMonthlyPrice": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldPlanPayWith": {
+        "message": "string"
+      },
+      "shieldPlanPayWithCard": {
+        "message": "string"
+      },
+      "shieldPlanPayWithToken": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldPlanPaymentTitle": {
+        "message": "string"
+      },
+      "shieldPlanSave": {
+        "message": "string"
+      },
+      "shieldPlanSelectToken": {
+        "message": "string"
+      },
+      "shieldPlanTitle": {
+        "message": "string"
+      },
+      "shieldPlanYearly": {
+        "message": "string"
+      },
+      "shieldStartNowCTA": {
+        "message": "string"
+      },
+      "shieldStartNowCTAWithTrial": {
+        "message": "string"
+      },
+      "shieldTx": {
+        "message": "string"
+      },
+      "shieldTxBillingAccount": {
+        "message": "string"
+      },
+      "shieldTxCancelDetails": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldTxCancelImmediateDetails": {
+        "message": "string"
+      },
+      "shieldTxCancelNotAllowed": {
+        "message": "string"
+      },
+      "shieldTxCancelNotAllowedPendingVerification": {
+        "message": "string"
+      },
+      "shieldTxCancelWhenPausedDetails": {
+        "message": "string"
+      },
+      "shieldTxDetails1DescriptionTrial": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldTxDetails1Title": {
+        "message": "string"
+      },
+      "shieldTxDetails2Description": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldTxDetails2Title": {
+        "message": "string"
+      },
+      "shieldTxDetails3DescriptionCrypto": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldTxDetails3DescriptionCryptoWithAccount": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldTxDetails3Title": {
+        "message": "string"
+      },
+      "shieldTxDetailsManage": {
+        "message": "string"
+      },
+      "shieldTxDetailsTitle": {
+        "message": "string"
+      },
+      "shieldTxMembershipActive": {
+        "message": "string"
+      },
+      "shieldTxMembershipBenefits": {
+        "message": "string"
+      },
+      "shieldTxMembershipBenefits1Description": {
+        "message": "string"
+      },
+      "shieldTxMembershipBenefits1Title": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldTxMembershipBenefits2Description": {
+        "message": "string"
+      },
+      "shieldTxMembershipBenefits2Title": {
+        "message": "string"
+      },
+      "shieldTxMembershipBenefits3Description": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldTxMembershipBenefits3DescriptionInactive": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldTxMembershipBenefits3LinkRewards": {
+        "message": "string"
+      },
+      "shieldTxMembershipBenefits3SignUp": {
+        "message": "string"
+      },
+      "shieldTxMembershipBenefits3Title": {
+        "message": "string"
+      },
+      "shieldTxMembershipBenefitsInactive": {
+        "message": "string"
+      },
+      "shieldTxMembershipBenefitsViewAll": {
+        "message": "string"
+      },
+      "shieldTxMembershipBillingDetailsViewBillingHistory": {
+        "message": "string"
+      },
+      "shieldTxMembershipCancel": {
+        "message": "string"
+      },
+      "shieldTxMembershipCancelNotification": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldTxMembershipCancelledDate": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldTxMembershipErrorInsufficientFunds": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldTxMembershipErrorPausedCard": {
+        "message": "string"
+      },
+      "shieldTxMembershipErrorPausedCardAction": {
+        "message": "string"
+      },
+      "shieldTxMembershipErrorPausedCardTooltip": {
+        "message": "string"
+      },
+      "shieldTxMembershipErrorPausedCryptoInsufficientFunds": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldTxMembershipErrorPausedCryptoInsufficientFundsAction": {
+        "message": "string"
+      },
+      "shieldTxMembershipErrorPausedCryptoTooltip": {
+        "message": "string"
+      },
+      "shieldTxMembershipErrorPausedUnexpected": {
+        "message": "string"
+      },
+      "shieldTxMembershipErrorPausedUnexpectedAction": {
+        "message": "string"
+      },
+      "shieldTxMembershipFreeTrial": {
+        "message": "string"
+      },
+      "shieldTxMembershipFreeTrialDaysLeft": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldTxMembershipId": {
+        "message": "string"
+      },
+      "shieldTxMembershipInactive": {
+        "message": "string"
+      },
+      "shieldTxMembershipMakeClaim": {
+        "message": "string"
+      },
+      "shieldTxMembershipPaused": {
+        "message": "string"
+      },
+      "shieldTxMembershipRenew": {
+        "message": "string"
+      },
+      "shieldTxMembershipRenewDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldTxMembershipResubscribe": {
+        "message": "string"
+      },
+      "shieldTxMembershipSubmitCase": {
+        "message": "string"
+      },
+      "shieldTxPastPlans": {
+        "message": "string"
+      },
+      "shieldTxPastPlansMonthly": {
+        "message": "string"
+      },
+      "shieldTxPastPlansYearly": {
+        "message": "string"
+      },
+      "shieldTxViewPastInvoice": {
+        "message": "string"
+      },
+      "show": {
+        "message": "string"
+      },
+      "showAccount": {
+        "message": "string"
+      },
+      "showAdvancedDetails": {
+        "message": "string"
+      },
+      "showDefaultAddress": {
+        "message": "string"
+      },
+      "showDefaultAddressDescription": {
+        "message": "string"
+      },
+      "showExtensionInFullSizeView": {
+        "message": "string"
+      },
+      "showExtensionInFullSizeViewDescription": {
+        "message": "string"
+      },
+      "showFiatConversionInTestnets": {
+        "message": "string"
+      },
+      "showFiatConversionInTestnetsDescription": {
+        "message": "string"
+      },
+      "showFiatConversionInTestnetsDescriptionV2": {
+        "description": "string",
+        "message": "string"
+      },
+      "showHexData": {
+        "message": "string"
+      },
+      "showHexDataDescription": {
+        "message": "string"
+      },
+      "showLess": {
+        "message": "string"
+      },
+      "showMore": {
+        "message": "string"
+      },
+      "showNativeTokenAsMainBalance": {
+        "message": "string"
+      },
+      "showNft": {
+        "message": "string"
+      },
+      "showPermissions": {
+        "message": "string"
+      },
+      "showPrivateKey": {
+        "message": "string"
+      },
+      "showSRP": {
+        "message": "string"
+      },
+      "showTestnetNetworks": {
+        "message": "string"
+      },
+      "showTestnetNetworksDescription": {
+        "message": "string"
+      },
+      "sidePanelMigrationToast": {
+        "description": "string",
+        "message": "string"
+      },
+      "sign": {
+        "message": "string"
+      },
+      "signatureRequest": {
+        "message": "string"
+      },
+      "signature_decoding_bid_nft_tooltip": {
+        "message": "string"
+      },
+      "signature_decoding_list_nft_tooltip": {
+        "message": "string"
+      },
+      "signed": {
+        "message": "string"
+      },
+      "signing": {
+        "message": "string"
+      },
+      "signingInWith": {
+        "message": "string"
+      },
+      "signingWith": {
+        "message": "string"
+      },
+      "simulationApproveHeading": {
+        "message": "string"
+      },
+      "simulationDetailsApproveDesc": {
+        "message": "string"
+      },
+      "simulationDetailsERC20ApproveDesc": {
+        "message": "string"
+      },
+      "simulationDetailsFiatNotAvailable": {
+        "message": "string"
+      },
+      "simulationDetailsIncomingHeading": {
+        "message": "string"
+      },
+      "simulationDetailsIncomingHeadingReceived": {
+        "message": "string"
+      },
+      "simulationDetailsIncomingHeadingReceiving": {
+        "message": "string"
+      },
+      "simulationDetailsNoChanges": {
+        "message": "string"
+      },
+      "simulationDetailsOutgoingHeading": {
+        "message": "string"
+      },
+      "simulationDetailsOutgoingHeadingSending": {
+        "message": "string"
+      },
+      "simulationDetailsOutgoingHeadingSent": {
+        "message": "string"
+      },
+      "simulationDetailsRevokeSetApprovalForAllDesc": {
+        "message": "string"
+      },
+      "simulationDetailsSetApprovalForAllDesc": {
+        "message": "string"
+      },
+      "simulationDetailsTitle": {
+        "message": "string"
+      },
+      "simulationDetailsTitleEnforced": {
+        "message": "string"
+      },
+      "simulationDetailsTitleTooltip": {
+        "message": "string"
+      },
+      "simulationDetailsTitleTooltipEnforced": {
+        "message": "string"
+      },
+      "simulationDetailsTotalFiat": {
+        "description": "string",
+        "message": "string"
+      },
+      "simulationDetailsTransactionReverted": {
+        "message": "string"
+      },
+      "simulationDetailsUnavailable": {
+        "message": "string"
+      },
+      "simulationErrorMessageV2": {
+        "message": "string"
+      },
+      "simulationsSettingDescription": {
+        "message": "string"
+      },
+      "simulationsSettingDescriptionV2": {
+        "message": "string"
+      },
+      "simulationsSettingSubHeader": {
+        "message": "string"
+      },
+      "singleNetwork": {
+        "message": "string"
+      },
+      "sites": {
+        "message": "string"
+      },
+      "siweIssued": {
+        "message": "string"
+      },
+      "siweNetwork": {
+        "message": "string"
+      },
+      "siweRequestId": {
+        "message": "string"
+      },
+      "siweResources": {
+        "message": "string"
+      },
+      "siweURI": {
+        "message": "string"
+      },
+      "skip": {
+        "message": "string"
+      },
+      "skipDeepLinkInterstitial": {
+        "message": "string"
+      },
+      "skipDeepLinkInterstitialDescription": {
+        "message": "string"
+      },
+      "skipLinkConfirmationScreens": {
+        "message": "string"
+      },
+      "skipLinkConfirmationScreensDescription": {
+        "message": "string"
+      },
+      "slippage": {
+        "message": "string"
+      },
+      "slippageAuto": {
+        "message": "string"
+      },
+      "slippageEditAriaLabel": {
+        "message": "string"
+      },
+      "slippageExplanation": {
+        "message": "string"
+      },
+      "smartAccount": {
+        "message": "string"
+      },
+      "smartAccountDappRequestsDescription": {
+        "message": "string"
+      },
+      "smartAccountDappRequestsTitle": {
+        "message": "string"
+      },
+      "smartAccountLabel": {
+        "message": "string"
+      },
+      "smartAccountRequestsFromDapps": {
+        "message": "string"
+      },
+      "smartAccountRequestsFromDappsDescription": {
+        "message": "string"
+      },
+      "smartAccountUpgradeBannerDescription": {
+        "message": "string"
+      },
+      "smartAccountUpgradeBannerTitle": {
+        "message": "string"
+      },
+      "smartContractAddress": {
+        "message": "string"
+      },
+      "smartContractAddressWarning": {
+        "message": "string"
+      },
+      "smartContracts": {
+        "message": "string"
+      },
+      "smartSwapsErrorNotEnoughFunds": {
+        "message": "string"
+      },
+      "smartSwapsErrorUnavailable": {
+        "message": "string"
+      },
+      "smartTransactionCancelled": {
+        "message": "string"
+      },
+      "smartTransactionCancelledDescription": {
+        "message": "string"
+      },
+      "smartTransactionError": {
+        "message": "string"
+      },
+      "smartTransactionErrorDescription": {
+        "message": "string"
+      },
+      "smartTransactionPending": {
+        "message": "string"
+      },
+      "smartTransactionSuccess": {
+        "message": "string"
+      },
+      "smartTransactions": {
+        "message": "string"
+      },
+      "smartTransactionsEnabledDescription": {
+        "message": "string"
+      },
+      "smartTransactionsEnabledLink": {
+        "message": "string"
+      },
+      "smartTransactionsEnabledTitle": {
+        "message": "string"
+      },
+      "snapAccountCreated": {
+        "message": "string"
+      },
+      "snapAccountCreatedDescription": {
+        "message": "string"
+      },
+      "snapAccountCreationFailed": {
+        "message": "string"
+      },
+      "snapAccountCreationFailedDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "snapAccountRedirectFinishSigningTitle": {
+        "message": "string"
+      },
+      "snapAccountRedirectSiteDescription": {
+        "message": "string"
+      },
+      "snapAccountRemovalFailed": {
+        "message": "string"
+      },
+      "snapAccountRemovalFailedDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "snapAccountRemoved": {
+        "message": "string"
+      },
+      "snapAccountRemovedDescription": {
+        "message": "string"
+      },
+      "snapConnectTo": {
+        "description": "string",
+        "message": "string"
+      },
+      "snapConnectionPermissionDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "snapConnectionWarning": {
+        "description": "string",
+        "message": "string"
+      },
+      "snapDetailWebsite": {
+        "message": "string"
+      },
+      "snapHomeMenu": {
+        "message": "string"
+      },
+      "snapInstallRequest": {
+        "description": "string",
+        "message": "string"
+      },
+      "snapInstallSuccess": {
+        "message": "string"
+      },
+      "snapInstallWarningCheck": {
+        "description": "string",
+        "message": "string"
+      },
+      "snapInstallWarningHeading": {
+        "message": "string"
+      },
+      "snapInstallWarningPermissionDescriptionForBip32View": {
+        "description": "string",
+        "message": "string"
+      },
+      "snapInstallWarningPermissionDescriptionForEntropy": {
+        "description": "string",
+        "message": "string"
+      },
+      "snapInstallWarningPermissionNameForEntropy": {
+        "description": "string",
+        "message": "string"
+      },
+      "snapInstallWarningPermissionNameForViewPublicKey": {
+        "description": "string",
+        "message": "string"
+      },
+      "snapInstallationErrorDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "snapInstallationErrorTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "snapResultError": {
+        "message": "string"
+      },
+      "snapResultSuccess": {
+        "message": "string"
+      },
+      "snapResultSuccessDescription": {
+        "message": "string"
+      },
+      "snapUIAccountSelectorTitle": {
+        "message": "string"
+      },
+      "snapUIAssetSelectorTitle": {
+        "message": "string"
+      },
+      "snapUpdateAlertDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "snapUpdateAvailable": {
+        "message": "string"
+      },
+      "snapUpdateErrorDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "snapUpdateErrorTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "snapUpdateRequest": {
+        "description": "string",
+        "message": "string"
+      },
+      "snapUpdateSuccess": {
+        "message": "string"
+      },
+      "snapUrlIsBlocked": {
+        "message": "string"
+      },
+      "snaps": {
+        "message": "string"
+      },
+      "snapsConnected": {
+        "message": "string"
+      },
+      "snapsNoInsight": {
+        "message": "string"
+      },
+      "snapsPrivacyWarningFirstMessage": {
+        "description": "string",
+        "message": "string"
+      },
+      "snapsPrivacyWarningSecondMessage": {
+        "description": "string",
+        "message": "string"
+      },
+      "snapsPrivacyWarningThirdMessage": {
+        "description": "string",
+        "message": "string"
+      },
+      "snapsSettings": {
+        "message": "string"
+      },
+      "snapsTermsOfUse": {
+        "message": "string"
+      },
+      "snapsToggle": {
+        "message": "string"
+      },
+      "snapsUIError": {
+        "description": "string",
+        "message": "string"
+      },
+      "solanaAccountRequested": {
+        "message": "string"
+      },
+      "solanaAccountRequired": {
+        "message": "string"
+      },
+      "someNetworks": {
+        "message": "string"
+      },
+      "somethingDoesntLookRight": {
+        "description": "string",
+        "message": "string"
+      },
+      "somethingIsWrong": {
+        "message": "string"
+      },
+      "somethingWentWrong": {
+        "message": "string"
+      },
+      "sortBy": {
+        "message": "string"
+      },
+      "sortByAlphabetically": {
+        "message": "string"
+      },
+      "sortByDecliningBalance": {
+        "description": "string",
+        "message": "string"
+      },
+      "source": {
+        "message": "string"
+      },
+      "spamModalBlockedDescription": {
+        "message": "string"
+      },
+      "spamModalBlockedTitle": {
+        "message": "string"
+      },
+      "spamModalDescription": {
+        "message": "string"
+      },
+      "spamModalTemporaryBlockButton": {
+        "message": "string"
+      },
+      "spamModalTitle": {
+        "message": "string"
+      },
+      "speed": {
+        "message": "string"
+      },
+      "speedUp": {
+        "message": "string"
+      },
+      "speedUpCancellation": {
+        "message": "string"
+      },
+      "speedUpTransactionDescription": {
+        "message": "string"
+      },
+      "speedUpTransactionFailed": {
+        "message": "string"
+      },
+      "speedUpTransactionTitle": {
+        "message": "string"
+      },
+      "spender": {
+        "message": "string"
+      },
+      "spenderTooltipDesc": {
+        "message": "string"
+      },
+      "spenderTooltipERC20ApproveDesc": {
+        "message": "string"
+      },
+      "spendingCap": {
+        "message": "string"
+      },
+      "spendingCaps": {
+        "message": "string"
+      },
+      "srpAlreadyImportedError": {
+        "message": "string"
+      },
+      "srpDetailsDescription": {
+        "message": "string"
+      },
+      "srpDetailsOwnsAccessListItemOne": {
+        "message": "string"
+      },
+      "srpDetailsOwnsAccessListItemThree": {
+        "message": "string"
+      },
+      "srpDetailsOwnsAccessListItemTwo": {
+        "message": "string"
+      },
+      "srpDetailsOwnsAccessListTitle": {
+        "message": "string"
+      },
+      "srpDetailsTitle": {
+        "message": "string"
+      },
+      "srpImportDuplicateAccountError": {
+        "message": "string"
+      },
+      "srpInputNumberOfWords": {
+        "description": "string",
+        "message": "string"
+      },
+      "srpListName": {
+        "description": "string",
+        "message": "string"
+      },
+      "srpListNumberOfAccounts": {
+        "description": "string",
+        "message": "string"
+      },
+      "srpListSelectionDescription": {
+        "message": "string"
+      },
+      "srpListSingleOrZero": {
+        "description": "string",
+        "message": "string"
+      },
+      "srpListStateBackedUp": {
+        "message": "string"
+      },
+      "srpListStateNotBackedUp": {
+        "message": "string"
+      },
+      "srpPasteFailedTooManyWords": {
+        "description": "string",
+        "message": "string"
+      },
+      "srpPasteTip": {
+        "description": "string",
+        "message": "string"
+      },
+      "srpSecurityQuizGetStarted": {
+        "message": "string"
+      },
+      "srpSecurityQuizImgAlt": {
+        "message": "string"
+      },
+      "srpSecurityQuizIntroduction": {
+        "message": "string"
+      },
+      "srpSecurityQuizQuestionOneQuestion": {
+        "message": "string"
+      },
+      "srpSecurityQuizQuestionOneRightAnswer": {
+        "message": "string"
+      },
+      "srpSecurityQuizQuestionOneRightAnswerDescription": {
+        "message": "string"
+      },
+      "srpSecurityQuizQuestionOneRightAnswerTitle": {
+        "message": "string"
+      },
+      "srpSecurityQuizQuestionOneWrongAnswer": {
+        "message": "string"
+      },
+      "srpSecurityQuizQuestionOneWrongAnswerDescription": {
+        "message": "string"
+      },
+      "srpSecurityQuizQuestionOneWrongAnswerTitle": {
+        "message": "string"
+      },
+      "srpSecurityQuizQuestionTwoQuestion": {
+        "message": "string"
+      },
+      "srpSecurityQuizQuestionTwoRightAnswer": {
+        "message": "string"
+      },
+      "srpSecurityQuizQuestionTwoRightAnswerDescription": {
+        "message": "string"
+      },
+      "srpSecurityQuizQuestionTwoRightAnswerTitle": {
+        "message": "string"
+      },
+      "srpSecurityQuizQuestionTwoWrongAnswer": {
+        "message": "string"
+      },
+      "srpSecurityQuizQuestionTwoWrongAnswerDescription": {
+        "message": "string"
+      },
+      "srpSecurityQuizQuestionTwoWrongAnswerTitle": {
+        "message": "string"
+      },
+      "srpSecurityQuizTitle": {
+        "message": "string"
+      },
+      "srpToggleShow": {
+        "description": "string",
+        "message": "string"
+      },
+      "srpWordHidden": {
+        "description": "string",
+        "message": "string"
+      },
+      "srpWordShown": {
+        "description": "string",
+        "message": "string"
+      },
+      "stable": {
+        "message": "string"
+      },
+      "stableLowercase": {
+        "message": "string"
+      },
+      "stake": {
+        "message": "string"
+      },
+      "staked": {
+        "message": "string"
+      },
+      "stakingDeposit": {
+        "message": "string"
+      },
+      "stakingWithdrawal": {
+        "message": "string"
+      },
+      "standardAccountLabel": {
+        "message": "string"
+      },
+      "stateCorruptionAreYouSure": {
+        "message": "string"
+      },
+      "stateCorruptionCopyAndRestoreBeforeRecovery": {
+        "description": "string",
+        "message": "string"
+      },
+      "stateCorruptionCopyAndRestoreBeforeReset": {
+        "description": "string",
+        "message": "string"
+      },
+      "stateCorruptionDetectedNoBackup": {
+        "message": "string"
+      },
+      "stateCorruptionDetectedWithBackup": {
+        "message": "string"
+      },
+      "stateCorruptionMetamaskDatabaseCannotBeAccessed": {
+        "message": "string"
+      },
+      "stateCorruptionResetMetaMaskState": {
+        "message": "string"
+      },
+      "stateCorruptionResettingDatabase": {
+        "message": "string"
+      },
+      "stateCorruptionRestoreAccountsFromBackup": {
+        "message": "string"
+      },
+      "stateCorruptionRestoringDatabase": {
+        "message": "string"
+      },
+      "stateCorruptionTheseInstructions": {
+        "description": "string",
+        "message": "string"
+      },
+      "stateCorruptionTheseInstructionsLinkTitle": {
+        "message": "string"
+      },
+      "stateLogError": {
+        "message": "string"
+      },
+      "stateLogFileName": {
+        "message": "string"
+      },
+      "stateLogs": {
+        "message": "string"
+      },
+      "stateLogsDescription": {
+        "message": "string"
+      },
+      "stateLogsModalDescription": {
+        "message": "string"
+      },
+      "status": {
+        "message": "string"
+      },
+      "statusNotConnected": {
+        "message": "string"
+      },
+      "step1LatticeWallet": {
+        "message": "string"
+      },
+      "step1LatticeWalletMsg": {
+        "description": "string",
+        "message": "string"
+      },
+      "step1LedgerWallet": {
+        "message": "string"
+      },
+      "step1LedgerWalletMsg": {
+        "description": "string",
+        "message": "string"
+      },
+      "step1TrezorWallet": {
+        "message": "string"
+      },
+      "step1TrezorWalletMsg": {
+        "description": "string",
+        "message": "string"
+      },
+      "step2LedgerWallet": {
+        "message": "string"
+      },
+      "step2LedgerWalletMsg": {
+        "description": "string",
+        "message": "string"
+      },
+      "stillConnectingTo": {
+        "description": "string",
+        "message": "string"
+      },
+      "stillGettingMessage": {
+        "message": "string"
+      },
+      "storageErrorAction": {
+        "message": "string"
+      },
+      "storageErrorDescriptionDefault": {
+        "message": "string"
+      },
+      "storageErrorDescriptionNoSpace": {
+        "message": "string"
+      },
+      "storageErrorTitle": {
+        "message": "string"
+      },
+      "strong": {
+        "message": "string"
+      },
+      "stxCancelled": {
+        "message": "string"
+      },
+      "stxCancelledDescription": {
+        "message": "string"
+      },
+      "stxCancelledSubDescription": {
+        "message": "string"
+      },
+      "stxFailure": {
+        "message": "string"
+      },
+      "stxFailureDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "stxOptInDescriptionV2": {
+        "message": "string"
+      },
+      "stxOptInSupportedNetworksDescription": {
+        "message": "string"
+      },
+      "stxPendingPrivatelySubmittingSwap": {
+        "message": "string"
+      },
+      "stxPendingPubliclySubmittingSwap": {
+        "message": "string"
+      },
+      "stxSuccess": {
+        "message": "string"
+      },
+      "stxSuccessDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "stxSwapCompleteIn": {
+        "description": "string",
+        "message": "string"
+      },
+      "stxTryingToCancel": {
+        "message": "string"
+      },
+      "stxUnknown": {
+        "message": "string"
+      },
+      "stxUnknownDescription": {
+        "message": "string"
+      },
+      "stxUserCancelled": {
+        "message": "string"
+      },
+      "stxUserCancelledDescription": {
+        "message": "string"
+      },
+      "submit": {
+        "message": "string"
+      },
+      "submitted": {
+        "message": "string"
+      },
+      "suggestedBySnap": {
+        "description": "string",
+        "message": "string"
+      },
+      "suggestedCurrencySymbol": {
+        "message": "string"
+      },
+      "suggestedTokenName": {
+        "message": "string"
+      },
+      "summary": {
+        "message": "string"
+      },
+      "supplied": {
+        "message": "string"
+      },
+      "support": {
+        "message": "string"
+      },
+      "supportCenter": {
+        "message": "string"
+      },
+      "supportMultiRpcInformation": {
+        "message": "string"
+      },
+      "supportedLanguagesSectionTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "surveyConversion": {
+        "message": "string"
+      },
+      "surveyTitle": {
+        "message": "string"
+      },
+      "swap": {
+        "message": "string"
+      },
+      "swapAdjustSlippage": {
+        "message": "string"
+      },
+      "swapAggregator": {
+        "message": "string"
+      },
+      "swapAllowSwappingOf": {
+        "description": "string",
+        "message": "string"
+      },
+      "swapAmountReceived": {
+        "message": "string"
+      },
+      "swapAmountReceivedInfo": {
+        "message": "string"
+      },
+      "swapAndSend": {
+        "message": "string"
+      },
+      "swapApproval": {
+        "description": "string",
+        "message": "string"
+      },
+      "swapAreYouStillThere": {
+        "message": "string"
+      },
+      "swapAreYouStillThereDescription": {
+        "message": "string"
+      },
+      "swapConfirmWithHwWallet": {
+        "message": "string"
+      },
+      "swapContractDataDisabledErrorDescription": {
+        "message": "string"
+      },
+      "swapContractDataDisabledErrorTitle": {
+        "message": "string"
+      },
+      "swapCustom": {
+        "message": "string"
+      },
+      "swapDecentralizedExchange": {
+        "message": "string"
+      },
+      "swapDetailsTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "swapDirectContract": {
+        "message": "string"
+      },
+      "swapEditLimit": {
+        "message": "string"
+      },
+      "swapEnableDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "swapEnableTokenForSwapping": {
+        "description": "string",
+        "message": "string"
+      },
+      "swapEstimatedNetworkFees": {
+        "message": "string"
+      },
+      "swapEstimatedNetworkFeesInfo": {
+        "message": "string"
+      },
+      "swapFailedErrorDescriptionWithSupportLink": {
+        "description": "string",
+        "message": "string"
+      },
+      "swapFailedErrorTitle": {
+        "message": "string"
+      },
+      "swapFetchingQuoteNofN": {
+        "description": "string",
+        "message": "string"
+      },
+      "swapFetchingQuotes": {
+        "message": "string"
+      },
+      "swapFetchingQuotesErrorDescription": {
+        "message": "string"
+      },
+      "swapFetchingQuotesErrorTitle": {
+        "message": "string"
+      },
+      "swapFromTo": {
+        "description": "string",
+        "message": "string"
+      },
+      "swapGasFeesExplanation": {
+        "description": "string",
+        "message": "string"
+      },
+      "swapGasFeesExplanationLinkText": {
+        "description": "string",
+        "message": "string"
+      },
+      "swapGasFeesIncluded": {
+        "message": "string"
+      },
+      "swapGasFeesSplit": {
+        "message": "string"
+      },
+      "swapGasFeesSponsored": {
+        "message": "string"
+      },
+      "swapGasFeesSponsoredExplanation": {
+        "message": "string"
+      },
+      "swapIncludesMMFee": {
+        "description": "string",
+        "message": "string"
+      },
+      "swapLearnMore": {
+        "message": "string"
+      },
+      "swapLiquiditySourceInfo": {
+        "message": "string"
+      },
+      "swapMaxSlippage": {
+        "message": "string"
+      },
+      "swapMetaMaskFee": {
+        "message": "string"
+      },
+      "swapMetaMaskFeeDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "swapNQuotesWithDot": {
+        "description": "string",
+        "message": "string"
+      },
+      "swapOnceTransactionHasProcess": {
+        "description": "string",
+        "message": "string"
+      },
+      "swapProcessing": {
+        "message": "string"
+      },
+      "swapQuoteDetails": {
+        "message": "string"
+      },
+      "swapQuoteSource": {
+        "message": "string"
+      },
+      "swapQuotesExpiredErrorDescription": {
+        "message": "string"
+      },
+      "swapQuotesExpiredErrorTitle": {
+        "message": "string"
+      },
+      "swapQuotesNotAvailableDescription": {
+        "message": "string"
+      },
+      "swapQuotesNotAvailableErrorDescription": {
+        "message": "string"
+      },
+      "swapQuotesNotAvailableErrorTitle": {
+        "message": "string"
+      },
+      "swapRate": {
+        "message": "string"
+      },
+      "swapReceiving": {
+        "message": "string"
+      },
+      "swapReceivingInfoTooltip": {
+        "message": "string"
+      },
+      "swapRequestForQuotation": {
+        "message": "string"
+      },
+      "swapSelect": {
+        "message": "string"
+      },
+      "swapSelectAQuote": {
+        "message": "string"
+      },
+      "swapSelectAToken": {
+        "message": "string"
+      },
+      "swapSelectQuotePopoverDescription": {
+        "message": "string"
+      },
+      "swapSelectToken": {
+        "message": "string"
+      },
+      "swapShowLatestQuotes": {
+        "message": "string"
+      },
+      "swapSlippageAutoDescription": {
+        "message": "string"
+      },
+      "swapSlippageHighDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "swapSlippageHighTitle": {
+        "message": "string"
+      },
+      "swapSlippageLowDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "swapSlippageLowTitle": {
+        "message": "string"
+      },
+      "swapSlippageNegativeDescription": {
+        "message": "string"
+      },
+      "swapSlippageNegativeTitle": {
+        "message": "string"
+      },
+      "swapSlippageOverLimitDescription": {
+        "message": "string"
+      },
+      "swapSlippageOverLimitTitle": {
+        "message": "string"
+      },
+      "swapSlippagePercent": {
+        "description": "string",
+        "message": "string"
+      },
+      "swapSlippageTooltip": {
+        "message": "string"
+      },
+      "swapSlippageZeroDescription": {
+        "message": "string"
+      },
+      "swapSlippageZeroTitle": {
+        "message": "string"
+      },
+      "swapSource": {
+        "message": "string"
+      },
+      "swapSuggestedGasSettingToolTipMessage": {
+        "message": "string"
+      },
+      "swapToConfirmWithHwWallet": {
+        "message": "string"
+      },
+      "swapTokenAvailable": {
+        "description": "string",
+        "message": "string"
+      },
+      "swapTokenNotAvailable": {
+        "message": "string"
+      },
+      "swapTokenToToken": {
+        "description": "string",
+        "message": "string"
+      },
+      "swapTokens": {
+        "message": "string"
+      },
+      "swapTransactionComplete": {
+        "message": "string"
+      },
+      "swapTwoTransactions": {
+        "message": "string"
+      },
+      "swapUnknown": {
+        "message": "string"
+      },
+      "swapValidationInsufficientGasMessage": {
+        "message": "string"
+      },
+      "swapZeroSlippage": {
+        "message": "string"
+      },
+      "swapsMaxSlippage": {
+        "message": "string"
+      },
+      "swapsViewInActivity": {
+        "message": "string"
+      },
+      "switch": {
+        "message": "string"
+      },
+      "switchBack": {
+        "message": "string"
+      },
+      "switchBackToPopup": {
+        "message": "string"
+      },
+      "switchEthereumChainConfirmationDescription": {
+        "message": "string"
+      },
+      "switchEthereumChainConfirmationTitle": {
+        "message": "string"
+      },
+      "switchNetwork": {
+        "message": "string"
+      },
+      "switchToMetaMaskDefaultRpc": {
+        "description": "string",
+        "message": "string"
+      },
+      "switchToPopup": {
+        "message": "string"
+      },
+      "switchToSidePanel": {
+        "message": "string"
+      },
+      "switchToThisAccount": {
+        "message": "string"
+      },
+      "switchingNetworksCancelsPendingConfirmations": {
+        "message": "string"
+      },
+      "symbol": {
+        "message": "string"
+      },
+      "symbolBetweenZeroTwelve": {
+        "message": "string"
+      },
+      "syncing": {
+        "message": "string"
+      },
+      "tapToReveal": {
+        "message": "string"
+      },
+      "tapToRevealNote": {
+        "message": "string"
+      },
+      "tenPercentIncreased": {
+        "message": "string"
+      },
+      "terms": {
+        "message": "string"
+      },
+      "termsOfService": {
+        "message": "string"
+      },
+      "termsOfUseAgree": {
+        "message": "string"
+      },
+      "termsOfUseAgreeText": {
+        "message": "string"
+      },
+      "termsOfUseFooterText": {
+        "message": "string"
+      },
+      "termsOfUseTitle": {
+        "message": "string"
+      },
+      "testNetworks": {
+        "message": "string"
+      },
+      "testnets": {
+        "message": "string"
+      },
+      "theme": {
+        "message": "string"
+      },
+      "themeDescription": {
+        "message": "string"
+      },
+      "thirdPartyApis": {
+        "message": "string"
+      },
+      "thirdPartyApisDescription": {
+        "message": "string"
+      },
+      "thirdPartySoftware": {
+        "description": "string",
+        "message": "string"
+      },
+      "thisContactWillBeDeleted": {
+        "message": "string"
+      },
+      "time": {
+        "message": "string"
+      },
+      "to": {
+        "message": "string"
+      },
+      "toggleDecodeDescription": {
+        "message": "string"
+      },
+      "token": {
+        "message": "string"
+      },
+      "tokenAddress": {
+        "message": "string"
+      },
+      "tokenAlreadyAdded": {
+        "message": "string"
+      },
+      "tokenAutoDetection": {
+        "message": "string"
+      },
+      "tokenContractAddress": {
+        "message": "string"
+      },
+      "tokenContractError": {
+        "message": "string"
+      },
+      "tokenContractWarning": {
+        "message": "string"
+      },
+      "tokenCount": {
+        "description": "string",
+        "message": "string"
+      },
+      "tokenDecimal": {
+        "message": "string"
+      },
+      "tokenDecimalFetchFailed": {
+        "message": "string"
+      },
+      "tokenDetails": {
+        "message": "string"
+      },
+      "tokenId": {
+        "message": "string"
+      },
+      "tokenList": {
+        "message": "string"
+      },
+      "tokenMarketplace": {
+        "message": "string"
+      },
+      "tokenPermissionCount": {
+        "description": "string",
+        "message": "string"
+      },
+      "tokenPermissionsCount": {
+        "description": "string",
+        "message": "string"
+      },
+      "tokenStandard": {
+        "message": "string"
+      },
+      "tokenStock": {
+        "message": "string"
+      },
+      "tokenStream": {
+        "message": "string"
+      },
+      "tokenSubscription": {
+        "message": "string"
+      },
+      "tokenSymbol": {
+        "message": "string"
+      },
+      "tokenTransfer": {
+        "message": "string"
+      },
+      "tokens": {
+        "message": "string"
+      },
+      "tokensCount": {
+        "description": "string",
+        "message": "string"
+      },
+      "tokensInCollection": {
+        "message": "string"
+      },
+      "tooltipSatusConnectedUpperCase": {
+        "message": "string"
+      },
+      "total": {
+        "message": "string"
+      },
+      "totalVolume": {
+        "message": "string"
+      },
+      "transaction": {
+        "message": "string"
+      },
+      "transactionConfirmed": {
+        "message": "string"
+      },
+      "transactionDataFunction": {
+        "message": "string"
+      },
+      "transactionDetailGasHeading": {
+        "message": "string"
+      },
+      "transactionError": {
+        "message": "string"
+      },
+      "transactionErrorNoContract": {
+        "message": "string"
+      },
+      "transactionFailed": {
+        "message": "string"
+      },
+      "transactionFee": {
+        "message": "string"
+      },
+      "transactionFlowNetwork": {
+        "message": "string"
+      },
+      "transactionHistoryBaseFee": {
+        "message": "string"
+      },
+      "transactionHistoryL1GasLabel": {
+        "message": "string"
+      },
+      "transactionHistoryL2GasLimitLabel": {
+        "message": "string"
+      },
+      "transactionHistoryL2GasPriceLabel": {
+        "message": "string"
+      },
+      "transactionHistoryMaxFeePerGas": {
+        "message": "string"
+      },
+      "transactionHistoryPriorityFee": {
+        "message": "string"
+      },
+      "transactionHistoryTotalGasFee": {
+        "message": "string"
+      },
+      "transactionIdLabel": {
+        "description": "string",
+        "message": "string"
+      },
+      "transactionIncludesTypes": {
+        "message": "string"
+      },
+      "transactionSettings": {
+        "message": "string"
+      },
+      "transactionShield": {
+        "message": "string"
+      },
+      "transactionSubmitted": {
+        "message": "string"
+      },
+      "transactionTotalGasFee": {
+        "description": "string",
+        "message": "string"
+      },
+      "transactions": {
+        "message": "string"
+      },
+      "transactionsAndAssets": {
+        "message": "string"
+      },
+      "transfer": {
+        "message": "string"
+      },
+      "transferCrypto": {
+        "message": "string"
+      },
+      "transferFrom": {
+        "message": "string"
+      },
+      "transferRequest": {
+        "message": "string"
+      },
+      "trezor": {
+        "description": "string",
+        "message": "string"
+      },
+      "tronBandwidth": {
+        "message": "string"
+      },
+      "tronBandwidthCoverageDescriptionPlural": {
+        "description": "string",
+        "message": "string"
+      },
+      "tronBandwidthCoverageDescriptionSingular": {
+        "message": "string"
+      },
+      "tronDailyResources": {
+        "message": "string"
+      },
+      "tronDailyResourcesDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "tronEnergy": {
+        "message": "string"
+      },
+      "tronEnergyCoverageDescriptionPlural": {
+        "description": "string",
+        "message": "string"
+      },
+      "tronEnergyCoverageDescriptionSingular": {
+        "message": "string"
+      },
+      "troubleConnectingToLedgerU2FOnFirefox": {
+        "description": "string",
+        "message": "string"
+      },
+      "troubleConnectingToLedgerU2FOnFirefox2": {
+        "description": "string",
+        "message": "string"
+      },
+      "troubleConnectingToLedgerU2FOnFirefoxLedgerSolution": {
+        "description": "string",
+        "message": "string"
+      },
+      "troubleConnectingToLedgerU2FOnFirefoxLedgerSolution2": {
+        "description": "string",
+        "message": "string"
+      },
+      "troubleConnectingToWallet": {
+        "description": "string",
+        "message": "string"
+      },
+      "troubleStartingMessage": {
+        "message": "string"
+      },
+      "troubleStartingTitle": {
+        "message": "string"
+      },
+      "trustSignalBlockDescription": {
+        "message": "string"
+      },
+      "trustSignalBlockTitle": {
+        "message": "string"
+      },
+      "trustSignalContinueAnyway": {
+        "message": "string"
+      },
+      "tryAgain": {
+        "message": "string"
+      },
+      "turnOff": {
+        "message": "string"
+      },
+      "turnOffMetamaskNotificationsError": {
+        "message": "string"
+      },
+      "turnOn": {
+        "message": "string"
+      },
+      "turnOnMetamaskNotifications": {
+        "message": "string"
+      },
+      "turnOnMetamaskNotificationsButton": {
+        "message": "string"
+      },
+      "turnOnMetamaskNotificationsError": {
+        "message": "string"
+      },
+      "turnOnMetamaskNotificationsMessageFirst": {
+        "message": "string"
+      },
+      "turnOnMetamaskNotificationsMessagePrivacyBold": {
+        "message": "string"
+      },
+      "turnOnMetamaskNotificationsMessagePrivacyLink": {
+        "message": "string"
+      },
+      "turnOnMetamaskNotificationsMessageSecond": {
+        "message": "string"
+      },
+      "turnOnMetamaskNotificationsMessageThird": {
+        "message": "string"
+      },
+      "turnOnTokenDetection": {
+        "message": "string"
+      },
+      "tutorial": {
+        "message": "string"
+      },
+      "txAlertTitle": {
+        "message": "string"
+      },
+      "typeYourSRP": {
+        "message": "string"
+      },
+      "u2f": {
+        "description": "string",
+        "message": "string"
+      },
+      "unableToConnectTo": {
+        "description": "string",
+        "message": "string"
+      },
+      "unableToDownload": {
+        "message": "string"
+      },
+      "unapproved": {
+        "message": "string"
+      },
+      "unavailable": {
+        "message": "string"
+      },
+      "unexpectedBehavior": {
+        "message": "string"
+      },
+      "unifiedSwapAllowSwappingOf": {
+        "message": "string"
+      },
+      "unifiedSwapFromTo": {
+        "description": "string",
+        "message": "string"
+      },
+      "units": {
+        "message": "string"
+      },
+      "unknown": {
+        "message": "string"
+      },
+      "unknownCollection": {
+        "message": "string"
+      },
+      "unknownNetworkForGatorPermissions": {
+        "description": "string",
+        "message": "string"
+      },
+      "unknownNetworkForKeyEntropy": {
+        "description": "string",
+        "message": "string"
+      },
+      "unknownQrCode": {
+        "message": "string"
+      },
+      "unlimited": {
+        "message": "string"
+      },
+      "unlock": {
+        "message": "string"
+      },
+      "unlockPageIncorrectPassword": {
+        "message": "string"
+      },
+      "unlockPageTooManyFailedAttempts": {
+        "message": "string"
+      },
+      "unlockToReveal": {
+        "description": "string",
+        "message": "string"
+      },
+      "unpin": {
+        "message": "string"
+      },
+      "unrecognizedChain": {
+        "description": "string",
+        "message": "string"
+      },
+      "unsendableAsset": {
+        "description": "string",
+        "message": "string"
+      },
+      "unstableTokenPriceDescription": {
+        "message": "string"
+      },
+      "unstableTokenPriceTitle": {
+        "message": "string"
+      },
+      "update": {
+        "message": "string"
+      },
+      "updateEthereumChainConfirmationDescription": {
+        "message": "string"
+      },
+      "updateInformation": {
+        "message": "string"
+      },
+      "updateNetworkConfirmationTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "updateOrEditNetworkInformations": {
+        "message": "string"
+      },
+      "updateRequest": {
+        "message": "string"
+      },
+      "updateRpc": {
+        "description": "string",
+        "message": "string"
+      },
+      "updateToTheLatestVersion": {
+        "message": "string"
+      },
+      "updatedRpcForNetworks": {
+        "message": "string"
+      },
+      "updatedToMetaMaskDefault": {
+        "description": "string",
+        "message": "string"
+      },
+      "uploadDropFile": {
+        "message": "string"
+      },
+      "uploadFile": {
+        "message": "string"
+      },
+      "urlErrorMsg": {
+        "message": "string"
+      },
+      "urlUnknown": {
+        "message": "string"
+      },
+      "use4ByteResolution": {
+        "message": "string"
+      },
+      "useDifferentLoginMethod": {
+        "message": "string"
+      },
+      "useMultiAccountBalanceChecker": {
+        "message": "string"
+      },
+      "useMultiAccountBalanceCheckerSettingDescription": {
+        "message": "string"
+      },
+      "useMultiAccountBalanceCheckerSettingDescriptionV2": {
+        "message": "string"
+      },
+      "useNftDetection": {
+        "message": "string"
+      },
+      "useNftDetectionDescription": {
+        "message": "string"
+      },
+      "useNftDetectionDescriptionText": {
+        "message": "string"
+      },
+      "usePhishingDetection": {
+        "message": "string"
+      },
+      "usePhishingDetectionDescription": {
+        "message": "string"
+      },
+      "useSafeChainsListValidation": {
+        "message": "string"
+      },
+      "useSafeChainsListValidationDescription": {
+        "message": "string"
+      },
+      "useSafeChainsListValidationDescriptionV2": {
+        "message": "string"
+      },
+      "useSafeChainsListValidationWebsite": {
+        "description": "string",
+        "message": "string"
+      },
+      "useTokenDetectionPrivacyDesc": {
+        "message": "string"
+      },
+      "usedByClients": {
+        "message": "string"
+      },
+      "userOpContractDeployError": {
+        "message": "string"
+      },
+      "value": {
+        "message": "string"
+      },
+      "version": {
+        "message": "string"
+      },
+      "view": {
+        "message": "string"
+      },
+      "viewActivity": {
+        "message": "string"
+      },
+      "viewAddressOnExplorer": {
+        "description": "string",
+        "message": "string"
+      },
+      "viewDetails": {
+        "message": "string"
+      },
+      "viewOnBlockExplorer": {
+        "message": "string"
+      },
+      "viewOnCustomBlockExplorer": {
+        "description": "string",
+        "message": "string"
+      },
+      "viewOnEtherscan": {
+        "description": "string",
+        "message": "string"
+      },
+      "viewOnExplorer": {
+        "message": "string"
+      },
+      "viewOnOpensea": {
+        "message": "string"
+      },
+      "viewTokenDetails": {
+        "message": "string"
+      },
+      "viewTransaction": {
+        "message": "string"
+      },
+      "viewinExplorer": {
+        "description": "string",
+        "message": "string"
+      },
+      "visitSite": {
+        "message": "string"
+      },
+      "visitSupportDataConsentModalAccept": {
+        "message": "string"
+      },
+      "visitSupportDataConsentModalDescription": {
+        "message": "string"
+      },
+      "visitSupportDataConsentModalReject": {
+        "message": "string"
+      },
+      "visitSupportDataConsentModalTitle": {
+        "message": "string"
+      },
+      "visitWebSite": {
+        "message": "string"
+      },
+      "volume": {
+        "message": "string"
+      },
+      "wallet": {
+        "message": "string"
+      },
+      "walletConnectionGuide": {
+        "message": "string"
+      },
+      "walletName": {
+        "message": "string"
+      },
+      "walletReadyLearn": {
+        "description": "string",
+        "message": "string"
+      },
+      "walletReadyLoseSrp": {
+        "message": "string"
+      },
+      "walletReadyLoseSrpFromReminder": {
+        "message": "string"
+      },
+      "wantToAddThisNetwork": {
+        "message": "string"
+      },
+      "wantsToAddThisAsset": {
+        "message": "string"
+      },
+      "warning": {
+        "message": "string"
+      },
+      "warningFromSnap": {
+        "description": "string",
+        "message": "string"
+      },
+      "watchEthereumAccountsDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "watchEthereumAccountsToggle": {
+        "message": "string"
+      },
+      "watchOutMessage": {
+        "description": "string",
+        "message": "string"
+      },
+      "web3": {
+        "message": "string"
+      },
+      "web3ShimUsageNotification": {
+        "description": "string",
+        "message": "string"
+      },
+      "webhid": {
+        "description": "string",
+        "message": "string"
+      },
+      "websites": {
+        "description": "string",
+        "message": "string"
+      },
+      "weekly": {
+        "message": "string"
+      },
+      "welcomeBack": {
+        "message": "string"
+      },
+      "whatsThis": {
+        "message": "string"
+      },
+      "willApproveAmountForBridging": {
+        "message": "string"
+      },
+      "willApproveAmountForSwapping": {
+        "message": "string"
+      },
+      "withdrawing": {
+        "message": "string"
+      },
+      "wrongNetworkName": {
+        "message": "string"
+      },
+      "wrongPassword": {
+        "description": "string",
+        "message": "string"
+      },
+      "year": {
+        "message": "string"
+      },
+      "yes": {
+        "message": "string"
+      },
+      "you": {
+        "message": "string"
+      },
+      "youApprove": {
+        "message": "string"
+      },
+      "youNeedToAllowCameraAccess": {
+        "message": "string"
+      },
+      "youReceived": {
+        "description": "string",
+        "message": "string"
+      },
+      "youSent": {
+        "description": "string",
+        "message": "string"
+      },
+      "yourActivity": {
+        "message": "string"
+      },
+      "yourBalance": {
+        "message": "string"
+      },
+      "yourNFTmayBeAtRisk": {
+        "message": "string"
+      },
+      "yourWalletIsReady": {
+        "message": "string"
+      },
+      "yourWalletIsReadyFromReminder": {
+        "message": "string"
+      }
+    },
+    "currentLocale": "string",
+    "en": {
+      "CSS_loadingTakingTooLongActionText": {
+        "description": "string",
+        "message": "string"
+      },
+      "CSS_loadingTakingTooLongMessageText": {
+        "description": "string",
+        "message": "string"
+      },
+      "QRHardwareInvalidTransactionTitle": {
+        "message": "string"
+      },
+      "QRHardwareMismatchedSignId": {
+        "message": "string"
+      },
+      "QRHardwarePubkeyAccountOutOfRange": {
+        "message": "string"
+      },
+      "QRHardwareScanInstructions": {
+        "message": "string"
+      },
+      "QRHardwareSignRequestCancel": {
+        "message": "string"
+      },
+      "QRHardwareSignRequestDescription": {
+        "message": "string"
+      },
+      "QRHardwareSignRequestGetSignature": {
+        "message": "string"
+      },
+      "QRHardwareSignRequestSubtitle": {
+        "message": "string"
+      },
+      "QRHardwareSignRequestTitle": {
+        "message": "string"
+      },
+      "QRHardwareUnknownQRCodeTitle": {
+        "message": "string"
+      },
+      "QRHardwareUnknownWalletQRCode": {
+        "message": "string"
+      },
+      "QRHardwareWalletImporterTitle": {
+        "message": "string"
+      },
+      "QRHardwareWalletSteps1Description": {
+        "message": "string"
+      },
+      "QRHardwareWalletSteps1Title": {
+        "message": "string"
+      },
+      "QRHardwareWalletSteps2Description": {
+        "message": "string"
+      },
+      "SrpListHideAccounts": {
+        "description": "string",
+        "message": "string"
+      },
+      "SrpListHideSingleAccount": {
+        "message": "string"
+      },
+      "SrpListShowAccounts": {
+        "description": "string",
+        "message": "string"
+      },
+      "SrpListShowSingleAccount": {
+        "message": "string"
+      },
+      "about": {
+        "message": "string"
+      },
+      "aboutMetaMask": {
+        "message": "string"
+      },
+      "accept": {
+        "message": "string"
+      },
+      "acceptAndClose": {
+        "message": "string"
+      },
+      "acceptTermsOfUse": {
+        "description": "string",
+        "message": "string"
+      },
+      "accessingYourCamera": {
+        "message": "string"
+      },
+      "account": {
+        "message": "string"
+      },
+      "accountActivity": {
+        "message": "string"
+      },
+      "accountActivityText": {
+        "message": "string"
+      },
+      "accountAlreadyExistsLogin": {
+        "message": "string"
+      },
+      "accountAlreadyExistsLoginDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "accountAlreadyExistsTitle": {
+        "message": "string"
+      },
+      "accountDetails": {
+        "message": "string"
+      },
+      "accountDetailsSrpBackUpMessage": {
+        "description": "string",
+        "message": "string"
+      },
+      "accountIdenticon": {
+        "message": "string"
+      },
+      "accountIdenticonDescription": {
+        "message": "string"
+      },
+      "accountIsntConnectedToastText": {
+        "message": "string"
+      },
+      "accountName": {
+        "message": "string"
+      },
+      "accountNameAlreadyInUse": {
+        "description": "string",
+        "message": "string"
+      },
+      "accountNameDuplicate": {
+        "description": "string",
+        "message": "string"
+      },
+      "accountNameReserved": {
+        "description": "string",
+        "message": "string"
+      },
+      "accountNotFoundCreateOne": {
+        "message": "string"
+      },
+      "accountNotFoundDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "accountNotFoundTitle": {
+        "message": "string"
+      },
+      "accountOptions": {
+        "message": "string"
+      },
+      "accountPermissionToast": {
+        "message": "string"
+      },
+      "accountSelectionRequired": {
+        "message": "string"
+      },
+      "accountSmallCase": {
+        "message": "string"
+      },
+      "accountTypeNotSupported": {
+        "message": "string"
+      },
+      "accounts": {
+        "message": "string"
+      },
+      "accountsConnected": {
+        "message": "string"
+      },
+      "accountsPermissionsTitle": {
+        "message": "string"
+      },
+      "accountsSmallCase": {
+        "message": "string"
+      },
+      "actionUnavailable": {
+        "message": "string"
+      },
+      "active": {
+        "message": "string"
+      },
+      "activity": {
+        "message": "string"
+      },
+      "activityEmptyDescription": {
+        "message": "string"
+      },
+      "add": {
+        "message": "string"
+      },
+      "addACustomNetwork": {
+        "message": "string"
+      },
+      "addAHardwareWallet": {
+        "message": "string"
+      },
+      "addANetwork": {
+        "message": "string"
+      },
+      "addANickname": {
+        "message": "string"
+      },
+      "addAUrl": {
+        "message": "string"
+      },
+      "addAccount": {
+        "message": "string"
+      },
+      "addAccountFromNetwork": {
+        "description": "string",
+        "message": "string"
+      },
+      "addAccountOrWallet": {
+        "message": "string"
+      },
+      "addAcquiredTokens": {
+        "message": "string"
+      },
+      "addAlias": {
+        "message": "string"
+      },
+      "addBitcoinAccountLabel": {
+        "message": "string"
+      },
+      "addBlockExplorer": {
+        "message": "string"
+      },
+      "addBlockExplorerUrl": {
+        "message": "string"
+      },
+      "addContact": {
+        "message": "string"
+      },
+      "addCustomNetwork": {
+        "message": "string"
+      },
+      "addEthereumChainWarningModalHeader": {
+        "description": "string",
+        "message": "string"
+      },
+      "addEthereumChainWarningModalHeaderPartTwo": {
+        "message": "string"
+      },
+      "addEthereumChainWarningModalListHeader": {
+        "message": "string"
+      },
+      "addEthereumChainWarningModalListPointOne": {
+        "message": "string"
+      },
+      "addEthereumChainWarningModalListPointThree": {
+        "message": "string"
+      },
+      "addEthereumChainWarningModalListPointTwo": {
+        "message": "string"
+      },
+      "addEthereumChainWarningModalTitle": {
+        "message": "string"
+      },
+      "addEthereumWatchOnlyAccount": {
+        "message": "string"
+      },
+      "addFriendsAndAddresses": {
+        "message": "string"
+      },
+      "addFunds": {
+        "message": "string"
+      },
+      "addFundsModalBuyCrypto": {
+        "message": "string"
+      },
+      "addFundsModalReceiveTokens": {
+        "message": "string"
+      },
+      "addFundsModalSwapTokens": {
+        "message": "string"
+      },
+      "addHardwareWalletLabel": {
+        "message": "string"
+      },
+      "addIPFSGateway": {
+        "message": "string"
+      },
+      "addMemo": {
+        "message": "string"
+      },
+      "addNetwork": {
+        "message": "string"
+      },
+      "addNetworkConfirmationTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "addNetworkDescription": {
+        "message": "string"
+      },
+      "addNewAccount": {
+        "message": "string"
+      },
+      "addNewEthereumAccountLabel": {
+        "message": "string"
+      },
+      "addNewSolanaAccountLabel": {
+        "message": "string"
+      },
+      "addNewTronAccountLabel": {
+        "message": "string"
+      },
+      "addNft": {
+        "message": "string"
+      },
+      "addNfts": {
+        "message": "string"
+      },
+      "addNonEvmAccount": {
+        "description": "string",
+        "message": "string"
+      },
+      "addNonEvmAccountFromNetworkPicker": {
+        "description": "string",
+        "message": "string"
+      },
+      "addRpcUrl": {
+        "message": "string"
+      },
+      "addSnapAccountToggle": {
+        "message": "string"
+      },
+      "addSnapAccountsDescription": {
+        "message": "string"
+      },
+      "addSuggestedNFTs": {
+        "message": "string"
+      },
+      "addSuggestedTokens": {
+        "message": "string"
+      },
+      "addToken": {
+        "message": "string"
+      },
+      "addUrl": {
+        "message": "string"
+      },
+      "addWallet": {
+        "message": "string"
+      },
+      "addedProtectionDescription": {
+        "message": "string"
+      },
+      "addedProtectionOptionalBadge": {
+        "message": "string"
+      },
+      "addedProtectionTitle": {
+        "message": "string"
+      },
+      "addedProtectionTooltip": {
+        "message": "string"
+      },
+      "additionalNetworks": {
+        "message": "string"
+      },
+      "address": {
+        "message": "string"
+      },
+      "addressCopied": {
+        "message": "string"
+      },
+      "addressLabel": {
+        "description": "string",
+        "message": "string"
+      },
+      "addressMismatch": {
+        "message": "string"
+      },
+      "addressMismatchOriginal": {
+        "description": "string",
+        "message": "string"
+      },
+      "addressMismatchPunycode": {
+        "description": "string",
+        "message": "string"
+      },
+      "addressQrCodeModalDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "addressQrCodeModalHeading": {
+        "description": "string",
+        "message": "string"
+      },
+      "addressQrCodeModalTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "addresses": {
+        "description": "string",
+        "message": "string"
+      },
+      "addressesLabel": {
+        "description": "string",
+        "message": "string"
+      },
+      "advanced": {
+        "message": "string"
+      },
+      "advancedDetailsDataDesc": {
+        "message": "string"
+      },
+      "advancedDetailsHexDesc": {
+        "message": "string"
+      },
+      "advancedDetailsNonceDesc": {
+        "message": "string"
+      },
+      "advancedDetailsNonceTooltip": {
+        "message": "string"
+      },
+      "advancedEIP1559ModalTitle": {
+        "message": "string"
+      },
+      "advancedGasPriceModalTitle": {
+        "message": "string"
+      },
+      "advancedGasPriceTitle": {
+        "message": "string"
+      },
+      "advancedPermissionSmallCase": {
+        "message": "string"
+      },
+      "advancedPermissionsSmallCase": {
+        "message": "string"
+      },
+      "airDropPatternDescription": {
+        "message": "string"
+      },
+      "airDropPatternTitle": {
+        "message": "string"
+      },
+      "airgapVault": {
+        "message": "string"
+      },
+      "alert": {
+        "message": "string"
+      },
+      "alertAccountTypeUpgradeMessage": {
+        "message": "string"
+      },
+      "alertAccountTypeUpgradeTitle": {
+        "message": "string"
+      },
+      "alertActionBurnAddress": {
+        "message": "string"
+      },
+      "alertActionBuyWithNativeCurrency": {
+        "message": "string"
+      },
+      "alertActionEditNetworkFee": {
+        "message": "string"
+      },
+      "alertActionUpdateGas": {
+        "message": "string"
+      },
+      "alertActionUpdateGasFee": {
+        "message": "string"
+      },
+      "alertActionUpdateGasFeeLevel": {
+        "message": "string"
+      },
+      "alertContentMultipleApprovals": {
+        "message": "string"
+      },
+      "alertDisableTooltip": {
+        "message": "string"
+      },
+      "alertInsufficientPayTokenBalance": {
+        "message": "string"
+      },
+      "alertInsufficientPayTokenBalanceFeesNoTarget": {
+        "message": "string"
+      },
+      "alertInsufficientPayTokenNative": {
+        "description": "string",
+        "message": "string"
+      },
+      "alertMessageAddressMismatchWarning": {
+        "message": "string"
+      },
+      "alertMessageAddressTrustSignal": {
+        "message": "string"
+      },
+      "alertMessageAddressTrustSignalMalicious": {
+        "message": "string"
+      },
+      "alertMessageBurnAddress": {
+        "message": "string"
+      },
+      "alertMessageChangeInSimulationResults": {
+        "message": "string"
+      },
+      "alertMessageFirstTimeInteraction": {
+        "message": "string"
+      },
+      "alertMessageGasEstimateFailed": {
+        "message": "string"
+      },
+      "alertMessageGasFeeLow": {
+        "message": "string"
+      },
+      "alertMessageGasTooLow": {
+        "message": "string"
+      },
+      "alertMessageInsufficientBalanceWithNativeCurrency": {
+        "message": "string"
+      },
+      "alertMessageNoGasPrice": {
+        "message": "string"
+      },
+      "alertMessageOriginTrustSignalMalicious": {
+        "message": "string"
+      },
+      "alertMessageOriginTrustSignalWarning": {
+        "message": "string"
+      },
+      "alertMessageSignInDomainMismatch": {
+        "message": "string"
+      },
+      "alertMessageSignInWrongAccount": {
+        "message": "string"
+      },
+      "alertMessageSuggestedGasFeeHigh": {
+        "message": "string"
+      },
+      "alertMessageTokenTrustSignalMalicious": {
+        "message": "string"
+      },
+      "alertMessageTokenTrustSignalWarning": {
+        "message": "string"
+      },
+      "alertModalAcknowledge": {
+        "message": "string"
+      },
+      "alertModalDetails": {
+        "message": "string"
+      },
+      "alertModalReviewAllAlerts": {
+        "message": "string"
+      },
+      "alertNoPayTokenQuotesMessage": {
+        "message": "string"
+      },
+      "alertNoPayTokenQuotesTitle": {
+        "message": "string"
+      },
+      "alertPayHardwareAccountMessage": {
+        "message": "string"
+      },
+      "alertPayHardwareAccountTitle": {
+        "message": "string"
+      },
+      "alertReasonChangeInSimulationResults": {
+        "message": "string"
+      },
+      "alertReasonFirstTimeInteraction": {
+        "message": "string"
+      },
+      "alertReasonGasEstimateFailed": {
+        "message": "string"
+      },
+      "alertReasonGasFeeLow": {
+        "message": "string"
+      },
+      "alertReasonGasSponsorshipUnavailable": {
+        "message": "string"
+      },
+      "alertReasonGasTooLow": {
+        "message": "string"
+      },
+      "alertReasonInsufficientBalance": {
+        "message": "string"
+      },
+      "alertReasonMultipleApprovals": {
+        "message": "string"
+      },
+      "alertReasonNoGasPrice": {
+        "message": "string"
+      },
+      "alertReasonOriginTrustSignalMalicious": {
+        "message": "string"
+      },
+      "alertReasonOriginTrustSignalVerified": {
+        "message": "string"
+      },
+      "alertReasonOriginTrustSignalWarning": {
+        "message": "string"
+      },
+      "alertReasonPendingTransactions": {
+        "message": "string"
+      },
+      "alertReasonSignIn": {
+        "message": "string"
+      },
+      "alertReasonSuggestedGasFeeHigh": {
+        "message": "string"
+      },
+      "alertReasonTokenTrustSignalMalicious": {
+        "message": "string"
+      },
+      "alertReasonTokenTrustSignalWarning": {
+        "message": "string"
+      },
+      "alertReasonWrongAccount": {
+        "message": "string"
+      },
+      "alertSelectedAccountWarning": {
+        "message": "string"
+      },
+      "alerts": {
+        "message": "string"
+      },
+      "all": {
+        "message": "string"
+      },
+      "allNetworks": {
+        "message": "string"
+      },
+      "allPermissions": {
+        "message": "string"
+      },
+      "allPopularNetworks": {
+        "message": "string"
+      },
+      "allTimeHigh": {
+        "message": "string"
+      },
+      "allTimeLow": {
+        "message": "string"
+      },
+      "allTokens": {
+        "message": "string"
+      },
+      "allowAddRpc": {
+        "message": "string"
+      },
+      "allowAddRpcDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "allowNotifications": {
+        "message": "string"
+      },
+      "amount": {
+        "message": "string"
+      },
+      "amountReceived": {
+        "message": "string"
+      },
+      "amountSent": {
+        "message": "string"
+      },
+      "andForListItems": {
+        "description": "string",
+        "message": "string"
+      },
+      "andForTwoItems": {
+        "description": "string",
+        "message": "string"
+      },
+      "annual": {
+        "message": "string"
+      },
+      "appDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "appName": {
+        "description": "string",
+        "message": "string"
+      },
+      "appNameBeta": {
+        "description": "string",
+        "message": "string"
+      },
+      "appNameFlask": {
+        "description": "string",
+        "message": "string"
+      },
+      "apply": {
+        "message": "string"
+      },
+      "approve": {
+        "message": "string"
+      },
+      "approveButtonText": {
+        "message": "string"
+      },
+      "approveIncreaseAllowance": {
+        "description": "string",
+        "message": "string"
+      },
+      "approveSpendingCap": {
+        "description": "string",
+        "message": "string"
+      },
+      "approveToken": {
+        "description": "string",
+        "message": "string"
+      },
+      "approved": {
+        "message": "string"
+      },
+      "approvedOn": {
+        "description": "string",
+        "message": "string"
+      },
+      "approvedOnForAccounts": {
+        "description": "string",
+        "message": "string"
+      },
+      "areYouSure": {
+        "message": "string"
+      },
+      "asset": {
+        "message": "string"
+      },
+      "assetChartNoHistoricalPrices": {
+        "message": "string"
+      },
+      "assetOptions": {
+        "message": "string"
+      },
+      "assets": {
+        "message": "string"
+      },
+      "assetsDescription": {
+        "message": "string"
+      },
+      "asterdexReferralSubtitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "attemptToCancelSwapForFree": {
+        "message": "string"
+      },
+      "attributes": {
+        "message": "string"
+      },
+      "attributions": {
+        "message": "string"
+      },
+      "authorizedPermissions": {
+        "message": "string"
+      },
+      "autoDetectTokens": {
+        "message": "string"
+      },
+      "autoDetectTokensDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "autoDetectTokensDescriptionV2": {
+        "message": "string"
+      },
+      "autoLock": {
+        "message": "string"
+      },
+      "autoLockAfter15Seconds": {
+        "message": "string"
+      },
+      "autoLockAfter1Minute": {
+        "message": "string"
+      },
+      "autoLockAfter30Seconds": {
+        "message": "string"
+      },
+      "autoLockAfter5Minutes": {
+        "message": "string"
+      },
+      "autoLockAfterMinutes": {
+        "message": "string"
+      },
+      "autoLockNever": {
+        "message": "string"
+      },
+      "autoLockTimeLimit": {
+        "message": "string"
+      },
+      "autoLockTimeLimitDescription": {
+        "message": "string"
+      },
+      "available": {
+        "message": "string"
+      },
+      "average": {
+        "message": "string"
+      },
+      "back": {
+        "message": "string"
+      },
+      "backToHome": {
+        "message": "string"
+      },
+      "backUpIncomplete": {
+        "message": "string"
+      },
+      "backup": {
+        "message": "string"
+      },
+      "backupAndSync": {
+        "message": "string"
+      },
+      "backupAndSyncBasicFunctionalityNameMention": {
+        "message": "string"
+      },
+      "backupAndSyncEnable": {
+        "message": "string"
+      },
+      "backupAndSyncEnableConfirmation": {
+        "description": "string",
+        "message": "string"
+      },
+      "backupAndSyncEnableDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "backupAndSyncEnableDescriptionUpdatePreferences": {
+        "description": "string",
+        "message": "string"
+      },
+      "backupAndSyncEnableDescriptionUpdatePreferencesPath": {
+        "message": "string"
+      },
+      "backupAndSyncFeatureAccounts": {
+        "message": "string"
+      },
+      "backupAndSyncFeatureContacts": {
+        "message": "string"
+      },
+      "backupAndSyncManageWhatYouSync": {
+        "message": "string"
+      },
+      "backupAndSyncManageWhatYouSyncDescription": {
+        "message": "string"
+      },
+      "backupAndSyncPrivacyLink": {
+        "message": "string"
+      },
+      "backupApprovalInfo": {
+        "message": "string"
+      },
+      "backupApprovalNotice": {
+        "message": "string"
+      },
+      "backupKeyringSnapReminder": {
+        "message": "string"
+      },
+      "backupNow": {
+        "message": "string"
+      },
+      "balance": {
+        "message": "string"
+      },
+      "balanceOutdated": {
+        "message": "string"
+      },
+      "baseFee": {
+        "message": "string"
+      },
+      "basic": {
+        "message": "string"
+      },
+      "basicConfigurationDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "basicConfigurationDescriptionV2": {
+        "description": "string",
+        "message": "string"
+      },
+      "basicConfigurationLabel": {
+        "message": "string"
+      },
+      "basicConfigurationModalCheckbox": {
+        "message": "string"
+      },
+      "basicConfigurationModalDisclaimerOffPart1": {
+        "message": "string"
+      },
+      "basicConfigurationModalDisclaimerOffPart2": {
+        "message": "string"
+      },
+      "basicConfigurationModalDisclaimerOn": {
+        "message": "string"
+      },
+      "basicConfigurationModalHeadingOff": {
+        "message": "string"
+      },
+      "basicConfigurationModalHeadingOn": {
+        "message": "string"
+      },
+      "basicFunctionalityRequired_description": {
+        "message": "string"
+      },
+      "basicFunctionalityRequired_goToHome": {
+        "message": "string"
+      },
+      "basicFunctionalityRequired_openCreateSnapAccountPage": {
+        "message": "string"
+      },
+      "basicFunctionalityRequired_openDefiPage": {
+        "message": "string"
+      },
+      "basicFunctionalityRequired_openMusdConversionPage": {
+        "message": "string"
+      },
+      "basicFunctionalityRequired_openNotificationsPage": {
+        "message": "string"
+      },
+      "basicFunctionalityRequired_openPerpsPage": {
+        "message": "string"
+      },
+      "basicFunctionalityRequired_openRewardsPage": {
+        "message": "string"
+      },
+      "basicFunctionalityRequired_openSnapsPage": {
+        "message": "string"
+      },
+      "basicFunctionalityRequired_openSwapsPage": {
+        "message": "string"
+      },
+      "basicFunctionalityRequired_openTransactionShieldPage": {
+        "message": "string"
+      },
+      "basicFunctionalityRequired_reviewInSettings": {
+        "message": "string"
+      },
+      "basicFunctionalityRequired_title": {
+        "message": "string"
+      },
+      "basicFunctionalityRequired_toggleLabel": {
+        "message": "string"
+      },
+      "bestQuote": {
+        "message": "string"
+      },
+      "bestQuoteTooltip": {
+        "message": "string"
+      },
+      "beta": {
+        "message": "string"
+      },
+      "betaMetamaskVersion": {
+        "message": "string"
+      },
+      "betaTerms": {
+        "message": "string"
+      },
+      "blockExplorerAccountAction": {
+        "description": "string",
+        "message": "string"
+      },
+      "blockExplorerAssetAction": {
+        "description": "string",
+        "message": "string"
+      },
+      "blockExplorerSwapAction": {
+        "description": "string",
+        "message": "string"
+      },
+      "blockExplorerUrl": {
+        "message": "string"
+      },
+      "blockExplorerUrlDefinition": {
+        "message": "string"
+      },
+      "blockExplorerView": {
+        "description": "string",
+        "message": "string"
+      },
+      "blockaid": {
+        "message": "string"
+      },
+      "blockaidAlertDescriptionBlur": {
+        "message": "string"
+      },
+      "blockaidAlertDescriptionMalicious": {
+        "message": "string"
+      },
+      "blockaidAlertDescriptionOpenSea": {
+        "message": "string"
+      },
+      "blockaidAlertDescriptionOthers": {
+        "message": "string"
+      },
+      "blockaidAlertDescriptionTokenTransfer": {
+        "message": "string"
+      },
+      "blockaidAlertDescriptionWithdraw": {
+        "message": "string"
+      },
+      "blockaidDescriptionApproveFarming": {
+        "message": "string"
+      },
+      "blockaidDescriptionBlurFarming": {
+        "message": "string"
+      },
+      "blockaidDescriptionErrored": {
+        "message": "string"
+      },
+      "blockaidDescriptionMaliciousDomain": {
+        "message": "string"
+      },
+      "blockaidDescriptionMightLoseAssets": {
+        "message": "string"
+      },
+      "blockaidDescriptionSeaportFarming": {
+        "message": "string"
+      },
+      "blockaidDescriptionTransferFarming": {
+        "message": "string"
+      },
+      "blockaidMessage": {
+        "message": "string"
+      },
+      "blockaidTitleDeceptive": {
+        "message": "string"
+      },
+      "blockaidTitleMayNotBeSafe": {
+        "message": "string"
+      },
+      "blockaidTitleSuspicious": {
+        "message": "string"
+      },
+      "blockies": {
+        "message": "string"
+      },
+      "borrowed": {
+        "message": "string"
+      },
+      "boughtFor": {
+        "message": "string"
+      },
+      "bridge": {
+        "message": "string"
+      },
+      "bridgeAllowSwappingOf": {
+        "description": "string",
+        "message": "string"
+      },
+      "bridgeApproval": {
+        "description": "string",
+        "message": "string"
+      },
+      "bridgeApprovalWarning": {
+        "message": "string"
+      },
+      "bridgeApprovalWarningForHardware": {
+        "message": "string"
+      },
+      "bridgeBlockExplorerLinkCopied": {
+        "message": "string"
+      },
+      "bridgeConfirmTwoTransactions": {
+        "message": "string"
+      },
+      "bridgeCreateSolanaAccount": {
+        "message": "string"
+      },
+      "bridgeCreateSolanaAccountDescription": {
+        "message": "string"
+      },
+      "bridgeCreateSolanaAccountTitle": {
+        "message": "string"
+      },
+      "bridgeDetailsTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "bridgeEnterAmount": {
+        "message": "string"
+      },
+      "bridgeExplorerLinkViewOn": {
+        "message": "string"
+      },
+      "bridgeFee": {
+        "message": "string"
+      },
+      "bridgeFromTo": {
+        "description": "string",
+        "message": "string"
+      },
+      "bridgeGasFeesSplit": {
+        "message": "string"
+      },
+      "bridgeGetNewQuote": {
+        "message": "string"
+      },
+      "bridgeLowestCost": {
+        "message": "string"
+      },
+      "bridgeMarketClosedAction": {
+        "message": "string"
+      },
+      "bridgeMarketClosedDescription": {
+        "message": "string"
+      },
+      "bridgeMarketClosedModalDescription": {
+        "message": "string"
+      },
+      "bridgeMarketClosedModalLearnMore": {
+        "message": "string"
+      },
+      "bridgeMarketClosedModalTitle": {
+        "message": "string"
+      },
+      "bridgeMarketClosedTitle": {
+        "message": "string"
+      },
+      "bridgeNoMMFee": {
+        "message": "string"
+      },
+      "bridgePoints": {
+        "description": "string",
+        "message": "string"
+      },
+      "bridgePoints_couldntLoad": {
+        "description": "string",
+        "message": "string"
+      },
+      "bridgePoints_error": {
+        "description": "string",
+        "message": "string"
+      },
+      "bridgePoints_error_content": {
+        "description": "string",
+        "message": "string"
+      },
+      "bridgePoints_tooltip": {
+        "description": "string",
+        "message": "string"
+      },
+      "bridgePoints_tooltip_content_1": {
+        "description": "string",
+        "message": "string"
+      },
+      "bridgePoints_tooltip_content_2": {
+        "description": "string",
+        "message": "string"
+      },
+      "bridgePriceImpact": {
+        "message": "string"
+      },
+      "bridgePriceImpactFiatAlert": {
+        "message": "string"
+      },
+      "bridgePriceImpactHigh": {
+        "message": "string"
+      },
+      "bridgePriceImpactHighDescription": {
+        "message": "string"
+      },
+      "bridgePriceImpactNormalDescription": {
+        "message": "string"
+      },
+      "bridgePriceImpactTooltipTitle": {
+        "message": "string"
+      },
+      "bridgePriceImpactVeryHigh": {
+        "message": "string"
+      },
+      "bridgePriceImpactVeryHighDescription": {
+        "message": "string"
+      },
+      "bridgePriceImpactWarningAriaLabel": {
+        "message": "string"
+      },
+      "bridgePriceImpactWarningTitle": {
+        "message": "string"
+      },
+      "bridgeQuoteStreamCompleteAmountTooHigh": {
+        "message": "string"
+      },
+      "bridgeQuoteStreamCompleteAmountTooLow": {
+        "message": "string"
+      },
+      "bridgeQuoteStreamCompleteRetry": {
+        "message": "string"
+      },
+      "bridgeQuoteStreamCompleteRwaGeoRestricted": {
+        "message": "string"
+      },
+      "bridgeQuoteStreamCompleteRwaMarketUnavailable": {
+        "message": "string"
+      },
+      "bridgeQuoteStreamCompleteRwaNativeTokenUnsupported": {
+        "message": "string"
+      },
+      "bridgeQuoteStreamCompleteSlippageTooHigh": {
+        "message": "string"
+      },
+      "bridgeQuoteStreamCompleteSlippageTooLow": {
+        "message": "string"
+      },
+      "bridgeQuoteStreamCompleteTokenNotSupported": {
+        "message": "string"
+      },
+      "bridgeQuotesSortedByCost": {
+        "message": "string"
+      },
+      "bridgeReceive": {
+        "description": "string",
+        "message": "string"
+      },
+      "bridgeReceiveLoading": {
+        "message": "string"
+      },
+      "bridgeSelectDestinationAccount": {
+        "message": "string"
+      },
+      "bridgeSelectDifferentQuote": {
+        "message": "string"
+      },
+      "bridgeSelectNetwork": {
+        "message": "string"
+      },
+      "bridgeSelectQuote": {
+        "message": "string"
+      },
+      "bridgeSelectTokenAmountAndAccount": {
+        "message": "string"
+      },
+      "bridgeSelectTokenAndAmount": {
+        "message": "string"
+      },
+      "bridgeSend": {
+        "description": "string",
+        "message": "string"
+      },
+      "bridgeSendLoading": {
+        "message": "string"
+      },
+      "bridgeSolanaAccountCreated": {
+        "message": "string"
+      },
+      "bridgeStatusComplete": {
+        "description": "string",
+        "message": "string"
+      },
+      "bridgeStatusFailed": {
+        "description": "string",
+        "message": "string"
+      },
+      "bridgeStatusInProgress": {
+        "description": "string",
+        "message": "string"
+      },
+      "bridgeStepActionBridgeComplete": {
+        "description": "string",
+        "message": "string"
+      },
+      "bridgeStepActionBridgePending": {
+        "description": "string",
+        "message": "string"
+      },
+      "bridgeStepActionSwapComplete": {
+        "description": "string",
+        "message": "string"
+      },
+      "bridgeStepActionSwapPending": {
+        "description": "string",
+        "message": "string"
+      },
+      "bridgeTo": {
+        "message": "string"
+      },
+      "bridgeTokenNotFound": {
+        "message": "string"
+      },
+      "bridgeTransactionProgress": {
+        "message": "string"
+      },
+      "bridgeTxDetailsBridged": {
+        "message": "string"
+      },
+      "bridgeTxDetailsBridging": {
+        "message": "string"
+      },
+      "bridgeTxDetailsDelayedDescription": {
+        "message": "string"
+      },
+      "bridgeTxDetailsDelayedDescriptionSupport": {
+        "message": "string"
+      },
+      "bridgeTxDetailsDelayedTitle": {
+        "message": "string"
+      },
+      "bridgeTxDetailsNonce": {
+        "message": "string"
+      },
+      "bridgeTxDetailsStatus": {
+        "message": "string"
+      },
+      "bridgeTxDetailsSwapped": {
+        "message": "string"
+      },
+      "bridgeTxDetailsSwapping": {
+        "message": "string"
+      },
+      "bridgeTxDetailsTimestamp": {
+        "message": "string"
+      },
+      "bridgeTxDetailsTimestampValue": {
+        "description": "string",
+        "message": "string"
+      },
+      "bridgeTxDetailsTokenAmountOnChain": {
+        "description": "string",
+        "message": "string"
+      },
+      "bridgeTxDetailsTotalGasFee": {
+        "message": "string"
+      },
+      "bridgeTxDetailsYouReceived": {
+        "message": "string"
+      },
+      "bridgeTxDetailsYouSent": {
+        "message": "string"
+      },
+      "bridgeValidationInsufficientGasMessage": {
+        "message": "string"
+      },
+      "bridgeValidationInsufficientGasTitle": {
+        "message": "string"
+      },
+      "bridged": {
+        "message": "string"
+      },
+      "bridgedToChain": {
+        "message": "string"
+      },
+      "bridging": {
+        "message": "string"
+      },
+      "browserNotSupported": {
+        "message": "string"
+      },
+      "builtAroundTheWorld": {
+        "message": "string"
+      },
+      "busy": {
+        "message": "string"
+      },
+      "buy": {
+        "message": "string"
+      },
+      "buyMoreAsset": {
+        "description": "string",
+        "message": "string"
+      },
+      "buyNow": {
+        "message": "string"
+      },
+      "buyTabOpenedToastDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "buyTabOpenedToastText": {
+        "description": "string",
+        "message": "string"
+      },
+      "bytes": {
+        "message": "string"
+      },
+      "canToggleInSettings": {
+        "message": "string"
+      },
+      "cancel": {
+        "message": "string"
+      },
+      "cancelSpeedupAlreadyConfirmedDescription": {
+        "message": "string"
+      },
+      "cancelSpeedupFailedDescription": {
+        "message": "string"
+      },
+      "cancelTransactionDescription": {
+        "message": "string"
+      },
+      "cancelTransactionFailed": {
+        "message": "string"
+      },
+      "cancelTransactionTitle": {
+        "message": "string"
+      },
+      "cancelled": {
+        "message": "string"
+      },
+      "carouselAllCaughtUp": {
+        "description": "string",
+        "message": "string"
+      },
+      "chainId": {
+        "message": "string"
+      },
+      "chainIdDefinition": {
+        "message": "string"
+      },
+      "chainIdExistsErrorMsg": {
+        "message": "string"
+      },
+      "chainListReturnedDifferentTickerSymbol": {
+        "message": "string"
+      },
+      "changeInSettings": {
+        "message": "string"
+      },
+      "changePasswordDetailsSocial": {
+        "message": "string"
+      },
+      "changePasswordLoading": {
+        "message": "string"
+      },
+      "changePasswordLoadingNote": {
+        "message": "string"
+      },
+      "changePasswordWarning": {
+        "message": "string"
+      },
+      "changePasswordWarningDescription": {
+        "message": "string"
+      },
+      "checkNetworkConnectivity": {
+        "message": "string"
+      },
+      "checkNetworkConnectivityOr": {
+        "description": "string",
+        "message": "string"
+      },
+      "chooseYourNetwork": {
+        "message": "string"
+      },
+      "chooseYourNetworkDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "chooseYourNetworkDescriptionCallToAction": {
+        "message": "string"
+      },
+      "chromeRequiredForHardwareWallets": {
+        "message": "string"
+      },
+      "circulatingSupply": {
+        "message": "string"
+      },
+      "clear": {
+        "message": "string"
+      },
+      "clearActivity": {
+        "message": "string"
+      },
+      "clearActivityButton": {
+        "message": "string"
+      },
+      "clearActivityDescription": {
+        "message": "string"
+      },
+      "clearFilters": {
+        "message": "string"
+      },
+      "click": {
+        "message": "string"
+      },
+      "clickToConnectLedgerViaWebHID": {
+        "description": "string",
+        "message": "string"
+      },
+      "close": {
+        "message": "string"
+      },
+      "closeSlide": {
+        "description": "string",
+        "message": "string"
+      },
+      "closeWindowAnytime": {
+        "message": "string"
+      },
+      "coingecko": {
+        "message": "string"
+      },
+      "collectionName": {
+        "message": "string"
+      },
+      "comboNoOptions": {
+        "description": "string",
+        "message": "string"
+      },
+      "communityContributedLanguagesSectionTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "completed": {
+        "message": "string"
+      },
+      "concentratedSupplyDistributionDescription": {
+        "message": "string"
+      },
+      "concentratedSupplyDistributionTitle": {
+        "message": "string"
+      },
+      "configureSnapPopupDescription": {
+        "message": "string"
+      },
+      "configureSnapPopupInstallDescription": {
+        "message": "string"
+      },
+      "configureSnapPopupInstallTitle": {
+        "message": "string"
+      },
+      "configureSnapPopupLink": {
+        "message": "string"
+      },
+      "configureSnapPopupTitle": {
+        "message": "string"
+      },
+      "confirm": {
+        "message": "string"
+      },
+      "confirmAccountTypeSmartContract": {
+        "message": "string"
+      },
+      "confirmAccountTypeStandard": {
+        "message": "string"
+      },
+      "confirmAlertModalAcknowledgeMultiple": {
+        "message": "string"
+      },
+      "confirmAlertModalAcknowledgeSingle": {
+        "message": "string"
+      },
+      "confirmFieldAllowance": {
+        "message": "string"
+      },
+      "confirmFieldAvailablePerDay": {
+        "message": "string"
+      },
+      "confirmFieldExpiration": {
+        "message": "string"
+      },
+      "confirmFieldFrequency": {
+        "message": "string"
+      },
+      "confirmFieldInitialAllowance": {
+        "message": "string"
+      },
+      "confirmFieldMaxAllowance": {
+        "message": "string"
+      },
+      "confirmFieldNeverExpires": {
+        "message": "string"
+      },
+      "confirmFieldPaymaster": {
+        "message": "string"
+      },
+      "confirmFieldPeriodDurationBiWeekly": {
+        "message": "string"
+      },
+      "confirmFieldPeriodDurationDaily": {
+        "message": "string"
+      },
+      "confirmFieldPeriodDurationHourly": {
+        "message": "string"
+      },
+      "confirmFieldPeriodDurationMonthly": {
+        "message": "string"
+      },
+      "confirmFieldPeriodDurationSeconds": {
+        "description": "string",
+        "message": "string"
+      },
+      "confirmFieldPeriodDurationWeekly": {
+        "message": "string"
+      },
+      "confirmFieldPeriodDurationYearly": {
+        "message": "string"
+      },
+      "confirmFieldStartDate": {
+        "message": "string"
+      },
+      "confirmFieldStreamRate": {
+        "message": "string"
+      },
+      "confirmFieldTooltipJustification": {
+        "message": "string"
+      },
+      "confirmFieldTooltipPaymaster": {
+        "message": "string"
+      },
+      "confirmFieldTotalExposure": {
+        "message": "string"
+      },
+      "confirmGasFeeTokenBalance": {
+        "message": "string"
+      },
+      "confirmGasFeeTokenInsufficientBalance": {
+        "message": "string"
+      },
+      "confirmGasFeeTokenMetaMaskFee": {
+        "message": "string"
+      },
+      "confirmGasFeeTokenModalNativeToggleMetaMask": {
+        "message": "string"
+      },
+      "confirmGasFeeTokenModalNativeToggleWallet": {
+        "message": "string"
+      },
+      "confirmGasFeeTokenModalPayETH": {
+        "message": "string"
+      },
+      "confirmGasFeeTokenModalPayToken": {
+        "message": "string"
+      },
+      "confirmGasFeeTokenModalTitle": {
+        "message": "string"
+      },
+      "confirmGasFeeTokenToast": {
+        "message": "string"
+      },
+      "confirmGasFeeTokenTooltip": {
+        "message": "string"
+      },
+      "confirmInfoAccountNow": {
+        "message": "string"
+      },
+      "confirmInfoSwitchingTo": {
+        "message": "string"
+      },
+      "confirmNestedTransactionTitle": {
+        "message": "string"
+      },
+      "confirmPassword": {
+        "message": "string"
+      },
+      "confirmRecoveryPhrase": {
+        "message": "string"
+      },
+      "confirmRecoveryPhraseDetails": {
+        "message": "string"
+      },
+      "confirmRecoveryPhraseTitle": {
+        "message": "string"
+      },
+      "confirmRecoveryPhraseTitleSettings": {
+        "message": "string"
+      },
+      "confirmSimulationApprove": {
+        "message": "string"
+      },
+      "confirmSrpErrorDescription": {
+        "message": "string"
+      },
+      "confirmSrpErrorTitle": {
+        "message": "string"
+      },
+      "confirmSrpSuccessDescription": {
+        "message": "string"
+      },
+      "confirmSrpSuccessTitle": {
+        "message": "string"
+      },
+      "confirmTitleAccountTypeSwitch": {
+        "message": "string"
+      },
+      "confirmTitleApproveTransactionNFT": {
+        "message": "string"
+      },
+      "confirmTitleDeployContract": {
+        "message": "string"
+      },
+      "confirmTitleDescApproveTransaction": {
+        "message": "string"
+      },
+      "confirmTitleDescDelegationRevoke": {
+        "message": "string"
+      },
+      "confirmTitleDescDelegationUpgrade": {
+        "message": "string"
+      },
+      "confirmTitleDescDeployContract": {
+        "message": "string"
+      },
+      "confirmTitleDescERC20ApproveTransaction": {
+        "message": "string"
+      },
+      "confirmTitleDescERC20Revocation": {
+        "message": "string"
+      },
+      "confirmTitleDescPermission": {
+        "message": "string"
+      },
+      "confirmTitleDescPermitSignature": {
+        "message": "string"
+      },
+      "confirmTitleDescSIWESignature": {
+        "message": "string"
+      },
+      "confirmTitleDescSign": {
+        "message": "string"
+      },
+      "confirmTitlePermission": {
+        "message": "string"
+      },
+      "confirmTitlePermitTokens": {
+        "message": "string"
+      },
+      "confirmTitleRevokeApproveTransaction": {
+        "message": "string"
+      },
+      "confirmTitleSIWESignature": {
+        "message": "string"
+      },
+      "confirmTitleSending": {
+        "message": "string"
+      },
+      "confirmTitleSetApprovalForAllRevokeTransaction": {
+        "message": "string"
+      },
+      "confirmTitleSignature": {
+        "message": "string"
+      },
+      "confirmTitleTransaction": {
+        "message": "string"
+      },
+      "confirmationAlertDetails": {
+        "message": "string"
+      },
+      "confirmationAlertModalTitleDescription": {
+        "message": "string"
+      },
+      "confirmed": {
+        "message": "string"
+      },
+      "confusableCharacterTooltip": {
+        "message": "string"
+      },
+      "confusableUnicode": {
+        "message": "string"
+      },
+      "confusableZeroWidthUnicode": {
+        "message": "string"
+      },
+      "confusingEnsDomain": {
+        "message": "string"
+      },
+      "connect": {
+        "message": "string"
+      },
+      "connectAccount": {
+        "message": "string"
+      },
+      "connectAccounts": {
+        "message": "string"
+      },
+      "connectAnAccountHeader": {
+        "message": "string"
+      },
+      "connectHardwareDevice": {
+        "description": "string",
+        "message": "string"
+      },
+      "connectManually": {
+        "message": "string"
+      },
+      "connectMoreAccounts": {
+        "message": "string"
+      },
+      "connectSnap": {
+        "description": "string",
+        "message": "string"
+      },
+      "connectWithMetaMask": {
+        "message": "string"
+      },
+      "connectedAccountsDescriptionPlural": {
+        "description": "string",
+        "message": "string"
+      },
+      "connectedAccountsDescriptionSingular": {
+        "message": "string"
+      },
+      "connectedAccountsEmptyDescription": {
+        "message": "string"
+      },
+      "connectedAccountsListTooltip": {
+        "description": "string",
+        "message": "string"
+      },
+      "connectedSites": {
+        "message": "string"
+      },
+      "connectedSitesAndSnaps": {
+        "message": "string"
+      },
+      "connectedSitesDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "connectedSitesEmptyDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "connectedSnapAndNoAccountDescription": {
+        "message": "string"
+      },
+      "connectedSnaps": {
+        "message": "string"
+      },
+      "connectedWithAccount": {
+        "description": "string",
+        "message": "string"
+      },
+      "connectedWithAccountName": {
+        "description": "string",
+        "message": "string"
+      },
+      "connectedWithNetwork": {
+        "description": "string",
+        "message": "string"
+      },
+      "connectedWithNetworkName": {
+        "description": "string",
+        "message": "string"
+      },
+      "connecting": {
+        "message": "string"
+      },
+      "connectingTo": {
+        "message": "string"
+      },
+      "connectingToGoerli": {
+        "message": "string"
+      },
+      "connectingToLineaGoerli": {
+        "message": "string"
+      },
+      "connectingToLineaMainnet": {
+        "message": "string"
+      },
+      "connectingToLineaSepolia": {
+        "message": "string"
+      },
+      "connectingToMainnet": {
+        "message": "string"
+      },
+      "connectingToSepolia": {
+        "message": "string"
+      },
+      "connectionDescription": {
+        "message": "string"
+      },
+      "connectionFailed": {
+        "message": "string"
+      },
+      "connectionFailedDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "connectionPopoverDescription": {
+        "message": "string"
+      },
+      "connectionRequest": {
+        "message": "string"
+      },
+      "connectionsRemovedModalDescription": {
+        "message": "string"
+      },
+      "connectionsRemovedModalTitle": {
+        "message": "string"
+      },
+      "contactDeleted": {
+        "message": "string"
+      },
+      "contactDetails": {
+        "message": "string"
+      },
+      "contactUpdated": {
+        "message": "string"
+      },
+      "contactUs": {
+        "message": "string"
+      },
+      "contacts": {
+        "message": "string"
+      },
+      "contentFromSnap": {
+        "description": "string",
+        "message": "string"
+      },
+      "continue": {
+        "message": "string"
+      },
+      "contract": {
+        "message": "string"
+      },
+      "contractAddress": {
+        "message": "string"
+      },
+      "contractAddressError": {
+        "message": "string"
+      },
+      "contractDeployment": {
+        "message": "string"
+      },
+      "contractInteraction": {
+        "message": "string"
+      },
+      "convertTokenToNFTDescription": {
+        "message": "string"
+      },
+      "convertTokenToNFTExistDescription": {
+        "message": "string"
+      },
+      "coolWallet": {
+        "message": "string"
+      },
+      "copiedExclamation": {
+        "message": "string"
+      },
+      "copiedToClipboard": {
+        "message": "string"
+      },
+      "copyAddress": {
+        "message": "string"
+      },
+      "copyAddressShort": {
+        "message": "string"
+      },
+      "copyPrivateKey": {
+        "message": "string"
+      },
+      "copyToClipboard": {
+        "message": "string"
+      },
+      "copyTransactionId": {
+        "message": "string"
+      },
+      "correct": {
+        "message": "string"
+      },
+      "create": {
+        "message": "string"
+      },
+      "createMultichainAccountButton": {
+        "description": "string",
+        "message": "string"
+      },
+      "createMultichainAccountButtonLoading": {
+        "description": "string",
+        "message": "string"
+      },
+      "createNewAccountHeader": {
+        "message": "string"
+      },
+      "createPassword": {
+        "message": "string"
+      },
+      "createPasswordCreate": {
+        "message": "string"
+      },
+      "createPasswordDetails": {
+        "message": "string"
+      },
+      "createPasswordDetailsSocial": {
+        "description": "string",
+        "message": "string"
+      },
+      "createPasswordDetailsSocialReset": {
+        "message": "string"
+      },
+      "createPasswordMarketing": {
+        "message": "string"
+      },
+      "createSnapAccountDescription": {
+        "message": "string"
+      },
+      "createSnapAccountTitle": {
+        "message": "string"
+      },
+      "createSolanaAccount": {
+        "message": "string"
+      },
+      "creatorAddress": {
+        "message": "string"
+      },
+      "cryptoCompare": {
+        "message": "string"
+      },
+      "currencyConversion": {
+        "message": "string"
+      },
+      "currencyRateCheckToggle": {
+        "message": "string"
+      },
+      "currencyRateCheckToggleDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "currencySymbol": {
+        "message": "string"
+      },
+      "currencySymbolDefinition": {
+        "message": "string"
+      },
+      "current": {
+        "message": "string"
+      },
+      "currentAccountNotConnected": {
+        "message": "string"
+      },
+      "currentEstimatedBaseFee": {
+        "message": "string"
+      },
+      "currentEstimatedPriorityFeeRange": {
+        "message": "string"
+      },
+      "currentExtension": {
+        "message": "string"
+      },
+      "currentHistoricalBaseFeeRange": {
+        "message": "string"
+      },
+      "currentHistoricalPriorityFeeRange": {
+        "message": "string"
+      },
+      "currentLanguage": {
+        "message": "string"
+      },
+      "currentNetwork": {
+        "description": "string",
+        "message": "string"
+      },
+      "currentQuestion": {
+        "message": "string"
+      },
+      "currentlyUnavailable": {
+        "message": "string"
+      },
+      "curveHighGasEstimate": {
+        "message": "string"
+      },
+      "curveLowGasEstimate": {
+        "message": "string"
+      },
+      "curveMediumGasEstimate": {
+        "message": "string"
+      },
+      "custom": {
+        "message": "string"
+      },
+      "customGasSettingToolTipMessage": {
+        "description": "string",
+        "message": "string"
+      },
+      "customNetworks": {
+        "message": "string"
+      },
+      "customSlippage": {
+        "message": "string"
+      },
+      "customToken": {
+        "message": "string"
+      },
+      "customTokenWarningInTokenDetectionNetwork": {
+        "message": "string"
+      },
+      "customerSupport": {
+        "message": "string"
+      },
+      "customizeYourNotifications": {
+        "message": "string"
+      },
+      "customizeYourNotificationsText": {
+        "message": "string"
+      },
+      "dappConnections": {
+        "message": "string"
+      },
+      "dappScanMaliciousTitle": {
+        "message": "string"
+      },
+      "dappScanMaliciousWarning": {
+        "message": "string"
+      },
+      "dappSuggested": {
+        "message": "string"
+      },
+      "dappSuggestedGasSettingToolTipMessage": {
+        "description": "string",
+        "message": "string"
+      },
+      "dappSuggestedHigh": {
+        "message": "string"
+      },
+      "dappSwapAdvantage": {
+        "message": "string"
+      },
+      "dappSwapAdvantageSaveOnly": {
+        "message": "string"
+      },
+      "dappSwapBenefits": {
+        "message": "string"
+      },
+      "dappSwapQuoteDifference": {
+        "message": "string"
+      },
+      "dappSwapRewardText": {
+        "message": "string"
+      },
+      "darkTheme": {
+        "message": "string"
+      },
+      "data": {
+        "message": "string"
+      },
+      "dataCollectionForMarketing": {
+        "message": "string"
+      },
+      "dataCollectionForMarketingDescription": {
+        "message": "string"
+      },
+      "dataCollectionForMarketingDescriptionSocialLogin": {
+        "message": "string"
+      },
+      "dataCollectionWarningPopoverButton": {
+        "message": "string"
+      },
+      "dataCollectionWarningPopoverDescription": {
+        "message": "string"
+      },
+      "dataUnavailable": {
+        "message": "string"
+      },
+      "date": {
+        "message": "string"
+      },
+      "dateCreated": {
+        "message": "string"
+      },
+      "dcent": {
+        "message": "string"
+      },
+      "debitCreditPurchaseOptions": {
+        "message": "string"
+      },
+      "debug": {
+        "message": "string"
+      },
+      "decimal": {
+        "message": "string"
+      },
+      "decimalsMustZerotoTen": {
+        "message": "string"
+      },
+      "decrypt": {
+        "message": "string"
+      },
+      "decryptCopy": {
+        "message": "string"
+      },
+      "decryptInlineError": {
+        "description": "string",
+        "message": "string"
+      },
+      "decryptMessageNotice": {
+        "description": "string",
+        "message": "string"
+      },
+      "decryptMetamask": {
+        "message": "string"
+      },
+      "decryptRequest": {
+        "message": "string"
+      },
+      "deepLink_Caution": {
+        "message": "string"
+      },
+      "deepLink_Continue": {
+        "message": "string"
+      },
+      "deepLink_ContinueDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "deepLink_DontRemindMeAgain": {
+        "message": "string"
+      },
+      "deepLink_Error404Description": {
+        "message": "string"
+      },
+      "deepLink_Error404Title": {
+        "message": "string"
+      },
+      "deepLink_Error404_CTA": {
+        "description": "string",
+        "message": "string"
+      },
+      "deepLink_Error404_CTA_LinkText": {
+        "description": "string",
+        "message": "string"
+      },
+      "deepLink_ErrorMissingUrl": {
+        "message": "string"
+      },
+      "deepLink_ErrorOtherDescription": {
+        "message": "string"
+      },
+      "deepLink_ErrorOtherTitle": {
+        "message": "string"
+      },
+      "deepLink_GoToTheHomePageButton": {
+        "message": "string"
+      },
+      "deepLink_RedirectingToMetaMask": {
+        "message": "string"
+      },
+      "deepLink_ThirdPartyDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "deepLink_theAssetPage": {
+        "message": "string"
+      },
+      "deepLink_theBuyPage": {
+        "message": "string"
+      },
+      "deepLink_theCardOnboardingPage": {
+        "message": "string"
+      },
+      "deepLink_theHomePage": {
+        "message": "string"
+      },
+      "deepLink_theMusdEducationPage": {
+        "message": "string"
+      },
+      "deepLink_theNFTsPage": {
+        "message": "string"
+      },
+      "deepLink_theNotificationsPage": {
+        "message": "string"
+      },
+      "deepLink_theOnboardingPage": {
+        "message": "string"
+      },
+      "deepLink_thePerpsMarketDetailPage": {
+        "message": "string"
+      },
+      "deepLink_thePerpsMarketListPage": {
+        "message": "string"
+      },
+      "deepLink_thePerpsPage": {
+        "message": "string"
+      },
+      "deepLink_thePredictPage": {
+        "message": "string"
+      },
+      "deepLink_theRewardsPage": {
+        "message": "string"
+      },
+      "deepLink_theSellPage": {
+        "message": "string"
+      },
+      "deepLink_theSwapsPage": {
+        "message": "string"
+      },
+      "deepLink_theSwapsRampsPage": {
+        "message": "string"
+      },
+      "deepLink_theTransactionShieldPage": {
+        "message": "string"
+      },
+      "default": {
+        "message": "string"
+      },
+      "defaultRpcUrl": {
+        "message": "string"
+      },
+      "defaultSettingsSubTitle": {
+        "message": "string"
+      },
+      "defaultSettingsTitle": {
+        "message": "string"
+      },
+      "defi": {
+        "message": "string"
+      },
+      "defiEmptyDescription": {
+        "message": "string"
+      },
+      "defiReferralCheckboxLabel": {
+        "description": "string",
+        "message": "string"
+      },
+      "defiReferralTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "defiTabErrorContent": {
+        "message": "string"
+      },
+      "defiTabErrorTitle": {
+        "message": "string"
+      },
+      "delete": {
+        "message": "string"
+      },
+      "deleteActivityAndNonceData": {
+        "message": "string"
+      },
+      "deleteMetaMetricsData": {
+        "message": "string"
+      },
+      "deleteMetaMetricsDataDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "deleteMetaMetricsDataDescriptionV2": {
+        "description": "string",
+        "message": "string"
+      },
+      "deleteMetaMetricsDataErrorDesc": {
+        "message": "string"
+      },
+      "deleteMetaMetricsDataErrorTitle": {
+        "message": "string"
+      },
+      "deleteMetaMetricsDataErrorToast": {
+        "message": "string"
+      },
+      "deleteMetaMetricsDataModalDesc": {
+        "message": "string"
+      },
+      "deleteMetaMetricsDataModalTitle": {
+        "message": "string"
+      },
+      "deleteMetaMetricsDataRequestedDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "deleteMetaMetricsDataToast": {
+        "message": "string"
+      },
+      "deleteNetworkIntro": {
+        "message": "string"
+      },
+      "deleteNetworkTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "depositCrypto": {
+        "message": "string"
+      },
+      "deprecatedNetwork": {
+        "message": "string"
+      },
+      "deprecatedNetworkButtonMsg": {
+        "message": "string"
+      },
+      "deprecatedNetworkDescription": {
+        "message": "string"
+      },
+      "description": {
+        "message": "string"
+      },
+      "descriptionFromSnap": {
+        "description": "string",
+        "message": "string"
+      },
+      "destinationAccountPickerNoEligible": {
+        "message": "string"
+      },
+      "destinationAccountPickerNoMatching": {
+        "message": "string"
+      },
+      "destinationAccountPickerSearchPlaceholderToMainnet": {
+        "message": "string"
+      },
+      "destinationAccountPickerSearchPlaceholderToSolana": {
+        "message": "string"
+      },
+      "destinationTransactionIdLabel": {
+        "description": "string",
+        "message": "string"
+      },
+      "details": {
+        "message": "string"
+      },
+      "developerOptions": {
+        "message": "string"
+      },
+      "developerTools": {
+        "message": "string"
+      },
+      "disabledGasOptionToolTipMessage": {
+        "description": "string",
+        "message": "string"
+      },
+      "disconnect": {
+        "message": "string"
+      },
+      "disconnectAllAccounts": {
+        "message": "string"
+      },
+      "disconnectAllAccountsConfirmationDescription": {
+        "message": "string"
+      },
+      "disconnectAllAccountsText": {
+        "message": "string"
+      },
+      "disconnectAllDescriptionText": {
+        "message": "string"
+      },
+      "disconnectAllSites": {
+        "message": "string"
+      },
+      "disconnectAllSitesDescriptionText": {
+        "message": "string"
+      },
+      "disconnectAllSitesError": {
+        "message": "string"
+      },
+      "disconnectAllSitesSuccess": {
+        "message": "string"
+      },
+      "disconnectAllSnapsText": {
+        "message": "string"
+      },
+      "disconnectMessage": {
+        "message": "string"
+      },
+      "disconnectPrompt": {
+        "message": "string"
+      },
+      "disconnectThisAccount": {
+        "message": "string"
+      },
+      "discover": {
+        "message": "string"
+      },
+      "discoverSnaps": {
+        "description": "string",
+        "message": "string"
+      },
+      "dismiss": {
+        "message": "string"
+      },
+      "dismissReminderDescriptionField": {
+        "message": "string"
+      },
+      "dismissReminderField": {
+        "message": "string"
+      },
+      "displayNftMedia": {
+        "message": "string"
+      },
+      "displayNftMediaDescription": {
+        "message": "string"
+      },
+      "displayNftMediaDescriptionV2": {
+        "message": "string"
+      },
+      "doNotShare": {
+        "message": "string"
+      },
+      "domain": {
+        "message": "string"
+      },
+      "done": {
+        "message": "string"
+      },
+      "dontShowThisAgain": {
+        "message": "string"
+      },
+      "download": {
+        "message": "string"
+      },
+      "downloadAppDescription": {
+        "message": "string"
+      },
+      "downloadAppTitle": {
+        "message": "string"
+      },
+      "downloadGoogleChrome": {
+        "message": "string"
+      },
+      "downloadMetaMaskMobileDescription": {
+        "message": "string"
+      },
+      "downloadMetaMaskMobileQrNote": {
+        "message": "string"
+      },
+      "downloadMetaMaskMobileTitle": {
+        "message": "string"
+      },
+      "downloadNow": {
+        "message": "string"
+      },
+      "downloadStateLogs": {
+        "message": "string"
+      },
+      "dropped": {
+        "message": "string"
+      },
+      "duplicateContactTooltip": {
+        "message": "string"
+      },
+      "duplicateContactWarning": {
+        "message": "string"
+      },
+      "durationSuffixDay": {
+        "description": "string",
+        "message": "string"
+      },
+      "durationSuffixHour": {
+        "description": "string",
+        "message": "string"
+      },
+      "durationSuffixMillisecond": {
+        "description": "string",
+        "message": "string"
+      },
+      "durationSuffixMinute": {
+        "description": "string",
+        "message": "string"
+      },
+      "durationSuffixMonth": {
+        "description": "string",
+        "message": "string"
+      },
+      "durationSuffixSecond": {
+        "description": "string",
+        "message": "string"
+      },
+      "durationSuffixWeek": {
+        "description": "string",
+        "message": "string"
+      },
+      "durationSuffixYear": {
+        "description": "string",
+        "message": "string"
+      },
+      "earn": {
+        "message": "string"
+      },
+      "edit": {
+        "message": "string"
+      },
+      "editANickname": {
+        "message": "string"
+      },
+      "editAccounts": {
+        "message": "string"
+      },
+      "editAddressNickname": {
+        "message": "string"
+      },
+      "editContact": {
+        "message": "string"
+      },
+      "editGasFeeModalTitle": {
+        "message": "string"
+      },
+      "editGasLimitOutOfBounds": {
+        "message": "string"
+      },
+      "editGasMaxFeeHigh": {
+        "message": "string"
+      },
+      "editGasMaxFeeLow": {
+        "message": "string"
+      },
+      "editGasMaxFeePriorityImbalance": {
+        "message": "string"
+      },
+      "editGasMaxPriorityFeeBelowMinimum": {
+        "message": "string"
+      },
+      "editGasMaxPriorityFeeHigh": {
+        "message": "string"
+      },
+      "editGasMaxPriorityFeeLow": {
+        "message": "string"
+      },
+      "editGasPriceTooLow": {
+        "message": "string"
+      },
+      "editGasTooLow": {
+        "message": "string"
+      },
+      "editInPortfolio": {
+        "message": "string"
+      },
+      "editNetwork": {
+        "message": "string"
+      },
+      "editNetworkLink": {
+        "message": "string"
+      },
+      "editNetworksTitle": {
+        "message": "string"
+      },
+      "editNonceField": {
+        "message": "string"
+      },
+      "editNonceMessage": {
+        "message": "string"
+      },
+      "editPermissions": {
+        "message": "string"
+      },
+      "editSpendingCap": {
+        "message": "string"
+      },
+      "editSpendingCapAccountBalance": {
+        "message": "string"
+      },
+      "editSpendingCapDesc": {
+        "message": "string"
+      },
+      "editSpendingCapError": {
+        "message": "string"
+      },
+      "editSpendingCapSpecialCharError": {
+        "message": "string"
+      },
+      "enableAutoDetect": {
+        "message": "string"
+      },
+      "enableFromSettings": {
+        "message": "string"
+      },
+      "enableSmartContractAccount": {
+        "message": "string"
+      },
+      "enableSmartContractAccountDescription": {
+        "message": "string"
+      },
+      "enableSnap": {
+        "message": "string"
+      },
+      "enableToken": {
+        "description": "string",
+        "message": "string"
+      },
+      "enabled": {
+        "message": "string"
+      },
+      "enabledNetworks": {
+        "message": "string"
+      },
+      "encryptionPublicKeyNotice": {
+        "description": "string",
+        "message": "string"
+      },
+      "encryptionPublicKeyRequest": {
+        "message": "string"
+      },
+      "endpointReturnedDifferentChainId": {
+        "description": "string",
+        "message": "string"
+      },
+      "enhancedTokenDetectionAlertMessage": {
+        "message": "string"
+      },
+      "ensDomainsSettingDescriptionIntroduction": {
+        "message": "string"
+      },
+      "ensDomainsSettingDescriptionOutroduction": {
+        "message": "string"
+      },
+      "ensDomainsSettingDescriptionPart1": {
+        "message": "string"
+      },
+      "ensDomainsSettingDescriptionPart2": {
+        "message": "string"
+      },
+      "ensDomainsSettingTitle": {
+        "message": "string"
+      },
+      "ensUnknownError": {
+        "message": "string"
+      },
+      "enterANameToIdentifyTheUrl": {
+        "message": "string"
+      },
+      "enterChainId": {
+        "message": "string"
+      },
+      "enterNetworkName": {
+        "message": "string"
+      },
+      "enterOptionalPassword": {
+        "message": "string"
+      },
+      "enterPasswordContinue": {
+        "message": "string"
+      },
+      "enterPasswordCurrent": {
+        "message": "string"
+      },
+      "enterRpcUrl": {
+        "message": "string"
+      },
+      "enterSymbol": {
+        "message": "string"
+      },
+      "enterTokenNameOrAddress": {
+        "message": "string"
+      },
+      "enterYourPassword": {
+        "message": "string"
+      },
+      "enterYourPasswordContinue": {
+        "message": "string"
+      },
+      "enterYourPasswordSocialLoginFlow": {
+        "message": "string"
+      },
+      "errorCode": {
+        "description": "string",
+        "message": "string"
+      },
+      "errorDetails": {
+        "description": "string",
+        "message": "string"
+      },
+      "errorGettingSafeChainList": {
+        "message": "string"
+      },
+      "errorLegalTextFirstInfo": {
+        "message": "string"
+      },
+      "errorLegalTextNoPersonalInfo": {
+        "message": "string"
+      },
+      "errorLegalTextSecondInfo": {
+        "message": "string"
+      },
+      "errorLegalTextSummary": {
+        "message": "string"
+      },
+      "errorMessage": {
+        "description": "string",
+        "message": "string"
+      },
+      "errorName": {
+        "description": "string",
+        "message": "string"
+      },
+      "errorPageContactSupport": {
+        "description": "string",
+        "message": "string"
+      },
+      "errorPageDescribeUsWhatHappened": {
+        "description": "string",
+        "message": "string"
+      },
+      "errorPageInfo": {
+        "description": "string",
+        "message": "string"
+      },
+      "errorPageMessageTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "errorPageSentryFormTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "errorPageSentryMessagePlaceholder": {
+        "description": "string",
+        "message": "string"
+      },
+      "errorPageSentrySuccessMessageText": {
+        "description": "string",
+        "message": "string"
+      },
+      "errorPageTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "errorPageTryAgain": {
+        "description": "string",
+        "message": "string"
+      },
+      "errorStack": {
+        "description": "string",
+        "message": "string"
+      },
+      "errorWhileConnectingToRPC": {
+        "message": "string"
+      },
+      "errorWithSnap": {
+        "description": "string",
+        "message": "string"
+      },
+      "estimatedChanges": {
+        "message": "string"
+      },
+      "estimatedFee": {
+        "message": "string"
+      },
+      "estimatedFeeTooltip": {
+        "message": "string"
+      },
+      "estimatedPointsRow": {
+        "message": "string"
+      },
+      "estimatedTime": {
+        "message": "string"
+      },
+      "ethGasPriceFetchWarning": {
+        "message": "string"
+      },
+      "ethereumAndEvms": {
+        "message": "string"
+      },
+      "ethereumProviderAccess": {
+        "description": "string",
+        "message": "string"
+      },
+      "etherscan": {
+        "message": "string"
+      },
+      "etherscanView": {
+        "message": "string"
+      },
+      "etherscanViewOn": {
+        "message": "string"
+      },
+      "existingChainId": {
+        "message": "string"
+      },
+      "experimental": {
+        "message": "string"
+      },
+      "exploreDefi": {
+        "message": "string"
+      },
+      "exportYourData": {
+        "message": "string"
+      },
+      "exportYourDataButton": {
+        "message": "string"
+      },
+      "exportYourDataDescription": {
+        "message": "string"
+      },
+      "extendWalletWithSnaps": {
+        "description": "string",
+        "message": "string"
+      },
+      "externalAccount": {
+        "message": "string"
+      },
+      "externalExtension": {
+        "message": "string"
+      },
+      "externalNameSourcesSetting": {
+        "message": "string"
+      },
+      "externalNameSourcesSettingDescription": {
+        "message": "string"
+      },
+      "externalNameSourcesSettingDescriptionV2": {
+        "message": "string"
+      },
+      "failed": {
+        "message": "string"
+      },
+      "failedToFetchChainId": {
+        "message": "string"
+      },
+      "failover": {
+        "message": "string"
+      },
+      "failoverRpcUrl": {
+        "message": "string"
+      },
+      "failureMessage": {
+        "message": "string"
+      },
+      "fast": {
+        "message": "string"
+      },
+      "fieldRequired": {
+        "message": "string"
+      },
+      "fileImportFail": {
+        "description": "string",
+        "message": "string"
+      },
+      "fileUploaderDescription": {
+        "message": "string"
+      },
+      "fileUploaderInvalidFileTypeError": {
+        "message": "string"
+      },
+      "fileUploaderMaxFileSizeError": {
+        "description": "string",
+        "message": "string"
+      },
+      "flaskWelcomeUninstall": {
+        "description": "string",
+        "message": "string"
+      },
+      "flaskWelcomeWarning1": {
+        "description": "string",
+        "message": "string"
+      },
+      "flaskWelcomeWarning2": {
+        "description": "string",
+        "message": "string"
+      },
+      "flaskWelcomeWarning3": {
+        "description": "string",
+        "message": "string"
+      },
+      "flaskWelcomeWarning4": {
+        "description": "string",
+        "message": "string"
+      },
+      "flaskWelcomeWarningAcceptButton": {
+        "description": "string",
+        "message": "string"
+      },
+      "floatAmountToken": {
+        "message": "string"
+      },
+      "forbiddenIpfsGateway": {
+        "message": "string"
+      },
+      "forgetDevice": {
+        "message": "string"
+      },
+      "forgotPassword": {
+        "message": "string"
+      },
+      "forgotPasswordModalButton": {
+        "message": "string"
+      },
+      "forgotPasswordModalButtonLink": {
+        "message": "string"
+      },
+      "forgotPasswordModalContactSupport": {
+        "description": "string",
+        "message": "string"
+      },
+      "forgotPasswordModalContactSupportLink": {
+        "message": "string"
+      },
+      "forgotPasswordModalDescription1": {
+        "message": "string"
+      },
+      "forgotPasswordModalDescription2": {
+        "message": "string"
+      },
+      "forgotPasswordModalTitle": {
+        "message": "string"
+      },
+      "forgotPasswordSocialDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "forgotPasswordSocialStep1": {
+        "description": "string",
+        "message": "string"
+      },
+      "forgotPasswordSocialStep1Biometrics": {
+        "message": "string"
+      },
+      "forgotPasswordSocialStep2": {
+        "description": "string",
+        "message": "string"
+      },
+      "form": {
+        "message": "string"
+      },
+      "freeTrialDays": {
+        "description": "string",
+        "message": "string"
+      },
+      "from": {
+        "message": "string"
+      },
+      "function": {
+        "message": "string"
+      },
+      "fundYourWallet": {
+        "description": "string",
+        "message": "string"
+      },
+      "gas": {
+        "message": "string"
+      },
+      "gasLimit": {
+        "message": "string"
+      },
+      "gasLimitTooLow": {
+        "message": "string"
+      },
+      "gasPrice": {
+        "message": "string"
+      },
+      "gasPriceExcessive": {
+        "message": "string"
+      },
+      "gasPriceFetchFailed": {
+        "message": "string"
+      },
+      "gasSponsorshipReserveBalanceWarning": {
+        "description": "string",
+        "message": "string"
+      },
+      "gasTimingHoursShort": {
+        "description": "string",
+        "message": "string"
+      },
+      "gasTimingLow": {
+        "message": "string"
+      },
+      "gasTimingMinutesShort": {
+        "description": "string",
+        "message": "string"
+      },
+      "gasTimingSecondsShort": {
+        "description": "string",
+        "message": "string"
+      },
+      "gasUsed": {
+        "message": "string"
+      },
+      "gatorPermissionAnnualFrequency": {
+        "description": "string",
+        "message": "string"
+      },
+      "gatorPermissionCustomFrequency": {
+        "description": "string",
+        "message": "string"
+      },
+      "gatorPermissionDailyFrequency": {
+        "description": "string",
+        "message": "string"
+      },
+      "gatorPermissionFortnightlyFrequency": {
+        "description": "string",
+        "message": "string"
+      },
+      "gatorPermissionMonthlyFrequency": {
+        "description": "string",
+        "message": "string"
+      },
+      "gatorPermissionNoExpiration": {
+        "description": "string",
+        "message": "string"
+      },
+      "gatorPermissionTokenPeriodicFrequencyLabel": {
+        "description": "string",
+        "message": "string"
+      },
+      "gatorPermissionTokenStreamFrequencyLabel": {
+        "description": "string",
+        "message": "string"
+      },
+      "gatorPermissionWeeklyFrequency": {
+        "description": "string",
+        "message": "string"
+      },
+      "gatorPermissionsExpirationDate": {
+        "description": "string",
+        "message": "string"
+      },
+      "gatorPermissionsHideDetails": {
+        "description": "string",
+        "message": "string"
+      },
+      "gatorPermissionsInitialAllowance": {
+        "description": "string",
+        "message": "string"
+      },
+      "gatorPermissionsJustification": {
+        "description": "string",
+        "message": "string"
+      },
+      "gatorPermissionsMaxAllowance": {
+        "description": "string",
+        "message": "string"
+      },
+      "gatorPermissionsRevocationPending": {
+        "description": "string",
+        "message": "string"
+      },
+      "gatorPermissionsRevoke": {
+        "description": "string",
+        "message": "string"
+      },
+      "gatorPermissionsShowDetails": {
+        "description": "string",
+        "message": "string"
+      },
+      "gatorPermissionsStartDate": {
+        "description": "string",
+        "message": "string"
+      },
+      "gatorPermissionsStreamRate": {
+        "description": "string",
+        "message": "string"
+      },
+      "gatorPermissionsStreamingAmountLabel": {
+        "description": "string",
+        "message": "string"
+      },
+      "general": {
+        "message": "string"
+      },
+      "generalCameraError": {
+        "message": "string"
+      },
+      "generalCameraErrorTitle": {
+        "message": "string"
+      },
+      "generalDescription": {
+        "message": "string"
+      },
+      "genericExplorerView": {
+        "message": "string"
+      },
+      "getDollarMore": {
+        "message": "string"
+      },
+      "getTheNewestFeatures": {
+        "message": "string"
+      },
+      "getYourWalletReadyToUseWeb3": {
+        "description": "string",
+        "message": "string"
+      },
+      "gmxReferralSubtitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "goToSite": {
+        "message": "string"
+      },
+      "goerli": {
+        "message": "string"
+      },
+      "gotIt": {
+        "message": "string"
+      },
+      "grantExactAccess": {
+        "message": "string"
+      },
+      "gwei": {
+        "message": "string"
+      },
+      "hardware": {
+        "message": "string"
+      },
+      "hardwareWalletConnected": {
+        "message": "string"
+      },
+      "hardwareWalletErrorContinueButton": {
+        "message": "string"
+      },
+      "hardwareWalletErrorReconnectButton": {
+        "message": "string"
+      },
+      "hardwareWalletErrorRecoveryConnection1": {
+        "message": "string"
+      },
+      "hardwareWalletErrorRecoveryConnection2": {
+        "message": "string"
+      },
+      "hardwareWalletErrorRecoveryConnection3": {
+        "message": "string"
+      },
+      "hardwareWalletErrorRecoveryConnection4": {
+        "description": "string",
+        "message": "string"
+      },
+      "hardwareWalletErrorRecoveryTitle": {
+        "message": "string"
+      },
+      "hardwareWalletErrorRecoveryUnlock1": {
+        "description": "string",
+        "message": "string"
+      },
+      "hardwareWalletErrorRecoveryUnlock2": {
+        "message": "string"
+      },
+      "hardwareWalletErrorTitleBlindSignNotSupported": {
+        "message": "string"
+      },
+      "hardwareWalletErrorTitleBlindSignNotSupportedInstruction1": {
+        "message": "string"
+      },
+      "hardwareWalletErrorTitleBlindSignNotSupportedInstruction2": {
+        "message": "string"
+      },
+      "hardwareWalletErrorTitleConnectYourDevice": {
+        "description": "string",
+        "message": "string"
+      },
+      "hardwareWalletErrorTitleDeviceLocked": {
+        "description": "string",
+        "message": "string"
+      },
+      "hardwareWalletErrorUnknownErrorDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "hardwareWalletErrorUnknownErrorTitle": {
+        "message": "string"
+      },
+      "hardwareWalletEthAppNotOpenDescription": {
+        "message": "string"
+      },
+      "hardwareWalletLegacyDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "hardwareWalletLookingForDevice": {
+        "description": "string",
+        "message": "string"
+      },
+      "hardwareWalletSubmissionWarningStep1": {
+        "message": "string"
+      },
+      "hardwareWalletSubmissionWarningStep2": {
+        "message": "string"
+      },
+      "hardwareWalletSubmissionWarningTitle": {
+        "message": "string"
+      },
+      "hardwareWalletSupportLinkConversion": {
+        "message": "string"
+      },
+      "hardwareWalletTitleEthAppNotOpen": {
+        "message": "string"
+      },
+      "hardwareWalletTypeConnected": {
+        "description": "string",
+        "message": "string"
+      },
+      "hardwareWallets": {
+        "message": "string"
+      },
+      "hardwareWalletsInfo": {
+        "message": "string"
+      },
+      "hardwareWalletsMsg": {
+        "message": "string"
+      },
+      "helpAndSettings": {
+        "message": "string"
+      },
+      "here": {
+        "description": "string",
+        "message": "string"
+      },
+      "hexData": {
+        "message": "string"
+      },
+      "hexDataPlaceholder": {
+        "message": "string"
+      },
+      "hidden": {
+        "message": "string"
+      },
+      "hide": {
+        "message": "string"
+      },
+      "hideAccount": {
+        "message": "string"
+      },
+      "hideAdvancedDetails": {
+        "message": "string"
+      },
+      "hideSentitiveInfo": {
+        "message": "string"
+      },
+      "hideTokenPrompt": {
+        "message": "string"
+      },
+      "hideTokenSymbol": {
+        "description": "string",
+        "message": "string"
+      },
+      "hideZeroBalanceTokens": {
+        "message": "string"
+      },
+      "high": {
+        "message": "string"
+      },
+      "highGasSettingToolTipMessage": {
+        "description": "string",
+        "message": "string"
+      },
+      "highLowercase": {
+        "message": "string"
+      },
+      "highestCurrentBid": {
+        "message": "string"
+      },
+      "highestFloorPrice": {
+        "message": "string"
+      },
+      "history": {
+        "message": "string"
+      },
+      "holdToRevealContent1": {
+        "description": "string",
+        "message": "string"
+      },
+      "holdToRevealContent2": {
+        "description": "string",
+        "message": "string"
+      },
+      "holdToRevealContent3": {
+        "description": "string",
+        "message": "string"
+      },
+      "holdToRevealContent4": {
+        "description": "string",
+        "message": "string"
+      },
+      "holdToRevealContent5": {
+        "description": "string",
+        "message": "string"
+      },
+      "holdToRevealContentPrivateKey1": {
+        "description": "string",
+        "message": "string"
+      },
+      "holdToRevealContentPrivateKey2": {
+        "description": "string",
+        "message": "string"
+      },
+      "holdToRevealLockedLabel": {
+        "message": "string"
+      },
+      "holdToRevealPrivateKey": {
+        "message": "string"
+      },
+      "holdToRevealPrivateKeyTitle": {
+        "message": "string"
+      },
+      "holdToRevealSRP": {
+        "message": "string"
+      },
+      "holdToRevealSRPTitle": {
+        "message": "string"
+      },
+      "holdToRevealUnlockedLabel": {
+        "message": "string"
+      },
+      "honeypotDescription": {
+        "message": "string"
+      },
+      "honeypotTitle": {
+        "message": "string"
+      },
+      "hyperliquidReferralSubtitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "iUnderstand": {
+        "message": "string"
+      },
+      "id": {
+        "message": "string"
+      },
+      "imToken": {
+        "message": "string"
+      },
+      "import": {
+        "description": "string",
+        "message": "string"
+      },
+      "importAWallet": {
+        "message": "string"
+      },
+      "importAccountError": {
+        "message": "string"
+      },
+      "importAccountErrorIsSRP": {
+        "message": "string"
+      },
+      "importAccountErrorNotAValidPrivateKey": {
+        "message": "string"
+      },
+      "importAccountErrorNotHexadecimal": {
+        "message": "string"
+      },
+      "importAccountJsonLoading1": {
+        "message": "string"
+      },
+      "importAccountJsonLoading2": {
+        "message": "string"
+      },
+      "importAccountMsg": {
+        "message": "string"
+      },
+      "importAccountWithSocialMsg": {
+        "message": "string"
+      },
+      "importAccountWithSocialMsgLearnMore": {
+        "description": "string",
+        "message": "string"
+      },
+      "importAnAccount": {
+        "message": "string"
+      },
+      "importNFT": {
+        "message": "string"
+      },
+      "importNFTAddressToolTip": {
+        "message": "string"
+      },
+      "importNFTPage": {
+        "message": "string"
+      },
+      "importNFTTokenIdToolTip": {
+        "message": "string"
+      },
+      "importPrivateKey": {
+        "message": "string"
+      },
+      "importSecretRecoveryPhrase": {
+        "message": "string"
+      },
+      "importTokenQuestion": {
+        "message": "string"
+      },
+      "importTokenWarning": {
+        "message": "string"
+      },
+      "importTokensCamelCase": {
+        "message": "string"
+      },
+      "importTokensError": {
+        "message": "string"
+      },
+      "importWalletOrAccountHeader": {
+        "message": "string"
+      },
+      "importWalletSuccess": {
+        "description": "string",
+        "message": "string"
+      },
+      "imported": {
+        "description": "string",
+        "message": "string"
+      },
+      "includesXTransactions": {
+        "message": "string"
+      },
+      "incorrect": {
+        "message": "string"
+      },
+      "infuraBlockedNotification": {
+        "description": "string",
+        "message": "string"
+      },
+      "insights": {
+        "message": "string"
+      },
+      "insightsFromSnap": {
+        "description": "string",
+        "message": "string"
+      },
+      "install": {
+        "message": "string"
+      },
+      "installOrigin": {
+        "message": "string"
+      },
+      "installRequest": {
+        "message": "string"
+      },
+      "installedOn": {
+        "description": "string",
+        "message": "string"
+      },
+      "insufficientBalance": {
+        "message": "string"
+      },
+      "insufficientBalanceToCoverFees": {
+        "message": "string"
+      },
+      "insufficientFunds": {
+        "message": "string"
+      },
+      "insufficientFundsSend": {
+        "message": "string"
+      },
+      "insufficientLockedLiquidityDescription": {
+        "message": "string"
+      },
+      "insufficientLockedLiquidityTitle": {
+        "message": "string"
+      },
+      "insufficientTokens": {
+        "message": "string"
+      },
+      "interactWithSmartContract": {
+        "message": "string"
+      },
+      "interactingWith": {
+        "message": "string"
+      },
+      "interactingWithTransactionDescription": {
+        "message": "string"
+      },
+      "interaction": {
+        "message": "string"
+      },
+      "invalidAddress": {
+        "message": "string"
+      },
+      "invalidAddressRecipient": {
+        "message": "string"
+      },
+      "invalidAssetType": {
+        "message": "string"
+      },
+      "invalidChainIdTooBig": {
+        "message": "string"
+      },
+      "invalidCustomNetworkAlertContent1": {
+        "description": "string",
+        "message": "string"
+      },
+      "invalidCustomNetworkAlertContent2": {
+        "message": "string"
+      },
+      "invalidCustomNetworkAlertContent3": {
+        "description": "string",
+        "message": "string"
+      },
+      "invalidCustomNetworkAlertTitle": {
+        "message": "string"
+      },
+      "invalidHexData": {
+        "message": "string"
+      },
+      "invalidHexNumber": {
+        "message": "string"
+      },
+      "invalidHexNumberLeadingZeros": {
+        "message": "string"
+      },
+      "invalidIpfsGateway": {
+        "message": "string"
+      },
+      "invalidNumber": {
+        "message": "string"
+      },
+      "invalidNumberLeadingZeros": {
+        "message": "string"
+      },
+      "invalidRPC": {
+        "message": "string"
+      },
+      "invalidSeedPhrase": {
+        "message": "string"
+      },
+      "invalidSeedPhraseCaseSensitive": {
+        "message": "string"
+      },
+      "invalidSeedPhraseNotFound": {
+        "message": "string"
+      },
+      "invalidValue": {
+        "message": "string"
+      },
+      "ipfsGateway": {
+        "message": "string"
+      },
+      "ipfsGatewayDescription": {
+        "message": "string"
+      },
+      "ipfsGatewayDescriptionV2": {
+        "message": "string"
+      },
+      "ipfsToggleModalDescriptionOne": {
+        "message": "string"
+      },
+      "ipfsToggleModalDescriptionTwo": {
+        "description": "string",
+        "message": "string"
+      },
+      "ipfsToggleModalSettings": {
+        "message": "string"
+      },
+      "isSigningOrSubmitting": {
+        "message": "string"
+      },
+      "isSigningOrSubmittingPayToken": {
+        "message": "string"
+      },
+      "jazzicons": {
+        "message": "string"
+      },
+      "jsonFile": {
+        "description": "string",
+        "message": "string"
+      },
+      "keycardShell": {
+        "message": "string"
+      },
+      "keyringAccountName": {
+        "message": "string"
+      },
+      "keyringAccountPublicAddress": {
+        "message": "string"
+      },
+      "keyringSnapRemovalResult1": {
+        "description": "string",
+        "message": "string"
+      },
+      "keyringSnapRemovalResultNotSuccessful": {
+        "description": "string",
+        "message": "string"
+      },
+      "keyringSnapRemoveConfirmation": {
+        "description": "string",
+        "message": "string"
+      },
+      "keystone": {
+        "message": "string"
+      },
+      "knownAddressRecipient": {
+        "message": "string"
+      },
+      "knownTokenWarning": {
+        "message": "string"
+      },
+      "language": {
+        "message": "string"
+      },
+      "lastSold": {
+        "message": "string"
+      },
+      "lattice": {
+        "description": "string",
+        "message": "string"
+      },
+      "lavaDomeCopyWarning": {
+        "message": "string"
+      },
+      "learnHow": {
+        "message": "string"
+      },
+      "learnMore": {
+        "message": "string"
+      },
+      "learnMoreAboutGas": {
+        "description": "string",
+        "message": "string"
+      },
+      "learnMoreAboutPrivacy": {
+        "message": "string"
+      },
+      "learnMoreKeystone": {
+        "message": "string"
+      },
+      "learnMoreUpperCase": {
+        "message": "string"
+      },
+      "learnMoreUpperCaseWithDot": {
+        "message": "string"
+      },
+      "learnScamRisk": {
+        "message": "string"
+      },
+      "leaveMetaMask": {
+        "message": "string"
+      },
+      "leaveMetaMaskDesc": {
+        "message": "string"
+      },
+      "ledger": {
+        "description": "string",
+        "message": "string"
+      },
+      "ledgerAccountRestriction": {
+        "message": "string"
+      },
+      "ledgerConnectionInstructionCloseOtherApps": {
+        "message": "string"
+      },
+      "ledgerConnectionInstructionHeader": {
+        "message": "string"
+      },
+      "ledgerConnectionInstructionStepFour": {
+        "message": "string"
+      },
+      "ledgerConnectionInstructionStepThree": {
+        "message": "string"
+      },
+      "ledgerDeviceOpenFailureMessage": {
+        "message": "string"
+      },
+      "ledgerErrorConnectionIssue": {
+        "message": "string"
+      },
+      "ledgerErrorDevicedLocked": {
+        "message": "string"
+      },
+      "ledgerErrorEthAppNotOpen": {
+        "message": "string"
+      },
+      "ledgerErrorTransactionDataNotPadded": {
+        "message": "string"
+      },
+      "ledgerEthAppNftNotSupportedNotification": {
+        "message": "string"
+      },
+      "ledgerFirefoxNotSupportedDescription1": {
+        "message": "string"
+      },
+      "ledgerFirefoxNotSupportedDescription2": {
+        "message": "string"
+      },
+      "ledgerFirefoxNotSupportedDescription3": {
+        "message": "string"
+      },
+      "ledgerFirefoxNotSupportedLink": {
+        "message": "string"
+      },
+      "ledgerFirefoxNotSupportedTitle": {
+        "message": "string"
+      },
+      "ledgerLiveApp": {
+        "message": "string"
+      },
+      "ledgerLocked": {
+        "message": "string"
+      },
+      "ledgerMultipleDevicesUnsupportedInfoDescription": {
+        "message": "string"
+      },
+      "ledgerMultipleDevicesUnsupportedInfoTitle": {
+        "message": "string"
+      },
+      "ledgerTimeout": {
+        "message": "string"
+      },
+      "ledgerWebHIDNotConnectedErrorMessage": {
+        "description": "string",
+        "message": "string"
+      },
+      "lightTheme": {
+        "message": "string"
+      },
+      "likeToImportToken": {
+        "message": "string"
+      },
+      "likeToImportTokens": {
+        "message": "string"
+      },
+      "lineaGoerli": {
+        "message": "string"
+      },
+      "lineaMainnet": {
+        "message": "string"
+      },
+      "lineaSepolia": {
+        "message": "string"
+      },
+      "link": {
+        "message": "string"
+      },
+      "linkCentralizedExchanges": {
+        "message": "string"
+      },
+      "links": {
+        "message": "string"
+      },
+      "loading": {
+        "message": "string"
+      },
+      "loadingScreenSnapMessage": {
+        "message": "string"
+      },
+      "loadingTokenList": {
+        "message": "string"
+      },
+      "localCurrency": {
+        "message": "string"
+      },
+      "localhost": {
+        "message": "string"
+      },
+      "lock": {
+        "message": "string"
+      },
+      "lockMetaMaskLoadingMessage": {
+        "message": "string"
+      },
+      "lockTimeInvalid": {
+        "message": "string"
+      },
+      "logOut": {
+        "message": "string"
+      },
+      "loginErrorConnectButton": {
+        "message": "string"
+      },
+      "loginErrorConnectDescription": {
+        "message": "string"
+      },
+      "loginErrorConnectTitle": {
+        "message": "string"
+      },
+      "loginErrorGenericButton": {
+        "message": "string"
+      },
+      "loginErrorGenericDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "loginErrorGenericSupport": {
+        "message": "string"
+      },
+      "loginErrorGenericTitle": {
+        "message": "string"
+      },
+      "loginErrorResetWalletDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "loginErrorSessionExpiredButton": {
+        "message": "string"
+      },
+      "loginErrorSessionExpiredDescription": {
+        "message": "string"
+      },
+      "loginErrorSessionExpiredTitle": {
+        "message": "string"
+      },
+      "logo": {
+        "description": "string",
+        "message": "string"
+      },
+      "low": {
+        "message": "string"
+      },
+      "lowGasSettingToolTipMessage": {
+        "description": "string",
+        "message": "string"
+      },
+      "lowLowercase": {
+        "message": "string"
+      },
+      "mainnet": {
+        "message": "string"
+      },
+      "mainnetToken": {
+        "message": "string"
+      },
+      "makeAnotherSwap": {
+        "message": "string"
+      },
+      "makeSmartContractsEasier": {
+        "message": "string"
+      },
+      "makeSmartContractsEasierDescription": {
+        "message": "string"
+      },
+      "manage": {
+        "message": "string"
+      },
+      "manageDefaultSettings": {
+        "message": "string"
+      },
+      "manageInstitutionalWallets": {
+        "message": "string"
+      },
+      "manageInstitutionalWalletsDescription": {
+        "message": "string"
+      },
+      "manageNetworksMenuHeading": {
+        "message": "string"
+      },
+      "managePermissions": {
+        "message": "string"
+      },
+      "manageWalletRecovery": {
+        "message": "string"
+      },
+      "marketCap": {
+        "message": "string"
+      },
+      "marketCapFDV": {
+        "message": "string"
+      },
+      "marketDetails": {
+        "message": "string"
+      },
+      "marketRate": {
+        "message": "string"
+      },
+      "maskicons": {
+        "message": "string"
+      },
+      "max": {
+        "message": "string"
+      },
+      "maxBaseFee": {
+        "message": "string"
+      },
+      "maxBaseFeeMustBeGreaterThanPriorityFee": {
+        "message": "string"
+      },
+      "maxFee": {
+        "message": "string"
+      },
+      "maxFeeTooltip": {
+        "message": "string"
+      },
+      "medium": {
+        "message": "string"
+      },
+      "mediumGasSettingToolTipMessage": {
+        "description": "string",
+        "message": "string"
+      },
+      "memo": {
+        "message": "string"
+      },
+      "merklRewardsClaimBonus": {
+        "description": "string",
+        "message": "string"
+      },
+      "merklRewardsToastFailed": {
+        "description": "string",
+        "message": "string"
+      },
+      "merklRewardsToastInProgress": {
+        "description": "string",
+        "message": "string"
+      },
+      "merklRewardsToastSuccess": {
+        "description": "string",
+        "message": "string"
+      },
+      "merklRewardsUnexpectedError": {
+        "description": "string",
+        "message": "string"
+      },
+      "message": {
+        "message": "string"
+      },
+      "metaMaskConnectStatusParagraphOne": {
+        "message": "string"
+      },
+      "metaMaskConnectStatusParagraphThree": {
+        "message": "string"
+      },
+      "metaMaskConnectStatusParagraphTwo": {
+        "message": "string"
+      },
+      "metaMetricsIdNotAvailableError": {
+        "message": "string"
+      },
+      "metadataModalSourceTooltip": {
+        "description": "string",
+        "message": "string"
+      },
+      "metamaskFee": {
+        "message": "string"
+      },
+      "metamaskNotificationsAreOff": {
+        "message": "string"
+      },
+      "metamaskSwap": {
+        "message": "string"
+      },
+      "metamaskSwapsOfflineDescription": {
+        "message": "string"
+      },
+      "metamaskVersion": {
+        "message": "string"
+      },
+      "methodData": {
+        "message": "string"
+      },
+      "methodDataTransactionDesc": {
+        "message": "string"
+      },
+      "methodNotSupported": {
+        "message": "string"
+      },
+      "metrics": {
+        "message": "string"
+      },
+      "minimumReceivedExplanation": {
+        "message": "string"
+      },
+      "minimumReceivedExplanationTitle": {
+        "message": "string"
+      },
+      "minimumReceivedLabel": {
+        "message": "string"
+      },
+      "minute": {
+        "message": "string"
+      },
+      "mismatchedChainLinkText": {
+        "description": "string",
+        "message": "string"
+      },
+      "mismatchedChainRecommendation": {
+        "description": "string",
+        "message": "string"
+      },
+      "mismatchedNetworkName": {
+        "message": "string"
+      },
+      "mismatchedNetworkSymbol": {
+        "message": "string"
+      },
+      "mismatchedRpcChainId": {
+        "message": "string"
+      },
+      "mismatchedRpcUrl": {
+        "message": "string"
+      },
+      "missingSetting": {
+        "message": "string"
+      },
+      "missingSettingRequest": {
+        "message": "string"
+      },
+      "month": {
+        "message": "string"
+      },
+      "monthly": {
+        "message": "string"
+      },
+      "more": {
+        "message": "string"
+      },
+      "moreAccounts": {
+        "description": "string",
+        "message": "string"
+      },
+      "moreCapital": {
+        "message": "string"
+      },
+      "moreNetworks": {
+        "description": "string",
+        "message": "string"
+      },
+      "moreQuotes": {
+        "message": "string"
+      },
+      "multichainAccountAddressCopied": {
+        "description": "string",
+        "message": "string"
+      },
+      "multichainAccountIntroLearnMore": {
+        "description": "string",
+        "message": "string"
+      },
+      "multichainAccountIntroSameAddressDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "multichainAccountIntroSameAddressTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "multichainAccountIntroSettingUp": {
+        "description": "string",
+        "message": "string"
+      },
+      "multichainAccountIntroViewAccounts": {
+        "description": "string",
+        "message": "string"
+      },
+      "multichainAccountIntroWhatDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "multichainAccountIntroWhatTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "multichainAccountPrivateKeyCopied": {
+        "description": "string",
+        "message": "string"
+      },
+      "multichainAccountsIntroductionModalTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "multichainAddEthereumChainConfirmationDescription": {
+        "message": "string"
+      },
+      "multichainAddressViewAll": {
+        "message": "string"
+      },
+      "multichainProviderAccess": {
+        "description": "string",
+        "message": "string"
+      },
+      "multichainQuoteCardRateExplanation": {
+        "message": "string"
+      },
+      "multichainQuoteCardRateLabel": {
+        "message": "string"
+      },
+      "multipleSnapConnectionWarning": {
+        "description": "string",
+        "message": "string"
+      },
+      "musdBonusExplanation": {
+        "description": "string",
+        "message": "string"
+      },
+      "musdBonusPoweredByRelay": {
+        "description": "string",
+        "message": "string"
+      },
+      "musdBoostDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "musdBoostTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "musdBuyMusd": {
+        "message": "string"
+      },
+      "musdClaimSendingTo": {
+        "description": "string",
+        "message": "string"
+      },
+      "musdClaimSendingToWallet": {
+        "description": "string",
+        "message": "string"
+      },
+      "musdClaimTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "musdClaimableBonus": {
+        "description": "string",
+        "message": "string"
+      },
+      "musdClaimableBonusTooltip": {
+        "description": "string",
+        "message": "string"
+      },
+      "musdClaimableBonusTooltipAria": {
+        "description": "string",
+        "message": "string"
+      },
+      "musdConversionActivityTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "musdConversionBonusTooltipAria": {
+        "description": "string",
+        "message": "string"
+      },
+      "musdConversionFeeTooltipDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "musdConversionTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "musdConversionToastFailed": {
+        "message": "string"
+      },
+      "musdConversionToastInProgress": {
+        "description": "string",
+        "message": "string"
+      },
+      "musdConversionToastSuccess": {
+        "message": "string"
+      },
+      "musdConversionToastSuccessDescription": {
+        "message": "string"
+      },
+      "musdConvert": {
+        "message": "string"
+      },
+      "musdConvertAndGetBonus": {
+        "description": "string",
+        "message": "string"
+      },
+      "musdEarnBonusPercentage": {
+        "description": "string",
+        "message": "string"
+      },
+      "musdEducationGetStarted": {
+        "message": "string"
+      },
+      "musdEducationHeadline": {
+        "description": "string",
+        "message": "string"
+      },
+      "musdEducationNotNow": {
+        "message": "string"
+      },
+      "musdGetBonusPercentage": {
+        "description": "string",
+        "message": "string"
+      },
+      "musdGetMusd": {
+        "message": "string"
+      },
+      "musdMetaMaskUsd": {
+        "description": "string",
+        "message": "string"
+      },
+      "musdTermsApply": {
+        "message": "string"
+      },
+      "mustSelectOne": {
+        "message": "string"
+      },
+      "name": {
+        "message": "string"
+      },
+      "nameAddressLabel": {
+        "description": "string",
+        "message": "string"
+      },
+      "nameAlreadyInUse": {
+        "message": "string"
+      },
+      "nameFooterTrustWarning": {
+        "description": "string",
+        "message": "string"
+      },
+      "nameInstructionsMalicious": {
+        "description": "string",
+        "message": "string"
+      },
+      "nameInstructionsNew": {
+        "description": "string",
+        "message": "string"
+      },
+      "nameInstructionsRecognized": {
+        "description": "string",
+        "message": "string"
+      },
+      "nameInstructionsSaved": {
+        "description": "string",
+        "message": "string"
+      },
+      "nameInstructionsWarning": {
+        "description": "string",
+        "message": "string"
+      },
+      "nameLabel": {
+        "description": "string",
+        "message": "string"
+      },
+      "nameModalMaybeProposedName": {
+        "description": "string",
+        "message": "string"
+      },
+      "nameModalTitleMalicious": {
+        "description": "string",
+        "message": "string"
+      },
+      "nameModalTitleNew": {
+        "description": "string",
+        "message": "string"
+      },
+      "nameModalTitleRecognized": {
+        "description": "string",
+        "message": "string"
+      },
+      "nameModalTitleSaved": {
+        "description": "string",
+        "message": "string"
+      },
+      "nameModalTitleVerified": {
+        "description": "string",
+        "message": "string"
+      },
+      "nameModalTitleWarning": {
+        "description": "string",
+        "message": "string"
+      },
+      "nameProviderProposedBy": {
+        "description": "string",
+        "message": "string"
+      },
+      "nameProvider_ens": {
+        "message": "string"
+      },
+      "nameProvider_etherscan": {
+        "message": "string"
+      },
+      "nameProvider_lens": {
+        "message": "string"
+      },
+      "nameProvider_token": {
+        "message": "string"
+      },
+      "nameResolutionFailedError": {
+        "message": "string"
+      },
+      "nameResolutionZeroAddressError": {
+        "message": "string"
+      },
+      "nameSetPlaceholder": {
+        "description": "string",
+        "message": "string"
+      },
+      "nameSetPlaceholderSuggested": {
+        "description": "string",
+        "message": "string"
+      },
+      "nativeNetworkPermissionRequestDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "nativeTokenScamWarningConversion": {
+        "message": "string"
+      },
+      "nativeTokenScamWarningDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "nativeTokenScamWarningDescriptionExpectedTokenFallback": {
+        "description": "string",
+        "message": "string"
+      },
+      "nativeTokenScamWarningTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "needHelp": {
+        "description": "string",
+        "message": "string"
+      },
+      "needHelpFeedback": {
+        "message": "string"
+      },
+      "needHelpLinkText": {
+        "message": "string"
+      },
+      "needHelpSubmitTicket": {
+        "message": "string"
+      },
+      "needImportFile": {
+        "description": "string",
+        "message": "string"
+      },
+      "negativeOrZeroAmountToken": {
+        "message": "string"
+      },
+      "negativeValuesNotAllowed": {
+        "message": "string"
+      },
+      "network": {
+        "message": "string"
+      },
+      "networkChanged": {
+        "message": "string"
+      },
+      "networkChangedMessage": {
+        "description": "string",
+        "message": "string"
+      },
+      "networkDetails": {
+        "message": "string"
+      },
+      "networkFee": {
+        "message": "string"
+      },
+      "networkFeeExplanation": {
+        "message": "string"
+      },
+      "networkFeeExplanationTitle": {
+        "message": "string"
+      },
+      "networkMenu": {
+        "message": "string"
+      },
+      "networkMenuHeading": {
+        "message": "string"
+      },
+      "networkName": {
+        "message": "string"
+      },
+      "networkNameBitcoin": {
+        "message": "string"
+      },
+      "networkNameBitcoinSegwit": {
+        "message": "string"
+      },
+      "networkNameDefinition": {
+        "message": "string"
+      },
+      "networkNameEthereum": {
+        "message": "string"
+      },
+      "networkNameGoerli": {
+        "message": "string"
+      },
+      "networkNamePolygon": {
+        "message": "string"
+      },
+      "networkNameSolana": {
+        "message": "string"
+      },
+      "networkNameTron": {
+        "message": "string"
+      },
+      "networkOptions": {
+        "message": "string"
+      },
+      "networkPermissionToast": {
+        "message": "string"
+      },
+      "networkProvider": {
+        "message": "string"
+      },
+      "networkStatus": {
+        "message": "string"
+      },
+      "networkStatusBaseFeeTooltip": {
+        "description": "string",
+        "message": "string"
+      },
+      "networkStatusPriorityFeeTooltip": {
+        "message": "string"
+      },
+      "networkStatusStabilityFeeTooltip": {
+        "description": "string",
+        "message": "string"
+      },
+      "networkSuggested": {
+        "message": "string"
+      },
+      "networkTabCustom": {
+        "message": "string"
+      },
+      "networkTabPopular": {
+        "message": "string"
+      },
+      "networkURL": {
+        "message": "string"
+      },
+      "networkURLDefinition": {
+        "message": "string"
+      },
+      "networkUrlErrorWarning": {
+        "description": "string",
+        "message": "string"
+      },
+      "networks": {
+        "message": "string"
+      },
+      "networksSmallCase": {
+        "message": "string"
+      },
+      "nevermind": {
+        "message": "string"
+      },
+      "new": {
+        "message": "string"
+      },
+      "newAccount": {
+        "message": "string"
+      },
+      "newAccountIconMessage": {
+        "description": "string",
+        "message": "string"
+      },
+      "newAccountIconTitle": {
+        "message": "string"
+      },
+      "newAccountNumberName": {
+        "description": "string",
+        "message": "string"
+      },
+      "newContract": {
+        "message": "string"
+      },
+      "newNFTDetectedInImportNFTsMessageStrongText": {
+        "message": "string"
+      },
+      "newNFTDetectedInImportNFTsMsg": {
+        "description": "string",
+        "message": "string"
+      },
+      "newNFTDetectedInNFTsTabMessage": {
+        "message": "string"
+      },
+      "newNFTsAutodetected": {
+        "message": "string"
+      },
+      "newNetworkAdded": {
+        "message": "string"
+      },
+      "newNetworkEdited": {
+        "message": "string"
+      },
+      "newNftAddedMessage": {
+        "message": "string"
+      },
+      "newPassword": {
+        "message": "string"
+      },
+      "newPasswordCreate": {
+        "message": "string"
+      },
+      "newPrivacyPolicyActionButton": {
+        "message": "string"
+      },
+      "newPrivacyPolicyTitle": {
+        "message": "string"
+      },
+      "newRpcUrl": {
+        "message": "string"
+      },
+      "newTokensImportedMessage": {
+        "description": "string",
+        "message": "string"
+      },
+      "newTokensImportedTitle": {
+        "message": "string"
+      },
+      "next": {
+        "message": "string"
+      },
+      "nftAddFailedMessage": {
+        "message": "string"
+      },
+      "nftAddressError": {
+        "description": "string",
+        "message": "string"
+      },
+      "nftAlreadyAdded": {
+        "message": "string"
+      },
+      "nftAutoDetectionEnabled": {
+        "message": "string"
+      },
+      "nftBought": {
+        "message": "string"
+      },
+      "nftEmptyDescription": {
+        "message": "string"
+      },
+      "nftMinted": {
+        "message": "string"
+      },
+      "nftOptions": {
+        "message": "string"
+      },
+      "nftTokenIdPlaceholder": {
+        "message": "string"
+      },
+      "nftWarningContent": {
+        "description": "string",
+        "message": "string"
+      },
+      "nftWarningContentBold": {
+        "description": "string",
+        "message": "string"
+      },
+      "nftWarningContentGrey": {
+        "message": "string"
+      },
+      "nfts": {
+        "message": "string"
+      },
+      "nftsPreviouslyOwned": {
+        "message": "string"
+      },
+      "nickname": {
+        "message": "string"
+      },
+      "no": {
+        "message": "string"
+      },
+      "noAccountsFound": {
+        "message": "string"
+      },
+      "noConnectionDescription": {
+        "message": "string"
+      },
+      "noDefaultAddress": {
+        "description": "string",
+        "message": "string"
+      },
+      "noDomainResolution": {
+        "message": "string"
+      },
+      "noHardwareWalletOrSnapsSupport": {
+        "message": "string"
+      },
+      "noMMFeeSwapping": {
+        "message": "string"
+      },
+      "noNetworkFee": {
+        "message": "string"
+      },
+      "noNetworksAvailable": {
+        "message": "string"
+      },
+      "noNetworksFound": {
+        "message": "string"
+      },
+      "noNetworksSelected": {
+        "message": "string"
+      },
+      "noOptionsAvailableMessage": {
+        "message": "string"
+      },
+      "noSnaps": {
+        "message": "string"
+      },
+      "noTokensMatchingYourFilters": {
+        "message": "string"
+      },
+      "noWebcamFound": {
+        "message": "string"
+      },
+      "noWebcamFoundTitle": {
+        "message": "string"
+      },
+      "noZeroValue": {
+        "message": "string"
+      },
+      "nonContractAddressAlertDesc": {
+        "message": "string"
+      },
+      "nonContractAddressAlertTitle": {
+        "message": "string"
+      },
+      "nonce": {
+        "message": "string"
+      },
+      "none": {
+        "message": "string"
+      },
+      "notBusy": {
+        "message": "string"
+      },
+      "notCurrentAccount": {
+        "message": "string"
+      },
+      "notEnoughGas": {
+        "message": "string"
+      },
+      "notificationDetail": {
+        "message": "string"
+      },
+      "notificationDetailBaseFee": {
+        "message": "string"
+      },
+      "notificationDetailGasLimit": {
+        "message": "string"
+      },
+      "notificationDetailGasUsed": {
+        "message": "string"
+      },
+      "notificationDetailMaxFee": {
+        "message": "string"
+      },
+      "notificationDetailNetwork": {
+        "message": "string"
+      },
+      "notificationDetailNetworkFee": {
+        "message": "string"
+      },
+      "notificationDetailPriorityFee": {
+        "message": "string"
+      },
+      "notificationItemCheckBlockExplorer": {
+        "message": "string"
+      },
+      "notificationItemCollection": {
+        "message": "string"
+      },
+      "notificationItemConfirmed": {
+        "message": "string"
+      },
+      "notificationItemError": {
+        "message": "string"
+      },
+      "notificationItemFrom": {
+        "message": "string"
+      },
+      "notificationItemLidoStakeReadyToBeWithdrawn": {
+        "message": "string"
+      },
+      "notificationItemLidoStakeReadyToBeWithdrawnMessage": {
+        "message": "string"
+      },
+      "notificationItemLidoWithdrawalRequestedMessage": {
+        "message": "string"
+      },
+      "notificationItemNFTReceivedFrom": {
+        "message": "string"
+      },
+      "notificationItemNFTSentTo": {
+        "message": "string"
+      },
+      "notificationItemNetwork": {
+        "message": "string"
+      },
+      "notificationItemRate": {
+        "message": "string"
+      },
+      "notificationItemReceived": {
+        "message": "string"
+      },
+      "notificationItemReceivedFrom": {
+        "message": "string"
+      },
+      "notificationItemSent": {
+        "message": "string"
+      },
+      "notificationItemSentTo": {
+        "message": "string"
+      },
+      "notificationItemStakeCompleted": {
+        "message": "string"
+      },
+      "notificationItemStaked": {
+        "message": "string"
+      },
+      "notificationItemStakingProvider": {
+        "message": "string"
+      },
+      "notificationItemStatus": {
+        "message": "string"
+      },
+      "notificationItemSwapped": {
+        "message": "string"
+      },
+      "notificationItemSwappedFor": {
+        "message": "string"
+      },
+      "notificationItemTo": {
+        "message": "string"
+      },
+      "notificationItemTransactionId": {
+        "message": "string"
+      },
+      "notificationItemUnStakeCompleted": {
+        "message": "string"
+      },
+      "notificationItemUnStaked": {
+        "message": "string"
+      },
+      "notificationItemUnStakingRequested": {
+        "message": "string"
+      },
+      "notificationTransactionFailedMessage": {
+        "description": "string",
+        "message": "string"
+      },
+      "notificationTransactionFailedTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "notificationTransactionSuccessMessage": {
+        "description": "string",
+        "message": "string"
+      },
+      "notificationTransactionSuccessTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "notificationTransactionSuccessView": {
+        "description": "string",
+        "message": "string"
+      },
+      "notifications": {
+        "message": "string"
+      },
+      "notificationsFeatureToggle": {
+        "description": "string",
+        "message": "string"
+      },
+      "notificationsFeatureToggleDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "notificationsMarkAllAsRead": {
+        "message": "string"
+      },
+      "notificationsPageEmptyTitle": {
+        "message": "string"
+      },
+      "notificationsPageErrorContent": {
+        "message": "string"
+      },
+      "notificationsPageErrorTitle": {
+        "message": "string"
+      },
+      "notificationsPageNoNotificationsContent": {
+        "message": "string"
+      },
+      "notificationsSettingsBoxError": {
+        "message": "string"
+      },
+      "notificationsSettingsPageAllowNotifications": {
+        "message": "string"
+      },
+      "notificationsSettingsPageAllowNotificationsLink": {
+        "message": "string"
+      },
+      "numberOfTokens": {
+        "message": "string"
+      },
+      "ofTextNofM": {
+        "message": "string"
+      },
+      "off": {
+        "message": "string"
+      },
+      "offlineForMaintenance": {
+        "message": "string"
+      },
+      "ok": {
+        "message": "string"
+      },
+      "on": {
+        "message": "string"
+      },
+      "onboardedMetametricsAccept": {
+        "message": "string"
+      },
+      "onboardedMetametricsDisagree": {
+        "message": "string"
+      },
+      "onboardedMetametricsKey1": {
+        "message": "string"
+      },
+      "onboardedMetametricsKey2": {
+        "message": "string"
+      },
+      "onboardedMetametricsKey3": {
+        "message": "string"
+      },
+      "onboardedMetametricsLink": {
+        "message": "string"
+      },
+      "onboardedMetametricsParagraph1": {
+        "description": "string",
+        "message": "string"
+      },
+      "onboardedMetametricsParagraph2": {
+        "message": "string"
+      },
+      "onboardedMetametricsParagraph3": {
+        "message": "string"
+      },
+      "onboardedMetametricsTitle": {
+        "message": "string"
+      },
+      "onboardingAdvancedPrivacyIPFSDescription": {
+        "message": "string"
+      },
+      "onboardingAdvancedPrivacyIPFSInvalid": {
+        "message": "string"
+      },
+      "onboardingAdvancedPrivacyIPFSTitle": {
+        "message": "string"
+      },
+      "onboardingAdvancedPrivacyIPFSValid": {
+        "message": "string"
+      },
+      "onboardingAdvancedPrivacyNetworkDescription": {
+        "message": "string"
+      },
+      "onboardingAdvancedPrivacyNetworkDescriptionCallToAction": {
+        "message": "string"
+      },
+      "onboardingAdvancedPrivacyNetworkTitle": {
+        "message": "string"
+      },
+      "onboardingContinueWith": {
+        "description": "string",
+        "message": "string"
+      },
+      "onboardingCreateWallet": {
+        "message": "string"
+      },
+      "onboardingImportWallet": {
+        "message": "string"
+      },
+      "onboardingLoginFooter": {
+        "message": "string"
+      },
+      "onboardingLoginFooterPrivacyNotice": {
+        "message": "string"
+      },
+      "onboardingLoginFooterTermsOfUse": {
+        "message": "string"
+      },
+      "onboardingMetametricCheckboxDescriptionOne": {
+        "message": "string"
+      },
+      "onboardingMetametricCheckboxDescriptionOneUpdated": {
+        "message": "string"
+      },
+      "onboardingMetametricCheckboxDescriptionTwo": {
+        "message": "string"
+      },
+      "onboardingMetametricCheckboxTitleOne": {
+        "message": "string"
+      },
+      "onboardingMetametricCheckboxTitleTwo": {
+        "message": "string"
+      },
+      "onboardingMetametricsContinue": {
+        "message": "string"
+      },
+      "onboardingMetametricsDescription": {
+        "message": "string"
+      },
+      "onboardingMetametricsTitle": {
+        "message": "string"
+      },
+      "onboardingOptionIcon": {
+        "description": "string",
+        "message": "string"
+      },
+      "onboardingSignInWith": {
+        "description": "string",
+        "message": "string"
+      },
+      "onboardingSrpCreate": {
+        "message": "string"
+      },
+      "onboardingSrpImport": {
+        "message": "string"
+      },
+      "onboardingSrpImportError": {
+        "message": "string"
+      },
+      "onboardingSrpInputClearAll": {
+        "message": "string"
+      },
+      "onboardingSrpInputPlaceholder": {
+        "message": "string"
+      },
+      "oneKey": {
+        "description": "string",
+        "message": "string"
+      },
+      "only": {
+        "message": "string"
+      },
+      "onlyConnectTrust": {
+        "description": "string",
+        "message": "string"
+      },
+      "onlyIntegersAllowed": {
+        "message": "string"
+      },
+      "onlyNumbersAllowed": {
+        "message": "string"
+      },
+      "openFullScreen": {
+        "message": "string"
+      },
+      "openFullScreenForLedgerWebHid": {
+        "description": "string",
+        "message": "string"
+      },
+      "openInBlockExplorer": {
+        "message": "string"
+      },
+      "openMultichainAccountAddressMenu": {
+        "message": "string"
+      },
+      "openSettings": {
+        "message": "string"
+      },
+      "openWallet": {
+        "message": "string"
+      },
+      "options": {
+        "message": "string"
+      },
+      "or": {
+        "message": "string"
+      },
+      "origin": {
+        "message": "string"
+      },
+      "originChanged": {
+        "message": "string"
+      },
+      "originChangedMessage": {
+        "description": "string",
+        "message": "string"
+      },
+      "osTheme": {
+        "message": "string"
+      },
+      "other": {
+        "message": "string"
+      },
+      "otherPermissionsOnSiteDescription": {
+        "message": "string"
+      },
+      "otherPermissionsOnSiteTitle": {
+        "message": "string"
+      },
+      "otherSnaps": {
+        "description": "string",
+        "message": "string"
+      },
+      "others": {
+        "message": "string"
+      },
+      "outdatedBrowserNotification": {
+        "message": "string"
+      },
+      "overrideContentSecurityPolicyHeader": {
+        "message": "string"
+      },
+      "overrideContentSecurityPolicyHeaderDescription": {
+        "message": "string"
+      },
+      "padlock": {
+        "message": "string"
+      },
+      "paidByMetaMask": {
+        "message": "string"
+      },
+      "paidWith": {
+        "message": "string"
+      },
+      "participateInMetaMetrics": {
+        "message": "string"
+      },
+      "participateInMetaMetricsDescription": {
+        "message": "string"
+      },
+      "password": {
+        "message": "string"
+      },
+      "passwordChangedRecently": {
+        "message": "string"
+      },
+      "passwordChangedRecentlyDescription": {
+        "message": "string"
+      },
+      "passwordNotLongEnough": {
+        "message": "string"
+      },
+      "passwordTermsWarning": {
+        "message": "string"
+      },
+      "passwordTermsWarningSocial": {
+        "message": "string"
+      },
+      "passwordToggleHide": {
+        "message": "string"
+      },
+      "passwordToggleShow": {
+        "message": "string"
+      },
+      "passwordsDontMatch": {
+        "message": "string"
+      },
+      "paste": {
+        "message": "string"
+      },
+      "pastePrivateKey": {
+        "description": "string",
+        "message": "string"
+      },
+      "payWith": {
+        "description": "string",
+        "message": "string"
+      },
+      "payWithModalTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "pending": {
+        "message": "string"
+      },
+      "pendingConfirmationAddNetworkAlertMessage": {
+        "description": "string",
+        "message": "string"
+      },
+      "pendingConfirmationSwitchNetworkAlertMessage": {
+        "description": "string",
+        "message": "string"
+      },
+      "pendingTransactionAlertMessage": {
+        "description": "string",
+        "message": "string"
+      },
+      "pendingTransactionAlertMessageHyperlink": {
+        "description": "string",
+        "message": "string"
+      },
+      "perSecond": {
+        "message": "string"
+      },
+      "percentChange": {
+        "message": "string"
+      },
+      "permissionFor": {
+        "message": "string"
+      },
+      "permissionFrom": {
+        "message": "string"
+      },
+      "permissionRequested": {
+        "message": "string"
+      },
+      "permissionRequestedForAccounts": {
+        "description": "string",
+        "message": "string"
+      },
+      "permissionRevoked": {
+        "message": "string"
+      },
+      "permissionRevokedForAccounts": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_accessNamedSnap": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_accessNetwork": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_accessNetworkDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_accessSnap": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_accessSnapDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_assets": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_assetsDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_cronjob": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_cronjobDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_dialog": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_dialogDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_ethereumAccounts": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_ethereumProvider": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_ethereumProviderDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_getEntropy": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_getEntropyDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_getLocale": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_getLocaleDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_getPreferences": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_getPreferencesDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_homePage": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_homePageDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_keyring": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_keyringDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_lifecycleHooks": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_lifecycleHooksDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_manageAccounts": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_manageAccountsDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_manageBip32Keys": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_manageBip44AndBip32KeysDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_manageBip44Keys": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_manageState": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_manageStateDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_multichainProvider": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_multichainProviderDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_nameLookup": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_nameLookupDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_notifications": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_notificationsDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_protocol": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_protocolDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_rpc": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_rpcDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_rpcDescriptionOriginList": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_signatureInsight": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_signatureInsightDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_signatureInsightOrigin": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_signatureInsightOriginDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_transactionInsight": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_transactionInsightDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_transactionInsightOrigin": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_transactionInsightOriginDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_unknown": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_viewBip32PublicKeys": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_viewBip32PublicKeysDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_viewNamedBip32PublicKeys": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_walletSwitchEthereumChain": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_webAssembly": {
+        "description": "string",
+        "message": "string"
+      },
+      "permission_webAssemblyDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "permissions": {
+        "message": "string"
+      },
+      "permissionsPageEmptyDescription": {
+        "message": "string"
+      },
+      "permitSimulationChange_approve": {
+        "message": "string"
+      },
+      "permitSimulationChange_bidding": {
+        "message": "string"
+      },
+      "permitSimulationChange_listing": {
+        "message": "string"
+      },
+      "permitSimulationChange_nft_listing": {
+        "message": "string"
+      },
+      "permitSimulationChange_receive": {
+        "message": "string"
+      },
+      "permitSimulationChange_revoke2": {
+        "message": "string"
+      },
+      "permitSimulationChange_transfer": {
+        "message": "string"
+      },
+      "permitSimulationDetailInfo": {
+        "message": "string"
+      },
+      "permittedChainToastUpdate": {
+        "message": "string"
+      },
+      "perps": {
+        "message": "string"
+      },
+      "perps24hVolume": {
+        "message": "string"
+      },
+      "perpsActivity": {
+        "message": "string"
+      },
+      "perpsAddExposure": {
+        "message": "string"
+      },
+      "perpsAddExposureDescriptionLong": {
+        "message": "string"
+      },
+      "perpsAddExposureDescriptionShort": {
+        "message": "string"
+      },
+      "perpsAddFunds": {
+        "message": "string"
+      },
+      "perpsAddFundsDescription": {
+        "message": "string"
+      },
+      "perpsAddMargin": {
+        "message": "string"
+      },
+      "perpsAddMarginDescription": {
+        "message": "string"
+      },
+      "perpsAddToFavorites": {
+        "message": "string"
+      },
+      "perpsAutoClose": {
+        "message": "string"
+      },
+      "perpsAvailable": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsAvailableBalance": {
+        "message": "string"
+      },
+      "perpsAvailableToAdd": {
+        "message": "string"
+      },
+      "perpsAvailableToClose": {
+        "message": "string"
+      },
+      "perpsAvailableToSubtract": {
+        "message": "string"
+      },
+      "perpsAvailableToTrade": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsBatchCancelFailed": {
+        "message": "string"
+      },
+      "perpsBatchCloseFailed": {
+        "message": "string"
+      },
+      "perpsCancelAllOrders": {
+        "message": "string"
+      },
+      "perpsCancelOrder": {
+        "message": "string"
+      },
+      "perpsCandleIntervals": {
+        "message": "string"
+      },
+      "perpsCandlePeriodDays": {
+        "message": "string"
+      },
+      "perpsCandlePeriodHours": {
+        "message": "string"
+      },
+      "perpsCandlePeriodMinutes": {
+        "message": "string"
+      },
+      "perpsCloseAll": {
+        "message": "string"
+      },
+      "perpsCloseAmount": {
+        "message": "string"
+      },
+      "perpsCloseLong": {
+        "message": "string"
+      },
+      "perpsClosePartialMinNotional": {
+        "message": "string"
+      },
+      "perpsClosePosition": {
+        "message": "string"
+      },
+      "perpsCloseShort": {
+        "message": "string"
+      },
+      "perpsConfirmCloseLong": {
+        "message": "string"
+      },
+      "perpsConfirmCloseShort": {
+        "message": "string"
+      },
+      "perpsConnectionTimeout": {
+        "message": "string"
+      },
+      "perpsContactSupport": {
+        "message": "string"
+      },
+      "perpsDateToday": {
+        "message": "string"
+      },
+      "perpsDateYesterday": {
+        "message": "string"
+      },
+      "perpsDepositActivityTitle": {
+        "message": "string"
+      },
+      "perpsDepositFailed": {
+        "message": "string"
+      },
+      "perpsDepositFundsTitle": {
+        "message": "string"
+      },
+      "perpsDepositTitle": {
+        "message": "string"
+      },
+      "perpsDeposits": {
+        "message": "string"
+      },
+      "perpsDetails": {
+        "message": "string"
+      },
+      "perpsDirection": {
+        "message": "string"
+      },
+      "perpsDisclaimer": {
+        "message": "string"
+      },
+      "perpsEmptyDescription": {
+        "message": "string"
+      },
+      "perpsEntryPrice": {
+        "message": "string"
+      },
+      "perpsEstSize": {
+        "message": "string"
+      },
+      "perpsEstimatedPnlAtStopLoss": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsEstimatedPnlAtTakeProfit": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsExploreMarkets": {
+        "message": "string"
+      },
+      "perpsFees": {
+        "message": "string"
+      },
+      "perpsFilterAll": {
+        "message": "string"
+      },
+      "perpsFilterCommodities": {
+        "message": "string"
+      },
+      "perpsFilterCrypto": {
+        "message": "string"
+      },
+      "perpsFilterForex": {
+        "message": "string"
+      },
+      "perpsFilterNew": {
+        "message": "string"
+      },
+      "perpsFilterStocks": {
+        "message": "string"
+      },
+      "perpsFunding": {
+        "message": "string"
+      },
+      "perpsFundingPayments": {
+        "message": "string"
+      },
+      "perpsFundingRate": {
+        "message": "string"
+      },
+      "perpsFundingRateTooltip": {
+        "message": "string"
+      },
+      "perpsGeoBlockedDescription": {
+        "message": "string"
+      },
+      "perpsGeoBlockedTitle": {
+        "message": "string"
+      },
+      "perpsGiveFeedback": {
+        "message": "string"
+      },
+      "perpsIncludesPnl": {
+        "message": "string"
+      },
+      "perpsInsufficientMargin": {
+        "message": "string"
+      },
+      "perpsLearnBasics": {
+        "message": "string"
+      },
+      "perpsLearnMore": {
+        "message": "string"
+      },
+      "perpsLeverage": {
+        "message": "string"
+      },
+      "perpsLimit": {
+        "message": "string"
+      },
+      "perpsLimitPrice": {
+        "message": "string"
+      },
+      "perpsLimitPriceAboveCurrentPrice": {
+        "message": "string"
+      },
+      "perpsLimitPriceBelowCurrentPrice": {
+        "message": "string"
+      },
+      "perpsLimitPriceNearLiquidation": {
+        "message": "string"
+      },
+      "perpsLiquidationDistance": {
+        "message": "string"
+      },
+      "perpsLiquidationPrice": {
+        "message": "string"
+      },
+      "perpsLong": {
+        "message": "string"
+      },
+      "perpsMargin": {
+        "message": "string"
+      },
+      "perpsMarginRiskWarning": {
+        "message": "string"
+      },
+      "perpsMarket": {
+        "message": "string"
+      },
+      "perpsMarketNotFound": {
+        "message": "string"
+      },
+      "perpsMarketNotFoundDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsMarkets": {
+        "message": "string"
+      },
+      "perpsMid": {
+        "message": "string"
+      },
+      "perpsModify": {
+        "message": "string"
+      },
+      "perpsModifyPosition": {
+        "message": "string"
+      },
+      "perpsMore": {
+        "message": "string"
+      },
+      "perpsNetworkError": {
+        "message": "string"
+      },
+      "perpsNoMarketsFound": {
+        "message": "string"
+      },
+      "perpsNoTransactions": {
+        "message": "string"
+      },
+      "perpsOpenInterest": {
+        "message": "string"
+      },
+      "perpsOpenInterestTooltip": {
+        "message": "string"
+      },
+      "perpsOpenLong": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsOpenOrders": {
+        "message": "string"
+      },
+      "perpsOpenShort": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsOraclePrice": {
+        "message": "string"
+      },
+      "perpsOraclePriceTooltip": {
+        "message": "string"
+      },
+      "perpsOrderDate": {
+        "message": "string"
+      },
+      "perpsOrderFailed": {
+        "message": "string"
+      },
+      "perpsOrderOriginalSize": {
+        "message": "string"
+      },
+      "perpsOrderRejected": {
+        "message": "string"
+      },
+      "perpsOrderStatus": {
+        "message": "string"
+      },
+      "perpsOrderValue": {
+        "message": "string"
+      },
+      "perpsOrders": {
+        "message": "string"
+      },
+      "perpsPnl": {
+        "message": "string"
+      },
+      "perpsPosition": {
+        "message": "string"
+      },
+      "perpsPositions": {
+        "message": "string"
+      },
+      "perpsRateLimitExceeded": {
+        "message": "string"
+      },
+      "perpsRecentActivity": {
+        "message": "string"
+      },
+      "perpsReduceExposure": {
+        "message": "string"
+      },
+      "perpsReduceExposureDescriptionLong": {
+        "message": "string"
+      },
+      "perpsReduceExposureDescriptionShort": {
+        "message": "string"
+      },
+      "perpsReduceOnly": {
+        "message": "string"
+      },
+      "perpsRemoveFromFavorites": {
+        "message": "string"
+      },
+      "perpsRemoveMargin": {
+        "message": "string"
+      },
+      "perpsRemoveMarginDescription": {
+        "message": "string"
+      },
+      "perpsReturn": {
+        "message": "string"
+      },
+      "perpsReversePosition": {
+        "message": "string"
+      },
+      "perpsReversePositionDescriptionLong": {
+        "message": "string"
+      },
+      "perpsReversePositionDescriptionShort": {
+        "message": "string"
+      },
+      "perpsSaveChanges": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsSearchMarkets": {
+        "message": "string"
+      },
+      "perpsSeeAll": {
+        "message": "string"
+      },
+      "perpsServiceUnavailable": {
+        "message": "string"
+      },
+      "perpsShort": {
+        "message": "string"
+      },
+      "perpsSize": {
+        "message": "string"
+      },
+      "perpsSlippageExceeded": {
+        "message": "string"
+      },
+      "perpsSortByFundingRate": {
+        "message": "string"
+      },
+      "perpsSortByHighToLow": {
+        "message": "string"
+      },
+      "perpsSortByLowToHigh": {
+        "message": "string"
+      },
+      "perpsSortByOpenInterest": {
+        "message": "string"
+      },
+      "perpsSortByPriceChange": {
+        "message": "string"
+      },
+      "perpsSortBySection": {
+        "message": "string"
+      },
+      "perpsSortByTitle": {
+        "message": "string"
+      },
+      "perpsSortByVolume": {
+        "message": "string"
+      },
+      "perpsStartNewTrade": {
+        "message": "string"
+      },
+      "perpsStartTrading": {
+        "message": "string"
+      },
+      "perpsStats": {
+        "message": "string"
+      },
+      "perpsStatusCanceled": {
+        "message": "string"
+      },
+      "perpsStatusCompleted": {
+        "message": "string"
+      },
+      "perpsStatusFilled": {
+        "message": "string"
+      },
+      "perpsStatusOpen": {
+        "message": "string"
+      },
+      "perpsStatusQueued": {
+        "message": "string"
+      },
+      "perpsStatusRejected": {
+        "message": "string"
+      },
+      "perpsStatusTriggered": {
+        "message": "string"
+      },
+      "perpsStopLoss": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsStopLossInvalidPrice": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsSubmitting": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsTakeProfit": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsTakeProfitInvalidPrice": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastCancelOrderFailed": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastCancelOrderSuccess": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastCloseFailed": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastCloseInProgress": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastClosePnlSubtitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastMarginAddSuccess": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastMarginAdjustmentFailed": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastMarginAdjustmentFailedDescriptionFallback": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastMarginRemoveSuccess": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastOrderFailed": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastOrderFailedDescriptionFallback": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastOrderFilled": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastOrderPlaced": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastOrderPlacementSubtitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastOrderSubmitted": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastPartialCloseFailed": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastPartialCloseInProgress": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastPartialCloseSuccess": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastPositionStillActive": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastReverseFailed": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastReverseInProgress": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastReverseSuccess": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastSubmitInProgress": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastTradeSuccess": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastUpdateFailed": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastUpdateInProgress": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsToastUpdateSuccess": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsTotalBalance": {
+        "message": "string"
+      },
+      "perpsTradePerps": {
+        "message": "string"
+      },
+      "perpsTrades": {
+        "message": "string"
+      },
+      "perpsTutorialChooseLeverageDescription": {
+        "message": "string"
+      },
+      "perpsTutorialChooseLeverageTitle": {
+        "message": "string"
+      },
+      "perpsTutorialCloseAnytimeDescription": {
+        "message": "string"
+      },
+      "perpsTutorialCloseAnytimeTitle": {
+        "message": "string"
+      },
+      "perpsTutorialContinue": {
+        "message": "string"
+      },
+      "perpsTutorialGoLongShortDescription": {
+        "message": "string"
+      },
+      "perpsTutorialGoLongShortSubtitle": {
+        "message": "string"
+      },
+      "perpsTutorialGoLongShortTitle": {
+        "message": "string"
+      },
+      "perpsTutorialLetsGo": {
+        "message": "string"
+      },
+      "perpsTutorialReadyToTradeDescription": {
+        "message": "string"
+      },
+      "perpsTutorialReadyToTradeTitle": {
+        "message": "string"
+      },
+      "perpsTutorialSkip": {
+        "message": "string"
+      },
+      "perpsTutorialWatchLiquidationDescription": {
+        "message": "string"
+      },
+      "perpsTutorialWatchLiquidationTitle": {
+        "message": "string"
+      },
+      "perpsTutorialWhatArePerpsDescription": {
+        "message": "string"
+      },
+      "perpsTutorialWhatArePerpsSubtitle": {
+        "message": "string"
+      },
+      "perpsTutorialWhatArePerpsTitle": {
+        "message": "string"
+      },
+      "perpsUnrealizedPnl": {
+        "message": "string"
+      },
+      "perpsWatchlist": {
+        "message": "string"
+      },
+      "perpsWithdraw": {
+        "message": "string"
+      },
+      "perpsWithdrawEstimatedTime": {
+        "message": "string"
+      },
+      "perpsWithdrawFailed": {
+        "message": "string"
+      },
+      "perpsWithdrawFee": {
+        "message": "string"
+      },
+      "perpsWithdrawFundsTitle": {
+        "message": "string"
+      },
+      "perpsWithdrawInsufficient": {
+        "message": "string"
+      },
+      "perpsWithdrawInvalidAddress": {
+        "message": "string"
+      },
+      "perpsWithdrawInvalidAmount": {
+        "message": "string"
+      },
+      "perpsWithdrawMinNotice": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsWithdrawMinutesApprox": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsWithdrawNoAccount": {
+        "message": "string"
+      },
+      "perpsWithdrawReceive": {
+        "message": "string"
+      },
+      "perpsWithdrawRoutesError": {
+        "message": "string"
+      },
+      "perpsWithdrawToastErrorTitle": {
+        "message": "string"
+      },
+      "perpsWithdrawToastSuccessDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "perpsWithdrawToastSuccessTitle": {
+        "message": "string"
+      },
+      "perpsYouReceive": {
+        "message": "string"
+      },
+      "perpsYouWillReceive": {
+        "message": "string"
+      },
+      "personalAddressDetected": {
+        "message": "string"
+      },
+      "pin": {
+        "description": "string",
+        "message": "string"
+      },
+      "pinMetaMask": {
+        "message": "string"
+      },
+      "pinMetaMaskDescription": {
+        "message": "string"
+      },
+      "pinToTop": {
+        "message": "string"
+      },
+      "pinned": {
+        "message": "string"
+      },
+      "pleaseConfirm": {
+        "message": "string"
+      },
+      "pna25ModalBlogPostLink": {
+        "message": "string"
+      },
+      "pna25ModalBody1": {
+        "message": "string"
+      },
+      "pna25ModalBody2": {
+        "message": "string"
+      },
+      "pna25ModalBody3": {
+        "message": "string"
+      },
+      "pna25ModalTitle": {
+        "message": "string"
+      },
+      "popularNetworkAddToolTip": {
+        "description": "string",
+        "message": "string"
+      },
+      "popularNetworks": {
+        "message": "string"
+      },
+      "preferencesAndDisplay": {
+        "message": "string"
+      },
+      "prev": {
+        "message": "string"
+      },
+      "price": {
+        "message": "string"
+      },
+      "priceUnavailable": {
+        "message": "string"
+      },
+      "primaryType": {
+        "message": "string"
+      },
+      "priority": {
+        "message": "string"
+      },
+      "priorityFee": {
+        "message": "string"
+      },
+      "priorityFeeProperCase": {
+        "message": "string"
+      },
+      "priorityFeeTooHigh": {
+        "message": "string"
+      },
+      "privacy": {
+        "message": "string"
+      },
+      "privacyMsg": {
+        "message": "string"
+      },
+      "privateKey": {
+        "description": "string",
+        "message": "string"
+      },
+      "privateKeyCopyWarning": {
+        "description": "string",
+        "message": "string"
+      },
+      "privateKeyHidden": {
+        "description": "string",
+        "message": "string"
+      },
+      "privateKeyShow": {
+        "description": "string",
+        "message": "string"
+      },
+      "privateKeyShown": {
+        "description": "string",
+        "message": "string"
+      },
+      "privateKeyWarning": {
+        "message": "string"
+      },
+      "privateKeys": {
+        "description": "string",
+        "message": "string"
+      },
+      "privateNetwork": {
+        "message": "string"
+      },
+      "proceed": {
+        "message": "string"
+      },
+      "proceedWithTransaction": {
+        "message": "string"
+      },
+      "productAnnouncements": {
+        "message": "string"
+      },
+      "provide": {
+        "message": "string"
+      },
+      "publicAddress": {
+        "message": "string"
+      },
+      "pushNotificationLimitOrderFilledDescriptionLong": {
+        "description": "string",
+        "message": "string"
+      },
+      "pushNotificationLimitOrderFilledDescriptionShort": {
+        "description": "string",
+        "message": "string"
+      },
+      "pushNotificationLimitOrderFilledTitle": {
+        "message": "string"
+      },
+      "pushNotificationPositionLiquidatedDescriptionLong": {
+        "description": "string",
+        "message": "string"
+      },
+      "pushNotificationPositionLiquidatedDescriptionShort": {
+        "description": "string",
+        "message": "string"
+      },
+      "pushNotificationPositionLiquidatedTitle": {
+        "message": "string"
+      },
+      "pushNotificationShieldClaimCreatedDescriptionShort": {
+        "message": "string"
+      },
+      "pushNotificationShieldClaimCreatedTitle": {
+        "message": "string"
+      },
+      "pushNotificationShieldClaimStatusUpdatedDescriptionShort": {
+        "message": "string"
+      },
+      "pushNotificationShieldClaimStatusUpdatedTitle": {
+        "message": "string"
+      },
+      "pushNotificationShieldLearnMoreCta": {
+        "message": "string"
+      },
+      "pushNotificationShieldSubscriptionCreatedDescriptionShort": {
+        "message": "string"
+      },
+      "pushNotificationShieldSubscriptionPaymentFailedDescriptionShort": {
+        "message": "string"
+      },
+      "pushNotificationShieldSubscriptionTitle": {
+        "message": "string"
+      },
+      "pushNotificationShieldUpdatePaymentCta": {
+        "message": "string"
+      },
+      "pushNotificationStopLossTriggeredDescriptionLong": {
+        "description": "string",
+        "message": "string"
+      },
+      "pushNotificationStopLossTriggeredDescriptionShort": {
+        "description": "string",
+        "message": "string"
+      },
+      "pushNotificationStopLossTriggeredTitle": {
+        "message": "string"
+      },
+      "pushNotificationTakeProfitTriggeredDescriptionLong": {
+        "description": "string",
+        "message": "string"
+      },
+      "pushNotificationTakeProfitTriggeredDescriptionShort": {
+        "description": "string",
+        "message": "string"
+      },
+      "pushNotificationTakeProfitTriggeredTitle": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsFundsReceivedDescription": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsFundsReceivedDescriptionDefault": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsFundsReceivedTitle": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsFundsSentDescription": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsFundsSentDescriptionDefault": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsFundsSentTitle": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsNftReceivedDescription": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsNftReceivedTitle": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsNftSentDescription": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsNftSentTitle": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsStakingLidoStakeCompletedDescription": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsStakingLidoStakeCompletedTitle": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsStakingLidoStakeReadyToBeWithdrawnDescription": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsStakingLidoStakeReadyToBeWithdrawnTitle": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsStakingLidoWithdrawalCompletedDescription": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsStakingLidoWithdrawalCompletedTitle": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsStakingLidoWithdrawalRequestedDescription": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsStakingLidoWithdrawalRequestedTitle": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsStakingRocketpoolStakeCompletedDescription": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsStakingRocketpoolStakeCompletedTitle": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsStakingRocketpoolUnstakeCompletedDescription": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsStakingRocketpoolUnstakeCompletedTitle": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsSwapCompletedDescription": {
+        "message": "string"
+      },
+      "pushPlatformNotificationsSwapCompletedTitle": {
+        "message": "string"
+      },
+      "qr": {
+        "description": "string",
+        "message": "string"
+      },
+      "queued": {
+        "message": "string"
+      },
+      "quizIntroduction": {
+        "message": "string"
+      },
+      "quotedTotalCost": {
+        "message": "string"
+      },
+      "rank": {
+        "message": "string"
+      },
+      "rateIncludesMMFee": {
+        "message": "string"
+      },
+      "readdToken": {
+        "message": "string"
+      },
+      "receive": {
+        "message": "string"
+      },
+      "receiveCrypto": {
+        "message": "string"
+      },
+      "received": {
+        "message": "string"
+      },
+      "receivingAddress": {
+        "description": "string",
+        "message": "string"
+      },
+      "recipient": {
+        "message": "string"
+      },
+      "recipientAddressPlaceholderNew": {
+        "message": "string"
+      },
+      "recipientEditAriaLabel": {
+        "message": "string"
+      },
+      "recipientPlaceholderText": {
+        "message": "string"
+      },
+      "recoveryPhraseReminderBackupStart": {
+        "message": "string"
+      },
+      "recoveryPhraseReminderConfirm": {
+        "message": "string"
+      },
+      "recoveryPhraseReminderSubText": {
+        "message": "string"
+      },
+      "recoveryPhraseReminderTitle": {
+        "message": "string"
+      },
+      "redeposit": {
+        "message": "string"
+      },
+      "refreshList": {
+        "message": "string"
+      },
+      "reject": {
+        "message": "string"
+      },
+      "rejectAll": {
+        "message": "string"
+      },
+      "rejected": {
+        "message": "string"
+      },
+      "remove": {
+        "message": "string"
+      },
+      "removeAccount": {
+        "message": "string"
+      },
+      "removeAccountModalBannerDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "removeAccountModalBannerTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "removeAll": {
+        "message": "string"
+      },
+      "removeKeyringSnap": {
+        "message": "string"
+      },
+      "removeKeyringSnapToolTip": {
+        "message": "string"
+      },
+      "removeNFT": {
+        "message": "string"
+      },
+      "removeNftErrorMessage": {
+        "message": "string"
+      },
+      "removeNftMessage": {
+        "message": "string"
+      },
+      "removeSnap": {
+        "message": "string"
+      },
+      "removeSnapAccountDescription": {
+        "message": "string"
+      },
+      "removeSnapAccountTitle": {
+        "message": "string"
+      },
+      "removeSnapConfirmation": {
+        "description": "string",
+        "message": "string"
+      },
+      "removeSnapDescription": {
+        "message": "string"
+      },
+      "rename": {
+        "description": "string",
+        "message": "string"
+      },
+      "replace": {
+        "message": "string"
+      },
+      "reportIssue": {
+        "message": "string"
+      },
+      "reportThisError": {
+        "message": "string"
+      },
+      "requestFrom": {
+        "message": "string"
+      },
+      "requestFromInfo": {
+        "message": "string"
+      },
+      "requestFromInfoSnap": {
+        "message": "string"
+      },
+      "requestFromTransactionDescription": {
+        "message": "string"
+      },
+      "requestingFor": {
+        "message": "string"
+      },
+      "requestingForAccount": {
+        "description": "string",
+        "message": "string"
+      },
+      "requestingForNetwork": {
+        "description": "string",
+        "message": "string"
+      },
+      "required": {
+        "message": "string"
+      },
+      "requiredToken": {
+        "description": "string",
+        "message": "string"
+      },
+      "reset": {
+        "message": "string"
+      },
+      "resetWallet": {
+        "message": "string"
+      },
+      "resetWalletBoldTextOne": {
+        "message": "string"
+      },
+      "resetWalletBoldTextTwo": {
+        "message": "string"
+      },
+      "resetWalletButton": {
+        "message": "string"
+      },
+      "resetWalletDescriptionOne": {
+        "message": "string"
+      },
+      "resetWalletDescriptionTwo": {
+        "description": "string",
+        "message": "string"
+      },
+      "resetWalletTitle": {
+        "message": "string"
+      },
+      "resolutionProtocol": {
+        "description": "string",
+        "message": "string"
+      },
+      "restartMetamask": {
+        "message": "string"
+      },
+      "restore": {
+        "message": "string"
+      },
+      "restoreUserData": {
+        "message": "string"
+      },
+      "restoreWalletDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "resultPageError": {
+        "message": "string"
+      },
+      "resultPageErrorDefaultMessage": {
+        "message": "string"
+      },
+      "resultPageSuccess": {
+        "message": "string"
+      },
+      "resultPageSuccessDefaultMessage": {
+        "message": "string"
+      },
+      "retryTransaction": {
+        "message": "string"
+      },
+      "reusedTokenNameWarning": {
+        "message": "string"
+      },
+      "revealMultichainPrivateKeysBannerDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "revealMultichainPrivateKeysBannerTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "revealSecretRecoveryPhrase": {
+        "message": "string"
+      },
+      "revealSecretRecoveryPhraseSettings": {
+        "message": "string"
+      },
+      "revealSeedWords": {
+        "message": "string"
+      },
+      "revealSeedWordsDescription1": {
+        "description": "string",
+        "message": "string"
+      },
+      "revealSeedWordsQR": {
+        "message": "string"
+      },
+      "revealSeedWordsSRPName": {
+        "message": "string"
+      },
+      "revealSeedWordsText": {
+        "message": "string"
+      },
+      "revealSeedWordsWarning": {
+        "message": "string"
+      },
+      "revealSensitiveContent": {
+        "message": "string"
+      },
+      "review": {
+        "message": "string"
+      },
+      "reviewAlert": {
+        "message": "string"
+      },
+      "reviewAlerts": {
+        "message": "string"
+      },
+      "reviewPendingTransactions": {
+        "message": "string"
+      },
+      "reviewPermissions": {
+        "message": "string"
+      },
+      "revokePermission": {
+        "message": "string"
+      },
+      "revokePermissionTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "revokeSimulationDetailsDesc": {
+        "message": "string"
+      },
+      "revokeTokenApprovals": {
+        "message": "string"
+      },
+      "reward": {
+        "message": "string"
+      },
+      "rewardsAuthFailDescription": {
+        "message": "string"
+      },
+      "rewardsAuthFailTitle": {
+        "message": "string"
+      },
+      "rewardsErrorMessagesAccountAlreadyRegistered": {
+        "message": "string"
+      },
+      "rewardsErrorMessagesFailedToClaimReward": {
+        "message": "string"
+      },
+      "rewardsErrorMessagesRequestRejected": {
+        "message": "string"
+      },
+      "rewardsErrorMessagesServiceNotAvailable": {
+        "message": "string"
+      },
+      "rewardsErrorMessagesSomethingWentWrong": {
+        "message": "string"
+      },
+      "rewardsLinkAccount": {
+        "message": "string"
+      },
+      "rewardsLinkAccountError": {
+        "message": "string"
+      },
+      "rewardsOnboardingIntroDescription": {
+        "message": "string"
+      },
+      "rewardsOnboardingIntroGeoCheckFailedDescription": {
+        "message": "string"
+      },
+      "rewardsOnboardingIntroGeoCheckFailedTitle": {
+        "message": "string"
+      },
+      "rewardsOnboardingIntroGeoCheckRetry": {
+        "message": "string"
+      },
+      "rewardsOnboardingIntroRewardsAuthFailRetry": {
+        "message": "string"
+      },
+      "rewardsOnboardingIntroStepConfirm": {
+        "message": "string"
+      },
+      "rewardsOnboardingIntroStepConfirmLoadingEligibility": {
+        "message": "string"
+      },
+      "rewardsOnboardingIntroStepConfirmLoadingRegion": {
+        "message": "string"
+      },
+      "rewardsOnboardingIntroStepSkip": {
+        "message": "string"
+      },
+      "rewardsOnboardingIntroTitle": {
+        "message": "string"
+      },
+      "rewardsOnboardingIntroUnsupportedRegionDescription": {
+        "message": "string"
+      },
+      "rewardsOnboardingIntroUnsupportedRegionTitle": {
+        "message": "string"
+      },
+      "rewardsOnboardingStep1Description": {
+        "message": "string"
+      },
+      "rewardsOnboardingStep1Title": {
+        "message": "string"
+      },
+      "rewardsOnboardingStep2Description": {
+        "message": "string"
+      },
+      "rewardsOnboardingStep2Title": {
+        "message": "string"
+      },
+      "rewardsOnboardingStep3Description": {
+        "message": "string"
+      },
+      "rewardsOnboardingStep3Title": {
+        "message": "string"
+      },
+      "rewardsOnboardingStep4LegalDisclaimer": {
+        "description": "string",
+        "message": "string"
+      },
+      "rewardsOnboardingStep4LegalDisclaimerLearnMoreLink": {
+        "message": "string"
+      },
+      "rewardsOnboardingStep4LegalDisclaimerTermsLink": {
+        "message": "string"
+      },
+      "rewardsOnboardingStep4OptInError": {
+        "message": "string"
+      },
+      "rewardsOnboardingStep4ReferralCodeError": {
+        "message": "string"
+      },
+      "rewardsOnboardingStep4ReferralCodeInput": {
+        "message": "string"
+      },
+      "rewardsOnboardingStep4ReferralCodePlaceholder": {
+        "message": "string"
+      },
+      "rewardsOnboardingStep4ReferralCodeUnknownError": {
+        "message": "string"
+      },
+      "rewardsOnboardingStep4ReferralCodeUnknownErrorDescription": {
+        "message": "string"
+      },
+      "rewardsOnboardingStep4Title": {
+        "message": "string"
+      },
+      "rewardsOnboardingStep4TitleWithReferralCode": {
+        "message": "string"
+      },
+      "rewardsOnboardingStepConfirm": {
+        "message": "string"
+      },
+      "rewardsOnboardingStepOptIn": {
+        "message": "string"
+      },
+      "rewardsOptInVerifyingReferralCode": {
+        "description": "string",
+        "message": "string"
+      },
+      "rewardsPointsBalance": {
+        "description": "string",
+        "message": "string"
+      },
+      "rewardsPointsBalance_couldntLoad": {
+        "description": "string",
+        "message": "string"
+      },
+      "rewardsPointsIcon": {
+        "description": "string",
+        "message": "string"
+      },
+      "rewardsQRCodeDescription": {
+        "message": "string"
+      },
+      "rewardsQRCodeTitle": {
+        "message": "string"
+      },
+      "rewardsSignInFailed": {
+        "description": "string",
+        "message": "string"
+      },
+      "rewardsSignInToViewPoints": {
+        "description": "string",
+        "message": "string"
+      },
+      "rewardsSignUp": {
+        "message": "string"
+      },
+      "rewardsSigningIn": {
+        "description": "string",
+        "message": "string"
+      },
+      "rpcNameOptional": {
+        "message": "string"
+      },
+      "rpcUrl": {
+        "message": "string"
+      },
+      "safeTransferFrom": {
+        "message": "string"
+      },
+      "save": {
+        "message": "string"
+      },
+      "scanInstructions": {
+        "message": "string"
+      },
+      "scanQrCode": {
+        "message": "string"
+      },
+      "scrollDown": {
+        "message": "string"
+      },
+      "search": {
+        "message": "string"
+      },
+      "searchAnAcccountOrContact": {
+        "message": "string"
+      },
+      "searchForAnAssetToSend": {
+        "message": "string"
+      },
+      "searchNetworks": {
+        "message": "string"
+      },
+      "searchNfts": {
+        "message": "string"
+      },
+      "searchTokens": {
+        "message": "string"
+      },
+      "searchTokensByNameOrAddress": {
+        "message": "string"
+      },
+      "searchYourAccounts": {
+        "description": "string",
+        "message": "string"
+      },
+      "second": {
+        "message": "string"
+      },
+      "secretRecoveryPhrase": {
+        "message": "string"
+      },
+      "secretRecoveryPhrasePlusNumber": {
+        "description": "string",
+        "message": "string"
+      },
+      "secureWallet": {
+        "message": "string"
+      },
+      "secureWalletRemindLaterButton": {
+        "message": "string"
+      },
+      "security": {
+        "message": "string"
+      },
+      "securityAlert": {
+        "message": "string"
+      },
+      "securityAlerts": {
+        "message": "string"
+      },
+      "securityAlertsDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "securityAlertsDescriptionV2": {
+        "message": "string"
+      },
+      "securityAndPassword": {
+        "message": "string"
+      },
+      "securityAndPrivacy": {
+        "message": "string"
+      },
+      "securityChangePassword": {
+        "message": "string"
+      },
+      "securityChangePasswordDescription": {
+        "message": "string"
+      },
+      "securityChangePasswordTitle": {
+        "message": "string"
+      },
+      "securityChangePasswordToastError": {
+        "message": "string"
+      },
+      "securityChangePasswordToastSuccess": {
+        "message": "string"
+      },
+      "securityDefaultSettingsSocialLogin": {
+        "message": "string"
+      },
+      "securityDescription": {
+        "message": "string"
+      },
+      "securityLoginWithSocial": {
+        "description": "string",
+        "message": "string"
+      },
+      "securityLoginWithSrpBackedUp": {
+        "message": "string"
+      },
+      "securityLoginWithSrpNotBackedUp": {
+        "message": "string"
+      },
+      "securityMessageLinkForNetworks": {
+        "message": "string"
+      },
+      "securityProviderPoweredBy": {
+        "description": "string",
+        "message": "string"
+      },
+      "securitySocialLoginDefaultSettingsDescription": {
+        "message": "string"
+      },
+      "securitySocialLoginEnabled": {
+        "message": "string"
+      },
+      "securitySocialLoginEnabledDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "securitySocialLoginLabel": {
+        "description": "string",
+        "message": "string"
+      },
+      "securitySrpDescription": {
+        "message": "string"
+      },
+      "securitySrpLabel": {
+        "message": "string"
+      },
+      "securitySrpWalletRecovery": {
+        "message": "string"
+      },
+      "seeAllPermissions": {
+        "description": "string",
+        "message": "string"
+      },
+      "seeDetails": {
+        "message": "string"
+      },
+      "seedPhraseReq": {
+        "message": "string"
+      },
+      "seedPhraseReviewDetails": {
+        "description": "string",
+        "message": "string"
+      },
+      "seedPhraseReviewTitle": {
+        "message": "string"
+      },
+      "seedPhraseReviewTitleSettings": {
+        "message": "string"
+      },
+      "select": {
+        "message": "string"
+      },
+      "selectAccountToConnect": {
+        "message": "string"
+      },
+      "selectAll": {
+        "message": "string"
+      },
+      "selectAnAccount": {
+        "message": "string"
+      },
+      "selectAnAccountAlreadyConnected": {
+        "message": "string"
+      },
+      "selectEnableDisplayMediaPrivacyPreference": {
+        "message": "string"
+      },
+      "selectHdPath": {
+        "message": "string"
+      },
+      "selectNFTPrivacyPreference": {
+        "message": "string"
+      },
+      "selectNetworkToFilter": {
+        "message": "string"
+      },
+      "selectPathHelp": {
+        "message": "string"
+      },
+      "selectRecipient": {
+        "message": "string"
+      },
+      "selectRpcUrl": {
+        "message": "string"
+      },
+      "selectSecretRecoveryPhrase": {
+        "message": "string"
+      },
+      "selectType": {
+        "message": "string"
+      },
+      "selectedAccountMismatch": {
+        "message": "string"
+      },
+      "send": {
+        "message": "string"
+      },
+      "sendBugReport": {
+        "message": "string"
+      },
+      "sendSelectReceiveAsset": {
+        "message": "string"
+      },
+      "sendSelectSendAsset": {
+        "message": "string"
+      },
+      "sendingAsset": {
+        "message": "string"
+      },
+      "sendingDisabled": {
+        "message": "string"
+      },
+      "sendingNativeAsset": {
+        "description": "string",
+        "message": "string"
+      },
+      "sent": {
+        "message": "string"
+      },
+      "sentSpecifiedTokens": {
+        "description": "string",
+        "message": "string"
+      },
+      "sentTokenAsToken": {
+        "description": "string",
+        "message": "string"
+      },
+      "sepolia": {
+        "message": "string"
+      },
+      "setApprovalForAll": {
+        "message": "string"
+      },
+      "setApprovalForAllRedesignedTitle": {
+        "message": "string"
+      },
+      "setApprovalForAllTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "setUp": {
+        "description": "string",
+        "message": "string"
+      },
+      "settingAddSnapAccount": {
+        "message": "string"
+      },
+      "settings": {
+        "message": "string"
+      },
+      "settingsSearchCantFindSetting": {
+        "description": "string",
+        "message": "string"
+      },
+      "settingsSearchMatchingNotFound": {
+        "message": "string"
+      },
+      "settingsSearchRequestHere": {
+        "message": "string"
+      },
+      "shieldClaim": {
+        "message": "string"
+      },
+      "shieldClaimChainNotSupported": {
+        "message": "string"
+      },
+      "shieldClaimDeleteDraft": {
+        "message": "string"
+      },
+      "shieldClaimDeleteDraftDescription": {
+        "message": "string"
+      },
+      "shieldClaimDeletedDraft": {
+        "message": "string"
+      },
+      "shieldClaimDescription": {
+        "message": "string"
+      },
+      "shieldClaimDescriptionPlaceholder": {
+        "message": "string"
+      },
+      "shieldClaimDetails": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldClaimDetailsViewClaims": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldClaimDraftDeleteFailed": {
+        "message": "string"
+      },
+      "shieldClaimDraftDeleteFailedDescription": {
+        "message": "string"
+      },
+      "shieldClaimDraftSaveFailed": {
+        "message": "string"
+      },
+      "shieldClaimDraftSaveFailedDescription": {
+        "message": "string"
+      },
+      "shieldClaimDraftSaved": {
+        "message": "string"
+      },
+      "shieldClaimDraftSavedDescription": {
+        "message": "string"
+      },
+      "shieldClaimDuplicateClaimExists": {
+        "message": "string"
+      },
+      "shieldClaimEmail": {
+        "message": "string"
+      },
+      "shieldClaimEmailHelpText": {
+        "message": "string"
+      },
+      "shieldClaimFileErrorCountExceeded": {
+        "message": "string"
+      },
+      "shieldClaimFileErrorInvalidType": {
+        "message": "string"
+      },
+      "shieldClaimFileErrorSizeExceeded": {
+        "message": "string"
+      },
+      "shieldClaimFileUploader": {
+        "message": "string"
+      },
+      "shieldClaimFileUploaderAcceptText": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldClaimFileUploaderHelpText": {
+        "message": "string"
+      },
+      "shieldClaimGroupActive": {
+        "message": "string"
+      },
+      "shieldClaimGroupActiveNote": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldClaimGroupCompleted": {
+        "message": "string"
+      },
+      "shieldClaimGroupDrafts": {
+        "message": "string"
+      },
+      "shieldClaimGroupNoCompletedClaims": {
+        "message": "string"
+      },
+      "shieldClaimGroupNoCompletedClaimsDescription": {
+        "message": "string"
+      },
+      "shieldClaimGroupNoOpenClaims": {
+        "message": "string"
+      },
+      "shieldClaimGroupNoOpenClaimsDescription": {
+        "message": "string"
+      },
+      "shieldClaimGroupRejected": {
+        "message": "string"
+      },
+      "shieldClaimImpactedTxHash": {
+        "message": "string"
+      },
+      "shieldClaimImpactedTxHashHelpText": {
+        "message": "string"
+      },
+      "shieldClaimImpactedTxHashHelpTextLink": {
+        "message": "string"
+      },
+      "shieldClaimImpactedTxHashNotEligible": {
+        "message": "string"
+      },
+      "shieldClaimImpactedWalletAddress": {
+        "message": "string"
+      },
+      "shieldClaimIncidentDetails": {
+        "message": "string"
+      },
+      "shieldClaimInvalidChainId": {
+        "message": "string"
+      },
+      "shieldClaimInvalidEmail": {
+        "message": "string"
+      },
+      "shieldClaimInvalidRequired": {
+        "message": "string"
+      },
+      "shieldClaimInvalidTxHash": {
+        "message": "string"
+      },
+      "shieldClaimInvalidWalletAddress": {
+        "message": "string"
+      },
+      "shieldClaimMaxClaimsLimitExceeded": {
+        "message": "string"
+      },
+      "shieldClaimMaxDraftsReached": {
+        "message": "string"
+      },
+      "shieldClaimNetwork": {
+        "message": "string"
+      },
+      "shieldClaimPersonalDetails": {
+        "message": "string"
+      },
+      "shieldClaimReimbursementWalletAddress": {
+        "message": "string"
+      },
+      "shieldClaimReimbursementWalletAddressHelpText": {
+        "message": "string"
+      },
+      "shieldClaimSameWalletAddressesError": {
+        "message": "string"
+      },
+      "shieldClaimSaveAsDraft": {
+        "message": "string"
+      },
+      "shieldClaimSelectAccount": {
+        "message": "string"
+      },
+      "shieldClaimSelectNetwork": {
+        "message": "string"
+      },
+      "shieldClaimSignatureCoverageNotCovered": {
+        "message": "string"
+      },
+      "shieldClaimSubmissionWindowExpired": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldClaimSubmit": {
+        "message": "string"
+      },
+      "shieldClaimSubmitError": {
+        "message": "string"
+      },
+      "shieldClaimSubmitSuccess": {
+        "message": "string"
+      },
+      "shieldClaimSubmitSuccessDescription": {
+        "message": "string"
+      },
+      "shieldClaimTransactionNotFound": {
+        "message": "string"
+      },
+      "shieldClaimTransactionNotFromWalletAddress": {
+        "message": "string"
+      },
+      "shieldClaimTransactionNotSuccessful": {
+        "message": "string"
+      },
+      "shieldClaimViewGuidelines": {
+        "message": "string"
+      },
+      "shieldClaimWalletOwnershipValidationFailed": {
+        "message": "string"
+      },
+      "shieldClaimsLastEdited": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldClaimsListTitle": {
+        "message": "string"
+      },
+      "shieldClaimsNumber": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldClaimsTabHistory": {
+        "message": "string"
+      },
+      "shieldClaimsTabPending": {
+        "message": "string"
+      },
+      "shieldConfirmMembership": {
+        "message": "string"
+      },
+      "shieldCoverageAlertCovered": {
+        "message": "string"
+      },
+      "shieldCoverageAlertHighRiskTransaction": {
+        "message": "string"
+      },
+      "shieldCoverageAlertMessageChainNotSupported": {
+        "message": "string"
+      },
+      "shieldCoverageAlertMessageLearnHowCoverageWorks": {
+        "message": "string"
+      },
+      "shieldCoverageAlertMessagePaused": {
+        "message": "string"
+      },
+      "shieldCoverageAlertMessagePausedAcknowledgeButton": {
+        "message": "string"
+      },
+      "shieldCoverageAlertMessagePotentialRisks": {
+        "message": "string"
+      },
+      "shieldCoverageAlertMessageSignatureNotSupported": {
+        "message": "string"
+      },
+      "shieldCoverageAlertMessageTitle": {
+        "message": "string"
+      },
+      "shieldCoverageAlertMessageTitleCovered": {
+        "message": "string"
+      },
+      "shieldCoverageAlertMessageTitlePaused": {
+        "message": "string"
+      },
+      "shieldCoverageAlertMessageTitleSignatureRequest": {
+        "message": "string"
+      },
+      "shieldCoverageAlertMessageTitleSignatureRequestCovered": {
+        "message": "string"
+      },
+      "shieldCoverageAlertMessageTokenTrustSignalWarning": {
+        "message": "string"
+      },
+      "shieldCoverageAlertMessageTxTypeNotSupported": {
+        "message": "string"
+      },
+      "shieldCoverageAlertMessageUnknown": {
+        "message": "string"
+      },
+      "shieldCoverageEnding": {
+        "message": "string"
+      },
+      "shieldCoverageEndingAction": {
+        "message": "string"
+      },
+      "shieldCoverageEndingDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldCovered": {
+        "message": "string"
+      },
+      "shieldEntryModalGetStarted": {
+        "message": "string"
+      },
+      "shieldEntryModalSubtitleA": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldEntryModalSubtitleB": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldEntryModalTitleA": {
+        "message": "string"
+      },
+      "shieldEntryModalTitleB": {
+        "message": "string"
+      },
+      "shieldErrorPayerAddressAlreadyUsed": {
+        "message": "string"
+      },
+      "shieldEstimatedChangesMonthlyTooltipText": {
+        "message": "string"
+      },
+      "shieldFooterAgreement": {
+        "message": "string"
+      },
+      "shieldManagePlan": {
+        "message": "string"
+      },
+      "shieldNotCovered": {
+        "message": "string"
+      },
+      "shieldPastPlansTitle": {
+        "message": "string"
+      },
+      "shieldPaused": {
+        "message": "string"
+      },
+      "shieldPaymentPaused": {
+        "message": "string"
+      },
+      "shieldPaymentPausedActionCardPayment": {
+        "message": "string"
+      },
+      "shieldPaymentPausedActionCryptoPayment": {
+        "message": "string"
+      },
+      "shieldPaymentPausedActionUnexpectedError": {
+        "message": "string"
+      },
+      "shieldPaymentPausedDescriptionCardPayment": {
+        "message": "string"
+      },
+      "shieldPaymentPausedDescriptionCryptoPayment": {
+        "message": "string"
+      },
+      "shieldPaymentPausedDescriptionUnexpectedError": {
+        "message": "string"
+      },
+      "shieldPlanAnnual": {
+        "message": "string"
+      },
+      "shieldPlanAnnualPrice": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldPlanBillingDate": {
+        "message": "string"
+      },
+      "shieldPlanCard": {
+        "message": "string"
+      },
+      "shieldPlanCryptoMonthlyNote": {
+        "message": "string"
+      },
+      "shieldPlanDetails": {
+        "message": "string"
+      },
+      "shieldPlanDetails1": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldPlanDetails2": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldPlanDetails3": {
+        "message": "string"
+      },
+      "shieldPlanDetailsRewards": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldPlanDetailsRewardsDescription": {
+        "message": "string"
+      },
+      "shieldPlanDetailsRewardsTitle": {
+        "message": "string"
+      },
+      "shieldPlanErrorText": {
+        "message": "string"
+      },
+      "shieldPlanFooterNoteMonthly": {
+        "message": "string"
+      },
+      "shieldPlanFooterNoteYearly": {
+        "message": "string"
+      },
+      "shieldPlanMonthly": {
+        "message": "string"
+      },
+      "shieldPlanMonthlyPrice": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldPlanPayWith": {
+        "message": "string"
+      },
+      "shieldPlanPayWithCard": {
+        "message": "string"
+      },
+      "shieldPlanPayWithToken": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldPlanPaymentTitle": {
+        "message": "string"
+      },
+      "shieldPlanSave": {
+        "message": "string"
+      },
+      "shieldPlanSelectToken": {
+        "message": "string"
+      },
+      "shieldPlanTitle": {
+        "message": "string"
+      },
+      "shieldPlanYearly": {
+        "message": "string"
+      },
+      "shieldStartNowCTA": {
+        "message": "string"
+      },
+      "shieldStartNowCTAWithTrial": {
+        "message": "string"
+      },
+      "shieldTx": {
+        "message": "string"
+      },
+      "shieldTxBillingAccount": {
+        "message": "string"
+      },
+      "shieldTxCancelDetails": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldTxCancelImmediateDetails": {
+        "message": "string"
+      },
+      "shieldTxCancelNotAllowed": {
+        "message": "string"
+      },
+      "shieldTxCancelNotAllowedPendingVerification": {
+        "message": "string"
+      },
+      "shieldTxCancelWhenPausedDetails": {
+        "message": "string"
+      },
+      "shieldTxDetails1DescriptionTrial": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldTxDetails1Title": {
+        "message": "string"
+      },
+      "shieldTxDetails2Description": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldTxDetails2Title": {
+        "message": "string"
+      },
+      "shieldTxDetails3DescriptionCrypto": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldTxDetails3DescriptionCryptoWithAccount": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldTxDetails3Title": {
+        "message": "string"
+      },
+      "shieldTxDetailsManage": {
+        "message": "string"
+      },
+      "shieldTxDetailsTitle": {
+        "message": "string"
+      },
+      "shieldTxMembershipActive": {
+        "message": "string"
+      },
+      "shieldTxMembershipBenefits": {
+        "message": "string"
+      },
+      "shieldTxMembershipBenefits1Description": {
+        "message": "string"
+      },
+      "shieldTxMembershipBenefits1Title": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldTxMembershipBenefits2Description": {
+        "message": "string"
+      },
+      "shieldTxMembershipBenefits2Title": {
+        "message": "string"
+      },
+      "shieldTxMembershipBenefits3Description": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldTxMembershipBenefits3DescriptionInactive": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldTxMembershipBenefits3LinkRewards": {
+        "message": "string"
+      },
+      "shieldTxMembershipBenefits3SignUp": {
+        "message": "string"
+      },
+      "shieldTxMembershipBenefits3Title": {
+        "message": "string"
+      },
+      "shieldTxMembershipBenefitsInactive": {
+        "message": "string"
+      },
+      "shieldTxMembershipBenefitsViewAll": {
+        "message": "string"
+      },
+      "shieldTxMembershipBillingDetailsViewBillingHistory": {
+        "message": "string"
+      },
+      "shieldTxMembershipCancel": {
+        "message": "string"
+      },
+      "shieldTxMembershipCancelNotification": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldTxMembershipCancelledDate": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldTxMembershipErrorInsufficientFunds": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldTxMembershipErrorPausedCard": {
+        "message": "string"
+      },
+      "shieldTxMembershipErrorPausedCardAction": {
+        "message": "string"
+      },
+      "shieldTxMembershipErrorPausedCardTooltip": {
+        "message": "string"
+      },
+      "shieldTxMembershipErrorPausedCryptoInsufficientFunds": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldTxMembershipErrorPausedCryptoInsufficientFundsAction": {
+        "message": "string"
+      },
+      "shieldTxMembershipErrorPausedCryptoTooltip": {
+        "message": "string"
+      },
+      "shieldTxMembershipErrorPausedUnexpected": {
+        "message": "string"
+      },
+      "shieldTxMembershipErrorPausedUnexpectedAction": {
+        "message": "string"
+      },
+      "shieldTxMembershipFreeTrial": {
+        "message": "string"
+      },
+      "shieldTxMembershipFreeTrialDaysLeft": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldTxMembershipId": {
+        "message": "string"
+      },
+      "shieldTxMembershipInactive": {
+        "message": "string"
+      },
+      "shieldTxMembershipMakeClaim": {
+        "message": "string"
+      },
+      "shieldTxMembershipPaused": {
+        "message": "string"
+      },
+      "shieldTxMembershipRenew": {
+        "message": "string"
+      },
+      "shieldTxMembershipRenewDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "shieldTxMembershipResubscribe": {
+        "message": "string"
+      },
+      "shieldTxMembershipSubmitCase": {
+        "message": "string"
+      },
+      "shieldTxPastPlans": {
+        "message": "string"
+      },
+      "shieldTxPastPlansMonthly": {
+        "message": "string"
+      },
+      "shieldTxPastPlansYearly": {
+        "message": "string"
+      },
+      "shieldTxViewPastInvoice": {
+        "message": "string"
+      },
+      "show": {
+        "message": "string"
+      },
+      "showAccount": {
+        "message": "string"
+      },
+      "showAdvancedDetails": {
+        "message": "string"
+      },
+      "showDefaultAddress": {
+        "message": "string"
+      },
+      "showDefaultAddressDescription": {
+        "message": "string"
+      },
+      "showExtensionInFullSizeView": {
+        "message": "string"
+      },
+      "showExtensionInFullSizeViewDescription": {
+        "message": "string"
+      },
+      "showFiatConversionInTestnets": {
+        "message": "string"
+      },
+      "showFiatConversionInTestnetsDescription": {
+        "message": "string"
+      },
+      "showFiatConversionInTestnetsDescriptionV2": {
+        "description": "string",
+        "message": "string"
+      },
+      "showHexData": {
+        "message": "string"
+      },
+      "showHexDataDescription": {
+        "message": "string"
+      },
+      "showLess": {
+        "message": "string"
+      },
+      "showMore": {
+        "message": "string"
+      },
+      "showNativeTokenAsMainBalance": {
+        "message": "string"
+      },
+      "showNft": {
+        "message": "string"
+      },
+      "showPermissions": {
+        "message": "string"
+      },
+      "showPrivateKey": {
+        "message": "string"
+      },
+      "showSRP": {
+        "message": "string"
+      },
+      "showTestnetNetworks": {
+        "message": "string"
+      },
+      "showTestnetNetworksDescription": {
+        "message": "string"
+      },
+      "sidePanelMigrationToast": {
+        "description": "string",
+        "message": "string"
+      },
+      "sign": {
+        "message": "string"
+      },
+      "signatureRequest": {
+        "message": "string"
+      },
+      "signature_decoding_bid_nft_tooltip": {
+        "message": "string"
+      },
+      "signature_decoding_list_nft_tooltip": {
+        "message": "string"
+      },
+      "signed": {
+        "message": "string"
+      },
+      "signing": {
+        "message": "string"
+      },
+      "signingInWith": {
+        "message": "string"
+      },
+      "signingWith": {
+        "message": "string"
+      },
+      "simulationApproveHeading": {
+        "message": "string"
+      },
+      "simulationDetailsApproveDesc": {
+        "message": "string"
+      },
+      "simulationDetailsERC20ApproveDesc": {
+        "message": "string"
+      },
+      "simulationDetailsFiatNotAvailable": {
+        "message": "string"
+      },
+      "simulationDetailsIncomingHeading": {
+        "message": "string"
+      },
+      "simulationDetailsIncomingHeadingReceived": {
+        "message": "string"
+      },
+      "simulationDetailsIncomingHeadingReceiving": {
+        "message": "string"
+      },
+      "simulationDetailsNoChanges": {
+        "message": "string"
+      },
+      "simulationDetailsOutgoingHeading": {
+        "message": "string"
+      },
+      "simulationDetailsOutgoingHeadingSending": {
+        "message": "string"
+      },
+      "simulationDetailsOutgoingHeadingSent": {
+        "message": "string"
+      },
+      "simulationDetailsRevokeSetApprovalForAllDesc": {
+        "message": "string"
+      },
+      "simulationDetailsSetApprovalForAllDesc": {
+        "message": "string"
+      },
+      "simulationDetailsTitle": {
+        "message": "string"
+      },
+      "simulationDetailsTitleEnforced": {
+        "message": "string"
+      },
+      "simulationDetailsTitleTooltip": {
+        "message": "string"
+      },
+      "simulationDetailsTitleTooltipEnforced": {
+        "message": "string"
+      },
+      "simulationDetailsTotalFiat": {
+        "description": "string",
+        "message": "string"
+      },
+      "simulationDetailsTransactionReverted": {
+        "message": "string"
+      },
+      "simulationDetailsUnavailable": {
+        "message": "string"
+      },
+      "simulationErrorMessageV2": {
+        "message": "string"
+      },
+      "simulationsSettingDescription": {
+        "message": "string"
+      },
+      "simulationsSettingDescriptionV2": {
+        "message": "string"
+      },
+      "simulationsSettingSubHeader": {
+        "message": "string"
+      },
+      "singleNetwork": {
+        "message": "string"
+      },
+      "sites": {
+        "message": "string"
+      },
+      "siweIssued": {
+        "message": "string"
+      },
+      "siweNetwork": {
+        "message": "string"
+      },
+      "siweRequestId": {
+        "message": "string"
+      },
+      "siweResources": {
+        "message": "string"
+      },
+      "siweURI": {
+        "message": "string"
+      },
+      "skip": {
+        "message": "string"
+      },
+      "skipDeepLinkInterstitial": {
+        "message": "string"
+      },
+      "skipDeepLinkInterstitialDescription": {
+        "message": "string"
+      },
+      "skipLinkConfirmationScreens": {
+        "message": "string"
+      },
+      "skipLinkConfirmationScreensDescription": {
+        "message": "string"
+      },
+      "slippage": {
+        "message": "string"
+      },
+      "slippageAuto": {
+        "message": "string"
+      },
+      "slippageEditAriaLabel": {
+        "message": "string"
+      },
+      "slippageExplanation": {
+        "message": "string"
+      },
+      "smartAccount": {
+        "message": "string"
+      },
+      "smartAccountDappRequestsDescription": {
+        "message": "string"
+      },
+      "smartAccountDappRequestsTitle": {
+        "message": "string"
+      },
+      "smartAccountLabel": {
+        "message": "string"
+      },
+      "smartAccountRequestsFromDapps": {
+        "message": "string"
+      },
+      "smartAccountRequestsFromDappsDescription": {
+        "message": "string"
+      },
+      "smartAccountUpgradeBannerDescription": {
+        "message": "string"
+      },
+      "smartAccountUpgradeBannerTitle": {
+        "message": "string"
+      },
+      "smartContractAddress": {
+        "message": "string"
+      },
+      "smartContractAddressWarning": {
+        "message": "string"
+      },
+      "smartContracts": {
+        "message": "string"
+      },
+      "smartSwapsErrorNotEnoughFunds": {
+        "message": "string"
+      },
+      "smartSwapsErrorUnavailable": {
+        "message": "string"
+      },
+      "smartTransactionCancelled": {
+        "message": "string"
+      },
+      "smartTransactionCancelledDescription": {
+        "message": "string"
+      },
+      "smartTransactionError": {
+        "message": "string"
+      },
+      "smartTransactionErrorDescription": {
+        "message": "string"
+      },
+      "smartTransactionPending": {
+        "message": "string"
+      },
+      "smartTransactionSuccess": {
+        "message": "string"
+      },
+      "smartTransactions": {
+        "message": "string"
+      },
+      "smartTransactionsEnabledDescription": {
+        "message": "string"
+      },
+      "smartTransactionsEnabledLink": {
+        "message": "string"
+      },
+      "smartTransactionsEnabledTitle": {
+        "message": "string"
+      },
+      "snapAccountCreated": {
+        "message": "string"
+      },
+      "snapAccountCreatedDescription": {
+        "message": "string"
+      },
+      "snapAccountCreationFailed": {
+        "message": "string"
+      },
+      "snapAccountCreationFailedDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "snapAccountRedirectFinishSigningTitle": {
+        "message": "string"
+      },
+      "snapAccountRedirectSiteDescription": {
+        "message": "string"
+      },
+      "snapAccountRemovalFailed": {
+        "message": "string"
+      },
+      "snapAccountRemovalFailedDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "snapAccountRemoved": {
+        "message": "string"
+      },
+      "snapAccountRemovedDescription": {
+        "message": "string"
+      },
+      "snapConnectTo": {
+        "description": "string",
+        "message": "string"
+      },
+      "snapConnectionPermissionDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "snapConnectionWarning": {
+        "description": "string",
+        "message": "string"
+      },
+      "snapDetailWebsite": {
+        "message": "string"
+      },
+      "snapHomeMenu": {
+        "message": "string"
+      },
+      "snapInstallRequest": {
+        "description": "string",
+        "message": "string"
+      },
+      "snapInstallSuccess": {
+        "message": "string"
+      },
+      "snapInstallWarningCheck": {
+        "description": "string",
+        "message": "string"
+      },
+      "snapInstallWarningHeading": {
+        "message": "string"
+      },
+      "snapInstallWarningPermissionDescriptionForBip32View": {
+        "description": "string",
+        "message": "string"
+      },
+      "snapInstallWarningPermissionDescriptionForEntropy": {
+        "description": "string",
+        "message": "string"
+      },
+      "snapInstallWarningPermissionNameForEntropy": {
+        "description": "string",
+        "message": "string"
+      },
+      "snapInstallWarningPermissionNameForViewPublicKey": {
+        "description": "string",
+        "message": "string"
+      },
+      "snapInstallationErrorDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "snapInstallationErrorTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "snapResultError": {
+        "message": "string"
+      },
+      "snapResultSuccess": {
+        "message": "string"
+      },
+      "snapResultSuccessDescription": {
+        "message": "string"
+      },
+      "snapUIAccountSelectorTitle": {
+        "message": "string"
+      },
+      "snapUIAssetSelectorTitle": {
+        "message": "string"
+      },
+      "snapUpdateAlertDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "snapUpdateAvailable": {
+        "message": "string"
+      },
+      "snapUpdateErrorDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "snapUpdateErrorTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "snapUpdateRequest": {
+        "description": "string",
+        "message": "string"
+      },
+      "snapUpdateSuccess": {
+        "message": "string"
+      },
+      "snapUrlIsBlocked": {
+        "message": "string"
+      },
+      "snaps": {
+        "message": "string"
+      },
+      "snapsConnected": {
+        "message": "string"
+      },
+      "snapsNoInsight": {
+        "message": "string"
+      },
+      "snapsPrivacyWarningFirstMessage": {
+        "description": "string",
+        "message": "string"
+      },
+      "snapsPrivacyWarningSecondMessage": {
+        "description": "string",
+        "message": "string"
+      },
+      "snapsPrivacyWarningThirdMessage": {
+        "description": "string",
+        "message": "string"
+      },
+      "snapsSettings": {
+        "message": "string"
+      },
+      "snapsTermsOfUse": {
+        "message": "string"
+      },
+      "snapsToggle": {
+        "message": "string"
+      },
+      "snapsUIError": {
+        "description": "string",
+        "message": "string"
+      },
+      "solanaAccountRequested": {
+        "message": "string"
+      },
+      "solanaAccountRequired": {
+        "message": "string"
+      },
+      "someNetworks": {
+        "message": "string"
+      },
+      "somethingDoesntLookRight": {
+        "description": "string",
+        "message": "string"
+      },
+      "somethingIsWrong": {
+        "message": "string"
+      },
+      "somethingWentWrong": {
+        "message": "string"
+      },
+      "sortBy": {
+        "message": "string"
+      },
+      "sortByAlphabetically": {
+        "message": "string"
+      },
+      "sortByDecliningBalance": {
+        "description": "string",
+        "message": "string"
+      },
+      "source": {
+        "message": "string"
+      },
+      "spamModalBlockedDescription": {
+        "message": "string"
+      },
+      "spamModalBlockedTitle": {
+        "message": "string"
+      },
+      "spamModalDescription": {
+        "message": "string"
+      },
+      "spamModalTemporaryBlockButton": {
+        "message": "string"
+      },
+      "spamModalTitle": {
+        "message": "string"
+      },
+      "speed": {
+        "message": "string"
+      },
+      "speedUp": {
+        "message": "string"
+      },
+      "speedUpCancellation": {
+        "message": "string"
+      },
+      "speedUpTransactionDescription": {
+        "message": "string"
+      },
+      "speedUpTransactionFailed": {
+        "message": "string"
+      },
+      "speedUpTransactionTitle": {
+        "message": "string"
+      },
+      "spender": {
+        "message": "string"
+      },
+      "spenderTooltipDesc": {
+        "message": "string"
+      },
+      "spenderTooltipERC20ApproveDesc": {
+        "message": "string"
+      },
+      "spendingCap": {
+        "message": "string"
+      },
+      "spendingCaps": {
+        "message": "string"
+      },
+      "srpAlreadyImportedError": {
+        "message": "string"
+      },
+      "srpDetailsDescription": {
+        "message": "string"
+      },
+      "srpDetailsOwnsAccessListItemOne": {
+        "message": "string"
+      },
+      "srpDetailsOwnsAccessListItemThree": {
+        "message": "string"
+      },
+      "srpDetailsOwnsAccessListItemTwo": {
+        "message": "string"
+      },
+      "srpDetailsOwnsAccessListTitle": {
+        "message": "string"
+      },
+      "srpDetailsTitle": {
+        "message": "string"
+      },
+      "srpImportDuplicateAccountError": {
+        "message": "string"
+      },
+      "srpInputNumberOfWords": {
+        "description": "string",
+        "message": "string"
+      },
+      "srpListName": {
+        "description": "string",
+        "message": "string"
+      },
+      "srpListNumberOfAccounts": {
+        "description": "string",
+        "message": "string"
+      },
+      "srpListSelectionDescription": {
+        "message": "string"
+      },
+      "srpListSingleOrZero": {
+        "description": "string",
+        "message": "string"
+      },
+      "srpListStateBackedUp": {
+        "message": "string"
+      },
+      "srpListStateNotBackedUp": {
+        "message": "string"
+      },
+      "srpPasteFailedTooManyWords": {
+        "description": "string",
+        "message": "string"
+      },
+      "srpPasteTip": {
+        "description": "string",
+        "message": "string"
+      },
+      "srpSecurityQuizGetStarted": {
+        "message": "string"
+      },
+      "srpSecurityQuizImgAlt": {
+        "message": "string"
+      },
+      "srpSecurityQuizIntroduction": {
+        "message": "string"
+      },
+      "srpSecurityQuizQuestionOneQuestion": {
+        "message": "string"
+      },
+      "srpSecurityQuizQuestionOneRightAnswer": {
+        "message": "string"
+      },
+      "srpSecurityQuizQuestionOneRightAnswerDescription": {
+        "message": "string"
+      },
+      "srpSecurityQuizQuestionOneRightAnswerTitle": {
+        "message": "string"
+      },
+      "srpSecurityQuizQuestionOneWrongAnswer": {
+        "message": "string"
+      },
+      "srpSecurityQuizQuestionOneWrongAnswerDescription": {
+        "message": "string"
+      },
+      "srpSecurityQuizQuestionOneWrongAnswerTitle": {
+        "message": "string"
+      },
+      "srpSecurityQuizQuestionTwoQuestion": {
+        "message": "string"
+      },
+      "srpSecurityQuizQuestionTwoRightAnswer": {
+        "message": "string"
+      },
+      "srpSecurityQuizQuestionTwoRightAnswerDescription": {
+        "message": "string"
+      },
+      "srpSecurityQuizQuestionTwoRightAnswerTitle": {
+        "message": "string"
+      },
+      "srpSecurityQuizQuestionTwoWrongAnswer": {
+        "message": "string"
+      },
+      "srpSecurityQuizQuestionTwoWrongAnswerDescription": {
+        "message": "string"
+      },
+      "srpSecurityQuizQuestionTwoWrongAnswerTitle": {
+        "message": "string"
+      },
+      "srpSecurityQuizTitle": {
+        "message": "string"
+      },
+      "srpToggleShow": {
+        "description": "string",
+        "message": "string"
+      },
+      "srpWordHidden": {
+        "description": "string",
+        "message": "string"
+      },
+      "srpWordShown": {
+        "description": "string",
+        "message": "string"
+      },
+      "stable": {
+        "message": "string"
+      },
+      "stableLowercase": {
+        "message": "string"
+      },
+      "stake": {
+        "message": "string"
+      },
+      "staked": {
+        "message": "string"
+      },
+      "stakingDeposit": {
+        "message": "string"
+      },
+      "stakingWithdrawal": {
+        "message": "string"
+      },
+      "standardAccountLabel": {
+        "message": "string"
+      },
+      "stateCorruptionAreYouSure": {
+        "message": "string"
+      },
+      "stateCorruptionCopyAndRestoreBeforeRecovery": {
+        "description": "string",
+        "message": "string"
+      },
+      "stateCorruptionCopyAndRestoreBeforeReset": {
+        "description": "string",
+        "message": "string"
+      },
+      "stateCorruptionDetectedNoBackup": {
+        "message": "string"
+      },
+      "stateCorruptionDetectedWithBackup": {
+        "message": "string"
+      },
+      "stateCorruptionMetamaskDatabaseCannotBeAccessed": {
+        "message": "string"
+      },
+      "stateCorruptionResetMetaMaskState": {
+        "message": "string"
+      },
+      "stateCorruptionResettingDatabase": {
+        "message": "string"
+      },
+      "stateCorruptionRestoreAccountsFromBackup": {
+        "message": "string"
+      },
+      "stateCorruptionRestoringDatabase": {
+        "message": "string"
+      },
+      "stateCorruptionTheseInstructions": {
+        "description": "string",
+        "message": "string"
+      },
+      "stateCorruptionTheseInstructionsLinkTitle": {
+        "message": "string"
+      },
+      "stateLogError": {
+        "message": "string"
+      },
+      "stateLogFileName": {
+        "message": "string"
+      },
+      "stateLogs": {
+        "message": "string"
+      },
+      "stateLogsDescription": {
+        "message": "string"
+      },
+      "stateLogsModalDescription": {
+        "message": "string"
+      },
+      "status": {
+        "message": "string"
+      },
+      "statusNotConnected": {
+        "message": "string"
+      },
+      "step1LatticeWallet": {
+        "message": "string"
+      },
+      "step1LatticeWalletMsg": {
+        "description": "string",
+        "message": "string"
+      },
+      "step1LedgerWallet": {
+        "message": "string"
+      },
+      "step1LedgerWalletMsg": {
+        "description": "string",
+        "message": "string"
+      },
+      "step1TrezorWallet": {
+        "message": "string"
+      },
+      "step1TrezorWalletMsg": {
+        "description": "string",
+        "message": "string"
+      },
+      "step2LedgerWallet": {
+        "message": "string"
+      },
+      "step2LedgerWalletMsg": {
+        "description": "string",
+        "message": "string"
+      },
+      "stillConnectingTo": {
+        "description": "string",
+        "message": "string"
+      },
+      "stillGettingMessage": {
+        "message": "string"
+      },
+      "storageErrorAction": {
+        "message": "string"
+      },
+      "storageErrorDescriptionDefault": {
+        "message": "string"
+      },
+      "storageErrorDescriptionNoSpace": {
+        "message": "string"
+      },
+      "storageErrorTitle": {
+        "message": "string"
+      },
+      "strong": {
+        "message": "string"
+      },
+      "stxCancelled": {
+        "message": "string"
+      },
+      "stxCancelledDescription": {
+        "message": "string"
+      },
+      "stxCancelledSubDescription": {
+        "message": "string"
+      },
+      "stxFailure": {
+        "message": "string"
+      },
+      "stxFailureDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "stxOptInDescriptionV2": {
+        "message": "string"
+      },
+      "stxOptInSupportedNetworksDescription": {
+        "message": "string"
+      },
+      "stxPendingPrivatelySubmittingSwap": {
+        "message": "string"
+      },
+      "stxPendingPubliclySubmittingSwap": {
+        "message": "string"
+      },
+      "stxSuccess": {
+        "message": "string"
+      },
+      "stxSuccessDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "stxSwapCompleteIn": {
+        "description": "string",
+        "message": "string"
+      },
+      "stxTryingToCancel": {
+        "message": "string"
+      },
+      "stxUnknown": {
+        "message": "string"
+      },
+      "stxUnknownDescription": {
+        "message": "string"
+      },
+      "stxUserCancelled": {
+        "message": "string"
+      },
+      "stxUserCancelledDescription": {
+        "message": "string"
+      },
+      "submit": {
+        "message": "string"
+      },
+      "submitted": {
+        "message": "string"
+      },
+      "suggestedBySnap": {
+        "description": "string",
+        "message": "string"
+      },
+      "suggestedCurrencySymbol": {
+        "message": "string"
+      },
+      "suggestedTokenName": {
+        "message": "string"
+      },
+      "summary": {
+        "message": "string"
+      },
+      "supplied": {
+        "message": "string"
+      },
+      "support": {
+        "message": "string"
+      },
+      "supportCenter": {
+        "message": "string"
+      },
+      "supportMultiRpcInformation": {
+        "message": "string"
+      },
+      "supportedLanguagesSectionTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "surveyConversion": {
+        "message": "string"
+      },
+      "surveyTitle": {
+        "message": "string"
+      },
+      "swap": {
+        "message": "string"
+      },
+      "swapAdjustSlippage": {
+        "message": "string"
+      },
+      "swapAggregator": {
+        "message": "string"
+      },
+      "swapAllowSwappingOf": {
+        "description": "string",
+        "message": "string"
+      },
+      "swapAmountReceived": {
+        "message": "string"
+      },
+      "swapAmountReceivedInfo": {
+        "message": "string"
+      },
+      "swapAndSend": {
+        "message": "string"
+      },
+      "swapApproval": {
+        "description": "string",
+        "message": "string"
+      },
+      "swapAreYouStillThere": {
+        "message": "string"
+      },
+      "swapAreYouStillThereDescription": {
+        "message": "string"
+      },
+      "swapConfirmWithHwWallet": {
+        "message": "string"
+      },
+      "swapContractDataDisabledErrorDescription": {
+        "message": "string"
+      },
+      "swapContractDataDisabledErrorTitle": {
+        "message": "string"
+      },
+      "swapCustom": {
+        "message": "string"
+      },
+      "swapDecentralizedExchange": {
+        "message": "string"
+      },
+      "swapDetailsTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "swapDirectContract": {
+        "message": "string"
+      },
+      "swapEditLimit": {
+        "message": "string"
+      },
+      "swapEnableDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "swapEnableTokenForSwapping": {
+        "description": "string",
+        "message": "string"
+      },
+      "swapEstimatedNetworkFees": {
+        "message": "string"
+      },
+      "swapEstimatedNetworkFeesInfo": {
+        "message": "string"
+      },
+      "swapFailedErrorDescriptionWithSupportLink": {
+        "description": "string",
+        "message": "string"
+      },
+      "swapFailedErrorTitle": {
+        "message": "string"
+      },
+      "swapFetchingQuoteNofN": {
+        "description": "string",
+        "message": "string"
+      },
+      "swapFetchingQuotes": {
+        "message": "string"
+      },
+      "swapFetchingQuotesErrorDescription": {
+        "message": "string"
+      },
+      "swapFetchingQuotesErrorTitle": {
+        "message": "string"
+      },
+      "swapFromTo": {
+        "description": "string",
+        "message": "string"
+      },
+      "swapGasFeesExplanation": {
+        "description": "string",
+        "message": "string"
+      },
+      "swapGasFeesExplanationLinkText": {
+        "description": "string",
+        "message": "string"
+      },
+      "swapGasFeesIncluded": {
+        "message": "string"
+      },
+      "swapGasFeesSplit": {
+        "message": "string"
+      },
+      "swapGasFeesSponsored": {
+        "message": "string"
+      },
+      "swapGasFeesSponsoredExplanation": {
+        "message": "string"
+      },
+      "swapIncludesMMFee": {
+        "description": "string",
+        "message": "string"
+      },
+      "swapLearnMore": {
+        "message": "string"
+      },
+      "swapLiquiditySourceInfo": {
+        "message": "string"
+      },
+      "swapMaxSlippage": {
+        "message": "string"
+      },
+      "swapMetaMaskFee": {
+        "message": "string"
+      },
+      "swapMetaMaskFeeDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "swapNQuotesWithDot": {
+        "description": "string",
+        "message": "string"
+      },
+      "swapOnceTransactionHasProcess": {
+        "description": "string",
+        "message": "string"
+      },
+      "swapProcessing": {
+        "message": "string"
+      },
+      "swapQuoteDetails": {
+        "message": "string"
+      },
+      "swapQuoteSource": {
+        "message": "string"
+      },
+      "swapQuotesExpiredErrorDescription": {
+        "message": "string"
+      },
+      "swapQuotesExpiredErrorTitle": {
+        "message": "string"
+      },
+      "swapQuotesNotAvailableDescription": {
+        "message": "string"
+      },
+      "swapQuotesNotAvailableErrorDescription": {
+        "message": "string"
+      },
+      "swapQuotesNotAvailableErrorTitle": {
+        "message": "string"
+      },
+      "swapRate": {
+        "message": "string"
+      },
+      "swapReceiving": {
+        "message": "string"
+      },
+      "swapReceivingInfoTooltip": {
+        "message": "string"
+      },
+      "swapRequestForQuotation": {
+        "message": "string"
+      },
+      "swapSelect": {
+        "message": "string"
+      },
+      "swapSelectAQuote": {
+        "message": "string"
+      },
+      "swapSelectAToken": {
+        "message": "string"
+      },
+      "swapSelectQuotePopoverDescription": {
+        "message": "string"
+      },
+      "swapSelectToken": {
+        "message": "string"
+      },
+      "swapShowLatestQuotes": {
+        "message": "string"
+      },
+      "swapSlippageAutoDescription": {
+        "message": "string"
+      },
+      "swapSlippageHighDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "swapSlippageHighTitle": {
+        "message": "string"
+      },
+      "swapSlippageLowDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "swapSlippageLowTitle": {
+        "message": "string"
+      },
+      "swapSlippageNegativeDescription": {
+        "message": "string"
+      },
+      "swapSlippageNegativeTitle": {
+        "message": "string"
+      },
+      "swapSlippageOverLimitDescription": {
+        "message": "string"
+      },
+      "swapSlippageOverLimitTitle": {
+        "message": "string"
+      },
+      "swapSlippagePercent": {
+        "description": "string",
+        "message": "string"
+      },
+      "swapSlippageTooltip": {
+        "message": "string"
+      },
+      "swapSlippageZeroDescription": {
+        "message": "string"
+      },
+      "swapSlippageZeroTitle": {
+        "message": "string"
+      },
+      "swapSource": {
+        "message": "string"
+      },
+      "swapSuggestedGasSettingToolTipMessage": {
+        "message": "string"
+      },
+      "swapToConfirmWithHwWallet": {
+        "message": "string"
+      },
+      "swapTokenAvailable": {
+        "description": "string",
+        "message": "string"
+      },
+      "swapTokenNotAvailable": {
+        "message": "string"
+      },
+      "swapTokenToToken": {
+        "description": "string",
+        "message": "string"
+      },
+      "swapTokens": {
+        "message": "string"
+      },
+      "swapTransactionComplete": {
+        "message": "string"
+      },
+      "swapTwoTransactions": {
+        "message": "string"
+      },
+      "swapUnknown": {
+        "message": "string"
+      },
+      "swapValidationInsufficientGasMessage": {
+        "message": "string"
+      },
+      "swapZeroSlippage": {
+        "message": "string"
+      },
+      "swapsMaxSlippage": {
+        "message": "string"
+      },
+      "swapsViewInActivity": {
+        "message": "string"
+      },
+      "switch": {
+        "message": "string"
+      },
+      "switchBack": {
+        "message": "string"
+      },
+      "switchBackToPopup": {
+        "message": "string"
+      },
+      "switchEthereumChainConfirmationDescription": {
+        "message": "string"
+      },
+      "switchEthereumChainConfirmationTitle": {
+        "message": "string"
+      },
+      "switchNetwork": {
+        "message": "string"
+      },
+      "switchToMetaMaskDefaultRpc": {
+        "description": "string",
+        "message": "string"
+      },
+      "switchToPopup": {
+        "message": "string"
+      },
+      "switchToSidePanel": {
+        "message": "string"
+      },
+      "switchToThisAccount": {
+        "message": "string"
+      },
+      "switchingNetworksCancelsPendingConfirmations": {
+        "message": "string"
+      },
+      "symbol": {
+        "message": "string"
+      },
+      "symbolBetweenZeroTwelve": {
+        "message": "string"
+      },
+      "syncing": {
+        "message": "string"
+      },
+      "tapToReveal": {
+        "message": "string"
+      },
+      "tapToRevealNote": {
+        "message": "string"
+      },
+      "tenPercentIncreased": {
+        "message": "string"
+      },
+      "terms": {
+        "message": "string"
+      },
+      "termsOfService": {
+        "message": "string"
+      },
+      "termsOfUseAgree": {
+        "message": "string"
+      },
+      "termsOfUseAgreeText": {
+        "message": "string"
+      },
+      "termsOfUseFooterText": {
+        "message": "string"
+      },
+      "termsOfUseTitle": {
+        "message": "string"
+      },
+      "testNetworks": {
+        "message": "string"
+      },
+      "testnets": {
+        "message": "string"
+      },
+      "theme": {
+        "message": "string"
+      },
+      "themeDescription": {
+        "message": "string"
+      },
+      "thirdPartyApis": {
+        "message": "string"
+      },
+      "thirdPartyApisDescription": {
+        "message": "string"
+      },
+      "thirdPartySoftware": {
+        "description": "string",
+        "message": "string"
+      },
+      "thisContactWillBeDeleted": {
+        "message": "string"
+      },
+      "time": {
+        "message": "string"
+      },
+      "to": {
+        "message": "string"
+      },
+      "toggleDecodeDescription": {
+        "message": "string"
+      },
+      "token": {
+        "message": "string"
+      },
+      "tokenAddress": {
+        "message": "string"
+      },
+      "tokenAlreadyAdded": {
+        "message": "string"
+      },
+      "tokenAutoDetection": {
+        "message": "string"
+      },
+      "tokenContractAddress": {
+        "message": "string"
+      },
+      "tokenContractError": {
+        "message": "string"
+      },
+      "tokenContractWarning": {
+        "message": "string"
+      },
+      "tokenCount": {
+        "description": "string",
+        "message": "string"
+      },
+      "tokenDecimal": {
+        "message": "string"
+      },
+      "tokenDecimalFetchFailed": {
+        "message": "string"
+      },
+      "tokenDetails": {
+        "message": "string"
+      },
+      "tokenId": {
+        "message": "string"
+      },
+      "tokenList": {
+        "message": "string"
+      },
+      "tokenMarketplace": {
+        "message": "string"
+      },
+      "tokenPermissionCount": {
+        "description": "string",
+        "message": "string"
+      },
+      "tokenPermissionsCount": {
+        "description": "string",
+        "message": "string"
+      },
+      "tokenStandard": {
+        "message": "string"
+      },
+      "tokenStock": {
+        "message": "string"
+      },
+      "tokenStream": {
+        "message": "string"
+      },
+      "tokenSubscription": {
+        "message": "string"
+      },
+      "tokenSymbol": {
+        "message": "string"
+      },
+      "tokenTransfer": {
+        "message": "string"
+      },
+      "tokens": {
+        "message": "string"
+      },
+      "tokensCount": {
+        "description": "string",
+        "message": "string"
+      },
+      "tokensInCollection": {
+        "message": "string"
+      },
+      "tooltipSatusConnectedUpperCase": {
+        "message": "string"
+      },
+      "total": {
+        "message": "string"
+      },
+      "totalVolume": {
+        "message": "string"
+      },
+      "transaction": {
+        "message": "string"
+      },
+      "transactionConfirmed": {
+        "message": "string"
+      },
+      "transactionDataFunction": {
+        "message": "string"
+      },
+      "transactionDetailGasHeading": {
+        "message": "string"
+      },
+      "transactionError": {
+        "message": "string"
+      },
+      "transactionErrorNoContract": {
+        "message": "string"
+      },
+      "transactionFailed": {
+        "message": "string"
+      },
+      "transactionFee": {
+        "message": "string"
+      },
+      "transactionFlowNetwork": {
+        "message": "string"
+      },
+      "transactionHistoryBaseFee": {
+        "message": "string"
+      },
+      "transactionHistoryL1GasLabel": {
+        "message": "string"
+      },
+      "transactionHistoryL2GasLimitLabel": {
+        "message": "string"
+      },
+      "transactionHistoryL2GasPriceLabel": {
+        "message": "string"
+      },
+      "transactionHistoryMaxFeePerGas": {
+        "message": "string"
+      },
+      "transactionHistoryPriorityFee": {
+        "message": "string"
+      },
+      "transactionHistoryTotalGasFee": {
+        "message": "string"
+      },
+      "transactionIdLabel": {
+        "description": "string",
+        "message": "string"
+      },
+      "transactionIncludesTypes": {
+        "message": "string"
+      },
+      "transactionSettings": {
+        "message": "string"
+      },
+      "transactionShield": {
+        "message": "string"
+      },
+      "transactionSubmitted": {
+        "message": "string"
+      },
+      "transactionTotalGasFee": {
+        "description": "string",
+        "message": "string"
+      },
+      "transactions": {
+        "message": "string"
+      },
+      "transactionsAndAssets": {
+        "message": "string"
+      },
+      "transfer": {
+        "message": "string"
+      },
+      "transferCrypto": {
+        "message": "string"
+      },
+      "transferFrom": {
+        "message": "string"
+      },
+      "transferRequest": {
+        "message": "string"
+      },
+      "trezor": {
+        "description": "string",
+        "message": "string"
+      },
+      "tronBandwidth": {
+        "message": "string"
+      },
+      "tronBandwidthCoverageDescriptionPlural": {
+        "description": "string",
+        "message": "string"
+      },
+      "tronBandwidthCoverageDescriptionSingular": {
+        "message": "string"
+      },
+      "tronDailyResources": {
+        "message": "string"
+      },
+      "tronDailyResourcesDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "tronEnergy": {
+        "message": "string"
+      },
+      "tronEnergyCoverageDescriptionPlural": {
+        "description": "string",
+        "message": "string"
+      },
+      "tronEnergyCoverageDescriptionSingular": {
+        "message": "string"
+      },
+      "troubleConnectingToLedgerU2FOnFirefox": {
+        "description": "string",
+        "message": "string"
+      },
+      "troubleConnectingToLedgerU2FOnFirefox2": {
+        "description": "string",
+        "message": "string"
+      },
+      "troubleConnectingToLedgerU2FOnFirefoxLedgerSolution": {
+        "description": "string",
+        "message": "string"
+      },
+      "troubleConnectingToLedgerU2FOnFirefoxLedgerSolution2": {
+        "description": "string",
+        "message": "string"
+      },
+      "troubleConnectingToWallet": {
+        "description": "string",
+        "message": "string"
+      },
+      "troubleStartingMessage": {
+        "message": "string"
+      },
+      "troubleStartingTitle": {
+        "message": "string"
+      },
+      "trustSignalBlockDescription": {
+        "message": "string"
+      },
+      "trustSignalBlockTitle": {
+        "message": "string"
+      },
+      "trustSignalContinueAnyway": {
+        "message": "string"
+      },
+      "tryAgain": {
+        "message": "string"
+      },
+      "turnOff": {
+        "message": "string"
+      },
+      "turnOffMetamaskNotificationsError": {
+        "message": "string"
+      },
+      "turnOn": {
+        "message": "string"
+      },
+      "turnOnMetamaskNotifications": {
+        "message": "string"
+      },
+      "turnOnMetamaskNotificationsButton": {
+        "message": "string"
+      },
+      "turnOnMetamaskNotificationsError": {
+        "message": "string"
+      },
+      "turnOnMetamaskNotificationsMessageFirst": {
+        "message": "string"
+      },
+      "turnOnMetamaskNotificationsMessagePrivacyBold": {
+        "message": "string"
+      },
+      "turnOnMetamaskNotificationsMessagePrivacyLink": {
+        "message": "string"
+      },
+      "turnOnMetamaskNotificationsMessageSecond": {
+        "message": "string"
+      },
+      "turnOnMetamaskNotificationsMessageThird": {
+        "message": "string"
+      },
+      "turnOnTokenDetection": {
+        "message": "string"
+      },
+      "tutorial": {
+        "message": "string"
+      },
+      "txAlertTitle": {
+        "message": "string"
+      },
+      "typeYourSRP": {
+        "message": "string"
+      },
+      "u2f": {
+        "description": "string",
+        "message": "string"
+      },
+      "unableToConnectTo": {
+        "description": "string",
+        "message": "string"
+      },
+      "unableToDownload": {
+        "message": "string"
+      },
+      "unapproved": {
+        "message": "string"
+      },
+      "unavailable": {
+        "message": "string"
+      },
+      "unexpectedBehavior": {
+        "message": "string"
+      },
+      "unifiedSwapAllowSwappingOf": {
+        "message": "string"
+      },
+      "unifiedSwapFromTo": {
+        "description": "string",
+        "message": "string"
+      },
+      "units": {
+        "message": "string"
+      },
+      "unknown": {
+        "message": "string"
+      },
+      "unknownCollection": {
+        "message": "string"
+      },
+      "unknownNetworkForGatorPermissions": {
+        "description": "string",
+        "message": "string"
+      },
+      "unknownNetworkForKeyEntropy": {
+        "description": "string",
+        "message": "string"
+      },
+      "unknownQrCode": {
+        "message": "string"
+      },
+      "unlimited": {
+        "message": "string"
+      },
+      "unlock": {
+        "message": "string"
+      },
+      "unlockPageIncorrectPassword": {
+        "message": "string"
+      },
+      "unlockPageTooManyFailedAttempts": {
+        "message": "string"
+      },
+      "unlockToReveal": {
+        "description": "string",
+        "message": "string"
+      },
+      "unpin": {
+        "message": "string"
+      },
+      "unrecognizedChain": {
+        "description": "string",
+        "message": "string"
+      },
+      "unsendableAsset": {
+        "description": "string",
+        "message": "string"
+      },
+      "unstableTokenPriceDescription": {
+        "message": "string"
+      },
+      "unstableTokenPriceTitle": {
+        "message": "string"
+      },
+      "update": {
+        "message": "string"
+      },
+      "updateEthereumChainConfirmationDescription": {
+        "message": "string"
+      },
+      "updateInformation": {
+        "message": "string"
+      },
+      "updateNetworkConfirmationTitle": {
+        "description": "string",
+        "message": "string"
+      },
+      "updateOrEditNetworkInformations": {
+        "message": "string"
+      },
+      "updateRequest": {
+        "message": "string"
+      },
+      "updateRpc": {
+        "description": "string",
+        "message": "string"
+      },
+      "updateToTheLatestVersion": {
+        "message": "string"
+      },
+      "updatedRpcForNetworks": {
+        "message": "string"
+      },
+      "updatedToMetaMaskDefault": {
+        "description": "string",
+        "message": "string"
+      },
+      "uploadDropFile": {
+        "message": "string"
+      },
+      "uploadFile": {
+        "message": "string"
+      },
+      "urlErrorMsg": {
+        "message": "string"
+      },
+      "urlUnknown": {
+        "message": "string"
+      },
+      "use4ByteResolution": {
+        "message": "string"
+      },
+      "useDifferentLoginMethod": {
+        "message": "string"
+      },
+      "useMultiAccountBalanceChecker": {
+        "message": "string"
+      },
+      "useMultiAccountBalanceCheckerSettingDescription": {
+        "message": "string"
+      },
+      "useMultiAccountBalanceCheckerSettingDescriptionV2": {
+        "message": "string"
+      },
+      "useNftDetection": {
+        "message": "string"
+      },
+      "useNftDetectionDescription": {
+        "message": "string"
+      },
+      "useNftDetectionDescriptionText": {
+        "message": "string"
+      },
+      "usePhishingDetection": {
+        "message": "string"
+      },
+      "usePhishingDetectionDescription": {
+        "message": "string"
+      },
+      "useSafeChainsListValidation": {
+        "message": "string"
+      },
+      "useSafeChainsListValidationDescription": {
+        "message": "string"
+      },
+      "useSafeChainsListValidationDescriptionV2": {
+        "message": "string"
+      },
+      "useSafeChainsListValidationWebsite": {
+        "description": "string",
+        "message": "string"
+      },
+      "useTokenDetectionPrivacyDesc": {
+        "message": "string"
+      },
+      "usedByClients": {
+        "message": "string"
+      },
+      "userOpContractDeployError": {
+        "message": "string"
+      },
+      "value": {
+        "message": "string"
+      },
+      "version": {
+        "message": "string"
+      },
+      "view": {
+        "message": "string"
+      },
+      "viewActivity": {
+        "message": "string"
+      },
+      "viewAddressOnExplorer": {
+        "description": "string",
+        "message": "string"
+      },
+      "viewDetails": {
+        "message": "string"
+      },
+      "viewOnBlockExplorer": {
+        "message": "string"
+      },
+      "viewOnCustomBlockExplorer": {
+        "description": "string",
+        "message": "string"
+      },
+      "viewOnEtherscan": {
+        "description": "string",
+        "message": "string"
+      },
+      "viewOnExplorer": {
+        "message": "string"
+      },
+      "viewOnOpensea": {
+        "message": "string"
+      },
+      "viewTokenDetails": {
+        "message": "string"
+      },
+      "viewTransaction": {
+        "message": "string"
+      },
+      "viewinExplorer": {
+        "description": "string",
+        "message": "string"
+      },
+      "visitSite": {
+        "message": "string"
+      },
+      "visitSupportDataConsentModalAccept": {
+        "message": "string"
+      },
+      "visitSupportDataConsentModalDescription": {
+        "message": "string"
+      },
+      "visitSupportDataConsentModalReject": {
+        "message": "string"
+      },
+      "visitSupportDataConsentModalTitle": {
+        "message": "string"
+      },
+      "visitWebSite": {
+        "message": "string"
+      },
+      "volume": {
+        "message": "string"
+      },
+      "wallet": {
+        "message": "string"
+      },
+      "walletConnectionGuide": {
+        "message": "string"
+      },
+      "walletName": {
+        "message": "string"
+      },
+      "walletReadyLearn": {
+        "description": "string",
+        "message": "string"
+      },
+      "walletReadyLoseSrp": {
+        "message": "string"
+      },
+      "walletReadyLoseSrpFromReminder": {
+        "message": "string"
+      },
+      "wantToAddThisNetwork": {
+        "message": "string"
+      },
+      "wantsToAddThisAsset": {
+        "message": "string"
+      },
+      "warning": {
+        "message": "string"
+      },
+      "warningFromSnap": {
+        "description": "string",
+        "message": "string"
+      },
+      "watchEthereumAccountsDescription": {
+        "description": "string",
+        "message": "string"
+      },
+      "watchEthereumAccountsToggle": {
+        "message": "string"
+      },
+      "watchOutMessage": {
+        "description": "string",
+        "message": "string"
+      },
+      "web3": {
+        "message": "string"
+      },
+      "web3ShimUsageNotification": {
+        "description": "string",
+        "message": "string"
+      },
+      "webhid": {
+        "description": "string",
+        "message": "string"
+      },
+      "websites": {
+        "description": "string",
+        "message": "string"
+      },
+      "weekly": {
+        "message": "string"
+      },
+      "welcomeBack": {
+        "message": "string"
+      },
+      "whatsThis": {
+        "message": "string"
+      },
+      "willApproveAmountForBridging": {
+        "message": "string"
+      },
+      "willApproveAmountForSwapping": {
+        "message": "string"
+      },
+      "withdrawing": {
+        "message": "string"
+      },
+      "wrongNetworkName": {
+        "message": "string"
+      },
+      "wrongPassword": {
+        "description": "string",
+        "message": "string"
+      },
+      "year": {
+        "message": "string"
+      },
+      "yes": {
+        "message": "string"
+      },
+      "you": {
+        "message": "string"
+      },
+      "youApprove": {
+        "message": "string"
+      },
+      "youNeedToAllowCameraAccess": {
+        "message": "string"
+      },
+      "youReceived": {
+        "description": "string",
+        "message": "string"
+      },
+      "youSent": {
+        "description": "string",
+        "message": "string"
+      },
+      "yourActivity": {
+        "message": "string"
+      },
+      "yourBalance": {
+        "message": "string"
+      },
+      "yourNFTmayBeAtRisk": {
+        "message": "string"
+      },
+      "yourWalletIsReady": {
+        "message": "string"
+      },
+      "yourWalletIsReadyFromReminder": {
+        "message": "string"
+      }
+    }
+  },
   "logs": [],
   "metamask": {
     "accountGroupsMetadata": {
-      "entropy:01K98E0QDS4HYMTRJ5WHZ73ZWJ/0": {
+      "entropy:01KGPGYE2JJGMXDJPEVXKPJ1JG/0": {
+        "hidden": {
+          "lastUpdatedAt": "number",
+          "value": "boolean"
+        },
+        "lastSelected": "number",
         "name": {
-          "value": "string",
-          "lastUpdatedAt": "number"
+          "lastUpdatedAt": "number",
+          "value": "string"
         },
         "pinned": {
-          "value": "boolean",
-          "lastUpdatedAt": "number"
-        },
-        "hidden": {
-          "value": "boolean",
-          "lastUpdatedAt": "number"
-        },
-        "lastSelected": "number"
+          "lastUpdatedAt": "number",
+          "value": "boolean"
+        }
       }
     },
     "accountIdByAddress": {
-      "*": "string"
-    },
-    "accountsAssets": {
-      "<solana-account-1>": ["string"],
-      "<bitcoin-account-1>": ["string"],
-      "<tron-account-1>": ["string"]
+      "0x5cfe73b6021e818b776b421b1c4db2474086a7e1": "string",
+      "4tE76eixEgyJDrdykdWJR1XBkzUk4cLMvqjR2xVJUxer": "string",
+      "TJ3QZbBREK1Xybe1jf4nR9Attb8i54vGS3": "string",
+      "bc1qg6whd6pc0cguh6gpp3ewujm53hv32ta9hdp252": "string"
     },
     "accountState": "null",
+    "accountTree": {
+      "wallets": {
+        "entropy:01KGPGYE2JJGMXDJPEVXKPJ1JG": {
+          "groups": {
+            "entropy:01KGPGYE2JJGMXDJPEVXKPJ1JG/0": {
+              "accounts": [
+                "string"
+              ],
+              "id": "string",
+              "metadata": {
+                "entropy": {
+                  "groupIndex": "number"
+                },
+                "hidden": "boolean",
+                "lastSelected": "number",
+                "name": "string",
+                "pinned": "boolean"
+              },
+              "type": "string"
+            }
+          },
+          "id": "string",
+          "metadata": {
+            "entropy": {
+              "id": "string"
+            },
+            "name": "string"
+          },
+          "status": "string",
+          "type": "string"
+        }
+      }
+    },
+    "accountWalletsMetadata": {},
+    "accountsAssets": {
+      "<bitcoin-account-1>": [
+        "string"
+      ],
+      "<solana-account-1>": [
+        "string"
+      ],
+      "<tron-account-1>": [
+        "string"
+      ]
+    },
     "accountsByChainId": {
       "0x1": {
         "0x5CfE73b6021E818B776b421B1c4Db2474086a7e1": {
@@ -239,49 +19541,12 @@
         }
       }
     },
-    "accountTree": {
-      "wallets": {
-        "entropy:01K98E0QDS4HYMTRJ5WHZ73ZWJ": {
-          "type": "string",
-          "id": "string",
-          "metadata": {
-            "name": "string",
-            "entropy": {
-              "id": "string"
-            }
-          },
-          "status": "string",
-          "groups": {
-            "entropy:01K98E0QDS4HYMTRJ5WHZ73ZWJ/0": {
-              "type": "string",
-              "id": "string",
-              "metadata": {
-                "name": "string",
-                "pinned": "boolean",
-                "hidden": "boolean",
-                "entropy": {
-                  "groupIndex": "number"
-                },
-                "lastSelected": "number"
-              },
-              "accounts": [
-                "d5e45e4a-3b04-4a09-a5e1-39762e5c6be4",
-                "<solana-account-1>",
-                "<bitcoin-account-1>",
-                "<tron-account-1>"
-              ]
-            }
-          }
-        }
-      }
-    },
-    "accountWalletsMetadata": {},
     "activeProvider": "string",
     "activeQrCodeScanRequest": "null",
+    "addSnapAccountEnabled": "boolean",
     "addressBook": {},
     "addressScanCache": {},
     "addressSecurityAlertResponses": {},
-    "addSnapAccountEnabled": "boolean",
     "advancedGasFee": {},
     "alertEnabledness": {
       "smartTransactionsMigration": "boolean",
@@ -299,309 +19564,388 @@
     "allNfts": {},
     "allTokens": {},
     "announcements": {},
-    "appActiveTab": {
-      "favIconUrl": "null",
-      "host": "string",
-      "href": "string",
-      "id": "number",
-      "origin": "string",
-      "protocol": "string",
-      "title": "string",
-      "url": "string"
-    },
     "approvalFlows": [],
     "assetExchangeRates": {},
-    "assetsMetadata": {
-      "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501": {
+    "assetPreferences": {},
+    "assetsBalance": {
+      "688e01b8-3134-4ef4-80e6-8772bab38ef7": {
+        "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501": {
+          "amount": "string"
+        }
+      },
+      "d5e45e4a-3b04-4a09-a5e1-39762e5c6be4": {
+        "eip155:1337/slip44:1": {
+          "amount": "string"
+        }
+      }
+    },
+    "assetsInfo": {
+      "eip155:1/slip44:60": {
+        "decimals": "number",
         "name": "string",
         "symbol": "string",
+        "type": "string"
+      },
+      "eip155:10/slip44:60": {
+        "aggregators": [],
+        "decimals": "number",
+        "image": "string",
+        "name": "string",
+        "symbol": "string",
+        "type": "string"
+      },
+      "eip155:1337/slip44:1": {
+        "decimals": "number",
+        "name": "string",
+        "symbol": "string",
+        "type": "string"
+      },
+      "eip155:42161/slip44:60": {
+        "aggregators": [],
+        "decimals": "number",
+        "image": "string",
+        "name": "string",
+        "symbol": "string",
+        "type": "string"
+      },
+      "eip155:59144/slip44:60": {
+        "aggregators": [],
+        "decimals": "number",
+        "image": "string",
+        "name": "string",
+        "symbol": "string",
+        "type": "string"
+      },
+      "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501": {
+        "decimals": "number",
+        "image": "string",
+        "name": "string",
+        "symbol": "string",
+        "type": "string"
+      }
+    },
+    "assetsMetadata": {
+      "bip122:000000000019d6689c085ae165831e93/slip44:0": {
         "fungible": "boolean",
         "iconUrl": "string",
+        "name": "string",
+        "symbol": "string",
         "units": [
           {
+            "decimals": "number",
             "name": "string",
-            "symbol": "string",
-            "decimals": "number"
+            "symbol": "string"
+          }
+        ]
+      },
+      "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501": {
+        "fungible": "boolean",
+        "iconUrl": "string",
+        "name": "string",
+        "symbol": "string",
+        "units": [
+          {
+            "decimals": "number",
+            "name": "string",
+            "symbol": "string"
           }
         ]
       },
       "tron:728126428/slip44:195": {
-        "name": "string",
-        "symbol": "string",
         "fungible": "boolean",
         "iconUrl": "string",
-        "units": [
-          {
-            "name": "string",
-            "symbol": "string",
-            "decimals": "number"
-          }
-        ]
-      },
-      "tron:728126428/slip44:195-staked-for-bandwidth": {
         "name": "string",
         "symbol": "string",
-        "fungible": "boolean",
-        "iconUrl": "string",
         "units": [
           {
+            "decimals": "number",
             "name": "string",
-            "symbol": "string",
-            "decimals": "number"
-          }
-        ]
-      },
-      "tron:728126428/slip44:195-staked-for-energy": {
-        "name": "string",
-        "symbol": "string",
-        "fungible": "boolean",
-        "iconUrl": "string",
-        "units": [
-          {
-            "name": "string",
-            "symbol": "string",
-            "decimals": "number"
-          }
-        ]
-      },
-      "tron:728126428/slip44:195-ready-for-withdrawal": {
-        "name": "string",
-        "symbol": "string",
-        "fungible": "boolean",
-        "iconUrl": "string",
-        "units": [
-          {
-            "name": "string",
-            "symbol": "string",
-            "decimals": "number"
+            "symbol": "string"
           }
         ]
       },
       "tron:728126428/slip44:195-in-lock-period": {
-        "name": "string",
-        "symbol": "string",
         "fungible": "boolean",
         "iconUrl": "string",
+        "name": "string",
+        "symbol": "string",
         "units": [
           {
+            "decimals": "number",
             "name": "string",
-            "symbol": "string",
-            "decimals": "number"
+            "symbol": "string"
+          }
+        ]
+      },
+      "tron:728126428/slip44:195-ready-for-withdrawal": {
+        "fungible": "boolean",
+        "iconUrl": "string",
+        "name": "string",
+        "symbol": "string",
+        "units": [
+          {
+            "decimals": "number",
+            "name": "string",
+            "symbol": "string"
+          }
+        ]
+      },
+      "tron:728126428/slip44:195-staked-for-bandwidth": {
+        "fungible": "boolean",
+        "iconUrl": "string",
+        "name": "string",
+        "symbol": "string",
+        "units": [
+          {
+            "decimals": "number",
+            "name": "string",
+            "symbol": "string"
+          }
+        ]
+      },
+      "tron:728126428/slip44:195-staked-for-energy": {
+        "fungible": "boolean",
+        "iconUrl": "string",
+        "name": "string",
+        "symbol": "string",
+        "units": [
+          {
+            "decimals": "number",
+            "name": "string",
+            "symbol": "string"
           }
         ]
       },
       "tron:728126428/slip44:195-staking-rewards": {
-        "name": "string",
-        "symbol": "string",
         "fungible": "boolean",
         "iconUrl": "string",
-        "units": [
-          {
-            "name": "string",
-            "symbol": "string",
-            "decimals": "number"
-          }
-        ]
-      },
-      "tron:728126428/slip44:energy": {
         "name": "string",
         "symbol": "string",
-        "fungible": "boolean",
-        "iconUrl": "string",
         "units": [
           {
+            "decimals": "number",
             "name": "string",
-            "symbol": "string",
-            "decimals": "number"
-          }
-        ]
-      },
-      "tron:728126428/slip44:maximum-energy": {
-        "name": "string",
-        "symbol": "string",
-        "fungible": "boolean",
-        "iconUrl": "string",
-        "units": [
-          {
-            "name": "string",
-            "symbol": "string",
-            "decimals": "number"
+            "symbol": "string"
           }
         ]
       },
       "tron:728126428/slip44:bandwidth": {
-        "name": "string",
-        "symbol": "string",
         "fungible": "boolean",
         "iconUrl": "string",
+        "name": "string",
+        "symbol": "string",
         "units": [
           {
+            "decimals": "number",
             "name": "string",
-            "symbol": "string",
-            "decimals": "number"
+            "symbol": "string"
+          }
+        ]
+      },
+      "tron:728126428/slip44:energy": {
+        "fungible": "boolean",
+        "iconUrl": "string",
+        "name": "string",
+        "symbol": "string",
+        "units": [
+          {
+            "decimals": "number",
+            "name": "string",
+            "symbol": "string"
           }
         ]
       },
       "tron:728126428/slip44:maximum-bandwidth": {
-        "name": "string",
-        "symbol": "string",
         "fungible": "boolean",
         "iconUrl": "string",
+        "name": "string",
+        "symbol": "string",
         "units": [
           {
+            "decimals": "number",
             "name": "string",
-            "symbol": "string",
-            "decimals": "number"
+            "symbol": "string"
           }
         ]
       },
-      "bip122:000000000019d6689c085ae165831e93/slip44:0": {
-        "name": "string",
-        "symbol": "string",
+      "tron:728126428/slip44:maximum-energy": {
         "fungible": "boolean",
         "iconUrl": "string",
+        "name": "string",
+        "symbol": "string",
         "units": [
           {
+            "decimals": "number",
             "name": "string",
-            "symbol": "string",
-            "decimals": "number"
+            "symbol": "string"
           }
         ]
       }
     },
+    "assetsPrice": {
+      "eip155:1/slip44:60": {
+        "assetPriceType": "string",
+        "dilutedMarketCap": "number",
+        "id": "string",
+        "lastUpdated": "number",
+        "marketCap": "number",
+        "price": "number",
+        "pricePercentChange1d": "number",
+        "totalVolume": "number",
+        "usdPrice": "number"
+      },
+      "eip155:1337/slip44:1": {
+        "assetPriceType": "string",
+        "id": "string",
+        "price": "number",
+        "usdPrice": "number"
+      },
+      "eip155:42161/slip44:60": {
+        "assetPriceType": "string",
+        "id": "string",
+        "price": "number",
+        "usdPrice": "number"
+      },
+      "eip155:59144/slip44:60": {
+        "assetPriceType": "string",
+        "id": "string",
+        "price": "number",
+        "usdPrice": "number"
+      }
+    },
     "balances": {
+      "<bitcoin-account-1>": {
+        "bip122:000000000019d6689c085ae165831e93/slip44:0": {
+          "amount": "string",
+          "unit": "string"
+        }
+      },
       "<solana-account-1>": {
         "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501": {
-          "unit": "string",
-          "amount": "string"
+          "amount": "string",
+          "unit": "string"
         }
       },
       "<tron-account-1>": {
-        "tron:728126428/slip44:195": {
-          "unit": "string",
-          "amount": "string"
-        },
-        "tron:3448148188/slip44:195": {
-          "unit": "string",
-          "amount": "string"
-        },
         "tron:2494104990/slip44:195": {
-          "unit": "string",
-          "amount": "string"
-        },
-        "tron:728126428/slip44:195-staked-for-bandwidth": {
-          "unit": "string",
-          "amount": "string"
-        },
-        "tron:3448148188/slip44:195-staked-for-bandwidth": {
-          "unit": "string",
-          "amount": "string"
-        },
-        "tron:2494104990/slip44:195-staked-for-bandwidth": {
-          "unit": "string",
-          "amount": "string"
-        },
-        "tron:728126428/slip44:195-staked-for-energy": {
-          "unit": "string",
-          "amount": "string"
-        },
-        "tron:3448148188/slip44:195-staked-for-energy": {
-          "unit": "string",
-          "amount": "string"
-        },
-        "tron:2494104990/slip44:195-staked-for-energy": {
-          "unit": "string",
-          "amount": "string"
-        },
-        "tron:728126428/slip44:195-ready-for-withdrawal": {
-          "unit": "string",
-          "amount": "string"
-        },
-        "tron:3448148188/slip44:195-ready-for-withdrawal": {
-          "unit": "string",
-          "amount": "string"
-        },
-        "tron:2494104990/slip44:195-ready-for-withdrawal": {
-          "unit": "string",
-          "amount": "string"
-        },
-        "tron:728126428/slip44:195-staking-rewards": {
-          "unit": "string",
-          "amount": "string"
-        },
-        "tron:3448148188/slip44:195-staking-rewards": {
-          "unit": "string",
-          "amount": "string"
-        },
-        "tron:2494104990/slip44:195-staking-rewards": {
-          "unit": "string",
-          "amount": "string"
-        },
-        "tron:728126428/slip44:195-in-lock-period": {
-          "unit": "string",
-          "amount": "string"
-        },
-        "tron:3448148188/slip44:195-in-lock-period": {
-          "unit": "string",
-          "amount": "string"
+          "amount": "string",
+          "unit": "string"
         },
         "tron:2494104990/slip44:195-in-lock-period": {
-          "unit": "string",
-          "amount": "string"
+          "amount": "string",
+          "unit": "string"
         },
-        "tron:728126428/slip44:energy": {
-          "unit": "string",
-          "amount": "string"
+        "tron:2494104990/slip44:195-ready-for-withdrawal": {
+          "amount": "string",
+          "unit": "string"
         },
-        "tron:3448148188/slip44:energy": {
-          "unit": "string",
-          "amount": "string"
+        "tron:2494104990/slip44:195-staked-for-bandwidth": {
+          "amount": "string",
+          "unit": "string"
         },
-        "tron:2494104990/slip44:energy": {
-          "unit": "string",
-          "amount": "string"
+        "tron:2494104990/slip44:195-staked-for-energy": {
+          "amount": "string",
+          "unit": "string"
         },
-        "tron:728126428/slip44:maximum-energy": {
-          "unit": "string",
-          "amount": "string"
-        },
-        "tron:3448148188/slip44:maximum-energy": {
-          "unit": "string",
-          "amount": "string"
-        },
-        "tron:2494104990/slip44:maximum-energy": {
-          "unit": "string",
-          "amount": "string"
-        },
-        "tron:728126428/slip44:bandwidth": {
-          "unit": "string",
-          "amount": "string"
-        },
-        "tron:3448148188/slip44:bandwidth": {
-          "unit": "string",
-          "amount": "string"
+        "tron:2494104990/slip44:195-staking-rewards": {
+          "amount": "string",
+          "unit": "string"
         },
         "tron:2494104990/slip44:bandwidth": {
-          "unit": "string",
-          "amount": "string"
+          "amount": "string",
+          "unit": "string"
         },
-        "tron:728126428/slip44:maximum-bandwidth": {
-          "unit": "string",
-          "amount": "string"
-        },
-        "tron:3448148188/slip44:maximum-bandwidth": {
-          "unit": "string",
-          "amount": "string"
+        "tron:2494104990/slip44:energy": {
+          "amount": "string",
+          "unit": "string"
         },
         "tron:2494104990/slip44:maximum-bandwidth": {
-          "unit": "string",
-          "amount": "string"
-        }
-      },
-      "<bitcoin-account-1>": {
-        "bip122:000000000019d6689c085ae165831e93/slip44:0": {
-          "unit": "string",
-          "amount": "string"
+          "amount": "string",
+          "unit": "string"
+        },
+        "tron:2494104990/slip44:maximum-energy": {
+          "amount": "string",
+          "unit": "string"
+        },
+        "tron:3448148188/slip44:195": {
+          "amount": "string",
+          "unit": "string"
+        },
+        "tron:3448148188/slip44:195-in-lock-period": {
+          "amount": "string",
+          "unit": "string"
+        },
+        "tron:3448148188/slip44:195-ready-for-withdrawal": {
+          "amount": "string",
+          "unit": "string"
+        },
+        "tron:3448148188/slip44:195-staked-for-bandwidth": {
+          "amount": "string",
+          "unit": "string"
+        },
+        "tron:3448148188/slip44:195-staked-for-energy": {
+          "amount": "string",
+          "unit": "string"
+        },
+        "tron:3448148188/slip44:195-staking-rewards": {
+          "amount": "string",
+          "unit": "string"
+        },
+        "tron:3448148188/slip44:bandwidth": {
+          "amount": "string",
+          "unit": "string"
+        },
+        "tron:3448148188/slip44:energy": {
+          "amount": "string",
+          "unit": "string"
+        },
+        "tron:3448148188/slip44:maximum-bandwidth": {
+          "amount": "string",
+          "unit": "string"
+        },
+        "tron:3448148188/slip44:maximum-energy": {
+          "amount": "string",
+          "unit": "string"
+        },
+        "tron:728126428/slip44:195": {
+          "amount": "string",
+          "unit": "string"
+        },
+        "tron:728126428/slip44:195-in-lock-period": {
+          "amount": "string",
+          "unit": "string"
+        },
+        "tron:728126428/slip44:195-ready-for-withdrawal": {
+          "amount": "string",
+          "unit": "string"
+        },
+        "tron:728126428/slip44:195-staked-for-bandwidth": {
+          "amount": "string",
+          "unit": "string"
+        },
+        "tron:728126428/slip44:195-staked-for-energy": {
+          "amount": "string",
+          "unit": "string"
+        },
+        "tron:728126428/slip44:195-staking-rewards": {
+          "amount": "string",
+          "unit": "string"
+        },
+        "tron:728126428/slip44:bandwidth": {
+          "amount": "string",
+          "unit": "string"
+        },
+        "tron:728126428/slip44:energy": {
+          "amount": "string",
+          "unit": "string"
+        },
+        "tron:728126428/slip44:maximum-bandwidth": {
+          "amount": "string",
+          "unit": "string"
+        },
+        "tron:728126428/slip44:maximum-energy": {
+          "amount": "string",
+          "unit": "string"
         }
       }
     },
@@ -609,44 +19953,64 @@
       "browser": "string",
       "os": "string"
     },
-    "cachedMarketDataByProvider": "object",
-    "cachedUserDataByProvider": "object",
     "cacheTimestamp": "number",
+    "cachedMarketDataByProvider": {},
+    "cachedUserDataByProvider": {},
     "canTrackWalletFundsObtained": "boolean",
     "claims": [],
     "claimsConfigurations": {
-      "supportedNetworks": ["string"],
+      "supportedNetworks": [
+        "string"
+      ],
       "validSubmissionWindowDays": "number"
     },
     "completedOnboarding": "boolean",
     "connectedStatusPopoverHasBeenShown": "boolean",
     "connectivityStatus": "string",
-    "conversionRates": {},
+    "conversionRates": {
+      "bip122:000000000019d6689c085ae165831e93/slip44:0": {
+        "conversionTime": "number",
+        "currency": "string",
+        "expirationTime": "number",
+        "marketData": {
+          "allTimeHigh": "string",
+          "allTimeLow": "string",
+          "circulatingSupply": "string",
+          "fungible": "boolean",
+          "marketCap": "string",
+          "pricePercentChange": {
+            "P14D": "number",
+            "P1D": "number",
+            "P1Y": "number",
+            "P200D": "number",
+            "P30D": "number",
+            "P7D": "number",
+            "PT1H": "number"
+          },
+          "totalVolume": "string"
+        },
+        "rate": "string"
+      }
+    },
     "coverageResults": {},
-    "cryptocurrencies": ["string"],
+    "cryptocurrencies": [
+      "string"
+    ],
     "currencyRates": {
-      "BNB": {
-        "conversionDate": "null",
-        "conversionRate": "null",
-        "usdConversionRate": "null"
-      },
       "ETH": {
-        "conversionDate": "number",
-        "conversionRate": "number",
-        "usdConversionRate": "number"
-      },
-      "POL": {
         "conversionDate": "null",
-        "conversionRate": "null",
+        "conversionRate": "number",
         "usdConversionRate": "null"
       }
     },
     "currentAppVersion": "string",
     "currentCurrency": "string",
     "currentExtensionPopupId": "number",
-    "dappSwapComparisonData": {},
     "currentLocale": "string",
     "currentMigrationVersion": "number",
+    "customAssets": {},
+    "dappSwapComparisonData": {},
+    "dataCollectionForMarketing": "boolean",
     "database": {
       "blockedSnaps": [
         {
@@ -654,17 +20018,5409 @@
           "versionRange": "string"
         }
       ],
-      "verifiedSnaps": {}
+      "verifiedSnaps": {
+        "npm:0xname-resolver-snap": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            }
+          },
+          "versions": {
+            "0.1.2": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@0sum/pepu-snap": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string"
+            }
+          },
+          "versions": {
+            "0.1.5": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@aeternity-snap/plugin": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.0.9": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@algorandfoundation/algorand-metamask-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string"
+            }
+          },
+          "versions": {
+            "10.0.2": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@amax/amaxsnap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.0.5": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@ans-abstract-name-service/ans-snap": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "knowledgeBase": "string"
+            }
+          },
+          "versions": {
+            "0.1.3": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@ardata-tech/qubic-wallet": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "1.0.7": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@astar-network/snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.9.1": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@avail-project/avail-snap": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "1.0.8": {
+              "checksum": "string"
+            },
+            "1.1.0": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@bitfinding/unblind-second-factor-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.3.0": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@bitpandacustody/trust-vault-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.1.11": {
+              "checksum": "string"
+            },
+            "1.0.0": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@blockchain-lab-um/masca": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "1.2.2": {
+              "checksum": "string"
+            },
+            "1.3.0": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@bobanetwork/snap-account-abstraction-keyring-hc": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "1.1.19": {
+              "checksum": "string"
+            },
+            "1.1.22": {
+              "checksum": "string"
+            },
+            "1.1.26": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@celestials-id/celestials-snap": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "1.0.2": {
+              "checksum": "string"
+            },
+            "1.1.0": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@chainsafe/aleo-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string"
+            }
+          },
+          "versions": {
+            "1.2.0": {
+              "checksum": "string"
+            },
+            "1.2.2": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@chainsafe/polkadot-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.11.3": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@chainsafe/webzjs-zcash-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.2.4": {
+              "checksum": "string"
+            },
+            "0.2.6": {
+              "checksum": "string"
+            },
+            "0.3.0": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@clustersxyz/metamask-snap": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.1.0": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@colabs-dev/name-resolver": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            }
+          },
+          "versions": {
+            "0.3.6": {
+              "checksum": "string"
+            },
+            "0.3.7": {
+              "checksum": "string"
+            },
+            "0.3.8": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@consensys/starknet-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "3.1.0-staging": {
+              "checksum": "string"
+            },
+            "4.2.0": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@cosmsnap/snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.1.20": {
+              "checksum": "string"
+            },
+            "0.1.22": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@coti-io/coti-snap": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "1.0.19-8ac5b7": {
+              "checksum": "string"
+            },
+            "1.0.46-0a9f13": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@cubist-labs/cubesigner-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.2.13": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@cypher-laboratory/alicesring-snap": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string"
+            }
+          },
+          "versions": {
+            "0.3.10": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@d3-inc/d3connect-snap": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "knowledgeBase": "string"
+            }
+          },
+          "versions": {
+            "0.3.3": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@doggyfi-official/kobosu": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.1.10": {
+              "checksum": "string"
+            },
+            "0.1.9": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@dotmundo-io/dotmundo-resolution-snap": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "1.0.4": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@drift-labs/snap-solana": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.2.1": {
+              "checksum": "string"
+            },
+            "0.2.3": {
+              "checksum": "string"
+            },
+            "0.3.0": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@enjin-io/snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.1.2": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@ethereum-attestation-service/eas-metamask-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            }
+          },
+          "versions": {
+            "0.1.6": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@fioprotocol/fio-wallet-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "1.0.2": {
+              "checksum": "string"
+            },
+            "1.1.1": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@fort-major/msq": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.3.4": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@galactica-net/snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "1.0.3": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@gobob/bob-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "2.0.11": {
+              "checksum": "string"
+            },
+            "2.2.1": {
+              "checksum": "string"
+            },
+            "2.2.2": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@goplus/riskdetect-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.1.8": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@greymass/eos-wallet": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "1.1.0": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@hashgraph/hedera-identify-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.2.1": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@hashgraph/hedera-wallet-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.6.2": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@hathor/snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "knowledgeBase": "string"
+            }
+          },
+          "versions": {
+            "0.4.2": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@hiveio/metamask-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "1.6.0": {
+              "checksum": "string"
+            },
+            "1.7.0": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@hivemindhq/snap": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "knowledgeBase": "string"
+            }
+          },
+          "versions": {
+            "1.2.4": {
+              "checksum": "string"
+            },
+            "1.3.1": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@idriss-crypto/snap": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string"
+            }
+          },
+          "versions": {
+            "0.1.2": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@kleros/scout-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "1.3.9": {
+              "checksum": "string"
+            },
+            "1.4.1": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@kunalabs-io/sui-metamask-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "1.0.1": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@l3mbda/metamask-snap": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "1.0.4": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@leapwallet/metamask-cosmos-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.1.17": {
+              "checksum": "string"
+            },
+            "0.1.18": {
+              "checksum": "string"
+            },
+            "0.1.21": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@liquidlink-lab/iota-metamask-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.0.14": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@massalabs/metamask-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            }
+          },
+          "versions": {
+            "1.2.1": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@mendi-finance/alert-snap": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "1.0.1": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@metamask/background-events-example-snap": {
+          "id": "string",
+          "metadata": {
+            "hidden": "boolean",
+            "name": "string"
+          },
+          "versions": {
+            "1.0.0": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@metamask/bip32-example-snap": {
+          "id": "string",
+          "metadata": {
+            "hidden": "boolean",
+            "name": "string"
+          },
+          "versions": {
+            "0.35.0-flask.1": {
+              "checksum": "string"
+            },
+            "0.35.2-flask.1": {
+              "checksum": "string"
+            },
+            "0.37.2-flask.1": {
+              "checksum": "string"
+            },
+            "0.37.3-flask.1": {
+              "checksum": "string"
+            },
+            "1.0.0": {
+              "checksum": "string"
+            },
+            "2.0.1": {
+              "checksum": "string"
+            },
+            "2.1.0": {
+              "checksum": "string"
+            },
+            "2.1.1": {
+              "checksum": "string"
+            },
+            "2.1.2": {
+              "checksum": "string"
+            },
+            "2.2.0": {
+              "checksum": "string"
+            },
+            "2.2.1": {
+              "checksum": "string"
+            },
+            "2.3.0": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@metamask/bip44-example-snap": {
+          "id": "string",
+          "metadata": {
+            "hidden": "boolean",
+            "name": "string"
+          },
+          "versions": {
+            "0.37.2-flask.1": {
+              "checksum": "string"
+            },
+            "0.38.0-flask.1": {
+              "checksum": "string"
+            },
+            "0.38.1-flask.1": {
+              "checksum": "string"
+            },
+            "1.0.0": {
+              "checksum": "string"
+            },
+            "2.0.1": {
+              "checksum": "string"
+            },
+            "2.1.0": {
+              "checksum": "string"
+            },
+            "2.1.1": {
+              "checksum": "string"
+            },
+            "2.1.2": {
+              "checksum": "string"
+            },
+            "2.1.3": {
+              "checksum": "string"
+            },
+            "2.2.0": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@metamask/bitcoin-wallet-snap": {
+          "id": "string",
+          "metadata": {
+            "hidden": "boolean",
+            "name": "string"
+          },
+          "versions": {
+            "1.8.0": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@metamask/client-status-example-snap": {
+          "id": "string",
+          "metadata": {
+            "hidden": "boolean",
+            "name": "string"
+          },
+          "versions": {
+            "1.0.1": {
+              "checksum": "string"
+            },
+            "1.0.2": {
+              "checksum": "string"
+            },
+            "1.0.3": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@metamask/cronjob-duration-example-snap": {
+          "id": "string",
+          "metadata": {
+            "hidden": "boolean",
+            "name": "string"
+          },
+          "versions": {
+            "1.0.0": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@metamask/cronjob-example-snap": {
+          "id": "string",
+          "metadata": {
+            "hidden": "boolean",
+            "name": "string"
+          },
+          "versions": {
+            "0.37.2-flask.1": {
+              "checksum": "string"
+            },
+            "0.38.0-flask.1": {
+              "checksum": "string"
+            },
+            "0.38.1-flask.1": {
+              "checksum": "string"
+            },
+            "1.0.0": {
+              "checksum": "string"
+            },
+            "2.0.1": {
+              "checksum": "string"
+            },
+            "2.1.0": {
+              "checksum": "string"
+            },
+            "2.1.1": {
+              "checksum": "string"
+            },
+            "2.1.3": {
+              "checksum": "string"
+            },
+            "2.1.4": {
+              "checksum": "string"
+            },
+            "2.2.0": {
+              "checksum": "string"
+            },
+            "3.0.0": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@metamask/dialog-example-snap": {
+          "id": "string",
+          "metadata": {
+            "hidden": "boolean",
+            "name": "string"
+          },
+          "versions": {
+            "0.37.2-flask.1": {
+              "checksum": "string"
+            },
+            "0.38.0-flask.1": {
+              "checksum": "string"
+            },
+            "0.38.1-flask.1": {
+              "checksum": "string"
+            },
+            "1.0.0": {
+              "checksum": "string"
+            },
+            "2.0.1": {
+              "checksum": "string"
+            },
+            "2.1.0": {
+              "checksum": "string"
+            },
+            "2.2.0": {
+              "checksum": "string"
+            },
+            "2.2.1": {
+              "checksum": "string"
+            },
+            "2.3.0": {
+              "checksum": "string"
+            },
+            "2.3.1": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@metamask/error-example-snap": {
+          "id": "string",
+          "metadata": {
+            "hidden": "boolean",
+            "name": "string"
+          },
+          "versions": {
+            "0.37.2-flask.1": {
+              "checksum": "string"
+            },
+            "0.38.0-flask.1": {
+              "checksum": "string"
+            },
+            "0.38.1-flask.1": {
+              "checksum": "string"
+            },
+            "1.0.0": {
+              "checksum": "string"
+            },
+            "2.0.1": {
+              "checksum": "string"
+            },
+            "2.1.0": {
+              "checksum": "string"
+            },
+            "2.1.1": {
+              "checksum": "string"
+            },
+            "2.1.2": {
+              "checksum": "string"
+            },
+            "2.1.3": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@metamask/ethereum-provider-example-snap": {
+          "id": "string",
+          "metadata": {
+            "hidden": "boolean",
+            "name": "string"
+          },
+          "versions": {
+            "0.37.2-flask.1": {
+              "checksum": "string"
+            },
+            "0.38.0-flask.1": {
+              "checksum": "string"
+            },
+            "0.38.1-flask.1": {
+              "checksum": "string"
+            },
+            "1.0.0": {
+              "checksum": "string"
+            },
+            "2.0.1": {
+              "checksum": "string"
+            },
+            "2.1.0": {
+              "checksum": "string"
+            },
+            "2.1.1": {
+              "checksum": "string"
+            },
+            "2.1.2": {
+              "checksum": "string"
+            },
+            "2.1.3": {
+              "checksum": "string"
+            },
+            "2.2.1": {
+              "checksum": "string"
+            },
+            "2.3.0": {
+              "checksum": "string"
+            },
+            "2.4.0": {
+              "checksum": "string"
+            },
+            "3.0.0": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@metamask/ethers-js-example-snap": {
+          "id": "string",
+          "metadata": {
+            "hidden": "boolean",
+            "name": "string"
+          },
+          "versions": {
+            "0.37.2-flask.1": {
+              "checksum": "string"
+            },
+            "0.38.0-flask.1": {
+              "checksum": "string"
+            },
+            "0.38.1-flask.1": {
+              "checksum": "string"
+            },
+            "1.0.0": {
+              "checksum": "string"
+            },
+            "2.0.1": {
+              "checksum": "string"
+            },
+            "2.1.0": {
+              "checksum": "string"
+            },
+            "2.1.1": {
+              "checksum": "string"
+            },
+            "2.1.2": {
+              "checksum": "string"
+            },
+            "2.1.3": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@metamask/file-upload-example-snap": {
+          "id": "string",
+          "metadata": {
+            "hidden": "boolean",
+            "name": "string"
+          },
+          "versions": {
+            "1.0.1": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@metamask/get-entropy-example-snap": {
+          "id": "string",
+          "metadata": {
+            "hidden": "boolean",
+            "name": "string"
+          },
+          "versions": {
+            "0.37.2-flask.1": {
+              "checksum": "string"
+            },
+            "0.38.0-flask.1": {
+              "checksum": "string"
+            },
+            "0.38.1-flask.1": {
+              "checksum": "string"
+            },
+            "1.0.0": {
+              "checksum": "string"
+            },
+            "2.0.1": {
+              "checksum": "string"
+            },
+            "2.1.0": {
+              "checksum": "string"
+            },
+            "2.1.1": {
+              "checksum": "string"
+            },
+            "2.1.2": {
+              "checksum": "string"
+            },
+            "2.1.3": {
+              "checksum": "string"
+            },
+            "2.2.0": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@metamask/get-file-example-snap": {
+          "id": "string",
+          "metadata": {
+            "hidden": "boolean",
+            "name": "string"
+          },
+          "versions": {
+            "1.0.1": {
+              "checksum": "string"
+            },
+            "1.1.0": {
+              "checksum": "string"
+            },
+            "1.1.1": {
+              "checksum": "string"
+            },
+            "1.1.2": {
+              "checksum": "string"
+            },
+            "1.1.3": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@metamask/get-locale-example-snap": {
+          "id": "string",
+          "metadata": {
+            "hidden": "boolean",
+            "name": "string"
+          },
+          "versions": {
+            "0.38.1-flask.1": {
+              "checksum": "string"
+            },
+            "1.0.0": {
+              "checksum": "string"
+            },
+            "2.0.1": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@metamask/home-page-example-snap": {
+          "id": "string",
+          "metadata": {
+            "hidden": "boolean",
+            "name": "string"
+          },
+          "versions": {
+            "1.1.0": {
+              "checksum": "string"
+            },
+            "1.1.1": {
+              "checksum": "string"
+            },
+            "1.1.2": {
+              "checksum": "string"
+            },
+            "1.1.3": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@metamask/images-example-snap": {
+          "id": "string",
+          "metadata": {
+            "hidden": "boolean",
+            "name": "string"
+          },
+          "versions": {
+            "1.1.0": {
+              "checksum": "string"
+            },
+            "1.1.1": {
+              "checksum": "string"
+            },
+            "1.2.0": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@metamask/insights-example-snap": {
+          "id": "string",
+          "metadata": {
+            "hidden": "boolean",
+            "name": "string"
+          },
+          "versions": {
+            "0.37.2-flask.1": {
+              "checksum": "string"
+            },
+            "0.38.0-flask.1": {
+              "checksum": "string"
+            },
+            "0.38.1-flask.1": {
+              "checksum": "string"
+            },
+            "1.0.0": {
+              "checksum": "string"
+            },
+            "2.0.1": {
+              "checksum": "string"
+            },
+            "2.1.0": {
+              "checksum": "string"
+            },
+            "2.2.0": {
+              "checksum": "string"
+            },
+            "2.2.1": {
+              "checksum": "string"
+            },
+            "2.2.2": {
+              "checksum": "string"
+            },
+            "2.2.3": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@metamask/interactive-ui-example-snap": {
+          "id": "string",
+          "metadata": {
+            "hidden": "boolean",
+            "name": "string"
+          },
+          "versions": {
+            "2.0.0": {
+              "checksum": "string"
+            },
+            "2.1.0": {
+              "checksum": "string"
+            },
+            "2.2.0": {
+              "checksum": "string"
+            },
+            "2.2.1": {
+              "checksum": "string"
+            },
+            "2.3.0": {
+              "checksum": "string"
+            },
+            "2.4.0": {
+              "checksum": "string"
+            },
+            "2.5.0": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@metamask/json-rpc-example-snap": {
+          "id": "string",
+          "metadata": {
+            "hidden": "boolean",
+            "name": "string"
+          },
+          "versions": {
+            "0.37.2-flask.1": {
+              "checksum": "string"
+            },
+            "0.37.3-flask.1": {
+              "checksum": "string"
+            },
+            "1.0.0": {
+              "checksum": "string"
+            },
+            "2.0.1": {
+              "checksum": "string"
+            },
+            "2.1.0": {
+              "checksum": "string"
+            },
+            "2.1.1": {
+              "checksum": "string"
+            },
+            "2.1.2": {
+              "checksum": "string"
+            },
+            "2.1.3": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@metamask/jsx-example-snap": {
+          "id": "string",
+          "metadata": {
+            "hidden": "boolean",
+            "name": "string"
+          },
+          "versions": {
+            "1.1.1": {
+              "checksum": "string"
+            },
+            "1.2.0": {
+              "checksum": "string"
+            },
+            "1.2.1": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@metamask/lifecycle-hooks-example-snap": {
+          "id": "string",
+          "metadata": {
+            "hidden": "boolean",
+            "name": "string"
+          },
+          "versions": {
+            "0.38.0-flask.1": {
+              "checksum": "string"
+            },
+            "1.0.0": {
+              "checksum": "string"
+            },
+            "2.0.1": {
+              "checksum": "string"
+            },
+            "2.1.0": {
+              "checksum": "string"
+            },
+            "2.1.1": {
+              "checksum": "string"
+            },
+            "2.1.2": {
+              "checksum": "string"
+            },
+            "2.1.3": {
+              "checksum": "string"
+            },
+            "2.2.0": {
+              "checksum": "string"
+            },
+            "2.3.0": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@metamask/localization-example-snap": {
+          "id": "string",
+          "metadata": {
+            "hidden": "boolean",
+            "name": "string"
+          },
+          "versions": {
+            "1.1.1": {
+              "checksum": "string"
+            },
+            "1.1.2": {
+              "checksum": "string"
+            },
+            "1.1.3": {
+              "checksum": "string"
+            },
+            "1.1.4": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@metamask/manage-state-example-snap": {
+          "id": "string",
+          "metadata": {
+            "hidden": "boolean",
+            "name": "string"
+          },
+          "versions": {
+            "0.37.2-flask.1": {
+              "checksum": "string"
+            },
+            "0.38.0-flask.1": {
+              "checksum": "string"
+            },
+            "0.38.1-flask.1": {
+              "checksum": "string"
+            },
+            "1.0.0": {
+              "checksum": "string"
+            },
+            "2.0.1": {
+              "checksum": "string"
+            },
+            "2.2.0": {
+              "checksum": "string"
+            },
+            "2.2.1": {
+              "checksum": "string"
+            },
+            "2.2.2": {
+              "checksum": "string"
+            },
+            "2.2.3": {
+              "checksum": "string"
+            },
+            "3.0.0": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@metamask/multichain-provider-example-snap": {
+          "id": "string",
+          "metadata": {
+            "hidden": "boolean",
+            "name": "string"
+          },
+          "versions": {
+            "1.0.0": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@metamask/name-lookup-example-snap": {
+          "id": "string",
+          "metadata": {
+            "hidden": "boolean",
+            "name": "string"
+          },
+          "versions": {
+            "3.1.0": {
+              "checksum": "string"
+            },
+            "3.1.1": {
+              "checksum": "string"
+            },
+            "3.1.2": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@metamask/network-example-snap": {
+          "id": "string",
+          "metadata": {
+            "hidden": "boolean",
+            "name": "string"
+          },
+          "versions": {
+            "0.37.2-flask.1": {
+              "checksum": "string"
+            },
+            "0.38.0-flask.1": {
+              "checksum": "string"
+            },
+            "0.38.1-flask.1": {
+              "checksum": "string"
+            },
+            "0.38.2-flask.1": {
+              "checksum": "string"
+            },
+            "1.0.0": {
+              "checksum": "string"
+            },
+            "2.0.1": {
+              "checksum": "string"
+            },
+            "2.1.0": {
+              "checksum": "string"
+            },
+            "2.1.1": {
+              "checksum": "string"
+            },
+            "2.1.2": {
+              "checksum": "string"
+            },
+            "2.1.3": {
+              "checksum": "string"
+            },
+            "2.2.0": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@metamask/notification-example-snap": {
+          "id": "string",
+          "metadata": {
+            "hidden": "boolean",
+            "name": "string"
+          },
+          "versions": {
+            "0.37.2-flask.1": {
+              "checksum": "string"
+            },
+            "0.38.0-flask.1": {
+              "checksum": "string"
+            },
+            "0.38.1-flask.1": {
+              "checksum": "string"
+            },
+            "1.0.0": {
+              "checksum": "string"
+            },
+            "2.0.1": {
+              "checksum": "string"
+            },
+            "2.1.0": {
+              "checksum": "string"
+            },
+            "2.1.1": {
+              "checksum": "string"
+            },
+            "2.1.3": {
+              "checksum": "string"
+            },
+            "2.1.4": {
+              "checksum": "string"
+            },
+            "2.2.0": {
+              "checksum": "string"
+            },
+            "2.3.0": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@metamask/preferences-example-snap": {
+          "id": "string",
+          "metadata": {
+            "hidden": "boolean",
+            "name": "string"
+          },
+          "versions": {
+            "1.0.0": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@metamask/protocol-example-snap": {
+          "id": "string",
+          "metadata": {
+            "hidden": "boolean",
+            "name": "string"
+          },
+          "versions": {
+            "1.0.0": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@metamask/snap-simple-keyring-snap": {
+          "id": "string",
+          "metadata": {
+            "hidden": "boolean",
+            "name": "string"
+          },
+          "versions": {
+            "1.0.1": {
+              "checksum": "string"
+            },
+            "1.1.0": {
+              "checksum": "string"
+            },
+            "1.1.1": {
+              "checksum": "string"
+            },
+            "1.1.2": {
+              "checksum": "string"
+            },
+            "1.1.6": {
+              "checksum": "string"
+            },
+            "2.0.0": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@metamask/tron-wallet-snap": {
+          "id": "string",
+          "metadata": {
+            "hidden": "boolean",
+            "name": "string"
+          },
+          "versions": {
+            "1.21.1": {
+              "checksum": "string"
+            },
+            "1.25.0": {
+              "checksum": "string",
+              "clientVersions": {
+                "extension": "string",
+                "mobile": "string"
+              }
+            }
+          }
+        },
+        "npm:@metamask/wasm-example-snap": {
+          "id": "string",
+          "metadata": {
+            "hidden": "boolean",
+            "name": "string"
+          },
+          "versions": {
+            "0.37.2-flask.1": {
+              "checksum": "string"
+            },
+            "0.37.3-flask.1": {
+              "checksum": "string"
+            },
+            "1.0.0": {
+              "checksum": "string"
+            },
+            "2.0.1": {
+              "checksum": "string"
+            },
+            "2.1.0": {
+              "checksum": "string"
+            },
+            "2.1.1": {
+              "checksum": "string"
+            },
+            "2.1.2": {
+              "checksum": "string"
+            },
+            "2.1.3": {
+              "checksum": "string"
+            },
+            "2.1.4": {
+              "checksum": "string"
+            },
+            "2.1.5": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@metamask/webpack-plugin-example-snap": {
+          "id": "string",
+          "metadata": {
+            "hidden": "boolean",
+            "name": "string"
+          },
+          "versions": {
+            "2.0.0": {
+              "checksum": "string"
+            },
+            "2.1.3": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@mindsend/kadena-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "1.0.7": {
+              "checksum": "string"
+            },
+            "1.0.8": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@multiversx/metamask-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "1.0.2": {
+              "checksum": "string"
+            },
+            "2.0.0": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@near-snap/plugin": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.7.0": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@nightlylabs/metamask-move-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            }
+          },
+          "versions": {
+            "0.1.6": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@nocturne-xyz/snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.10.2": {
+              "checksum": "string"
+            },
+            "0.11.0": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@nodefortress/cc-snap": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string"
+            }
+          },
+          "versions": {
+            "0.1.14": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@nufi/cardano-metamask-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.2.0": {
+              "checksum": "string"
+            },
+            "0.2.1": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@obsidia/xnap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "1.0.0": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@oneid-xyz/connect-snap": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            }
+          },
+          "versions": {
+            "1.0.2": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@partisiablockchain/snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.1.2": {
+              "checksum": "string"
+            },
+            "0.2.1": {
+              "checksum": "string"
+            },
+            "0.3.0": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@pianity/arsnap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.2.1": {
+              "checksum": "string"
+            },
+            "0.2.2": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@polkagate/snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "2.3.2": {
+              "checksum": "string"
+            },
+            "2.5.1": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@postfiat/pftl-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string"
+            }
+          },
+          "versions": {
+            "1.1.5": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@pushprotocol/snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "1.1.12": {
+              "checksum": "string"
+            },
+            "1.1.13": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@qtumproject/qtum-wallet": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.2.0": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@qubic-lib/qubic-mm-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.0.3": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@quickintel/quickintel-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "1.0.1": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@rarimo/rarime": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "2.0.2": {
+              "checksum": "string"
+            },
+            "2.0.3": {
+              "checksum": "string"
+            },
+            "2.1.0": {
+              "checksum": "string"
+            },
+            "2.1.1": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@rss3/social-notifier-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string"
+            }
+          },
+          "versions": {
+            "0.1.13": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@safeheron/mpcsnap": {
+          "id": "string",
+          "metadata": {
+            "additionalSourceCode": [
+              {
+                "name": "string",
+                "url": "string"
+              }
+            ],
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "keyRecovery": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "2.4.8": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@secure-ci/snap": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.0.14": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@shapeshiftoss/metamask-snaps": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "1.0.0": {
+              "checksum": "string"
+            },
+            "1.0.9": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@silencelaboratories/silent-shard-snap": {
+          "id": "string",
+          "metadata": {
+            "additionalSourceCode": [
+              {
+                "name": "string",
+                "url": "string"
+              }
+            ],
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "keyRecovery": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "1.2.10": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@snowballmoney/metamask-snap": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            }
+          },
+          "versions": {
+            "0.2.1": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@solflare-wallet/solana-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "1.0.3": {
+              "checksum": "string"
+            },
+            "1.0.4": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@taker007/crypto-guardian-snap": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "knowledgeBase": "string"
+            }
+          },
+          "versions": {
+            "1.1.1": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@taxdao/fintax-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.1.4": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@tenderly/metamask-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "1.2.3": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@tezoroproject/snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.9.0": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@token-kit/tapp-snap": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.0.4": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@tuum-tech/authflow-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            }
+          },
+          "versions": {
+            "0.1.4": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@tuum-tech/identify": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "1.5.0": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@unipasswallet/unipass-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.1.1": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@unstoppabledomains/unstoppable-resolution-snap": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            }
+          },
+          "versions": {
+            "1.0.1": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@usecapsule/account-snap": {
+          "id": "string",
+          "metadata": {
+            "additionalSourceCode": [
+              {
+                "name": "string",
+                "url": "string"
+              }
+            ],
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "privateCode": "boolean",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "keyRecovery": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "1.0.0": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@ututrust/utu-metamask-snap": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "1.10.13": {
+              "checksum": "string"
+            },
+            "1.10.15": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@vegaprotocol/snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.3.1": {
+              "checksum": "string"
+            },
+            "1.0.1": {
+              "checksum": "string"
+            },
+            "1.0.2": {
+              "checksum": "string"
+            },
+            "1.0.3": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@vital-wallet/neo-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.1.2": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@web3-antivirus/web3-antivirus-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.1.5": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@web3-name-sdk/snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.0.7": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@web3mq/snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "faq": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "1.0.0": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@xmtp/snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "1.2.2": {
+              "checksum": "string"
+            },
+            "1.3.0": {
+              "checksum": "string"
+            },
+            "1.3.6": {
+              "checksum": "string"
+            },
+            "1.3.7": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@xrpname/snap": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.1.3": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@xtreamly/xtreamly_slippage_predictor": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "1.0.25": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@yigitkara/chain-guardian": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "knowledgeBase": "string"
+            }
+          },
+          "versions": {
+            "0.1.3": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:@zenchain-protocol/zazen": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.0.6": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:aegis-snap": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.2.1": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:ans-mmsnap": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.1.3": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:azero-wallet": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.3.4": {
+              "checksum": "string"
+            },
+            "0.3.6": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:bch-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.1.1": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:beranames_resolver": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "1.0.1": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:bitbadges-snap": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.1.1": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:blockfence-insights": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.1.2": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:btcsnap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "2.0.3": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:casper-manager": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "1.0.3": {
+              "checksum": "string"
+            },
+            "1.0.4": {
+              "checksum": "string"
+            },
+            "2.0.0": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:dedaub-metamask-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "faq": "string",
+              "knowledgeBase": "string"
+            }
+          },
+          "versions": {
+            "1.0.6": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:defi-armor-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.2.3": {
+              "checksum": "string"
+            },
+            "0.2.4": {
+              "checksum": "string"
+            },
+            "0.2.5": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:dmail-snap": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.1.6": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:filsnap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "1.0.3": {
+              "checksum": "string"
+            },
+            "1.1.0": {
+              "checksum": "string"
+            },
+            "1.5.4": {
+              "checksum": "string"
+            },
+            "1.6.1": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:freename-resolution-snap": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            }
+          },
+          "versions": {
+            "1.0.6": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:genius-miners-lite": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            }
+          },
+          "versions": {
+            "0.1.5": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:getheminames_resolver": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            }
+          },
+          "versions": {
+            "0.1.3": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:hapilabs-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "1.0.2": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:hashdit-snap-security": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "1.0.2": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:hln-resolver-snap": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "knowledgeBase": "string"
+            }
+          },
+          "versions": {
+            "0.1.3": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:hns-id": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.1.16": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:iotex-snap": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            }
+          },
+          "versions": {
+            "1.5.3": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:keychain-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.3.6": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:know-your-transaction": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "knowledgeBase": "string"
+            }
+          },
+          "versions": {
+            "0.1.1": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:metamask-aura-connect-snap": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "knowledgeBase": "string"
+            }
+          },
+          "versions": {
+            "0.1.3": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:mina-portal": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.1.6": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:nomis": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.1.5": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:noves-foresight": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            }
+          },
+          "versions": {
+            "0.0.5": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:quai-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.1.9": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:rentality": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "1.0.9": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:rubic-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.4.0": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:safe-send": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "knowledgeBase": "string"
+            }
+          },
+          "versions": {
+            "1.0.2": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:scorechain-safetransfer": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "1.0.6": {
+              "checksum": "string"
+            },
+            "1.0.8": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:self-name-resolution": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            }
+          },
+          "versions": {
+            "0.1.4": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:social-names-snap": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string"
+            }
+          },
+          "versions": {
+            "0.3.0": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:sonic_resolver": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            }
+          },
+          "versions": {
+            "1.0.1": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:stellar-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "1.0.9": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:tezos-metamask-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "1.0.7": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:themiracle-benefits-tracker": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.1.5": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:unleashnfts": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.1.9": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:vaulta-wallet": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "1.1.1": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:walletchat-metamask-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.2.1": {
+              "checksum": "string"
+            },
+            "0.2.2": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:web3-security-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "1.0.3": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:wise-signer-snap": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string"
+            }
+          },
+          "versions": {
+            "0.0.6": {
+              "checksum": "string"
+            },
+            "0.0.8": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:xdcdomains-snap": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.1.17": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:xrpl-snap": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "1.0.3": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:zetalink": {
+          "id": "string",
+          "metadata": {
+            "audits": [
+              {
+                "auditor": "string",
+                "report": "string"
+              }
+            ],
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.2.1": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:zns-connect": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string",
+              "faq": "string",
+              "knowledgeBase": "string"
+            }
+          },
+          "versions": {
+            "0.1.7": {
+              "checksum": "string"
+            }
+          }
+        },
+        "npm:zyfi-paymaster-insight-snap": {
+          "id": "string",
+          "metadata": {
+            "author": {
+              "name": "string",
+              "website": "string"
+            },
+            "category": "string",
+            "description": "string",
+            "name": "string",
+            "screenshots": [
+              "string"
+            ],
+            "sourceCode": "string",
+            "summary": "string",
+            "support": {
+              "contact": "string"
+            },
+            "website": "string"
+          },
+          "versions": {
+            "0.1.0": {
+              "checksum": "string"
+            }
+          }
+        }
+      }
     },
     "databaseUnavailable": "boolean",
-    "dataCollectionForMarketing": "boolean",
     "defaultHomeActiveTabName": "null",
     "delegations": {},
     "depositInProgress": "boolean",
     "depositRequests": [],
     "dismissSeedBackUpReminder": "boolean",
-    "domains": {},
+    "domains": {
+      "http://localhost:3000": "string",
+      "http://localhost:8000": "string",
+      "https://alpha.mycactus.io": "string",
+      "https://app-beta.signer.cubist.dev": "string",
+      "https://app-gamma.signer.cubist.dev": "string",
+      "https://app.bitgo-test.com": "string",
+      "https://app.bitgo.com": "string",
+      "https://app.metamask.io": "string",
+      "https://app.signer.cubist.dev": "string",
+      "https://apps-portal.safe.global": "string",
+      "https://console.dev.mpcvault.com": "string",
+      "https://console.fireblocks.io": "string",
+      "https://console.mpcvault.com": "string",
+      "https://debug.mycactus.dev:1443": "string",
+      "https://dev10-console.waterballoons.xyz": "string",
+      "https://dev4-console.waterballoons.xyz": "string",
+      "https://developer.metamask.io": "string",
+      "https://docs.metamask.io": "string",
+      "https://eu-console.fireblocks.io": "string",
+      "https://eu2-console.fireblocks.io": "string",
+      "https://local.waterballoons.xyz:4200": "string",
+      "https://localhost:3000": "string",
+      "https://neptune-custody-ui.metamask-institutional.io": "string",
+      "https://portfolio-builds.metafi-dev.codefi.network": "string",
+      "https://portfolio.metamask.io": "string",
+      "https://pre.mycactus.com": "string",
+      "https://sandbox.fireblocks.io": "string",
+      "https://saturn-custody-ui.metamask-institutional.io": "string",
+      "https://ui-preprod-v2.qa.zodia.io": "string",
+      "https://ui-preprod-v2.uat.zodia.io": "string",
+      "https://ui-v2.qa.zodia.io": "string",
+      "https://ui-v2.sit.zodia.io": "string",
+      "https://v2.custody.zodia.io": "string",
+      "https://www.mycactus.com": "string",
+      "https://www.mycactus.dev": "string",
+      "localhost:8000": "string",
+      "npm:@metamask/bitcoin-wallet-snap": "string",
+      "npm:@metamask/ens-resolver-snap": "string",
+      "npm:@metamask/gator-permissions-snap": "string",
+      "npm:@metamask/institutional-wallet-snap": "string",
+      "npm:@metamask/message-signing-snap": "string",
+      "npm:@metamask/permissions-kernel-snap": "string",
+      "npm:@metamask/solana-wallet-snap": "string",
+      "npm:@metamask/tron-wallet-snap": "string"
+    },
     "drafts": [],
+    "enableMV3TimestampSave": "boolean",
     "enabledNetworkMap": {
       "bip122": {
         "bip122:000000000019d6689c085ae165831e93": "boolean",
@@ -675,44 +25431,29 @@
       },
       "eip155": {
         "0x1": "boolean",
-        "0x539": "boolean",
         "0x18c7": "boolean",
+        "0x2105": "boolean",
+        "0x279f": "boolean",
+        "0x38": "boolean",
+        "0x539": "boolean",
+        "0x89": "boolean",
+        "0xa": "boolean",
+        "0xa4b1": "boolean",
         "0xaa36a7": "boolean",
         "0xe705": "boolean",
-        "0xe708": "boolean",
-        "0x279f": "boolean",
-        "0x2105": "boolean",
-        "0xa4b1": "boolean",
-        "0x38": "boolean",
-        "0xa": "boolean",
-        "0x89": "boolean"
+        "0xe708": "boolean"
       },
       "solana": {
-        "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp": "boolean",
         "solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z": "boolean",
+        "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp": "boolean",
         "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1": "boolean"
       },
       "tron": {
-        "tron:728126428": "boolean",
+        "tron:2494104990": "boolean",
         "tron:3448148188": "boolean",
-        "tron:2494104990": "boolean"
+        "tron:728126428": "boolean"
       }
     },
-    "nativeAssetIdentifiers": {
-      "eip155:1": "string",
-      "eip155:11155111": "string",
-      "eip155:59141": "string",
-      "eip155:59144": "string",
-      "eip155:1337": "string",
-      "eip155:10143": "string",
-      "eip155:8453": "string",
-      "eip155:42161": "string",
-      "eip155:56": "string",
-      "eip155:10": "string",
-      "eip155:137": "string",
-      "eip155:6343": "string"
-    },
-    "enableMV3TimestampSave": "boolean",
     "ensEntries": {
       "0x1": {
         ".": {
@@ -760,17 +25501,6 @@
     "ensResolutionsByAddress": {},
     "estimatedGasFeeTimeBounds": {},
     "events": {
-      "cronjob-npm:@metamask/tron-wallet-snap-0": {
-        "date": "string",
-        "id": "string",
-        "recurring": "boolean",
-        "request": {
-          "method": "string"
-        },
-        "schedule": "string",
-        "scheduledAt": "string",
-        "snapId": "string"
-      },
       "cronjob-npm:@metamask/bitcoin-wallet-snap-0": {
         "date": "string",
         "id": "string",
@@ -803,6 +25533,17 @@
         "schedule": "string",
         "scheduledAt": "string",
         "snapId": "string"
+      },
+      "cronjob-npm:@metamask/tron-wallet-snap-0": {
+        "date": "string",
+        "id": "string",
+        "recurring": "boolean",
+        "request": {
+          "method": "string"
+        },
+        "schedule": "string",
+        "scheduledAt": "string",
+        "snapId": "string"
       }
     },
     "eventsBeforeMetricsOptIn": [
@@ -819,152 +25560,169 @@
     "firstTimeInfo": {},
     "forgottenPassword": "boolean",
     "fragments": {},
-    "fullScreenGasPollTokens": ["string"],
+    "fullScreenGasPollTokens": [
+      "string"
+    ],
     "gasEstimateType": "string",
     "gasFeeEstimates": {},
     "gasFeeEstimatesByChainId": {},
     "grantedPermissions": [],
-    "lastSyncedTimestamp": "number",
-    "hasPlacedFirstOrder": {
-      "testnet": "boolean",
-      "mainnet": "boolean"
-    },
     "hadAdvancedGasFeesSetPriorToMigration92_3": "boolean",
     "hasAccountTreeSyncingSyncedAtLeastOnce": "boolean",
+    "hasPlacedFirstOrder": {
+      "mainnet": "boolean",
+      "testnet": "boolean"
+    },
     "hasShownMultichainAccountsIntroModal": "boolean",
     "hiddenAccountList": [],
     "hip3ConfigVersion": "number",
     "historicalPrices": {},
     "ignoredNfts": [],
+    "initialDelayEndTimestamp": "number",
+    "initialEnqueueCompleted": "boolean",
     "initializationAttempts": "number",
     "initializationError": "null",
     "initializationState": "string",
-    "initialEnqueueCompleted": "boolean",
-    "initialDelayEndTimestamp": "number",
     "insights": {},
     "interfaces": {},
     "internalAccounts": {
       "accounts": {
-        "d5e45e4a-3b04-4a09-a5e1-39762e5c6be4": {
-          "id": "string",
+        "<bitcoin-account-1>": {
           "address": "string",
-          "options": {
-            "entropySource": "string",
-            "derivationPath": "string",
-            "groupIndex": "number",
-            "entropy": {
-              "type": "string",
-              "id": "string",
-              "derivationPath": "string",
-              "groupIndex": "number"
-            }
-          },
-          "methods": ["string"],
-          "scopes": ["string"],
-          "type": "string",
+          "id": "string",
           "metadata": {
-            "name": "string",
             "importTime": "number",
-            "lastSelected": "number",
             "keyring": {
               "type": "string"
+            },
+            "lastSelected": "number",
+            "name": "string",
+            "snap": {
+              "enabled": "boolean",
+              "id": "string",
+              "name": "string"
             }
-          }
+          },
+          "methods": [
+            "string"
+          ],
+          "options": {
+            "entropy": {
+              "derivationPath": "string",
+              "groupIndex": "number",
+              "id": "string",
+              "type": "string"
+            },
+            "entropySource": "string",
+            "exportable": "boolean"
+          },
+          "scopes": [
+            "string"
+          ],
+          "type": "string"
         },
         "<solana-account-1>": {
-          "type": "string",
-          "scopes": ["string"],
-          "id": "string",
           "address": "string",
+          "id": "string",
+          "metadata": {
+            "importTime": "number",
+            "keyring": {
+              "type": "string"
+            },
+            "lastSelected": "number",
+            "name": "string",
+            "snap": {
+              "enabled": "boolean",
+              "id": "string",
+              "name": "string"
+            }
+          },
+          "methods": [
+            "string"
+          ],
           "options": {
-            "entropySource": "string",
             "derivationPath": "string",
-            "index": "number",
             "entropy": {
-              "type": "string",
-              "id": "string",
               "derivationPath": "string",
-              "groupIndex": "number"
-            }
-          },
-          "methods": ["string"],
-          "metadata": {
-            "name": "string",
-            "importTime": "number",
-            "keyring": {
+              "groupIndex": "number",
+              "id": "string",
               "type": "string"
             },
-            "snap": {
-              "id": "string",
-              "name": "string",
-              "enabled": "boolean"
-            },
-            "lastSelected": "number"
-          }
-        },
-        "<bitcoin-account-1>": {
-          "type": "string",
-          "scopes": ["string"],
-          "id": "string",
-          "address": "string",
-          "options": {
-            "exportable": "boolean",
             "entropySource": "string",
-            "entropy": {
-              "type": "string",
-              "id": "string",
-              "derivationPath": "string",
-              "groupIndex": "number"
-            }
+            "index": "number"
           },
-          "methods": ["string"],
-          "metadata": {
-            "name": "string",
-            "importTime": "number",
-            "keyring": {
-              "type": "string"
-            },
-            "snap": {
-              "id": "string",
-              "name": "string",
-              "enabled": "boolean"
-            },
-            "lastSelected": "number"
-          }
+          "scopes": [
+            "string"
+          ],
+          "type": "string"
         },
         "<tron-account-1>": {
-          "type": "string",
-          "scopes": ["string"],
-          "id": "string",
           "address": "string",
-          "options": {
-            "exportable": "boolean",
-            "addressType": "string",
-            "scope": "string",
-            "index": "number",
-            "groupIndex": "number",
-            "entropySource": "string",
-            "entropy": {
-              "type": "string",
-              "id": "string",
-              "derivationPath": "string",
-              "groupIndex": "number"
-            }
-          },
-          "methods": ["string"],
+          "id": "string",
           "metadata": {
-            "name": "string",
             "importTime": "number",
             "keyring": {
               "type": "string"
             },
+            "lastSelected": "number",
+            "name": "string",
             "snap": {
+              "enabled": "boolean",
               "id": "string",
-              "name": "string",
-              "enabled": "boolean"
+              "name": "string"
+            }
+          },
+          "methods": [
+            "string"
+          ],
+          "options": {
+            "addressType": "string",
+            "entropy": {
+              "derivationPath": "string",
+              "groupIndex": "number",
+              "id": "string",
+              "type": "string"
             },
-            "lastSelected": "number"
-          }
+            "entropySource": "string",
+            "exportable": "boolean",
+            "groupIndex": "number",
+            "index": "number",
+            "scope": "string"
+          },
+          "scopes": [
+            "string"
+          ],
+          "type": "string"
+        },
+        "d5e45e4a-3b04-4a09-a5e1-39762e5c6be4": {
+          "address": "string",
+          "id": "string",
+          "metadata": {
+            "importTime": "number",
+            "keyring": {
+              "type": "string"
+            },
+            "lastSelected": "number",
+            "name": "string"
+          },
+          "methods": [
+            "string"
+          ],
+          "options": {
+            "derivationPath": "string",
+            "entropy": {
+              "derivationPath": "string",
+              "groupIndex": "number",
+              "id": "string",
+              "type": "string"
+            },
+            "entropySource": "string",
+            "groupIndex": "number"
+          },
+          "scopes": [
+            "string"
+          ],
+          "type": "string"
         }
       },
       "selectedAccount": "string"
@@ -980,12 +25738,12 @@
     "isEligible": "boolean",
     "isEvmSelected": "boolean",
     "isFeatureAnnouncementsEnabled": "boolean",
-    "isFirstTimeUser": {
-      "testnet": "boolean",
-      "mainnet": "boolean"
-    },
     "isFetchingGatorPermissions": "boolean",
     "isFetchingMetamaskNotifications": "boolean",
+    "isFirstTimeUser": {
+      "mainnet": "boolean",
+      "testnet": "boolean"
+    },
     "isInitialized": "boolean",
     "isIpfsGatewayEnabled": "boolean",
     "isMetamaskNotificationsFeatureSeen": "boolean",
@@ -994,19 +25752,20 @@
     "isPushEnabled": "boolean",
     "isRampCardClosed": "boolean",
     "isReady": "boolean",
-    "isTestnet": "boolean",
     "isSeedlessOnboardingUserAuthenticated": "boolean",
     "isSignedIn": "boolean",
+    "isTestnet": "boolean",
     "isUiOpen": "boolean",
     "isUnlocked": "boolean",
-    "pendingExtensionVersion": "null",
     "isUpdatingFCMToken": "boolean",
     "isUpdatingMetamaskNotifications": "boolean",
     "isUpdatingMetamaskNotificationsAccount": [],
     "isWalletResetInProgress": "boolean",
     "keyrings": [
       {
-        "accounts": ["string"],
+        "accounts": [
+          "string"
+        ],
         "metadata": {
           "id": "string",
           "name": "string"
@@ -1021,36 +25780,29 @@
     "lastDepositTransactionId": "null",
     "lastError": "null",
     "lastFetchedBlockNumbers": {},
+    "lastSyncedTimestamp": "number",
     "lastUpdateTimestamp": "number",
     "lastUpdated": "number",
     "lastUpdatedAt": "null",
     "lastUpdatedFromVersion": "null",
     "lastViewedUserSurvey": "null",
+    "lastWithdrawResult": "null",
     "latestNonAnonymousEventTimestamp": "number",
     "ledgerTransportType": "string",
+    "localOverrides": {},
     "logs": {},
-    "lastWithdrawResult": "null",
     "manageInstitutionalWallets": "boolean",
-    "marketData": {
-      "0x1": {},
-      "0x2105": {},
-      "0x38": {},
-      "0x539": {},
-      "0x89": {},
-      "0xa": {},
-      "0xa4b1": {},
-      "0xe708": {}
-    },
+    "marketData": {},
     "marketFilterPreferences": {
-      "optionId": "string",
-      "direction": "string"
+      "direction": "string",
+      "optionId": "string"
     },
     "marketingCampaignCookieId": "null",
-    "metamaskNotificationsList": [],
-    "metamaskNotificationsReadList": [],
     "metaMetricsDataDeletionId": "null",
     "metaMetricsDataDeletionTimestamp": "number",
     "metaMetricsId": "string",
+    "metamaskNotificationsList": [],
+    "metamaskNotificationsReadList": [],
     "methodData": {},
     "minimumBalanceForRentExemptionInLamports": "string",
     "multichainNetworkConfigurationsByChainId": {
@@ -1121,22 +25873,300 @@
         "nativeCurrency": "string"
       }
     },
-    "musdConversionEducationSeen": "boolean",
     "musdConversionDismissedCtaKeys": [],
+    "musdConversionEducationSeen": "boolean",
+    "nameSources": {},
     "names": {
       "ethereumAddress": {}
     },
-    "nameSources": {},
+    "nativeAssetIdentifiers": {
+      "eip155:1": "string",
+      "eip155:10": "string",
+      "eip155:10143": "string",
+      "eip155:11155111": "string",
+      "eip155:1337": "string",
+      "eip155:137": "string",
+      "eip155:42161": "string",
+      "eip155:56": "string",
+      "eip155:59141": "string",
+      "eip155:59144": "string",
+      "eip155:6343": "string",
+      "eip155:8453": "string"
+    },
     "networkConfigurations": {},
-    "networkConfigurationsByChainId": {},
+    "networkConfigurationsByChainId": {
+      "0x1": {
+        "blockExplorerUrls": [
+          "string"
+        ],
+        "chainId": "string",
+        "defaultBlockExplorerUrlIndex": "number",
+        "defaultRpcEndpointIndex": "number",
+        "name": "string",
+        "nativeCurrency": "string",
+        "rpcEndpoints": [
+          {
+            "failoverUrls": [],
+            "networkClientId": "string",
+            "type": "string",
+            "url": "string"
+          }
+        ]
+      },
+      "0x18c7": {
+        "blockExplorerUrls": [
+          "string"
+        ],
+        "chainId": "string",
+        "defaultBlockExplorerUrlIndex": "number",
+        "defaultRpcEndpointIndex": "number",
+        "name": "string",
+        "nativeCurrency": "string",
+        "rpcEndpoints": [
+          {
+            "failoverUrls": [],
+            "networkClientId": "string",
+            "type": "string",
+            "url": "string"
+          }
+        ]
+      },
+      "0x2105": {
+        "blockExplorerUrls": [
+          "string"
+        ],
+        "chainId": "string",
+        "defaultBlockExplorerUrlIndex": "number",
+        "defaultRpcEndpointIndex": "number",
+        "name": "string",
+        "nativeCurrency": "string",
+        "rpcEndpoints": [
+          {
+            "failoverUrls": [],
+            "networkClientId": "string",
+            "type": "string",
+            "url": "string"
+          }
+        ]
+      },
+      "0x279f": {
+        "blockExplorerUrls": [
+          "string"
+        ],
+        "chainId": "string",
+        "defaultBlockExplorerUrlIndex": "number",
+        "defaultRpcEndpointIndex": "number",
+        "name": "string",
+        "nativeCurrency": "string",
+        "rpcEndpoints": [
+          {
+            "failoverUrls": [],
+            "networkClientId": "string",
+            "type": "string",
+            "url": "string"
+          }
+        ]
+      },
+      "0x38": {
+        "blockExplorerUrls": [
+          "string"
+        ],
+        "chainId": "string",
+        "defaultBlockExplorerUrlIndex": "number",
+        "defaultRpcEndpointIndex": "number",
+        "name": "string",
+        "nativeCurrency": "string",
+        "rpcEndpoints": [
+          {
+            "failoverUrls": [],
+            "networkClientId": "string",
+            "type": "string",
+            "url": "string"
+          }
+        ]
+      },
+      "0x539": {
+        "blockExplorerUrls": [],
+        "chainId": "string",
+        "defaultRpcEndpointIndex": "number",
+        "lastUpdatedAt": "number",
+        "name": "string",
+        "nativeCurrency": "string",
+        "rpcEndpoints": [
+          {
+            "networkClientId": "string",
+            "type": "string",
+            "url": "string"
+          }
+        ]
+      },
+      "0x89": {
+        "blockExplorerUrls": [
+          "string"
+        ],
+        "chainId": "string",
+        "defaultBlockExplorerUrlIndex": "number",
+        "defaultRpcEndpointIndex": "number",
+        "name": "string",
+        "nativeCurrency": "string",
+        "rpcEndpoints": [
+          {
+            "failoverUrls": [],
+            "networkClientId": "string",
+            "type": "string",
+            "url": "string"
+          }
+        ]
+      },
+      "0xa": {
+        "blockExplorerUrls": [
+          "string"
+        ],
+        "chainId": "string",
+        "defaultBlockExplorerUrlIndex": "number",
+        "defaultRpcEndpointIndex": "number",
+        "name": "string",
+        "nativeCurrency": "string",
+        "rpcEndpoints": [
+          {
+            "failoverUrls": [],
+            "networkClientId": "string",
+            "type": "string",
+            "url": "string"
+          }
+        ]
+      },
+      "0xa4b1": {
+        "blockExplorerUrls": [
+          "string"
+        ],
+        "chainId": "string",
+        "defaultBlockExplorerUrlIndex": "number",
+        "defaultRpcEndpointIndex": "number",
+        "name": "string",
+        "nativeCurrency": "string",
+        "rpcEndpoints": [
+          {
+            "failoverUrls": [],
+            "networkClientId": "string",
+            "type": "string",
+            "url": "string"
+          }
+        ]
+      },
+      "0xaa36a7": {
+        "blockExplorerUrls": [
+          "string"
+        ],
+        "chainId": "string",
+        "defaultBlockExplorerUrlIndex": "number",
+        "defaultRpcEndpointIndex": "number",
+        "name": "string",
+        "nativeCurrency": "string",
+        "rpcEndpoints": [
+          {
+            "failoverUrls": [],
+            "networkClientId": "string",
+            "type": "string",
+            "url": "string"
+          }
+        ]
+      },
+      "0xe705": {
+        "blockExplorerUrls": [
+          "string"
+        ],
+        "chainId": "string",
+        "defaultBlockExplorerUrlIndex": "number",
+        "defaultRpcEndpointIndex": "number",
+        "name": "string",
+        "nativeCurrency": "string",
+        "rpcEndpoints": [
+          {
+            "failoverUrls": [],
+            "networkClientId": "string",
+            "type": "string",
+            "url": "string"
+          }
+        ]
+      },
+      "0xe708": {
+        "blockExplorerUrls": [
+          "string"
+        ],
+        "chainId": "string",
+        "defaultBlockExplorerUrlIndex": "number",
+        "defaultRpcEndpointIndex": "number",
+        "name": "string",
+        "nativeCurrency": "string",
+        "rpcEndpoints": [
+          {
+            "failoverUrls": [],
+            "networkClientId": "string",
+            "type": "string",
+            "url": "string"
+          }
+        ]
+      }
+    },
     "networkConnectionBanner": {
       "status": "string"
     },
     "networksMetadata": {
-      "networkConfigurationId": {
+      "3a5eb6f2-cb62-428d-897c-b7ded577d7c2": {
         "EIPS": {
           "1559": "boolean"
         },
+        "status": "string"
+      },
+      "arbitrum-mainnet": {
+        "EIPS": {
+          "1559": "boolean"
+        },
+        "status": "string"
+      },
+      "base-mainnet": {
+        "EIPS": {},
+        "status": "string"
+      },
+      "bsc-mainnet": {
+        "EIPS": {},
+        "status": "string"
+      },
+      "linea-mainnet": {
+        "EIPS": {
+          "1559": "boolean"
+        },
+        "status": "string"
+      },
+      "linea-sepolia": {
+        "EIPS": {},
+        "status": "string"
+      },
+      "mainnet": {
+        "EIPS": {
+          "1559": "boolean"
+        },
+        "status": "string"
+      },
+      "megaeth-testnet-v2": {
+        "EIPS": {},
+        "status": "string"
+      },
+      "monad-testnet": {
+        "EIPS": {},
+        "status": "string"
+      },
+      "optimism-mainnet": {
+        "EIPS": {},
+        "status": "string"
+      },
+      "polygon-mainnet": {
+        "EIPS": {},
+        "status": "string"
+      },
+      "sepolia": {
+        "EIPS": {},
         "status": "string"
       }
     },
@@ -1146,8 +26176,8 @@
     "nftsDetectionNoticeDismissed": "boolean",
     "nftsDropdownState": {},
     "nonEvmTransactions": {
-      "<solana-account-1>": {},
       "<bitcoin-account-1>": {},
+      "<solana-account-1>": {},
       "<tron-account-1>": {}
     },
     "nonRPCGasFeeApisDisabled": "boolean",
@@ -1164,13 +26194,13 @@
     "outdatedBrowserWarningLastShown": "null",
     "overrideContentSecurityPolicyHeader": "boolean",
     "participateInMetaMetrics": "boolean",
-    "pendingRedirectRoute": "null",
     "pendingApprovalCount": "number",
     "pendingApprovals": {},
+    "pendingExtensionVersion": "null",
+    "pendingRedirectRoute": "null",
     "pendingRevocations": [],
     "pendingShieldCohort": "null",
     "pendingShieldCohortTxType": "null",
-    "pna25Acknowledged": "boolean",
     "permissionActivityLog": [
       {
         "id": "number",
@@ -1185,6 +26215,7 @@
     "permissionHistory": {},
     "perpsBalances": {},
     "pinnedAccountList": [],
+    "pna25Acknowledged": "boolean",
     "popupGasPollTokens": [],
     "preferences": {
       "avatarType": "string",
@@ -1193,8 +26224,8 @@
       "featureNotificationsEnabled": "boolean",
       "hideZeroBalanceTokens": "boolean",
       "privacyMode": "boolean",
-      "showDefaultAddress": "boolean",
       "showConfirmationAdvancedDetails": "boolean",
+      "showDefaultAddress": "boolean",
       "showExtensionInFullSizeView": "boolean",
       "showFiatInTestnets": "boolean",
       "showMultiRpcModal": "boolean",
@@ -1237,6 +26268,20 @@
         "conversionRate": "number"
       }
     },
+    "rawRemoteFeatureFlags": {
+      "feature1": "boolean",
+      "feature2": "boolean",
+      "feature3": [
+        {
+          "name": "string",
+          "scope": {
+            "type": "string",
+            "value": "number"
+          },
+          "value": "string"
+        }
+      ]
+    },
     "recoveryPhraseReminderHasBeenShown": "boolean",
     "recoveryPhraseReminderLastShown": "number",
     "referrals": {
@@ -1252,40 +26297,23 @@
         "value": "string"
       }
     },
-    "rawRemoteFeatureFlags": {
-      "feature1": "boolean",
-      "feature2": "boolean",
-      "feature3": [
-        {
-          "name": "string",
-          "value": "string",
-          "scope": {
-            "type": "string",
-            "value": "number"
-          }
-        }
-      ]
-    },
-    "thresholdCache": {
-      "*": "number"
-    },
-    "localOverrides": {},
     "rewardsAccounts": {},
     "rewardsActiveAccount": "null",
     "rewardsPointsEstimateHistory": [],
-    "rewardsSeasons": {},
     "rewardsSeasonStatuses": {},
+    "rewardsSeasons": {},
     "rewardsSubscriptions": {},
     "securityAlertsEnabled": "boolean",
     "seedPhraseBackedUp": "null",
     "segmentApiCalls": {},
     "selectedAccountGroup": "string",
+    "selectedCurrency": "string",
     "selectedMultichainNetworkChainId": "string",
-    "selectedPaymentToken": "null",
     "selectedNetworkClientId": "string",
-    "shieldSubscriptionError": "null",
+    "selectedPaymentToken": "null",
     "shieldEndingToastLastClickedOrClosed": "null",
     "shieldPausedToastLastClickedOrClosed": "null",
+    "shieldSubscriptionError": "null",
     "showAccountBanner": "boolean",
     "showBetaHeader": "boolean",
     "showDownloadMobileAppSlide": "boolean",
@@ -1293,24 +26321,11 @@
     "showPermissionsTour": "boolean",
     "showShieldEntryModalOnce": "null",
     "showSidePanelMigrationToast": "boolean",
-    "storageWriteErrorType": "null",
     "showTestnetMessageInDropdown": "boolean",
     "sidePanelGasPollTokens": [],
     "signature": "string",
     "signatureRequests": {},
     "signatureSecurityAlertResponses": {},
-    "syncQueue": {
-      "01KGPGYE2JJGMXDJPEVXKPJ1JG": [
-        {
-          "address": "string",
-          "scopes": ["string"]
-        },
-        {
-          "address": "string",
-          "scopes": ["string", "string", "string"]
-        }
-      ]
-    },
     "slides": [],
     "smartTransactionsState": {
       "fees": {
@@ -1339,10 +26354,1409 @@
       "userOptInV2": "null"
     },
     "snapRegistryList": {},
+    "snaps": {
+      "npm:@metamask/bitcoin-wallet-snap": {
+        "blocked": "boolean",
+        "enabled": "boolean",
+        "hideSnapBranding": "boolean",
+        "id": "string",
+        "initialPermissions": {
+          "endowment:assets": {
+            "scopes": [
+              "string"
+            ]
+          },
+          "endowment:cronjob": {
+            "jobs": [
+              {
+                "duration": "string",
+                "request": {
+                  "method": "string"
+                }
+              }
+            ]
+          },
+          "endowment:keyring": {},
+          "endowment:lifecycle-hooks": {},
+          "endowment:network-access": {},
+          "endowment:webassembly": {},
+          "snap_dialog": {},
+          "snap_getBip32Entropy": [
+            {
+              "curve": "string",
+              "path": [
+                "string"
+              ]
+            }
+          ],
+          "snap_getPreferences": {},
+          "snap_manageAccounts": {},
+          "snap_manageState": {}
+        },
+        "localizationFiles": [
+          {
+            "locale": "string",
+            "messages": {
+              "MmssingNonWitnessUtxo": {
+                "message": "string"
+              },
+              "amount": {
+                "message": "string"
+              },
+              "asset": {
+                "message": "string"
+              },
+              "balance": {
+                "message": "string"
+              },
+              "base58": {
+                "message": "string"
+              },
+              "bech32": {
+                "message": "string"
+              },
+              "cancel": {
+                "message": "string"
+              },
+              "clear": {
+                "message": "string"
+              },
+              "confirmation.account": {
+                "message": "string"
+              },
+              "confirmation.confirmButton": {
+                "message": "string"
+              },
+              "confirmation.estimatedChanges": {
+                "message": "string"
+              },
+              "confirmation.estimatedChanges.send": {
+                "message": "string"
+              },
+              "confirmation.origin": {
+                "message": "string"
+              },
+              "confirmation.origin.tooltip": {
+                "message": "string"
+              },
+              "confirmation.requestOrigin": {
+                "message": "string"
+              },
+              "confirmation.signAndSendTransaction.title": {
+                "message": "string"
+              },
+              "confirmation.signMessage.confirmButton": {
+                "message": "string"
+              },
+              "confirmation.signMessage.message": {
+                "message": "string"
+              },
+              "confirmation.signMessage.title": {
+                "message": "string"
+              },
+              "continue": {
+                "message": "string"
+              },
+              "error": {
+                "message": "string"
+              },
+              "error.0": {
+                "message": "string"
+              },
+              "error.1000": {
+                "message": "string"
+              },
+              "error.2000": {
+                "message": "string"
+              },
+              "error.3000": {
+                "message": "string"
+              },
+              "error.4000": {
+                "message": "string"
+              },
+              "error.5000": {
+                "message": "string"
+              },
+              "error.6000": {
+                "message": "string"
+              },
+              "error.7000": {
+                "message": "string"
+              },
+              "error.8000": {
+                "message": "string"
+              },
+              "error.9000": {
+                "message": "string"
+              },
+              "error.internal": {
+                "message": "string"
+              },
+              "feeRate": {
+                "message": "string"
+              },
+              "feeRateTooLow": {
+                "message": "string"
+              },
+              "feeTooLow": {
+                "message": "string"
+              },
+              "from": {
+                "message": "string"
+              },
+              "inputTooLarge": {
+                "message": "string"
+              },
+              "insufficientFunds": {
+                "message": "string"
+              },
+              "invalidBase58PayloadLength": {
+                "message": "string"
+              },
+              "invalidCharacter": {
+                "message": "string"
+              },
+              "invalidLegacyPrefix": {
+                "message": "string"
+              },
+              "legacyAddressTooLong": {
+                "message": "string"
+              },
+              "max": {
+                "message": "string"
+              },
+              "minutes": {
+                "message": "string"
+              },
+              "missingDigits": {
+                "message": "string"
+              },
+              "network": {
+                "message": "string"
+              },
+              "networkFee": {
+                "message": "string"
+              },
+              "networkFeeTooltip": {
+                "message": "string"
+              },
+              "networkValidation": {
+                "message": "string"
+              },
+              "noRecipients": {
+                "message": "string"
+              },
+              "noUtxosSelected": {
+                "message": "string"
+              },
+              "outOfRange": {
+                "message": "string"
+              },
+              "outputBelowDustLimit": {
+                "message": "string"
+              },
+              "psbt": {
+                "message": "string"
+              },
+              "recipient": {
+                "message": "string"
+              },
+              "recipientPlaceholder": {
+                "message": "string"
+              },
+              "review": {
+                "message": "string"
+              },
+              "reviewTransactionWarning": {
+                "message": "string"
+              },
+              "send": {
+                "message": "string"
+              },
+              "sending": {
+                "message": "string"
+              },
+              "toAddress": {
+                "message": "string"
+              },
+              "tooPrecise": {
+                "message": "string"
+              },
+              "total": {
+                "message": "string"
+              },
+              "transactionSpeed": {
+                "message": "string"
+              },
+              "transactionSpeedTooltip": {
+                "message": "string"
+              },
+              "unexpected": {
+                "message": "string"
+              },
+              "unknownError": {
+                "message": "string"
+              },
+              "unknownUtxo": {
+                "message": "string"
+              },
+              "witnessProgram": {
+                "message": "string"
+              },
+              "witnessVersion": {
+                "message": "string"
+              }
+            }
+          }
+        ],
+        "manifest": {
+          "description": "string",
+          "initialPermissions": {
+            "endowment:assets": {
+              "scopes": [
+                "string"
+              ]
+            },
+            "endowment:cronjob": {
+              "jobs": [
+                {
+                  "duration": "string",
+                  "request": {
+                    "method": "string"
+                  }
+                }
+              ]
+            },
+            "endowment:keyring": {},
+            "endowment:lifecycle-hooks": {},
+            "endowment:network-access": {},
+            "endowment:webassembly": {},
+            "snap_dialog": {},
+            "snap_getBip32Entropy": [
+              {
+                "curve": "string",
+                "path": [
+                  "string"
+                ]
+              }
+            ],
+            "snap_getPreferences": {},
+            "snap_manageAccounts": {},
+            "snap_manageState": {}
+          },
+          "manifestVersion": "string",
+          "platformVersion": "string",
+          "proposedName": "string",
+          "repository": {
+            "type": "string",
+            "url": "string"
+          },
+          "source": {
+            "locales": [
+              "string"
+            ],
+            "location": {
+              "npm": {
+                "filePath": "string",
+                "iconPath": "string",
+                "packageName": "string",
+                "registry": "string"
+              }
+            },
+            "shasum": "string"
+          },
+          "version": "string"
+        },
+        "preinstalled": "boolean",
+        "removable": "boolean",
+        "status": "string",
+        "version": "string",
+        "versionHistory": [
+          {
+            "date": "number",
+            "origin": "string",
+            "version": "string"
+          }
+        ]
+      },
+      "npm:@metamask/ens-resolver-snap": {
+        "blocked": "boolean",
+        "enabled": "boolean",
+        "id": "string",
+        "initialPermissions": {
+          "endowment:ethereum-provider": {},
+          "endowment:name-lookup": {},
+          "endowment:network-access": {}
+        },
+        "localizationFiles": [],
+        "manifest": {
+          "description": "string",
+          "initialPermissions": {
+            "endowment:ethereum-provider": {},
+            "endowment:name-lookup": {},
+            "endowment:network-access": {}
+          },
+          "manifestVersion": "string",
+          "platformVersion": "string",
+          "proposedName": "string",
+          "repository": {
+            "type": "string",
+            "url": "string"
+          },
+          "source": {
+            "location": {
+              "npm": {
+                "filePath": "string",
+                "iconPath": "string",
+                "packageName": "string",
+                "registry": "string"
+              }
+            },
+            "shasum": "string"
+          },
+          "version": "string"
+        },
+        "preinstalled": "boolean",
+        "removable": "boolean",
+        "status": "string",
+        "version": "string",
+        "versionHistory": [
+          {
+            "date": "number",
+            "origin": "string",
+            "version": "string"
+          }
+        ]
+      },
+      "npm:@metamask/gator-permissions-snap": {
+        "blocked": "boolean",
+        "enabled": "boolean",
+        "hideSnapBranding": "boolean",
+        "id": "string",
+        "initialConnections": {
+          "npm:@metamask/permissions-kernel-snap": {}
+        },
+        "initialPermissions": {
+          "endowment:ethereum-provider": {},
+          "endowment:network-access": {},
+          "endowment:rpc": {
+            "dapps": "boolean",
+            "snaps": "boolean"
+          },
+          "snap_dialog": {},
+          "snap_getPreferences": {},
+          "snap_manageState": {}
+        },
+        "localizationFiles": [],
+        "manifest": {
+          "description": "string",
+          "initialConnections": {
+            "npm:@metamask/permissions-kernel-snap": {}
+          },
+          "initialPermissions": {
+            "endowment:ethereum-provider": {},
+            "endowment:network-access": {},
+            "endowment:rpc": {
+              "dapps": "boolean",
+              "snaps": "boolean"
+            },
+            "snap_dialog": {},
+            "snap_getPreferences": {},
+            "snap_manageState": {}
+          },
+          "manifestVersion": "string",
+          "platformVersion": "string",
+          "proposedName": "string",
+          "repository": {
+            "type": "string",
+            "url": "string"
+          },
+          "source": {
+            "location": {
+              "npm": {
+                "filePath": "string",
+                "iconPath": "string",
+                "packageName": "string",
+                "registry": "string"
+              }
+            },
+            "shasum": "string"
+          },
+          "version": "string"
+        },
+        "preinstalled": "boolean",
+        "removable": "boolean",
+        "status": "string",
+        "version": "string",
+        "versionHistory": [
+          {
+            "date": "number",
+            "origin": "string",
+            "version": "string"
+          }
+        ]
+      },
+      "npm:@metamask/institutional-wallet-snap": {
+        "blocked": "boolean",
+        "enabled": "boolean",
+        "hideSnapBranding": "boolean",
+        "id": "string",
+        "initialConnections": {
+          "http://localhost:3000": {},
+          "http://localhost:8000": {},
+          "https://alpha.mycactus.io": {},
+          "https://app-beta.signer.cubist.dev": {},
+          "https://app-gamma.signer.cubist.dev": {},
+          "https://app.bitgo-test.com": {},
+          "https://app.bitgo.com": {},
+          "https://app.signer.cubist.dev": {},
+          "https://apps-portal.safe.global": {},
+          "https://console.dev.mpcvault.com": {},
+          "https://console.fireblocks.io": {},
+          "https://console.mpcvault.com": {},
+          "https://debug.mycactus.dev:1443": {},
+          "https://dev10-console.waterballoons.xyz": {},
+          "https://dev4-console.waterballoons.xyz": {},
+          "https://eu-console.fireblocks.io": {},
+          "https://eu2-console.fireblocks.io": {},
+          "https://local.waterballoons.xyz:4200": {},
+          "https://localhost:3000": {},
+          "https://neptune-custody-ui.metamask-institutional.io": {},
+          "https://pre.mycactus.com": {},
+          "https://sandbox.fireblocks.io": {},
+          "https://saturn-custody-ui.metamask-institutional.io": {},
+          "https://ui-preprod-v2.qa.zodia.io": {},
+          "https://ui-preprod-v2.uat.zodia.io": {},
+          "https://ui-v2.qa.zodia.io": {},
+          "https://ui-v2.sit.zodia.io": {},
+          "https://v2.custody.zodia.io": {},
+          "https://www.mycactus.com": {},
+          "https://www.mycactus.dev": {},
+          "localhost:8000": {}
+        },
+        "initialPermissions": {
+          "endowment:cronjob": {
+            "jobs": [
+              {
+                "expression": "string",
+                "request": {
+                  "method": "string"
+                }
+              }
+            ]
+          },
+          "endowment:ethereum-provider": {},
+          "endowment:keyring": {
+            "allowedOrigins": [
+              "string"
+            ]
+          },
+          "endowment:network-access": {},
+          "endowment:page-home": {},
+          "endowment:rpc": {
+            "allowedOrigins": [
+              "string"
+            ]
+          },
+          "snap_dialog": {},
+          "snap_manageAccounts": {},
+          "snap_manageState": {},
+          "snap_notify": {}
+        },
+        "localizationFiles": [],
+        "manifest": {
+          "description": "string",
+          "initialConnections": {
+            "http://localhost:3000": {},
+            "http://localhost:8000": {},
+            "https://alpha.mycactus.io": {},
+            "https://app-beta.signer.cubist.dev": {},
+            "https://app-gamma.signer.cubist.dev": {},
+            "https://app.bitgo-test.com": {},
+            "https://app.bitgo.com": {},
+            "https://app.signer.cubist.dev": {},
+            "https://apps-portal.safe.global": {},
+            "https://console.dev.mpcvault.com": {},
+            "https://console.fireblocks.io": {},
+            "https://console.mpcvault.com": {},
+            "https://debug.mycactus.dev:1443": {},
+            "https://dev10-console.waterballoons.xyz": {},
+            "https://dev4-console.waterballoons.xyz": {},
+            "https://eu-console.fireblocks.io": {},
+            "https://eu2-console.fireblocks.io": {},
+            "https://local.waterballoons.xyz:4200": {},
+            "https://localhost:3000": {},
+            "https://neptune-custody-ui.metamask-institutional.io": {},
+            "https://pre.mycactus.com": {},
+            "https://sandbox.fireblocks.io": {},
+            "https://saturn-custody-ui.metamask-institutional.io": {},
+            "https://ui-preprod-v2.qa.zodia.io": {},
+            "https://ui-preprod-v2.uat.zodia.io": {},
+            "https://ui-v2.qa.zodia.io": {},
+            "https://ui-v2.sit.zodia.io": {},
+            "https://v2.custody.zodia.io": {},
+            "https://www.mycactus.com": {},
+            "https://www.mycactus.dev": {},
+            "localhost:8000": {}
+          },
+          "initialPermissions": {
+            "endowment:cronjob": {
+              "jobs": [
+                {
+                  "expression": "string",
+                  "request": {
+                    "method": "string"
+                  }
+                }
+              ]
+            },
+            "endowment:ethereum-provider": {},
+            "endowment:keyring": {
+              "allowedOrigins": [
+                "string"
+              ]
+            },
+            "endowment:network-access": {},
+            "endowment:page-home": {},
+            "endowment:rpc": {
+              "allowedOrigins": [
+                "string"
+              ]
+            },
+            "snap_dialog": {},
+            "snap_manageAccounts": {},
+            "snap_manageState": {},
+            "snap_notify": {}
+          },
+          "manifestVersion": "string",
+          "proposedName": "string",
+          "repository": {
+            "type": "string",
+            "url": "string"
+          },
+          "source": {
+            "location": {
+              "npm": {
+                "filePath": "string",
+                "iconPath": "string",
+                "packageName": "string",
+                "registry": "string"
+              }
+            },
+            "shasum": "string"
+          },
+          "version": "string"
+        },
+        "preinstalled": "boolean",
+        "removable": "boolean",
+        "status": "string",
+        "version": "string",
+        "versionHistory": [
+          {
+            "date": "number",
+            "origin": "string",
+            "version": "string"
+          }
+        ]
+      },
+      "npm:@metamask/message-signing-snap": {
+        "blocked": "boolean",
+        "enabled": "boolean",
+        "id": "string",
+        "initialConnections": {
+          "https://app.metamask.io": {},
+          "https://developer.metamask.io": {},
+          "https://docs.metamask.io": {},
+          "https://portfolio-builds.metafi-dev.codefi.network": {},
+          "https://portfolio.metamask.io": {},
+          "npm:@metamask/gator-permissions-snap": {}
+        },
+        "initialPermissions": {
+          "endowment:rpc": {
+            "dapps": "boolean",
+            "snaps": "boolean"
+          },
+          "snap_getEntropy": {}
+        },
+        "localizationFiles": [],
+        "manifest": {
+          "description": "string",
+          "initialConnections": {
+            "https://app.metamask.io": {},
+            "https://developer.metamask.io": {},
+            "https://docs.metamask.io": {},
+            "https://portfolio-builds.metafi-dev.codefi.network": {},
+            "https://portfolio.metamask.io": {},
+            "npm:@metamask/gator-permissions-snap": {}
+          },
+          "initialPermissions": {
+            "endowment:rpc": {
+              "dapps": "boolean",
+              "snaps": "boolean"
+            },
+            "snap_getEntropy": {}
+          },
+          "manifestVersion": "string",
+          "platformVersion": "string",
+          "proposedName": "string",
+          "repository": {
+            "type": "string",
+            "url": "string"
+          },
+          "source": {
+            "location": {
+              "npm": {
+                "filePath": "string",
+                "iconPath": "string",
+                "packageName": "string",
+                "registry": "string"
+              }
+            },
+            "shasum": "string"
+          },
+          "version": "string"
+        },
+        "preinstalled": "boolean",
+        "removable": "boolean",
+        "status": "string",
+        "version": "string",
+        "versionHistory": [
+          {
+            "date": "number",
+            "origin": "string",
+            "version": "string"
+          }
+        ]
+      },
+      "npm:@metamask/permissions-kernel-snap": {
+        "blocked": "boolean",
+        "enabled": "boolean",
+        "hideSnapBranding": "boolean",
+        "id": "string",
+        "initialPermissions": {
+          "endowment:rpc": {
+            "dapps": "boolean",
+            "snaps": "boolean"
+          }
+        },
+        "localizationFiles": [],
+        "manifest": {
+          "description": "string",
+          "initialPermissions": {
+            "endowment:rpc": {
+              "dapps": "boolean",
+              "snaps": "boolean"
+            }
+          },
+          "manifestVersion": "string",
+          "platformVersion": "string",
+          "proposedName": "string",
+          "repository": {
+            "type": "string",
+            "url": "string"
+          },
+          "source": {
+            "location": {
+              "npm": {
+                "filePath": "string",
+                "iconPath": "string",
+                "packageName": "string",
+                "registry": "string"
+              }
+            },
+            "shasum": "string"
+          },
+          "version": "string"
+        },
+        "preinstalled": "boolean",
+        "removable": "boolean",
+        "status": "string",
+        "version": "string",
+        "versionHistory": [
+          {
+            "date": "number",
+            "origin": "string",
+            "version": "string"
+          }
+        ]
+      },
+      "npm:@metamask/solana-wallet-snap": {
+        "blocked": "boolean",
+        "enabled": "boolean",
+        "hideSnapBranding": "boolean",
+        "id": "string",
+        "initialConnections": {
+          "https://portfolio.metamask.io": {}
+        },
+        "initialPermissions": {
+          "endowment:assets": {
+            "scopes": [
+              "string"
+            ]
+          },
+          "endowment:cronjob": {
+            "jobs": []
+          },
+          "endowment:keyring": {
+            "allowedOrigins": [
+              "string"
+            ]
+          },
+          "endowment:lifecycle-hooks": {},
+          "endowment:name-lookup": {
+            "chains": [
+              "string"
+            ]
+          },
+          "endowment:network-access": {},
+          "endowment:protocol": {
+            "scopes": {
+              "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp": {
+                "methods": [
+                  "string"
+                ]
+              },
+              "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1": {
+                "methods": [
+                  "string"
+                ]
+              }
+            }
+          },
+          "endowment:rpc": {
+            "dapps": "boolean",
+            "snaps": "boolean"
+          },
+          "snap_dialog": {},
+          "snap_getBip32Entropy": [
+            {
+              "curve": "string",
+              "path": [
+                "string"
+              ]
+            }
+          ],
+          "snap_getPreferences": {},
+          "snap_manageAccounts": {},
+          "snap_manageState": {}
+        },
+        "localizationFiles": [
+          {
+            "locale": "string",
+            "messages": {
+              "confirmation.account": {
+                "message": "string"
+              },
+              "confirmation.advanced.data": {
+                "message": "string"
+              },
+              "confirmation.advanced.hide": {
+                "message": "string"
+              },
+              "confirmation.advanced.programId": {
+                "message": "string"
+              },
+              "confirmation.advanced.show": {
+                "message": "string"
+              },
+              "confirmation.advanced.unknownInstruction": {
+                "message": "string"
+              },
+              "confirmation.cancelButton": {
+                "message": "string"
+              },
+              "confirmation.confirmButton": {
+                "message": "string"
+              },
+              "confirmation.estimatedChanges": {
+                "message": "string"
+              },
+              "confirmation.estimatedChanges.noChanges": {
+                "message": "string"
+              },
+              "confirmation.estimatedChanges.notAvailable": {
+                "message": "string"
+              },
+              "confirmation.estimatedChanges.receive": {
+                "message": "string"
+              },
+              "confirmation.estimatedChanges.send": {
+                "message": "string"
+              },
+              "confirmation.estimatedChanges.tooltip": {
+                "message": "string"
+              },
+              "confirmation.fee": {
+                "message": "string"
+              },
+              "confirmation.feeError": {
+                "message": "string"
+              },
+              "confirmation.network": {
+                "message": "string"
+              },
+              "confirmation.origin": {
+                "message": "string"
+              },
+              "confirmation.origin.tooltip": {
+                "message": "string"
+              },
+              "confirmation.recipient": {
+                "message": "string"
+              },
+              "confirmation.sendAndConfirmTransaction.title": {
+                "message": "string"
+              },
+              "confirmation.signAndSendTransaction.title": {
+                "message": "string"
+              },
+              "confirmation.signIn.badAccount": {
+                "message": "string"
+              },
+              "confirmation.signIn.badDomain": {
+                "message": "string"
+              },
+              "confirmation.signIn.chainId": {
+                "message": "string"
+              },
+              "confirmation.signIn.description": {
+                "message": "string"
+              },
+              "confirmation.signIn.domain": {
+                "message": "string"
+              },
+              "confirmation.signIn.expirationTime": {
+                "message": "string"
+              },
+              "confirmation.signIn.issuedAt": {
+                "message": "string"
+              },
+              "confirmation.signIn.message": {
+                "message": "string"
+              },
+              "confirmation.signIn.nonce": {
+                "message": "string"
+              },
+              "confirmation.signIn.notBefore": {
+                "message": "string"
+              },
+              "confirmation.signIn.requestId": {
+                "message": "string"
+              },
+              "confirmation.signIn.resources": {
+                "message": "string"
+              },
+              "confirmation.signIn.signingInWith": {
+                "message": "string"
+              },
+              "confirmation.signIn.statement": {
+                "message": "string"
+              },
+              "confirmation.signIn.title": {
+                "message": "string"
+              },
+              "confirmation.signIn.unknownDomain": {
+                "message": "string"
+              },
+              "confirmation.signIn.version": {
+                "message": "string"
+              },
+              "confirmation.signMessage.message": {
+                "message": "string"
+              },
+              "confirmation.signMessage.title": {
+                "message": "string"
+              },
+              "confirmation.signTransaction.title": {
+                "message": "string"
+              },
+              "confirmation.simulationErrorSubtitle": {
+                "message": "string"
+              },
+              "confirmation.simulationErrorTitle": {
+                "message": "string"
+              },
+              "confirmation.validationErrorLearnMore": {
+                "message": "string"
+              },
+              "confirmation.validationErrorSecurityAdviced": {
+                "message": "string"
+              },
+              "confirmation.validationErrorSubtitle": {
+                "message": "string"
+              },
+              "confirmation.validationErrorTitle": {
+                "message": "string"
+              },
+              "send.amountField": {
+                "message": "string"
+              },
+              "send.amountGreatherThanMinimumBalanceForRentExemptionError": {
+                "message": "string"
+              },
+              "send.amountRequiredError": {
+                "message": "string"
+              },
+              "send.assetField": {
+                "message": "string"
+              },
+              "send.balance": {
+                "message": "string"
+              },
+              "send.cancelButton": {
+                "message": "string"
+              },
+              "send.confirmation.cancelButton": {
+                "message": "string"
+              },
+              "send.confirmation.fee": {
+                "message": "string"
+              },
+              "send.confirmation.from": {
+                "message": "string"
+              },
+              "send.confirmation.network": {
+                "message": "string"
+              },
+              "send.confirmation.recipient": {
+                "message": "string"
+              },
+              "send.confirmation.sendButton": {
+                "message": "string"
+              },
+              "send.confirmation.title": {
+                "message": "string"
+              },
+              "send.confirmation.transactionSpeed": {
+                "message": "string"
+              },
+              "send.confirmation.viewTransaction": {
+                "message": "string"
+              },
+              "send.continueButton": {
+                "message": "string"
+              },
+              "send.fromField": {
+                "message": "string"
+              },
+              "send.fromRequiredError": {
+                "message": "string"
+              },
+              "send.insufficientBalance": {
+                "message": "string"
+              },
+              "send.insuffientSolToCoverFee": {
+                "message": "string"
+              },
+              "send.maxButton": {
+                "message": "string"
+              },
+              "send.selectedTokenPriceNotAvailable": {
+                "message": "string"
+              },
+              "send.send-pending.subtitle": {
+                "message": "string"
+              },
+              "send.send-pending.title": {
+                "message": "string"
+              },
+              "send.simulationMessageAPIError": {
+                "message": "string"
+              },
+              "send.simulationMessageError": {
+                "message": "string"
+              },
+              "send.simulationTitleAPIError": {
+                "message": "string"
+              },
+              "send.simulationTitleError": {
+                "message": "string"
+              },
+              "send.title": {
+                "message": "string"
+              },
+              "send.toDomainResolutionStatus.error": {
+                "message": "string"
+              },
+              "send.toDomainResolutionStatus.fetched": {
+                "message": "string"
+              },
+              "send.toDomainResolutionStatus.fetching": {
+                "message": "string"
+              },
+              "send.toDomainResolutionStatus.initial": {
+                "message": "string"
+              },
+              "send.toField": {
+                "message": "string"
+              },
+              "send.toInvalidError": {
+                "message": "string"
+              },
+              "send.toInvalidErrorDomain": {
+                "message": "string"
+              },
+              "send.toPlaceholder": {
+                "message": "string"
+              },
+              "send.toRequiredError": {
+                "message": "string"
+              },
+              "send.transaction-failure.subtitle": {
+                "message": "string"
+              },
+              "send.transaction-failure.title": {
+                "message": "string"
+              },
+              "send.transaction-success.subtitle": {
+                "message": "string"
+              },
+              "send.transaction-success.title": {
+                "message": "string"
+              },
+              "transactionScan.errors.accountAlreadyInUse": {
+                "message": "string"
+              },
+              "transactionScan.errors.insufficientSol": {
+                "message": "string"
+              },
+              "transactionScan.errors.slippageToleranceExceeded": {
+                "message": "string"
+              },
+              "transactionScan.errors.unknownError": {
+                "message": "string"
+              }
+            }
+          }
+        ],
+        "manifest": {
+          "description": "string",
+          "initialConnections": {
+            "https://portfolio.metamask.io": {}
+          },
+          "initialPermissions": {
+            "endowment:assets": {
+              "scopes": [
+                "string"
+              ]
+            },
+            "endowment:cronjob": {
+              "jobs": []
+            },
+            "endowment:keyring": {
+              "allowedOrigins": [
+                "string"
+              ]
+            },
+            "endowment:lifecycle-hooks": {},
+            "endowment:name-lookup": {
+              "chains": [
+                "string"
+              ]
+            },
+            "endowment:network-access": {},
+            "endowment:protocol": {
+              "scopes": {
+                "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp": {
+                  "methods": [
+                    "string"
+                  ]
+                },
+                "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1": {
+                  "methods": [
+                    "string"
+                  ]
+                }
+              }
+            },
+            "endowment:rpc": {
+              "dapps": "boolean",
+              "snaps": "boolean"
+            },
+            "snap_dialog": {},
+            "snap_getBip32Entropy": [
+              {
+                "curve": "string",
+                "path": [
+                  "string"
+                ]
+              }
+            ],
+            "snap_getPreferences": {},
+            "snap_manageAccounts": {},
+            "snap_manageState": {}
+          },
+          "manifestVersion": "string",
+          "platformVersion": "string",
+          "proposedName": "string",
+          "repository": {
+            "type": "string",
+            "url": "string"
+          },
+          "source": {
+            "locales": [
+              "string"
+            ],
+            "location": {
+              "npm": {
+                "filePath": "string",
+                "iconPath": "string",
+                "packageName": "string",
+                "registry": "string"
+              }
+            },
+            "shasum": "string"
+          },
+          "version": "string"
+        },
+        "preinstalled": "boolean",
+        "removable": "boolean",
+        "status": "string",
+        "version": "string",
+        "versionHistory": [
+          {
+            "date": "number",
+            "origin": "string",
+            "version": "string"
+          }
+        ]
+      },
+      "npm:@metamask/tron-wallet-snap": {
+        "blocked": "boolean",
+        "enabled": "boolean",
+        "hideSnapBranding": "boolean",
+        "id": "string",
+        "initialConnections": {
+          "https://portfolio.metamask.io": {}
+        },
+        "initialPermissions": {
+          "endowment:assets": {
+            "scopes": [
+              "string"
+            ]
+          },
+          "endowment:cronjob": {
+            "jobs": [
+              {
+                "duration": "string",
+                "request": {
+                  "method": "string"
+                }
+              }
+            ]
+          },
+          "endowment:keyring": {
+            "allowedOrigins": [
+              "string"
+            ]
+          },
+          "endowment:network-access": {},
+          "snap_dialog": {},
+          "snap_getBip32Entropy": [
+            {
+              "curve": "string",
+              "path": [
+                "string"
+              ]
+            }
+          ],
+          "snap_getPreferences": {},
+          "snap_manageAccounts": {},
+          "snap_manageState": {}
+        },
+        "localizationFiles": [
+          {
+            "locale": "string",
+            "messages": {
+              "confirmation.account": {
+                "message": "string"
+              },
+              "confirmation.bandwidthConsumed": {
+                "message": "string"
+              },
+              "confirmation.cancelButton": {
+                "message": "string"
+              },
+              "confirmation.confirmButton": {
+                "message": "string"
+              },
+              "confirmation.estimatedChanges.noChanges": {
+                "message": "string"
+              },
+              "confirmation.estimatedChanges.notAvailable": {
+                "message": "string"
+              },
+              "confirmation.estimatedChanges.receive": {
+                "message": "string"
+              },
+              "confirmation.estimatedChanges.send": {
+                "message": "string"
+              },
+              "confirmation.estimatedChanges.title": {
+                "message": "string"
+              },
+              "confirmation.estimatedChanges.tooltip": {
+                "message": "string"
+              },
+              "confirmation.estimatedChanges.unsupportedContract": {
+                "message": "string"
+              },
+              "confirmation.from": {
+                "message": "string"
+              },
+              "confirmation.network": {
+                "message": "string"
+              },
+              "confirmation.origin": {
+                "message": "string"
+              },
+              "confirmation.origin.tooltip": {
+                "message": "string"
+              },
+              "confirmation.signMessage.message": {
+                "message": "string"
+              },
+              "confirmation.signMessage.title": {
+                "message": "string"
+              },
+              "confirmation.signTransaction.title": {
+                "message": "string"
+              },
+              "confirmation.simulationErrorSubtitle": {
+                "message": "string"
+              },
+              "confirmation.simulationErrorTitle": {
+                "message": "string"
+              },
+              "confirmation.simulationMessageAPIError": {
+                "message": "string"
+              },
+              "confirmation.simulationTitleAPIError": {
+                "message": "string"
+              },
+              "confirmation.to": {
+                "message": "string"
+              },
+              "confirmation.transaction.title": {
+                "message": "string"
+              },
+              "confirmation.transactionFee": {
+                "message": "string"
+              },
+              "confirmation.validationErrorLearnMore": {
+                "message": "string"
+              },
+              "confirmation.validationErrorSecurityAdviced": {
+                "message": "string"
+              },
+              "confirmation.validationErrorSubtitle": {
+                "message": "string"
+              },
+              "confirmation.validationErrorTitle": {
+                "message": "string"
+              },
+              "transactionScan.errors.insufficientBalance": {
+                "message": "string"
+              },
+              "transactionScan.errors.insufficientFunds": {
+                "message": "string"
+              },
+              "transactionScan.errors.invalidAddress": {
+                "message": "string"
+              },
+              "transactionScan.errors.invalidTransaction": {
+                "message": "string"
+              },
+              "transactionScan.errors.unknownError": {
+                "message": "string"
+              },
+              "transactionScan.errors.unsupportedEIP712Message": {
+                "message": "string"
+              }
+            }
+          }
+        ],
+        "manifest": {
+          "description": "string",
+          "initialConnections": {
+            "https://portfolio.metamask.io": {}
+          },
+          "initialPermissions": {
+            "endowment:assets": {
+              "scopes": [
+                "string"
+              ]
+            },
+            "endowment:cronjob": {
+              "jobs": [
+                {
+                  "duration": "string",
+                  "request": {
+                    "method": "string"
+                  }
+                }
+              ]
+            },
+            "endowment:keyring": {
+              "allowedOrigins": [
+                "string"
+              ]
+            },
+            "endowment:network-access": {},
+            "snap_dialog": {},
+            "snap_getBip32Entropy": [
+              {
+                "curve": "string",
+                "path": [
+                  "string"
+                ]
+              }
+            ],
+            "snap_getPreferences": {},
+            "snap_manageAccounts": {},
+            "snap_manageState": {}
+          },
+          "manifestVersion": "string",
+          "platformVersion": "string",
+          "proposedName": "string",
+          "repository": {
+            "type": "string",
+            "url": "string"
+          },
+          "source": {
+            "locales": [
+              "string"
+            ],
+            "location": {
+              "npm": {
+                "filePath": "string",
+                "iconPath": "string",
+                "packageName": "string",
+                "registry": "string"
+              }
+            },
+            "shasum": "string"
+          },
+          "version": "string"
+        },
+        "preinstalled": "boolean",
+        "removable": "boolean",
+        "status": "string",
+        "version": "string",
+        "versionHistory": [
+          {
+            "date": "number",
+            "origin": "string",
+            "version": "string"
+          }
+        ]
+      }
+    },
     "snapsAddSnapAccountModalDismissed": "boolean",
     "socialBackupsMetadata": [],
     "srpSessionData": {
-      "01KA0MT07W98B2G9474CFDC6VM": {
+      "01KGPGYE2JJGMXDJPEVXKPJ1JG": {
         "profile": {
           "identifierId": "string",
           "metaMetricsId": "string",
@@ -1355,6 +27769,7 @@
       }
     },
     "storageMetadata": [],
+    "storageWriteErrorType": "null",
     "subjectMetadata": {
       "npm:@metamask/bitcoin-wallet-snap": {
         "extensionId": "null",
@@ -1366,6 +27781,15 @@
         "version": "string"
       },
       "npm:@metamask/ens-resolver-snap": {
+        "extensionId": "null",
+        "iconUrl": "null",
+        "name": "string",
+        "origin": "string",
+        "subjectType": "string",
+        "svgIcon": "string",
+        "version": "string"
+      },
+      "npm:@metamask/gator-permissions-snap": {
         "extensionId": "null",
         "iconUrl": "null",
         "name": "string",
@@ -1401,15 +27825,6 @@
         "svgIcon": "string",
         "version": "string"
       },
-      "npm:@metamask/gator-permissions-snap": {
-        "extensionId": "null",
-        "iconUrl": "null",
-        "name": "string",
-        "origin": "string",
-        "subjectType": "string",
-        "svgIcon": "string",
-        "version": "string"
-      },
       "npm:@metamask/solana-wallet-snap": {
         "extensionId": "null",
         "iconUrl": "null",
@@ -1429,29 +27844,1378 @@
         "version": "string"
       }
     },
-    "subjects": {},
-    "submitHistory": [],
-    "subscriptionAccountsSeen": ["string"],
-    "subscriptions": [],
-    "surveyLinkLastClickedOrClosed": "null",
-    "termsOfUseLastAgreed": "number",
-    "theme": "string",
-    "throttledOrigins": {},
-    "timeoutMinutes": "number",
-    "tokenBalances": {
-      "0x5cfe73b6021e818b776b421b1c4db2474086a7e1": {
-        "0x539": {
-          "0x0000000000000000000000000000000000000000": "string"
+    "subjects": {
+      "http://localhost:3000": {
+        "origin": "string",
+        "permissions": {
+          "wallet_snap": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "npm:@metamask/institutional-wallet-snap": {}
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          }
+        }
+      },
+      "http://localhost:8000": {
+        "origin": "string",
+        "permissions": {
+          "wallet_snap": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "npm:@metamask/institutional-wallet-snap": {}
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          }
+        }
+      },
+      "https://alpha.mycactus.io": {
+        "origin": "string",
+        "permissions": {
+          "wallet_snap": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "npm:@metamask/institutional-wallet-snap": {}
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          }
+        }
+      },
+      "https://app-beta.signer.cubist.dev": {
+        "origin": "string",
+        "permissions": {
+          "wallet_snap": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "npm:@metamask/institutional-wallet-snap": {}
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          }
+        }
+      },
+      "https://app-gamma.signer.cubist.dev": {
+        "origin": "string",
+        "permissions": {
+          "wallet_snap": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "npm:@metamask/institutional-wallet-snap": {}
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          }
+        }
+      },
+      "https://app.bitgo-test.com": {
+        "origin": "string",
+        "permissions": {
+          "wallet_snap": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "npm:@metamask/institutional-wallet-snap": {}
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          }
+        }
+      },
+      "https://app.bitgo.com": {
+        "origin": "string",
+        "permissions": {
+          "wallet_snap": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "npm:@metamask/institutional-wallet-snap": {}
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          }
+        }
+      },
+      "https://app.metamask.io": {
+        "origin": "string",
+        "permissions": {
+          "wallet_snap": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "npm:@metamask/message-signing-snap": {}
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          }
+        }
+      },
+      "https://app.signer.cubist.dev": {
+        "origin": "string",
+        "permissions": {
+          "wallet_snap": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "npm:@metamask/institutional-wallet-snap": {}
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          }
+        }
+      },
+      "https://apps-portal.safe.global": {
+        "origin": "string",
+        "permissions": {
+          "wallet_snap": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "npm:@metamask/institutional-wallet-snap": {}
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          }
+        }
+      },
+      "https://console.dev.mpcvault.com": {
+        "origin": "string",
+        "permissions": {
+          "wallet_snap": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "npm:@metamask/institutional-wallet-snap": {}
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          }
+        }
+      },
+      "https://console.fireblocks.io": {
+        "origin": "string",
+        "permissions": {
+          "wallet_snap": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "npm:@metamask/institutional-wallet-snap": {}
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          }
+        }
+      },
+      "https://console.mpcvault.com": {
+        "origin": "string",
+        "permissions": {
+          "wallet_snap": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "npm:@metamask/institutional-wallet-snap": {}
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          }
+        }
+      },
+      "https://debug.mycactus.dev:1443": {
+        "origin": "string",
+        "permissions": {
+          "wallet_snap": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "npm:@metamask/institutional-wallet-snap": {}
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          }
+        }
+      },
+      "https://dev10-console.waterballoons.xyz": {
+        "origin": "string",
+        "permissions": {
+          "wallet_snap": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "npm:@metamask/institutional-wallet-snap": {}
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          }
+        }
+      },
+      "https://dev4-console.waterballoons.xyz": {
+        "origin": "string",
+        "permissions": {
+          "wallet_snap": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "npm:@metamask/institutional-wallet-snap": {}
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          }
+        }
+      },
+      "https://developer.metamask.io": {
+        "origin": "string",
+        "permissions": {
+          "wallet_snap": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "npm:@metamask/message-signing-snap": {}
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          }
+        }
+      },
+      "https://docs.metamask.io": {
+        "origin": "string",
+        "permissions": {
+          "wallet_snap": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "npm:@metamask/message-signing-snap": {}
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          }
+        }
+      },
+      "https://eu-console.fireblocks.io": {
+        "origin": "string",
+        "permissions": {
+          "wallet_snap": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "npm:@metamask/institutional-wallet-snap": {}
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          }
+        }
+      },
+      "https://eu2-console.fireblocks.io": {
+        "origin": "string",
+        "permissions": {
+          "wallet_snap": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "npm:@metamask/institutional-wallet-snap": {}
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          }
+        }
+      },
+      "https://local.waterballoons.xyz:4200": {
+        "origin": "string",
+        "permissions": {
+          "wallet_snap": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "npm:@metamask/institutional-wallet-snap": {}
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          }
+        }
+      },
+      "https://localhost:3000": {
+        "origin": "string",
+        "permissions": {
+          "wallet_snap": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "npm:@metamask/institutional-wallet-snap": {}
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          }
+        }
+      },
+      "https://neptune-custody-ui.metamask-institutional.io": {
+        "origin": "string",
+        "permissions": {
+          "wallet_snap": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "npm:@metamask/institutional-wallet-snap": {}
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          }
+        }
+      },
+      "https://portfolio-builds.metafi-dev.codefi.network": {
+        "origin": "string",
+        "permissions": {
+          "wallet_snap": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "npm:@metamask/message-signing-snap": {}
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          }
+        }
+      },
+      "https://portfolio.metamask.io": {
+        "origin": "string",
+        "permissions": {
+          "wallet_snap": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "npm:@metamask/message-signing-snap": {},
+                  "npm:@metamask/solana-wallet-snap": {},
+                  "npm:@metamask/tron-wallet-snap": {}
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          }
+        }
+      },
+      "https://pre.mycactus.com": {
+        "origin": "string",
+        "permissions": {
+          "wallet_snap": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "npm:@metamask/institutional-wallet-snap": {}
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          }
+        }
+      },
+      "https://sandbox.fireblocks.io": {
+        "origin": "string",
+        "permissions": {
+          "wallet_snap": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "npm:@metamask/institutional-wallet-snap": {}
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          }
+        }
+      },
+      "https://saturn-custody-ui.metamask-institutional.io": {
+        "origin": "string",
+        "permissions": {
+          "wallet_snap": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "npm:@metamask/institutional-wallet-snap": {}
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          }
+        }
+      },
+      "https://ui-preprod-v2.qa.zodia.io": {
+        "origin": "string",
+        "permissions": {
+          "wallet_snap": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "npm:@metamask/institutional-wallet-snap": {}
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          }
+        }
+      },
+      "https://ui-preprod-v2.uat.zodia.io": {
+        "origin": "string",
+        "permissions": {
+          "wallet_snap": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "npm:@metamask/institutional-wallet-snap": {}
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          }
+        }
+      },
+      "https://ui-v2.qa.zodia.io": {
+        "origin": "string",
+        "permissions": {
+          "wallet_snap": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "npm:@metamask/institutional-wallet-snap": {}
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          }
+        }
+      },
+      "https://ui-v2.sit.zodia.io": {
+        "origin": "string",
+        "permissions": {
+          "wallet_snap": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "npm:@metamask/institutional-wallet-snap": {}
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          }
+        }
+      },
+      "https://v2.custody.zodia.io": {
+        "origin": "string",
+        "permissions": {
+          "wallet_snap": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "npm:@metamask/institutional-wallet-snap": {}
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          }
+        }
+      },
+      "https://www.mycactus.com": {
+        "origin": "string",
+        "permissions": {
+          "wallet_snap": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "npm:@metamask/institutional-wallet-snap": {}
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          }
+        }
+      },
+      "https://www.mycactus.dev": {
+        "origin": "string",
+        "permissions": {
+          "wallet_snap": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "npm:@metamask/institutional-wallet-snap": {}
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          }
+        }
+      },
+      "localhost:8000": {
+        "origin": "string",
+        "permissions": {
+          "wallet_snap": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "npm:@metamask/institutional-wallet-snap": {}
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          }
+        }
+      },
+      "npm:@metamask/bitcoin-wallet-snap": {
+        "origin": "string",
+        "permissions": {
+          "endowment:assets": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": [
+                  "string"
+                ]
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "endowment:cronjob": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "jobs": [
+                    {
+                      "duration": "string",
+                      "request": {
+                        "method": "string"
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "endowment:keyring": {
+            "caveats": "null",
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "endowment:lifecycle-hooks": {
+            "caveats": "null",
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "endowment:network-access": {
+            "caveats": "null",
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "endowment:webassembly": {
+            "caveats": "null",
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "snap_dialog": {
+            "caveats": "null",
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "snap_getBip32Entropy": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": [
+                  {
+                    "curve": "string",
+                    "path": [
+                      "string"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "snap_getPreferences": {
+            "caveats": "null",
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "snap_manageAccounts": {
+            "caveats": "null",
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "snap_manageState": {
+            "caveats": "null",
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          }
+        }
+      },
+      "npm:@metamask/ens-resolver-snap": {
+        "origin": "string",
+        "permissions": {
+          "endowment:ethereum-provider": {
+            "caveats": "null",
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "endowment:name-lookup": {
+            "caveats": "null",
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "endowment:network-access": {
+            "caveats": "null",
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          }
+        }
+      },
+      "npm:@metamask/gator-permissions-snap": {
+        "origin": "string",
+        "permissions": {
+          "endowment:ethereum-provider": {
+            "caveats": "null",
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "endowment:network-access": {
+            "caveats": "null",
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "endowment:rpc": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "dapps": "boolean",
+                  "snaps": "boolean"
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "snap_dialog": {
+            "caveats": "null",
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "snap_getPreferences": {
+            "caveats": "null",
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "snap_manageState": {
+            "caveats": "null",
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "wallet_snap": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "npm:@metamask/message-signing-snap": {}
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          }
+        }
+      },
+      "npm:@metamask/institutional-wallet-snap": {
+        "origin": "string",
+        "permissions": {
+          "endowment:cronjob": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "jobs": [
+                    {
+                      "expression": "string",
+                      "request": {
+                        "method": "string"
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "endowment:ethereum-provider": {
+            "caveats": "null",
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "endowment:keyring": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "allowedOrigins": [
+                    "string"
+                  ]
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "endowment:network-access": {
+            "caveats": "null",
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "endowment:page-home": {
+            "caveats": "null",
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "endowment:rpc": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "allowedOrigins": [
+                    "string"
+                  ]
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "snap_dialog": {
+            "caveats": "null",
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "snap_manageAccounts": {
+            "caveats": "null",
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "snap_manageState": {
+            "caveats": "null",
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "snap_notify": {
+            "caveats": "null",
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          }
+        }
+      },
+      "npm:@metamask/message-signing-snap": {
+        "origin": "string",
+        "permissions": {
+          "endowment:rpc": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "dapps": "boolean",
+                  "snaps": "boolean"
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "snap_getEntropy": {
+            "caveats": "null",
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          }
+        }
+      },
+      "npm:@metamask/permissions-kernel-snap": {
+        "origin": "string",
+        "permissions": {
+          "endowment:rpc": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "dapps": "boolean",
+                  "snaps": "boolean"
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "wallet_snap": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "npm:@metamask/gator-permissions-snap": {}
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          }
+        }
+      },
+      "npm:@metamask/solana-wallet-snap": {
+        "origin": "string",
+        "permissions": {
+          "endowment:assets": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": [
+                  "string"
+                ]
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "endowment:cronjob": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "jobs": []
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "endowment:keyring": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "allowedOrigins": [
+                    "string"
+                  ]
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "endowment:lifecycle-hooks": {
+            "caveats": "null",
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "endowment:name-lookup": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": [
+                  "string"
+                ]
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "endowment:network-access": {
+            "caveats": "null",
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "endowment:protocol": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp": {
+                    "methods": [
+                      "string"
+                    ]
+                  },
+                  "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1": {
+                    "methods": [
+                      "string"
+                    ]
+                  }
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "endowment:rpc": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "dapps": "boolean",
+                  "snaps": "boolean"
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "snap_dialog": {
+            "caveats": "null",
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "snap_getBip32Entropy": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": [
+                  {
+                    "curve": "string",
+                    "path": [
+                      "string"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "snap_getPreferences": {
+            "caveats": "null",
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "snap_manageAccounts": {
+            "caveats": "null",
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "snap_manageState": {
+            "caveats": "null",
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          }
+        }
+      },
+      "npm:@metamask/tron-wallet-snap": {
+        "origin": "string",
+        "permissions": {
+          "endowment:assets": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": [
+                  "string"
+                ]
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "endowment:cronjob": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "jobs": [
+                    {
+                      "duration": "string",
+                      "request": {
+                        "method": "string"
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "endowment:keyring": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": {
+                  "allowedOrigins": [
+                    "string"
+                  ]
+                }
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "endowment:network-access": {
+            "caveats": "null",
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "snap_dialog": {
+            "caveats": "null",
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "snap_getBip32Entropy": {
+            "caveats": [
+              {
+                "type": "string",
+                "value": [
+                  {
+                    "curve": "string",
+                    "path": [
+                      "string"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "snap_getPreferences": {
+            "caveats": "null",
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "snap_manageAccounts": {
+            "caveats": "null",
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          },
+          "snap_manageState": {
+            "caveats": "null",
+            "date": "number",
+            "id": "string",
+            "invoker": "string",
+            "parentCapability": "string"
+          }
         }
       }
     },
+    "submitHistory": [],
+    "subscriptionAccountsSeen": [
+      "string"
+    ],
+    "subscriptions": [],
+    "surveyLinkLastClickedOrClosed": "null",
+    "syncQueue": {
+      "01KGPGYE2JJGMXDJPEVXKPJ1JG": [
+        {
+          "address": "string",
+          "scopes": [
+            "string"
+          ]
+        }
+      ]
+    },
+    "termsOfUseLastAgreed": "number",
+    "theme": "string",
+    "thresholdCache": {
+      "*": "number"
+    },
+    "throttledOrigins": {},
+    "timeoutMinutes": "number",
+    "tokenBalances": {},
     "tokenScanCache": {},
+    "tokenWarnings": [],
     "tokensChainsCache": {
       "0x539": {
         "data": {
           "0x0d8775f648430679a709e98d2b0cb6250d2887ef": {
             "address": "string",
-            "aggregators": ["string"],
+            "aggregators": [
+              "string"
+            ],
             "decimals": "number",
             "iconUrl": "string",
             "name": "string",
@@ -1460,7 +29224,9 @@
           },
           "0x6b175474e89094c44da98b954eedeac495271d0f": {
             "address": "string",
-            "aggregators": ["string"],
+            "aggregators": [
+              "string"
+            ],
             "decimals": "number",
             "erc20Permit": "boolean",
             "fees": {
@@ -1479,12 +29245,11 @@
         "timestamp": "number"
       }
     },
-    "tokenWarnings": [],
-    "tradeConfigurations": {
-      "testnet": {},
-      "mainnet": {}
-    },
     "tracesBeforeMetricsOptIn": [],
+    "tradeConfigurations": {
+      "mainnet": {},
+      "testnet": {}
+    },
     "traits": {
       "install_date_ext": "string",
       "storage_kind": "string"
@@ -1514,30 +29279,29 @@
     "useMultiAccountBalanceChecker": "boolean",
     "useNftDetection": "boolean",
     "usePhishDetect": "boolean",
-    "userOperations": {},
     "useSafeChainsListValidation": "boolean",
     "useTokenDetection": "boolean",
     "useTransactionSimulations": "boolean",
+    "userOperations": {},
     "versionInfo": [],
     "watchEthereumAccountEnabled": "boolean",
     "watchlistMarkets": {
-      "testnet": [],
-      "mainnet": []
+      "mainnet": [],
+      "testnet": []
     },
+    "web3ShimUsageOrigins": {},
     "withdrawInProgress": "boolean",
     "withdrawalProgress": {
-      "progress": "number",
+      "activeWithdrawalId": "null",
       "lastUpdated": "number",
-      "activeWithdrawalId": "null"
+      "progress": "number"
     },
-    "withdrawalRequests": [],
-    "web3ShimUsageOrigins": {},
-    "verifiedSnaps": {}
+    "withdrawalRequests": []
   },
   "perpsTutorial": {
-    "tutorialModalOpen": "boolean",
     "activeStep": "string",
-    "tutorialCompleted": "boolean"
+    "tutorialCompleted": "boolean",
+    "tutorialModalOpen": "boolean"
   },
   "platform": {
     "arch": "string",
@@ -1557,27 +29321,27 @@
     "isFetched": "boolean"
   },
   "rewards": {
-    "onboardingModalOpen": "boolean",
-    "onboardingActiveStep": "string",
-    "onboardingModalRendered": "boolean",
-    "onboardingReferralCode": "string",
-    "geoLocation": "null",
-    "optinAllowedForGeo": "null",
-    "optinAllowedForGeoLoading": "boolean",
-    "optinAllowedForGeoError": "boolean",
-    "candidateSubscriptionId": "string",
-    "seasonStatus": "null",
-    "seasonStatusError": "null",
-    "seasonStatusLoading": "boolean",
-    "rewardsEnabled": "boolean",
-    "rewardsBadgeHidden": "boolean",
     "accountLinkedTimestamp": "null",
+    "candidateSubscriptionId": "string",
     "errorToast": {
       "actionText": "string",
       "description": "string",
       "isOpen": "boolean",
       "title": "string"
-    }
+    },
+    "geoLocation": "null",
+    "onboardingActiveStep": "string",
+    "onboardingModalOpen": "boolean",
+    "onboardingModalRendered": "boolean",
+    "onboardingReferralCode": "string",
+    "optinAllowedForGeo": "null",
+    "optinAllowedForGeoError": "boolean",
+    "optinAllowedForGeoLoading": "boolean",
+    "rewardsBadgeHidden": "boolean",
+    "rewardsEnabled": "boolean",
+    "seasonStatus": "null",
+    "seasonStatusError": "null",
+    "seasonStatusLoading": "boolean"
   },
   "smartAccounts": {
     "toggleStates": {}
@@ -1604,8 +29368,8 @@
     "quotesFetchStartTime": "null",
     "reviewSwapClickedTimestamp": "null",
     "swapsSTXLoading": "boolean",
-    "topAssets": {},
     "toToken": "null",
+    "topAssets": {},
     "tradeTxId": "null",
     "transactionSettingsOpened": "boolean"
   },

--- a/test/e2e/tests/settings/state-logs.json
+++ b/test/e2e/tests/settings/state-logs.json
@@ -19439,9 +19439,7 @@
         "entropy:01KGPGYE2JJGMXDJPEVXKPJ1JG": {
           "groups": {
             "entropy:01KGPGYE2JJGMXDJPEVXKPJ1JG/0": {
-              "accounts": [
-                "string"
-              ],
+              "accounts": ["string"],
               "id": "string",
               "metadata": {
                 "entropy": {
@@ -19469,15 +19467,9 @@
     },
     "accountWalletsMetadata": {},
     "accountsAssets": {
-      "<bitcoin-account-1>": [
-        "string"
-      ],
-      "<solana-account-1>": [
-        "string"
-      ],
-      "<tron-account-1>": [
-        "string"
-      ]
+      "<bitcoin-account-1>": ["string"],
+      "<solana-account-1>": ["string"],
+      "<tron-account-1>": ["string"]
     },
     "accountsByChainId": {
       "0x1": {
@@ -19959,9 +19951,7 @@
     "canTrackWalletFundsObtained": "boolean",
     "claims": [],
     "claimsConfigurations": {
-      "supportedNetworks": [
-        "string"
-      ],
+      "supportedNetworks": ["string"],
       "validSubmissionWindowDays": "number"
     },
     "completedOnboarding": "boolean",
@@ -19993,9 +19983,7 @@
       }
     },
     "coverageResults": {},
-    "cryptocurrencies": [
-      "string"
-    ],
+    "cryptocurrencies": ["string"],
     "currencyRates": {
       "ETH": {
         "conversionDate": "null",
@@ -20029,9 +20017,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -20056,9 +20042,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -20167,9 +20151,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -20199,9 +20181,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -20233,9 +20213,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -20259,9 +20237,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -20290,9 +20266,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -20356,9 +20330,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -20392,9 +20364,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -20426,9 +20396,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -20492,9 +20460,7 @@
             },
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -20525,9 +20491,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -20559,9 +20523,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -20587,9 +20549,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -20626,9 +20586,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -20747,9 +20705,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -20773,9 +20729,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -20832,9 +20786,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -20865,9 +20817,7 @@
             },
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -20903,9 +20853,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -21000,9 +20948,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -21034,9 +20980,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -21165,9 +21109,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -21199,9 +21141,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -21233,9 +21173,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -21293,9 +21231,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -21349,9 +21285,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -21386,9 +21320,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -21412,9 +21344,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -21446,9 +21376,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -21539,9 +21467,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -22497,9 +22423,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -22534,9 +22458,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -22600,9 +22522,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -22687,9 +22607,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -22747,9 +22665,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -22780,9 +22696,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -22818,9 +22732,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -22854,9 +22766,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -22891,9 +22801,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -22922,9 +22830,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -22959,9 +22865,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -22993,9 +22897,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -23057,9 +22959,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -23100,9 +23000,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -23163,9 +23061,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -23197,9 +23093,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -23239,9 +23133,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -23267,9 +23159,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -23299,9 +23189,7 @@
             },
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -23357,9 +23245,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -23391,9 +23277,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -23424,9 +23308,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -23452,9 +23334,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -23486,9 +23366,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -23574,9 +23452,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -23709,9 +23585,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -23741,9 +23615,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -23775,9 +23647,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -23901,9 +23771,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -23952,9 +23820,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -23980,9 +23846,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -24096,9 +23960,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -24124,9 +23986,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -24313,9 +24173,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -24347,9 +24205,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -24382,9 +24238,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -24409,9 +24263,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -24436,9 +24288,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -24469,9 +24319,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -24575,9 +24423,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -24631,9 +24477,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -24685,9 +24529,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -24711,9 +24553,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -24739,9 +24579,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -24797,9 +24635,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -24830,9 +24666,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -24881,9 +24715,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -24936,9 +24768,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -24961,9 +24791,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -25073,9 +24901,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -25137,9 +24963,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -25174,9 +24998,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -25227,9 +25049,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -25260,9 +25080,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -25294,9 +25112,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -25322,9 +25138,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -25349,9 +25163,7 @@
             "category": "string",
             "description": "string",
             "name": "string",
-            "screenshots": [
-              "string"
-            ],
+            "screenshots": ["string"],
             "sourceCode": "string",
             "summary": "string",
             "support": {
@@ -25560,9 +25372,7 @@
     "firstTimeInfo": {},
     "forgottenPassword": "boolean",
     "fragments": {},
-    "fullScreenGasPollTokens": [
-      "string"
-    ],
+    "fullScreenGasPollTokens": ["string"],
     "gasEstimateType": "string",
     "gasFeeEstimates": {},
     "gasFeeEstimatesByChainId": {},
@@ -25603,9 +25413,7 @@
               "name": "string"
             }
           },
-          "methods": [
-            "string"
-          ],
+          "methods": ["string"],
           "options": {
             "entropy": {
               "derivationPath": "string",
@@ -25616,9 +25424,7 @@
             "entropySource": "string",
             "exportable": "boolean"
           },
-          "scopes": [
-            "string"
-          ],
+          "scopes": ["string"],
           "type": "string"
         },
         "<solana-account-1>": {
@@ -25637,9 +25443,7 @@
               "name": "string"
             }
           },
-          "methods": [
-            "string"
-          ],
+          "methods": ["string"],
           "options": {
             "derivationPath": "string",
             "entropy": {
@@ -25651,9 +25455,7 @@
             "entropySource": "string",
             "index": "number"
           },
-          "scopes": [
-            "string"
-          ],
+          "scopes": ["string"],
           "type": "string"
         },
         "<tron-account-1>": {
@@ -25672,9 +25474,7 @@
               "name": "string"
             }
           },
-          "methods": [
-            "string"
-          ],
+          "methods": ["string"],
           "options": {
             "addressType": "string",
             "entropy": {
@@ -25689,9 +25489,7 @@
             "index": "number",
             "scope": "string"
           },
-          "scopes": [
-            "string"
-          ],
+          "scopes": ["string"],
           "type": "string"
         },
         "d5e45e4a-3b04-4a09-a5e1-39762e5c6be4": {
@@ -25705,9 +25503,7 @@
             "lastSelected": "number",
             "name": "string"
           },
-          "methods": [
-            "string"
-          ],
+          "methods": ["string"],
           "options": {
             "derivationPath": "string",
             "entropy": {
@@ -25719,9 +25515,7 @@
             "entropySource": "string",
             "groupIndex": "number"
           },
-          "scopes": [
-            "string"
-          ],
+          "scopes": ["string"],
           "type": "string"
         }
       },
@@ -25763,9 +25557,7 @@
     "isWalletResetInProgress": "boolean",
     "keyrings": [
       {
-        "accounts": [
-          "string"
-        ],
+        "accounts": ["string"],
         "metadata": {
           "id": "string",
           "name": "string"
@@ -25896,9 +25688,7 @@
     "networkConfigurations": {},
     "networkConfigurationsByChainId": {
       "0x1": {
-        "blockExplorerUrls": [
-          "string"
-        ],
+        "blockExplorerUrls": ["string"],
         "chainId": "string",
         "defaultBlockExplorerUrlIndex": "number",
         "defaultRpcEndpointIndex": "number",
@@ -25914,9 +25704,7 @@
         ]
       },
       "0x18c7": {
-        "blockExplorerUrls": [
-          "string"
-        ],
+        "blockExplorerUrls": ["string"],
         "chainId": "string",
         "defaultBlockExplorerUrlIndex": "number",
         "defaultRpcEndpointIndex": "number",
@@ -25932,9 +25720,7 @@
         ]
       },
       "0x2105": {
-        "blockExplorerUrls": [
-          "string"
-        ],
+        "blockExplorerUrls": ["string"],
         "chainId": "string",
         "defaultBlockExplorerUrlIndex": "number",
         "defaultRpcEndpointIndex": "number",
@@ -25950,9 +25736,7 @@
         ]
       },
       "0x279f": {
-        "blockExplorerUrls": [
-          "string"
-        ],
+        "blockExplorerUrls": ["string"],
         "chainId": "string",
         "defaultBlockExplorerUrlIndex": "number",
         "defaultRpcEndpointIndex": "number",
@@ -25968,9 +25752,7 @@
         ]
       },
       "0x38": {
-        "blockExplorerUrls": [
-          "string"
-        ],
+        "blockExplorerUrls": ["string"],
         "chainId": "string",
         "defaultBlockExplorerUrlIndex": "number",
         "defaultRpcEndpointIndex": "number",
@@ -26001,9 +25783,7 @@
         ]
       },
       "0x89": {
-        "blockExplorerUrls": [
-          "string"
-        ],
+        "blockExplorerUrls": ["string"],
         "chainId": "string",
         "defaultBlockExplorerUrlIndex": "number",
         "defaultRpcEndpointIndex": "number",
@@ -26019,9 +25799,7 @@
         ]
       },
       "0xa": {
-        "blockExplorerUrls": [
-          "string"
-        ],
+        "blockExplorerUrls": ["string"],
         "chainId": "string",
         "defaultBlockExplorerUrlIndex": "number",
         "defaultRpcEndpointIndex": "number",
@@ -26037,9 +25815,7 @@
         ]
       },
       "0xa4b1": {
-        "blockExplorerUrls": [
-          "string"
-        ],
+        "blockExplorerUrls": ["string"],
         "chainId": "string",
         "defaultBlockExplorerUrlIndex": "number",
         "defaultRpcEndpointIndex": "number",
@@ -26055,9 +25831,7 @@
         ]
       },
       "0xaa36a7": {
-        "blockExplorerUrls": [
-          "string"
-        ],
+        "blockExplorerUrls": ["string"],
         "chainId": "string",
         "defaultBlockExplorerUrlIndex": "number",
         "defaultRpcEndpointIndex": "number",
@@ -26073,9 +25847,7 @@
         ]
       },
       "0xe705": {
-        "blockExplorerUrls": [
-          "string"
-        ],
+        "blockExplorerUrls": ["string"],
         "chainId": "string",
         "defaultBlockExplorerUrlIndex": "number",
         "defaultRpcEndpointIndex": "number",
@@ -26091,9 +25863,7 @@
         ]
       },
       "0xe708": {
-        "blockExplorerUrls": [
-          "string"
-        ],
+        "blockExplorerUrls": ["string"],
         "chainId": "string",
         "defaultBlockExplorerUrlIndex": "number",
         "defaultRpcEndpointIndex": "number",
@@ -26362,9 +26132,7 @@
         "id": "string",
         "initialPermissions": {
           "endowment:assets": {
-            "scopes": [
-              "string"
-            ]
+            "scopes": ["string"]
           },
           "endowment:cronjob": {
             "jobs": [
@@ -26384,9 +26152,7 @@
           "snap_getBip32Entropy": [
             {
               "curve": "string",
-              "path": [
-                "string"
-              ]
+              "path": ["string"]
             }
           ],
           "snap_getPreferences": {},
@@ -26614,9 +26380,7 @@
           "description": "string",
           "initialPermissions": {
             "endowment:assets": {
-              "scopes": [
-                "string"
-              ]
+              "scopes": ["string"]
             },
             "endowment:cronjob": {
               "jobs": [
@@ -26636,9 +26400,7 @@
             "snap_getBip32Entropy": [
               {
                 "curve": "string",
-                "path": [
-                  "string"
-                ]
+                "path": ["string"]
               }
             ],
             "snap_getPreferences": {},
@@ -26653,9 +26415,7 @@
             "url": "string"
           },
           "source": {
-            "locales": [
-              "string"
-            ],
+            "locales": ["string"],
             "location": {
               "npm": {
                 "filePath": "string",
@@ -26848,16 +26608,12 @@
           },
           "endowment:ethereum-provider": {},
           "endowment:keyring": {
-            "allowedOrigins": [
-              "string"
-            ]
+            "allowedOrigins": ["string"]
           },
           "endowment:network-access": {},
           "endowment:page-home": {},
           "endowment:rpc": {
-            "allowedOrigins": [
-              "string"
-            ]
+            "allowedOrigins": ["string"]
           },
           "snap_dialog": {},
           "snap_manageAccounts": {},
@@ -26913,16 +26669,12 @@
             },
             "endowment:ethereum-provider": {},
             "endowment:keyring": {
-              "allowedOrigins": [
-                "string"
-              ]
+              "allowedOrigins": ["string"]
             },
             "endowment:network-access": {},
             "endowment:page-home": {},
             "endowment:rpc": {
-              "allowedOrigins": [
-                "string"
-              ]
+              "allowedOrigins": ["string"]
             },
             "snap_dialog": {},
             "snap_manageAccounts": {},
@@ -27091,36 +26843,26 @@
         },
         "initialPermissions": {
           "endowment:assets": {
-            "scopes": [
-              "string"
-            ]
+            "scopes": ["string"]
           },
           "endowment:cronjob": {
             "jobs": []
           },
           "endowment:keyring": {
-            "allowedOrigins": [
-              "string"
-            ]
+            "allowedOrigins": ["string"]
           },
           "endowment:lifecycle-hooks": {},
           "endowment:name-lookup": {
-            "chains": [
-              "string"
-            ]
+            "chains": ["string"]
           },
           "endowment:network-access": {},
           "endowment:protocol": {
             "scopes": {
               "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp": {
-                "methods": [
-                  "string"
-                ]
+                "methods": ["string"]
               },
               "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1": {
-                "methods": [
-                  "string"
-                ]
+                "methods": ["string"]
               }
             }
           },
@@ -27132,9 +26874,7 @@
           "snap_getBip32Entropy": [
             {
               "curve": "string",
-              "path": [
-                "string"
-              ]
+              "path": ["string"]
             }
           ],
           "snap_getPreferences": {},
@@ -27437,36 +27177,26 @@
           },
           "initialPermissions": {
             "endowment:assets": {
-              "scopes": [
-                "string"
-              ]
+              "scopes": ["string"]
             },
             "endowment:cronjob": {
               "jobs": []
             },
             "endowment:keyring": {
-              "allowedOrigins": [
-                "string"
-              ]
+              "allowedOrigins": ["string"]
             },
             "endowment:lifecycle-hooks": {},
             "endowment:name-lookup": {
-              "chains": [
-                "string"
-              ]
+              "chains": ["string"]
             },
             "endowment:network-access": {},
             "endowment:protocol": {
               "scopes": {
                 "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp": {
-                  "methods": [
-                    "string"
-                  ]
+                  "methods": ["string"]
                 },
                 "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1": {
-                  "methods": [
-                    "string"
-                  ]
+                  "methods": ["string"]
                 }
               }
             },
@@ -27478,9 +27208,7 @@
             "snap_getBip32Entropy": [
               {
                 "curve": "string",
-                "path": [
-                  "string"
-                ]
+                "path": ["string"]
               }
             ],
             "snap_getPreferences": {},
@@ -27495,9 +27223,7 @@
             "url": "string"
           },
           "source": {
-            "locales": [
-              "string"
-            ],
+            "locales": ["string"],
             "location": {
               "npm": {
                 "filePath": "string",
@@ -27532,9 +27258,7 @@
         },
         "initialPermissions": {
           "endowment:assets": {
-            "scopes": [
-              "string"
-            ]
+            "scopes": ["string"]
           },
           "endowment:cronjob": {
             "jobs": [
@@ -27547,18 +27271,14 @@
             ]
           },
           "endowment:keyring": {
-            "allowedOrigins": [
-              "string"
-            ]
+            "allowedOrigins": ["string"]
           },
           "endowment:network-access": {},
           "snap_dialog": {},
           "snap_getBip32Entropy": [
             {
               "curve": "string",
-              "path": [
-                "string"
-              ]
+              "path": ["string"]
             }
           ],
           "snap_getPreferences": {},
@@ -27684,9 +27404,7 @@
           },
           "initialPermissions": {
             "endowment:assets": {
-              "scopes": [
-                "string"
-              ]
+              "scopes": ["string"]
             },
             "endowment:cronjob": {
               "jobs": [
@@ -27699,18 +27417,14 @@
               ]
             },
             "endowment:keyring": {
-              "allowedOrigins": [
-                "string"
-              ]
+              "allowedOrigins": ["string"]
             },
             "endowment:network-access": {},
             "snap_dialog": {},
             "snap_getBip32Entropy": [
               {
                 "curve": "string",
-                "path": [
-                  "string"
-                ]
+                "path": ["string"]
               }
             ],
             "snap_getPreferences": {},
@@ -27725,9 +27439,7 @@
             "url": "string"
           },
           "source": {
-            "locales": [
-              "string"
-            ],
+            "locales": ["string"],
             "location": {
               "npm": {
                 "filePath": "string",
@@ -28538,9 +28250,7 @@
             "caveats": [
               {
                 "type": "string",
-                "value": [
-                  "string"
-                ]
+                "value": ["string"]
               }
             ],
             "date": "number",
@@ -28611,9 +28321,7 @@
                 "value": [
                   {
                     "curve": "string",
-                    "path": [
-                      "string"
-                    ]
+                    "path": ["string"]
                   }
                 ]
               }
@@ -28777,9 +28485,7 @@
               {
                 "type": "string",
                 "value": {
-                  "allowedOrigins": [
-                    "string"
-                  ]
+                  "allowedOrigins": ["string"]
                 }
               }
             ],
@@ -28807,9 +28513,7 @@
               {
                 "type": "string",
                 "value": {
-                  "allowedOrigins": [
-                    "string"
-                  ]
+                  "allowedOrigins": ["string"]
                 }
               }
             ],
@@ -28916,9 +28620,7 @@
             "caveats": [
               {
                 "type": "string",
-                "value": [
-                  "string"
-                ]
+                "value": ["string"]
               }
             ],
             "date": "number",
@@ -28945,9 +28647,7 @@
               {
                 "type": "string",
                 "value": {
-                  "allowedOrigins": [
-                    "string"
-                  ]
+                  "allowedOrigins": ["string"]
                 }
               }
             ],
@@ -28967,9 +28667,7 @@
             "caveats": [
               {
                 "type": "string",
-                "value": [
-                  "string"
-                ]
+                "value": ["string"]
               }
             ],
             "date": "number",
@@ -28990,14 +28688,10 @@
                 "type": "string",
                 "value": {
                   "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp": {
-                    "methods": [
-                      "string"
-                    ]
+                    "methods": ["string"]
                   },
                   "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1": {
-                    "methods": [
-                      "string"
-                    ]
+                    "methods": ["string"]
                   }
                 }
               }
@@ -29036,9 +28730,7 @@
                 "value": [
                   {
                     "curve": "string",
-                    "path": [
-                      "string"
-                    ]
+                    "path": ["string"]
                   }
                 ]
               }
@@ -29078,9 +28770,7 @@
             "caveats": [
               {
                 "type": "string",
-                "value": [
-                  "string"
-                ]
+                "value": ["string"]
               }
             ],
             "date": "number",
@@ -29114,9 +28804,7 @@
               {
                 "type": "string",
                 "value": {
-                  "allowedOrigins": [
-                    "string"
-                  ]
+                  "allowedOrigins": ["string"]
                 }
               }
             ],
@@ -29146,9 +28834,7 @@
                 "value": [
                   {
                     "curve": "string",
-                    "path": [
-                      "string"
-                    ]
+                    "path": ["string"]
                   }
                 ]
               }
@@ -29183,18 +28869,14 @@
       }
     },
     "submitHistory": [],
-    "subscriptionAccountsSeen": [
-      "string"
-    ],
+    "subscriptionAccountsSeen": ["string"],
     "subscriptions": [],
     "surveyLinkLastClickedOrClosed": "null",
     "syncQueue": {
       "01KGPGYE2JJGMXDJPEVXKPJ1JG": [
         {
           "address": "string",
-          "scopes": [
-            "string"
-          ]
+          "scopes": ["string"]
         }
       ]
     },
@@ -29213,9 +28895,7 @@
         "data": {
           "0x0d8775f648430679a709e98d2b0cb6250d2887ef": {
             "address": "string",
-            "aggregators": [
-              "string"
-            ],
+            "aggregators": ["string"],
             "decimals": "number",
             "iconUrl": "string",
             "name": "string",
@@ -29224,9 +28904,7 @@
           },
           "0x6b175474e89094c44da98b954eedeac495271d0f": {
             "address": "string",
-            "aggregators": [
-              "string"
-            ],
+            "aggregators": ["string"],
             "decimals": "number",
             "erc20Permit": "boolean",
             "fees": {

--- a/test/e2e/tests/settings/state-logs.spec.ts
+++ b/test/e2e/tests/settings/state-logs.spec.ts
@@ -172,7 +172,7 @@ describe('State logs', function () {
           .withAssetsController({
             assetsBalance: {
               'd5e45e4a-3b04-4a09-a5e1-39762e5c6be4': {
-                'eip155:1337/slip44:60': { amount: '25' },
+                'eip155:1337/slip44:1': { amount: '25' },
               },
             },
           })

--- a/test/e2e/tests/smart-transactions/mocks.ts
+++ b/test/e2e/tests/smart-transactions/mocks.ts
@@ -647,13 +647,16 @@ export async function mockGasIncludedTransactionRequests(
   await mockSentinelNetworks(mockServer);
 
   // Mock getQuoteStream (SSE) so the swap page receives a quote (ETH -> MUSD).
+  // thenStream only supports a single read, so use thenCallback with the SSE
+  // payload serialized as a string body so every request gets a fresh response.
   await mockServer
     .forGet(/getQuoteStream/u)
-    .thenStream(
-      200,
-      mockSseEventSource(MOCK_ETH_MUSD_QUOTE_STREAM),
-      SSE_RESPONSE_HEADER,
-    );
+    .always()
+    .thenCallback(() => ({
+      statusCode: 200,
+      headers: SSE_RESPONSE_HEADER,
+      body: ssePayload(MOCK_ETH_MUSD_QUOTE_STREAM),
+    }));
 
   await mockServer
     .forPost(
@@ -936,6 +939,15 @@ const MOCK_ETH_DAI_QUOTE = [
     estimatedProcessingTimeInSeconds: 0,
   },
 ];
+
+function ssePayload(mockQuotes: unknown[]): string {
+  return mockQuotes
+    .map(
+      (quote, i) =>
+        `event: quote\nid: ${Date.now().toString()}-${i + 1}\ndata: ${JSON.stringify(quote)}\n\n`,
+    )
+    .join('');
+}
 
 function mockSseEventSource(mockQuotes: unknown[], delay: number = 2000) {
   let index = 0;

--- a/test/e2e/tests/smart-transactions/smart-transactions.spec.ts
+++ b/test/e2e/tests/smart-transactions/smart-transactions.spec.ts
@@ -160,7 +160,7 @@ describe('Smart Transactions', function () {
     );
   });
 
-  it('should Swap with gas included fee', async function () {
+  it.only('should Swap with gas included fee', async function () {
     await withFixturesForSmartTransactions(
       {
         title: this.test?.fullTitle(),

--- a/test/e2e/tests/smart-transactions/smart-transactions.spec.ts
+++ b/test/e2e/tests/smart-transactions/smart-transactions.spec.ts
@@ -160,7 +160,7 @@ describe('Smart Transactions', function () {
     );
   });
 
-  it.only('should Swap with gas included fee', async function () {
+  it('should Swap with gas included fee', async function () {
     await withFixturesForSmartTransactions(
       {
         title: this.test?.fullTitle(),

--- a/test/e2e/tests/solana/common-solana.ts
+++ b/test/e2e/tests/solana/common-solana.ts
@@ -1928,7 +1928,7 @@ export async function mockTokenApiAssets(mockServer: Mockttp) {
 
       if (assetIds.includes('eip155:1337')) {
         results.push({
-          assetId: 'eip155:1337/slip44:60',
+          assetId: 'eip155:1337/slip44:1',
           name: 'Ethereum',
           symbol: 'ETH',
           decimals: 18,

--- a/test/e2e/tests/solana/mocks/accounts-api.ts
+++ b/test/e2e/tests/solana/mocks/accounts-api.ts
@@ -35,7 +35,7 @@ export function mockAccountsApiV5MultiaccountBalances(mockServer: Mockttp) {
   const balances = [
     {
       accountId: `eip155:1337:${DEFAULT_FIXTURE_ACCOUNT_LOWERCASE}`,
-      assetId: 'eip155:1337/slip44:60',
+      assetId: 'eip155:1337/slip44:1',
       balance: '25',
     },
     {

--- a/test/e2e/tests/solana/send-spl-token.spec.ts
+++ b/test/e2e/tests/solana/send-spl-token.spec.ts
@@ -70,7 +70,7 @@ async function mockAccountsApiV5WithSolana(
   const balances = [
     {
       accountId: `eip155:1337:${DEFAULT_FIXTURE_ACCOUNT_LOWERCASE}`,
-      assetId: 'eip155:1337/slip44:60',
+      assetId: 'eip155:1337/slip44:1',
       balance: '25',
     },
     {

--- a/test/e2e/tests/solana/swap.spec.ts
+++ b/test/e2e/tests/solana/swap.spec.ts
@@ -78,7 +78,7 @@ async function mockAccountsApiV5WithSolana(mockServer: Mockttp) {
   const balances = [
     {
       accountId: `eip155:1337:${DEFAULT_FIXTURE_ACCOUNT_LOWERCASE}`,
-      assetId: 'eip155:1337/slip44:60',
+      assetId: 'eip155:1337/slip44:1',
       balance: '25',
     },
     {

--- a/test/e2e/tests/tokens/add-hide-token.spec.ts
+++ b/test/e2e/tests/tokens/add-hide-token.spec.ts
@@ -44,7 +44,7 @@ function mockCommonApis(mockServer: Mockttp) {
         const results = [];
         if (assetIds.includes('eip155:1337')) {
           results.push({
-            assetId: 'eip155:1337/slip44:60',
+            assetId: 'eip155:1337/slip44:1',
             name: 'Ethereum',
             symbol: 'ETH',
             decimals: 18,

--- a/test/integration/data/integration-init-state.json
+++ b/test/integration/data/integration-init-state.json
@@ -311,7 +311,6 @@
   },
   "announcements": [],
   "approvalFlows": [],
-  "assetsMetadata": {},
   "assetsBalance": {
     "cf8dace4-9439-4bd4-b3a8-88c821c8fcb3": {
       "eip155:11155111/slip44:60": {
@@ -331,6 +330,7 @@
       "symbol": "SepoliaETH"
     }
   },
+  "assetsMetadata": {},
   "assetsPrice": {
     "eip155:1/slip44:60": {
       "assetPriceType": "fungible",
@@ -366,7 +366,6 @@
   },
   "currentAppVersion": "11.14.5",
   "currentCurrency": "usd",
-  "selectedCurrency": "usd",
   "currentLocale": "en",
   "customNonceValue": "",
   "database": {
@@ -875,6 +874,7 @@
   "securityAlertsEnabled": true,
   "seedPhraseBackedUp": true,
   "selectedAccountGroup": "entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0",
+  "selectedCurrency": "usd",
   "selectedMultichainNetworkChainId": "bip122:000000000019d6689c085ae165831e93",
   "selectedNetworkClientId": "sepolia",
   "showAccountBanner": false,

--- a/test/integration/data/onboarding-completion-route.json
+++ b/test/integration/data/onboarding-completion-route.json
@@ -105,7 +105,6 @@
   },
   "currentAppVersion": "11.14.4-flask.0",
   "currentCurrency": "usd",
-  "selectedCurrency": "usd",
   "currentExtensionPopupId": 1715943310719,
   "currentLocale": "en",
   "currentMigrationVersion": 119,
@@ -310,6 +309,7 @@
       }
     }
   },
+  "selectedCurrency": "usd",
   "selectedMultichainNetworkChainId": "bip122:000000000019d6689c085ae165831e93",
   "selectedNetworkClientId": "sepolia",
   "shieldEndingToastLastClickedOrClosed": null,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared E2E fixtures and global mocks used across many tests, so mistakes in asset-id mapping or balance overrides could cause widespread test failures, but changes are test-only and not production logic.
> 
> **Overview**
> Improves E2E stability around *assets-unify-state* by aligning chain `1337` native asset identifiers to `slip44:1` across fixtures, builders, mocks, and websocket notifications, with backward-compatible token metadata responses for both `slip44:1` and legacy `slip44:60`.
> 
> Updates the Accounts API v5 mock to support a generic `nativeBalance` override (and chain-specific slip44 selection), and adjusts several flaky tests/page objects with explicit timeouts and waits (e.g., onboarding completion, permissions, name lookup, profile metrics, and websocket balance resilience).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77c00afce2d80dce29012da7ce1afcf6aa38e850. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->