### PR TITLE
[Draft] [Bug]: NFTs in Send flow overlapping

### DIFF
--- a/ui/pages/confirmations/components/UI/asset/asset.test.tsx
+++ b/ui/pages/confirmations/components/UI/asset/asset.test.tsx
@@ -200,4 +200,33 @@ describe('NFTAsset', () => {
 
     expect(getByText('Native SegWit')).toBeInTheDocument();
   });
+
+  it('renders default image placeholder when NFT has no image and no collection image', () => {
+    const assetWithoutAnyImage = {
+      ...mockNFTERC721Asset,
+      image: undefined,
+      collection: {
+        name: 'Test Collection',
+        imageUrl: undefined,
+      },
+    };
+
+    const { getByTestId } = render(<Asset asset={assetWithoutAnyImage} />);
+
+    expect(getByTestId('nft-asset')).toBeInTheDocument();
+    expect(getByTestId('nft-default-image')).toBeInTheDocument();
+  });
+
+  it('renders default image placeholder when NFT has empty string image and no collection', () => {
+    const assetWithEmptyImage = {
+      ...mockNFTERC721Asset,
+      image: '',
+      collection: null,
+    };
+
+    const { getByTestId } = render(<Asset asset={assetWithEmptyImage} />);
+
+    expect(getByTestId('nft-asset')).toBeInTheDocument();
+    expect(getByTestId('nft-default-image')).toBeInTheDocument();
+  });
 });

--- a/ui/pages/confirmations/components/UI/asset/asset.tsx
+++ b/ui/pages/confirmations/components/UI/asset/asset.tsx
@@ -28,6 +28,7 @@ import { accountTypeLabel } from '../../../constants/network';
 import { useFormatters } from '../../../../../hooks/useFormatters';
 import { AccountTypeLabel } from '../account-type-label';
 import { getAvatarTokenSrc } from '../../../../../components/app/assets/asset-list/cells/asset-cell-badge';
+import NftDefaultImage from '../../../../../components/app/assets/nfts/nft-default-image/nft-default-image';
 
 type AssetProps = {
   asset: AssetType;
@@ -90,7 +91,20 @@ const NftAsset = ({ asset, onClick, isSelected }: AssetProps) => {
                 objectFit: 'cover',
               }}
             />
-          ) : null}
+          ) : (
+            <Box
+              style={{
+                width: 32,
+                height: 32,
+                borderRadius: 8,
+              }}
+            >
+              <NftDefaultImage
+                className="nft-default-image-placeholder"
+                clickable={false}
+              />
+            </Box>
+          )}
         </BadgeWrapper>
       </Box>
       <Box

--- a/ui/pages/confirmations/components/UI/asset/index.scss
+++ b/ui/pages/confirmations/components/UI/asset/index.scss
@@ -5,4 +5,13 @@
     background-color: var(--color-background-hover) !important;
     cursor: pointer;
   }
+
+  // Override default NFT image styles for consistent sizing in send flow
+  .nft-default-image-placeholder {
+    .nft-default {
+      padding-top: 0 !important;
+      width: 100%;
+      height: 100%;
+    }
+  }
 }

--- a/ui/pages/confirmations/hooks/useNftImageUrl.ts
+++ b/ui/pages/confirmations/hooks/useNftImageUrl.ts
@@ -3,7 +3,7 @@ import { getIpfsGateway } from '../../../selectors';
 import useGetAssetImageUrl from '../../../hooks/useGetAssetImageUrl';
 
 export function useNftImageUrl(imageUrl: string) {
-  const ipfsGateway = useSelector(getIpfsGateway);
+  const ipfsGateway = useSelector(getIpfsGateway) as string;
   const nftImageURL = useGetAssetImageUrl(imageUrl, ipfsGateway);
 
   const isImageHosted = imageUrl && !imageUrl.startsWith('ipfs:');


### PR DESCRIPTION
## Summary

Bug fix implemented by agent.

**Source:** https://github.com/MetaMask/metamask-extension/issues/40669

## Changes

| Metric | Value |
|--------|-------|
| Files changed | 4 |
| Lines added | +54 |
| Lines removed | -2 |

**Files:**
- `ui/pages/confirmations/components/UI/asset/asset.test.tsx`
- `ui/pages/confirmations/components/UI/asset/asset.tsx`
- `ui/pages/confirmations/components/UI/asset/index.scss`
- `ui/pages/confirmations/hooks/useNftImageUrl.ts`

## Validation

**Status:** Awaiting CI
- unit: failed (source=local, scope=targeted, advisory)
- CI: pending full-repo verification

## Review

**Status:** approved (high confidence)

**Findings:**
- [low] Type assertion 'as string' in useNftImageUrl.ts could be unsafe if getIpfsGateway selector can return null/undefined, though likely safe in practice

## Agent Chain

| Step | Status | Duration | Attempt |
|------|--------|----------|---------|
| triage | passed | 14s | 1 |
| plan | failed | 139s | 1 |
| execute | passed | 145s | 1 |
| validate | failed | 0s | 1 |
| fix | passed | 19s | 1 |
| validate | failed | 0s | 2 |
| fix | passed | 106s | 2 |
| validate | failed | 0s | 3 |
| review | passed | 52s | 1 |
| __meta | passed | - | 0 |

## Metadata

- **Run ID:** `34dde9fd-b74b-4158-a7d3-bd1ff1c4ac53`
- **Total cost:** $1.7554
- **Evidence:** partial

---
*This PR was created by the MetaMask Autonomous Engineering Platform.*