### PR TITLE
fix: handle missing nonce cases in tx notif and history for 7702 cp-13.29.0

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -4787,6 +4787,14 @@
     "message": "View on $1",
     "description": "Additional content in a notification that appears when a transaction is confirmed and has a block explorer URL."
   },
+  "notificationTransactionWithoutNonceFailedMessage": {
+    "message": "Transaction failed! $1",
+    "description": "Content of the browser notification that appears when a EIP-7702 transaction fails"
+  },
+  "notificationTransactionWithoutNonceSuccessMessage": {
+    "message": "Transaction confirmed!",
+    "description": "Content of the browser notification that appears when a nonce-less transaction is confirmed"
+  },
   "notifications": {
     "message": "Notifications"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -4787,6 +4787,14 @@
     "message": "View on $1",
     "description": "Additional content in a notification that appears when a transaction is confirmed and has a block explorer URL."
   },
+  "notificationTransactionWithoutNonceFailedMessage": {
+    "message": "Transaction failed! $1",
+    "description": "Content of the browser notification that appears when a EIP-7702 transaction fails"
+  },
+  "notificationTransactionWithoutNonceSuccessMessage": {
+    "message": "Transaction confirmed!",
+    "description": "Content of the browser notification that appears when a nonce-less transaction is confirmed"
+  },
   "notifications": {
     "message": "Notifications"
   },

--- a/app/scripts/platforms/extension.js
+++ b/app/scripts/platforms/extension.js
@@ -201,7 +201,9 @@ export default class ExtensionPlatform {
     );
 
     const title = t('notificationTransactionSuccessTitle');
-    let message = t('notificationTransactionSuccessMessage', nonce);
+    let message = Number.isNaN(nonce)
+      ? t('notificationTransactionWithoutNonceSuccessMessage')
+      : t('notificationTransactionSuccessMessage', nonce);
 
     if (url.length) {
       message += ` ${t('notificationTransactionSuccessView', view)}`;
@@ -213,11 +215,10 @@ export default class ExtensionPlatform {
   async _showFailedTransaction(txMeta, errorMessage) {
     const nonce = parseInt(txMeta.txParams.nonce, 16);
     const title = t('notificationTransactionFailedTitle');
-    const message = t(
-      'notificationTransactionFailedMessage',
-      nonce,
-      errorMessage || txMeta.error.message,
-    );
+    const errorMessageText = errorMessage || txMeta.error.message;
+    const message = Number.isNaN(nonce)
+      ? t('notificationTransactionWithoutNonceFailedMessage', errorMessageText)
+      : t('notificationTransactionFailedMessage', nonce, errorMessageText);
     await this._showNotification(title, message);
   }
 

--- a/app/scripts/platforms/extension.test.js
+++ b/app/scripts/platforms/extension.test.js
@@ -1,5 +1,6 @@
 import browser from 'webextension-polyfill';
 import { TransactionStatus } from '@metamask/transaction-controller';
+import { getBlockExplorerLink } from '@metamask/etherscan-link';
 import { t } from '../../../shared/lib/translate';
 import ExtensionPlatform from './extension';
 
@@ -14,7 +15,16 @@ jest.mock('webextension-polyfill', () => {
     },
     notifications: {
       create: jest.fn(),
+      onClicked: {
+        hasListener: jest.fn(),
+      },
     },
+  };
+});
+
+jest.mock('@metamask/etherscan-link', () => {
+  return {
+    getBlockExplorerLink: jest.fn(),
   };
 });
 
@@ -94,6 +104,54 @@ describe('extension platform', () => {
     });
   });
 
+  describe('_showConfirmedTransaction', () => {
+    it('should show confirmed transaction with nonce', async () => {
+      const txMeta = {
+        txParams: { nonce: '0x1' },
+        error: { message: 'Error message' },
+      };
+      browser.notifications.onClicked.hasListener.mockReturnValue(true);
+      getBlockExplorerLink.mockReturnValue('http://explorer-mock');
+
+      const extensionPlatform = new ExtensionPlatform();
+      const showNotificationSpy = jest.spyOn(
+        extensionPlatform,
+        '_showNotification',
+      );
+
+      await extensionPlatform._showConfirmedTransaction(txMeta);
+
+      expect(showNotificationSpy).toHaveBeenCalledWith(
+        'Confirmed transaction',
+        'Transaction 1 confirmed! View on Explorer Mock',
+        'http://explorer-mock',
+      );
+    });
+
+    it('should show confirmed transaction without nonce', async () => {
+      const txMeta = {
+        txParams: { nonce: undefined },
+        error: { message: 'Error message' },
+      };
+      browser.notifications.onClicked.hasListener.mockReturnValue(true);
+      getBlockExplorerLink.mockReturnValue('http://explorer-mock');
+
+      const extensionPlatform = new ExtensionPlatform();
+      const showNotificationSpy = jest.spyOn(
+        extensionPlatform,
+        '_showNotification',
+      );
+
+      await extensionPlatform._showConfirmedTransaction(txMeta);
+
+      expect(showNotificationSpy).toHaveBeenCalledWith(
+        'Confirmed transaction',
+        'Transaction confirmed! View on Explorer Mock',
+        'http://explorer-mock',
+      );
+    });
+  });
+
   describe('_showFailedTransaction', () => {
     it('should show failed transaction with nonce', async () => {
       const txMeta = {
@@ -114,7 +172,26 @@ describe('extension platform', () => {
       );
     });
 
-    it('should show failed transaction with errorMessage', async () => {
+    it('should show failed transaction without nonce', async () => {
+      const txMeta = {
+        txParams: { nonce: undefined },
+        error: { message: 'Error message' },
+      };
+      const extensionPlatform = new ExtensionPlatform();
+      const showNotificationSpy = jest.spyOn(
+        extensionPlatform,
+        '_showNotification',
+      );
+
+      await extensionPlatform._showFailedTransaction(txMeta);
+
+      expect(showNotificationSpy).toHaveBeenCalledWith(
+        'Failed transaction',
+        `Transaction failed! ${txMeta.error.message}`,
+      );
+    });
+
+    it('should show failed transaction with nonce and with errorMessage', async () => {
       const errorMessage = 'Test error message';
       const txMeta = {
         txParams: { nonce: '0x1' },
@@ -131,6 +208,26 @@ describe('extension platform', () => {
       expect(showNotificationSpy).toHaveBeenCalledWith(
         'Failed transaction',
         `Transaction 1 failed! ${errorMessage}`,
+      );
+    });
+
+    it('should show failed transaction without nonce and with errorMessage', async () => {
+      const errorMessage = 'Test error message';
+      const txMeta = {
+        txParams: { nonce: undefined },
+        error: { message: 'Error message' },
+      };
+      const extensionPlatform = new ExtensionPlatform();
+      const showNotificationSpy = jest.spyOn(
+        extensionPlatform,
+        '_showNotification',
+      );
+
+      await extensionPlatform._showFailedTransaction(txMeta, errorMessage);
+
+      expect(showNotificationSpy).toHaveBeenCalledWith(
+        'Failed transaction',
+        `Transaction failed! ${errorMessage}`,
       );
     });
   });

--- a/ui/components/app/transaction-breakdown/transaction-breakdown.component.js
+++ b/ui/components/app/transaction-breakdown/transaction-breakdown.component.js
@@ -72,14 +72,14 @@ export default class TransactionBreakdown extends PureComponent {
     return (
       <div className={classnames('transaction-breakdown', className)}>
         <div className="transaction-breakdown__title">{t('transaction')}</div>
-        <TransactionBreakdownRow divider title={t('nonce')}>
-          {typeof nonce === 'undefined' ? null : (
+        {nonce !== undefined && (
+          <TransactionBreakdownRow divider title={t('nonce')}>
             <HexToDecimal
               className="transaction-breakdown__value"
               value={nonce}
             />
-          )}
-        </TransactionBreakdownRow>
+          </TransactionBreakdownRow>
+        )}
         {sourceAmountFormatted && (
           <TransactionBreakdownRow title={t('amountSent')}>
             <span

--- a/ui/components/app/transaction-breakdown/transaction-breakdown.test.js
+++ b/ui/components/app/transaction-breakdown/transaction-breakdown.test.js
@@ -60,6 +60,34 @@ describe('TransactionBreakdown', () => {
     });
   });
 
+  describe('with a typical transaction without nonce', () => {
+    it('renders properly', () => {
+      const { getAllByTestId } = renderWithProvider(
+        <TransactionBreakdown
+          transaction={{
+            txParams: {
+              gas: '0xb72a', // 46,890
+              gasPrice: '0x930c19db', // 2,467,043,803
+              value: '0x2386f26fc10000', // 10,000,000,000,000,000
+            },
+          }}
+          primaryCurrency="-0.01 ETH"
+        />,
+        store,
+      );
+
+      expect(
+        getActualDataFrom(getAllByTestId('transaction-breakdown-row')),
+      ).toStrictEqual([
+        // No nonce visible
+        ['Amount', '-0.01 ETH'],
+        ['Gas limit (units)', '46890'],
+        ['Gas price', '2.467043803'],
+        ['Total', '0.01011568ETH'],
+      ]);
+    });
+  });
+
   describe('with a typical EIP-1559 transaction', () => {
     it('renders properly', () => {
       const { getAllByTestId } = renderWithProvider(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

On Tempo - but also for all transactions using EIP-7702 on other chains - no nonce is stored in the transaction metadata, causing UI glitches in various places:
- Transaction confirmation notification showing "Transaction NaN Confirmed!"
- Empty "nonce" section in the tx activity modal.

This PR solves both of those issues, for Tempo and other chains leveraging EIP-7702 (gasless).

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: remove the `nonce` line from tx activity popin when nonce is missing.
CHANGELOG entry: remove the nonce from tx success/failure messages when nonce is missing.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/NEB-928?atlOrigin=eyJpIjoiOTIxMjA2ZDUzMjQwNGY1ZWJmNDRlNjJmNmQ0NGU3MjIiLCJwIjoiaiJ9

## **Manual testing steps**

0. Make sure notifications are enabled for when a tx is confirmed.
1. You can perform any tx from Extension on Tempo (as long as you don't use a Hardware Wallet) to generate an activity in the Activity tab. 
2. Observe "Transaction Confirmed" notification (vs. "Transaction NaN confirmed" before)
3. Click on the successful tx on Activity tab
4. Observe absence of any nonce line (vs. empty "nonce" field before).

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

<img width="300"  alt="image" src="https://github.com/user-attachments/assets/ee506276-61ce-49ce-b681-9d7c74cc47b2" />

<img width="300" alt="image" src="https://github.com/user-attachments/assets/6548a27b-a9a6-4c89-a67f-229d205224a4" />


### **After**

<!-- [screenshots/recordings] -->

<img width="300" alt="image" src="https://github.com/user-attachments/assets/b17ace1f-af51-450e-9a2e-dffe1c9aa771" />

<img width="300" alt="image" src="https://github.com/user-attachments/assets/0c69aba9-e656-48a7-9fa2-8c5e6b85cf8e" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only adjust user-facing notification/transaction breakdown messaging when `nonce` is missing, with added test coverage and no impact to signing, state, or network logic.
> 
> **Overview**
> Prevents `NaN`/empty nonce display for nonce-less (e.g. EIP-7702) transactions.
> 
> Extension transaction success/failure notifications now switch to new i18n strings when `txParams.nonce` is absent, and the transaction breakdown UI hides the nonce row entirely in that case. Tests were expanded to cover both nonce-present and nonce-missing scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 230a9e51e07b18681bb352a1d147ea0a5bc0d806. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->