### PR TITLE
fix(security): Constrain raw `store` and `submitRequestToBackground` exposure in state hooks 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -263,3 +263,7 @@ development/generate-lavamoat-policies.js             @MetaMask/extension-platfo
 # Background Process
 app/scripts/lib/createMetaRPCHandler.js              @MetaMask/extension-platform
 app/scripts/lib/metaRPCClientFactory.ts              @MetaMask/extension-platform
+app/scripts/lib/setup-initial-state-hooks.*          @MetaMask/extension-platform
+
+# UI Bootstrap
+/ui/index.js                                         @MetaMask/extension-platform

--- a/.metamaskrc.dist
+++ b/.metamaskrc.dist
@@ -61,6 +61,11 @@ BLOCKAID_PUBLIC_KEY=
 ; Enables the Settings Page - Developer Options
 ; ENABLE_SETTINGS_PAGE_DEV_OPTIONS=true
 
+; Enables agentic/CDP automation hooks on `globalThis.stateHooks` in debug builds.
+; Requires `METAMASK_DEBUG=true`. Only set this when running the CDP automation
+; harness — not needed for manual QA or general local development.
+; METAMASK_AGENTIC_HOOKS=true
+
 ; SENTRY CONFIGURATION
 ; SENTRY_DSN             - For production builds only (do NOT use in development)
 ; SENTRY_DSN_DEV         - For local dev and one-off QA testing (sends to 'test-metamask' project)

--- a/builds.yml
+++ b/builds.yml
@@ -329,6 +329,10 @@ env:
   # Modified in <root>/development/build/scripts.js:@setEnvironmentVariables
   # Also see DEBUG and NODE_DEBUG
   - METAMASK_DEBUG: false
+  # Enables agentic/CDP automation hooks on `globalThis.stateHooks`
+  # (see `ui/index.js`). Requires `METAMASK_DEBUG=true` to take effect.
+  # Off by default so manual QA debug builds do not expose the automation surface.
+  - METAMASK_AGENTIC_HOOKS: false
   # Modified in <root>/development/build/scripts.js:@setEnvironmentVariables
   - IN_TEST
   # Modified in <root>/development/build/scripts.js:@setEnvironmentVariables

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -324,9 +324,10 @@ type StateHooks = {
    */
   resetWebVitalsMetrics?: () => void;
 
-  // Agentic dev hooks (METAMASK_DEBUG only) — curated surface for CDP automation.
-  // Typed loosely because these are debug-only entry points consumed by CDP
-  // automation scripts that perform their own runtime checks.
+  // Agentic dev hooks — curated surface for CDP automation.
+  // Present only when both METAMASK_DEBUG and METAMASK_AGENTIC_HOOKS are true
+  // at build time. Typed loosely because these are debug-only entry points
+  // consumed by CDP automation scripts that perform their own runtime checks.
   store?: {
     getState: () => unknown;
     subscribe: (listener: () => void) => () => void;

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -324,15 +324,20 @@ type StateHooks = {
    */
   resetWebVitalsMetrics?: () => void;
 
-  // Agentic dev hooks (METAMASK_DEBUG only) — expose internals for CDP automation.
-  // Typed as `unknown` because these are untyped debug-only entry points consumed
-  // by CDP automation scripts that perform their own runtime checks.
-  store?: unknown;
+  // Agentic dev hooks (METAMASK_DEBUG only) — curated surface for CDP automation.
+  // Typed loosely because these are debug-only entry points consumed by CDP
+  // automation scripts that perform their own runtime checks.
+  store?: {
+    getState: () => unknown;
+    subscribe: (listener: () => void) => () => void;
+  };
   submitRequestToBackground?: (
     method: string,
     args?: unknown[],
   ) => Promise<unknown>;
-  getPerpsStreamManager?: () => unknown;
+  services?: {
+    perps: unknown;
+  };
 };
 
 export declare global {

--- a/ui/index.js
+++ b/ui/index.js
@@ -463,11 +463,37 @@ function setupStateHooks(store) {
     exposeLongTaskMetricsForTesting();
   }
 
-  // Agentic dev hooks — expose internals for CDP automation
+  // Agentic dev hooks — curated surface for CDP automation.
+  // Gated on METAMASK_DEBUG; stripped from release builds by DefinePlugin.
   if (process.env.METAMASK_DEBUG) {
-    globalThis.stateHooks.store = store;
-    globalThis.stateHooks.submitRequestToBackground = submitRequestToBackground;
-    globalThis.stateHooks.getPerpsStreamManager = getPerpsStreamManager;
+    // Background RPC methods allowlisted for agentic automation.
+    // Additions require PR review — each entry should document its use case.
+    const AGENTIC_BACKGROUND_METHODS = new Set([
+      // seed empty — harness team opens a follow-up PR to populate
+    ]);
+
+    // Read-only store facade: getState + subscribe, no dispatch.
+    globalThis.stateHooks.store = {
+      getState: () => store.getState(),
+      subscribe: (listener) => store.subscribe(listener),
+    };
+
+    // Allowlisted background RPC — same signature as the real submitRequestToBackground.
+    globalThis.stateHooks.submitRequestToBackground = (method, args) => {
+      if (!AGENTIC_BACKGROUND_METHODS.has(method)) {
+        throw new Error(
+          `stateHooks.submitRequestToBackground: "${method}" is not in the ` +
+            `agentic allowlist. Add it to AGENTIC_BACKGROUND_METHODS in ` +
+            `ui/index.js via PR review.`,
+        );
+      }
+      return submitRequestToBackground(method, args);
+    };
+
+    // UI-side service singletons for agentic automation.
+    globalThis.stateHooks.services = {
+      perps: getPerpsStreamManager(),
+    };
   }
 }
 

--- a/ui/index.js
+++ b/ui/index.js
@@ -464,8 +464,9 @@ function setupStateHooks(store) {
   }
 
   // Agentic dev hooks — curated surface for CDP automation.
-  // Gated on METAMASK_DEBUG; stripped from release builds by DefinePlugin.
-  if (process.env.METAMASK_DEBUG) {
+  // Requires METAMASK_DEBUG AND METAMASK_AGENTIC_HOOKS. Both are compile-time
+  // constants; DefinePlugin dead-code-eliminates this block in release builds.
+  if (process.env.METAMASK_DEBUG && process.env.METAMASK_AGENTIC_HOOKS) {
     // Background RPC methods allowlisted for agentic automation.
     // Additions require PR review — each entry should document its use case.
     const AGENTIC_BACKGROUND_METHODS = new Set([


### PR DESCRIPTION
## **Description**

Constrains the agentic/CDP automation hooks added in #41648 (`globalThis.stateHooks.store`, `.submitRequestToBackground`, `.getPerpsStreamManager`) so that a build-flag regression or unexpected dev-mode reachability cannot grant god-mode access to the full Redux store or background RPC surface.

Compared to `#41648`, autonomous agents will need to be set up with the following changes:

- Set `METAMASK_AGENTIC_HOOKS=true` in addition to `METAMASK_DEBUG=true`. 
- `globalThis.stateHooks.store.getState()` is available. Just `.store` or `.store.dispatch` is blocked.
- `globalThis.stateHooks.submitRequestToBackground` currently doesn't allow anything so any methods needed by agents will have to be added to the `AGENTIC_BACKGROUND_METHODS` Set defined in `ui/index.js`.
- `globalThis.stateHooks.services.perps()` instead of `globalThis.stateHooks.getPerpsStreamManager()`.

**Scope:**

1. **Read-only `store` facade.** Replaces raw Redux store exposure with `{ getState, subscribe }` only — no `dispatch`, no `replaceReducer`. Observation/wait-for-condition flows still work; arbitrary state mutation is removed.
2. **Allowlist-gated `submitRequestToBackground`.** Wraps the real RPC with a `Set<string>` check against `AGENTIC_BACKGROUND_METHODS`. The seed is empty — harness authors must open follow-up PRs listing specific methods with justification, making additions auditable. Non-allowlisted calls throw a clear error pointing at the allowlist location.
3. **`stateHooks.services.perps` namespace.** Moves `getPerpsStreamManager` into a `services` bucket, establishing the pattern for future UI-side service singletons (swaps, bridge, etc.) rather than growing flat top-level entries.
4. **New `METAMASK_AGENTIC_HOOKS` build flag.** Hooks now require **both** `METAMASK_DEBUG` **and** `METAMASK_AGENTIC_HOOKS` at compile time. Manual QA and general local debug builds stop exposing the automation surface unless the flag is explicitly opted in via `.metamaskrc`. Both flags are DefinePlugin constants → dead-code-eliminated in release builds.
5. **CODEOWNERS for bootstrap files.** `app/scripts/lib/setup-initial-state-hooks.*` and `/ui/index.js` — the two entry points where `globalThis.stateHooks` is populated — now route through `@MetaMask/extension-platform` review, so future changes to the capability surface are visible to the team responsible for it.

**Why:** `submitRequestToBackground` is the full wire protocol to the background (keyring ops, transactions, networks, permissions). Exposing it raw on `globalThis` — gated only by a single compile-time flag — is a significant blast radius if the gate ever misfires (supply-chain injection, debug leak to release, LavaMoat compartment escape in debug builds). Curating the surface and adding a second flag provides defense-in-depth without breaking the agentic harness (names/call-signatures preserved; behavior changes only at the capability boundary).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Follows up on #41648 (original exposure) and #41687 (`PERPS_ENABLED` in main builds — the latter makes `getPerpsStreamManager` reachable in default debug builds, which motivated tightening this surface now).

## **Manual testing steps**

1. Build with `METAMASK_DEBUG=true` and `METAMASK_AGENTIC_HOOKS=true`.
   - Confirm `window.stateHooks.store.getState()` returns the Redux state.
   - Confirm `window.stateHooks.store.dispatch` is undefined.
   - Confirm `window.stateHooks.submitRequestToBackground('anyMethod')` throws with the "not in the agentic allowlist" message.
   - Confirm `window.stateHooks.services.perps` is the `PerpsStreamManager` singleton.
2. Build with `METAMASK_DEBUG=true` and `METAMASK_AGENTIC_HOOKS=false` (or unset).
   - Confirm `window.stateHooks.store`, `.submitRequestToBackground`, and `.services` are all undefined (block is dead-code-eliminated).
3. Build a release artifact and confirm the block does not appear in the bundle.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
