### PR TITLE
feat: show `expired` and `revoked` tags on permissions

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -3097,6 +3097,14 @@
     "message": "Streaming amount",
     "description": "Label for the stream rate of a permission"
   },
+  "gatorPermissionsStatusExpired": {
+    "message": "Expired",
+    "description": "Tag label for a gator permission that has expired"
+  },
+  "gatorPermissionsStatusRevoked": {
+    "message": "Revoked",
+    "description": "Tag label for a gator permission that has been revoked"
+  },
   "general": {
     "message": "General"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -3089,14 +3089,6 @@
     "message": "Start date",
     "description": "Label for the start date of a permission"
   },
-  "gatorPermissionsStreamRate": {
-    "message": "Stream rate",
-    "description": "Label for the stream rate of a permission"
-  },
-  "gatorPermissionsStreamingAmountLabel": {
-    "message": "Streaming amount",
-    "description": "Label for the stream rate of a permission"
-  },
   "gatorPermissionsStatusExpired": {
     "message": "Expired",
     "description": "Tag label for a gator permission that has expired"
@@ -3104,6 +3096,14 @@
   "gatorPermissionsStatusRevoked": {
     "message": "Revoked",
     "description": "Tag label for a gator permission that has been revoked"
+  },
+  "gatorPermissionsStreamRate": {
+    "message": "Stream rate",
+    "description": "Label for the stream rate of a permission"
+  },
+  "gatorPermissionsStreamingAmountLabel": {
+    "message": "Streaming amount",
+    "description": "Label for the stream rate of a permission"
   },
   "general": {
     "message": "General"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -3089,6 +3089,14 @@
     "message": "Start date",
     "description": "Label for the start date of a permission"
   },
+  "gatorPermissionsStatusExpired": {
+    "message": "Expired",
+    "description": "Tag label for a gator permission that has expired"
+  },
+  "gatorPermissionsStatusRevoked": {
+    "message": "Revoked",
+    "description": "Tag label for a gator permission that has been revoked"
+  },
   "gatorPermissionsStreamRate": {
     "message": "Stream rate",
     "description": "Label for the stream rate of a permission"

--- a/ui/components/multichain/pages/gator-permissions/components/__snapshots__/review-gator-permission-item.test.tsx.snap
+++ b/ui/components/multichain/pages/gator-permissions/components/__snapshots__/review-gator-permission-item.test.tsx.snap
@@ -11,13 +11,19 @@ exports[`Permission List Item render ERC20 token permissions renders erc20 token
     >
       <div
         class="flex flex-row gap-2 justify-between"
-        style="flex: 1; align-self: center;"
+        style="align-items: center;"
       >
-        <p
-          class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default truncate"
+        <div
+          class="flex flex-row gap-2"
+          style="flex: 1; min-width: 0; align-items: center;"
         >
-          localhost:8000
-        </p>
+          <p
+            class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default truncate"
+            style="min-width: 0;"
+          >
+            localhost:8000
+          </p>
+        </div>
         <button
           class="inline-flex items-center justify-center rounded-xl px-4 font-medium min-w-20 overflow-hidden relative h-12 transition-all duration-100 ease-linear active:scale-[0.97] active:ease-[cubic-bezier(0.3,0.8,0.3,1)] bg-icon-default text-primary-inverse hover:bg-icon-default-hover active:bg-icon-default-pressed focus-visible:ring-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-default"
           role="button"
@@ -201,13 +207,19 @@ exports[`Permission List Item render ERC20 token permissions renders erc20 token
     >
       <div
         class="flex flex-row gap-2 justify-between"
-        style="flex: 1; align-self: center;"
+        style="align-items: center;"
       >
-        <p
-          class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default truncate"
+        <div
+          class="flex flex-row gap-2"
+          style="flex: 1; min-width: 0; align-items: center;"
         >
-          localhost:8000
-        </p>
+          <p
+            class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default truncate"
+            style="min-width: 0;"
+          >
+            localhost:8000
+          </p>
+        </div>
         <button
           class="inline-flex items-center justify-center rounded-xl px-4 font-medium min-w-20 overflow-hidden relative h-12 transition-all duration-100 ease-linear active:scale-[0.97] active:ease-[cubic-bezier(0.3,0.8,0.3,1)] bg-icon-default text-primary-inverse hover:bg-icon-default-hover active:bg-icon-default-pressed focus-visible:ring-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-default"
           role="button"
@@ -396,13 +408,19 @@ exports[`Permission List Item render ERC20 token permissions renders erc20 token
     >
       <div
         class="flex flex-row gap-2 justify-between"
-        style="flex: 1; align-self: center;"
+        style="align-items: center;"
       >
-        <p
-          class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default truncate"
+        <div
+          class="flex flex-row gap-2"
+          style="flex: 1; min-width: 0; align-items: center;"
         >
-          localhost:8000
-        </p>
+          <p
+            class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default truncate"
+            style="min-width: 0;"
+          >
+            localhost:8000
+          </p>
+        </div>
         <button
           class="inline-flex items-center justify-center rounded-xl px-4 font-medium min-w-20 overflow-hidden relative h-12 transition-all duration-100 ease-linear active:scale-[0.97] active:ease-[cubic-bezier(0.3,0.8,0.3,1)] bg-icon-default text-primary-inverse hover:bg-icon-default-hover active:bg-icon-default-pressed focus-visible:ring-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-default"
           role="button"
@@ -565,13 +583,19 @@ exports[`Permission List Item render ERC20 token permissions renders erc20 token
     >
       <div
         class="flex flex-row gap-2 justify-between"
-        style="flex: 1; align-self: center;"
+        style="align-items: center;"
       >
-        <p
-          class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default truncate"
+        <div
+          class="flex flex-row gap-2"
+          style="flex: 1; min-width: 0; align-items: center;"
         >
-          localhost:8000
-        </p>
+          <p
+            class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default truncate"
+            style="min-width: 0;"
+          >
+            localhost:8000
+          </p>
+        </div>
         <button
           class="inline-flex items-center justify-center rounded-xl px-4 font-medium min-w-20 overflow-hidden relative h-12 transition-all duration-100 ease-linear active:scale-[0.97] active:ease-[cubic-bezier(0.3,0.8,0.3,1)] bg-icon-default text-primary-inverse hover:bg-icon-default-hover active:bg-icon-default-pressed focus-visible:ring-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-default"
           role="button"
@@ -755,13 +779,19 @@ exports[`Permission List Item render NATIVE token permissions renders native tok
     >
       <div
         class="flex flex-row gap-2 justify-between"
-        style="flex: 1; align-self: center;"
+        style="align-items: center;"
       >
-        <p
-          class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default truncate"
+        <div
+          class="flex flex-row gap-2"
+          style="flex: 1; min-width: 0; align-items: center;"
         >
-          localhost:8000
-        </p>
+          <p
+            class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default truncate"
+            style="min-width: 0;"
+          >
+            localhost:8000
+          </p>
+        </div>
         <button
           class="inline-flex items-center justify-center rounded-xl px-4 font-medium min-w-20 overflow-hidden relative h-12 transition-all duration-100 ease-linear active:scale-[0.97] active:ease-[cubic-bezier(0.3,0.8,0.3,1)] bg-icon-default text-primary-inverse hover:bg-icon-default-hover active:bg-icon-default-pressed focus-visible:ring-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-default"
           role="button"
@@ -945,13 +975,19 @@ exports[`Permission List Item render NATIVE token permissions renders native tok
     >
       <div
         class="flex flex-row gap-2 justify-between"
-        style="flex: 1; align-self: center;"
+        style="align-items: center;"
       >
-        <p
-          class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default truncate"
+        <div
+          class="flex flex-row gap-2"
+          style="flex: 1; min-width: 0; align-items: center;"
         >
-          localhost:8000
-        </p>
+          <p
+            class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default truncate"
+            style="min-width: 0;"
+          >
+            localhost:8000
+          </p>
+        </div>
         <button
           class="inline-flex items-center justify-center rounded-xl px-4 font-medium min-w-20 overflow-hidden relative h-12 transition-all duration-100 ease-linear active:scale-[0.97] active:ease-[cubic-bezier(0.3,0.8,0.3,1)] bg-icon-default text-primary-inverse hover:bg-icon-default-hover active:bg-icon-default-pressed focus-visible:ring-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-default"
           role="button"

--- a/ui/components/multichain/pages/gator-permissions/components/review-gator-permission-item.test.tsx
+++ b/ui/components/multichain/pages/gator-permissions/components/review-gator-permission-item.test.tsx
@@ -244,7 +244,9 @@ describe('Permission List Item', () => {
             store,
           );
           expect(
-            getByRole('button', { name: messages.gatorPermissionsRevoke.message }),
+            getByRole('button', {
+              name: messages.gatorPermissionsRevoke.message,
+            }),
           ).toBeInTheDocument();
         });
 
@@ -261,7 +263,9 @@ describe('Permission List Item', () => {
             store,
           );
           expect(
-            getByRole('button', { name: messages.gatorPermissionsRevoke.message }),
+            getByRole('button', {
+              name: messages.gatorPermissionsRevoke.message,
+            }),
           ).toBeInTheDocument();
         });
 

--- a/ui/components/multichain/pages/gator-permissions/components/review-gator-permission-item.test.tsx
+++ b/ui/components/multichain/pages/gator-permissions/components/review-gator-permission-item.test.tsx
@@ -147,7 +147,6 @@ describe('Permission List Item', () => {
             ],
           },
           siteOrigin: 'http://localhost:8000',
-          status: 'Active',
         };
 
       const mockNativeTokenPeriodicPermission: PermissionInfoWithMetadata<NativeTokenPeriodicPermission> =
@@ -177,7 +176,6 @@ describe('Permission List Item', () => {
             ],
           },
           siteOrigin: 'http://localhost:8000',
-          status: 'Active',
         };
 
       describe('permission status tag', () => {
@@ -557,7 +555,6 @@ describe('Permission List Item', () => {
             ],
           },
           siteOrigin: 'http://localhost:8000',
-          status: 'Active',
         };
 
       const mockErc20TokenStreamPermission: PermissionInfoWithMetadata<Erc20TokenStreamPermission> =
@@ -589,7 +586,6 @@ describe('Permission List Item', () => {
             ],
           },
           siteOrigin: 'http://localhost:8000',
-          status: 'Active',
         };
 
       it('renders erc20 token stream permission correctly', () => {

--- a/ui/components/multichain/pages/gator-permissions/components/review-gator-permission-item.test.tsx
+++ b/ui/components/multichain/pages/gator-permissions/components/review-gator-permission-item.test.tsx
@@ -12,6 +12,7 @@ import { Settings } from 'luxon';
 import { renderWithProvider } from '../../../../../../test/lib/render-helpers-navigate';
 import configureStore from '../../../../../store/store';
 import mockState from '../../../../../../test/data/mock-state.json';
+import { getPendingRevocations } from '../../../../../selectors/gator-permissions/gator-permissions';
 import { ReviewGatorPermissionItem } from './review-gator-permission-item';
 
 const mockAccountAddress = '0x4f71DA06987BfeDE90aF0b33E1e3e4ffDCEE7a63';
@@ -143,6 +144,7 @@ describe('Permission List Item', () => {
             ],
           },
           siteOrigin: 'http://localhost:8000',
+          status: 'Active',
         };
 
       const mockNativeTokenPeriodicPermission: PermissionInfoWithMetadata<NativeTokenPeriodicPermission> =
@@ -172,7 +174,152 @@ describe('Permission List Item', () => {
             ],
           },
           siteOrigin: 'http://localhost:8000',
+          status: 'Active',
         };
+
+      describe('permission status tag', () => {
+        it('shows an expired tag when permission status is Expired', () => {
+          const { getByTestId } = renderWithProvider(
+            <ReviewGatorPermissionItem
+              networkName={mockNetworkName}
+              gatorPermission={{
+                ...mockNativeTokenStreamPermission,
+                status: 'Expired',
+              }}
+              onRevokeClick={() => mockOnClick()}
+            />,
+            store,
+          );
+          expect(
+            getByTestId('review-gator-permission-status-tag'),
+          ).toHaveTextContent('Expired');
+        });
+
+        it('shows a revoked tag when permission status is Revoked', () => {
+          const { getByTestId } = renderWithProvider(
+            <ReviewGatorPermissionItem
+              networkName={mockNetworkName}
+              gatorPermission={{
+                ...mockNativeTokenStreamPermission,
+                status: 'Revoked',
+              }}
+              onRevokeClick={() => mockOnClick()}
+            />,
+            store,
+          );
+          expect(
+            getByTestId('review-gator-permission-status-tag'),
+          ).toHaveTextContent('Revoked');
+        });
+
+        it('does not show a status tag when permission status is Active', () => {
+          const { queryByTestId } = renderWithProvider(
+            <ReviewGatorPermissionItem
+              networkName={mockNetworkName}
+              gatorPermission={{
+                ...mockNativeTokenStreamPermission,
+                status: 'Active',
+              }}
+              onRevokeClick={() => mockOnClick()}
+            />,
+            store,
+          );
+          expect(
+            queryByTestId('review-gator-permission-status-tag'),
+          ).not.toBeInTheDocument();
+        });
+      });
+
+      describe('revoke button label', () => {
+        it('shows Revoke when permission status is Active', () => {
+          const { getByRole } = renderWithProvider(
+            <ReviewGatorPermissionItem
+              networkName={mockNetworkName}
+              gatorPermission={mockNativeTokenStreamPermission}
+              onRevokeClick={() => mockOnClick()}
+            />,
+            store,
+          );
+          expect(
+            getByRole('button', { name: 'Revoke' }),
+          ).toBeInTheDocument();
+        });
+
+        it('shows Remove when permission status is Expired', () => {
+          const { getByRole } = renderWithProvider(
+            <ReviewGatorPermissionItem
+              networkName={mockNetworkName}
+              gatorPermission={{
+                ...mockNativeTokenStreamPermission,
+                status: 'Expired',
+              }}
+              onRevokeClick={() => mockOnClick()}
+            />,
+            store,
+          );
+          expect(
+            getByRole('button', { name: 'Remove' }),
+          ).toBeInTheDocument();
+        });
+
+        it('shows Remove when permission status is Revoked', () => {
+          const { getByRole } = renderWithProvider(
+            <ReviewGatorPermissionItem
+              networkName={mockNetworkName}
+              gatorPermission={{
+                ...mockNativeTokenStreamPermission,
+                status: 'Revoked',
+              }}
+              onRevokeClick={() => mockOnClick()}
+            />,
+            store,
+          );
+          expect(
+            getByRole('button', { name: 'Remove' }),
+          ).toBeInTheDocument();
+        });
+
+        it('shows Revocation pending when hasRevokeBeenClicked is true even if status is Expired', () => {
+          const { getByRole } = renderWithProvider(
+            <ReviewGatorPermissionItem
+              networkName={mockNetworkName}
+              gatorPermission={{
+                ...mockNativeTokenStreamPermission,
+                status: 'Expired',
+              }}
+              hasRevokeBeenClicked
+              onRevokeClick={() => mockOnClick()}
+            />,
+            store,
+          );
+          expect(
+            getByRole('button', { name: 'Revocation pending' }),
+          ).toBeInTheDocument();
+        });
+
+        it('shows Revocation pending when permission context is in pending revocations', () => {
+          jest.mocked(getPendingRevocations).mockReturnValueOnce([
+            {
+              txId: '1',
+              permissionContext: '0x00000000',
+            },
+          ]);
+          const { getByRole } = renderWithProvider(
+            <ReviewGatorPermissionItem
+              networkName={mockNetworkName}
+              gatorPermission={{
+                ...mockNativeTokenStreamPermission,
+                status: 'Revoked',
+              }}
+              onRevokeClick={() => mockOnClick()}
+            />,
+            store,
+          );
+          expect(
+            getByRole('button', { name: 'Revocation pending' }),
+          ).toBeInTheDocument();
+        });
+      });
 
       it('renders native token stream permission correctly', () => {
         const { container, getByTestId } = renderWithProvider(
@@ -399,6 +546,7 @@ describe('Permission List Item', () => {
             ],
           },
           siteOrigin: 'http://localhost:8000',
+          status: 'Active',
         };
 
       const mockErc20TokenStreamPermission: PermissionInfoWithMetadata<Erc20TokenStreamPermission> =
@@ -430,6 +578,7 @@ describe('Permission List Item', () => {
             ],
           },
           siteOrigin: 'http://localhost:8000',
+          status: 'Active',
         };
 
       it('renders erc20 token stream permission correctly', () => {

--- a/ui/components/multichain/pages/gator-permissions/components/review-gator-permission-item.test.tsx
+++ b/ui/components/multichain/pages/gator-permissions/components/review-gator-permission-item.test.tsx
@@ -9,7 +9,10 @@ import {
 } from '@metamask/gator-permissions-controller';
 import { fireEvent } from '@testing-library/react';
 import { Settings } from 'luxon';
-import { renderWithProvider } from '../../../../../../test/lib/render-helpers-navigate';
+import {
+  en as messages,
+  renderWithProvider,
+} from '../../../../../../test/lib/render-helpers-navigate';
 import configureStore from '../../../../../store/store';
 import mockState from '../../../../../../test/data/mock-state.json';
 import { getPendingRevocations } from '../../../../../selectors/gator-permissions/gator-permissions';
@@ -241,11 +244,11 @@ describe('Permission List Item', () => {
             store,
           );
           expect(
-            getByRole('button', { name: 'Revoke' }),
+            getByRole('button', { name: messages.gatorPermissionsRevoke.message }),
           ).toBeInTheDocument();
         });
 
-        it('shows Remove when permission status is Expired', () => {
+        it('shows Revoke when permission status is Expired', () => {
           const { getByRole } = renderWithProvider(
             <ReviewGatorPermissionItem
               networkName={mockNetworkName}
@@ -258,7 +261,7 @@ describe('Permission List Item', () => {
             store,
           );
           expect(
-            getByRole('button', { name: 'Remove' }),
+            getByRole('button', { name: messages.gatorPermissionsRevoke.message }),
           ).toBeInTheDocument();
         });
 
@@ -275,7 +278,7 @@ describe('Permission List Item', () => {
             store,
           );
           expect(
-            getByRole('button', { name: 'Remove' }),
+            getByRole('button', { name: messages.remove.message }),
           ).toBeInTheDocument();
         });
 
@@ -293,7 +296,9 @@ describe('Permission List Item', () => {
             store,
           );
           expect(
-            getByRole('button', { name: 'Revocation pending' }),
+            getByRole('button', {
+              name: messages.gatorPermissionsRevocationPending.message,
+            }),
           ).toBeInTheDocument();
         });
 
@@ -316,7 +321,9 @@ describe('Permission List Item', () => {
             store,
           );
           expect(
-            getByRole('button', { name: 'Revocation pending' }),
+            getByRole('button', {
+              name: messages.gatorPermissionsRevocationPending.message,
+            }),
           ).toBeInTheDocument();
         });
       });

--- a/ui/components/multichain/pages/gator-permissions/components/review-gator-permission-item.tsx
+++ b/ui/components/multichain/pages/gator-permissions/components/review-gator-permission-item.tsx
@@ -12,13 +12,13 @@ import {
   ButtonIcon,
   ButtonIconSize,
   IconName,
-  Button,
+  Button
 } from '@metamask/design-system-react';
-import { PermissionInfoWithMetadata } from '@metamask/gator-permissions-controller';
+import { GatorPermissionStatus, PermissionInfoWithMetadata } from '@metamask/gator-permissions-controller';
 import { getURLHost } from '../../../../../helpers/utils/util';
 import Card from '../../../../ui/card';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
-import { BackgroundColor } from '../../../../../helpers/constants/design-system';
+import { BackgroundColor, TextColor as DesignSystemTextColor } from '../../../../../helpers/constants/design-system';
 import { getPendingRevocations } from '../../../../../selectors/gator-permissions/gator-permissions';
 import { useGatorPermissionTokenInfo } from '../../../../../hooks/gator-permissions/useGatorPermissionTokenInfo';
 import { useBoolean } from '../../../../../hooks/useBoolean';
@@ -43,6 +43,39 @@ function permissionDataForReview(permission: {
     return permission.data as Record<string, unknown>;
   }
   return {};
+}
+
+type InactivePermissionStatusTag = {
+  label: string;
+  backgroundColor: BackgroundColor;
+  labelColor: TextColor;
+};
+
+function getInactivePermissionStatusTag(
+  permissionStatus: GatorPermissionStatus,
+  translate: ReturnType<typeof useI18nContext>,
+): InactivePermissionStatusTag | null {
+  switch (permissionStatus) {
+    case 'Active':
+      return null;
+    case 'Expired':
+      return {
+        label: translate('gatorPermissionsStatusExpired'),
+        backgroundColor: BackgroundColor.warningMuted,
+        labelColor: TextColor.WarningDefault,
+      };
+    case 'Revoked':
+      return {
+        label: translate('gatorPermissionsStatusRevoked'),
+        backgroundColor: BackgroundColor.errorMuted,
+        labelColor: TextColor.ErrorDefault,
+      };
+    default: {
+      throw new Error(
+        `Unexpected gator permission status: ${String(permissionStatus)}`,
+      );
+    }
+  }
 }
 
 type ReviewGatorPermissionItemProps = {
@@ -105,30 +138,22 @@ export const ReviewGatorPermissionItem = ({
     );
   }, [pendingRevocations, permissionContext, hasRevokeBeenClicked]);
 
+  const revokeButtonLabel = useMemo(() => {
+    if (isPendingRevocation) {
+      return t('gatorPermissionsRevocationPending');
+    }
+    if (status === 'Revoked') {
+      return t('remove');
+    }
+    return t('gatorPermissionsRevoke');
+  }, [isPendingRevocation, status, t]);
+
   const permissionData = useMemo(
     () => permissionDataForReview(permissionResponse.permission),
     [permissionResponse.permission],
   );
 
-  const revokeButtonLabel = (() => {
-    if (isPendingRevocation) {
-      return t('gatorPermissionsRevocationPending');
-    }
-    if (status === 'Expired' || status === 'Revoked') {
-      return t('remove');
-    }
-    return t('gatorPermissionsRevoke');
-  })();
-
-  const statusTagLabel = (() => {
-    if (status === 'Expired') {
-      return t('gatorPermissionsStatusExpired');
-    }
-    if (status === 'Revoked') {
-      return t('gatorPermissionsStatusRevoked');
-    }
-    return null;
-  })();
+  const statusTag = getInactivePermissionStatusTag(status, t);
 
   const commonRendererProps = useMemo(
     () => ({
@@ -183,10 +208,14 @@ export const ReviewGatorPermissionItem = ({
             >
               {getURLHost(siteOrigin)}
             </Text>
-            {statusTagLabel ? (
+            {statusTag ? (
               <Tag
                 data-testid="review-gator-permission-status-tag"
-                label={statusTagLabel}
+                label={statusTag.label}
+                backgroundColor={statusTag.backgroundColor}
+                labelProps={{ color: statusTag.labelColor as DesignSystemTextColor}}
+                textVariant={TextVariant.BodySm}
+                style={{ flexShrink: 0 }}
               />
             ) : null}
           </Box>

--- a/ui/components/multichain/pages/gator-permissions/components/review-gator-permission-item.tsx
+++ b/ui/components/multichain/pages/gator-permissions/components/review-gator-permission-item.tsx
@@ -22,6 +22,7 @@ import { BackgroundColor } from '../../../../../helpers/constants/design-system'
 import { getPendingRevocations } from '../../../../../selectors/gator-permissions/gator-permissions';
 import { useGatorPermissionTokenInfo } from '../../../../../hooks/gator-permissions/useGatorPermissionTokenInfo';
 import { useBoolean } from '../../../../../hooks/useBoolean';
+import { Tag } from '../../../../component-library';
 import { ReviewPermissionRenderer } from './review-permission-renderer';
 
 /**
@@ -74,7 +75,7 @@ export const ReviewGatorPermissionItem = ({
 }: ReviewGatorPermissionItemProps) => {
   const t = useI18nContext();
 
-  const { permissionResponse, siteOrigin } = gatorPermission;
+  const { permissionResponse, siteOrigin, status } = gatorPermission;
   const {
     chainId,
     permission: {
@@ -108,6 +109,26 @@ export const ReviewGatorPermissionItem = ({
     () => permissionDataForReview(permissionResponse.permission),
     [permissionResponse.permission],
   );
+
+  const revokeButtonLabel = (() => {
+    if (isPendingRevocation) {
+      return t('gatorPermissionsRevocationPending');
+    }
+    if (status === 'Expired' || status === 'Revoked') {
+      return t('remove');
+    }
+    return t('gatorPermissionsRevoke');
+  })();
+
+  const statusTagLabel = (() => {
+    if (status === 'Expired') {
+      return t('gatorPermissionsStatusExpired');
+    }
+    if (status === 'Revoked') {
+      return t('gatorPermissionsStatusRevoked');
+    }
+    return null;
+  })();
 
   const commonRendererProps = useMemo(
     () => ({
@@ -143,12 +164,32 @@ export const ReviewGatorPermissionItem = ({
         <Box
           flexDirection={BoxFlexDirection.Row}
           justifyContent={BoxJustifyContent.Between}
-          style={{ flex: '1', alignSelf: 'center' }}
           gap={2}
+          style={{ alignItems: 'center' }}
         >
-          <Text variant={TextVariant.BodyMd} ellipsis>
-            {getURLHost(siteOrigin)}
-          </Text>
+          <Box
+            flexDirection={BoxFlexDirection.Row}
+            gap={2}
+            style={{
+              flex: 1,
+              minWidth: 0,
+              alignItems: 'center',
+            }}
+          >
+            <Text
+              variant={TextVariant.BodyMd}
+              ellipsis
+              style={{ minWidth: 0 }}
+            >
+              {getURLHost(siteOrigin)}
+            </Text>
+            {statusTagLabel ? (
+              <Tag
+                data-testid="review-gator-permission-status-tag"
+                label={statusTagLabel}
+              />
+            ) : null}
+          </Box>
           <Button
             onClick={onRevokeClick}
             disabled={isPendingRevocation}
@@ -166,9 +207,7 @@ export const ReviewGatorPermissionItem = ({
               }
               variant={TextVariant.BodyMd}
             >
-              {isPendingRevocation
-                ? t('gatorPermissionsRevocationPending')
-                : t('gatorPermissionsRevoke')}
+              {revokeButtonLabel}
             </Text>
           </Button>
         </Box>

--- a/ui/components/multichain/pages/gator-permissions/components/review-gator-permission-item.tsx
+++ b/ui/components/multichain/pages/gator-permissions/components/review-gator-permission-item.tsx
@@ -12,13 +12,19 @@ import {
   ButtonIcon,
   ButtonIconSize,
   IconName,
-  Button
+  Button,
 } from '@metamask/design-system-react';
-import { GatorPermissionStatus, PermissionInfoWithMetadata } from '@metamask/gator-permissions-controller';
+import {
+  GatorPermissionStatus,
+  PermissionInfoWithMetadata,
+} from '@metamask/gator-permissions-controller';
 import { getURLHost } from '../../../../../helpers/utils/util';
 import Card from '../../../../ui/card';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
-import { BackgroundColor, TextColor as DesignSystemTextColor } from '../../../../../helpers/constants/design-system';
+import {
+  BackgroundColor,
+  TextColor as DesignSystemTextColor,
+} from '../../../../../helpers/constants/design-system';
 import { getPendingRevocations } from '../../../../../selectors/gator-permissions/gator-permissions';
 import { useGatorPermissionTokenInfo } from '../../../../../hooks/gator-permissions/useGatorPermissionTokenInfo';
 import { useBoolean } from '../../../../../hooks/useBoolean';
@@ -201,11 +207,7 @@ export const ReviewGatorPermissionItem = ({
               alignItems: 'center',
             }}
           >
-            <Text
-              variant={TextVariant.BodyMd}
-              ellipsis
-              style={{ minWidth: 0 }}
-            >
+            <Text variant={TextVariant.BodyMd} ellipsis style={{ minWidth: 0 }}>
               {getURLHost(siteOrigin)}
             </Text>
             {statusTag ? (
@@ -213,7 +215,9 @@ export const ReviewGatorPermissionItem = ({
                 data-testid="review-gator-permission-status-tag"
                 label={statusTag.label}
                 backgroundColor={statusTag.backgroundColor}
-                labelProps={{ color: statusTag.labelColor as DesignSystemTextColor}}
+                labelProps={{
+                  color: statusTag.labelColor as DesignSystemTextColor,
+                }}
                 textVariant={TextVariant.BodySm}
                 style={{ flexShrink: 0 }}
               />


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Permissions that have either expired or have been revoked on-chain will now have the `status` assigned by @metamask/delegation-controller. This PR adds a `<Tag>` to expired and revoked permissions, indicating the status. For permissions that have been revoked, the "Revoke" button becomes "Remove".

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Advanced Permissions now show either expired or revoked status in Dapp Connections

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<img width="502" height="807" alt="Screenshot 2026-04-21 at 1 02 40 PM" src="https://github.com/user-attachments/assets/bcbecb5b-192f-443a-bc3c-2a6c34070c9a" />

<img width="458" height="393" alt="Screenshot 2026-04-14 at 3 34 54 PM" src="https://github.com/user-attachments/assets/9ab336bd-1108-402a-a97c-d6e8bb4ea2be" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change: adds localized status tags and adjusts the revoke button label based on permission status/pending revocation, with snapshot and unit test updates.
> 
> **Overview**
> Adds localized `Expired` and `Revoked` status tags to `ReviewGatorPermissionItem`, rendering a colored `<Tag>` next to the site host for inactive permissions.
> 
> Updates the action button label to show **Remove** for revoked permissions and **Revocation pending** when a revocation is in progress (via local click state or `getPendingRevocations`), and refreshes tests/snapshots to cover the new UI states.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 341b514680687996e9c60a9413892cc18692efa1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->