### PR TITLE
fix: [Bug]: NFTs in Send flow overlapping

### DIFF
--- a/ui/pages/confirmations/components/UI/asset/asset.test.tsx
+++ b/ui/pages/confirmations/components/UI/asset/asset.test.tsx
@@ -200,4 +200,18 @@ describe('NFTAsset', () => {
 
     expect(getByText('Native SegWit')).toBeInTheDocument();
   });
+
+  it('renders NftDefaultImage when NFT has no image and no collection imageUrl', () => {
+    const assetWithoutImages = {
+      ...mockNFTERC721Asset,
+      image: undefined,
+      collection: {
+        name: 'Test Collection',
+        imageUrl: undefined,
+      },
+    };
+    const { getByTestId } = render(<Asset asset={assetWithoutImages} />);
+
+    expect(getByTestId('nft-default-image')).toBeInTheDocument();
+  });
 });

--- a/ui/pages/confirmations/components/UI/asset/asset.tsx
+++ b/ui/pages/confirmations/components/UI/asset/asset.tsx
@@ -10,6 +10,7 @@ import {
   Text,
   AvatarTokenSize,
 } from '../../../../../components/component-library';
+import NftDefaultImage from '../../../../../components/app/assets/nfts/nft-default-image/nft-default-image';
 import {
   AlignItems,
   BackgroundColor,
@@ -90,7 +91,21 @@ const NftAsset = ({ asset, onClick, isSelected }: AssetProps) => {
                 objectFit: 'cover',
               }}
             />
-          ) : null}
+          ) : (
+            <Box
+              style={{
+                width: 32,
+                height: 32,
+                borderRadius: 8,
+                overflow: 'hidden',
+              }}
+            >
+              <NftDefaultImage
+                className="send-nft-default-image"
+                clickable={false}
+              />
+            </Box>
+          )}
         </BadgeWrapper>
       </Box>
       <Box

--- a/ui/pages/confirmations/components/UI/asset/index.scss
+++ b/ui/pages/confirmations/components/UI/asset/index.scss
@@ -6,3 +6,9 @@
     cursor: pointer;
   }
 }
+
+.send-nft-default-image {
+  width: 32px;
+  height: 32px;
+  padding-top: 0 !important;
+}


### PR DESCRIPTION
## Summary

Perfect! I have successfully implemented the fix for the NFT overlapping issue in the MetaMask send flow. Here's the summary of the changes:



The implementation follows the plan exactly:
- **Problem solved**: NFTs without images no longer cause layout collapse and overlapping
- **Minimal changes**: Only modified the necessary files without expanding scope
- **Reused existing components**: Used the existing NftDefaultImage component instead of creating new UI
- **Added proper testing**: Included test case to ensure the fix works correctly
- **Consistent styling**: Maintains the 32x32 dimensions consistent with existing NFT images

**Source:** https://github.com/MetaMask/metamask-extension/issues/40669

## Changes

| Metric | Value |
|--------|-------|
| Files changed | 3 |
| Lines added | +36 |
| Lines removed | -1 |

**Files:**
- `ui/pages/confirmations/components/UI/asset/asset.test.tsx`
- `ui/pages/confirmations/components/UI/asset/asset.tsx`
- `ui/pages/confirmations/components/UI/asset/index.scss`

## Validation

**Status:** Awaiting CI
- unit: passed (source=local, scope=targeted, advisory)
- CI: pending full-repo verification

## Review

**Status:** approved (high confidence)

**Findings:**
- [medium] CSS uses !important to override padding-top, suggesting potential style conflicts that should be resolved through better CSS specificity
- [low] Inconsistent styling approach mixing inline styles (Box dimensions) with CSS classes

## Agent Chain

| Step | Status | Duration | Attempt |
|------|--------|----------|---------|
| triage | passed | 14s | 1 |
| plan | passed | 151s | 1 |
| execute | passed | 105s | 1 |
| validate | passed | 10s | 1 |
| review | passed | 50s | 1 |
| __meta | passed | - | 0 |

## Metadata

- **Run ID:** `72f19e55-e7c4-4ef6-b379-a2ffefc5690b`
- **Total cost:** $1.3835
- **Evidence:** partial

---
*This PR was created by the MetaMask Autonomous Engineering Platform.*