### PR TITLE
feat: failed transactions badge

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -1980,7 +1980,7 @@ export function setupController(
     let badgeColor = BADGE_COLOR_APPROVAL;
 
     if (failedTxCount > 0) {
-      label = getBadgeLabel(failedTxCount, BADGE_MAX_COUNT);
+      label = '\u200B';
       badgeColor = BADGE_COLOR_FAILED;
     } else if (pendingApprovalCount > 0) {
       label = getBadgeLabel(pendingApprovalCount, BADGE_MAX_COUNT);

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -120,6 +120,7 @@ const lazyListener =
 const BADGE_COLOR_APPROVAL = '#0376C9';
 const BADGE_COLOR_FAILED = lightTheme.colors.error.default;
 const BADGE_MAX_COUNT = 9;
+const maxSeenFailedNonces = 99;
 
 const inTest = process.env.IN_TEST;
 
@@ -188,7 +189,6 @@ let notificationIsOpen = false;
 let uiIsTriggering = false;
 let openSidePanelCount = 0;
 let failedTxCount = 0;
-let hasDeferredFailureNotification = false;
 const seenFailedNonces = new Set();
 const openMetamaskTabsIDs = {};
 const requestAccountTabIds = {};
@@ -1610,6 +1610,18 @@ export function setupController(
     );
   };
 
+  const hasPersistentUiOpen = () => {
+    return (
+      openPopupCount > 0 ||
+      openSidePanelCount > 0 ||
+      Object.keys(openMetamaskTabsIDs).length > 0
+    );
+  };
+
+  const isOnlyNotificationOpen = () => {
+    return notificationIsOpen && !hasPersistentUiOpen();
+  };
+
   const onCloseEnvironmentInstances = (isClientOpen, environmentType) => {
     // if all instances of metamask are closed we call a method on the controller to stop gasFeeController polling
     if (isClientOpen === false) {
@@ -1705,7 +1717,11 @@ export function setupController(
 
         finished(portStream, () => {
           notificationIsOpen = false;
-          flushDeferredFailureNotification();
+          // Render any failure badge that was suppressed while the notification was open
+          if (failedTxCount > 0) {
+            setClientOpenOptions('activity');
+          }
+          updateBadge();
           const isClientOpen = isClientOpenStatus();
           controller.isClientOpen = isClientOpen;
           onCloseEnvironmentInstances(
@@ -1911,36 +1927,18 @@ export function setupController(
     }
 
     if (nonceKey) {
+      if (seenFailedNonces.size >= maxSeenFailedNonces) {
+        seenFailedNonces.clear();
+      }
       seenFailedNonces.add(nonceKey);
     }
 
-    const onlyNotificationOpen =
-      notificationIsOpen &&
-      openPopupCount === 0 &&
-      openSidePanelCount === 0 &&
-      Object.keys(openMetamaskTabsIDs).length === 0;
-
-    if (onlyNotificationOpen) {
-      // Defer showing the badge until the notification closes
-      failedTxCount += 1;
-      hasDeferredFailureNotification = true;
-      return;
-    }
-
-    if (isClientOpenStatus()) {
+    // Skip if a persistent UI is open, transaction status is in the Activity tab
+    if (hasPersistentUiOpen()) {
       return;
     }
 
     failedTxCount += 1;
-    setClientOpenOptions('activity');
-    updateBadge();
-  }
-
-  function flushDeferredFailureNotification() {
-    if (!hasDeferredFailureNotification) {
-      return;
-    }
-    hasDeferredFailureNotification = false;
     setClientOpenOptions('activity');
     updateBadge();
   }
@@ -1951,7 +1949,6 @@ export function setupController(
       return;
     }
 
-    hasDeferredFailureNotification = false;
     failedTxCount = 0;
     setClientOpenOptions();
     updateBadge();
@@ -1979,7 +1976,8 @@ export function setupController(
     let label = '';
     let badgeColor = BADGE_COLOR_APPROVAL;
 
-    if (failedTxCount > 0) {
+    // Defer showing the failure badge until the notification closes
+    if (failedTxCount > 0 && !isOnlyNotificationOpen()) {
       label = '\u200B';
       badgeColor = BADGE_COLOR_FAILED;
     } else if (pendingApprovalCount > 0) {

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -1926,6 +1926,11 @@ export function setupController(
       return;
     }
 
+    // Skip if a persistent UI is open, transaction status is in the Activity tab
+    if (hasPersistentUiOpen()) {
+      return;
+    }
+
     if (nonceKey) {
       if (seenFailedNonces.size >= maxSeenFailedNonces) {
         seenFailedNonces.clear();
@@ -1933,22 +1938,18 @@ export function setupController(
       seenFailedNonces.add(nonceKey);
     }
 
-    // Skip if a persistent UI is open, transaction status is in the Activity tab
-    if (hasPersistentUiOpen()) {
-      return;
+    failedTxCount += 1;
+
+    // Defer landing page until notification closes; close handler re-applies
+    if (!isOnlyNotificationOpen()) {
+      setClientOpenOptions('activity');
     }
 
-    failedTxCount += 1;
-    setClientOpenOptions('activity');
     updateBadge();
   }
 
   function clearFailedTxBadge() {
     seenFailedNonces.clear();
-    if (failedTxCount <= 0) {
-      return;
-    }
-
     failedTxCount = 0;
     setClientOpenOptions();
     updateBadge();

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -188,6 +188,8 @@ let notificationIsOpen = false;
 let uiIsTriggering = false;
 let openSidePanelCount = 0;
 let failedTxCount = 0;
+let hasDeferredFailureNotification = false;
+let lastFailedNonce;
 const openMetamaskTabsIDs = {};
 const requestAccountTabIds = {};
 let controller;
@@ -1703,6 +1705,7 @@ export function setupController(
 
         finished(portStream, () => {
           notificationIsOpen = false;
+          flushDeferredNotificationFailures();
           const isClientOpen = isClientOpenStatus();
           controller.isClientOpen = isClientOpen;
           onCloseEnvironmentInstances(
@@ -1713,6 +1716,7 @@ export function setupController(
       }
 
       if (processName === ENVIRONMENT_TYPE_FULLSCREEN) {
+        clearFailedTxBadge();
         const tabId = remotePort.sender.tab.id;
         openMetamaskTabsIDs[tabId] = true;
 
@@ -1871,13 +1875,13 @@ export function setupController(
   );
 
   controller.controllerMessenger.subscribe(
-    'TransactionController:transactionFailed',
-    onTransactionFailed,
-  );
-
-  controller.controllerMessenger.subscribe(
-    'TransactionController:transactionDropped',
-    onTransactionFailed,
+    'TransactionController:transactionStatusUpdated',
+    ({ transactionMeta }) => {
+      const { status, txParams } = transactionMeta ?? {};
+      if (status === 'failed' || status === 'dropped') {
+        onTransactionFailed({ txParams });
+      }
+    },
   );
 
   function setClientOpenOptions(tab) {
@@ -1896,8 +1900,29 @@ export function setupController(
     }
   }
 
-  function onTransactionFailed() {
-    if (isClientOpenStatus()) {
+  function onTransactionFailed({ txParams }) {
+    const { nonce } = txParams ?? {};
+    if (nonce !== undefined && nonce === lastFailedNonce) {
+      return;
+    }
+    lastFailedNonce = nonce;
+
+    const onlyNotificationOpen =
+      notificationIsOpen &&
+      openPopupCount === 0 &&
+      openSidePanelCount === 0 &&
+      Object.keys(openMetamaskTabsIDs).length === 0;
+
+    const isClientOpen = isClientOpenStatus();
+
+    if (onlyNotificationOpen) {
+      // Defer showing the badge until the notification closes
+      failedTxCount += 1;
+      hasDeferredFailureNotification = true;
+      return;
+    }
+
+    if (isClientOpen) {
       return;
     }
 
@@ -1906,11 +1931,22 @@ export function setupController(
     updateBadge();
   }
 
+  function flushDeferredNotificationFailures() {
+    if (!hasDeferredFailureNotification) {
+      return;
+    }
+    hasDeferredFailureNotification = false;
+    setClientOpenOptions('activity');
+    updateBadge();
+  }
+
   function clearFailedTxBadge() {
-    if (!failedTxCount) {
+    lastFailedNonce = undefined;
+    if (failedTxCount <= 0) {
       return;
     }
 
+    hasDeferredFailureNotification = false;
     failedTxCount = 0;
     setClientOpenOptions();
     updateBadge();
@@ -1929,7 +1965,8 @@ export function setupController(
 
   /**
    * Updates the Web Extension's "badge" number, on the little fox in the toolbar.
-   * The number reflects the current number of pending transactions or message signatures needing user approval.
+   * Failed transactions take priority and show a red count badge.
+   * Pending approvals show the standard blue count badge.
    */
   function updateBadge() {
     const pendingApprovalCount = getPendingApprovalCount();
@@ -1937,11 +1974,11 @@ export function setupController(
     let label = '';
     let badgeColor = BADGE_COLOR_APPROVAL;
 
-    if (pendingApprovalCount) {
-      label = getBadgeLabel(pendingApprovalCount, BADGE_MAX_COUNT);
-    } else if (failedTxCount) {
+    if (failedTxCount > 0) {
       label = getBadgeLabel(failedTxCount, BADGE_MAX_COUNT);
       badgeColor = BADGE_COLOR_FAILED;
+    } else if (pendingApprovalCount > 0) {
+      label = getBadgeLabel(pendingApprovalCount, BADGE_MAX_COUNT);
     }
 
     try {

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -1979,7 +1979,7 @@ export function setupController(
 
     // Defer showing the failure badge until the notification closes
     if (failedTxCount > 0 && !isOnlyNotificationOpen()) {
-      label = '\u200B';
+      label = getBadgeLabel(failedTxCount, BADGE_MAX_COUNT);
       badgeColor = BADGE_COLOR_FAILED;
     } else if (pendingApprovalCount > 0) {
       label = getBadgeLabel(pendingApprovalCount, BADGE_MAX_COUNT);

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -189,7 +189,7 @@ let uiIsTriggering = false;
 let openSidePanelCount = 0;
 let failedTxCount = 0;
 let hasDeferredFailureNotification = false;
-let lastFailedNonce;
+const seenFailedNonces = new Set();
 const openMetamaskTabsIDs = {};
 const requestAccountTabIds = {};
 let controller;
@@ -1705,7 +1705,7 @@ export function setupController(
 
         finished(portStream, () => {
           notificationIsOpen = false;
-          flushDeferredNotificationFailures();
+          flushDeferredFailureNotification();
           const isClientOpen = isClientOpenStatus();
           controller.isClientOpen = isClientOpen;
           onCloseEnvironmentInstances(
@@ -1876,12 +1876,7 @@ export function setupController(
 
   controller.controllerMessenger.subscribe(
     'TransactionController:transactionStatusUpdated',
-    ({ transactionMeta }) => {
-      const { status, txParams } = transactionMeta ?? {};
-      if (status === 'failed' || status === 'dropped') {
-        onTransactionFailed({ txParams });
-      }
-    },
+    onTransactionStatusUpdated,
   );
 
   function setClientOpenOptions(tab) {
@@ -1900,20 +1895,30 @@ export function setupController(
     }
   }
 
-  function onTransactionFailed({ txParams }) {
-    const { nonce } = txParams ?? {};
-    if (nonce !== undefined && nonce === lastFailedNonce) {
+  function onTransactionStatusUpdated({ transactionMeta }) {
+    const { status, txParams, chainId } = transactionMeta ?? {};
+    if (status !== 'failed' && status !== 'dropped') {
       return;
     }
-    lastFailedNonce = nonce;
+
+    const { from, nonce } = txParams ?? {};
+    const nonceKey =
+      from && nonce !== undefined && chainId
+        ? `${chainId}:${from.toLowerCase()}:${nonce}`
+        : undefined;
+    if (nonceKey && seenFailedNonces.has(nonceKey)) {
+      return;
+    }
+
+    if (nonceKey) {
+      seenFailedNonces.add(nonceKey);
+    }
 
     const onlyNotificationOpen =
       notificationIsOpen &&
       openPopupCount === 0 &&
       openSidePanelCount === 0 &&
       Object.keys(openMetamaskTabsIDs).length === 0;
-
-    const isClientOpen = isClientOpenStatus();
 
     if (onlyNotificationOpen) {
       // Defer showing the badge until the notification closes
@@ -1922,7 +1927,7 @@ export function setupController(
       return;
     }
 
-    if (isClientOpen) {
+    if (isClientOpenStatus()) {
       return;
     }
 
@@ -1931,7 +1936,7 @@ export function setupController(
     updateBadge();
   }
 
-  function flushDeferredNotificationFailures() {
+  function flushDeferredFailureNotification() {
     if (!hasDeferredFailureNotification) {
       return;
     }
@@ -1941,7 +1946,7 @@ export function setupController(
   }
 
   function clearFailedTxBadge() {
-    lastFailedNonce = undefined;
+    seenFailedNonces.clear();
     if (failedTxCount <= 0) {
       return;
     }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Revised implementation of badge on the MM toolbar icon when a transaction fails while MM instance is closed. Failure badge takes priority over pending-approvals badge and clears when the user opens MM.

- Subscribes to TransactionController:transactionStatusUpdated to catch failed / dropped statuses
- Defers badge update if only the notification window is open, flushing it on close


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: feat: show badge on transaction failure while MM is closed

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to a dApp (ex: Aave)
2. Initiate a transaction, set very low base fee 
3. Confirm (ensure MM is closed)
4. Observe toolbar icon

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**


https://github.com/user-attachments/assets/7426607f-c79a-4747-aebb-74d61f4ac6d1



<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches background event handling and badge/popup routing logic, which can affect how the extension opens and how users are notified of tx state. Risk is limited to UI signaling (no transaction execution/auth changes) but could cause incorrect badge counts or unwanted landing-page behavior.
> 
> **Overview**
> Adds a **failed/dropped transaction** toolbar badge that takes priority over the approvals badge when MetaMask has no persistent UI open.
> 
> Background now listens to `TransactionController:transactionStatusUpdated`, increments a red failure counter (deduped by `chainId/from/nonce`), and routes the next toolbar open to the Activity tab. Badge/landing-page updates are **deferred while only the notification window is open**, then flushed on notification close, and the failure badge is cleared when the user opens MetaMask (popup/sidepanel/fullscreen).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83b0c6840da071157d3eb6316e07fd0304bb5d2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->