### PR TITLE
ci: enforce merge commit for stable-sync → release/* PRs

### DIFF
--- a/.github/workflows/block-stable-sync-to-release.yml
+++ b/.github/workflows/block-stable-sync-to-release.yml
@@ -1,0 +1,31 @@
+name: Block stable-sync to release PRs
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, edited]
+    branches:
+      - 'release/*'
+  merge_group:
+
+jobs:
+  check-branch:
+    name: Block stable-sync-* to release/*
+    # Pre-filter: only spin up runner for branches starting with 'stable-sync-'
+    # This saves runner time for most PRs while still doing exact regex check below
+    if: startsWith(github.head_ref, 'stable-sync-')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check exact branch pattern
+        env:
+          SOURCE_BRANCH: ${{ github.head_ref }}
+          TARGET_BRANCH: ${{ github.base_ref }}
+        run: |
+          # Check if source branch matches stable-sync-* targeting release/X.Y.Z
+          if [[ "$TARGET_BRANCH" =~ ^release/[0-9]+\.[0-9]+\.[0-9]+$ && "$SOURCE_BRANCH" =~ ^stable-sync- ]]; then
+            echo "❌ ERROR: Manual merge from stable-sync-* branches to release/* is not allowed!"
+            echo "Source branch '$SOURCE_BRANCH' matches the blocked pattern."
+            echo "These branches should only be merged via automated workflows, comment 'Merge my PR' to merge."
+            exit 1
+          fi
+
+          echo "✅ Branch check passed"

--- a/.github/workflows/merge-my-pr.yml
+++ b/.github/workflows/merge-my-pr.yml
@@ -8,6 +8,8 @@ on:
 env:
   VERSION_BUMP_HEAD_BRANCH_PATTERN: '^version-bump/[0-9]+\.[0-9]+\.[0-9]+$'
   STABLE_MAIN_HEAD_BRANCH_PATTERN: '^stable-main-[0-9]+\.[0-9]+\.[0-9]+$'
+  STABLE_SYNC_HEAD_BRANCH_PATTERN: '^stable-sync-'
+  RELEASE_BASE_BRANCH_PATTERN: '^release/[0-9]+\.[0-9]+\.[0-9]+$'
 
 jobs:
   merge-my-pr:
@@ -41,8 +43,9 @@ jobs:
               pull_number: parseInt(process.env.PR_NUMBER, 10),
             });
 
-            // Export head ref for subsequent steps
+            // Export head/base refs for subsequent steps
             core.exportVariable('PR_HEAD_REF', pr.head.ref);
+            core.exportVariable('PR_BASE_REF', pr.base.ref);
 
       - name: Check the branch name against patterns
         id: check-branch
@@ -53,6 +56,9 @@ jobs:
           elif [[ "${PR_HEAD_REF}" =~ ${STABLE_MAIN_HEAD_BRANCH_PATTERN} ]]; then
             echo "Branch name matches stable main pattern"
             echo "stable-main=true" >> "$GITHUB_OUTPUT"
+          elif [[ "${PR_HEAD_REF}" =~ ${STABLE_SYNC_HEAD_BRANCH_PATTERN} ]] && [[ "${PR_BASE_REF}" =~ ${RELEASE_BASE_BRANCH_PATTERN} ]]; then
+            echo "Branch name matches stable-sync -> release pattern"
+            echo "stable-sync-release=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Merge approved version bump PR
@@ -75,5 +81,15 @@ jobs:
           # Merge PRs from stable-main-X.Y.Z into main
           required-base-branch: 'main'
           head-branch-pattern: '^stable-main-[0-9]+\.[0-9]+\.[0-9]+$'
+          merge-method: 'merge'
+          github-token: ${{ secrets.METAMASK_EXTENSION_BRANCH_SYNC_TOKEN }}
+
+      - name: Merge approved stable-sync to release PR
+        if: ${{ steps.check-branch.outputs.stable-sync-release == 'true' }}
+        uses: MetaMask/github-tools/.github/actions/merge-approved-pr@v1
+        with:
+          pr-number: ${{ github.event.issue.number }}
+          required-base-branch: ${{ env.PR_BASE_REF }}
+          head-branch-pattern: '^stable-sync-'
           merge-method: 'merge'
           github-token: ${{ secrets.METAMASK_EXTENSION_BRANCH_SYNC_TOKEN }}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Stable → `release/*` sync PRs (branch name with `stable-sync-*`) should keep a linear merge history. GitHub’s default UI still allows squash/rebase, which would break that expectation. 

Stable → `main` sync PRs are already guarded with a blocker workflow plus the **Merge my PR** automation. But there was no guard for `stable-sync-*` → `release/X.Y.Z` PRs. A reviewer could squash from the UI and corrupt release history.

In this PR:
- Add `block-stable-sync-to-release.yml`, mirroring `block-stable-main-to-main.yml`:  fail the check when branch name matches `stable-sync-*` and base matches semver `release/X.Y.Z`, with messaging to use **Merge my PR**.
- Extend `.github/workflows/merge-my-pr.yml` so we can comment exactly `Merge my PR` to merge PRs with `merge-method: merge commit`.


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/INFRA-3401

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PR merge enforcement for `release/*` branches by blocking manual `stable-sync-*` merges and routing them through an automated comment-triggered merge path; misconfiguration could unintentionally block or allow merges.
> 
> **Overview**
> Adds a new GitHub Actions workflow (`block-stable-sync-to-release.yml`) that **fails PR checks** when a `stable-sync-*` branch targets a semver `release/X.Y.Z` branch, preventing manual merges.
> 
> Extends `merge-my-pr.yml` to recognize `stable-sync-*` -> `release/X.Y.Z` PRs (exporting base ref and matching new patterns) and to **merge them via the existing comment-triggered automation** using the PR’s base branch and `merge` strategy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21895f0e552bb8e401ce18c1813ec9ece1959c8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->