### PR TITLE
fix: NFTs in Send flow overlapping

### DIFF
--- a/ui/pages/confirmations/components/UI/asset/asset.test.tsx
+++ b/ui/pages/confirmations/components/UI/asset/asset.test.tsx
@@ -187,8 +187,21 @@ describe('NFTAsset', () => {
     };
     const { getByAltText } = render(<Asset asset={assetWithoutImage} />);
 
-    const image = getByAltText('Test NFT');
+    const image = getByAltText('Test NFT logo');
     expect(image).toHaveAttribute('src', 'https://example.com/collection.png');
+  });
+
+  it('renders NFT asset with AvatarToken fallback when no image is available', () => {
+    const assetWithoutAnyImage = {
+      ...mockNFTERC721Asset,
+      image: undefined,
+      collection: { ...mockNFTERC721Asset.collection, imageUrl: undefined },
+    };
+    mockUseNftImageUrl.mockReturnValue('');
+    const { getByTestId } = render(<Asset asset={assetWithoutAnyImage} />);
+    
+    expect(getByTestId('nft-asset')).toBeInTheDocument();
+    // AvatarToken should render instead of null, preventing layout issues
   });
 
   it('renders account type label when account type is provided', () => {

--- a/ui/pages/confirmations/components/UI/asset/asset.tsx
+++ b/ui/pages/confirmations/components/UI/asset/asset.tsx
@@ -78,19 +78,12 @@ const NftAsset = ({ asset, onClick, isSelected }: AssetProps) => {
             ) : null
           }
         >
-          {image || collection?.imageUrl ? (
-            <Box
-              as="img"
-              src={nftItemSrc || (collection?.imageUrl as string)}
-              alt={name}
-              style={{
-                width: 32,
-                height: 32,
-                borderRadius: 8,
-                objectFit: 'cover',
-              }}
-            />
-          ) : null}
+          <AvatarToken
+            size={AvatarTokenSize.Md}
+            src={nftItemSrc || (collection?.imageUrl as string)}
+            name={name || collection?.name || 'NFT'}
+            showHalo={false}
+          />
         </BadgeWrapper>
       </Box>
       <Box


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Perfect! I've successfully implemented the fix for the NFT overlap issue. Let me provide the summary:

## **Changelog**

CHANGELOG entry: Fixed perfect! I've successfully implemented the fix for the NFT overlap issue. Let me provide the summary:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/40669

## **Manual testing steps**

1. Hold at least two NFTs, with at least one missing a generated image in the NFTs tab.
2. Click Send.
3. Scroll down to the NFTs section.
4. Notice the NFTs are overlapping in the Send flow.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.