### PR TITLE
test(webpack): fix watch build_id test flake

### DIFF
--- a/development/webpack/test/webpack.config.test.ts
+++ b/development/webpack/test/webpack.config.test.ts
@@ -27,9 +27,7 @@ function getWebpackInstance(config: Configuration) {
 
 async function withWatching<T>(
   config: Configuration,
-  callback: (
-    waitForBuild: (trigger?: () => void) => Promise<void>,
-  ) => Promise<T>,
+  callback: (watch: (trigger?: () => void) => Promise<void>) => Promise<T>,
 ) {
   const compiler = webpack(config);
   // @ts-expect-error - Node types need to be updated.
@@ -54,19 +52,16 @@ async function withWatching<T>(
   assert(watchHandle, 'Webpack did not return a watch handle.');
   const watching = watchHandle;
 
-  const waitForBuild = (trigger?: () => void) => {
-    if (!trigger) {
-      return build.promise;
-    }
+  const watch = (trigger: () => void = () => watching.invalidate()) => {
     // @ts-expect-error - Node types need to be updated.
     build = Promise.withResolvers<void>();
     trigger();
-    watching.invalidate();
     return build.promise;
   };
 
   try {
-    return await callback(waitForBuild);
+    await build.promise;
+    return await callback(watch);
   } finally {
     await new Promise<void>((resolveClose, rejectClose) =>
       watching.close((error) => (error ? rejectClose(error) : resolveClose())),
@@ -335,7 +330,7 @@ ${Object.entries(env)
     assert.strictEqual(manifestPlugin.options.setBuildId, true);
   });
 
-  it('keeps build_id stable for no-op watch rebuilds and changes it for real edits', async () => {
+  it('keeps build_id stable for same-content file saves and changes it for real edits', async () => {
     using tempDirectory = fs.mkdtempDisposableSync(
       join(tmpdir(), 'manifest-plugin-watch-test-'),
     );
@@ -378,15 +373,20 @@ ${Object.entries(env)
           }),
         ],
       },
-      async (waitForBuild) => {
-        await waitForBuild();
+      async (rebuild) => {
         const firstBuildId = readBuildId();
         assert.ok(firstBuildId, 'expected initial build_id');
 
-        await waitForBuild(() => writeSource(fs.readFileSync(sourceFilePath)));
+        await rebuild(() =>
+          // Resave the watched source without changing its contents.
+          writeSource(fs.readFileSync(sourceFilePath)),
+        );
         const secondBuildId = readBuildId();
 
-        await waitForBuild(() => writeSource('console.log("v2");\n'));
+        await rebuild(() =>
+          // Change the watched source contents to trigger a real edit rebuild.
+          writeSource('console.log("v2");\n'),
+        );
         const thirdBuildId = readBuildId();
 
         assert.strictEqual(


### PR DESCRIPTION
## **Description**

The webpack watch test helper previously combined watched-file writes with `watching.invalidate()`. That let an invalidate-only rebuild resolve before webpack attached the real file change to the next compilation, which made the `build_id` assertion flaky in CI.

This change updates the helper to wait for one rebuild source at a time while preserving the same-content resave case, so the test still verifies that saving a watched file without changing its contents keeps the build_id stable while real edits change it.



## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Run `yarn lint:changed:fix`
2. Run `yarn tsx --test development/webpack/test/webpack.config.test.ts`

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[skip-e2e]
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to a webpack config test helper and a single watch-mode assertion, with no production code paths affected.
> 
> **Overview**
> Makes the `withWatching` test helper wait for the initial watch compilation to finish and replaces `waitForBuild` with a `watch`/`rebuild` function that resets the pending build promise and triggers exactly one rebuild (defaulting to `watching.invalidate()`).
> 
> Updates the `build_id` watch test to use this new helper, explicitly separating a *same-content resave* rebuild from a *real content change* rebuild, and renames the test to match the behavior being validated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6520d8a507016e52e545cf6d85c52c740ad4df4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->