### PR TITLE
fix(perps): block stop loss beyond liquidation boundaries

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5887,6 +5887,10 @@
     "message": "Stop loss must be $1 $2 price",
     "description": "Validation error when stop loss price is on the wrong side of the reference price. $1 is above/below, $2 is current/entry."
   },
+  "perpsStopLossInvalidLiquidationPrice": {
+    "message": "Stop loss must be $1 liquidation price",
+    "description": "Validation error when stop loss crosses the liquidation price boundary. $1 is above/below."
+  },
   "perpsSubmitting": {
     "message": "Submitting...",
     "description": "Loading text shown while an order is being submitted"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -5887,6 +5887,10 @@
     "message": "Stop loss must be $1 $2 price",
     "description": "Validation error when stop loss price is on the wrong side of the reference price. $1 is above/below, $2 is current/entry."
   },
+  "perpsStopLossInvalidLiquidationPrice": {
+    "message": "Stop loss must be $1 liquidation price",
+    "description": "Validation error when stop loss crosses the liquidation price boundary. $1 is above/below."
+  },
   "perpsSubmitting": {
     "message": "Submitting...",
     "description": "Loading text shown while an order is being submitted"

--- a/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.test.tsx
+++ b/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.test.tsx
@@ -646,6 +646,24 @@ describe('AutoCloseSection', () => {
       );
     });
 
+    it('shows liquidation-boundary error when long SL is below liquidation price', () => {
+      renderWithProvider(
+        <AutoCloseSection
+          {...defaultProps}
+          enabled={true}
+          direction="long"
+          currentPrice={50000}
+          liquidationPrice={45000}
+          stopLossPrice="44000"
+        />,
+        mockStore,
+      );
+
+      expect(screen.getByTestId('sl-validation-error')).toHaveTextContent(
+        /above.*liquidation/iu,
+      );
+    });
+
     it('uses limit price as reference for limit orders', () => {
       renderWithProvider(
         <AutoCloseSection

--- a/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.tsx
+++ b/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.tsx
@@ -24,9 +24,8 @@ import type { AutoCloseSectionProps } from '../../order-entry.types';
 import { isSignedDecimalInput, isUnsignedDecimalInput } from '../../utils';
 import {
   isValidTakeProfitPrice,
-  isValidStopLossPrice,
+  getStopLossValidationResult,
   getTakeProfitErrorDirection,
-  getStopLossErrorDirection,
 } from '../../../utils/tpslValidation';
 import { formatRoePercent, getPnlDisplayColor } from '../../../utils';
 
@@ -55,6 +54,7 @@ import { formatRoePercent, getPnlDisplayColor } from '../../../utils';
  * @param props.limitPrice - Limit price string; used as the baseline for both validation and % ↔ price conversions on limit orders
  * @param props.leverage - Leverage multiplier for RoE% calculation
  * @param props.asset - Asset symbol for fetching dynamic closing fee rates
+ * @param props.liquidationPrice
  */
 export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
   enabled,
@@ -65,6 +65,7 @@ export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
   onStopLossPriceChange,
   direction,
   currentPrice,
+  liquidationPrice,
   entryPrice: entryPriceProp,
   estimatedSize,
   orderType,
@@ -352,17 +353,24 @@ export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
     [takeProfitPrice, validationReferencePrice, direction],
   );
 
+  const stopLossValidation = useMemo(
+    () =>
+      getStopLossValidationResult(stopLossPrice, {
+        currentPrice: validationReferencePrice,
+        direction,
+        liquidationPrice,
+      }),
+    [stopLossPrice, validationReferencePrice, direction, liquidationPrice],
+  );
+
   const isSlInvalid = useMemo(
     () =>
       Boolean(
         stopLossPrice.trim() &&
           validationReferencePrice > 0 &&
-          !isValidStopLossPrice(stopLossPrice, {
-            currentPrice: validationReferencePrice,
-            direction,
-          }),
+          !stopLossValidation.isValid,
       ),
-    [stopLossPrice, validationReferencePrice, direction],
+    [stopLossPrice, validationReferencePrice, stopLossValidation.isValid],
   );
 
   const tpErrorMessage = useMemo(() => {
@@ -379,11 +387,18 @@ export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
     if (!isSlInvalid) {
       return null;
     }
-    return t('perpsStopLossInvalidPrice', [
-      getStopLossErrorDirection(direction),
-      priceLabel,
-    ]);
-  }, [isSlInvalid, direction, priceLabel, t]);
+    return t(
+      stopLossValidation.referencePrice === 'liquidation'
+        ? 'perpsStopLossInvalidLiquidationPrice'
+        : 'perpsStopLossInvalidPrice',
+      [
+        stopLossValidation.direction,
+        stopLossValidation.referencePrice === 'liquidation'
+          ? undefined
+          : priceLabel,
+      ].filter(Boolean) as string[],
+    );
+  }, [isSlInvalid, stopLossValidation, priceLabel, t]);
 
   return (
     <Box flexDirection={BoxFlexDirection.Column} gap={3}>

--- a/ui/components/app/perps/order-entry/order-entry.tsx
+++ b/ui/components/app/perps/order-entry/order-entry.tsx
@@ -352,6 +352,7 @@ export const OrderEntry: React.FC<OrderEntryProps> = ({
             onStopLossPriceChange={handleStopLossPriceChange}
             direction={formState.direction}
             currentPrice={currentPrice}
+            liquidationPrice={calculations.liquidationPriceRaw}
             leverage={formState.leverage}
             entryPrice={undefined}
             estimatedSize={estimatedSize}

--- a/ui/components/app/perps/order-entry/order-entry.types.ts
+++ b/ui/components/app/perps/order-entry/order-entry.types.ts
@@ -215,6 +215,8 @@ export type AutoCloseSectionProps = {
   direction: OrderDirection;
   /** Current asset price (for TP/SL calculations and new orders) */
   currentPrice: number;
+  /** Estimated liquidation price as a raw number for stop-loss boundary validation */
+  liquidationPrice?: number | null;
   /** Position entry price (for modify mode - use instead of currentPrice for accurate % calc) */
   entryPrice?: number;
   /** Signed position size in asset units (positive=long, negative=short) for estimated PnL */

--- a/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.test.tsx
+++ b/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.test.tsx
@@ -167,6 +167,33 @@ describe('UpdateTPSLModalContent', () => {
     });
   });
 
+  describe('stop loss validation', () => {
+    it('shows a liquidation-price validation error and disables submit for short positions above liquidation', async () => {
+      const shortPosition = mockPositions[1];
+
+      renderTpslModalContent({
+        position: shortPosition,
+        currentPrice: 45000,
+      });
+
+      const slInput = screen.getAllByPlaceholderText(
+        '0.00',
+      )[1] as HTMLInputElement;
+
+      fireEvent.change(slInput, { target: { value: '50000' } });
+
+      expect(screen.getByTestId('sl-validation-error')).toHaveTextContent(
+        'Stop loss must be below liquidation price',
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('perps-update-tpsl-modal-submit'),
+        ).toBeDisabled();
+      });
+    });
+  });
+
   describe('initialization', () => {
     it('initializes TP/SL prices from position data', () => {
       renderTpslModalContent();

--- a/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.tsx
+++ b/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.tsx
@@ -48,9 +48,8 @@ import {
 import { PerpsGeoBlockModal } from '../perps-geo-block-modal';
 import {
   isValidTakeProfitPrice,
-  isValidStopLossPrice,
+  getStopLossValidationResult,
   getTakeProfitErrorDirection,
-  getStopLossErrorDirection,
 } from '../utils/tpslValidation';
 
 // RoE (Return on Equity) preset percentages - matching mobile
@@ -250,17 +249,35 @@ export const UpdateTPSLModalContent: React.FC<UpdateTPSLModalContentProps> = ({
     [editingTpPrice, currentPrice, positionDirection],
   );
 
+  const liquidationPrice = useMemo(() => {
+    if (!position.liquidationPrice) {
+      return null;
+    }
+
+    const parsedLiquidationPrice = Number.parseFloat(
+      position.liquidationPrice.replaceAll(',', ''),
+    );
+    return Number.isNaN(parsedLiquidationPrice) ? null : parsedLiquidationPrice;
+  }, [position.liquidationPrice]);
+
+  const stopLossValidation = useMemo(
+    () =>
+      getStopLossValidationResult(editingSlPrice, {
+        currentPrice,
+        direction: positionDirection,
+        liquidationPrice,
+      }),
+    [editingSlPrice, currentPrice, positionDirection, liquidationPrice],
+  );
+
   const isSlInvalid = useMemo(
     () =>
       Boolean(
         editingSlPrice.replaceAll(',', '').trim() &&
           currentPrice > 0 &&
-          !isValidStopLossPrice(editingSlPrice, {
-            currentPrice,
-            direction: positionDirection,
-          }),
+          !stopLossValidation.isValid,
       ),
-    [editingSlPrice, currentPrice, positionDirection],
+    [editingSlPrice, currentPrice, stopLossValidation.isValid],
   );
 
   const hasInvalidTPSL = isTpInvalid || isSlInvalid;
@@ -755,10 +772,17 @@ export const UpdateTPSLModalContent: React.FC<UpdateTPSLModalContentProps> = ({
             color={TextColor.ErrorDefault}
             data-testid="sl-validation-error"
           >
-            {t('perpsStopLossInvalidPrice', [
-              getStopLossErrorDirection(positionDirection),
-              'current',
-            ])}
+            {t(
+              stopLossValidation.referencePrice === 'liquidation'
+                ? 'perpsStopLossInvalidLiquidationPrice'
+                : 'perpsStopLossInvalidPrice',
+              [
+                stopLossValidation.direction,
+                stopLossValidation.referencePrice === 'liquidation'
+                  ? undefined
+                  : 'current',
+              ].filter(Boolean) as string[],
+            )}
           </Text>
         )}
       </Box>

--- a/ui/components/app/perps/utils/tpslValidation.test.ts
+++ b/ui/components/app/perps/utils/tpslValidation.test.ts
@@ -1,6 +1,7 @@
 import {
   isValidTakeProfitPrice,
   isValidStopLossPrice,
+  getStopLossValidationResult,
   getTakeProfitErrorDirection,
   getStopLossErrorDirection,
 } from './tpslValidation';
@@ -132,6 +133,26 @@ describe('tpslValidation', () => {
           }),
         ).toBe(false);
       });
+
+      it('returns false when SL is below liquidation price', () => {
+        expect(
+          isValidStopLossPrice('39000', {
+            currentPrice,
+            direction: 'long',
+            liquidationPrice: 40000,
+          }),
+        ).toBe(false);
+      });
+
+      it('returns true when SL is between current and liquidation price', () => {
+        expect(
+          isValidStopLossPrice('45000', {
+            currentPrice,
+            direction: 'long',
+            liquidationPrice: 40000,
+          }),
+        ).toBe(true);
+      });
     });
 
     describe('short direction', () => {
@@ -151,6 +172,26 @@ describe('tpslValidation', () => {
             direction: 'short',
           }),
         ).toBe(false);
+      });
+
+      it('returns false when SL is above liquidation price', () => {
+        expect(
+          isValidStopLossPrice('61000', {
+            currentPrice,
+            direction: 'short',
+            liquidationPrice: 60000,
+          }),
+        ).toBe(false);
+      });
+
+      it('returns true when SL is between current and liquidation price', () => {
+        expect(
+          isValidStopLossPrice('55000', {
+            currentPrice,
+            direction: 'short',
+            liquidationPrice: 60000,
+          }),
+        ).toBe(true);
       });
     });
 
@@ -180,6 +221,16 @@ describe('tpslValidation', () => {
         expect(isValidStopLossPrice('100', { currentPrice })).toBe(true);
       });
 
+      it('falls back to current price validation when liquidation price is unavailable', () => {
+        expect(
+          isValidStopLossPrice('55000', {
+            currentPrice,
+            direction: 'short',
+            liquidationPrice: null,
+          }),
+        ).toBe(true);
+      });
+
       it('handles formatted prices with commas and dollar signs', () => {
         expect(
           isValidStopLossPrice('$45,000', {
@@ -194,6 +245,52 @@ describe('tpslValidation', () => {
             direction: 'long',
           }),
         ).toBe(false);
+      });
+    });
+  });
+
+  describe('getStopLossValidationResult', () => {
+    const currentPrice = 50000;
+
+    it('reports current price boundary errors for short positions', () => {
+      expect(
+        getStopLossValidationResult('45000', {
+          currentPrice,
+          direction: 'short',
+          liquidationPrice: 60000,
+        }),
+      ).toStrictEqual({
+        isValid: false,
+        direction: 'above',
+        referencePrice: 'current',
+      });
+    });
+
+    it('reports liquidation price boundary errors for short positions', () => {
+      expect(
+        getStopLossValidationResult('61000', {
+          currentPrice,
+          direction: 'short',
+          liquidationPrice: 60000,
+        }),
+      ).toStrictEqual({
+        isValid: false,
+        direction: 'below',
+        referencePrice: 'liquidation',
+      });
+    });
+
+    it('reports liquidation price boundary errors for long positions', () => {
+      expect(
+        getStopLossValidationResult('39000', {
+          currentPrice,
+          direction: 'long',
+          liquidationPrice: 40000,
+        }),
+      ).toStrictEqual({
+        isValid: false,
+        direction: 'above',
+        referencePrice: 'liquidation',
       });
     });
   });

--- a/ui/components/app/perps/utils/tpslValidation.ts
+++ b/ui/components/app/perps/utils/tpslValidation.ts
@@ -16,6 +16,13 @@ type Direction = 'long' | 'short';
 type ValidationParams = {
   currentPrice: number;
   direction?: Direction;
+  liquidationPrice?: number | null;
+};
+
+export type StopLossValidationResult = {
+  isValid: boolean;
+  direction: 'above' | 'below' | '';
+  referencePrice: 'current' | 'liquidation' | '';
 };
 
 /**
@@ -52,21 +59,69 @@ export const isValidTakeProfitPrice = (
  * @param params.currentPrice
  * @param params.direction
  */
-export const isValidStopLossPrice = (
+export function isValidStopLossPrice(price: string, params: ValidationParams) {
+  return getStopLossValidationResult(price, params).isValid;
+}
+
+/**
+ * Validates stop loss against both the current price and, when available,
+ * the liquidation price. A valid stop loss must stay between those two
+ * boundaries for the current position direction.
+ *
+ * @param price - The stop loss price string (may include `$` / `,` formatting)
+ * @param params - Object with `currentPrice`, `direction`, and optional `liquidationPrice`
+ * @param params.currentPrice
+ * @param params.direction
+ * @param params.liquidationPrice
+ */
+export function getStopLossValidationResult(
   price: string,
-  { currentPrice, direction }: ValidationParams,
-): boolean => {
+  { currentPrice, direction, liquidationPrice }: ValidationParams,
+): StopLossValidationResult {
   if (!currentPrice || !direction || !price) {
-    return true;
+    return { isValid: true, direction: '', referencePrice: '' };
   }
 
   const slPrice = Number.parseFloat(price.replaceAll(/[$,]/gu, ''));
   if (Number.isNaN(slPrice)) {
-    return true;
+    return { isValid: true, direction: '', referencePrice: '' };
   }
 
-  return direction === 'long' ? slPrice < currentPrice : slPrice > currentPrice;
-};
+  const isWithinCurrentBoundary =
+    direction === 'long' ? slPrice < currentPrice : slPrice > currentPrice;
+
+  if (!isWithinCurrentBoundary) {
+    return {
+      isValid: false,
+      direction: direction === 'long' ? 'below' : 'above',
+      referencePrice: 'current',
+    };
+  }
+
+  if (
+    liquidationPrice === undefined ||
+    liquidationPrice === null ||
+    !Number.isFinite(liquidationPrice) ||
+    liquidationPrice <= 0
+  ) {
+    return { isValid: true, direction: '', referencePrice: '' };
+  }
+
+  const isWithinLiquidationBoundary =
+    direction === 'long'
+      ? slPrice > liquidationPrice
+      : slPrice < liquidationPrice;
+
+  if (!isWithinLiquidationBoundary) {
+    return {
+      isValid: false,
+      direction: direction === 'long' ? 'above' : 'below',
+      referencePrice: 'liquidation',
+    };
+  }
+
+  return { isValid: true, direction: '', referencePrice: '' };
+}
 
 /**
  * Returns the directional word for a take-profit validation error message.

--- a/ui/pages/perps/perps-order-entry-page.test.tsx
+++ b/ui/pages/perps/perps-order-entry-page.test.tsx
@@ -784,6 +784,33 @@ describe('PerpsOrderEntryPage', () => {
         expect(screen.getByTestId('submit-order-button')).toBeDisabled();
       });
     });
+
+    it('disables submit when auto-close stop loss crosses liquidation price', async () => {
+      const store = mockStore(createMockState());
+      renderWithProvider(<PerpsOrderEntryPage />, store);
+
+      const amountContainer = screen.getByTestId('amount-input-field');
+      const amountInput = amountContainer.querySelector('input');
+      fireEvent.change(amountInput as HTMLInputElement, {
+        target: { value: '1000' },
+      });
+
+      fireEvent.click(screen.getByTestId('auto-close-toggle'));
+
+      const slContainer = screen.getByTestId('sl-price-input');
+      const slInput = slContainer.querySelector('input');
+      fireEvent.change(slInput as HTMLInputElement, {
+        target: { value: '1' },
+      });
+
+      expect(screen.getByTestId('sl-validation-error')).toHaveTextContent(
+        /liquidation/iu,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('submit-order-button')).toBeDisabled();
+      });
+    });
   });
 
   describe('order submission', () => {

--- a/ui/pages/perps/perps-order-entry-page.tsx
+++ b/ui/pages/perps/perps-order-entry-page.tsx
@@ -88,7 +88,7 @@ import {
 } from '../../components/app/perps/order-entry/limit-price-warnings';
 import {
   isValidTakeProfitPrice,
-  isValidStopLossPrice,
+  getStopLossValidationResult,
 } from '../../components/app/perps/utils/tpslValidation';
 import { PerpsDetailPageSkeleton } from '../../components/app/perps/perps-skeletons';
 import {
@@ -514,14 +514,15 @@ const PerpsOrderEntryPage: React.FC = () => {
     );
     const slInvalid = Boolean(
       sl?.trim() &&
-        !isValidStopLossPrice(sl, {
+        !getStopLossValidationResult(sl, {
           currentPrice: referencePrice,
           direction: dir,
-        }),
+          liquidationPrice: orderCalculations?.liquidationPriceRaw,
+        }).isValid,
     );
 
     return tpInvalid || slInvalid;
-  }, [orderFormState, orderType, currentPrice, orderMode]);
+  }, [orderFormState, orderType, currentPrice, orderMode, orderCalculations]);
 
   const isInsufficientFunds = useMemo(() => {
     if (!orderFormState || orderMode === 'close') {


### PR DESCRIPTION
## **Description**

This PR fixes issue #41898, where the Perps order entry flow still allowed stop loss values beyond the liquidation boundary.

The original fix only covered the update TP/SL modal for existing positions. This follow-up fixes the actual live submit path used by the Perps order entry page, makes stop-loss validation liquidation-aware in the auto-close section, and disables the real page-level submit button when the stop loss crosses liquidation.

## **Changelog**

CHANGELOG entry: Fixed a bug that allowed Perps stop loss values beyond the liquidation price.

## **Related issues**

Fixes: #41898

## **Manual testing steps**

1. Open the Perps order entry page for a market such as ETH.
2. Enter an amount so the liquidation price is calculated.
3. Enable Auto close.
4. Enter a stop loss beyond the liquidation boundary.
5. Verify the UI shows the liquidation validation error.
6. Verify the Open Long / Open Short submit button is disabled.
7. Enter a stop loss back within the valid range between the entry/current price and liquidation price.
8. Verify the validation error clears and the submit button becomes enabled again.

## **Screenshots/Recordings**

### **Before**
| | |
|---|---|
| <img width="394" height="728" alt="Before 1" src="https://github.com/user-attachments/assets/e907fef7-a828-43d8-97b2-62c2128ef4b7" /> | <img width="393" height="728" alt="Before 2" src="https://github.com/user-attachments/assets/912ee1fc-9170-4d37-93e5-0171f3c4e5f0" /> |

### **After**
| | |
|---|---|
| <img width="379" height="730" alt="After 1" src="https://github.com/user-attachments/assets/268d47aa-d6d4-40e4-9eed-1203a8e95804" /> | <img width="379" height="731" alt="After 2" src="https://github.com/user-attachments/assets/2231d040-f38b-4ed3-9530-004858b5b767" /> |

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability.
- [x] I've included tests if applicable.
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable.
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes order-entry and TP/SL editing validation to block stop-loss values that cross liquidation boundaries, which can affect whether users can submit orders. Risk is moderate due to new boundary logic and dependence on liquidation price parsing/availability.
> 
> **Overview**
> **Stop-loss validation is now liquidation-aware** across perps order entry and the update TP/SL modal, preventing SL values that would cross the liquidation boundary.
> 
> This introduces `getStopLossValidationResult` (replacing direct `isValidStopLossPrice` usage in several UI paths) to distinguish *current-price* vs *liquidation-price* validation failures, wires `liquidationPrice` into `AutoCloseSection` and the page-level submit-disable logic, and adds a new i18n message (`perpsStopLossInvalidLiquidationPrice`) plus expanded test coverage for the new boundary and disabled-submit behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29cb42b891fa683957393e472c6c8e9a81101a27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->