### PR TITLE
fix: keep explore markets live

### DIFF
--- a/ui/components/app/perps/hooks/usePerpsTabExploreData.test.ts
+++ b/ui/components/app/perps/hooks/usePerpsTabExploreData.test.ts
@@ -1,0 +1,110 @@
+import { act } from '@testing-library/react-hooks';
+import { renderHookWithProvider } from '../../../../../test/lib/render-helpers-navigate';
+import mockState from '../../../../../test/data/mock-state.json';
+import { mockCryptoMarkets, mockHip3Markets } from '../mocks';
+import { PERPS_CONSTANTS } from '../constants';
+import {
+  usePerpsLiveMarketData,
+  usePerpsLivePrices,
+} from '../../../../hooks/perps/stream';
+import { usePerpsTabExploreData } from './usePerpsTabExploreData';
+
+jest.mock('../../../../hooks/perps/stream', () => ({
+  usePerpsLiveMarketData: jest.fn(),
+  usePerpsLivePrices: jest.fn(),
+}));
+
+describe('usePerpsTabExploreData', () => {
+  const mockRefresh = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+
+    jest.mocked(usePerpsLiveMarketData).mockReturnValue({
+      markets: [...mockCryptoMarkets, ...mockHip3Markets],
+      cryptoMarkets: mockCryptoMarkets,
+      hip3Markets: mockHip3Markets,
+      isInitialLoading: false,
+      error: null,
+      refresh: mockRefresh,
+    });
+    jest.mocked(usePerpsLivePrices).mockReturnValue({
+      prices: {},
+      isInitialLoading: false,
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns explore preview markets and watchlist markets from the same live source', () => {
+    const { result } = renderHookWithProvider(() => usePerpsTabExploreData(), {
+      metamask: {
+        ...mockState.metamask,
+        isTestnet: false,
+        watchlistMarkets: {
+          mainnet: ['BTC', 'ETH'],
+          testnet: [],
+        },
+      },
+    });
+
+    expect(result.current.exploreMarkets).toHaveLength(
+      PERPS_CONSTANTS.EXPLORE_MARKETS_LIMIT,
+    );
+    expect(result.current.exploreMarkets[0].symbol).toBe('BTC');
+    expect(
+      result.current.watchlistMarkets.map((market) => market.symbol),
+    ).toEqual(['BTC', 'ETH']);
+  });
+
+  it('overlays live price updates onto tab markets', () => {
+    jest.mocked(usePerpsLivePrices).mockReturnValue({
+      prices: {
+        BTC: {
+          symbol: 'BTC',
+          price: '99999',
+          percentChange24h: '12.34',
+          timestamp: 1,
+        },
+      },
+      isInitialLoading: false,
+    });
+
+    const { result } = renderHookWithProvider(() => usePerpsTabExploreData(), {
+      metamask: {
+        ...mockState.metamask,
+        isTestnet: false,
+        watchlistMarkets: {
+          mainnet: ['BTC'],
+          testnet: [],
+        },
+      },
+    });
+
+    expect(result.current.exploreMarkets[0].price).toBe('99999');
+    expect(result.current.exploreMarkets[0].change24hPercent).toBe('12.34');
+    expect(result.current.watchlistMarkets[0].price).toBe('99999');
+  });
+
+  it('refreshes snapshot-backed market fields on an interval', () => {
+    renderHookWithProvider(() => usePerpsTabExploreData(), {
+      metamask: {
+        ...mockState.metamask,
+        isTestnet: false,
+        watchlistMarkets: {
+          mainnet: ['BTC'],
+          testnet: [],
+        },
+      },
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(30000);
+    });
+
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/components/app/perps/hooks/usePerpsTabExploreData.test.ts
+++ b/ui/components/app/perps/hooks/usePerpsTabExploreData.test.ts
@@ -76,4 +76,21 @@ describe('usePerpsTabExploreData', () => {
     expect(result.current.exploreMarkets[0].change24hPercent).toBe('12.34');
     expect(result.current.watchlistMarkets[0].price).toBe('99999');
   });
+
+  it('preserves the user watchlist symbol order', () => {
+    const { result } = renderHookWithProvider(() => usePerpsTabExploreData(), {
+      metamask: {
+        ...mockState.metamask,
+        isTestnet: false,
+        watchlistMarkets: {
+          mainnet: ['ETH', 'BTC'],
+          testnet: [],
+        },
+      },
+    });
+
+    expect(
+      result.current.watchlistMarkets.map((market) => market.symbol),
+    ).toEqual(['ETH', 'BTC']);
+  });
 });

--- a/ui/components/app/perps/hooks/usePerpsTabExploreData.test.ts
+++ b/ui/components/app/perps/hooks/usePerpsTabExploreData.test.ts
@@ -40,7 +40,9 @@ describe('usePerpsTabExploreData', () => {
     );
     expect(result.current.exploreMarkets[0].symbol).toBe('BTC');
     expect(
-      result.current.watchlistMarkets.map((market: PerpsMarketData) => market.symbol),
+      result.current.watchlistMarkets.map(
+        (market: PerpsMarketData) => market.symbol,
+      ),
     ).toEqual(['BTC', 'ETH']);
   });
 
@@ -91,7 +93,9 @@ describe('usePerpsTabExploreData', () => {
     });
 
     expect(
-      result.current.watchlistMarkets.map((market: PerpsMarketData) => market.symbol),
+      result.current.watchlistMarkets.map(
+        (market: PerpsMarketData) => market.symbol,
+      ),
     ).toEqual(['ETH', 'BTC']);
   });
 });

--- a/ui/components/app/perps/hooks/usePerpsTabExploreData.test.ts
+++ b/ui/components/app/perps/hooks/usePerpsTabExploreData.test.ts
@@ -1,3 +1,4 @@
+import type { PerpsMarketData } from '@metamask/perps-controller';
 import { renderHookWithProvider } from '../../../../../test/lib/render-helpers-navigate';
 import mockState from '../../../../../test/data/mock-state.json';
 import { mockCryptoMarkets, mockHip3Markets } from '../mocks';
@@ -39,7 +40,7 @@ describe('usePerpsTabExploreData', () => {
     );
     expect(result.current.exploreMarkets[0].symbol).toBe('BTC');
     expect(
-      result.current.watchlistMarkets.map((market) => market.symbol),
+      result.current.watchlistMarkets.map((market: PerpsMarketData) => market.symbol),
     ).toEqual(['BTC', 'ETH']);
   });
 
@@ -90,7 +91,7 @@ describe('usePerpsTabExploreData', () => {
     });
 
     expect(
-      result.current.watchlistMarkets.map((market) => market.symbol),
+      result.current.watchlistMarkets.map((market: PerpsMarketData) => market.symbol),
     ).toEqual(['ETH', 'BTC']);
   });
 });

--- a/ui/components/app/perps/hooks/usePerpsTabExploreData.test.ts
+++ b/ui/components/app/perps/hooks/usePerpsTabExploreData.test.ts
@@ -1,42 +1,25 @@
-import { act } from '@testing-library/react-hooks';
 import { renderHookWithProvider } from '../../../../../test/lib/render-helpers-navigate';
 import mockState from '../../../../../test/data/mock-state.json';
 import { mockCryptoMarkets, mockHip3Markets } from '../mocks';
 import { PERPS_CONSTANTS } from '../constants';
-import {
-  usePerpsLiveMarketData,
-  usePerpsLivePrices,
-} from '../../../../hooks/perps/stream';
+import { usePerpsLiveMarketListData } from '../../../../hooks/perps/stream';
 import { usePerpsTabExploreData } from './usePerpsTabExploreData';
 
 jest.mock('../../../../hooks/perps/stream', () => ({
-  usePerpsLiveMarketData: jest.fn(),
-  usePerpsLivePrices: jest.fn(),
+  usePerpsLiveMarketListData: jest.fn(),
 }));
 
 describe('usePerpsTabExploreData', () => {
-  const mockRefresh = jest.fn();
-
   beforeEach(() => {
     jest.clearAllMocks();
-    jest.useFakeTimers();
-
-    jest.mocked(usePerpsLiveMarketData).mockReturnValue({
+    jest.mocked(usePerpsLiveMarketListData).mockReturnValue({
       markets: [...mockCryptoMarkets, ...mockHip3Markets],
       cryptoMarkets: mockCryptoMarkets,
       hip3Markets: mockHip3Markets,
       isInitialLoading: false,
       error: null,
-      refresh: mockRefresh,
+      refresh: jest.fn(),
     });
-    jest.mocked(usePerpsLivePrices).mockReturnValue({
-      prices: {},
-      isInitialLoading: false,
-    });
-  });
-
-  afterEach(() => {
-    jest.useRealTimers();
   });
 
   it('returns explore preview markets and watchlist markets from the same live source', () => {
@@ -60,17 +43,22 @@ describe('usePerpsTabExploreData', () => {
     ).toEqual(['BTC', 'ETH']);
   });
 
-  it('overlays live price updates onto tab markets', () => {
-    jest.mocked(usePerpsLivePrices).mockReturnValue({
-      prices: {
-        BTC: {
-          symbol: 'BTC',
+  it('derives tab markets from the live market list contract', () => {
+    jest.mocked(usePerpsLiveMarketListData).mockReturnValue({
+      markets: [
+        {
+          ...mockCryptoMarkets[0],
           price: '99999',
-          percentChange24h: '12.34',
-          timestamp: 1,
+          change24hPercent: '12.34',
         },
-      },
+        ...mockCryptoMarkets.slice(1),
+        ...mockHip3Markets,
+      ],
+      cryptoMarkets: mockCryptoMarkets,
+      hip3Markets: mockHip3Markets,
       isInitialLoading: false,
+      error: null,
+      refresh: jest.fn(),
     });
 
     const { result } = renderHookWithProvider(() => usePerpsTabExploreData(), {
@@ -87,24 +75,5 @@ describe('usePerpsTabExploreData', () => {
     expect(result.current.exploreMarkets[0].price).toBe('99999');
     expect(result.current.exploreMarkets[0].change24hPercent).toBe('12.34');
     expect(result.current.watchlistMarkets[0].price).toBe('99999');
-  });
-
-  it('refreshes snapshot-backed market fields on an interval', () => {
-    renderHookWithProvider(() => usePerpsTabExploreData(), {
-      metamask: {
-        ...mockState.metamask,
-        isTestnet: false,
-        watchlistMarkets: {
-          mainnet: ['BTC'],
-          testnet: [],
-        },
-      },
-    });
-
-    act(() => {
-      jest.advanceTimersByTime(30000);
-    });
-
-    expect(mockRefresh).toHaveBeenCalledTimes(1);
   });
 });

--- a/ui/components/app/perps/hooks/usePerpsTabExploreData.ts
+++ b/ui/components/app/perps/hooks/usePerpsTabExploreData.ts
@@ -1,17 +1,12 @@
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import type { PerpsMarketData } from '@metamask/perps-controller';
-import {
-  usePerpsLiveMarketData,
-  usePerpsLivePrices,
-} from '../../../../hooks/perps/stream';
+import { usePerpsLiveMarketListData } from '../../../../hooks/perps/stream';
 import {
   selectPerpsIsTestnet,
   selectPerpsWatchlistMarkets,
 } from '../../../../selectors/perps-controller';
 import { PERPS_CONSTANTS } from '../constants';
-
-const DEFAULT_REFRESH_INTERVAL_MS = 30000;
 
 export type UsePerpsTabExploreDataOptions = {
   refreshIntervalMs?: number;
@@ -26,63 +21,15 @@ export type UsePerpsTabExploreDataReturn = {
 export function usePerpsTabExploreData(
   options: UsePerpsTabExploreDataOptions = {},
 ): UsePerpsTabExploreDataReturn {
-  const { refreshIntervalMs = DEFAULT_REFRESH_INTERVAL_MS } = options;
-  const { markets, isInitialLoading, refresh } = usePerpsLiveMarketData();
+  const { refreshIntervalMs } = options;
+  const { markets: liveMarkets, isInitialLoading } = usePerpsLiveMarketListData(
+    { refreshIntervalMs },
+  );
   const watchlistMarketsState = useSelector(selectPerpsWatchlistMarkets);
   const isTestnet = useSelector(selectPerpsIsTestnet);
   const watchlistSymbols = isTestnet
     ? watchlistMarketsState.testnet
     : watchlistMarketsState.mainnet;
-
-  const marketSymbols = useMemo(
-    () =>
-      Array.from(new Set(markets.map((market) => market.symbol))).sort(
-        (left, right) => left.localeCompare(right),
-      ),
-    [markets],
-  );
-  const marketSymbolsKey = useMemo(
-    () => marketSymbols.join('|'),
-    [marketSymbols],
-  );
-
-  const { prices } = usePerpsLivePrices({
-    symbols: marketSymbols,
-    activateStream: true,
-    includeMarketData: false,
-  });
-
-  useEffect(() => {
-    if (!marketSymbolsKey) {
-      return undefined;
-    }
-
-    const intervalId = globalThis.setInterval(() => {
-      refresh();
-    }, refreshIntervalMs);
-
-    return () => globalThis.clearInterval(intervalId);
-  }, [marketSymbolsKey, refresh, refreshIntervalMs]);
-
-  const liveMarkets = useMemo(() => {
-    if (Object.keys(prices).length === 0) {
-      return markets;
-    }
-
-    return markets.map((market) => {
-      const liveUpdate = prices[market.symbol];
-      if (!liveUpdate) {
-        return market;
-      }
-
-      return {
-        ...market,
-        price: liveUpdate.price ?? market.price,
-        change24hPercent:
-          liveUpdate.percentChange24h ?? market.change24hPercent,
-      };
-    });
-  }, [markets, prices]);
 
   const watchlistSymbolSet = useMemo(
     () => new Set(watchlistSymbols.map((symbol) => symbol.toUpperCase())),

--- a/ui/components/app/perps/hooks/usePerpsTabExploreData.ts
+++ b/ui/components/app/perps/hooks/usePerpsTabExploreData.ts
@@ -1,0 +1,110 @@
+import { useEffect, useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import type { PerpsMarketData } from '@metamask/perps-controller';
+import {
+  usePerpsLiveMarketData,
+  usePerpsLivePrices,
+} from '../../../../hooks/perps/stream';
+import {
+  selectPerpsIsTestnet,
+  selectPerpsWatchlistMarkets,
+} from '../../../../selectors/perps-controller';
+import { PERPS_CONSTANTS } from '../constants';
+
+const DEFAULT_REFRESH_INTERVAL_MS = 30000;
+
+export type UsePerpsTabExploreDataOptions = {
+  refreshIntervalMs?: number;
+};
+
+export type UsePerpsTabExploreDataReturn = {
+  exploreMarkets: PerpsMarketData[];
+  watchlistMarkets: PerpsMarketData[];
+  isInitialLoading: boolean;
+};
+
+export function usePerpsTabExploreData(
+  options: UsePerpsTabExploreDataOptions = {},
+): UsePerpsTabExploreDataReturn {
+  const { refreshIntervalMs = DEFAULT_REFRESH_INTERVAL_MS } = options;
+  const { markets, isInitialLoading, refresh } = usePerpsLiveMarketData();
+  const watchlistMarketsState = useSelector(selectPerpsWatchlistMarkets);
+  const isTestnet = useSelector(selectPerpsIsTestnet);
+  const watchlistSymbols = isTestnet
+    ? watchlistMarketsState.testnet
+    : watchlistMarketsState.mainnet;
+
+  const marketSymbols = useMemo(
+    () =>
+      Array.from(new Set(markets.map((market) => market.symbol))).sort(
+        (left, right) => left.localeCompare(right),
+      ),
+    [markets],
+  );
+  const marketSymbolsKey = useMemo(
+    () => marketSymbols.join('|'),
+    [marketSymbols],
+  );
+
+  const { prices } = usePerpsLivePrices({
+    symbols: marketSymbols,
+    activateStream: true,
+    includeMarketData: false,
+  });
+
+  useEffect(() => {
+    if (!marketSymbolsKey) {
+      return undefined;
+    }
+
+    const intervalId = globalThis.setInterval(() => {
+      refresh();
+    }, refreshIntervalMs);
+
+    return () => globalThis.clearInterval(intervalId);
+  }, [marketSymbolsKey, refresh, refreshIntervalMs]);
+
+  const liveMarkets = useMemo(() => {
+    if (Object.keys(prices).length === 0) {
+      return markets;
+    }
+
+    return markets.map((market) => {
+      const liveUpdate = prices[market.symbol];
+      if (!liveUpdate) {
+        return market;
+      }
+
+      return {
+        ...market,
+        price: liveUpdate.price ?? market.price,
+        change24hPercent:
+          liveUpdate.percentChange24h ?? market.change24hPercent,
+      };
+    });
+  }, [markets, prices]);
+
+  const watchlistSymbolSet = useMemo(
+    () => new Set(watchlistSymbols.map((symbol) => symbol.toUpperCase())),
+    [watchlistSymbols],
+  );
+
+  const exploreMarkets = useMemo(
+    () => liveMarkets.slice(0, PERPS_CONSTANTS.EXPLORE_MARKETS_LIMIT),
+    [liveMarkets],
+  );
+
+  const filteredWatchlistMarkets = useMemo(
+    () =>
+      liveMarkets.filter((market) =>
+        watchlistSymbolSet.has(market.symbol.toUpperCase()),
+      ),
+    [liveMarkets, watchlistSymbolSet],
+  );
+
+  return {
+    exploreMarkets,
+    watchlistMarkets: filteredWatchlistMarkets,
+    isInitialLoading,
+  };
+}

--- a/ui/components/app/perps/hooks/usePerpsTabExploreData.ts
+++ b/ui/components/app/perps/hooks/usePerpsTabExploreData.ts
@@ -31,9 +31,12 @@ export function usePerpsTabExploreData(
     ? watchlistMarketsState.testnet
     : watchlistMarketsState.mainnet;
 
-  const watchlistSymbolSet = useMemo(
-    () => new Set(watchlistSymbols.map((symbol) => symbol.toUpperCase())),
-    [watchlistSymbols],
+  const liveMarketMap = useMemo(
+    () =>
+      new Map(
+        liveMarkets.map((market) => [market.symbol.toUpperCase(), market]),
+      ),
+    [liveMarkets],
   );
 
   const exploreMarkets = useMemo(
@@ -43,10 +46,10 @@ export function usePerpsTabExploreData(
 
   const filteredWatchlistMarkets = useMemo(
     () =>
-      liveMarkets.filter((market) =>
-        watchlistSymbolSet.has(market.symbol.toUpperCase()),
-      ),
-    [liveMarkets, watchlistSymbolSet],
+      watchlistSymbols
+        .map((symbol) => liveMarketMap.get(symbol.toUpperCase()))
+        .filter((market): market is PerpsMarketData => Boolean(market)),
+    [liveMarketMap, watchlistSymbols],
   );
 
   return {

--- a/ui/components/app/perps/perps-view.test.tsx
+++ b/ui/components/app/perps/perps-view.test.tsx
@@ -7,6 +7,7 @@ import { usePerpsTransactionHistory } from '../../../hooks/perps/usePerpsTransac
 import * as streamHooks from '../../../hooks/perps/stream';
 import * as mocks from './mocks';
 import { PerpsView } from './perps-view';
+import { usePerpsTabExploreData } from './hooks/usePerpsTabExploreData';
 
 const mockSubmitRequestToBackground = jest.fn().mockResolvedValue(undefined);
 const mockGetPerpsStreamManager = jest.fn();
@@ -56,17 +57,21 @@ jest.mock('../../../hooks/perps/stream', () => {
       account: streamMocks.mockAccountState,
       isInitialLoading: false,
     })),
-    usePerpsLiveMarketData: jest.fn(() => ({
-      markets: [
-        ...streamMocks.mockCryptoMarkets,
-        ...streamMocks.mockHip3Markets,
-      ],
-      cryptoMarkets: streamMocks.mockCryptoMarkets,
-      hip3Markets: streamMocks.mockHip3Markets,
-      isInitialLoading: false,
-    })),
   };
 });
+
+jest.mock('./hooks/usePerpsTabExploreData', () => ({
+  usePerpsTabExploreData: jest.fn(() => ({
+    exploreMarkets: [
+      ...mocks.mockCryptoMarkets,
+      ...mocks.mockHip3Markets,
+    ].slice(0, 5),
+    watchlistMarkets: mocks.mockCryptoMarkets.filter((market) =>
+      ['BTC', 'ETH'].includes(market.symbol),
+    ),
+    isInitialLoading: false,
+  })),
+}));
 
 const mockUsePerpsEligibility = jest.fn(() => ({ isEligible: true }));
 jest.mock('../../../hooks/perps/usePerpsEligibility', () => ({
@@ -100,6 +105,13 @@ describe('PerpsView', () => {
     });
     jest.mocked(streamHooks.usePerpsLiveOrders).mockReturnValue({
       orders: mocks.mockOrders,
+      isInitialLoading: false,
+    });
+    jest.mocked(usePerpsTabExploreData).mockReturnValue({
+      exploreMarkets: [...mocks.mockCryptoMarkets, ...mocks.mockHip3Markets],
+      watchlistMarkets: mocks.mockCryptoMarkets.filter((market) =>
+        ['BTC', 'ETH'].includes(market.symbol),
+      ),
       isInitialLoading: false,
     });
     mockGetPerpsStreamManager.mockReturnValue({
@@ -474,5 +486,20 @@ describe('PerpsView', () => {
 
       expect(screen.getByTestId('perps-view')).toBeInTheDocument();
     });
+  });
+
+  it('passes tab explore and watchlist markets from the tab hook', () => {
+    jest.mocked(usePerpsTabExploreData).mockReturnValue({
+      exploreMarkets: [mocks.mockCryptoMarkets[0]],
+      watchlistMarkets: [mocks.mockCryptoMarkets[1]],
+      isInitialLoading: false,
+    });
+
+    renderWithProvider(<PerpsView />, mockStore);
+
+    expect(screen.getByTestId('explore-markets-BTC')).toBeInTheDocument();
+    expect(screen.queryByTestId('explore-markets-ETH')).not.toBeInTheDocument();
+    expect(screen.getByTestId('perps-watchlist-ETH')).toBeInTheDocument();
+    expect(screen.queryByTestId('perps-watchlist-BTC')).not.toBeInTheDocument();
   });
 });

--- a/ui/components/app/perps/perps-view.tsx
+++ b/ui/components/app/perps/perps-view.tsx
@@ -11,7 +11,6 @@ import { useDispatch, useSelector } from 'react-redux';
 import {
   usePerpsLivePositions,
   usePerpsLiveOrders,
-  usePerpsLiveMarketData,
 } from '../../../hooks/perps/stream';
 import { usePerpsTransactionHistory } from '../../../hooks/perps/usePerpsTransactionHistory';
 import { PERPS_RECENT_ACTIVITY_MAX_TRANSACTIONS } from '../../../../shared/constants/perps';
@@ -44,6 +43,7 @@ import {
 import { PerpsSupportLearn } from './perps-support-learn';
 import { PerpsTutorialModal } from './perps-tutorial-modal';
 import { PerpsWatchlist } from './perps-watchlist';
+import { usePerpsTabExploreData } from './hooks/usePerpsTabExploreData';
 
 /**
  * PerpsView component displays the perpetuals trading view
@@ -80,8 +80,11 @@ export const PerpsView: React.FC = () => {
     usePerpsLivePositions();
   const { orders: allOrders, isInitialLoading: ordersLoading } =
     usePerpsLiveOrders();
-  const { markets: allMarkets, isInitialLoading: marketsLoading } =
-    usePerpsLiveMarketData();
+  const {
+    exploreMarkets,
+    watchlistMarkets,
+    isInitialLoading: marketsLoading,
+  } = usePerpsTabExploreData();
 
   const {
     transactions: allRecentActivityTransactions,
@@ -260,10 +263,10 @@ export const PerpsView: React.FC = () => {
       />
 
       {/* Watchlist */}
-      <PerpsWatchlist />
+      <PerpsWatchlist markets={watchlistMarkets} />
 
       {/* Explore markets */}
-      <PerpsExploreMarkets markets={allMarkets} />
+      <PerpsExploreMarkets markets={exploreMarkets} />
 
       {/* Recent Activity */}
       <PerpsRecentActivity

--- a/ui/components/app/perps/perps-watchlist/perps-watchlist.test.tsx
+++ b/ui/components/app/perps/perps-watchlist/perps-watchlist.test.tsx
@@ -15,22 +15,9 @@ jest.mock('react-router-dom', () => ({
   useNavigate: () => mockNavigate,
 }));
 
-jest.mock('../../../../hooks/perps/stream', () => ({
-  usePerpsLiveMarketData: () => ({
-    cryptoMarkets: mockCryptoMarkets,
-    hip3Markets: [],
-    isInitialLoading: false,
-  }),
-}));
-
 const mockStore = configureStore({
   metamask: {
     ...mockState.metamask,
-    isTestnet: false,
-    watchlistMarkets: {
-      testnet: [],
-      mainnet: ['BTC', 'ETH'],
-    },
   },
 });
 
@@ -40,26 +27,38 @@ describe('PerpsWatchlist', () => {
   });
 
   it('renders the watchlist section', () => {
-    renderWithProvider(<PerpsWatchlist />, mockStore);
+    renderWithProvider(
+      <PerpsWatchlist markets={mockCryptoMarkets.slice(0, 2)} />,
+      mockStore,
+    );
 
     expect(screen.getByTestId('perps-watchlist')).toBeInTheDocument();
   });
 
   it('displays the watchlist heading', () => {
-    renderWithProvider(<PerpsWatchlist />, mockStore);
+    renderWithProvider(
+      <PerpsWatchlist markets={mockCryptoMarkets.slice(0, 2)} />,
+      mockStore,
+    );
 
     expect(screen.getByText(/watchlist/iu)).toBeInTheDocument();
   });
 
   it('renders market cards for watchlist symbols (BTC, ETH) that exist in market data', () => {
-    renderWithProvider(<PerpsWatchlist />, mockStore);
+    renderWithProvider(
+      <PerpsWatchlist markets={mockCryptoMarkets.slice(0, 2)} />,
+      mockStore,
+    );
 
     expect(screen.getByTestId('perps-watchlist-BTC')).toBeInTheDocument();
     expect(screen.getByTestId('perps-watchlist-ETH')).toBeInTheDocument();
   });
 
   it('displays market name, volume, and price for each watchlist item', () => {
-    renderWithProvider(<PerpsWatchlist />, mockStore);
+    renderWithProvider(
+      <PerpsWatchlist markets={mockCryptoMarkets.slice(0, 2)} />,
+      mockStore,
+    );
 
     expect(screen.getByText(tEn('networkNameBitcoin'))).toBeInTheDocument();
     expect(screen.getByText(tEn('networkNameEthereum'))).toBeInTheDocument();
@@ -70,12 +69,21 @@ describe('PerpsWatchlist', () => {
   });
 
   it('navigates to market detail when a watchlist card is clicked', () => {
-    renderWithProvider(<PerpsWatchlist />, mockStore);
+    renderWithProvider(
+      <PerpsWatchlist markets={mockCryptoMarkets.slice(0, 2)} />,
+      mockStore,
+    );
 
     fireEvent.click(screen.getByTestId('perps-watchlist-ETH'));
 
     expect(mockNavigate).toHaveBeenCalledWith(
       `${PERPS_MARKET_DETAIL_ROUTE}/ETH`,
     );
+  });
+
+  it('renders nothing when there are no watchlist markets', () => {
+    renderWithProvider(<PerpsWatchlist markets={[]} />, mockStore);
+
+    expect(screen.queryByTestId('perps-watchlist')).not.toBeInTheDocument();
   });
 });

--- a/ui/components/app/perps/perps-watchlist/perps-watchlist.tsx
+++ b/ui/components/app/perps/perps-watchlist/perps-watchlist.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useCallback } from 'react';
+import React, { useCallback } from 'react';
 import {
   Box,
   BoxFlexDirection,
@@ -8,38 +8,22 @@ import {
   FontWeight,
 } from '@metamask/design-system-react';
 import { useNavigate } from 'react-router-dom';
-import { useSelector } from 'react-redux';
+import type { PerpsMarketData } from '@metamask/perps-controller';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
-import { usePerpsLiveMarketData } from '../../../../hooks/perps/stream';
 import { PERPS_MARKET_DETAIL_ROUTE } from '../../../../helpers/constants/routes';
 import { PerpsMarketCard } from '../perps-market-card';
-import {
-  selectPerpsIsTestnet,
-  selectPerpsWatchlistMarkets,
-} from '../../../../selectors/perps-controller';
 
 /**
  * PerpsWatchlist displays a list of watched markets.
- * Resolves symbols from Redux with usePerpsLiveMarketData for live price and change.
+ * Receives already-resolved markets from the Perps tab data hook.
  */
-export const PerpsWatchlist: React.FC = () => {
+export type PerpsWatchlistProps = {
+  markets: PerpsMarketData[];
+};
+
+export const PerpsWatchlist: React.FC<PerpsWatchlistProps> = ({ markets }) => {
   const t = useI18nContext();
   const navigate = useNavigate();
-  const { cryptoMarkets, hip3Markets } = usePerpsLiveMarketData();
-  const watchlistMarketsState = useSelector(selectPerpsWatchlistMarkets);
-  const isTestnet = useSelector(selectPerpsIsTestnet);
-  const watchlistSymbols = isTestnet
-    ? watchlistMarketsState.testnet
-    : watchlistMarketsState.mainnet;
-
-  const watchlistMarkets = useMemo(() => {
-    const allMarkets = [...cryptoMarkets, ...hip3Markets];
-    return watchlistSymbols
-      .map((symbol) =>
-        allMarkets.find((m) => m.symbol.toUpperCase() === symbol.toUpperCase()),
-      )
-      .filter(Boolean) as typeof allMarkets;
-  }, [cryptoMarkets, hip3Markets, watchlistSymbols]);
 
   const handleMarketClick = useCallback(
     (symbol: string) => {
@@ -48,7 +32,7 @@ export const PerpsWatchlist: React.FC = () => {
     [navigate],
   );
 
-  if (watchlistMarkets.length === 0) {
+  if (markets.length === 0) {
     return null;
   }
 
@@ -70,7 +54,7 @@ export const PerpsWatchlist: React.FC = () => {
         <Text fontWeight={FontWeight.Medium}>{t('perpsWatchlist')}</Text>
       </Box>
       <Box flexDirection={BoxFlexDirection.Column}>
-        {watchlistMarkets.map((market) => (
+        {markets.map((market) => (
           <PerpsMarketCard
             key={market.symbol}
             symbol={market.symbol}

--- a/ui/hooks/perps/stream/index.mock.ts
+++ b/ui/hooks/perps/stream/index.mock.ts
@@ -160,11 +160,9 @@ export type UsePerpsLiveMarketListDataOptions = {
   refreshIntervalMs?: number;
 };
 
-export type UsePerpsLiveMarketListDataReturn = UsePerpsLiveMarketDataReturn;
-
 export function usePerpsLiveMarketListData(
   _options: UsePerpsLiveMarketListDataOptions = {},
-): UsePerpsLiveMarketListDataReturn {
+): UsePerpsLiveMarketDataReturn {
   return usePerpsLiveMarketData();
 }
 

--- a/ui/hooks/perps/stream/index.mock.ts
+++ b/ui/hooks/perps/stream/index.mock.ts
@@ -156,6 +156,18 @@ export function usePerpsLiveMarketData(
   };
 }
 
+export type UsePerpsLiveMarketListDataOptions = {
+  refreshIntervalMs?: number;
+};
+
+export type UsePerpsLiveMarketListDataReturn = UsePerpsLiveMarketDataReturn;
+
+export function usePerpsLiveMarketListData(
+  _options: UsePerpsLiveMarketListDataOptions = {},
+): UsePerpsLiveMarketListDataReturn {
+  return usePerpsLiveMarketData();
+}
+
 // ============================================================================
 // Candle Hook
 // ============================================================================

--- a/ui/hooks/perps/stream/index.ts
+++ b/ui/hooks/perps/stream/index.ts
@@ -92,6 +92,11 @@ export {
   type UsePerpsLiveMarketDataOptions,
   type UsePerpsLiveMarketDataReturn,
 } from './usePerpsLiveMarketData';
+export {
+  usePerpsLiveMarketListData,
+  type UsePerpsLiveMarketListDataOptions,
+  type UsePerpsLiveMarketListDataReturn,
+} from './usePerpsLiveMarketListData';
 
 // Re-export types from @metamask/perps-controller for convenience
 export type {

--- a/ui/hooks/perps/stream/usePerpsLiveMarketData.test.ts
+++ b/ui/hooks/perps/stream/usePerpsLiveMarketData.test.ts
@@ -39,6 +39,7 @@ function createMockStreamManager(cachedMarkets?: PerpsMarketData[]) {
     getCachedData: jest.fn(() => cachedMarkets ?? []),
     hasCachedData: jest.fn(() => Boolean(cachedMarkets?.length)),
     clearCache: jest.fn(),
+    refresh: jest.fn(),
     subscribe: jest.fn((cb: SubscribeCallback) => {
       subscriber = cb;
       if (cachedMarkets?.length) {
@@ -190,7 +191,7 @@ describe('usePerpsLiveMarketData', () => {
     expect(result.current.markets).toEqual([]);
   });
 
-  it('refresh clears cache and resets loading state', () => {
+  it('refresh triggers a market refresh without resetting loading state', () => {
     const allMarkets = [createMockMarket({ symbol: 'BTC', volume: '$1.2B' })];
 
     const { streamManager } = createMockStreamManager(allMarkets);
@@ -211,10 +212,10 @@ describe('usePerpsLiveMarketData', () => {
     });
 
     expect(
-      (streamManager as unknown as { markets: { clearCache: jest.Mock } })
-        .markets.clearCache,
+      (streamManager as unknown as { markets: { refresh: jest.Mock } }).markets
+        .refresh,
     ).toHaveBeenCalled();
-    expect(result.current.isInitialLoading).toBe(true);
+    expect(result.current.isInitialLoading).toBe(false);
   });
 
   it('excludes zero-volume HIP-3 markets from hip3Markets', () => {

--- a/ui/hooks/perps/stream/usePerpsLiveMarketData.ts
+++ b/ui/hooks/perps/stream/usePerpsLiveMarketData.ts
@@ -130,10 +130,7 @@ export function usePerpsLiveMarketData(
     if (!streamManager) {
       return;
     }
-    // Clear and re-subscribe to trigger a fresh fetch
-    streamManager.markets.clearCache();
-    hasReceivedData.current = false;
-    setIsInitialLoading(true);
+    streamManager.markets.refresh();
   }, [streamManager]);
 
   useEffect(() => {

--- a/ui/hooks/perps/stream/usePerpsLiveMarketListData.test.ts
+++ b/ui/hooks/perps/stream/usePerpsLiveMarketListData.test.ts
@@ -9,8 +9,9 @@ jest.mock('./usePerpsLivePrices');
 
 const mockUsePerpsLiveMarketData =
   usePerpsLiveMarketData as jest.MockedFunction<typeof usePerpsLiveMarketData>;
-const mockUsePerpsLivePrices =
-  usePerpsLivePrices as jest.MockedFunction<typeof usePerpsLivePrices>;
+const mockUsePerpsLivePrices = usePerpsLivePrices as jest.MockedFunction<
+  typeof usePerpsLivePrices
+>;
 
 const createMockMarket = (
   overrides: Partial<PerpsMarketData> = {},

--- a/ui/hooks/perps/stream/usePerpsLiveMarketListData.test.ts
+++ b/ui/hooks/perps/stream/usePerpsLiveMarketListData.test.ts
@@ -123,4 +123,36 @@ describe('usePerpsLiveMarketListData', () => {
 
     expect(refresh).toHaveBeenCalledTimes(1);
   });
+
+  it('keeps derived market arrays stable when inputs are unchanged', () => {
+    const refresh = jest.fn();
+    const cryptoMarket = createMockMarket({ symbol: 'BTC' });
+    const hip3Market = createMockMarket({
+      symbol: 'xyz:TSLA',
+      marketSource: 'xyz',
+    });
+
+    mockUsePerpsLiveMarketData.mockReturnValue({
+      markets: [cryptoMarket, hip3Market],
+      cryptoMarkets: [cryptoMarket],
+      hip3Markets: [hip3Market],
+      isInitialLoading: false,
+      error: null,
+      refresh,
+    });
+    mockUsePerpsLivePrices.mockReturnValue({
+      prices: {},
+      isInitialLoading: false,
+    });
+
+    const { result, rerender } = renderHook(() => usePerpsLiveMarketListData());
+
+    const firstCryptoMarkets = result.current.cryptoMarkets;
+    const firstHip3Markets = result.current.hip3Markets;
+
+    rerender();
+
+    expect(result.current.cryptoMarkets).toBe(firstCryptoMarkets);
+    expect(result.current.hip3Markets).toBe(firstHip3Markets);
+  });
 });

--- a/ui/hooks/perps/stream/usePerpsLiveMarketListData.test.ts
+++ b/ui/hooks/perps/stream/usePerpsLiveMarketListData.test.ts
@@ -1,0 +1,126 @@
+import { renderHook } from '@testing-library/react-hooks';
+import type { PerpsMarketData } from '@metamask/perps-controller';
+import { usePerpsLiveMarketData } from './usePerpsLiveMarketData';
+import { usePerpsLiveMarketListData } from './usePerpsLiveMarketListData';
+import { usePerpsLivePrices } from './usePerpsLivePrices';
+
+jest.mock('./usePerpsLiveMarketData');
+jest.mock('./usePerpsLivePrices');
+
+const mockUsePerpsLiveMarketData =
+  usePerpsLiveMarketData as jest.MockedFunction<typeof usePerpsLiveMarketData>;
+const mockUsePerpsLivePrices =
+  usePerpsLivePrices as jest.MockedFunction<typeof usePerpsLivePrices>;
+
+const createMockMarket = (
+  overrides: Partial<PerpsMarketData> = {},
+): PerpsMarketData => ({
+  symbol: overrides.symbol ?? 'BTC',
+  name: overrides.name ?? 'Bitcoin',
+  maxLeverage: overrides.maxLeverage ?? '20x',
+  price: overrides.price ?? '$50,000',
+  change24h: overrides.change24h ?? '+$1,250.00',
+  change24hPercent: overrides.change24hPercent ?? '+2.5%',
+  volume: overrides.volume ?? '$1.2B',
+  openInterest: overrides.openInterest,
+  nextFundingTime: overrides.nextFundingTime,
+  fundingIntervalHours: overrides.fundingIntervalHours,
+  fundingRate: overrides.fundingRate,
+  marketSource: overrides.marketSource,
+  marketType: overrides.marketType,
+});
+
+describe('usePerpsLiveMarketListData', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('activates live prices for all current market symbols', () => {
+    const markets = [
+      createMockMarket({ symbol: 'BTC' }),
+      createMockMarket({ symbol: 'ETH' }),
+    ];
+
+    mockUsePerpsLiveMarketData.mockReturnValue({
+      markets,
+      cryptoMarkets: markets,
+      hip3Markets: [],
+      isInitialLoading: false,
+      error: null,
+      refresh: jest.fn(),
+    });
+    mockUsePerpsLivePrices.mockReturnValue({
+      prices: {},
+      isInitialLoading: false,
+    });
+
+    renderHook(() => usePerpsLiveMarketListData());
+
+    expect(mockUsePerpsLivePrices).toHaveBeenCalledWith({
+      symbols: ['BTC', 'ETH'],
+      activateStream: true,
+      includeMarketData: false,
+    });
+  });
+
+  it('overlays live price and 24h change onto the market list', () => {
+    const market = createMockMarket({ symbol: 'BTC' });
+
+    mockUsePerpsLiveMarketData.mockReturnValue({
+      markets: [market],
+      cryptoMarkets: [market],
+      hip3Markets: [],
+      isInitialLoading: false,
+      error: null,
+      refresh: jest.fn(),
+    });
+    mockUsePerpsLivePrices.mockReturnValue({
+      prices: {
+        BTC: {
+          symbol: 'BTC',
+          price: '$99,999',
+          percentChange24h: '+9.9%',
+          timestamp: 123,
+        },
+      },
+      isInitialLoading: false,
+    });
+
+    const { result } = renderHook(() => usePerpsLiveMarketListData());
+
+    expect(result.current.markets[0]).toMatchObject({
+      symbol: 'BTC',
+      price: '$99,999',
+      change24hPercent: '+9.9%',
+    });
+  });
+
+  it('refreshes market snapshots on an interval while markets are present', () => {
+    const refresh = jest.fn();
+    const market = createMockMarket({ symbol: 'BTC' });
+
+    mockUsePerpsLiveMarketData.mockReturnValue({
+      markets: [market],
+      cryptoMarkets: [market],
+      hip3Markets: [],
+      isInitialLoading: false,
+      error: null,
+      refresh,
+    });
+    mockUsePerpsLivePrices.mockReturnValue({
+      prices: {},
+      isInitialLoading: false,
+    });
+
+    renderHook(() => usePerpsLiveMarketListData());
+
+    jest.advanceTimersByTime(30000);
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/hooks/perps/stream/usePerpsLiveMarketListData.ts
+++ b/ui/hooks/perps/stream/usePerpsLiveMarketListData.ts
@@ -33,7 +33,10 @@ export function usePerpsLiveMarketListData(
   } = usePerpsLiveMarketData();
 
   const marketSymbols = useMemo(
-    () => Array.from(new Set(markets.map((market) => market.symbol))).sort(),
+    () =>
+      Array.from(new Set(markets.map((market) => market.symbol))).sort(
+        (left, right) => left.localeCompare(right),
+      ),
     [markets],
   );
   // Use a stable key so the refresh effect only resets when the symbol set changes.
@@ -53,11 +56,11 @@ export function usePerpsLiveMarketListData(
       return undefined;
     }
 
-    const intervalId = window.setInterval(() => {
+    const intervalId = globalThis.setInterval(() => {
       refresh();
     }, refreshIntervalMs);
 
-    return () => window.clearInterval(intervalId);
+    return () => globalThis.clearInterval(intervalId);
   }, [marketSymbolsKey, refresh, refreshIntervalMs]);
 
   const liveMarkets = useMemo(() => {

--- a/ui/hooks/perps/stream/usePerpsLiveMarketListData.ts
+++ b/ui/hooks/perps/stream/usePerpsLiveMarketListData.ts
@@ -1,0 +1,99 @@
+import { useEffect, useMemo } from 'react';
+import type { PerpsMarketData } from '@metamask/perps-controller';
+import {
+  usePerpsLiveMarketData,
+  type UsePerpsLiveMarketDataReturn,
+} from './usePerpsLiveMarketData';
+import { usePerpsLivePrices } from './usePerpsLivePrices';
+
+const DEFAULT_REFRESH_INTERVAL_MS = 30000;
+
+export type UsePerpsLiveMarketListDataOptions = {
+  refreshIntervalMs?: number;
+};
+
+export type UsePerpsLiveMarketListDataReturn = Pick<
+  UsePerpsLiveMarketDataReturn,
+  'cryptoMarkets' | 'hip3Markets' | 'isInitialLoading' | 'error' | 'refresh'
+> & {
+  markets: PerpsMarketData[];
+};
+
+export function usePerpsLiveMarketListData(
+  options: UsePerpsLiveMarketListDataOptions = {},
+): UsePerpsLiveMarketListDataReturn {
+  const { refreshIntervalMs = DEFAULT_REFRESH_INTERVAL_MS } = options;
+  const {
+    markets,
+    cryptoMarkets,
+    hip3Markets,
+    isInitialLoading,
+    error,
+    refresh,
+  } = usePerpsLiveMarketData();
+
+  const marketSymbols = useMemo(
+    () => Array.from(new Set(markets.map((market) => market.symbol))).sort(),
+    [markets],
+  );
+  const marketSymbolsKey = useMemo(
+    () => marketSymbols.join('|'),
+    [marketSymbols],
+  );
+
+  const { prices } = usePerpsLivePrices({
+    symbols: marketSymbols,
+    activateStream: true,
+    includeMarketData: false,
+  });
+
+  useEffect(() => {
+    if (!marketSymbolsKey) {
+      return undefined;
+    }
+
+    const intervalId = window.setInterval(() => {
+      refresh();
+    }, refreshIntervalMs);
+
+    return () => window.clearInterval(intervalId);
+  }, [marketSymbolsKey, refresh, refreshIntervalMs]);
+
+  const liveMarkets = useMemo(() => {
+    if (Object.keys(prices).length === 0) {
+      return markets;
+    }
+
+    return markets.map((market) => {
+      const liveUpdate = prices[market.symbol];
+      if (!liveUpdate) {
+        return market;
+      }
+
+      return {
+        ...market,
+        price: liveUpdate.price ?? market.price,
+        change24hPercent:
+          liveUpdate.percentChange24h ?? market.change24hPercent,
+      };
+    });
+  }, [markets, prices]);
+
+  const liveMarketMap = useMemo(
+    () => new Map(liveMarkets.map((market) => [market.symbol, market])),
+    [liveMarkets],
+  );
+
+  return {
+    markets: liveMarkets,
+    cryptoMarkets: cryptoMarkets.map(
+      (market) => liveMarketMap.get(market.symbol) ?? market,
+    ),
+    hip3Markets: hip3Markets.map(
+      (market) => liveMarketMap.get(market.symbol) ?? market,
+    ),
+    isInitialLoading,
+    error,
+    refresh,
+  };
+}

--- a/ui/hooks/perps/stream/usePerpsLiveMarketListData.ts
+++ b/ui/hooks/perps/stream/usePerpsLiveMarketListData.ts
@@ -36,6 +36,7 @@ export function usePerpsLiveMarketListData(
     () => Array.from(new Set(markets.map((market) => market.symbol))).sort(),
     [markets],
   );
+  // Use a stable key so the refresh effect only resets when the symbol set changes.
   const marketSymbolsKey = useMemo(
     () => marketSymbols.join('|'),
     [marketSymbols],
@@ -83,15 +84,21 @@ export function usePerpsLiveMarketListData(
     () => new Map(liveMarkets.map((market) => [market.symbol, market])),
     [liveMarkets],
   );
+  const liveCryptoMarkets = useMemo(
+    () =>
+      cryptoMarkets.map((market) => liveMarketMap.get(market.symbol) ?? market),
+    [cryptoMarkets, liveMarketMap],
+  );
+  const liveHip3Markets = useMemo(
+    () =>
+      hip3Markets.map((market) => liveMarketMap.get(market.symbol) ?? market),
+    [hip3Markets, liveMarketMap],
+  );
 
   return {
     markets: liveMarkets,
-    cryptoMarkets: cryptoMarkets.map(
-      (market) => liveMarketMap.get(market.symbol) ?? market,
-    ),
-    hip3Markets: hip3Markets.map(
-      (market) => liveMarketMap.get(market.symbol) ?? market,
-    ),
+    cryptoMarkets: liveCryptoMarkets,
+    hip3Markets: liveHip3Markets,
     isInitialLoading,
     error,
     refresh,

--- a/ui/hooks/perps/stream/usePerpsLivePrices.test.ts
+++ b/ui/hooks/perps/stream/usePerpsLivePrices.test.ts
@@ -120,6 +120,34 @@ describe('usePerpsLivePrices', () => {
     nowSpy.mockRestore();
   });
 
+  it('returns a stable prices reference when inputs are unchanged', () => {
+    const priceUpdates: StreamPriceUpdate[] = [
+      {
+        symbol: 'BTC',
+        price: '100',
+        timestamp: 111,
+      },
+    ];
+
+    mockUsePerpsChannel.mockReturnValue({
+      data: priceUpdates,
+      isInitialLoading: false,
+    });
+
+    const { result, rerender } = renderHook(
+      ({ symbols }) => usePerpsLivePrices({ symbols }),
+      {
+        initialProps: { symbols: ['BTC'] },
+      },
+    );
+
+    const firstPrices = result.current.prices;
+
+    rerender({ symbols: ['BTC'] });
+
+    expect(result.current.prices).toBe(firstPrices);
+  });
+
   it('activates and deactivates the background price stream when requested', () => {
     mockUsePerpsChannel.mockReturnValue({
       data: [],

--- a/ui/hooks/perps/stream/usePerpsLivePrices.test.ts
+++ b/ui/hooks/perps/stream/usePerpsLivePrices.test.ts
@@ -1,8 +1,13 @@
 import { renderHook } from '@testing-library/react-hooks';
 import type { PriceUpdate } from '@metamask/perps-controller';
+import { submitRequestToBackground } from '../../../store/background-connection';
 import { usePerpsChannel } from './usePerpsChannel';
 import { usePerpsLivePrices } from './usePerpsLivePrices';
-import { submitRequestToBackground } from '../../../store/background-connection';
+
+type StreamPriceUpdate = PriceUpdate & {
+  timestamp?: number;
+  markPrice?: string;
+};
 
 jest.mock('./usePerpsChannel', () => ({
   usePerpsChannel: jest.fn(),
@@ -26,7 +31,7 @@ describe('usePerpsLivePrices', () => {
   });
 
   it('returns empty prices while initial loading is true', () => {
-    const priceUpdates = [{ symbol: 'BTC', price: '100' }] as PriceUpdate[];
+    const priceUpdates: StreamPriceUpdate[] = [{ symbol: 'BTC', price: '100' }];
     mockUsePerpsChannel.mockReturnValue({
       data: priceUpdates,
       isInitialLoading: true,
@@ -59,7 +64,7 @@ describe('usePerpsLivePrices', () => {
   });
 
   it('filters by requested symbols and keeps provided timestamp/markPrice', () => {
-    const priceUpdates = [
+    const priceUpdates: StreamPriceUpdate[] = [
       {
         symbol: 'BTC',
         price: '100',
@@ -73,7 +78,7 @@ describe('usePerpsLivePrices', () => {
         timestamp: 222,
         markPrice: '201',
       },
-    ] as PriceUpdate[];
+    ];
 
     mockUsePerpsChannel.mockReturnValue({
       data: priceUpdates,
@@ -99,7 +104,7 @@ describe('usePerpsLivePrices', () => {
   it('uses fallback timestamp and preserves missing markPrice', () => {
     const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(999);
     mockUsePerpsChannel.mockReturnValue({
-      data: [{ symbol: 'BTC', price: '100' }] as PriceUpdate[],
+      data: [{ symbol: 'BTC', price: '100' }] as StreamPriceUpdate[],
       isInitialLoading: false,
     });
 

--- a/ui/hooks/perps/stream/usePerpsLivePrices.test.ts
+++ b/ui/hooks/perps/stream/usePerpsLivePrices.test.ts
@@ -1,8 +1,8 @@
 import { renderHook } from '@testing-library/react-hooks';
 import type { PriceUpdate } from '@metamask/perps-controller';
 import { submitRequestToBackground } from '../../../store/background-connection';
-import { usePerpsChannel } from './usePerpsChannel';
 import { usePerpsLivePrices } from './usePerpsLivePrices';
+import { usePerpsChannel } from './usePerpsChannel';
 
 type StreamPriceUpdate = PriceUpdate & {
   timestamp?: number;

--- a/ui/hooks/perps/stream/usePerpsLivePrices.test.ts
+++ b/ui/hooks/perps/stream/usePerpsLivePrices.test.ts
@@ -4,7 +4,7 @@ import { submitRequestToBackground } from '../../../store/background-connection'
 import { usePerpsLivePrices } from './usePerpsLivePrices';
 import { usePerpsChannel } from './usePerpsChannel';
 
-type StreamPriceUpdate = PriceUpdate & {
+type StreamPriceUpdate = Omit<PriceUpdate, 'timestamp'> & {
   timestamp?: number;
   markPrice?: string;
 };

--- a/ui/hooks/perps/stream/usePerpsLivePrices.test.ts
+++ b/ui/hooks/perps/stream/usePerpsLivePrices.test.ts
@@ -1,33 +1,31 @@
 import { renderHook } from '@testing-library/react-hooks';
-import type { PriceUpdate } from '@metamask/perps-controller';
 import { submitRequestToBackground } from '../../../store/background-connection';
-import { usePerpsLivePrices } from './usePerpsLivePrices';
 import { usePerpsChannel } from './usePerpsChannel';
+import { usePerpsLivePrices } from './usePerpsLivePrices';
 
-type StreamPriceUpdate = Omit<PriceUpdate, 'timestamp'> & {
+type StreamPriceUpdate = {
+  symbol: string;
+  price: string;
   timestamp?: number;
   markPrice?: string;
+  percentChange24h?: string;
 };
+
+jest.mock('../../../store/background-connection', () => ({
+  submitRequestToBackground: jest.fn(),
+}));
 
 jest.mock('./usePerpsChannel', () => ({
   usePerpsChannel: jest.fn(),
 }));
 
-jest.mock('../../../store/background-connection', () => ({
-  submitRequestToBackground: jest.fn().mockResolvedValue(undefined),
-}));
-
-const mockUsePerpsChannel = usePerpsChannel as jest.MockedFunction<
-  typeof usePerpsChannel
->;
-const mockSubmitRequestToBackground =
-  submitRequestToBackground as jest.MockedFunction<
-    typeof submitRequestToBackground
-  >;
+const mockUsePerpsChannel = jest.mocked(usePerpsChannel);
+const mockSubmitRequestToBackground = jest.mocked(submitRequestToBackground);
 
 describe('usePerpsLivePrices', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockSubmitRequestToBackground.mockResolvedValue(undefined);
   });
 
   it('returns empty prices while initial loading is true', () => {
@@ -63,7 +61,7 @@ describe('usePerpsLivePrices', () => {
     });
   });
 
-  it('filters by requested symbols and keeps provided timestamp/markPrice', () => {
+  it('filters by requested symbols and keeps provided timestamp and markPrice', () => {
     const priceUpdates: StreamPriceUpdate[] = [
       {
         symbol: 'BTC',
@@ -104,7 +102,7 @@ describe('usePerpsLivePrices', () => {
   it('uses fallback timestamp and preserves missing markPrice', () => {
     const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(999);
     mockUsePerpsChannel.mockReturnValue({
-      data: [{ symbol: 'BTC', price: '100' }] as StreamPriceUpdate[],
+      data: [{ symbol: 'BTC', price: '100' }],
       isInitialLoading: false,
     });
 
@@ -130,15 +128,15 @@ describe('usePerpsLivePrices', () => {
 
     const { unmount } = renderHook(() =>
       usePerpsLivePrices({
-        symbols: ['ETH', 'BTC'],
+        symbols: ['ETH', 'BTC', 'ETH'],
         activateStream: true,
-        includeMarketData: true,
+        includeMarketData: false,
       }),
     );
 
     expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
       'perpsActivatePriceStream',
-      [{ symbols: ['BTC', 'ETH'], includeMarketData: true }],
+      [{ symbols: ['BTC', 'ETH'], includeMarketData: false }],
     );
 
     unmount();
@@ -149,11 +147,10 @@ describe('usePerpsLivePrices', () => {
     );
   });
 
-  it('logs debug output when stream activation or cleanup fails', async () => {
+  it('logs activation and cleanup failures without throwing', async () => {
     const debugSpy = jest
       .spyOn(console, 'debug')
       .mockImplementation(() => undefined);
-
     mockUsePerpsChannel.mockReturnValue({
       data: [],
       isInitialLoading: false,
@@ -170,15 +167,13 @@ describe('usePerpsLivePrices', () => {
     );
 
     await Promise.resolve();
+    unmount();
+    await Promise.resolve();
 
     expect(debugSpy).toHaveBeenCalledWith(
       '[usePerpsLivePrices] perpsActivatePriceStream failed:',
       expect.any(Error),
     );
-
-    unmount();
-    await Promise.resolve();
-
     expect(debugSpy).toHaveBeenCalledWith(
       '[usePerpsLivePrices] perpsDeactivatePriceStream failed:',
       expect.any(Error),

--- a/ui/hooks/perps/stream/usePerpsLivePrices.test.ts
+++ b/ui/hooks/perps/stream/usePerpsLivePrices.test.ts
@@ -143,4 +143,42 @@ describe('usePerpsLivePrices', () => {
       [],
     );
   });
+
+  it('logs debug output when stream activation or cleanup fails', async () => {
+    const debugSpy = jest
+      .spyOn(console, 'debug')
+      .mockImplementation(() => undefined);
+
+    mockUsePerpsChannel.mockReturnValue({
+      data: [],
+      isInitialLoading: false,
+    });
+    mockSubmitRequestToBackground
+      .mockRejectedValueOnce(new Error('activate failed'))
+      .mockRejectedValueOnce(new Error('deactivate failed'));
+
+    const { unmount } = renderHook(() =>
+      usePerpsLivePrices({
+        symbols: ['BTC'],
+        activateStream: true,
+      }),
+    );
+
+    await Promise.resolve();
+
+    expect(debugSpy).toHaveBeenCalledWith(
+      '[usePerpsLivePrices] perpsActivatePriceStream failed:',
+      expect.any(Error),
+    );
+
+    unmount();
+    await Promise.resolve();
+
+    expect(debugSpy).toHaveBeenCalledWith(
+      '[usePerpsLivePrices] perpsDeactivatePriceStream failed:',
+      expect.any(Error),
+    );
+
+    debugSpy.mockRestore();
+  });
 });

--- a/ui/hooks/perps/stream/usePerpsLivePrices.test.ts
+++ b/ui/hooks/perps/stream/usePerpsLivePrices.test.ts
@@ -2,14 +2,23 @@ import { renderHook } from '@testing-library/react-hooks';
 import type { PriceUpdate } from '@metamask/perps-controller';
 import { usePerpsChannel } from './usePerpsChannel';
 import { usePerpsLivePrices } from './usePerpsLivePrices';
+import { submitRequestToBackground } from '../../../store/background-connection';
 
 jest.mock('./usePerpsChannel', () => ({
   usePerpsChannel: jest.fn(),
 }));
 
+jest.mock('../../../store/background-connection', () => ({
+  submitRequestToBackground: jest.fn().mockResolvedValue(undefined),
+}));
+
 const mockUsePerpsChannel = usePerpsChannel as jest.MockedFunction<
   typeof usePerpsChannel
 >;
+const mockSubmitRequestToBackground =
+  submitRequestToBackground as jest.MockedFunction<
+    typeof submitRequestToBackground
+  >;
 
 describe('usePerpsLivePrices', () => {
   beforeEach(() => {
@@ -56,6 +65,7 @@ describe('usePerpsLivePrices', () => {
         price: '100',
         timestamp: 111,
         markPrice: '101',
+        percentChange24h: '+3.1%',
       },
       {
         symbol: 'ETH',
@@ -81,6 +91,7 @@ describe('usePerpsLivePrices', () => {
         price: '100',
         timestamp: 111,
         markPrice: '101',
+        percentChange24h: '+3.1%',
       },
     });
   });
@@ -104,5 +115,32 @@ describe('usePerpsLivePrices', () => {
     });
 
     nowSpy.mockRestore();
+  });
+
+  it('activates and deactivates the background price stream when requested', () => {
+    mockUsePerpsChannel.mockReturnValue({
+      data: [],
+      isInitialLoading: false,
+    });
+
+    const { unmount } = renderHook(() =>
+      usePerpsLivePrices({
+        symbols: ['ETH', 'BTC'],
+        activateStream: true,
+        includeMarketData: true,
+      }),
+    );
+
+    expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+      'perpsActivatePriceStream',
+      [{ symbols: ['BTC', 'ETH'], includeMarketData: true }],
+    );
+
+    unmount();
+
+    expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+      'perpsDeactivatePriceStream',
+      [],
+    );
   });
 });

--- a/ui/hooks/perps/stream/usePerpsLivePrices.ts
+++ b/ui/hooks/perps/stream/usePerpsLivePrices.ts
@@ -28,12 +28,7 @@ export type UsePerpsLivePricesReturn = {
   isInitialLoading: boolean;
 };
 
-type StreamPriceUpdate = Omit<PriceUpdate, 'timestamp'> & {
-  timestamp?: number;
-  markPrice?: string;
-};
-
-const EMPTY_PRICES: StreamPriceUpdate[] = [];
+const EMPTY_PRICES: PriceUpdate[] = [];
 const EMPTY_PRICES_RECORD: Record<string, PriceUpdate> = {};
 
 const getPricesChannel = (sm: PerpsStreamManager) => sm.prices;
@@ -93,9 +88,10 @@ export function usePerpsLivePrices(
     };
   }, [activateStream, includeMarketData, symbolsKey]);
 
-  const { data: priceArray, isInitialLoading } = usePerpsChannel<
-    StreamPriceUpdate[]
-  >(getPricesChannel, EMPTY_PRICES);
+  const { data: priceArray, isInitialLoading } = usePerpsChannel<PriceUpdate[]>(
+    getPricesChannel,
+    EMPTY_PRICES,
+  );
 
   const requestedSymbols = useMemo(
     () => (symbolsKey ? new Set(symbolsKey.split('|')) : new Set<string>()),

--- a/ui/hooks/perps/stream/usePerpsLivePrices.ts
+++ b/ui/hooks/perps/stream/usePerpsLivePrices.ts
@@ -1,8 +1,8 @@
 import type { PriceUpdate } from '@metamask/perps-controller';
+import { useEffect, useMemo } from 'react';
 import type { PerpsStreamManager } from '../../../providers/perps';
 import { submitRequestToBackground } from '../../../store/background-connection';
 import { usePerpsChannel } from './usePerpsChannel';
-import { useEffect, useMemo } from 'react';
 
 /**
  * Options for usePerpsLivePrices hook
@@ -28,8 +28,13 @@ export type UsePerpsLivePricesReturn = {
   isInitialLoading: boolean;
 };
 
+type StreamPriceUpdate = PriceUpdate & {
+  timestamp?: number;
+  markPrice?: string;
+};
+
 // Stable empty object reference to prevent re-renders
-const EMPTY_PRICES: PriceUpdate[] = [];
+const EMPTY_PRICES: StreamPriceUpdate[] = [];
 const EMPTY_PRICES_RECORD: Record<string, PriceUpdate> = {};
 
 const getPricesChannel = (sm: PerpsStreamManager) => sm.prices;
@@ -85,7 +90,10 @@ export function usePerpsLivePrices(
     ]).catch((err) => {
       // Background may not be ready yet; keep this best-effort and rely on
       // later retries or future consumers to react to stream data.
-      console.debug('[usePerpsLivePrices] perpsActivatePriceStream failed:', err);
+      console.debug(
+        '[usePerpsLivePrices] perpsActivatePriceStream failed:',
+        err,
+      );
     });
 
     return () => {
@@ -101,10 +109,9 @@ export function usePerpsLivePrices(
     };
   }, [activateStream, symbolsKey, includeMarketData]);
 
-  const { data: priceArray, isInitialLoading } = usePerpsChannel(
-    getPricesChannel,
-    EMPTY_PRICES,
-  );
+  const { data: priceArray, isInitialLoading } = usePerpsChannel<
+    StreamPriceUpdate[]
+  >(getPricesChannel, EMPTY_PRICES);
 
   if (isInitialLoading || priceArray.length === 0) {
     return { prices: EMPTY_PRICES_RECORD, isInitialLoading };
@@ -114,12 +121,10 @@ export function usePerpsLivePrices(
   const priceRecord: Record<string, PriceUpdate> = {};
   priceArray.forEach((update) => {
     if (symbols.length === 0 || symbols.includes(update.symbol)) {
-      const ts = (update as { timestamp?: number }).timestamp;
-      const mark = (update as { markPrice?: string }).markPrice;
       priceRecord[update.symbol] = {
         ...update,
-        timestamp: ts ?? Date.now(),
-        markPrice: mark,
+        timestamp: update.timestamp ?? Date.now(),
+        markPrice: update.markPrice,
       };
     }
   });

--- a/ui/hooks/perps/stream/usePerpsLivePrices.ts
+++ b/ui/hooks/perps/stream/usePerpsLivePrices.ts
@@ -28,13 +28,8 @@ export type UsePerpsLivePricesReturn = {
   isInitialLoading: boolean;
 };
 
-type StreamPriceUpdate = Omit<PriceUpdate, 'timestamp'> & {
-  timestamp?: number;
-  markPrice?: string;
-};
-
 // Stable empty object reference to prevent re-renders
-const EMPTY_PRICES: StreamPriceUpdate[] = [];
+const EMPTY_PRICES: PriceUpdate[] = [];
 const EMPTY_PRICES_RECORD: Record<string, PriceUpdate> = {};
 
 const getPricesChannel = (sm: PerpsStreamManager) => sm.prices;
@@ -112,9 +107,10 @@ export function usePerpsLivePrices(
     };
   }, [activateStream, symbolsKey, includeMarketData]);
 
-  const { data: priceArray, isInitialLoading } = usePerpsChannel<
-    StreamPriceUpdate[]
-  >(getPricesChannel, EMPTY_PRICES);
+  const { data: priceArray, isInitialLoading } = usePerpsChannel<PriceUpdate[]>(
+    getPricesChannel,
+    EMPTY_PRICES,
+  );
 
   if (isInitialLoading || priceArray.length === 0) {
     return { prices: EMPTY_PRICES_RECORD, isInitialLoading };
@@ -124,11 +120,7 @@ export function usePerpsLivePrices(
   const priceRecord: Record<string, PriceUpdate> = {};
   priceArray.forEach((update) => {
     if (symbols.length === 0 || symbols.includes(update.symbol)) {
-      priceRecord[update.symbol] = {
-        ...update,
-        timestamp: update.timestamp ?? Date.now(),
-        markPrice: update.markPrice,
-      };
+      priceRecord[update.symbol] = update;
     }
   });
 

--- a/ui/hooks/perps/stream/usePerpsLivePrices.ts
+++ b/ui/hooks/perps/stream/usePerpsLivePrices.ts
@@ -1,6 +1,8 @@
 import type { PriceUpdate } from '@metamask/perps-controller';
 import type { PerpsStreamManager } from '../../../providers/perps';
+import { submitRequestToBackground } from '../../../store/background-connection';
 import { usePerpsChannel } from './usePerpsChannel';
+import { useEffect, useMemo } from 'react';
 
 /**
  * Options for usePerpsLivePrices hook
@@ -10,6 +12,10 @@ export type UsePerpsLivePricesOptions = {
   symbols: string[];
   /** Throttle delay in milliseconds (default: 0 - no throttling) */
   throttleMs?: number;
+  /** Whether to activate the background price stream for these symbols */
+  activateStream?: boolean;
+  /** Optional passthrough for controller market data enrichment */
+  includeMarketData?: boolean;
 };
 
 /**
@@ -57,6 +63,34 @@ const getPricesChannel = (sm: PerpsStreamManager) => sm.prices;
 export function usePerpsLivePrices(
   options: UsePerpsLivePricesOptions,
 ): UsePerpsLivePricesReturn {
+  const {
+    symbols,
+    activateStream = false,
+    includeMarketData = false,
+  } = options;
+  const symbolsKey = useMemo(
+    () => Array.from(new Set(symbols)).sort().join('|'),
+    [symbols],
+  );
+
+  useEffect(() => {
+    if (!activateStream || !symbolsKey) {
+      return undefined;
+    }
+
+    const activeSymbols = symbolsKey.split('|');
+
+    submitRequestToBackground('perpsActivatePriceStream', [
+      { symbols: activeSymbols, includeMarketData },
+    ]).catch(() => undefined);
+
+    return () => {
+      submitRequestToBackground('perpsDeactivatePriceStream', []).catch(
+        () => undefined,
+      );
+    };
+  }, [activateStream, symbolsKey, includeMarketData]);
+
   const { data: priceArray, isInitialLoading } = usePerpsChannel(
     getPricesChannel,
     EMPTY_PRICES,
@@ -67,15 +101,13 @@ export function usePerpsLivePrices(
   }
 
   // Convert array to record, filtered to requested symbols
-  const { symbols } = options;
   const priceRecord: Record<string, PriceUpdate> = {};
   priceArray.forEach((update) => {
     if (symbols.length === 0 || symbols.includes(update.symbol)) {
       const ts = (update as { timestamp?: number }).timestamp;
       const mark = (update as { markPrice?: string }).markPrice;
       priceRecord[update.symbol] = {
-        symbol: update.symbol,
-        price: update.price,
+        ...update,
         timestamp: ts ?? Date.now(),
         markPrice: mark,
       };

--- a/ui/hooks/perps/stream/usePerpsLivePrices.ts
+++ b/ui/hooks/perps/stream/usePerpsLivePrices.ts
@@ -82,11 +82,21 @@ export function usePerpsLivePrices(
 
     submitRequestToBackground('perpsActivatePriceStream', [
       { symbols: activeSymbols, includeMarketData },
-    ]).catch(() => undefined);
+    ]).catch((err) => {
+      // Background may not be ready yet; keep this best-effort and rely on
+      // later retries or future consumers to react to stream data.
+      console.debug('[usePerpsLivePrices] perpsActivatePriceStream failed:', err);
+    });
 
     return () => {
       submitRequestToBackground('perpsDeactivatePriceStream', []).catch(
-        () => undefined,
+        (err) => {
+          // Expected when the port closes before cleanup completes.
+          console.debug(
+            '[usePerpsLivePrices] perpsDeactivatePriceStream failed:',
+            err,
+          );
+        },
       );
     };
   }, [activateStream, symbolsKey, includeMarketData]);

--- a/ui/hooks/perps/stream/usePerpsLivePrices.ts
+++ b/ui/hooks/perps/stream/usePerpsLivePrices.ts
@@ -28,8 +28,12 @@ export type UsePerpsLivePricesReturn = {
   isInitialLoading: boolean;
 };
 
-// Stable empty object reference to prevent re-renders
-const EMPTY_PRICES: PriceUpdate[] = [];
+type StreamPriceUpdate = Omit<PriceUpdate, 'timestamp'> & {
+  timestamp?: number;
+  markPrice?: string;
+};
+
+const EMPTY_PRICES: StreamPriceUpdate[] = [];
 const EMPTY_PRICES_RECORD: Record<string, PriceUpdate> = {};
 
 const getPricesChannel = (sm: PerpsStreamManager) => sm.prices;
@@ -42,23 +46,6 @@ const getPricesChannel = (sm: PerpsStreamManager) => sm.prices;
  *
  * @param options - Configuration options
  * @returns Object containing prices map and loading state
- * @example
- * ```tsx
- * function PriceDisplay() {
- *   const { prices, isInitialLoading } = usePerpsLivePrices({
- *     symbols: ['BTC', 'ETH'],
- *   });
- *
- *   if (isInitialLoading) return <Spinner />;
- *
- *   return (
- *     <div>
- *       BTC: {prices.BTC?.price}
- *       ETH: {prices.ETH?.price}
- *     </div>
- *   );
- * }
- * ```
  */
 export function usePerpsLivePrices(
   options: UsePerpsLivePricesOptions,
@@ -85,42 +72,43 @@ export function usePerpsLivePrices(
 
     submitRequestToBackground('perpsActivatePriceStream', [
       { symbols: activeSymbols, includeMarketData },
-    ]).catch((err) => {
-      // Background may not be ready yet; keep this best-effort and rely on
-      // later retries or future consumers to react to stream data.
+    ]).catch((error) => {
+      // Background readiness can lag popup mounting; keep this best-effort.
       console.debug(
         '[usePerpsLivePrices] perpsActivatePriceStream failed:',
-        err,
+        error,
       );
     });
 
     return () => {
       submitRequestToBackground('perpsDeactivatePriceStream', []).catch(
-        (err) => {
-          // Expected when the port closes before cleanup completes.
+        (error) => {
+          // Expected when the background port closes before cleanup completes.
           console.debug(
             '[usePerpsLivePrices] perpsDeactivatePriceStream failed:',
-            err,
+            error,
           );
         },
       );
     };
-  }, [activateStream, symbolsKey, includeMarketData]);
+  }, [activateStream, includeMarketData, symbolsKey]);
 
-  const { data: priceArray, isInitialLoading } = usePerpsChannel<PriceUpdate[]>(
-    getPricesChannel,
-    EMPTY_PRICES,
-  );
+  const { data: priceArray, isInitialLoading } = usePerpsChannel<
+    StreamPriceUpdate[]
+  >(getPricesChannel, EMPTY_PRICES);
 
   if (isInitialLoading || priceArray.length === 0) {
     return { prices: EMPTY_PRICES_RECORD, isInitialLoading };
   }
 
-  // Convert array to record, filtered to requested symbols
   const priceRecord: Record<string, PriceUpdate> = {};
   priceArray.forEach((update) => {
     if (symbols.length === 0 || symbols.includes(update.symbol)) {
-      priceRecord[update.symbol] = update;
+      priceRecord[update.symbol] = {
+        ...update,
+        timestamp: update.timestamp ?? Date.now(),
+        markPrice: update.markPrice,
+      };
     }
   });
 

--- a/ui/hooks/perps/stream/usePerpsLivePrices.ts
+++ b/ui/hooks/perps/stream/usePerpsLivePrices.ts
@@ -1,5 +1,5 @@
-import type { PriceUpdate } from '@metamask/perps-controller';
 import { useEffect, useMemo } from 'react';
+import type { PriceUpdate } from '@metamask/perps-controller';
 import type { PerpsStreamManager } from '../../../providers/perps';
 import { submitRequestToBackground } from '../../../store/background-connection';
 import { usePerpsChannel } from './usePerpsChannel';
@@ -74,7 +74,10 @@ export function usePerpsLivePrices(
     includeMarketData = false,
   } = options;
   const symbolsKey = useMemo(
-    () => Array.from(new Set(symbols)).sort().join('|'),
+    () =>
+      Array.from(new Set(symbols))
+        .sort((left, right) => left.localeCompare(right))
+        .join('|'),
     [symbols],
   );
 

--- a/ui/hooks/perps/stream/usePerpsLivePrices.ts
+++ b/ui/hooks/perps/stream/usePerpsLivePrices.ts
@@ -28,7 +28,7 @@ export type UsePerpsLivePricesReturn = {
   isInitialLoading: boolean;
 };
 
-type StreamPriceUpdate = PriceUpdate & {
+type StreamPriceUpdate = Omit<PriceUpdate, 'timestamp'> & {
   timestamp?: number;
   markPrice?: string;
 };

--- a/ui/hooks/perps/stream/usePerpsLivePrices.ts
+++ b/ui/hooks/perps/stream/usePerpsLivePrices.ts
@@ -97,20 +97,29 @@ export function usePerpsLivePrices(
     StreamPriceUpdate[]
   >(getPricesChannel, EMPTY_PRICES);
 
-  if (isInitialLoading || priceArray.length === 0) {
-    return { prices: EMPTY_PRICES_RECORD, isInitialLoading };
-  }
+  const requestedSymbols = useMemo(
+    () => (symbolsKey ? new Set(symbolsKey.split('|')) : new Set<string>()),
+    [symbolsKey],
+  );
 
-  const priceRecord: Record<string, PriceUpdate> = {};
-  priceArray.forEach((update) => {
-    if (symbols.length === 0 || symbols.includes(update.symbol)) {
-      priceRecord[update.symbol] = {
-        ...update,
-        timestamp: update.timestamp ?? Date.now(),
-        markPrice: update.markPrice,
-      };
+  const prices = useMemo(() => {
+    if (isInitialLoading || priceArray.length === 0) {
+      return EMPTY_PRICES_RECORD;
     }
-  });
 
-  return { prices: priceRecord, isInitialLoading };
+    const priceRecord: Record<string, PriceUpdate> = {};
+    priceArray.forEach((update) => {
+      if (requestedSymbols.size === 0 || requestedSymbols.has(update.symbol)) {
+        priceRecord[update.symbol] = {
+          ...update,
+          timestamp: update.timestamp ?? Date.now(),
+          markPrice: update.markPrice,
+        };
+      }
+    });
+
+    return priceRecord;
+  }, [isInitialLoading, priceArray, requestedSymbols]);
+
+  return { prices, isInitialLoading };
 }

--- a/ui/hooks/perps/stream/usePerpsLivePrices.ts
+++ b/ui/hooks/perps/stream/usePerpsLivePrices.ts
@@ -63,6 +63,10 @@ export function usePerpsLivePrices(
       return undefined;
     }
 
+    // The background `prices` channel is currently a single shared stream.
+    // Activating here is safe because the current product flow has one active
+    // owner at a time; if we later support concurrent owners, the bridge API
+    // should move to scoped subscriptions or ref-counted teardown.
     const activeSymbols = symbolsKey.split('|');
 
     submitRequestToBackground('perpsActivatePriceStream', [

--- a/ui/pages/perps/market-list/index.test.tsx
+++ b/ui/pages/perps/market-list/index.test.tsx
@@ -248,5 +248,4 @@ describe('MarketListView', () => {
       });
     });
   });
-
 });

--- a/ui/pages/perps/market-list/index.test.tsx
+++ b/ui/pages/perps/market-list/index.test.tsx
@@ -16,10 +16,9 @@ jest.mock('react-router-dom', () => ({
   useNavigate: () => mockNavigate,
 }));
 
-// Mock usePerpsLiveMarketData hook to avoid controller dependency
-const mockUsePerpsLiveMarketData = jest.fn();
+const mockUsePerpsLiveMarketListData = jest.fn();
 jest.mock('../../../hooks/perps/stream', () => ({
-  usePerpsLiveMarketData: () => mockUsePerpsLiveMarketData(),
+  usePerpsLiveMarketListData: () => mockUsePerpsLiveMarketListData(),
   usePerpsLiveAccount: () => ({ account: null }),
 }));
 
@@ -36,9 +35,13 @@ describe('MarketListView', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     // Default mock returns loaded state with markets
-    mockUsePerpsLiveMarketData.mockReturnValue({
+    mockUsePerpsLiveMarketListData.mockReturnValue({
       markets: [...mockCryptoMarkets, ...mockHip3Markets],
+      cryptoMarkets: mockCryptoMarkets,
+      hip3Markets: mockHip3Markets,
       isInitialLoading: false,
+      error: null,
+      refresh: jest.fn(),
     });
   });
 
@@ -72,14 +75,45 @@ describe('MarketListView', () => {
 
       expect(screen.getByTestId('back-button')).toBeInTheDocument();
     });
+
+    it('renders live price and change values from the list hook', async () => {
+      const [firstMarket] = mockCryptoMarkets;
+      mockUsePerpsLiveMarketListData.mockReturnValue({
+        markets: [
+          {
+            ...firstMarket,
+            price: '$99,999',
+            change24hPercent: '+9.9%',
+          },
+          ...mockCryptoMarkets.slice(1),
+          ...mockHip3Markets,
+        ],
+        cryptoMarkets: mockCryptoMarkets,
+        hip3Markets: mockHip3Markets,
+        isInitialLoading: false,
+        error: null,
+        refresh: jest.fn(),
+      });
+
+      renderWithProvider(<MarketListView />, mockStore);
+
+      await waitFor(() => {
+        expect(screen.getByText('$99,999')).toBeInTheDocument();
+        expect(screen.getByText('+9.9%')).toBeInTheDocument();
+      });
+    });
   });
 
   describe('loading state', () => {
     it('shows loading skeletons initially', () => {
       // Override mock to return loading state
-      mockUsePerpsLiveMarketData.mockReturnValue({
+      mockUsePerpsLiveMarketListData.mockReturnValue({
         markets: [],
+        cryptoMarkets: [],
+        hip3Markets: [],
         isInitialLoading: true,
+        error: null,
+        refresh: jest.fn(),
       });
 
       renderWithProvider(<MarketListView />, mockStore);
@@ -214,4 +248,5 @@ describe('MarketListView', () => {
       });
     });
   });
+
 });

--- a/ui/pages/perps/market-list/index.tsx
+++ b/ui/pages/perps/market-list/index.tsx
@@ -23,8 +23,8 @@ import {
 } from '../../../../shared/constants/perps-events';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
-  usePerpsLiveMarketData,
   usePerpsLiveAccount,
+  usePerpsLiveMarketListData,
 } from '../../../hooks/perps/stream';
 import {
   filterMarketsByQuery,
@@ -156,7 +156,7 @@ export const MarketListView: React.FC = () => {
 
   // Use stream hooks for real-time market data
   const { markets: allMarkets, isInitialLoading: marketsLoading } =
-    usePerpsLiveMarketData();
+    usePerpsLiveMarketListData();
   const { account } = usePerpsLiveAccount();
 
   // Read initial filter from URL params (set by deeplink)

--- a/ui/providers/perps/PerpsDataChannel.test.ts
+++ b/ui/providers/perps/PerpsDataChannel.test.ts
@@ -297,9 +297,8 @@ describe('PerpsDataChannel', () => {
     });
 
     it('connects an idle channel without clearing cached data first', () => {
-      const connectFn = jest.fn<() => void, [(data: TestData) => void]>(
-        () => jest.fn(),
-      );
+      const connectFn = jest.fn<() => void, [(data: TestData) => void]>();
+      connectFn.mockImplementation(() => jest.fn());
       const channel = createChannel(connectFn);
 
       channel.pushData({ value: 7 });

--- a/ui/providers/perps/PerpsDataChannel.test.ts
+++ b/ui/providers/perps/PerpsDataChannel.test.ts
@@ -268,6 +268,48 @@ describe('PerpsDataChannel', () => {
     });
   });
 
+  describe('refresh', () => {
+    it('reconnects an active channel and keeps subscribers attached', () => {
+      const firstUnsubscribe = jest.fn();
+      const secondUnsubscribe = jest.fn();
+      const connectFn = jest
+        .fn<() => void, [(data: TestData) => void]>()
+        .mockImplementationOnce((callback) => {
+          callback({ value: 1 });
+          return firstUnsubscribe;
+        })
+        .mockImplementationOnce((callback) => {
+          callback({ value: 2 });
+          return secondUnsubscribe;
+        });
+
+      const channel = createChannel(connectFn);
+      const subscriber = jest.fn();
+
+      channel.subscribe(subscriber);
+      channel.refresh();
+
+      expect(connectFn).toHaveBeenCalledTimes(2);
+      expect(firstUnsubscribe).toHaveBeenCalledTimes(1);
+      expect(subscriber).toHaveBeenNthCalledWith(1, { value: 1 });
+      expect(subscriber).toHaveBeenNthCalledWith(2, { value: 2 });
+      expect(channel.getCachedData()).toEqual({ value: 2 });
+    });
+
+    it('connects an idle channel without clearing cached data first', () => {
+      const connectFn = jest.fn<() => void, [(data: TestData) => void]>(
+        () => jest.fn(),
+      );
+      const channel = createChannel(connectFn);
+
+      channel.pushData({ value: 7 });
+      channel.refresh();
+
+      expect(connectFn).toHaveBeenCalledTimes(1);
+      expect(channel.getCachedData()).toEqual({ value: 7 });
+    });
+  });
+
   describe('setConnectFn', () => {
     it('replaces the connect function used for new connections', () => {
       const connectFn1 = jest.fn(() => jest.fn());

--- a/ui/providers/perps/PerpsDataChannel.ts
+++ b/ui/providers/perps/PerpsDataChannel.ts
@@ -123,6 +123,11 @@ export class PerpsDataChannel<TData> {
       return;
     }
 
+    // Refresh is intentionally last-write-wins for channels backed by
+    // non-cancellable async work. For example, the markets channel reconnects
+    // by issuing a new RPC and its unsubscribe is a no-op, so an older in-flight
+    // request may still resolve after refresh. That is acceptable for the
+    // current idempotent market snapshot callers.
     if (!this.isConnected) {
       this.connect();
       return;

--- a/ui/providers/perps/PerpsDataChannel.ts
+++ b/ui/providers/perps/PerpsDataChannel.ts
@@ -113,6 +113,26 @@ export class PerpsDataChannel<TData> {
   }
 
   /**
+   * Reconnect to the data source without clearing subscribers or cache.
+   *
+   * Useful for background refreshes where the UI should keep showing the
+   * last known good data until the next fetch resolves.
+   */
+  refresh(): void {
+    if (!this.connectFn) {
+      return;
+    }
+
+    if (!this.isConnected) {
+      this.connect();
+      return;
+    }
+
+    this.disconnect();
+    this.connect();
+  }
+
+  /**
    * Manually push data into the channel (bypasses WebSocket).
    * Used after REST API calls to immediately reflect changes
    * while waiting for WebSocket to catch up.


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

## Context

  The Perps market surfaces in extension were not updating. Users could leave the full Explore list open, or stay on the main Perps tab, and see stale prices and related market data until they navigated away or reopened the surface.

  This is separate from the recent idle/connectivity work. That work improves reconnect behavior, but it does not make the Explore list, tab Explore preview, or Watchlist behave like live market surfaces during a healthy session.

  ## Problem

  The Perps market surfaces were effectively rendering from market snapshots, so:

  - price and 24h change could remain stale while the popup stayed open
  - snapshot-backed metrics like volume, fundingRate, and openInterest only refreshed on the initial fetch
  - the market detail page could appear live while the Explore list and main tab cards looked frozen
  - the main Perps tab Watchlist and Explore preview were on a separate stale path from the full Explore list

  ## Solution

  This PR makes both Perps market surfaces live while keeping stream ownership in reusable hooks.

  It adds a shared live market list composition path that:

  - starts from the cached market snapshot path
  - overlays live price and change24hPercent from the background price stream
  - periodically refreshes snapshot-backed fields without clearing the last known market list

  It then uses that shared live market source in two places:

  - the full Explore market list
  - the main Perps tab, where a tab-specific hook derives the Explore preview and Watchlist from the same live market data

  It also adds a non-destructive refresh path in the market data channel so the UI keeps showing warm data while refreshes are in flight or if a refresh fails.

  ## Notes

  This PR now covers both:

  - the full Explore market list route
  - the main Perps tab Explore preview and Watchlist

  The Watchlist path also preserves the user’s stored watchlist ordering while still using live market data.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:  Fixed a bug that caused Perps market prices and related data to stop updating while the popup stayed open

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2959

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/96b51864-5e46-40e7-898e-7144bea8d8ee





## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Perps streaming/refresh behavior and introduces interval-based refresh plus background stream activation, which could affect update frequency, lifecycle cleanup, or stale-data edge cases if miswired.
> 
> **Overview**
> Perps market list surfaces now use a new shared `usePerpsLiveMarketListData` hook that overlays live `price`/`change24hPercent` updates onto the cached market snapshot list and periodically triggers snapshot refreshes without clearing the last-known data.
> 
> The main `PerpsView` is refactored to source its Explore preview and Watchlist from a new `usePerpsTabExploreData` hook, and `PerpsWatchlist` is changed to accept pre-resolved `markets` as props (preserving user watchlist order) instead of pulling from Redux/stream hooks directly. Under the hood, `PerpsDataChannel` gains a non-destructive `refresh()` reconnect path, `usePerpsLiveMarketData.refresh()` now calls this, and `usePerpsLivePrices` can (optionally) activate/deactivate the background price stream; tests are updated/added accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e09099d5f36f064207ce5439f523e2d9b45c048f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->