### PR TITLE
test: fix flaky test `Check balance For a non 0 balance account - USD balance`

### DIFF
--- a/test/e2e/page-objects/pages/home/non-evm-homepage.ts
+++ b/test/e2e/page-objects/pages/home/non-evm-homepage.ts
@@ -17,15 +17,14 @@ class NonEvmHomepage extends HomePage {
 
   async checkPageIsLoaded({ amount }: { amount?: string } = {}): Promise<void> {
     await super.checkPageIsLoaded();
-    await this.driver.delay(regularDelayMs); // workaround to avoid flakiness
     if (amount) {
-      await this.driver.wait(async () => {
-        await this.driver.waitForSelector({
+      await this.driver.waitForSelector(
+        {
           text: `${amount}`,
           tag: 'span',
-        });
-        return true;
-      }, 60000);
+        },
+        { timeout: 60000 },
+      );
     }
   }
 

--- a/test/e2e/page-objects/pages/home/non-evm-homepage.ts
+++ b/test/e2e/page-objects/pages/home/non-evm-homepage.ts
@@ -1,4 +1,3 @@
-import { regularDelayMs } from '../../../helpers';
 import HomePage from './homepage';
 
 class NonEvmHomepage extends HomePage {
@@ -18,13 +17,10 @@ class NonEvmHomepage extends HomePage {
   async checkPageIsLoaded({ amount }: { amount?: string } = {}): Promise<void> {
     await super.checkPageIsLoaded();
     if (amount) {
-      await this.driver.waitForSelector(
-        {
-          text: `${amount}`,
-          tag: 'span',
-        },
-        { timeout: 60000 },
-      );
+      await this.driver.waitForSelector({
+        text: `${amount}`,
+        tag: 'span',
+      });
     }
   }
 

--- a/test/e2e/tests/tron/check-balance.spec.ts
+++ b/test/e2e/tests/tron/check-balance.spec.ts
@@ -48,7 +48,8 @@ describe('Check balance', function (this: Suite) {
 
         const nonEvmHomePage = new NonEvmHomepage(driver);
         // TRX_BALANCE = 6072392 SUN = ~6.07 TRX * $0.29469 = ~$1.79
-        await nonEvmHomePage.checkPageIsLoaded({ amount: '$10.18' });
+        // Total Fiat = TRX $1.79, HTX DAO $5.30, USDT $2.80, USDD $0.29 = $10.18
+        await nonEvmHomePage.checkPageIsLoaded({ amount: '$10.58' });
       },
     );
   });

--- a/test/e2e/tests/tron/check-balance.spec.ts
+++ b/test/e2e/tests/tron/check-balance.spec.ts
@@ -49,7 +49,7 @@ describe('Check balance', function (this: Suite) {
         const nonEvmHomePage = new NonEvmHomepage(driver);
         // TRX_BALANCE = 6072392 SUN = ~6.07 TRX * $0.29469 = ~$1.79
         // Total Fiat = TRX $1.79, HTX DAO $5.30, USDT $2.80, USDD $0.29 = $10.18
-        await nonEvmHomePage.checkPageIsLoaded({ amount: '$10.58' });
+        await nonEvmHomePage.checkPageIsLoaded({ amount: '$10.18' });
       },
     );
   });

--- a/test/e2e/tests/tron/mocks/common-tron.ts
+++ b/test/e2e/tests/tron/mocks/common-tron.ts
@@ -709,6 +709,7 @@ export async function mockTronAssets(
 ): Promise<MockedEndpoint> {
   return mockServer
     .forGet('https://tokens.api.cx.metamask.io/v3/assets')
+    .always()
     .thenCallback(() => ({
       statusCode: 200,
       json: [


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The test is flaky as sometimes there are 2 requests made to the assets API, leading to a different balance (only Tron token).

Now we apply the assets mock always, so we ensure we'll always get the same tokens, no matter if 1 or 2 calls happen.

<img width="1069" height="510" alt="image" src="https://github.com/user-attachments/assets/598fe429-bebc-4b82-9d20-3a66cfacf47d" />

Failed test had $1.79 without the rest of tokens loaded:
<img width="1152" height="836" alt="image" src="https://github.com/user-attachments/assets/26dfc75e-daec-4b19-aeff-484ba0622f0e" />


Expected: all tokens loaded, so balance is $10.58

<img width="1192" height="917" alt="image" src="https://github.com/user-attachments/assets/39faa494-2077-433e-9a9c-a96b4688e744" />


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are confined to E2E test code and mocks; main impact is potential change in test timing/expectations, not production behavior.
> 
> **Overview**
> Fixes Tron E2E balance-test flakiness by making the `GET https://tokens.api.cx.metamask.io/v3/assets` mock in `mockTronAssets` apply to every request (via `.always()`), ensuring consistent token lists even when the app calls the endpoint multiple times.
> 
> Simplifies `NonEvmHomepage.checkPageIsLoaded` by removing an extra delay and a custom polling loop, relying on a direct `waitForSelector` when asserting an `amount`, and updates the Tron USD-balance test comment to reflect the expected aggregated fiat total (`$10.18`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 385911ecbf8185a85449690e6b527f7257593748. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->