### PR TITLE
feat: add Hyperliquid referral flow on address switch → connect

### DIFF
--- a/app/scripts/controllers/permissions/background-api.test.ts
+++ b/app/scripts/controllers/permissions/background-api.test.ts
@@ -331,6 +331,89 @@ describe('permission background API methods', () => {
         },
       );
     });
+
+    it('invokes onPermittedAccountsAdded when a new CAIP account id is added', () => {
+      const onPermittedAccountsAdded = jest.fn();
+      const permissionController = {
+        getCaveat: jest.fn().mockReturnValue({
+          value: {
+            requiredScopes: {
+              'eip155:1': {
+                accounts: ['eip155:1:0x1'],
+              },
+            },
+            optionalScopes: {},
+            isMultichainOrigin: false,
+          },
+        }),
+        updateCaveat: jest.fn(),
+      };
+
+      const accountsController = {
+        getAccountByAddress: jest.fn().mockReturnValue({
+          address: '0x2',
+          scopes: ['eip155:1'],
+        }),
+        state: {
+          internalAccounts: MOCK_EMPTY_INTERNAL_ACCOUNTS,
+        },
+      };
+
+      MockNetworkSelectors.getNetworkConfigurationsByCaipChainId.mockReturnValue(
+        { 'eip155:1': MOCK_NETWORK_CONFIG },
+      );
+
+      setupPermissionBackgroundApiMethods({
+        permissionController,
+        accountsController,
+        onPermittedAccountsAdded,
+      }).addPermittedAccount('foo.com', '0x2');
+
+      expect(onPermittedAccountsAdded).toHaveBeenCalledWith({
+        origin: 'foo.com',
+        newlyAddedCaipAccountIds: ['eip155:1:0x2'],
+      });
+    });
+
+    it('does not invoke onPermittedAccountsAdded when the account was already permitted', () => {
+      const onPermittedAccountsAdded = jest.fn();
+      const permissionController = {
+        getCaveat: jest.fn().mockReturnValue({
+          value: {
+            requiredScopes: {
+              'eip155:1': {
+                accounts: ['eip155:1:0x2'],
+              },
+            },
+            optionalScopes: {},
+            isMultichainOrigin: false,
+          },
+        }),
+        updateCaveat: jest.fn(),
+      };
+
+      const accountsController = {
+        getAccountByAddress: jest.fn().mockReturnValue({
+          address: '0x2',
+          scopes: ['eip155:1'],
+        }),
+        state: {
+          internalAccounts: MOCK_EMPTY_INTERNAL_ACCOUNTS,
+        },
+      };
+
+      MockNetworkSelectors.getNetworkConfigurationsByCaipChainId.mockReturnValue(
+        { 'eip155:1': MOCK_NETWORK_CONFIG },
+      );
+
+      setupPermissionBackgroundApiMethods({
+        permissionController,
+        accountsController,
+        onPermittedAccountsAdded,
+      }).addPermittedAccount('foo.com', '0x2');
+
+      expect(onPermittedAccountsAdded).not.toHaveBeenCalled();
+    });
   });
 
   describe('addPermittedAccounts', () => {

--- a/app/scripts/controllers/permissions/background-api.test.ts
+++ b/app/scripts/controllers/permissions/background-api.test.ts
@@ -414,6 +414,48 @@ describe('permission background API methods', () => {
 
       expect(onPermittedAccountsAdded).not.toHaveBeenCalled();
     });
+
+    it('does not invoke onPermittedAccountsAdded when caveat address casing differs from internal account', () => {
+      const onPermittedAccountsAdded = jest.fn();
+      const mixedCaseAddress = '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed';
+      const lowerCasePermittedId = `eip155:1:${mixedCaseAddress.toLowerCase()}`;
+      const permissionController = {
+        getCaveat: jest.fn().mockReturnValue({
+          value: {
+            requiredScopes: {
+              'eip155:1': {
+                accounts: [lowerCasePermittedId],
+              },
+            },
+            optionalScopes: {},
+            isMultichainOrigin: false,
+          },
+        }),
+        updateCaveat: jest.fn(),
+      };
+
+      const accountsController = {
+        getAccountByAddress: jest.fn().mockReturnValue({
+          address: mixedCaseAddress,
+          scopes: ['eip155:1'],
+        }),
+        state: {
+          internalAccounts: MOCK_EMPTY_INTERNAL_ACCOUNTS,
+        },
+      };
+
+      MockNetworkSelectors.getNetworkConfigurationsByCaipChainId.mockReturnValue(
+        { 'eip155:1': MOCK_NETWORK_CONFIG },
+      );
+
+      setupPermissionBackgroundApiMethods({
+        permissionController,
+        accountsController,
+        onPermittedAccountsAdded,
+      }).addPermittedAccount('foo.com', mixedCaseAddress);
+
+      expect(onPermittedAccountsAdded).not.toHaveBeenCalled();
+    });
   });
 
   describe('addPermittedAccounts', () => {

--- a/app/scripts/controllers/permissions/background-api.test.ts
+++ b/app/scripts/controllers/permissions/background-api.test.ts
@@ -371,7 +371,7 @@ describe('permission background API methods', () => {
 
       expect(onPermittedAccountsAdded).toHaveBeenCalledWith({
         origin: 'foo.com',
-        newlyAddedCaipAccountIds: ['eip155:1:0x2'],
+        newCaipAccountIds: ['eip155:1:0x2'],
       });
     });
 

--- a/app/scripts/controllers/permissions/background-api.ts
+++ b/app/scripts/controllers/permissions/background-api.ts
@@ -27,6 +27,11 @@ import type { MultichainNetworkControllerState } from '@metamask/multichain-netw
 import { getNetworkConfigurationsByCaipChainId } from '../../../../shared/lib/selectors/networks';
 
 export type PermissionBackgroundApiOptions = {
+  // Invoked after permitted accounts are extended for an origin
+  onPermittedAccountsAdded?: (payload: {
+    origin: string;
+    newlyAddedCaipAccountIds: CaipAccountId[];
+  }) => void;
   permissionController: {
     getCaveat(
       origin: string,
@@ -80,6 +85,7 @@ export function getPermissionBackgroundApiMethods({
   accountsController,
   networkController,
   multichainNetworkController,
+  onPermittedAccountsAdded,
 }: PermissionBackgroundApiOptions) {
   // Returns the CAIP-25 caveat or undefined if it does not exist
   const getCaip25Caveat = (
@@ -263,7 +269,18 @@ export function getPermissionBackgroundApiMethods({
       new Set([...existingPermittedAccountIds, ...caipAccountIds]),
     );
 
+    const newlyAddedCaipAccountIds = caipAccountIds.filter(
+      (id) => !existingPermittedAccountIds.includes(id),
+    ) as CaipAccountId[];
+
     setPermittedAccounts(origin, updatedAccountIds as CaipAccountId[]);
+
+    if (newlyAddedCaipAccountIds.length > 0) {
+      onPermittedAccountsAdded?.({
+        origin,
+        newlyAddedCaipAccountIds,
+      });
+    }
   };
 
   const addMoreChains = (origin: string, chainIds: string[]): void => {

--- a/app/scripts/controllers/permissions/background-api.ts
+++ b/app/scripts/controllers/permissions/background-api.ts
@@ -19,6 +19,7 @@ import {
   type CaipChainId,
   parseCaipAccountId,
   parseCaipChainId,
+  toCaipAccountId,
 } from '@metamask/utils';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 import type { AccountsControllerState } from '@metamask/accounts-controller';
@@ -258,7 +259,10 @@ export function getPermissionBackgroundApiMethods({
     // setPermittedAccounts currently sets accounts on all matching
     // namespaces, not just the exact CaipChainId.
     const caipAccountIds = internalAccounts.map((internalAccount) => {
-      return `${internalAccount.scopes[0]}:${internalAccount.address}`;
+      const { namespace, reference } = parseCaipChainId(
+        internalAccount.scopes[0],
+      );
+      return toCaipAccountId(namespace, reference, internalAccount.address);
     });
 
     const existingPermittedAccountIds = getCaipAccountIdsFromCaip25CaveatValue(
@@ -266,14 +270,17 @@ export function getPermissionBackgroundApiMethods({
     );
 
     const updatedAccountIds = Array.from(
-      new Set([...existingPermittedAccountIds, ...caipAccountIds]),
+      new Set<CaipAccountId>([
+        ...existingPermittedAccountIds,
+        ...caipAccountIds,
+      ]),
     );
 
     const newlyAddedCaipAccountIds = caipAccountIds.filter(
       (id) => !existingPermittedAccountIds.includes(id),
-    ) as CaipAccountId[];
+    );
 
-    setPermittedAccounts(origin, updatedAccountIds as CaipAccountId[]);
+    setPermittedAccounts(origin, updatedAccountIds);
 
     if (newlyAddedCaipAccountIds.length > 0) {
       onPermittedAccountsAdded?.({

--- a/app/scripts/controllers/permissions/background-api.ts
+++ b/app/scripts/controllers/permissions/background-api.ts
@@ -25,6 +25,7 @@ import type { InternalAccount } from '@metamask/keyring-internal-api';
 import type { AccountsControllerState } from '@metamask/accounts-controller';
 import type { NetworkState } from '@metamask/network-controller';
 import type { MultichainNetworkControllerState } from '@metamask/multichain-network-controller';
+import log from 'loglevel';
 import { getNetworkConfigurationsByCaipChainId } from '../../../../shared/lib/selectors/networks';
 
 export type PermissionBackgroundApiOptions = {
@@ -283,10 +284,17 @@ export function getPermissionBackgroundApiMethods({
     setPermittedAccounts(origin, updatedAccountIds);
 
     if (newCaipAccountIds.length > 0) {
-      onPermittedAccountsAdded?.({
-        origin,
-        newCaipAccountIds,
-      });
+      try {
+        onPermittedAccountsAdded?.({
+          origin,
+          newCaipAccountIds,
+        });
+      } catch (error) {
+        log.error(
+          'PermissionBackgroundApi onPermittedAccountsAdded callback threw:',
+          error,
+        );
+      }
     }
   };
 

--- a/app/scripts/controllers/permissions/background-api.ts
+++ b/app/scripts/controllers/permissions/background-api.ts
@@ -9,6 +9,7 @@ import {
   Caip25EndowmentPermissionName,
   setNonSCACaipAccountIdsInCaip25CaveatValue,
   getCaipAccountIdsFromCaip25CaveatValue,
+  isCaipAccountIdInPermittedAccountIds,
   isInternalAccountInPermittedAccountIds,
   getAllScopesFromCaip25CaveatValue,
   setChainIdsInCaip25CaveatValue,
@@ -278,7 +279,8 @@ export function getPermissionBackgroundApiMethods({
     );
 
     const newCaipAccountIds = caipAccountIds.filter(
-      (id) => !existingPermittedAccountIds.includes(id),
+      (id) =>
+        !isCaipAccountIdInPermittedAccountIds(id, existingPermittedAccountIds),
     );
 
     setPermittedAccounts(origin, updatedAccountIds);

--- a/app/scripts/controllers/permissions/background-api.ts
+++ b/app/scripts/controllers/permissions/background-api.ts
@@ -31,7 +31,7 @@ export type PermissionBackgroundApiOptions = {
   // Invoked after permitted accounts are extended for an origin
   onPermittedAccountsAdded?: (payload: {
     origin: string;
-    newlyAddedCaipAccountIds: CaipAccountId[];
+    newCaipAccountIds: CaipAccountId[];
   }) => void;
   permissionController: {
     getCaveat(
@@ -276,16 +276,16 @@ export function getPermissionBackgroundApiMethods({
       ]),
     );
 
-    const newlyAddedCaipAccountIds = caipAccountIds.filter(
+    const newCaipAccountIds = caipAccountIds.filter(
       (id) => !existingPermittedAccountIds.includes(id),
     );
 
     setPermittedAccounts(origin, updatedAccountIds);
 
-    if (newlyAddedCaipAccountIds.length > 0) {
+    if (newCaipAccountIds.length > 0) {
       onPermittedAccountsAdded?.({
         origin,
-        newlyAddedCaipAccountIds,
+        newCaipAccountIds,
       });
     }
   };

--- a/app/scripts/lib/createDefiReferralMiddleware.ts
+++ b/app/scripts/lib/createDefiReferralMiddleware.ts
@@ -29,9 +29,13 @@ const WAIT_AFTER_FIRST_REQUEST_MS = SECOND * 10;
 export enum ReferralTriggerType {
   NewConnection = 'new_connection',
   OnNavigateConnectedTab = 'on_navigate_connected_tab',
-  /** User switched account and permitted a dapp connection for the selected address */
+  // Permitted accounts were extended for the origin via the permission background API
   PermittedAccountAdded = 'permitted_account_added',
 }
+
+type HandleDefiReferralOptions = {
+  activePermittedAddressOverride?: string;
+};
 
 function isExtendedJSONRPCRequest(
   req: JsonRpcRequest,
@@ -106,6 +110,7 @@ export function createDefiReferralMiddleware(
     partner: DefiReferralPartnerConfig,
     tabId: number,
     triggerType: ReferralTriggerType,
+    options?: HandleDefiReferralOptions,
   ) => Promise<void>,
 ) {
   return createAsyncMiddleware(

--- a/app/scripts/lib/createDefiReferralMiddleware.ts
+++ b/app/scripts/lib/createDefiReferralMiddleware.ts
@@ -29,6 +29,8 @@ const WAIT_AFTER_FIRST_REQUEST_MS = SECOND * 10;
 export enum ReferralTriggerType {
   NewConnection = 'new_connection',
   OnNavigateConnectedTab = 'on_navigate_connected_tab',
+  /** User switched account and permitted a dapp connection for the selected address */
+  PermittedAccountAdded = 'permitted_account_added',
 }
 
 function isExtendedJSONRPCRequest(

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -242,6 +242,10 @@ import {
   ASSETS_UNIFY_STATE_VERSION_1,
 } from '../../shared/lib/assets-unify-state/remote-feature-flag';
 import { onStreamClosed } from '../../shared/lib/stream-utils';
+import {
+  DEFI_REFERRAL_PARTNERS,
+  DefiReferralPartner,
+} from '../../shared/constants/defi-referrals';
 import { keyringSnapPermissionsBuilder } from './lib/snap-keyring/keyring-snaps-permissions';
 
 import { AddressBookPetnamesBridge } from './lib/AddressBookPetnamesBridge';
@@ -3394,6 +3398,8 @@ export default class MetamaskController extends EventEmitter {
         accountsController,
         networkController,
         multichainNetworkController,
+        onPermittedAccountsAdded:
+          this._onPermittedAccountsAddedViaBackgroundApi.bind(this),
       }),
 
       // Snaps
@@ -5866,6 +5872,68 @@ export default class MetamaskController extends EventEmitter {
   }
 
   /**
+   * Runs when CAIP-25 permitted accounts are extended via the permission background API.
+   * If the origin is Hyperliquid and the globally selected account is EVM and included
+   * among the newly permitted accounts, it triggers the DeFi referral flow.
+   *
+   * @param {{ origin: string; newlyAddedCaipAccountIds: string[] }} details - Added accounts payload.
+   */
+  _onPermittedAccountsAddedViaBackgroundApi(details) {
+    const { origin, newlyAddedCaipAccountIds } = details;
+
+    // Only run for Hyperliquid
+    const partner = DEFI_REFERRAL_PARTNERS[DefiReferralPartner.Hyperliquid];
+    if (origin !== partner.origin) {
+      return;
+    }
+
+    const { accounts, selectedAccount: selectedAccountId } =
+      this.accountsController.state.internalAccounts;
+    const selectedAccount = accounts[selectedAccountId];
+    if (!selectedAccount?.address || !isEvmAccountType(selectedAccount.type)) {
+      return;
+    }
+
+    const selectedMatchesNewPermit = newlyAddedCaipAccountIds.some(
+      (caipAccountId) => {
+        try {
+          const { address } = parseCaipAccountId(caipAccountId);
+          return isEqualCaseInsensitive(address, selectedAccount.address);
+        } catch {
+          return false;
+        }
+      },
+    );
+
+    if (!selectedMatchesNewPermit) {
+      return;
+    }
+
+    const { appActiveTab } = this.appStateController.state;
+    if (
+      !appActiveTab?.id ||
+      typeof appActiveTab.id !== 'number' ||
+      appActiveTab.origin !== origin
+    ) {
+      return;
+    }
+
+    this.handleDefiReferral(
+      partner,
+      appActiveTab.id,
+      ReferralTriggerType.PermittedAccountAdded,
+      {
+        activePermittedAddressOverride: selectedAccount.address,
+      },
+    ).catch((error) => {
+      log.error(
+        `Failed to handle ${partner.name} referral after permitted account added: `,
+        error,
+      );
+    });
+  }
+
+  /**
    * Handles DeFi referral approval flow for a partner.
    * Shows approval confirmation screen if needed and manages referral URL redirection.
    * This can be triggered by connection permission grants or existing connections.
@@ -5873,8 +5941,10 @@ export default class MetamaskController extends EventEmitter {
    * @param {import('../../../shared/constants/defi-referrals').DefiReferralPartnerConfig} partner - The partner configuration.
    * @param {number} tabId - The browser tab ID to update.
    * @param {ReferralTriggerType} triggerType - The trigger type.
+   * @param {object} [options] - Optional behavior.
+   * @param {string} [options.activePermittedAddressOverride] - When set, use this permitted address for referral state instead of the first sorted permitted account.
    */
-  async handleDefiReferral(partner, tabId, triggerType) {
+  async handleDefiReferral(partner, tabId, triggerType, options = {}) {
     const isReferralEnabled =
       this.remoteFeatureFlagController?.state?.remoteFeatureFlags
         ?.extensionUxDefiReferralPartners?.[partner.id];
@@ -5899,8 +5969,13 @@ export default class MetamaskController extends EventEmitter {
       return;
     }
 
-    // First account is the active permitted account for this partner
-    const activePermittedAccount = permittedAccounts[0];
+    const { activePermittedAddressOverride } = options;
+    const activePermittedAccount =
+      (activePermittedAddressOverride &&
+        permittedAccounts.find((addr) =>
+          isEqualCaseInsensitive(addr, activePermittedAddressOverride),
+        )) ??
+      permittedAccounts[0];
 
     const referralStatusByAccount =
       this.preferencesController.state.referrals[partner.id];

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3399,7 +3399,7 @@ export default class MetamaskController extends EventEmitter {
         networkController,
         multichainNetworkController,
         onPermittedAccountsAdded:
-          this._onPermittedAccountsAddedViaBackgroundApi.bind(this),
+          this._handleDefiReferralOnPermittedAccountsAdded.bind(this),
       }),
 
       // Snaps
@@ -5878,7 +5878,7 @@ export default class MetamaskController extends EventEmitter {
    *
    * @param {{ origin: string; newlyAddedCaipAccountIds: string[] }} details - Added accounts payload.
    */
-  _onPermittedAccountsAddedViaBackgroundApi(details) {
+  _handleDefiReferralOnPermittedAccountsAdded(details) {
     const { origin, newlyAddedCaipAccountIds } = details;
 
     // Only run for Hyperliquid

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -5876,10 +5876,10 @@ export default class MetamaskController extends EventEmitter {
    * If the origin is Hyperliquid and the globally selected account is EVM and included
    * among the newly permitted accounts, it triggers the DeFi referral flow.
    *
-   * @param {{ origin: string; newlyAddedCaipAccountIds: string[] }} details - Added accounts payload.
+   * @param {{ origin: string; newCaipAccountIds: import('@metamask/utils').CaipAccountId[] }} details - Added accounts payload.
    */
   _handleDefiReferralOnPermittedAccountsAdded(details) {
-    const { origin, newlyAddedCaipAccountIds } = details;
+    const { origin, newCaipAccountIds } = details;
 
     // Only run for Hyperliquid
     const partner = DEFI_REFERRAL_PARTNERS[DefiReferralPartner.Hyperliquid];
@@ -5894,16 +5894,14 @@ export default class MetamaskController extends EventEmitter {
       return;
     }
 
-    const selectedMatchesNewPermit = newlyAddedCaipAccountIds.some(
-      (caipAccountId) => {
-        try {
-          const { address } = parseCaipAccountId(caipAccountId);
-          return isEqualCaseInsensitive(address, selectedAccount.address);
-        } catch {
-          return false;
-        }
-      },
-    );
+    const selectedMatchesNewPermit = newCaipAccountIds.some((caipAccountId) => {
+      try {
+        const { address } = parseCaipAccountId(caipAccountId);
+        return isEqualCaseInsensitive(address, selectedAccount.address);
+      } catch {
+        return false;
+      }
+    });
 
     if (!selectedMatchesNewPermit) {
       return;

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -6133,7 +6133,7 @@ describe('MetaMaskController', () => {
       it('calls handleDefiReferral when the selected EVM account matches a new permitted CAIP id and appActiveTab matches', () => {
         metamaskController._handleDefiReferralOnPermittedAccountsAdded({
           origin: HL_ORIGIN,
-          newlyAddedCaipAccountIds: [mockCaipAccountId],
+          newCaipAccountIds: [mockCaipAccountId],
         });
 
         expect(handleDefiReferralSpy).toHaveBeenCalledTimes(1);
@@ -6150,7 +6150,7 @@ describe('MetaMaskController', () => {
       it('does nothing when origin is not Hyperliquid', () => {
         metamaskController._handleDefiReferralOnPermittedAccountsAdded({
           origin: DEFI_REFERRAL_PARTNERS[DefiReferralPartner.GMX].origin,
-          newlyAddedCaipAccountIds: [mockCaipAccountId],
+          newCaipAccountIds: [mockCaipAccountId],
         });
 
         expect(handleDefiReferralSpy).not.toHaveBeenCalled();
@@ -6169,7 +6169,7 @@ describe('MetaMaskController', () => {
 
         metamaskController._handleDefiReferralOnPermittedAccountsAdded({
           origin: HL_ORIGIN,
-          newlyAddedCaipAccountIds: [mockCaipAccountId],
+          newCaipAccountIds: [mockCaipAccountId],
         });
 
         expect(handleDefiReferralSpy).not.toHaveBeenCalled();
@@ -6184,7 +6184,7 @@ describe('MetaMaskController', () => {
 
         metamaskController._handleDefiReferralOnPermittedAccountsAdded({
           origin: HL_ORIGIN,
-          newlyAddedCaipAccountIds: [otherCaipId],
+          newCaipAccountIds: [otherCaipId],
         });
 
         expect(handleDefiReferralSpy).not.toHaveBeenCalled();
@@ -6205,7 +6205,7 @@ describe('MetaMaskController', () => {
 
         metamaskController._handleDefiReferralOnPermittedAccountsAdded({
           origin: HL_ORIGIN,
-          newlyAddedCaipAccountIds: [mockCaipAccountId],
+          newCaipAccountIds: [mockCaipAccountId],
         });
 
         expect(handleDefiReferralSpy).not.toHaveBeenCalled();
@@ -6226,7 +6226,7 @@ describe('MetaMaskController', () => {
 
         metamaskController._handleDefiReferralOnPermittedAccountsAdded({
           origin: HL_ORIGIN,
-          newlyAddedCaipAccountIds: [mockCaipAccountId],
+          newCaipAccountIds: [mockCaipAccountId],
         });
 
         expect(handleDefiReferralSpy).not.toHaveBeenCalled();
@@ -6239,7 +6239,7 @@ describe('MetaMaskController', () => {
 
         metamaskController._handleDefiReferralOnPermittedAccountsAdded({
           origin: HL_ORIGIN,
-          newlyAddedCaipAccountIds: [mockCaipAccountId],
+          newCaipAccountIds: [mockCaipAccountId],
         });
 
         expect(handleDefiReferralSpy).not.toHaveBeenCalled();

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -45,7 +45,11 @@ import browser from 'webextension-polyfill';
 import { JsonRpcEngine } from '@metamask/json-rpc-engine';
 import { errorCodes } from '@metamask/rpc-errors';
 import { ERC20 } from '@metamask/controller-utils';
-import { parseCaipAccountId } from '@metamask/utils';
+import {
+  parseCaipAccountId,
+  parseCaipChainId,
+  toCaipAccountId,
+} from '@metamask/utils';
 
 import { createTestProviderTools } from '../../test/stub/provider';
 import {
@@ -84,6 +88,7 @@ import {
   getPermittedAccountsForScopesByOrigin,
 } from './controllers/permissions';
 import { forwardRequestToSnap } from './lib/forwardRequestToSnap';
+import { ReferralTriggerType } from './lib/createDefiReferralMiddleware';
 import MetaMaskController from './metamask-controller';
 
 // Opt out of the global `isAssetsUnifyStateFeatureEnabled` mock (see test/jest/setup.js)
@@ -5759,6 +5764,32 @@ describe('MetaMaskController', () => {
         });
       });
 
+      it('triggers approval without pop-up when permitted account was added via background API', async () => {
+        jest
+          .spyOn(metamaskController, 'getPermittedAccounts')
+          .mockReturnValueOnce(mockPermittedAccounts);
+        jest
+          .spyOn(metamaskController.approvalController, 'add')
+          .mockResolvedValueOnce({});
+
+        await metamaskController.handleDefiReferral(
+          DEFI_REFERRAL_PARTNERS[DefiReferralPartner.Hyperliquid],
+          mockTabId,
+          ReferralTriggerType.PermittedAccountAdded,
+        );
+        expect(metamaskController.approvalController.add).toHaveBeenCalledWith({
+          origin: HYPERLIQUID_ORIGIN,
+          type: HYPERLIQUID_APPROVAL_TYPE,
+          requestData: {
+            learnMoreUrl: HYPERLIQUID_LEARN_MORE_URL,
+            partnerId: DefiReferralPartner.Hyperliquid,
+            partnerName: HYPERLIQUID_NAME,
+            selectedAddress: mockPermittedAccount,
+          },
+          shouldShowRequest: false,
+        });
+      });
+
       it('handles user approval', async () => {
         jest
           .spyOn(metamaskController, 'getPermittedAccounts')
@@ -6042,6 +6073,176 @@ describe('MetaMaskController', () => {
             mockPermittedAccount,
           );
         });
+      });
+    });
+
+    describe('_handleDefiReferralOnPermittedAccountsAdded', () => {
+      const HL_ORIGIN =
+        DEFI_REFERRAL_PARTNERS[DefiReferralPartner.Hyperliquid].origin;
+
+      let mockEvmAccount;
+      let mockCaipAccountId;
+      let handleDefiReferralSpy;
+
+      beforeEach(() => {
+        jest
+          .mocked(parseCaipAccountId)
+          .mockImplementation(
+            jest.requireActual('@metamask/utils').parseCaipAccountId,
+          );
+
+        mockEvmAccount = createMockInternalAccount({
+          address: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb',
+        });
+        const { namespace, reference } = parseCaipChainId(
+          mockEvmAccount.scopes[0],
+        );
+        mockCaipAccountId = toCaipAccountId(
+          namespace,
+          reference,
+          mockEvmAccount.address,
+        );
+
+        handleDefiReferralSpy = jest
+          .spyOn(metamaskController, 'handleDefiReferral')
+          .mockResolvedValue(undefined);
+
+        metamaskController.accountsController.update((state) => {
+          state.internalAccounts.accounts[mockEvmAccount.id] = mockEvmAccount;
+          state.internalAccounts.selectedAccount = mockEvmAccount.id;
+        });
+
+        metamaskController.appStateController.update((state) => {
+          state.appActiveTab = {
+            id: 914,
+            title: 'Hyperliquid',
+            origin: HL_ORIGIN,
+            protocol: 'https:',
+            url: `${HL_ORIGIN}/trade`,
+            host: 'app.hyperliquid.xyz',
+            href: `${HL_ORIGIN}/trade`,
+          };
+        });
+      });
+
+      afterEach(() => {
+        handleDefiReferralSpy.mockRestore();
+        jest.mocked(parseCaipAccountId).mockReset();
+      });
+
+      it('calls handleDefiReferral when the selected EVM account matches a new permitted CAIP id and appActiveTab matches', () => {
+        metamaskController._handleDefiReferralOnPermittedAccountsAdded({
+          origin: HL_ORIGIN,
+          newlyAddedCaipAccountIds: [mockCaipAccountId],
+        });
+
+        expect(handleDefiReferralSpy).toHaveBeenCalledTimes(1);
+        expect(handleDefiReferralSpy).toHaveBeenCalledWith(
+          DEFI_REFERRAL_PARTNERS[DefiReferralPartner.Hyperliquid],
+          914,
+          ReferralTriggerType.PermittedAccountAdded,
+          {
+            activePermittedAddressOverride: mockEvmAccount.address,
+          },
+        );
+      });
+
+      it('does nothing when origin is not Hyperliquid', () => {
+        metamaskController._handleDefiReferralOnPermittedAccountsAdded({
+          origin: DEFI_REFERRAL_PARTNERS[DefiReferralPartner.GMX].origin,
+          newlyAddedCaipAccountIds: [mockCaipAccountId],
+        });
+
+        expect(handleDefiReferralSpy).not.toHaveBeenCalled();
+      });
+
+      it('does nothing when the selected account is not EVM', () => {
+        const solAccount = createMockInternalAccount({
+          type: SolAccountType.DataAccount,
+        });
+        metamaskController.accountsController.update((state) => {
+          state.internalAccounts.accounts = {
+            [solAccount.id]: solAccount,
+          };
+          state.internalAccounts.selectedAccount = solAccount.id;
+        });
+
+        metamaskController._handleDefiReferralOnPermittedAccountsAdded({
+          origin: HL_ORIGIN,
+          newlyAddedCaipAccountIds: [mockCaipAccountId],
+        });
+
+        expect(handleDefiReferralSpy).not.toHaveBeenCalled();
+      });
+
+      it('does nothing when newly permitted ids do not include the selected account address', () => {
+        const otherCaipId = toCaipAccountId(
+          'eip155',
+          '1',
+          '0x0000000000000000000000000000000000000001',
+        );
+
+        metamaskController._handleDefiReferralOnPermittedAccountsAdded({
+          origin: HL_ORIGIN,
+          newlyAddedCaipAccountIds: [otherCaipId],
+        });
+
+        expect(handleDefiReferralSpy).not.toHaveBeenCalled();
+      });
+
+      it('does nothing when appActiveTab origin does not match', () => {
+        metamaskController.appStateController.update((state) => {
+          state.appActiveTab = {
+            id: 914,
+            title: 'Other',
+            origin: 'https://example.com',
+            protocol: 'https:',
+            url: 'https://example.com/',
+            host: 'example.com',
+            href: 'https://example.com/',
+          };
+        });
+
+        metamaskController._handleDefiReferralOnPermittedAccountsAdded({
+          origin: HL_ORIGIN,
+          newlyAddedCaipAccountIds: [mockCaipAccountId],
+        });
+
+        expect(handleDefiReferralSpy).not.toHaveBeenCalled();
+      });
+
+      it('does nothing when appActiveTab has no numeric id', () => {
+        metamaskController.appStateController.update((state) => {
+          state.appActiveTab = {
+            id: 'not-a-number',
+            title: 'Hyperliquid',
+            origin: HL_ORIGIN,
+            protocol: 'https:',
+            url: `${HL_ORIGIN}/`,
+            host: 'app.hyperliquid.xyz',
+            href: `${HL_ORIGIN}/`,
+          };
+        });
+
+        metamaskController._handleDefiReferralOnPermittedAccountsAdded({
+          origin: HL_ORIGIN,
+          newlyAddedCaipAccountIds: [mockCaipAccountId],
+        });
+
+        expect(handleDefiReferralSpy).not.toHaveBeenCalled();
+      });
+
+      it('does nothing when appActiveTab is undefined', () => {
+        metamaskController.appStateController.update((state) => {
+          state.appActiveTab = undefined;
+        });
+
+        metamaskController._handleDefiReferralOnPermittedAccountsAdded({
+          origin: HL_ORIGIN,
+          newlyAddedCaipAccountIds: [mockCaipAccountId],
+        });
+
+        expect(handleDefiReferralSpy).not.toHaveBeenCalled();
       });
     });
   });

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -5660,6 +5660,79 @@ describe('MetaMaskController', () => {
         });
       });
 
+      it('uses activePermittedAddressOverride for approval when it matches a later permitted account', async () => {
+        jest
+          .spyOn(metamaskController, 'getPermittedAccounts')
+          .mockReturnValueOnce(mockPermittedAccounts);
+        jest
+          .spyOn(metamaskController.approvalController, 'add')
+          .mockResolvedValueOnce({ approved: true });
+
+        await metamaskController.handleDefiReferral(
+          DEFI_REFERRAL_PARTNERS[DefiReferralPartner.Hyperliquid],
+          mockTabId,
+          mockNewConnectionTriggerType,
+          { activePermittedAddressOverride: '0x456' },
+        );
+        expect(metamaskController.approvalController.add).toHaveBeenCalledWith({
+          origin: HYPERLIQUID_ORIGIN,
+          type: HYPERLIQUID_APPROVAL_TYPE,
+          requestData: {
+            learnMoreUrl: HYPERLIQUID_LEARN_MORE_URL,
+            partnerId: DefiReferralPartner.Hyperliquid,
+            partnerName: HYPERLIQUID_NAME,
+            selectedAddress: '0x456',
+          },
+          shouldShowRequest: true,
+        });
+        expect(
+          metamaskController._handleDefiReferralApprovedAccount,
+        ).toHaveBeenCalledWith(
+          DEFI_REFERRAL_PARTNERS[DefiReferralPartner.Hyperliquid],
+          '0x456',
+          mockPermittedAccounts,
+          [],
+        );
+        expect(
+          metamaskController._handleDefiReferralRedirect,
+        ).toHaveBeenCalledWith(
+          DEFI_REFERRAL_PARTNERS[DefiReferralPartner.Hyperliquid],
+          mockTabId,
+          '0x456',
+        );
+      });
+
+      it('uses caveat address casing when activePermittedAddressOverride matches case-insensitively', async () => {
+        const caveatAddress = '0xAbCdEf0000000000000000000000000000000001';
+        const permittedAccountsForCasing = [caveatAddress, '0x456'];
+        jest
+          .spyOn(metamaskController, 'getPermittedAccounts')
+          .mockReturnValueOnce(permittedAccountsForCasing);
+        jest
+          .spyOn(metamaskController.approvalController, 'add')
+          .mockResolvedValueOnce({});
+
+        await metamaskController.handleDefiReferral(
+          DEFI_REFERRAL_PARTNERS[DefiReferralPartner.Hyperliquid],
+          mockTabId,
+          mockNewConnectionTriggerType,
+          {
+            activePermittedAddressOverride: caveatAddress.toLowerCase(),
+          },
+        );
+        expect(metamaskController.approvalController.add).toHaveBeenCalledWith({
+          origin: HYPERLIQUID_ORIGIN,
+          type: HYPERLIQUID_APPROVAL_TYPE,
+          requestData: {
+            learnMoreUrl: HYPERLIQUID_LEARN_MORE_URL,
+            partnerId: DefiReferralPartner.Hyperliquid,
+            partnerName: HYPERLIQUID_NAME,
+            selectedAddress: caveatAddress,
+          },
+          shouldShowRequest: true,
+        });
+      });
+
       it('triggers approval without pop-up for a new unprocessed account on navigate to connected tab', async () => {
         jest
           .spyOn(metamaskController, 'getPermittedAccounts')


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The referral prompt flow for Hyperliquid currently can run on first connect (RPC / middleware) but not when the user adds another permitted account for the same origin via the permission background API (e.g. “connect account” flow).

This PR:

- Adds an optional **`onPermittedAccountsAdded`** hook to the permission background API (`background-api.ts`). After `setPermittedAccounts`, it notifies the consumer with **`{ origin, newlyAddedCaipAccountIds }`** only when at least one CAIP account id is newly permitted (not already in the caveat).
- Wires **`onPermittedAccountsAdded`** from `metamask-controller.js` to **`_handleDefiReferralOnPermittedAccountsAdded`**, which:
  - No-ops unless the origin is **Hyperliquid**, the **globally selected** account is **EVM**, the selected address appears among the **newly** permitted CAIP ids, and **`appStateController.state.appActiveTab`** matches that origin and has a numeric **`id`** (used as the tab id for `handleDefiReferral`).
- Extends **`handleDefiReferral`** with optional **`activePermittedAddressOverride`** so referral state uses the intended permitted address (resolved against `getPermittedAccounts` for consistent casing) instead of always defaulting to the first sorted permitted account.
- Adds **`ReferralTriggerType.PermittedAccountAdded`** to differentiate this trigger from the others.

CAIP account ids built in `addMoreAccounts` now use **`parseCaipChainId` + `toCaipAccountId`** for correct typing without redundant assertions.

## **Changelog**

CHANGELOG entry: Hyperliquid DeFi referral flow now runs after permitting an additional account for the site from the account-picker

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CEUX-1028

## **Manual testing steps**

### 1. Account that has never been connected to Hyperliquid before
1. Open Hyperliquid and connect MetaMask with any account
2. Switch account using account picker to one that has not previously connected on Hyperliquid before
3. Connect using the dapp control bar widget
4. Verify the referral prompt is triggered upon connection
5. Verify that when the referral prompt is accepted the Hyperliquid tab URL redirects to "https://app.hyperliquid.xyz/join/MMREFCSI"

Example:

https://github.com/user-attachments/assets/013e8fbf-d544-4a22-a681-9e205a14d193

### 2. Account that has referral status Approved but has not seen the prompt before
1. Open Hyperliquid and connect MetaMask with **more than one** account
2. Accept the referral prompt when seen (this sets the status to Approved for all accounts connected)
3. Disconnect
4. Reconnect with **the first of those accounts only**
7. Switch account using account picker to one of the other previously connected (and now approved) accounts
8. Connect using the dapp control bar widget
9. Verify that the referral prompt is **not** triggered but the URL **does** update to the referral page

Example:

https://github.com/user-attachments/assets/6a611fa3-1d68-481f-a234-add78cdcd33f

### 3. Account that has been connected to Hyperliquid before and accepted/rejected the referral
1. Open Hyperliquid and connect MetaMask with any account
11. Switch account using account picker to one that has connected to HL before and seen the prompt
12. Connect using the dapp control bar widget
13. Verify the referral prompt is not shown upon connection

### 3. Other dapps
1. For scenarios 1 and 2 test with unrelated origins (e.g. AsterDex, GMX) and verify the prompt does not show

### 4. Multiple tabs
1. Verify that having multiple Hyperliquid tabs open does not affect any of the above scenarios; when the referral prompt is accepted the tab that was active when the new account was connected should be the only one that gets redirected to the referral page

## **Screenshots/Recordings**

See testing steps.

### **Before**

### **After**

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new callback pathway from permission updates into `MetaMaskController`, affecting CAIP-25 permitted-account mutation and referral triggering logic; main risk is unintended referral prompts or missed triggers due to account/CAIP-id matching and tab checks.
> 
> **Overview**
> Adds an optional `onPermittedAccountsAdded` hook to the permission background API and calls it after `addPermittedAccount(s)` extends CAIP-25 accounts, including error-guarded logging and stricter CAIP account-id construction via `parseCaipChainId` + `toCaipAccountId`.
> 
> Wires this hook in `metamask-controller.js` to trigger the Hyperliquid DeFi referral flow when the *newly permitted* CAIP IDs include the globally selected EVM account and the active tab matches the origin, introducing `ReferralTriggerType.PermittedAccountAdded` and an `activePermittedAddressOverride` option so referral state/approval uses the intended permitted address (with case-insensitive matching).
> 
> Expands unit coverage for the new callback behavior, override selection, and Hyperliquid-only gating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3651da3131a87f08672ce312c36bf33e80855072. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->