### PR TITLE
fix: For an account that is not backed-up, going back from recovery flow lands on Preferences and display instead of Security and password

### DIFF
--- a/ui/pages/settings/settings.container.js
+++ b/ui/pages/settings/settings.container.js
@@ -36,6 +36,7 @@ import {
   TRANSACTION_SHIELD_MANAGE_PLAN_ROUTE,
   TRANSACTION_SHIELD_MANAGE_PAST_PLAN_ROUTE,
   NOTIFICATIONS_SETTINGS_ROUTE,
+  ONBOARDING_REVEAL_SRP_ROUTE,
 } from '../../helpers/constants/routes';
 import { getProviderConfig } from '../../../shared/lib/selectors/networks';
 import { toggleNetworkMenu } from '../../store/actions';
@@ -89,6 +90,10 @@ const mapStateToProps = (state, ownProps) => {
   const isRevealSrpListPage = Boolean(pathname.match(REVEAL_SRP_LIST_ROUTE));
   const isPasswordChangePage = Boolean(
     pathname.match(SECURITY_PASSWORD_CHANGE_ROUTE),
+  );
+  const isWalletRecoveryBackupPage = Boolean(
+    pathname.match(ONBOARDING_REVEAL_SRP_ROUTE) &&
+    searchParams.get('isFromSettingsSecurity') === 'true',
   );
   const isTransactionShieldPage = Boolean(
     pathname.startsWith(TRANSACTION_SHIELD_ROUTE),
@@ -150,7 +155,7 @@ const mapStateToProps = (state, ownProps) => {
     backRoute = NETWORKS_ROUTE;
   } else if (isAddPopularCustomNetwork) {
     backRoute = NETWORKS_ROUTE;
-  } else if (isRevealSrpListPage || isPasswordChangePage) {
+  } else if (isRevealSrpListPage || isPasswordChangePage || isWalletRecoveryBackupPage) {
     backRoute = SECURITY_ROUTE;
   } else if (isShieldClaimNewPage) {
     backRoute = TRANSACTION_SHIELD_CLAIM_ROUTES.BASE;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Perfect! I've successfully implemented the fix for the wallet recovery backup navigation issue. Here's what was done:

## **Changelog**

CHANGELOG entry: Fixed perfect! I've successfully implemented the fix for the wallet recovery backup navigation issue. Here's what was done:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/41781

## **Manual testing steps**

1. Create a new wallet and skip SRP recovery.
2. Go to **Settings** > **Security and password**.
3. Click **Manage wallet recovery**.
4. Click **Backup**.
5. Do not enter the password, and click the back arrow or close with the **X**.
6. Notice the page shown is **Preferences and display** instead of **Security and password**.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.