### PR TITLE
ci: new speed vs security balance for is-high-risk-environment

### DIFF
--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -17,7 +17,7 @@ jobs:
       # For a `push` event, the branch is `github.ref_name`.
       BRANCH: ${{ github.head_ref || github.ref_name }}
     steps:
-      - name: Checkout and setup high risk environment
+      - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: ${{ github.ref_name == 'main' || github.ref_name == 'stable' || startsWith(github.ref_name, 'release/') }}

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout and setup high risk environment
         uses: MetaMask/action-checkout-and-setup@v3
         with:
-          is-high-risk-environment: true
+          is-high-risk-environment: ${{ github.ref_name == 'main' || github.ref_name == 'stable' || startsWith(github.ref_name, 'release/') }}
           skip-allow-scripts: true
 
       - name: Build storybook

--- a/.github/workflows/build-ts-migration-dashboard.yml
+++ b/.github/workflows/build-ts-migration-dashboard.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v3
         with:
-          is-high-risk-environment: true
+          is-high-risk-environment: ${{ github.ref_name == 'main' || github.ref_name == 'stable' || startsWith(github.ref_name, 'release/') }}
           skip-allow-scripts: true
 
       - name: Build ts migration dashboard

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v3
         with:
-          is-high-risk-environment: ${{ github.ref_name == 'main' || github.ref_name == 'stable' || startsWith(github.ref_name, 'release/') }}
+          is-high-risk-environment: false
           skip-allow-scripts: true
 
       - name: Lint
@@ -449,7 +449,7 @@ jobs:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v3
         with:
-          is-high-risk-environment: ${{ github.ref_name == 'main' || github.ref_name == 'stable' || startsWith(github.ref_name, 'release/') }}
+          is-high-risk-environment: false
           skip-allow-scripts: true
 
       - name: Download artifact 'build-dist-browserify'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,7 +79,7 @@ jobs:
         uses: MetaMask/action-checkout-and-setup@v3
         id: checkout-and-setup
         with:
-          is-high-risk-environment: false
+          is-high-risk-environment: ${{ github.ref_name == 'main' || github.ref_name == 'stable' || startsWith(github.ref_name, 'release/') }}
           cache-node-modules: true
           skip-allow-scripts: true
 
@@ -110,7 +110,7 @@ jobs:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v3
         with:
-          is-high-risk-environment: false
+          is-high-risk-environment: ${{ github.ref_name == 'main' || github.ref_name == 'stable' || startsWith(github.ref_name, 'release/') }}
           skip-allow-scripts: true
 
       - name: Lint
@@ -272,7 +272,6 @@ jobs:
     if: ${{ needs.get-requirements.outputs.skip-everything != 'true' }}
     uses: ./.github/workflows/run-build.yml
     with:
-      is-high-risk-environment: false
       build-name: build-dist-webpack
       build-command: yarn webpack:lavamoat:build --zip
       bundle-analyzer: true
@@ -285,7 +284,6 @@ jobs:
     if: ${{ needs.get-requirements.outputs.skip-everything != 'true' }}
     uses: ./.github/workflows/run-build.yml
     with:
-      is-high-risk-environment: false
       build-name: build-dist-mv2-webpack
       build-command: yarn webpack:lavamoat:build:mv2 --zip
       builds-from-run: ${{ needs.get-requirements.outputs.builds-from-run }}
@@ -297,7 +295,6 @@ jobs:
     if: ${{ needs.get-requirements.outputs.skip-everything != 'true' }}
     uses: ./.github/workflows/run-build.yml
     with:
-      is-high-risk-environment: false
       build-name: build-beta-webpack
       build-command: yarn webpack:lavamoat:build --type beta --zip
       builds-from-run: ${{ needs.get-requirements.outputs.builds-from-run }}
@@ -309,7 +306,6 @@ jobs:
     if: ${{ needs.get-requirements.outputs.skip-everything != 'true' }}
     uses: ./.github/workflows/run-build.yml
     with:
-      is-high-risk-environment: false
       build-name: build-beta-mv2-webpack
       build-command: yarn webpack:lavamoat:build:mv2 --type beta --zip
       builds-from-run: ${{ needs.get-requirements.outputs.builds-from-run }}
@@ -321,7 +317,6 @@ jobs:
     if: ${{ needs.get-requirements.outputs.skip-everything != 'true' }}
     uses: ./.github/workflows/run-build.yml
     with:
-      is-high-risk-environment: false
       build-name: build-flask-webpack
       build-command: yarn webpack:lavamoat:build --type flask --zip
       builds-from-run: ${{ needs.get-requirements.outputs.builds-from-run }}
@@ -333,7 +328,6 @@ jobs:
     if: ${{ needs.get-requirements.outputs.skip-everything != 'true' }}
     uses: ./.github/workflows/run-build.yml
     with:
-      is-high-risk-environment: false
       build-name: build-flask-mv2-webpack
       build-command: yarn webpack:lavamoat:build:mv2 --type flask --zip
       builds-from-run: ${{ needs.get-requirements.outputs.builds-from-run }}
@@ -345,7 +339,6 @@ jobs:
     if: ${{ needs.get-requirements.outputs.skip-everything != 'true' }}
     uses: ./.github/workflows/run-build.yml
     with:
-      is-high-risk-environment: false
       build-name: build-test-webpack
       build-command: yarn build:test:webpack --zip
       builds-from-run: ${{ needs.get-requirements.outputs.builds-from-run }}
@@ -357,7 +350,6 @@ jobs:
     if: ${{ needs.get-requirements.outputs.skip-everything != 'true' }}
     uses: ./.github/workflows/run-build.yml
     with:
-      is-high-risk-environment: false
       build-name: build-test-mv2-webpack
       build-command: yarn build:test:webpack:mv2 --zip
       builds-from-run: ${{ needs.get-requirements.outputs.builds-from-run }}
@@ -369,7 +361,6 @@ jobs:
     if: ${{ needs.get-requirements.outputs.skip-everything != 'true' }}
     uses: ./.github/workflows/run-build.yml
     with:
-      is-high-risk-environment: false
       build-name: build-test-flask-webpack
       build-command: yarn build:test:flask:webpack --zip
       builds-from-run: ${{ needs.get-requirements.outputs.builds-from-run }}
@@ -381,7 +372,6 @@ jobs:
     if: ${{ needs.get-requirements.outputs.skip-everything != 'true' }}
     uses: ./.github/workflows/run-build.yml
     with:
-      is-high-risk-environment: false
       build-name: build-test-flask-mv2-webpack
       build-command: yarn build:test:flask:webpack:mv2 --zip
       builds-from-run: ${{ needs.get-requirements.outputs.builds-from-run }}
@@ -459,7 +449,7 @@ jobs:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v3
         with:
-          is-high-risk-environment: false
+          is-high-risk-environment: ${{ github.ref_name == 'main' || github.ref_name == 'stable' || startsWith(github.ref_name, 'release/') }}
           skip-allow-scripts: true
 
       - name: Download artifact 'build-dist-browserify'

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -46,7 +46,6 @@ jobs:
   build-dist-webpack:
     uses: ./.github/workflows/run-build.yml
     with:
-      is-high-risk-environment: false
       build-name: build-dist-webpack
       build-command: yarn webpack:lavamoat:build --zip
       builds-from-run: ${{ github.run_id }}
@@ -55,7 +54,6 @@ jobs:
   build-dist-mv2-webpack:
     uses: ./.github/workflows/run-build.yml
     with:
-      is-high-risk-environment: false
       build-name: build-dist-mv2-webpack
       build-command: yarn webpack:lavamoat:build:mv2 --zip
       builds-from-run: ${{ github.run_id }}
@@ -64,7 +62,6 @@ jobs:
   build-experimental-webpack:
     uses: ./.github/workflows/run-build.yml
     with:
-      is-high-risk-environment: false
       build-name: build-experimental-webpack
       build-command: yarn webpack:lavamoat:build --type experimental --zip
       builds-from-run: ${{ github.run_id }}
@@ -73,7 +70,6 @@ jobs:
   build-experimental-mv2-webpack:
     uses: ./.github/workflows/run-build.yml
     with:
-      is-high-risk-environment: false
       build-name: build-experimental-mv2-webpack
       build-command: yarn webpack:lavamoat:build:mv2 --type experimental --zip
       builds-from-run: ${{ github.run_id }}
@@ -104,7 +100,7 @@ jobs:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v3
         with:
-          is-high-risk-environment: false
+          is-high-risk-environment: true
           skip-allow-scripts: true
 
       - name: Post nightly builds notification

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -41,10 +41,10 @@ jobs:
       BRANCH: ${{ github.head_ref || github.ref_name }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
-      - name: Checkout and setup
+      - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v3
         with:
-          is-high-risk-environment: true
+          is-high-risk-environment: ${{ github.ref_name == 'main' || github.ref_name == 'stable' || startsWith(github.ref_name, 'release/') }}
           skip-allow-scripts: true
 
       - name: Find the associated PR
@@ -128,10 +128,10 @@ jobs:
       BUILDS_FROM_RUN: ${{ inputs.builds-from-run }}
       TEST_PLAN_VERSION: ${{ needs.generate-test-plan.outputs.test_plan_version }}
     steps:
-      - name: Checkout and setup high risk environment
+      - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v3
         with:
-          is-high-risk-environment: true
+          is-high-risk-environment: ${{ github.ref_name == 'main' || github.ref_name == 'stable' || startsWith(github.ref_name, 'release/') }}
           skip-allow-scripts: true
           fetch-depth: 0 # This is needed to get merge base to calculate bundle size diff
 

--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -3,10 +3,6 @@ name: Run build
 on:
   workflow_call:
     inputs:
-      is-high-risk-environment:
-        type: boolean
-        default: true
-        description: Whether the build is running in a high-risk environment (e.g. production) or not.
       build-name:
         required: true
         type: string
@@ -95,7 +91,7 @@ jobs:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v3
         with:
-          is-high-risk-environment: ${{ inputs.is-high-risk-environment }}
+          is-high-risk-environment: ${{ github.ref_name == 'main' || github.ref_name == 'stable' || startsWith(github.ref_name, 'release/') }}
           skip-allow-scripts: true
 
       # Running tsc is only needed for webpack builds. Webpack uses typescript, but lavamoat node

--- a/development/metamaskbot-build-announce/artifacts.test.ts
+++ b/development/metamaskbot-build-announce/artifacts.test.ts
@@ -48,9 +48,10 @@ describe('buildArtifactsBody', () => {
     expect(result).toContain('Builds ready [abc1234]');
     expect(result).not.toContain('reused from');
     expect(result).toContain(
-      'Please do not use these builds with accounts that contain significant real money, they might not be safe.',
+      'Please do not use these builds with accounts that contain significant real money.',
     );
-    expect(result).not.toContain('REALLY');
+    expect(result).toContain('cache poisoning</a>');
+    expect(result).not.toContain('reused, so they are even more suspect');
   });
 
   it('includes build links and reused tag when builds are reused', () => {
@@ -65,7 +66,7 @@ describe('buildArtifactsBody', () => {
     expect(result).toContain(`metamask-chrome-${VERSION}.zip`);
     expect(result).toContain('Builds ready [def5678] [reused from abc1234]');
     expect(result).toContain(
-      'REALLY please do not use these builds with accounts that contain significant real money, they are extra questionable because they are reused builds.',
+      'Please do not use these builds with accounts that contain significant real money.',
     );
   });
 

--- a/development/metamaskbot-build-announce/artifacts.test.ts
+++ b/development/metamaskbot-build-announce/artifacts.test.ts
@@ -47,6 +47,10 @@ describe('buildArtifactsBody', () => {
     expect(result).toContain('build-dist-webpack');
     expect(result).toContain('Builds ready [abc1234]');
     expect(result).not.toContain('reused from');
+    expect(result).toContain(
+      'Please do not use these builds with accounts that contain significant real money, they might not be safe.',
+    );
+    expect(result).not.toContain('REALLY');
   });
 
   it('includes build links and reused tag when builds are reused', () => {
@@ -60,6 +64,9 @@ describe('buildArtifactsBody', () => {
 
     expect(result).toContain(`metamask-chrome-${VERSION}.zip`);
     expect(result).toContain('Builds ready [def5678] [reused from abc1234]');
+    expect(result).toContain(
+      'REALLY please do not use these builds with accounts that contain significant real money, they are extra questionable because they are reused builds.',
+    );
   });
 
   it('wraps everything in a collapsible details element with the sha', () => {

--- a/development/metamaskbot-build-announce/artifacts.ts
+++ b/development/metamaskbot-build-announce/artifacts.ts
@@ -229,16 +229,16 @@ export function buildArtifactsBody({
     artifacts.link('allArtifacts'),
   );
 
-  const hiddenContent = `<ul>${contentRows
-    .map((row) => `<li>${row}</li>`)
-    .join('\n')}</ul>`;
-
   const isReused = buildsFromSha !== shortSha;
   const reusedTag = isReused ? ` [reused from ${buildsFromSha}]` : '';
 
   const warning = isReused
-    ? `\n\n> ⚠️ **REALLY please do not use these builds with accounts that contain significant real money, they are extra questionable because they are reused builds.**`
-    : `\n\n> ⚠️ Please do not use these builds with accounts that contain significant real money, they might not be safe.`;
+    ? `⚠️ <b>REALLY please do not use these builds with accounts that contain significant real money, they are extra questionable because they are reused builds.</b>`
+    : `⚠️ Please do not use these builds with accounts that contain significant real money, they might not be safe.`;
 
-  return `<details><summary>Builds ready [${shortSha}]${reusedTag}</summary>${hiddenContent}</details>${warning}\n\n`;
+  const hiddenContent = `<p>${warning}</p><ul>${contentRows
+    .map((row) => `<li>${row}</li>`)
+    .join('\n')}</ul>`;
+
+  return `<details><summary>Builds ready [${shortSha}]${reusedTag}</summary>${hiddenContent}</details>\n\n`;
 }

--- a/development/metamaskbot-build-announce/artifacts.ts
+++ b/development/metamaskbot-build-announce/artifacts.ts
@@ -232,11 +232,12 @@ export function buildArtifactsBody({
   const isReused = buildsFromSha !== shortSha;
   const reusedTag = isReused ? ` [reused from ${buildsFromSha}]` : '';
 
-  const warning = isReused
-    ? `⚠️ <b>REALLY please do not use these builds with accounts that contain significant real money, they are extra questionable because they are reused builds.</b>`
-    : `⚠️ Please do not use these builds with accounts that contain significant real money, they might not be safe.`;
+  const warningItem =
+    `<li>⚠️ Make sure the build is safe before downloading and running this build.` +
+    `<ul><li>Please do not use these builds with accounts that contain significant real money.</li>\n` +
+    `<li>Beware the security risks of <a href="https://adnanthekhan.com/2024/05/06/the-monsters-in-your-build-cache-github-actions-cache-poisoning/">cache poisoning</a>.</li></ul></li>`;
 
-  const hiddenContent = `<p>${warning}</p><ul>${contentRows
+  const hiddenContent = `<ul>${warningItem}\n${contentRows
     .map((row) => `<li>${row}</li>`)
     .join('\n')}</ul>`;
 

--- a/development/metamaskbot-build-announce/artifacts.ts
+++ b/development/metamaskbot-build-announce/artifacts.ts
@@ -233,8 +233,12 @@ export function buildArtifactsBody({
     .map((row) => `<li>${row}</li>`)
     .join('\n')}</ul>`;
 
-  const reusedTag =
-    buildsFromSha === shortSha ? '' : ` [reused from ${buildsFromSha}]`;
+  const isReused = buildsFromSha !== shortSha;
+  const reusedTag = isReused ? ` [reused from ${buildsFromSha}]` : '';
 
-  return `<details><summary>Builds ready [${shortSha}]${reusedTag}</summary>${hiddenContent}</details>\n\n`;
+  const warning = isReused
+    ? `\n\n> ⚠️ **REALLY please do not use these builds with accounts that contain significant real money, they are extra questionable because they are reused builds.**`
+    : `\n\n> ⚠️ Please do not use these builds with accounts that contain significant real money, they might not be safe.`;
+
+  return `<details><summary>Builds ready [${shortSha}]${reusedTag}</summary>${hiddenContent}</details>${warning}\n\n`;
 }


### PR DESCRIPTION
## **Description**

### Basic idea

- prep-deps, which writes to cache, should not be reading from cache on main and stable **<-- this is an increase in security**
- build jobs and publish-prerelease, as they do right now on every branch, should not use cache on main and stable **<-- this is the status quo**
- Allow cache in every job on PRs **<-- this is a decrease in security, but a considerable speed gain**

### Enabled by

MetaMask/action-checkout-and-setup#64

### Main decision point
```
 is-high-risk-environment: ${{ github.ref_name == 'main' || github.ref_name == 'stable' || startsWith(github.ref_name, 'release/') }}
```

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Closes: MetaMask/MetaMask-planning#7176

<!--## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**
[skip-e2e]-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI caching/trust boundaries via `is-high-risk-environment`, which can impact build speed and supply-chain risk if misclassified, though changes are localized to workflow configuration and messaging.
> 
> **Overview**
> Adjusts CI to compute `is-high-risk-environment` dynamically based on branch (`main`, `stable`, `release/*`) across build, storybook, TS migration dashboard, and prerelease workflows, and removes the now-redundant `is-high-risk-environment` input/plumbing from the reusable `run-build` workflow.
> 
> Updates the MetaMask bot “Builds ready” PR comment to always include a prominent safety warning (real-money accounts + cache poisoning link), with tests updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 006a500936a9460b1a99298de7146f51b26dcb95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->