### PR TITLE
fix: Error state: Long/Short button not disabled when user has no perps funds

### DIFF
--- a/ui/pages/perps/perps-order-entry-page.test.tsx
+++ b/ui/pages/perps/perps-order-entry-page.test.tsx
@@ -508,7 +508,7 @@ describe('PerpsOrderEntryPage', () => {
       expect(screen.getByTestId('submit-order-button')).toBeDisabled();
     });
 
-    it('shows an add funds CTA when new order balance is zero', async () => {
+    it('disables submit when new order balance is zero', () => {
       mockLiveAccount.mockReturnValue({
         account: {
           ...mockAccountState,
@@ -522,17 +522,11 @@ describe('PerpsOrderEntryPage', () => {
 
       const submitButton = screen.getByTestId('submit-order-button');
 
-      expect(submitButton).not.toBeDisabled();
-      expect(submitButton).toHaveTextContent(messages.addFunds.message);
-
-      await act(async () => {
-        fireEvent.click(submitButton);
-      });
-
-      expect(mockTriggerDeposit).toHaveBeenCalledTimes(1);
+      expect(submitButton).toBeDisabled();
+      expect(submitButton).not.toHaveTextContent(messages.addFunds.message);
     });
 
-    it('shows geo-block modal instead of depositing when user is not eligible and balance is zero', async () => {
+    it('disables submit when user is not eligible and balance is zero', () => {
       mockUsePerpsEligibility.mockReturnValue({ isEligible: false });
       mockLiveAccount.mockReturnValue({
         account: {
@@ -546,14 +540,7 @@ describe('PerpsOrderEntryPage', () => {
       renderWithProvider(<PerpsOrderEntryPage />, store);
 
       const submitButton = screen.getByTestId('submit-order-button');
-      expect(submitButton).not.toBeDisabled();
-
-      await act(async () => {
-        fireEvent.click(submitButton);
-      });
-
-      expect(mockTriggerDeposit).not.toHaveBeenCalled();
-      expect(screen.getByTestId('perps-geo-block-modal')).toBeInTheDocument();
+      expect(submitButton).toBeDisabled();
     });
 
     it('shows geo-block modal instead of placing order when user is not eligible and has balance', async () => {

--- a/ui/pages/perps/perps-order-entry-page.tsx
+++ b/ui/pages/perps/perps-order-entry-page.tsx
@@ -1095,28 +1095,8 @@ const PerpsOrderEntryPage: React.FC = () => {
   ]);
 
   const handlePrimaryAction = useCallback(async () => {
-    if (hasNoAvailableBalance) {
-      if (!isEligible) {
-        setIsGeoBlockModalOpen(true);
-        return;
-      }
-      if (!selectedAddress || isDepositLoading) {
-        return;
-      }
-
-      await triggerDeposit();
-      return;
-    }
-
     await handleOrderSubmit();
-  }, [
-    handleOrderSubmit,
-    hasNoAvailableBalance,
-    isDepositLoading,
-    isEligible,
-    selectedAddress,
-    triggerDeposit,
-  ]);
+  }, [handleOrderSubmit]);
 
   useEffect(() => {
     if (!pendingOrderSymbol) {

--- a/ui/pages/perps/perps-order-entry-page.tsx
+++ b/ui/pages/perps/perps-order-entry-page.tsx
@@ -546,6 +546,7 @@ const PerpsOrderEntryPage: React.FC = () => {
     isDepositLoading ||
     isOrderPending ||
     (orderMode === 'new' && isLoadingAccount) ||
+    hasNoAvailableBalance ||
     (isPrimaryTradeAction &&
       (isLimitPriceInvalid ||
         isLimitPriceUnfavorable ||
@@ -1195,10 +1196,6 @@ const PerpsOrderEntryPage: React.FC = () => {
   const displayName = getDisplayName(market.symbol);
   const isLong = orderDirection === 'long';
   const submitButtonText = (() => {
-    if (hasNoAvailableBalance) {
-      return t('addFunds');
-    }
-
     switch (orderMode) {
       case 'modify':
         return t('perpsModifyPosition');


### PR DESCRIPTION
## **Description**

The Long/Short submit button on the perps order entry page was enabled even when the user had zero perps balance. When `availableBalance <= 0` in new order mode, `isPrimaryTradeAction` was `false`, which short-circuited the entire `isSubmitDisabled` validation block to `false` — the button was never disabled.

Fix: add `hasNoAvailableBalance` as a standalone condition in `isSubmitDisabled`, and remove the `addFunds` text branch from `submitButtonText` so the button shows the standard Long/Short label while disabled.

## **Changelog**

CHANGELOG entry: Fixed a bug where the Long/Short submit button remained enabled when the perps account had zero balance.

## **Related issues**

Fixes: [TAT-2831](https://consensyssoftware.atlassian.net/browse/TAT-2831)

## **Manual testing steps**

1. Unlock wallet and navigate to the Perps tab
2. Switch to an account with zero perps balance (Available to trade: 0.00 USDC)
3. Open any market order entry (e.g., BTC → Long)
4. Observe the Long/Short submit button is **disabled**
5. Confirm button label shows "Open Long BTC" (not "Add Funds")

## **Screenshots/Recordings**

<!-- Gateway will replace this section with uploaded artifacts from evidence-manifest.json -->

| Before | After |
|--------|-------|
| Button enabled with "Add Funds" label | Button disabled with "Open Long BTC" label |

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## **Validation Recipe**

<details>
<summary>recipe.json — automated validation graph</summary>

```json
{
  "title": "Perps order entry: submit button disabled when no balance",
  "description": "Verifies that the Long/Short submit button is disabled when the perps account has zero balance",
  "validate": {
    "workflow": {
      "pre_conditions": ["wallet.unlocked"],
      "entry": "setup-select-zero-account",
      "nodes": {
        "setup-select-zero-account": {
          "action": "eval_async",
          "expression": "(async () => { stateHooks.submitRequestToBackground('setSelectedInternalAccount', ['d875ea9f-3f76-4b3a-97de-ec91e2a33ed2']); for (let i = 0; i < 25; i++) { const sel = stateHooks.store.getState().metamask.internalAccounts.selectedAccount; if (sel === 'd875ea9f-3f76-4b3a-97de-ec91e2a33ed2') return 'switched'; await new Promise(r => setTimeout(r, 200)); } return 'timeout'; })()",
          "next": "setup-navigate-order-entry"
        },
        "setup-navigate-order-entry": {
          "action": "navigate",
          "target": "PerpsOrderEntry",
          "params": { "symbol": "BTC", "direction": "long" },
          "next": "setup-wait-page-load"
        },
        "setup-wait-page-load": {
          "action": "wait_for",
          "test_id": "perps-order-entry-page",
          "timeout_ms": 15000,
          "next": "gate-wait-button-stable"
        },
        "gate-wait-button-stable": {
          "action": "eval_async",
          "expression": "(async () => { const MAX = 25; for (let i = 0; i < MAX; i++) { const el = document.querySelector('[data-testid=\"submit-order-button\"]'); if (el) { const t = (el.textContent || '').toLowerCase(); if (t.includes('long') || t.includes('short') || t.includes('add funds') || t.includes('add margin')) return { disabled: el.disabled, text: el.textContent }; } await new Promise(r => setTimeout(r, 300)); } const el2 = document.querySelector('[data-testid=\"submit-order-button\"]'); return { disabled: el2?.disabled ?? null, text: el2?.textContent ?? 'timeout' }; })()",
          "next": "ac1-assert-button-disabled"
        },
        "ac1-assert-button-disabled": {
          "action": "eval_sync",
          "expression": "document.querySelector('[data-testid=\"submit-order-button\"]')?.disabled ?? false",
          "assert": {
            "operator": "eq",
            "value": true
          },
          "next": "ac1-screenshot-button-disabled"
        },
        "ac1-screenshot-button-disabled": {
          "action": "screenshot",
          "filename": "evidence-ac1-button-disabled.png",
          "next": "ac2-assert-button-text-long"
        },
        "ac2-assert-button-text-long": {
          "action": "eval_sync",
          "expression": "(document.querySelector('[data-testid=\"submit-order-button\"]')?.textContent ?? '').toLowerCase()",
          "assert": {
            "operator": "contains",
            "value": "long"
          },
          "next": "ac2-screenshot-button-text"
        },
        "ac2-screenshot-button-text": {
          "action": "screenshot",
          "filename": "evidence-ac2-button-text.png",
          "next": "teardown-restore-account"
        },
        "teardown-restore-account": {
          "action": "eval_async",
          "expression": "(async () => { stateHooks.submitRequestToBackground('setSelectedInternalAccount', ['0285a92b-905c-4814-8a16-52fe1db60357']); for (let i = 0; i < 25; i++) { const sel = stateHooks.store.getState().metamask.internalAccounts.selectedAccount; if (sel === '0285a92b-905c-4814-8a16-52fe1db60357') return 'restored'; await new Promise(r => setTimeout(r, 200)); } return 'timeout'; })()",
          "next": "done"
        },
        "done": {
          "action": "end",
          "status": "pass"
        }
      }
    }
  }
}
```

</details>

## **Recipe Workflow**

<details>
<summary>workflow.mmd — execution graph</summary>

```mermaid
flowchart TD
  %% Perps order entry: submit button disabled when no balance
  __entry__([\"ENTRY\"]) --> node_setup_select_zero_account
  node_setup_select_zero_account[\"setup-select-zero-account<br/>eval_async\"]
  node_setup_navigate_order_entry[\"setup-navigate-order-entry<br/>navigate\"]
  node_setup_wait_page_load[\"setup-wait-page-load<br/>wait_for\"]
  node_gate_wait_button_stable[\"gate-wait-button-stable<br/>eval_async\"]
  node_ac1_assert_button_disabled[\"ac1-assert-button-disabled<br/>eval_sync\"]
  node_ac1_screenshot_button_disabled[\"ac1-screenshot-button-disabled<br/>screenshot\"]
  node_ac2_assert_button_text_long[\"ac2-assert-button-text-long<br/>eval_sync\"]
  node_ac2_screenshot_button_text[\"ac2-screenshot-button-text<br/>screenshot\"]
  node_teardown_restore_account[\"teardown-restore-account<br/>eval_async\"]
  node_done([\"done<br/>PASS\"])
  node_setup_select_zero_account --> node_setup_navigate_order_entry
  node_setup_navigate_order_entry --> node_setup_wait_page_load
  node_setup_wait_page_load --> node_gate_wait_button_stable
  node_gate_wait_button_stable --> node_ac1_assert_button_disabled
  node_ac1_assert_button_disabled --> node_ac1_screenshot_button_disabled
  node_ac1_screenshot_button_disabled --> node_ac2_assert_button_text_long
  node_ac2_assert_button_text_long --> node_ac2_screenshot_button_text
  node_ac2_screenshot_button_text --> node_teardown_restore_account
  node_teardown_restore_account --> node_done
```

</details>


[TAT-2831]: https://consensyssoftware.atlassian.net/browse/TAT-2831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ