### PR TITLE
refactor(bundle-size): add webpack summary rows

### DIFF
--- a/development/metamaskbot-build-announce/bundle-size.test.ts
+++ b/development/metamaskbot-build-announce/bundle-size.test.ts
@@ -78,11 +78,19 @@ describe('buildBundleSizeDiffSection', () => {
     zip: 4200,
     timestamp: 2,
   };
+  const storedBundleSizeData = {
+    [MERGE_BASE]: {
+      background: 1500,
+      ui: 2400,
+      common: 400,
+      other: 80,
+      contentScripts: 40,
+      zip: 4000,
+    },
+  };
 
   function mockSuccessfulFetches(
-    storedData: Record<string, unknown> = {
-      [MERGE_BASE]: { background: 1500, ui: 2400, common: 400 },
-    },
+    storedData: Record<string, unknown> = storedBundleSizeData,
   ) {
     mockFetch
       .mockResolvedValueOnce({
@@ -95,25 +103,37 @@ describe('buildBundleSizeDiffSection', () => {
       } as unknown as Response);
   }
 
-  it('renders rows for other, content scripts, and zip', async () => {
+  it('returns a collapsible details section with size diff rows', async () => {
     mockSuccessfulFetches();
 
     const result = await buildBundleSizeDiffSection(artifacts, MERGE_BASE);
 
     expect(result).toContain('<details>');
     expect(result).toContain('Bundle size diffs');
-    expect(result).toContain('other: total 100 Bytes');
-    expect(result).toContain('content scripts: total 60 Bytes');
-    expect(result).toContain('zip: total 4.1 KiB');
+    expect(result).toContain(
+      'background: total 1.56 KiB, diff +100 Bytes (6.67%)',
+    );
+    expect(result).toContain('ui: total 2.44 KiB, diff +100 Bytes (4.17%)');
+    expect(result).toContain('common: total 400 Bytes, diff 0 Bytes (0%)');
+    expect(result).toContain('other: total 100 Bytes, diff +20 Bytes (25%)');
+    expect(result).toContain(
+      'content scripts: total 60 Bytes, diff +20 Bytes (50%)',
+    );
+    expect(result).toContain('zip: total 4.1 KiB, diff +200 Bytes (5%)');
   });
 
-  it('shows n/a for missing baseline fields during the cutover', async () => {
+  it('renders available diffs and n/a for missing baseline fields during the cutover', async () => {
     mockSuccessfulFetches({
       [MERGE_BASE]: { background: 1500, ui: 2400, common: 400 },
     });
 
     const result = await buildBundleSizeDiffSection(artifacts, MERGE_BASE);
 
+    expect(result).toContain(
+      'background: total 1.56 KiB, diff +100 Bytes (6.67%)',
+    );
+    expect(result).toContain('ui: total 2.44 KiB, diff +100 Bytes (4.17%)');
+    expect(result).toContain('common: total 400 Bytes, diff 0 Bytes (0%)');
     expect(result).toContain('other: total 100 Bytes, diff n/a');
     expect(result).toContain('content scripts: total 60 Bytes, diff n/a');
     expect(result).toContain('zip: total 4.1 KiB, diff n/a');
@@ -126,6 +146,10 @@ describe('buildBundleSizeDiffSection', () => {
 
     expect(result).toContain('Comparison unavailable.');
     expect(result).toContain('background: total 1.56 KiB, diff n/a');
+    expect(result).toContain('ui: total 2.44 KiB, diff n/a');
+    expect(result).toContain('common: total 400 Bytes, diff n/a');
+    expect(result).toContain('other: total 100 Bytes, diff n/a');
+    expect(result).toContain('content scripts: total 60 Bytes, diff n/a');
     expect(result).toContain('zip: total 4.1 KiB, diff n/a');
   });
 
@@ -157,14 +181,42 @@ describe('buildBundleSizeDiffSection', () => {
       } as unknown as Response)
       .mockResolvedValueOnce({
         ok: true,
-        json: () =>
-          Promise.resolve({
-            [MERGE_BASE]: { background: 1500, ui: 2400, common: 400 },
-          }),
+        json: () => Promise.resolve(storedBundleSizeData),
       } as unknown as Response);
 
     const result = await buildBundleSizeDiffSection(artifacts, MERGE_BASE);
 
     expect(result).toContain('Warning! Bundle size has increased!');
+  });
+
+  it('shows a reduction notice when tracked bundles shrink beyond the threshold', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            ...webpackSummary,
+            background: 100,
+            ui: 100,
+            common: 100,
+          }),
+      } as unknown as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(storedBundleSizeData),
+      } as unknown as Response);
+
+    const result = await buildBundleSizeDiffSection(artifacts, MERGE_BASE);
+
+    expect(result).toContain('Bundle size reduced!');
+  });
+
+  it('shows no warning when tracked bundle diffs are within threshold', async () => {
+    mockSuccessfulFetches();
+
+    const result = await buildBundleSizeDiffSection(artifacts, MERGE_BASE);
+
+    expect(result).not.toContain('Warning!');
+    expect(result).not.toContain('Bundle size reduced!');
   });
 });

--- a/development/metamaskbot-build-announce/bundle-size.test.ts
+++ b/development/metamaskbot-build-announce/bundle-size.test.ts
@@ -69,147 +69,102 @@ describe('buildBundleSizeDiffSection', () => {
     '1',
   );
 
-  const prStats = {
-    background: 1100,
-    ui: 2200,
-    common: 300,
-    other: 400,
-    contentScripts: 500,
-    zip: 600,
+  const webpackSummary = {
+    background: 1600,
+    ui: 2500,
+    common: 400,
+    other: 100,
+    contentScripts: 60,
+    zip: 4200,
     timestamp: 2,
   };
-  const devStats = {
-    [MERGE_BASE]: {
-      background: 1000,
-      ui: 2000,
-      common: 300,
-    },
-  };
 
-  function mockSuccessfulFetches() {
+  function mockSuccessfulFetches(
+    storedData: Record<string, unknown> = {
+      [MERGE_BASE]: { background: 1500, ui: 2400, common: 400 },
+    },
+  ) {
     mockFetch
       .mockResolvedValueOnce({
         ok: true,
-        json: () => Promise.resolve(prStats),
+        json: () => Promise.resolve(webpackSummary),
       } as unknown as Response)
       .mockResolvedValueOnce({
         ok: true,
-        json: () => Promise.resolve(devStats),
+        json: () => Promise.resolve(storedData),
       } as unknown as Response);
   }
 
-  it('returns a collapsible details section with size diff rows', async () => {
+  it('renders rows for other, content scripts, and zip', async () => {
     mockSuccessfulFetches();
 
     const result = await buildBundleSizeDiffSection(artifacts, MERGE_BASE);
 
     expect(result).toContain('<details>');
     expect(result).toContain('Bundle size diffs');
-    expect(result).toContain('background:');
-    expect(result).toContain('ui:');
-    expect(result).toContain('common:');
-    expect(result).toContain('other:');
-    expect(result).toContain('contentScripts:');
-    expect(result).toContain('zip:');
+    expect(result).toContain('other: total 100 Bytes');
+    expect(result).toContain('content scripts: total 60 Bytes');
+    expect(result).toContain('zip: total 4.1 KiB');
   });
 
-  it('shows a warning when the background bundle increases beyond the threshold', async () => {
-    const bigIncrease = {
-      background: 3000,
-      ui: 2000,
-      common: 300,
-      other: 0,
-      contentScripts: 0,
-      timestamp: 2,
-    };
-    mockFetch
-      .mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve(bigIncrease),
-      } as unknown as Response)
-      .mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve(devStats),
-      } as unknown as Response);
+  it('shows n/a for missing baseline fields during the cutover', async () => {
+    mockSuccessfulFetches({
+      [MERGE_BASE]: { background: 1500, ui: 2400, common: 400 },
+    });
 
     const result = await buildBundleSizeDiffSection(artifacts, MERGE_BASE);
 
-    expect(result).toContain('Warning! Bundle size has increased!');
+    expect(result).toContain('other: total 100 Bytes, diff n/a');
+    expect(result).toContain('content scripts: total 60 Bytes, diff n/a');
+    expect(result).toContain('zip: total 4.1 KiB, diff n/a');
   });
 
-  it('shows a reduction notice when the bundle shrinks beyond the threshold', async () => {
-    const bigDecrease = {
-      background: 100,
-      ui: 100,
-      common: 100,
-      other: 0,
-      contentScripts: 0,
-      timestamp: 2,
-    };
-    mockFetch
-      .mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve(bigDecrease),
-      } as unknown as Response)
-      .mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve(devStats),
-      } as unknown as Response);
+  it('renders comparison unavailable when the merge base baseline is missing', async () => {
+    mockSuccessfulFetches({});
 
     const result = await buildBundleSizeDiffSection(artifacts, MERGE_BASE);
 
-    expect(result).toContain('Bundle size reduced!');
+    expect(result).toContain('Comparison unavailable.');
+    expect(result).toContain('background: total 1.56 KiB, diff n/a');
+    expect(result).toContain('zip: total 4.1 KiB, diff n/a');
   });
 
-  it('shows no warning when diffs are within threshold', async () => {
-    mockSuccessfulFetches();
-
-    const result = await buildBundleSizeDiffSection(artifacts, MERGE_BASE);
-
-    expect(result).not.toContain('Warning!');
-    expect(result).not.toContain('Bundle size reduced!');
-  });
-
-  it('throws when the PR bundle size stats fetch fails', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      statusText: 'Not Found',
-    } as Response);
-
-    await expect(
-      buildBundleSizeDiffSection(artifacts, MERGE_BASE),
-    ).rejects.toThrow('Failed to fetch prBundleSizeStats');
-  });
-
-  it('throws when the dev bundle size data fetch fails', async () => {
+  it('renders bundle size unavailable when the current summary fetch fails', async () => {
     mockFetch
-      .mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve(prStats),
-      } as unknown as Response)
       .mockResolvedValueOnce({
         ok: false,
         statusText: 'Not Found',
-      } as Response);
-
-    await expect(
-      buildBundleSizeDiffSection(artifacts, MERGE_BASE),
-    ).rejects.toThrow('Failed to fetch devBundleSizeStats');
-  });
-
-  it('uses 0 for dev sizes when the merge base hash is not in the data', async () => {
-    mockFetch
-      .mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve(prStats),
-      } as unknown as Response)
+      } as Response)
       .mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve({}),
       } as unknown as Response);
 
-    const result = await buildBundleSizeDiffSection(artifacts, 'unknown-hash');
+    const result = await buildBundleSizeDiffSection(artifacts, MERGE_BASE);
 
-    expect(result).toContain('Bundle size diffs');
+    expect(result).toContain('Bundle size data unavailable.');
+  });
+
+  it('shows a warning when the background diff exceeds the threshold', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            ...webpackSummary,
+            background: 3000,
+          }),
+      } as unknown as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            [MERGE_BASE]: { background: 1500, ui: 2400, common: 400 },
+          }),
+      } as unknown as Response);
+
+    const result = await buildBundleSizeDiffSection(artifacts, MERGE_BASE);
+
+    expect(result).toContain('Warning! Bundle size has increased!');
   });
 });

--- a/development/metamaskbot-build-announce/bundle-size.ts
+++ b/development/metamaskbot-build-announce/bundle-size.ts
@@ -1,5 +1,24 @@
 import type { ArtifactLinks } from './artifacts';
 
+const bundlePartLabels = {
+  background: 'background',
+  ui: 'ui',
+  common: 'common',
+  other: 'other',
+  contentScripts: 'content scripts',
+} as const;
+
+type BundlePart = keyof typeof bundlePartLabels;
+type BundleSizeSummary = Partial<Record<string, number>>;
+type StoredBundleSizeData = Record<string, BundleSizeSummary>;
+
+const bundleParts = Object.keys(bundlePartLabels) as BundlePart[];
+
+const zipLabel = 'zip';
+
+/** The threshold for whether to highlight a change in bundle size, in bytes. */
+const BUNDLE_SIZE_THRESHOLD = 1_000;
+
 /**
  * Converts a byte count to a human-readable string (e.g. "1.5 KiB").
  *
@@ -15,13 +34,13 @@ export function getHumanReadableSize(bytes: number): string {
   const kibibyteSize = 1024;
   const magnitudes = ['Bytes', 'KiB', 'MiB'];
   let magnitudeIndex = 0;
-  if (absBytes > Math.pow(kibibyteSize, 2)) {
+  if (absBytes > kibibyteSize ** 2) {
     magnitudeIndex = 2;
   } else if (absBytes > kibibyteSize) {
     magnitudeIndex = 1;
   }
   return `${parseFloat(
-    (bytes / Math.pow(kibibyteSize, magnitudeIndex)).toFixed(2),
+    (bytes / kibibyteSize ** magnitudeIndex).toFixed(2),
   )} ${magnitudes[magnitudeIndex]}`;
 }
 
@@ -39,83 +58,173 @@ export function getPercentageChange(from: number, to: number): number {
   return parseFloat((((to - from) / Math.abs(from)) * 100).toFixed(2));
 }
 
-/** The threshold for whether to highlight a change in bundle size, in bytes. */
-const BUNDLE_SIZE_THRESHOLD = 1_000;
+async function fetchJson(url: string, label: string): Promise<unknown> {
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${label}, status ${response.statusText}`);
+  }
+
+  return await response.json();
+}
+
+function getBundlePartSizes(
+  summary: BundleSizeSummary,
+): Record<BundlePart, number> {
+  return Object.fromEntries(
+    bundleParts.map((part) => [part, summary[part] ?? 0]),
+  ) as Record<BundlePart, number>;
+}
+
+function getBaselineSizes(
+  storedBundleSizeData: StoredBundleSizeData | null,
+  mergeBaseCommitHash: string,
+): Partial<Record<BundlePart | 'zip', number>> | null {
+  return storedBundleSizeData?.[mergeBaseCommitHash] ?? null;
+}
+
+function getHumanReadableDiffSize(bytes: number): string {
+  const size = getHumanReadableSize(bytes);
+
+  return bytes > 0 ? `+${size}` : size;
+}
+
+function buildSizeDiffLine({
+  label,
+  currentSize,
+  baselineSize,
+}: {
+  label: string;
+  currentSize: number;
+  baselineSize?: number;
+}): string {
+  if (baselineSize === undefined) {
+    return `${label}: total ${getHumanReadableSize(currentSize)}, diff n/a`;
+  }
+
+  return `${label}: total ${getHumanReadableSize(currentSize)}, diff ${getHumanReadableDiffSize(
+    currentSize - baselineSize,
+  )} (${getPercentageChange(baselineSize, currentSize)}%)`;
+}
+
+function buildSectionBody(lines: string[], prefix?: string): string {
+  const content = lines.map((line) => `<li>${line}</li>`).join('\n');
+  const lead = prefix ? `${prefix}` : '';
+
+  return `${lead}<ul>${content}</ul>`;
+}
+
+function buildDetails(summary: string, body: string): string {
+  return `<details><summary>${summary}</summary>${body}</details>\n\n`;
+}
+
+async function fetchOptionalBundleSizeSummary(
+  url: string,
+): Promise<BundleSizeSummary | null> {
+  try {
+    return (await fetchJson(url, 'bundleSizeStats')) as BundleSizeSummary;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchOptionalStoredBundleSizeData(
+  url: string,
+): Promise<StoredBundleSizeData | null> {
+  try {
+    return (await fetchJson(url, 'bundleSizeData')) as StoredBundleSizeData;
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Fetches bundle size stats and builds the bundle size diff collapsible section.
  *
  * @param artifacts - The artifact links object from getArtifactLinks.
  * @param mergeBaseCommitHash - The merge base commit hash for comparison.
- * @returns HTML string for the bundle size diff section, or empty string on error.
+ * @returns HTML string for the bundle size diff section.
  */
 export async function buildBundleSizeDiffSection(
   artifacts: ArtifactLinks,
   mergeBaseCommitHash: string,
 ): Promise<string> {
-  const prBundleSizeStatsResponse = await fetch(artifacts.bundleSizeStats.url);
-  if (!prBundleSizeStatsResponse.ok) {
-    throw new Error(
-      `Failed to fetch prBundleSizeStats, status ${prBundleSizeStatsResponse.statusText}`,
+  const [currentSummary, storedBundleSizeData] = await Promise.all([
+    fetchOptionalBundleSizeSummary(artifacts.bundleSizeStats.url),
+    fetchOptionalStoredBundleSizeData(artifacts.bundleSizeData.url),
+  ]);
+
+  if (!currentSummary) {
+    return buildDetails('Bundle size diffs', 'Bundle size data unavailable.');
+  }
+
+  const currentSizes = getBundlePartSizes(currentSummary);
+  const currentZipSize = currentSummary.zip ?? 0;
+  const baselineSizes = getBaselineSizes(
+    storedBundleSizeData,
+    mergeBaseCommitHash,
+  );
+
+  if (!baselineSizes) {
+    const unavailableLines = bundleParts.map((part) =>
+      buildSizeDiffLine({
+        label: bundlePartLabels[part],
+        currentSize: currentSizes[part],
+      }),
+    );
+    unavailableLines.push(
+      buildSizeDiffLine({
+        label: zipLabel,
+        currentSize: currentZipSize,
+      }),
+    );
+
+    return buildDetails(
+      'Bundle size diffs',
+      buildSectionBody(unavailableLines, 'Comparison unavailable.'),
     );
   }
-  // This annotation narrows the untyped json() result to the known schema of the bundle size stats artifact.
-  const prBundleSizeStats: Record<string, number> =
-    await prBundleSizeStatsResponse.json();
 
-  const devBundleSizeStatsResponse = await fetch(artifacts.bundleSizeData.url);
-  if (!devBundleSizeStatsResponse.ok) {
-    throw new Error(
-      `Failed to fetch devBundleSizeStats, status ${devBundleSizeStatsResponse.statusText}`,
-    );
-  }
-  // This annotation narrows the untyped json() result to the known schema of the dev bundle size data.
-  const devBundleSizeStats: Record<
-    string,
-    Record<string, number>
-  > = await devBundleSizeStatsResponse.json();
+  const sizeDiffRows = bundleParts.map((part) =>
+    buildSizeDiffLine({
+      label: bundlePartLabels[part],
+      currentSize: currentSizes[part],
+      baselineSize: baselineSizes[part],
+    }),
+  );
+  sizeDiffRows.push(
+    buildSizeDiffLine({
+      label: zipLabel,
+      currentSize: currentZipSize,
+      baselineSize: baselineSizes.zip,
+    }),
+  );
 
-  const bundleParts = [
-    'background',
-    'ui',
-    'common',
-    'other',
-    'contentScripts',
-    ...(prBundleSizeStats.zip === undefined ? [] : ['zip']),
-  ] as const;
-
-  const getDevSize = (part: string) =>
-    devBundleSizeStats[mergeBaseCommitHash]?.[part] ?? 0;
-  const getDiff = (part: string) => prBundleSizeStats[part] - getDevSize(part);
-
-  const sizeDiffRows = bundleParts.map((part) => {
-    return `${part}: ${getHumanReadableSize(getDiff(part))} (${getPercentageChange(
-      getDevSize(part),
-      prBundleSizeStats[part],
-    )}%)`;
-  });
-
-  const sizeDiffHiddenContent = `<ul>${sizeDiffRows
-    .map((row) => `<li>${row}</li>`)
-    .join('\n')}</ul>`;
-
-  const sizeDiffBackground = getDiff('background') + getDiff('common');
-  const sizeDiffUi = getDiff('ui') + getDiff('common');
+  const sizeDiffBackground =
+    currentSizes.background -
+    (baselineSizes.background ?? 0) +
+    currentSizes.common -
+    (baselineSizes.common ?? 0);
+  const sizeDiffUi =
+    currentSizes.ui -
+    (baselineSizes.ui ?? 0) +
+    currentSizes.common -
+    (baselineSizes.common ?? 0);
 
   let sizeDiffWarning: string | undefined;
   if (
     sizeDiffBackground > BUNDLE_SIZE_THRESHOLD ||
     sizeDiffUi > BUNDLE_SIZE_THRESHOLD
   ) {
-    sizeDiffWarning = `🚨 Warning! Bundle size has increased!`;
+    sizeDiffWarning = '🚨 Warning! Bundle size has increased!';
   } else if (
     sizeDiffBackground < -BUNDLE_SIZE_THRESHOLD ||
     sizeDiffUi < -BUNDLE_SIZE_THRESHOLD
   ) {
-    sizeDiffWarning = `🚀 Bundle size reduced!`;
+    sizeDiffWarning = '🚀 Bundle size reduced!';
   }
 
   const sizeDiffTitle = `Bundle size diffs${sizeDiffWarning ? ` [${sizeDiffWarning}]` : ''}`;
 
-  return `<details><summary>${sizeDiffTitle}</summary>${sizeDiffHiddenContent}</details>\n\n`;
+  return buildDetails(sizeDiffTitle, buildSectionBody(sizeDiffRows));
 }


### PR DESCRIPTION
## Summary
- expand the bundle-size comment semantics to include `other`, `content scripts`, and `zip`
- make the renderer tolerate the cutover by handling missing baselines and unavailable comparisons explicitly
- keep the output in the old simple collapsible format for now

## Why
- this isolates the product behavior change from the live CI cutover and from the later presentation polish
- reviewers can focus on row semantics and baseline handling without mixing in markdown/table churn

## Impact
- PR comments surface the new webpack summary categories
- missing baseline values show as `n/a` instead of being misread as hard increases

## Stack

Bundle-size migration stack:

1. #41908 - Add build-owned bundle-size summary emission to `ManifestPlugin`
2. #41909 - Redefine webpack `--stats` and remove analyzer support
3. #41910 - Atomic live cutover for CI, history writing, PR bot, and old collector deletion
4. #41911 - Add webpack summary rows and comment behavior for the new bundle parts (YOU ARE HERE)
5. #41912 - Polish the PR comment layout and missing-baseline behavior
6. #42123 - Share bundle-size summary helpers/types with the PR comment consumer

## Checks
- `yarn lint:changed:fix`
- `yarn test:unit development/metamaskbot-build-announce/bundle-size.test.ts`
