### PR TITLE
fix(confirmations): exclude testnet tokens from MetaMask Pay sources cp-13.28.0

### DIFF
--- a/ui/pages/confirmations/utils/transaction-pay.test.ts
+++ b/ui/pages/confirmations/utils/transaction-pay.test.ts
@@ -4,6 +4,7 @@ import type {
   TransactionPayRequiredToken,
   TransactionPaymentToken,
 } from '@metamask/transaction-pay-controller';
+import { CHAIN_IDS } from '../../../../shared/constants/network';
 import { Asset, AssetStandard } from '../types/send';
 import {
   getTokenTransferData,
@@ -299,6 +300,47 @@ describe('transaction-pay utils', () => {
 
     it('returns empty array when tokens is empty', () => {
       const result = getAvailableTokens({ tokens: [] });
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('excludes tokens on testnet chains, keeping mainnet tokens', () => {
+      const tokens = [
+        createMockAsset({
+          address: TOKEN_ADDRESS_MOCK,
+          chainId: CHAIN_IDS.SEPOLIA,
+        }),
+        createMockAsset({
+          address: TOKEN_ADDRESS_MOCK,
+          chainId: CHAIN_IDS.LINEA_SEPOLIA,
+        }),
+        createMockAsset({
+          address: TOKEN_ADDRESS_2_MOCK,
+          chainId: CHAIN_IDS.MAINNET,
+        }),
+      ];
+
+      const result = getAvailableTokens({ tokens });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].address).toBe(TOKEN_ADDRESS_2_MOCK);
+      expect(result[0].chainId).toBe(CHAIN_IDS.MAINNET);
+    });
+
+    it('excludes testnet tokens even when selected as the pay token', () => {
+      const payToken = createMockPaymentToken({
+        address: TOKEN_ADDRESS_MOCK,
+        chainId: CHAIN_IDS.SEPOLIA,
+      });
+      const tokens = [
+        createMockAsset({
+          address: TOKEN_ADDRESS_MOCK,
+          chainId: CHAIN_IDS.SEPOLIA,
+          balance: '1000000000000000000',
+        }),
+      ];
+
+      const result = getAvailableTokens({ payToken, tokens });
 
       expect(result).toHaveLength(0);
     });

--- a/ui/pages/confirmations/utils/transaction-pay.ts
+++ b/ui/pages/confirmations/utils/transaction-pay.ts
@@ -6,6 +6,7 @@ import type {
 } from '@metamask/transaction-pay-controller';
 import { getNativeTokenAddress } from '@metamask/assets-controllers';
 import { BigNumber } from 'bignumber.js';
+import { isTestNetwork } from '../../../helpers/utils/network-helper';
 import { Asset, AssetStandard } from '../types/send';
 
 const FOUR_BYTE_TOKEN_TRANSFER = '0xa9059cbb';
@@ -75,6 +76,13 @@ export function getAvailableTokens({
           token.standard !== AssetStandard.Native) ||
         !token.accountType?.includes('eip155')
       ) {
+        return false;
+      }
+
+      // MetaMask Pay can't source funds from testnets (quotes route through
+      // bridges/swaps that don't support them), so exclude testnet tokens
+      // from both the Pay-with list and the auto-selected default.
+      if (token.chainId && isTestNetwork(token.chainId as Hex)) {
         return false;
       }
 


### PR DESCRIPTION
## **Description**

MetaMask Pay's `getAvailableTokens` was listing testnet tokens (e.g. Sepolia ETH) alongside mainnet tokens in the "Pay with" selector. Pay quotes route through bridges/swaps that don't support testnets, so selecting one would fail.

Filter out any token whose `chainId` matches a known testnet via `isTestNetwork`, applied before the selected/required/balance checks so testnet tokens are excluded even when they'd otherwise be force-included as the current pay token or a required token.

## **Changelog**

CHANGELOG entry: Fixed a bug that caused testnet tokens to appear as payment options in MetaMask Pay.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1210

## **Manual testing steps**

1. Build the extension and open a wallet with balances on both mainnet and Sepolia (or any testnet).
2. Open a confirmation that triggers MetaMask Pay token selection.
3. Open the "Pay with" token list.
4. Verify testnet tokens (e.g. Sepolia ETH, Linea Sepolia) are not shown.
5. Verify mainnet tokens with non-zero balance still appear and can be selected.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a simple `isTestNetwork` filter to the MetaMask Pay token source list, with targeted unit tests, and does not change transaction building or signing logic.
> 
> **Overview**
> MetaMask Pay token selection now filters out any asset whose `chainId` is recognized as a test network via `isTestNetwork`, so testnet tokens never appear in the *Pay with* list (even if they are currently selected or otherwise force-included).
> 
> Unit tests for `getAvailableTokens` were extended to cover excluding Sepolia/Linea Sepolia tokens while keeping mainnet tokens, and ensuring testnet tokens are still excluded when set as the selected pay token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e9af155a218a0083bfd8cf2ee6b8fd869691c14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->