### PR TITLE
test: fix flaky test `Bridge tests Preserves bridge state when navigating back from the asset page`

### DIFF
--- a/test/e2e/page-objects/pages/bridge/quote-page.ts
+++ b/test/e2e/page-objects/pages/bridge/quote-page.ts
@@ -175,7 +175,7 @@ class BridgeQuotePage {
     await this.driver.clickElement(assetPicker);
     await this.driver.pasteIntoField(this.assetPrickerSearchInput, token);
     console.log(`Filled search input with ${token}`);
-    await this.driver.clickElement({
+    await this.driver.clickElementAndWaitToDisappear({
       css: this.tokenButton,
       text: token,
     });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The test is flaky because after selecting the token, we try to click an element before the asset modal has been closed. We get the `ElementClickInterceptedError`  error.
To prevent that, we wait until the modal is closed before proceeding with the next action


<img width="1050" height="812" alt="image" src="https://github.com/user-attachments/assets/5469051d-2a15-40e8-a332-e48449b53318" />

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that adds an explicit wait after token selection to avoid click interception from the still-closing asset picker modal.
> 
> **Overview**
> Stabilizes the Bridge E2E flow by updating `BridgeQuotePage.searchForAssetAndSelect` to use `driver.clickElementAndWaitToDisappear` when selecting a token, ensuring the asset picker UI has closed before subsequent actions run (mitigating `ElementClickInterceptedError` flake).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f461e1330fa624f802b4d804cddad3496d966ab4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->