### PR TITLE
chore: TPSL classification

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -6013,6 +6013,9 @@
   "perpsTrades": {
     "message": "Trades"
   },
+  "perpsTriggerPrice": {
+    "message": "Trigger price"
+  },
   "perpsTutorialChooseLeverageDescription": {
     "message": "Leverage amplifies both gains and losses. With 40x leverage, a 1% price move equals a 40% gain or loss on your margin."
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -6013,6 +6013,9 @@
   "perpsTrades": {
     "message": "Trades"
   },
+  "perpsTriggerPrice": {
+    "message": "Trigger price"
+  },
   "perpsTutorialChooseLeverageDescription": {
     "message": "Leverage amplifies both gains and losses. With 40x leverage, a 1% price move equals a 40% gain or loss on your margin."
   },

--- a/ui/components/app/perps/order-card/order-card.test.tsx
+++ b/ui/components/app/perps/order-card/order-card.test.tsx
@@ -113,6 +113,43 @@ describe('OrderCard', () => {
       ).toBeInTheDocument();
     });
 
+    it('shows market symbol only after size for TP/SL, not before the label', () => {
+      const order = createMockOrder({
+        side: 'sell',
+        orderType: 'limit',
+        symbol: 'ETH',
+        size: '1.5',
+        isTrigger: true,
+        reduceOnly: true,
+        detailedOrderType: 'Take Profit Limit',
+        triggerPrice: '3200',
+        price: '3200',
+      });
+      renderWithProvider(<OrderCard order={order} />, mockStore);
+
+      expect(
+        screen.getByText('Take profit limit close long'),
+      ).toBeInTheDocument();
+      expect(screen.getByText('1.5 ETH')).toBeInTheDocument();
+      expect(screen.queryByText(/^ETH$/u)).not.toBeInTheDocument();
+    });
+
+    it('shows "Trigger price" subtitle for TP/SL orders', () => {
+      const order = createMockOrder({
+        side: 'sell',
+        isTrigger: true,
+        reduceOnly: true,
+        detailedOrderType: 'Take Profit Limit',
+        triggerPrice: '3200',
+        price: '3200',
+      });
+      renderWithProvider(<OrderCard order={order} />, mockStore);
+
+      expect(
+        screen.getByText(messages.perpsTriggerPrice.message),
+      ).toBeInTheDocument();
+    });
+
     it('displays "Stop market close short" for a SL trigger (buy side)', () => {
       const order = createMockOrder({
         side: 'buy',

--- a/ui/components/app/perps/order-card/order-card.test.tsx
+++ b/ui/components/app/perps/order-card/order-card.test.tsx
@@ -50,25 +50,81 @@ describe('OrderCard', () => {
     expect(screen.getByText('TSLA')).toBeInTheDocument();
   });
 
-  it('displays Long for buy side order', () => {
-    const order = createMockOrder({ side: 'buy' });
-    renderWithProvider(<OrderCard order={order} />, mockStore);
+  describe('order label (formatOrderLabel)', () => {
+    it('displays "Limit long" for a plain buy limit order', () => {
+      const order = createMockOrder({ side: 'buy', orderType: 'limit' });
+      renderWithProvider(<OrderCard order={order} />, mockStore);
 
-    expect(screen.getByText(messages.perpsLong.message)).toBeInTheDocument();
-  });
+      expect(screen.getByText('Limit long')).toBeInTheDocument();
+    });
 
-  it('displays Short for sell side order', () => {
-    const order = createMockOrder({ side: 'sell' });
-    renderWithProvider(<OrderCard order={order} />, mockStore);
+    it('displays "Limit short" for a plain sell limit order', () => {
+      const order = createMockOrder({ side: 'sell', orderType: 'limit' });
+      renderWithProvider(<OrderCard order={order} />, mockStore);
 
-    expect(screen.getByText(messages.perpsShort.message)).toBeInTheDocument();
-  });
+      expect(screen.getByText('Limit short')).toBeInTheDocument();
+    });
 
-  it('displays the order type', () => {
-    const order = createMockOrder({ orderType: 'limit' });
-    renderWithProvider(<OrderCard order={order} />, mockStore);
+    it('displays "Market long" for a plain buy market order', () => {
+      const order = createMockOrder({
+        side: 'buy',
+        orderType: 'market',
+        price: '0',
+      });
+      renderWithProvider(<OrderCard order={order} />, mockStore);
 
-    expect(screen.getByText(messages.perpsLimit.message)).toBeInTheDocument();
+      expect(screen.getByText('Market long')).toBeInTheDocument();
+    });
+
+    it('displays "Limit close long" for a reduce-only sell limit order', () => {
+      const order = createMockOrder({
+        side: 'sell',
+        orderType: 'limit',
+        reduceOnly: true,
+      });
+      renderWithProvider(<OrderCard order={order} />, mockStore);
+
+      expect(screen.getByText('Limit close long')).toBeInTheDocument();
+    });
+
+    it('displays "Limit close short" for a reduce-only buy limit order', () => {
+      const order = createMockOrder({
+        side: 'buy',
+        orderType: 'limit',
+        reduceOnly: true,
+      });
+      renderWithProvider(<OrderCard order={order} />, mockStore);
+
+      expect(screen.getByText('Limit close short')).toBeInTheDocument();
+    });
+
+    it('displays "Take profit limit close long" for a TP trigger (sell side)', () => {
+      const order = createMockOrder({
+        side: 'sell',
+        orderType: 'limit',
+        isTrigger: true,
+        reduceOnly: true,
+        detailedOrderType: 'Take Profit Limit',
+      });
+      renderWithProvider(<OrderCard order={order} />, mockStore);
+
+      expect(
+        screen.getByText('Take profit limit close long'),
+      ).toBeInTheDocument();
+    });
+
+    it('displays "Stop market close short" for a SL trigger (buy side)', () => {
+      const order = createMockOrder({
+        side: 'buy',
+        orderType: 'market',
+        isTrigger: true,
+        reduceOnly: true,
+        detailedOrderType: 'Stop Market',
+      });
+      renderWithProvider(<OrderCard order={order} />, mockStore);
+
+      expect(screen.getByText('Stop market close short')).toBeInTheDocument();
+    });
   });
 
   it('displays the order size with symbol', () => {
@@ -98,9 +154,7 @@ describe('OrderCard', () => {
     });
     renderWithProvider(<OrderCard order={order} />, mockStore);
 
-    // "Market" appears in both the value slot and the order type slot
-    const marketElements = screen.getAllByText(messages.perpsMarket.message);
-    expect(marketElements.length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText(messages.perpsMarket.message)).toBeInTheDocument();
   });
 
   it('renders the token logo', () => {

--- a/ui/components/app/perps/order-card/order-card.test.tsx
+++ b/ui/components/app/perps/order-card/order-card.test.tsx
@@ -146,6 +146,23 @@ describe('OrderCard', () => {
     expect(screen.getByText('$3,500.00')).toBeInTheDocument();
   });
 
+  it('displays TP/SL trigger price, not size × price notional', () => {
+    const order = createMockOrder({
+      orderType: 'limit',
+      side: 'sell',
+      isTrigger: true,
+      reduceOnly: true,
+      detailedOrderType: 'Take Profit Limit',
+      triggerPrice: '3200.00',
+      price: '3200.00',
+      size: '2.0',
+    });
+    renderWithProvider(<OrderCard order={order} />, mockStore);
+
+    expect(screen.getByText('$3,200.00')).toBeInTheDocument();
+    expect(screen.queryByText('$6,400.00')).not.toBeInTheDocument();
+  });
+
   it('displays Market label when order value is zero', () => {
     const order = createMockOrder({
       orderType: 'market',

--- a/ui/components/app/perps/order-card/order-card.tsx
+++ b/ui/components/app/perps/order-card/order-card.tsx
@@ -28,7 +28,8 @@ export type OrderCardProps = {
 
 /**
  * OrderCard component displays individual order information
- * Two rows: symbol + order label on left, USD value on right
+ * Two rows on the left: symbol + order label (TP/SL: label only; symbol follows size below),
+ * trigger or notional value on the right
  *
  * @param options0 - Component props
  * @param options0.order - The order data to display
@@ -44,6 +45,8 @@ export const OrderCard: React.FC<OrderCardProps> = ({
   const t = useI18nContext();
   const { formatCurrencyWithMinThreshold } = useFormatters();
   const displayName = getDisplayName(order.symbol);
+  const isTriggerBasedOrder =
+    order.isTrigger === true || order.isPositionTpsl === true;
 
   const handleClick = useCallback(() => {
     if (onClick) {
@@ -58,9 +61,6 @@ export const OrderCard: React.FC<OrderCardProps> = ({
 
   // Limit/market: notional (size × limit price). TP/SL: trigger level (take-profit / stop-loss price).
   const orderValueUsd = useMemo(() => {
-    const isTriggerBasedOrder =
-      order.isTrigger === true || order.isPositionTpsl === true;
-
     if (isTriggerBasedOrder) {
       const triggerLevel =
         parseFloat(order.triggerPrice || order.price || '0') || 0;
@@ -76,15 +76,17 @@ export const OrderCard: React.FC<OrderCardProps> = ({
     }
     return null;
   }, [
-    order.isTrigger,
-    order.isPositionTpsl,
+    isTriggerBasedOrder,
     order.triggerPrice,
     order.size,
     order.price,
     formatCurrencyWithMinThreshold,
   ]);
 
-  const baseStyles = 'cursor-pointer pt-2 pb-2 px-4 h-[62px]';
+  const baseStyles = 'cursor-pointer pt-2 pb-2 px-4';
+  // Non-trigger rows keep the fixed 62 px height to match the position/token tabs.
+  // Trigger-based (TP/SL) rows grow with content; min-h keeps the floor at 62 px.
+  const heightStyle = isTriggerBasedOrder ? 'h-auto min-h-[62px]' : 'h-[62px]';
   const variantStyles =
     variant === 'muted'
       ? 'bg-muted hover:bg-muted-hover active:bg-muted-pressed'
@@ -95,9 +97,11 @@ export const OrderCard: React.FC<OrderCardProps> = ({
       className={twMerge(
         // Reset ButtonBase defaults for card layout
         'justify-start rounded-none min-w-0',
-        // Card styles (matches tokens tab: 62px height, 8px v-padding, 16px h-padding, 16px gap)
-        'gap-4 text-left',
+        // items-center keeps each column's content block centered in the card height,
+        // whether the label fits on one line or wraps to two.
+        'gap-4 text-left items-center',
         baseStyles,
+        heightStyle,
         variantStyles,
       )}
       isFullWidth
@@ -118,16 +122,25 @@ export const OrderCard: React.FC<OrderCardProps> = ({
         alignItems={BoxAlignItems.Start}
         gap={1}
       >
-        <Box
-          flexDirection={BoxFlexDirection.Row}
-          alignItems={BoxAlignItems.Center}
-          gap={1}
-        >
-          <Text fontWeight={FontWeight.Medium}>{displayName}</Text>
-          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
-            {formatOrderLabel(order)}
-          </Text>
-        </Box>
+        {isTriggerBasedOrder ? (
+          // TP/SL: render label directly in the column so it wraps freely.
+          // The symbol is redundant here — it appears after the size below.
+          <Text fontWeight={FontWeight.Medium}>{formatOrderLabel(order)}</Text>
+        ) : (
+          <Box
+            flexDirection={BoxFlexDirection.Row}
+            alignItems={BoxAlignItems.Center}
+            gap={1}
+          >
+            <Text fontWeight={FontWeight.Medium}>{displayName}</Text>
+            <Text
+              variant={TextVariant.BodySm}
+              color={TextColor.TextAlternative}
+            >
+              {formatOrderLabel(order)}
+            </Text>
+          </Box>
+        )}
         <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
           {order.size} {displayName}
         </Text>
@@ -143,6 +156,11 @@ export const OrderCard: React.FC<OrderCardProps> = ({
         <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
           {orderValueUsd ?? t('perpsMarket')}
         </Text>
+        {isTriggerBasedOrder && orderValueUsd && (
+          <Text variant={TextVariant.BodyXs} color={TextColor.TextAlternative}>
+            {t('perpsTriggerPrice')}
+          </Text>
+        )}
       </Box>
     </ButtonBase>
   );

--- a/ui/components/app/perps/order-card/order-card.tsx
+++ b/ui/components/app/perps/order-card/order-card.tsx
@@ -15,7 +15,8 @@ import { useNavigate } from 'react-router-dom';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { useFormatters } from '../../../../hooks/useFormatters';
 import { PerpsTokenLogo } from '../perps-token-logo';
-import { formatOrderType, getDisplayName } from '../utils';
+import { getDisplayName } from '../utils';
+import { formatOrderLabel } from '../utils/orderUtils';
 import type { Order } from '../types';
 import { PERPS_MARKET_DETAIL_ROUTE } from '../../../../helpers/constants/routes';
 
@@ -27,7 +28,7 @@ export type OrderCardProps = {
 
 /**
  * OrderCard component displays individual order information
- * Two rows: symbol/type/side + size on left, USD value + limit price on right
+ * Two rows: symbol + order label on left, USD value on right
  *
  * @param options0 - Component props
  * @param options0.order - The order data to display
@@ -42,7 +43,6 @@ export const OrderCard: React.FC<OrderCardProps> = ({
   const navigate = useNavigate();
   const t = useI18nContext();
   const { formatCurrencyWithMinThreshold } = useFormatters();
-  const isBuy = order.side === 'buy';
   const displayName = getDisplayName(order.symbol);
 
   const handleClick = useCallback(() => {
@@ -107,7 +107,7 @@ export const OrderCard: React.FC<OrderCardProps> = ({
         >
           <Text fontWeight={FontWeight.Medium}>{displayName}</Text>
           <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
-            {isBuy ? t('perpsLong') : t('perpsShort')}
+            {formatOrderLabel(order)}
           </Text>
         </Box>
         <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
@@ -115,7 +115,7 @@ export const OrderCard: React.FC<OrderCardProps> = ({
         </Text>
       </Box>
 
-      {/* Right side: USD value + limit price */}
+      {/* Right side: USD value */}
       <Box
         className="shrink-0"
         flexDirection={BoxFlexDirection.Column}
@@ -124,9 +124,6 @@ export const OrderCard: React.FC<OrderCardProps> = ({
       >
         <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
           {orderValueUsd ?? t('perpsMarket')}
-        </Text>
-        <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
-          {formatOrderType(order.orderType)}
         </Text>
       </Box>
     </ButtonBase>

--- a/ui/components/app/perps/order-card/order-card.tsx
+++ b/ui/components/app/perps/order-card/order-card.tsx
@@ -56,15 +56,33 @@ export const OrderCard: React.FC<OrderCardProps> = ({
     }
   }, [navigate, order, onClick]);
 
-  // Calculate order value in USD (size * price), formatted like position values
+  // Limit/market: notional (size × limit price). TP/SL: trigger level (take-profit / stop-loss price).
   const orderValueUsd = useMemo(() => {
+    const isTriggerBasedOrder =
+      order.isTrigger === true || order.isPositionTpsl === true;
+
+    if (isTriggerBasedOrder) {
+      const triggerLevel =
+        parseFloat(order.triggerPrice || order.price || '0') || 0;
+      if (triggerLevel > 0) {
+        return formatCurrencyWithMinThreshold(triggerLevel, 'USD');
+      }
+    }
+
     const size = parseFloat(order.size) || 0;
     const price = parseFloat(order.price) || 0;
     if (size > 0 && price > 0) {
       return formatCurrencyWithMinThreshold(size * price, 'USD');
     }
     return null;
-  }, [order.size, order.price, formatCurrencyWithMinThreshold]);
+  }, [
+    order.isTrigger,
+    order.isPositionTpsl,
+    order.triggerPrice,
+    order.size,
+    order.price,
+    formatCurrencyWithMinThreshold,
+  ]);
 
   const baseStyles = 'cursor-pointer pt-2 pb-2 px-4 h-[62px]';
   const variantStyles =

--- a/ui/components/app/perps/perps-view.test.tsx
+++ b/ui/components/app/perps/perps-view.test.tsx
@@ -177,33 +177,13 @@ describe('PerpsView', () => {
       expect(screen.getByTestId('order-card-order-001')).toBeInTheDocument();
     });
 
-    it('renders TP/SL trigger orders in Open orders', () => {
-      jest.mocked(streamHooks.usePerpsLiveOrders).mockReturnValueOnce({
-        orders: [
-          {
-            orderId: 'tp-only-1',
-            symbol: 'ARB',
-            side: 'sell',
-            orderType: 'limit',
-            size: '500.0',
-            originalSize: '500.0',
-            price: '1.15',
-            filledSize: '0',
-            remainingSize: '500.0',
-            status: 'open',
-            timestamp: Date.now(),
-            isTrigger: true,
-            triggerPrice: '1.15',
-            detailedOrderType: 'Take Profit Limit',
-            reduceOnly: true,
-          },
-        ],
-        isInitialLoading: false,
-      });
-
+    it('filters TP/SL trigger orders from Open orders on the Perps tab', () => {
       renderWithProvider(<PerpsView />, mockStore);
 
-      expect(screen.getByTestId('order-card-tp-only-1')).toBeInTheDocument();
+      expect(screen.getByTestId('order-card-order-001')).toBeInTheDocument();
+      expect(
+        screen.queryByTestId('order-card-order-004'),
+      ).not.toBeInTheDocument();
     });
 
     it('displays position section header', () => {

--- a/ui/components/app/perps/perps-view.test.tsx
+++ b/ui/components/app/perps/perps-view.test.tsx
@@ -177,6 +177,35 @@ describe('PerpsView', () => {
       expect(screen.getByTestId('order-card-order-001')).toBeInTheDocument();
     });
 
+    it('renders TP/SL trigger orders in Open orders', () => {
+      jest.mocked(streamHooks.usePerpsLiveOrders).mockReturnValueOnce({
+        orders: [
+          {
+            orderId: 'tp-only-1',
+            symbol: 'ARB',
+            side: 'sell',
+            orderType: 'limit',
+            size: '500.0',
+            originalSize: '500.0',
+            price: '1.15',
+            filledSize: '0',
+            remainingSize: '500.0',
+            status: 'open',
+            timestamp: Date.now(),
+            isTrigger: true,
+            triggerPrice: '1.15',
+            detailedOrderType: 'Take Profit Limit',
+            reduceOnly: true,
+          },
+        ],
+        isInitialLoading: false,
+      });
+
+      renderWithProvider(<PerpsView />, mockStore);
+
+      expect(screen.getByTestId('order-card-tp-only-1')).toBeInTheDocument();
+    });
+
     it('displays position section header', () => {
       renderWithProvider(<PerpsView />, mockStore);
 

--- a/ui/components/app/perps/perps-view.tsx
+++ b/ui/components/app/perps/perps-view.tsx
@@ -93,8 +93,8 @@ export const PerpsView: React.FC = () => {
   } = usePerpsTransactionHistory();
 
   // Recent Activity shows only trade executions, deposits, and withdrawals.
-  // Open orders are already surfaced in PerpsPositionsOrders above.
-  // Funding payments belong in the full activity page.
+  // Open orders (including TP/SL triggers) are listed in PerpsPositionsOrders above.
+  // Funding payments belong on the full activity page.
   const recentActivityTransactions = useMemo(
     () =>
       allRecentActivityTransactions.filter(
@@ -106,14 +106,12 @@ export const PerpsView: React.FC = () => {
     [allRecentActivityTransactions],
   );
 
-  // Show only user-placed limit orders resting on the orderbook.
-  // Excludes:
-  // - isTrigger: TP/SL trigger orders
-  // - isSynthetic: synthetic/virtual orders not placed directly by the user
+  // Open orders for this account: resting limits and TP/SL trigger orders.
+  // Excludes isSynthetic display-only rows (those are derived for market detail UI).
   const orders = useMemo(() => {
     return allOrders.filter(
       (order) =>
-        order.status === 'open' && !order.isTrigger && !order.isSynthetic,
+        order.status === 'open' && !order.isSynthetic,
     );
   }, [allOrders]);
 

--- a/ui/components/app/perps/perps-view.tsx
+++ b/ui/components/app/perps/perps-view.tsx
@@ -93,7 +93,8 @@ export const PerpsView: React.FC = () => {
   } = usePerpsTransactionHistory();
 
   // Recent Activity shows only trade executions, deposits, and withdrawals.
-  // Open orders (including TP/SL triggers) are listed in PerpsPositionsOrders above.
+  // Open limit/market orders (excluding TP/SL triggers) are in PerpsPositionsOrders;
+  // TP/SL trigger rows are listed on the per-asset market detail page only.
   // Funding payments belong on the full activity page.
   const recentActivityTransactions = useMemo(
     () =>
@@ -106,12 +107,15 @@ export const PerpsView: React.FC = () => {
     [allRecentActivityTransactions],
   );
 
-  // Open orders for this account: resting limits and TP/SL trigger orders.
-  // Excludes isSynthetic display-only rows (those are derived for market detail UI).
+  // Open orders on the Perps tab: user-placed limits/markets on the book only.
+  // Excludes TP/SL (isTrigger / isPositionTpsl — those list on market detail) and synthetics.
   const orders = useMemo(() => {
     return allOrders.filter(
       (order) =>
-        order.status === 'open' && !order.isSynthetic,
+        order.status === 'open' &&
+        !order.isTrigger &&
+        order.isPositionTpsl !== true &&
+        !order.isSynthetic,
     );
   }, [allOrders]);
 

--- a/ui/components/app/perps/utils/index.ts
+++ b/ui/components/app/perps/utils/index.ts
@@ -21,6 +21,7 @@ export {
   shouldDisplayOrderInMarketDetailsOrders,
   buildDisplayOrdersWithSyntheticTpsl,
   isOrderAssociatedWithFullPosition,
+  formatOrderLabel,
 } from './orderUtils';
 
 export { formatPerpsPrice, type PerpsPriceRange } from './formatPerpsPrice';

--- a/ui/components/app/perps/utils/orderUtils.test.ts
+++ b/ui/components/app/perps/utils/orderUtils.test.ts
@@ -4,6 +4,7 @@ import {
   shouldDisplayOrderInMarketDetailsOrders,
   buildDisplayOrdersWithSyntheticTpsl,
   normalizeMarketDetailsOrders,
+  formatOrderLabel,
 } from './orderUtils';
 
 const makeOrder = (overrides: Partial<Order> = {}): Order => ({
@@ -328,6 +329,118 @@ describe('orderUtils', () => {
         orders: [limitOrder],
       });
       expect(result).toHaveLength(3);
+    });
+  });
+
+  describe('formatOrderLabel', () => {
+    it('returns "Limit long" for a plain buy limit order', () => {
+      const order = makeOrder({ side: 'buy', orderType: 'limit' });
+      expect(formatOrderLabel(order)).toBe('Limit long');
+    });
+
+    it('returns "Limit short" for a plain sell limit order', () => {
+      const order = makeOrder({ side: 'sell', orderType: 'limit' });
+      expect(formatOrderLabel(order)).toBe('Limit short');
+    });
+
+    it('returns "Market long" for a plain buy market order', () => {
+      const order = makeOrder({ side: 'buy', orderType: 'market' });
+      expect(formatOrderLabel(order)).toBe('Market long');
+    });
+
+    it('returns "Market short" for a plain sell market order', () => {
+      const order = makeOrder({ side: 'sell', orderType: 'market' });
+      expect(formatOrderLabel(order)).toBe('Market short');
+    });
+
+    it('returns "Limit close long" for a reduce-only sell limit order', () => {
+      const order = makeOrder({
+        side: 'sell',
+        orderType: 'limit',
+        reduceOnly: true,
+      });
+      expect(formatOrderLabel(order)).toBe('Limit close long');
+    });
+
+    it('returns "Limit close short" for a reduce-only buy limit order', () => {
+      const order = makeOrder({
+        side: 'buy',
+        orderType: 'limit',
+        reduceOnly: true,
+      });
+      expect(formatOrderLabel(order)).toBe('Limit close short');
+    });
+
+    it('returns "Market close long" for a reduce-only sell market order', () => {
+      const order = makeOrder({
+        side: 'sell',
+        orderType: 'market',
+        reduceOnly: true,
+      });
+      expect(formatOrderLabel(order)).toBe('Market close long');
+    });
+
+    it('returns "Market close short" for a reduce-only buy market order', () => {
+      const order = makeOrder({
+        side: 'buy',
+        orderType: 'market',
+        reduceOnly: true,
+      });
+      expect(formatOrderLabel(order)).toBe('Market close short');
+    });
+
+    it('returns "Take profit limit close long" for a TP trigger (sell)', () => {
+      const order = makeOrder({
+        side: 'sell',
+        orderType: 'limit',
+        isTrigger: true,
+        reduceOnly: true,
+        detailedOrderType: 'Take Profit Limit',
+      });
+      expect(formatOrderLabel(order)).toBe('Take profit limit close long');
+    });
+
+    it('returns "Take profit market close short" for a TP trigger (buy)', () => {
+      const order = makeOrder({
+        side: 'buy',
+        orderType: 'market',
+        isTrigger: true,
+        reduceOnly: true,
+        detailedOrderType: 'Take Profit Market',
+      });
+      expect(formatOrderLabel(order)).toBe('Take profit market close short');
+    });
+
+    it('returns "Stop limit close long" for a SL trigger (sell)', () => {
+      const order = makeOrder({
+        side: 'sell',
+        orderType: 'limit',
+        isTrigger: true,
+        reduceOnly: true,
+        detailedOrderType: 'Stop Limit',
+      });
+      expect(formatOrderLabel(order)).toBe('Stop limit close long');
+    });
+
+    it('returns "Stop market close short" for a SL trigger (buy)', () => {
+      const order = makeOrder({
+        side: 'buy',
+        orderType: 'market',
+        isTrigger: true,
+        reduceOnly: true,
+        detailedOrderType: 'Stop Market',
+      });
+      expect(formatOrderLabel(order)).toBe('Stop market close short');
+    });
+
+    it('treats isTrigger alone as closing (no reduceOnly)', () => {
+      const order = makeOrder({
+        side: 'sell',
+        orderType: 'market',
+        isTrigger: true,
+        detailedOrderType: 'Stop Market',
+      });
+      expect(formatOrderLabel(order)).toBe('Stop market close long');
     });
   });
 });

--- a/ui/components/app/perps/utils/orderUtils.test.ts
+++ b/ui/components/app/perps/utils/orderUtils.test.ts
@@ -116,27 +116,24 @@ describe('orderUtils', () => {
   });
 
   describe('shouldDisplayOrderInMarketDetailsOrders', () => {
-    it('shows non-reduce-only orders', () => {
-      const order = makeOrder({ reduceOnly: false });
-      expect(shouldDisplayOrderInMarketDetailsOrders(order)).toBe(true);
+    it('includes non-reduce-only and limit orders', () => {
+      expect(shouldDisplayOrderInMarketDetailsOrders(makeOrder())).toBe(true);
+      expect(
+        shouldDisplayOrderInMarketDetailsOrders(
+          makeOrder({ orderType: 'limit', reduceOnly: false }),
+        ),
+      ).toBe(true);
     });
 
-    it('shows limit orders', () => {
-      const order = makeOrder({ orderType: 'limit', reduceOnly: false });
-      expect(shouldDisplayOrderInMarketDetailsOrders(order)).toBe(true);
-    });
-
-    it('shows trigger orders that are not position-attached', () => {
-      const order = makeOrder({
+    it('includes trigger orders and partial reduce-only closes', () => {
+      const triggerOrder = makeOrder({
         isTrigger: true,
         reduceOnly: false,
         triggerPrice: '3200.00',
       });
-      expect(shouldDisplayOrderInMarketDetailsOrders(order)).toBe(true);
-    });
+      expect(shouldDisplayOrderInMarketDetailsOrders(triggerOrder)).toBe(true);
 
-    it('shows reduce-only orders not associated with full position', () => {
-      const order = makeOrder({
+      const partialClose = makeOrder({
         reduceOnly: true,
         symbol: 'ETH',
         side: 'sell',
@@ -144,13 +141,13 @@ describe('orderUtils', () => {
         originalSize: '0.5',
       });
       const position = makePosition({ symbol: 'ETH', size: '1.0' });
-      expect(shouldDisplayOrderInMarketDetailsOrders(order, position)).toBe(
-        true,
-      );
+      expect(
+        shouldDisplayOrderInMarketDetailsOrders(partialClose, position),
+      ).toBe(true);
     });
 
-    it('hides reduce-only orders associated with full position', () => {
-      const order = makeOrder({
+    it('includes full-position reduce-only and isPositionTpsl orders', () => {
+      const fullClose = makeOrder({
         reduceOnly: true,
         symbol: 'ETH',
         side: 'sell',
@@ -158,17 +155,15 @@ describe('orderUtils', () => {
         originalSize: '1.0',
       });
       const position = makePosition({ symbol: 'ETH', size: '1.0' });
-      expect(shouldDisplayOrderInMarketDetailsOrders(order, position)).toBe(
-        false,
+      expect(shouldDisplayOrderInMarketDetailsOrders(fullClose, position)).toBe(
+        true,
       );
-    });
 
-    it('hides orders with isPositionTpsl true', () => {
-      const order = makeOrder({
+      const positionTpsl = makeOrder({
         reduceOnly: true,
         isPositionTpsl: true,
       });
-      expect(shouldDisplayOrderInMarketDetailsOrders(order)).toBe(false);
+      expect(shouldDisplayOrderInMarketDetailsOrders(positionTpsl)).toBe(true);
     });
   });
 
@@ -290,7 +285,7 @@ describe('orderUtils', () => {
       expect(result).toHaveLength(1);
     });
 
-    it('hides full-position TP/SL reduce-only orders', () => {
+    it('includes full-position TP/SL reduce-only orders', () => {
       const tpslOrder = makeOrder({
         reduceOnly: true,
         isPositionTpsl: true,
@@ -299,7 +294,8 @@ describe('orderUtils', () => {
         detailedOrderType: 'Take Profit Limit',
       });
       const result = normalizeMarketDetailsOrders({ orders: [tpslOrder] });
-      expect(result).toHaveLength(0);
+      expect(result).toHaveLength(1);
+      expect(result[0].orderId).toBe('order-1');
     });
 
     it('shows partial-close reduce-only orders', () => {
@@ -318,7 +314,7 @@ describe('orderUtils', () => {
       expect(result).toHaveLength(1);
     });
 
-    it('adds synthetic TP/SL rows and filters them through position check', () => {
+    it('adds synthetic TP/SL rows and keeps them in the list', () => {
       const limitOrder = makeOrder({
         orderType: 'limit',
         reduceOnly: false,

--- a/ui/components/app/perps/utils/orderUtils.ts
+++ b/ui/components/app/perps/utils/orderUtils.ts
@@ -167,24 +167,21 @@ export const isOrderAssociatedWithFullPosition = (
 };
 
 /**
- * Determines whether an order should be shown in Market Details > Orders.
+ * Determines whether an order should be shown in Market Details > Orders
+ * (the perps asset / position detail screen).
  *
- * - All non-reduce-only orders are shown.
- * - Reduce-only orders are shown only when they are NOT full-position TP/SL.
+ * Full-position TP/SL and `isPositionTpsl` rows are included here so users can
+ * see and act on them alongside other open orders, in addition to the position
+ * summary. `isOrderAssociatedWithFullPosition` remains for other call sites.
  *
- * @param order - The order to check
- * @param position - The current position (if any)
+ * @param _order - The order to check (reserved for future filtering)
+ * @param _position - The current position (reserved for future filtering)
  * @returns Whether the order should be displayed
  */
 export const shouldDisplayOrderInMarketDetailsOrders = (
-  order: Order,
-  position?: Position,
-): boolean => {
-  if (!order.reduceOnly) {
-    return true;
-  }
-  return !isOrderAssociatedWithFullPosition(order, position);
-};
+  _order: Order,
+  _position?: Position,
+): boolean => true;
 
 const buildSyntheticTriggerOrder = (
   parentOrder: Order,
@@ -306,7 +303,7 @@ export const buildDisplayOrdersWithSyntheticTpsl = (
  * Normalizes orders for the Perps Market Details > Orders section.
  *
  * Composes display-order enrichment (synthetic TP/SL rows) with visibility
- * filtering (hides full-position TP/SL, keeps everything else).
+ * filtering (currently all enriched orders are shown, including full-position TP/SL).
  *
  * @param options0 - Options object
  * @param options0.orders - The orders to normalize

--- a/ui/components/app/perps/utils/orderUtils.ts
+++ b/ui/components/app/perps/utils/orderUtils.ts
@@ -1,4 +1,5 @@
 import BigNumber from 'bignumber.js';
+import { capitalize } from 'lodash';
 import type { Order, Position } from '@metamask/perps-controller';
 
 const FULL_POSITION_SIZE_TOLERANCE = new BigNumber('0.00000001');
@@ -324,4 +325,42 @@ export const normalizeMarketDetailsOrders = ({
   return ordersWithSyntheticTpsl.filter((order) =>
     shouldDisplayOrderInMarketDetailsOrders(order, existingPosition),
   );
+};
+
+/**
+ * Formats an order label following the pattern: [Type] [close?] [direction]
+ * Matches the mobile canonical formatter in app/components/UI/Perps/utils/orderUtils.ts.
+ *
+ * Examples:
+ * - "Market long" / "Limit short"
+ * - "Limit close long" / "Market close short"
+ * - "Stop market close long" / "Take profit limit close short"
+ *
+ * Rules:
+ * - isClosing = reduceOnly || isTrigger
+ * - direction for closing: sell → long, buy → short
+ * - direction for opening: buy → long, sell → short
+ * - typeString = detailedOrderType if present, otherwise "Limit" or "Market"
+ * - lodash capitalize: uppercases first char, lowercases the rest
+ *
+ * @param order - The order to label
+ * @returns Formatted label string in sentence case
+ */
+export const formatOrderLabel = (order: Order): string => {
+  const { side, detailedOrderType, orderType, reduceOnly, isTrigger } = order;
+  const isClosing = Boolean(reduceOnly || isTrigger);
+
+  let direction: string;
+  if (isClosing) {
+    direction = side === 'sell' ? 'long' : 'short';
+  } else {
+    direction = side === 'buy' ? 'long' : 'short';
+  }
+
+  const typeString =
+    detailedOrderType || (orderType === 'limit' ? 'Limit' : 'Market');
+
+  return isClosing
+    ? capitalize(`${typeString} close ${direction}`)
+    : capitalize(`${typeString} ${direction}`);
 };

--- a/ui/components/app/perps/utils/transactionTransforms.ts
+++ b/ui/components/app/perps/utils/transactionTransforms.ts
@@ -21,6 +21,7 @@ import {
   type PerpsTransaction,
 } from '../types/transactionHistory';
 import { getDisplaySymbol } from '../utils';
+import { formatOrderLabel } from './orderUtils';
 
 /**
  * Determines the close direction category for aggregation purposes.
@@ -190,53 +191,6 @@ export function aggregateFillsByTimestamp(fills: OrderFill[]): OrderFill[] {
   allFills.sort((a, b) => b.timestamp - a.timestamp);
 
   return allFills;
-}
-
-/**
- * Format an order label following the pattern: [Type] [Close?] [Direction]
- *
- * Examples:
- * - Market Long
- * - Market Close Long
- * - Limit Short
- * - Limit Close Short
- * - Stop Market Close Long
- * - Take Profit Limit Close Short
- *
- * @param order - The order object
- * @returns Formatted order label string
- */
-function formatOrderLabel(order: Order): string {
-  const { side, detailedOrderType, orderType, reduceOnly, isTrigger } = order;
-
-  // Determine if this is a closing order
-  const isClosing = Boolean(reduceOnly || isTrigger);
-
-  // Determine direction based on whether it's closing or not
-  let direction: string;
-  if (isClosing) {
-    // For closing orders: sell closes long, buy closes short
-    direction = side === 'sell' ? 'long' : 'short';
-  } else {
-    // For opening orders: buy is long, sell is short
-    direction = side === 'buy' ? 'long' : 'short';
-  }
-
-  // Get the order type string
-  // Use detailedOrderType if available (e.g., "Stop Market", "Take Profit Limit")
-  // Otherwise fall back to basic orderType
-  const typeString =
-    detailedOrderType || (orderType === 'limit' ? 'Limit' : 'Market');
-
-  // Build the label: [Type] [Close?] [Direction]
-  // Capitalize first letter
-  const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
-
-  if (isClosing) {
-    return capitalize(`${typeString} close ${direction}`);
-  }
-
-  return capitalize(`${typeString} ${direction}`);
 }
 
 /**

--- a/ui/pages/perps/perps-market-detail-page.tsx
+++ b/ui/pages/perps/perps-market-detail-page.tsx
@@ -457,8 +457,8 @@ const PerpsMarketDetailPage: React.FC = () => {
   }, [position]);
 
   // Filter and sort open orders for this market, then normalize for display.
-  // Normalization adds synthetic TP/SL rows for parent orders and filters out
-  // full-position TP/SL (those stay on the position card / auto-close section).
+  // Normalization adds synthetic TP/SL rows for parent orders when no matching
+  // real trigger exists; full-position TP/SL also appear in this Orders list.
   const orders = useMemo(() => {
     if (!decodedSymbol) {
       return [];


### PR DESCRIPTION
## **Description**

perps order UI was not treating TP/SL correctly for short vs long positions.

Centralized TP/SL–related order logic in orderUtils (with unit tests) and wired the perps order card to use it.
Trimmed duplicate logic out of transactionTransforms.

## **Changelog**

CHANGELOG entry: Classify TP/SL orders 

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2905

## **Manual testing steps**

Open a market order. Modify tpsl for that market order. TPSL orders should appear within the market detail page. TPSL orders should _not_ appear within the main perps tab (aligns with mobile experience)

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/80379a72-f152-4053-9a8c-0a1064dfd4ad

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how TP/SL (trigger) orders are labeled, valued, and filtered between the Perps tab and market detail pages; mistakes could hide orders or show incorrect prices. Logic is centralized and covered by new unit/UI tests, reducing regression risk.
> 
> **Overview**
> **Unifies TP/SL (trigger) order classification and display across the Perps UI.** Open Orders on the main Perps tab now explicitly filter out TP/SL rows (`isTrigger` and `isPositionTpsl`), leaving TP/SL visibility to the per-market detail page.
> 
> **Updates order labeling and pricing for trigger-based orders.** `OrderCard` now uses a shared `formatOrderLabel` utility, shows trigger price (not size×price notional) for TP/SL, adds a `Trigger price` subtitle, and tweaks layout to allow multi-line TP/SL labels.
> 
> **Centralizes order-label logic and adjusts market-detail order visibility.** `formatOrderLabel` is added to `orderUtils` (and removed from `transactionTransforms`), and market detail normalization now includes full-position TP/SL orders rather than filtering them out; extensive new tests cover label formatting, TP/SL rendering, and filtering behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbbde7b9f7b1d03b52fffc9c9be8c602802b3bd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->