### PR TITLE
fix: NFTs in Send flow overlapping

### DIFF
--- a/ui/pages/confirmations/components/UI/asset/asset.test.tsx
+++ b/ui/pages/confirmations/components/UI/asset/asset.test.tsx
@@ -200,4 +200,25 @@ describe('NFTAsset', () => {
 
     expect(getByText('Native SegWit')).toBeInTheDocument();
   });
+
+  it('renders placeholder when both asset image and collection image are missing', () => {
+    mockUseNftImageUrl.mockReturnValue('');
+    const assetWithoutAnyImage = {
+      ...mockNFTERC721Asset,
+      image: undefined,
+      collection: {
+        ...mockNFTERC721Asset.collection,
+        imageUrl: undefined,
+      },
+    };
+    const { getByTestId } = render(<Asset asset={assetWithoutAnyImage} />);
+
+    const nftAsset = getByTestId('nft-asset');
+    expect(nftAsset).toBeInTheDocument();
+    
+    // Should maintain consistent dimensions even without image
+    const imageContainer = nftAsset.querySelector('[style*="width: 32px; height: 32px"]');
+    expect(imageContainer).toBeInTheDocument();
+    expect(imageContainer).toHaveStyle('height: 32px');
+  });
 });

--- a/ui/pages/confirmations/components/UI/asset/asset.tsx
+++ b/ui/pages/confirmations/components/UI/asset/asset.tsx
@@ -78,19 +78,41 @@ const NftAsset = ({ asset, onClick, isSelected }: AssetProps) => {
             ) : null
           }
         >
-          {image || collection?.imageUrl ? (
-            <Box
-              as="img"
-              src={nftItemSrc || (collection?.imageUrl as string)}
-              alt={name}
-              style={{
-                width: 32,
-                height: 32,
-                borderRadius: 8,
-                objectFit: 'cover',
-              }}
-            />
-          ) : null}
+          <Box
+            style={{
+              width: 32,
+              height: 32,
+              borderRadius: 8,
+              minWidth: 32,
+              minHeight: 32,
+            }}
+          >
+            {(image || collection?.imageUrl) ? (
+              <Box
+                as="img"
+                src={nftItemSrc || (collection?.imageUrl as string)}
+                alt={name}
+                style={{
+                  width: '100%',
+                  height: '100%',
+                  borderRadius: 8,
+                  objectFit: 'cover',
+                }}
+              />
+            ) : (
+              <Box
+                style={{
+                  width: '100%',
+                  height: '100%',
+                  borderRadius: 8,
+                  backgroundColor: 'var(--color-background-alternative)',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                }}
+              />
+            )}
+          </Box>
         </BadgeWrapper>
       </Box>
       <Box


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Perfect! I've successfully implemented the fix for the NFT overlapping bug. Let me provide the summary:



The fix addresses the root cause where NFTs without images were rendering `null`, causing layout collapse and overlapping in the virtual list. Now the component always renders a consistent container that maintains the expected dimensions, preventing the overlapping issue.

## **Changelog**

CHANGELOG entry: Fixed perfect! I've successfully implemented the fix for the NFT overlapping bug. Let me provide the summary:



The fix addresses the root cause where NFTs without images were rendering `null`, causing layout collapse and overlapping in the virtual list. Now the component always renders a consistent container that maintains the expected dimensions, preventing the overlapping issue

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/40669

## **Manual testing steps**

1. Hold at least two NFTs, with at least one missing a generated image in the NFTs tab.
2. Click Send.
3. Scroll down to the NFTs section.
4. Notice the NFTs are overlapping in the Send flow.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.