### PR TITLE
ci: update all actions to Node 24

### DIFF
--- a/.github/workflows/check-feature-flag-registry-drift.yml
+++ b/.github/workflows/check-feature-flag-registry-drift.yml
@@ -83,7 +83,7 @@ jobs:
     environment: default-branch
     steps:
       - name: Send Slack notification
-        uses: MetaMask/github-tools/.github/actions/feature-flag-drift-slack-noti@main
+        uses: MetaMask/github-tools/.github/actions/feature-flag-drift-slack-noti@v1
         with:
           title: MetaMask Extension
           slack-webhook: ${{ secrets.SLACK_WEBHOOK_FEATURE_FLAG_DRIFT }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -439,8 +439,8 @@ jobs:
           path: coverage
 
       - name: SonarCloud Scan
-        # This is SonarSource/sonarqube-scan-action@v7.0.0
-        uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9
+        # This is SonarSource/sonarqube-scan-action@v7.1.0
+        uses: SonarSource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 

--- a/.github/workflows/merge-previous-release-branches.yml
+++ b/.github/workflows/merge-previous-release-branches.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Merge previous releases
         if: steps.validate.outputs.is-valid == 'true'
-        uses: metamask/github-tools/.github/actions/merge-previous-releases@v1.2.0
+        uses: metamask/github-tools/.github/actions/merge-previous-releases@v1
         with:
           new-release-branch: ${{ github.event.ref }}
           github-token: ${{ secrets.METAMASK_EXTENSION_BRANCH_SYNC_TOKEN }}

--- a/.github/workflows/release-branch-sync.yml
+++ b/.github/workflows/release-branch-sync.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Sync release branches with stable
-        uses: metamask/github-tools/.github/actions/release-branch-sync@v1.2.0
+        uses: metamask/github-tools/.github/actions/release-branch-sync@v1
         with:
           merged-release-branch: ${{ github.event.pull_request.head.ref }}
           github-token: ${{ secrets.STABLE_SYNC_TOKEN }}


### PR DESCRIPTION
## **Description**

The bulk of the work was done in MetaMask/github-tools#234

This just finishes it off with
-  SonarSource update
- change `@main` to `@v1`
- change `v1.2.0` to `@v1`

## **Changelog**

CHANGELOG entry: null

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**
[skip-e2e]-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only changes that update action references; main risk is CI behavior changes if the new action versions differ or introduce incompatibilities.
> 
> **Overview**
> Updates GitHub Actions workflow dependencies to stable version tags.
> 
> Switches the feature-flag drift Slack notification action from `@main` to `@v1`, changes release branch automation actions from `@v1.2.0` to `@v1`, and bumps the pinned SonarCloud scan action from `v7.0.0` to `v7.1.0` (new commit SHA).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b564078db9524ecf8144933b1e58a7865d39e9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->