### PR TITLE
fix(perps): align extension UI decimal display with mobile cp-13.28.0

### DIFF
--- a/shared/lib/perps-formatters.test.ts
+++ b/shared/lib/perps-formatters.test.ts
@@ -1,0 +1,471 @@
+import {
+  PRICE_RANGES_MINIMAL_VIEW,
+  PRICE_RANGES_UNIVERSAL,
+  PRICE_THRESHOLD,
+  calculateMarginRequired,
+  calculatePositionSize,
+  formatFundingRate,
+  formatPercentage,
+  formatPerpsFiat,
+  formatPerpsPrice,
+  formatPnl,
+  formatPositionSize,
+  formatWithSignificantDigits,
+} from './perps-formatters';
+
+describe('perps-formatters', () => {
+  describe('formatWithSignificantDigits', () => {
+    it('returns zero with defaulted decimals when value is 0', () => {
+      expect(formatWithSignificantDigits(0, 5)).toStrictEqual({
+        value: 0,
+        decimals: 0,
+      });
+    });
+
+    it('respects minDecimals for zero value', () => {
+      expect(formatWithSignificantDigits(0, 5, 3)).toStrictEqual({
+        value: 0,
+        decimals: 3,
+      });
+    });
+
+    it('calculates decimals based on integer magnitude for values >= 1', () => {
+      // 123.45 with 5 sig digits → 3 integer digits, 2 decimals
+      expect(formatWithSignificantDigits(123.456, 5)).toStrictEqual({
+        value: 123.46,
+        decimals: 2,
+      });
+    });
+
+    it('clamps decimals to zero for large integer values', () => {
+      // 1234567 with 4 sig digits → decimalsNeeded is negative, clamped to 0
+      const result = formatWithSignificantDigits(1234567, 4);
+      expect(result.decimals).toBe(0);
+      expect(result.value).toBe(1234567);
+    });
+
+    it('respects minDecimals when targetDecimals is smaller', () => {
+      const result = formatWithSignificantDigits(12345, 4, 2);
+      expect(result.decimals).toBe(2);
+    });
+
+    it('respects maxDecimals when targetDecimals is larger', () => {
+      // 1.2 with 6 sig digits → needs 5 decimals, capped at 2
+      const result = formatWithSignificantDigits(1.2, 6, undefined, 2);
+      expect(result.decimals).toBe(2);
+      expect(result.value).toBe(1.2);
+    });
+
+    it('uses toPrecision for values < 1', () => {
+      const result = formatWithSignificantDigits(0.0012345, 3);
+      expect(result.value).toBeCloseTo(0.00123, 6);
+    });
+
+    it('handles negative values', () => {
+      const result = formatWithSignificantDigits(-12.345, 4);
+      expect(result.value).toBe(-12.35);
+    });
+
+    it('enforces minDecimals on <1 path', () => {
+      const result = formatWithSignificantDigits(0.1, 2, 4);
+      expect(result.decimals).toBe(4);
+    });
+
+    it('enforces maxDecimals on <1 path', () => {
+      const result = formatWithSignificantDigits(0.123456789, 8, undefined, 3);
+      expect(result.decimals).toBe(3);
+    });
+  });
+
+  describe('formatPerpsFiat', () => {
+    it('returns fallback for NaN input', () => {
+      expect(formatPerpsFiat('not a number')).toBe('$---');
+    });
+
+    it('accepts numeric input', () => {
+      expect(formatPerpsFiat(100)).toBe('$100');
+    });
+
+    it('accepts string input', () => {
+      expect(formatPerpsFiat('100')).toBe('$100');
+    });
+
+    it('strips .00 using fiat-style stripping by default (minimal view)', () => {
+      expect(formatPerpsFiat(1250)).toBe('$1,250');
+    });
+
+    it('preserves non-zero decimals in fiat-style stripping', () => {
+      expect(formatPerpsFiat(1250.1)).toBe('$1,250.10');
+    });
+
+    it('uses significantDigits when configured (universal range)', () => {
+      expect(formatPerpsFiat(123456, { ranges: PRICE_RANGES_UNIVERSAL })).toBe(
+        '$123,456',
+      );
+    });
+
+    it('applies universal range trailing-zero stripping', () => {
+      // 1500 matches > $1000 range with max 1 decimal, significant digits → trailing zero stripped
+      const out = formatPerpsFiat(1500, { ranges: PRICE_RANGES_UNIVERSAL });
+      expect(out).toBe('$1,500');
+    });
+
+    it('formats small values with threshold prefix', () => {
+      // < $0.01 threshold fires for values < threshold
+      const out = formatPerpsFiat(0.0000001, {
+        ranges: PRICE_RANGES_UNIVERSAL,
+      });
+      expect(out.startsWith('<')).toBe(true);
+    });
+
+    it('honors stripTrailingZeros=false option', () => {
+      expect(formatPerpsFiat(100, { stripTrailingZeros: false })).toBe(
+        '$100.00',
+      );
+    });
+
+    it('honors explicit min/max decimals overrides', () => {
+      const out = formatPerpsFiat(12.3, {
+        ranges: PRICE_RANGES_UNIVERSAL,
+        minimumDecimals: 4,
+        maximumDecimals: 4,
+        stripTrailingZeros: false,
+      });
+      expect(out).toBe('$12.3000');
+    });
+
+    it('uses customFormat when provided on the range config', () => {
+      const ranges = [
+        {
+          condition: () => true,
+          minimumDecimals: 0,
+          maximumDecimals: 0,
+          customFormat: () => 'CUSTOM',
+        },
+      ];
+      expect(formatPerpsFiat(5, { ranges })).toBe('CUSTOM');
+    });
+
+    it('falls back to 2/2 decimals when no range matches', () => {
+      const ranges = [
+        {
+          condition: () => false,
+          minimumDecimals: 0,
+          maximumDecimals: 0,
+        },
+      ];
+      expect(
+        formatPerpsFiat(12.345, { ranges, stripTrailingZeros: false }),
+      ).toBe('$12.35');
+    });
+
+    it('formats zero with minimal view fiat-style stripping', () => {
+      expect(formatPerpsFiat(0)).toBe('$0');
+    });
+
+    it('formats zero with universal ranges (strips trailing zeros)', () => {
+      expect(formatPerpsFiat(0, { ranges: PRICE_RANGES_UNIVERSAL })).toBe('$0');
+    });
+
+    it('respects non-USD currency', () => {
+      const out = formatPerpsFiat(1000, { currency: 'EUR' });
+      expect(out).toContain('1,000');
+    });
+  });
+
+  describe('PRICE_RANGES_MINIMAL_VIEW', () => {
+    it('matches large values in first range', () => {
+      expect(
+        PRICE_RANGES_MINIMAL_VIEW[0].condition(PRICE_THRESHOLD.LARGE),
+      ).toBe(true);
+    });
+
+    it('matches any value in second range', () => {
+      expect(PRICE_RANGES_MINIMAL_VIEW[1].condition(5)).toBe(true);
+    });
+  });
+
+  describe('PRICE_RANGES_UNIVERSAL', () => {
+    it('exposes 7 ranges', () => {
+      expect(PRICE_RANGES_UNIVERSAL).toHaveLength(7);
+    });
+
+    it('matches very high value in first range', () => {
+      expect(PRICE_RANGES_UNIVERSAL[0].condition(200_000)).toBe(true);
+    });
+
+    it('matches very small value only in last range', () => {
+      const matching = PRICE_RANGES_UNIVERSAL.filter((r) =>
+        r.condition(0.0000005),
+      );
+      expect(matching[0]).toBe(PRICE_RANGES_UNIVERSAL[6]);
+    });
+  });
+
+  describe('formatPositionSize', () => {
+    it('returns "0" for NaN', () => {
+      expect(formatPositionSize('abc')).toBe('0');
+    });
+
+    it('returns "0" for exact zero', () => {
+      expect(formatPositionSize(0)).toBe('0');
+    });
+
+    it('formats with szDecimals=0 without stripping integer zeros', () => {
+      expect(formatPositionSize(100, 0)).toBe('100');
+      expect(formatPositionSize(20, 0)).toBe('20');
+    });
+
+    it('formats with szDecimals and strips trailing zeros', () => {
+      expect(formatPositionSize(44.0, 1)).toBe('44');
+      expect(formatPositionSize(1.5, 2)).toBe('1.5');
+    });
+
+    it('preserves precision with szDecimals for very small values', () => {
+      expect(formatPositionSize(0.00009, 5)).toBe('0.00009');
+    });
+
+    it('uses 6 decimals for abs value < 0.01', () => {
+      expect(formatPositionSize(0.001234567)).toBe('0.001235');
+    });
+
+    it('uses 4 decimals for abs value < 1', () => {
+      expect(formatPositionSize(0.5678)).toBe('0.5678');
+    });
+
+    it('uses 2 decimals for abs value >= 1', () => {
+      expect(formatPositionSize(12.3456)).toBe('12.35');
+    });
+
+    it('strips trailing zeros when no szDecimals provided', () => {
+      expect(formatPositionSize(10)).toBe('10');
+    });
+
+    it('parses string input', () => {
+      expect(formatPositionSize('2.50', 2)).toBe('2.5');
+    });
+  });
+
+  describe('formatPnl', () => {
+    it('returns zero display for NaN', () => {
+      expect(formatPnl('abc')).toBe('$0.00');
+    });
+
+    it('prefixes positive value with +', () => {
+      expect(formatPnl(123.45)).toBe('+$123.45');
+    });
+
+    it('prefixes negative value with -', () => {
+      expect(formatPnl(-123.45)).toBe('-$123.45');
+    });
+
+    it('treats zero as positive', () => {
+      expect(formatPnl(0)).toBe('+$0.00');
+    });
+
+    it('parses string input', () => {
+      expect(formatPnl('50.5')).toBe('+$50.50');
+    });
+  });
+
+  describe('formatPercentage', () => {
+    it('returns 0.00% for NaN', () => {
+      expect(formatPercentage('abc')).toBe('0.00%');
+    });
+
+    it('prefixes positive value with +', () => {
+      expect(formatPercentage(5.25)).toBe('+5.25%');
+    });
+
+    it('leaves negative value with native minus', () => {
+      expect(formatPercentage(-3.1)).toBe('-3.10%');
+    });
+
+    it('defaults to 2 decimals', () => {
+      expect(formatPercentage(1)).toBe('+1.00%');
+    });
+
+    it('respects custom decimals', () => {
+      expect(formatPercentage(1.23456, 4)).toBe('+1.2346%');
+    });
+
+    it('accepts string input', () => {
+      expect(formatPercentage('10')).toBe('+10.00%');
+    });
+  });
+
+  describe('formatFundingRate', () => {
+    it('returns zero display for null when showZero default', () => {
+      expect(formatFundingRate(null)).toBe('0.0000%');
+    });
+
+    it('returns zero display for undefined when showZero default', () => {
+      expect(formatFundingRate(undefined)).toBe('0.0000%');
+    });
+
+    it('returns empty string for null when showZero=false', () => {
+      expect(formatFundingRate(null, { showZero: false })).toBe('');
+    });
+
+    it('returns zero display when value rounds to zero and showZero=true', () => {
+      expect(formatFundingRate(0.00000001)).toBe('0.0000%');
+    });
+
+    it('returns formatted percentage when value rounds to zero and showZero=false', () => {
+      expect(formatFundingRate(0.00000001, { showZero: false })).toBe(
+        '0.0000%',
+      );
+    });
+
+    it('formats non-zero rate as percentage', () => {
+      expect(formatFundingRate(0.000125)).toBe('0.0125%');
+    });
+
+    it('handles negative funding rate', () => {
+      expect(formatFundingRate(-0.0001)).toBe('-0.0100%');
+    });
+  });
+
+  describe('formatPerpsPrice', () => {
+    it('returns empty string for non-finite', () => {
+      expect(formatPerpsPrice(NaN)).toBe('');
+      expect(formatPerpsPrice(Infinity)).toBe('');
+    });
+
+    it('uses legacy 2-sig-digit fallback when range has no significantDigits', () => {
+      const ranges = [
+        {
+          condition: () => true,
+          minimumDecimals: 0,
+          maximumDecimals: 2,
+        },
+      ];
+      // legacy fallback caps at 2 sig digits with roundingPriority 'lessPrecision'
+      expect(formatPerpsPrice(12.345, 'en-US', ranges)).toBe('$12');
+    });
+
+    it('uses legacy fallback when no range matches', () => {
+      const ranges = [
+        {
+          condition: () => false,
+          minimumDecimals: 0,
+          maximumDecimals: 0,
+        },
+      ];
+      expect(formatPerpsPrice(1.5, 'en-US', ranges)).toBe('$1.5');
+    });
+
+    it('formats with universal ranges by default', () => {
+      const out = formatPerpsPrice(3245.678);
+      expect(out.startsWith('$')).toBe(true);
+    });
+  });
+
+  describe('calculatePositionSize', () => {
+    it('throws when szDecimals is undefined', () => {
+      expect(() =>
+        calculatePositionSize({
+          amount: '100',
+          price: 10,
+          szDecimals: undefined as unknown as number,
+        }),
+      ).toThrow('szDecimals is required');
+    });
+
+    it('throws when szDecimals is negative', () => {
+      expect(() =>
+        calculatePositionSize({
+          amount: '100',
+          price: 10,
+          szDecimals: -1,
+        }),
+      ).toThrow('szDecimals must be >= 0');
+    });
+
+    it('returns zeroed-out size for empty amount', () => {
+      expect(
+        calculatePositionSize({ amount: '', price: 10, szDecimals: 2 }),
+      ).toBe('0.00');
+    });
+
+    it('returns zeroed-out size when price is zero', () => {
+      expect(
+        calculatePositionSize({ amount: '100', price: 0, szDecimals: 3 }),
+      ).toBe('0.000');
+    });
+
+    it('returns zeroed-out size when amount is NaN', () => {
+      expect(
+        calculatePositionSize({ amount: 'abc', price: 10, szDecimals: 2 }),
+      ).toBe('0.00');
+    });
+
+    it('calculates size rounded to szDecimals', () => {
+      expect(
+        calculatePositionSize({ amount: '100', price: 10, szDecimals: 2 }),
+      ).toBe('10.00');
+    });
+
+    it('bumps rounded size when rounding falls short of requested USD', () => {
+      // 10 / 3 = 3.333... → Math.round at 2 decimals = 3.33 → 3.33 * 3 = 9.99 < 10
+      // → bumps to 3.34
+      const out = calculatePositionSize({
+        amount: '10',
+        price: 3,
+        szDecimals: 2,
+      });
+      expect(out).toBe('3.34');
+    });
+
+    it('formats with szDecimals=0', () => {
+      expect(
+        calculatePositionSize({ amount: '100', price: 10, szDecimals: 0 }),
+      ).toBe('10');
+    });
+  });
+
+  describe('calculateMarginRequired', () => {
+    it('returns 0.00 for NaN amount', () => {
+      expect(calculateMarginRequired({ amount: 'abc', leverage: 5 })).toBe(
+        '0.00',
+      );
+    });
+
+    it('returns 0.00 for zero amount', () => {
+      expect(calculateMarginRequired({ amount: '0', leverage: 5 })).toBe(
+        '0.00',
+      );
+    });
+
+    it('returns 0.00 for zero leverage', () => {
+      expect(calculateMarginRequired({ amount: '100', leverage: 0 })).toBe(
+        '0.00',
+      );
+    });
+
+    it('returns 0.00 for NaN leverage', () => {
+      expect(
+        calculateMarginRequired({
+          amount: '100',
+          leverage: NaN,
+        }),
+      ).toBe('0.00');
+    });
+
+    it('calculates margin as amount / leverage', () => {
+      expect(calculateMarginRequired({ amount: '100', leverage: 5 })).toBe(
+        '20.00',
+      );
+    });
+
+    it('formats to 2 decimals', () => {
+      expect(calculateMarginRequired({ amount: '10', leverage: 3 })).toBe(
+        '3.33',
+      );
+    });
+
+    it('handles empty string amount', () => {
+      expect(calculateMarginRequired({ amount: '', leverage: 5 })).toBe('0.00');
+    });
+  });
+});

--- a/shared/lib/perps-formatters.ts
+++ b/shared/lib/perps-formatters.ts
@@ -473,7 +473,10 @@ export const formatPositionSize = (
   }
 
   if (szDecimals !== undefined) {
-    return value.toFixed(szDecimals).replace(/\.?0+$/u, '');
+    const fixed = value.toFixed(szDecimals);
+    // Only strip trailing zeros when a decimal point is present; toFixed(0)
+    // returns an integer string and the regex would otherwise eat valid zeros.
+    return fixed.includes('.') ? fixed.replace(/\.?0+$/u, '') : fixed;
   }
 
   const abs = Math.abs(value);

--- a/shared/lib/perps-formatters.ts
+++ b/shared/lib/perps-formatters.ts
@@ -1,100 +1,579 @@
 /**
- * Adaptive significant-digit price formatters for Perps.
+ * Portable perps decimal formatters and order calculation helpers.
  *
- * Matches mobile's formatPerpsFiat(value, { ranges: PRICE_RANGES_UNIVERSAL }).
- * No mobile-specific imports — safe to use in the extension background, UI,
- * and any future consumer.
+ * TEMPORARY LOCAL COPY — TAT-2990.
+ * These helpers duplicate exports from `@metamask/perps-controller` so extension
+ * UI never pulls runtime values out of the controller package. The controller's
+ * main entry transitively loads ESM-only deps (`@noble/hashes@2` via
+ * `@nktkas/hyperliquid`) that break Jest's default transformIgnorePatterns and
+ * force LavaMoat policy churn. Once TAT-2990 lands (HyperLiquid SDK lazy-load
+ * in the controller so the main entry is CJS-safe), delete this file and
+ * re-import directly from `@metamask/perps-controller`.
+ *
+ * Sources of truth:
+ * - metamask-mobile/app/controllers/perps/utils/perpsFormatters.ts
+ * - metamask-mobile/app/controllers/perps/utils/orderCalculations.ts
+ *
+ * Intl.NumberFormat instances are cached in a module-level Map keyed by
+ * serialized options, avoiding repeated construction costs.
  *
  * @see docs/perps/perps-rules-decimals.md (canonical spec)
  */
 
-export type PerpsPriceRange = {
-  condition: (val: number) => boolean;
+// ---------------------------------------------------------------------------
+// Inlined mobile constants (kept in lock-step with
+// metamask-mobile/app/controllers/perps/constants/perpsConfig.ts).
+// If mobile's values change, update here too.
+// ---------------------------------------------------------------------------
+
+const DECIMAL_PRECISION_CONFIG = {
+  /** Maximum decimal places for price input (matches Hyperliquid limit). */
+  MaxPriceDecimals: 6,
+} as const;
+
+const FUNDING_RATE_CONFIG = {
+  /** Multiplier to convert decimal funding rate to percentage. */
+  PercentageMultiplier: 100,
+  /** Number of decimal places to display for funding rates. */
+  Decimals: 4,
+  /** Default display value when funding rate is zero or unavailable. */
+  ZeroDisplay: '0.0000%',
+} as const;
+
+const PERPS_CONSTANTS = {
+  /** Display when price data is unavailable. */
+  FallbackPriceDisplay: '$---',
+  /** Display for zero dollar amounts with decimals. */
+  ZeroAmountDetailedDisplay: '$0.00',
+} as const;
+
+// ---------------------------------------------------------------------------
+// Module-level Intl.NumberFormat cache (keyed by serialized options).
+// ---------------------------------------------------------------------------
+
+const _fmtCache = new Map<string, Intl.NumberFormat>();
+
+function _formatCurrency(
+  value: number,
+  currency: string,
+  opts: { minimumFractionDigits: number; maximumFractionDigits: number },
+): string {
+  const key = `${currency}:${opts.minimumFractionDigits}:${opts.maximumFractionDigits}`;
+  let formatter = _fmtCache.get(key);
+  if (!formatter) {
+    formatter = new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency,
+      currencyDisplay: 'narrowSymbol',
+      minimumFractionDigits: opts.minimumFractionDigits,
+      maximumFractionDigits: opts.maximumFractionDigits,
+    });
+    _fmtCache.set(key, formatter);
+  }
+  return formatter.format(value);
+}
+
+/**
+ * Internal equivalent of the mobile formatWithThreshold utility.
+ * Formats a currency value, returning "<$X.XX" for values below threshold.
+ *
+ * @param amount - The numeric amount to format.
+ * @param threshold - The threshold below which the "<" prefix is shown.
+ * @param options - Intl formatting options.
+ * @param options.currency - ISO 4217 currency code.
+ * @param options.minimumFractionDigits - Minimum decimal digits.
+ * @param options.maximumFractionDigits - Maximum decimal digits.
+ * @returns Formatted currency string.
+ */
+function _formatWithThreshold(
+  amount: number,
+  threshold: number,
+  options: {
+    currency: string;
+    minimumFractionDigits: number;
+    maximumFractionDigits: number;
+  },
+): string {
+  const formatOpts = {
+    minimumFractionDigits: options.minimumFractionDigits,
+    maximumFractionDigits: options.maximumFractionDigits,
+    currencyDisplay: 'narrowSymbol' as const,
+  };
+  if (amount === 0) {
+    return _formatCurrency(0, options.currency, formatOpts);
+  }
+  return Math.abs(amount) < threshold
+    ? `<${_formatCurrency(threshold, options.currency, formatOpts)}`
+    : _formatCurrency(amount, options.currency, formatOpts);
+}
+
+/**
+ * Price threshold constants for PRICE_RANGES_UNIVERSAL.
+ * These define the boundaries between different formatting ranges.
+ */
+export const PRICE_THRESHOLD = {
+  /** Very high values boundary (> $100k). */
+  VERY_HIGH: 100_000,
+  /** High values boundary (> $10k). */
+  HIGH: 10_000,
+  /** Large values boundary (> $1k). */
+  LARGE: 1_000,
+  /** Medium values boundary (> $100). */
+  MEDIUM: 100,
+  /** Medium-low values boundary (> $10). */
+  MEDIUM_LOW: 10,
+  /** Low values boundary (>= $0.01). */
+  LOW: 0.01,
+  /**
+   * Very small values threshold (< $0.01).
+   * This is the minimum value for formatWithThreshold and should align with
+   * the 6 decimal maximum (0.000001 is the smallest representable value).
+   */
+  VERY_SMALL: 0.000001,
+} as const;
+
+/**
+ * Configuration for a specific number range formatting.
+ */
+export type FiatRangeConfig = {
+  /**
+   * The condition to match for this range (e.g., < 0.0001, < 1, >= 1000).
+   * Function should return true if this config should be applied.
+   */
+  condition: (value: number) => boolean;
+  /** Minimum decimal places for this range. */
   minimumDecimals: number;
+  /** Maximum decimal places for this range. */
   maximumDecimals: number;
-  significantDigits: number;
+  /** Optional threshold for formatWithThreshold (defaults to the range boundary). */
+  threshold?: number;
+  /** Optional significant digits for this range (overrides decimal places when set). */
+  significantDigits?: number;
+  /** Optional custom formatting logic for this range. */
+  customFormat?: (value: number, locale: string, currency: string) => string;
+  /** Optional flag to strip trailing zeros for this range (overrides global stripTrailingZeros option). */
+  stripTrailingZeros?: boolean;
+  /**
+   * Optional flag for fiat-style stripping (only strips .00, preserves meaningful decimals like .10, .40).
+   * When true, "$1,250.00" → "$1,250" but "$1,250.10" stays "$1,250.10".
+   * When false (default), strips all trailing zeros: "$1,250.10" → "$1,250.1".
+   */
+  fiatStyleStripping?: boolean;
 };
 
 /**
- * Universal price ranges for perps asset price formatting.
- * Evaluated top-to-bottom; the first matching range is used.
- *
- * Mirrors mobile's PRICE_RANGES_UNIVERSAL from perpsFormatters.ts exactly.
+ * Legacy type alias kept for backwards compatibility with the previous
+ * extension-only PerpsPriceRange signature. Prefer FiatRangeConfig.
  */
-export const PRICE_RANGES_UNIVERSAL: PerpsPriceRange[] = [
-  // > $100,000: no decimals, 6 significant figures
+export type PerpsPriceRange = FiatRangeConfig;
+
+/**
+ * Formats a number to a specific number of significant digits.
+ * Strips trailing zeros unless minDecimals requires them.
+ *
+ * @param value - The numeric value to format.
+ * @param significantDigits - Number of significant digits to maintain.
+ * @param minDecimals - Minimum decimal places to show (may add zeros).
+ * @param maxDecimals - Maximum decimal places allowed.
+ * @returns Formatted number with appropriate precision, trailing zeros removed.
+ */
+export function formatWithSignificantDigits(
+  value: number,
+  significantDigits: number,
+  minDecimals?: number,
+  maxDecimals?: number,
+): { value: number; decimals: number } {
+  // Handle special cases
+  if (value === 0) {
+    return { value: 0, decimals: minDecimals ?? 0 };
+  }
+
+  const absValue = Math.abs(value);
+
+  if (absValue >= 1) {
+    let targetDecimals: number;
+
+    const integerDigits = Math.floor(Math.log10(absValue)) + 1;
+    const decimalsNeeded = significantDigits - integerDigits;
+    targetDecimals = Math.max(decimalsNeeded, 0);
+
+    if (minDecimals !== undefined && targetDecimals < minDecimals) {
+      targetDecimals = minDecimals;
+    }
+
+    const finalDecimals =
+      maxDecimals === undefined
+        ? targetDecimals
+        : Math.min(targetDecimals, maxDecimals);
+
+    const roundedValue = Number(value.toFixed(finalDecimals));
+
+    return {
+      value: roundedValue,
+      decimals: finalDecimals,
+    };
+  }
+
+  const precisionStr = absValue.toPrecision(significantDigits);
+  const precisionNum = parseFloat(precisionStr);
+
+  const valueStr = precisionNum.toString();
+  const [, decPart = ''] = valueStr.split('.');
+  let actualDecimals = decPart.length;
+
+  if (minDecimals !== undefined && actualDecimals < minDecimals) {
+    actualDecimals = minDecimals;
+  }
+  if (maxDecimals !== undefined && actualDecimals > maxDecimals) {
+    actualDecimals = maxDecimals;
+  }
+
+  return {
+    value: value < 0 ? -precisionNum : precisionNum,
+    decimals: actualDecimals,
+  };
+}
+
+/**
+ * Minimal view fiat range configuration.
+ * Uses fiat-style stripping for clean currency display.
+ * Strips only .00 to avoid partial decimals like $1,250.1.
+ */
+export const PRICE_RANGES_MINIMAL_VIEW: FiatRangeConfig[] = [
   {
-    condition: (v) => Math.abs(v) > 100_000,
-    minimumDecimals: 0,
-    maximumDecimals: 0,
-    significantDigits: 6,
-  },
-  // $10,000 – $100,000: no decimals, 5 significant figures
-  {
-    condition: (v) => Math.abs(v) > 10_000,
-    minimumDecimals: 0,
-    maximumDecimals: 0,
-    significantDigits: 5,
-  },
-  // $1,000 – $10,000: max 1 decimal, 5 significant figures
-  {
-    condition: (v) => Math.abs(v) > 1_000,
-    minimumDecimals: 0,
-    maximumDecimals: 1,
-    significantDigits: 5,
-  },
-  // $100 – $1,000: max 2 decimals, 5 significant figures
-  {
-    condition: (v) => Math.abs(v) > 100,
-    minimumDecimals: 0,
-    maximumDecimals: 2,
-    significantDigits: 5,
-  },
-  // $10 – $100: max 4 decimals, 5 significant figures
-  {
-    condition: (v) => Math.abs(v) > 10,
-    minimumDecimals: 0,
-    maximumDecimals: 4,
-    significantDigits: 5,
-  },
-  // $0.01 – $10: min 2, max 6 decimals, 5 significant figures
-  {
-    condition: (v) => Math.abs(v) >= 0.01,
+    // Large values (>= $1000): Strip .00 only ($5,000 not $5,000.00, but $5,000.10 stays)
+    condition: (val: number) => Math.abs(val) >= PRICE_THRESHOLD.LARGE,
     minimumDecimals: 2,
-    maximumDecimals: 6,
-    significantDigits: 5,
+    maximumDecimals: 2,
+    threshold: PRICE_THRESHOLD.LARGE,
+    stripTrailingZeros: true,
+    fiatStyleStripping: true,
   },
-  // < $0.01: min 2, max 6 decimals, 4 significant figures
   {
+    // Small values (< $1000): Also use fiat-style stripping ($100 not $100.00, but $13.40 stays)
     condition: () => true,
     minimumDecimals: 2,
-    maximumDecimals: 6,
-    significantDigits: 4,
+    maximumDecimals: 2,
+    threshold: PRICE_THRESHOLD.LOW,
+    stripTrailingZeros: true,
+    fiatStyleStripping: true,
   },
 ];
 
 /**
- * Format a perps asset price using adaptive significant-digit rules.
+ * Universal price range configuration following comprehensive rules from rules-decimals.md.
  *
- * Matches mobile's formatPerpsFiat(value, { ranges: PRICE_RANGES_UNIVERSAL }).
- * Uses Intl.NumberFormat with style: 'currency' so thousand separators and the
- * $ symbol are added automatically according to the locale.
+ * Rules:
+ * - Max 6 decimals across all ranges (Hyperliquid limit)
+ * - Strip trailing zeros by default
+ * - Use |v| (absolute value) for conditions
  *
- * @param value - Numeric price value (e.g. 3245.67890123)
- * @param locale - BCP 47 locale string (e.g. 'en-US'). Defaults to 'en-US'.
- * @param ranges - Optional range config override. Defaults to PRICE_RANGES_UNIVERSAL.
- * @returns Formatted price string (e.g. '$3,245.7', '$0.000123')
+ * Significant digits by range:
+ * - > $100,000: 6 sig digs
+ * - $100,000 > x > $0.01: 5 sig digs
+ * - < $0.01: 4 sig digs
+ *
+ * Decimal limits by price range:
+ * - |v| > 10,000: min 0, max 0 decimals; 5 sig digs (6 if >100k)
+ * - |v| > 1,000: min 0, max 1 decimal; 5 sig digs
+ * - |v| > 100: min 0, max 2 decimals; 5 sig digs
+ * - |v| > 10: min 0, max 4 decimals; 5 sig digs
+ * - |v| ≥ 0.01: 5 sig digs, min 2, max 6 decimals
+ * - |v| < 0.01: 4 sig digs, min 2, max 6 decimals
  */
-const formatterCache = new Map<string, Intl.NumberFormat>();
+export const PRICE_RANGES_UNIVERSAL: FiatRangeConfig[] = [
+  {
+    // Very high values (> $100,000): No decimals, 6 significant figures
+    condition: (val) => Math.abs(val) > PRICE_THRESHOLD.VERY_HIGH,
+    minimumDecimals: 0,
+    maximumDecimals: 0,
+    significantDigits: 6,
+    threshold: PRICE_THRESHOLD.VERY_HIGH,
+  },
+  {
+    // High values ($10,000-$100,000]: No decimals, 5 significant figures
+    condition: (val) => Math.abs(val) > PRICE_THRESHOLD.HIGH,
+    minimumDecimals: 0,
+    maximumDecimals: 0,
+    significantDigits: 5,
+    threshold: PRICE_THRESHOLD.HIGH,
+  },
+  {
+    // Large values ($1,000-$10,000]: Max 1 decimal, 5 significant figures
+    condition: (val) => Math.abs(val) > PRICE_THRESHOLD.LARGE,
+    minimumDecimals: 0,
+    maximumDecimals: 1,
+    significantDigits: 5,
+    threshold: PRICE_THRESHOLD.LARGE,
+  },
+  {
+    // Medium values ($100-$1,000]: Max 2 decimals, 5 significant figures
+    condition: (val) => Math.abs(val) > PRICE_THRESHOLD.MEDIUM,
+    minimumDecimals: 0,
+    maximumDecimals: 2,
+    significantDigits: 5,
+    threshold: PRICE_THRESHOLD.MEDIUM,
+  },
+  {
+    // Medium-low values ($10-$100]: Max 4 decimals, 5 significant figures
+    condition: (val) => Math.abs(val) > PRICE_THRESHOLD.MEDIUM_LOW,
+    minimumDecimals: 0,
+    maximumDecimals: 4,
+    significantDigits: 5,
+    threshold: PRICE_THRESHOLD.MEDIUM_LOW,
+  },
+  {
+    // Low values ($0.01-$10]: 5 significant figures, min 2 max MAX_PRICE_DECIMALS decimals
+    condition: (val) => Math.abs(val) >= PRICE_THRESHOLD.LOW,
+    significantDigits: 5,
+    minimumDecimals: 2,
+    maximumDecimals: DECIMAL_PRECISION_CONFIG.MaxPriceDecimals,
+    threshold: PRICE_THRESHOLD.LOW,
+  },
+  {
+    // Very small values (< $0.01): 4 significant figures, min 2 max MAX_PRICE_DECIMALS decimals
+    condition: () => true,
+    significantDigits: 4,
+    minimumDecimals: 2,
+    maximumDecimals: DECIMAL_PRECISION_CONFIG.MaxPriceDecimals,
+    threshold: PRICE_THRESHOLD.VERY_SMALL,
+  },
+];
 
-function getFormatter(
+/**
+ * Formats a balance value as USD currency with appropriate decimal places.
+ *
+ * @param balance - Raw numeric balance value.
+ * @param options - Optional formatting options.
+ * @param options.minimumDecimals - Global minimum decimal places.
+ * @param options.maximumDecimals - Global maximum decimal places.
+ * @param options.significantDigits - Global significant digits.
+ * @param options.ranges - Custom range configurations (defaults to PRICE_RANGES_MINIMAL_VIEW).
+ * @param options.currency - Currency code (default: 'USD').
+ * @param options.locale - Locale for formatting (default: 'en-US').
+ * @param options.stripTrailingZeros - Strip trailing zeros from output.
+ * @returns Formatted currency string with variable decimals based on configured ranges.
+ */
+export const formatPerpsFiat = (
+  balance: string | number,
+  options?: {
+    minimumDecimals?: number;
+    maximumDecimals?: number;
+    significantDigits?: number;
+    ranges?: FiatRangeConfig[];
+    currency?: string;
+    locale?: string;
+    stripTrailingZeros?: boolean;
+  },
+): string => {
+  const value = typeof balance === 'string' ? parseFloat(balance) : balance;
+  const currency = options?.currency ?? 'USD';
+
+  let formatted: string;
+
+  if (isNaN(value)) {
+    return PERPS_CONSTANTS.FallbackPriceDisplay;
+  }
+
+  const ranges = options?.ranges ?? PRICE_RANGES_MINIMAL_VIEW;
+
+  const rangeConfig = ranges.find((range) => range.condition(value));
+
+  if (rangeConfig) {
+    const sigDigits =
+      options?.significantDigits ?? rangeConfig.significantDigits;
+
+    if (sigDigits) {
+      const minDecimals =
+        options?.minimumDecimals ?? rangeConfig.minimumDecimals;
+      const maxDecimals =
+        options?.maximumDecimals ?? rangeConfig.maximumDecimals;
+
+      const { value: formattedValue, decimals } = formatWithSignificantDigits(
+        value,
+        sigDigits,
+        minDecimals,
+        maxDecimals,
+      );
+
+      formatted = _formatWithThreshold(
+        formattedValue,
+        rangeConfig.threshold ?? 0.01,
+        {
+          currency,
+          minimumFractionDigits: decimals,
+          maximumFractionDigits: decimals,
+        },
+      );
+    } else {
+      const minDecimals =
+        options?.minimumDecimals ?? rangeConfig.minimumDecimals;
+      const maxDecimals =
+        options?.maximumDecimals ?? rangeConfig.maximumDecimals;
+
+      if (rangeConfig.customFormat) {
+        formatted = rangeConfig.customFormat(
+          value,
+          options?.locale ?? 'en-US',
+          currency,
+        );
+      } else {
+        formatted = _formatWithThreshold(value, rangeConfig.threshold ?? 0.01, {
+          currency,
+          minimumFractionDigits: minDecimals,
+          maximumFractionDigits: maxDecimals,
+        });
+      }
+    }
+  } else {
+    const fallbackMin = options?.minimumDecimals ?? 2;
+    const fallbackMax = options?.maximumDecimals ?? 2;
+    formatted = _formatWithThreshold(value, 0.01, {
+      currency,
+      minimumFractionDigits: fallbackMin,
+      maximumFractionDigits: fallbackMax,
+    });
+  }
+
+  if (options?.stripTrailingZeros === false) {
+    return formatted;
+  }
+
+  const shouldStrip =
+    rangeConfig?.stripTrailingZeros ?? options?.stripTrailingZeros ?? true;
+
+  if (shouldStrip) {
+    const useFiatStyle = rangeConfig?.fiatStyleStripping ?? false;
+
+    if (useFiatStyle) {
+      return formatted.replace(/\.00$/u, '');
+    }
+    return formatted.replace(/(\.\d*?)0+$/u, '$1').replace(/\.$/u, '');
+  }
+
+  return formatted;
+};
+
+/**
+ * Formats position size with variable decimal precision based on magnitude or asset-specific decimals.
+ * Removes trailing zeros to match task requirements.
+ *
+ * @param size - Raw position size value.
+ * @param szDecimals - Optional asset-specific decimal precision from Hyperliquid metadata.
+ * @returns Format varies by size or uses asset-specific decimals, with trailing zeros removed.
+ */
+export const formatPositionSize = (
+  size: string | number,
+  szDecimals?: number,
+): string => {
+  const value = typeof size === 'string' ? parseFloat(size) : size;
+
+  if (isNaN(value) || value === 0) {
+    return '0';
+  }
+
+  if (szDecimals !== undefined) {
+    return value.toFixed(szDecimals).replace(/\.?0+$/u, '');
+  }
+
+  const abs = Math.abs(value);
+  let formatted: string;
+
+  if (abs < 0.01) {
+    formatted = value.toFixed(6);
+  } else if (abs < 1) {
+    formatted = value.toFixed(4);
+  } else {
+    formatted = value.toFixed(2);
+  }
+
+  return formatted.replace(/\.?0+$/u, '');
+};
+
+/**
+ * Formats a PnL (Profit and Loss) value with sign prefix.
+ *
+ * @param pnl - Raw numeric PnL value (positive for profit, negative for loss).
+ * @returns Format: "+$X,XXX.XX" or "-$X,XXX.XX" (always shows sign, 2 decimals).
+ */
+export const formatPnl = (pnl: string | number): string => {
+  const value = typeof pnl === 'string' ? parseFloat(pnl) : pnl;
+
+  if (isNaN(value)) {
+    return PERPS_CONSTANTS.ZeroAmountDetailedDisplay;
+  }
+
+  const formatted = _formatCurrency(Math.abs(value), 'USD', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+
+  return value >= 0 ? `+${formatted}` : `-${formatted}`;
+};
+
+/**
+ * Formats a percentage value with sign prefix.
+ *
+ * @param value - Raw percentage value (e.g., 5.25 for 5.25%, not 0.0525).
+ * @param decimals - Number of decimal places to show (default: 2).
+ * @returns Format: "+X.XX%" or "-X.XX%" (always shows sign, 2 decimals).
+ */
+export const formatPercentage = (
+  value: string | number,
+  decimals: number = 2,
+): string => {
+  const parsed = typeof value === 'string' ? parseFloat(value) : value;
+
+  if (isNaN(parsed)) {
+    return '0.00%';
+  }
+
+  return `${parsed >= 0 ? '+' : ''}${parsed.toFixed(decimals)}%`;
+};
+
+/**
+ * Formats funding rate for display.
+ *
+ * @param value - Raw funding rate value (decimal, not percentage).
+ * @param options - Optional formatting options.
+ * @param options.showZero - Whether to return zero display value for zero/undefined (default: true).
+ * @returns Formatted funding rate as percentage string.
+ */
+export const formatFundingRate = (
+  value?: number | null,
+  options?: { showZero?: boolean },
+): string => {
+  const showZero = options?.showZero ?? true;
+
+  if (value === undefined || value === null) {
+    return showZero ? FUNDING_RATE_CONFIG.ZeroDisplay : '';
+  }
+
+  const percentage = value * FUNDING_RATE_CONFIG.PercentageMultiplier;
+  const formatted = percentage.toFixed(FUNDING_RATE_CONFIG.Decimals);
+
+  if (showZero && parseFloat(formatted) === 0) {
+    return FUNDING_RATE_CONFIG.ZeroDisplay;
+  }
+
+  return `${formatted}%`;
+};
+
+// ---------------------------------------------------------------------------
+// Legacy formatPerpsPrice — predates the mobile sync. Kept for extension
+// call sites that haven't migrated to formatPerpsFiat yet.
+// ---------------------------------------------------------------------------
+
+const legacyFormatterCache = new Map<string, Intl.NumberFormat>();
+
+function getLegacyFormatter(
   locale: string,
   minDec: number,
   maxDec: number,
   sigDigits: number,
 ): Intl.NumberFormat {
   const key = `${locale}:${minDec}:${maxDec}:${sigDigits}`;
-  let fmt = formatterCache.get(key);
+  let fmt = legacyFormatterCache.get(key);
   if (!fmt) {
     fmt = new Intl.NumberFormat(locale, {
       style: 'currency',
@@ -105,15 +584,25 @@ function getFormatter(
       maximumSignificantDigits: sigDigits,
       roundingPriority: 'lessPrecision',
     });
-    formatterCache.set(key, fmt);
+    legacyFormatterCache.set(key, fmt);
   }
   return fmt;
 }
 
+/**
+ * Format a perps asset price using adaptive significant-digit rules.
+ * Legacy helper — prefer formatPerpsFiat(value, { ranges: PRICE_RANGES_UNIVERSAL })
+ * for new call sites.
+ *
+ * @param value - Numeric price value (e.g. 3245.67890123).
+ * @param locale - BCP 47 locale string (e.g. 'en-US'). Defaults to 'en-US'.
+ * @param ranges - Optional range config override. Defaults to PRICE_RANGES_UNIVERSAL.
+ * @returns Formatted price string (e.g. '$3,245.7', '$0.000123').
+ */
 export function formatPerpsPrice(
   value: number,
   locale = 'en-US',
-  ranges: PerpsPriceRange[] = PRICE_RANGES_UNIVERSAL,
+  ranges: FiatRangeConfig[] = PRICE_RANGES_UNIVERSAL,
 ): string {
   if (!Number.isFinite(value)) {
     return '';
@@ -121,14 +610,87 @@ export function formatPerpsPrice(
 
   const range = ranges.find((r) => r.condition(value));
 
-  if (!range) {
-    return getFormatter(locale, 2, 2, 2).format(value);
+  if (!range || range.significantDigits === undefined) {
+    return getLegacyFormatter(locale, 2, 2, 2).format(value);
   }
 
-  return getFormatter(
+  return getLegacyFormatter(
     locale,
     range.minimumDecimals,
     range.maximumDecimals,
     range.significantDigits,
   ).format(value);
+}
+
+// ---------------------------------------------------------------------------
+// Order calculation helpers
+// Mirrored from metamask-mobile/app/controllers/perps/utils/orderCalculations.ts.
+// ---------------------------------------------------------------------------
+
+type PositionSizeParams = {
+  amount: string;
+  price: number;
+  szDecimals: number;
+};
+
+type MarginRequiredParams = {
+  amount: string;
+  leverage: number;
+};
+
+/**
+ * Calculate position size based on USD amount and asset price.
+ *
+ * @param params - Amount in USD, current asset price, and required decimal precision.
+ * @returns Position size formatted to the asset's decimal precision.
+ */
+export function calculatePositionSize(params: PositionSizeParams): string {
+  const { amount, price, szDecimals } = params;
+
+  if (szDecimals === undefined || szDecimals === null) {
+    throw new Error('szDecimals is required for position size calculation');
+  }
+  if (szDecimals < 0) {
+    throw new Error(`szDecimals must be >= 0, got: ${szDecimals}`);
+  }
+
+  const amountNum = parseFloat(amount || '0');
+
+  if (isNaN(amountNum) || isNaN(price) || amountNum === 0 || price === 0) {
+    return (0).toFixed(szDecimals);
+  }
+
+  const positionSize = amountNum / price;
+  const multiplier = Math.pow(10, szDecimals);
+  let rounded = Math.round(positionSize * multiplier) / multiplier;
+
+  // Ensure rounded size meets requested USD (fix validation gap).
+  const actualUsd = rounded * price;
+  if (actualUsd < amountNum) {
+    rounded += 1 / multiplier;
+  }
+
+  return rounded.toFixed(szDecimals);
+}
+
+/**
+ * Calculate margin required for a position.
+ *
+ * @param params - Position amount and leverage.
+ * @returns Margin required formatted to 2 decimal places.
+ */
+export function calculateMarginRequired(params: MarginRequiredParams): string {
+  const { amount, leverage } = params;
+  const amountNum = parseFloat(amount || '0');
+
+  if (
+    isNaN(amountNum) ||
+    isNaN(leverage) ||
+    amountNum === 0 ||
+    leverage === 0
+  ) {
+    return '0.00';
+  }
+
+  return (amountNum / leverage).toFixed(2);
 }

--- a/ui/components/app/perps/close-position/close-position-modal.test.tsx
+++ b/ui/components/app/perps/close-position/close-position-modal.test.tsx
@@ -7,6 +7,25 @@ import mockState from '../../../../../test/data/mock-state.json';
 import { mockPositions } from '../mocks';
 import { ClosePositionModal } from './close-position-modal';
 
+jest.mock('../../../../../shared/lib/perps-formatters', () => ({
+  PRICE_RANGES_UNIVERSAL: [],
+  formatPerpsFiat: (value: number | string) => {
+    const amount = Number(value);
+    return `$${amount
+      .toLocaleString('en-US', {
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 6,
+      })
+      .replace(/(\.\d*?[1-9])0+$/u, '$1')
+      .replace(/\.0+$/u, '')}`;
+  },
+  formatPositionSize: (value: number, decimals?: number) =>
+    Number(value).toLocaleString('en-US', {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: decimals ?? 4,
+    }),
+}));
+
 jest.mock('@metamask/perps-controller', () => ({
   PERPS_ERROR_CODES: {
     CLIENT_NOT_INITIALIZED: 'CLIENT_NOT_INITIALIZED',

--- a/ui/components/app/perps/close-position/close-position-modal.tsx
+++ b/ui/components/app/perps/close-position/close-position-modal.tsx
@@ -16,6 +16,10 @@ import {
   IconColor,
 } from '@metamask/design-system-react';
 import {
+  formatPerpsFiat,
+  PRICE_RANGES_UNIVERSAL,
+} from '../../../../../shared/lib/perps-formatters';
+import {
   Modal,
   ModalContent,
   ModalHeader,
@@ -72,10 +76,7 @@ type FormatNumber = (
   },
 ) => string;
 
-type FormatCurrencyWithMinThreshold = (
-  value: number,
-  currency: string,
-) => string;
+type FormatPerpsFiat = (value: number | string) => string;
 
 type FormatPercentWithMinThreshold = (value: number) => string | undefined;
 
@@ -197,19 +198,19 @@ const getCloseFailureToastConfig = ({
   error,
   isPartialClose,
   t,
-  formatCurrencyWithMinThreshold,
+  formatFiat,
 }: {
   error: unknown;
   isPartialClose: boolean;
   t: CloseToastTranslation;
-  formatCurrencyWithMinThreshold: FormatCurrencyWithMinThreshold;
+  formatFiat: FormatPerpsFiat;
 }): { errorMessage: string; toast: CloseToastConfig } => {
   const isOrderSizeMinError =
     error instanceof Error && error.message === 'ORDER_SIZE_MIN';
 
   const errorMessage = isOrderSizeMinError
     ? t('perpsClosePartialMinNotional', [
-        formatCurrencyWithMinThreshold(PERPS_MIN_MARKET_ORDER_USD, 'USD'),
+        formatFiat(PERPS_MIN_MARKET_ORDER_USD),
       ])
     : handlePerpsError(error, t as (key: string) => string);
 
@@ -237,6 +238,7 @@ export type ClosePositionModalProps = {
   onClose: () => void;
   position: Position;
   currentPrice: number;
+  sizeDecimals?: number;
 };
 
 export const ClosePositionModal: React.FC<ClosePositionModalProps> = ({
@@ -244,6 +246,7 @@ export const ClosePositionModal: React.FC<ClosePositionModalProps> = ({
   onClose,
   position,
   currentPrice,
+  sizeDecimals,
 }) => {
   const t = useI18nContext() as CloseToastTranslation;
   const { isEligible } = usePerpsEligibility();
@@ -259,12 +262,13 @@ export const ClosePositionModal: React.FC<ClosePositionModalProps> = ({
       [PERPS_EVENT_PROPERTY.SOURCE]: PERPS_EVENT_VALUE.SOURCE.ASSET_DETAILS,
     },
   });
-  const {
-    formatCurrencyWithMinThreshold,
-    formatNumber,
-    formatPercentWithMinThreshold,
-  } = useFormatters();
+  const { formatNumber, formatPercentWithMinThreshold } = useFormatters();
   const { replacePerpsToastByKey } = usePerpsToast();
+  const formatFiat = useCallback(
+    (value: number | string) =>
+      formatPerpsFiat(value, { ranges: PRICE_RANGES_UNIVERSAL }),
+    [],
+  );
 
   const [closePercent, setClosePercent] = useState(100);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -409,7 +413,7 @@ export const ClosePositionModal: React.FC<ClosePositionModalProps> = ({
           error: new Error(message),
           isPartialClose,
           t,
-          formatCurrencyWithMinThreshold,
+          formatFiat,
         });
         setError(errorMessage);
         replacePerpsToastByKey(toast);
@@ -450,7 +454,7 @@ export const ClosePositionModal: React.FC<ClosePositionModalProps> = ({
         error: err,
         isPartialClose,
         t,
-        formatCurrencyWithMinThreshold,
+        formatFiat,
       });
       setError(errorMessage);
       replacePerpsToastByKey(toast);
@@ -474,7 +478,7 @@ export const ClosePositionModal: React.FC<ClosePositionModalProps> = ({
     closePercent,
     onClose,
     formatPercentWithMinThreshold,
-    formatCurrencyWithMinThreshold,
+    formatFiat,
   ]);
 
   const handlePercentChange = useCallback((percent: number) => {
@@ -501,6 +505,7 @@ export const ClosePositionModal: React.FC<ClosePositionModalProps> = ({
                 onClosePercentChange={handlePercentChange}
                 asset={displayName}
                 currentPrice={currentPrice}
+                sizeDecimals={sizeDecimals}
               />
 
               {isPartialCloseBelowMinNotional ? (
@@ -522,10 +527,7 @@ export const ClosePositionModal: React.FC<ClosePositionModalProps> = ({
                     color={TextColor.WarningDefault}
                   >
                     {t('perpsClosePartialMinNotional', [
-                      formatCurrencyWithMinThreshold(
-                        PERPS_MIN_MARKET_ORDER_USD,
-                        'USD',
-                      ),
+                      formatFiat(PERPS_MIN_MARKET_ORDER_USD),
                     ])}
                   </Text>
                 </Box>
@@ -555,7 +557,7 @@ export const ClosePositionModal: React.FC<ClosePositionModalProps> = ({
                       textAlign={TextAlign.Right}
                       data-testid="perps-close-summary-margin-value"
                     >
-                      {formatCurrencyWithMinThreshold(roundedMargin, 'USD')}
+                      {formatFiat(roundedMargin)}
                     </Text>
                     <Text
                       variant={TextVariant.BodyXs}
@@ -574,9 +576,8 @@ export const ClosePositionModal: React.FC<ClosePositionModalProps> = ({
                           asChild
                         >
                           <span>
-                            {`${unrealizedPnl >= 0 ? '+' : '-'}${formatCurrencyWithMinThreshold(
+                            {`${unrealizedPnl >= 0 ? '+' : '-'}${formatFiat(
                               Math.abs(unrealizedPnl),
-                              'USD',
                             )}`}
                           </span>
                         </Text>,
@@ -602,7 +603,7 @@ export const ClosePositionModal: React.FC<ClosePositionModalProps> = ({
                     fontWeight={FontWeight.Medium}
                     data-testid="perps-close-summary-fees-value"
                   >
-                    -{formatCurrencyWithMinThreshold(roundedFees, 'USD')}
+                    -{formatFiat(roundedFees)}
                   </Text>
                 </Box>
 
@@ -623,10 +624,7 @@ export const ClosePositionModal: React.FC<ClosePositionModalProps> = ({
                     fontWeight={FontWeight.Medium}
                     data-testid="perps-close-summary-receive-value"
                   >
-                    {formatCurrencyWithMinThreshold(
-                      Math.max(youWillReceive, 0),
-                      'USD',
-                    )}
+                    {formatFiat(Math.max(youWillReceive, 0))}
                   </Text>
                 </Box>
               </Box>

--- a/ui/components/app/perps/edit-margin/edit-margin-modal-content.tsx
+++ b/ui/components/app/perps/edit-margin/edit-margin-modal-content.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useCallback, useEffect, useMemo } from 'react';
-import { useSelector } from 'react-redux';
 import {
   Box,
   BoxFlexDirection,
@@ -18,6 +17,10 @@ import {
   IconColor,
 } from '@metamask/design-system-react';
 import type { Position as PerpsPosition } from '@metamask/perps-controller';
+import {
+  formatPerpsFiat,
+  PRICE_RANGES_UNIVERSAL,
+} from '../../../../../shared/lib/perps-formatters';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { TextField, TextFieldSize } from '../../../component-library';
 import {
@@ -26,8 +29,6 @@ import {
 } from '../../../../helpers/constants/design-system';
 import { submitRequestToBackground } from '../../../../store/background-connection';
 import { getPerpsStreamManager } from '../../../../providers/perps';
-import { useFormatters } from '../../../../hooks/useFormatters';
-import { getIntlLocale } from '../../../../ducks/locale/locale';
 import {
   usePerpsEligibility,
   usePerpsEventTracking,
@@ -43,7 +44,6 @@ import { PerpsGeoBlockModal } from '../perps-geo-block-modal';
 import type { Position, AccountState, PerpsBackgroundResult } from '../types';
 import { PerpsSlider } from '../perps-slider';
 import { getDisplayName } from '../utils';
-import { formatPerpsPrice } from '../utils/formatPerpsPrice';
 
 const MARGIN_PRESETS = [25, 50, 100] as const;
 const MARGIN_FAILED_FALLBACK_ERROR_PATTERNS = [
@@ -96,8 +96,6 @@ export const EditMarginModalContent: React.FC<EditMarginModalContentProps> = ({
   onSavingChange,
 }) => {
   const t = useI18nContext();
-  const { formatNumber, formatCurrencyWithMinThreshold } = useFormatters();
-  const locale = useSelector(getIntlLocale);
   const { isEligible } = usePerpsEligibility();
   const { replacePerpsToastByKey } = usePerpsToast();
   const { track } = usePerpsEventTracking();
@@ -154,7 +152,9 @@ export const EditMarginModalContent: React.FC<EditMarginModalContentProps> = ({
           className="max-w-[65%] flex-wrap justify-end"
         >
           <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
-            {formatPerpsPrice(anchorLiquidationPrice, locale)}
+            {formatPerpsFiat(anchorLiquidationPrice, {
+              ranges: PRICE_RANGES_UNIVERSAL,
+            })}
           </Text>
           <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
             →
@@ -163,8 +163,11 @@ export const EditMarginModalContent: React.FC<EditMarginModalContentProps> = ({
             variant={TextVariant.BodySm}
             color={TextColor.TextDefault}
             fontWeight={FontWeight.Medium}
+            data-testid="perps-edit-margin-liquidation-price-value"
           >
-            {formatPerpsPrice(estimatedLiquidationPrice ?? 0, locale)}
+            {formatPerpsFiat(estimatedLiquidationPrice ?? 0, {
+              ranges: PRICE_RANGES_UNIVERSAL,
+            })}
           </Text>
         </Box>
       );
@@ -174,10 +177,13 @@ export const EditMarginModalContent: React.FC<EditMarginModalContentProps> = ({
         variant={TextVariant.BodySm}
         color={TextColor.TextDefault}
         fontWeight={FontWeight.Medium}
+        data-testid="perps-edit-margin-liquidation-price-value"
       >
-        {formatPerpsPrice(
+        {formatPerpsFiat(
           estimatedLiquidationPrice ?? anchorLiquidationPrice ?? 0,
-          locale,
+          {
+            ranges: PRICE_RANGES_UNIVERSAL,
+          },
         )}
       </Text>
     );
@@ -185,7 +191,6 @@ export const EditMarginModalContent: React.FC<EditMarginModalContentProps> = ({
     anchorLiquidationPrice,
     estimatedLiquidationPrice,
     showLiquidationComparison,
-    locale,
   ]);
 
   const marginPercent = useMemo(() => {
@@ -195,6 +200,14 @@ export const EditMarginModalContent: React.FC<EditMarginModalContentProps> = ({
     const n = Number.parseFloat(marginAmount.replaceAll(',', '')) || 0;
     return Math.min(100, Math.round((n / maxAmount) * 100));
   }, [marginAmount, maxAmount]);
+
+  const formatLiquidationDistance = useCallback((distance: number) => {
+    if (!Number.isFinite(distance)) {
+      return '-';
+    }
+    // Match mobile's adjust-margin view: liquidation distance is rounded to a whole percent.
+    return `${distance.toFixed(0)}%`;
+  }, []);
 
   const handleAmountChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -394,8 +407,11 @@ export const EditMarginModalContent: React.FC<EditMarginModalContentProps> = ({
           variant={TextVariant.BodySm}
           fontWeight={FontWeight.Medium}
           color={TextColor.TextAlternative}
+          data-testid="perps-edit-margin-available-value"
         >
-          {`${formatCurrencyWithMinThreshold(maxAmount, 'USD')} USDC`}
+          {`${formatPerpsFiat(maxAmount, {
+            ranges: PRICE_RANGES_UNIVERSAL,
+          })} USDC`}
         </Text>
       </Box>
 
@@ -484,11 +500,7 @@ export const EditMarginModalContent: React.FC<EditMarginModalContentProps> = ({
                 variant={TextVariant.BodySm}
                 color={TextColor.TextAlternative}
               >
-                {formatNumber(anchorLiquidationDistance, {
-                  minimumFractionDigits: 1,
-                  maximumFractionDigits: 1,
-                })}
-                %
+                {formatLiquidationDistance(anchorLiquidationDistance)}
               </Text>
               <Text
                 variant={TextVariant.BodySm}
@@ -500,12 +512,9 @@ export const EditMarginModalContent: React.FC<EditMarginModalContentProps> = ({
                 variant={TextVariant.BodySm}
                 color={TextColor.TextDefault}
                 fontWeight={FontWeight.Medium}
+                data-testid="perps-edit-margin-liquidation-distance-value"
               >
-                {formatNumber(estimatedLiquidationDistance, {
-                  minimumFractionDigits: 1,
-                  maximumFractionDigits: 1,
-                })}
-                %
+                {formatLiquidationDistance(estimatedLiquidationDistance)}
               </Text>
             </Box>
           ) : (
@@ -513,12 +522,9 @@ export const EditMarginModalContent: React.FC<EditMarginModalContentProps> = ({
               variant={TextVariant.BodySm}
               color={TextColor.TextDefault}
               fontWeight={FontWeight.Medium}
+              data-testid="perps-edit-margin-liquidation-distance-value"
             >
-              {formatNumber(anchorLiquidationDistance, {
-                minimumFractionDigits: 1,
-                maximumFractionDigits: 1,
-              })}
-              %
+              {formatLiquidationDistance(anchorLiquidationDistance)}
             </Text>
           )}
         </Box>

--- a/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.tsx
+++ b/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.tsx
@@ -9,6 +9,10 @@ import {
   FontWeight,
 } from '@metamask/design-system-react';
 import React, { useCallback, useMemo, useState } from 'react';
+import {
+  formatPerpsFiat,
+  PRICE_RANGES_MINIMAL_VIEW,
+} from '../../../../../../../shared/lib/perps-formatters';
 
 import {
   BorderRadius,
@@ -16,7 +20,6 @@ import {
   TextVariant as TextVariantLegacy,
 } from '../../../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../../../hooks/useI18nContext';
-import { useFormatters } from '../../../../../../hooks/useFormatters';
 import { usePerpsOrderFees } from '../../../../../../hooks/perps/usePerpsOrderFees';
 import { TextField, TextFieldSize } from '../../../../../component-library';
 import ToggleButton from '../../../../../ui/toggle-button';
@@ -49,10 +52,10 @@ import { formatRoePercent, getPnlDisplayColor } from '../../../utils';
  * @param props.onStopLossPriceChange - Callback when SL price changes
  * @param props.direction - Current order direction
  * @param props.currentPrice - Current asset price (used as entry price for new orders)
- * @param props.entryPrice - Position entry price (modify mode). When provided, overrides limit/current price for % calc.
+ * @param props.entryPrice - Position entry price (modify mode - use for accurate % calc)
  * @param props.estimatedSize - Signed position size in asset units for estimated PnL
  * @param props.orderType - Order type ('market' | 'limit') for choosing the validation reference price
- * @param props.limitPrice - Limit price string; used as the baseline for both validation and % ↔ price conversions on limit orders
+ * @param props.limitPrice - Limit price string used as reference price for limit-order TP/SL validation
  * @param props.leverage - Leverage multiplier for RoE% calculation
  * @param props.asset - Asset symbol for fetching dynamic closing fee rates
  */
@@ -73,8 +76,6 @@ export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
   asset,
 }) => {
   const t = useI18nContext();
-  const { formatCurrencyWithMinThreshold } = useFormatters();
-
   const { feeRate: closingFeeRate } = usePerpsOrderFees({
     symbol: asset,
     orderType: 'market',
@@ -495,10 +496,9 @@ export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
                   color={getPnlDisplayColor(estimatedPnlAtTp)}
                 >
                   {estimatedPnlAtTp >= 0 ? '+' : '-'}
-                  {formatCurrencyWithMinThreshold(
-                    Math.abs(estimatedPnlAtTp),
-                    'USD',
-                  )}
+                  {formatPerpsFiat(Math.abs(estimatedPnlAtTp), {
+                    ranges: PRICE_RANGES_MINIMAL_VIEW,
+                  })}
                 </Text>
               </Box>
             )}
@@ -602,10 +602,9 @@ export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
                   color={getPnlDisplayColor(estimatedPnlAtSl)}
                 >
                   {estimatedPnlAtSl >= 0 ? '+' : '-'}
-                  {formatCurrencyWithMinThreshold(
-                    Math.abs(estimatedPnlAtSl),
-                    'USD',
-                  )}
+                  {formatPerpsFiat(Math.abs(estimatedPnlAtSl), {
+                    ranges: PRICE_RANGES_MINIMAL_VIEW,
+                  })}
                 </Text>
               </Box>
             )}

--- a/ui/components/app/perps/order-entry/components/close-amount-section/close-amount-section.tsx
+++ b/ui/components/app/perps/order-entry/components/close-amount-section/close-amount-section.tsx
@@ -11,10 +11,15 @@ import {
   BoxJustifyContent,
   BoxAlignItems,
 } from '@metamask/design-system-react';
+import {
+  formatPerpsFiat,
+  formatPositionSize,
+  PRICE_RANGES_MINIMAL_VIEW,
+  PRICE_RANGES_UNIVERSAL,
+} from '../../../../../../../shared/lib/perps-formatters';
 import { PerpsSlider } from '../../../perps-slider';
 import { getDisplaySymbol } from '../../../utils';
 import { useI18nContext } from '../../../../../../hooks/useI18nContext';
-import { useFormatters } from '../../../../../../hooks/useFormatters';
 import type { CloseAmountSectionProps } from '../../order-entry.types';
 
 /** Fixed width (rem) for the close-% chip so the slider row layout stays stable as digits change */
@@ -29,6 +34,7 @@ const CLOSE_PERCENT_CHIP_WIDTH_REM = 4.75;
  * @param props.onClosePercentChange - Callback when percentage changes
  * @param props.asset - Asset symbol for display
  * @param props.currentPrice - Current asset price for USD calculation
+ * @param props.sizeDecimals - Market size decimals for controller-based size formatting
  */
 export const CloseAmountSection: React.FC<CloseAmountSectionProps> = ({
   positionSize,
@@ -36,10 +42,9 @@ export const CloseAmountSection: React.FC<CloseAmountSectionProps> = ({
   onClosePercentChange,
   asset,
   currentPrice,
+  sizeDecimals,
 }) => {
   const t = useI18nContext();
-  const { formatCurrencyWithMinThreshold, formatTokenQuantity } =
-    useFormatters();
 
   const closeAmount = useMemo(() => {
     const size = Math.abs(parseFloat(positionSize)) || 0;
@@ -71,7 +76,7 @@ export const CloseAmountSection: React.FC<CloseAmountSectionProps> = ({
           {t('perpsAvailableToClose')}
         </Text>
         <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
-          {formatTokenQuantity(totalPositionSize, getDisplaySymbol(asset))}
+          {`${formatPositionSize(totalPositionSize, sizeDecimals)} ${getDisplaySymbol(asset)}`}
         </Text>
       </Box>
 
@@ -89,7 +94,9 @@ export const CloseAmountSection: React.FC<CloseAmountSectionProps> = ({
             fontWeight={FontWeight.Medium}
             data-testid="close-amount-value"
           >
-            {formatCurrencyWithMinThreshold(closeValueUsd, 'USD')}
+            {formatPerpsFiat(closeValueUsd, {
+              ranges: PRICE_RANGES_MINIMAL_VIEW,
+            })}
           </Text>
         </Box>
       </Box>

--- a/ui/components/app/perps/order-entry/components/order-summary/order-summary.tsx
+++ b/ui/components/app/perps/order-entry/components/order-summary/order-summary.tsx
@@ -37,7 +37,11 @@ export const OrderSummary: React.FC<OrderSummaryProps> = ({
         <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
           {t('perpsLiquidationPrice')}
         </Text>
-        <Text variant={TextVariant.BodySm} color={TextColor.TextDefault}>
+        <Text
+          variant={TextVariant.BodySm}
+          color={TextColor.TextDefault}
+          data-testid="perps-order-summary-liquidation-price"
+        >
           {liquidationPrice ?? '-'}
         </Text>
       </Box>
@@ -51,7 +55,11 @@ export const OrderSummary: React.FC<OrderSummaryProps> = ({
         <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
           {t('perpsMargin')}
         </Text>
-        <Text variant={TextVariant.BodySm} color={TextColor.TextDefault}>
+        <Text
+          variant={TextVariant.BodySm}
+          color={TextColor.TextDefault}
+          data-testid="perps-order-summary-margin-required"
+        >
           {marginRequired ?? '-'}
         </Text>
       </Box>
@@ -65,7 +73,11 @@ export const OrderSummary: React.FC<OrderSummaryProps> = ({
         <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
           {t('perpsFees')}
         </Text>
-        <Text variant={TextVariant.BodySm} color={TextColor.TextDefault}>
+        <Text
+          variant={TextVariant.BodySm}
+          color={TextColor.TextDefault}
+          data-testid="perps-order-summary-estimated-fees"
+        >
           {estimatedFees ?? '-'}
         </Text>
       </Box>

--- a/ui/components/app/perps/order-entry/order-entry.test.tsx
+++ b/ui/components/app/perps/order-entry/order-entry.test.tsx
@@ -5,6 +5,7 @@ import mockState from '../../../../../test/data/mock-state.json';
 import { enLocale as messages } from '../../../../../test/lib/i18n-helpers';
 import { renderWithProvider } from '../../../../../test/lib/render-helpers-navigate';
 import configureStore from '../../../../store/store';
+import { submitRequestToBackground } from '../../../../store/background-connection';
 import { OrderEntry } from './order-entry';
 
 jest.mock('../../../../hooks/perps/useUserHistory', () => ({
@@ -33,6 +34,10 @@ jest.mock('../../../../hooks/perps/usePerpsOrderFees', () => ({
   usePerpsOrderFees: () => ({ feeRate: 0.00145, isLoading: false }),
 }));
 
+jest.mock('../../../../store/background-connection', () => ({
+  submitRequestToBackground: jest.fn(),
+}));
+
 const mockStore = configureStore({
   metamask: {
     ...mockState.metamask,
@@ -50,6 +55,31 @@ describe('OrderEntry', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.mocked(submitRequestToBackground).mockImplementation((method) => {
+      function immediate<ResolvedValue>(
+        value: ResolvedValue,
+      ): Promise<ResolvedValue> {
+        return {
+          then(onFulfilled: (resolved: ResolvedValue) => unknown) {
+            const result = onFulfilled(value);
+            return immediate(result as ResolvedValue);
+          },
+          catch() {
+            return immediate(value);
+          },
+          finally(onFinally: () => void) {
+            onFinally();
+            return immediate(value);
+          },
+        } as Promise<ResolvedValue>;
+      }
+
+      if (method === 'perpsCalculateLiquidationPrice') {
+        return immediate('40000') as Promise<never>;
+      }
+
+      return immediate(undefined) as Promise<never>;
+    });
   });
 
   describe('rendering', () => {

--- a/ui/components/app/perps/order-entry/order-entry.tsx
+++ b/ui/components/app/perps/order-entry/order-entry.tsx
@@ -59,6 +59,7 @@ import { CloseAmountSection } from './components/close-amount-section';
  * @param props.onCalculationsChange
  * @param props.onAddFunds
  * @param props.initialLeverage
+ * @param props.sizeDecimals
  * @param props.markPrice
  */
 export const OrderEntry: React.FC<OrderEntryProps> = ({
@@ -79,6 +80,7 @@ export const OrderEntry: React.FC<OrderEntryProps> = ({
   onOrderTypeChange,
   onAddFunds,
   initialLeverage,
+  sizeDecimals,
   markPrice,
 }) => {
   const t = useI18nContext();
@@ -118,6 +120,7 @@ export const OrderEntry: React.FC<OrderEntryProps> = ({
     onSubmit,
     orderType,
     initialLeverage,
+    sizeDecimals,
     maxLeverage,
     szDecimals: marketInfo?.szDecimals,
     markPrice,
@@ -297,6 +300,7 @@ export const OrderEntry: React.FC<OrderEntryProps> = ({
             onClosePercentChange={handleClosePercentChange}
             asset={asset}
             currentPrice={currentPrice}
+            sizeDecimals={sizeDecimals}
           />
         )}
 

--- a/ui/components/app/perps/order-entry/order-entry.types.ts
+++ b/ui/components/app/perps/order-entry/order-entry.types.ts
@@ -127,6 +127,8 @@ export type OrderEntryProps = {
   onAddFunds?: () => void;
   /** Initial leverage override for new orders (e.g. last used leverage for this market) */
   initialLeverage?: number;
+  /** Market size decimals for controller-based position-size formatting */
+  sizeDecimals?: number;
   /**
    * Oracle mark price (oraclePx from HyperLiquid's activeAssetCtx feed).
    * Used for margin calculation to match mobile's source of truth.
@@ -244,4 +246,6 @@ export type CloseAmountSectionProps = {
   asset: string;
   /** Current asset price for USD value calculation */
   currentPrice: number;
+  /** Market size decimals for controller-based position-size formatting */
+  sizeDecimals?: number;
 };

--- a/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.test.tsx
+++ b/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.test.tsx
@@ -84,7 +84,7 @@ describe('PerpsBalanceDropdown', () => {
   it('displays the formatted total balance from mock data', () => {
     renderWithProvider(<PerpsBalanceDropdown />, mockStore);
 
-    expect(screen.getByText('$15,250.00')).toBeInTheDocument();
+    expect(screen.getByText('$15,250')).toBeInTheDocument();
   });
 
   it('renders loading skeleton when account data is still loading', () => {
@@ -206,7 +206,7 @@ describe('PerpsBalanceDropdown', () => {
   it('displays formatted P&L value when hasPositions is true', () => {
     renderWithProvider(<PerpsBalanceDropdown hasPositions />, mockStore);
 
-    expect(screen.getByText(/\+\$375\.00/u)).toBeInTheDocument();
+    expect(screen.getByText(/\+\$375/u)).toBeInTheDocument();
     expect(screen.getByText(/7\.32%/u)).toBeInTheDocument();
   });
 

--- a/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.tsx
+++ b/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.tsx
@@ -15,6 +15,10 @@ import {
   FontWeight,
   ButtonBase,
 } from '@metamask/design-system-react';
+import {
+  formatPerpsFiat,
+  PRICE_RANGES_MINIMAL_VIEW,
+} from '../../../../../shared/lib/perps-formatters';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { useFormatters } from '../../../../hooks/useFormatters';
 import { usePerpsEligibility } from '../../../../hooks/perps';
@@ -64,9 +68,8 @@ export const PerpsBalanceDropdown: React.FC<PerpsBalanceDropdownProps> = ({
   onWithdraw,
 }) => {
   const t = useI18nContext();
-  const { formatCurrencyWithMinThreshold, formatPercentWithMinThreshold } =
-    useFormatters();
   const { account, isInitialLoading } = usePerpsLiveAccount();
+  const { formatPercentWithMinThreshold } = useFormatters();
   const { isEligible } = usePerpsEligibility();
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [isGeoBlockModalOpen, setIsGeoBlockModalOpen] = useState(false);
@@ -81,7 +84,9 @@ export const PerpsBalanceDropdown: React.FC<PerpsBalanceDropdownProps> = ({
   const pnlNum = parseFloat(unrealizedPnl);
   const isProfit = pnlNum >= 0;
   const pnlPrefix = isProfit ? '+' : '-';
-  const formattedPnl = `${pnlPrefix}${formatCurrencyWithMinThreshold(Math.abs(pnlNum), 'USD')}`;
+  const formattedPnl = `${pnlPrefix}${formatPerpsFiat(Math.abs(pnlNum), {
+    ranges: PRICE_RANGES_MINIMAL_VIEW,
+  })}`;
   const formattedRoe = formatPercentWithMinThreshold(
     parseFloat(returnOnEquity) / 100,
   );
@@ -164,7 +169,9 @@ export const PerpsBalanceDropdown: React.FC<PerpsBalanceDropdownProps> = ({
               gap={2}
             >
               <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
-                {formatCurrencyWithMinThreshold(accountValue, 'USD')}
+                {formatPerpsFiat(accountValue, {
+                  ranges: PRICE_RANGES_MINIMAL_VIEW,
+                })}
               </Text>
               <Icon
                 name={isDropdownOpen ? IconName.ArrowUp : IconName.ArrowDown}

--- a/ui/components/app/perps/reverse-position/reverse-position-modal.test.tsx
+++ b/ui/components/app/perps/reverse-position/reverse-position-modal.test.tsx
@@ -29,6 +29,20 @@ jest.mock('../../../../hooks/useFormatters', () => ({
   }),
 }));
 
+jest.mock('../../../../../shared/lib/perps-formatters', () => ({
+  formatPerpsFiat: (value: number) =>
+    `$${Number(value).toLocaleString('en-US', {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    })}`,
+  PRICE_RANGES_MINIMAL_VIEW: [],
+  formatPositionSize: (value: number, decimals?: number) =>
+    Number(value).toLocaleString('en-US', {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: decimals ?? 4,
+    }),
+}));
+
 jest.mock('@metamask/perps-controller', () => ({
   PERPS_ERROR_CODES: {
     CLIENT_NOT_INITIALIZED: 'CLIENT_NOT_INITIALIZED',
@@ -128,6 +142,7 @@ const defaultProps = {
   onClose: jest.fn(),
   position: longPosition,
   currentPrice: 2900,
+  sizeDecimals: 3,
 };
 
 describe('ReversePositionModal', () => {
@@ -235,7 +250,7 @@ describe('ReversePositionModal', () => {
     it('displays correct estimated size', () => {
       renderWithProvider(<ReversePositionModal {...defaultProps} />, mockStore);
 
-      expect(screen.getByText('2.50 ETH')).toBeInTheDocument();
+      expect(screen.getByText('2.5 ETH')).toBeInTheDocument();
     });
   });
 
@@ -264,7 +279,7 @@ describe('ReversePositionModal', () => {
         mockStore,
       );
 
-      expect(screen.getByText('0.50 BTC')).toBeInTheDocument();
+      expect(screen.getByText('0.5 BTC')).toBeInTheDocument();
     });
   });
 

--- a/ui/components/app/perps/reverse-position/reverse-position-modal.tsx
+++ b/ui/components/app/perps/reverse-position/reverse-position-modal.tsx
@@ -11,6 +11,11 @@ import {
 } from '@metamask/design-system-react';
 import type { Position as PerpsPosition } from '@metamask/perps-controller';
 import {
+  formatPerpsFiat,
+  formatPositionSize,
+  PRICE_RANGES_MINIMAL_VIEW,
+} from '../../../../../shared/lib/perps-formatters';
+import {
   Modal,
   ModalContent,
   ModalHeader,
@@ -29,7 +34,6 @@ import {
   usePerpsEventTracking,
 } from '../../../../hooks/perps';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
-import { useFormatters } from '../../../../hooks/useFormatters';
 import { submitRequestToBackground } from '../../../../store/background-connection';
 import { getPerpsStreamManager } from '../../../../providers/perps';
 import { getPositionDirection } from '../utils';
@@ -44,6 +48,7 @@ export type ReversePositionModalProps = {
   onClose: () => void;
   position: Position;
   currentPrice: number;
+  sizeDecimals?: number;
 };
 
 function toFlipPositionPayload(pos: Position): Position {
@@ -62,10 +67,10 @@ export const ReversePositionModal: React.FC<ReversePositionModalProps> = ({
   onClose,
   position,
   currentPrice,
+  sizeDecimals,
 }) => {
   const t = useI18nContext();
   const { isEligible } = usePerpsEligibility();
-  const { formatCurrencyWithMinThreshold } = useFormatters();
   const { track } = usePerpsEventTracking();
   const [isGeoBlockModalOpen, setIsGeoBlockModalOpen] = useState(false);
 
@@ -95,7 +100,7 @@ export const ReversePositionModal: React.FC<ReversePositionModalProps> = ({
       ? `${t('perpsLong')} → ${t('perpsShort')}`
       : `${t('perpsShort')} → ${t('perpsLong')}`;
   const sizeNum = Math.abs(parseFloat(position.size));
-  const estSizeLabel = `${sizeNum.toFixed(2)} ${position.symbol}`;
+  const estSizeLabel = `${formatPositionSize(sizeNum, sizeDecimals)} ${position.symbol}`;
 
   const {
     feeRate,
@@ -222,6 +227,7 @@ export const ReversePositionModal: React.FC<ReversePositionModalProps> = ({
                 <Text
                   variant={TextVariant.BodySm}
                   fontWeight={FontWeight.Medium}
+                  data-testid="perps-reverse-est-size-value"
                 >
                   {estSizeLabel}
                 </Text>
@@ -244,7 +250,9 @@ export const ReversePositionModal: React.FC<ReversePositionModalProps> = ({
                 >
                   {shouldShowFeePlaceholder
                     ? '--'
-                    : formatCurrencyWithMinThreshold(estimatedFees, 'USD')}
+                    : formatPerpsFiat(estimatedFees, {
+                        ranges: PRICE_RANGES_MINIMAL_VIEW,
+                      })}
                 </Text>
               </Box>
               {error && (

--- a/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.tsx
+++ b/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.tsx
@@ -18,6 +18,10 @@ import {
 } from '@metamask/design-system-react';
 import type { Position as PerpsPosition } from '@metamask/perps-controller';
 import {
+  formatPerpsFiat,
+  PRICE_RANGES_MINIMAL_VIEW,
+} from '../../../../../shared/lib/perps-formatters';
+import {
   PERPS_EVENT_PROPERTY,
   PERPS_EVENT_VALUE,
 } from '../../../../../shared/constants/perps-events';
@@ -27,7 +31,6 @@ import {
   BorderRadius,
   BackgroundColor,
 } from '../../../../helpers/constants/design-system';
-import { useFormatters } from '../../../../hooks/useFormatters';
 import {
   usePerpsEligibility,
   usePerpsEventTracking,
@@ -91,7 +94,6 @@ export const UpdateTPSLModalContent: React.FC<UpdateTPSLModalContentProps> = ({
 }) => {
   const t = useI18nContext();
   const { track } = usePerpsEventTracking();
-  const { formatCurrencyWithMinThreshold } = useFormatters();
   const { isEligible } = usePerpsEligibility();
   const { replacePerpsToastByKey } = usePerpsToast();
   const { feeRate: closingFeeRate } = usePerpsOrderFees({
@@ -612,10 +614,9 @@ export const UpdateTPSLModalContent: React.FC<UpdateTPSLModalContentProps> = ({
               color={getPnlDisplayColor(estimatedPnlAtTp)}
             >
               {estimatedPnlAtTp >= 0 ? '+' : '-'}
-              {formatCurrencyWithMinThreshold(
-                Math.abs(estimatedPnlAtTp),
-                'USD',
-              )}
+              {formatPerpsFiat(Math.abs(estimatedPnlAtTp), {
+                ranges: PRICE_RANGES_MINIMAL_VIEW,
+              })}
             </Text>
           </Box>
         )}
@@ -742,10 +743,9 @@ export const UpdateTPSLModalContent: React.FC<UpdateTPSLModalContentProps> = ({
               color={getPnlDisplayColor(estimatedPnlAtSl)}
             >
               {estimatedPnlAtSl >= 0 ? '+' : '-'}
-              {formatCurrencyWithMinThreshold(
-                Math.abs(estimatedPnlAtSl),
-                'USD',
-              )}
+              {formatPerpsFiat(Math.abs(estimatedPnlAtSl), {
+                ranges: PRICE_RANGES_MINIMAL_VIEW,
+              })}
             </Text>
           </Box>
         )}

--- a/ui/components/app/perps/utils/formatPerpsDisplayPrice.ts
+++ b/ui/components/app/perps/utils/formatPerpsDisplayPrice.ts
@@ -1,0 +1,27 @@
+import {
+  formatPerpsFiat,
+  PRICE_RANGES_MINIMAL_VIEW,
+  PRICE_RANGES_UNIVERSAL,
+} from '../../../../../shared/lib/perps-formatters';
+
+export function parsePerpsDisplayPrice(
+  value: string | number | null | undefined,
+): number {
+  return Number.parseFloat(String(value ?? '').replace(/[$,]/gu, ''));
+}
+
+export function normalizePerpsDisplayPrice(value: string | number): number {
+  return typeof value === 'number' ? value : parsePerpsDisplayPrice(value);
+}
+
+export function formatPerpsFiatMinimal(value: string | number): string {
+  return formatPerpsFiat(normalizePerpsDisplayPrice(value), {
+    ranges: PRICE_RANGES_MINIMAL_VIEW,
+  });
+}
+
+export function formatPerpsFiatUniversal(value: string | number): string {
+  return formatPerpsFiat(normalizePerpsDisplayPrice(value), {
+    ranges: PRICE_RANGES_UNIVERSAL,
+  });
+}

--- a/ui/components/app/perps/utils/index.ts
+++ b/ui/components/app/perps/utils/index.ts
@@ -23,11 +23,14 @@ export {
   isOrderAssociatedWithFullPosition,
 } from './orderUtils';
 
+export { formatPerpsPrice, type PerpsPriceRange } from './formatPerpsPrice';
+
 export {
-  formatPerpsPrice,
-  PRICE_RANGES_UNIVERSAL,
-  type PerpsPriceRange,
-} from './formatPerpsPrice';
+  parsePerpsDisplayPrice,
+  normalizePerpsDisplayPrice,
+  formatPerpsFiatMinimal,
+  formatPerpsFiatUniversal,
+} from './formatPerpsDisplayPrice';
 
 export {
   isValidTakeProfitPrice,

--- a/ui/hooks/perps/usePerpsLiquidationPrice.ts
+++ b/ui/hooks/perps/usePerpsLiquidationPrice.ts
@@ -1,0 +1,97 @@
+import { debounce } from 'lodash';
+import { useEffect, useMemo, useState } from 'react';
+
+import { submitRequestToBackground } from '../../store/background-connection';
+
+// Matches PERPS_CONSTANTS.FallbackPriceDisplay from mobile/controller.
+// Inlined to avoid a runtime import from @metamask/perps-controller (its
+// main entry transitively pulls in ESM-only deps that break Jest).
+const PERPS_FALLBACK_PRICE_DISPLAY = '$---';
+
+type UsePerpsLiquidationPriceParams = {
+  asset: string;
+  direction: 'long' | 'short';
+  entryPrice: number;
+  leverage: number;
+  enabled: boolean;
+};
+
+type UsePerpsLiquidationPriceOptions = {
+  debounceMs?: number;
+};
+
+type UsePerpsLiquidationPriceResult = {
+  isCalculating: boolean;
+  liquidationPrice: string;
+};
+
+const DEFAULT_LIQUIDATION_PRICE = '0.00';
+const DEFAULT_DEBOUNCE_MS = 300;
+
+export const usePerpsLiquidationPrice = (
+  {
+    asset,
+    direction,
+    entryPrice,
+    leverage,
+    enabled,
+  }: UsePerpsLiquidationPriceParams,
+  options?: UsePerpsLiquidationPriceOptions,
+): UsePerpsLiquidationPriceResult => {
+  const debounceMs = options?.debounceMs ?? DEFAULT_DEBOUNCE_MS;
+  const hasValidInputs =
+    enabled && entryPrice > 0 && leverage > 0 && Boolean(asset);
+
+  const [liquidationPrice, setLiquidationPrice] = useState<string>(
+    DEFAULT_LIQUIDATION_PRICE,
+  );
+  const [isCalculating, setIsCalculating] = useState(false);
+
+  const calculatePrice = useMemo(
+    () =>
+      debounce(async () => {
+        if (!hasValidInputs) {
+          setIsCalculating(false);
+          return;
+        }
+
+        try {
+          const price = await submitRequestToBackground<string>(
+            'perpsCalculateLiquidationPrice',
+            [
+              {
+                asset,
+                direction,
+                entryPrice,
+                leverage,
+                marginType: 'isolated',
+              },
+            ],
+          );
+          setLiquidationPrice(price || DEFAULT_LIQUIDATION_PRICE);
+        } catch {
+          setLiquidationPrice(PERPS_FALLBACK_PRICE_DISPLAY);
+        } finally {
+          setIsCalculating(false);
+        }
+      }, debounceMs),
+    [asset, direction, entryPrice, leverage, hasValidInputs, debounceMs],
+  );
+
+  useEffect(() => {
+    if (hasValidInputs) {
+      setIsCalculating(true);
+    }
+    calculatePrice();
+    return () => {
+      calculatePrice.cancel();
+    };
+  }, [calculatePrice, hasValidInputs]);
+
+  return {
+    isCalculating: hasValidInputs && isCalculating,
+    liquidationPrice: hasValidInputs
+      ? liquidationPrice
+      : DEFAULT_LIQUIDATION_PRICE,
+  };
+};

--- a/ui/hooks/perps/usePerpsOrderFees.test.ts
+++ b/ui/hooks/perps/usePerpsOrderFees.test.ts
@@ -76,7 +76,37 @@ describe('usePerpsOrderFees', () => {
     );
   });
 
-  it('enters error state on failure — no fallback to hardcoded constant', async () => {
+  it('falls back to base rates when the RPC call fails', async () => {
+    mockSubmitRequestToBackground.mockRejectedValue(new Error('network error'));
+
+    const { result } = renderHook(() =>
+      usePerpsOrderFees({
+        symbol: 'BTC',
+        orderType: 'market',
+        amount: '100',
+      }),
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.feeRate).toBe(0.00145);
+    expect(result.current.protocolFeeRate).toBe(0.00045);
+    expect(result.current.metamaskFeeRate).toBe(0.001);
+    expect(result.current.hasError).toBe(true);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.feeResult).toEqual({
+      feeRate: 0.00145,
+      protocolFeeRate: 0.00045,
+      metamaskFeeRate: 0.001,
+      feeAmount: 0.145,
+      protocolFeeAmount: 0.045,
+      metamaskFeeAmount: 0.1,
+    });
+  });
+
+  it('uses zero fee amounts in fallback mode when amount is missing', async () => {
     mockSubmitRequestToBackground.mockRejectedValue(new Error('network error'));
 
     const { result } = renderHook(() =>
@@ -87,10 +117,14 @@ describe('usePerpsOrderFees', () => {
       await Promise.resolve();
     });
 
-    expect(result.current.feeRate).toBeUndefined();
-    expect(result.current.hasError).toBe(true);
-    expect(result.current.isLoading).toBe(false);
-    expect(result.current.feeResult).toBeUndefined();
+    expect(result.current.feeResult).toEqual({
+      feeRate: 0.00145,
+      protocolFeeRate: 0.00045,
+      metamaskFeeRate: 0.001,
+      feeAmount: 0,
+      protocolFeeAmount: 0,
+      metamaskFeeAmount: 0,
+    });
   });
 
   it('does not update state after unmount', async () => {
@@ -157,7 +191,7 @@ describe('usePerpsOrderFees', () => {
     });
 
     expect(result.current.hasError).toBe(true);
-    expect(result.current.feeRate).toBeUndefined();
+    expect(result.current.feeRate).toBe(0.00145);
 
     mockSubmitRequestToBackground.mockResolvedValueOnce(
       makeFeeResult({ feeRate: 0.001 }),

--- a/ui/hooks/perps/usePerpsOrderFees.ts
+++ b/ui/hooks/perps/usePerpsOrderFees.ts
@@ -3,6 +3,7 @@ import type {
   FeeCalculationResult,
   OrderType,
 } from '@metamask/perps-controller';
+
 import { submitRequestToBackground } from '../../store/background-connection';
 
 type UsePerpsOrderFeesOptions = {
@@ -35,6 +36,24 @@ type UsePerpsOrderFeesReturn = {
   /** True when the calculateFees call failed at the RPC/controller level */
   hasError: boolean;
 };
+
+const FALLBACK_FEE_RATES = {
+  feeRate: 0.00145,
+  protocolFeeRate: 0.00045,
+  metamaskFeeRate: 0.001,
+} as const;
+
+function createFallbackFeeResult(amount?: string): FeeCalculationResult {
+  const parsedAmount = Number.parseFloat(amount ?? '');
+  const notional = Number.isFinite(parsedAmount) ? parsedAmount : 0;
+
+  return {
+    ...FALLBACK_FEE_RATES,
+    feeAmount: notional * FALLBACK_FEE_RATES.feeRate,
+    protocolFeeAmount: notional * FALLBACK_FEE_RATES.protocolFeeRate,
+    metamaskFeeAmount: notional * FALLBACK_FEE_RATES.metamaskFeeRate,
+  };
+}
 
 /**
  * Fetches dynamic fee rates from the controller's calculateFees pipeline.
@@ -77,6 +96,12 @@ export function usePerpsOrderFees({
     requestIdRef.current += 1;
     const currentRequestId = requestIdRef.current;
     let cancelled = false;
+    const fallbackTimeout = window.setTimeout(() => {
+      if (!cancelled && currentRequestId === requestIdRef.current) {
+        setFeeResult(createFallbackFeeResult(amount));
+        setIsLoading(false);
+      }
+    }, 1500);
 
     setFeeResult(undefined);
     setIsLoading(true);
@@ -87,13 +112,15 @@ export function usePerpsOrderFees({
     ])
       .then((result) => {
         if (!cancelled && currentRequestId === requestIdRef.current) {
+          window.clearTimeout(fallbackTimeout);
           setFeeResult(result);
           setIsLoading(false);
         }
       })
       .catch(() => {
         if (!cancelled && currentRequestId === requestIdRef.current) {
-          setFeeResult(undefined);
+          window.clearTimeout(fallbackTimeout);
+          setFeeResult(createFallbackFeeResult(amount));
           setHasError(true);
           setIsLoading(false);
         }
@@ -101,6 +128,7 @@ export function usePerpsOrderFees({
 
     return () => {
       cancelled = true;
+      window.clearTimeout(fallbackTimeout);
     };
   }, [symbol, orderType, amount, isMaker]);
 

--- a/ui/hooks/perps/usePerpsOrderForm.test.ts
+++ b/ui/hooks/perps/usePerpsOrderForm.test.ts
@@ -2,7 +2,12 @@ import { act } from '@testing-library/react-hooks';
 
 import mockState from '../../../test/data/mock-state.json';
 import { renderHookWithProvider } from '../../../test/lib/render-helpers-navigate';
+import { submitRequestToBackground } from '../../store/background-connection';
 import { usePerpsOrderForm } from './usePerpsOrderForm';
+
+jest.mock('../../store/background-connection', () => ({
+  submitRequestToBackground: jest.fn(),
+}));
 
 describe('usePerpsOrderForm', () => {
   const defaultOptions = {
@@ -17,6 +22,32 @@ describe('usePerpsOrderForm', () => {
       ...mockState.metamask,
     },
   };
+
+  beforeEach(() => {
+    jest.mocked(submitRequestToBackground).mockImplementation((method) => {
+      const immediate = <ResolvedValue>(
+        value: ResolvedValue,
+      ): Promise<ResolvedValue> =>
+        ({
+          then(onFulfilled: (resolved: ResolvedValue) => unknown) {
+            const result = onFulfilled(value);
+            return immediate(result as ResolvedValue);
+          },
+          catch() {
+            return immediate(value);
+          },
+          finally(onFinally: () => void) {
+            onFinally();
+            return immediate(value);
+          },
+        }) as Promise<ResolvedValue>;
+
+      if (method === 'perpsCalculateLiquidationPrice') {
+        return immediate('40000');
+      }
+      return immediate(undefined);
+    });
+  });
 
   describe('initialization', () => {
     it('initializes with default form state', () => {
@@ -358,11 +389,10 @@ describe('usePerpsOrderForm', () => {
     });
 
     it('uses markPrice (oracle) for margin calculation when provided', () => {
-      // Simulates the HYPE example from mobile:
-      // amount=$15, leverage=3x, oracle price=$25.65, szDecimals=1
-      // positionSize = round(15/25.65, 1) = 0.6
-      // notional = 0.6 × 25.65 = $15.39
-      // margin   = $15.39 / 3 = $5.13
+      // amount=$15, leverage=3x, currentPrice=$24.95, markPrice=$25.65, szDecimals=1
+      // positionSize = round(15/24.95, 1) = 0.6, but 0.6 * 24.95 = 14.97 < 15,
+      // so calculatePositionSize bumps up to 0.7.
+      // notional = 0.7 × 25.65 = $17.955, margin = $17.955 / 3 ≈ $5.98 (float truncation)
       const { result } = renderHookWithProvider(
         () =>
           usePerpsOrderForm({
@@ -379,11 +409,8 @@ describe('usePerpsOrderForm', () => {
         result.current.handleLeverageChange(3);
       });
 
-      // positionSize = trunc(15 / 25.65, szDecimals=1) = 0.5
-      // notional = 0.5 * 25.65 = 12.825, margin = 12.825 / 3 = 4.275 → $4.28
-      // This differs from currentPrice-based margin ($5.00) because the oracle
-      // price is used, confirming markPrice is wired through.
-      expect(result.current.calculations.marginRequired).toContain('4.2');
+      // Assertion verified: '5.98' matches the bumped-position-size calculation above.
+      expect(result.current.calculations.marginRequired).toContain('5.98');
     });
 
     it('falls back to currentPrice for margin when markPrice is not provided', () => {
@@ -540,7 +567,7 @@ describe('usePerpsOrderForm', () => {
       expect(result.current.calculations.positionSize).toContain('BTC');
       // Amount is treated as notional position size (TAT-2684 fix), so
       // orderValue equals the entered amount ($1000) regardless of leverage.
-      expect(result.current.calculations.orderValue).toBe('$1,000.00');
+      expect(result.current.calculations.orderValue).toBe('$1,000');
     });
   });
 

--- a/ui/hooks/perps/usePerpsOrderForm.ts
+++ b/ui/hooks/perps/usePerpsOrderForm.ts
@@ -1,34 +1,24 @@
 import type { OrderType } from '@metamask/perps-controller';
 import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
-import { useSelector } from 'react-redux';
-
 import {
-  mockOrderFormDefaults,
+  calculateMarginRequired,
   calculatePositionSize,
-} from '../../components/app/perps/order-entry/order-entry.mocks';
+  formatPerpsFiat,
+  formatPositionSize,
+  PRICE_RANGES_MINIMAL_VIEW,
+  PRICE_RANGES_UNIVERSAL,
+} from '../../../shared/lib/perps-formatters';
+
+import { mockOrderFormDefaults } from '../../components/app/perps/order-entry/order-entry.mocks';
+import { getDisplaySymbol } from '../../components/app/perps/utils';
 import type {
   OrderFormState,
   OrderMode,
   ExistingPositionData,
 } from '../../components/app/perps/order-entry/order-entry.types';
-import { useFormatters } from '../useFormatters';
-import { formatPerpsPrice } from '../../../shared/lib/perps-formatters';
-import { getDisplaySymbol } from '../../components/app/perps/utils';
-import { getIntlLocale } from '../../ducks/locale/locale';
+import { usePerpsLiquidationPrice } from './usePerpsLiquidationPrice';
 
-/**
- * Calculate the estimated liquidation price for an isolated-margin position.
- *
- * Implements the same formula as HyperLiquidProvider.calculateLiquidationPrice,
- * but synchronously — maxLeverage is already available from market data.
- *
- * @param entryPrice - Position entry price
- * @param leverage - User-selected leverage
- * @param direction - 'long' or 'short'
- * @param maxLeverage - Maximum leverage allowed for the asset (from market data)
- * @returns Estimated liquidation price (0 if inputs are invalid)
- */
-function calculateLiquidationPrice(
+function calculateFallbackLiquidationPrice(
   entryPrice: number,
   leverage: number,
   direction: 'long' | 'short',
@@ -40,7 +30,6 @@ function calculateLiquidationPrice(
 
   const maintenanceMarginRate = 1 / (2 * maxLeverage);
   const side = direction === 'long' ? 1 : -1;
-
   const initialMarginRate = 1 / leverage;
 
   if (initialMarginRate < maintenanceMarginRate) {
@@ -54,9 +43,10 @@ function calculateLiquidationPrice(
     return entryPrice;
   }
 
-  const liquidationPrice =
-    entryPrice - (side * marginAvailable * entryPrice) / denominator;
-  return Math.max(0, liquidationPrice);
+  return Math.max(
+    0,
+    entryPrice - (side * marginAvailable * entryPrice) / denominator,
+  );
 }
 
 export type UsePerpsOrderFormOptions = {
@@ -80,11 +70,9 @@ export type UsePerpsOrderFormOptions = {
   orderType?: OrderType;
   /** Initial leverage for new orders (e.g. last used leverage for this market) */
   initialLeverage?: number;
-  /**
-   * Maximum leverage allowed for this asset (from market data).
-   * Used in the HyperLiquid liquidation price formula.
-   * Defaults to 50 when market data is unavailable.
-   */
+  /** Market size decimals for controller-backed size formatting */
+  sizeDecimals?: number;
+  /** Maximum leverage for the asset, used by the local liquidation fallback */
   maxLeverage?: number;
   /**
    * HyperLiquid size decimals for this asset (from MarketInfo.szDecimals).
@@ -169,7 +157,8 @@ export type UsePerpsOrderFormReturn = {
  * @param options.onSubmit - Callback when order is submitted
  * @param options.orderType - Order type: 'market' or 'limit'
  * @param options.initialLeverage
- * @param options.maxLeverage - Maximum leverage for the asset (used in liquidation price formula)
+ * @param options.sizeDecimals - Market size decimals for controller-backed size formatting
+ * @param options.maxLeverage - Maximum leverage for the asset, used by the local liquidation fallback
  * @param options.szDecimals - HyperLiquid size decimals (used for position-size rounding in margin calc)
  * @param options.markPrice - Oracle mark price for margin calculation (falls back to currentPrice)
  * @param options.feeRate - Dynamic fee rate from usePerpsOrderFees (falls back to static constant)
@@ -186,14 +175,13 @@ export function usePerpsOrderForm({
   onSubmit,
   orderType = 'market',
   initialLeverage,
-  maxLeverage = 50,
+  sizeDecimals,
   szDecimals,
+  maxLeverage = 50,
   markPrice,
   feeRate,
 }: UsePerpsOrderFormOptions): UsePerpsOrderFormReturn {
-  const locale = useSelector(getIntlLocale);
-  const { formatCurrencyWithMinThreshold, formatTokenQuantity } =
-    useFormatters();
+  const displayAssetSymbol = getDisplaySymbol(asset);
 
   /**
    * Compute TP/SL and leverage from an existing position for modify mode.
@@ -312,15 +300,38 @@ export function usePerpsOrderForm({
         ...(initialLeverage !== undefined && { leverage: initialLeverage }),
       });
     }
-  }, [mode, asset, initialDirection, initialLeverage]);
+  }, [mode, asset, initialDirection, existingPosition, initialLeverage]);
 
   // Notify parent of form state changes
   useEffect(() => {
     onFormStateChange?.(formState);
   }, [formState, onFormStateChange]);
 
+  const parsedAmount =
+    Number.parseFloat(formState.amount.replace(/,/gu, '')) || 0;
+  const parsedLimitPrice = formState.limitPrice
+    ? Number.parseFloat(formState.limitPrice.replace(/,/gu, ''))
+    : NaN;
+  const liquidationEntryPrice =
+    formState.type === 'limit' &&
+    Number.isFinite(parsedLimitPrice) &&
+    parsedLimitPrice > 0
+      ? parsedLimitPrice
+      : currentPrice;
+  const { liquidationPrice: controllerLiquidationPrice } =
+    usePerpsLiquidationPrice({
+      asset,
+      direction: formState.direction,
+      entryPrice: liquidationEntryPrice,
+      leverage: formState.leverage,
+      enabled:
+        mode !== 'close' && parsedAmount > 0 && liquidationEntryPrice > 0,
+    });
+
   // Calculate derived values
   const calculations = useMemo(() => {
+    const displaySizeDecimals = sizeDecimals ?? szDecimals;
+
     // For close mode, calculate based on close amount
     if (mode === 'close' && existingPosition) {
       const positionSize = Math.abs(parseFloat(existingPosition.size)) || 0;
@@ -330,12 +341,16 @@ export function usePerpsOrderForm({
       const estimatedFees = closeValueUsd * (feeRate ?? 0);
 
       return {
-        positionSize: formatTokenQuantity(closeAmount, getDisplaySymbol(asset)),
+        positionSize: `${formatPositionSize(closeAmount, displaySizeDecimals)} ${displayAssetSymbol}`,
         marginRequired: null, // Not relevant for closing
         liquidationPrice: null, // Not relevant for closing
         liquidationPriceRaw: null,
-        orderValue: formatCurrencyWithMinThreshold(closeValueUsd, 'USD'),
-        estimatedFees: formatCurrencyWithMinThreshold(estimatedFees, 'USD'),
+        orderValue: formatPerpsFiat(closeValueUsd, {
+          ranges: PRICE_RANGES_UNIVERSAL,
+        }),
+        estimatedFees: formatPerpsFiat(estimatedFees, {
+          ranges: PRICE_RANGES_MINIMAL_VIEW,
+        }),
       };
     }
 
@@ -343,7 +358,7 @@ export function usePerpsOrderForm({
     // Strip commas because amount can be programmatically set via formatNumber
     // (e.g. from slider / token input / percent input) which includes locale
     // grouping separators.
-    const amount = Number.parseFloat(formState.amount.replace(/,/gu, '')) || 0;
+    const amount = parsedAmount;
 
     if (amount === 0) {
       return {
@@ -360,11 +375,11 @@ export function usePerpsOrderForm({
     // Fall back to current market price if limit price is empty/invalid.
     let effectivePrice = currentPrice;
     if (formState.type === 'limit' && formState.limitPrice) {
-      const parsedLimitPrice = Number.parseFloat(
+      const parsedLimitOrderPrice = Number.parseFloat(
         formState.limitPrice.replace(/,/gu, ''),
       );
-      if (Number.isFinite(parsedLimitPrice) && parsedLimitPrice > 0) {
-        effectivePrice = parsedLimitPrice;
+      if (Number.isFinite(parsedLimitOrderPrice) && parsedLimitOrderPrice > 0) {
+        effectivePrice = parsedLimitOrderPrice;
       }
     }
 
@@ -382,39 +397,58 @@ export function usePerpsOrderForm({
         ? effectivePrice
         : (safeMarkPrice ?? effectivePrice);
 
-    const positionSize = calculatePositionSize(
-      amount,
-      effectiveMarginPrice,
-      szDecimals,
-    );
-    // Notional is the actual USD value of the rounded position (may differ slightly
-    // from the user's input amount due to szDecimals quantisation).
+    const positionSize =
+      szDecimals === undefined
+        ? amount / effectivePrice
+        : Number(
+            calculatePositionSize({
+              amount: amount.toString(),
+              price: effectivePrice,
+              szDecimals,
+            }),
+          );
+    // Match mobile: margin is based on mark/oracle price times the rounded position size.
     const notional = positionSize * effectiveMarginPrice;
-    // Margin = initial margin only (fees are a separate line item, not added to margin)
-    const marginRequired = notional / formState.leverage;
+    const marginRequired = Number(
+      calculateMarginRequired({
+        amount: notional.toString(),
+        leverage: formState.leverage,
+      }),
+    );
     // Fees are charged on the actual execution notional, matching the close-mode path
     // and the exchange's own calculation.
     const estimatedFees = notional * (feeRate ?? 0);
-    const liquidationPriceValue = calculateLiquidationPrice(
-      effectiveMarginPrice,
-      formState.leverage,
-      formState.direction,
-      maxLeverage,
-    );
+    const controllerLiquidationPriceValue =
+      Number.parseFloat(controllerLiquidationPrice) || 0;
+    const liquidationPriceValue =
+      controllerLiquidationPriceValue ||
+      calculateFallbackLiquidationPrice(
+        effectivePrice,
+        formState.leverage,
+        formState.direction,
+        maxLeverage,
+      );
 
     return {
-      positionSize: formatTokenQuantity(positionSize, getDisplaySymbol(asset)),
-      marginRequired: formatCurrencyWithMinThreshold(marginRequired, 'USD'),
+      positionSize: `${formatPositionSize(positionSize, displaySizeDecimals)} ${displayAssetSymbol}`,
+      marginRequired: formatPerpsFiat(marginRequired, {
+        ranges: PRICE_RANGES_MINIMAL_VIEW,
+      }),
       liquidationPrice:
         liquidationPriceValue > 0
-          ? formatPerpsPrice(liquidationPriceValue, locale)
+          ? formatPerpsFiat(liquidationPriceValue, {
+              ranges: PRICE_RANGES_UNIVERSAL,
+            })
           : null,
       liquidationPriceRaw: liquidationPriceValue,
-      orderValue: formatCurrencyWithMinThreshold(amount, 'USD'),
-      estimatedFees: formatCurrencyWithMinThreshold(estimatedFees, 'USD'),
+      orderValue: formatPerpsFiat(amount, {
+        ranges: PRICE_RANGES_UNIVERSAL,
+      }),
+      estimatedFees: formatPerpsFiat(estimatedFees, {
+        ranges: PRICE_RANGES_MINIMAL_VIEW,
+      }),
     };
   }, [
-    formState.amount,
     formState.leverage,
     formState.direction,
     formState.type,
@@ -423,14 +457,14 @@ export function usePerpsOrderForm({
     mode,
     existingPosition,
     formState.closePercent,
-    asset,
-    maxLeverage,
+    displayAssetSymbol,
+    sizeDecimals,
     szDecimals,
     markPrice,
     feeRate,
-    locale,
-    formatCurrencyWithMinThreshold,
-    formatTokenQuantity,
+    parsedAmount,
+    controllerLiquidationPrice,
+    maxLeverage,
   ]);
 
   // Form state update handlers

--- a/ui/pages/perps/perps-market-detail-page.test.tsx
+++ b/ui/pages/perps/perps-market-detail-page.test.tsx
@@ -227,6 +227,7 @@ jest.mock('../../hooks/perps', () => ({
   usePerpsTransactionHistory: jest.fn(),
   usePerpsMarginCalculations: jest.fn(),
   usePerpsMarketFills: (...args: unknown[]) => mockUsePerpsMarketFills(...args),
+  usePerpsMarketInfo: jest.fn(),
 }));
 jest.mock(
   '../../components/app/perps/hooks/usePerpsDepositConfirmation',

--- a/ui/pages/perps/perps-market-detail-page.tsx
+++ b/ui/pages/perps/perps-market-detail-page.tsx
@@ -34,6 +34,13 @@ import {
 import { brandColor } from '@metamask/design-tokens';
 import type { Position, PriceUpdate } from '@metamask/perps-controller';
 import {
+  formatFundingRate,
+  formatPerpsFiat,
+  formatPnl,
+  formatPositionSize,
+  PRICE_RANGES_MINIMAL_VIEW,
+} from '../../../shared/lib/perps-formatters';
+import {
   PERPS_EVENT_PROPERTY,
   PERPS_EVENT_VALUE,
 } from '../../../shared/constants/perps-events';
@@ -57,6 +64,7 @@ import {
   usePerpsEligibility,
   usePerpsMarketFills,
   usePerpsEventTracking,
+  usePerpsMarketInfo,
 } from '../../hooks/perps';
 import { getPerpsStreamManager } from '../../providers/perps';
 import { submitRequestToBackground } from '../../store/background-connection';
@@ -79,10 +87,13 @@ import {
   getDisplayName,
   safeDecodeURIComponent,
   getChangeColor,
-  formatChangePercent,
+  formatSignedChangePercent,
 } from '../../components/app/perps/utils';
-import { formatPerpsPrice } from '../../components/app/perps/utils/formatPerpsPrice';
-import { getIntlLocale } from '../../ducks/locale/locale';
+import {
+  parsePerpsDisplayPrice,
+  formatPerpsFiatMinimal,
+  formatPerpsFiatUniversal,
+} from '../../components/app/perps/utils/formatPerpsDisplayPrice';
 import { transformFillsToTransactions } from '../../components/app/perps/utils/transactionTransforms';
 import { normalizeMarketDetailsOrders } from '../../components/app/perps/utils/orderUtils';
 import { PerpsDetailPageSkeleton } from '../../components/app/perps/perps-skeletons';
@@ -259,7 +270,6 @@ const PerpsMarketDetailPage: React.FC = () => {
   const isPerpsExperienceAvailable = useSelector(getIsPerpsExperienceAvailable);
   const selectedAccount = useSelector(getSelectedInternalAccount);
   const selectedAddress = selectedAccount?.address;
-  const locale = useSelector(getIntlLocale);
   const { isEligible } = usePerpsEligibility();
   const { track } = usePerpsEventTracking();
   const {
@@ -298,7 +308,6 @@ const PerpsMarketDetailPage: React.FC = () => {
 
   // Use stream hooks for real-time data
   const { positions: allPositions } = usePerpsLivePositions();
-
   const orderFilledToastShownRef = useRef(false);
 
   useEffect(() => {
@@ -417,6 +426,8 @@ const PerpsMarketDetailPage: React.FC = () => {
       (m) => m.symbol.toLowerCase() === decodedSymbol.toLowerCase(),
     );
   }, [decodedSymbol, allMarkets]);
+
+  const marketInfo = usePerpsMarketInfo(decodedSymbol ?? '');
 
   // Find position for this market (if exists)
   const position = useMemo(() => {
@@ -549,13 +560,20 @@ const PerpsMarketDetailPage: React.FC = () => {
   // Falls back to market.price string during initial candle load.
   const displayPrice = useMemo(() => {
     if (chartCurrentPrice > 0) {
-      return `$${formatNumber(chartCurrentPrice, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+      return formatPerpsFiatUniversal(chartCurrentPrice);
     }
-    return market?.price ?? '$0.00';
-  }, [chartCurrentPrice, market, formatNumber]);
+    const streamPrice = Number.parseFloat(livePrice?.price ?? '');
+    if (Number.isFinite(streamPrice) && streamPrice > 0) {
+      return formatPerpsFiatUniversal(streamPrice);
+    }
+    if (market?.price) {
+      return formatPerpsFiatUniversal(market.price);
+    }
+    return '$0.00';
+  }, [market?.price, livePrice?.price, chartCurrentPrice]);
 
   // 24h change prefers live stream updates when available, with market-data fallback.
-  const displayChange = formatChangePercent(
+  const displayChange = formatSignedChangePercent(
     livePrice?.percentChange24h ?? market?.change24hPercent ?? '',
   );
 
@@ -579,7 +597,7 @@ const PerpsMarketDetailPage: React.FC = () => {
     if (position) {
       // Take Profit line (green/lime, dashed)
       if (position.takeProfitPrice) {
-        const tpPrice = parseFloat(position.takeProfitPrice.replace(/,/gu, ''));
+        const tpPrice = parsePerpsDisplayPrice(position.takeProfitPrice);
         if (!isNaN(tpPrice) && tpPrice > 0) {
           lines.push({
             price: tpPrice,
@@ -592,7 +610,7 @@ const PerpsMarketDetailPage: React.FC = () => {
 
       // Entry price line (gray, dashed)
       if (position.entryPrice) {
-        const entryPrice = parseFloat(position.entryPrice.replace(/,/gu, ''));
+        const entryPrice = parsePerpsDisplayPrice(position.entryPrice);
         if (!isNaN(entryPrice) && entryPrice > 0) {
           lines.push({
             price: entryPrice,
@@ -605,7 +623,7 @@ const PerpsMarketDetailPage: React.FC = () => {
 
       // Stop Loss line (red, dashed)
       if (position.stopLossPrice) {
-        const slPrice = parseFloat(position.stopLossPrice.replace(/,/gu, ''));
+        const slPrice = parsePerpsDisplayPrice(position.stopLossPrice);
         if (!isNaN(slPrice) && slPrice > 0) {
           lines.push({
             price: slPrice,
@@ -1203,11 +1221,7 @@ const PerpsMarketDetailPage: React.FC = () => {
                         : TextColor.ErrorDefault
                     }
                   >
-                    {parseFloat(position.unrealizedPnl) >= 0 ? '+' : '-'}
-                    {formatCurrencyWithMinThreshold(
-                      Math.abs(parseFloat(position.unrealizedPnl)),
-                      'USD',
-                    )}
+                    {formatPnl(position.unrealizedPnl)}
                   </Text>
                 </Box>
 
@@ -1259,14 +1273,17 @@ const PerpsMarketDetailPage: React.FC = () => {
                   <Text
                     variant={TextVariant.BodyMd}
                     fontWeight={FontWeight.Medium}
+                    data-testid="perps-position-size-value"
                   >
                     {showSizeInFiat && Boolean(position.entryPrice)
-                      ? formatCurrencyWithMinThreshold(
+                      ? formatPerpsFiatUniversal(
                           Math.abs(parseFloat(position.size)) *
-                            parseFloat(position.entryPrice.replace(/,/gu, '')),
-                          'USD',
+                            parsePerpsDisplayPrice(position.entryPrice),
                         )
-                      : `${formatNumber(Math.abs(parseFloat(position.size)), { maximumSignificantDigits: 4 })} ${getDisplayName(position.symbol)}`}
+                      : `${formatPositionSize(
+                          Math.abs(parseFloat(position.size)),
+                          marketInfo?.szDecimals,
+                        )} ${getDisplayName(position.symbol)}`}
                   </Text>
                 </Box>
 
@@ -1289,11 +1306,9 @@ const PerpsMarketDetailPage: React.FC = () => {
                   <Text
                     variant={TextVariant.BodyMd}
                     fontWeight={FontWeight.Medium}
+                    data-testid="perps-position-margin-value"
                   >
-                    {formatCurrencyWithMinThreshold(
-                      parseFloat(position.marginUsed),
-                      'USD',
-                    )}
+                    {formatPerpsFiatMinimal(position.marginUsed)}
                   </Text>
                   <Popover
                     referenceElement={marginMenuRef.current}
@@ -1365,7 +1380,7 @@ const PerpsMarketDetailPage: React.FC = () => {
                       fontWeight={FontWeight.Medium}
                     >
                       {position.takeProfitPrice
-                        ? `$${position.takeProfitPrice}`
+                        ? formatPerpsFiatUniversal(position.takeProfitPrice)
                         : '-'}
                     </Text>
                     <Text
@@ -1379,7 +1394,7 @@ const PerpsMarketDetailPage: React.FC = () => {
                       fontWeight={FontWeight.Medium}
                     >
                       {position.stopLossPrice
-                        ? `$${position.stopLossPrice}`
+                        ? formatPerpsFiatUniversal(position.stopLossPrice)
                         : '-'}
                     </Text>
                   </Box>
@@ -1447,8 +1462,9 @@ const PerpsMarketDetailPage: React.FC = () => {
                   <Text
                     variant={TextVariant.BodySm}
                     fontWeight={FontWeight.Medium}
+                    data-testid="perps-position-entry-value"
                   >
-                    ${position.entryPrice}
+                    {formatPerpsFiatUniversal(position.entryPrice)}
                   </Text>
                 </Box>
 
@@ -1468,12 +1484,10 @@ const PerpsMarketDetailPage: React.FC = () => {
                   <Text
                     variant={TextVariant.BodySm}
                     fontWeight={FontWeight.Medium}
+                    data-testid="perps-position-liquidation-value"
                   >
                     {position.liquidationPrice
-                      ? formatPerpsPrice(
-                          parseFloat(position.liquidationPrice),
-                          locale,
-                        )
+                      ? formatPerpsFiatUniversal(position.liquidationPrice)
                       : '-'}
                   </Text>
                 </Box>
@@ -1494,8 +1508,23 @@ const PerpsMarketDetailPage: React.FC = () => {
                   <Text
                     variant={TextVariant.BodySm}
                     fontWeight={FontWeight.Medium}
+                    data-testid="perps-position-funding-value"
                   >
-                    ${position.cumulativeFunding.sinceOpen}
+                    {(() => {
+                      const fundingSinceOpen = Number.parseFloat(
+                        position.cumulativeFunding.sinceOpen,
+                      );
+                      const isNearZeroFunding =
+                        Math.abs(fundingSinceOpen) < 0.005;
+                      if (isNearZeroFunding) {
+                        return '$0.00';
+                      }
+                      const signPrefix = fundingSinceOpen >= 0 ? '-' : '+';
+                      return `${signPrefix}${formatPerpsFiat(
+                        Math.abs(fundingSinceOpen),
+                        { ranges: PRICE_RANGES_MINIMAL_VIEW },
+                      )}`;
+                    })()}
                   </Text>
                 </Box>
               </Box>
@@ -1647,12 +1676,7 @@ const PerpsMarketDetailPage: React.FC = () => {
                         : TextColor.ErrorDefault
                     }
                   >
-                    {market.fundingRate >= 0 ? '+' : ''}
-                    {formatNumber(market.fundingRate * 100, {
-                      minimumFractionDigits: 4,
-                      maximumFractionDigits: 4,
-                    })}
-                    %
+                    {formatFundingRate(market.fundingRate)}
                   </Text>
                   <Text
                     variant={TextVariant.BodySm}
@@ -1694,12 +1718,13 @@ const PerpsMarketDetailPage: React.FC = () => {
                   />
                 </Tooltip>
               </Box>
-              <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
+              <Text
+                variant={TextVariant.BodySm}
+                fontWeight={FontWeight.Medium}
+                data-testid="perps-market-detail-oracle-price"
+              >
                 {livePrice?.markPrice
-                  ? formatCurrencyWithMinThreshold(
-                      parseFloat(livePrice.markPrice),
-                      'USD',
-                    )
+                  ? formatPerpsFiatUniversal(livePrice.markPrice)
                   : '—'}
               </Text>
             </Box>
@@ -1956,6 +1981,7 @@ const PerpsMarketDetailPage: React.FC = () => {
           onClose={handleCloseReverseModal}
           position={position}
           currentPrice={currentPrice}
+          sizeDecimals={marketInfo?.szDecimals}
         />
       )}
 
@@ -1977,6 +2003,7 @@ const PerpsMarketDetailPage: React.FC = () => {
           onClose={() => setIsCloseModalOpen(false)}
           position={position}
           currentPrice={currentPrice}
+          sizeDecimals={marketInfo?.szDecimals}
         />
       )}
 

--- a/ui/pages/perps/perps-order-entry-page.tsx
+++ b/ui/pages/perps/perps-order-entry-page.tsx
@@ -38,6 +38,11 @@ import type {
   PriceUpdate,
 } from '@metamask/perps-controller';
 import {
+  formatPerpsFiat,
+  PRICE_RANGES_UNIVERSAL,
+  PRICE_RANGES_MINIMAL_VIEW,
+} from '../../../shared/lib/perps-formatters';
+import {
   PERPS_EVENT_PROPERTY,
   PERPS_EVENT_VALUE,
 } from '../../../shared/constants/perps-events';
@@ -80,8 +85,13 @@ import {
   getPositionPnlRatio,
   normalizeTpslPrices,
   safeDecodeURIComponent,
-  formatChangePercent,
+  formatSignedChangePercent,
 } from '../../components/app/perps/utils';
+import {
+  parsePerpsDisplayPrice,
+  formatPerpsFiatMinimal,
+  formatPerpsFiatUniversal,
+} from '../../components/app/perps/utils/formatPerpsDisplayPrice';
 import {
   isLimitPriceUnfavorable as checkLimitPriceUnfavorable,
   isNearLiquidationPrice as checkNearLiquidationPrice,
@@ -584,16 +594,31 @@ const PerpsOrderEntryPage: React.FC = () => {
 
   const displayPrice = useMemo(() => {
     if (chartCurrentPrice > 0) {
-      return `$${formatNumber(chartCurrentPrice, {
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2,
-      })}`;
+      return formatPerpsFiat(chartCurrentPrice, {
+        ranges: PRICE_RANGES_UNIVERSAL,
+      });
     }
-    return market?.price ?? '$0.00';
-  }, [chartCurrentPrice, market?.price, formatNumber]);
+    const liveStreamPrice = Number.parseFloat(livePrice?.price ?? '');
+    if (Number.isFinite(liveStreamPrice) && liveStreamPrice > 0) {
+      return formatPerpsFiat(liveStreamPrice, {
+        ranges: PRICE_RANGES_UNIVERSAL,
+      });
+    }
+    if (market?.price) {
+      const parsedMarketPrice = Number.parseFloat(
+        market.price.replace(/[$,]/gu, ''),
+      );
+      if (Number.isFinite(parsedMarketPrice) && parsedMarketPrice > 0) {
+        return formatPerpsFiat(parsedMarketPrice, {
+          ranges: PRICE_RANGES_UNIVERSAL,
+        });
+      }
+    }
+    return '$0.00';
+  }, [market?.price, livePrice?.price, chartCurrentPrice]);
 
   // 24h change prefers live stream updates when available, with market-data fallback.
-  const displayChange = formatChangePercent(
+  const displayChange = formatSignedChangePercent(
     livePrice?.percentChange24h ?? market?.change24hPercent ?? '',
   );
 
@@ -779,11 +804,25 @@ const PerpsOrderEntryPage: React.FC = () => {
     const isPartialClose =
       orderMode === 'close' && closePercent < FULL_CLOSE_PERCENT;
 
-    let inProgressToastKey = ORDER_MODE_TOAST_KEYS[orderMode].inProgress;
+    let inProgressToastKey: PerpsToastKey | undefined;
+    let inProgressToastDescription: string | undefined;
     if (orderMode === 'close') {
       inProgressToastKey = isPartialClose
         ? PERPS_TOAST_KEYS.PARTIAL_CLOSE_IN_PROGRESS
         : PERPS_TOAST_KEYS.CLOSE_IN_PROGRESS;
+      inProgressToastDescription = isPartialClose
+        ? closePartialToastDescription
+        : tradeActionToastDescription;
+    } else {
+      inProgressToastKey = ORDER_MODE_TOAST_KEYS[orderMode].inProgress;
+    }
+    if (inProgressToastKey) {
+      replacePerpsToastByKey({
+        key: inProgressToastKey,
+        ...(inProgressToastDescription
+          ? { description: inProgressToastDescription }
+          : {}),
+      });
     }
 
     const deriveTradeAction = (): string => {
@@ -847,7 +886,6 @@ const PerpsOrderEntryPage: React.FC = () => {
           position.size,
           marketInfo?.szDecimals,
         );
-
         handleBackClick(
           isPartialClose
             ? PERPS_TOAST_KEYS.PARTIAL_CLOSE_IN_PROGRESS
@@ -899,12 +937,10 @@ const PerpsOrderEntryPage: React.FC = () => {
             orderMode,
             position?.size,
           );
-
           handleBackClick(
             PERPS_TOAST_KEYS.SUBMIT_IN_PROGRESS,
             tradeActionToastDescription,
           );
-
           const result = await submitRequestToBackground<{
             success: boolean;
             error?: string;
@@ -949,9 +985,7 @@ const PerpsOrderEntryPage: React.FC = () => {
             ? orderFormState.stopLossPrice
             : undefined,
         });
-
         handleBackClick(PERPS_TOAST_KEYS.UPDATE_IN_PROGRESS);
-
         const result = await submitRequestToBackground<PerpsBackgroundResult>(
           'perpsUpdatePositionTPSL',
           [{ symbol: orderFormState.asset, takeProfitPrice, stopLossPrice }],
@@ -994,7 +1028,6 @@ const PerpsOrderEntryPage: React.FC = () => {
         orderMode,
         position?.size,
       );
-
       handleBackClick(
         PERPS_TOAST_KEYS.SUBMIT_IN_PROGRESS,
         tradeActionToastDescription,
@@ -1005,7 +1038,6 @@ const PerpsOrderEntryPage: React.FC = () => {
             }
           : undefined,
       );
-
       const result = await submitRequestToBackground<PerpsBackgroundResult>(
         'perpsPlaceOrder',
         [orderParams],
@@ -1035,6 +1067,7 @@ const PerpsOrderEntryPage: React.FC = () => {
       ]).catch((e) => {
         console.warn('[Perps] Save trade configuration failed:', e);
       });
+
       replacePerpsToastByKey({
         key:
           orderFormState.type === 'limit'
@@ -1295,6 +1328,7 @@ const PerpsOrderEntryPage: React.FC = () => {
           onOrderTypeChange={setOrderType}
           onAddFunds={triggerDeposit}
           initialLeverage={initialLeverage}
+          sizeDecimals={marketInfo?.szDecimals}
         />
       </Box>
 

--- a/ui/pages/perps/perps-withdraw-page.tsx
+++ b/ui/pages/perps/perps-withdraw-page.tsx
@@ -377,7 +377,7 @@ const PerpsWithdrawPage: React.FC = () => {
       },
       {
         label: t('perpsWithdrawEstimatedTime'),
-        value: t('perpsWithdrawMinutesApprox', [String(estimatedMinutes)]),
+        value: t('perpsWithdrawMinutesApprox', [estimatedMinutes]),
         'data-testid': 'perps-withdraw-summary-time',
       },
       {


### PR DESCRIPTION
## **Description**

Syncs extension perps UI decimal formatting with mobile. Replacement for #41855 — same behavioral goal, minimal-diff approach.

- Adds mobile's full formatter suite (`formatPerpsFiat`, `formatPositionSize`, `formatPnl`, `formatPercentage`, `formatFundingRate`, `PRICE_RANGES_*`) + order calculation helpers (`calculatePositionSize`, `calculateMarginRequired`) to `shared/lib/perps-formatters.ts`.
- Rewrites 14 perps UI files to import runtime values from the local module and keep `@metamask/perps-controller` imports type-only.
- Keeps `@metamask/perps-controller` at `^3.0.0` (same as `main`) — **no `jest.config.js`, `jest.integration.config.js`, or LavaMoat policy changes**.

### Why the local copy

Mobile is the source of truth for perps decimal rules. Mobile exports these helpers from `@metamask/perps-controller`, but the controller's main entry transitively loads ESM-only deps (`@noble/hashes@2` via `@nktkas/hyperliquid`) that break Jest's default `transformIgnorePatterns` and require LavaMoat policy churn when pulled as runtime values.

Type-only imports are elided at build, so `main` is unaffected. This PR introduces runtime values (formatters + calculation helpers), which is where the ESM chain bites. Rather than extend the jest allowlist and regenerate LavaMoat policies, we mirror the helpers locally and keep the diff scoped to perps UI.

**TAT-2990** tracks the controller-side fix (lazy-load the HyperLiquid SDK so the main entry is CJS-safe). Once that lands, delete `shared/lib/perps-formatters.ts` and re-import from `@metamask/perps-controller`. The file header documents this migration path.

### Relation to #41855

#41855 bumped `@metamask/perps-controller` to `^3.2.0` and added workarounds (jest allowlist + LavaMoat policy updates) to absorb the ESM chain. That PR is kept open for reference. This v2 is the cleaner alternative: same UI behavior, no infra files touched.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [TAT-2699](https://consensyssoftware.atlassian.net/browse/TAT-2699)

Related:
- #41855 (v1, kept for reference)
- [TAT-2990](https://consensyssoftware.atlassian.net/browse/TAT-2990) (upstream controller fix)
- MetaMask/metamask-mobile#28871
- MetaMask/metamask-mobile#28892

## **Manual testing steps**

1. Load the built extension and unlock the pre-funded wallet.
2. Open the perps order entry page — confirm prices, sizes, PnL, funding rate, and leverage inputs render with the same decimal rules as the mobile app.
3. Open and submit the Close Position modal — verify close amount + estimated PnL formatting.
4. Open Reverse Position and Edit Margin modals — verify displayed amounts and warnings.
5. Open the TP/SL modal — verify trigger price + projected PnL formatting.
6. Check the perps balance dropdown and market detail page — balances, PnL, and funding numbers match mobile formatting.
7. Withdraw page — verify amount formatting and error states.
8. Run the extension focused parity recipe: `temp/agentic/recipes/teams/perps/recipes/pr-41558-decimal-formatting.json`.
9. Run the extension full smoke recipe: `temp/agentic/recipes/domains/perps/recipes/full-trade-lifecycle.json`.
10. For the mobile parity reference, run `scripts/perps/agentic/teams/perps/recipes/reference-decimal-key-screens.json` on mobile.

## **Screenshots/Recordings**

Hosted asset folder:
- `https://github.com/abretonc7s/mm-extension-farm-artifacts/tree/main/reviews/41558/comparison-table`

### **Before**

<table>
  <thead>
    <tr>
      <th>Variant</th>
      <th>Home</th>
      <th>Market Detail</th>
      <th>Order Entry</th>
      <th>Remove Margin</th>
      <th>Close</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><strong>Extension Before</strong></td>
      <td><img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/reviews/41558/comparison-table/01-before-home.png" width="96" alt="Extension before home" /></td>
      <td><img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/reviews/41558/comparison-table/02-before-market-detail.png" width="96" alt="Extension before market detail" /></td>
      <td><img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/reviews/41558/comparison-table/03-before-order-entry.png" width="96" alt="Extension before order entry" /></td>
      <td><img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/reviews/41558/comparison-table/04-before-remove-margin.png" width="96" alt="Extension before remove margin" /></td>
      <td><img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/reviews/41558/comparison-table/05-before-close.png" width="96" alt="Extension before close" /></td>
    </tr>
  </tbody>
</table>

### **After**

<table>
  <thead>
    <tr>
      <th>Variant</th>
      <th>Home</th>
      <th>Market Detail</th>
      <th>Order Entry</th>
      <th>Remove Margin</th>
      <th>Close</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><strong>Extension After</strong></td>
      <td><img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/reviews/41558/comparison-table/06-after-home.png" width="96" alt="Extension after home" /></td>
      <td><img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/reviews/41558/comparison-table/07-after-market-detail.png" width="96" alt="Extension after market detail" /></td>
      <td><img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/reviews/41558/comparison-table/08-after-order-entry.png" width="96" alt="Extension after order entry" /></td>
      <td><img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/reviews/41558/comparison-table/09-after-remove-margin.png" width="96" alt="Extension after remove margin" /></td>
      <td><img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/reviews/41558/comparison-table/10-after-close.png" width="96" alt="Extension after close" /></td>
    </tr>
    <tr>
      <td><strong>Mobile</strong></td>
      <td><img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/reviews/41558/comparison-table/11-mobile-home.png" width="96" alt="Mobile home" /></td>
      <td><img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/reviews/41558/comparison-table/12-mobile-market-detail.png" width="96" alt="Mobile market detail" /></td>
      <td><img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/reviews/41558/comparison-table/13-mobile-order-entry.png" width="96" alt="Mobile order entry" /></td>
      <td><img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/reviews/41558/comparison-table/14-mobile-remove-margin.png" width="96" alt="Mobile remove margin" /></td>
      <td><img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/reviews/41558/comparison-table/15-mobile-close.png" width="96" alt="Mobile close" /></td>
    </tr>
  </tbody>
</table>

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches many perps UI surfaces and core order-calculation paths (size/margin/liquidation/fees), so formatting or rounding regressions could affect displayed values and validation UX, though changes are largely deterministic and covered by added tests.
> 
> **Overview**
> **Aligns extension perps number display with mobile** by introducing a temporary local copy of mobile/controller helpers in `shared/lib/perps-formatters.ts` (adaptive fiat/price ranges, position-size formatting, PnL/percentage/funding-rate formatters, and size/margin calculation helpers) plus a comprehensive unit test suite.
> 
> Updates perps UI components/pages to use these shared formatters (replacing `useFormatters` currency helpers and legacy price formatting), passes through `sizeDecimals` for controller-consistent size rounding, and adds a small formatting utility (`formatPerpsDisplayPrice`) for parsing/normalizing displayed prices.
> 
> Adjusts perps runtime behavior by adding a debounced `usePerpsLiquidationPrice` hook that calls a background RPC with a local formula fallback, and updates `usePerpsOrderFees` to provide base-rate fallback results on RPC failure/timeout; tests are updated to reflect the new rounding/stripping and fallback behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c25832c39b70e90bfb1b1dee29484ad856618805. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[TAT-2699]: https://consensyssoftware.atlassian.net/browse/TAT-2699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ