### PR TITLE
fix: disconnect perps websocket on lock and final wallet close cp-13.28.0

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1694,6 +1694,34 @@ export default class MetamaskController extends EventEmitter {
     }
   }
 
+  /**
+   * Disconnect an active Perps session without affecting non-Perps users.
+   *
+   * Perps is an optional feature, so guard on build inclusion, controller
+   * presence, and active connection state before calling into the controller.
+   */
+  async #disconnectPerpsIfActive() {
+    if (
+      !getIsPerpsIncludedInBuild() ||
+      !this.messengerClientsByName.PerpsController ||
+      typeof this.messengerClientApi.perpsDisconnect !== 'function'
+    ) {
+      return;
+    }
+
+    if (
+      this.messengerClientApi.perpsGetConnectionState?.() === 'disconnected'
+    ) {
+      return;
+    }
+
+    try {
+      await this.messengerClientApi.perpsDisconnect();
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
   resetStates(resetMethods) {
     resetMethods.forEach((resetMethod) => {
       try {
@@ -7071,6 +7099,9 @@ export default class MetamaskController extends EventEmitter {
       );
       messengerSubscriptions.clear();
       perpsStream?.destroy();
+      if (this.activeControllerConnections === 0) {
+        this.#disconnectPerpsIfActive();
+      }
     });
   }
 
@@ -8277,6 +8308,7 @@ export default class MetamaskController extends EventEmitter {
     // KeyringController event. Other controllers subscribe to the 'lock'
     // event of the MetaMaskController itself.
     this.emit('lock');
+    this.#disconnectPerpsIfActive();
   }
 
   /**

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1700,23 +1700,25 @@ export default class MetamaskController extends EventEmitter {
    * Perps is an optional feature, so guard on build inclusion, controller
    * presence, and active connection state before calling into the controller.
    */
-  async #disconnectPerpsIfActive() {
-    if (
-      !getIsPerpsIncludedInBuild() ||
-      !this.messengerClientsByName.PerpsController ||
-      typeof this.messengerClientApi.perpsDisconnect !== 'function'
-    ) {
-      return;
-    }
-
-    if (
-      this.messengerClientApi.perpsGetConnectionState?.() === 'disconnected'
-    ) {
-      return;
-    }
-
+  #disconnectPerpsIfActive() {
     try {
-      await this.messengerClientApi.perpsDisconnect();
+      if (
+        !getIsPerpsIncludedInBuild() ||
+        !this.messengerClientsByName.PerpsController ||
+        typeof this.messengerClientApi.perpsDisconnect !== 'function'
+      ) {
+        return;
+      }
+
+      if (
+        this.messengerClientApi.perpsGetConnectionState?.() === 'disconnected'
+      ) {
+        return;
+      }
+
+      this.messengerClientApi.perpsDisconnect().catch((error) => {
+        console.error(error);
+      });
     } catch (error) {
       console.error(error);
     }
@@ -7100,6 +7102,7 @@ export default class MetamaskController extends EventEmitter {
       messengerSubscriptions.clear();
       perpsStream?.destroy();
       if (this.activeControllerConnections === 0) {
+        // Destroy the UI bridge stream first, then disconnect the controller-owned Perps WS.
         this.#disconnectPerpsIfActive();
       }
     });

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -74,7 +74,7 @@ import {
   DefiReferralPartner,
 } from '../../shared/constants/defi-referrals';
 import { PATCH_STORE_SUBSTREAM_METHODS } from '../../shared/constants/patch-store-substream-methods';
-import { getEnabledAdvancedPermissions } from '../../shared/lib/environment';
+import * as environment from '../../shared/lib/environment';
 import * as metamaskControllerUtils from '../../shared/lib/metamask-controller-utils';
 import { ReferralStatus } from './controllers/preferences-controller';
 import { METAMASK_COOKIE_HANDLER } from './constants/stream';
@@ -562,6 +562,9 @@ describe('MetaMaskController', () => {
 
     beforeEach(() => {
       jest.spyOn(MetaMaskController.prototype, 'resetStates');
+      jest
+        .spyOn(environment, 'getIsPerpsIncludedInBuild')
+        .mockReturnValue(false);
 
       jest
         .spyOn(
@@ -1179,6 +1182,52 @@ describe('MetaMaskController', () => {
       });
     });
 
+    describe('_onLock', () => {
+      it('disconnects an active perps websocket', async () => {
+        jest
+          .spyOn(environment, 'getIsPerpsIncludedInBuild')
+          .mockReturnValue(true);
+        const perpsDisconnect = jest.fn().mockResolvedValue(undefined);
+
+        metamaskController.messengerClientsByName.PerpsController = {};
+        metamaskController.messengerClientApi.perpsDisconnect = perpsDisconnect;
+        jest
+          .spyOn(
+            metamaskController.messengerClientApi,
+            'perpsGetConnectionState',
+          )
+          .mockImplementation()
+          .mockReturnValue('connected');
+
+        metamaskController._onLock();
+        await waitForAllPromises();
+
+        expect(perpsDisconnect).toHaveBeenCalledTimes(1);
+      });
+
+      it('does not disconnect perps when no perps controller is available', async () => {
+        jest
+          .spyOn(environment, 'getIsPerpsIncludedInBuild')
+          .mockReturnValue(true);
+        const perpsDisconnect = jest.fn().mockResolvedValue(undefined);
+
+        delete metamaskController.messengerClientsByName.PerpsController;
+        metamaskController.messengerClientApi.perpsDisconnect = perpsDisconnect;
+        jest
+          .spyOn(
+            metamaskController.messengerClientApi,
+            'perpsGetConnectionState',
+          )
+          .mockImplementation()
+          .mockReturnValue('connected');
+
+        metamaskController._onLock();
+        await waitForAllPromises();
+
+        expect(perpsDisconnect).not.toHaveBeenCalled();
+      });
+    });
+
     describe('#createNewVaultAndKeychain', () => {
       it('can only create new vault on keyringController once', async () => {
         const password = 'a-fake-password';
@@ -1652,7 +1701,7 @@ describe('MetaMaskController', () => {
     describe('wallet_requestExecutionPermissions (processRequestExecutionPermissions)', () => {
       beforeEach(() => {
         jest
-          .mocked(getEnabledAdvancedPermissions)
+          .mocked(environment.getEnabledAdvancedPermissions)
           .mockReturnValue(['erc20-token-revocation']);
         jest.mocked(forwardRequestToSnap).mockResolvedValue({});
       });
@@ -1799,7 +1848,7 @@ describe('MetaMaskController', () => {
             cacheTimestamp: 0,
           });
         jest
-          .mocked(getEnabledAdvancedPermissions)
+          .mocked(environment.getEnabledAdvancedPermissions)
           .mockReturnValue(['erc20-token-revocation']);
       });
 
@@ -3596,6 +3645,47 @@ describe('MetaMaskController', () => {
         await testStreams[0].onFinishedCallbackPromise;
 
         expect(metamaskController.activeControllerConnections).toBe(0);
+      });
+
+      it('disconnects perps only after the final controller connection closes', async () => {
+        jest
+          .spyOn(environment, 'getIsPerpsIncludedInBuild')
+          .mockReturnValue(true);
+        const perpsDisconnect = jest.fn().mockResolvedValue(undefined);
+
+        metamaskController.messengerClientsByName.PerpsController = {};
+        metamaskController.messengerClientApi.perpsDisconnect = perpsDisconnect;
+        jest
+          .spyOn(
+            metamaskController.messengerClientApi,
+            'perpsGetConnectionState',
+          )
+          .mockImplementation()
+          .mockReturnValue('connected');
+
+        const firstStream = createTestStream();
+        const secondStream = createTestStream();
+
+        metamaskController.setupTrustedCommunication(
+          firstStream.testStream,
+          {},
+        );
+        metamaskController.setupTrustedCommunication(
+          secondStream.testStream,
+          {},
+        );
+
+        await firstStream.onStreamEndPromise;
+        firstStream.testStream.end();
+        await waitForAllPromises();
+
+        expect(perpsDisconnect).not.toHaveBeenCalled();
+
+        await secondStream.onStreamEndPromise;
+        secondStream.testStream.end();
+        await waitForAllPromises();
+
+        expect(perpsDisconnect).toHaveBeenCalledTimes(1);
       });
 
       // this test could be improved by testing for actual behavior of handlers,

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -1218,6 +1218,24 @@ describe('MetaMaskController', () => {
 
         expect(perpsDisconnect).not.toHaveBeenCalled();
       });
+
+      it('does not disconnect perps when connection is already disconnected', async () => {
+        jest
+          .spyOn(environment, 'getIsPerpsIncludedInBuild')
+          .mockReturnValue(true);
+        const perpsDisconnect = jest.fn().mockResolvedValue(undefined);
+
+        metamaskController.messengerClientsByName.PerpsController = {};
+        metamaskController.messengerClientApi.perpsDisconnect = perpsDisconnect;
+        metamaskController.messengerClientApi.perpsGetConnectionState = jest
+          .fn()
+          .mockReturnValue('disconnected');
+
+        metamaskController._onLock();
+        await waitForAllPromises();
+
+        expect(perpsDisconnect).not.toHaveBeenCalled();
+      });
     });
 
     describe('#createNewVaultAndKeychain', () => {

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -87,13 +87,16 @@ import { forwardRequestToSnap } from './lib/forwardRequestToSnap';
 import MetaMaskController from './metamask-controller';
 
 jest.mock('./messenger-client-init/perps-controller-init', () => ({
-  PerpsControllerInit: jest.fn().mockReturnValue({
+  PerpsControllerInit: jest.fn().mockImplementation(() => ({
     messengerClient: {
       state: {},
       name: 'PerpsController',
     },
-    api: {},
-  }),
+    api: {
+      perpsDisconnect: jest.fn().mockResolvedValue(undefined),
+      perpsGetConnectionState: jest.fn().mockReturnValue('disconnected'),
+    },
+  })),
 }));
 
 jest.mock('webextension-polyfill', () => ({
@@ -1190,9 +1193,14 @@ describe('MetaMaskController', () => {
         const perpsDisconnect = jest.fn().mockResolvedValue(undefined);
 
         metamaskController.messengerClientsByName.PerpsController = {};
-        metamaskController.messengerClientApi.perpsDisconnect = perpsDisconnect;
-        metamaskController.messengerClientApi.perpsGetConnectionState = jest
-          .fn()
+        jest
+          .spyOn(metamaskController.messengerClientApi, 'perpsDisconnect')
+          .mockImplementation(perpsDisconnect);
+        jest
+          .spyOn(
+            metamaskController.messengerClientApi,
+            'perpsGetConnectionState',
+          )
           .mockReturnValue('connected');
 
         metamaskController._onLock();
@@ -1208,9 +1216,14 @@ describe('MetaMaskController', () => {
         const perpsDisconnect = jest.fn().mockResolvedValue(undefined);
 
         delete metamaskController.messengerClientsByName.PerpsController;
-        metamaskController.messengerClientApi.perpsDisconnect = perpsDisconnect;
-        metamaskController.messengerClientApi.perpsGetConnectionState = jest
-          .fn()
+        jest
+          .spyOn(metamaskController.messengerClientApi, 'perpsDisconnect')
+          .mockImplementation(perpsDisconnect);
+        jest
+          .spyOn(
+            metamaskController.messengerClientApi,
+            'perpsGetConnectionState',
+          )
           .mockReturnValue('connected');
 
         metamaskController._onLock();
@@ -1226,9 +1239,14 @@ describe('MetaMaskController', () => {
         const perpsDisconnect = jest.fn().mockResolvedValue(undefined);
 
         metamaskController.messengerClientsByName.PerpsController = {};
-        metamaskController.messengerClientApi.perpsDisconnect = perpsDisconnect;
-        metamaskController.messengerClientApi.perpsGetConnectionState = jest
-          .fn()
+        jest
+          .spyOn(metamaskController.messengerClientApi, 'perpsDisconnect')
+          .mockImplementation(perpsDisconnect);
+        jest
+          .spyOn(
+            metamaskController.messengerClientApi,
+            'perpsGetConnectionState',
+          )
           .mockReturnValue('disconnected');
 
         metamaskController._onLock();
@@ -3664,9 +3682,14 @@ describe('MetaMaskController', () => {
         const perpsDisconnect = jest.fn().mockResolvedValue(undefined);
 
         metamaskController.messengerClientsByName.PerpsController = {};
-        metamaskController.messengerClientApi.perpsDisconnect = perpsDisconnect;
-        metamaskController.messengerClientApi.perpsGetConnectionState = jest
-          .fn()
+        jest
+          .spyOn(metamaskController.messengerClientApi, 'perpsDisconnect')
+          .mockImplementation(perpsDisconnect);
+        jest
+          .spyOn(
+            metamaskController.messengerClientApi,
+            'perpsGetConnectionState',
+          )
           .mockReturnValue('connected');
 
         const firstStream = createTestStream();

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -1191,12 +1191,8 @@ describe('MetaMaskController', () => {
 
         metamaskController.messengerClientsByName.PerpsController = {};
         metamaskController.messengerClientApi.perpsDisconnect = perpsDisconnect;
-        jest
-          .spyOn(
-            metamaskController.messengerClientApi,
-            'perpsGetConnectionState',
-          )
-          .mockImplementation()
+        metamaskController.messengerClientApi.perpsGetConnectionState = jest
+          .fn()
           .mockReturnValue('connected');
 
         metamaskController._onLock();
@@ -1213,12 +1209,8 @@ describe('MetaMaskController', () => {
 
         delete metamaskController.messengerClientsByName.PerpsController;
         metamaskController.messengerClientApi.perpsDisconnect = perpsDisconnect;
-        jest
-          .spyOn(
-            metamaskController.messengerClientApi,
-            'perpsGetConnectionState',
-          )
-          .mockImplementation()
+        metamaskController.messengerClientApi.perpsGetConnectionState = jest
+          .fn()
           .mockReturnValue('connected');
 
         metamaskController._onLock();
@@ -3655,12 +3647,8 @@ describe('MetaMaskController', () => {
 
         metamaskController.messengerClientsByName.PerpsController = {};
         metamaskController.messengerClientApi.perpsDisconnect = perpsDisconnect;
-        jest
-          .spyOn(
-            metamaskController.messengerClientApi,
-            'perpsGetConnectionState',
-          )
-          .mockImplementation()
+        metamaskController.messengerClientApi.perpsGetConnectionState = jest
+          .fn()
           .mockReturnValue('connected');
 
         const firstStream = createTestStream();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Fixes a lifecycle gap where the Perps WebSocket could stay open in the background after logout/lock or after the last wallet UI closed. That behavior meant Perps messages could continue to arrive even though the user had ended the wallet session.

The solution reuses the existing Perps controller lifecycle instead of introducing platform divergence or a broader refactor. MetaMaskController now triggers a guarded Perps disconnect on the two relevant session end signals: wallet lock and final trusted controller connection close. The guards ensure the behavior is inert for non-Perps builds and non-Perps users, while the added controller tests cover lock handling and multi-window close behavior.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed the Perps WebSocket to unsubscribe after logout/lock

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/41883 https://consensyssoftware.atlassian.net/browse/TAT-2975

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/4d2b5130-8576-4074-97b6-55519157546e



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session lifecycle behavior by disconnecting the Perps WebSocket on wallet lock and when the last trusted UI stream closes, which could affect Perps connectivity timing for active users. Guards reduce impact for non-Perps builds, but errors in state detection could cause unexpected disconnects.
> 
> **Overview**
> Prevents Perps traffic from persisting after a wallet session ends by adding a guarded `#disconnectPerpsIfActive()` helper and invoking it on two signals: **wallet lock** (`_onLock`) and **final trusted controller connection close** (when `activeControllerConnections` drops to `0`).
> 
> Updates controller tests to mock Perps APIs, default Perps build inclusion to `false`, and adds coverage ensuring disconnect happens only when Perps is included, a Perps controller exists, and the connection is currently active (including multi-window close behavior).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a568a264c0f8f3600f8a8f23449459e20f71132. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->