### PR TITLE
chore: move SettingsToggleItem

### DIFF
--- a/ui/pages/settings-v2/preferences-and-display-tab/show-default-address-item.tsx
+++ b/ui/pages/settings-v2/preferences-and-display-tab/show-default-address-item.tsx
@@ -21,7 +21,7 @@ import {
   DEFAULT_ADDRESS_OPTIONS,
   type DefaultAddressScope,
 } from '../../../../shared/constants/default-address';
-import { SettingsToggleItem } from '../../settings/settings-toggle-item';
+import { SettingsToggleItem } from '../shared/settings-toggle-item';
 import { PREFERENCES_ITEMS } from '../search-config';
 
 export const ShowDefaultAddressItem = () => {

--- a/ui/pages/settings-v2/privacy-tab/basic-functionality-item.tsx
+++ b/ui/pages/settings-v2/privacy-tab/basic-functionality-item.tsx
@@ -4,7 +4,7 @@ import { useI18nContext } from '../../../hooks/useI18nContext';
 import { getUseExternalServices } from '../../../selectors';
 import { toggleExternalServices } from '../../../store/actions';
 import { openBasicFunctionalityModal } from '../../../ducks/app/app';
-import { SettingsToggleItem } from '../../settings/settings-toggle-item';
+import { SettingsToggleItem } from '../shared/settings-toggle-item';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 import {
   MetaMetricsEventCategory,

--- a/ui/pages/settings-v2/privacy-tab/data-collection-item.tsx
+++ b/ui/pages/settings-v2/privacy-tab/data-collection-item.tsx
@@ -14,7 +14,7 @@ import {
   setDataCollectionForMarketing,
   setMarketingConsent,
 } from '../../../store/actions';
-import { SettingsToggleItem } from '../../settings/settings-toggle-item';
+import { SettingsToggleItem } from '../shared/settings-toggle-item';
 import { PRIVACY_ITEMS } from '../search-config';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 import {

--- a/ui/pages/settings-v2/privacy-tab/ipfs-gateway-item.tsx
+++ b/ui/pages/settings-v2/privacy-tab/ipfs-gateway-item.tsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Box, BoxFlexDirection } from '@metamask/design-system-react';
 import { FormTextField } from '../../../components/component-library';
 import { useI18nContext } from '../../../hooks/useI18nContext';
-import { SettingsToggleItem } from '../../settings/settings-toggle-item';
+import { SettingsToggleItem } from '../shared/settings-toggle-item';
 import {
   setIpfsGateway,
   setIsIpfsGatewayEnabled,

--- a/ui/pages/settings-v2/privacy-tab/metametrics-item.tsx
+++ b/ui/pages/settings-v2/privacy-tab/metametrics-item.tsx
@@ -23,7 +23,7 @@ import {
   MetaMetricsEventName,
   MetaMetricsUserTrait,
 } from '../../../../shared/constants/metametrics';
-import { SettingsToggleItem } from '../../settings/settings-toggle-item';
+import { SettingsToggleItem } from '../shared/settings-toggle-item';
 import { PRIVACY_ITEMS } from '../search-config';
 
 export const MetametricsToggleItem = () => {

--- a/ui/pages/settings-v2/shared/autodetect-nfts-item.tsx
+++ b/ui/pages/settings-v2/shared/autodetect-nfts-item.tsx
@@ -8,8 +8,8 @@ import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
-import { SettingsToggleItem } from '../../settings/settings-toggle-item';
 import { ASSET_ITEMS } from '../search-config';
+import { SettingsToggleItem } from './settings-toggle-item';
 
 export const AutodetectNftsToggleItem = () => {
   const t = useI18nContext();

--- a/ui/pages/settings-v2/shared/create-toggle-item.tsx
+++ b/ui/pages/settings-v2/shared/create-toggle-item.tsx
@@ -2,7 +2,6 @@ import React, { useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import type { Json } from '@metamask/utils';
 import { useI18nContext } from '../../../hooks/useI18nContext';
-import { SettingsToggleItem } from '../../settings/settings-toggle-item';
 import type { MetaMaskReduxState } from '../../../store/store';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 import {
@@ -10,6 +9,7 @@ import {
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
 import type { SettingItemProps } from '../types';
+import { SettingsToggleItem } from './settings-toggle-item';
 
 const selectAlwaysFalse = (): boolean => false;
 

--- a/ui/pages/settings-v2/shared/display-nft-media-item.tsx
+++ b/ui/pages/settings-v2/shared/display-nft-media-item.tsx
@@ -8,8 +8,8 @@ import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
-import { SettingsToggleItem } from '../../settings/settings-toggle-item';
 import { ASSET_ITEMS } from '../search-config';
+import { SettingsToggleItem } from './settings-toggle-item';
 
 export const DisplayNftMediaToggleItem = () => {
   const t = useI18nContext();

--- a/ui/pages/settings-v2/shared/settings-toggle-item.tsx
+++ b/ui/pages/settings-v2/shared/settings-toggle-item.tsx
@@ -9,7 +9,7 @@ import {
   BoxJustifyContent,
   BoxAlignItems,
 } from '@metamask/design-system-react';
-import ToggleButton from '../../components/ui/toggle-button';
+import ToggleButton from '../../../components/ui/toggle-button';
 
 export type SettingsToggleItemProps = {
   title: string;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Tiny PR to move SettingsToggleItem to the settings v2 shared folder. This is part of the cleanup of legacy settings code.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only updates component import paths; main risk is a broken build/runtime if any path resolution or bundling assumptions were missed.
> 
> **Overview**
> Consolidates `SettingsToggleItem` usage in Settings v2 by updating several preference/privacy toggle items to import it from the new `settings-v2/shared/settings-toggle-item` location.
> 
> Fixes the moved component’s internal `ToggleButton` import path so it correctly resolves from its new directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 621f17799b757c93e08d8367fe7b39c6da6a2711. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->