### PR TITLE
fix: delegate geolocation controller messenger cp-13.28.0

### DIFF
--- a/app/scripts/messenger-client-init/messengers/perps-controller-messenger.test.ts
+++ b/app/scripts/messenger-client-init/messengers/perps-controller-messenger.test.ts
@@ -1,0 +1,56 @@
+import { Messenger } from '@metamask/messenger';
+import { getRootMessenger } from '../../lib/messenger';
+import { getPerpsControllerMessenger } from './perps-controller-messenger';
+
+describe('getPerpsControllerMessenger', () => {
+  it('returns a messenger instance', () => {
+    const messenger = getRootMessenger<never, never>();
+    const perpsControllerMessenger = getPerpsControllerMessenger(messenger);
+
+    expect(perpsControllerMessenger).toBeInstanceOf(Messenger);
+  });
+
+  it('delegates required actions for PerpsController', () => {
+    const messenger = getRootMessenger<never, never>();
+    const delegateSpy = jest.spyOn(messenger, 'delegate');
+
+    getPerpsControllerMessenger(messenger);
+
+    expect(delegateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actions: expect.arrayContaining([
+          'NetworkController:getState',
+          'NetworkController:getNetworkClientById',
+          'NetworkController:findNetworkClientIdByChainId',
+          'KeyringController:getState',
+          'KeyringController:signTypedMessage',
+          'TransactionController:addTransaction',
+          'RemoteFeatureFlagController:getState',
+          'AccountTreeController:getAccountsFromSelectedAccountGroup',
+          'GeolocationController:getGeolocation',
+          'AuthenticationController:getBearerToken',
+          'MetaMetricsController:trackEvent',
+          'StorageService:getItem',
+          'StorageService:setItem',
+          'StorageService:removeItem',
+        ]),
+      }),
+    );
+  });
+
+  it('delegates required events for PerpsController', () => {
+    const messenger = getRootMessenger<never, never>();
+    const delegateSpy = jest.spyOn(messenger, 'delegate');
+
+    getPerpsControllerMessenger(messenger);
+
+    expect(delegateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        events: expect.arrayContaining([
+          'RemoteFeatureFlagController:stateChange',
+          'AccountTreeController:selectedAccountGroupChange',
+        ]),
+      }),
+    );
+  });
+});

--- a/app/scripts/messenger-client-init/messengers/perps-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/perps-controller-messenger.ts
@@ -3,6 +3,7 @@ import {
   AccountTreeControllerGetAccountsFromSelectedAccountGroupAction,
   AccountTreeControllerSelectedAccountGroupChangeEvent,
 } from '@metamask/account-tree-controller';
+import { GeolocationControllerGetGeolocationAction } from '@metamask/geolocation-controller';
 import {
   KeyringControllerGetStateAction,
   KeyringControllerSignTypedMessageAction,
@@ -35,6 +36,7 @@ type AllowedActions =
   | TransactionControllerAddTransactionAction
   | RemoteFeatureFlagControllerGetStateAction
   | AccountTreeControllerGetAccountsFromSelectedAccountGroupAction
+  | GeolocationControllerGetGeolocationAction
   | AuthenticationController.AuthenticationControllerGetBearerTokenAction
   | MetaMetricsControllerTrackEventAction
   | StorageServiceGetItemAction
@@ -81,6 +83,7 @@ export function getPerpsControllerMessenger(
       'TransactionController:addTransaction',
       'RemoteFeatureFlagController:getState',
       'AccountTreeController:getAccountsFromSelectedAccountGroup',
+      'GeolocationController:getGeolocation',
       'AuthenticationController:getBearerToken',
       'MetaMetricsController:trackEvent',
       'StorageService:getItem',

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
@@ -239,7 +239,7 @@
     "lastDepositResult": null,
     "lastDepositTransactionId": null,
     "lastError": null,
-    "lastFetchedAt": null,
+    "lastFetchedAt": "number",
     "lastFetchedBlockNumbers": "object",
     "lastSyncedTimestamp": "number",
     "lastUpdateTimestamp": "number",

--- a/test/e2e/tests/settings/state-logs.json
+++ b/test/e2e/tests/settings/state-logs.json
@@ -1021,7 +1021,7 @@
     "lastDepositResult": "null",
     "lastDepositTransactionId": "null",
     "lastError": "null",
-    "lastFetchedAt": "null",
+    "lastFetchedAt": "number",
     "lastFetchedBlockNumbers": {},
     "lastUpdateTimestamp": "number",
     "lastUpdated": "number",


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes the following error:

```
Error: A handler for GeolocationController:getGeolocation has not been registered
    at Messenger.call (Messenger.mjs:161:19)
    at PerpsController.refreshEligibility (PerpsController.mjs:2446:54)
    at Object.refreshEligibility (PerpsController.mjs:702:48)
    at FeatureFlagConfigurationService.setBlockedRegions (FeatureFlagConfigurationService.mjs:184:17)
    at FeatureFlagConfigurationService.refreshEligibility (FeatureFlagConfigurationService.mjs:150:18)
    at PerpsController.refreshEligibilityOnFeatureFlagChange (PerpsController.mjs:694:93)
    at PerpsController.startEligibilityMonitoring (PerpsController.mjs:2419:18)
    at MetamaskController.postOnboardingInitialization (metamask-controller.js:1639:41)
    at new MetamaskController (metamask-controller.js:1530:12)
    at setupController (background.js:1440:16)
```

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Add Geolocation delegation to PerpsController

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized messenger delegation change plus test/snapshot updates; low risk aside from potential mismatches if action names/types change.
> 
> **Overview**
> Fixes Perps eligibility refresh failures by **delegating `GeolocationController:getGeolocation`** through the `PerpsController` restricted messenger (`getPerpsControllerMessenger`).
> 
> Adds a unit test to assert the `PerpsController` messenger delegates the required actions/events (including geolocation), and updates e2e state-schema snapshots to expect `lastFetchedAt` as a `number` rather than `null`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 962fbd38432971851421cbffe0792554ec7e10f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->