### PR TITLE
refactor: migrate components from `multichain-accounts` to design-system-react

### DIFF
--- a/ui/components/multichain-accounts/account-remove-modal/account-remove-modal.stories.tsx
+++ b/ui/components/multichain-accounts/account-remove-modal/account-remove-modal.stories.tsx
@@ -4,7 +4,7 @@ import {
   AccountRemoveModal,
   AccountRemoveModalProps,
 } from './account-remove-modal';
-import { Button } from '../../component-library';
+import { Button } from '@metamask/design-system-react';
 
 export default {
   title: 'Components/MultichainAccounts/AccountRemoveModal',

--- a/ui/components/multichain-accounts/account-remove-modal/account-remove-modal.tsx
+++ b/ui/components/multichain-accounts/account-remove-modal/account-remove-modal.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { FontWeight, Text, TextVariant } from '@metamask/design-system-react';
 
 import {
   BannerAlert,
@@ -10,16 +11,13 @@ import {
   ModalFooter,
   ModalHeader,
   ModalOverlay,
-  Text,
 } from '../../component-library';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
   AlignItems,
   Display,
   FlexDirection,
-  FontWeight,
   JustifyContent,
-  TextVariant,
 } from '../../../helpers/constants/design-system';
 import { PreferredAvatar } from '../../app/preferred-avatar';
 import { AddressCopyButton } from '../../multichain';
@@ -55,9 +53,9 @@ export const AccountRemoveModal = ({
           >
             <PreferredAvatar address={accountAddress} />
             <Text
-              variant={TextVariant.bodyLgMedium}
-              marginTop={2}
-              marginBottom={2}
+              variant={TextVariant.BodyLg}
+              fontWeight={FontWeight.Medium}
+              className="mt-2 mb-2"
             >
               {accountName}
             </Text>
@@ -68,10 +66,10 @@ export const AccountRemoveModal = ({
             marginTop={6}
             marginBottom={2}
           >
-            <Text variant={TextVariant.bodyMd} fontWeight={FontWeight.Bold}>
+            <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Bold}>
               {t('removeAccountModalBannerTitle')}
             </Text>
-            <Text variant={TextVariant.bodyMd}>
+            <Text variant={TextVariant.BodyMd}>
               {t('removeAccountModalBannerDescription')}
             </Text>
           </BannerAlert>

--- a/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
+++ b/ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx
@@ -1,14 +1,9 @@
 import React, { useCallback, useContext, useMemo, useRef } from 'react';
 import { createSearchParams, useNavigate } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
-import {
-  IconName as DesignSystemIconName,
-  TextColor as DesignSystemTextColor,
-} from '@metamask/design-system-react';
+import { Icon, IconName, TextColor } from '@metamask/design-system-react';
 import {
   Box,
-  Icon,
-  IconName,
   ModalFocus,
   Popover,
   PopoverPosition,
@@ -201,31 +196,27 @@ export const MultichainAccountMenu = ({
     const baseMenuItems: MenuItemConfig[] = [
       {
         textKey: 'accountDetails',
-        iconName: DesignSystemIconName.Details,
+        iconName: IconName.Details,
         onClick: handleAccountDetailsClick,
       },
       {
         textKey: 'rename',
-        iconName: DesignSystemIconName.Edit,
+        iconName: IconName.Edit,
         onClick: handleAccountRenameClick,
       },
       {
         textKey: 'addresses',
-        iconName: DesignSystemIconName.QrCode,
+        iconName: IconName.QrCode,
         onClick: handleAccountAddressesClick,
       },
       {
         textKey: isPinned ? 'unpin' : 'pinToTop',
-        iconName: isPinned
-          ? DesignSystemIconName.Unpin
-          : DesignSystemIconName.Pin,
+        iconName: isPinned ? IconName.Unpin : IconName.Pin,
         onClick: handleAccountPinClick,
       },
       {
         textKey: isHidden ? 'showAccount' : 'hideAccount',
-        iconName: isHidden
-          ? DesignSystemIconName.Eye
-          : DesignSystemIconName.EyeSlash,
+        iconName: isHidden ? IconName.Eye : IconName.EyeSlash,
         onClick: handleAccountHideClick,
       },
     ];
@@ -233,9 +224,9 @@ export const MultichainAccountMenu = ({
     if (isRemovable) {
       baseMenuItems.push({
         textKey: 'remove',
-        iconName: DesignSystemIconName.Trash,
+        iconName: IconName.Trash,
         onClick: handleAccountRemoveClick,
-        textColor: DesignSystemTextColor.ErrorDefault,
+        textColor: TextColor.ErrorDefault,
       });
     }
 

--- a/ui/components/multichain-accounts/multichain-private-key-list/multichain-private-key-list.tsx
+++ b/ui/components/multichain-accounts/multichain-private-key-list/multichain-private-key-list.tsx
@@ -4,12 +4,11 @@ import { type AccountGroupId } from '@metamask/account-api';
 import { CaipChainId } from '@metamask/utils';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { KeyringTypes } from '@metamask/keyring-controller';
+import { Text, TextColor, TextVariant } from '@metamask/design-system-react';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
   Display,
   FlexDirection,
-  TextVariant,
-  TextColor,
   BlockSize,
 } from '../../../helpers/constants/design-system';
 import {
@@ -17,7 +16,6 @@ import {
   Button,
   ButtonSize,
   ButtonVariant,
-  Text,
   TextField,
   TextFieldSize,
   TextFieldType,
@@ -154,7 +152,7 @@ const MultichainPrivateKeyList = ({
     () => (
       <Box paddingTop={8} paddingBottom={4}>
         <Box>
-          <Text variant={TextVariant.bodyMd} color={TextColor.textDefault}>
+          <Text variant={TextVariant.BodyMd} color={TextColor.TextDefault}>
             {t('enterYourPassword')}
           </Text>
           <TextField
@@ -169,8 +167,8 @@ const MultichainPrivateKeyList = ({
           />
           {wrongPassword ? (
             <Text
-              variant={TextVariant.bodySm}
-              color={TextColor.errorDefault}
+              variant={TextVariant.BodySm}
+              color={TextColor.ErrorDefault}
               data-testid="wrong-password-msg"
             >
               {t('wrongPassword')}


### PR DESCRIPTION
## Description

This change continues the migration from deprecated `ui/components/component-library` usage toward `@metamask/design-system-react` for multichain account UI.

**What changed**

- **account-remove-modal**: `Text` (and typography enums) from the design system; modal stack and `BannerAlert` stay on the component library.
- **account-remove-modal stories**: `Button` from the design system.
- **multichain-account-menu**: `Icon`, `IconName`, and `TextColor` from the design system; `Popover`, `ModalFocus`, and `Box` stay on the component library.
- **multichain-private-key-list**: `Text` from the design system; `TextField` and `Button` stay on the component library.

Props were mapped to the DSR Tailwind-based API (e.g. `TextVariant.BodyMd`, spacing via `className` where needed).

## Changelog

CHANGELOG entry: null

## Related issues

Related: [MUL-1678](https://consensyssoftware.atlassian.net/browse/MUL-1678)

## Manual testing steps

1. Open the account removal flow for a removable multichain account and confirm copy, banner, and actions look correct.
2. Open the account overflow menu (three dots) and confirm icons and labels, including remove when applicable.
3. Open the private key export flow for a multichain account, enter password, and confirm labels and error text for a wrong password.

## Screenshots/Recordings

https://github.com/user-attachments/assets/1359d76c-0c6a-47e4-9ed5-a3343944db17

## Pre-merge author checklist

- [x] MetaMask Contributor Docs and Extension Coding Standards
- [x] PR template completed
- [x] Existing unit tests; `yarn test:unit` for affected files


Made with [Cursor](https://cursor.com)

[MUL-1678]: https://consensyssoftware.atlassian.net/browse/MUL-1678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MUL-1669]: https://consensyssoftware.atlassian.net/browse/MUL-1669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MUL-1678]: https://consensyssoftware.atlassian.net/browse/MUL-1678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a UI refactor swapping design-system components/enums; main risk is minor visual/regression issues due to variant/color/spacing mapping changes.
> 
> **Overview**
> Migrates several `multichain-accounts` UI components off the deprecated `component-library` primitives and onto `@metamask/design-system-react` equivalents.
> 
> `AccountRemoveModal` and `MultichainPrivateKeyList` switch typography to DSR (`Text`, `TextVariant`, `FontWeight`/`TextColor`) and update spacing to match the new API, while `MultichainAccountMenu` switches icon and error text color enums to DSR. Storybook for `AccountRemoveModal` also swaps its `Button` import to DSR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e4de6019fb32ad11ec5088ce4401d5b5a163916. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->