### PR TITLE
fix: cp-13.28.0 fix notifications settings account name truncation

### DIFF
--- a/ui/components/multichain/notifications-settings-account/notifications-settings-account.tsx
+++ b/ui/components/multichain/notifications-settings-account/notifications-settings-account.tsx
@@ -33,17 +33,21 @@ export function NotificationsSettingsAccount({
       gap={3}
       paddingTop={2}
       paddingBottom={2}
+      className="min-w-0"
     >
       <PreferredAvatar address={checksumAddress} />
       <Box
         flexDirection={BoxFlexDirection.Column}
         alignItems={BoxAlignItems.Start}
         justifyContent={BoxJustifyContent.Between}
+        className="min-w-0"
       >
         <Text
           variant={TextVariant.BodyMd}
           fontWeight={FontWeight.Medium}
           textAlign={TextAlign.Left}
+          ellipsis
+          className="w-full"
         >
           {name ?? checksumAddress}
         </Text>

--- a/ui/components/multichain/notifications-settings-box/notifications-settings-box.tsx
+++ b/ui/components/multichain/notifications-settings-box/notifications-settings-box.tsx
@@ -40,7 +40,7 @@ export function NotificationsSettingsBox({
         flexDirection={BoxFlexDirection.Row}
         alignItems={BoxAlignItems.Center}
         justifyContent={BoxJustifyContent.Between}
-        className="notifications-settings-box w-full"
+        className="notifications-settings-box w-full min-w-0"
         gap={4}
       >
         {children}

--- a/ui/pages/settings-v2/settings-v2.tsx
+++ b/ui/pages/settings-v2/settings-v2.tsx
@@ -308,7 +308,7 @@ const SettingsV2Layout = ({ children }: { children: React.ReactNode }) => {
           />
         </Box>
         <Box
-          className={classnames('flex-auto flex-col w-full pt-2', {
+          className={classnames('flex-auto flex-col w-full min-w-0 pt-2', {
             flex: !isOnSettingsRoot,
             'hidden sm:flex': isOnSettingsRoot && !isSidepanel,
             hidden: isOnSettingsRoot && isSidepanel,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

If there is a long account name, the notifications settings page wasn't truncating it properly and instead the content was getting pushed out of the box. This PR adds some CSS fixes.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fixes text truncation on notifications settings account name

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/41870

## **Manual testing steps**

1. Give an account a long name with no spaces
2. Go to Settings > Notifications
3. Adjust the viewport from small to wide
4. See that the screen adjusts as expected and the long name gets truncated rather than pushing the content out of the box

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

See issue

### **After**

Small viewport:
<img width="377" height="777" alt="image" src="https://github.com/user-attachments/assets/4c1e208e-59b2-4b23-a005-7e697880ab5f" />

Larger viewport (fullscreen):
<img width="813" height="774" alt="image" src="https://github.com/user-attachments/assets/144ef08a-2ca9-43cd-9591-94461e158a8c" />

Fullscreen max:
<img width="1510" height="775" alt="image" src="https://github.com/user-attachments/assets/c73d441e-3187-4b22-a96f-246acbbb489e" />

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS/layout-only changes to flex containers to prevent overflow; no business logic or data handling is modified.
> 
> **Overview**
> Fixes overflow in the notifications settings UI by allowing flex children to shrink and truncating long account names.
> 
> Adds `min-w-0` to key flex containers (`NotificationsSettingsAccount`, `NotificationsSettingsBox`, and the Settings V2 content pane) and enables `Text` ellipsis with full-width styling so long names don’t push toggles/content out of view.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c51f48cc32d1f8c2d5c5da40bd36a3daed7e6b2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->