### PR TITLE
fix(perf): Fix CLS formatting in quality gates, align thresholds with google standards

### DIFF
--- a/development/metamaskbot-build-announce/compare-benchmarks.ts
+++ b/development/metamaskbot-build-announce/compare-benchmarks.ts
@@ -191,6 +191,8 @@ export function buildMetricLines(
     let displayIcon: string = COMPARISON_SEVERITY.Pass.icon;
     let hasIssue = false;
     const details: string[] = [];
+    const formatValue = (value: number): string =>
+      metric === 'cls' ? value.toFixed(3) : `${value.toFixed(0)}ms`;
 
     for (const pKey of percentiles) {
       const key = `${metric}:${pKey}`;
@@ -228,7 +230,7 @@ export function buildMetricLines(
 
         if (isIssue) {
           const delta = formatDeltaPercent(rel.deltaPercent);
-          details.push(`${pKey}: ${rel.current.toFixed(0)}ms (${delta})`);
+          details.push(`${pKey}: ${formatValue(rel.current)} (${delta})`);
           hasIssue = true;
           displayIcon = updateDisplayIcon(icon, displayIcon);
         }
@@ -240,7 +242,7 @@ export function buildMetricLines(
           icon = violationIcon(violation.severity);
           isIssue = true;
           details.push(
-            `${pKey}: ${violation.value.toFixed(0)}ms (no baseline)`,
+            `${pKey}: ${formatValue(violation.value)} (no baseline)`,
           );
           hasIssue = true;
           displayIcon = updateDisplayIcon(icon, displayIcon);

--- a/development/metamaskbot-build-announce/performance-benchmarks.test.ts
+++ b/development/metamaskbot-build-announce/performance-benchmarks.test.ts
@@ -886,7 +886,7 @@ describe('buildBenchmarkSection', () => {
 
       expect(html).not.toContain('<code>importWalletToSocialScreen</code>');
       expect(html).toContain('<code>doneButtonToHomeScreen</code>');
-      expect(html).toMatch(/<div>🔴/u);
+      expect(html).toMatch(/🔴 <code>doneButtonToHomeScreen<\/code>/u);
     });
 
     it('does not show timer details for benchmarks without timer data', () => {

--- a/development/metamaskbot-build-announce/performance-benchmarks.ts
+++ b/development/metamaskbot-build-announce/performance-benchmarks.ts
@@ -505,19 +505,27 @@ function countHealthEntries(
 }
 
 /**
- * Formats timer details from StatisticalResult into a readable HTML list with traffic lights.
- * Only returns timer breakdown if entry has multiple timers (user journey benchmarks).
+ * Converts a camelCase benchmark name to its snake_case metric-key form
+ * (e.g. `loadNewAccount` → `load_new_account`). Used to detect per-metric
+ * tags that would be redundant with the row label.
+ */
+function toSnakeCase(name: string): string {
+  return name.replace(/([a-z0-9])([A-Z])/gu, '$1_$2').toLowerCase();
+}
+
+/**
+ * Returns a compact inline annotation listing per-metric threshold issues for
+ * a multi-timer benchmark entry (e.g. ` · 🟡 <code>cls</code>`). Returns an
+ * empty string when the entry has a single timer, no per-metric issues, or
+ * the only firing metric is the benchmark's primary timer (in which case the
+ * row-level icon already conveys the status).
+ *
+ * The result is meant to be appended to the row-level cell, not to replace it.
  *
  * @param entry - Benchmark entry with all stats (mean, p75, p95)
- * @param baselineMetrics - Historical baseline for comparison (optional)
- * @param logHref
- * @returns HTML string with timer breakdown, or empty string if single timer
+ * @returns HTML string with per-metric issue tags, or empty string
  */
-function formatTimerDetails(
-  entry: BenchmarkEntry,
-  baselineMetrics: HistoricalBaselineReference[string] | undefined,
-  logHref?: string,
-): string {
+function formatTimerIssueTags(entry: BenchmarkEntry): string {
   const timerCount = Object.keys(entry.mean).length;
 
   if (timerCount <= 1) {
@@ -525,53 +533,46 @@ function formatTimerDetails(
   }
 
   const thresholdConfig = THRESHOLD_REGISTRY[entry.benchmarkName];
+  if (!thresholdConfig) {
+    return '';
+  }
 
-  const entries = Object.entries(entry.mean)
-    .map(([metricName]) => {
-      let icon = HEALTH_ICON[EntryHealth.Pass];
-      let hasIssue = false;
+  const primaryMetricKey = toSnakeCase(entry.benchmarkName);
 
-      if (thresholdConfig?.[metricName]) {
-        const metricResult = {
-          p75: { [metricName]: entry.p75[metricName] },
-          p95: { [metricName]: entry.p95[metricName] },
-        } as BenchmarkResults;
-
-        const { violations } = validateResultThresholds(metricResult, {
-          [metricName]: thresholdConfig[metricName],
-        });
-
-        const hasFail = violations.some(
-          (v) => v.severity === THRESHOLD_SEVERITY.Fail,
-        );
-        const hasWarn = violations.some(
-          (v) => v.severity === THRESHOLD_SEVERITY.Warn,
-        );
-
-        if (hasFail) {
-          icon = HEALTH_ICON[EntryHealth.Fail];
-          hasIssue = true;
-        } else if (hasWarn) {
-          icon = HEALTH_ICON[EntryHealth.Warn];
-          hasIssue = true;
-        }
-      }
-
-      if (!hasIssue) {
+  const tags = Object.keys(entry.mean)
+    .map((metricName) => {
+      if (!thresholdConfig[metricName] || metricName === primaryMetricKey) {
         return null;
       }
 
-      const logsLine = logHref
-        ? `<br><a href="${logHref}">[Show logs]</a>`
-        : '';
-      return `<div>${icon} <code>${metricName}</code>${logsLine}</div>`;
-    })
-    .filter((item) => item !== null)
-    .join('');
+      const metricResult = {
+        p75: { [metricName]: entry.p75[metricName] },
+        p95: { [metricName]: entry.p95[metricName] },
+      } as BenchmarkResults;
 
-  return entries
-    ? `<div style="text-align: left; margin: 4px 0 8px 0; padding-left: 8px;">${entries}</div>`
-    : '';
+      const { violations } = validateResultThresholds(metricResult, {
+        [metricName]: thresholdConfig[metricName],
+      });
+
+      const hasFail = violations.some(
+        (v) => v.severity === THRESHOLD_SEVERITY.Fail,
+      );
+      const hasWarn = violations.some(
+        (v) => v.severity === THRESHOLD_SEVERITY.Warn,
+      );
+
+      if (!hasFail && !hasWarn) {
+        return null;
+      }
+
+      const icon = hasFail
+        ? HEALTH_ICON[EntryHealth.Fail]
+        : HEALTH_ICON[EntryHealth.Warn];
+      return `${icon} <code>${metricName}</code>`;
+    })
+    .filter((tag): tag is string => tag !== null);
+
+  return tags.length > 0 ? ` · ${tags.join(' · ')}` : '';
 }
 
 /**
@@ -807,27 +808,14 @@ export function buildBenchmarkSection(
               const icon = HEALTH_ICON[health];
               const logHref = entry.artifactUrl ?? runUrl;
 
-              const timerDetails = formatTimerDetails(
-                entry,
-                baselineMetrics,
-                logHref,
-              );
-
+              const timerIssueTags = formatTimerIssueTags(entry);
               const logsLink = logHref
                 ? `<a href="${logHref}">[Show logs]</a>`
                 : '';
 
-              let cell: string;
-              switch (true) {
-                case Boolean(timerDetails):
-                  cell = timerDetails;
-                  break;
-                case Boolean(logHref):
-                  cell = `${icon} ${logsLink}`;
-                  break;
-                default:
-                  cell = icon;
-              }
+              const cell = logHref
+                ? `${icon} ${logsLink}${timerIssueTags}`
+                : `${icon}${timerIssueTags}`;
               return `<td align="left">${cell}</td>`;
             })
             .join('');

--- a/development/metamaskbot-build-announce/performance-benchmarks.ts
+++ b/development/metamaskbot-build-announce/performance-benchmarks.ts
@@ -508,6 +508,9 @@ function countHealthEntries(
  * Converts a camelCase benchmark name to its snake_case metric-key form
  * (e.g. `loadNewAccount` → `load_new_account`). Used to detect per-metric
  * tags that would be redundant with the row label.
+ *
+ * @param name - camelCase benchmark name
+ * @returns snake_case metric key
  */
 function toSnakeCase(name: string): string {
   return name.replace(/([a-z0-9])([A-Z])/gu, '$1_$2').toLowerCase();

--- a/test/e2e/benchmarks/utils/thresholds.ts
+++ b/test/e2e/benchmarks/utils/thresholds.ts
@@ -8,13 +8,14 @@ export const DEFAULT_CI_MULTIPLIER = 1.5;
 
 /**
  * CLS (Cumulative Layout Shift) canary thresholds.
- * Extension pages produce CLS ≈ 0. Any non-zero value is a real signal
- * (layout shift from lazy-loaded component, dynamic banner, skeleton screen).
- * Unitless — no CI multiplier needed. Google thresholds applied.
+ * Extension pages should produce CLS ≈ 0; any measurable shift is a real
+ * signal (lazy-loaded component, dynamic banner, skeleton screen).
+ * Unitless — no CI multiplier needed. Uses Google's standard CWV boundaries:
+ * p75 ≤ 0.1 "good" / ≤ 0.25 "needs-improvement" / > 0.25 "poor".
  */
 const CLS_THRESHOLDS = {
   cls: {
-    p75: { warn: 0.05, fail: 0.1 },
+    p75: { warn: 0.1, fail: 0.25 },
     p95: { warn: 0.1, fail: 0.25 },
   },
 } satisfies ThresholdConfig;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

PR #41494 added CLS as a benchmark quality gate but introduced three issues that this PR addresses.

**1. CLS values displayed with a `ms` suffix in the bot build comparison report.**

`buildMetricLines` in `compare-benchmarks.ts` formatted every metric as `"<value>ms"`, including CLS. CLS is a unitless layout-shift score, not a duration, so values rendered as e.g. `"0ms"` — `toFixed(0)` also rounded the score to an integer, hiding all meaningful precision. This PR introduces a per-metric `formatValue` helper: CLS prints to 3 decimals with no unit suffix (e.g. `0.003`), all other metrics keep their existing `"<value>ms"` format.

**2. CLS `p75` thresholds were stricter than Google's standard Core Web Vitals boundaries.**

`CLS_THRESHOLDS.cls.p75` was configured as `warn 0.05 / fail 0.1`, which is tighter than Google's canonical CWV boundaries:
- ≤ 0.1 → "good"
- ≤ 0.25 → "needs-improvement"
- \> 0.25 → "poor"

Since CLS is a calibrated score with well-defined industry thresholds, the gate should align with them to avoid false positives on values that would still be classified as "good" by web vitals standards. This PR updates `p75` to `warn 0.1 / fail 0.25`. `p95` already matches Google's boundaries and is unchanged.

**3. Benchmark cells with per-metric threshold violations rendered inconsistently from their siblings.**

`formatTimerDetails` in `performance-benchmarks.ts` **replaced** the entire cell with a nested `<div style="text-align: left; margin: 4px 0 8px 0; padding-left: 8px;"><div>🟡 <code>metric</code><br>[Show logs]</div></div>` block whenever any per-metric threshold fired, producing a visually inconsistent cell (padding, line break, duplicated `[Show logs]` link) that only affected rows with a violation. Visible examples in recent runs: [`importSrpHome` with `cls`](https://github.com/MetaMask/metamask-extension/pull/41798#issuecomment-4255225506) and [`loadNewAccount` with `load_new_account`](https://github.com/MetaMask/metamask-extension/pull/41798#issuecomment-4255511530).

This PR renames the helper to `formatTimerIssueTags` and has it return a compact inline suffix (e.g. ` · 🟡 <code>cls</code>`) appended to the normal `${icon} ${logsLink}` cell. Every cell now shares the same shape regardless of threshold state.

It also suppresses tags whose name equals `toSnakeCase(benchmarkName)` — on interaction benchmarks like `loadNewAccount` and `confirmTx` the single threshold key matches the benchmark's primary timer, so the tag would only echo the row label. Genuine per-metric cases like `cls` on `importSrpHome` are unaffected.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/6739

Follow-up to: #41494

## **Manual testing steps**

1. Inspect `test/e2e/benchmarks/utils/thresholds.ts` — `CLS_THRESHOLDS.cls.p75` should be `{ warn: 0.1, fail: 0.25 }`.
2. Inspect `development/metamaskbot-build-announce/compare-benchmarks.ts` — `buildMetricLines` should include a `formatValue` helper that branches on `metric === 'cls'`.
3. Inspect `development/metamaskbot-build-announce/performance-benchmarks.ts` — `formatTimerIssueTags` should return an inline ` · <icon> <code>metric</code>` suffix, and the cell switch should always render `${icon} ${logsLink}${timerIssueTags}`.
4. On the next bot build comment, confirm:
    - CLS lines in the comparison block render as e.g. `p75: 0.003 (...)` instead of `p75: 0ms (...)`.
    - Every benchmark cell follows the same `<icon> [Show logs]` shape.
    - Rows with a tripped threshold append a compact inline tag (e.g. `🟡 [Show logs] · 🟡 cls`).
    - Interaction benchmarks (`loadNewAccount`, `confirmTx`) do not render a redundant primary-timer tag.

## **Screenshots/Recordings**

N/A — threshold config + report formatting change, no UI impact.

### **Before**

- CLS values displayed as `"0ms"` in the bot build comparison report
- CLS `p75` gate fired at `> 0.05` (warn) / `> 0.1` (fail), stricter than Google's "good" ceiling
- Cells with a tripped per-metric threshold rendered as a nested `<div>` block with padding, line break, and a duplicated `[Show logs]` link, breaking alignment with sibling cells

### **After**

- CLS values display to 3 decimals with no unit suffix (e.g. `0.003`)
- CLS `p75` gate aligned with Google CWV boundaries (`> 0.1` warn, `> 0.25` fail)
- Every cell renders as `<icon> [Show logs]`, optionally followed by a compact ` · <icon> <code>metric</code>` suffix for non-primary-timer violations

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to benchmark report formatting and threshold constants; risk is mainly altered CI gating sensitivity for CLS `p75` and minor HTML output differences in bot comments.
> 
> **Overview**
> Fixes CLS handling in the benchmark quality-gate/reporting pipeline by formatting CLS as a unitless value (3 decimals, no `ms`) in `compare-benchmarks.ts` and aligning CLS `p75` thresholds to Google Core Web Vitals boundaries in `thresholds.ts`.
> 
> Refactors benchmark table rendering to avoid replacing matrix cells with nested timer-detail HTML: `performance-benchmarks.ts` now appends compact per-metric issue tags (excluding redundant primary-timer tags via `toSnakeCase`) to the normal `${icon} [Show logs]` cell, with tests updated to match the new output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89e5c0fd0ccb991c430b20f309ff35beaf8ef6c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->