### PR TITLE
fix: smart transaction status page suppression cp-13.28.0

### DIFF
--- a/ui/hooks/useSuppressConfirmNavigate.test.ts
+++ b/ui/hooks/useSuppressConfirmNavigate.test.ts
@@ -1,6 +1,5 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { getExtensionSkipTransactionStatusPage } from '../../shared/lib/selectors/smart-transactions';
-import { selectSmartTransactions } from '../selectors/toast';
 import { useSuppressNavigation } from './useSuppressConfirmNavigate';
 
 const mockUseSelector = jest.fn();
@@ -12,10 +11,6 @@ jest.mock('react-redux', () => ({
 
 jest.mock('../../shared/lib/selectors/smart-transactions', () => ({
   getExtensionSkipTransactionStatusPage: jest.fn(),
-}));
-
-jest.mock('../selectors/toast', () => ({
-  selectSmartTransactions: jest.fn(),
 }));
 
 jest.mock('../../shared/lib/environment-type', () => ({
@@ -30,19 +25,13 @@ describe('useSupressNavigation', () => {
   function renderUseSuppressNavigation({
     toastEnabled,
     isInteractive,
-    smartTransactions = [],
   }: {
     toastEnabled: boolean;
     isInteractive: boolean;
-    smartTransactions?: unknown[];
   }) {
     mockUseSelector.mockImplementation((selector: unknown) => {
       if (selector === getExtensionSkipTransactionStatusPage) {
         return toastEnabled;
-      }
-
-      if (selector === selectSmartTransactions) {
-        return smartTransactions;
       }
 
       return undefined;
@@ -56,7 +45,6 @@ describe('useSupressNavigation', () => {
     const suppressNavigation = renderUseSuppressNavigation({
       toastEnabled: true,
       isInteractive: true,
-      smartTransactions: [{ txId: 'tx-1' }],
     });
 
     expect(
@@ -73,7 +61,6 @@ describe('useSupressNavigation', () => {
     const suppressNavigation = renderUseSuppressNavigation({
       toastEnabled: true,
       isInteractive: true,
-      smartTransactions: [],
     });
 
     expect(suppressNavigation(undefined, [])).toBe(false);
@@ -83,7 +70,6 @@ describe('useSupressNavigation', () => {
     const suppressNavigation = renderUseSuppressNavigation({
       toastEnabled: true,
       isInteractive: true,
-      smartTransactions: [],
     });
 
     expect(

--- a/ui/hooks/useSuppressConfirmNavigate.test.ts
+++ b/ui/hooks/useSuppressConfirmNavigate.test.ts
@@ -69,16 +69,6 @@ describe('useSupressNavigation', () => {
     ).toBe(true);
   });
 
-  it('returns true when there is no confirmation id but a smart transaction approval exists', () => {
-    const suppressNavigation = renderUseSuppressNavigation({
-      toastEnabled: true,
-      isInteractive: true,
-      smartTransactions: [{ txId: 'tx-1' }],
-    });
-
-    expect(suppressNavigation(undefined, [])).toBe(true);
-  });
-
   it('returns false when there is no confirmation id and no smart transaction approval exists', () => {
     const suppressNavigation = renderUseSuppressNavigation({
       toastEnabled: true,

--- a/ui/hooks/useSuppressConfirmNavigate.ts
+++ b/ui/hooks/useSuppressConfirmNavigate.ts
@@ -5,7 +5,6 @@ import type { Json } from '@metamask/utils';
 import { getExtensionSkipTransactionStatusPage } from '../../shared/lib/selectors/smart-transactions';
 import { isInteractiveUI } from '../../shared/lib/environment-type';
 import { SMART_TRANSACTION_CONFIRMATION_TYPES } from '../../shared/constants/app';
-import { selectSmartTransactions } from '../selectors/toast';
 
 // Suppress navigation for smart transaction status page confirmations
 // when transaction toasts are enabled
@@ -13,7 +12,6 @@ export function useSuppressNavigation() {
   const transactionToastsEnabled = useSelector(
     getExtensionSkipTransactionStatusPage,
   );
-  const smartTransactions = useSelector(selectSmartTransactions);
   const isInteractive = isInteractiveUI(); // sidepanel | popup | fullscreen
 
   return useCallback(
@@ -24,10 +22,6 @@ export function useSuppressNavigation() {
       // Ignore if transaction toasts are not enabled and we're not in an interactive environment
       if (!isInteractive || !transactionToastsEnabled) {
         return false;
-      }
-
-      if (!confirmationId) {
-        return smartTransactions.length > 0;
       }
 
       const confirmation = confirmations.find((c) => c.id === confirmationId);
@@ -42,6 +36,6 @@ export function useSuppressNavigation() {
 
       return false;
     },
-    [isInteractive, smartTransactions.length, transactionToastsEnabled],
+    [isInteractive, transactionToastsEnabled],
   );
 }

--- a/ui/pages/confirmations/confirmation/confirmation.js
+++ b/ui/pages/confirmations/confirmation/confirmation.js
@@ -50,7 +50,11 @@ import { Box } from '../../../components/component-library';
 import Loading from '../../../components/ui/loading-screen';
 import SnapAuthorshipHeader from '../../../components/app/snaps/snap-authorship-header';
 import { SnapUIRenderer } from '../../../components/app/snaps/snap-ui-renderer';
-import { SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES } from '../../../../shared/constants/app';
+import {
+  SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES,
+  SMART_TRANSACTION_CONFIRMATION_TYPES,
+} from '../../../../shared/constants/app';
+import { getExtensionSkipTransactionStatusPage } from '../../../../shared/lib/selectors/smart-transactions';
 import { DAY } from '../../../../shared/constants/time';
 import { Nav } from '../components/confirm/nav';
 import { ConfirmContextProvider } from '../context/confirm';
@@ -247,6 +251,9 @@ export default function ConfirmationPage({
   const networkConfigurationsByChainId = useSelector(
     getNetworkConfigurationsByChainId,
   );
+  const skipSmartTransactionStatusPage = useSelector(
+    getExtensionSkipTransactionStatusPage,
+  );
   const [approvalFlowLoadingText, setApprovalFlowLoadingText] = useState(null);
 
   const { id } = useParams();
@@ -305,6 +312,10 @@ export default function ConfirmationPage({
 
   // When pendingConfirmation is undefined, this will also be undefined
   const snapName = isSnapDialog && name;
+
+  const isSmartTransactionStatus =
+    pendingConfirmation?.type ===
+    SMART_TRANSACTION_CONFIRMATION_TYPES.showSmartTransactionStatusPage;
 
   const hasHeaderMaybe = isSnapDialog;
   const hasHeader =
@@ -468,6 +479,10 @@ export default function ConfirmationPage({
       return <Loading loadingMessage={approvalFlowLoadingText} />;
     }
 
+    return null;
+  }
+
+  if (isSmartTransactionStatus && skipSmartTransactionStatusPage) {
     return null;
   }
 

--- a/ui/pages/confirmations/hooks/useConfirmationNavigation.ts
+++ b/ui/pages/confirmations/hooks/useConfirmationNavigation.ts
@@ -23,7 +23,6 @@ import {
   selectPendingApprovalsForNavigation,
 } from '../../../selectors';
 import { sanitizeRedirectUrl } from '../../../../shared/lib/safe-redirect';
-import { useSuppressNavigation } from '../../../hooks/useSuppressConfirmNavigate';
 
 export enum ConfirmationLoader {
   Default = 'default',
@@ -47,7 +46,6 @@ export function useConfirmationNavigation() {
   const confirmations = useSelector(selectPendingApprovalsForNavigation);
   const approvalFlows = useSelector(getApprovalFlows, isEqual);
   const navigate = useNavigate();
-  const suppressNavigation = useSuppressNavigation();
   const { search: queryString } = useLocation();
   const count = confirmations.length;
 
@@ -64,10 +62,6 @@ export function useConfirmationNavigation() {
 
   const navigateToId = useCallback(
     (confirmationId?: string) => {
-      if (suppressNavigation(confirmationId, confirmations)) {
-        return;
-      }
-
       const url = getConfirmationRoute(
         confirmationId,
         confirmations,
@@ -79,13 +73,7 @@ export function useConfirmationNavigation() {
         navigate(url, { replace: true });
       }
     },
-    [
-      approvalFlows?.length,
-      confirmations,
-      navigate,
-      queryString,
-      suppressNavigation,
-    ],
+    [approvalFlows?.length, confirmations, navigate, queryString],
   );
 
   const navigateToIndex = useCallback(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

STX status page was occasionally flashing after the user confirms a Send. There is a race condition between when approvalFlows and pendingApproval gets populated.

This adds a render guard at confirmation.js to prevent the status page from rendering when the flag is on and in a STX confirmation status.


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Enable the extensionSkipStatusPage flag
2. Proceed with a stx Send flow ie. EVM send

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**



https://github.com/user-attachments/assets/caa98b47-2ad6-4ad8-8c35-53eec793fad1




## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes confirmation routing/rendering by skipping the smart transaction status page based on a feature flag, which could inadvertently hide or mis-route confirmations if conditions are incorrect. Scope is limited to the confirmations UI flow with updated unit tests.
> 
> **Overview**
> Refactors smart-transaction status-page suppression to be handled at the `ConfirmationPage` render layer: when the pending confirmation is `showSmartTransactionStatusPage` and `getExtensionSkipTransactionStatusPage` is enabled, the page now returns `null` (effectively skipping that confirmation UI).
> 
> Simplifies `useSuppressNavigation` to only suppress when the *current* confirmation matches the smart-transaction status type (removing the prior fallback based on `selectSmartTransactions` and `confirmationId` being undefined), and removes suppression logic entirely from `useConfirmationNavigation`; associated unit tests were updated to match the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32b44d8bd6a29b9a198e6a0a282076562786e52c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->