### PR TITLE
fix: delay cold perps chart startup on detail page

### DIFF
--- a/ui/hooks/perps/stream/usePerpsLiveCandles.ts
+++ b/ui/hooks/perps/stream/usePerpsLiveCandles.ts
@@ -110,7 +110,6 @@ export function usePerpsLiveCandles(
     }
 
     const streamManager = getPerpsStreamManager();
-
     const unsubscribe = streamManager.candles.subscribe({
       symbol,
       interval,

--- a/ui/hooks/perps/stream/usePerpsLiveCandles.ts
+++ b/ui/hooks/perps/stream/usePerpsLiveCandles.ts
@@ -110,6 +110,7 @@ export function usePerpsLiveCandles(
     }
 
     const streamManager = getPerpsStreamManager();
+
     const unsubscribe = streamManager.candles.subscribe({
       symbol,
       interval,

--- a/ui/pages/perps/perps-market-detail-page.test.tsx
+++ b/ui/pages/perps/perps-market-detail-page.test.tsx
@@ -145,6 +145,28 @@ const mockSubmitRequestToBackground = jest
 let latestPriceSubscriber:
   | ((updates: { symbol: string; percentChange24h?: string }[]) => void)
   | undefined;
+const mockHasCachedCandles = jest.fn(() => false);
+const mockUsePerpsLiveCandles = jest.fn(() => ({
+  candleData: {
+    symbol: 'ETH',
+    interval: '5m',
+    candles: [
+      {
+        time: 1768188300000,
+        open: '2880.0',
+        high: '2920.0',
+        low: '2870.0',
+        close: '2900.0',
+        volume: '100.0',
+      },
+    ],
+  },
+  isInitialLoading: false,
+  isLoadingMore: false,
+  hasHistoricalData: true,
+  error: null,
+  fetchMoreHistory: jest.fn(),
+}));
 const mockPriceSubscribe = jest.fn((callback) => {
   latestPriceSubscriber = callback;
   return jest.fn();
@@ -188,6 +210,9 @@ jest.mock('../../providers/perps', () => ({
     pushPositionsWithOverrides: jest.fn(),
     prewarm: jest.fn(),
     cleanupPrewarm: jest.fn(),
+    candles: {
+      hasCachedCandles: (...args: unknown[]) => mockHasCachedCandles(...args),
+    },
     isInitialized: () => true,
     init: jest.fn(),
   }),
@@ -255,27 +280,7 @@ jest.mock('../../hooks/perps/stream', () => ({
     markets: [...mockCryptoMarkets, ...mockHip3Markets],
     isInitialLoading: false,
   }),
-  usePerpsLiveCandles: () => ({
-    candleData: {
-      symbol: 'ETH',
-      interval: '5m',
-      candles: [
-        {
-          time: 1768188300000,
-          open: '2880.0',
-          high: '2920.0',
-          low: '2870.0',
-          close: '2900.0',
-          volume: '100.0',
-        },
-      ],
-    },
-    isInitialLoading: false,
-    isLoadingMore: false,
-    hasHistoricalData: true,
-    error: null,
-    fetchMoreHistory: jest.fn(),
-  }),
+  usePerpsLiveCandles: (...args: unknown[]) => mockUsePerpsLiveCandles(...args),
 }));
 
 jest.mock('../../hooks/perps/usePerpsOrderFees', () => ({
@@ -353,9 +358,31 @@ describe('PerpsMarketDetailPage', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockHasCachedCandles.mockReturnValue(false);
     mockUsePerpsEligibility.mockReturnValue({ isEligible: true });
     mockReplacePerpsToastByKey.mockReset();
     mockTriggerDeposit.mockClear();
+    mockUsePerpsLiveCandles.mockReturnValue({
+      candleData: {
+        symbol: 'ETH',
+        interval: '5m',
+        candles: [
+          {
+            time: 1768188300000,
+            open: '2880.0',
+            high: '2920.0',
+            low: '2870.0',
+            close: '2900.0',
+            volume: '100.0',
+          },
+        ],
+      },
+      isInitialLoading: false,
+      isLoadingMore: false,
+      hasHistoricalData: true,
+      error: null,
+      fetchMoreHistory: jest.fn(),
+    });
     mockLiveAccount.mockReturnValue({
       account: mockAccountState,
       isInitialLoading: false,
@@ -375,6 +402,10 @@ describe('PerpsMarketDetailPage', () => {
       search: '',
       state: null,
     });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   describe('when perps feature is enabled', () => {
@@ -634,6 +665,60 @@ describe('PerpsMarketDetailPage', () => {
 
       expect(getByTestId('perps-market-detail-chart')).toBeInTheDocument();
       expect(getByTestId('perps-candlestick-chart')).toBeInTheDocument();
+    });
+
+    it('delays cold chart startup until the detail page has been stable', async () => {
+      jest.useFakeTimers();
+      const store = mockStore(createMockState(true));
+
+      await renderPage(store);
+
+      expect(mockUsePerpsLiveCandles).toHaveBeenCalledWith(
+        expect.objectContaining({
+          symbol: '',
+          interval: '5m',
+        }),
+      );
+
+      act(() => {
+        jest.advanceTimersByTime(1999);
+      });
+
+      expect(mockUsePerpsLiveCandles).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          symbol: 'ETH',
+          interval: '5m',
+        }),
+      );
+
+      act(() => {
+        jest.advanceTimersByTime(1);
+      });
+
+      await waitFor(() => {
+        expect(mockUsePerpsLiveCandles).toHaveBeenCalledWith(
+          expect.objectContaining({
+            symbol: 'ETH',
+            interval: '5m',
+          }),
+        );
+      });
+
+      jest.useRealTimers();
+    });
+
+    it('starts the chart immediately when cached candles already exist', async () => {
+      mockHasCachedCandles.mockReturnValue(true);
+      const store = mockStore(createMockState(true));
+
+      await renderPage(store);
+
+      expect(mockUsePerpsLiveCandles).toHaveBeenCalledWith(
+        expect.objectContaining({
+          symbol: 'ETH',
+          interval: '5m',
+        }),
+      );
     });
 
     it('displays favorite button', async () => {

--- a/ui/pages/perps/perps-market-detail-page.tsx
+++ b/ui/pages/perps/perps-market-detail-page.tsx
@@ -113,6 +113,8 @@ import {
 import { setTutorialModalOpen } from '../../ducks/perps';
 import { PerpsTutorialModal } from '../../components/app/perps/perps-tutorial-modal';
 
+const CHART_COLD_START_DELAY_MS = 2000;
+
 /**
  * Calculate the funding countdown string (time until next UTC hour).
  * Funding on HyperLiquid is paid every hour on the hour (UTC).
@@ -471,19 +473,54 @@ const PerpsMarketDetailPage: React.FC = () => {
     CandlePeriod.FiveMinutes,
   );
   const chartRef = useRef<PerpsCandlestickChartRef>(null);
+  const selectedPeriodRef = useRef(selectedPeriod);
+  selectedPeriodRef.current = selectedPeriod;
+  const [isChartReady, setIsChartReady] = useState(false);
+
+  useEffect(() => {
+    if (!decodedSymbol) {
+      setIsChartReady(false);
+      return undefined;
+    }
+
+    const streamManager = getPerpsStreamManager();
+    if (
+      streamManager.candles.hasCachedCandles(
+        decodedSymbol,
+        selectedPeriodRef.current,
+      )
+    ) {
+      setIsChartReady(true);
+      return undefined;
+    }
+
+    setIsChartReady(false);
+
+    const timer = setTimeout(() => {
+      setIsChartReady(true);
+    }, CHART_COLD_START_DELAY_MS);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [decodedSymbol]);
+
+  const candleSymbol = isChartReady ? (decodedSymbol ?? '') : '';
 
   // Live candle data from CandleStreamChannel
   const {
     candleData,
-    isInitialLoading: isCandleLoading,
+    isInitialLoading: isLiveCandleLoading,
     error: candleError,
     fetchMoreHistory,
   } = usePerpsLiveCandles({
-    symbol: decodedSymbol ?? '',
+    symbol: candleSymbol,
     interval: selectedPeriod,
     duration: TimeDuration.YearToDate,
     throttleMs: 1000,
   });
+  const isChartStarting = Boolean(decodedSymbol) && !isChartReady;
+  const isCandleLoading = isChartStarting || isLiveCandleLoading;
 
   // Fetch market-specific fills (WebSocket + REST) for Recent Activity
   const { fills: marketFills, isInitialLoading: fillsLoading } =

--- a/ui/providers/perps/CandleStreamChannel.test.ts
+++ b/ui/providers/perps/CandleStreamChannel.test.ts
@@ -201,11 +201,24 @@ describe('CandleStreamChannel', () => {
       expect(cb).not.toHaveBeenCalled();
     });
 
-    it('passes duration in perpsActivateCandleStream call', () => {
+    it('reports whether cached candles exist for a symbol and interval', () => {
+      expect(channel.hasCachedCandles('BTC', CandlePeriod.OneHour)).toBe(false);
+
+      channel.pushFromBackground({
+        symbol: 'BTC',
+        interval: CandlePeriod.OneHour,
+        data: makeCandleData([100, 200]),
+      });
+
+      expect(channel.hasCachedCandles('BTC', CandlePeriod.OneHour)).toBe(true);
+      expect(channel.hasCachedCandles('ETH', CandlePeriod.OneHour)).toBe(false);
+    });
+
+    it('uses a light cold-start duration for a brand-new chart open', () => {
       channel.subscribe({
         symbol: 'BTC',
         interval: CandlePeriod.OneHour,
-        duration: TimeDuration.OneDay,
+        duration: TimeDuration.YearToDate,
         callback: jest.fn(),
       });
 
@@ -218,6 +231,34 @@ describe('CandleStreamChannel', () => {
             symbol: 'BTC',
             interval: CandlePeriod.OneHour,
             duration: TimeDuration.OneDay,
+          }),
+        ],
+      );
+    });
+
+    it('uses an even lighter duration when cached candles already exist', () => {
+      channel.pushFromBackground({
+        symbol: 'BTC',
+        interval: CandlePeriod.OneHour,
+        data: makeCandleData([100, 200]),
+      });
+
+      channel.subscribe({
+        symbol: 'BTC',
+        interval: CandlePeriod.OneHour,
+        duration: TimeDuration.YearToDate,
+        callback: jest.fn(),
+      });
+
+      jest.advanceTimersByTime(DEBOUNCE_MS);
+
+      expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+        'perpsActivateCandleStream',
+        [
+          expect.objectContaining({
+            symbol: 'BTC',
+            interval: CandlePeriod.OneHour,
+            duration: TimeDuration.OneHour,
           }),
         ],
       );

--- a/ui/providers/perps/CandleStreamChannel.ts
+++ b/ui/providers/perps/CandleStreamChannel.ts
@@ -16,7 +16,8 @@
 import type { CandleData } from '@metamask/perps-controller';
 import {
   type CandlePeriod,
-  type TimeDuration,
+  TimeDuration,
+  type TimeDuration as TimeDurationType,
   calculateCandleCount,
 } from '../../components/app/perps/constants/chartConfig';
 import { submitRequestToBackground } from '../../store/background-connection';
@@ -33,11 +34,19 @@ const LOAD_MORE_MAX = 500;
 /** Debounce delay before firing perpsActivateCandleStream */
 const CONNECT_DEBOUNCE_MS = 500;
 
-/** Grace period before actually tearing down a candle stream after the last
- *  subscriber leaves. Covers brief navigation gaps (tab switch, route
- *  transition) so we don't destroy and re-create the same subscription,
- *  which would trigger a redundant fetchHistoricalCandles and risk 429s. */
+/**
+ * Grace period before actually tearing down a candle stream after the last
+ * subscriber leaves. Covers brief navigation gaps (tab switch, route
+ * transition) so we don't destroy and re-create the same subscription,
+ * which would trigger a redundant fetchHistoricalCandles and risk 429s.
+ */
 const DISCONNECT_GRACE_MS = 5_000;
+
+/** Initial history to request for a brand-new chart open */
+const COLD_START_DURATION = TimeDuration.OneDay;
+
+/** Initial history to request when revisiting a warm chart */
+const WARM_START_DURATION = TimeDuration.OneHour;
 
 /** Per-subscriber state */
 type SubscriberEntry = {
@@ -91,8 +100,20 @@ function parseCacheKey(key: string): {
   };
 }
 
+function getInitialActivationDuration(
+  cache: CandleData | null,
+): TimeDurationType {
+  return cache?.candles?.length ? WARM_START_DURATION : COLD_START_DURATION;
+}
+
 export class CandleStreamChannel {
   private readonly channels = new Map<string, ChannelEntry>();
+
+  hasCachedCandles(symbol: string, interval: CandlePeriod): boolean {
+    return Boolean(
+      this.channels.get(cacheKey(symbol, interval))?.cache?.candles?.length,
+    );
+  }
 
   /**
    * Subscribe to candle data for a symbol+interval pair.
@@ -419,10 +440,11 @@ export class CandleStreamChannel {
       }
 
       const { symbol, interval } = parseCacheKey(key);
+      const initialDuration = getInitialActivationDuration(entry.cache);
       entry.isConnected = true;
 
       submitRequestToBackground('perpsActivateCandleStream', [
-        { symbol, interval, duration: entry.duration },
+        { symbol, interval, duration: initialDuration },
       ]).catch((err) => {
         console.warn(
           '[CandleStreamChannel] Failed to activate streaming for key:',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

  Opening a new Perps market detail page could still trigger chart 429 Too Many Requests errors, even after the earlier candle stream churn reductions. The remaining problem was the initial candle snapshot on a cold detail-page chart open.

  This mattered because chart 429s were also consuming provider budget that could affect other Perps actions on the same session.

  ## Reason for change

  The detail page chart was still starting its candle subscription immediately on cold market opens. That initial subscribeToCandles -> fetchHistoricalCandles path was enough to hit rate limits when switching through markets quickly.

  ## Improvement

  This PR delays cold chart startup on the Perps market detail page until the page has been stable briefly, while allowing warm charts with cached candles to start immediately.

  The change:

  - adds a read-only candle cache probe in the candle channel
  - uses that probe on the market detail page to distinguish cold vs warm chart opens
  - delays only cold detail page chart startup
  - keeps warm revisits immediate
  - keeps the generic candle hook simple instead of pushing page-specific timing policy into it

  This is a narrow release safe mitigation for chart 429s without widening scope into controller refactoring.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added delay for chart startup on the Perps market detail page until the page is stable

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes candle-stream activation timing and requested history duration, which could affect chart load behavior and data freshness during navigation across markets. Scope is limited to Perps chart streaming and includes updated tests.
> 
> **Overview**
> **Mitigates Perps chart 429s** by delaying candle streaming on the market detail page for *cold opens* until the page is stable (~`2000ms`), while allowing *warm opens* to start immediately when candle cache exists.
> 
> Adds a `CandleStreamChannel.hasCachedCandles()` probe and uses it both in `perps-market-detail-page.tsx` (to gate `usePerpsLiveCandles` by temporarily passing an empty symbol) and in `CandleStreamChannel` activation logic to request a lighter initial history (`OneDay` on cold start, `OneHour` when cached). Tests were updated/added to cover the delay behavior and warm-vs-cold activation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68de07706d6275c6c70c950822e76ebe9ae69de2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->