### PR TITLE
feat: Add new feature flag for new hardware wallet onboarding flow

### DIFF
--- a/.metamaskrc.dist
+++ b/.metamaskrc.dist
@@ -89,3 +89,8 @@ BLOCKAID_PUBLIC_KEY=
 
 ; This variable is required to run performance tests
 TEST_SRP_2=
+
+; Set to `true` to enable the new hardware wallet onboarding flow
+; (device discovery, error handling, account selection).
+; Entry points to connecting remain unchanged regardless of this flag.
+NEW_HARDWARE_WALLET_ONBOARDING='false'

--- a/builds.yml
+++ b/builds.yml
@@ -387,6 +387,8 @@ env:
   # Build-time gate: when false AssetsController is instantiated but state remains empty.
   # When true, the controller populates state (subject to remote feature flag).
   - ASSETS_UNIFIED_STATE_ENABLED: false
+  # Build-time gate: when true, hardware wallet onboarding uses the new flow.
+  - NEW_HARDWARE_WALLET_ONBOARDING: false
 
   ###
   # Meta variables

--- a/shared/lib/environment.test.ts
+++ b/shared/lib/environment.test.ts
@@ -3,6 +3,7 @@ import {
   getEnabledAdvancedPermissions,
   getIsPerpsIncludedInBuild,
   getIsAssetsUnifiedStateIncludedInBuild,
+  getIsNewHardwareWalletOnboardingEnabled,
   isProduction,
   isGatorPermissionsRevocationFeatureEnabled,
 } from './environment';
@@ -152,5 +153,32 @@ describe('getIsPerpsIncludedInBuild', () => {
   it('returns false when PERPS_ENABLED is undefined', () => {
     delete process.env.PERPS_ENABLED;
     expect(getIsPerpsIncludedInBuild()).toBe(false);
+  });
+});
+
+describe('getIsNewHardwareWalletOnboardingEnabled', () => {
+  let originalValue: string | undefined;
+
+  beforeAll(() => {
+    originalValue = process.env.NEW_HARDWARE_WALLET_ONBOARDING;
+  });
+
+  afterAll(() => {
+    process.env.NEW_HARDWARE_WALLET_ONBOARDING = originalValue;
+  });
+
+  it('returns true when NEW_HARDWARE_WALLET_ONBOARDING is "true"', () => {
+    process.env.NEW_HARDWARE_WALLET_ONBOARDING = 'true';
+    expect(getIsNewHardwareWalletOnboardingEnabled()).toBe(true);
+  });
+
+  it('returns false when NEW_HARDWARE_WALLET_ONBOARDING is "false"', () => {
+    process.env.NEW_HARDWARE_WALLET_ONBOARDING = 'false';
+    expect(getIsNewHardwareWalletOnboardingEnabled()).toBe(false);
+  });
+
+  it('returns false when NEW_HARDWARE_WALLET_ONBOARDING is undefined', () => {
+    delete process.env.NEW_HARDWARE_WALLET_ONBOARDING;
+    expect(getIsNewHardwareWalletOnboardingEnabled()).toBe(false);
   });
 });

--- a/shared/lib/environment.ts
+++ b/shared/lib/environment.ts
@@ -60,6 +60,15 @@ export const isGatorPermissionsRevocationFeatureEnabled = (): boolean => {
   );
 };
 
+/**
+ * Compile-time gate (`NEW_HARDWARE_WALLET_ONBOARDING`): when true the
+ * extension uses the redesigned hardware-wallet onboarding flows (device
+ * discovery and error handling).
+ */
+export const getIsNewHardwareWalletOnboardingEnabled = (): boolean => {
+  return process.env.NEW_HARDWARE_WALLET_ONBOARDING?.toString() === 'true';
+};
+
 export const getIsSidePanelFeatureEnabled = (): boolean => {
   // In browser context, check if the API exists (Firefox doesn't have it)
   if (

--- a/test/env.js
+++ b/test/env.js
@@ -18,3 +18,4 @@ process.env.SEEDLESS_ONBOARDING_ENABLED = 'true';
 process.env.METAMASK_SHIELD_ENABLED = 'false';
 process.env.PERPS_ENABLED = 'true';
 process.env.ASSETS_UNIFIED_STATE_ENABLED = 'true';
+process.env.NEW_HARDWARE_WALLET_ONBOARDING = 'false';


### PR DESCRIPTION
## **Description**
This PR adds new feature flag for controlling new hardware wallet onboarding flow.
We're not using this new feature flag yet. It will be used later on when we start with new hardware wallet onboarding implementation.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->
CHANGELOG entry: null

## **Related issues**
Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1557

## **Manual testing steps**
1. Follow the example.

```
import { getIsNewHardwareWalletOnboardingEnabled } from '../../../shared/lib/environment';

const HardwareWalletFlow = () => {
  if (getIsNewHardwareWalletOnboardingEnabled()) {
    return <NewDeviceDiscovery />;
  }
  return <LegacyHardwarePairing />;
};
```

## **Screenshots/Recordings**

### **Before**
No UI changes. Nothing to show here.

### **After**
No UI changes. Nothing to show here.

## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new environment-gated boolean and wires it into build/test configuration without changing runtime behavior unless the flag is enabled.
> 
> **Overview**
> Adds a new compile-time feature flag, `NEW_HARDWARE_WALLET_ONBOARDING`, to gate the redesigned hardware-wallet onboarding flow.
> 
> Wires the flag through build configuration (`builds.yml`), sample env config (`.metamaskrc.dist`), and test env defaults (`test/env.js`), and introduces `getIsNewHardwareWalletOnboardingEnabled()` plus unit tests to read/validate the flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43d19a9a45fa126f5ecac2db2b9eafb523c45dd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->