### PR TITLE
chore: bump perps-controller version v3.2.0 cp-13.28.0

### DIFF
--- a/app/scripts/controllers/perps/infrastructure.ts
+++ b/app/scripts/controllers/perps/infrastructure.ts
@@ -257,6 +257,19 @@ function createCacheInvalidator(): PerpsCacheInvalidator {
   };
 }
 
+function createDiskCache(): PerpsPlatformDependencies['diskCache'] {
+  return {
+    getItem: async (key: string) => localStorage.getItem(key),
+    getItemSync: (key: string) => localStorage.getItem(key),
+    setItem: async (key: string, value: string) => {
+      localStorage.setItem(key, value);
+    },
+    removeItem: async (key: string) => {
+      localStorage.removeItem(key);
+    },
+  };
+}
+
 /**
  * Create the complete PerpsPlatformDependencies for the extension.
  *
@@ -276,6 +289,7 @@ export function createPerpsInfrastructure(
     featureFlags: createFeatureFlags(),
     marketDataFormatters: createMarketDataFormatters(),
     cacheInvalidator: createCacheInvalidator(),
+    diskCache: createDiskCache(),
     rewards: {
       getPerpsDiscountForAccount: async (
         _caipAccountId: `${string}:${string}:${string}`,

--- a/package.json
+++ b/package.json
@@ -373,7 +373,7 @@
     "@metamask/permission-controller": "^12.2.1",
     "@metamask/permission-log-controller": "^5.0.0",
     "@metamask/permissions-kernel-snap": "^1.1.0",
-    "@metamask/perps-controller": "^3.0.0",
+    "@metamask/perps-controller": "^3.2.0",
     "@metamask/phishing-controller": "^17.1.1",
     "@metamask/polling-controller": "^16.0.2",
     "@metamask/post-message-stream": "^10.0.0",


### PR DESCRIPTION
## **Description**

Bumps perps-controller to latest package, including an AbortError change that helps reduce 429s on Perps detail screen

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: bumps perps-controller to latest version

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> This is a dependency-only version bump with no direct code changes in the extension; risk is limited to behavioral changes introduced by `@metamask/perps-controller@3.2.0`.
> 
> **Overview**
> Updates the `@metamask/perps-controller` dependency from `^3.1.1` to `^3.2.0`, and refreshes `yarn.lock` to match the new resolved version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b0803a584d655a77ef646a180a088cbbed200d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->