### PR TITLE
fix: fallback classic tx for smart-contract deployment

### DIFF
--- a/app/scripts/lib/transaction/util.test.ts
+++ b/app/scripts/lib/transaction/util.test.ts
@@ -1,5 +1,4 @@
 import { InternalAccount } from '@metamask/keyring-internal-api';
-import { TransactionParams } from '@metamask/eth-json-rpc-middleware';
 import { MiddlewareContext } from '@metamask/json-rpc-engine/v2';
 import {
   TransactionController,
@@ -7,7 +6,7 @@ import {
   TransactionType,
 } from '@metamask/transaction-controller';
 import { UserOperationController } from '@metamask/user-operation-controller';
-import { cloneDeep } from 'lodash';
+import { cloneDeep, omit } from 'lodash';
 import { Hex } from '@metamask/utils';
 import {
   generateSecurityAlertId,
@@ -65,14 +64,18 @@ jest.mock('../account-supports-7702', () => ({
 const SECURITY_ALERT_ID_MOCK = '123';
 const BATCHID_MOCK = '0xmockBatchId' as Hex;
 const FROM_FIELD_MOCK = '0x1';
+const TO_FIELD_MOCK = '0x2';
+const DATA_FIELD_MOCK = '0x3';
 
 const INTERNAL_ACCOUNT_ADDRESS = '0xec1adf982415d2ef5ec55899b9bfb8bc0f29251b';
 const INTERNAL_ACCOUNT = createMockInternalAccount({
   address: INTERNAL_ACCOUNT_ADDRESS,
 });
 
-const TRANSACTION_PARAMS_MOCK: TransactionParams = {
+const TRANSACTION_PARAMS_MOCK = {
   from: FROM_FIELD_MOCK,
+  to: TO_FIELD_MOCK,
+  data: DATA_FIELD_MOCK,
 };
 
 const TRANSACTION_OPTIONS_MOCK: AddTransactionOptions = {
@@ -854,6 +857,33 @@ describe('Transaction Utils', () => {
           type: undefined,
           gasFeeToken: '0x20c0000000000000000000000000000000000000',
           excludeNativeTokenForFee: true,
+        });
+      });
+
+      it('sends a classic tx if `to` is missing (contract deployment)', async () => {
+        const transactionParamsMockWithoutTo = omit(
+          TRANSACTION_PARAMS_MOCK,
+          'to',
+        );
+        await addDappTransaction({
+          ...dappRequest,
+          transactionParams: transactionParamsMockWithoutTo,
+          chainId: '0xa5bf',
+        });
+
+        expect(
+          request.transactionController.addTransaction,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          request.transactionController.addTransaction,
+        ).toHaveBeenCalledWith(transactionParamsMockWithoutTo, {
+          ...TRANSACTION_OPTIONS_MOCK,
+          method: makeDappRequest().method,
+          requireApproval: true,
+          securityAlertResponse: makeRequestContext().assertGet(
+            'securityAlertResponse',
+          ),
+          type: undefined,
         });
       });
     });

--- a/app/scripts/lib/transaction/util.ts
+++ b/app/scripts/lib/transaction/util.ts
@@ -148,15 +148,25 @@ async function addTransactionOnTempo(
     keyringController as Parameters<typeof accountSupports7702>[1],
   );
 
-  // Classic transaction, we simply set pathUSD as default
-  // and add excludeNativeTokenForFee to signal to ignore native.
+  // Non-Tempo transaction (not type 0x76)
   if (!isTempoTransactionType(request.transactionParams)) {
+    if (!request.transactionParams.to) {
+      log.debug(
+        'addTransactionOnTempo: Smart-Contract deployment tx detected. Fallback to classic tx.',
+      );
+      // Classic transaction
+      return addTransactionWithController(request);
+    }
     if (!isEip7702SupportedByAccount) {
       log.debug(
         'addTransactionOnTempo: Tempo chain but wallet does not support 7702. Falling back to legacy transactions',
       );
+      // Classic transaction
       return addTransactionWithController(request);
     }
+
+    // We make it a EIP-7702 tx, seting pathUSD as default gasToken
+    // and add excludeNativeTokenForFee to signal to ignore native.
     return addTransactionWithController(
       getTempoEvmTransactionArgs({ request, chainId }),
     );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

- Smart contract deployment cannot technically be done when using EIP-7702.
- MetaMask Tempo support relies on EIP-7702, meaning that smart-contract deployments will fail. 
- However, with Tempo we fallback to classic transactions when EIP-7702 is not available (ex: Hardware Wallets), so this PR applies a similar logic but for when the transaction is detected as a smart-contract deployment transaction.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: tempo fallback to classic transaction if contract deployment

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/NEB-968

## **Manual testing steps**

1. Go to https://metamask.github.io/test-dapp/ with an account funded with `pathUSD`.
2. Find the "ERC20" section and attempt to create a token.
3. The transaction should succeed, unlike before.

Limitation: Like for the HW fallback, user won't be warned if he doesn't have enough gas to pay for fees.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
<img width="300"  alt="image" src="https://github.com/user-attachments/assets/2664a30c-ff3c-4940-ab65-a99265725bac" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Tempo-chain transaction routing logic; incorrect detection of missing `to` could change how transactions are constructed/sent on Tempo networks. Scope is small and covered by a new unit test.
> 
> **Overview**
> Fixes Tempo-chain handling for **smart-contract deployment** transactions by detecting missing `transactionParams.to` and **skipping the EIP-7702/Tempo parameter rewrite**, falling back to a classic `addTransaction` call.
> 
> Adds a unit test ensuring `addDappTransaction` on a Tempo chain sends a classic tx when `to` is absent (contract deployment).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e603d42b1371824aea694ad18efd49e95e67724f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->