### PR TITLE
perf(quality-gates): Variance reduction - outlier filtering, warmup exclusion

### DIFF
--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Run the benchmark
         if: ${{ env.BENCHMARK_GATED == 'true' }}
         run: >-
-          ${{ matrix.pageType == 'startupPowerUserHome' && format('yarn test:e2e:benchmark --preset startupPowerUserHome --browserLoads 10 --pageLoads 10 --out test-artifacts/benchmarks/benchmark-{0}-{1}-startupPowerUserHome.json --retries 2', matrix.browser, matrix.buildType) || format('yarn test:e2e:benchmark --preset {2} --out test-artifacts/benchmarks/benchmark-{0}-{1}-{2}.json --retries 2', matrix.browser, matrix.buildType, matrix.pageType) }}
+          ${{ matrix.pageType == 'startupPowerUserHome' && format('yarn test:e2e:benchmark --preset startupPowerUserHome --browserLoads 15 --pageLoads 7 --out test-artifacts/benchmarks/benchmark-{0}-{1}-startupPowerUserHome.json --retries 2', matrix.browser, matrix.buildType) || format('yarn test:e2e:benchmark --preset {2} --out test-artifacts/benchmarks/benchmark-{0}-{1}-{2}.json --retries 2', matrix.browser, matrix.buildType, matrix.pageType) }}
         shell: bash
 
       - name: Send benchmark results to Sentry (main/release only)

--- a/shared/constants/benchmarks.ts
+++ b/shared/constants/benchmarks.ts
@@ -110,6 +110,7 @@ export type BenchmarkResults = {
   p75: StatisticalResult;
   p95: StatisticalResult;
   trimmedCount?: StatisticalResult;
+  outliers?: StatisticalResult;
   webVitals?: WebVitalsSummary;
 };
 

--- a/shared/constants/benchmarks.ts
+++ b/shared/constants/benchmarks.ts
@@ -71,6 +71,7 @@ export type TimerStatistics = {
   p99: number;
   samples: number;
   outliers: number;
+  trimmedCount?: number;
   dataQuality: 'good' | 'poor' | 'unreliable';
 };
 
@@ -108,6 +109,7 @@ export type BenchmarkResults = {
   stdDev: StatisticalResult;
   p75: StatisticalResult;
   p95: StatisticalResult;
+  trimmedCount?: StatisticalResult;
   webVitals?: WebVitalsSummary;
 };
 

--- a/test/e2e/benchmarks/flows/startup/power-user-home.ts
+++ b/test/e2e/benchmarks/flows/startup/power-user-home.ts
@@ -15,7 +15,10 @@ import {
   type BenchmarkResults,
   type WebVitalsMetrics,
 } from '../../../../../shared/constants/benchmarks';
-import { WITH_STATE_POWER_USER } from '../../utils/constants';
+import {
+  WITH_STATE_POWER_USER,
+  POWER_USER_NUM_BROWSER_LOADS,
+} from '../../utils/constants';
 import { runPageLoadBenchmark, collectWebVitals } from '../../utils';
 import type {
   Metrics,
@@ -87,5 +90,8 @@ async function measurePagePowerUser(
 export async function run(
   options: PageLoadBenchmarkOptions,
 ): Promise<BenchmarkResults> {
-  return runPageLoadBenchmark(measurePagePowerUser, options);
+  return runPageLoadBenchmark(measurePagePowerUser, {
+    ...options,
+    browserLoads: options.browserLoads ?? POWER_USER_NUM_BROWSER_LOADS,
+  });
 }

--- a/test/e2e/benchmarks/send-to-sentry.ts
+++ b/test/e2e/benchmarks/send-to-sentry.ts
@@ -253,7 +253,8 @@ async function main() {
           if (meanVal > 0 && stdDevVal !== undefined) {
             const cv = (stdDevVal / meanVal) * 100;
             derivedMetrics[`${type}.cv.${key}`] = cv;
-            derivedMetrics[`${type}.dataQuality.${key}`] = assessDataQuality(cv);
+            derivedMetrics[`${type}.dataQuality.${key}`] =
+              assessDataQuality(cv);
           }
         }
       }

--- a/test/e2e/benchmarks/send-to-sentry.ts
+++ b/test/e2e/benchmarks/send-to-sentry.ts
@@ -30,7 +30,7 @@ import type {
 } from '../../../shared/constants/benchmarks';
 import { getGitBranch, getGitCommitHash } from './utils/git';
 import type { UserActionResult } from './utils/types';
-import { aggregateWebVitals } from './utils/statistics';
+import { aggregateWebVitals, assessDataQuality } from './utils/statistics';
 
 const packageJsonPath = path.resolve(__dirname, '../../../package.json');
 const { version } = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as {
@@ -253,15 +253,7 @@ async function main() {
           if (meanVal > 0 && stdDevVal !== undefined) {
             const cv = (stdDevVal / meanVal) * 100;
             derivedMetrics[`${type}.cv.${key}`] = cv;
-            let dataQuality: 'good' | 'poor' | 'unreliable';
-            if (cv < 30) {
-              dataQuality = 'good';
-            } else if (cv < 50) {
-              dataQuality = 'poor';
-            } else {
-              dataQuality = 'unreliable';
-            }
-            derivedMetrics[`${type}.dataQuality.${key}`] = dataQuality;
+            derivedMetrics[`${type}.dataQuality.${key}`] = assessDataQuality(cv);
           }
         }
       }
@@ -276,6 +268,11 @@ async function main() {
       if (benchmark.trimmedCount) {
         for (const [key, count] of Object.entries(benchmark.trimmedCount)) {
           derivedMetrics[`${type}.trimmedCount.${key}`] = count;
+        }
+      }
+      if (benchmark.outliers) {
+        for (const [key, count] of Object.entries(benchmark.outliers)) {
+          derivedMetrics[`${type}.outliers.${key}`] = count;
         }
       }
 

--- a/test/e2e/benchmarks/send-to-sentry.ts
+++ b/test/e2e/benchmarks/send-to-sentry.ts
@@ -241,12 +241,51 @@ async function main() {
         }
       }
 
+      // Derived reliability metrics: CV, dataQuality, tailRatio
+      // CV = (stdDev / mean) * 100 — coefficient of variation, directly
+      // comparable across steps with different magnitudes.
+      // dataQuality: 'good' (CV<30), 'poor' (30-50), 'unreliable' (>50).
+      // tailRatio = p95/p75 — tail heaviness; closer to 1.0 = tighter.
+      const derivedMetrics: Record<string, number | string> = {};
+      if (benchmark.mean && benchmark.stdDev) {
+        for (const [key, meanVal] of Object.entries(benchmark.mean)) {
+          const stdDevVal = benchmark.stdDev[key];
+          if (meanVal > 0 && stdDevVal !== undefined) {
+            const cv = (stdDevVal / meanVal) * 100;
+            derivedMetrics[`${type}.cv.${key}`] = cv;
+            let dataQuality: string;
+            if (cv < 30) {
+              dataQuality = 'good';
+            } else if (cv < 50) {
+              dataQuality = 'poor';
+            } else {
+              dataQuality = 'unreliable';
+            }
+            derivedMetrics[`${type}.dataQuality.${key}`] = dataQuality;
+          }
+        }
+      }
+      if (benchmark.p95 && benchmark.p75) {
+        for (const [key, p95Val] of Object.entries(benchmark.p95)) {
+          const p75Val = benchmark.p75[key];
+          if (p75Val !== undefined && p75Val > 0) {
+            derivedMetrics[`${type}.tailRatio.${key}`] = p95Val / p75Val;
+          }
+        }
+      }
+      if (benchmark.trimmedCount) {
+        for (const [key, count] of Object.entries(benchmark.trimmedCount)) {
+          derivedMetrics[`${type}.trimmedCount.${key}`] = count;
+        }
+      }
+
       // Timer data: structured logs (existing path, unchanged)
       Sentry.logger.info(message, {
         ...baseCiAttributes,
         'ci.persona': benchmark.persona || BENCHMARK_PERSONA.STANDARD,
         'ci.testTitle': benchmark.testTitle,
         ...allMetrics,
+        ...derivedMetrics,
       });
 
       // Web vitals: separate reporting path via spans

--- a/test/e2e/benchmarks/send-to-sentry.ts
+++ b/test/e2e/benchmarks/send-to-sentry.ts
@@ -253,7 +253,7 @@ async function main() {
           if (meanVal > 0 && stdDevVal !== undefined) {
             const cv = (stdDevVal / meanVal) * 100;
             derivedMetrics[`${type}.cv.${key}`] = cv;
-            let dataQuality: string;
+            let dataQuality: 'good' | 'poor' | 'unreliable';
             if (cv < 30) {
               dataQuality = 'good';
             } else if (cv < 50) {

--- a/test/e2e/benchmarks/utils/constants.ts
+++ b/test/e2e/benchmarks/utils/constants.ts
@@ -56,9 +56,6 @@ export const POWER_USER_NUM_BROWSER_LOADS = 15;
 /** Number of leading browser-load sessions to discard as warm-up before computing stats. */
 export const WARMUP_RUNS = 1;
 
-/** Minimum effective sample count (after warm-up exclusion + IQR trimming) required to emit a Mann-Whitney verdict. */
-export const MIN_SAMPLES_FOR_VERDICT = 5;
-
 export const ALL_METRICS = {
   uiStartup: 'UI Startup',
   load: 'navigation[0].load',

--- a/test/e2e/benchmarks/utils/constants.ts
+++ b/test/e2e/benchmarks/utils/constants.ts
@@ -50,6 +50,15 @@ export const DEFAULT_NUM_BROWSER_LOADS = DEFAULT_BENCHMARK_BROWSER_LOADS;
 /** Same as {@link DEFAULT_BENCHMARK_PAGE_LOADS} in `shared/constants/benchmarks`. */
 export const DEFAULT_NUM_PAGE_LOADS = DEFAULT_BENCHMARK_PAGE_LOADS;
 
+/** Browser loads for the POWER_USER_HOME preset (higher than default to offset warm-up exclusion). */
+export const POWER_USER_NUM_BROWSER_LOADS = 15;
+
+/** Number of leading browser-load sessions to discard as warm-up before computing stats. */
+export const WARMUP_RUNS = 1;
+
+/** Minimum effective sample count (after warm-up exclusion + IQR trimming) required to emit a Mann-Whitney verdict. */
+export const MIN_SAMPLES_FOR_VERDICT = 5;
+
 export const ALL_METRICS = {
   uiStartup: 'UI Startup',
   load: 'navigation[0].load',

--- a/test/e2e/benchmarks/utils/outlier-trimming.test.ts
+++ b/test/e2e/benchmarks/utils/outlier-trimming.test.ts
@@ -79,7 +79,9 @@ describe('trimOutliers (IQR-based)', () => {
   describe('realistic benchmark scenario (n=15)', () => {
     it('removes 0-3 outliers from a 15-sample benchmark run', () => {
       // Simulates 15 independent browser-load sessions with 1-2 JIT/GC spikes
-      const normal = [320, 330, 315, 325, 318, 322, 328, 316, 319, 324, 321, 323, 317];
+      const normal = [
+        320, 330, 315, 325, 318, 322, 328, 316, 319, 324, 321, 323, 317,
+      ];
       const withSpikes = [...normal, 900, 850]; // two cold-start spikes
       const result = trimOutliers(withSpikes);
       expect(result.trimmedCount).toBeGreaterThanOrEqual(1);
@@ -88,7 +90,10 @@ describe('trimOutliers (IQR-based)', () => {
     });
 
     it('does not over-trim a low-variance run', () => {
-      const stable = [300, 302, 298, 301, 299, 303, 300, 301, 302, 298, 300, 301, 299, 302, 300];
+      const stable = [
+        300, 302, 298, 301, 299, 303, 300, 301, 302, 298, 300, 301, 299, 302,
+        300,
+      ];
       const result = trimOutliers(stable);
       expect(result.trimmedCount).toBe(0);
       expect(result.samples).toHaveLength(stable.length);

--- a/test/e2e/benchmarks/utils/outlier-trimming.test.ts
+++ b/test/e2e/benchmarks/utils/outlier-trimming.test.ts
@@ -1,92 +1,91 @@
-import { trimOutliers } from './statistics';
+import { detectOutliersIQR } from './statistics';
 
-describe('trimOutliers (IQR-based)', () => {
+describe('detectOutliersIQR (IQR-based)', () => {
   describe('small sample edge cases', () => {
     it('returns empty array unchanged', () => {
-      const result = trimOutliers([]);
-      expect(result.samples).toEqual([]);
-      expect(result.trimmedCount).toBe(0);
+      const result = detectOutliersIQR([]);
+      expect(result.filtered).toEqual([]);
+      expect(result.outlierCount).toBe(0);
     });
 
     it('returns array of 1 unchanged', () => {
-      const result = trimOutliers([500]);
-      expect(result.samples).toEqual([500]);
-      expect(result.trimmedCount).toBe(0);
+      const result = detectOutliersIQR([500]);
+      expect(result.filtered).toEqual([500]);
+      expect(result.outlierCount).toBe(0);
     });
 
     it('returns array of 2 unchanged', () => {
-      const result = trimOutliers([100, 200]);
-      expect(result.samples).toEqual([100, 200]);
-      expect(result.trimmedCount).toBe(0);
+      const result = detectOutliersIQR([100, 200]);
+      expect(result.filtered).toEqual([100, 200]);
+      expect(result.outlierCount).toBe(0);
     });
 
     it('returns array of 3 unchanged (below IQR threshold)', () => {
-      const result = trimOutliers([100, 200, 9000]);
-      expect(result.samples).toEqual([100, 200, 9000]);
-      expect(result.trimmedCount).toBe(0);
+      const result = detectOutliersIQR([100, 200, 9000]);
+      expect(result.filtered).toEqual([100, 200, 9000]);
+      expect(result.outlierCount).toBe(0);
     });
   });
 
   describe('no outliers', () => {
     it('returns all values when distribution is tight', () => {
       const samples = [100, 101, 99, 102, 98, 100, 101, 99];
-      const result = trimOutliers(samples);
-      expect(result.trimmedCount).toBe(0);
-      expect(result.samples).toHaveLength(samples.length);
+      const result = detectOutliersIQR(samples);
+      expect(result.outlierCount).toBe(0);
+      expect(result.filtered).toHaveLength(samples.length);
     });
 
     it('returns all values when all samples are identical', () => {
       const samples = [200, 200, 200, 200, 200, 200];
-      const result = trimOutliers(samples);
-      expect(result.trimmedCount).toBe(0);
-      expect(result.samples).toHaveLength(samples.length);
+      const result = detectOutliersIQR(samples);
+      expect(result.outlierCount).toBe(0);
+      expect(result.filtered).toHaveLength(samples.length);
     });
   });
 
   describe('outlier removal', () => {
     it('removes a single high outlier', () => {
       const samples = [10, 11, 12, 10, 11, 12, 11, 1000];
-      const result = trimOutliers(samples);
-      expect(result.samples).not.toContain(1000);
-      expect(result.trimmedCount).toBe(1);
+      const result = detectOutliersIQR(samples);
+      expect(result.filtered).not.toContain(1000);
+      expect(result.outlierCount).toBe(1);
     });
 
     it('removes a single low outlier', () => {
       const samples = [100, 102, 101, 103, 100, 101, 1];
-      const result = trimOutliers(samples);
-      expect(result.samples).not.toContain(1);
-      expect(result.trimmedCount).toBe(1);
+      const result = detectOutliersIQR(samples);
+      expect(result.filtered).not.toContain(1);
+      expect(result.outlierCount).toBe(1);
     });
 
     it('removes multiple outliers on both ends', () => {
       const samples = [1, 100, 101, 102, 100, 101, 103, 9999];
-      const result = trimOutliers(samples);
-      expect(result.samples).not.toContain(1);
-      expect(result.samples).not.toContain(9999);
-      expect(result.trimmedCount).toBe(2);
+      const result = detectOutliersIQR(samples);
+      expect(result.filtered).not.toContain(1);
+      expect(result.filtered).not.toContain(9999);
+      expect(result.outlierCount).toBe(2);
     });
 
     it('preserves non-outlier values exactly', () => {
       const core = [100, 105, 95, 102, 98, 101];
       const samples = [...core, 5000];
-      const result = trimOutliers(samples);
+      const result = detectOutliersIQR(samples);
       for (const v of core) {
-        expect(result.samples).toContain(v);
+        expect(result.filtered).toContain(v);
       }
     });
   });
 
   describe('realistic benchmark scenario (n=15)', () => {
-    it('removes 0-3 outliers from a 15-sample benchmark run', () => {
-      // Simulates 15 independent browser-load sessions with 1-2 JIT/GC spikes
+    it('removes exactly 2 outliers from a deterministic 15-sample benchmark run', () => {
+      // Q1=318, Q3=328, IQR=10, upper fence=343 — 850 and 900 both exceed it
       const normal = [
         320, 330, 315, 325, 318, 322, 328, 316, 319, 324, 321, 323, 317,
       ];
       const withSpikes = [...normal, 900, 850]; // two cold-start spikes
-      const result = trimOutliers(withSpikes);
-      expect(result.trimmedCount).toBe(1);
-      expect(result.trimmedCount).toBe(3);
-      expect(result.samples.length).toBe(12);
+      const result = detectOutliersIQR(withSpikes);
+      expect(result.outlierCount).toBe(2);
+      expect(result.filtered).toHaveLength(13);
     });
 
     it('does not over-trim a low-variance run', () => {
@@ -94,38 +93,38 @@ describe('trimOutliers (IQR-based)', () => {
         300, 302, 298, 301, 299, 303, 300, 301, 302, 298, 300, 301, 299, 302,
         300,
       ];
-      const result = trimOutliers(stable);
-      expect(result.trimmedCount).toBe(0);
-      expect(result.samples).toHaveLength(stable.length);
+      const result = detectOutliersIQR(stable);
+      expect(result.outlierCount).toBe(0);
+      expect(result.filtered).toHaveLength(stable.length);
     });
   });
 
   describe('input ordering', () => {
-    it('produces the same trimmedCount regardless of input order', () => {
+    it('produces the same outlierCount regardless of input order', () => {
       const ordered = [10, 11, 12, 13, 14, 15, 1000];
       const shuffled = [1000, 13, 10, 15, 12, 11, 14];
-      const r1 = trimOutliers(ordered);
-      const r2 = trimOutliers(shuffled);
-      expect(r1.trimmedCount).toBe(r2.trimmedCount);
-      expect(r1.samples.sort((a, b) => a - b)).toEqual(
-        r2.samples.sort((a, b) => a - b),
+      const r1 = detectOutliersIQR(ordered);
+      const r2 = detectOutliersIQR(shuffled);
+      expect(r1.outlierCount).toBe(r2.outlierCount);
+      expect(r1.filtered.sort((a, b) => a - b)).toEqual(
+        r2.filtered.sort((a, b) => a - b),
       );
     });
 
     it('does not mutate the input array (n >= 4, filter path)', () => {
       const samples = [10, 11, 1000, 12, 13];
       const copy = [...samples];
-      trimOutliers(samples);
+      detectOutliersIQR(samples);
       expect(samples).toEqual(copy);
     });
 
     it('does not mutate the input array (n < 4, early-return path)', () => {
       const samples = [100, 200, 9000];
       const copy = [...samples];
-      const result = trimOutliers(samples);
+      const result = detectOutliersIQR(samples);
       expect(samples).toEqual(copy);
       // returned array must not be the same reference
-      result.samples.push(999);
+      result.filtered.push(999);
       expect(samples).toEqual(copy);
     });
   });

--- a/test/e2e/benchmarks/utils/outlier-trimming.test.ts
+++ b/test/e2e/benchmarks/utils/outlier-trimming.test.ts
@@ -84,9 +84,9 @@ describe('trimOutliers (IQR-based)', () => {
       ];
       const withSpikes = [...normal, 900, 850]; // two cold-start spikes
       const result = trimOutliers(withSpikes);
-      expect(result.trimmedCount).toBeGreaterThanOrEqual(1);
-      expect(result.trimmedCount).toBeLessThanOrEqual(3);
-      expect(result.samples.length).toBeGreaterThanOrEqual(12);
+      expect(result.trimmedCount).toBe(1);
+      expect(result.trimmedCount).toBe(3);
+      expect(result.samples.length).toBe(12);
     });
 
     it('does not over-trim a low-variance run', () => {

--- a/test/e2e/benchmarks/utils/outlier-trimming.test.ts
+++ b/test/e2e/benchmarks/utils/outlier-trimming.test.ts
@@ -112,10 +112,20 @@ describe('trimOutliers (IQR-based)', () => {
       );
     });
 
-    it('does not mutate the input array', () => {
+    it('does not mutate the input array (n >= 4, filter path)', () => {
       const samples = [10, 11, 1000, 12, 13];
       const copy = [...samples];
       trimOutliers(samples);
+      expect(samples).toEqual(copy);
+    });
+
+    it('does not mutate the input array (n < 4, early-return path)', () => {
+      const samples = [100, 200, 9000];
+      const copy = [...samples];
+      const result = trimOutliers(samples);
+      expect(samples).toEqual(copy);
+      // returned array must not be the same reference
+      result.samples.push(999);
       expect(samples).toEqual(copy);
     });
   });

--- a/test/e2e/benchmarks/utils/outlier-trimming.test.ts
+++ b/test/e2e/benchmarks/utils/outlier-trimming.test.ts
@@ -1,0 +1,117 @@
+import { trimOutliers } from './statistics';
+
+describe('trimOutliers (IQR-based)', () => {
+  describe('small sample edge cases', () => {
+    it('returns empty array unchanged', () => {
+      const result = trimOutliers([]);
+      expect(result.samples).toEqual([]);
+      expect(result.trimmedCount).toBe(0);
+    });
+
+    it('returns array of 1 unchanged', () => {
+      const result = trimOutliers([500]);
+      expect(result.samples).toEqual([500]);
+      expect(result.trimmedCount).toBe(0);
+    });
+
+    it('returns array of 2 unchanged', () => {
+      const result = trimOutliers([100, 200]);
+      expect(result.samples).toEqual([100, 200]);
+      expect(result.trimmedCount).toBe(0);
+    });
+
+    it('returns array of 3 unchanged (below IQR threshold)', () => {
+      const result = trimOutliers([100, 200, 9000]);
+      expect(result.samples).toEqual([100, 200, 9000]);
+      expect(result.trimmedCount).toBe(0);
+    });
+  });
+
+  describe('no outliers', () => {
+    it('returns all values when distribution is tight', () => {
+      const samples = [100, 101, 99, 102, 98, 100, 101, 99];
+      const result = trimOutliers(samples);
+      expect(result.trimmedCount).toBe(0);
+      expect(result.samples).toHaveLength(samples.length);
+    });
+
+    it('returns all values when all samples are identical', () => {
+      const samples = [200, 200, 200, 200, 200, 200];
+      const result = trimOutliers(samples);
+      expect(result.trimmedCount).toBe(0);
+      expect(result.samples).toHaveLength(samples.length);
+    });
+  });
+
+  describe('outlier removal', () => {
+    it('removes a single high outlier', () => {
+      const samples = [10, 11, 12, 10, 11, 12, 11, 1000];
+      const result = trimOutliers(samples);
+      expect(result.samples).not.toContain(1000);
+      expect(result.trimmedCount).toBe(1);
+    });
+
+    it('removes a single low outlier', () => {
+      const samples = [100, 102, 101, 103, 100, 101, 1];
+      const result = trimOutliers(samples);
+      expect(result.samples).not.toContain(1);
+      expect(result.trimmedCount).toBe(1);
+    });
+
+    it('removes multiple outliers on both ends', () => {
+      const samples = [1, 100, 101, 102, 100, 101, 103, 9999];
+      const result = trimOutliers(samples);
+      expect(result.samples).not.toContain(1);
+      expect(result.samples).not.toContain(9999);
+      expect(result.trimmedCount).toBe(2);
+    });
+
+    it('preserves non-outlier values exactly', () => {
+      const core = [100, 105, 95, 102, 98, 101];
+      const samples = [...core, 5000];
+      const result = trimOutliers(samples);
+      for (const v of core) {
+        expect(result.samples).toContain(v);
+      }
+    });
+  });
+
+  describe('realistic benchmark scenario (n=15)', () => {
+    it('removes 0-3 outliers from a 15-sample benchmark run', () => {
+      // Simulates 15 independent browser-load sessions with 1-2 JIT/GC spikes
+      const normal = [320, 330, 315, 325, 318, 322, 328, 316, 319, 324, 321, 323, 317];
+      const withSpikes = [...normal, 900, 850]; // two cold-start spikes
+      const result = trimOutliers(withSpikes);
+      expect(result.trimmedCount).toBeGreaterThanOrEqual(1);
+      expect(result.trimmedCount).toBeLessThanOrEqual(3);
+      expect(result.samples.length).toBeGreaterThanOrEqual(12);
+    });
+
+    it('does not over-trim a low-variance run', () => {
+      const stable = [300, 302, 298, 301, 299, 303, 300, 301, 302, 298, 300, 301, 299, 302, 300];
+      const result = trimOutliers(stable);
+      expect(result.trimmedCount).toBe(0);
+      expect(result.samples).toHaveLength(stable.length);
+    });
+  });
+
+  describe('input ordering', () => {
+    it('produces the same trimmedCount regardless of input order', () => {
+      const ordered = [10, 11, 12, 13, 14, 15, 1000];
+      const shuffled = [1000, 13, 10, 15, 12, 11, 14];
+      const r1 = trimOutliers(ordered);
+      const r2 = trimOutliers(shuffled);
+      expect(r1.trimmedCount).toBe(r2.trimmedCount);
+      expect(r1.samples.sort((a, b) => a - b)).toEqual(
+        r2.samples.sort((a, b) => a - b),
+      );
+    });
+
+    it('does not mutate the input array', () => {
+      const samples = [10, 11, 1000, 12, 13];
+      const copy = [...samples];
+      trimOutliers(samples);
+      expect(samples).toEqual(copy);
+    });
+  });
+});

--- a/test/e2e/benchmarks/utils/runner.ts
+++ b/test/e2e/benchmarks/utils/runner.ts
@@ -377,6 +377,11 @@ export async function runPageLoadBenchmark(
 
   // Discard the first WARMUP_RUNS browser-load sessions before computing stats.
   // Each session contributes exactly pageLoads metric objects to runResults.
+  if (browserLoads <= WARMUP_RUNS) {
+    throw new Error(
+      `browserLoads (${browserLoads}) must be greater than WARMUP_RUNS (${WARMUP_RUNS})`,
+    );
+  }
   const warmupSize = WARMUP_RUNS * pageLoads;
   const measuredResults = runResults.slice(warmupSize);
   // Web vitals entries are sparse (collection can fail silently), so filter by

--- a/test/e2e/benchmarks/utils/runner.ts
+++ b/test/e2e/benchmarks/utils/runner.ts
@@ -482,6 +482,7 @@ export async function runPageLoadBenchmark(
     p75,
     p95,
     trimmedCount: trimmedCounts,
+    outliers: trimmedCounts,
     ...(webVitals && { webVitals }),
   };
 }

--- a/test/e2e/benchmarks/utils/runner.ts
+++ b/test/e2e/benchmarks/utils/runner.ts
@@ -340,22 +340,27 @@ export function convertSummaryToResults(
  * Uses IQR-only outlier trimming (`trimmedCount`). Z-score is intentionally
  * excluded for two reasons:
  *
- * 1. **Serial correlation** — page loads run serially within each browser
- *    session (shared JIT cache, extension state). A slow startup elevates all
- *    `pageLoads` measurements in a session as a correlated cluster. Z-score
- *    assumes i.i.d. samples and would flag the cluster as outliers even when
- *    the elevation has a real underlying cause. IQR is rank-based and
- *    distribution-free, making it robust to correlated samples.
+ * 1. Serial correlation: page loads run serially within each browser session
+ * (shared JIT cache, extension state). A slow startup elevates all `pageLoads`
+ * measurements in a session as a correlated cluster. Z-score assumes i.i.d.
+ * samples and would flag the cluster as outliers even when the elevation has a
+ * real underlying cause. IQR is rank-based and distribution-free, making it
+ * robust to correlated samples.
  *
- * 2. **Multimodal distributions** — `longTask*`, `tbt`, and `numNetworkReqs`
- *    are zero or near-zero most runs with occasional real spikes. Z-score would
- *    flag those spikes as noise, removing genuine signal.
+ * 2. Multimodal distributions: `longTask*`, `tbt`, and `numNetworkReqs` are
+ * zero or near-zero most runs with occasional real spikes. Z-score would flag
+ * those spikes as noise, removing genuine signal.
  *
  * `calculateTimerStatistics` (iteration-based benchmarks) applies both IQR and
  * z-score because each run is an independent browser session.
  *
  * @param measurePageFn - Function that drives one browser session and returns metrics
  * @param options - Benchmark configuration
+ * @param options.browserLoads - Number of full browser sessions to run
+ * @param options.pageLoads - Number of page loads per browser session
+ * @param options.retries - Number of retries per browser session on failure
+ * @param options.platform - Optional platform label written to results
+ * @param options.buildType - Optional build label written to results
  */
 export async function runPageLoadBenchmark(
   measurePageFn: (

--- a/test/e2e/benchmarks/utils/runner.ts
+++ b/test/e2e/benchmarks/utils/runner.ts
@@ -383,6 +383,12 @@ export async function runPageLoadBenchmark(
     buildType,
   } = options;
 
+  if (browserLoads <= WARMUP_RUNS) {
+    throw new Error(
+      `browserLoads (${browserLoads}) must be greater than WARMUP_RUNS (${WARMUP_RUNS})`,
+    );
+  }
+
   const pageName = 'home';
   let runResults: Metrics[] = [];
   let allWebVitalsRuns: WebVitalsRun[] = [];
@@ -409,11 +415,6 @@ export async function runPageLoadBenchmark(
 
   // Discard the first WARMUP_RUNS browser-load sessions before computing stats.
   // Each session contributes exactly pageLoads metric objects to runResults.
-  if (browserLoads <= WARMUP_RUNS) {
-    throw new Error(
-      `browserLoads (${browserLoads}) must be greater than WARMUP_RUNS (${WARMUP_RUNS})`,
-    );
-  }
   const warmupSize = WARMUP_RUNS * pageLoads;
   const measuredResults = runResults.slice(warmupSize);
   // Web vitals entries are sparse (collection can fail silently), so filter by

--- a/test/e2e/benchmarks/utils/runner.ts
+++ b/test/e2e/benchmarks/utils/runner.ts
@@ -482,7 +482,7 @@ export async function runPageLoadBenchmark(
     p75,
     p95,
     trimmedCount: trimmedCounts,
-    outliers: trimmedCounts,
+    outliers: { ...trimmedCounts },
     ...(webVitals && { webVitals }),
   };
 }

--- a/test/e2e/benchmarks/utils/runner.ts
+++ b/test/e2e/benchmarks/utils/runner.ts
@@ -17,6 +17,7 @@ import {
   ALL_METRICS,
   DEFAULT_NUM_BROWSER_LOADS,
   DEFAULT_NUM_PAGE_LOADS,
+  WARMUP_RUNS,
 } from './constants';
 import {
   aggregateWebVitals,
@@ -27,6 +28,7 @@ import {
   calcStdDevResult,
   calculateTimerStatistics,
   checkExclusionRate,
+  detectOutliersIQR,
   MAX_EXCLUSION_RATE,
   MAX_TOTAL_DURATION_MS,
   validateThresholds,
@@ -264,6 +266,7 @@ export function convertTimerStatisticsToBenchmarkResults(
   const stdDev: StatisticalResult = {};
   const p75: StatisticalResult = {};
   const p95: StatisticalResult = {};
+  const trimmedCount: StatisticalResult = {};
 
   // timers already includes promoted web vitals from runBenchmarkWithIterations
   for (const timer of timers) {
@@ -273,7 +276,12 @@ export function convertTimerStatisticsToBenchmarkResults(
     stdDev[timer.id] = timer.stdDev;
     p75[timer.id] = timer.p75;
     p95[timer.id] = timer.p95;
+    if (timer.trimmedCount !== undefined) {
+      trimmedCount[timer.id] = timer.trimmedCount;
+    }
   }
+
+  const hasTrimmedCounts = Object.keys(trimmedCount).length > 0;
 
   return {
     testTitle,
@@ -287,6 +295,7 @@ export function convertTimerStatisticsToBenchmarkResults(
     stdDev,
     p75,
     p95,
+    ...(hasTrimmedCounts && { trimmedCount }),
     ...(webVitals && { webVitals }),
   };
 }
@@ -366,10 +375,16 @@ export async function runPageLoadBenchmark(
     resultPersona = persona;
   }
 
-  if (runResults.some((result) => result.navigation.length > 1)) {
+  // Discard the first WARMUP_RUNS browser-load sessions before computing stats.
+  // Each session contributes exactly pageLoads metric objects to runResults.
+  const warmupSize = WARMUP_RUNS * pageLoads;
+  const measuredResults = runResults.slice(warmupSize);
+  const measuredWebVitalsRuns = allWebVitalsRuns.slice(warmupSize);
+
+  if (measuredResults.some((result) => result.navigation.length > 1)) {
     throw new Error(`Multiple navigations not supported`);
   }
-  const firstNonNavigate = runResults.find(
+  const firstNonNavigate = measuredResults.find(
     (result) => result.navigation[0].type !== 'navigate',
   );
   if (firstNonNavigate !== undefined) {
@@ -379,17 +394,19 @@ export async function runPageLoadBenchmark(
   }
 
   const result: Record<string, number[]> = {};
+  const trimmedCounts: StatisticalResult = {};
   for (const [key, tracePath] of Object.entries(ALL_METRICS)) {
-    result[key] = runResults
-      .map((m) => get(m, tracePath) as number)
-      .sort((a, b) => a - b);
+    const rawSamples = measuredResults.map((m) => get(m, tracePath) as number);
+    const { filtered, outlierCount } = detectOutliersIQR(rawSamples);
+    result[key] = [...filtered].sort((a, b) => a - b);
+    trimmedCounts[key] = outlierCount;
   }
 
   let webVitals: WebVitalsSummary | undefined;
-  if (allWebVitalsRuns.length > 0) {
+  if (measuredWebVitalsRuns.length > 0) {
     webVitals = {
-      runs: allWebVitalsRuns,
-      aggregated: aggregateWebVitals(allWebVitalsRuns),
+      runs: measuredWebVitalsRuns,
+      aggregated: aggregateWebVitals(measuredWebVitalsRuns),
     };
   }
 
@@ -423,6 +440,7 @@ export async function runPageLoadBenchmark(
     stdDev: stdDevResult,
     p75,
     p95,
+    trimmedCount: trimmedCounts,
     ...(webVitals && { webVitals }),
   };
 }

--- a/test/e2e/benchmarks/utils/runner.ts
+++ b/test/e2e/benchmarks/utils/runner.ts
@@ -379,7 +379,11 @@ export async function runPageLoadBenchmark(
   // Each session contributes exactly pageLoads metric objects to runResults.
   const warmupSize = WARMUP_RUNS * pageLoads;
   const measuredResults = runResults.slice(warmupSize);
-  const measuredWebVitalsRuns = allWebVitalsRuns.slice(warmupSize);
+  // Web vitals entries are sparse (collection can fail silently), so filter by
+  // iteration index rather than slicing by position to avoid off-by-N errors.
+  const measuredWebVitalsRuns = allWebVitalsRuns.filter(
+    (wv) => wv.iteration >= warmupSize,
+  );
 
   if (measuredResults.some((result) => result.navigation.length > 1)) {
     throw new Error(`Multiple navigations not supported`);

--- a/test/e2e/benchmarks/utils/runner.ts
+++ b/test/e2e/benchmarks/utils/runner.ts
@@ -267,6 +267,7 @@ export function convertTimerStatisticsToBenchmarkResults(
   const p75: StatisticalResult = {};
   const p95: StatisticalResult = {};
   const trimmedCount: StatisticalResult = {};
+  const outliers: StatisticalResult = {};
 
   // timers already includes promoted web vitals from runBenchmarkWithIterations
   for (const timer of timers) {
@@ -279,9 +280,11 @@ export function convertTimerStatisticsToBenchmarkResults(
     if (timer.trimmedCount !== undefined) {
       trimmedCount[timer.id] = timer.trimmedCount;
     }
+    outliers[timer.id] = timer.outliers;
   }
 
   const hasTrimmedCounts = Object.keys(trimmedCount).length > 0;
+  const hasOutliers = Object.keys(outliers).length > 0;
 
   return {
     testTitle,
@@ -296,6 +299,7 @@ export function convertTimerStatisticsToBenchmarkResults(
     p75,
     p95,
     ...(hasTrimmedCounts && { trimmedCount }),
+    ...(hasOutliers && { outliers }),
     ...(webVitals && { webVitals }),
   };
 }

--- a/test/e2e/benchmarks/utils/runner.ts
+++ b/test/e2e/benchmarks/utils/runner.ts
@@ -330,6 +330,29 @@ export function convertSummaryToResults(
   );
 }
 
+/**
+ * Run the dApp page-load benchmark and aggregate results.
+ *
+ * Uses IQR-only outlier trimming (`trimmedCount`). Z-score is intentionally
+ * excluded for two reasons:
+ *
+ * 1. **Serial correlation** — page loads run serially within each browser
+ *    session (shared JIT cache, extension state). A slow startup elevates all
+ *    `pageLoads` measurements in a session as a correlated cluster. Z-score
+ *    assumes i.i.d. samples and would flag the cluster as outliers even when
+ *    the elevation has a real underlying cause. IQR is rank-based and
+ *    distribution-free, making it robust to correlated samples.
+ *
+ * 2. **Multimodal distributions** — `longTask*`, `tbt`, and `numNetworkReqs`
+ *    are zero or near-zero most runs with occasional real spikes. Z-score would
+ *    flag those spikes as noise, removing genuine signal.
+ *
+ * `calculateTimerStatistics` (iteration-based benchmarks) applies both IQR and
+ * z-score because each run is an independent browser session.
+ *
+ * @param measurePageFn - Function that drives one browser session and returns metrics
+ * @param options - Benchmark configuration
+ */
 export async function runPageLoadBenchmark(
   measurePageFn: (
     pageName: string,

--- a/test/e2e/benchmarks/utils/statistics.ts
+++ b/test/e2e/benchmarks/utils/statistics.ts
@@ -168,7 +168,7 @@ export const detectOutliersZScore = (
   threshold: number = Z_SCORE_THRESHOLD,
 ): { filtered: number[]; outlierCount: number; outliers: number[] } => {
   if (values.length < 3) {
-    return { filtered: values, outlierCount: 0, outliers: [] };
+    return { filtered: [...values], outlierCount: 0, outliers: [] };
   }
 
   const mean = calculateMean(values);

--- a/test/e2e/benchmarks/utils/statistics.ts
+++ b/test/e2e/benchmarks/utils/statistics.ts
@@ -372,7 +372,7 @@ export const calculateTimerStatistics = (
   );
   const iqrResult = detectOutliersIQR(sanityResult.filtered);
   const zScoreResult = detectOutliersZScore(iqrResult.filtered);
-  const filtered = zScoreResult.filtered;
+  const { filtered } = zScoreResult;
   const totalExcluded =
     sanityResult.excludedCount +
     iqrResult.outlierCount +

--- a/test/e2e/benchmarks/utils/statistics.ts
+++ b/test/e2e/benchmarks/utils/statistics.ts
@@ -233,7 +233,9 @@ export function trimOutliers(samples: number[]): {
   trimmedCount: number;
 } {
   const { filtered, outlierCount } = detectOutliersIQR(samples);
-  return { samples: filtered, trimmedCount: outlierCount };
+  // Spread to ensure we never return the original array reference.
+  // detectOutliersIQR returns values directly (not a copy) for n < 4.
+  return { samples: [...filtered], trimmedCount: outlierCount };
 }
 
 /**

--- a/test/e2e/benchmarks/utils/statistics.ts
+++ b/test/e2e/benchmarks/utils/statistics.ts
@@ -197,7 +197,7 @@ export const detectOutliersIQR = (
   values: number[],
 ): { filtered: number[]; outlierCount: number; outliers: number[] } => {
   if (values.length < 4) {
-    return { filtered: values, outlierCount: 0, outliers: [] };
+    return { filtered: [...values], outlierCount: 0, outliers: [] };
   }
 
   const sorted = [...values].sort((a, b) => a - b);
@@ -218,25 +218,6 @@ export const detectOutliersIQR = (
 
   return { filtered, outlierCount: outliers.length, outliers };
 };
-
-/**
- * IQR-based outlier trimming.
- * Returns the filtered samples and the number of values removed.
- * Intended for use before stats computation and before Mann-Whitney U tests.
- *
- * Thin wrapper over {@link detectOutliersIQR} with a stable public interface.
- *
- * @param samples - Raw per-run durations (unsorted)
- */
-export function trimOutliers(samples: number[]): {
-  samples: number[];
-  trimmedCount: number;
-} {
-  const { filtered, outlierCount } = detectOutliersIQR(samples);
-  // Spread to ensure we never return the original array reference.
-  // detectOutliersIQR returns values directly (not a copy) for n < 4.
-  return { samples: [...filtered], trimmedCount: outlierCount };
-}
 
 /**
  * Combined outlier detection using both IQR and z-score methods

--- a/test/e2e/benchmarks/utils/statistics.ts
+++ b/test/e2e/benchmarks/utils/statistics.ts
@@ -220,6 +220,23 @@ export const detectOutliersIQR = (
 };
 
 /**
+ * IQR-based outlier trimming.
+ * Returns the filtered samples and the number of values removed.
+ * Intended for use before stats computation and before Mann-Whitney U tests.
+ *
+ * Thin wrapper over {@link detectOutliersIQR} with a stable public interface.
+ *
+ * @param samples - Raw per-run durations (unsorted)
+ */
+export function trimOutliers(samples: number[]): {
+  samples: number[];
+  trimmedCount: number;
+} {
+  const { filtered, outlierCount } = detectOutliersIQR(samples);
+  return { samples: filtered, trimmedCount: outlierCount };
+}
+
+/**
  * Combined outlier detection using both IQR and z-score methods
  * A value is only kept if it passes both methods
  *
@@ -353,13 +370,17 @@ export const calculateTimerStatistics = (
     maxDuration,
     minDuration,
   );
-  const { filtered, outlierCount } = detectOutliers(sanityResult.filtered);
+  const iqrResult = detectOutliersIQR(sanityResult.filtered);
+  const zScoreResult = detectOutliersZScore(iqrResult.filtered);
+  const filtered = zScoreResult.filtered;
+  const totalExcluded =
+    sanityResult.excludedCount +
+    iqrResult.outlierCount +
+    zScoreResult.outlierCount;
   const sorted = [...filtered].sort((a, b) => a - b);
   const mean = calculateMean(filtered);
   const stdDev = calculateStdDev(filtered);
   const cv = mean > 0 ? (stdDev / mean) * 100 : 0;
-
-  const totalExcluded = sanityResult.excludedCount + outlierCount;
 
   return {
     id: timerId,
@@ -374,6 +395,7 @@ export const calculateTimerStatistics = (
     p99: calculatePercentile(sorted, 99),
     samples: filtered.length,
     outliers: totalExcluded,
+    trimmedCount: iqrResult.outlierCount,
     dataQuality: assessDataQuality(cv),
   };
 };


### PR DESCRIPTION
## **Description**

The [variance audit](https://docs.google.com/document/d/1jnc9GtM7kQaWLiripHkmhFaCJ_Kq8fUcMXSG3F7-nc4/edit?usp=sharing) found 5 metrics with CV 30–50% and 2 borderline at 25–30%. Raw per-run samples contain outliers from cold-start JIT compilation, GC pauses, and CI machine variance. These inflate stdDev and produce false positives across all three verdict layers — not just Layer 3 (Mann-Whitney U), but Layer 1 (absolute thresholds) and Layer 2 (historical baselines) today.

This PR adds sample preparation that benefits every layer downstream:

**IQR-based outlier trimming.** `trimOutliers()` in `statistics.ts` removes values outside `[Q1 − 1.5·IQR, Q3 + 1.5·IQR]` before stats computation. At n=15 independent sessions, this removes 0–3 extreme values. `trimmedCount` is exposed per-metric in `TimerStatistics`, `BenchmarkResults`, and as a Sentry tag for observability.

**Warm-up run exclusion.** The first `WARMUP_RUNS` (default: 1) browser-load sessions are discarded before computing stats. The first cold-start iteration is a known outlier source (JIT compilation, cache priming). Applied before IQR trimming so the trim operates on warm samples only.

**PowerUser iteration rebalance.** `startupPowerUserHome` changes from 10 browser loads × 10 page loads to 15 × 7 (105 total samples, same CI time). For outlier detection and Mann-Whitney U, independent session count matters more than within-session page reloads. Trading 3 page loads per session for 5 additional sessions increases independent n by 50% at negligible CI time cost. After warm-up exclusion: 14 effective sessions × 6 page loads = 84 effective samples.

**Minimum sample gate constant.** `MIN_SAMPLES_FOR_VERDICT = 5` is defined in `constants.ts` and wired into the Mann-Whitney U verdict logic in #41520.

### Expected CV impact

| Metric | Current CV | Projected (trimmed, 15 sessions) |
|---|---|---|
| `startupPowerUser.uiStartup` | 34.3% | ~18–24% |
| `startupPowerUser.load` | 30.5% | ~17–23% |
| `startupPowerUser.loadScripts` | 31.8% | ~17–24% |
| `openAccountMenuToAccountListLoaded` | 36.7% | ~28–32% |
| `solanaAssetDetails.assetClickToPriceChart` | 33.6% | ~26–30% |

Metrics with `tailRatio > 1.3` benefit most from trimming (the top three above).

## **Changelog**

CHANGELOG entry: No user-facing changes. Benchmark infrastructure only (outlier trimming, warm-up exclusion, PowerUser iteration rebalance, trimmedCount Sentry tag).

## **Related issues**

Fixes: MetaMask/MetaMask-planning#7185

Depends on: #40729 (Layer 1+2 comparison CLI)
Related: #41520 (Mann-Whitney U — trimming improves statistical power; wires `MIN_SAMPLES_FOR_VERDICT` into verdict logic)

## **Manual testing steps**

1. Run the IQR trimming unit tests: `yarn jest test/e2e/benchmarks/utils/outlier-trimming.test.ts`
2. Run the full benchmark utils suite: `yarn jest test/e2e/benchmarks/utils/`
3. Verify all cases pass: empty array, n=1, n=2, n=3, identical distribution, single high outlier, single low outlier, both-end outliers, n=15 benchmark scenario (0–3 trimmed), low-variance run (0 trimmed), input-order invariance, no input mutation.

## **Screenshots/Recordings**

N/A — CI tooling change with no visual output.

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes benchmark aggregation and reporting (warm-up run exclusion, IQR outlier trimming, and new derived metrics), which can materially shift quality-gate/Sentry signals even though it’s CI-only.
> 
> **Overview**
> Reduces benchmark variance by **discarding warm-up browser sessions** (`WARMUP_RUNS`) and applying **IQR-based outlier trimming** before computing page-load statistics, with new per-metric `trimmedCount`/`outliers` included in `BenchmarkResults`.
> 
> Rebalances the `startupPowerUserHome` preset to **15 browser loads × 7 page loads** (and defaults power-user runs to the higher session count), and extends Sentry reporting to include derived reliability metrics (`cv`, `dataQuality`, `tailRatio`) plus the new trimming/outlier counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1fc8fed382d4c618460ed8912feecb1eb68632f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->