### PR TITLE
ci: Skip failed benchmark entries in quality-gate `runComparison`

### DIFF
--- a/development/metamaskbot-build-announce/compare-benchmarks.test.ts
+++ b/development/metamaskbot-build-announce/compare-benchmarks.test.ts
@@ -185,6 +185,23 @@ describe('compare-benchmarks', () => {
       const result = runComparison(benchmarks, {});
       expect(result.comparisons).toHaveLength(0);
     });
+
+    it('skips entries from failed benchmark runs (missing p75/p95)', () => {
+      const benchmarks = [
+        {
+          name: 'benchmark-chrome-browserify-startupStandardHome',
+          data: {
+            startupStandardHome: { error: 'Browser crashed' } as never,
+          },
+        },
+      ];
+
+      const result = runComparison(benchmarks, {});
+      expect(result.comparisons).toHaveLength(0);
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('missing p75/p95'),
+      );
+    });
   });
 });
 

--- a/development/metamaskbot-build-announce/compare-benchmarks.ts
+++ b/development/metamaskbot-build-announce/compare-benchmarks.ts
@@ -86,6 +86,13 @@ export function runComparison(
 
   for (const { name, data } of benchmarks) {
     for (const [entryName, results] of Object.entries(data)) {
+      if (!results.p75 || !results.p95) {
+        console.warn(
+          `Skipping "${entryName}" in "${name}": missing p75/p95 (benchmark likely failed).`,
+        );
+        continue;
+      }
+
       const thresholdConfig = THRESHOLD_REGISTRY[entryName];
 
       if (!thresholdConfig) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

When a benchmark flow throws (browser crash, Selenium timeout, etc.), `run-benchmark.ts` writes `{ error: "..." }` as the entry. The quality-gate then loads this and crashes on `results.p75['uiStartup']` because the error-shaped object has no `p75`/`p95` fields.

Guard with an early-continue when `results.p75` or `results.p95` is missing, logging a warning so the failure is visible in the gate output without crashing the entire job.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI quality-gate behavior to ignore malformed/failed benchmark outputs, which could reduce signal if failures are frequent despite warning logs.
> 
> **Overview**
> Prevents the benchmark quality-gate `runComparison` from crashing when a benchmark run fails and emits an error-shaped result.
> 
> `runComparison` now **skips entries missing `p75`/`p95`**, logs a warning indicating the entry/file was ignored, and continues evaluating the remaining benchmarks. A new unit test covers the skip-and-warn behavior for failed runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1874c4b73c7a25737dd65b7aaae150910ff65b43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->