### PR TITLE
ci: remove merge_group from block-stable-sync-to-release job

### DIFF
--- a/.github/workflows/block-stable-sync-to-release.yml
+++ b/.github/workflows/block-stable-sync-to-release.yml
@@ -5,7 +5,6 @@ on:
     types: [opened, reopened, synchronize, edited]
     branches:
       - 'release/*'
-  merge_group:
 
 jobs:
   check-branch:


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The `block-stable-sync-to-release` workflow should only enforce the stable-sync branch rule for PRs targeting `release/*` branch.  `merge_group` is for GitHub’s merge queue, and release branches do not use the merge queue, so that trigger was unnecessary.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

address comment from here: https://github.com/MetaMask/metamask-extension/pull/41876/files#r3110859267

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CI workflow trigger change with no application/runtime impact; risk is limited to potentially allowing merge-queue merges to bypass this specific check.
> 
> **Overview**
> Updates the `block-stable-sync-to-release` GitHub Actions workflow to **stop running on `merge_group` (merge queue) events**, leaving it triggered only by `pull_request` activity targeting `release/*` branches.
> 
> This means merge-queue runs will no longer be blocked/failed by this branch-pattern enforcement; the check now applies only during the PR lifecycle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfcb0548966eafbda0dfcdcb2b8a1dd45f53a38b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->