### PR TITLE
fix: tp/sl limit curent price

### DIFF
--- a/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.test.tsx
+++ b/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.test.tsx
@@ -407,6 +407,106 @@ describe('AutoCloseSection', () => {
 
       expect(onStopLossPriceChange).toHaveBeenCalledWith('44550');
     });
+
+    it('uses limit price as baseline when typing SL % on a limit order', () => {
+      // currentPrice=$3,000 but limitPrice=$2,000 (below-market limit buy).
+      // 10% RoE at leverage=10: priceChange = 10/(10*100) = 1% -> $2,000 * 0.99 = $1,980 (not $2,970)
+      const onStopLossPriceChange = jest.fn();
+      renderWithProvider(
+        <AutoCloseSection
+          {...defaultProps}
+          enabled={true}
+          direction="long"
+          currentPrice={3000}
+          orderType="limit"
+          limitPrice="2000"
+          leverage={10}
+          onStopLossPriceChange={onStopLossPriceChange}
+        />,
+        mockStore,
+      );
+
+      const container = screen.getByTestId('sl-percent-input');
+      const input = container.querySelector('input');
+      expect(input).not.toBeNull();
+      fireEvent.change(input as HTMLInputElement, { target: { value: '10' } });
+
+      expect(onStopLossPriceChange).toHaveBeenCalledWith('1980');
+    });
+
+    it('uses limit price as baseline when typing TP % on a limit order', () => {
+      // currentPrice=$3,000 but limitPrice=$2,000.
+      // 10% RoE at leverage=10: priceChange = 1% -> $2,000 * 1.01 = $2,020 (not $3,030)
+      const onTakeProfitPriceChange = jest.fn();
+      renderWithProvider(
+        <AutoCloseSection
+          {...defaultProps}
+          enabled={true}
+          direction="long"
+          currentPrice={3000}
+          orderType="limit"
+          limitPrice="2000"
+          leverage={10}
+          onTakeProfitPriceChange={onTakeProfitPriceChange}
+        />,
+        mockStore,
+      );
+
+      const container = screen.getByTestId('tp-percent-input');
+      const input = container.querySelector('input');
+      expect(input).not.toBeNull();
+      fireEvent.change(input as HTMLInputElement, { target: { value: '10' } });
+
+      expect(onTakeProfitPriceChange).toHaveBeenCalledWith('2020');
+    });
+
+    it('displays SL % relative to limit price when a price is pre-set on a limit order', () => {
+      // SL at $1,980 with limit entry $2,000 at 10x leverage:
+      // RoE% = (2000 - 1980) / 2000 * 10 * 100 = 10%  (not relative to $3,000)
+      renderWithProvider(
+        <AutoCloseSection
+          {...defaultProps}
+          enabled={true}
+          direction="long"
+          currentPrice={3000}
+          orderType="limit"
+          limitPrice="2000"
+          leverage={10}
+          stopLossPrice="1980"
+        />,
+        mockStore,
+      );
+
+      const container = screen.getByTestId('sl-percent-input');
+      const percentInput = container.querySelector('input');
+      expect(percentInput).toHaveValue('10');
+    });
+
+    it('falls back to current price for % calculation when limit price is empty', () => {
+      // Same as regular market order when limitPrice is empty
+      // 10% RoE at 10x from $3,000: SL = $3,000 * 0.99 = $2,970
+      const onStopLossPriceChange = jest.fn();
+      renderWithProvider(
+        <AutoCloseSection
+          {...defaultProps}
+          enabled={true}
+          direction="long"
+          currentPrice={3000}
+          orderType="limit"
+          limitPrice=""
+          leverage={10}
+          onStopLossPriceChange={onStopLossPriceChange}
+        />,
+        mockStore,
+      );
+
+      const container = screen.getByTestId('sl-percent-input');
+      const input = container.querySelector('input');
+      expect(input).not.toBeNull();
+      fireEvent.change(input as HTMLInputElement, { target: { value: '10' } });
+
+      expect(onStopLossPriceChange).toHaveBeenCalledWith('2970');
+    });
   });
 
   describe('percent input focus/blur behavior (no decimal insertion)', () => {

--- a/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.tsx
+++ b/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.tsx
@@ -49,10 +49,10 @@ import { formatRoePercent, getPnlDisplayColor } from '../../../utils';
  * @param props.onStopLossPriceChange - Callback when SL price changes
  * @param props.direction - Current order direction
  * @param props.currentPrice - Current asset price (used as entry price for new orders)
- * @param props.entryPrice - Position entry price (modify mode - use for accurate % calc)
+ * @param props.entryPrice - Position entry price (modify mode). When provided, overrides limit/current price for % calc.
  * @param props.estimatedSize - Signed position size in asset units for estimated PnL
  * @param props.orderType - Order type ('market' | 'limit') for choosing the validation reference price
- * @param props.limitPrice - Limit price string used as reference price for limit-order TP/SL validation
+ * @param props.limitPrice - Limit price string; used as the baseline for both validation and % ↔ price conversions on limit orders
  * @param props.leverage - Leverage multiplier for RoE% calculation
  * @param props.asset - Asset symbol for fetching dynamic closing fee rates
  */
@@ -80,8 +80,20 @@ export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
     orderType: 'market',
   });
 
-  // In modify mode use position's entry price; otherwise use current price
-  const entryPrice = entryPriceProp ?? currentPrice;
+  // Priority: explicit entry price (modify mode) > limit price (limit orders) > current price.
+  // This ensures % ↔ price conversions are anchored to the price the user will actually fill at.
+  const entryPrice = useMemo(() => {
+    if (entryPriceProp !== undefined) {
+      return entryPriceProp;
+    }
+    if (orderType === 'limit' && limitPrice?.trim()) {
+      const parsed = Number.parseFloat(limitPrice.replaceAll(/[$,]/gu, ''));
+      if (Number.isFinite(parsed) && parsed > 0) {
+        return parsed;
+      }
+    }
+    return currentPrice;
+  }, [entryPriceProp, orderType, limitPrice, currentPrice]);
 
   // Raw percent strings preserved while the user is actively typing in percent fields.
   // When focused, these strings are shown verbatim to prevent mid-keystroke reformatting.


### PR DESCRIPTION
## **Description**

When creating a limit order, the TP/SL percentage fields were calculating the target price relative to the **current market price** instead of the **limit (entry) price** the user set.

**Root cause:** `AutoCloseSection` computed `entryPrice = entryPriceProp ?? currentPrice` as the baseline for `percentToPrice` and `priceToPercent`. Since `order-entry.tsx` always passes `entryPrice={undefined}` for new orders, any limit price set by the user was ignored — the % math always anchored to the live market price. The validation logic (`validationReferencePrice`) and PnL display (`pnlEntryPrice`) already correctly used the limit price; only the % ↔ price conversion was missing this.

**Fix:** `entryPrice` is now a `useMemo` that follows the same priority as `validationReferencePrice`: explicit entry price (modify mode) → parsed limit price (limit orders) → current market price (market orders).

## **Changelog**

CHANGELOG entry: Fixed a bug where TP/SL percentage inputs on limit orders calculated prices relative to the current market price instead of the limit entry price.

## **Related issues**

Fixes: TAT-2968

## **Manual testing steps**

1. Go to the Perps market page (e.g. ETH)
2. Select **Limit** order type and set a limit price below the current market (e.g. `$2,000` when market is `$3,000`)
3. Toggle **Auto Close** on
4. In the SL % field, type `10`
5. Verify the SL price field shows a value relative to `$2,000` (e.g. `$1,980` at 10x leverage), **not** relative to `$3,000` (which would be `$2,970`)
6. Repeat for the TP % field — should produce a value above `$2,000` (e.g. `$2,020`), not above `$3,000`
7. Verify that entering a price in the SL/TP price field correctly reflects back the % relative to the limit price

## **Screenshots/Recordings**

### **Before**
### **After**

<img width="495" height="969" alt="Screenshot 2026-04-16 at 11 16 52" src="https://github.com/user-attachments/assets/6b73b348-1a74-4a7f-a8e6-0ff4fd22b729" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.