### PR TITLE
fix(perps): improve order submission toast flow and add order filled listener

### DIFF
--- a/ui/components/app/perps/close-position/close-position-modal.tsx
+++ b/ui/components/app/perps/close-position/close-position-modal.tsx
@@ -378,6 +378,7 @@ export const ClosePositionModal: React.FC<ClosePositionModalProps> = ({
     );
 
     try {
+      onClose();
       const result = await submitRequestToBackground<{
         success: boolean;
         error?: string;
@@ -429,7 +430,6 @@ export const ClosePositionModal: React.FC<ClosePositionModalProps> = ({
           formatPercentWithMinThreshold,
         }),
       );
-      onClose();
     } catch (err) {
       const errMessage =
         err instanceof Error ? err.message : 'An unknown error occurred';

--- a/ui/components/app/perps/perps-toast/perps-toast-provider.tsx
+++ b/ui/components/app/perps/perps-toast/perps-toast-provider.tsx
@@ -27,6 +27,8 @@ export type { PerpsToastKey, PerpsToastVariant };
 export type PerpsToastRouteState = {
   perpsToastKey?: PerpsToastKey;
   perpsToastDescription?: string;
+  pendingOrderSymbol?: string;
+  pendingOrderFilledDescription?: string;
 };
 
 export type PerpsToastConfig = {

--- a/ui/pages/perps/perps-market-detail-page.test.tsx
+++ b/ui/pages/perps/perps-market-detail-page.test.tsx
@@ -238,12 +238,14 @@ jest.mock(
   }),
 );
 
+const mockLivePositions = jest.fn(() => ({
+  positions: mockPositions,
+  isInitialLoading: false,
+}));
+
 // Mock the perps stream hooks
 jest.mock('../../hooks/perps/stream', () => ({
-  usePerpsLivePositions: () => ({
-    positions: mockPositions,
-    isInitialLoading: false,
-  }),
+  usePerpsLivePositions: () => mockLivePositions(),
   usePerpsLiveOrders: () => ({
     orders: mockOrders,
     isInitialLoading: false,
@@ -358,6 +360,10 @@ describe('PerpsMarketDetailPage', () => {
       account: mockAccountState,
       isInitialLoading: false,
     });
+    mockLivePositions.mockReturnValue({
+      positions: mockPositions,
+      isInitialLoading: false,
+    });
     mockUsePerpsMarketFills.mockReturnValue({
       fills: [],
       isInitialLoading: false,
@@ -389,6 +395,115 @@ describe('PerpsMarketDetailPage', () => {
       await renderPage(store);
 
       expect(screen.getByText(/15\.79%/u)).toBeInTheDocument();
+    });
+
+    it('shows order filled toast when route state has pendingOrderSymbol and matching position exists', async () => {
+      mockUseLocation.mockReturnValue({
+        pathname: '/perps/market/ETH',
+        search: '',
+        state: {
+          pendingOrderSymbol: 'ETH',
+          pendingOrderFilledDescription: 'Long 0.33 ETH',
+        },
+      });
+      const store = mockStore(createMockState(true));
+
+      await renderPage(store);
+
+      expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith({
+        key: 'perpsToastOrderFilled',
+        description: 'Long 0.33 ETH',
+      });
+    });
+
+    it('shows order filled toast without description when pendingOrderFilledDescription is absent', async () => {
+      mockUseLocation.mockReturnValue({
+        pathname: '/perps/market/ETH',
+        search: '',
+        state: {
+          pendingOrderSymbol: 'ETH',
+        },
+      });
+      const store = mockStore(createMockState(true));
+
+      await renderPage(store);
+
+      expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith({
+        key: 'perpsToastOrderFilled',
+      });
+    });
+
+    it('does not show order filled toast when no matching position exists', async () => {
+      mockUseLocation.mockReturnValue({
+        pathname: '/perps/market/ETH',
+        search: '',
+        state: {
+          pendingOrderSymbol: 'DOGE',
+          pendingOrderFilledDescription: 'Long 100 DOGE',
+        },
+      });
+      const store = mockStore(createMockState(true));
+
+      await renderPage(store);
+
+      expect(mockReplacePerpsToastByKey).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'perpsToastOrderFilled',
+        }),
+      );
+    });
+
+    it('does not show order filled toast when pendingOrderSymbol is absent', async () => {
+      mockUseLocation.mockReturnValue({
+        pathname: '/perps/market/ETH',
+        search: '',
+        state: { someOtherKey: 'value' },
+      });
+      const store = mockStore(createMockState(true));
+
+      await renderPage(store);
+
+      expect(mockReplacePerpsToastByKey).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'perpsToastOrderFilled',
+        }),
+      );
+    });
+
+    it('does not show order filled toast when pendingOrderSymbol is not a string', async () => {
+      mockUseLocation.mockReturnValue({
+        pathname: '/perps/market/ETH',
+        search: '',
+        state: {
+          pendingOrderSymbol: 123,
+        },
+      });
+      const store = mockStore(createMockState(true));
+
+      await renderPage(store);
+
+      expect(mockReplacePerpsToastByKey).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'perpsToastOrderFilled',
+        }),
+      );
+    });
+
+    it('does not show order filled toast when route state is null', async () => {
+      mockUseLocation.mockReturnValue({
+        pathname: '/perps/market/ETH',
+        search: '',
+        state: null,
+      });
+      const store = mockStore(createMockState(true));
+
+      await renderPage(store);
+
+      expect(mockReplacePerpsToastByKey).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'perpsToastOrderFilled',
+        }),
+      );
     });
 
     it('shows handed-off perps toast and clears route state', async () => {

--- a/ui/pages/perps/perps-market-detail-page.tsx
+++ b/ui/pages/perps/perps-market-detail-page.tsx
@@ -298,6 +298,40 @@ const PerpsMarketDetailPage: React.FC = () => {
 
   // Use stream hooks for real-time data
   const { positions: allPositions } = usePerpsLivePositions();
+
+  const orderFilledToastShownRef = useRef(false);
+
+  useEffect(() => {
+    if (orderFilledToastShownRef.current) {
+      return;
+    }
+
+    const routeState = location.state as Record<string, unknown> | null;
+    const pendingSymbol =
+      typeof routeState?.pendingOrderSymbol === 'string'
+        ? routeState.pendingOrderSymbol
+        : null;
+
+    if (!pendingSymbol) {
+      return;
+    }
+
+    const hasPosition = allPositions.some((p) => p.symbol === pendingSymbol);
+    if (hasPosition) {
+      orderFilledToastShownRef.current = true;
+
+      const filledDescription =
+        typeof routeState?.pendingOrderFilledDescription === 'string'
+          ? routeState.pendingOrderFilledDescription
+          : undefined;
+
+      replacePerpsToastByKey({
+        key: PERPS_TOAST_KEYS.ORDER_FILLED,
+        ...(filledDescription ? { description: filledDescription } : {}),
+      });
+    }
+  }, [location.state, allPositions, replacePerpsToastByKey]);
+
   const { orders: allOrders } = usePerpsLiveOrders();
   const { account, isInitialLoading: isLoadingAccount } = usePerpsLiveAccount();
   const { markets: allMarkets, isInitialLoading: marketsLoading } =

--- a/ui/pages/perps/perps-order-entry-page.test.tsx
+++ b/ui/pages/perps/perps-order-entry-page.test.tsx
@@ -815,15 +815,18 @@ describe('PerpsOrderEntryPage', () => {
           }),
         ],
       );
+      expect(mockUseNavigate).toHaveBeenCalledWith('/perps/market/ETH', {
+        state: expect.objectContaining({
+          perpsToastKey: 'perpsToastSubmitInProgress',
+          pendingOrderSymbol: 'ETH',
+          pendingOrderFilledDescription:
+            expect.stringMatching(/^Long [^ ]+ ETH$/u),
+        }),
+      });
       expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith(
         expect.objectContaining({
-          key: 'perpsToastSubmitInProgress',
-        }),
-      );
-      expect(mockReplacePerpsToastByKey).not.toHaveBeenCalledWith(
-        expect.objectContaining({
-          key: 'perpsToastSubmitInProgress',
-          description: expect.any(String),
+          key: 'perpsToastOrderSubmitted',
+          autoHideTime: 3000,
         }),
       );
     });
@@ -911,17 +914,15 @@ describe('PerpsOrderEntryPage', () => {
           },
         ],
       );
-      expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith({
-        key: 'perpsToastCloseInProgress',
-        description: expect.stringMatching(/^Long [^ ]+ ETH$/u),
-      });
       expect(mockUseNavigate).toHaveBeenCalledWith('/perps/market/ETH', {
         state: expect.objectContaining({
-          perpsToastKey: 'perpsToastTradeSuccess',
-          perpsToastDescription: expect.stringMatching(
-            /^Your PnL is -?\d+\.\d{2}%$/u,
-          ),
+          perpsToastKey: 'perpsToastCloseInProgress',
+          perpsToastDescription: expect.stringMatching(/^Long [^ ]+ ETH$/u),
         }),
+      });
+      expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith({
+        key: 'perpsToastTradeSuccess',
+        description: expect.stringMatching(/^Your PnL is -?\d+\.\d{2}%$/u),
       });
     });
 
@@ -956,17 +957,17 @@ describe('PerpsOrderEntryPage', () => {
           }),
         ],
       );
-      expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith(
-        expect.objectContaining({
-          key: 'perpsToastPartialCloseInProgress',
-          description: expect.stringMatching(/^Long [^ ]+ ETH$/u),
-        }),
-      );
       expect(mockUseNavigate).toHaveBeenCalledWith('/perps/market/ETH', {
         state: expect.objectContaining({
-          perpsToastKey: 'perpsToastPartialCloseSuccess',
+          perpsToastKey: 'perpsToastPartialCloseInProgress',
+          perpsToastDescription: expect.stringMatching(/^Long [^ ]+ ETH$/u),
         }),
       });
+      expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'perpsToastPartialCloseSuccess',
+        }),
+      );
     });
 
     it('falls back to close subtitle when close PnL cannot be calculated', async () => {
@@ -992,9 +993,13 @@ describe('PerpsOrderEntryPage', () => {
 
       expect(mockUseNavigate).toHaveBeenCalledWith('/perps/market/ETH', {
         state: expect.objectContaining({
-          perpsToastKey: 'perpsToastTradeSuccess',
+          perpsToastKey: 'perpsToastCloseInProgress',
           perpsToastDescription: expect.stringMatching(/^Long [^ ]+ ETH$/u),
         }),
+      });
+      expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith({
+        key: 'perpsToastTradeSuccess',
+        description: expect.stringMatching(/^Long [^ ]+ ETH$/u),
       });
     });
 
@@ -1020,15 +1025,15 @@ describe('PerpsOrderEntryPage', () => {
         fireEvent.click(screen.getByTestId('submit-order-button'));
       });
 
-      expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith({
-        key: 'perpsToastCloseInProgress',
-        description: expect.stringMatching(/^Short [^ ]+ ETH$/u),
-      });
       expect(mockUseNavigate).toHaveBeenCalledWith('/perps/market/ETH', {
         state: expect.objectContaining({
-          perpsToastKey: 'perpsToastTradeSuccess',
+          perpsToastKey: 'perpsToastCloseInProgress',
           perpsToastDescription: expect.stringMatching(/^Short [^ ]+ ETH$/u),
         }),
+      });
+      expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith({
+        key: 'perpsToastTradeSuccess',
+        description: expect.stringMatching(/^Short [^ ]+ ETH$/u),
       });
     });
 
@@ -1055,9 +1060,12 @@ describe('PerpsOrderEntryPage', () => {
 
       expect(mockUseNavigate).toHaveBeenCalledWith('/perps/market/ETH', {
         state: expect.objectContaining({
-          perpsToastKey: 'perpsToastTradeSuccess',
-          perpsToastDescription: 'Your PnL is 0.80%',
+          perpsToastKey: 'perpsToastCloseInProgress',
         }),
+      });
+      expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith({
+        key: 'perpsToastTradeSuccess',
+        description: 'Your PnL is 0.80%',
       });
     });
 
@@ -1085,11 +1093,11 @@ describe('PerpsOrderEntryPage', () => {
       );
       expect(mockUseNavigate).toHaveBeenCalledWith('/perps/market/ETH', {
         state: expect.objectContaining({
-          perpsToastKey: 'perpsToastUpdateSuccess',
+          perpsToastKey: 'perpsToastUpdateInProgress',
         }),
       });
-      expect(mockReplacePerpsToastByKey).not.toHaveBeenCalledWith({
-        key: 'perpsToastUpdateInProgress',
+      expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith({
+        key: 'perpsToastUpdateSuccess',
       });
     });
 
@@ -1124,9 +1132,14 @@ describe('PerpsOrderEntryPage', () => {
       );
       expect(mockUseNavigate).toHaveBeenCalledWith('/perps/market/ETH', {
         state: expect.objectContaining({
-          perpsToastKey: 'perpsToastOrderPlaced',
+          perpsToastKey: 'perpsToastSubmitInProgress',
         }),
       });
+      expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'perpsToastOrderPlaced',
+        }),
+      );
     });
 
     it('submits existing position TP/SL values unchanged in modify mode', async () => {
@@ -1555,23 +1568,17 @@ describe('PerpsOrderEntryPage', () => {
           }),
         ],
       );
-      expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith(
-        expect.objectContaining({
-          key: 'perpsToastSubmitInProgress',
-        }),
-      );
-      expect(mockReplacePerpsToastByKey).not.toHaveBeenCalledWith(
-        expect.objectContaining({
-          key: 'perpsToastSubmitInProgress',
-          description: expect.any(String),
-        }),
-      );
       expect(mockUseNavigate).toHaveBeenCalledWith('/perps/market/ETH', {
         state: expect.objectContaining({
-          perpsToastKey: 'perpsToastOrderPlaced',
-          perpsToastDescription: expect.stringMatching(/^Long [^ ]+ ETH$/u),
+          perpsToastKey: 'perpsToastSubmitInProgress',
         }),
       });
+      expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'perpsToastOrderPlaced',
+          autoHideTime: 3000,
+        }),
+      );
     });
 
     it('does not submit a limit order when locale-formatted limit price is entered', async () => {
@@ -1615,43 +1622,7 @@ describe('PerpsOrderEntryPage', () => {
       jest.useRealTimers();
     });
 
-    it('navigates back when position appears after market order', async () => {
-      const store = mockStore(createMockState());
-      const { rerender } = renderWithProvider(<PerpsOrderEntryPage />, store);
-
-      const amountContainer = screen.getByTestId('amount-input-field');
-      const input = amountContainer.querySelector('input');
-      fireEvent.change(input as HTMLInputElement, {
-        target: { value: '1000' },
-      });
-
-      await act(async () => {
-        fireEvent.click(screen.getByTestId('submit-order-button'));
-      });
-
-      mockLivePositions.mockReturnValue({
-        positions: [
-          {
-            ...mockPositions[0],
-            symbol: 'ETH',
-          },
-        ],
-        isInitialLoading: false,
-      });
-
-      await act(async () => {
-        rerender(<PerpsOrderEntryPage />);
-      });
-
-      expect(mockUseNavigate).toHaveBeenCalledWith('/perps/market/ETH', {
-        state: expect.objectContaining({
-          perpsToastKey: 'perpsToastOrderFilled',
-          perpsToastDescription: expect.stringMatching(/^Long [^ ]+ ETH$/u),
-        }),
-      });
-    });
-
-    it('navigates back after 15s timeout if position never appears', async () => {
+    it('navigates immediately to market detail with pendingOrderSymbol for market order', async () => {
       const store = mockStore(createMockState());
       renderWithProvider(<PerpsOrderEntryPage />, store);
 
@@ -1665,12 +1636,14 @@ describe('PerpsOrderEntryPage', () => {
         fireEvent.click(screen.getByTestId('submit-order-button'));
       });
 
-      await act(async () => {
-        jest.advanceTimersByTime(15000);
+      expect(mockUseNavigate).toHaveBeenCalledWith('/perps/market/ETH', {
+        state: expect.objectContaining({
+          perpsToastKey: 'perpsToastSubmitInProgress',
+          pendingOrderSymbol: 'ETH',
+          pendingOrderFilledDescription:
+            expect.stringMatching(/^Long [^ ]+ ETH$/u),
+        }),
       });
-
-      expect(mockHidePerpsToast).toHaveBeenCalledTimes(1);
-      expect(mockUseNavigate).toHaveBeenCalledWith('/perps/market/ETH');
     });
   });
 });

--- a/ui/pages/perps/perps-order-entry-page.tsx
+++ b/ui/pages/perps/perps-order-entry-page.tsx
@@ -286,14 +286,9 @@ const PerpsOrderEntryPage: React.FC = () => {
   const [orderCalculations, setOrderCalculations] =
     useState<OrderCalculations | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [pendingOrderSymbol, setPendingOrderSymbol] = useState<string | null>(
-    null,
-  );
-  const [pendingOrderToastDescription, setPendingOrderToastDescription] =
-    useState<string | null>(null);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
-  const isOrderPending = isSubmitting || pendingOrderSymbol !== null;
+  const isOrderPending = isSubmitting;
 
   // Dynamic fee rate for close-mode order submission tracking
   const { feeRate: closeFeeRate } = usePerpsOrderFees({
@@ -769,7 +764,6 @@ const PerpsOrderEntryPage: React.FC = () => {
     }
 
     setIsSubmitting(true);
-    setPendingOrderToastDescription(null);
     setSubmitError(null);
 
     const tradeActionToastDescription = getTradeActionToastDescription();
@@ -781,23 +775,10 @@ const PerpsOrderEntryPage: React.FC = () => {
       orderMode === 'close' && closePercent < FULL_CLOSE_PERCENT;
 
     let inProgressToastKey = ORDER_MODE_TOAST_KEYS[orderMode].inProgress;
-    let inProgressToastDescription: string | undefined;
-
     if (orderMode === 'close') {
       inProgressToastKey = isPartialClose
         ? PERPS_TOAST_KEYS.PARTIAL_CLOSE_IN_PROGRESS
         : PERPS_TOAST_KEYS.CLOSE_IN_PROGRESS;
-      inProgressToastDescription = isPartialClose
-        ? closePartialToastDescription
-        : tradeActionToastDescription;
-    }
-    if (inProgressToastKey !== undefined) {
-      replacePerpsToastByKey({
-        key: inProgressToastKey,
-        ...(inProgressToastDescription
-          ? { description: inProgressToastDescription }
-          : {}),
-      });
     }
 
     const deriveTradeAction = (): string => {
@@ -861,6 +842,16 @@ const PerpsOrderEntryPage: React.FC = () => {
           position.size,
           marketInfo?.szDecimals,
         );
+
+        handleBackClick(
+          isPartialClose
+            ? PERPS_TOAST_KEYS.PARTIAL_CLOSE_IN_PROGRESS
+            : PERPS_TOAST_KEYS.CLOSE_IN_PROGRESS,
+          isPartialClose
+            ? closePartialToastDescription
+            : tradeActionToastDescription,
+        );
+
         const result = await submitRequestToBackground<PerpsBackgroundResult>(
           'perpsClosePosition',
           [closeParams],
@@ -885,25 +876,30 @@ const PerpsOrderEntryPage: React.FC = () => {
           [PERPS_EVENT_PROPERTY.SIZE]: String(closeNotionalUsd),
           [PERPS_EVENT_PROPERTY.METAMASK_FEE]: String(closeEstimatedFees),
         });
-        handleBackClick(
-          isPartialClose
+        replacePerpsToastByKey({
+          key: isPartialClose
             ? PERPS_TOAST_KEYS.PARTIAL_CLOSE_SUCCESS
             : PERPS_TOAST_KEYS.TRADE_SUCCESS,
-          closeSuccessToastDescription,
-        );
+          description: closeSuccessToastDescription,
+        });
         return;
       } else if (orderMode === 'modify' && position) {
         const marginAmount =
           Number.parseFloat(orderFormState.amount.replaceAll(',', '')) || 0;
 
         if (marginAmount > 0) {
-          // Add to position: place order with additional size + TP/SL
           const orderParams = formStateToOrderParams(
             orderFormState,
             currentPrice,
             orderMode,
             position?.size,
           );
+
+          handleBackClick(
+            PERPS_TOAST_KEYS.SUBMIT_IN_PROGRESS,
+            tradeActionToastDescription,
+          );
+
           const result = await submitRequestToBackground<{
             success: boolean;
             error?: string;
@@ -933,17 +929,13 @@ const PerpsOrderEntryPage: React.FC = () => {
           ]).catch((e) => {
             console.warn('[Perps] Save trade configuration failed:', e);
           });
-
-          // Existing position is already in `allPositions`, so pending-order
-          // confirmation would resolve immediately; navigate like limit orders.
-          handleBackClick(
-            PERPS_TOAST_KEYS.ORDER_PLACED,
-            tradeActionToastDescription,
-          );
+          replacePerpsToastByKey({
+            key: PERPS_TOAST_KEYS.ORDER_PLACED,
+            description: tradeActionToastDescription,
+          });
           return;
         }
 
-        // Amount is 0: only update TP/SL
         const { takeProfitPrice, stopLossPrice } = normalizeTpslPrices({
           takeProfitPrice: orderFormState.autoCloseEnabled
             ? orderFormState.takeProfitPrice
@@ -952,6 +944,9 @@ const PerpsOrderEntryPage: React.FC = () => {
             ? orderFormState.stopLossPrice
             : undefined,
         });
+
+        handleBackClick(PERPS_TOAST_KEYS.UPDATE_IN_PROGRESS);
+
         const result = await submitRequestToBackground<PerpsBackgroundResult>(
           'perpsUpdatePositionTPSL',
           [{ symbol: orderFormState.asset, takeProfitPrice, stopLossPrice }],
@@ -982,7 +977,9 @@ const PerpsOrderEntryPage: React.FC = () => {
           [PERPS_EVENT_PROPERTY.METAMASK_FEE]:
             orderCalculations?.estimatedFees ?? null,
         });
-        handleBackClick(PERPS_TOAST_KEYS.UPDATE_SUCCESS);
+        replacePerpsToastByKey({
+          key: PERPS_TOAST_KEYS.UPDATE_SUCCESS,
+        });
         return;
       }
 
@@ -992,6 +989,12 @@ const PerpsOrderEntryPage: React.FC = () => {
         orderMode,
         position?.size,
       );
+
+      handleBackClick(
+        PERPS_TOAST_KEYS.SUBMIT_IN_PROGRESS,
+        tradeActionToastDescription,
+      );
+
       const result = await submitRequestToBackground<PerpsBackgroundResult>(
         'perpsPlaceOrder',
         [orderParams],
@@ -1021,16 +1024,14 @@ const PerpsOrderEntryPage: React.FC = () => {
       ]).catch((e) => {
         console.warn('[Perps] Save trade configuration failed:', e);
       });
-
-      if (orderFormState.type === 'limit') {
-        handleBackClick(
-          PERPS_TOAST_KEYS.ORDER_PLACED,
-          tradeActionToastDescription,
-        );
-        return;
-      }
-      setPendingOrderToastDescription(tradeActionToastDescription ?? null);
-      setPendingOrderSymbol(orderFormState.asset);
+      replacePerpsToastByKey({
+        key:
+          orderFormState.type === 'limit'
+            ? PERPS_TOAST_KEYS.ORDER_PLACED
+            : PERPS_TOAST_KEYS.ORDER_SUBMITTED,
+        description: tradeActionToastDescription,
+        autoHideTime: 3000,
+      });
     } catch (error) {
       if (inProgressToastKey) {
         hidePerpsToast();
@@ -1116,41 +1117,6 @@ const PerpsOrderEntryPage: React.FC = () => {
     selectedAddress,
     triggerDeposit,
   ]);
-
-  useEffect(() => {
-    if (!pendingOrderSymbol) {
-      return;
-    }
-    const hasPosition = allPositions.some(
-      (p) => p.symbol === pendingOrderSymbol,
-    );
-    if (hasPosition) {
-      setPendingOrderSymbol(null);
-      const toastDescription = pendingOrderToastDescription ?? undefined;
-      setPendingOrderToastDescription(null);
-      setIsSubmitting(false);
-      handleBackClick(PERPS_TOAST_KEYS.ORDER_FILLED, toastDescription);
-    }
-  }, [
-    pendingOrderSymbol,
-    allPositions,
-    handleBackClick,
-    pendingOrderToastDescription,
-  ]);
-
-  useEffect(() => {
-    if (!pendingOrderSymbol) {
-      return undefined;
-    }
-    const timeout = setTimeout(() => {
-      setPendingOrderSymbol(null);
-      setPendingOrderToastDescription(null);
-      setIsSubmitting(false);
-      hidePerpsToast();
-      handleBackClick();
-    }, 15000);
-    return () => clearTimeout(timeout);
-  }, [pendingOrderSymbol, handleBackClick, hidePerpsToast]);
 
   if (!isPerpsExperienceAvailable) {
     return <Navigate to={DEFAULT_ROUTE} replace />;

--- a/ui/pages/perps/perps-order-entry-page.tsx
+++ b/ui/pages/perps/perps-order-entry-page.tsx
@@ -598,7 +598,11 @@ const PerpsOrderEntryPage: React.FC = () => {
   );
 
   const handleBackClick = useCallback(
-    (perpsToastKey?: PerpsToastKey, perpsToastDescription?: string) => {
+    (
+      perpsToastKey?: PerpsToastKey,
+      perpsToastDescription?: string,
+      extraState?: Partial<PerpsToastRouteState>,
+    ) => {
       if (!decodedSymbol) {
         return;
       }
@@ -615,6 +619,7 @@ const PerpsOrderEntryPage: React.FC = () => {
       const toastRouteState: PerpsToastRouteState = {
         perpsToastKey,
         ...(perpsToastDescription ? { perpsToastDescription } : {}),
+        ...extraState,
       };
       navigate(marketDetailPath, { state: toastRouteState });
     },
@@ -993,6 +998,12 @@ const PerpsOrderEntryPage: React.FC = () => {
       handleBackClick(
         PERPS_TOAST_KEYS.SUBMIT_IN_PROGRESS,
         tradeActionToastDescription,
+        orderFormState.type === 'market'
+          ? {
+              pendingOrderSymbol: orderFormState.asset,
+              pendingOrderFilledDescription: tradeActionToastDescription,
+            }
+          : undefined,
       );
 
       const result = await submitRequestToBackground<PerpsBackgroundResult>(


### PR DESCRIPTION
## **Description**

The perps order submission flow had several toast notification issues:

1. **Incorrect toast timing**: In-progress toasts were shown before navigation but success/failure toasts required staying on the order entry page. Now the user navigates back to the market detail page immediately after the in-progress toast, and success toasts are shown via `replacePerpsToastByKey` after the background request completes.
2. **Close modal dismissed too late**: The close-position modal waited for the background request to complete before dismissing. Now `onClose()` is called before the `await`, giving the user immediate feedback.
3. **Order filled detection moved to market detail page**: For new market orders, the pending order symbol and description are passed via route state. The market detail page watches `allPositions` for the symbol to appear and shows the `ORDER_FILLED` toast once (guarded by a ref to prevent duplicates).
4. **Removed 15-second timeout fallback and pending state**: The old approach kept the user on the order entry page with a pending state and a 15-second timeout. This is no longer needed since the user navigates back immediately.

## **Changelog**

CHANGELOG entry: Improved perps trading toast notifications to show correct in-progress and success messages, and navigate the user back to the market detail page immediately after order submission.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2851

## **Manual testing steps**

1. Open the MetaMask extension and navigate to the Perps trading section
2. Select a market (e.g., ETH-PERP) and open the order entry page
3. Place a new **market** order (long or short)
4. Verify you are immediately navigated back to the market detail page with a "Submitting your trade" in-progress toast (with spinner)
5. Verify the in-progress toast auto-hides after ~3 seconds and an "Order submitted" toast appears
6. Once the position appears in the positions list, verify an "Order filled" success toast is shown (only once)
7. Place a new **limit** order and verify you see "Submitting your trade" then "Order placed" toasts
8. Open a position and use the **close position** modal — verify the modal dismisses immediately and a "Closing position" in-progress toast appears, followed by a success toast
9. Modify an existing position's TP/SL — verify "Updating position" in-progress toast, then "Position updated" success toast

## **Screenshots/Recordings**

### **Before**

### **After**

https://github.com/user-attachments/assets/c52cebe6-7085-4ebb-a9a0-7e754ec29b4e



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect user-visible trading UX flow and toast sequencing across navigation, so regressions could cause missing/duplicated toasts or confusing status messaging during order/close/modify actions.
> 
> **Overview**
> Perps order submission now navigates back to the market detail page immediately while handing off an *in-progress* toast via route state, then shows the final success toast (`ORDER_SUBMITTED`/`ORDER_PLACED`, close success, TP/SL update success, etc.) after the background request resolves.
> 
> Market detail adds a one-time “order filled” listener driven by new route-state fields (`pendingOrderSymbol`/`pendingOrderFilledDescription`) that watches live positions and triggers `PERPS_TOAST_KEYS.ORDER_FILLED` when the matching position appears; `PerpsToastRouteState` is extended accordingly and tests are updated to cover these cases.
> 
> The close-position modal now dismisses immediately by calling `onClose()` before awaiting `perpsClosePosition`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f708d94d8738faae9cb3d975f5aa042fea00960. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->