### PR TITLE
feat: Accounts metrics

### DIFF
--- a/app/scripts/controllers/metametrics-controller.test.ts
+++ b/app/scripts/controllers/metametrics-controller.test.ts
@@ -2044,6 +2044,7 @@ describe('MetaMetricsController', function () {
           [MetaMetricsUserTrait.NumberOfTrezorAccounts]: 0,
           [MetaMetricsUserTrait.NumberOfLatticeAccounts]: 0,
           [MetaMetricsUserTrait.NumberOfQrHardwareAccounts]: 0,
+          [MetaMetricsUserTrait.NumberOfHardwareWallets]: 0,
           [MetaMetricsUserTrait.OpenSeaApiEnabled]: true,
           [MetaMetricsUserTrait.ThreeBoxEnabled]: false,
           [MetaMetricsUserTrait.Theme]: 'default',
@@ -2423,6 +2424,9 @@ describe('MetaMetricsController', function () {
         expect(traits?.[MetaMetricsUserTrait.NumberOfSnapAccounts]).toBe(4);
         expect(traits?.[MetaMetricsUserTrait.NumberOfImportedAccounts]).toBe(0);
         expect(traits?.[MetaMetricsUserTrait.NumberOfLedgerAccounts]).toBe(0);
+        // 1 unique entropy id → 1 HD entropy.
+        expect(traits?.[MetaMetricsUserTrait.NumberOfHDEntropies]).toBe(1);
+        expect(traits?.[MetaMetricsUserTrait.NumberOfHardwareWallets]).toBe(0);
       });
     });
 
@@ -2512,6 +2516,10 @@ describe('MetaMetricsController', function () {
         expect(traits?.[MetaMetricsUserTrait.NumberOfLatticeAccounts]).toBe(1);
         // QR hardware includes both 'QR Hardware Wallet Device' and 'OneKey Hardware'.
         expect(traits?.[MetaMetricsUserTrait.NumberOfQrHardwareAccounts]).toBe(2);
+        // 1 mnemonic entropy id → 1 HD entropy; hardware wallets don't contribute.
+        expect(traits?.[MetaMetricsUserTrait.NumberOfHDEntropies]).toBe(1);
+        // ledger(1) + trezor(1) + lattice(1) + qr(2) = 5.
+        expect(traits?.[MetaMetricsUserTrait.NumberOfHardwareWallets]).toBe(5);
       });
     });
   });
@@ -2664,59 +2672,266 @@ describe('MetaMetricsController', function () {
     });
   });
 
-  describe('getNumberOfHDEntropies', function () {
-    it('counts HD entropies correctly across various keyring configurations', async function () {
-      await withController(({ controller: _ }) => {
-        const testScenarios = [
-          {
-            name: 'with undefined keyrings',
-            state: { keyrings: undefined },
-            expectedCount: 0,
-          },
-          {
-            name: 'with empty keyrings array',
-            state: { keyrings: [] },
-            expectedCount: 0,
-          },
-          {
-            name: 'with one HD keyring',
-            state: {
-              keyrings: [{ type: KeyringType.hdKeyTree, accounts: ['0x123'] }],
-            },
-            expectedCount: 1,
-          },
-          {
-            name: 'with two HD keyrings',
-            state: {
-              keyrings: [
-                { type: KeyringType.hdKeyTree, accounts: ['0x123'] },
-                { type: KeyringType.hdKeyTree, accounts: ['0x456'] },
-              ],
-            },
-            expectedCount: 2,
-          },
-          {
-            name: 'with mixed keyring types',
-            state: {
-              keyrings: [
-                { type: KeyringType.hdKeyTree, accounts: ['0x123'] },
-                { type: KeyringType.imported, accounts: ['0x456'] },
-                { type: KeyringType.ledger, accounts: ['0x789'] },
-                { type: KeyringType.hdKeyTree, accounts: ['0xabc'] },
-              ],
-            },
-            expectedCount: 2,
-          },
-        ];
+  describe('#getAccountCompositionTraits', function () {
+    function buildStateWithAccounts(
+      accounts: Record<string, unknown>,
+    ): Parameters<MetaMetricsController['_buildUserTraitsObject']>[0] {
+      return {
+        addressBook: {},
+        allNfts: {},
+        allTokens: {},
+        ...mockNetworkState({ chainId: CHAIN_IDS.MAINNET }),
+        internalAccounts: {
+          accounts: accounts as MetaMaskState['internalAccounts']['accounts'],
+          selectedAccount: Object.keys(accounts)[0] ?? '',
+        },
+        multichainNetworkConfigurationsByChainId: {},
+        ledgerTransportType: LedgerTransportTypes.webhid,
+        openSeaEnabled: false,
+        useNftDetection: false,
+        theme: 'default' as ThemeType,
+        useTokenDetection: false,
+        names: {},
+        currentCurrency: 'usd',
+        securityAlertsEnabled: false,
+        participateInMetaMetrics: true,
+        dataCollectionForMarketing: false,
+        preferences: {
+          privacyMode: false,
+          tokenNetworkFilter: {},
+          tokenSortConfig: { key: '', order: 'dsc', sortCallback: 'stringNumeric' },
+          showNativeTokenAsMainBalance: false,
+        } as Preferences,
+        srpSessionData: undefined,
+        keyrings: [],
+      };
+    }
 
-        testScenarios.forEach((scenario) => {
-          // Implement the same logic as the private method
-          const hdKeyringCount =
-            scenario.state.keyrings?.filter(
-              (keyring) => keyring.type === KeyringType.hdKeyTree,
-            ).length ?? 0;
-          expect(hdKeyringCount).toBe(scenario.expectedCount);
-        });
+    it('returns zeros for an empty accounts object', async function () {
+      await withController(({ controller }) => {
+        const traits = controller._buildUserTraitsObject(
+          buildStateWithAccounts({}),
+        );
+        expect(traits?.[MetaMetricsUserTrait.NumberOfHDEntropies]).toBe(0);
+        expect(traits?.[MetaMetricsUserTrait.NumberOfHardwareWallets]).toBe(0);
+        expect(traits?.[MetaMetricsUserTrait.NumberOfAccountGroups]).toBe(0);
+        expect(traits?.[MetaMetricsUserTrait.NumberOfImportedAccounts]).toBe(0);
+        expect(traits?.[MetaMetricsUserTrait.NumberOfSnapAccounts]).toBe(0);
+        expect(traits?.[MetaMetricsUserTrait.NumberOfLedgerAccounts]).toBe(0);
+        expect(traits?.[MetaMetricsUserTrait.NumberOfTrezorAccounts]).toBe(0);
+        expect(traits?.[MetaMetricsUserTrait.NumberOfLatticeAccounts]).toBe(0);
+        expect(traits?.[MetaMetricsUserTrait.NumberOfQrHardwareAccounts]).toBe(0);
+      });
+    });
+
+    it('counts a single SRP with multiple account groups as one HD entropy', async function () {
+      await withController(({ controller }) => {
+        const traits = controller._buildUserTraitsObject(
+          buildStateWithAccounts({
+            'evm-0': {
+              id: 'evm-0',
+              metadata: { keyring: { type: KeyringType.hdKeyTree } },
+              options: { entropy: { type: 'mnemonic', id: 'srp1', groupIndex: 0 } },
+            },
+            'evm-1': {
+              id: 'evm-1',
+              metadata: { keyring: { type: KeyringType.hdKeyTree } },
+              options: { entropy: { type: 'mnemonic', id: 'srp1', groupIndex: 1 } },
+            },
+            'evm-2': {
+              id: 'evm-2',
+              metadata: { keyring: { type: KeyringType.hdKeyTree } },
+              options: { entropy: { type: 'mnemonic', id: 'srp1', groupIndex: 2 } },
+            },
+          }),
+        );
+        expect(traits?.[MetaMetricsUserTrait.NumberOfHDEntropies]).toBe(1);
+        expect(traits?.[MetaMetricsUserTrait.NumberOfAccountGroups]).toBe(3);
+        expect(traits?.[MetaMetricsUserTrait.NumberOfHardwareWallets]).toBe(0);
+      });
+    });
+
+    it('counts multiple distinct SRPs as separate HD entropies', async function () {
+      await withController(({ controller }) => {
+        const traits = controller._buildUserTraitsObject(
+          buildStateWithAccounts({
+            'evm-srp1': {
+              id: 'evm-srp1',
+              metadata: { keyring: { type: KeyringType.hdKeyTree } },
+              options: { entropy: { type: 'mnemonic', id: 'srp1', groupIndex: 0 } },
+            },
+            'evm-srp2': {
+              id: 'evm-srp2',
+              metadata: { keyring: { type: KeyringType.hdKeyTree } },
+              options: { entropy: { type: 'mnemonic', id: 'srp2', groupIndex: 0 } },
+            },
+            'evm-srp3': {
+              id: 'evm-srp3',
+              metadata: { keyring: { type: KeyringType.hdKeyTree } },
+              options: { entropy: { type: 'mnemonic', id: 'srp3', groupIndex: 0 } },
+            },
+          }),
+        );
+        expect(traits?.[MetaMetricsUserTrait.NumberOfHDEntropies]).toBe(3);
+        expect(traits?.[MetaMetricsUserTrait.NumberOfAccountGroups]).toBe(3);
+      });
+    });
+
+    it('does not count hardware wallets toward HD entropies', async function () {
+      await withController(({ controller }) => {
+        const traits = controller._buildUserTraitsObject(
+          buildStateWithAccounts({
+            'ledger-1': {
+              id: 'ledger-1',
+              metadata: { keyring: { type: KeyringType.ledger } },
+              options: {},
+            },
+            'ledger-2': {
+              id: 'ledger-2',
+              metadata: { keyring: { type: KeyringType.ledger } },
+              options: {},
+            },
+            'trezor-1': {
+              id: 'trezor-1',
+              metadata: { keyring: { type: KeyringType.trezor } },
+              options: {},
+            },
+            'lattice-1': {
+              id: 'lattice-1',
+              metadata: { keyring: { type: KeyringType.lattice } },
+              options: {},
+            },
+            'qr-1': {
+              id: 'qr-1',
+              metadata: { keyring: { type: KeyringType.qr } },
+              options: {},
+            },
+            'onekey-1': {
+              id: 'onekey-1',
+              metadata: { keyring: { type: KeyringType.oneKey } },
+              options: {},
+            },
+          }),
+        );
+        expect(traits?.[MetaMetricsUserTrait.NumberOfHDEntropies]).toBe(0);
+        expect(traits?.[MetaMetricsUserTrait.NumberOfLedgerAccounts]).toBe(2);
+        expect(traits?.[MetaMetricsUserTrait.NumberOfTrezorAccounts]).toBe(1);
+        expect(traits?.[MetaMetricsUserTrait.NumberOfLatticeAccounts]).toBe(1);
+        expect(traits?.[MetaMetricsUserTrait.NumberOfQrHardwareAccounts]).toBe(2);
+        // ledger(2) + trezor(1) + lattice(1) + qr(2) = 6.
+        expect(traits?.[MetaMetricsUserTrait.NumberOfHardwareWallets]).toBe(6);
+      });
+    });
+
+    it('does not count imported accounts toward HD entropies or hardware wallets', async function () {
+      await withController(({ controller }) => {
+        const traits = controller._buildUserTraitsObject(
+          buildStateWithAccounts({
+            'imported-1': {
+              id: 'imported-1',
+              metadata: { keyring: { type: KeyringType.imported } },
+              options: {},
+            },
+            'imported-2': {
+              id: 'imported-2',
+              metadata: { keyring: { type: KeyringType.imported } },
+              options: {},
+            },
+          }),
+        );
+        expect(traits?.[MetaMetricsUserTrait.NumberOfHDEntropies]).toBe(0);
+        expect(traits?.[MetaMetricsUserTrait.NumberOfHardwareWallets]).toBe(0);
+        expect(traits?.[MetaMetricsUserTrait.NumberOfImportedAccounts]).toBe(2);
+      });
+    });
+
+    it('computes number_of_hardware_wallets as the sum of all hardware wallet types', async function () {
+      await withController(({ controller }) => {
+        const traits = controller._buildUserTraitsObject(
+          buildStateWithAccounts({
+            'ledger-1': { id: 'ledger-1', metadata: { keyring: { type: KeyringType.ledger } }, options: {} },
+            'ledger-2': { id: 'ledger-2', metadata: { keyring: { type: KeyringType.ledger } }, options: {} },
+            'trezor-1': { id: 'trezor-1', metadata: { keyring: { type: KeyringType.trezor } }, options: {} },
+            'lattice-1': { id: 'lattice-1', metadata: { keyring: { type: KeyringType.lattice } }, options: {} },
+            'lattice-2': { id: 'lattice-2', metadata: { keyring: { type: KeyringType.lattice } }, options: {} },
+            'qr-1': { id: 'qr-1', metadata: { keyring: { type: KeyringType.qr } }, options: {} },
+            'onekey-1': { id: 'onekey-1', metadata: { keyring: { type: KeyringType.oneKey } }, options: {} },
+          }),
+        );
+        // ledger(2) + trezor(1) + lattice(2) + qr(1) + onekey(1) = 7.
+        expect(traits?.[MetaMetricsUserTrait.NumberOfHardwareWallets]).toBe(7);
+      });
+    });
+
+    it('handles accounts with unknown keyring type without throwing', async function () {
+      await withController(({ controller }) => {
+        expect(() =>
+          controller._buildUserTraitsObject(
+            buildStateWithAccounts({
+              'unknown-acc': {
+                id: 'unknown-acc',
+                metadata: { keyring: { type: 'SomeUnknownKeyring' } },
+                options: {},
+              },
+            }),
+          ),
+        ).not.toThrow();
+      });
+    });
+
+    it('handles accounts with missing metadata without throwing', async function () {
+      await withController(({ controller }) => {
+        expect(() =>
+          controller._buildUserTraitsObject(
+            buildStateWithAccounts({
+              'no-metadata-acc': {
+                id: 'no-metadata-acc',
+                metadata: undefined,
+                options: {},
+              },
+            }),
+          ),
+        ).not.toThrow();
+      });
+    });
+
+    it('derives total wallets from hd_entropies + hardware_wallets + imported_accounts', async function () {
+      await withController(({ controller }) => {
+        const traits = controller._buildUserTraitsObject(
+          buildStateWithAccounts({
+            'evm-0': {
+              id: 'evm-0',
+              metadata: { keyring: { type: KeyringType.hdKeyTree } },
+              options: { entropy: { type: 'mnemonic', id: 'srp1', groupIndex: 0 } },
+            },
+            'evm-1': {
+              id: 'evm-1',
+              metadata: { keyring: { type: KeyringType.hdKeyTree } },
+              options: { entropy: { type: 'mnemonic', id: 'srp2', groupIndex: 0 } },
+            },
+            'ledger-1': {
+              id: 'ledger-1',
+              metadata: { keyring: { type: KeyringType.ledger } },
+              options: {},
+            },
+            'imported-1': {
+              id: 'imported-1',
+              metadata: { keyring: { type: KeyringType.imported } },
+              options: {},
+            },
+            // Snap accounts are excluded from total wallet count.
+            'snap-1': {
+              id: 'snap-1',
+              metadata: { keyring: { type: KeyringType.snap } },
+              options: {},
+            },
+          }),
+        );
+        const hdEntropies = traits?.[MetaMetricsUserTrait.NumberOfHDEntropies] ?? 0;
+        const hardwareWallets = traits?.[MetaMetricsUserTrait.NumberOfHardwareWallets] ?? 0;
+        const importedAccounts = traits?.[MetaMetricsUserTrait.NumberOfImportedAccounts] ?? 0;
+        // 2 SRPs + 1 hardware + 1 imported = 4 total wallets.
+        expect(hdEntropies + hardwareWallets + importedAccounts).toBe(4);
       });
     });
   });

--- a/app/scripts/controllers/metametrics-controller.test.ts
+++ b/app/scripts/controllers/metametrics-controller.test.ts
@@ -2037,6 +2037,13 @@ describe('MetaMetricsController', function () {
           [MetaMetricsUserTrait.NumberOfNfts]: 4,
           [MetaMetricsUserTrait.NumberOfTokens]: 5,
           [MetaMetricsUserTrait.NumberOfHDEntropies]: 0,
+          [MetaMetricsUserTrait.NumberOfAccountGroups]: 2,
+          [MetaMetricsUserTrait.NumberOfImportedAccounts]: 0,
+          [MetaMetricsUserTrait.NumberOfSnapAccounts]: 0,
+          [MetaMetricsUserTrait.NumberOfLedgerAccounts]: 0,
+          [MetaMetricsUserTrait.NumberOfTrezorAccounts]: 0,
+          [MetaMetricsUserTrait.NumberOfLatticeAccounts]: 0,
+          [MetaMetricsUserTrait.NumberOfQrHardwareAccounts]: 0,
           [MetaMetricsUserTrait.OpenSeaApiEnabled]: true,
           [MetaMetricsUserTrait.ThreeBoxEnabled]: false,
           [MetaMetricsUserTrait.Theme]: 'default',
@@ -2195,6 +2202,7 @@ describe('MetaMetricsController', function () {
         expect(updatedTraits).toStrictEqual({
           [MetaMetricsUserTrait.AddressBookEntries]: 4,
           [MetaMetricsUserTrait.NumberOfAccounts]: 3,
+          [MetaMetricsUserTrait.NumberOfAccountGroups]: 3,
           [MetaMetricsUserTrait.NumberOfTokens]: 1,
           [MetaMetricsUserTrait.OpenSeaApiEnabled]: false,
           [MetaMetricsUserTrait.ShowNativeTokenAsMainBalance]: false,
@@ -2339,6 +2347,171 @@ describe('MetaMetricsController', function () {
           multichainNetworkConfigurationsByChainId: {},
         });
         expect(updatedTraits).toStrictEqual(null);
+      });
+    });
+
+    it('should count BIP44 multichain accounts as one account group per entropy+index pair', async function () {
+      // Simulate 2 account groups from 1 SRP, each with EVM + BTC + SOL addresses.
+      const srp1 = 'entropy-source-id-1';
+      const mockAccounts = {
+        'evm-0': {
+          id: 'evm-0',
+          metadata: { keyring: { type: KeyringType.hdKeyTree } },
+          options: { entropy: { type: 'mnemonic', id: srp1, groupIndex: 0, derivationPath: "m/44'/60'/0'/0/0" } },
+        } as unknown as InternalAccount,
+        'btc-0': {
+          id: 'btc-0',
+          metadata: { keyring: { type: KeyringType.snap } },
+          options: { entropy: { type: 'mnemonic', id: srp1, groupIndex: 0, derivationPath: "m/44'/0'/0'/0/0" } },
+        } as unknown as InternalAccount,
+        'sol-0': {
+          id: 'sol-0',
+          metadata: { keyring: { type: KeyringType.snap } },
+          options: { entropy: { type: 'mnemonic', id: srp1, groupIndex: 0, derivationPath: "m/44'/501'/0'/0'" } },
+        } as unknown as InternalAccount,
+        'evm-1': {
+          id: 'evm-1',
+          metadata: { keyring: { type: KeyringType.hdKeyTree } },
+          options: { entropy: { type: 'mnemonic', id: srp1, groupIndex: 1, derivationPath: "m/44'/60'/1'/0/0" } },
+        } as unknown as InternalAccount,
+        'btc-1': {
+          id: 'btc-1',
+          metadata: { keyring: { type: KeyringType.snap } },
+          options: { entropy: { type: 'mnemonic', id: srp1, groupIndex: 1, derivationPath: "m/44'/0'/1'/0/0" } },
+        } as unknown as InternalAccount,
+        'sol-1': {
+          id: 'sol-1',
+          metadata: { keyring: { type: KeyringType.snap } },
+          options: { entropy: { type: 'mnemonic', id: srp1, groupIndex: 1, derivationPath: "m/44'/501'/1'/0'" } },
+        } as unknown as InternalAccount,
+      };
+      const networkState = mockNetworkState({ chainId: CHAIN_IDS.MAINNET });
+      await withController(({ controller }) => {
+        const traits = controller._buildUserTraitsObject({
+          addressBook: {},
+          allNfts: {},
+          allTokens: {},
+          ...networkState,
+          internalAccounts: {
+            accounts: mockAccounts,
+            selectedAccount: 'evm-0',
+          },
+          multichainNetworkConfigurationsByChainId: {},
+          ledgerTransportType: LedgerTransportTypes.webhid,
+          openSeaEnabled: false,
+          useNftDetection: false,
+          theme: 'default' as ThemeType,
+          useTokenDetection: false,
+          names: {},
+          currentCurrency: 'usd',
+          securityAlertsEnabled: false,
+          participateInMetaMetrics: true,
+          dataCollectionForMarketing: false,
+          preferences: {
+            privacyMode: false,
+            tokenNetworkFilter: {},
+            tokenSortConfig: { key: '', order: 'dsc', sortCallback: 'stringNumeric' },
+            showNativeTokenAsMainBalance: false,
+          } as Preferences,
+          srpSessionData: undefined,
+          keyrings: [],
+        });
+
+        // 6 internal accounts but only 2 unique {srp, groupIndex} pairs → 2 groups.
+        expect(traits?.[MetaMetricsUserTrait.NumberOfAccountGroups]).toBe(2);
+        // BTC + SOL accounts (3 per group × 2 groups - EVM accounts) = 4 snap accounts.
+        expect(traits?.[MetaMetricsUserTrait.NumberOfSnapAccounts]).toBe(4);
+        expect(traits?.[MetaMetricsUserTrait.NumberOfImportedAccounts]).toBe(0);
+        expect(traits?.[MetaMetricsUserTrait.NumberOfLedgerAccounts]).toBe(0);
+      });
+    });
+
+    it('should correctly count imported, snap, and hardware wallet account types', async function () {
+      const mockAccounts = {
+        'hd-acc': {
+          id: 'hd-acc',
+          metadata: { keyring: { type: KeyringType.hdKeyTree } },
+          options: { entropy: { type: 'mnemonic', id: 'srp1', groupIndex: 0, derivationPath: "m/44'/60'/0'/0/0" } },
+        } as unknown as InternalAccount,
+        'imported-acc': {
+          id: 'imported-acc',
+          metadata: { keyring: { type: KeyringType.imported } },
+          options: {},
+        } as unknown as InternalAccount,
+        'snap-acc': {
+          id: 'snap-acc',
+          metadata: { keyring: { type: KeyringType.snap } },
+          options: {},
+        } as unknown as InternalAccount,
+        'ledger-acc': {
+          id: 'ledger-acc',
+          metadata: { keyring: { type: KeyringType.ledger } },
+          options: {},
+        } as unknown as InternalAccount,
+        'trezor-acc': {
+          id: 'trezor-acc',
+          metadata: { keyring: { type: KeyringType.trezor } },
+          options: {},
+        } as unknown as InternalAccount,
+        'lattice-acc': {
+          id: 'lattice-acc',
+          metadata: { keyring: { type: KeyringType.lattice } },
+          options: {},
+        } as unknown as InternalAccount,
+        'qr-acc': {
+          id: 'qr-acc',
+          metadata: { keyring: { type: KeyringType.qr } },
+          options: {},
+        } as unknown as InternalAccount,
+        'onekey-acc': {
+          id: 'onekey-acc',
+          metadata: { keyring: { type: KeyringType.oneKey } },
+          options: {},
+        } as unknown as InternalAccount,
+      };
+
+      const networkState = mockNetworkState({ chainId: CHAIN_IDS.MAINNET });
+      await withController(({ controller }) => {
+        const traits = controller._buildUserTraitsObject({
+          addressBook: {},
+          allNfts: {},
+          allTokens: {},
+          ...networkState,
+          internalAccounts: {
+            accounts: mockAccounts,
+            selectedAccount: 'hd-acc',
+          },
+          multichainNetworkConfigurationsByChainId: {},
+          ledgerTransportType: LedgerTransportTypes.webhid,
+          openSeaEnabled: false,
+          useNftDetection: false,
+          theme: 'default' as ThemeType,
+          useTokenDetection: false,
+          names: {},
+          currentCurrency: 'usd',
+          securityAlertsEnabled: false,
+          participateInMetaMetrics: true,
+          dataCollectionForMarketing: false,
+          preferences: {
+            privacyMode: false,
+            tokenNetworkFilter: {},
+            tokenSortConfig: { key: '', order: 'dsc', sortCallback: 'stringNumeric' },
+            showNativeTokenAsMainBalance: false,
+          } as Preferences,
+          srpSessionData: undefined,
+          keyrings: [],
+        });
+
+        // 8 accounts: 1 HD group + 1 imported + 1 standalone snap + 1 ledger +
+        //             1 trezor + 1 lattice + 1 qr + 1 onekey = 8 distinct groups.
+        expect(traits?.[MetaMetricsUserTrait.NumberOfAccountGroups]).toBe(8);
+        expect(traits?.[MetaMetricsUserTrait.NumberOfImportedAccounts]).toBe(1);
+        expect(traits?.[MetaMetricsUserTrait.NumberOfSnapAccounts]).toBe(1);
+        expect(traits?.[MetaMetricsUserTrait.NumberOfLedgerAccounts]).toBe(1);
+        expect(traits?.[MetaMetricsUserTrait.NumberOfTrezorAccounts]).toBe(1);
+        expect(traits?.[MetaMetricsUserTrait.NumberOfLatticeAccounts]).toBe(1);
+        // QR hardware includes both 'QR Hardware Wallet Device' and 'OneKey Hardware'.
+        expect(traits?.[MetaMetricsUserTrait.NumberOfQrHardwareAccounts]).toBe(2);
       });
     });
   });

--- a/app/scripts/controllers/metametrics-controller.test.ts
+++ b/app/scripts/controllers/metametrics-controller.test.ts
@@ -2358,32 +2358,74 @@ describe('MetaMetricsController', function () {
         'evm-0': {
           id: 'evm-0',
           metadata: { keyring: { type: KeyringType.hdKeyTree } },
-          options: { entropy: { type: 'mnemonic', id: srp1, groupIndex: 0, derivationPath: "m/44'/60'/0'/0/0" } },
+          options: {
+            entropy: {
+              type: 'mnemonic',
+              id: srp1,
+              groupIndex: 0,
+              derivationPath: "m/44'/60'/0'/0/0",
+            },
+          },
         } as unknown as InternalAccount,
         'btc-0': {
           id: 'btc-0',
           metadata: { keyring: { type: KeyringType.snap } },
-          options: { entropy: { type: 'mnemonic', id: srp1, groupIndex: 0, derivationPath: "m/44'/0'/0'/0/0" } },
+          options: {
+            entropy: {
+              type: 'mnemonic',
+              id: srp1,
+              groupIndex: 0,
+              derivationPath: "m/44'/0'/0'/0/0",
+            },
+          },
         } as unknown as InternalAccount,
         'sol-0': {
           id: 'sol-0',
           metadata: { keyring: { type: KeyringType.snap } },
-          options: { entropy: { type: 'mnemonic', id: srp1, groupIndex: 0, derivationPath: "m/44'/501'/0'/0'" } },
+          options: {
+            entropy: {
+              type: 'mnemonic',
+              id: srp1,
+              groupIndex: 0,
+              derivationPath: "m/44'/501'/0'/0'",
+            },
+          },
         } as unknown as InternalAccount,
         'evm-1': {
           id: 'evm-1',
           metadata: { keyring: { type: KeyringType.hdKeyTree } },
-          options: { entropy: { type: 'mnemonic', id: srp1, groupIndex: 1, derivationPath: "m/44'/60'/1'/0/0" } },
+          options: {
+            entropy: {
+              type: 'mnemonic',
+              id: srp1,
+              groupIndex: 1,
+              derivationPath: "m/44'/60'/1'/0/0",
+            },
+          },
         } as unknown as InternalAccount,
         'btc-1': {
           id: 'btc-1',
           metadata: { keyring: { type: KeyringType.snap } },
-          options: { entropy: { type: 'mnemonic', id: srp1, groupIndex: 1, derivationPath: "m/44'/0'/1'/0/0" } },
+          options: {
+            entropy: {
+              type: 'mnemonic',
+              id: srp1,
+              groupIndex: 1,
+              derivationPath: "m/44'/0'/1'/0/0",
+            },
+          },
         } as unknown as InternalAccount,
         'sol-1': {
           id: 'sol-1',
           metadata: { keyring: { type: KeyringType.snap } },
-          options: { entropy: { type: 'mnemonic', id: srp1, groupIndex: 1, derivationPath: "m/44'/501'/1'/0'" } },
+          options: {
+            entropy: {
+              type: 'mnemonic',
+              id: srp1,
+              groupIndex: 1,
+              derivationPath: "m/44'/501'/1'/0'",
+            },
+          },
         } as unknown as InternalAccount,
       };
       const networkState = mockNetworkState({ chainId: CHAIN_IDS.MAINNET });
@@ -2411,7 +2453,11 @@ describe('MetaMetricsController', function () {
           preferences: {
             privacyMode: false,
             tokenNetworkFilter: {},
-            tokenSortConfig: { key: '', order: 'dsc', sortCallback: 'stringNumeric' },
+            tokenSortConfig: {
+              key: '',
+              order: 'dsc',
+              sortCallback: 'stringNumeric',
+            },
             showNativeTokenAsMainBalance: false,
           } as Preferences,
           srpSessionData: undefined,
@@ -2435,7 +2481,14 @@ describe('MetaMetricsController', function () {
         'hd-acc': {
           id: 'hd-acc',
           metadata: { keyring: { type: KeyringType.hdKeyTree } },
-          options: { entropy: { type: 'mnemonic', id: 'srp1', groupIndex: 0, derivationPath: "m/44'/60'/0'/0/0" } },
+          options: {
+            entropy: {
+              type: 'mnemonic',
+              id: 'srp1',
+              groupIndex: 0,
+              derivationPath: "m/44'/60'/0'/0/0",
+            },
+          },
         } as unknown as InternalAccount,
         'imported-acc': {
           id: 'imported-acc',
@@ -2499,7 +2552,11 @@ describe('MetaMetricsController', function () {
           preferences: {
             privacyMode: false,
             tokenNetworkFilter: {},
-            tokenSortConfig: { key: '', order: 'dsc', sortCallback: 'stringNumeric' },
+            tokenSortConfig: {
+              key: '',
+              order: 'dsc',
+              sortCallback: 'stringNumeric',
+            },
             showNativeTokenAsMainBalance: false,
           } as Preferences,
           srpSessionData: undefined,
@@ -2515,7 +2572,9 @@ describe('MetaMetricsController', function () {
         expect(traits?.[MetaMetricsUserTrait.NumberOfTrezorAccounts]).toBe(1);
         expect(traits?.[MetaMetricsUserTrait.NumberOfLatticeAccounts]).toBe(1);
         // QR hardware includes both 'QR Hardware Wallet Device' and 'OneKey Hardware'.
-        expect(traits?.[MetaMetricsUserTrait.NumberOfQrHardwareAccounts]).toBe(2);
+        expect(traits?.[MetaMetricsUserTrait.NumberOfQrHardwareAccounts]).toBe(
+          2,
+        );
         // 1 mnemonic entropy id → 1 HD entropy; hardware wallets don't contribute.
         expect(traits?.[MetaMetricsUserTrait.NumberOfHDEntropies]).toBe(1);
         // ledger(1) + trezor(1) + lattice(1) + qr(2) = 5.
@@ -2699,7 +2758,11 @@ describe('MetaMetricsController', function () {
         preferences: {
           privacyMode: false,
           tokenNetworkFilter: {},
-          tokenSortConfig: { key: '', order: 'dsc', sortCallback: 'stringNumeric' },
+          tokenSortConfig: {
+            key: '',
+            order: 'dsc',
+            sortCallback: 'stringNumeric',
+          },
           showNativeTokenAsMainBalance: false,
         } as Preferences,
         srpSessionData: undefined,
@@ -2720,7 +2783,9 @@ describe('MetaMetricsController', function () {
         expect(traits?.[MetaMetricsUserTrait.NumberOfLedgerAccounts]).toBe(0);
         expect(traits?.[MetaMetricsUserTrait.NumberOfTrezorAccounts]).toBe(0);
         expect(traits?.[MetaMetricsUserTrait.NumberOfLatticeAccounts]).toBe(0);
-        expect(traits?.[MetaMetricsUserTrait.NumberOfQrHardwareAccounts]).toBe(0);
+        expect(traits?.[MetaMetricsUserTrait.NumberOfQrHardwareAccounts]).toBe(
+          0,
+        );
       });
     });
 
@@ -2731,17 +2796,23 @@ describe('MetaMetricsController', function () {
             'evm-0': {
               id: 'evm-0',
               metadata: { keyring: { type: KeyringType.hdKeyTree } },
-              options: { entropy: { type: 'mnemonic', id: 'srp1', groupIndex: 0 } },
+              options: {
+                entropy: { type: 'mnemonic', id: 'srp1', groupIndex: 0 },
+              },
             },
             'evm-1': {
               id: 'evm-1',
               metadata: { keyring: { type: KeyringType.hdKeyTree } },
-              options: { entropy: { type: 'mnemonic', id: 'srp1', groupIndex: 1 } },
+              options: {
+                entropy: { type: 'mnemonic', id: 'srp1', groupIndex: 1 },
+              },
             },
             'evm-2': {
               id: 'evm-2',
               metadata: { keyring: { type: KeyringType.hdKeyTree } },
-              options: { entropy: { type: 'mnemonic', id: 'srp1', groupIndex: 2 } },
+              options: {
+                entropy: { type: 'mnemonic', id: 'srp1', groupIndex: 2 },
+              },
             },
           }),
         );
@@ -2758,17 +2829,23 @@ describe('MetaMetricsController', function () {
             'evm-srp1': {
               id: 'evm-srp1',
               metadata: { keyring: { type: KeyringType.hdKeyTree } },
-              options: { entropy: { type: 'mnemonic', id: 'srp1', groupIndex: 0 } },
+              options: {
+                entropy: { type: 'mnemonic', id: 'srp1', groupIndex: 0 },
+              },
             },
             'evm-srp2': {
               id: 'evm-srp2',
               metadata: { keyring: { type: KeyringType.hdKeyTree } },
-              options: { entropy: { type: 'mnemonic', id: 'srp2', groupIndex: 0 } },
+              options: {
+                entropy: { type: 'mnemonic', id: 'srp2', groupIndex: 0 },
+              },
             },
             'evm-srp3': {
               id: 'evm-srp3',
               metadata: { keyring: { type: KeyringType.hdKeyTree } },
-              options: { entropy: { type: 'mnemonic', id: 'srp3', groupIndex: 0 } },
+              options: {
+                entropy: { type: 'mnemonic', id: 'srp3', groupIndex: 0 },
+              },
             },
           }),
         );
@@ -2817,7 +2894,9 @@ describe('MetaMetricsController', function () {
         expect(traits?.[MetaMetricsUserTrait.NumberOfLedgerAccounts]).toBe(2);
         expect(traits?.[MetaMetricsUserTrait.NumberOfTrezorAccounts]).toBe(1);
         expect(traits?.[MetaMetricsUserTrait.NumberOfLatticeAccounts]).toBe(1);
-        expect(traits?.[MetaMetricsUserTrait.NumberOfQrHardwareAccounts]).toBe(2);
+        expect(traits?.[MetaMetricsUserTrait.NumberOfQrHardwareAccounts]).toBe(
+          2,
+        );
         // ledger(2) + trezor(1) + lattice(1) + qr(2) = 6.
         expect(traits?.[MetaMetricsUserTrait.NumberOfHardwareWallets]).toBe(6);
       });
@@ -2849,13 +2928,41 @@ describe('MetaMetricsController', function () {
       await withController(({ controller }) => {
         const traits = controller._buildUserTraitsObject(
           buildStateWithAccounts({
-            'ledger-1': { id: 'ledger-1', metadata: { keyring: { type: KeyringType.ledger } }, options: {} },
-            'ledger-2': { id: 'ledger-2', metadata: { keyring: { type: KeyringType.ledger } }, options: {} },
-            'trezor-1': { id: 'trezor-1', metadata: { keyring: { type: KeyringType.trezor } }, options: {} },
-            'lattice-1': { id: 'lattice-1', metadata: { keyring: { type: KeyringType.lattice } }, options: {} },
-            'lattice-2': { id: 'lattice-2', metadata: { keyring: { type: KeyringType.lattice } }, options: {} },
-            'qr-1': { id: 'qr-1', metadata: { keyring: { type: KeyringType.qr } }, options: {} },
-            'onekey-1': { id: 'onekey-1', metadata: { keyring: { type: KeyringType.oneKey } }, options: {} },
+            'ledger-1': {
+              id: 'ledger-1',
+              metadata: { keyring: { type: KeyringType.ledger } },
+              options: {},
+            },
+            'ledger-2': {
+              id: 'ledger-2',
+              metadata: { keyring: { type: KeyringType.ledger } },
+              options: {},
+            },
+            'trezor-1': {
+              id: 'trezor-1',
+              metadata: { keyring: { type: KeyringType.trezor } },
+              options: {},
+            },
+            'lattice-1': {
+              id: 'lattice-1',
+              metadata: { keyring: { type: KeyringType.lattice } },
+              options: {},
+            },
+            'lattice-2': {
+              id: 'lattice-2',
+              metadata: { keyring: { type: KeyringType.lattice } },
+              options: {},
+            },
+            'qr-1': {
+              id: 'qr-1',
+              metadata: { keyring: { type: KeyringType.qr } },
+              options: {},
+            },
+            'onekey-1': {
+              id: 'onekey-1',
+              metadata: { keyring: { type: KeyringType.oneKey } },
+              options: {},
+            },
           }),
         );
         // ledger(2) + trezor(1) + lattice(2) + qr(1) + onekey(1) = 7.
@@ -2902,12 +3009,16 @@ describe('MetaMetricsController', function () {
             'evm-0': {
               id: 'evm-0',
               metadata: { keyring: { type: KeyringType.hdKeyTree } },
-              options: { entropy: { type: 'mnemonic', id: 'srp1', groupIndex: 0 } },
+              options: {
+                entropy: { type: 'mnemonic', id: 'srp1', groupIndex: 0 },
+              },
             },
             'evm-1': {
               id: 'evm-1',
               metadata: { keyring: { type: KeyringType.hdKeyTree } },
-              options: { entropy: { type: 'mnemonic', id: 'srp2', groupIndex: 0 } },
+              options: {
+                entropy: { type: 'mnemonic', id: 'srp2', groupIndex: 0 },
+              },
             },
             'ledger-1': {
               id: 'ledger-1',
@@ -2927,9 +3038,12 @@ describe('MetaMetricsController', function () {
             },
           }),
         );
-        const hdEntropies = traits?.[MetaMetricsUserTrait.NumberOfHDEntropies] ?? 0;
-        const hardwareWallets = traits?.[MetaMetricsUserTrait.NumberOfHardwareWallets] ?? 0;
-        const importedAccounts = traits?.[MetaMetricsUserTrait.NumberOfImportedAccounts] ?? 0;
+        const hdEntropies =
+          traits?.[MetaMetricsUserTrait.NumberOfHDEntropies] ?? 0;
+        const hardwareWallets =
+          traits?.[MetaMetricsUserTrait.NumberOfHardwareWallets] ?? 0;
+        const importedAccounts =
+          traits?.[MetaMetricsUserTrait.NumberOfImportedAccounts] ?? 0;
         // 2 SRPs + 1 hardware + 1 imported = 4 total wallets.
         expect(hdEntropies + hardwareWallets + importedAccounts).toBe(4);
       });

--- a/app/scripts/controllers/metametrics-controller.test.ts
+++ b/app/scripts/controllers/metametrics-controller.test.ts
@@ -10,6 +10,11 @@ import {
   Token,
   TokensControllerState,
 } from '@metamask/assets-controllers';
+import {
+  EthAccountType,
+  BtcAccountType,
+  SolAccountType,
+} from '@metamask/keyring-api';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import { Browser } from 'webextension-polyfill';
 import { deriveStateFromMetadata } from '@metamask/base-controller';
@@ -46,6 +51,10 @@ import * as ManifestFlags from '../../../shared/lib/manifestFlags';
 import * as Utils from '../lib/util';
 import { mockNetworkState } from '../../../test/stub/networks';
 import { flushPromises } from '../../../test/lib/timer-helpers';
+import {
+  createMockInternalAccount,
+  createMockInternalAccounts,
+} from '../../../test/data/mock-accounts';
 import {
   MetaMetricsController,
   AllowedActions,
@@ -1892,6 +1901,35 @@ describe('MetaMetricsController', function () {
     };
   }
 
+  const buildKeyringAccount = (id: string, keyringType: string) => ({
+    id,
+    metadata: { keyring: { type: keyringType } },
+  });
+
+  const buildMnemonicEntropyAccount = ({
+    id,
+    entropyId,
+    groupIndex,
+    derivationPath,
+    keyringType = KeyringType.hdKeyTree,
+  }: {
+    id: string;
+    entropyId: string;
+    groupIndex: number;
+    derivationPath?: string;
+    keyringType?: string;
+  }) => ({
+    ...buildKeyringAccount(id, keyringType),
+    options: {
+      entropy: {
+        type: 'mnemonic' as const,
+        id: entropyId,
+        groupIndex,
+        ...(derivationPath ? { derivationPath } : {}),
+      },
+    },
+  });
+
   describe('_buildUserTraitsObject', function () {
     beforeEach(() => {
       jest.spyOn(Utils, 'getPlatform').mockReturnValue(PLATFORM_CHROME);
@@ -2391,81 +2429,73 @@ describe('MetaMetricsController', function () {
     });
 
     it('should count BIP44 multichain accounts as one account group per entropy+index pair', async function () {
-      // Simulate 2 account groups from 1 SRP, each with EVM + BTC + SOL addresses.
       const srp1 = 'entropy-source-id-1';
-      const mockAccounts = {
-        'evm-0': {
-          id: 'evm-0',
-          metadata: { keyring: { type: KeyringType.hdKeyTree } },
+      function mockBip44Account(
+        id: string,
+        type: InternalAccount['type'],
+        keyringType: InternalAccount['metadata']['keyring']['type'],
+        groupIndex: number,
+      ) {
+        return createMockInternalAccount({
+          id,
+          type,
+          metadata: { keyring: { type: keyringType } },
           options: {
             entropy: {
               type: 'mnemonic',
               id: srp1,
-              groupIndex: 0,
-              derivationPath: "m/44'/60'/0'/0/0",
+              groupIndex,
+              derivationPath: '',
             },
           },
-        } as unknown as InternalAccount,
-        'btc-0': {
-          id: 'btc-0',
-          metadata: { keyring: { type: KeyringType.snap } },
-          options: {
-            entropy: {
-              type: 'mnemonic',
-              id: srp1,
-              groupIndex: 0,
-              derivationPath: "m/44'/0'/0'/0/0",
-            },
-          },
-        } as unknown as InternalAccount,
-        'sol-0': {
-          id: 'sol-0',
-          metadata: { keyring: { type: KeyringType.snap } },
-          options: {
-            entropy: {
-              type: 'mnemonic',
-              id: srp1,
-              groupIndex: 0,
-              derivationPath: "m/44'/501'/0'/0'",
-            },
-          },
-        } as unknown as InternalAccount,
-        'evm-1': {
-          id: 'evm-1',
-          metadata: { keyring: { type: KeyringType.hdKeyTree } },
-          options: {
-            entropy: {
-              type: 'mnemonic',
-              id: srp1,
-              groupIndex: 1,
-              derivationPath: "m/44'/60'/1'/0/0",
-            },
-          },
-        } as unknown as InternalAccount,
-        'btc-1': {
-          id: 'btc-1',
-          metadata: { keyring: { type: KeyringType.snap } },
-          options: {
-            entropy: {
-              type: 'mnemonic',
-              id: srp1,
-              groupIndex: 1,
-              derivationPath: "m/44'/0'/1'/0/0",
-            },
-          },
-        } as unknown as InternalAccount,
-        'sol-1': {
-          id: 'sol-1',
-          metadata: { keyring: { type: KeyringType.snap } },
-          options: {
-            entropy: {
-              type: 'mnemonic',
-              id: srp1,
-              groupIndex: 1,
-              derivationPath: "m/44'/501'/1'/0'",
-            },
-          },
-        } as unknown as InternalAccount,
+        });
+      }
+
+      // 2 account groups from 1 SRP, each with EVM + BTC + SOL addresses.
+      const evm0 = mockBip44Account(
+        'evm-0',
+        EthAccountType.Eoa,
+        KeyringType.hdKeyTree,
+        0,
+      );
+      const btc0 = mockBip44Account(
+        'btc-0',
+        BtcAccountType.P2wpkh,
+        KeyringType.snap,
+        0,
+      );
+      const sol0 = mockBip44Account(
+        'sol-0',
+        SolAccountType.DataAccount,
+        KeyringType.snap,
+        0,
+      );
+      const evm1 = mockBip44Account(
+        'evm-1',
+        EthAccountType.Eoa,
+        KeyringType.hdKeyTree,
+        1,
+      );
+      const btc1 = mockBip44Account(
+        'btc-1',
+        BtcAccountType.P2wpkh,
+        KeyringType.snap,
+        1,
+      );
+      const sol1 = mockBip44Account(
+        'sol-1',
+        SolAccountType.DataAccount,
+        KeyringType.snap,
+        1,
+      );
+
+      const mockAccounts: Record<string, InternalAccount> = {
+        [evm0.id]: evm0,
+        [btc0.id]: btc0,
+        [sol0.id]: sol0,
+        [evm1.id]: evm1,
+        [btc1.id]: btc1,
+        [sol1.id]: sol1,
       };
       await withController(({ controller }) => {
         const traits = controller._buildUserTraitsObject(
@@ -2483,55 +2513,21 @@ describe('MetaMetricsController', function () {
     });
 
     it('should correctly count imported and hardware wallet account types', async function () {
-      const mockAccounts = {
-        'hd-acc': {
+      const mockAccounts = createMockInternalAccounts([
+        buildMnemonicEntropyAccount({
           id: 'hd-acc',
-          metadata: { keyring: { type: KeyringType.hdKeyTree } },
-          options: {
-            entropy: {
-              type: 'mnemonic',
-              id: 'srp1',
-              groupIndex: 0,
-              derivationPath: "m/44'/60'/0'/0/0",
-            },
-          },
-        } as unknown as InternalAccount,
-        'imported-acc': {
-          id: 'imported-acc',
-          metadata: { keyring: { type: KeyringType.imported } },
-          options: {},
-        } as unknown as InternalAccount,
-        'snap-acc': {
-          id: 'snap-acc',
-          metadata: { keyring: { type: KeyringType.snap } },
-          options: {},
-        } as unknown as InternalAccount,
-        'ledger-acc': {
-          id: 'ledger-acc',
-          metadata: { keyring: { type: KeyringType.ledger } },
-          options: {},
-        } as unknown as InternalAccount,
-        'trezor-acc': {
-          id: 'trezor-acc',
-          metadata: { keyring: { type: KeyringType.trezor } },
-          options: {},
-        } as unknown as InternalAccount,
-        'lattice-acc': {
-          id: 'lattice-acc',
-          metadata: { keyring: { type: KeyringType.lattice } },
-          options: {},
-        } as unknown as InternalAccount,
-        'qr-acc': {
-          id: 'qr-acc',
-          metadata: { keyring: { type: KeyringType.qr } },
-          options: {},
-        } as unknown as InternalAccount,
-        'onekey-acc': {
-          id: 'onekey-acc',
-          metadata: { keyring: { type: KeyringType.oneKey } },
-          options: {},
-        } as unknown as InternalAccount,
-      };
+          entropyId: 'srp1',
+          groupIndex: 0,
+          derivationPath: "m/44'/60'/0'/0/0",
+        }),
+        buildKeyringAccount('imported-acc', KeyringType.imported),
+        buildKeyringAccount('snap-acc', KeyringType.snap),
+        buildKeyringAccount('ledger-acc', KeyringType.ledger),
+        buildKeyringAccount('trezor-acc', KeyringType.trezor),
+        buildKeyringAccount('lattice-acc', KeyringType.lattice),
+        buildKeyringAccount('qr-acc', KeyringType.qr),
+        buildKeyringAccount('onekey-acc', KeyringType.oneKey),
+      ]);
       await withController(({ controller }) => {
         const traits = controller._buildUserTraitsObject(
           buildStateWithAccounts(mockAccounts),
@@ -2726,29 +2722,25 @@ describe('MetaMetricsController', function () {
     it('counts a single SRP with multiple account groups as one HD entropy', async function () {
       await withController(({ controller }) => {
         const traits = controller._buildUserTraitsObject(
-          buildStateWithAccounts({
-            'evm-0': {
-              id: 'evm-0',
-              metadata: { keyring: { type: KeyringType.hdKeyTree } },
-              options: {
-                entropy: { type: 'mnemonic', id: 'srp1', groupIndex: 0 },
-              },
-            } as unknown as InternalAccount,
-            'evm-1': {
-              id: 'evm-1',
-              metadata: { keyring: { type: KeyringType.hdKeyTree } },
-              options: {
-                entropy: { type: 'mnemonic', id: 'srp1', groupIndex: 1 },
-              },
-            } as unknown as InternalAccount,
-            'evm-2': {
-              id: 'evm-2',
-              metadata: { keyring: { type: KeyringType.hdKeyTree } },
-              options: {
-                entropy: { type: 'mnemonic', id: 'srp1', groupIndex: 2 },
-              },
-            } as unknown as InternalAccount,
-          }),
+          buildStateWithAccounts(
+            createMockInternalAccounts([
+              buildMnemonicEntropyAccount({
+                id: 'evm-0',
+                entropyId: 'srp1',
+                groupIndex: 0,
+              }),
+              buildMnemonicEntropyAccount({
+                id: 'evm-1',
+                entropyId: 'srp1',
+                groupIndex: 1,
+              }),
+              buildMnemonicEntropyAccount({
+                id: 'evm-2',
+                entropyId: 'srp1',
+                groupIndex: 2,
+              }),
+            ]),
+          ),
         );
         expect(traits?.[MetaMetricsUserTrait.NumberOfHDEntropies]).toBe(1);
         expect(traits?.[MetaMetricsUserTrait.NumberOfAccountGroups]).toBe(3);
@@ -2759,29 +2751,25 @@ describe('MetaMetricsController', function () {
     it('counts multiple distinct SRPs as separate HD entropies', async function () {
       await withController(({ controller }) => {
         const traits = controller._buildUserTraitsObject(
-          buildStateWithAccounts({
-            'evm-srp1': {
-              id: 'evm-srp1',
-              metadata: { keyring: { type: KeyringType.hdKeyTree } },
-              options: {
-                entropy: { type: 'mnemonic', id: 'srp1', groupIndex: 0 },
-              },
-            } as unknown as InternalAccount,
-            'evm-srp2': {
-              id: 'evm-srp2',
-              metadata: { keyring: { type: KeyringType.hdKeyTree } },
-              options: {
-                entropy: { type: 'mnemonic', id: 'srp2', groupIndex: 0 },
-              },
-            } as unknown as InternalAccount,
-            'evm-srp3': {
-              id: 'evm-srp3',
-              metadata: { keyring: { type: KeyringType.hdKeyTree } },
-              options: {
-                entropy: { type: 'mnemonic', id: 'srp3', groupIndex: 0 },
-              },
-            } as unknown as InternalAccount,
-          }),
+          buildStateWithAccounts(
+            createMockInternalAccounts([
+              buildMnemonicEntropyAccount({
+                id: 'evm-srp1',
+                entropyId: 'srp1',
+                groupIndex: 0,
+              }),
+              buildMnemonicEntropyAccount({
+                id: 'evm-srp2',
+                entropyId: 'srp2',
+                groupIndex: 0,
+              }),
+              buildMnemonicEntropyAccount({
+                id: 'evm-srp3',
+                entropyId: 'srp3',
+                groupIndex: 0,
+              }),
+            ]),
+          ),
         );
         expect(traits?.[MetaMetricsUserTrait.NumberOfHDEntropies]).toBe(3);
         expect(traits?.[MetaMetricsUserTrait.NumberOfAccountGroups]).toBe(3);
@@ -2791,38 +2779,16 @@ describe('MetaMetricsController', function () {
     it('does not count hardware wallets toward HD entropies', async function () {
       await withController(({ controller }) => {
         const traits = controller._buildUserTraitsObject(
-          buildStateWithAccounts({
-            'ledger-1': {
-              id: 'ledger-1',
-              metadata: { keyring: { type: KeyringType.ledger } },
-              options: {},
-            } as unknown as InternalAccount,
-            'ledger-2': {
-              id: 'ledger-2',
-              metadata: { keyring: { type: KeyringType.ledger } },
-              options: {},
-            } as unknown as InternalAccount,
-            'trezor-1': {
-              id: 'trezor-1',
-              metadata: { keyring: { type: KeyringType.trezor } },
-              options: {},
-            } as unknown as InternalAccount,
-            'lattice-1': {
-              id: 'lattice-1',
-              metadata: { keyring: { type: KeyringType.lattice } },
-              options: {},
-            } as unknown as InternalAccount,
-            'qr-1': {
-              id: 'qr-1',
-              metadata: { keyring: { type: KeyringType.qr } },
-              options: {},
-            } as unknown as InternalAccount,
-            'onekey-1': {
-              id: 'onekey-1',
-              metadata: { keyring: { type: KeyringType.oneKey } },
-              options: {},
-            } as unknown as InternalAccount,
-          }),
+          buildStateWithAccounts(
+            createMockInternalAccounts([
+              buildKeyringAccount('ledger-1', KeyringType.ledger),
+              buildKeyringAccount('ledger-2', KeyringType.ledger),
+              buildKeyringAccount('trezor-1', KeyringType.trezor),
+              buildKeyringAccount('lattice-1', KeyringType.lattice),
+              buildKeyringAccount('qr-1', KeyringType.qr),
+              buildKeyringAccount('onekey-1', KeyringType.oneKey),
+            ]),
+          ),
         );
         expect(traits?.[MetaMetricsUserTrait.NumberOfHDEntropies]).toBe(0);
         expect(traits?.[MetaMetricsUserTrait.NumberOfLedgerAccounts]).toBe(2);
@@ -2839,18 +2805,12 @@ describe('MetaMetricsController', function () {
     it('does not count imported accounts toward HD entropies or hardware wallets', async function () {
       await withController(({ controller }) => {
         const traits = controller._buildUserTraitsObject(
-          buildStateWithAccounts({
-            'imported-1': {
-              id: 'imported-1',
-              metadata: { keyring: { type: KeyringType.imported } },
-              options: {},
-            } as unknown as InternalAccount,
-            'imported-2': {
-              id: 'imported-2',
-              metadata: { keyring: { type: KeyringType.imported } },
-              options: {},
-            } as unknown as InternalAccount,
-          }),
+          buildStateWithAccounts(
+            createMockInternalAccounts([
+              buildKeyringAccount('imported-1', KeyringType.imported),
+              buildKeyringAccount('imported-2', KeyringType.imported),
+            ]),
+          ),
         );
         expect(traits?.[MetaMetricsUserTrait.NumberOfHDEntropies]).toBe(0);
         expect(traits?.[MetaMetricsUserTrait.NumberOfHardwareWallets]).toBe(0);
@@ -2861,43 +2821,17 @@ describe('MetaMetricsController', function () {
     it('computes number_of_hardware_wallets as the sum of all hardware wallet types', async function () {
       await withController(({ controller }) => {
         const traits = controller._buildUserTraitsObject(
-          buildStateWithAccounts({
-            'ledger-1': {
-              id: 'ledger-1',
-              metadata: { keyring: { type: KeyringType.ledger } },
-              options: {},
-            } as unknown as InternalAccount,
-            'ledger-2': {
-              id: 'ledger-2',
-              metadata: { keyring: { type: KeyringType.ledger } },
-              options: {},
-            } as unknown as InternalAccount,
-            'trezor-1': {
-              id: 'trezor-1',
-              metadata: { keyring: { type: KeyringType.trezor } },
-              options: {},
-            } as unknown as InternalAccount,
-            'lattice-1': {
-              id: 'lattice-1',
-              metadata: { keyring: { type: KeyringType.lattice } },
-              options: {},
-            } as unknown as InternalAccount,
-            'lattice-2': {
-              id: 'lattice-2',
-              metadata: { keyring: { type: KeyringType.lattice } },
-              options: {},
-            } as unknown as InternalAccount,
-            'qr-1': {
-              id: 'qr-1',
-              metadata: { keyring: { type: KeyringType.qr } },
-              options: {},
-            } as unknown as InternalAccount,
-            'onekey-1': {
-              id: 'onekey-1',
-              metadata: { keyring: { type: KeyringType.oneKey } },
-              options: {},
-            } as unknown as InternalAccount,
-          }),
+          buildStateWithAccounts(
+            createMockInternalAccounts([
+              buildKeyringAccount('ledger-1', KeyringType.ledger),
+              buildKeyringAccount('ledger-2', KeyringType.ledger),
+              buildKeyringAccount('trezor-1', KeyringType.trezor),
+              buildKeyringAccount('lattice-1', KeyringType.lattice),
+              buildKeyringAccount('lattice-2', KeyringType.lattice),
+              buildKeyringAccount('qr-1', KeyringType.qr),
+              buildKeyringAccount('onekey-1', KeyringType.oneKey),
+            ]),
+          ),
         );
         // 1 Ledger device + 1 Trezor + 1 Lattice + 1 QR (includes OneKey) = 4 distinct hardware wallets.
         expect(traits?.[MetaMetricsUserTrait.NumberOfHardwareWallets]).toBe(4);
@@ -2908,13 +2842,11 @@ describe('MetaMetricsController', function () {
       await withController(({ controller }) => {
         expect(() =>
           controller._buildUserTraitsObject(
-            buildStateWithAccounts({
-              'unknown-acc': {
-                id: 'unknown-acc',
-                metadata: { keyring: { type: 'SomeUnknownKeyring' } },
-                options: {},
-              } as unknown as InternalAccount,
-            }),
+            buildStateWithAccounts(
+              createMockInternalAccounts([
+                buildKeyringAccount('unknown-acc', 'SomeUnknownKeyring'),
+              ]),
+            ),
           ),
         ).not.toThrow();
       });
@@ -2924,13 +2856,17 @@ describe('MetaMetricsController', function () {
       await withController(({ controller }) => {
         expect(() =>
           controller._buildUserTraitsObject(
-            buildStateWithAccounts({
-              'no-metadata-acc': {
-                id: 'no-metadata-acc',
-                metadata: undefined,
-                options: {},
-              } as unknown as InternalAccount,
-            }),
+            buildStateWithAccounts(
+              createMockInternalAccounts([
+                {
+                  ...buildKeyringAccount(
+                    'no-metadata-acc',
+                    KeyringType.hdKeyTree,
+                  ),
+                  metadata: undefined,
+                },
+              ]),
+            ),
           ),
         ).not.toThrow();
       });
@@ -2939,38 +2875,24 @@ describe('MetaMetricsController', function () {
     it('derives total wallets from hd_entropies + hardware_wallets + imported_accounts', async function () {
       await withController(({ controller }) => {
         const traits = controller._buildUserTraitsObject(
-          buildStateWithAccounts({
-            'evm-0': {
-              id: 'evm-0',
-              metadata: { keyring: { type: KeyringType.hdKeyTree } },
-              options: {
-                entropy: { type: 'mnemonic', id: 'srp1', groupIndex: 0 },
-              },
-            } as unknown as InternalAccount,
-            'evm-1': {
-              id: 'evm-1',
-              metadata: { keyring: { type: KeyringType.hdKeyTree } },
-              options: {
-                entropy: { type: 'mnemonic', id: 'srp2', groupIndex: 0 },
-              },
-            } as unknown as InternalAccount,
-            'ledger-1': {
-              id: 'ledger-1',
-              metadata: { keyring: { type: KeyringType.ledger } },
-              options: {},
-            } as unknown as InternalAccount,
-            'imported-1': {
-              id: 'imported-1',
-              metadata: { keyring: { type: KeyringType.imported } },
-              options: {},
-            } as unknown as InternalAccount,
-            // Snap accounts are excluded from total wallet count.
-            'snap-1': {
-              id: 'snap-1',
-              metadata: { keyring: { type: KeyringType.snap } },
-              options: {},
-            } as unknown as InternalAccount,
-          }),
+          buildStateWithAccounts(
+            createMockInternalAccounts([
+              buildMnemonicEntropyAccount({
+                id: 'evm-0',
+                entropyId: 'srp1',
+                groupIndex: 0,
+              }),
+              buildMnemonicEntropyAccount({
+                id: 'evm-1',
+                entropyId: 'srp2',
+                groupIndex: 0,
+              }),
+              buildKeyringAccount('ledger-1', KeyringType.ledger),
+              buildKeyringAccount('imported-1', KeyringType.imported),
+              // Snap accounts are excluded from total wallet count.
+              buildKeyringAccount('snap-1', KeyringType.snap),
+            ]),
+          ),
         );
         const hdEntropies =
           traits?.[MetaMetricsUserTrait.NumberOfHDEntropies] ?? 0;

--- a/app/scripts/controllers/metametrics-controller.test.ts
+++ b/app/scripts/controllers/metametrics-controller.test.ts
@@ -2039,7 +2039,6 @@ describe('MetaMetricsController', function () {
           [MetaMetricsUserTrait.NumberOfHDEntropies]: 0,
           [MetaMetricsUserTrait.NumberOfAccountGroups]: 2,
           [MetaMetricsUserTrait.NumberOfImportedAccounts]: 0,
-          [MetaMetricsUserTrait.NumberOfSnapAccounts]: 0,
           [MetaMetricsUserTrait.NumberOfLedgerAccounts]: 0,
           [MetaMetricsUserTrait.NumberOfTrezorAccounts]: 0,
           [MetaMetricsUserTrait.NumberOfLatticeAccounts]: 0,
@@ -2466,8 +2465,6 @@ describe('MetaMetricsController', function () {
 
         // 6 internal accounts but only 2 unique {srp, groupIndex} pairs → 2 groups.
         expect(traits?.[MetaMetricsUserTrait.NumberOfAccountGroups]).toBe(2);
-        // BTC + SOL accounts (3 per group × 2 groups - EVM accounts) = 4 snap accounts.
-        expect(traits?.[MetaMetricsUserTrait.NumberOfSnapAccounts]).toBe(4);
         expect(traits?.[MetaMetricsUserTrait.NumberOfImportedAccounts]).toBe(0);
         expect(traits?.[MetaMetricsUserTrait.NumberOfLedgerAccounts]).toBe(0);
         // 1 unique entropy id → 1 HD entropy.
@@ -2476,7 +2473,7 @@ describe('MetaMetricsController', function () {
       });
     });
 
-    it('should correctly count imported, snap, and hardware wallet account types', async function () {
+    it('should correctly count imported and hardware wallet account types', async function () {
       const mockAccounts = {
         'hd-acc': {
           id: 'hd-acc',
@@ -2563,11 +2560,10 @@ describe('MetaMetricsController', function () {
           keyrings: [],
         });
 
-        // 8 accounts: 1 HD group + 1 imported + 1 standalone snap + 1 ledger +
+        // 8 accounts: 1 HD group + 1 imported + 1 snap + 1 ledger +
         //             1 trezor + 1 lattice + 1 qr + 1 onekey = 8 distinct groups.
         expect(traits?.[MetaMetricsUserTrait.NumberOfAccountGroups]).toBe(8);
         expect(traits?.[MetaMetricsUserTrait.NumberOfImportedAccounts]).toBe(1);
-        expect(traits?.[MetaMetricsUserTrait.NumberOfSnapAccounts]).toBe(1);
         expect(traits?.[MetaMetricsUserTrait.NumberOfLedgerAccounts]).toBe(1);
         expect(traits?.[MetaMetricsUserTrait.NumberOfTrezorAccounts]).toBe(1);
         expect(traits?.[MetaMetricsUserTrait.NumberOfLatticeAccounts]).toBe(1);
@@ -2779,7 +2775,6 @@ describe('MetaMetricsController', function () {
         expect(traits?.[MetaMetricsUserTrait.NumberOfHardwareWallets]).toBe(0);
         expect(traits?.[MetaMetricsUserTrait.NumberOfAccountGroups]).toBe(0);
         expect(traits?.[MetaMetricsUserTrait.NumberOfImportedAccounts]).toBe(0);
-        expect(traits?.[MetaMetricsUserTrait.NumberOfSnapAccounts]).toBe(0);
         expect(traits?.[MetaMetricsUserTrait.NumberOfLedgerAccounts]).toBe(0);
         expect(traits?.[MetaMetricsUserTrait.NumberOfTrezorAccounts]).toBe(0);
         expect(traits?.[MetaMetricsUserTrait.NumberOfLatticeAccounts]).toBe(0);

--- a/app/scripts/controllers/metametrics-controller.test.ts
+++ b/app/scripts/controllers/metametrics-controller.test.ts
@@ -2577,8 +2577,8 @@ describe('MetaMetricsController', function () {
         );
         // 1 mnemonic entropy id → 1 HD entropy; hardware wallets don't contribute.
         expect(traits?.[MetaMetricsUserTrait.NumberOfHDEntropies]).toBe(1);
-        // ledger(1) + trezor(1) + lattice(1) + qr(2) = 5.
-        expect(traits?.[MetaMetricsUserTrait.NumberOfHardwareWallets]).toBe(5);
+        // 1 of each type paired → 4 distinct hardware wallets (one per type).
+        expect(traits?.[MetaMetricsUserTrait.NumberOfHardwareWallets]).toBe(4);
       });
     });
   });
@@ -2897,8 +2897,8 @@ describe('MetaMetricsController', function () {
         expect(traits?.[MetaMetricsUserTrait.NumberOfQrHardwareAccounts]).toBe(
           2,
         );
-        // ledger(2) + trezor(1) + lattice(1) + qr(2) = 6.
-        expect(traits?.[MetaMetricsUserTrait.NumberOfHardwareWallets]).toBe(6);
+        // 1 Ledger device + 1 Trezor + 1 Lattice + 1 QR (OneKey) = 4 distinct hardware wallets.
+        expect(traits?.[MetaMetricsUserTrait.NumberOfHardwareWallets]).toBe(4);
       });
     });
 
@@ -2965,8 +2965,8 @@ describe('MetaMetricsController', function () {
             },
           }),
         );
-        // ledger(2) + trezor(1) + lattice(2) + qr(1) + onekey(1) = 7.
-        expect(traits?.[MetaMetricsUserTrait.NumberOfHardwareWallets]).toBe(7);
+        // 1 Ledger device + 1 Trezor + 1 Lattice + 1 QR (includes OneKey) = 4 distinct hardware wallets.
+        expect(traits?.[MetaMetricsUserTrait.NumberOfHardwareWallets]).toBe(4);
       });
     });
 

--- a/app/scripts/controllers/metametrics-controller.test.ts
+++ b/app/scripts/controllers/metametrics-controller.test.ts
@@ -50,7 +50,6 @@ import {
   MetaMetricsController,
   AllowedActions,
   AllowedEvents,
-  MetaMaskState,
   MetaMetricsControllerOptions,
 } from './metametrics-controller';
 import {
@@ -1853,6 +1852,46 @@ describe('MetaMetricsController', function () {
     });
   });
 
+  function buildStateWithAccounts(
+    accounts: Record<string, InternalAccount>,
+  ): Parameters<MetaMetricsController['_buildUserTraitsObject']>[0] {
+    return {
+      addressBook: {},
+      allNfts: {},
+      allTokens: {},
+      ...mockNetworkState({ chainId: CHAIN_IDS.MAINNET }),
+      internalAccounts: {
+        accounts,
+        selectedAccount: Object.keys(accounts)[0] ?? '',
+      },
+      multichainNetworkConfigurationsByChainId: {},
+      ledgerTransportType: LedgerTransportTypes.webhid,
+      openSeaEnabled: false,
+      useNftDetection: false,
+      theme: 'default' as ThemeType,
+      useTokenDetection: false,
+      names: {
+        [NameType.ETHEREUM_ADDRESS]: {},
+      },
+      currentCurrency: 'usd',
+      securityAlertsEnabled: false,
+      participateInMetaMetrics: true,
+      dataCollectionForMarketing: false,
+      preferences: {
+        privacyMode: false,
+        tokenNetworkFilter: {},
+        tokenSortConfig: {
+          key: '',
+          order: 'dsc',
+          sortCallback: 'stringNumeric',
+        },
+        showNativeTokenAsMainBalance: false,
+      } as Preferences,
+      srpSessionData: undefined,
+      keyrings: [],
+    };
+  }
+
   describe('_buildUserTraitsObject', function () {
     beforeEach(() => {
       jest.spyOn(Utils, 'getPlatform').mockReturnValue(PLATFORM_CHROME);
@@ -2428,43 +2467,10 @@ describe('MetaMetricsController', function () {
           },
         } as unknown as InternalAccount,
       };
-      const networkState = mockNetworkState({ chainId: CHAIN_IDS.MAINNET });
       await withController(({ controller }) => {
-        const traits = controller._buildUserTraitsObject({
-          addressBook: {},
-          allNfts: {},
-          allTokens: {},
-          ...networkState,
-          internalAccounts: {
-            accounts: mockAccounts,
-            selectedAccount: 'evm-0',
-          },
-          multichainNetworkConfigurationsByChainId: {},
-          ledgerTransportType: LedgerTransportTypes.webhid,
-          openSeaEnabled: false,
-          useNftDetection: false,
-          theme: 'default' as ThemeType,
-          useTokenDetection: false,
-          names: {
-            [NameType.ETHEREUM_ADDRESS]: {},
-          },
-          currentCurrency: 'usd',
-          securityAlertsEnabled: false,
-          participateInMetaMetrics: true,
-          dataCollectionForMarketing: false,
-          preferences: {
-            privacyMode: false,
-            tokenNetworkFilter: {},
-            tokenSortConfig: {
-              key: '',
-              order: 'dsc',
-              sortCallback: 'stringNumeric',
-            },
-            showNativeTokenAsMainBalance: false,
-          } as Preferences,
-          srpSessionData: undefined,
-          keyrings: [],
-        });
+        const traits = controller._buildUserTraitsObject(
+          buildStateWithAccounts(mockAccounts),
+        );
 
         // 6 internal accounts but only 2 unique {srp, groupIndex} pairs → 2 groups.
         expect(traits?.[MetaMetricsUserTrait.NumberOfAccountGroups]).toBe(2);
@@ -2526,44 +2532,10 @@ describe('MetaMetricsController', function () {
           options: {},
         } as unknown as InternalAccount,
       };
-
-      const networkState = mockNetworkState({ chainId: CHAIN_IDS.MAINNET });
       await withController(({ controller }) => {
-        const traits = controller._buildUserTraitsObject({
-          addressBook: {},
-          allNfts: {},
-          allTokens: {},
-          ...networkState,
-          internalAccounts: {
-            accounts: mockAccounts,
-            selectedAccount: 'hd-acc',
-          },
-          multichainNetworkConfigurationsByChainId: {},
-          ledgerTransportType: LedgerTransportTypes.webhid,
-          openSeaEnabled: false,
-          useNftDetection: false,
-          theme: 'default' as ThemeType,
-          useTokenDetection: false,
-          names: {
-            [NameType.ETHEREUM_ADDRESS]: {},
-          },
-          currentCurrency: 'usd',
-          securityAlertsEnabled: false,
-          participateInMetaMetrics: true,
-          dataCollectionForMarketing: false,
-          preferences: {
-            privacyMode: false,
-            tokenNetworkFilter: {},
-            tokenSortConfig: {
-              key: '',
-              order: 'dsc',
-              sortCallback: 'stringNumeric',
-            },
-            showNativeTokenAsMainBalance: false,
-          } as Preferences,
-          srpSessionData: undefined,
-          keyrings: [],
-        });
+        const traits = controller._buildUserTraitsObject(
+          buildStateWithAccounts(mockAccounts),
+        );
 
         // 8 accounts: 1 HD group + 1 imported + 1 snap + 1 ledger +
         //             1 trezor + 1 lattice + 1 qr + 1 onekey = 8 distinct groups.
@@ -2733,46 +2705,6 @@ describe('MetaMetricsController', function () {
   });
 
   describe('#getAccountCompositionTraits', function () {
-    function buildStateWithAccounts(
-      accounts: Record<string, unknown>,
-    ): Parameters<MetaMetricsController['_buildUserTraitsObject']>[0] {
-      return {
-        addressBook: {},
-        allNfts: {},
-        allTokens: {},
-        ...mockNetworkState({ chainId: CHAIN_IDS.MAINNET }),
-        internalAccounts: {
-          accounts: accounts as MetaMaskState['internalAccounts']['accounts'],
-          selectedAccount: Object.keys(accounts)[0] ?? '',
-        },
-        multichainNetworkConfigurationsByChainId: {},
-        ledgerTransportType: LedgerTransportTypes.webhid,
-        openSeaEnabled: false,
-        useNftDetection: false,
-        theme: 'default' as ThemeType,
-        useTokenDetection: false,
-        names: {
-          [NameType.ETHEREUM_ADDRESS]: {},
-        },
-        currentCurrency: 'usd',
-        securityAlertsEnabled: false,
-        participateInMetaMetrics: true,
-        dataCollectionForMarketing: false,
-        preferences: {
-          privacyMode: false,
-          tokenNetworkFilter: {},
-          tokenSortConfig: {
-            key: '',
-            order: 'dsc',
-            sortCallback: 'stringNumeric',
-          },
-          showNativeTokenAsMainBalance: false,
-        } as Preferences,
-        srpSessionData: undefined,
-        keyrings: [],
-      };
-    }
-
     it('returns zeros for an empty accounts object', async function () {
       await withController(({ controller }) => {
         const traits = controller._buildUserTraitsObject(
@@ -2801,21 +2733,21 @@ describe('MetaMetricsController', function () {
               options: {
                 entropy: { type: 'mnemonic', id: 'srp1', groupIndex: 0 },
               },
-            },
+            } as unknown as InternalAccount,
             'evm-1': {
               id: 'evm-1',
               metadata: { keyring: { type: KeyringType.hdKeyTree } },
               options: {
                 entropy: { type: 'mnemonic', id: 'srp1', groupIndex: 1 },
               },
-            },
+            } as unknown as InternalAccount,
             'evm-2': {
               id: 'evm-2',
               metadata: { keyring: { type: KeyringType.hdKeyTree } },
               options: {
                 entropy: { type: 'mnemonic', id: 'srp1', groupIndex: 2 },
               },
-            },
+            } as unknown as InternalAccount,
           }),
         );
         expect(traits?.[MetaMetricsUserTrait.NumberOfHDEntropies]).toBe(1);
@@ -2834,21 +2766,21 @@ describe('MetaMetricsController', function () {
               options: {
                 entropy: { type: 'mnemonic', id: 'srp1', groupIndex: 0 },
               },
-            },
+            } as unknown as InternalAccount,
             'evm-srp2': {
               id: 'evm-srp2',
               metadata: { keyring: { type: KeyringType.hdKeyTree } },
               options: {
                 entropy: { type: 'mnemonic', id: 'srp2', groupIndex: 0 },
               },
-            },
+            } as unknown as InternalAccount,
             'evm-srp3': {
               id: 'evm-srp3',
               metadata: { keyring: { type: KeyringType.hdKeyTree } },
               options: {
                 entropy: { type: 'mnemonic', id: 'srp3', groupIndex: 0 },
               },
-            },
+            } as unknown as InternalAccount,
           }),
         );
         expect(traits?.[MetaMetricsUserTrait.NumberOfHDEntropies]).toBe(3);
@@ -2864,32 +2796,32 @@ describe('MetaMetricsController', function () {
               id: 'ledger-1',
               metadata: { keyring: { type: KeyringType.ledger } },
               options: {},
-            },
+            } as unknown as InternalAccount,
             'ledger-2': {
               id: 'ledger-2',
               metadata: { keyring: { type: KeyringType.ledger } },
               options: {},
-            },
+            } as unknown as InternalAccount,
             'trezor-1': {
               id: 'trezor-1',
               metadata: { keyring: { type: KeyringType.trezor } },
               options: {},
-            },
+            } as unknown as InternalAccount,
             'lattice-1': {
               id: 'lattice-1',
               metadata: { keyring: { type: KeyringType.lattice } },
               options: {},
-            },
+            } as unknown as InternalAccount,
             'qr-1': {
               id: 'qr-1',
               metadata: { keyring: { type: KeyringType.qr } },
               options: {},
-            },
+            } as unknown as InternalAccount,
             'onekey-1': {
               id: 'onekey-1',
               metadata: { keyring: { type: KeyringType.oneKey } },
               options: {},
-            },
+            } as unknown as InternalAccount,
           }),
         );
         expect(traits?.[MetaMetricsUserTrait.NumberOfHDEntropies]).toBe(0);
@@ -2912,12 +2844,12 @@ describe('MetaMetricsController', function () {
               id: 'imported-1',
               metadata: { keyring: { type: KeyringType.imported } },
               options: {},
-            },
+            } as unknown as InternalAccount,
             'imported-2': {
               id: 'imported-2',
               metadata: { keyring: { type: KeyringType.imported } },
               options: {},
-            },
+            } as unknown as InternalAccount,
           }),
         );
         expect(traits?.[MetaMetricsUserTrait.NumberOfHDEntropies]).toBe(0);
@@ -2934,37 +2866,37 @@ describe('MetaMetricsController', function () {
               id: 'ledger-1',
               metadata: { keyring: { type: KeyringType.ledger } },
               options: {},
-            },
+            } as unknown as InternalAccount,
             'ledger-2': {
               id: 'ledger-2',
               metadata: { keyring: { type: KeyringType.ledger } },
               options: {},
-            },
+            } as unknown as InternalAccount,
             'trezor-1': {
               id: 'trezor-1',
               metadata: { keyring: { type: KeyringType.trezor } },
               options: {},
-            },
+            } as unknown as InternalAccount,
             'lattice-1': {
               id: 'lattice-1',
               metadata: { keyring: { type: KeyringType.lattice } },
               options: {},
-            },
+            } as unknown as InternalAccount,
             'lattice-2': {
               id: 'lattice-2',
               metadata: { keyring: { type: KeyringType.lattice } },
               options: {},
-            },
+            } as unknown as InternalAccount,
             'qr-1': {
               id: 'qr-1',
               metadata: { keyring: { type: KeyringType.qr } },
               options: {},
-            },
+            } as unknown as InternalAccount,
             'onekey-1': {
               id: 'onekey-1',
               metadata: { keyring: { type: KeyringType.oneKey } },
               options: {},
-            },
+            } as unknown as InternalAccount,
           }),
         );
         // 1 Ledger device + 1 Trezor + 1 Lattice + 1 QR (includes OneKey) = 4 distinct hardware wallets.
@@ -2981,7 +2913,7 @@ describe('MetaMetricsController', function () {
                 id: 'unknown-acc',
                 metadata: { keyring: { type: 'SomeUnknownKeyring' } },
                 options: {},
-              },
+              } as unknown as InternalAccount,
             }),
           ),
         ).not.toThrow();
@@ -2997,7 +2929,7 @@ describe('MetaMetricsController', function () {
                 id: 'no-metadata-acc',
                 metadata: undefined,
                 options: {},
-              },
+              } as unknown as InternalAccount,
             }),
           ),
         ).not.toThrow();
@@ -3014,30 +2946,30 @@ describe('MetaMetricsController', function () {
               options: {
                 entropy: { type: 'mnemonic', id: 'srp1', groupIndex: 0 },
               },
-            },
+            } as unknown as InternalAccount,
             'evm-1': {
               id: 'evm-1',
               metadata: { keyring: { type: KeyringType.hdKeyTree } },
               options: {
                 entropy: { type: 'mnemonic', id: 'srp2', groupIndex: 0 },
               },
-            },
+            } as unknown as InternalAccount,
             'ledger-1': {
               id: 'ledger-1',
               metadata: { keyring: { type: KeyringType.ledger } },
               options: {},
-            },
+            } as unknown as InternalAccount,
             'imported-1': {
               id: 'imported-1',
               metadata: { keyring: { type: KeyringType.imported } },
               options: {},
-            },
+            } as unknown as InternalAccount,
             // Snap accounts are excluded from total wallet count.
             'snap-1': {
               id: 'snap-1',
               metadata: { keyring: { type: KeyringType.snap } },
               options: {},
-            },
+            } as unknown as InternalAccount,
           }),
         );
         const hdEntropies =

--- a/app/scripts/controllers/metametrics-controller.test.ts
+++ b/app/scripts/controllers/metametrics-controller.test.ts
@@ -50,6 +50,7 @@ import {
   MetaMetricsController,
   AllowedActions,
   AllowedEvents,
+  MetaMaskState,
   MetaMetricsControllerOptions,
 } from './metametrics-controller';
 import {
@@ -2444,7 +2445,9 @@ describe('MetaMetricsController', function () {
           useNftDetection: false,
           theme: 'default' as ThemeType,
           useTokenDetection: false,
-          names: {},
+          names: {
+            [NameType.ETHEREUM_ADDRESS]: {},
+          },
           currentCurrency: 'usd',
           securityAlertsEnabled: false,
           participateInMetaMetrics: true,
@@ -2541,7 +2544,9 @@ describe('MetaMetricsController', function () {
           useNftDetection: false,
           theme: 'default' as ThemeType,
           useTokenDetection: false,
-          names: {},
+          names: {
+            [NameType.ETHEREUM_ADDRESS]: {},
+          },
           currentCurrency: 'usd',
           securityAlertsEnabled: false,
           participateInMetaMetrics: true,
@@ -2746,7 +2751,9 @@ describe('MetaMetricsController', function () {
         useNftDetection: false,
         theme: 'default' as ThemeType,
         useTokenDetection: false,
-        names: {},
+        names: {
+          [NameType.ETHEREUM_ADDRESS]: {},
+        },
         currentCurrency: 'usd',
         securityAlertsEnabled: false,
         participateInMetaMetrics: true,

--- a/app/scripts/controllers/metametrics-controller.ts
+++ b/app/scripts/controllers/metametrics-controller.ts
@@ -1574,7 +1574,9 @@ export class MetaMetricsController extends BaseController<
    *
    * @param metamaskState
    */
-  #getAccountCompositionTraits(metamaskState: MetaMaskState): Partial<MetaMetricsUserTraits> {
+  #getAccountCompositionTraits(
+    metamaskState: MetaMaskState,
+  ): Partial<MetaMetricsUserTraits> {
     const accountGroupKeys = new Set<string>();
     const hdEntropyIds = new Set<string>();
     let numberOfImportedAccounts = 0;
@@ -1621,7 +1623,11 @@ export class MetaMetricsController extends BaseController<
         | { type: string }
         | undefined;
 
-      if (entropy?.type === 'mnemonic' && 'id' in entropy && 'groupIndex' in entropy) {
+      if (
+        entropy?.type === 'mnemonic' &&
+        'id' in entropy &&
+        'groupIndex' in entropy
+      ) {
         accountGroupKeys.add(`${entropy.id}:${entropy.groupIndex}`);
         hdEntropyIds.add(entropy.id);
       } else {
@@ -1637,7 +1643,8 @@ export class MetaMetricsController extends BaseController<
       [MetaMetricsUserTrait.NumberOfLedgerAccounts]: numberOfLedgerAccounts,
       [MetaMetricsUserTrait.NumberOfTrezorAccounts]: numberOfTrezorAccounts,
       [MetaMetricsUserTrait.NumberOfLatticeAccounts]: numberOfLatticeAccounts,
-      [MetaMetricsUserTrait.NumberOfQrHardwareAccounts]: numberOfQrHardwareAccounts,
+      [MetaMetricsUserTrait.NumberOfQrHardwareAccounts]:
+        numberOfQrHardwareAccounts,
       [MetaMetricsUserTrait.NumberOfHardwareWallets]:
         numberOfLedgerAccounts +
         numberOfTrezorAccounts +

--- a/app/scripts/controllers/metametrics-controller.ts
+++ b/app/scripts/controllers/metametrics-controller.ts
@@ -34,6 +34,7 @@ import {
 } from '@metamask/base-controller';
 import type { Messenger } from '@metamask/messenger';
 import type { Json, Hex } from '@metamask/utils';
+import type { InternalAccount } from '@metamask/keyring-internal-api';
 import {
   ENVIRONMENT_TYPE_BACKGROUND,
   PLATFORM_FIREFOX,
@@ -82,7 +83,6 @@ import {
   type TraceCallback,
 } from '../../../shared/lib/trace';
 import { ENVIRONMENT } from '../../../development/build/constants';
-import type { InternalAccount } from '@metamask/keyring-internal-api';
 import { KeyringType } from '../../../shared/constants/keyring';
 import type { captureException } from '../../../shared/lib/sentry';
 import type { FlattenedBackgroundStateProxy } from '../../../shared/types';

--- a/app/scripts/controllers/metametrics-controller.ts
+++ b/app/scripts/controllers/metametrics-controller.ts
@@ -1441,9 +1441,6 @@ export class MetaMetricsController extends BaseController<
       [MetaMetricsUserTrait.NumberOfTokens]: this.#getNumberOfTokens(
         getTokensControllerAllTokens({ metamask: metamaskState }),
       ),
-      [MetaMetricsUserTrait.NumberOfHDEntropies]:
-        this.#getNumberOfHDEntropies(metamaskState) ??
-        this.previousUserTraits?.number_of_hd_entropies,
       ...this.#getAccountCompositionTraits(metamaskState),
       [MetaMetricsUserTrait.OpenSeaApiEnabled]: metamaskState.openSeaEnabled,
       [MetaMetricsUserTrait.ThreeBoxEnabled]: false, // deprecated, hard-coded as false
@@ -1567,19 +1564,6 @@ export class MetaMetricsController extends BaseController<
   }
 
   /**
-   * Returns the number of HD Entropies the user has.
-   *
-   * @param metamaskState
-   */
-  #getNumberOfHDEntropies(metamaskState: MetaMaskState): number {
-    return (
-      metamaskState.keyrings?.filter(
-        (keyring) => keyring.type === KeyringType.hdKeyTree,
-      ).length ?? 0
-    );
-  }
-
-  /**
    * Computes wallet composition traits from internalAccounts, which is always
    * available regardless of lock state (unlike keyrings).
    *
@@ -1592,6 +1576,7 @@ export class MetaMetricsController extends BaseController<
    */
   #getAccountCompositionTraits(metamaskState: MetaMaskState): Partial<MetaMetricsUserTraits> {
     const accountGroupKeys = new Set<string>();
+    const hdEntropyIds = new Set<string>();
     let numberOfImportedAccounts = 0;
     let numberOfSnapAccounts = 0;
     let numberOfLedgerAccounts = 0;
@@ -1638,12 +1623,14 @@ export class MetaMetricsController extends BaseController<
 
       if (entropy?.type === 'mnemonic' && 'id' in entropy && 'groupIndex' in entropy) {
         accountGroupKeys.add(`${entropy.id}:${entropy.groupIndex}`);
+        hdEntropyIds.add(entropy.id);
       } else {
         accountGroupKeys.add(accountId);
       }
     }
 
     return {
+      [MetaMetricsUserTrait.NumberOfHDEntropies]: hdEntropyIds.size,
       [MetaMetricsUserTrait.NumberOfAccountGroups]: accountGroupKeys.size,
       [MetaMetricsUserTrait.NumberOfImportedAccounts]: numberOfImportedAccounts,
       [MetaMetricsUserTrait.NumberOfSnapAccounts]: numberOfSnapAccounts,
@@ -1651,6 +1638,11 @@ export class MetaMetricsController extends BaseController<
       [MetaMetricsUserTrait.NumberOfTrezorAccounts]: numberOfTrezorAccounts,
       [MetaMetricsUserTrait.NumberOfLatticeAccounts]: numberOfLatticeAccounts,
       [MetaMetricsUserTrait.NumberOfQrHardwareAccounts]: numberOfQrHardwareAccounts,
+      [MetaMetricsUserTrait.NumberOfHardwareWallets]:
+        numberOfLedgerAccounts +
+        numberOfTrezorAccounts +
+        numberOfLatticeAccounts +
+        numberOfQrHardwareAccounts,
     };
   }
 

--- a/app/scripts/controllers/metametrics-controller.ts
+++ b/app/scripts/controllers/metametrics-controller.ts
@@ -82,6 +82,7 @@ import {
   type TraceCallback,
 } from '../../../shared/lib/trace';
 import { ENVIRONMENT } from '../../../development/build/constants';
+import type { InternalAccount } from '@metamask/keyring-internal-api';
 import { KeyringType } from '../../../shared/constants/keyring';
 import type { captureException } from '../../../shared/lib/sentry';
 import type { FlattenedBackgroundStateProxy } from '../../../shared/types';
@@ -1441,7 +1442,6 @@ export class MetaMetricsController extends BaseController<
       [MetaMetricsUserTrait.NumberOfTokens]: this.#getNumberOfTokens(
         getTokensControllerAllTokens({ metamask: metamaskState }),
       ),
-      ...this.#getAccountCompositionTraits(metamaskState),
       [MetaMetricsUserTrait.OpenSeaApiEnabled]: metamaskState.openSeaEnabled,
       [MetaMetricsUserTrait.ThreeBoxEnabled]: false, // deprecated, hard-coded as false
       [MetaMetricsUserTrait.Theme]: metamaskState.theme || 'default',
@@ -1472,6 +1472,7 @@ export class MetaMetricsController extends BaseController<
       [MetaMetricsUserTrait.InstallType]: getInstallType(),
       [MetaMetricsUserTrait.DeviceType]: getDeviceType(),
       [MetaMetricsUserTrait.Os]: getOs(),
+      ...this.#getAccountCompositionTraits(metamaskState),
     };
 
     if (!this.previousUserTraits && metamaskState.participateInMetaMetrics) {
@@ -1614,10 +1615,8 @@ export class MetaMetricsController extends BaseController<
       // BIP44 multichain accounts share an entropy source id and group index
       // across all chains (EVM, BTC, SOL, …). Deduplicating on that key gives
       // the count of account groups rather than individual chain addresses.
-      const entropy = account.options?.entropy as
-        | { type: 'mnemonic'; id: string; groupIndex: number }
-        | { type: string }
-        | undefined;
+      const entropy: InternalAccount['options']['entropy'] =
+        account.options?.entropy;
 
       if (
         entropy?.type === 'mnemonic' &&

--- a/app/scripts/controllers/metametrics-controller.ts
+++ b/app/scripts/controllers/metametrics-controller.ts
@@ -1593,23 +1593,23 @@ export class MetaMetricsController extends BaseController<
 
       switch (keyringType) {
         case KeyringType.imported:
-          numberOfImportedAccounts++;
+          numberOfImportedAccounts += 1;
           break;
         case KeyringType.snap:
-          numberOfSnapAccounts++;
+          numberOfSnapAccounts += 1;
           break;
         case KeyringType.ledger:
-          numberOfLedgerAccounts++;
+          numberOfLedgerAccounts += 1;
           break;
         case KeyringType.trezor:
-          numberOfTrezorAccounts++;
+          numberOfTrezorAccounts += 1;
           break;
         case KeyringType.lattice:
-          numberOfLatticeAccounts++;
+          numberOfLatticeAccounts += 1;
           break;
         case KeyringType.qr:
         case KeyringType.oneKey:
-          numberOfQrHardwareAccounts++;
+          numberOfQrHardwareAccounts += 1;
           break;
         default:
           break;

--- a/app/scripts/controllers/metametrics-controller.ts
+++ b/app/scripts/controllers/metametrics-controller.ts
@@ -1580,7 +1580,6 @@ export class MetaMetricsController extends BaseController<
     const accountGroupKeys = new Set<string>();
     const hdEntropyIds = new Set<string>();
     let numberOfImportedAccounts = 0;
-    let numberOfSnapAccounts = 0;
     let numberOfLedgerAccounts = 0;
     let numberOfTrezorAccounts = 0;
     let numberOfLatticeAccounts = 0;
@@ -1594,9 +1593,6 @@ export class MetaMetricsController extends BaseController<
       switch (keyringType) {
         case KeyringType.imported:
           numberOfImportedAccounts += 1;
-          break;
-        case KeyringType.snap:
-          numberOfSnapAccounts += 1;
           break;
         case KeyringType.ledger:
           numberOfLedgerAccounts += 1;
@@ -1639,7 +1635,6 @@ export class MetaMetricsController extends BaseController<
       [MetaMetricsUserTrait.NumberOfHDEntropies]: hdEntropyIds.size,
       [MetaMetricsUserTrait.NumberOfAccountGroups]: accountGroupKeys.size,
       [MetaMetricsUserTrait.NumberOfImportedAccounts]: numberOfImportedAccounts,
-      [MetaMetricsUserTrait.NumberOfSnapAccounts]: numberOfSnapAccounts,
       [MetaMetricsUserTrait.NumberOfLedgerAccounts]: numberOfLedgerAccounts,
       [MetaMetricsUserTrait.NumberOfTrezorAccounts]: numberOfTrezorAccounts,
       [MetaMetricsUserTrait.NumberOfLatticeAccounts]: numberOfLatticeAccounts,

--- a/app/scripts/controllers/metametrics-controller.ts
+++ b/app/scripts/controllers/metametrics-controller.ts
@@ -1444,6 +1444,7 @@ export class MetaMetricsController extends BaseController<
       [MetaMetricsUserTrait.NumberOfHDEntropies]:
         this.#getNumberOfHDEntropies(metamaskState) ??
         this.previousUserTraits?.number_of_hd_entropies,
+      ...this.#getAccountCompositionTraits(metamaskState),
       [MetaMetricsUserTrait.OpenSeaApiEnabled]: metamaskState.openSeaEnabled,
       [MetaMetricsUserTrait.ThreeBoxEnabled]: false, // deprecated, hard-coded as false
       [MetaMetricsUserTrait.Theme]: metamaskState.theme || 'default',
@@ -1576,6 +1577,81 @@ export class MetaMetricsController extends BaseController<
         (keyring) => keyring.type === KeyringType.hdKeyTree,
       ).length ?? 0
     );
+  }
+
+  /**
+   * Computes wallet composition traits from internalAccounts, which is always
+   * available regardless of lock state (unlike keyrings).
+   *
+   * number_of_account_groups deduplicates BIP44 multichain accounts by their
+   * entropy source and group index so that EVM + BTC + SOL addresses derived
+   * from the same SRP slot count as one account group, matching what users see
+   * in the Account Management UI.
+   *
+   * @param metamaskState
+   */
+  #getAccountCompositionTraits(metamaskState: MetaMaskState): Partial<MetaMetricsUserTraits> {
+    const accountGroupKeys = new Set<string>();
+    let numberOfImportedAccounts = 0;
+    let numberOfSnapAccounts = 0;
+    let numberOfLedgerAccounts = 0;
+    let numberOfTrezorAccounts = 0;
+    let numberOfLatticeAccounts = 0;
+    let numberOfQrHardwareAccounts = 0;
+
+    for (const [accountId, account] of Object.entries(
+      metamaskState.internalAccounts.accounts,
+    )) {
+      const keyringType = account.metadata?.keyring?.type;
+
+      switch (keyringType) {
+        case KeyringType.imported:
+          numberOfImportedAccounts++;
+          break;
+        case KeyringType.snap:
+          numberOfSnapAccounts++;
+          break;
+        case KeyringType.ledger:
+          numberOfLedgerAccounts++;
+          break;
+        case KeyringType.trezor:
+          numberOfTrezorAccounts++;
+          break;
+        case KeyringType.lattice:
+          numberOfLatticeAccounts++;
+          break;
+        case KeyringType.qr:
+        case KeyringType.oneKey:
+          numberOfQrHardwareAccounts++;
+          break;
+        default:
+          break;
+      }
+
+      // BIP44 multichain accounts share an entropy source id and group index
+      // across all chains (EVM, BTC, SOL, …). Deduplicating on that key gives
+      // the count of account groups rather than individual chain addresses.
+      const entropy = account.options?.entropy as
+        | { type: 'mnemonic'; id: string; groupIndex: number }
+        | { type: string }
+        | undefined;
+
+      if (entropy?.type === 'mnemonic' && 'id' in entropy && 'groupIndex' in entropy) {
+        accountGroupKeys.add(`${entropy.id}:${entropy.groupIndex}`);
+      } else {
+        accountGroupKeys.add(accountId);
+      }
+    }
+
+    return {
+      [MetaMetricsUserTrait.NumberOfAccountGroups]: accountGroupKeys.size,
+      [MetaMetricsUserTrait.NumberOfImportedAccounts]: numberOfImportedAccounts,
+      [MetaMetricsUserTrait.NumberOfSnapAccounts]: numberOfSnapAccounts,
+      [MetaMetricsUserTrait.NumberOfLedgerAccounts]: numberOfLedgerAccounts,
+      [MetaMetricsUserTrait.NumberOfTrezorAccounts]: numberOfTrezorAccounts,
+      [MetaMetricsUserTrait.NumberOfLatticeAccounts]: numberOfLatticeAccounts,
+      [MetaMetricsUserTrait.NumberOfQrHardwareAccounts]: numberOfQrHardwareAccounts,
+    };
   }
 
   /**

--- a/app/scripts/controllers/metametrics-controller.ts
+++ b/app/scripts/controllers/metametrics-controller.ts
@@ -1645,11 +1645,13 @@ export class MetaMetricsController extends BaseController<
       [MetaMetricsUserTrait.NumberOfLatticeAccounts]: numberOfLatticeAccounts,
       [MetaMetricsUserTrait.NumberOfQrHardwareAccounts]:
         numberOfQrHardwareAccounts,
+      // MetaMask enforces one paired device per hardware wallet type, so
+      // "types in use" equals "distinct devices".
       [MetaMetricsUserTrait.NumberOfHardwareWallets]:
-        numberOfLedgerAccounts +
-        numberOfTrezorAccounts +
-        numberOfLatticeAccounts +
-        numberOfQrHardwareAccounts,
+        (numberOfLedgerAccounts > 0 ? 1 : 0) +
+        (numberOfTrezorAccounts > 0 ? 1 : 0) +
+        (numberOfLatticeAccounts > 0 ? 1 : 0) +
+        (numberOfQrHardwareAccounts > 0 ? 1 : 0),
     };
   }
 

--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -591,6 +591,50 @@ export type MetaMetricsUserTraits = {
    * The operating system (normalized).
    */
   os?: Os;
+  /**
+   * Total BIP44 account groups across all keyring types — what users perceive
+   * as "accounts" in the Account Management UI.
+   */
+  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  number_of_account_groups?: number;
+  /**
+   * Number of accounts added via raw private key (Simple Key Pair keyring).
+   */
+  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  number_of_imported_accounts?: number;
+  /**
+   * Number of accounts managed by MetaMask Snaps.
+   */
+  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  number_of_snap_accounts?: number;
+  /**
+   * Number of account groups from Ledger hardware wallet.
+   */
+  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  number_of_ledger_accounts?: number;
+  /**
+   * Number of account groups from Trezor hardware wallet.
+   */
+  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  number_of_trezor_accounts?: number;
+  /**
+   * Number of account groups from Lattice (GridPlus) hardware wallet.
+   */
+  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  number_of_lattice_accounts?: number;
+  /**
+   * Number of account groups from QR-based hardware wallets (OneKey, Keystone,
+   * AirGap Vault, CoolWallet, DCent, Ngrave, imToken, Keycard Shell).
+   */
+  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  number_of_qr_hardware_accounts?: number;
 };
 
 export enum MetaMetricsUserTrait {
@@ -725,6 +769,36 @@ export enum MetaMetricsUserTrait {
    * The operating system (normalized).
    */
   Os = 'os',
+  /**
+   * Total BIP44 account groups across all keyring types — what users perceive
+   * as "accounts" in the Account Management UI.
+   */
+  NumberOfAccountGroups = 'number_of_account_groups',
+  /**
+   * Number of accounts added via raw private key (Simple Key Pair keyring).
+   */
+  NumberOfImportedAccounts = 'number_of_imported_accounts',
+  /**
+   * Number of accounts managed by MetaMask Snaps.
+   */
+  NumberOfSnapAccounts = 'number_of_snap_accounts',
+  /**
+   * Number of account groups from Ledger hardware wallet.
+   */
+  NumberOfLedgerAccounts = 'number_of_ledger_accounts',
+  /**
+   * Number of account groups from Trezor hardware wallet.
+   */
+  NumberOfTrezorAccounts = 'number_of_trezor_accounts',
+  /**
+   * Number of account groups from Lattice (GridPlus) hardware wallet.
+   */
+  NumberOfLatticeAccounts = 'number_of_lattice_accounts',
+  /**
+   * Number of account groups from QR-based hardware wallets (OneKey, Keystone,
+   * AirGap Vault, CoolWallet, DCent, Ngrave, imToken, Keycard Shell).
+   */
+  NumberOfQrHardwareAccounts = 'number_of_qr_hardware_accounts',
 }
 
 /**

--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -605,12 +605,6 @@ export type MetaMetricsUserTraits = {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   number_of_imported_accounts?: number;
   /**
-   * Number of accounts managed by MetaMask Snaps.
-   */
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  number_of_snap_accounts?: number;
-  /**
    * Number of account groups from Ledger hardware wallet.
    */
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
@@ -786,10 +780,6 @@ export enum MetaMetricsUserTrait {
    * Number of accounts added via raw private key (Simple Key Pair keyring).
    */
   NumberOfImportedAccounts = 'number_of_imported_accounts',
-  /**
-   * Number of accounts managed by MetaMask Snaps.
-   */
-  NumberOfSnapAccounts = 'number_of_snap_accounts',
   /**
    * Number of account groups from Ledger hardware wallet.
    */

--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -635,6 +635,14 @@ export type MetaMetricsUserTraits = {
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
   // eslint-disable-next-line @typescript-eslint/naming-convention
   number_of_qr_hardware_accounts?: number;
+  /**
+   * Total number of hardware wallet accounts across all hardware wallet types
+   * (Ledger, Trezor, Lattice, QR-based). Combined with number_of_hd_entropies
+   * and number_of_imported_accounts, gives the total number of wallets.
+   */
+  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  number_of_hardware_wallets?: number;
 };
 
 export enum MetaMetricsUserTrait {
@@ -799,6 +807,12 @@ export enum MetaMetricsUserTrait {
    * AirGap Vault, CoolWallet, DCent, Ngrave, imToken, Keycard Shell).
    */
   NumberOfQrHardwareAccounts = 'number_of_qr_hardware_accounts',
+  /**
+   * Total number of hardware wallet accounts across all hardware wallet types
+   * (Ledger, Trezor, Lattice, QR-based). Combined with number_of_hd_entropies
+   * and number_of_imported_accounts, gives the total number of wallets.
+   */
+  NumberOfHardwareWallets = 'number_of_hardware_wallets',
 }
 
 /**

--- a/test/data/mock-accounts.ts
+++ b/test/data/mock-accounts.ts
@@ -242,3 +242,84 @@ export const MOCK_ACCOUNT_ID_BY_ADDRESS = {
   [MOCK_ACCOUNT_HARDWARE.address]: MOCK_ACCOUNT_HARDWARE.id,
   [MOCK_ACCOUNT_PRIVATE_KEY.address]: MOCK_ACCOUNT_PRIVATE_KEY.id,
 };
+
+type MockInternalAccountOptions = Omit<
+  InternalAccount['options'],
+  'entropy'
+> & {
+  entropy?:
+    | {
+        type: 'mnemonic';
+        id: string;
+        groupIndex: number;
+        derivationPath?: string;
+      }
+    | { type: 'private-key' }
+    | { type: 'custom' };
+};
+
+type MockInternalAccountOverrides = Omit<
+  Partial<InternalAccount>,
+  'metadata' | 'options'
+> &
+  Pick<InternalAccount, 'id'> & {
+    metadata?: Partial<InternalAccount['metadata']>;
+    options?: MockInternalAccountOptions;
+  };
+
+function normalizeOptions(
+  options?: MockInternalAccountOptions,
+): InternalAccount['options'] {
+  if (!options?.entropy) {
+    return (options ?? {}) as InternalAccount['options'];
+  }
+
+  if (options.entropy.type !== 'mnemonic') {
+    return options as InternalAccount['options'];
+  }
+
+  return {
+    ...options,
+    entropy: {
+      ...options.entropy,
+      derivationPath: options.entropy.derivationPath ?? '',
+    },
+  };
+}
+
+export function createMockInternalAccount({
+  id,
+  address,
+  metadata,
+  options,
+  ...overrides
+}: MockInternalAccountOverrides): InternalAccount {
+  const normalizedOptions = normalizeOptions(options);
+
+  return {
+    ...MOCK_ACCOUNT_EOA,
+    ...overrides,
+    id,
+    address: address ?? `${id}-address`,
+    metadata: {
+      ...MOCK_ACCOUNT_EOA.metadata,
+      ...metadata,
+      keyring: {
+        ...MOCK_ACCOUNT_EOA.metadata.keyring,
+        ...metadata?.keyring,
+      },
+    },
+    options: normalizedOptions,
+  };
+}
+
+export function createMockInternalAccounts(
+  mockAccounts: MockInternalAccountOverrides[],
+): Record<string, InternalAccount> {
+  return Object.fromEntries(
+    mockAccounts.map((mockAccount) => [
+      mockAccount.id,
+      createMockInternalAccount(mockAccount),
+    ]),
+  );
+}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR adds detailed wallet composition metrics derived from the accounts controller. The goal here is to be able to answer questions about...
1. how many SRPs users have
2. How many hw wallets user have
3. How many total account groups users have
4. how many hardware wallet accounts users have. 

Fixes account wallet composition user properties that were unreliable when the wallet was locked.
  Previously, several traits were derived from keyrings, which is unavailable in locked state. This PR
  migrates all wallet composition traits to use internalAccounts, which is always available.

  Root cause: #getNumberOfHDEntropies read from metamaskState.keyrings, returning stale/empty data when
  locked.

  Fix: Replaced with #getAccountCompositionTraits, a single O(n) pass over internalAccounts.accounts that
  computes all wallet composition traits atomically.

  New/updated user properties schema

  ```┌────────────────────────────────┬───────────────────────────────────────────────────────────────────┐
  │            Property            │                            Description                            │
  ├────────────────────────────────┼───────────────────────────────────────────────────────────────────┤
  │ number_of_hd_entropies         │ Count of unique SRP (Secret Recovery Phrase) sources — deduped by │
  │                                │  entropy.id                                                       │
  ├────────────────────────────────┼───────────────────────────────────────────────────────────────────┤
  │ number_of_account_groups       │ Count of distinct {entropy.id, groupIndex} pairs; multichain      │
  │                                │ EVM+BTC+SOL accounts from the same SRP slot count as one group    │
  ├────────────────────────────────┼───────────────────────────────────────────────────────────────────┤
  │ number_of_imported_accounts    │ Private key imports (Simple Key Pair keyring)                     │
  ├────────────────────────────────┼───────────────────────────────────────────────────────────────────┤
  │ number_of_ledger_accounts      │ Ledger hardware wallet accounts                                   │
  ├────────────────────────────────┼───────────────────────────────────────────────────────────────────┤
  │ number_of_trezor_accounts      │ Trezor hardware wallet accounts                                   │
  ├────────────────────────────────┼───────────────────────────────────────────────────────────────────┤
  │ number_of_lattice_accounts     │ Lattice (GridPlus) hardware wallet accounts                       │
  ├────────────────────────────────┼───────────────────────────────────────────────────────────────────┤
  │ number_of_qr_hardware_accounts │ QR-based hardware wallet accounts (Keystone, OneKey, etc.)        │
  ├────────────────────────────────┼───────────────────────────────────────────────────────────────────┤
  │ number_of_hardware_wallets     │ Sum of all hardware wallet accounts — enables total wallet count  │
  └────────────────────────────────┴───────────────────────────────────────────────────────────────────┘
```

  Total wallet count can be derived in Segment as:
  number_of_hd_entropies + number_of_hardware_wallets + number_of_imported_accounts

  Test plan

  - Added a #getAccountCompositionTraits test suite covering: empty accounts, single SRP with multiple
  groups, multiple SRPs, hardware-only wallets, imported-only accounts, unknown/missing keyring metadata,
  and the total wallet derivation formula.

Mobile equivalent: https://github.com/MetaMask/metamask-mobile/pull/29015

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
5. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Update metrics to track wallet composition (number of accounts, number of hardware wallets etc)

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1396

## **Manual testing steps**

1. Build the extension locally
2. in another terminal window, run `node development/mock-segment.js`
3. import/create a wallet
4. you should notice the initial `Identify event received` logged with the correct `number_of_account_groups` logged as well as `number_of_hd_entropies`
5. import a private key
6. notice the `Identify event received` logged with the updated `number_of_account_groups` and `number_of_imported_accounts`
7. Connect a Ledger wallet and notice the `Identify event received` logged with updated `number_of_account_groups`, updated `number_of_ledger_accounts` and `number_of_hardware_wallets`
8. repeat the above steps with qr and trezor. The respective properties should all be updated.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

1. first load with one wallet and one account

```
[mock-segment]: Identify event received: 0x3f1cda5ef8550a209fe5e6ba2956f14a0db4d28dcf2413bb1915b351c3555856
{
  "address_book_entries": 0,
  "install_date_ext": "2026-04-18",
  "storage_kind": "split",
  "ledger_connection_type": "webhid",
  "networks_added": [
    "0x1",
    "0xaa36a7",
    "0xe705",
    "0xe708",
    "0x2105",
    "0xa4b1",
    "0x38",
    "0xa",
    "0x89",
    "0x279f",
    "0x18c7"
  ],
  "networks_without_ticker": [],
  "chain_id_list": [
    "eip155:1",
    "eip155:11155111",
    "eip155:59141",
    "eip155:59144",
    "eip155:8453",
    "eip155:42161",
    "eip155:56",
    "eip155:10",
    "eip155:137",
    "eip155:10143",
    "eip155:6343",
    "bip122:000000000019d6689c085ae165831e93",
    "bip122:000000000933ea01ad0ee984209779ba",
    "bip122:00000000da84f2bafbbc53dee25a72ae",
    "bip122:00000008819873e925422c1ff0f99f7c",
    "bip122:regtest",
    "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
    "solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z",
    "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
    "tron:728126428",
    "tron:3448148188",
    "tron:2494104990"
  ],
  "nft_autodetection_enabled": true,
  "number_of_accounts": 1,
  "number_of_nft_collections": 0,
  "number_of_nfts": 0,
  "number_of_tokens": 0,
  "number_of_hd_entropies": 1,
  "number_of_account_groups": 1,
  "number_of_imported_accounts": 0,
  "number_of_snap_accounts": 0,
  "number_of_ledger_accounts": 0,
  "number_of_trezor_accounts": 0,
  "number_of_lattice_accounts": 0,
  "number_of_qr_hardware_accounts": 0,
  "number_of_hardware_wallets": 0,
  "opensea_api_enabled": true,
  "three_box_enabled": false,
  "theme": "os",
  "token_detection_enabled": true,
  "show_native_token_as_main_balance": false,
  "current_currency": "usd",
  "security_providers": [
    "blockaid"
  ],
  "petname_addresses_count": 0,
  "is_metrics_opted_in": true,
  "has_marketing_consent": true,
  "token_sort_preference": "tokenFiatAmount",
  "privacy_mode_toggle": false,
  "selected_network_filter": [],
  "platform": "Brave",
  "install_type": "development",
  "device_type": "desktop",
  "os": "macOS"
}
```

2. Add a new account

```
[mock-segment]: Identify event received: 0x3f1cda5ef8550a209fe5e6ba2956f14a0db4d28dcf2413bb1915b351c3555856
{
  "number_of_accounts": 8,
  "number_of_account_groups": 2,
  "number_of_snap_accounts": 6
}
```

3. import a private key

```
[mock-segment]: Identify event received: 0x3f1cda5ef8550a209fe5e6ba2956f14a0db4d28dcf2413bb1915b351c3555856
{
  "number_of_accounts": 9,
  "number_of_account_groups": 3,
  "number_of_imported_accounts": 1
}
```

4. import a ledger wallet with 3 accounts

```
[mock-segment]: Identify event received: 0x3f1cda5ef8550a209fe5e6ba2956f14a0db4d28dcf2413bb1915b351c3555856
{
  "address_book_entries": 0,
  "install_date_ext": "2026-04-18",
  "storage_kind": "split",
  "ledger_connection_type": "webhid",
  "networks_added": [
    "0x1",
    "0x18c7",
    "0x2105",
    "0x279f",
    "0x38",
    "0x89",
    "0xa",
    "0xa4b1",
    "0xaa36a7",
    "0xe705",
    "0xe708"
  ],
  "networks_without_ticker": [],
  "chain_id_list": [
    "eip155:1",
    "eip155:6343",
    "eip155:8453",
    "eip155:10143",
    "eip155:56",
    "eip155:137",
    "eip155:10",
    "eip155:42161",
    "eip155:11155111",
    "eip155:59141",
    "eip155:59144",
    "bip122:000000000019d6689c085ae165831e93",
    "bip122:000000000933ea01ad0ee984209779ba",
    "bip122:00000000da84f2bafbbc53dee25a72ae",
    "bip122:00000008819873e925422c1ff0f99f7c",
    "bip122:regtest",
    "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp",
    "solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z",
    "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
    "tron:728126428",
    "tron:3448148188",
    "tron:2494104990"
  ],
  "nft_autodetection_enabled": true,
  "number_of_accounts": 12,
  "number_of_nft_collections": 0,
  "number_of_nfts": 0,
  "number_of_tokens": 12,
  "number_of_hd_entropies": 1,
  "number_of_account_groups": 6,
  "number_of_imported_accounts": 1,
  "number_of_snap_accounts": 6,
  "number_of_ledger_accounts": 3,
  "number_of_trezor_accounts": 0,
  "number_of_lattice_accounts": 0,
  "number_of_qr_hardware_accounts": 0,
  "number_of_hardware_wallets": 1,
  "opensea_api_enabled": true,
  "three_box_enabled": false,
  "theme": "os",
  "token_detection_enabled": true,
  "show_native_token_as_main_balance": false,
  "current_currency": "usd",
  "security_providers": [
    "blockaid"
  ],
  "petname_addresses_count": 0,
  "is_metrics_opted_in": true,
  "has_marketing_consent": true,
  "token_sort_preference": "tokenFiatAmount",
  "privacy_mode_toggle": false,
  "selected_network_filter": [
    "0x1"
  ],
  "profile_id": "80c1483d-c92f-4a53-a7c5-cdc03451765a",
  "platform": "Brave",
  "install_type": "development",
  "device_type": "desktop",
  "os": "macOS"
}
```

4. import a QR hardware wallet (keystone) with 4 accounts

```
[mock-segment]: Identify event received: 0x3f1cda5ef8550a209fe5e6ba2956f14a0db4d28dcf2413bb1915b351c3555856
{
  "number_of_accounts": 16,
  "number_of_account_groups": 10,
  "number_of_qr_hardware_accounts": 4,
  "number_of_hardware_wallets": 2
}
```


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.






<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes MetaMetrics identify trait calculation and schema for wallet/account composition, which could affect analytics accuracy and downstream dashboards even though it doesn't impact core wallet operations.
> 
> **Overview**
> Improves MetaMetrics *wallet composition* reporting by deriving counts from `internalAccounts` instead of `keyrings` (fixing incorrect/stale values when the wallet is locked).
> 
> Adds new user traits for account groups and hardware/imported account breakdown (`number_of_account_groups`, per-hardware-type counts, and `number_of_hardware_wallets`), including BIP44 multichain deduping by `{entropyId, groupIndex}`.
> 
> Updates and expands tests to cover the new trait calculations (multichain grouping, SRP entropy counting, imported vs hardware types, unknown/missing metadata), and adds test helpers for building mock internal accounts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a7f5aaac3b108cc93ee4d526ca50e4f0e3ec86c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->