### PR TITLE
fix: wallet recovery route and naming

### DIFF
--- a/ui/helpers/constants/routes.ts
+++ b/ui/helpers/constants/routes.ts
@@ -29,7 +29,7 @@ export const PRIVACY_ROUTE = '/settings/privacy';
 export const THIRD_PARTY_APIS_ROUTE = '/settings/privacy/third-party-apis';
 export const SECURITY_AND_PASSWORD_ROUTE = '/settings/security-and-password';
 export const AUTO_LOCK_ROUTE = '/settings/security-and-password/auto-lock';
-export const MANAGE_WALLET_RECOVERY_V2_ROUTE =
+export const MANAGE_WALLET_RECOVERY_ROUTE =
   '/settings/security-and-password/manage-wallet-recovery';
 export const SECURITY_PASSWORD_CHANGE_V2_ROUTE =
   '/settings/security-and-password/password';
@@ -78,8 +78,6 @@ export const CONTACTS_ADD_ROUTE = '/contacts/add';
 export const CONTACTS_VIEW_ROUTE = '/contacts/view';
 export const CONTACTS_EDIT_ROUTE = '/contacts/edit';
 export const SNAP_SETTINGS_ROUTE = '/settings/snap';
-export const REVEAL_SRP_LIST_ROUTE =
-  '/settings/security-and-privacy/reveal-srp-list';
 export const SECURITY_PASSWORD_CHANGE_ROUTE =
   '/settings/security-and-privacy/password-change';
 export const BACKUPANDSYNC_ROUTE =
@@ -252,7 +250,7 @@ export const ROUTES = [
     trackInAnalytics: true,
   },
   {
-    path: MANAGE_WALLET_RECOVERY_V2_ROUTE,
+    path: MANAGE_WALLET_RECOVERY_ROUTE,
     label: 'Manage Wallet Recovery Settings Page',
     trackInAnalytics: true,
   },
@@ -358,7 +356,7 @@ export const ROUTES = [
     trackInAnalytics: true,
   },
   {
-    path: REVEAL_SRP_LIST_ROUTE,
+    path: MANAGE_WALLET_RECOVERY_ROUTE,
     label: 'Reveal Secret Recovery Phrase List Page',
     trackInAnalytics: true,
   },

--- a/ui/helpers/constants/routes.ts
+++ b/ui/helpers/constants/routes.ts
@@ -356,11 +356,6 @@ export const ROUTES = [
     trackInAnalytics: true,
   },
   {
-    path: MANAGE_WALLET_RECOVERY_ROUTE,
-    label: 'Reveal Secret Recovery Phrase List Page',
-    trackInAnalytics: true,
-  },
-  {
     path: SECURITY_PASSWORD_CHANGE_ROUTE,
     label: 'Change Password',
     trackInAnalytics: true,

--- a/ui/pages/onboarding-flow/recovery-phrase/confirm-recovery-phrase.test.tsx
+++ b/ui/pages/onboarding-flow/recovery-phrase/confirm-recovery-phrase.test.tsx
@@ -8,7 +8,7 @@ import { setSeedPhraseBackedUp } from '../../../store/actions';
 import {
   ONBOARDING_COMPLETION_ROUTE,
   ONBOARDING_METAMETRICS,
-  REVEAL_SRP_LIST_ROUTE,
+  MANAGE_WALLET_RECOVERY_ROUTE,
 } from '../../../helpers/constants/routes';
 import * as BrowserRuntimeUtils from '../../../../shared/lib/browser-runtime.utils';
 import { PLATFORM_FIREFOX } from '../../../../shared/constants/app';
@@ -274,7 +274,7 @@ describe('Confirm Recovery Phrase Component', () => {
 
     fireEvent.click(closeButton);
 
-    expect(mockUseNavigate).toHaveBeenCalledWith(REVEAL_SRP_LIST_ROUTE, {
+    expect(mockUseNavigate).toHaveBeenCalledWith(MANAGE_WALLET_RECOVERY_ROUTE, {
       replace: true,
     });
   });

--- a/ui/pages/onboarding-flow/recovery-phrase/confirm-recovery-phrase.tsx
+++ b/ui/pages/onboarding-flow/recovery-phrase/confirm-recovery-phrase.tsx
@@ -38,7 +38,7 @@ import {
   ONBOARDING_COMPLETION_ROUTE,
   ONBOARDING_METAMETRICS,
   ONBOARDING_REVEAL_SRP_ROUTE,
-  REVEAL_SRP_LIST_ROUTE,
+  MANAGE_WALLET_RECOVERY_ROUTE,
 } from '../../../helpers/constants/routes';
 import { PLATFORM_FIREFOX } from '../../../../shared/constants/app';
 import { TraceName } from '../../../../shared/lib/trace';
@@ -198,7 +198,7 @@ export default function ConfirmRecoveryPhrase({ secretRecoveryPhrase = '' }) {
   ]);
 
   const onClose = useCallback(() => {
-    navigate(REVEAL_SRP_LIST_ROUTE, { replace: true });
+    navigate(MANAGE_WALLET_RECOVERY_ROUTE, { replace: true });
   }, [navigate]);
 
   return (

--- a/ui/pages/onboarding-flow/recovery-phrase/reveal-recovery-phrase.test.tsx
+++ b/ui/pages/onboarding-flow/recovery-phrase/reveal-recovery-phrase.test.tsx
@@ -7,7 +7,7 @@ import {
   ONBOARDING_COMPLETION_ROUTE,
   ONBOARDING_METAMETRICS,
   ONBOARDING_REVIEW_SRP_ROUTE,
-  REVEAL_SRP_LIST_ROUTE,
+  MANAGE_WALLET_RECOVERY_ROUTE,
 } from '../../../helpers/constants/routes';
 import { getSeedPhrase } from '../../../store/actions';
 import * as BrowserRuntimeUtils from '../../../../shared/lib/browser-runtime.utils';
@@ -352,9 +352,12 @@ describe('RevealRecoveryPhrase', () => {
       const backButton = getByTestId('reveal-recovery-phrase-back-button');
       fireEvent.click(backButton);
 
-      expect(mockUseNavigate).toHaveBeenCalledWith(REVEAL_SRP_LIST_ROUTE, {
-        replace: true,
-      });
+      expect(mockUseNavigate).toHaveBeenCalledWith(
+        MANAGE_WALLET_RECOVERY_ROUTE,
+        {
+          replace: true,
+        },
+      );
     });
   });
 });

--- a/ui/pages/onboarding-flow/recovery-phrase/reveal-recovery-phrase.tsx
+++ b/ui/pages/onboarding-flow/recovery-phrase/reveal-recovery-phrase.tsx
@@ -30,7 +30,7 @@ import {
   ONBOARDING_COMPLETION_ROUTE,
   ONBOARDING_METAMETRICS,
   ONBOARDING_REVIEW_SRP_ROUTE,
-  REVEAL_SRP_LIST_ROUTE,
+  MANAGE_WALLET_RECOVERY_ROUTE,
 } from '../../../helpers/constants/routes';
 import { getSeedPhraseBackedUp } from '../../../ducks/metamask/metamask';
 import { getBrowserName } from '../../../../shared/lib/browser-runtime.utils';
@@ -93,7 +93,7 @@ export default function RevealRecoveryPhrase({
 
   const returnToPreviousPage = useCallback(() => {
     if (isFromSettingsSecurity) {
-      navigate(REVEAL_SRP_LIST_ROUTE, { replace: true });
+      navigate(MANAGE_WALLET_RECOVERY_ROUTE, { replace: true });
     } else {
       navigate(DEFAULT_ROUTE, { replace: true });
     }

--- a/ui/pages/onboarding-flow/recovery-phrase/review-recovery-phrase.test.tsx
+++ b/ui/pages/onboarding-flow/recovery-phrase/review-recovery-phrase.test.tsx
@@ -5,7 +5,7 @@ import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate
 import {
   ONBOARDING_CONFIRM_SRP_ROUTE,
   ONBOARDING_METAMETRICS,
-  REVEAL_SRP_LIST_ROUTE,
+  MANAGE_WALLET_RECOVERY_ROUTE,
 } from '../../../helpers/constants/routes';
 import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
 import RecoveryPhrase from './review-recovery-phrase';
@@ -185,7 +185,7 @@ describe('Review Recovery Phrase Component', () => {
 
     fireEvent.click(closeButton);
 
-    expect(mockUseNavigate).toHaveBeenCalledWith(REVEAL_SRP_LIST_ROUTE, {
+    expect(mockUseNavigate).toHaveBeenCalledWith(MANAGE_WALLET_RECOVERY_ROUTE, {
       replace: true,
     });
   });

--- a/ui/pages/onboarding-flow/recovery-phrase/review-recovery-phrase.tsx
+++ b/ui/pages/onboarding-flow/recovery-phrase/review-recovery-phrase.tsx
@@ -27,7 +27,7 @@ import {
   ONBOARDING_METAMETRICS,
   ONBOARDING_REVEAL_SRP_ROUTE,
   ONBOARDING_COMPLETION_ROUTE,
-  REVEAL_SRP_LIST_ROUTE,
+  MANAGE_WALLET_RECOVERY_ROUTE,
 } from '../../../helpers/constants/routes';
 import {
   MetaMetricsEventCategory,
@@ -171,7 +171,7 @@ export default function RecoveryPhrase({
   }, [navigate, nextRouteQueryString]);
 
   const onClose = useCallback(() => {
-    navigate(REVEAL_SRP_LIST_ROUTE, { replace: true });
+    navigate(MANAGE_WALLET_RECOVERY_ROUTE, { replace: true });
   }, [navigate]);
 
   return (

--- a/ui/pages/settings-v2/security-and-password-tab/manage-wallet-recovery-item.test.tsx
+++ b/ui/pages/settings-v2/security-and-password-tab/manage-wallet-recovery-item.test.tsx
@@ -5,7 +5,7 @@ import thunk from 'redux-thunk';
 import mockState from '../../../../test/data/mock-state.json';
 import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
-import { MANAGE_WALLET_RECOVERY_V2_ROUTE } from '../../../helpers/constants/routes';
+import { MANAGE_WALLET_RECOVERY_ROUTE } from '../../../helpers/constants/routes';
 import ManageWalletRecoveryItem from './manage-wallet-recovery-item';
 
 const createMockStore = (overrides = {}) =>
@@ -21,7 +21,7 @@ describe('ManageWalletRecoveryItem', () => {
   it('renders the label', () => {
     const store = createMockStore();
     renderWithProvider(
-      <ManageWalletRecoveryItem route={MANAGE_WALLET_RECOVERY_V2_ROUTE} />,
+      <ManageWalletRecoveryItem route={MANAGE_WALLET_RECOVERY_ROUTE} />,
       store,
     );
 
@@ -33,12 +33,12 @@ describe('ManageWalletRecoveryItem', () => {
   it('renders the arrow link to reveal SRP page', () => {
     const store = createMockStore();
     renderWithProvider(
-      <ManageWalletRecoveryItem route={MANAGE_WALLET_RECOVERY_V2_ROUTE} />,
+      <ManageWalletRecoveryItem route={MANAGE_WALLET_RECOVERY_ROUTE} />,
       store,
     );
 
     const link = screen.getByRole('link');
-    expect(link).toHaveAttribute('href', MANAGE_WALLET_RECOVERY_V2_ROUTE);
+    expect(link).toHaveAttribute('href', MANAGE_WALLET_RECOVERY_ROUTE);
   });
 
   it('shows "Back up incomplete" tag when SRP is not backed up', () => {
@@ -47,7 +47,7 @@ describe('ManageWalletRecoveryItem', () => {
       seedPhraseBackedUp: false,
     });
     renderWithProvider(
-      <ManageWalletRecoveryItem route={MANAGE_WALLET_RECOVERY_V2_ROUTE} />,
+      <ManageWalletRecoveryItem route={MANAGE_WALLET_RECOVERY_ROUTE} />,
       store,
     );
 
@@ -63,7 +63,7 @@ describe('ManageWalletRecoveryItem', () => {
       seedPhraseBackedUp: true,
     });
     renderWithProvider(
-      <ManageWalletRecoveryItem route={MANAGE_WALLET_RECOVERY_V2_ROUTE} />,
+      <ManageWalletRecoveryItem route={MANAGE_WALLET_RECOVERY_ROUTE} />,
       store,
     );
 
@@ -78,7 +78,7 @@ describe('ManageWalletRecoveryItem', () => {
       seedPhraseBackedUp: false,
     });
     renderWithProvider(
-      <ManageWalletRecoveryItem route={MANAGE_WALLET_RECOVERY_V2_ROUTE} />,
+      <ManageWalletRecoveryItem route={MANAGE_WALLET_RECOVERY_ROUTE} />,
       store,
     );
 

--- a/ui/pages/settings-v2/security-and-password-tab/security-and-password-tab.tsx
+++ b/ui/pages/settings-v2/security-and-password-tab/security-and-password-tab.tsx
@@ -5,7 +5,7 @@ import { getPreferences, getUsePhishDetect } from '../../../selectors';
 import { setUsePhishDetect } from '../../../store/actions';
 import {
   AUTO_LOCK_ROUTE,
-  MANAGE_WALLET_RECOVERY_V2_ROUTE,
+  MANAGE_WALLET_RECOVERY_ROUTE,
   SECURITY_PASSWORD_CHANGE_V2_ROUTE,
 } from '../../../helpers/constants/routes';
 import { DEFAULT_AUTO_LOCK_TIME_LIMIT } from '../../../../shared/constants/preferences';
@@ -51,7 +51,7 @@ const SECURITY_AND_PASSWORD_SETTING_ITEMS: SettingItemConfig[] = [
   {
     id: 'manage-wallet-recovery',
     component: () => (
-      <ManageWalletRecoveryItem route={MANAGE_WALLET_RECOVERY_V2_ROUTE} />
+      <ManageWalletRecoveryItem route={MANAGE_WALLET_RECOVERY_ROUTE} />
     ),
   },
   { id: 'password', component: PasswordItem },

--- a/ui/pages/settings-v2/settings-registry.test.ts
+++ b/ui/pages/settings-v2/settings-registry.test.ts
@@ -2,7 +2,7 @@ import {
   DEVELOPER_OPTIONS_ROUTE,
   ASSETS_ROUTE,
   CURRENCY_ROUTE,
-  MANAGE_WALLET_RECOVERY_V2_ROUTE,
+  MANAGE_WALLET_RECOVERY_ROUTE,
   PRIVACY_ROUTE,
   SECURITY_PASSWORD_CHANGE_V2_ROUTE,
   SETTINGS_V2_ROUTE,
@@ -149,7 +149,7 @@ describe('settings-registry', () => {
       // Sub-pages
       expect(paths).toContain(CURRENCY_ROUTE);
       expect(paths).toContain(THEME_ROUTE);
-      expect(paths).toContain(MANAGE_WALLET_RECOVERY_V2_ROUTE);
+      expect(paths).toContain(MANAGE_WALLET_RECOVERY_ROUTE);
       expect(paths).toContain(SECURITY_PASSWORD_CHANGE_V2_ROUTE);
       expect(paths).toContain(TRANSACTION_SHIELD_MANAGE_PLAN_ROUTE);
       expect(paths).toContain(TRANSACTION_SHIELD_MANAGE_PAST_PLAN_ROUTE);

--- a/ui/pages/settings-v2/settings-registry.ts
+++ b/ui/pages/settings-v2/settings-registry.ts
@@ -12,7 +12,7 @@ import {
   CURRENCY_ROUTE,
   DEVELOPER_OPTIONS_ROUTE,
   DEVELOPER_TOOLS_ROUTE,
-  MANAGE_WALLET_RECOVERY_V2_ROUTE,
+  MANAGE_WALLET_RECOVERY_ROUTE,
   EXPERIMENTAL_ROUTE,
   LANGUAGE_ROUTE,
   NOTIFICATIONS_SETTINGS_ROUTE,
@@ -150,7 +150,7 @@ export const SETTINGS_V2_ROUTES: Record<string, SettingsV2RouteMeta> = {
       () => import('./security-and-password-tab/auto-lock-sub-page.tsx'),
     ),
   },
-  [MANAGE_WALLET_RECOVERY_V2_ROUTE]: {
+  [MANAGE_WALLET_RECOVERY_ROUTE]: {
     labelKey: 'manageWalletRecovery',
     parentPath: SECURITY_AND_PASSWORD_ROUTE,
     component: mmLazy(

--- a/ui/pages/settings/security-tab/security-tab.component.js
+++ b/ui/pages/settings/security-tab/security-tab.component.js
@@ -55,7 +55,7 @@ import {
 } from '../../../helpers/constants/design-system';
 import {
   ADD_POPULAR_CUSTOM_NETWORK,
-  REVEAL_SRP_LIST_ROUTE,
+  MANAGE_WALLET_RECOVERY_ROUTE,
   SECURITY_PASSWORD_CHANGE_ROUTE,
 } from '../../../helpers/constants/routes';
 import {
@@ -290,7 +290,7 @@ export default class SecurityTab extends PureComponent {
                       location: 'Settings',
                     },
                   });
-                  navigate(REVEAL_SRP_LIST_ROUTE);
+                  navigate(MANAGE_WALLET_RECOVERY_ROUTE);
                 }}
               >
                 {getButtonText()}

--- a/ui/pages/settings/security-tab/security-tab.test.js
+++ b/ui/pages/settings/security-tab/security-tab.test.js
@@ -12,7 +12,7 @@ import mockState from '../../../../test/data/mock-state.json';
 import { tEn, enLocale as messages } from '../../../../test/lib/i18n-helpers';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import { getIsSecurityAlertsEnabled } from '../../../selectors';
-import { REVEAL_SRP_LIST_ROUTE } from '../../../helpers/constants/routes';
+import { MANAGE_WALLET_RECOVERY_ROUTE } from '../../../helpers/constants/routes';
 import { FirstTimeFlowType } from '../../../../shared/constants/onboarding';
 import SecurityTab from './security-tab.container';
 
@@ -196,7 +196,7 @@ describe('Security Tab', () => {
 
     fireEvent.click(screen.getByTestId('reveal-seed-words'));
 
-    expect(mockUseNavigate).toHaveBeenCalledWith(REVEAL_SRP_LIST_ROUTE);
+    expect(mockUseNavigate).toHaveBeenCalledWith(MANAGE_WALLET_RECOVERY_ROUTE);
   });
 
   it('sets IPFS gateway', async () => {

--- a/ui/pages/settings/settings.component.js
+++ b/ui/pages/settings/settings.component.js
@@ -23,7 +23,7 @@ import {
   DEFAULT_ROUTE,
   NOTIFICATIONS_SETTINGS_ROUTE,
   SNAP_SETTINGS_ROUTE,
-  REVEAL_SRP_LIST_ROUTE,
+  MANAGE_WALLET_RECOVERY_ROUTE,
   BACKUPANDSYNC_ROUTE,
   SECURITY_PASSWORD_CHANGE_ROUTE,
   TRANSACTION_SHIELD_ROUTE,
@@ -569,7 +569,10 @@ class SettingsPage extends PureComponent {
           element={<NotificationsSettingsContent />}
         />
         <Route
-          path={toRelativeRoutePath(REVEAL_SRP_LIST_ROUTE, SETTINGS_ROUTE)}
+          path={toRelativeRoutePath(
+            MANAGE_WALLET_RECOVERY_ROUTE,
+            SETTINGS_ROUTE,
+          )}
           element={<RevealSrpList />}
         />
         <Route

--- a/ui/pages/settings/settings.container.js
+++ b/ui/pages/settings/settings.container.js
@@ -28,7 +28,7 @@ import {
   ADD_NETWORK_ROUTE,
   ADD_POPULAR_CUSTOM_NETWORK,
   SNAP_SETTINGS_ROUTE,
-  REVEAL_SRP_LIST_ROUTE,
+  MANAGE_WALLET_RECOVERY_ROUTE,
   BACKUPANDSYNC_ROUTE,
   SECURITY_PASSWORD_CHANGE_ROUTE,
   TRANSACTION_SHIELD_ROUTE,
@@ -56,10 +56,10 @@ const ROUTES_TO_I18N_KEYS = {
   [DEVELOPER_OPTIONS_ROUTE]: 'developerOptions',
   [EXPERIMENTAL_ROUTE]: 'experimental',
   [GENERAL_ROUTE]: 'general',
+  [MANAGE_WALLET_RECOVERY_ROUTE]: 'revealSecretRecoveryPhrase',
   [NETWORKS_FORM_ROUTE]: 'networks',
   [NETWORKS_ROUTE]: 'networks',
   [NOTIFICATIONS_SETTINGS_ROUTE]: 'notifications',
-  [REVEAL_SRP_LIST_ROUTE]: 'revealSecretRecoveryPhrase',
   [SECURITY_PASSWORD_CHANGE_ROUTE]: 'securityChangePassword',
   [SECURITY_ROUTE]: 'securityAndPrivacy',
   [TRANSACTION_SHIELD_CLAIM_ROUTES.NEW.FULL]: 'shieldClaim',
@@ -86,7 +86,9 @@ const mapStateToProps = (state, ownProps) => {
     searchParams.get(SHIELD_QUERY_PARAMS.showShieldEntryModal) === 'true';
   const snapIdFromSearch = searchParams.get('snapId');
 
-  const isRevealSrpListPage = Boolean(pathname.match(REVEAL_SRP_LIST_ROUTE));
+  const isRevealSrpListPage = Boolean(
+    pathname.match(MANAGE_WALLET_RECOVERY_ROUTE),
+  );
   const isPasswordChangePage = Boolean(
     pathname.match(SECURITY_PASSWORD_CHANGE_ROUTE),
   );
@@ -131,7 +133,7 @@ const mapStateToProps = (state, ownProps) => {
 
   let pathnameI18nKey = ROUTES_TO_I18N_KEYS[pathname];
 
-  // if pathname is `REVEAL_SRP_LIST_ROUTE` and socialLoginEnabled rename the tab title to "Manage recovery methods"
+  // if pathname is `MANAGE_WALLET_RECOVERY_ROUTE` and socialLoginEnabled rename the tab title to "Manage recovery methods"
   if (isRevealSrpListPage && socialLoginEnabled) {
     pathnameI18nKey = 'securitySrpWalletRecovery';
   }


### PR DESCRIPTION
## **Description**

Fixes the bug mentioned below and cleans up some naming.

**Changes:**
- Updated route path from `/settings/security-and-privacy/reveal-srp-list` (legacy settings) to `/settings/security-and-password/manage-wallet-recovery` (settings v2)
- Updated all references in onboarding flow and settings components
- Renamed `MANAGE_WALLET_RECOVERY_V2_ROUTE` to `MANAGE_WALLET_RECOVERY_ROUTE`

## **Changelog**

CHANGELOG entry: Fixes back button route from Manage Wallet Recovery page when SRP is not backed up

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/41781

## **Manual testing steps**

- Create a new wallet and skip SRP recovery
- Go to settings Security and password
- Click Manage wallet recovery
- Click Backup
- Do not enter password and click the back arrow or Close from the X
- Notice page is Security and password again

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily a routing refactor, but it touches multiple navigation paths (onboarding + settings) where a wrong route could strand users or break back/close behavior.
> 
> **Overview**
> Updates wallet recovery navigation to consistently use `MANAGE_WALLET_RECOVERY_ROUTE` (`/settings/security-and-password/manage-wallet-recovery`) and removes the legacy `REVEAL_SRP_LIST_ROUTE` constant/usage.
> 
> Onboarding SRP reveal/review/confirm screens and Settings (legacy security tab + Settings V2 registry/tab items) now route back/close actions and links to the Manage Wallet Recovery page, with tests adjusted accordingly; `MANAGE_WALLET_RECOVERY_V2_ROUTE` is renamed to `MANAGE_WALLET_RECOVERY_ROUTE`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 690e41843e85b0538c703fad1e0fc0dc11b56381. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->