### PR TITLE
fix: show bridge tx details if tx hash is in txHistory cp-13.27.0 cp-13.28.0

### DIFF
--- a/ui/ducks/bridge-status/selectors.ts
+++ b/ui/ducks/bridge-status/selectors.ts
@@ -256,7 +256,8 @@ const selectBridgeHistoryItemForTxHash = createSelector(
 
     const historyItem = Object.values(bridgeHistory).find(
       (item) =>
-        item.status.srcChain?.txHash?.toLowerCase() === txHash?.toLowerCase(),
+        txHash &&
+        item.status.srcChain?.txHash?.toLowerCase() === txHash.toLowerCase(),
     );
     if (historyItem) {
       return historyItem;

--- a/ui/ducks/bridge-status/selectors.ts
+++ b/ui/ducks/bridge-status/selectors.ts
@@ -254,6 +254,14 @@ const selectBridgeHistoryItemForTxHash = createSelector(
       return bridgeHistory[txHash];
     }
 
+    const historyItem = Object.values(bridgeHistory).find(
+      (item) =>
+        item.status.srcChain?.txHash?.toLowerCase() === txHash?.toLowerCase(),
+    );
+    if (historyItem) {
+      return historyItem;
+    }
+
     const txId = tx?.id;
     const actionId = tx?.actionId;
     if (txId && bridgeHistory[txId]) {

--- a/ui/hooks/bridge/useBridgeChainInfo.ts
+++ b/ui/hooks/bridge/useBridgeChainInfo.ts
@@ -45,9 +45,10 @@ export default function useBridgeChainInfo({
     ),
   );
 
-  const isEvmSwapOrBridge =
-    transaction?.type &&
-    [TransactionType.bridge, TransactionType.swap].includes(transaction.type);
+  const isEvmSwapOrBridge = bridgeHistoryItem
+    ? true
+    : transaction?.type &&
+      [TransactionType.bridge, TransactionType.swap].includes(transaction.type);
 
   if (!isEvmSwapOrBridge && !nonEvmTransaction) {
     return {

--- a/ui/hooks/bridge/useBridgeTxHistoryData.ts
+++ b/ui/hooks/bridge/useBridgeTxHistoryData.ts
@@ -63,7 +63,9 @@ function serialize(obj: unknown): unknown {
 }
 
 export function useBridgeTxHistoryData({
+  // Used in legacy transaction list
   transactionGroup,
+  // Used in activity list v2
   transaction: transactionViewData,
 }: UseBridgeTxHistoryDataProps) {
   const navigate = useNavigate();

--- a/ui/pages/bridge/transaction-details/transaction-details.test.tsx
+++ b/ui/pages/bridge/transaction-details/transaction-details.test.tsx
@@ -548,7 +548,7 @@ describe('transaction-details', () => {
         getMockStore({}, mockBridgeTxData.srcTxMetaId),
       );
       const expectedRows = [
-        'Statuscomplete',
+        'Statusconfirmed',
         'Time stampJun 21, 2025 at 12:43 AM',
         'You sent onPolygon',
         'Total gas fee0.00446 POL',

--- a/ui/pages/bridge/transaction-details/transaction-details.test.tsx
+++ b/ui/pages/bridge/transaction-details/transaction-details.test.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import type { Location as RouterLocation } from 'react-router-dom';
+import * as locationUtils from 'react-router-dom';
 import { EthAccountType, EthScope } from '@metamask/keyring-api';
-import { TransactionStatus } from '@metamask/transaction-controller';
+import {
+  TransactionStatus,
+  TransactionType,
+} from '@metamask/transaction-controller';
 import type { BridgeHistoryItem } from '@metamask/bridge-status-controller';
 import { StatusTypes } from '@metamask/bridge-controller';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
@@ -37,7 +41,7 @@ jest.mock('react-router-dom', () => ({
 const getMockStore = (
   transactionGroup: TransactionGroup,
   srcTxMetaId: string,
-  txHistoryItem: BridgeHistoryItem,
+  txHistoryItem?: BridgeHistoryItem,
 ) => {
   return configureStore(
     createBridgeMockStore({
@@ -58,17 +62,19 @@ const getMockStore = (
         transactions: [
           transactionGroup.primaryTransaction,
           transactionGroup.initialTransaction,
-        ],
+        ].filter(Boolean),
         currencyRates: {},
         preferences: {},
         ...mockNetworkState({ chainId: CHAIN_IDS.OPTIMISM }),
         completedOnboarding: true,
-        txHistory: {
-          [srcTxMetaId]: {
-            ...txHistoryItem,
-            account: '0x30e8ccad5a980bdf30447f8c2c48e70989d9d294',
-          },
-        },
+        txHistory: txHistoryItem
+          ? {
+              [srcTxMetaId]: {
+                ...txHistoryItem,
+                account: '0x30e8ccad5a980bdf30447f8c2c48e70989d9d294',
+              },
+            }
+          : {},
       },
     }),
   );
@@ -468,6 +474,102 @@ describe('transaction-details', () => {
       expect(
         queryByText(messages.bridgeTxDetailsNonce.message),
       ).not.toBeInTheDocument();
+    });
+
+    it('should render confirmed bridge tx when transactionCategory does not resolve to a Bridge transaction', () => {
+      jest.spyOn(locationUtils, 'useLocation').mockReturnValue({
+        ...mockLocation(),
+        state: {
+          transaction: {
+            ...mockBridgeTxData.transactionGroup.initialTransaction,
+            type: TransactionType.contractInteraction,
+            transactionCategory: 'DEPOSIT',
+          },
+        },
+      } as RouterLocation);
+      const { queryAllByTestId, getByText } = renderWithProvider(
+        <CrossChainSwapTxDetails />,
+        getMockStore({}, mockBridgeTxData.srcTxMetaId, {
+          ...mockBridgeTxData.bridgeHistoryItem,
+          status: {
+            ...mockBridgeTxData.bridgeHistoryItem.status,
+            status: StatusTypes.COMPLETE,
+          },
+        } as never),
+      );
+      const expectedRows = [
+        'Statuscomplete',
+        'BridgedPolygonOP',
+        'Time stamp',
+        'You sent2 USDC onPolygon',
+        'You received1.981 USDC onOP',
+        'Total gas fee0.00446 POL',
+        'Nonce3',
+      ];
+      expect(queryAllByTestId('transaction-detail-row')).toHaveLength(7);
+      queryAllByTestId('transaction-detail-row').forEach((row, i) => {
+        expect(row).toHaveTextContent(expectedRows[i]);
+      });
+
+      expect(
+        getByText(messages.bridgeDetailsTitle.message),
+      ).toBeInTheDocument();
+      expect(
+        getByText(
+          messages.bridgeExplorerLinkViewOn.message.replace(
+            '$1',
+            'PolygonScan',
+          ),
+        ),
+      ).toBeInTheDocument();
+      expect(
+        getByText(
+          messages.bridgeExplorerLinkViewOn.message.replace(
+            '$1',
+            'Optimism Explorer',
+          ),
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it('should render confirmed bridge tx when transactionCategory does not resolve to a Bridge transaction and bridgeHistoryItem is not found', () => {
+      jest.spyOn(locationUtils, 'useLocation').mockReturnValue({
+        ...mockLocation(),
+        state: {
+          transaction: {
+            ...mockBridgeTxData.transactionGroup.initialTransaction,
+            type: TransactionType.contractInteraction,
+            transactionCategory: 'BRIDGE_OUT',
+          },
+        },
+      } as RouterLocation);
+      const { queryAllByTestId, getByText } = renderWithProvider(
+        <CrossChainSwapTxDetails />,
+        getMockStore({}, mockBridgeTxData.srcTxMetaId),
+      );
+      const expectedRows = [
+        'Statuscomplete',
+        'Time stampJun 21, 2025 at 12:43 AM',
+        'You sent onPolygon',
+        'Total gas fee0.00446 POL',
+        'Nonce3',
+      ];
+      expect(queryAllByTestId('transaction-detail-row')).toHaveLength(5);
+      queryAllByTestId('transaction-detail-row').forEach((row, i) => {
+        expect(row).toHaveTextContent(expectedRows[i]);
+      });
+
+      expect(
+        getByText(messages.bridgeDetailsTitle.message),
+      ).toBeInTheDocument();
+      expect(
+        getByText(
+          messages.bridgeExplorerLinkViewOn.message.replace(
+            '$1',
+            'PolygonScan',
+          ),
+        ),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/ui/pages/bridge/transaction-details/transaction-details.tsx
+++ b/ui/pages/bridge/transaction-details/transaction-details.tsx
@@ -143,17 +143,15 @@ const CrossChainSwapTxDetails = () => {
   const destTxHash = bridgeHistoryItem?.status.destChain?.txHash;
   const destBlockExplorerUrl = getBlockExplorerUrl(destNetwork, destTxHash);
 
-  const bridgeStatus = bridgeHistoryItem
-    ? bridgeHistoryItem?.status.status
-    : srcChainTxMeta?.status === TransactionStatus.confirmed ||
-        transaction?.status === TransactionStatus.confirmed
-      ? StatusTypes.COMPLETE
-      : srcChainTxMeta?.status === TransactionStatus.failed ||
-          transaction?.status === TransactionStatus.failed
-        ? StatusTypes.FAILED
-        : StatusTypes.PENDING;
-  // Show src tx status for swaps
-  const status = isBridgeTx ? bridgeStatus : srcChainTxMeta?.status;
+  // Either the local tx or the transaction from accounts-api
+  const transactionStatus = srcChainTxMeta?.status || transaction?.status;
+  // Use txHistory status for bridge txs, fallback to src tx status if not a local bridge tx
+  const bridgeStatus =
+    (bridgeHistoryItem ? bridgeHistoryItem.status.status : transactionStatus) ??
+    StatusTypes.PENDING;
+
+  // Show src tx status for swaps, but use txHistory status for bridge txs
+  const status = isBridgeTx ? bridgeStatus : transactionStatus;
 
   const srcChainIconUrl = srcNetwork
     ? getImageForChainId(

--- a/ui/pages/bridge/transaction-details/transaction-details.tsx
+++ b/ui/pages/bridge/transaction-details/transaction-details.tsx
@@ -6,7 +6,11 @@ import {
   TransactionType,
   type TransactionMeta,
 } from '@metamask/transaction-controller';
-import { formatChainIdToHex, StatusTypes } from '@metamask/bridge-controller';
+import {
+  formatChainIdToHex,
+  isCrossChain,
+  StatusTypes,
+} from '@metamask/bridge-controller';
 import {
   AvatarNetwork,
   AvatarNetworkSize,
@@ -68,7 +72,7 @@ import {
 } from '../../../../shared/constants/bridge';
 import { Numeric } from '../../../../shared/lib/Numeric';
 import { getImageForChainId } from '../../../selectors/multichain';
-import { formatTokenAmount } from '../utils/quote';
+import { resolveTransactionType } from '../../../components/multichain/activity-v2/helpers';
 import {
   getBlockExplorerUrl,
   getBridgeAmountReceivedFormatted,
@@ -122,7 +126,15 @@ const CrossChainSwapTxDetails = () => {
     (tx) => tx.id === bridgeHistoryItem?.approvalTxId,
   );
 
-  const isBridgeTx = srcChainTxMeta?.type === TransactionType.bridge;
+  const isBridgeTx =
+    srcChainTxMeta?.type === TransactionType.bridge ||
+    (transaction?.transactionCategory &&
+      resolveTransactionType(transaction) === TransactionType.bridge) ||
+    (bridgeHistoryItem &&
+      isCrossChain(
+        bridgeHistoryItem.status.srcChain?.chainId,
+        bridgeHistoryItem.status.destChain?.chainId,
+      ));
 
   const srcTxHash = srcChainTxMeta?.hash;
   const srcBlockExplorerUrl = getBlockExplorerUrl(srcNetwork, srcTxHash);
@@ -132,7 +144,13 @@ const CrossChainSwapTxDetails = () => {
 
   const bridgeStatus = bridgeHistoryItem
     ? bridgeHistoryItem?.status.status
-    : StatusTypes.PENDING;
+    : srcChainTxMeta?.status === TransactionStatus.confirmed ||
+        transaction?.status === TransactionStatus.confirmed
+      ? StatusTypes.COMPLETE
+      : srcChainTxMeta?.status === TransactionStatus.failed ||
+          transaction?.status === TransactionStatus.failed
+        ? StatusTypes.FAILED
+        : StatusTypes.PENDING;
   // Show src tx status for swaps
   const status = isBridgeTx ? bridgeStatus : srcChainTxMeta?.status;
 

--- a/ui/pages/bridge/transaction-details/transaction-details.tsx
+++ b/ui/pages/bridge/transaction-details/transaction-details.tsx
@@ -80,6 +80,7 @@ import {
   getIsDelayed,
   STATUS_TO_COLOR_MAP,
 } from '../utils/tx-details';
+import { formatTokenAmount } from '../utils/quote';
 import TransactionDetailRow from './transaction-detail-row';
 import BridgeExplorerLinks from './bridge-explorer-links';
 import BridgeStepList from './bridge-step-list';

--- a/ui/pages/bridge/utils/tx-details.ts
+++ b/ui/pages/bridge/utils/tx-details.ts
@@ -128,7 +128,7 @@ export const getBridgeAmountReceivedFormatted = ({
  * @returns Whether the bridge history item is delayed
  */
 export const getIsDelayed = (
-  status: StatusTypes,
+  status: string,
   bridgeHistoryItem?: BridgeHistoryItem,
 ) => {
   const tenMinutesInMs = 10 * MINUTE;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR fixes activity display for delegated bridge transactions, specifically:

- if the transaction list item doesn't have a txMetaId, the selector returns the txHistory item if its `status.srcChain.txHash` matches (case-insensitive)

- if the transaction's `transactionCategory` does not resolve to swap/bridge, use the local txHistory to determine whether the Unified Swap/Bridge activity UI should be displayed

- In the unified tx details page, use the bridge status from the txHistory when available, and fallback to the transaction's confirmation status otherwise

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: show bridge tx details if tx hash is in txHistory 

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/41856

## **Manual testing steps**

1. Submit a 7702 gasless bridge transaction
2. Verify that activity list item is correct
3. Verify that tx-details page has complete data

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes bridge/swap classification and status source selection in the transaction details UI, which could affect what users see for certain transactions if txHistory lookups or category resolution are wrong.
> 
> **Overview**
> Bridge tx lookups now fall back to matching `txHistory` entries by `status.srcChain.txHash`, allowing bridge details to render when the stored history key isn’t the tx hash.
> 
> The bridge details page and chain-info hook broaden what counts as a bridge transaction (including `transactionCategory` resolution and cross-chain `txHistory` data) and prefer `txHistory` status for bridge transactions while falling back to the transaction’s own status when history is missing. Tests add coverage for these mismatched-category / missing-history cases, and `getIsDelayed` is loosened to accept a string status.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e85e95653f75132a9545bf82a1401f270c63094e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->