### PR TITLE
chore: Remove `erc20-token-revocation` from `GATOR_ENABLED_PERMISSION_TYPES` cp-13.28.0

### DIFF
--- a/builds.yml
+++ b/builds.yml
@@ -372,7 +372,7 @@ env:
   - METAMASK_RAMP_API_CONTENT_BASE_URL: https://on-ramp-content.api.cx.metamask.io
 
   # EIP-7715 Readable Permissions
-  - GATOR_ENABLED_PERMISSION_TYPES: 'native-token-stream,native-token-periodic,erc20-token-stream,erc20-token-periodic,erc20-token-revocation'
+  - GATOR_ENABLED_PERMISSION_TYPES: 'native-token-stream,native-token-periodic,erc20-token-stream,erc20-token-periodic'
   - PERMISSIONS_KERNEL_SNAP_ID: 'npm:@metamask/permissions-kernel-snap'
   - GATOR_PERMISSIONS_PROVIDER_SNAP_ID: 'npm:@metamask/gator-permissions-snap'
   - GATOR_PERMISSIONS_REVOCATION_ENABLED: true

--- a/test/e2e/json-rpc/wallet_requestExecutionPermissions.spec.ts
+++ b/test/e2e/json-rpc/wallet_requestExecutionPermissions.spec.ts
@@ -65,9 +65,12 @@ describe('wallet_requestExecutionPermissions', function () {
               chainId: '0x539',
               to: '0x1234567890123456789012345678901234567890',
               permission: {
-                type: 'erc20-token-revocation',
+                type: 'native-token-periodic',
                 isAdjustmentAllowed: true,
-                data: {},
+                data: {
+                  periodAmount: '0x100',
+                  periodDuration: 86400,
+                },
               },
               rules: [],
             },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Disables `erc20-token-revocation` permission type in dist builds.

`wallet_requestExecutionPermissions.spec.ts` requests a permission of `erc20-token-revocation` to ensure that the permission system behaves as expected. Because this permission type is now disabled, the test now uses `native-token-periodic` permission type.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: `erc20-token-revocation` permission type is no longer supported via `wallet_requestExecutionPermissions`

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to the test site from https://github.com/MetaMask/snap-7715-permissions
2. Click "Get supported permissions"

** Expect `erc20-token-revocation` to not appear in the list

3. Select `erc20-token-revocation` from the permission type dropdown
4. Click "Request permission"

** Expect error returned "Method `wallet_requestExecutionPermissions` is not supported. Details: Permission type 'erc20-token-revocation' is not enabled"

## **Screenshots/Recordings**

### **After**

<img width="1350" height="270" alt="image" src="https://github.com/user-attachments/assets/21d29f46-e5b4-4fc9-820f-4f2d7c92da49" />

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to build-time config and a single e2e test update, with no changes to runtime permission enforcement logic.
> 
> **Overview**
> Removes `erc20-token-revocation` from the build-time `GATOR_ENABLED_PERMISSION_TYPES` allowlist, effectively disabling that permission type in distributed builds.
> 
> Updates the `wallet_requestExecutionPermissions` e2e spec to request `native-token-periodic` instead (including required `data` fields) so the test continues to validate request-blocking behavior under the new enabled-permissions set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb7d2094a56016cc1a2b0cfb4cd7923e3be188e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->