### PR TITLE
fix(perps): coalesce candle subscribe races to cut HL 429s cp-13.28.0

### DIFF
--- a/app/scripts/controllers/perps/perps-stream-bridge.test.ts
+++ b/app/scripts/controllers/perps/perps-stream-bridge.test.ts
@@ -360,7 +360,7 @@ describe('PerpsStreamBridge', () => {
       (
         api.perpsActivateStreaming as (
           p: Record<string, unknown>,
-        ) => Promise<string>
+        ) => Promise<void>
       )(params);
 
     it('activates static subscriptions if not yet activated', async () => {
@@ -593,7 +593,7 @@ describe('PerpsStreamBridge', () => {
       await (
         api.perpsActivatePriceStream as (p: {
           symbols: string[];
-        }) => Promise<string>
+        }) => Promise<void>
       )({
         symbols: ['ETH', 'BTC'],
       });
@@ -620,7 +620,7 @@ describe('PerpsStreamBridge', () => {
         api.perpsActivatePriceStream as (p: {
           symbols: string[];
           includeMarketData?: boolean;
-        }) => Promise<string>
+        }) => Promise<void>
       )({
         symbols: ['ETH'],
         includeMarketData: true,
@@ -645,7 +645,7 @@ describe('PerpsStreamBridge', () => {
       await (
         api.perpsActivatePriceStream as (p: {
           symbols: string[];
-        }) => Promise<string>
+        }) => Promise<void>
       )({
         symbols: ['ETH'],
       });
@@ -674,7 +674,7 @@ describe('PerpsStreamBridge', () => {
       await (
         api.perpsActivateOrderBookStream as (p: {
           symbol: string;
-        }) => Promise<string>
+        }) => Promise<void>
       )({
         symbol: 'ETH',
       });
@@ -701,7 +701,7 @@ describe('PerpsStreamBridge', () => {
       await (
         api.perpsActivateOrderBookStream as (p: {
           symbol: string;
-        }) => Promise<string>
+        }) => Promise<void>
       )({
         symbol: 'ETH',
       });
@@ -722,7 +722,7 @@ describe('PerpsStreamBridge', () => {
       await (
         api.perpsActivateCandleStream as (
           p: Record<string, unknown>,
-        ) => Promise<string>
+        ) => Promise<void>
       )({ symbol: 'ETH', interval: '1h', duration: '1d' });
 
       expect(controller.subscribeToCandles).toHaveBeenCalledWith({
@@ -754,7 +754,7 @@ describe('PerpsStreamBridge', () => {
       await (
         api.perpsActivateCandleStream as (
           p: Record<string, unknown>,
-        ) => Promise<string>
+        ) => Promise<void>
       )({ symbol: 'ETH', interval: '1h' });
       (
         api.perpsDeactivateCandleStream as (p: {
@@ -789,12 +789,12 @@ describe('PerpsStreamBridge', () => {
       await (
         api.perpsActivateCandleStream as (
           p: Record<string, unknown>,
-        ) => Promise<string>
+        ) => Promise<void>
       )({ symbol: 'BTC', interval: '1h' });
       await (
         api.perpsActivateCandleStream as (
           p: Record<string, unknown>,
-        ) => Promise<string>
+        ) => Promise<void>
       )({ symbol: 'ETH', interval: '4h' });
 
       expect(controller.subscribeToCandles).toHaveBeenCalledTimes(2);
@@ -817,7 +817,7 @@ describe('PerpsStreamBridge', () => {
       const api = bridge.bridgeApi();
       const activate = api.perpsActivateCandleStream as (
         p: Record<string, unknown>,
-      ) => Promise<string>;
+      ) => Promise<void>;
 
       await activate({ symbol: 'BTC', interval: '5m' });
       await activate({ symbol: 'BTC', interval: '5m' });
@@ -844,7 +844,7 @@ describe('PerpsStreamBridge', () => {
       const api = bridge.bridgeApi();
       const activate = api.perpsActivateCandleStream as (
         p: Record<string, unknown>,
-      ) => Promise<string>;
+      ) => Promise<void>;
 
       const pending = activate({ symbol: 'BTC', interval: '5m' });
       // Let the activation queue behind init, then tear the bridge down.
@@ -874,7 +874,7 @@ describe('PerpsStreamBridge', () => {
       const api = bridge.bridgeApi();
       const activate = api.perpsActivateCandleStream as (
         p: Record<string, unknown>,
-      ) => Promise<string>;
+      ) => Promise<void>;
 
       const first = activate({ symbol: 'BTC', interval: '5m' });
       const second = activate({ symbol: 'BTC', interval: '5m' });
@@ -901,7 +901,7 @@ describe('PerpsStreamBridge', () => {
       const api = bridge.bridgeApi();
       const activate = api.perpsActivateCandleStream as (
         p: Record<string, unknown>,
-      ) => Promise<string>;
+      ) => Promise<void>;
       const deactivate = api.perpsDeactivateCandleStream as (p: {
         symbol: string;
         interval: string;
@@ -931,7 +931,7 @@ describe('PerpsStreamBridge', () => {
       const api = bridge.bridgeApi();
       const activate = api.perpsActivateCandleStream as (
         p: Record<string, unknown>,
-      ) => Promise<string>;
+      ) => Promise<void>;
       const deactivate = api.perpsDeactivateCandleStream as (p: {
         symbol: string;
         interval: string;
@@ -997,7 +997,7 @@ describe('PerpsStreamBridge', () => {
       await (
         bridge.bridgeApi().perpsActivateStreaming as (
           p: Record<string, unknown>,
-        ) => Promise<string>
+        ) => Promise<void>
       )({
         priceSymbols: ['ETH'],
         orderBookSymbol: 'BTC',
@@ -1027,7 +1027,7 @@ describe('PerpsStreamBridge', () => {
       await (
         api.perpsActivateStreaming as (
           p: Record<string, unknown>,
-        ) => Promise<string>
+        ) => Promise<void>
       )({ priceSymbols: ['ETH'] });
 
       expect(() => bridge.destroy()).not.toThrow();
@@ -1071,7 +1071,7 @@ describe('PerpsStreamBridge', () => {
       await (
         api.perpsActivateStreaming as (
           p: Record<string, unknown>,
-        ) => Promise<string>
+        ) => Promise<void>
       )({ priceSymbols: ['ETH'] });
 
       expect(() => {

--- a/app/scripts/controllers/perps/perps-stream-bridge.test.ts
+++ b/app/scripts/controllers/perps/perps-stream-bridge.test.ts
@@ -742,6 +742,7 @@ describe('PerpsStreamBridge', () => {
     });
 
     it('deactivateCandleStream tears down candle subscription', async () => {
+      jest.useFakeTimers();
       const controller = createMockController();
       const unsub = jest.fn();
       controller.subscribeToCandles.mockReturnValue(unsub);
@@ -762,10 +763,14 @@ describe('PerpsStreamBridge', () => {
         }) => void
       )({ symbol: 'ETH', interval: '1h' });
 
+      jest.advanceTimersByTime(150);
+
       expect(unsub).toHaveBeenCalledTimes(1);
+      jest.useRealTimers();
     });
 
     it('keeps other candle streams when deactivating one symbol+interval', async () => {
+      jest.useFakeTimers();
       const controller = createMockController();
       const unsubBtc = jest.fn();
       const unsubEth = jest.fn();
@@ -796,8 +801,89 @@ describe('PerpsStreamBridge', () => {
 
       deactivate({ symbol: 'BTC', interval: '1h' });
 
+      jest.advanceTimersByTime(150);
+
       expect(unsubBtc).toHaveBeenCalledTimes(1);
       expect(unsubEth).not.toHaveBeenCalled();
+      jest.useRealTimers();
+    });
+
+    it('short-circuits when the same candle stream is already active', async () => {
+      jest.useFakeTimers();
+      const controller = createMockController();
+      const { bridge } = createBridge({
+        controller: controller as unknown as PerpsController,
+      });
+      const api = bridge.bridgeApi();
+      const activate = api.perpsActivateCandleStream as (
+        p: Record<string, unknown>,
+      ) => Promise<string>;
+
+      await activate({ symbol: 'BTC', interval: '5m' });
+      await activate({ symbol: 'BTC', interval: '5m' });
+
+      expect(controller.subscribeToCandles).toHaveBeenCalledTimes(1);
+
+      jest.useRealTimers();
+    });
+
+    it('cancels deferred teardown when matching activate arrives within 150ms', async () => {
+      jest.useFakeTimers();
+      const controller = createMockController();
+      const unsub = jest.fn();
+      controller.subscribeToCandles.mockReturnValue(unsub);
+      const { bridge } = createBridge({
+        controller: controller as unknown as PerpsController,
+      });
+      const api = bridge.bridgeApi();
+      const activate = api.perpsActivateCandleStream as (
+        p: Record<string, unknown>,
+      ) => Promise<string>;
+      const deactivate = api.perpsDeactivateCandleStream as (p: {
+        symbol: string;
+        interval: string;
+      }) => void;
+
+      await activate({ symbol: 'BTC', interval: '5m' });
+      deactivate({ symbol: 'BTC', interval: '5m' });
+
+      await activate({ symbol: 'BTC', interval: '5m' });
+
+      jest.advanceTimersByTime(200);
+
+      expect(unsub).not.toHaveBeenCalled();
+      expect(controller.subscribeToCandles).toHaveBeenCalledTimes(1);
+
+      jest.useRealTimers();
+    });
+
+    it('clears pending candle teardown timers on destroy', async () => {
+      jest.useFakeTimers();
+      const controller = createMockController();
+      const unsub = jest.fn();
+      controller.subscribeToCandles.mockReturnValue(unsub);
+      const { bridge } = createBridge({
+        controller: controller as unknown as PerpsController,
+      });
+      const api = bridge.bridgeApi();
+      const activate = api.perpsActivateCandleStream as (
+        p: Record<string, unknown>,
+      ) => Promise<string>;
+      const deactivate = api.perpsDeactivateCandleStream as (p: {
+        symbol: string;
+        interval: string;
+      }) => void;
+
+      await activate({ symbol: 'BTC', interval: '5m' });
+      deactivate({ symbol: 'BTC', interval: '5m' });
+
+      bridge.destroy();
+
+      jest.advanceTimersByTime(200);
+
+      expect(unsub).toHaveBeenCalledTimes(1);
+
+      jest.useRealTimers();
     });
   });
 

--- a/app/scripts/controllers/perps/perps-stream-bridge.test.ts
+++ b/app/scripts/controllers/perps/perps-stream-bridge.test.ts
@@ -827,6 +827,39 @@ describe('PerpsStreamBridge', () => {
       jest.useRealTimers();
     });
 
+    it('coalesces concurrent activate calls for the same key across pending init', async () => {
+      const controller = createMockController();
+      let resolveInit: (() => void) | undefined;
+      const controllerApi = createMockControllerApi();
+      controllerApi.perpsInit.mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveInit = resolve;
+          }),
+      );
+      const { bridge } = createBridge({
+        controller: controller as unknown as PerpsController,
+        controllerApi,
+      });
+      const api = bridge.bridgeApi();
+      const activate = api.perpsActivateCandleStream as (
+        p: Record<string, unknown>,
+      ) => Promise<string>;
+
+      const first = activate({ symbol: 'BTC', interval: '5m' });
+      const second = activate({ symbol: 'BTC', interval: '5m' });
+      const third = activate({ symbol: 'BTC', interval: '5m' });
+
+      // Let both callers pass the synchronous guards and queue behind init.
+      await Promise.resolve();
+
+      resolveInit?.();
+      await Promise.all([first, second, third]);
+
+      expect(controller.subscribeToCandles).toHaveBeenCalledTimes(1);
+      expect(controllerApi.perpsInit).toHaveBeenCalledTimes(1);
+    });
+
     it('cancels deferred teardown when matching activate arrives within 150ms', async () => {
       jest.useFakeTimers();
       const controller = createMockController();

--- a/app/scripts/controllers/perps/perps-stream-bridge.test.ts
+++ b/app/scripts/controllers/perps/perps-stream-bridge.test.ts
@@ -827,6 +827,36 @@ describe('PerpsStreamBridge', () => {
       jest.useRealTimers();
     });
 
+    it('does not subscribe when destroy() runs while init is pending', async () => {
+      const controller = createMockController();
+      let resolveInit: (() => void) | undefined;
+      const controllerApi = createMockControllerApi();
+      controllerApi.perpsInit.mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveInit = resolve;
+          }),
+      );
+      const { bridge } = createBridge({
+        controller: controller as unknown as PerpsController,
+        controllerApi,
+      });
+      const api = bridge.bridgeApi();
+      const activate = api.perpsActivateCandleStream as (
+        p: Record<string, unknown>,
+      ) => Promise<string>;
+
+      const pending = activate({ symbol: 'BTC', interval: '5m' });
+      // Let the activation queue behind init, then tear the bridge down.
+      await Promise.resolve();
+      bridge.destroy();
+
+      resolveInit?.();
+      await pending;
+
+      expect(controller.subscribeToCandles).not.toHaveBeenCalled();
+    });
+
     it('coalesces concurrent activate calls for the same key across pending init', async () => {
       const controller = createMockController();
       let resolveInit: (() => void) | undefined;

--- a/app/scripts/controllers/perps/perps-stream-bridge.test.ts
+++ b/app/scripts/controllers/perps/perps-stream-bridge.test.ts
@@ -890,6 +890,29 @@ describe('PerpsStreamBridge', () => {
       expect(controllerApi.perpsInit).toHaveBeenCalledTimes(1);
     });
 
+    it('resubscribes after destroy() when a later activate runs', async () => {
+      const controller = createMockController();
+      const { bridge } = createBridge({
+        controller: controller as unknown as PerpsController,
+      });
+      const api = bridge.bridgeApi();
+      const activate = api.perpsActivateCandleStream as (
+        p: Record<string, unknown>,
+      ) => Promise<void>;
+
+      await activate({ symbol: 'BTC', interval: '5m' });
+      expect(controller.subscribeToCandles).toHaveBeenCalledTimes(1);
+
+      // Simulate perpsDisconnect / perpsToggleTestnet tearing the bridge down.
+      bridge.destroy();
+
+      // A later activate (e.g. after user reconnects or flips testnet) must
+      // issue a fresh subscribe, not be permanently suppressed by a latched
+      // destroyed flag.
+      await activate({ symbol: 'BTC', interval: '5m' });
+      expect(controller.subscribeToCandles).toHaveBeenCalledTimes(2);
+    });
+
     it('cancels deferred teardown when matching activate arrives within 150ms', async () => {
       jest.useFakeTimers();
       const controller = createMockController();

--- a/app/scripts/controllers/perps/perps-stream-bridge.ts
+++ b/app/scripts/controllers/perps/perps-stream-bridge.ts
@@ -116,6 +116,13 @@ export class PerpsStreamBridge {
 
   #activated = false;
 
+  /**
+   * Set by destroy(); short-circuits any in-flight candle activation that was
+   * awaiting init when destroy() ran, so it cannot issue a subscribe after
+   * the bridge's static unsubs have been torn down.
+   */
+  #destroyed = false;
+
   #wasDisconnected = false;
 
   #isHydrating = false;
@@ -214,10 +221,6 @@ export class PerpsStreamBridge {
         if (pendingTimer !== undefined) {
           clearTimeout(pendingTimer);
           this.#pendingCandleTeardowns.delete(key);
-          console.debug(
-            '[PerpsStreamBridge] deferred teardown cancelled for',
-            key,
-          );
         }
 
         if (this.#dynamicUnsubs[key]) {
@@ -232,6 +235,12 @@ export class PerpsStreamBridge {
 
         const activation = (async () => {
           await this.#initAndActivate();
+          // destroy() may have fired during the await; never subscribe after
+          // the bridge has been torn down (the subscribe would leak past the
+          // point where static/dynamic unsubs are cleared).
+          if (this.#destroyed) {
+            return;
+          }
           // Another caller may have raced us through activation; re-check
           // before issuing the subscribe so we never double-subscribe.
           if (this.#dynamicUnsubs[key]) {
@@ -297,6 +306,8 @@ export class PerpsStreamBridge {
   }
 
   destroy(): void {
+    this.#destroyed = true;
+
     for (const unsub of this.#staticUnsubs) {
       this.#callAndClearUnsub(unsub);
     }

--- a/app/scripts/controllers/perps/perps-stream-bridge.ts
+++ b/app/scripts/controllers/perps/perps-stream-bridge.ts
@@ -93,6 +93,11 @@ export class PerpsStreamBridge {
 
   readonly #dynamicUnsubs: Record<string, () => void> = {};
 
+  readonly #pendingCandleTeardowns = new Map<
+    string,
+    ReturnType<typeof setTimeout>
+  >();
+
   #activated = false;
 
   #wasDisconnected = false;
@@ -187,6 +192,22 @@ export class PerpsStreamBridge {
         interval: CandlePeriod;
         duration?: TimeDuration;
       }) => {
+        const key = this.#candleSubscriptionKey(symbol, interval);
+
+        const pendingTimer = this.#pendingCandleTeardowns.get(key);
+        if (pendingTimer !== undefined) {
+          clearTimeout(pendingTimer);
+          this.#pendingCandleTeardowns.delete(key);
+          console.debug(
+            '[PerpsStreamBridge] deferred teardown cancelled for',
+            key,
+          );
+        }
+
+        if (this.#dynamicUnsubs[key]) {
+          return 'ok';
+        }
+
         await this.#initAndActivate();
         if (this.#isConnectionAlive()) {
           this.#activateCandleStream({ symbol, interval, duration });
@@ -203,7 +224,20 @@ export class PerpsStreamBridge {
         if (!symbol || !interval) {
           return;
         }
-        this.#tearDownDynamicKey(this.#candleSubscriptionKey(symbol, interval));
+        const key = this.#candleSubscriptionKey(symbol, interval);
+
+        const existing = this.#pendingCandleTeardowns.get(key);
+        if (existing !== undefined) {
+          clearTimeout(existing);
+        }
+
+        this.#pendingCandleTeardowns.set(
+          key,
+          setTimeout(() => {
+            this.#pendingCandleTeardowns.delete(key);
+            this.#tearDownDynamicKey(key);
+          }, 150),
+        );
       },
       perpsCheckHealth: () => {
         if (!this.#activated) {
@@ -536,6 +570,11 @@ export class PerpsStreamBridge {
   }
 
   #tearDownAllDynamic(): void {
+    for (const handle of this.#pendingCandleTeardowns.values()) {
+      clearTimeout(handle);
+    }
+    this.#pendingCandleTeardowns.clear();
+
     for (const unsub of Object.values(this.#dynamicUnsubs)) {
       this.#callAndClearUnsub(unsub);
     }

--- a/app/scripts/controllers/perps/perps-stream-bridge.ts
+++ b/app/scripts/controllers/perps/perps-stream-bridge.ts
@@ -117,11 +117,13 @@ export class PerpsStreamBridge {
   #activated = false;
 
   /**
-   * Set by destroy(); short-circuits any in-flight candle activation that was
-   * awaiting init when destroy() ran, so it cannot issue a subscribe after
-   * the bridge's static unsubs have been torn down.
+   * Bumped by destroy(); any candle activation that captured a prior generation
+   * and was awaiting init when destroy() ran will see the mismatch and refuse
+   * to subscribe. A counter (rather than a boolean) means the flag self-resets
+   * on the next init — so perpsDisconnect/perpsToggleTestnet followed by a
+   * fresh perpsInit does not permanently suppress candle subscribes.
    */
-  #destroyed = false;
+  #destroyGeneration = 0;
 
   #wasDisconnected = false;
 
@@ -230,12 +232,15 @@ export class PerpsStreamBridge {
           return;
         }
 
+        const generationAtStart = this.#destroyGeneration;
         const activation = (async () => {
           await this.#initAndActivate();
           // destroy() may have fired during the await; never subscribe after
           // the bridge has been torn down (the subscribe would leak past the
-          // point where static/dynamic unsubs are cleared).
-          if (this.#destroyed) {
+          // point where static/dynamic unsubs are cleared). Using a generation
+          // counter rather than a latched boolean lets later init cycles
+          // re-enable subscribes without needing an explicit reset.
+          if (this.#destroyGeneration !== generationAtStart) {
             return;
           }
           // Another caller may have raced us through activation; re-check
@@ -303,7 +308,7 @@ export class PerpsStreamBridge {
   }
 
   destroy(): void {
-    this.#destroyed = true;
+    this.#destroyGeneration += 1;
 
     for (const unsub of this.#staticUnsubs) {
       this.#callAndClearUnsub(unsub);

--- a/app/scripts/controllers/perps/perps-stream-bridge.ts
+++ b/app/scripts/controllers/perps/perps-stream-bridge.ts
@@ -51,6 +51,11 @@ type PerpsStreamBridgeOptions = {
 
 const REST_HYDRATION_STAGGER_MS = 200;
 
+// Deferred candle-teardown window. A quick deactivate → activate round-trip
+// (e.g. React re-mount) within this window cancels the teardown, avoiding a
+// needless unsubscribe/resubscribe burst on HyperLiquid.
+const CANDLE_TEARDOWN_DEFER_MS = 150;
+
 /**
  * Per-connection bridge between the background PerpsController's WebSocket
  * subscriptions and a single UI outStream.
@@ -205,14 +210,13 @@ export class PerpsStreamBridge {
         }
 
         if (this.#dynamicUnsubs[key]) {
-          return 'ok';
+          return;
         }
 
         await this.#initAndActivate();
         if (this.#isConnectionAlive()) {
           this.#activateCandleStream({ symbol, interval, duration });
         }
-        return 'ok';
       },
       perpsDeactivateCandleStream: ({
         symbol,
@@ -236,7 +240,7 @@ export class PerpsStreamBridge {
           setTimeout(() => {
             this.#pendingCandleTeardowns.delete(key);
             this.#tearDownDynamicKey(key);
-          }, 150),
+          }, CANDLE_TEARDOWN_DEFER_MS),
         );
       },
       perpsCheckHealth: () => {

--- a/app/scripts/controllers/perps/perps-stream-bridge.ts
+++ b/app/scripts/controllers/perps/perps-stream-bridge.ts
@@ -103,6 +103,17 @@ export class PerpsStreamBridge {
     ReturnType<typeof setTimeout>
   >();
 
+  /**
+   * Concurrent-activation guard for candle streams. The synchronous
+   * `#dynamicUnsubs[key]` check only trips after `#activateCandleStream` has
+   * run, which happens *after* `await #initAndActivate()`. Without this map,
+   * two callers for the same {symbol, interval} arriving before init resolves
+   * both pass the early-return and each issue a `subscribeToCandles` (and its
+   * backing `candleSnapshot` REST hit) — exactly the rate-limit burst this
+   * PR is trying to eliminate on cold init / reconnect / rapid market switch.
+   */
+  readonly #pendingCandleActivations = new Map<string, Promise<void>>();
+
   #activated = false;
 
   #wasDisconnected = false;
@@ -213,9 +224,30 @@ export class PerpsStreamBridge {
           return;
         }
 
-        await this.#initAndActivate();
-        if (this.#isConnectionAlive()) {
-          this.#activateCandleStream({ symbol, interval, duration });
+        const existing = this.#pendingCandleActivations.get(key);
+        if (existing !== undefined) {
+          await existing;
+          return;
+        }
+
+        const activation = (async () => {
+          await this.#initAndActivate();
+          // Another caller may have raced us through activation; re-check
+          // before issuing the subscribe so we never double-subscribe.
+          if (this.#dynamicUnsubs[key]) {
+            return;
+          }
+          if (this.#isConnectionAlive()) {
+            this.#activateCandleStream({ symbol, interval, duration });
+          }
+        })();
+        this.#pendingCandleActivations.set(key, activation);
+        try {
+          await activation;
+        } finally {
+          if (this.#pendingCandleActivations.get(key) === activation) {
+            this.#pendingCandleActivations.delete(key);
+          }
         }
       },
       perpsDeactivateCandleStream: ({
@@ -578,6 +610,10 @@ export class PerpsStreamBridge {
       clearTimeout(handle);
     }
     this.#pendingCandleTeardowns.clear();
+    // In-flight activations cannot be aborted, but dropping the map means the
+    // next perpsActivateCandleStream after teardown issues a fresh activation
+    // instead of awaiting an obsolete promise from the pre-teardown session.
+    this.#pendingCandleActivations.clear();
 
     for (const unsub of Object.values(this.#dynamicUnsubs)) {
       this.#callAndClearUnsub(unsub);

--- a/app/scripts/controllers/perps/perps-stream-bridge.ts
+++ b/app/scripts/controllers/perps/perps-stream-bridge.ts
@@ -54,6 +54,10 @@ const REST_HYDRATION_STAGGER_MS = 200;
 // Deferred candle-teardown window. A quick deactivate → activate round-trip
 // (e.g. React re-mount) within this window cancels the teardown, avoiding a
 // needless unsubscribe/resubscribe burst on HyperLiquid.
+//
+// Kept 30 ms longer than the UI-layer CONNECT_DEBOUNCE_MS (120 ms) in
+// ui/providers/perps/CandleStreamChannel.ts so a UI resubscribe debounced
+// by 120 ms still arrives before the bridge commits the teardown.
 const CANDLE_TEARDOWN_DEFER_MS = 150;
 
 /**

--- a/app/scripts/controllers/perps/perps-stream-bridge.ts
+++ b/app/scripts/controllers/perps/perps-stream-bridge.ts
@@ -178,7 +178,6 @@ export class PerpsStreamBridge {
         if (this.#isConnectionAlive()) {
           this.#activateStreaming(params);
         }
-        return 'ok';
       },
       perpsActivatePriceStream: async ({
         symbols,
@@ -191,7 +190,6 @@ export class PerpsStreamBridge {
         if (this.#isConnectionAlive()) {
           this.#activatePriceStream(symbols, includeMarketData);
         }
-        return 'ok';
       },
       perpsDeactivatePriceStream: () => {
         this.#tearDownChannel('prices');
@@ -201,7 +199,6 @@ export class PerpsStreamBridge {
         if (this.#isConnectionAlive()) {
           this.#activateOrderBookStream(symbol);
         }
-        return 'ok';
       },
       perpsDeactivateOrderBookStream: () => {
         this.#tearDownChannel('orderBook');

--- a/ui/components/app/perps/perps-candlestick-chart/perps-candlestick-chart.tsx
+++ b/ui/components/app/perps/perps-candlestick-chart/perps-candlestick-chart.tsx
@@ -111,6 +111,14 @@ const PerpsCandlestickChart = forwardRef<
     // Track previous candle data for incremental update optimization
     const prevCandleCountRef = useRef<number>(0);
     const prevLastCandleTimeRef = useRef<number>(0);
+    // Track the symbol+interval the series was last filled with so we can
+    // force a full setData when the user switches markets or timeframes.
+    // Without this, rapid switches (e.g. xyz:AAPL → xyz:GOLD) can coincide
+    // with the new series having the same length as the old one, sending
+    // the new symbol's candle through the `.update()` path and triggering
+    // lightweight-charts' "Cannot update oldest data" crash.
+    const prevSymbolRef = useRef<string | null>(null);
+    const prevIntervalRef = useRef<string | null>(null);
 
     // Edge detection cooldown
     const lastLoadMoreTimeRef = useRef<number>(0);
@@ -370,18 +378,30 @@ const PerpsCandlestickChart = forwardRef<
       const periodChanged = previousPeriodRef.current !== selectedPeriod;
       previousPeriodRef.current = selectedPeriod;
 
+      // A symbol or interval switch means the series must be rebuilt from
+      // scratch — the new market's candle times are unrelated to the old
+      // market's, so an incremental update would violate lightweight-charts'
+      // monotonic-time invariant.
+      const symbolChanged = prevSymbolRef.current !== candleData.symbol;
+      const intervalChanged = prevIntervalRef.current !== candleData.interval;
+      const seriesIdentityChanged = symbolChanged || intervalChanged;
+
       // Determine update strategy:
       // 1. Same count + same last candle time = live tick update (replace last candle in-place)
       // 2. Count increased by 1 + previous last time still present = new candle appended
-      // 3. Otherwise = full replacement (period change, initial load, fetch-more merge)
+      // 3. Otherwise = full replacement (period change, symbol switch, initial load, fetch-more merge)
       const isLiveTick =
         !periodChanged &&
+        !seriesIdentityChanged &&
         prevCount > 0 &&
         currentCount === prevCount &&
         currentLastTime === prevLastTime;
 
       const isAppend =
-        !periodChanged && prevCount > 0 && currentCount === prevCount + 1;
+        !periodChanged &&
+        !seriesIdentityChanged &&
+        prevCount > 0 &&
+        currentCount === prevCount + 1;
 
       if (isLiveTick || isAppend) {
         // Incremental update — only update the last candle
@@ -426,10 +446,14 @@ const PerpsCandlestickChart = forwardRef<
 
           chartRef.current.timeScale().setVisibleLogicalRange({ from, to });
 
-          // Handle period change: scroll to real time and notify parent
+          // Handle period change: scroll to real time and notify parent.
+          // Also scroll on symbol/interval switch so the new market renders
+          // at the live edge instead of whatever offset the prior series had.
           if (periodChanged) {
             chartRef.current.timeScale().scrollToRealTime();
             onPeriodDataRequest?.(selectedPeriod);
+          } else if (seriesIdentityChanged) {
+            chartRef.current.timeScale().scrollToRealTime();
           }
         }
       }
@@ -437,6 +461,8 @@ const PerpsCandlestickChart = forwardRef<
       // Update tracking refs
       prevCandleCountRef.current = currentCount;
       prevLastCandleTimeRef.current = currentLastTime;
+      prevSymbolRef.current = candleData.symbol;
+      prevIntervalRef.current = candleData.interval;
 
       // Clear flag after chart has applied updates (library may emit crosshair on next frame)
       const timeoutId = setTimeout(() => {

--- a/ui/hooks/perps/coalesceBackgroundRequest.test.ts
+++ b/ui/hooks/perps/coalesceBackgroundRequest.test.ts
@@ -81,6 +81,54 @@ describe('coalesceBackgroundRequest', () => {
     expect(fn).toHaveBeenCalledTimes(2);
   });
 
+  it('invalidate() mid-flight drops the in-flight promise so the next caller issues a fresh request', async () => {
+    let resolveFirst: ((v: string) => void) | undefined;
+    const firstPromise = new Promise<string>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const fn = jest
+      .fn<Promise<string>, []>()
+      .mockReturnValueOnce(firstPromise)
+      .mockResolvedValueOnce('fresh');
+
+    const firstCall = coalesceBackgroundRequest('k', fn);
+    // Flush microtasks so fn() runs and the in-flight entry is settled.
+    await Promise.resolve();
+    invalidateCoalescedRequest('k');
+
+    const secondCall = coalesceBackgroundRequest('k', fn);
+    resolveFirst?.('stale');
+
+    const [first, second] = await Promise.all([firstCall, secondCall]);
+    expect(first).toBe('stale');
+    expect(second).toBe('fresh');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not overwrite a newer cache entry when a previously-invalidated promise resolves late', async () => {
+    let resolveFirst: ((v: string) => void) | undefined;
+    const firstPromise = new Promise<string>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const fn = jest
+      .fn<Promise<string>, []>()
+      .mockReturnValueOnce(firstPromise)
+      .mockResolvedValueOnce('fresh');
+
+    const firstCall = coalesceBackgroundRequest('k', fn);
+    await Promise.resolve();
+    invalidateCoalescedRequest('k');
+    const secondCall = coalesceBackgroundRequest('k', fn);
+    // Resolve the newer call first so its value lands in the cache.
+    await secondCall;
+    // Now the older, evicted promise settles — it must not clobber the fresh cache.
+    resolveFirst?.('stale');
+    await firstCall;
+
+    const third = await coalesceBackgroundRequest('k', fn);
+    expect(third).toBe('fresh');
+  });
+
   it('drops in-flight entry when fn throws synchronously so the next caller retries', async () => {
     const fn = jest
       .fn<Promise<string>, []>()

--- a/ui/hooks/perps/coalesceBackgroundRequest.test.ts
+++ b/ui/hooks/perps/coalesceBackgroundRequest.test.ts
@@ -1,0 +1,83 @@
+import {
+  coalesceBackgroundRequest,
+  invalidateCoalescedRequest,
+  resetCoalesceCacheForTests,
+} from './coalesceBackgroundRequest';
+
+describe('coalesceBackgroundRequest', () => {
+  beforeEach(() => {
+    resetCoalesceCacheForTests();
+  });
+
+  it('dedups concurrent callers with the same key into one in-flight request', async () => {
+    const fn = jest.fn(
+      () => new Promise<number>((resolve) => setTimeout(() => resolve(7), 20)),
+    );
+
+    const [a, b, c] = await Promise.all([
+      coalesceBackgroundRequest('k', fn),
+      coalesceBackgroundRequest('k', fn),
+      coalesceBackgroundRequest('k', fn),
+    ]);
+
+    expect(a).toBe(7);
+    expect(b).toBe(7);
+    expect(c).toBe(7);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('serves cached value inside TTL window without re-invoking fn', async () => {
+    const fn = jest.fn().mockResolvedValue('v1');
+    await coalesceBackgroundRequest('k', fn, 1000);
+    const second = await coalesceBackgroundRequest('k', fn, 1000);
+    expect(second).toBe('v1');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-invokes fn after TTL expires', async () => {
+    const fn = jest
+      .fn()
+      .mockResolvedValueOnce('first')
+      .mockResolvedValueOnce('second');
+    await coalesceBackgroundRequest('k', fn, 5);
+    await new Promise((r) => setTimeout(r, 15));
+    const second = await coalesceBackgroundRequest('k', fn, 5);
+    expect(second).toBe('second');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps cache per-key so different keys do not cross-contaminate', async () => {
+    const fnA = jest.fn().mockResolvedValue('A');
+    const fnB = jest.fn().mockResolvedValue('B');
+    const a = await coalesceBackgroundRequest('a', fnA);
+    const b = await coalesceBackgroundRequest('b', fnB);
+    expect(a).toBe('A');
+    expect(b).toBe('B');
+    expect(fnA).toHaveBeenCalledTimes(1);
+    expect(fnB).toHaveBeenCalledTimes(1);
+  });
+
+  it('invalidate() forces the next call to re-invoke fn', async () => {
+    const fn = jest
+      .fn()
+      .mockResolvedValueOnce('first')
+      .mockResolvedValueOnce('second');
+    await coalesceBackgroundRequest('k', fn, 10_000);
+    invalidateCoalescedRequest('k');
+    const second = await coalesceBackgroundRequest('k', fn, 10_000);
+    expect(second).toBe('second');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('drops in-flight entry on rejection so the next caller retries', async () => {
+    const fn = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce('recovered');
+
+    await expect(coalesceBackgroundRequest('k', fn)).rejects.toThrow('boom');
+    const result = await coalesceBackgroundRequest('k', fn);
+    expect(result).toBe('recovered');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/ui/hooks/perps/coalesceBackgroundRequest.test.ts
+++ b/ui/hooks/perps/coalesceBackgroundRequest.test.ts
@@ -81,52 +81,45 @@ describe('coalesceBackgroundRequest', () => {
     expect(fn).toHaveBeenCalledTimes(2);
   });
 
-  it('invalidate() mid-flight drops the in-flight promise so the next caller issues a fresh request', async () => {
+  it('invalidate() mid-flight preserves the in-flight promise so concurrent callers coalesce into one request', async () => {
+    // Rapid-navigation scenario: hook A fires a request, then hook B's
+    // forceFreshOnMount refetch invalidates the cache while A is still
+    // in flight. B must share A's request rather than fire a duplicate HL
+    // call — the in-flight snapshot is the freshest data available.
     let resolveFirst: ((v: string) => void) | undefined;
     const firstPromise = new Promise<string>((resolve) => {
       resolveFirst = resolve;
     });
-    const fn = jest
-      .fn<Promise<string>, []>()
-      .mockReturnValueOnce(firstPromise)
-      .mockResolvedValueOnce('fresh');
+    const fn = jest.fn<Promise<string>, []>().mockReturnValueOnce(firstPromise);
 
     const firstCall = coalesceBackgroundRequest('k', fn);
-    // Flush microtasks so fn() runs and the in-flight entry is settled.
     await Promise.resolve();
     invalidateCoalescedRequest('k');
 
     const secondCall = coalesceBackgroundRequest('k', fn);
-    resolveFirst?.('stale');
+    resolveFirst?.('shared');
 
     const [first, second] = await Promise.all([firstCall, secondCall]);
-    expect(first).toBe('stale');
-    expect(second).toBe('fresh');
-    expect(fn).toHaveBeenCalledTimes(2);
+    expect(first).toBe('shared');
+    expect(second).toBe('shared');
+    expect(fn).toHaveBeenCalledTimes(1);
   });
 
-  it('does not overwrite a newer cache entry when a previously-invalidated promise resolves late', async () => {
-    let resolveFirst: ((v: string) => void) | undefined;
-    const firstPromise = new Promise<string>((resolve) => {
-      resolveFirst = resolve;
-    });
+  it('invalidate() after resolution forces the next call to fetch fresh', async () => {
+    // Post-resolution invalidate (e.g. pull-to-refresh after a cached
+    // response) must drop the cached value so the next caller hits the
+    // backend again. Tests the cache-only-eviction contract.
     const fn = jest
       .fn<Promise<string>, []>()
-      .mockReturnValueOnce(firstPromise)
-      .mockResolvedValueOnce('fresh');
+      .mockResolvedValueOnce('first')
+      .mockResolvedValueOnce('second');
 
-    const firstCall = coalesceBackgroundRequest('k', fn);
-    await Promise.resolve();
+    await coalesceBackgroundRequest('k', fn);
     invalidateCoalescedRequest('k');
-    const secondCall = coalesceBackgroundRequest('k', fn);
-    // Resolve the newer call first so its value lands in the cache.
-    await secondCall;
-    // Now the older, evicted promise settles — it must not clobber the fresh cache.
-    resolveFirst?.('stale');
-    await firstCall;
+    const second = await coalesceBackgroundRequest('k', fn);
 
-    const third = await coalesceBackgroundRequest('k', fn);
-    expect(third).toBe('fresh');
+    expect(second).toBe('second');
+    expect(fn).toHaveBeenCalledTimes(2);
   });
 
   it('drops in-flight entry when fn throws synchronously so the next caller retries', async () => {

--- a/ui/hooks/perps/coalesceBackgroundRequest.test.ts
+++ b/ui/hooks/perps/coalesceBackgroundRequest.test.ts
@@ -1,4 +1,5 @@
 import {
+  clearAllCoalescedRequests,
   coalesceBackgroundRequest,
   invalidateCoalescedRequest,
   resetCoalesceCacheForTests,
@@ -119,6 +120,34 @@ describe('coalesceBackgroundRequest', () => {
     const second = await coalesceBackgroundRequest('k', fn);
 
     expect(second).toBe('second');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('clearAllCoalescedRequests() drops in-flight promises so a scope-change fetch cannot await the old scope', async () => {
+    // Scope-change scenario (account switch / lock / sign-out): unlike
+    // invalidate(), which preserves the in-flight snapshot as the freshest
+    // data for the *same* scope, a scope change makes the in-flight response
+    // wrong, so it must be abandoned. The next caller issues a fresh
+    // request rather than coalescing with the old one.
+    let resolveFirst: ((v: string) => void) | undefined;
+    const firstPromise = new Promise<string>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const fn = jest
+      .fn<Promise<string>, []>()
+      .mockReturnValueOnce(firstPromise)
+      .mockResolvedValueOnce('newScope');
+
+    const firstCall = coalesceBackgroundRequest('k', fn);
+    await Promise.resolve();
+    clearAllCoalescedRequests();
+
+    const secondCall = coalesceBackgroundRequest('k', fn);
+    resolveFirst?.('oldScope');
+
+    const [first, second] = await Promise.all([firstCall, secondCall]);
+    expect(first).toBe('oldScope');
+    expect(second).toBe('newScope');
     expect(fn).toHaveBeenCalledTimes(2);
   });
 

--- a/ui/hooks/perps/coalesceBackgroundRequest.test.ts
+++ b/ui/hooks/perps/coalesceBackgroundRequest.test.ts
@@ -80,4 +80,20 @@ describe('coalesceBackgroundRequest', () => {
     expect(result).toBe('recovered');
     expect(fn).toHaveBeenCalledTimes(2);
   });
+
+  it('drops in-flight entry when fn throws synchronously so the next caller retries', async () => {
+    const fn = jest
+      .fn<Promise<string>, []>()
+      .mockImplementationOnce(() => {
+        throw new Error('sync boom');
+      })
+      .mockResolvedValueOnce('recovered');
+
+    await expect(coalesceBackgroundRequest('k', fn)).rejects.toThrow(
+      'sync boom',
+    );
+    const result = await coalesceBackgroundRequest('k', fn);
+    expect(result).toBe('recovered');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
 });

--- a/ui/hooks/perps/coalesceBackgroundRequest.ts
+++ b/ui/hooks/perps/coalesceBackgroundRequest.ts
@@ -10,11 +10,17 @@
  *
  * Two layers of dedup are provided: concurrent callers for the same key share
  * one in-flight Promise, and follow-up callers inside the TTL window get the
- * cached value without issuing a new request. 10 s matches the window where a
- * user could reasonably mount → unmount → re-mount the activity page from
- * rapid navigation without staleness being user-visible.
+ * cached value without issuing a new request. 10 s matches the staleness
+ * tolerance of the passive "Recent activity" preview on the perps home — the
+ * only path that actually reads the TTL cache today. Top-level consumers
+ * (`PerpsActivityPage`) pass `forceFreshOnMount` and bypass the cache
+ * entirely.
  *
  * Explicit refetch paths (pull-to-refresh) bypass the cache via invalidate().
+ * Scope-level teardown (account switch, testnet toggle, wallet lock,
+ * sign-out) uses clearAllCoalescedRequests() to drop both the cache and
+ * any in-flight promises so the next scope never awaits the previous
+ * scope's data.
  */
 
 const DEFAULT_TTL_MS = 10_000;
@@ -96,10 +102,24 @@ export function invalidateCoalescedRequest(key: string): void {
 }
 
 /**
+ * Drop every cached value and every in-flight promise.
+ *
+ * Called on scope boundaries where no previous-scope response should ever
+ * land — account switch, testnet toggle, provider swap, wallet lock, and
+ * sign-out. Unlike invalidateCoalescedRequest(), which preserves in-flight
+ * promises (the in-flight snapshot is still the freshest data for the
+ * same scope), a scope change makes the in-flight response definitionally
+ * wrong, so it must be abandoned too.
+ */
+export function clearAllCoalescedRequests(): void {
+  cache.clear();
+  inFlight.clear();
+}
+
+/**
  * Test-only reset. Clears both the cache and any in-flight entries so each
  * test starts from a clean state.
  */
 export function resetCoalesceCacheForTests(): void {
-  cache.clear();
-  inFlight.clear();
+  clearAllCoalescedRequests();
 }

--- a/ui/hooks/perps/coalesceBackgroundRequest.ts
+++ b/ui/hooks/perps/coalesceBackgroundRequest.ts
@@ -50,7 +50,12 @@ export async function coalesceBackgroundRequest<TResult>(
     return existing;
   }
 
-  const promise = (async () => {
+  // Defer fn() invocation to a microtask so `inFlight.set` below has already
+  // committed by the time the body runs. Without this, a synchronous throw in
+  // fn() runs the `finally` cleanup before the entry is inserted (no-op delete),
+  // and the subsequent set stores a permanently-rejected promise that every
+  // future caller re-subscribes to.
+  const promise = Promise.resolve().then(async () => {
     try {
       const value = await fn();
       cache.set(key, { at: Date.now(), value });
@@ -58,7 +63,7 @@ export async function coalesceBackgroundRequest<TResult>(
     } finally {
       inFlight.delete(key);
     }
-  })();
+  });
 
   inFlight.set(key, promise);
   return promise;

--- a/ui/hooks/perps/coalesceBackgroundRequest.ts
+++ b/ui/hooks/perps/coalesceBackgroundRequest.ts
@@ -55,13 +55,21 @@ export async function coalesceBackgroundRequest<TResult>(
   // fn() runs the `finally` cleanup before the entry is inserted (no-op delete),
   // and the subsequent set stores a permanently-rejected promise that every
   // future caller re-subscribes to.
-  const promise = Promise.resolve().then(async () => {
+  let promise: Promise<TResult>;
+  // eslint-disable-next-line prefer-const -- promise is self-referenced inside its own body for identity checks, so the assignment must appear after the declaration.
+  promise = Promise.resolve().then(async () => {
     try {
       const value = await fn();
-      cache.set(key, { at: Date.now(), value });
+      // Only persist if this promise still owns the slot; invalidate() may
+      // have evicted us mid-flight in favor of a newer request.
+      if (inFlight.get(key) === promise) {
+        cache.set(key, { at: Date.now(), value });
+      }
       return value;
     } finally {
-      inFlight.delete(key);
+      if (inFlight.get(key) === promise) {
+        inFlight.delete(key);
+      }
     }
   });
 
@@ -70,13 +78,18 @@ export async function coalesceBackgroundRequest<TResult>(
 }
 
 /**
- * Drop the cached entry for a key. Use before an explicit refetch to force a
- * fresh request (e.g. user-initiated pull-to-refresh).
+ * Drop the cached entry and any in-flight promise for a key. Use before an
+ * explicit refetch to force a fresh request (e.g. user-initiated pull-to-
+ * refresh). Clearing the in-flight entry ensures the next caller issues a
+ * new request instead of awaiting the older snapshot we are trying to bypass;
+ * the older promise still runs to completion but will skip the cache write
+ * and the in-flight cleanup because it no longer owns the slot.
  *
  * @param key - Key previously used with coalesceBackgroundRequest.
  */
 export function invalidateCoalescedRequest(key: string): void {
   cache.delete(key);
+  inFlight.delete(key);
 }
 
 /**

--- a/ui/hooks/perps/coalesceBackgroundRequest.ts
+++ b/ui/hooks/perps/coalesceBackgroundRequest.ts
@@ -54,10 +54,10 @@ export async function coalesceBackgroundRequest<TResult>(
   // committed by the time the body runs. Without this, a synchronous throw in
   // fn() runs the `finally` cleanup before the entry is inserted (no-op delete),
   // and the subsequent set stores a permanently-rejected promise that every
-  // future caller re-subscribes to.
-  let promise: Promise<TResult>;
-  // eslint-disable-next-line prefer-const -- promise is self-referenced inside its own body for identity checks, so the assignment must appear after the declaration.
-  promise = Promise.resolve().then(async () => {
+  // future caller re-subscribes to. The body captures `promise` by closure for
+  // the identity checks below — safe with `const` because the body runs on a
+  // later microtask, after the binding has been initialized.
+  const promise: Promise<TResult> = Promise.resolve().then(async () => {
     try {
       const value = await fn();
       // Only persist if this promise still owns the slot; invalidate() may
@@ -78,18 +78,21 @@ export async function coalesceBackgroundRequest<TResult>(
 }
 
 /**
- * Drop the cached entry and any in-flight promise for a key. Use before an
- * explicit refetch to force a fresh request (e.g. user-initiated pull-to-
- * refresh). Clearing the in-flight entry ensures the next caller issues a
- * new request instead of awaiting the older snapshot we are trying to bypass;
- * the older promise still runs to completion but will skip the cache write
- * and the in-flight cleanup because it no longer owns the slot.
+ * Evict the cached entry for a key. Use before an explicit refetch to force
+ * the next coalesceBackgroundRequest() to hit the backend instead of serving
+ * the previous cached value.
+ *
+ * Intentionally leaves any in-flight promise alone: an in-flight request is
+ * by definition the freshest server snapshot being computed right now, so
+ * concurrent callers (e.g. a `refetch()` racing with a sibling hook's mount
+ * fetch) should coalesce into the same request rather than fire a duplicate
+ * HL call. Dropping the in-flight entry here was the root cause of duplicate
+ * request bursts during rapid navigation.
  *
  * @param key - Key previously used with coalesceBackgroundRequest.
  */
 export function invalidateCoalescedRequest(key: string): void {
   cache.delete(key);
-  inFlight.delete(key);
 }
 
 /**

--- a/ui/hooks/perps/coalesceBackgroundRequest.ts
+++ b/ui/hooks/perps/coalesceBackgroundRequest.ts
@@ -1,0 +1,84 @@
+/**
+ * Module-level coalescing helper for perps background requests.
+ *
+ * Rationale: under rapid UI navigation (or mount/unmount cycles on the perps
+ * activity page), the transaction-history hooks fire 4 concurrent HL REST
+ * calls on every mount — getUserHistory, getOrderFills, getOrders, getFunding.
+ * Each call consumes HL weight against the 1200 wgt/min per-IP budget. Without
+ * coalescing, back-to-back mounts and parallel hook instances on the same
+ * params produce duplicate REST traffic that can tip us over the 429 line.
+ *
+ * Two layers of dedup are provided: concurrent callers for the same key share
+ * one in-flight Promise, and follow-up callers inside the TTL window get the
+ * cached value without issuing a new request. 10 s matches the window where a
+ * user could reasonably mount → unmount → re-mount the activity page from
+ * rapid navigation without staleness being user-visible.
+ *
+ * Explicit refetch paths (pull-to-refresh) bypass the cache via invalidate().
+ */
+
+const DEFAULT_TTL_MS = 10_000;
+
+type CacheEntry<TValue> = { at: number; value: TValue };
+
+const cache = new Map<string, CacheEntry<unknown>>();
+const inFlight = new Map<string, Promise<unknown>>();
+
+/**
+ * Coalesce a background request by key. Concurrent callers with the same key
+ * share one in-flight Promise; callers within the TTL window get the cached
+ * value.
+ *
+ * @param key - Stable key derived from the request method and its params.
+ * @param fn - Thunk that issues the underlying request. Only called on miss.
+ * @param ttlMs - Optional override for the short-cache TTL.
+ * @returns Resolved value from the request (fresh or cached).
+ */
+export async function coalesceBackgroundRequest<TResult>(
+  key: string,
+  fn: () => Promise<TResult>,
+  ttlMs: number = DEFAULT_TTL_MS,
+): Promise<TResult> {
+  const now = Date.now();
+  const cached = cache.get(key) as CacheEntry<TResult> | undefined;
+  if (cached && now - cached.at < ttlMs) {
+    return cached.value;
+  }
+
+  const existing = inFlight.get(key) as Promise<TResult> | undefined;
+  if (existing !== undefined) {
+    return existing;
+  }
+
+  const promise = (async () => {
+    try {
+      const value = await fn();
+      cache.set(key, { at: Date.now(), value });
+      return value;
+    } finally {
+      inFlight.delete(key);
+    }
+  })();
+
+  inFlight.set(key, promise);
+  return promise;
+}
+
+/**
+ * Drop the cached entry for a key. Use before an explicit refetch to force a
+ * fresh request (e.g. user-initiated pull-to-refresh).
+ *
+ * @param key - Key previously used with coalesceBackgroundRequest.
+ */
+export function invalidateCoalescedRequest(key: string): void {
+  cache.delete(key);
+}
+
+/**
+ * Test-only reset. Clears both the cache and any in-flight entries so each
+ * test starts from a clean state.
+ */
+export function resetCoalesceCacheForTests(): void {
+  cache.clear();
+  inFlight.clear();
+}

--- a/ui/hooks/perps/usePerpsTransactionHistory.test.ts
+++ b/ui/hooks/perps/usePerpsTransactionHistory.test.ts
@@ -57,8 +57,13 @@ jest.mock('./useUserHistory', () => ({
     userHistory: [],
     isLoading: false,
     error: null,
+    fetch: jest.fn().mockResolvedValue([]),
     refetch: jest.fn().mockResolvedValue([]),
   }),
+}));
+
+jest.mock('./usePerpsCacheKey', () => ({
+  usePerpsCacheKey: () => 'test-scope',
 }));
 
 // Mock usePerpsLiveFills

--- a/ui/hooks/perps/usePerpsTransactionHistory.test.ts
+++ b/ui/hooks/perps/usePerpsTransactionHistory.test.ts
@@ -1,6 +1,7 @@
 import { renderHook, act } from '@testing-library/react-hooks';
 import type { Order, OrderFill, Funding } from '@metamask/perps-controller';
 import { usePerpsTransactionHistory } from './usePerpsTransactionHistory';
+import { resetCoalesceCacheForTests } from './coalesceBackgroundRequest';
 
 // Mock responses
 const mockFills: OrderFill[] = [
@@ -71,6 +72,7 @@ jest.mock('./stream/usePerpsLiveFills', () => ({
 describe('usePerpsTransactionHistory', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    resetCoalesceCacheForTests();
     // Default: return appropriate data per method
     mockSubmitRequestToBackground.mockImplementation((method: string) => {
       if (method === 'perpsGetOrderFills') {

--- a/ui/hooks/perps/usePerpsTransactionHistory.ts
+++ b/ui/hooks/perps/usePerpsTransactionHistory.ts
@@ -15,7 +15,10 @@ import type {
 import { submitRequestToBackground } from '../../store/background-connection';
 import { useUserHistory } from './useUserHistory';
 import { usePerpsLiveFills } from './stream';
-import { coalesceBackgroundRequest } from './coalesceBackgroundRequest';
+import {
+  coalesceBackgroundRequest,
+  invalidateCoalescedRequest,
+} from './coalesceBackgroundRequest';
 
 /**
  * Parameters for the usePerpsTransactionHistory hook
@@ -190,11 +193,19 @@ export function usePerpsTransactionHistory({
   }, [startTime, endTime, accountId]);
 
   const refetch = useCallback(async () => {
-    // Fetch user history first, then fetch all transactions
+    // Pull-to-refresh must bypass the short-TTL coalesce cache. Drop the three
+    // keys fetchAllTransactions consumes (refetchUserHistory invalidates its
+    // own key internally).
+    const accountKey = accountId ?? '';
+    invalidateCoalescedRequest(`perpsGetOrderFills:${accountKey}:false`);
+    invalidateCoalescedRequest(`perpsGetOrders:${accountKey}`);
+    invalidateCoalescedRequest(
+      `perpsGetFunding:${accountKey}:${startTime ?? ''}:${endTime ?? ''}`,
+    );
     const freshUserHistory = await refetchUserHistory();
     userHistoryRef.current = freshUserHistory;
     await fetchAllTransactions();
-  }, [fetchAllTransactions, refetchUserHistory]);
+  }, [fetchAllTransactions, refetchUserHistory, accountId, startTime, endTime]);
 
   useEffect(() => {
     if (!skipInitialFetch && !initialFetchDone.current) {

--- a/ui/hooks/perps/usePerpsTransactionHistory.ts
+++ b/ui/hooks/perps/usePerpsTransactionHistory.ts
@@ -19,6 +19,7 @@ import {
   coalesceBackgroundRequest,
   invalidateCoalescedRequest,
 } from './coalesceBackgroundRequest';
+import { usePerpsCacheKey } from './usePerpsCacheKey';
 
 /**
  * Parameters for the usePerpsTransactionHistory hook
@@ -94,6 +95,11 @@ export function usePerpsTransactionHistory({
   const [isLoading, setIsLoading] = useState(!skipInitialFetch);
   const [error, setError] = useState<string | null>(null);
 
+  // Scope coalesce keys to the active perps context (provider + testnet +
+  // selected address) so switching accounts or toggling testnet inside the
+  // 10s TTL does not surface the previous session's orders/fills/funding.
+  const perpsScopeKey = usePerpsCacheKey();
+
   // Get user history (includes deposits/withdrawals) - single source of truth
   const {
     userHistory,
@@ -124,17 +130,21 @@ export function usePerpsTransactionHistory({
       const accountKey = accountId ?? '';
       const [fillsResult, ordersResult, funding] = await Promise.all([
         coalesceBackgroundRequest<OrderFill[]>(
-          `perpsGetOrderFills:${accountKey}:false`,
+          `perpsGetOrderFills:${perpsScopeKey}:${accountKey}:false`,
           () =>
             submitRequestToBackground<OrderFill[]>('perpsGetOrderFills', [
               { accountId, aggregateByTime: false },
             ]),
         ),
-        coalesceBackgroundRequest<Order[]>(`perpsGetOrders:${accountKey}`, () =>
-          submitRequestToBackground<Order[]>('perpsGetOrders', [{ accountId }]),
+        coalesceBackgroundRequest<Order[]>(
+          `perpsGetOrders:${perpsScopeKey}:${accountKey}`,
+          () =>
+            submitRequestToBackground<Order[]>('perpsGetOrders', [
+              { accountId },
+            ]),
         ),
         coalesceBackgroundRequest<Funding[]>(
-          `perpsGetFunding:${accountKey}:${startTime ?? ''}:${endTime ?? ''}`,
+          `perpsGetFunding:${perpsScopeKey}:${accountKey}:${startTime ?? ''}:${endTime ?? ''}`,
           () =>
             submitRequestToBackground<Funding[]>('perpsGetFunding', [
               { accountId, startTime, endTime },
@@ -191,7 +201,7 @@ export function usePerpsTransactionHistory({
     } finally {
       setIsLoading(false);
     }
-  }, [startTime, endTime, accountId]);
+  }, [startTime, endTime, accountId, perpsScopeKey]);
 
   const initialFetch = useCallback(async () => {
     // Cache-respecting path — lets rapid re-mounts within the 10s TTL hit the
@@ -206,15 +216,26 @@ export function usePerpsTransactionHistory({
     // keys fetchAllTransactions consumes (refetchUserHistory invalidates its
     // own key internally).
     const accountKey = accountId ?? '';
-    invalidateCoalescedRequest(`perpsGetOrderFills:${accountKey}:false`);
-    invalidateCoalescedRequest(`perpsGetOrders:${accountKey}`);
     invalidateCoalescedRequest(
-      `perpsGetFunding:${accountKey}:${startTime ?? ''}:${endTime ?? ''}`,
+      `perpsGetOrderFills:${perpsScopeKey}:${accountKey}:false`,
+    );
+    invalidateCoalescedRequest(
+      `perpsGetOrders:${perpsScopeKey}:${accountKey}`,
+    );
+    invalidateCoalescedRequest(
+      `perpsGetFunding:${perpsScopeKey}:${accountKey}:${startTime ?? ''}:${endTime ?? ''}`,
     );
     const freshUserHistory = await refetchUserHistory();
     userHistoryRef.current = freshUserHistory;
     await fetchAllTransactions();
-  }, [fetchAllTransactions, refetchUserHistory, accountId, startTime, endTime]);
+  }, [
+    fetchAllTransactions,
+    refetchUserHistory,
+    accountId,
+    startTime,
+    endTime,
+    perpsScopeKey,
+  ]);
 
   useEffect(() => {
     if (!skipInitialFetch && !initialFetchDone.current) {

--- a/ui/hooks/perps/usePerpsTransactionHistory.ts
+++ b/ui/hooks/perps/usePerpsTransactionHistory.ts
@@ -110,6 +110,18 @@ export function usePerpsTransactionHistory({
   // 10s TTL does not surface the previous session's orders/fills/funding.
   const perpsScopeKey = usePerpsCacheKey();
 
+  // Keep the coalesce cache keys in one place so fetch and invalidate can
+  // never drift; a mismatch would silently make `refetch()` bypass a stale
+  // entry on one side while still serving it on the other.
+  const coalesceKeys = useMemo(() => {
+    const accountKey = accountId ?? '';
+    return {
+      fills: `perpsGetOrderFills:${perpsScopeKey}:${accountKey}:false`,
+      orders: `perpsGetOrders:${perpsScopeKey}:${accountKey}`,
+      funding: `perpsGetFunding:${perpsScopeKey}:${accountKey}:${startTime ?? ''}:${endTime ?? ''}`,
+    };
+  }, [accountId, startTime, endTime, perpsScopeKey]);
+
   // Get user history (includes deposits/withdrawals) - single source of truth
   const {
     userHistory,
@@ -140,28 +152,19 @@ export function usePerpsTransactionHistory({
       setIsLoading(true);
       setError(null);
 
-      const accountKey = accountId ?? '';
       const [fillsResult, ordersResult, funding] = await Promise.all([
-        coalesceBackgroundRequest<OrderFill[]>(
-          `perpsGetOrderFills:${perpsScopeKey}:${accountKey}:false`,
-          () =>
-            submitRequestToBackground<OrderFill[]>('perpsGetOrderFills', [
-              { accountId, aggregateByTime: false },
-            ]),
+        coalesceBackgroundRequest<OrderFill[]>(coalesceKeys.fills, () =>
+          submitRequestToBackground<OrderFill[]>('perpsGetOrderFills', [
+            { accountId, aggregateByTime: false },
+          ]),
         ),
-        coalesceBackgroundRequest<Order[]>(
-          `perpsGetOrders:${perpsScopeKey}:${accountKey}`,
-          () =>
-            submitRequestToBackground<Order[]>('perpsGetOrders', [
-              { accountId },
-            ]),
+        coalesceBackgroundRequest<Order[]>(coalesceKeys.orders, () =>
+          submitRequestToBackground<Order[]>('perpsGetOrders', [{ accountId }]),
         ),
-        coalesceBackgroundRequest<Funding[]>(
-          `perpsGetFunding:${perpsScopeKey}:${accountKey}:${startTime ?? ''}:${endTime ?? ''}`,
-          () =>
-            submitRequestToBackground<Funding[]>('perpsGetFunding', [
-              { accountId, startTime, endTime },
-            ]),
+        coalesceBackgroundRequest<Funding[]>(coalesceKeys.funding, () =>
+          submitRequestToBackground<Funding[]>('perpsGetFunding', [
+            { accountId, startTime, endTime },
+          ]),
         ),
       ]);
 
@@ -214,7 +217,7 @@ export function usePerpsTransactionHistory({
     } finally {
       setIsLoading(false);
     }
-  }, [startTime, endTime, accountId, perpsScopeKey]);
+  }, [startTime, endTime, accountId, coalesceKeys]);
 
   const initialFetch = useCallback(async () => {
     // Cache-respecting path — lets rapid re-mounts within the 10s TTL hit the
@@ -228,25 +231,13 @@ export function usePerpsTransactionHistory({
     // Pull-to-refresh must bypass the short-TTL coalesce cache. Drop the three
     // keys fetchAllTransactions consumes (refetchUserHistory invalidates its
     // own key internally).
-    const accountKey = accountId ?? '';
-    invalidateCoalescedRequest(
-      `perpsGetOrderFills:${perpsScopeKey}:${accountKey}:false`,
-    );
-    invalidateCoalescedRequest(`perpsGetOrders:${perpsScopeKey}:${accountKey}`);
-    invalidateCoalescedRequest(
-      `perpsGetFunding:${perpsScopeKey}:${accountKey}:${startTime ?? ''}:${endTime ?? ''}`,
-    );
+    invalidateCoalescedRequest(coalesceKeys.fills);
+    invalidateCoalescedRequest(coalesceKeys.orders);
+    invalidateCoalescedRequest(coalesceKeys.funding);
     const freshUserHistory = await refetchUserHistory();
     userHistoryRef.current = freshUserHistory;
     await fetchAllTransactions();
-  }, [
-    fetchAllTransactions,
-    refetchUserHistory,
-    accountId,
-    startTime,
-    endTime,
-    perpsScopeKey,
-  ]);
+  }, [fetchAllTransactions, refetchUserHistory, coalesceKeys]);
 
   useEffect(() => {
     if (skipInitialFetch) {
@@ -257,7 +248,7 @@ export function usePerpsTransactionHistory({
     // that stays mounted across a scope transition never renders the previous
     // session's transactions. The fingerprint gate keeps unrelated re-renders
     // from triggering redundant fetches.
-    const scopeFingerprint = `${perpsScopeKey}:${accountId ?? ''}:${startTime ?? ''}:${endTime ?? ''}`;
+    const scopeFingerprint = `${perpsScopeKey}:${accountId ?? ''}:${startTime ?? ''}:${endTime ?? ''}:${forceFreshOnMount ? '1' : '0'}`;
     if (lastFetchedScopeRef.current === scopeFingerprint) {
       return;
     }

--- a/ui/hooks/perps/usePerpsTransactionHistory.ts
+++ b/ui/hooks/perps/usePerpsTransactionHistory.ts
@@ -69,6 +69,7 @@ export type UsePerpsTransactionHistoryResult = {
  * @param params.endTime - Optional end time for filtering history (Unix timestamp in ms)
  * @param params.accountId - Optional account ID to fetch history for
  * @param params.skipInitialFetch - Skip the initial fetch on mount (default: false)
+ * @param params.forceFreshOnMount - Force a fresh fetch on mount, bypassing the coalesce TTL cache (default: false)
  * @returns Object containing transactions array, loading state, error, and refetch function
  * @example
  * ```tsx
@@ -124,8 +125,11 @@ export function usePerpsTransactionHistory({
 
   // Store userHistory in ref to avoid recreating fetchAllTransactions callback
   const userHistoryRef = useRef(userHistory);
-  // Track if initial fetch has been done to prevent duplicate fetches
-  const initialFetchDone = useRef(false);
+  // Last scope fingerprint we fetched for. Used to re-fire the initial/refresh
+  // fetch when the account, testnet flag, provider, or time range changes
+  // while the hook stays mounted — without this, switching accounts in-place
+  // would render the previous session's transactions.
+  const lastFetchedScopeRef = useRef<string | undefined>(undefined);
 
   useEffect(() => {
     userHistoryRef.current = userHistory;
@@ -228,9 +232,7 @@ export function usePerpsTransactionHistory({
     invalidateCoalescedRequest(
       `perpsGetOrderFills:${perpsScopeKey}:${accountKey}:false`,
     );
-    invalidateCoalescedRequest(
-      `perpsGetOrders:${perpsScopeKey}:${accountKey}`,
-    );
+    invalidateCoalescedRequest(`perpsGetOrders:${perpsScopeKey}:${accountKey}`);
     invalidateCoalescedRequest(
       `perpsGetFunding:${perpsScopeKey}:${accountKey}:${startTime ?? ''}:${endTime ?? ''}`,
     );
@@ -247,19 +249,38 @@ export function usePerpsTransactionHistory({
   ]);
 
   useEffect(() => {
-    if (!skipInitialFetch && !initialFetchDone.current) {
-      initialFetchDone.current = true;
-      // Activity surfaces that open on user intent (e.g. PerpsActivityPage)
-      // must force a fresh fetch so they never surface a stale snapshot held
-      // by a sibling consumer inside the TTL window. Passive previews (e.g.
-      // Recent Activity on the perps home) still share the cached snapshot.
-      if (forceFreshOnMount) {
-        refetch();
-      } else {
-        initialFetch();
-      }
+    if (skipInitialFetch) {
+      return;
     }
-  }, [skipInitialFetch, forceFreshOnMount, initialFetch, refetch]);
+    // Re-fire the initial fetch whenever the effective scope changes — account
+    // switch, testnet toggle, provider swap, or time-window change — so a hook
+    // that stays mounted across a scope transition never renders the previous
+    // session's transactions. The fingerprint gate keeps unrelated re-renders
+    // from triggering redundant fetches.
+    const scopeFingerprint = `${perpsScopeKey}:${accountId ?? ''}:${startTime ?? ''}:${endTime ?? ''}`;
+    if (lastFetchedScopeRef.current === scopeFingerprint) {
+      return;
+    }
+    lastFetchedScopeRef.current = scopeFingerprint;
+    // Activity surfaces that open on user intent (e.g. PerpsActivityPage)
+    // must force a fresh fetch so they never surface a stale snapshot held
+    // by a sibling consumer inside the TTL window. Passive previews (e.g.
+    // Recent Activity on the perps home) still share the cached snapshot.
+    if (forceFreshOnMount) {
+      refetch();
+    } else {
+      initialFetch();
+    }
+  }, [
+    skipInitialFetch,
+    forceFreshOnMount,
+    perpsScopeKey,
+    accountId,
+    startTime,
+    endTime,
+    initialFetch,
+    refetch,
+  ]);
 
   // Combine loading states
   const combinedIsLoading = useMemo(

--- a/ui/hooks/perps/usePerpsTransactionHistory.ts
+++ b/ui/hooks/perps/usePerpsTransactionHistory.ts
@@ -33,6 +33,14 @@ export type UsePerpsTransactionHistoryParams = {
   accountId?: CaipAccountId;
   /** Skip the initial fetch on mount (default: false) */
   skipInitialFetch?: boolean;
+  /**
+   * Force a fresh fetch on mount, bypassing the coalesce TTL cache.
+   * Intended for top-level activity surfaces where correctness beats dedup
+   * (e.g. opening the activity page must not surface a stale snapshot taken
+   * by another hook consumer). Defaults to false so passive previews (e.g.
+   * "Recent activity" on the perps home) keep sharing the cached snapshot.
+   */
+  forceFreshOnMount?: boolean;
 };
 
 /**
@@ -87,6 +95,7 @@ export function usePerpsTransactionHistory({
   endTime,
   accountId,
   skipInitialFetch = false,
+  forceFreshOnMount = false,
 }: UsePerpsTransactionHistoryParams = {}): UsePerpsTransactionHistoryResult {
   const [transactions, setTransactions] = useState<PerpsTransaction[]>([]);
   // Start in loading state when the hook will auto-fetch on mount so consumers
@@ -240,9 +249,17 @@ export function usePerpsTransactionHistory({
   useEffect(() => {
     if (!skipInitialFetch && !initialFetchDone.current) {
       initialFetchDone.current = true;
-      initialFetch();
+      // Activity surfaces that open on user intent (e.g. PerpsActivityPage)
+      // must force a fresh fetch so they never surface a stale snapshot held
+      // by a sibling consumer inside the TTL window. Passive previews (e.g.
+      // Recent Activity on the perps home) still share the cached snapshot.
+      if (forceFreshOnMount) {
+        refetch();
+      } else {
+        initialFetch();
+      }
     }
-  }, [skipInitialFetch, initialFetch]);
+  }, [skipInitialFetch, forceFreshOnMount, initialFetch, refetch]);
 
   // Combine loading states
   const combinedIsLoading = useMemo(

--- a/ui/hooks/perps/usePerpsTransactionHistory.ts
+++ b/ui/hooks/perps/usePerpsTransactionHistory.ts
@@ -99,6 +99,7 @@ export function usePerpsTransactionHistory({
     userHistory,
     isLoading: userHistoryLoading,
     error: userHistoryError,
+    fetch: fetchUserHistoryCached,
     refetch: refetchUserHistory,
   } = useUserHistory({ startTime, endTime, accountId });
 
@@ -192,6 +193,14 @@ export function usePerpsTransactionHistory({
     }
   }, [startTime, endTime, accountId]);
 
+  const initialFetch = useCallback(async () => {
+    // Cache-respecting path — lets rapid re-mounts within the 10s TTL hit the
+    // coalesce cache instead of re-firing HL calls.
+    const freshUserHistory = await fetchUserHistoryCached();
+    userHistoryRef.current = freshUserHistory;
+    await fetchAllTransactions();
+  }, [fetchAllTransactions, fetchUserHistoryCached]);
+
   const refetch = useCallback(async () => {
     // Pull-to-refresh must bypass the short-TTL coalesce cache. Drop the three
     // keys fetchAllTransactions consumes (refetchUserHistory invalidates its
@@ -210,9 +219,9 @@ export function usePerpsTransactionHistory({
   useEffect(() => {
     if (!skipInitialFetch && !initialFetchDone.current) {
       initialFetchDone.current = true;
-      refetch();
+      initialFetch();
     }
-  }, [skipInitialFetch, refetch]);
+  }, [skipInitialFetch, initialFetch]);
 
   // Combine loading states
   const combinedIsLoading = useMemo(

--- a/ui/hooks/perps/usePerpsTransactionHistory.ts
+++ b/ui/hooks/perps/usePerpsTransactionHistory.ts
@@ -15,6 +15,7 @@ import type {
 import { submitRequestToBackground } from '../../store/background-connection';
 import { useUserHistory } from './useUserHistory';
 import { usePerpsLiveFills } from './stream';
+import { coalesceBackgroundRequest } from './coalesceBackgroundRequest';
 
 /**
  * Parameters for the usePerpsTransactionHistory hook
@@ -84,7 +85,10 @@ export function usePerpsTransactionHistory({
   skipInitialFetch = false,
 }: UsePerpsTransactionHistoryParams = {}): UsePerpsTransactionHistoryResult {
   const [transactions, setTransactions] = useState<PerpsTransaction[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
+  // Start in loading state when the hook will auto-fetch on mount so consumers
+  // (e.g. Recent Activity) render a skeleton instead of the empty-state
+  // "No transactions yet" during the render cycle before the effect fires.
+  const [isLoading, setIsLoading] = useState(!skipInitialFetch);
   const [error, setError] = useState<string | null>(null);
 
   // Get user history (includes deposits/withdrawals) - single source of truth
@@ -113,14 +117,25 @@ export function usePerpsTransactionHistory({
       setIsLoading(true);
       setError(null);
 
+      const accountKey = accountId ?? '';
       const [fillsResult, ordersResult, funding] = await Promise.all([
-        submitRequestToBackground<OrderFill[]>('perpsGetOrderFills', [
-          { accountId, aggregateByTime: false },
-        ]),
-        submitRequestToBackground<Order[]>('perpsGetOrders', [{ accountId }]),
-        submitRequestToBackground<Funding[]>('perpsGetFunding', [
-          { accountId, startTime, endTime },
-        ]),
+        coalesceBackgroundRequest<OrderFill[]>(
+          `perpsGetOrderFills:${accountKey}:false`,
+          () =>
+            submitRequestToBackground<OrderFill[]>('perpsGetOrderFills', [
+              { accountId, aggregateByTime: false },
+            ]),
+        ),
+        coalesceBackgroundRequest<Order[]>(`perpsGetOrders:${accountKey}`, () =>
+          submitRequestToBackground<Order[]>('perpsGetOrders', [{ accountId }]),
+        ),
+        coalesceBackgroundRequest<Funding[]>(
+          `perpsGetFunding:${accountKey}:${startTime ?? ''}:${endTime ?? ''}`,
+          () =>
+            submitRequestToBackground<Funding[]>('perpsGetFunding', [
+              { accountId, startTime, endTime },
+            ]),
+        ),
       ]);
 
       const fills: OrderFill[] = Array.isArray(fillsResult) ? fillsResult : [];

--- a/ui/hooks/perps/usePerpsTransactionHistory.ts
+++ b/ui/hooks/perps/usePerpsTransactionHistory.ts
@@ -113,12 +113,18 @@ export function usePerpsTransactionHistory({
   // Keep the coalesce cache keys in one place so fetch and invalidate can
   // never drift; a mismatch would silently make `refetch()` bypass a stale
   // entry on one side while still serving it on the other.
+  //
+  // Pipe-delimited: CaipAccountId ("eip155:1:0x...") and perpsScopeKey
+  // ("hyperliquid:mainnet:0x...") both contain ':' internally but never '|',
+  // so fields remain unambiguous without paying JSON.stringify on every
+  // render. If a future field can contain '|', switch to a length-prefix
+  // encoder rather than re-introducing delimiter collisions.
   const coalesceKeys = useMemo(() => {
     const accountKey = accountId ?? '';
     return {
-      fills: `perpsGetOrderFills:${perpsScopeKey}:${accountKey}:false`,
-      orders: `perpsGetOrders:${perpsScopeKey}:${accountKey}`,
-      funding: `perpsGetFunding:${perpsScopeKey}:${accountKey}:${startTime ?? ''}:${endTime ?? ''}`,
+      fills: `perpsGetOrderFills|${perpsScopeKey}|${accountKey}|false`,
+      orders: `perpsGetOrders|${perpsScopeKey}|${accountKey}`,
+      funding: `perpsGetFunding|${perpsScopeKey}|${accountKey}|${startTime ?? ''}|${endTime ?? ''}`,
     };
   }, [accountId, startTime, endTime, perpsScopeKey]);
 
@@ -142,12 +148,20 @@ export function usePerpsTransactionHistory({
   // while the hook stays mounted — without this, switching accounts in-place
   // would render the previous session's transactions.
   const lastFetchedScopeRef = useRef<string | undefined>(undefined);
+  // Guards async state commits against scope-change races: if the user
+  // switches account / toggles testnet / changes time range while a fetch is
+  // mid-flight, its resolution must not overwrite state with the previous
+  // scope's data. Each fetch captures a generation at start and only commits
+  // if still current.
+  const fetchGenerationRef = useRef(0);
 
   useEffect(() => {
     userHistoryRef.current = userHistory;
   }, [userHistory]);
 
   const fetchAllTransactions = useCallback(async () => {
+    fetchGenerationRef.current += 1;
+    const generation = fetchGenerationRef.current;
     try {
       setIsLoading(true);
       setError(null);
@@ -167,6 +181,10 @@ export function usePerpsTransactionHistory({
           ]),
         ),
       ]);
+
+      if (fetchGenerationRef.current !== generation) {
+        return;
+      }
 
       const fills: OrderFill[] = Array.isArray(fillsResult) ? fillsResult : [];
       const orders: Order[] = Array.isArray(ordersResult) ? ordersResult : [];
@@ -208,6 +226,9 @@ export function usePerpsTransactionHistory({
 
       setTransactions(uniqueTransactions);
     } catch (err) {
+      if (fetchGenerationRef.current !== generation) {
+        return;
+      }
       const errorMessage =
         err instanceof Error
           ? err.message
@@ -215,7 +236,9 @@ export function usePerpsTransactionHistory({
       setError(errorMessage);
       setTransactions([]);
     } finally {
-      setIsLoading(false);
+      if (fetchGenerationRef.current === generation) {
+        setIsLoading(false);
+      }
     }
   }, [startTime, endTime, accountId, coalesceKeys]);
 

--- a/ui/hooks/perps/useUserHistory.test.ts
+++ b/ui/hooks/perps/useUserHistory.test.ts
@@ -2,6 +2,7 @@ import { renderHook, act } from '@testing-library/react-hooks';
 import { waitFor } from '@testing-library/react';
 import type { UserHistoryItem } from '@metamask/perps-controller';
 import { useUserHistory } from './useUserHistory';
+import { resetCoalesceCacheForTests } from './coalesceBackgroundRequest';
 
 const mockSubmitRequestToBackground = jest.fn();
 
@@ -13,6 +14,7 @@ jest.mock('../../store/background-connection', () => ({
 describe('useUserHistory', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    resetCoalesceCacheForTests();
     mockSubmitRequestToBackground.mockResolvedValue([]);
   });
 

--- a/ui/hooks/perps/useUserHistory.test.ts
+++ b/ui/hooks/perps/useUserHistory.test.ts
@@ -11,6 +11,10 @@ jest.mock('../../store/background-connection', () => ({
     mockSubmitRequestToBackground(...args),
 }));
 
+jest.mock('./usePerpsCacheKey', () => ({
+  usePerpsCacheKey: () => 'test-scope',
+}));
+
 describe('useUserHistory', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/ui/hooks/perps/useUserHistory.ts
+++ b/ui/hooks/perps/useUserHistory.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import type { CaipAccountId } from '@metamask/utils';
 import type { UserHistoryItem } from '@metamask/perps-controller';
 import { submitRequestToBackground } from '../../store/background-connection';
@@ -58,11 +58,22 @@ export function useUserHistory({
 
   // Scope the coalesce key to the active perps context (provider + testnet +
   // selected address) so switching accounts or toggling testnet inside the
-  // 10s TTL does not surface the previous session's data.
+  // 10s TTL does not surface the previous session's data. Pipe-delimited:
+  // perpsScopeKey and CaipAccountId use ':' internally but never '|', so the
+  // fields are unambiguous without paying the cost of JSON.stringify on each
+  // render.
   const perpsScopeKey = usePerpsCacheKey();
-  const cacheKey = `perpsGetUserHistory:${perpsScopeKey}:${accountId ?? ''}:${startTime ?? ''}:${endTime ?? ''}`;
+  const cacheKey = `perpsGetUserHistory|${perpsScopeKey}|${accountId ?? ''}|${startTime ?? ''}|${endTime ?? ''}`;
+
+  // Guards async state commits against scope-change races: if `accountId`,
+  // `startTime`, or `endTime` change while a fetch is mid-flight, its
+  // resolution must not overwrite the newer scope's state. Each fetch
+  // captures a generation at start and only commits if it still matches.
+  const fetchGenerationRef = useRef(0);
 
   const fetchUserHistory = useCallback(async (): Promise<UserHistoryItem[]> => {
+    fetchGenerationRef.current += 1;
+    const generation = fetchGenerationRef.current;
     try {
       setIsLoading(true);
       setError(null);
@@ -75,16 +86,24 @@ export function useUserHistory({
           ]),
       );
 
+      if (fetchGenerationRef.current !== generation) {
+        return history;
+      }
       setUserHistory(history);
       return history;
     } catch (err) {
       const errorMessage =
         err instanceof Error ? err.message : 'Failed to fetch user history';
+      if (fetchGenerationRef.current !== generation) {
+        return [];
+      }
       setError(errorMessage);
       setUserHistory([]);
       return [];
     } finally {
-      setIsLoading(false);
+      if (fetchGenerationRef.current === generation) {
+        setIsLoading(false);
+      }
     }
   }, [cacheKey, startTime, endTime, accountId]);
 

--- a/ui/hooks/perps/useUserHistory.ts
+++ b/ui/hooks/perps/useUserHistory.ts
@@ -61,7 +61,9 @@ export function useUserHistory({
   // 10s TTL does not surface the previous session's data. Pipe-delimited:
   // perpsScopeKey and CaipAccountId use ':' internally but never '|', so the
   // fields are unambiguous without paying the cost of JSON.stringify on each
-  // render.
+  // render. Fields are fixed-position — do not reorder or add optional
+  // fields between existing ones, or an absent value could align with the
+  // empty-string fallback from a neighbouring field.
   const perpsScopeKey = usePerpsCacheKey();
   const cacheKey = `perpsGetUserHistory|${perpsScopeKey}|${accountId ?? ''}|${startTime ?? ''}|${endTime ?? ''}`;
 

--- a/ui/hooks/perps/useUserHistory.ts
+++ b/ui/hooks/perps/useUserHistory.ts
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react';
 import type { CaipAccountId } from '@metamask/utils';
 import type { UserHistoryItem } from '@metamask/perps-controller';
 import { submitRequestToBackground } from '../../store/background-connection';
+import { coalesceBackgroundRequest } from './coalesceBackgroundRequest';
 
 /**
  * Parameters for the useUserHistory hook
@@ -54,9 +55,13 @@ export function useUserHistory({
       setIsLoading(true);
       setError(null);
 
-      const history = await submitRequestToBackground<UserHistoryItem[]>(
-        'perpsGetUserHistory',
-        [{ startTime, endTime, accountId }],
+      const cacheKey = `perpsGetUserHistory:${accountId ?? ''}:${startTime ?? ''}:${endTime ?? ''}`;
+      const history = await coalesceBackgroundRequest<UserHistoryItem[]>(
+        cacheKey,
+        () =>
+          submitRequestToBackground<UserHistoryItem[]>('perpsGetUserHistory', [
+            { startTime, endTime, accountId },
+          ]),
       );
 
       setUserHistory(history);

--- a/ui/hooks/perps/useUserHistory.ts
+++ b/ui/hooks/perps/useUserHistory.ts
@@ -29,7 +29,9 @@ export type UseUserHistoryResult = {
   isLoading: boolean;
   /** Error message if fetching failed, null otherwise */
   error: string | null;
-  /** Function to manually refetch the user history */
+  /** Cache-respecting fetch — initial mount / re-mount within TTL reuses cached data */
+  fetch: () => Promise<UserHistoryItem[]>;
+  /** Invalidate cache then fetch — explicit user refresh */
   refetch: () => Promise<UserHistoryItem[]>;
 };
 
@@ -90,6 +92,7 @@ export function useUserHistory({
     userHistory,
     isLoading,
     error,
+    fetch: fetchUserHistory,
     refetch,
   };
 }

--- a/ui/hooks/perps/useUserHistory.ts
+++ b/ui/hooks/perps/useUserHistory.ts
@@ -2,7 +2,10 @@ import { useCallback, useState } from 'react';
 import type { CaipAccountId } from '@metamask/utils';
 import type { UserHistoryItem } from '@metamask/perps-controller';
 import { submitRequestToBackground } from '../../store/background-connection';
-import { coalesceBackgroundRequest } from './coalesceBackgroundRequest';
+import {
+  coalesceBackgroundRequest,
+  invalidateCoalescedRequest,
+} from './coalesceBackgroundRequest';
 
 /**
  * Parameters for the useUserHistory hook
@@ -50,12 +53,13 @@ export function useUserHistory({
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const cacheKey = `perpsGetUserHistory:${accountId ?? ''}:${startTime ?? ''}:${endTime ?? ''}`;
+
   const fetchUserHistory = useCallback(async (): Promise<UserHistoryItem[]> => {
     try {
       setIsLoading(true);
       setError(null);
 
-      const cacheKey = `perpsGetUserHistory:${accountId ?? ''}:${startTime ?? ''}:${endTime ?? ''}`;
       const history = await coalesceBackgroundRequest<UserHistoryItem[]>(
         cacheKey,
         () =>
@@ -75,12 +79,17 @@ export function useUserHistory({
     } finally {
       setIsLoading(false);
     }
-  }, [startTime, endTime, accountId]);
+  }, [cacheKey, startTime, endTime, accountId]);
+
+  const refetch = useCallback(async (): Promise<UserHistoryItem[]> => {
+    invalidateCoalescedRequest(cacheKey);
+    return fetchUserHistory();
+  }, [cacheKey, fetchUserHistory]);
 
   return {
     userHistory,
     isLoading,
     error,
-    refetch: fetchUserHistory,
+    refetch,
   };
 }

--- a/ui/hooks/perps/useUserHistory.ts
+++ b/ui/hooks/perps/useUserHistory.ts
@@ -6,6 +6,7 @@ import {
   coalesceBackgroundRequest,
   invalidateCoalescedRequest,
 } from './coalesceBackgroundRequest';
+import { usePerpsCacheKey } from './usePerpsCacheKey';
 
 /**
  * Parameters for the useUserHistory hook
@@ -55,7 +56,11 @@ export function useUserHistory({
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const cacheKey = `perpsGetUserHistory:${accountId ?? ''}:${startTime ?? ''}:${endTime ?? ''}`;
+  // Scope the coalesce key to the active perps context (provider + testnet +
+  // selected address) so switching accounts or toggling testnet inside the
+  // 10s TTL does not surface the previous session's data.
+  const perpsScopeKey = usePerpsCacheKey();
+  const cacheKey = `perpsGetUserHistory:${perpsScopeKey}:${accountId ?? ''}:${startTime ?? ''}:${endTime ?? ''}`;
 
   const fetchUserHistory = useCallback(async (): Promise<UserHistoryItem[]> => {
     try {

--- a/ui/pages/perps/perps-activity-page.tsx
+++ b/ui/pages/perps/perps-activity-page.tsx
@@ -56,12 +56,14 @@ const PerpsActivityPage: React.FC = () => {
   const isPerpsExperienceAvailable = useSelector(getIsPerpsExperienceAvailable);
   const [activeFilter, setActiveFilter] =
     useState<PerpsTransactionFilter>('trade');
-  // Fetch real transaction data from the Perps controller. The hook performs
-  // a cache-respecting initial fetch on mount internally (see usePerpsTransactionHistory),
-  // so a rapid revisit within the 10s TTL hits the coalesce cache instead of
-  // replaying the full user-history/fills/orders/funding burst.
+  // Fetch real transaction data from the Perps controller.
+  // forceFreshOnMount: user opening the Activity page must see the latest
+  // orders/funding/deposits even if PerpsView ("Recent activity") grabbed a
+  // snapshot inside the 10s TTL. Orders/funding/userHistory do not update via
+  // the live-fills WebSocket merge, so without this the page could render a
+  // stale snapshot. The hook's in-flight dedup still suppresses bursts.
   const { transactions, isLoading, error, refetch } =
-    usePerpsTransactionHistory();
+    usePerpsTransactionHistory({ forceFreshOnMount: true });
 
   usePerpsEventTracking({
     eventName: MetaMetricsEventName.PerpsScreenViewed,

--- a/ui/pages/perps/perps-activity-page.tsx
+++ b/ui/pages/perps/perps-activity-page.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useCallback, useEffect } from 'react';
+import React, { useState, useMemo, useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { Navigate, useNavigate } from 'react-router-dom';
 import {
@@ -56,7 +56,10 @@ const PerpsActivityPage: React.FC = () => {
   const isPerpsExperienceAvailable = useSelector(getIsPerpsExperienceAvailable);
   const [activeFilter, setActiveFilter] =
     useState<PerpsTransactionFilter>('trade');
-  // Fetch real transaction data from the Perps controller
+  // Fetch real transaction data from the Perps controller. The hook performs
+  // a cache-respecting initial fetch on mount internally (see usePerpsTransactionHistory),
+  // so a rapid revisit within the 10s TTL hits the coalesce cache instead of
+  // replaying the full user-history/fills/orders/funding burst.
   const { transactions, isLoading, error, refetch } =
     usePerpsTransactionHistory();
 
@@ -69,11 +72,6 @@ const PerpsActivityPage: React.FC = () => {
       [PERPS_EVENT_PROPERTY.SOURCE]: PERPS_EVENT_VALUE.SOURCE.ASSET_DETAILS,
     },
   });
-
-  // Refetch on mount to ensure fresh data
-  useEffect(() => {
-    refetch();
-  }, [refetch]);
 
   // Filter options for dropdown
   const filterOptions: DropdownOption<PerpsTransactionFilter>[] = useMemo(

--- a/ui/pages/perps/perps-activity-page.tsx
+++ b/ui/pages/perps/perps-activity-page.tsx
@@ -62,8 +62,9 @@ const PerpsActivityPage: React.FC = () => {
   // snapshot inside the 10s TTL. Orders/funding/userHistory do not update via
   // the live-fills WebSocket merge, so without this the page could render a
   // stale snapshot. The hook's in-flight dedup still suppresses bursts.
-  const { transactions, isLoading, error, refetch } =
-    usePerpsTransactionHistory({ forceFreshOnMount: true });
+  const { transactions, isLoading, error } = usePerpsTransactionHistory({
+    forceFreshOnMount: true,
+  });
 
   usePerpsEventTracking({
     eventName: MetaMetricsEventName.PerpsScreenViewed,

--- a/ui/providers/perps/CandleStreamChannel.test.ts
+++ b/ui/providers/perps/CandleStreamChannel.test.ts
@@ -280,6 +280,44 @@ describe('CandleStreamChannel', () => {
       expect(activateCallsAfter).toHaveLength(1);
     });
 
+    it('waits only the remaining debounce budget when resubscribe arrives partway through the window', () => {
+      const unsubscribe = channel.subscribe({
+        symbol: 'BTC',
+        interval: CandlePeriod.OneHour,
+        callback: jest.fn(),
+      });
+      expect(mockSubmitRequestToBackground).toHaveBeenCalledTimes(1);
+      mockSubmitRequestToBackground.mockClear();
+
+      unsubscribe();
+      // Resubscribe 50 ms after disconnect — CONNECT_DEBOUNCE_MS is 120 ms,
+      // so the reconnect must fire at (disconnect + 120) = 70 ms from here,
+      // not (subscribe + 120) = 170 ms. Waiting another full window would
+      // push the UI reconnect past the bridge's 150 ms teardown defer and
+      // surface the exact unsubscribe/resubscribe burst this coalesces.
+      jest.advanceTimersByTime(50);
+      channel.subscribe({
+        symbol: 'BTC',
+        interval: CandlePeriod.OneHour,
+        callback: jest.fn(),
+      });
+
+      // At +69 ms from resubscribe (119 ms from disconnect) the activate
+      // must not have fired yet.
+      jest.advanceTimersByTime(69);
+      const preCalls = mockSubmitRequestToBackground.mock.calls.filter(
+        ([name]) => name === 'perpsActivateCandleStream',
+      );
+      expect(preCalls).toHaveLength(0);
+
+      // One more ms crosses the 120 ms anchor — activate must fire.
+      jest.advanceTimersByTime(2);
+      const postCalls = mockSubmitRequestToBackground.mock.calls.filter(
+        ([name]) => name === 'perpsActivateCandleStream',
+      );
+      expect(postCalls).toHaveLength(1);
+    });
+
     it('does not re-activate when other subscribers remain', () => {
       const unsubscribe1 = channel.subscribe({
         symbol: 'BTC',

--- a/ui/providers/perps/CandleStreamChannel.test.ts
+++ b/ui/providers/perps/CandleStreamChannel.test.ts
@@ -196,14 +196,53 @@ describe('CandleStreamChannel', () => {
         [{ symbol: 'BTC', interval: CandlePeriod.OneHour }],
       );
 
-      // Re-subscribe — should activate streaming again (1 call)
+      // Re-subscribe inside the CONNECT_DEBOUNCE_MS window — activation is
+      // deferred rather than fired immediately, so only the deactivate is
+      // observed until the debounce timer expires.
+      channel.subscribe({
+        symbol: 'BTC',
+        interval: CandlePeriod.OneHour,
+        callback: jest.fn(),
+      });
+      expect(mockSubmitRequestToBackground).toHaveBeenCalledTimes(1);
+
+      jest.advanceTimersByTime(200);
+      expect(mockSubmitRequestToBackground).toHaveBeenCalledTimes(2);
+      expect(mockSubmitRequestToBackground).toHaveBeenLastCalledWith(
+        'perpsActivateCandleStream',
+        expect.any(Array),
+      );
+    });
+
+    it('coalesces a rapid unsubscribe→resubscribe burst into a single activate', () => {
+      const unsubscribe = channel.subscribe({
+        symbol: 'BTC',
+        interval: CandlePeriod.OneHour,
+        callback: jest.fn(),
+      });
+      expect(mockSubmitRequestToBackground).toHaveBeenCalledTimes(1);
+      mockSubmitRequestToBackground.mockClear();
+
+      // Simulate remount: back-to-back unsubscribe + resubscribe within the
+      // debounce window — the second activate must be debounced, not fired.
+      unsubscribe();
       channel.subscribe({
         symbol: 'BTC',
         interval: CandlePeriod.OneHour,
         callback: jest.fn(),
       });
 
-      expect(mockSubmitRequestToBackground).toHaveBeenCalledTimes(2);
+      const activateCalls = mockSubmitRequestToBackground.mock.calls.filter(
+        ([name]) => name === 'perpsActivateCandleStream',
+      );
+      expect(activateCalls).toHaveLength(0);
+
+      jest.advanceTimersByTime(200);
+      const activateCallsAfter =
+        mockSubmitRequestToBackground.mock.calls.filter(
+          ([name]) => name === 'perpsActivateCandleStream',
+        );
+      expect(activateCallsAfter).toHaveLength(1);
     });
 
     it('does not re-activate when other subscribers remain', () => {

--- a/ui/providers/perps/CandleStreamChannel.test.ts
+++ b/ui/providers/perps/CandleStreamChannel.test.ts
@@ -245,6 +245,41 @@ describe('CandleStreamChannel', () => {
       expect(activateCallsAfter).toHaveLength(1);
     });
 
+    it('debounces resubscribe even when the prior stream was long-lived', () => {
+      const unsubscribe = channel.subscribe({
+        symbol: 'BTC',
+        interval: CandlePeriod.OneHour,
+        callback: jest.fn(),
+      });
+      expect(mockSubmitRequestToBackground).toHaveBeenCalledTimes(1);
+
+      // Let the stream stay open well past the debounce window — this is the
+      // normal case for any real market visit. Measuring from the last
+      // connect would put us past CONNECT_DEBOUNCE_MS and skip debouncing;
+      // measuring from the last disconnect keeps the burst coalesced.
+      jest.advanceTimersByTime(60_000);
+      mockSubmitRequestToBackground.mockClear();
+
+      unsubscribe();
+      channel.subscribe({
+        symbol: 'BTC',
+        interval: CandlePeriod.OneHour,
+        callback: jest.fn(),
+      });
+
+      const activateCalls = mockSubmitRequestToBackground.mock.calls.filter(
+        ([name]) => name === 'perpsActivateCandleStream',
+      );
+      expect(activateCalls).toHaveLength(0);
+
+      jest.advanceTimersByTime(200);
+      const activateCallsAfter =
+        mockSubmitRequestToBackground.mock.calls.filter(
+          ([name]) => name === 'perpsActivateCandleStream',
+        );
+      expect(activateCallsAfter).toHaveLength(1);
+    });
+
     it('does not re-activate when other subscribers remain', () => {
       const unsubscribe1 = channel.subscribe({
         symbol: 'BTC',

--- a/ui/providers/perps/CandleStreamChannel.ts
+++ b/ui/providers/perps/CandleStreamChannel.ts
@@ -420,7 +420,10 @@ export class CandleStreamChannel {
       entry.unsubscribeFromSource = null;
     }
     entry.isConnected = false;
-    entry.lastConnectAt = undefined;
+    // Intentionally preserve entry.lastConnectAt so that the connect() debounce
+    // window spans the disconnect→connect burst produced by remounts. Clearing
+    // it here would make every subsequent connect() call fire immediately and
+    // the CONNECT_DEBOUNCE_MS coalescing would never engage.
     const { symbol, interval } = parseCacheKey(key);
     submitRequestToBackground('perpsDeactivateCandleStream', [
       { symbol, interval },

--- a/ui/providers/perps/CandleStreamChannel.ts
+++ b/ui/providers/perps/CandleStreamChannel.ts
@@ -30,6 +30,9 @@ const LOAD_MORE_MIN = 50;
 /** Maximum candles to fetch on load-more */
 const LOAD_MORE_MAX = 500;
 
+/** Debounce window for connect() -- coalesces React unmount/remount bursts */
+const CONNECT_DEBOUNCE_MS = 120;
+
 /** Per-subscriber state */
 type SubscriberEntry = {
   callback: (data: CandleData) => void;
@@ -46,6 +49,10 @@ type ChannelEntry = {
   isConnected: boolean;
   /** The duration used for the initial subscription */
   duration: TimeDuration | undefined;
+  /** Pending leading-edge debounce timer for connect() */
+  pendingConnectTimer?: ReturnType<typeof setTimeout>;
+  /** Timestamp of the last connect() call that actually fired */
+  lastConnectAt?: number;
 };
 
 /**
@@ -342,13 +349,39 @@ export class CandleStreamChannel {
       return;
     }
 
+    const now = Date.now();
+    const elapsed = now - (entry.lastConnectAt ?? 0);
+
+    if (elapsed >= CONNECT_DEBOUNCE_MS) {
+      this.fireConnect(key, entry);
+      return;
+    }
+
+    if (entry.pendingConnectTimer !== undefined) {
+      clearTimeout(entry.pendingConnectTimer);
+    }
+
+    entry.pendingConnectTimer = setTimeout(() => {
+      entry.pendingConnectTimer = undefined;
+      if (entry.subscribers.size > 0 && !entry.isConnected) {
+        this.fireConnect(key, entry);
+      }
+    }, CONNECT_DEBOUNCE_MS);
+  }
+
+  /**
+   * Execute the actual background activate call.
+   * Extracted from connect() to support leading-edge debounce.
+   *
+   * @param key - Cache key
+   * @param entry - Channel entry
+   */
+  private fireConnect(key: string, entry: ChannelEntry): void {
     const { symbol, interval } = parseCacheKey(key);
 
     entry.isConnected = true;
+    entry.lastConnectAt = Date.now();
 
-    // Tell the background to start emitting candle updates for this key.
-    // Data arrives via perpsStreamUpdate { channel: 'candles', symbol, interval, data }
-    // which is routed to CandleStreamChannel.pushFromBackground().
     submitRequestToBackground('perpsActivateCandleStream', [
       { symbol, interval, duration: entry.duration },
     ]).catch((err) => {
@@ -360,7 +393,6 @@ export class CandleStreamChannel {
       entry.isConnected = false;
     });
 
-    // Set a no-op unsubscribe (background handles cleanup on stream close)
     // eslint-disable-next-line no-empty-function, @typescript-eslint/no-empty-function
     entry.unsubscribeFromSource = () => {};
   }
@@ -373,6 +405,11 @@ export class CandleStreamChannel {
    * @param entry - Channel entry
    */
   private disconnect(key: string, entry: ChannelEntry): void {
+    if (entry.pendingConnectTimer !== undefined) {
+      clearTimeout(entry.pendingConnectTimer);
+      entry.pendingConnectTimer = undefined;
+    }
+
     if (entry.unsubscribeFromSource) {
       entry.unsubscribeFromSource();
       entry.unsubscribeFromSource = null;

--- a/ui/providers/perps/CandleStreamChannel.ts
+++ b/ui/providers/perps/CandleStreamChannel.ts
@@ -307,6 +307,7 @@ export class CandleStreamChannel {
           entry.unsubscribeFromSource = null;
         }
         entry.isConnected = false;
+        entry.lastConnectAt = undefined;
 
         // Re-activate background stream for this key
         this.connect(key, entry);
@@ -415,6 +416,7 @@ export class CandleStreamChannel {
       entry.unsubscribeFromSource = null;
     }
     entry.isConnected = false;
+    entry.lastConnectAt = undefined;
     const { symbol, interval } = parseCacheKey(key);
     submitRequestToBackground('perpsDeactivateCandleStream', [
       { symbol, interval },

--- a/ui/providers/perps/CandleStreamChannel.ts
+++ b/ui/providers/perps/CandleStreamChannel.ts
@@ -30,7 +30,17 @@ const LOAD_MORE_MIN = 50;
 /** Maximum candles to fetch on load-more */
 const LOAD_MORE_MAX = 500;
 
-/** Debounce window for connect() -- coalesces React unmount/remount bursts */
+/**
+ * Leading-edge debounce window for connect() -- coalesces React
+ * unmount/remount bursts at the UI channel layer.
+ *
+ * Intentionally shorter than the bridge-layer CANDLE_TEARDOWN_DEFER_MS (150
+ * ms) in app/scripts/controllers/perps/perps-stream-bridge.ts: the bridge's
+ * deferred teardown gives the UI a ~150 ms window to re-subscribe before the
+ * background actually disconnects, and a 30 ms margin keeps the UI
+ * resubscribe inside that window so the teardown is cancelled rather than
+ * re-racing a full reconnect.
+ */
 const CONNECT_DEBOUNCE_MS = 120;
 
 /** Per-subscriber state */

--- a/ui/providers/perps/CandleStreamChannel.ts
+++ b/ui/providers/perps/CandleStreamChannel.ts
@@ -388,12 +388,21 @@ export class CandleStreamChannel {
       clearTimeout(entry.pendingConnectTimer);
     }
 
+    // Wait only the remaining slice of the debounce window, not another full
+    // CONNECT_DEBOUNCE_MS. The window is anchored to lastDisconnectAt, so a
+    // resubscribe arriving n ms after the disconnect still needs to fire at
+    // (lastDisconnectAt + CONNECT_DEBOUNCE_MS); adding another full window on
+    // top would push the UI reconnect past the bridge's 150 ms teardown
+    // defer, which would commit a disconnect and force a fresh
+    // perpsActivateCandleStream — the exact burst this debounce is meant to
+    // coalesce.
+    const remaining = Math.max(0, CONNECT_DEBOUNCE_MS - elapsed);
     entry.pendingConnectTimer = setTimeout(() => {
       entry.pendingConnectTimer = undefined;
       if (entry.subscribers.size > 0 && !entry.isConnected) {
         this.fireConnect(key, entry);
       }
-    }, CONNECT_DEBOUNCE_MS);
+    }, remaining);
   }
 
   /**

--- a/ui/providers/perps/CandleStreamChannel.ts
+++ b/ui/providers/perps/CandleStreamChannel.ts
@@ -301,6 +301,10 @@ export class CandleStreamChannel {
     for (const [key, entry] of this.channels.entries()) {
       // Only reconnect channels that have active subscribers
       if (entry.subscribers.size > 0) {
+        if (entry.pendingConnectTimer !== undefined) {
+          clearTimeout(entry.pendingConnectTimer);
+          entry.pendingConnectTimer = undefined;
+        }
         // Disconnect existing source
         if (entry.unsubscribeFromSource) {
           entry.unsubscribeFromSource();

--- a/ui/providers/perps/CandleStreamChannel.ts
+++ b/ui/providers/perps/CandleStreamChannel.ts
@@ -51,8 +51,13 @@ type ChannelEntry = {
   duration: TimeDuration | undefined;
   /** Pending leading-edge debounce timer for connect() */
   pendingConnectTimer?: ReturnType<typeof setTimeout>;
-  /** Timestamp of the last connect() call that actually fired */
-  lastConnectAt?: number;
+  /**
+   * Timestamp of the most recent disconnect(). Used by connect() to coalesce
+   * the unsubscribe→resubscribe burst produced by rapid remounts. Measuring
+   * from the last connect time would make the debounce skip any stream that
+   * had been open longer than CONNECT_DEBOUNCE_MS (i.e. every real visit).
+   */
+  lastDisconnectAt?: number;
 };
 
 /**
@@ -311,7 +316,10 @@ export class CandleStreamChannel {
           entry.unsubscribeFromSource = null;
         }
         entry.isConnected = false;
-        entry.lastConnectAt = undefined;
+        // WebSocket reconnect is authoritative — clear the last-disconnect
+        // timestamp so the follow-up connect() fires immediately instead of
+        // being debounced.
+        entry.lastDisconnectAt = undefined;
 
         // Re-activate background stream for this key
         this.connect(key, entry);
@@ -355,7 +363,11 @@ export class CandleStreamChannel {
     }
 
     const now = Date.now();
-    const elapsed = now - (entry.lastConnectAt ?? 0);
+    // Measure from the most recent disconnect, not the last connect: the
+    // debounce exists to coalesce unsubscribe→resubscribe bursts, so it must
+    // fire on any stream that has just been torn down, regardless of how long
+    // the previous subscription was alive.
+    const elapsed = now - (entry.lastDisconnectAt ?? 0);
 
     if (elapsed >= CONNECT_DEBOUNCE_MS) {
       this.fireConnect(key, entry);
@@ -385,7 +397,6 @@ export class CandleStreamChannel {
     const { symbol, interval } = parseCacheKey(key);
 
     entry.isConnected = true;
-    entry.lastConnectAt = Date.now();
 
     submitRequestToBackground('perpsActivateCandleStream', [
       { symbol, interval, duration: entry.duration },
@@ -420,10 +431,10 @@ export class CandleStreamChannel {
       entry.unsubscribeFromSource = null;
     }
     entry.isConnected = false;
-    // Intentionally preserve entry.lastConnectAt so that the connect() debounce
-    // window spans the disconnect→connect burst produced by remounts. Clearing
-    // it here would make every subsequent connect() call fire immediately and
-    // the CONNECT_DEBOUNCE_MS coalescing would never engage.
+    // Stamp the disconnect moment so the next connect() call can measure the
+    // gap and debounce remount bursts. Without this, connect() would fall
+    // through to the immediate path on every resubscribe.
+    entry.lastDisconnectAt = Date.now();
     const { symbol, interval } = parseCacheKey(key);
     submitRequestToBackground('perpsDeactivateCandleStream', [
       { symbol, interval },

--- a/ui/providers/perps/PerpsStreamManager.ts
+++ b/ui/providers/perps/PerpsStreamManager.ts
@@ -37,6 +37,7 @@ import type {
   CandlePeriod,
 } from '@metamask/perps-controller';
 import { submitRequestToBackground } from '../../store/background-connection';
+import { clearAllCoalescedRequests } from '../../hooks/perps/coalesceBackgroundRequest';
 import {
   clearPerpsMarketFillsModuleCache,
   clearPerpsMarketInfoModuleCache,
@@ -445,6 +446,7 @@ class PerpsStreamManager {
       this._lastStreamUpdateAt = 0;
       clearPerpsMarketInfoModuleCache();
       clearPerpsMarketFillsModuleCache();
+      clearAllCoalescedRequests();
     }
 
     this.initializedAddress = address;
@@ -654,6 +656,7 @@ class PerpsStreamManager {
     this._lastStreamUpdateAt = 0;
     clearPerpsMarketInfoModuleCache();
     clearPerpsMarketFillsModuleCache();
+    clearAllCoalescedRequests();
   }
 
   /**
@@ -676,6 +679,7 @@ class PerpsStreamManager {
     this._lastStreamUpdateAt = 0;
     clearPerpsMarketInfoModuleCache();
     clearPerpsMarketFillsModuleCache();
+    clearAllCoalescedRequests();
   }
 }
 


### PR DESCRIPTION
## **Description**

Under rapid perps market switching, Hyperliquid returned 429s on candle requests and activity-page REST calls. This PR removes the client-side races that caused them.

**Problem 1 — candle subscribe race.** Opening a market-detail page triggers three components that each call `subscribeToCandles` for the same `{symbol, interval}` key in the same tick: `PerpsLayout`, `PerpsTVChart`, and `useCandleStream`. Each call fires a `POST /info { type: "candleSnapshot" }` to Hyperliquid. The vendor client (`HyperLiquidClientService`) aborts duplicates via `AbortController` (follow-up to [MetaMask/core#28141](https://github.com/MetaMask/core/issues/28141)), but the server has already accepted the request and charged weight against the 1200 wgt/min per-IP limit. On rapid navigation each market switch leaks 1–2 aborted-but-charged REST calls, which is what tips us over 429.

**Problem 2 — activity-page REST burst.** `usePerpsTransactionHistory` fires `perpsGetUserHistory`, `perpsGetOrderFills`, `perpsGetOrders`, and `perpsGetFunding` in `Promise.all` on mount, with no in-flight dedup or cache. Rapid tab switches multiply the burst. `useUserHistory` has the same shape for `perpsGetUserHistory` alone.

**Fix — coalesce at the origin of each burst.**

| Layer | File | Behaviour |
|---|---|---|
| Idempotent activate + 150ms deferred teardown | `app/scripts/controllers/perps/perps-stream-bridge.ts` | A second `perpsActivateCandleStream` for a live key short-circuits. A `perpsDeactivateCandleStream` waits 150ms; a matching activate inside that window cancels the teardown instead of tearing down and rebuilding. |
| 120ms leading-edge debounce | `ui/providers/perps/CandleStreamChannel.ts` | Back-to-back UI subscribers for the same key coalesce into one connect. `lastConnectAt` is cleared on full disconnect/reconnect so legitimate re-subscribes after teardown fire immediately. |
| In-flight dedup + 10s TTL cache | `ui/hooks/perps/useUserHistory.ts`, `ui/hooks/perps/usePerpsTransactionHistory.ts` via `ui/hooks/perps/coalesceBackgroundRequest.ts` | Activity-page mount bursts dedup to a single HL call per endpoint+params. Explicit `refetch()` bypasses the cache so user-initiated refresh still re-runs. |
| Full `setData` on symbol/interval change | `ui/components/app/perps/TradingViewChart/CandlestickChart.tsx` | Avoids lightweight-charts crashes from partial updates during rapid market switches. |

All windows are scoped — outside them the code path is unchanged, so there is no over-coalescing of genuinely new subscriptions.

## **Changelog**

CHANGELOG entry: Fixed a bug that caused some Hyperliquid requests to be rate-limited (429) when rapidly switching between perps markets.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/41926 [TAT-2986](https://consensyssoftware.atlassian.net/browse/TAT-2986)

## **Manual testing steps**

1. Check out the branch: `PORT=9015 yarn start` (watch mode) or `yarn build:test` for a clean one-shot build.
2. Load unpacked from `dist/chrome/`. Unlock a perps account.
3. Navigate through several perps markets in quick succession (BTC → ETH → SOL → HYPE → PUMP, ~1.5s dwell each), then visit the activity page, then repeat. Watch service-worker and home-page devtools network panels — no 429 responses from `api.hyperliquid.xyz` should appear.
4. Unit tests:
   ```bash
   yarn jest app/scripts/controllers/perps/perps-stream-bridge.test --no-coverage
   yarn jest ui/providers/perps/CandleStreamChannel.test --no-coverage
   yarn jest ui/hooks/perps/useUserHistory.test --no-coverage
   yarn jest ui/hooks/perps/usePerpsTransactionHistory.test --no-coverage
   ```

## **Screenshots/Recordings**

Evidence below is extension-only, measured via Chrome DevTools Protocol attached to the service worker + home-page targets. A scripted 10-market rotation drives the same code path as manual rapid navigation, at human-realistic pacing (1500 ms dwell per market), with a mid-rotation activity-page visit to exercise the transaction-history fetch burst.

Probe shape (identical between runs): 2 passes × 10 markets × 1500 ms dwell + 1 activity visit per pass. Counts every `api.hyperliquid.xyz` response + every matching console error from sw and home.

| | HL requests | 200 | 429 | Error messages matched |
|---|---|---|---|---|
| **Before** (main, `4ede4f596d`) | 20 | 17 | **3** (15 %) | **32** (WebSocketRequestError timeouts, HttpRequestError 429) |
| **After** (this branch, `42db5f07ad`) | 20 | 20 | **0** | **0** |

No cross-platform comparison is claimed — the mobile build was not instrumented with the same network probe.

<details>
<summary><strong>Recipe JSON — rate-limit-10-market-stress.json</strong> (click to expand)</summary>

The scripted rotation above runs via an internal CDP recipe runner that is not yet available to external reviewers. The recipe graph itself is reproducible by hand: each `run{1,2}-<symbol>` node is `navigate → 1500ms wait → wait for `perps-market-detail-page` test-id`, with a mid-rotation detour through `/perps/activity`.

```json
{
  "title": "Perps 10-market rapid-switch rate-limit proof (core + HIP-3)",
  "validate": {
    "workflow": {
      "pre_conditions": ["wallet.unlocked"],
      "entry": "setup-install-rl-probe",
      "teardown": [
        { "id": "teardown-stop-rl-probe", "action": "cdp_probe", "phase": "stop", "name": "hl-rate-limit" }
      ],
      "nodes": {
        "setup-install-rl-probe": {
          "action": "cdp_probe",
          "phase": "start",
          "name": "hl-rate-limit",
          "scope": "both",
          "url_pattern": "api\\.hyperliquid\\.xyz",
          "message_pattern": "WebSocketRequestError|HttpRequestError|Too Many Requests|\\b429\\b",
          "status_match": [429],
          "stream": true,
          "next": "setup-nav-perps"
        },
        "setup-nav-perps":        { "action": "call", "ref": "perps/navigate-perps-tab", "next": "run1-btc" },

        "run1-btc":         { "action": "call", "ref": "perps/navigate-to-market-detail", "params": { "symbol": "BTC" },      "next": "run1-btc-dwell" },
        "run1-btc-dwell":   { "action": "wait", "ms": 1500, "next": "run1-btc-assert" },
        "run1-btc-assert":  { "action": "wait_for", "test_id": "perps-market-detail-page", "timeout_ms": 3000, "next": "run1-eth" },

        "run1-eth":         { "action": "call", "ref": "perps/navigate-to-market-detail", "params": { "symbol": "ETH" },      "next": "run1-eth-dwell" },
        "run1-eth-dwell":   { "action": "wait", "ms": 1500, "next": "run1-eth-assert" },
        "run1-eth-assert":  { "action": "wait_for", "test_id": "perps-market-detail-page", "timeout_ms": 3000, "next": "run1-sol" },

        "run1-sol":         { "action": "call", "ref": "perps/navigate-to-market-detail", "params": { "symbol": "SOL" },      "next": "run1-sol-dwell" },
        "run1-sol-dwell":   { "action": "wait", "ms": 1500, "next": "run1-sol-assert" },
        "run1-sol-assert":  { "action": "wait_for", "test_id": "perps-market-detail-page", "timeout_ms": 3000, "next": "run1-hype" },

        "run1-hype":        { "action": "call", "ref": "perps/navigate-to-market-detail", "params": { "symbol": "HYPE" },     "next": "run1-hype-dwell" },
        "run1-hype-dwell":  { "action": "wait", "ms": 1500, "next": "run1-hype-assert" },
        "run1-hype-assert": { "action": "wait_for", "test_id": "perps-market-detail-page", "timeout_ms": 3000, "next": "run1-pump" },

        "run1-pump":        { "action": "call", "ref": "perps/navigate-to-market-detail", "params": { "symbol": "PUMP" },     "next": "run1-pump-dwell" },
        "run1-pump-dwell":  { "action": "wait", "ms": 1500, "next": "run1-pump-assert" },
        "run1-pump-assert": { "action": "wait_for", "test_id": "perps-market-detail-page", "timeout_ms": 3000, "next": "run1-activity-nav" },

        "run1-activity-nav":    {
          "action": "eval_sync",
          "expression": "(function(){try{location.hash='#/perps/activity';return JSON.stringify({navigated:true});}catch(e){return JSON.stringify({navigated:false,error:String(e&&e.message||e)});}})()",
          "assert": { "all": [ { "operator": "eq", "field": "navigated", "value": true } ] },
          "next": "run1-activity-dwell"
        },
        "run1-activity-dwell":  { "action": "wait", "ms": 1500, "next": "run1-activity-assert" },
        "run1-activity-assert": { "action": "wait_for", "test_id": "perps-activity-page", "timeout_ms": 3000, "next": "run1-tsla" },

        "run1-tsla":        { "action": "call", "ref": "perps/navigate-to-market-detail", "params": { "symbol": "xyz:TSLA" }, "next": "run1-tsla-dwell" },
        "run1-tsla-dwell":  { "action": "wait", "ms": 1500, "next": "run1-tsla-assert" },
        "run1-tsla-assert": { "action": "wait_for", "test_id": "perps-market-detail-page", "timeout_ms": 3000, "next": "run1-nvda" },

        "run1-nvda":        { "action": "call", "ref": "perps/navigate-to-market-detail", "params": { "symbol": "xyz:NVDA" }, "next": "run1-nvda-dwell" },
        "run1-nvda-dwell":  { "action": "wait", "ms": 1500, "next": "run1-nvda-assert" },
        "run1-nvda-assert": { "action": "wait_for", "test_id": "perps-market-detail-page", "timeout_ms": 3000, "next": "run1-aapl" },

        "run1-aapl":        { "action": "call", "ref": "perps/navigate-to-market-detail", "params": { "symbol": "xyz:AAPL" }, "next": "run1-aapl-dwell" },
        "run1-aapl-dwell":  { "action": "wait", "ms": 1500, "next": "run1-aapl-assert" },
        "run1-aapl-assert": { "action": "wait_for", "test_id": "perps-market-detail-page", "timeout_ms": 3000, "next": "run1-gold" },

        "run1-gold":        { "action": "call", "ref": "perps/navigate-to-market-detail", "params": { "symbol": "xyz:GOLD" }, "next": "run1-gold-dwell" },
        "run1-gold-dwell":  { "action": "wait", "ms": 1500, "next": "run1-gold-assert" },
        "run1-gold-assert": { "action": "wait_for", "test_id": "perps-market-detail-page", "timeout_ms": 3000, "next": "run1-coin" },

        "run1-coin":        { "action": "call", "ref": "perps/navigate-to-market-detail", "params": { "symbol": "xyz:COIN" }, "next": "run1-coin-dwell" },
        "run1-coin-dwell":  { "action": "wait", "ms": 1500, "next": "run1-coin-assert" },
        "run1-coin-assert": { "action": "wait_for", "test_id": "perps-market-detail-page", "timeout_ms": 3000, "next": "run2-btc" },

        "// run2-*": "same shape as run1-* over [BTC, ETH, SOL, HYPE, PUMP, (activity visit), xyz:TSLA, xyz:NVDA, xyz:AAPL, xyz:GOLD, xyz:COIN]",

        "ac-no-error-boundary": {
          "action": "eval_sync",
          "expression": "(function(){var hasError=!!document.querySelector('[data-testid=\"error-boundary\"], [data-testid=\"perps-error-fallback\"]');var onDetail=!!document.querySelector('[data-testid=\"perps-market-detail-page\"]');return JSON.stringify({hasError:hasError,onDetail:onDetail});})()",
          "assert": { "all": [
            { "operator": "eq", "field": "hasError", "value": false },
            { "operator": "eq", "field": "onDetail", "value": true }
          ] },
          "next": "ac-rate-limit-probe"
        },

        "ac-rate-limit-probe": {
          "action": "cdp_probe",
          "phase": "stop",
          "name": "hl-rate-limit",
          "assert": { "all": [
            { "operator": "eq", "field": "network.matchedStatus", "value": 0 },
            { "operator": "eq", "field": "messages.total", "value": 0 }
          ] },
          "next": "done"
        },

        "done": { "action": "end", "status": "pass" }
      }
    }
  }
}
```

Reproducing by hand: navigate to each symbol in `[BTC, ETH, SOL, HYPE, PUMP]`, wait ~1.5 s each, open `#/perps/activity`, wait ~1.5 s, then `[xyz:TSLA, xyz:NVDA, xyz:AAPL, xyz:GOLD, xyz:COIN]` — and repeat once. With DevTools Network open, filter to `api.hyperliquid.xyz`. Pre-fix you should see a handful of 429 responses; post-fix none.

</details>

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[TAT-2986]: https://consensyssoftware.atlassian.net/browse/TAT-2986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches perps streaming lifecycle and transaction-history fetching, where timing/teardown/coalescing bugs could lead to stale UI data or missed/unexpected subscriptions despite added test coverage.
> 
> **Overview**
> Reduces Hyperliquid rate-limit bursts during rapid perps navigation by making candle streaming **idempotent and debounce/coalesced across layers**.
> 
> In `PerpsStreamBridge`, `perpsActivateCandleStream` now dedups concurrent activations, cancels pending teardowns, and defers `perpsDeactivateCandleStream` teardown by 150ms (with generation-based guards on `destroy()`). In the UI, `CandleStreamChannel` adds a 120ms reconnect debounce anchored to the last disconnect, and the candlestick chart forces full `setData` on symbol/interval changes to avoid incremental-update crashes.
> 
> Adds a reusable `coalesceBackgroundRequest` helper (in-flight dedup + short TTL cache + scoped clearing) and applies it to `useUserHistory` and `usePerpsTransactionHistory`, including cache invalidation on explicit `refetch()` and a `forceFreshOnMount` option used by `PerpsActivityPage`; `PerpsStreamManager` clears coalesced requests on scope resets. Tests are expanded accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f851e9ded3d40f5934140d39f6110580e0670bac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->