### PR TITLE
fix: Cannot use +/- to define TP/SL thresholds

### DIFF
--- a/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.test.tsx
+++ b/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.test.tsx
@@ -300,7 +300,7 @@ describe('AutoCloseSection', () => {
     });
 
     it('calculates RoE% for long SL position', () => {
-      // (45000 - 40500) / 45000 * 10 * 100 = 100%
+      // (40500 - 45000) / 45000 * 10 * 100 = -100% (loss zone, sign preserved)
       renderWithProvider(
         <AutoCloseSection
           {...defaultProps}
@@ -315,7 +315,7 @@ describe('AutoCloseSection', () => {
 
       const container = screen.getByTestId('sl-percent-input');
       const percentInput = container.querySelector('input');
-      expect(percentInput).toHaveValue('100');
+      expect(percentInput).toHaveValue('-100');
     });
 
     it('shows empty percent when TP price is empty', () => {
@@ -384,7 +384,7 @@ describe('AutoCloseSection', () => {
     });
 
     it('updates price when RoE% is entered for SL (long)', () => {
-      // 10% RoE at leverage=10: priceChange = 10/(10*100) = 1% -> 45000 * 0.99 = 44550
+      // -10% RoE at leverage=10: priceChange = -10/(10*100) = -1% -> 45000 * 0.99 = 44550
       const onStopLossPriceChange = jest.fn();
       renderWithProvider(
         <AutoCloseSection
@@ -402,7 +402,7 @@ describe('AutoCloseSection', () => {
       const input = container.querySelector('input');
       expect(input).not.toBeNull();
       fireEvent.change(input as HTMLInputElement, {
-        target: { value: '10' },
+        target: { value: '-10' },
       });
 
       expect(onStopLossPriceChange).toHaveBeenCalledWith('44550');
@@ -410,7 +410,7 @@ describe('AutoCloseSection', () => {
 
     it('uses limit price as baseline when typing SL % on a limit order', () => {
       // currentPrice=$3,000 but limitPrice=$2,000 (below-market limit buy).
-      // 10% RoE at leverage=10: priceChange = 10/(10*100) = 1% -> $2,000 * 0.99 = $1,980 (not $2,970)
+      // -10% RoE at leverage=10: priceChange = -10/(10*100) = -1% -> $2,000 * 0.99 = $1,980 (not $2,970)
       const onStopLossPriceChange = jest.fn();
       renderWithProvider(
         <AutoCloseSection
@@ -429,7 +429,7 @@ describe('AutoCloseSection', () => {
       const container = screen.getByTestId('sl-percent-input');
       const input = container.querySelector('input');
       expect(input).not.toBeNull();
-      fireEvent.change(input as HTMLInputElement, { target: { value: '10' } });
+      fireEvent.change(input as HTMLInputElement, { target: { value: '-10' } });
 
       expect(onStopLossPriceChange).toHaveBeenCalledWith('1980');
     });
@@ -462,7 +462,7 @@ describe('AutoCloseSection', () => {
 
     it('displays SL % relative to limit price when a price is pre-set on a limit order', () => {
       // SL at $1,980 with limit entry $2,000 at 10x leverage:
-      // RoE% = (2000 - 1980) / 2000 * 10 * 100 = 10%  (not relative to $3,000)
+      // RoE% = (1980 - 2000) / 2000 * 10 * 100 = -10% (loss zone, sign preserved)
       renderWithProvider(
         <AutoCloseSection
           {...defaultProps}
@@ -479,12 +479,12 @@ describe('AutoCloseSection', () => {
 
       const container = screen.getByTestId('sl-percent-input');
       const percentInput = container.querySelector('input');
-      expect(percentInput).toHaveValue('10');
+      expect(percentInput).toHaveValue('-10');
     });
 
     it('falls back to current price for % calculation when limit price is empty', () => {
       // Same as regular market order when limitPrice is empty
-      // 10% RoE at 10x from $3,000: SL = $3,000 * 0.99 = $2,970
+      // -10% RoE at 10x from $3,000: SL = $3,000 * 0.99 = $2,970
       const onStopLossPriceChange = jest.fn();
       renderWithProvider(
         <AutoCloseSection
@@ -503,7 +503,7 @@ describe('AutoCloseSection', () => {
       const container = screen.getByTestId('sl-percent-input');
       const input = container.querySelector('input');
       expect(input).not.toBeNull();
-      fireEvent.change(input as HTMLInputElement, { target: { value: '10' } });
+      fireEvent.change(input as HTMLInputElement, { target: { value: '-10' } });
 
       expect(onStopLossPriceChange).toHaveBeenCalledWith('2970');
     });

--- a/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.tsx
+++ b/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.tsx
@@ -103,11 +103,13 @@ export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
   const [isSlPercentFocused, setIsSlPercentFocused] = useState(false);
 
   /**
-   * Convert a target price to a RoE% for display.
-   * RoE% = ((targetPrice - entryPrice) / entryPrice) * leverage * 100
+   * Convert a target price to a signed RoE% for display.
+   * Positive = profit territory, negative = loss territory.
+   * long:  RoE% = ((price - entry) / entry) * leverage * 100
+   * short: RoE% = -((price - entry) / entry) * leverage * 100
    */
   const priceToPercent = useCallback(
-    (price: string, isTP: boolean): string => {
+    (price: string): string => {
       if (!price || !entryPrice) {
         return '';
       }
@@ -118,36 +120,27 @@ export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
 
       const diff = priceNum - entryPrice;
       const percentChange = (diff / entryPrice) * leverage * 100;
-
-      // For long: TP is above entry (positive RoE%), SL is below entry (show as positive loss%)
-      // For short: TP is below entry (show as positive profit%), SL is above entry (show as positive loss%)
-      if (direction === 'long') {
-        return formatRoePercent(isTP ? percentChange : -percentChange);
-      }
-      return formatRoePercent(isTP ? -percentChange : percentChange);
+      const signedRoe = direction === 'long' ? percentChange : -percentChange;
+      return formatRoePercent(signedRoe);
     },
     [entryPrice, leverage, direction],
   );
 
   /**
-   * Convert a RoE% to a target price.
-   * targetPrice = entryPrice * (1 + roePercent / (leverage * 100))
+   * Convert a signed RoE% to a target price.
+   * Positive signedRoe = profit territory, negative = loss territory.
+   * long:  targetPrice = entryPrice * (1 + signedRoe / (leverage * 100))
+   * short: targetPrice = entryPrice * (1 - signedRoe / (leverage * 100))
    */
   const percentToPrice = useCallback(
-    (percent: number, isTP: boolean): string => {
-      if (!entryPrice || percent === 0) {
+    (signedRoe: number): string => {
+      if (!entryPrice || signedRoe === 0) {
         return '';
       }
 
-      // For long: TP = entry * (1 + roe/lev), SL = entry * (1 - roe/lev)
-      // For short: TP = entry * (1 - roe/lev), SL = entry * (1 + roe/lev)
-      const priceChangeRatio = percent / (leverage * 100);
-      let multiplier: number;
-      if (direction === 'long') {
-        multiplier = isTP ? 1 + priceChangeRatio : 1 - priceChangeRatio;
-      } else {
-        multiplier = isTP ? 1 - priceChangeRatio : 1 + priceChangeRatio;
-      }
+      const priceChangeRatio = signedRoe / (leverage * 100);
+      const multiplier =
+        direction === 'long' ? 1 + priceChangeRatio : 1 - priceChangeRatio;
 
       const price = entryPrice * multiplier;
       const normalizedPrice = Number.parseFloat(price.toFixed(8));
@@ -198,10 +191,10 @@ export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
       if (value === '' || isSignedDecimalInput(value)) {
         setRawTpPercent(value);
         const numValue = parseFloat(value);
-        if (value === '' || value === '-') {
+        if (value === '' || value === '-' || value === '+') {
           onTakeProfitPriceChange('');
         } else if (!isNaN(numValue)) {
-          const newPrice = percentToPrice(numValue, true);
+          const newPrice = percentToPrice(numValue);
           onTakeProfitPriceChange(newPrice);
         }
       }
@@ -211,7 +204,7 @@ export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
 
   const handleTpPercentFocus = useCallback(() => {
     // Seed raw value from current derived percent so the cursor lands on existing content
-    const derived = priceToPercent(takeProfitPrice, true);
+    const derived = priceToPercent(takeProfitPrice);
     setRawTpPercent(derived);
     setIsTpPercentFocused(true);
   }, [priceToPercent, takeProfitPrice]);
@@ -255,10 +248,10 @@ export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
       if (value === '' || isSignedDecimalInput(value)) {
         setRawSlPercent(value);
         const numValue = parseFloat(value);
-        if (value === '' || value === '-') {
+        if (value === '' || value === '-' || value === '+') {
           onStopLossPriceChange('');
         } else if (!isNaN(numValue)) {
-          const newPrice = percentToPrice(numValue, false);
+          const newPrice = percentToPrice(numValue);
           onStopLossPriceChange(newPrice);
         }
       }
@@ -267,7 +260,7 @@ export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
   );
 
   const handleSlPercentFocus = useCallback(() => {
-    const derived = priceToPercent(stopLossPrice, false);
+    const derived = priceToPercent(stopLossPrice);
     setRawSlPercent(derived);
     setIsSlPercentFocused(true);
   }, [priceToPercent, stopLossPrice]);
@@ -279,12 +272,12 @@ export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
 
   // Calculate current RoE percentages for display (used when fields are not focused)
   const tpPercent = useMemo(
-    () => priceToPercent(takeProfitPrice, true),
+    () => priceToPercent(takeProfitPrice),
     [priceToPercent, takeProfitPrice],
   );
 
   const slPercent = useMemo(
-    () => priceToPercent(stopLossPrice, false),
+    () => priceToPercent(stopLossPrice),
     [priceToPercent, stopLossPrice],
   );
 

--- a/ui/components/app/perps/order-entry/utils.test.ts
+++ b/ui/components/app/perps/order-entry/utils.test.ts
@@ -46,11 +46,19 @@ describe('order-entry utils', () => {
       expect(isSignedDecimalInput('12.5')).toBe(true);
     });
 
+    it('accepts + prefix and +. intermediate state', () => {
+      expect(isSignedDecimalInput('+')).toBe(true);
+      expect(isSignedDecimalInput('+.')).toBe(true);
+      expect(isSignedDecimalInput('+12.5')).toBe(true);
+      expect(isSignedDecimalInput('+0')).toBe(true);
+    });
+
     it('rejects invalid signed decimal values', () => {
       expect(isSignedDecimalInput('--1')).toBe(false);
       expect(isSignedDecimalInput('-1-2')).toBe(false);
       expect(isSignedDecimalInput('1.2.3')).toBe(false);
       expect(isSignedDecimalInput('1a')).toBe(false);
+      expect(isSignedDecimalInput('++1')).toBe(false);
     });
   });
 });

--- a/ui/components/app/perps/order-entry/utils.ts
+++ b/ui/components/app/perps/order-entry/utils.ts
@@ -36,13 +36,13 @@ export const isUnsignedDecimalInput = (value: string): boolean => {
 };
 
 /**
- * Linear-time signed decimal validation with optional leading minus and
- * optional single decimal point. Accepts intermediate states like "-" and "-.".
+ * Linear-time signed decimal validation with optional leading sign (+ or -) and
+ * optional single decimal point. Accepts intermediate states like "-", "+", "-.".
  * @param value
  */
 export const isSignedDecimalInput = (value: string): boolean => {
   let startIndex = 0;
-  if (value.startsWith('-')) {
+  if (value.startsWith('-') || value.startsWith('+')) {
     startIndex = 1;
   }
 

--- a/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.test.tsx
+++ b/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.test.tsx
@@ -395,20 +395,36 @@ describe('UpdateTPSLModalContent', () => {
       expect(numValue).toBeCloseTo(3325, 0);
     });
 
-    it('updates SL price when a RoE% value is typed', () => {
-      // ETH: entry=2850, leverage=3, -50% RoE -> 2850 * (1 - 50/300) = 2850 * 0.8333 = 2375
+    it('updates SL price when a negative RoE% value is typed', () => {
+      // ETH: entry=2850, leverage=3, -50% RoE -> 2850 * (1 + (-50)/300) = 2850 * 0.8333 = 2375
       renderTpslModalContent();
 
       const percentInputs = screen.getAllByPlaceholderText('0');
       const slPercentInput = percentInputs[1];
       fireEvent.focus(slPercentInput);
-      fireEvent.change(slPercentInput, { target: { value: '50' } });
+      fireEvent.change(slPercentInput, { target: { value: '-50' } });
 
       const slPriceInput = screen.getAllByPlaceholderText(
         '0.00',
       )[1] as HTMLInputElement;
       const numValue = parseFloat(slPriceInput.value.replace(/,/gu, ''));
       expect(numValue).toBeCloseTo(2375, 0);
+    });
+
+    it('updates SL price when a positive RoE% is typed (SL in profit zone)', () => {
+      // ETH: entry=2850, leverage=3, +15% RoE -> 2850 * (1 + 15/300) = 2850 * 1.05 = 2992.5
+      renderTpslModalContent();
+
+      const percentInputs = screen.getAllByPlaceholderText('0');
+      const slPercentInput = percentInputs[1];
+      fireEvent.focus(slPercentInput);
+      fireEvent.change(slPercentInput, { target: { value: '15' } });
+
+      const slPriceInput = screen.getAllByPlaceholderText(
+        '0.00',
+      )[1] as HTMLInputElement;
+      const numValue = parseFloat(slPriceInput.value.replace(/,/gu, ''));
+      expect(numValue).toBeCloseTo(2992.5, 0);
     });
 
     it('clears TP price when percent input is cleared', () => {

--- a/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.tsx
+++ b/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.tsx
@@ -143,11 +143,13 @@ export const UpdateTPSLModalContent: React.FC<UpdateTPSLModalContentProps> = ({
   );
 
   /**
-   * Convert a target price to a RoE% for display.
-   * RoE% = ((targetPrice - entryPrice) / entryPrice) * leverage * 100
+   * Convert a target price to a signed RoE% for display.
+   * Positive = profit territory, negative = loss territory.
+   * Long: RoE% = ((targetPrice - entryPrice) / entryPrice) * leverage * 100
+   * Short: RoE% = -((targetPrice - entryPrice) / entryPrice) * leverage * 100
    */
   const priceToPercentForEdit = useCallback(
-    (price: string, isTP: boolean): string => {
+    (price: string): string => {
       if (!price || !entryPriceForEdit) {
         return '';
       }
@@ -158,43 +160,42 @@ export const UpdateTPSLModalContent: React.FC<UpdateTPSLModalContentProps> = ({
       }
       const diff = priceNum - entryPriceForEdit;
       const percentChange = (diff / entryPriceForEdit) * leverageForEdit * 100;
-      if (positionDirection === 'long') {
-        return formatRoePercent(isTP ? percentChange : -percentChange);
-      }
-      return formatRoePercent(isTP ? -percentChange : percentChange);
+      const signedRoe =
+        positionDirection === 'long' ? percentChange : -percentChange;
+      return formatRoePercent(signedRoe);
     },
     [entryPriceForEdit, leverageForEdit, positionDirection],
   );
 
   /**
-   * Convert a RoE% to a target price.
-   * targetPrice = entryPrice * (1 + roePercent / (leverage * 100))
+   * Convert a signed RoE% to a target price.
+   * Positive signedRoe = profit territory, negative = loss territory.
+   * long:  targetPrice = entryPrice * (1 + signedRoe / (leverage * 100))
+   * short: targetPrice = entryPrice * (1 - signedRoe / (leverage * 100))
    */
   const percentToPriceForEdit = useCallback(
-    (percent: number, isTP: boolean): string => {
-      if (!entryPriceForEdit || percent === 0) {
+    (signedRoe: number): string => {
+      if (!entryPriceForEdit || signedRoe === 0) {
         return '';
       }
-      const priceChangeRatio = percent / (leverageForEdit * 100);
-      let multiplier: number;
-      if (positionDirection === 'long') {
-        multiplier = isTP ? 1 + priceChangeRatio : 1 - priceChangeRatio;
-      } else {
-        multiplier = isTP ? 1 - priceChangeRatio : 1 + priceChangeRatio;
-      }
+      const priceChangeRatio = signedRoe / (leverageForEdit * 100);
+      const multiplier =
+        positionDirection === 'long'
+          ? 1 + priceChangeRatio
+          : 1 - priceChangeRatio;
       const price = entryPriceForEdit * multiplier;
-      return formatEditPrice(price);
+      return price > 0 ? formatEditPrice(price) : '';
     },
     [entryPriceForEdit, leverageForEdit, positionDirection, formatEditPrice],
   );
 
   const editingTpPercent = useMemo(
-    () => priceToPercentForEdit(editingTpPrice, true),
+    () => priceToPercentForEdit(editingTpPrice),
     [priceToPercentForEdit, editingTpPrice],
   );
 
   const editingSlPercent = useMemo(
-    () => priceToPercentForEdit(editingSlPrice, false),
+    () => priceToPercentForEdit(editingSlPrice),
     [priceToPercentForEdit, editingSlPrice],
   );
 
@@ -273,7 +274,7 @@ export const UpdateTPSLModalContent: React.FC<UpdateTPSLModalContentProps> = ({
 
   const handleTpPresetClick = useCallback(
     (percent: number) => {
-      const newPrice = percentToPriceForEdit(percent, true);
+      const newPrice = percentToPriceForEdit(percent);
       setEditingTpPrice(newPrice);
       // Preserve the exact preset value for display — avoids round-trip drift
       // caused by the price being rounded to 2 decimal places
@@ -286,9 +287,10 @@ export const UpdateTPSLModalContent: React.FC<UpdateTPSLModalContentProps> = ({
 
   const handleSlPresetClick = useCallback(
     (percent: number) => {
-      const newPrice = percentToPriceForEdit(percent, false);
+      // SL presets represent loss percentages — negate to get negative RoE
+      const newPrice = percentToPriceForEdit(-percent);
       setEditingSlPrice(newPrice);
-      const presetStr = String(percent);
+      const presetStr = String(-percent);
       setRawSlPercent(presetStr);
       setSlPresetPercent(presetStr);
     },
@@ -298,14 +300,14 @@ export const UpdateTPSLModalContent: React.FC<UpdateTPSLModalContentProps> = ({
   const handleTpPercentInputChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       const { value } = event.target;
-      if (value === '' || /^-?\d*(?:\.\d*)?$/u.test(value)) {
+      if (value === '' || /^[+-]?\d*(?:\.\d*)?$/u.test(value)) {
         setRawTpPercent(value);
         setTpPresetPercent(null);
         const numValue = Number.parseFloat(value);
-        if (value === '' || value === '-') {
+        if (value === '' || value === '-' || value === '+') {
           setEditingTpPrice('');
         } else if (!Number.isNaN(numValue)) {
-          const newPrice = percentToPriceForEdit(numValue, true);
+          const newPrice = percentToPriceForEdit(numValue);
           setEditingTpPrice(newPrice);
         }
       }
@@ -327,14 +329,14 @@ export const UpdateTPSLModalContent: React.FC<UpdateTPSLModalContentProps> = ({
   const handleSlPercentInputChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       const { value } = event.target;
-      if (value === '' || /^-?\d*(?:\.\d*)?$/u.test(value)) {
+      if (value === '' || /^[+-]?\d*(?:\.\d*)?$/u.test(value)) {
         setRawSlPercent(value);
         setSlPresetPercent(null);
         const numValue = Number.parseFloat(value);
-        if (value === '' || value === '-') {
+        if (value === '' || value === '-' || value === '+') {
           setEditingSlPrice('');
         } else if (!Number.isNaN(numValue)) {
-          const newPrice = percentToPriceForEdit(numValue, false);
+          const newPrice = percentToPriceForEdit(numValue);
           setEditingSlPrice(newPrice);
         }
       }
@@ -537,7 +539,7 @@ export const UpdateTPSLModalContent: React.FC<UpdateTPSLModalContentProps> = ({
           gap={2}
           alignItems={BoxAlignItems.Center}
         >
-          <Box className="flex-1">
+          <Box className="flex-1" data-testid="tpsl-tp-price-input">
             <TextField
               size={TextFieldSize.Md}
               value={editingTpPrice}
@@ -565,7 +567,7 @@ export const UpdateTPSLModalContent: React.FC<UpdateTPSLModalContentProps> = ({
               }
             />
           </Box>
-          <Box className="flex-1">
+          <Box className="flex-1" data-testid="tpsl-tp-percent-input">
             <TextField
               size={TextFieldSize.Md}
               value={
@@ -667,7 +669,7 @@ export const UpdateTPSLModalContent: React.FC<UpdateTPSLModalContentProps> = ({
           gap={2}
           alignItems={BoxAlignItems.Center}
         >
-          <Box className="flex-1">
+          <Box className="flex-1" data-testid="tpsl-sl-price-input">
             <TextField
               size={TextFieldSize.Md}
               value={editingSlPrice}
@@ -695,7 +697,7 @@ export const UpdateTPSLModalContent: React.FC<UpdateTPSLModalContentProps> = ({
               }
             />
           </Box>
-          <Box className="flex-1">
+          <Box className="flex-1" data-testid="tpsl-sl-percent-input">
             <TextField
               size={TextFieldSize.Md}
               value={

--- a/ui/components/app/perps/utils.ts
+++ b/ui/components/app/perps/utils.ts
@@ -494,19 +494,21 @@ export function getPnlDisplayColor(pnl: number): TextColor {
 
 /**
  * Format a RoE% value for display in TP/SL inputs.
- * Always returns the absolute value: integers with no decimal ("25"),
- * non-integers with 2 decimal places ("25.50").
+ * Preserves the sign: negative values are prefixed with "-".
+ * Integers have no decimal ("25"), non-integers use 2 decimal places ("25.50").
  *
  * @param value - The numeric percentage value to format
  * @returns The formatted percentage string
  * @example
  * formatRoePercent(10) => '10'
- * formatRoePercent(-25.5) => '25.50'
+ * formatRoePercent(-25.5) => '-25.50'
  * formatRoePercent(0) => '0'
  */
 export const formatRoePercent = (value: number): string => {
-  const rounded = Math.round(Math.abs(value) * 100) / 100;
-  return Number.isInteger(rounded) ? rounded.toFixed(0) : rounded.toFixed(2);
+  const rounded = Math.round(value * 100) / 100;
+  const abs = Math.abs(rounded);
+  const formatted = Number.isInteger(abs) ? abs.toFixed(0) : abs.toFixed(2);
+  return rounded < 0 ? `-${formatted}` : formatted;
 };
 
 const volumeMultipliers: Record<string, number> = {


### PR DESCRIPTION
## **Description**

Fixes the TP/SL percent input fields rejecting `+` and `-` signs in the perps trading UI. Three bugs were present: (1) `isSignedDecimalInput` only accepted `-`, not `+`; (2) `formatRoePercent` stripped the sign via `Math.abs()`; (3) the price converters used an `isTP` flag instead of reading the sign directly from the input, so typing `-5` produced the same price as `5`. The fix changes the converters to accept a signed RoE value and makes `formatRoePercent` sign-preserving.

## **Changelog**

CHANGELOG entry: Fixed a bug that prevented users from typing `+` or `-` signs in the Take Profit / Stop Loss percent input fields

## **Related issues**

Fixes: TAT-2947

## **Manual testing steps**

1. Open MetaMask with an active perps position on Hyperliquid mainnet
2. Tap the TP/SL row to open the Update TP/SL modal
3. In the TP percent field, type `+15` — price field should update to above entry
4. In the SL percent field, type `-5` — price field should update to below entry
5. Verify the SL percent field shows `-5` (not `5`)
6. Click an SL preset (e.g. `-10%`) — price should be below entry price

## **Screenshots/Recordings**

### **Before**

Typing `+15` in TP% field was silently rejected (no price update). Typing `-5` in SL% field showed the same price as typing `5` (sign ignored). SL presets showed incorrect above-entry prices.

### **After**

`+15` in TP% → price above entry. `-5` in SL% → price below entry. SL display shows `-5` not `5`.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates TP/SL RoE% parsing/formatting and conversion logic in perps order entry and TPSL edit modal, which can change the derived TP/SL prices users submit. Risk is moderate because incorrect sign handling could place thresholds on the wrong side of entry/current price.
> 
> **Overview**
> Fixes perps TP/SL percent fields to fully support signed RoE inputs (accepts `+` and `-`), and ensures the sign is preserved end-to-end rather than being stripped or inferred from an `isTP` flag.
> 
> This refactors `% ↔ price` conversion in `AutoCloseSection` and `UpdateTPSLModalContent` to operate on a *signed* RoE value, updates SL presets to emit negative RoE, and adds guardrails for intermediate `+`/`-` typing states.
> 
> Updates `isSignedDecimalInput` to accept `+` prefixes and changes `formatRoePercent` to preserve negative signs; tests are updated/added to assert correct signed display and price derivation (including limit-order baselines) and new `data-testid`s are added for TP/SL inputs in the update modal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f41936c47de6ceecd693154e4c7d3e508e2c5dce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->