### PR TITLE
ci: speed up uses of "fetch-depth: 0"

### DIFF
--- a/.github/scripts/check-feature-flag-registry.ts
+++ b/.github/scripts/check-feature-flag-registry.ts
@@ -6,6 +6,7 @@ import * as path from 'path';
 import { context, getOctokit } from '@actions/github';
 import { getRegisteredFlagNames } from '../../test/e2e/feature-flags';
 import { buildKnownFlagConstants } from './known-feature-flag-constants';
+import { getPrDiff } from './shared/get-pr-diff';
 
 const REGISTRY_DIR = 'test/e2e/feature-flags/';
 const SCANNABLE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx']);
@@ -99,7 +100,7 @@ async function main(): Promise<void> {
   const registeredFlags = new Set(getRegisteredFlagNames());
   console.log(`Registry contains ${registeredFlags.size} flags`);
 
-  const diff = getDiff(baseBranch);
+  const diff = getPrDiff({ baseBranch, directories: SCAN_DIRECTORIES });
   if (!diff.trim()) {
     console.log('No relevant diff found. Nothing to check.');
     process.exit(0);
@@ -109,7 +110,7 @@ async function main(): Promise<void> {
   const fileCount = [...fileChanges.values()].filter((c) => c.length > 0).length;
   console.log(`Found changes in ${fileCount} file(s)\n`);
 
-  logRegistryChanges(baseBranch);
+  logRegistryChanges(diff);
 
   // --- Collect flag references from added lines ---
   const allReferences: FlagReference[] = [];
@@ -227,25 +228,6 @@ async function main(): Promise<void> {
   if (sortedUnregistered.length > 0) {
     process.exit(1);
   }
-}
-
-function getDiff(baseBranch: string): string {
-  const candidates: string[][] = [
-    ['git', 'diff', `origin/${baseBranch}...HEAD`, '--', ...SCAN_DIRECTORIES],
-    ['git', 'diff', `origin/${baseBranch}..HEAD`, '--', ...SCAN_DIRECTORIES],
-    ['git', 'diff', `${baseBranch}...HEAD`, '--', ...SCAN_DIRECTORIES],
-    ['git', 'diff', `${baseBranch}..HEAD`, '--', ...SCAN_DIRECTORIES],
-  ];
-  let lastError: unknown;
-  for (const [cmd, ...args] of candidates) {
-    try {
-      return execFileSync(cmd, args, { encoding: 'utf-8', maxBuffer: 50 * 1024 * 1024 });
-    } catch (error) { lastError = error; }
-  }
-  console.error(`Could not compute diff against base branch "${baseBranch}".`);
-  console.error('Ensure the base branch is fetched (e.g. git fetch origin <base> --depth=1).');
-  console.error('Last error:', lastError);
-  process.exit(1);
 }
 
 type DiffResult = {
@@ -655,18 +637,20 @@ function stripStringLiterals(line: string): string { return processStrings(line,
 function maskStringLiterals(line: string): string { return processStrings(line, 'mask'); }
 
 /** Logs which flags were added/removed in the registry (informational only). */
-function logRegistryChanges(baseBranch: string): void {
+function logRegistryChanges(fullDiff: string): void {
   const registryFile = 'test/e2e/feature-flags/feature-flag-registry.ts';
-  const candidates: string[][] = [
-    ['git', 'diff', `origin/${baseBranch}...HEAD`, '--', registryFile],
-    ['git', 'diff', `${baseBranch}...HEAD`, '--', registryFile],
-  ];
+
+  // Extract the registry file section from the already-fetched diff
+  const sections = fullDiff.split(/^diff --git /mu);
   let registryDiff = '';
-  for (const [cmd, ...args] of candidates) {
-    try {
-      registryDiff = execFileSync(cmd, args, { encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024 });
+  for (const section of sections) {
+    if (
+      section.includes(`a/${registryFile}`) ||
+      section.includes(`b/${registryFile}`)
+    ) {
+      registryDiff = `diff --git ${section}`;
       break;
-    } catch { /* try next */ }
+    }
   }
 
   if (!registryDiff.trim()) {

--- a/.github/scripts/shared/get-pr-diff.ts
+++ b/.github/scripts/shared/get-pr-diff.ts
@@ -1,0 +1,151 @@
+/**
+ * get-pr-diff.ts
+ *
+ * Fetches a unified diff for the current PR using a three-tier strategy:
+ *   1. GitHub REST API (fastest — no git history needed)
+ *   2. git diff against BASE_SHA from the webhook payload (immutable)
+ *   3. git diff against the base branch name (original fallback)
+ *
+ * Environment variables (all optional, enables graceful degradation):
+ *   GITHUB_REPOSITORY  — owner/repo (set automatically by GitHub Actions)
+ *   BASE_SHA           — pull_request.base.sha from the event payload
+ *   GH_TOKEN           — GitHub token for API access
+ *
+ * Requires `gh` CLI (pre-installed on GitHub Actions runners) for tier 1.
+ */
+
+import { execFileSync } from 'child_process';
+import { context } from '@actions/github';
+
+export interface GetPrDiffOptions {
+  /** Base branch name (default: 'main'). Used only in the branch-based fallback. */
+  baseBranch?: string;
+  /** Directories to scope the git diff to (e.g. ['app/', 'ui/']). Omit for full diff. */
+  directories?: string[];
+  /** Maximum buffer size in bytes (default: 50 MB). */
+  maxBuffer?: number;
+}
+
+/**
+ * Filters a unified diff to only include hunks whose file paths start with one
+ * of the given directory prefixes. Returns the full diff when dirs is empty.
+ */
+function filterDiffByDirectories(diff: string, dirs: string[]): string {
+  if (dirs.length === 0) {
+    return diff;
+  }
+  const normalizedDirs = dirs.map((d) => {
+    const n = d.replace(/\\/g, '/');
+    return n.endsWith('/') ? n : `${n}/`;
+  });
+  const lines = diff.split('\n');
+  const result: string[] = [];
+  let include = false;
+
+  for (const line of lines) {
+    // Each file section starts with "diff --git a/... b/..."
+    if (line.startsWith('diff --git ')) {
+      // Extract the b/ path: "diff --git a/foo/bar b/foo/bar"
+      const match = / b\/(.+)$/.exec(line);
+      if (match) {
+        const filePath = match[1];
+        include = normalizedDirs.some((dir) =>
+          filePath.startsWith(dir) || filePath === dir.replace(/\/$/, ''),
+        );
+      } else {
+        include = false;
+      }
+    }
+    if (include) {
+      result.push(line);
+    }
+  }
+  return result.join('\n');
+}
+
+/**
+ * Returns a unified diff string for the current PR.
+ * Exits the process with code 1 if all strategies fail.
+ */
+export function getPrDiff(options: GetPrDiffOptions = {}): string {
+  const {
+    baseBranch = 'main',
+    directories = [],
+    maxBuffer = 50 * 1024 * 1024,
+  } = options;
+
+  // 1. Try GitHub API (no git history needed, fastest path)
+  const prNumber = context.payload.pull_request?.number;
+  const repo = process.env.GITHUB_REPOSITORY;
+  if (prNumber && repo) {
+    try {
+      const apiDiff = execFileSync(
+        'gh',
+        [
+          'api',
+          `repos/${repo}/pulls/${prNumber}`,
+          '-H',
+          'Accept: application/vnd.github.diff',
+        ],
+        { encoding: 'utf-8', maxBuffer },
+      );
+      if (apiDiff.trim()) {
+        console.log('Got diff from GitHub API');
+        return filterDiffByDirectories(apiDiff, directories);
+      }
+    } catch {
+      console.warn('GitHub API diff unavailable, falling back to git diff');
+    }
+  }
+
+  // 2. Try git diff using the base SHA from the event payload (immutable,
+  //    works even when the base branch has advanced since the event fired).
+  const baseSha = process.env.BASE_SHA;
+  if (baseSha) {
+    try {
+      execFileSync('git', ['fetch', 'origin', baseSha, '--depth=1'], {
+        stdio: 'pipe',
+      });
+      const args = ['diff', `${baseSha}...HEAD`];
+      if (directories.length > 0) {
+        args.push('--', ...directories);
+      }
+      return execFileSync('git', args, { encoding: 'utf-8', maxBuffer });
+    } catch {
+      console.warn(
+        `git diff with BASE_SHA (${baseSha}) failed, trying branch-based diff`,
+      );
+    }
+  }
+
+  // 3. Branch-based git diff (original fallback).
+  //    Fetch the base branch first — in a shallow clone it won't exist locally.
+  try {
+    execFileSync('git', ['fetch', 'origin', baseBranch, '--depth=1'], {
+      stdio: 'pipe',
+    });
+  } catch {
+    console.warn(`Could not fetch origin/${baseBranch}`);
+  }
+  const diffArgs = directories.length > 0 ? ['--', ...directories] : [];
+  const candidates: string[][] = [
+    ['git', 'diff', `origin/${baseBranch}...HEAD`, ...diffArgs],
+    ['git', 'diff', `origin/${baseBranch}..HEAD`, ...diffArgs],
+    ['git', 'diff', `${baseBranch}...HEAD`, ...diffArgs],
+    ['git', 'diff', `${baseBranch}..HEAD`, ...diffArgs],
+  ];
+  let lastError: unknown;
+  for (const [cmd, ...args] of candidates) {
+    try {
+      return execFileSync(cmd, args, { encoding: 'utf-8', maxBuffer });
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  console.error(`Could not compute diff against base branch "${baseBranch}".`);
+  console.error(
+    'Ensure the base branch is fetched (e.g. git fetch origin <base> --depth=1).',
+  );
+  console.error('Last error:', lastError);
+  process.exit(1);
+}

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -133,7 +133,6 @@ jobs:
         with:
           is-high-risk-environment: ${{ github.ref_name == 'main' || github.ref_name == 'stable' || startsWith(github.ref_name, 'release/') }}
           skip-allow-scripts: true
-          fetch-depth: 0 # This is needed to get merge base to calculate bundle size diff
 
       - name: Find the associated PR
         if: ${{ startsWith(env.BRANCH, 'release/') && (!env.PR_NUMBER || !env.BASE_COMMIT_HASH || !env.HEAD_COMMIT_HASH) }}
@@ -157,8 +156,10 @@ jobs:
 
       - name: Get merge base commit hash
         if: ${{ env.BASE_COMMIT_HASH && env.HEAD_COMMIT_HASH }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          merge_base_commit_hash="$(git merge-base "${BASE_COMMIT_HASH}" "${HEAD_COMMIT_HASH}")"
+          merge_base_commit_hash="$(gh api "repos/${GITHUB_REPOSITORY}/compare/${BASE_COMMIT_HASH}...${HEAD_COMMIT_HASH}" --jq '.merge_base_commit.sha')"
           echo "MERGE_BASE_COMMIT_HASH=${merge_base_commit_hash}" >> "${GITHUB_ENV}"
           echo "The merge base commit hash is '${merge_base_commit_hash}'"
 

--- a/.github/workflows/repository-health-checks.yml
+++ b/.github/workflows/repository-health-checks.yml
@@ -18,7 +18,6 @@ jobs:
         uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
-          fetch-depth: 0 # This is needed to checkout all branches
           skip-allow-scripts: true
 
       - name: ShellCheck Lint
@@ -183,6 +182,8 @@ jobs:
         if: ${{ !cancelled() }}
         env:
           GITHUB_BASE_REF: ${{ github.base_ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: yarn tsx .github/scripts/check-feature-flag-registry.ts
 
       - name: Check working tree
@@ -197,11 +198,6 @@ jobs:
         if: ${{ !cancelled() && github.event_name == 'pull_request'}}
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
-        run: |
-          # The following command generates a diff of changes between the common
-          # ancestor of $BASE_REF and HEAD, and the current commit (HEAD), for
-          # files in the current directory and its subdirectories. The output is
-          # then saved to a file called "diff".
-          git diff "$(git merge-base "origin/$BASE_REF" HEAD)" HEAD -- . > ./diff
-
-          yarn fitness-functions ci ./diff
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: yarn fitness-functions ci

--- a/development/fitness-functions/common/get-diff.ts
+++ b/development/fitness-functions/common/get-diff.ts
@@ -22,7 +22,7 @@ function getDiffByAutomationType(
   let diff;
   if (automationType === AUTOMATION_TYPE.CI) {
     const optionalArguments = process.argv.slice(3);
-    if (optionalArguments.length !== 1) {
+    if (optionalArguments.length > 1) {
       console.error('Invalid number of arguments.');
       process.exit(1);
     }
@@ -37,11 +37,19 @@ function getDiffByAutomationType(
   return diff;
 }
 
-function getCIDiff(path: string): string {
-  return fs.readFileSync(path, {
-    encoding: 'utf8',
-    flag: 'r',
-  });
+function getCIDiff(path?: string): string {
+  if (path) {
+    return fs.readFileSync(path, {
+      encoding: 'utf8',
+      flag: 'r',
+    });
+  }
+
+  // No file argument — fetch diff directly (requires CI environment variables).
+  // Lazy-import to avoid pulling @actions/github into local dev hooks.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports -- deliberate lazy require
+  const { getPrDiff } = require('../../../.github/scripts/shared/get-pr-diff');
+  return getPrDiff({ baseBranch: process.env.BASE_REF || 'main' });
 }
 
 function runGitCommand(args: string[]): string {


### PR DESCRIPTION
## **Description**

`fetch-depth: 0` is very slow, and most of the time we use it in CI, it's not needed.  We can get the merge base through `gh api`, and we can get the diffs by downloading select branches, not every branch.

### Eliminated the uses in these two workflows that run on every PR:
- repository-health-checks.yml
- publish-prerelease.yml

### Did not touch these four workflows:
- add-release-label.yml -- infrequent and hard to test
- publish-release-from-release-head.yml -- infrequent and hard to test
- tag-release-branch.yml -- infrequent and hard to test
- sonarcloud in main.yml -- SonarCloud documentation says that `fetch-depth: 0` is required

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Closes: MetaMask/MetaMask-planning#7198

<!--## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**--
[skip-e2e]>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI diff/merge-base computation and removes `fetch-depth: 0`, which can break PR checks if `gh`/tokens/env vars are missing or if diff filtering behaves differently in edge cases.
> 
> **Overview**
> Speeds up PR-facing CI by removing reliance on `fetch-depth: 0` and full-history git operations in `repository-health-checks.yml` and `publish-prerelease.yml`.
> 
> Adds a shared `getPrDiff` helper that prefers downloading the PR diff via `gh api`, then falls back to `git diff` using `BASE_SHA`, then finally branch-based `git diff`. The feature-flag registry check is updated to use this helper and to derive registry-file add/remove info from the already-fetched diff.
> 
> Updates the fitness-functions CI path to no longer require a pre-generated `./diff` file; it now fetches the PR diff internally (when no file arg is provided) using the same helper, and workflows provide `BASE_SHA`/`GH_TOKEN` to enable these paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4452673731573879950badb6bfe62d566648b80f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->