### PR TITLE
fix: Fix profile metrics service 431 errors cp-13.27.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -377,7 +377,7 @@
     "@metamask/post-message-stream": "^10.0.0",
     "@metamask/ppom-validator": "0.39.1",
     "@metamask/preinstalled-example-snap": "^0.7.2",
-    "@metamask/profile-metrics-controller": "^3.0.3",
+    "@metamask/profile-metrics-controller": "^3.0.4",
     "@metamask/profile-sync-controller": "^28.0.2",
     "@metamask/providers": "^22.1.1",
     "@metamask/rate-limit-controller": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7666,9 +7666,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/profile-metrics-controller@npm:^3.0.3":
-  version: 3.0.3
-  resolution: "@metamask/profile-metrics-controller@npm:3.0.3"
+"@metamask/profile-metrics-controller@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "@metamask/profile-metrics-controller@npm:3.0.4"
   dependencies:
     "@metamask/accounts-controller": "npm:^37.0.0"
     "@metamask/base-controller": "npm:^9.0.0"
@@ -7680,7 +7680,7 @@ __metadata:
     "@metamask/transaction-controller": "npm:^62.21.0"
     "@metamask/utils": "npm:^11.9.0"
     async-mutex: "npm:^0.5.0"
-  checksum: 10/19076756e1b100038fb058b0cd1e226690fd77857a802f7966b9fd53493997aab5826e84a1b4a85fe6f7bc650582beab6bb3cd6fef83c68fdb4eb0cc07233f24
+  checksum: 10/8f08113c6808611d88ff3464bf2593cb37d68130f2c0b034bcf081c6781a9705d0b9580eb394f133207ebacf030940d78a162125c6b7b8955a3901fdab89ae69
   languageName: node
   linkType: hard
 
@@ -34229,7 +34229,7 @@ __metadata:
     "@metamask/ppom-validator": "npm:0.39.1"
     "@metamask/preferences-controller": "npm:^23.0.0"
     "@metamask/preinstalled-example-snap": "npm:^0.7.2"
-    "@metamask/profile-metrics-controller": "npm:^3.0.3"
+    "@metamask/profile-metrics-controller": "npm:^3.0.4"
     "@metamask/profile-sync-controller": "npm:^28.0.2"
     "@metamask/providers": "npm:^22.1.1"
     "@metamask/rate-limit-controller": "npm:^7.0.0"


### PR DESCRIPTION
## **Description**

The profile metrics service (from the profile metrics controller package) is failing to strip cookies from requests to that service, which is causing HTTP 431 errors.

The package has been updated from 3.0.3 to 3.0.4, which includes just one change (to strip the cookies from this request), see: https://github.com/MetaMask/core/pull/8209

## **Changelog**

CHANGELOG entry: null

## **Related issues**

https://consensyssoftware.atlassian.net/browse/DUS-1869

## **Manual testing steps**

* Install the extension
* Open dev tools to the network tab
* Proceed through onboarding, opting _in_ to metrics and marketing consent
  * I believe only metrics is needed here, not marking consent, but I did not confirm
* Look for the call to the autentication API to the path `/profile/accounts`
* Ensure `Cookie` is not present in the request headers

## **Screenshots/Recordings**

### **Before**


<img width="1917" height="828" alt="Screenshot 2026-04-16 at 13 27 35" src="https://github.com/user-attachments/assets/bca8241d-feef-45ad-a0ba-a503805a64a6" />

### **After**

<img width="1920" height="845" alt="Screenshot 2026-04-16 at 13 23 52" src="https://github.com/user-attachments/assets/e8d5f279-fbe9-4ab5-a41e-b0885d73e9ab" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single dependency patch-level bump; behavior change is isolated to profile-metrics network requests (cookie stripping) with minimal blast radius beyond metrics/onboarding flows.
> 
> **Overview**
> Updates `@metamask/profile-metrics-controller` from `3.0.3` to `3.0.4`, pulling in an upstream fix intended to prevent HTTP 431 responses by stripping `Cookie` headers from profile metrics service requests.
> 
> Lockfile is updated accordingly; no application code changes beyond the dependency/lockfile bump.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 708d3df07b0b5e20230a4474c9597206c989d1f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->