### PR TITLE
test: globally mock isAssetsUnifyStateFeatureEnabled to false in unit test

### DIFF
--- a/app/scripts/lib/WalletFundsObtainedMonitor.test.ts
+++ b/app/scripts/lib/WalletFundsObtainedMonitor.test.ts
@@ -16,6 +16,14 @@ import {
   WalletFundsObtainedMonitorMessenger,
 } from './WalletFundsObtainedMonitor';
 
+// Opt out of the global `isAssetsUnifyStateFeatureEnabled` mock (see test/jest/setup.js)
+// so these tests exercise the real gating logic driven by the messenger mock.
+jest.mock('../../../shared/lib/assets-unify-state/remote-feature-flag', () =>
+  jest.requireActual(
+    '../../../shared/lib/assets-unify-state/remote-feature-flag',
+  ),
+);
+
 function createMessengerMock(): jest.Mocked<WalletFundsObtainedMonitorMessenger> {
   return {
     call: jest.fn(),

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -86,6 +86,12 @@ import {
 import { forwardRequestToSnap } from './lib/forwardRequestToSnap';
 import MetaMaskController from './metamask-controller';
 
+// Opt out of the global `isAssetsUnifyStateFeatureEnabled` mock (see test/jest/setup.js)
+// so these tests exercise the real feature-flag gating logic via state.
+jest.mock('../../shared/lib/assets-unify-state/remote-feature-flag', () =>
+  jest.requireActual('../../shared/lib/assets-unify-state/remote-feature-flag'),
+);
+
 jest.mock('./messenger-client-init/perps-controller-init', () => ({
   PerpsControllerInit: jest.fn().mockReturnValue({
     messengerClient: {

--- a/shared/lib/selectors/assets-migration.test.ts
+++ b/shared/lib/selectors/assets-migration.test.ts
@@ -22,6 +22,12 @@ import {
   getRatesControllerFiatCurrency,
 } from './assets-migration';
 
+// Opt out of the global `isAssetsUnifyStateFeatureEnabled` mock (see test/jest/setup.js)
+// so these selector tests exercise the real feature-flag gating logic.
+jest.mock('../assets-unify-state/remote-feature-flag', () =>
+  jest.requireActual('../assets-unify-state/remote-feature-flag'),
+);
+
 const mockAccountId = 'mock-account-id-1';
 const mockAccountId2 = 'mock-account-id-2';
 

--- a/test/jest/setup.js
+++ b/test/jest/setup.js
@@ -29,6 +29,18 @@ jest.mock('../../shared/lib/stores/browser-storage-adapter', () => {
   };
 });
 
+/**
+ * Globally force the assets-unify-state feature flag helper to return `false`
+ * for all unit tests. Individual tests can still override this by re-mocking
+ * the module locally with `jest.mock(...)`.
+ */
+jest.mock('../../shared/lib/assets-unify-state/remote-feature-flag', () => ({
+  ...jest.requireActual(
+    '../../shared/lib/assets-unify-state/remote-feature-flag',
+  ),
+  isAssetsUnifyStateFeatureEnabled: jest.fn(() => false),
+}));
+
 const UNRESOLVED = Symbol('timedOut');
 
 // Store this in case it gets stubbed later

--- a/ui/components/multichain/import-tokens-modal/import-tokens-modal.test.js
+++ b/ui/components/multichain/import-tokens-modal/import-tokens-modal.test.js
@@ -23,12 +23,10 @@ import { ImportTokensModal } from '.';
 
 // Opt out of the global `isAssetsUnifyStateFeatureEnabled` mock (see test/jest/setup.js)
 // so these tests exercise the real feature-flag gating logic via state.
-jest.mock(
-  '../../../../shared/lib/assets-unify-state/remote-feature-flag',
-  () =>
-    jest.requireActual(
-      '../../../../shared/lib/assets-unify-state/remote-feature-flag',
-    ),
+jest.mock('../../../../shared/lib/assets-unify-state/remote-feature-flag', () =>
+  jest.requireActual(
+    '../../../../shared/lib/assets-unify-state/remote-feature-flag',
+  ),
 );
 
 jest.mock('../../../hooks/bridge/useTokensWithFiltering');

--- a/ui/components/multichain/import-tokens-modal/import-tokens-modal.test.js
+++ b/ui/components/multichain/import-tokens-modal/import-tokens-modal.test.js
@@ -21,6 +21,16 @@ import { TokenStandard } from '../../../../shared/constants/transaction';
 import * as assetUtilsModule from '../../../../shared/lib/asset-utils';
 import { ImportTokensModal } from '.';
 
+// Opt out of the global `isAssetsUnifyStateFeatureEnabled` mock (see test/jest/setup.js)
+// so these tests exercise the real feature-flag gating logic via state.
+jest.mock(
+  '../../../../shared/lib/assets-unify-state/remote-feature-flag',
+  () =>
+    jest.requireActual(
+      '../../../../shared/lib/assets-unify-state/remote-feature-flag',
+    ),
+);
+
 jest.mock('../../../hooks/bridge/useTokensWithFiltering');
 jest.mock('@metamask/bridge-controller');
 jest.mock('../../../../shared/lib/asset-utils');

--- a/ui/hooks/useTokenBalances.test.ts
+++ b/ui/hooks/useTokenBalances.test.ts
@@ -13,6 +13,12 @@ import {
   stringifyBalance,
 } from './useTokenBalances';
 
+// Opt out of the global `isAssetsUnifyStateFeatureEnabled` mock (see test/jest/setup.js)
+// so these hook tests exercise the real feature-flag gating logic.
+jest.mock('../../shared/lib/assets-unify-state/remote-feature-flag', () =>
+  jest.requireActual('../../shared/lib/assets-unify-state/remote-feature-flag'),
+);
+
 jest.mock('../store/actions', () => ({
   tokenBalancesStartPolling: jest
     .fn()

--- a/ui/selectors/assets-unify-state/feature-flags.test.ts
+++ b/ui/selectors/assets-unify-state/feature-flags.test.ts
@@ -5,6 +5,14 @@ import {
   getIsAssetsUnifyStateEnabled,
 } from './feature-flags';
 
+// Opt out of the global `isAssetsUnifyStateFeatureEnabled` mock (see test/jest/setup.js)
+// so these selector tests exercise the real feature-flag gating logic.
+jest.mock('../../../shared/lib/assets-unify-state/remote-feature-flag', () =>
+  jest.requireActual(
+    '../../../shared/lib/assets-unify-state/remote-feature-flag',
+  ),
+);
+
 jest.mock('../../../shared/lib/environment', () => ({
   ...jest.requireActual('../../../shared/lib/environment'),
   getIsAssetsUnifiedStateIncludedInBuild: jest.fn(),


### PR DESCRIPTION
Add a global Jest mock in test/jest/setup.js that forces `isAssetsUnifyStateFeatureEnabled` to return `false` across all unit tests, keeping the feature flag disabled by default. Tests that exercise real gating logic (selectors, hooks, controller integration) opt out via a local `jest.mock(..., () => jest.requireActual(...))` call.

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: globally mock isAssetsUnifyStateFeatureEnabled to false in unit test

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that standardize feature-flag defaults; risk is mainly limited to unintentionally masking tests that should cover the enabled path if they don’t opt out.
> 
> **Overview**
> Sets a **global Jest mock** in `test/jest/setup.js` so `isAssetsUnifyStateFeatureEnabled` always returns `false`, keeping the assets-unify-state feature disabled by default across unit tests.
> 
> Updates a handful of tests (selectors/hooks/controller/lib) to explicitly *opt out* of that global mock via `jest.requireActual(...)` so they still exercise the real feature-flag gating logic when needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6c808ffdb35c700766351a0b54a4781afc92cec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->