### PR TITLE
fix(enforced-simulations): display original recipient and value

### DIFF
--- a/.metamaskrc.dist
+++ b/.metamaskrc.dist
@@ -10,11 +10,6 @@ SEEDLESS_ONBOARDING_ENABLED='false'
 ; Set this to `true` to enable Metamask Shield
 METAMASK_SHIELD_ENABLED='false'
 
-; Set this to `true` to force enforced simulations to apply whenever a
-; transaction has balance changes, bypassing the trust signal check.
-; Intended for local development and QA only.
-;FORCE_ENABLE_SIMULATIONS='true'
-
 ; Set to `true` to include PerpsController and perps features.
 ; main and experimental builds have this enabled by default; beta and flask do not.
 PERPS_ENABLED='true'
@@ -99,3 +94,12 @@ TEST_SRP_2=
 ; (device discovery, error handling, account selection).
 ; Entry points to connecting remain unchanged regardless of this flag.
 NEW_HARDWARE_WALLET_ONBOARDING='false'
+
+; Set this to `true` to enforce simulation balance changes by converting
+; external transactions to delegations.
+;ENABLE_ENFORCED_SIMULATIONS='true'
+
+; Set this to `true` to force enforced simulations to apply whenever a
+; transaction has balance changes, bypassing the trust signal check.
+; Intended for local development and QA only.
+;FORCE_ENABLE_SIMULATIONS='true'

--- a/.metamaskrc.dist
+++ b/.metamaskrc.dist
@@ -10,6 +10,11 @@ SEEDLESS_ONBOARDING_ENABLED='false'
 ; Set this to `true` to enable Metamask Shield
 METAMASK_SHIELD_ENABLED='false'
 
+; Set this to `true` to force enforced simulations to apply whenever a
+; transaction has balance changes, bypassing the trust signal check.
+; Intended for local development and QA only.
+;FORCE_ENABLE_SIMULATIONS='true'
+
 ; Set to `true` to include PerpsController and perps features.
 ; main and experimental builds have this enabled by default; beta and flask do not.
 PERPS_ENABLED='true'

--- a/app/scripts/messenger-client-init/confirmations/transaction-controller-init.ts
+++ b/app/scripts/messenger-client-init/confirmations/transaction-controller-init.ts
@@ -177,17 +177,16 @@ export const TransactionControllerInit: MessengerClientInitFunction<
     // @ts-expect-error Controller uses string for names rather than enum
     trace,
     hooks: {
-      // Note: `#afterAdd.updateTransaction` is actually called before adding the TransactionMeta to the state
-      // Reference: https://github.com/MetaMask/core/blob/main/packages/transaction-controller/src/TransactionController.ts#L1335
-      afterAdd: async (_params: { transactionMeta: TransactionMeta }) => {
-        return {
-          updateTransaction: async (transactionMeta: TransactionMeta) => {
-            await initMessenger.call(
-              'SubscriptionService:submitSubscriptionSponsorshipIntent',
-              transactionMeta,
-            );
-          },
-        };
+      afterAdd: async ({
+        transactionMeta,
+      }: {
+        transactionMeta: TransactionMeta;
+      }) => {
+        await initMessenger.call(
+          'SubscriptionService:submitSubscriptionSponsorshipIntent',
+          transactionMeta,
+        );
+        return {};
       },
       beforePublish: (transactionMeta: TransactionMeta) => {
         const response = initMessenger.call(

--- a/builds.yml
+++ b/builds.yml
@@ -433,6 +433,11 @@ env:
   # Enforce simulation balance changes by converting external transactions to delegations.
   - ENABLE_ENFORCED_SIMULATIONS: false
 
+  # Force enforced simulations to apply whenever a transaction has balance
+  # changes, bypassing the trust signal check. Intended for local
+  # development and QA only; must remain false for production builds.
+  - FORCE_ENABLE_SIMULATIONS: false
+
   # OAuth (Social login)
   - GOOGLE_CLIENT_ID_REF
   - APPLE_CLIENT_ID_REF

--- a/shared/lib/transaction/enforced-simulations.test.ts
+++ b/shared/lib/transaction/enforced-simulations.test.ts
@@ -85,6 +85,7 @@ describe('enforced-simulations', () => {
 
     afterEach(() => {
       delete process.env.ENABLE_ENFORCED_SIMULATIONS;
+      delete process.env.FORCE_ENABLE_SIMULATIONS;
     });
 
     it('returns true when all conditions are met and no state provided', () => {
@@ -352,6 +353,72 @@ describe('enforced-simulations', () => {
             }),
           ),
         ).toBe(true);
+      });
+    });
+
+    describe('with FORCE_ENABLE_SIMULATIONS', () => {
+      beforeEach(() => {
+        process.env.FORCE_ENABLE_SIMULATIONS = 'true';
+      });
+
+      it('returns true even when recipient is trusted', () => {
+        expect(
+          isEnforcedSimulationsEligible(
+            BASE_TRANSACTION_META,
+            buildState(ResultType.Trusted),
+          ),
+        ).toBe(true);
+      });
+
+      it('returns true even when all nested addresses are trusted', () => {
+        expect(
+          isEnforcedSimulationsEligible(
+            {
+              ...BASE_TRANSACTION_META,
+              nestedTransactions: [
+                { to: NESTED_ADDRESS_A as `0x${string}` },
+                { to: NESTED_ADDRESS_B as `0x${string}` },
+              ],
+            },
+            buildStateForAddresses({
+              [TO_ADDRESS]: ResultType.Trusted,
+              [NESTED_ADDRESS_A]: ResultType.Trusted,
+              [NESTED_ADDRESS_B]: ResultType.Trusted,
+            }),
+          ),
+        ).toBe(true);
+      });
+
+      it('still returns false when there are no balance changes', () => {
+        expect(
+          isEnforcedSimulationsEligible(
+            {
+              ...BASE_TRANSACTION_META,
+              simulationData: { tokenBalanceChanges: [] },
+            },
+            buildState(ResultType.Trusted),
+          ),
+        ).toBe(false);
+      });
+
+      it('still returns false when origin is MetaMask internal', () => {
+        expect(
+          isEnforcedSimulationsEligible(
+            { ...BASE_TRANSACTION_META, origin: ORIGIN_METAMASK },
+            buildState(ResultType.Trusted),
+          ),
+        ).toBe(false);
+      });
+
+      it('is ignored when value is not the string "true"', () => {
+        process.env.FORCE_ENABLE_SIMULATIONS = '1';
+
+        expect(
+          isEnforcedSimulationsEligible(
+            BASE_TRANSACTION_META,
+            buildState(ResultType.Trusted),
+          ),
+        ).toBe(false);
       });
     });
   });

--- a/shared/lib/transaction/enforced-simulations.ts
+++ b/shared/lib/transaction/enforced-simulations.ts
@@ -64,11 +64,22 @@ export function isEnforcedSimulationsEligible(
     return false;
   }
 
+  // When forcing is enabled, skip the trust signal check so enforced
+  // simulations always applies as long as balance changes are present.
+  // Intended for local development and QA only.
+  if (isForceEnabled()) {
+    return true;
+  }
+
   if (state && isTrusted(transactionMeta, state)) {
     return false;
   }
 
   return true;
+}
+
+function isForceEnabled(): boolean {
+  return process.env.FORCE_ENABLE_SIMULATIONS === 'true';
 }
 
 function isTrusted(

--- a/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.ts
@@ -1,5 +1,4 @@
 import { GasFeeEstimates } from '@metamask/gas-fee-controller';
-import { TxData } from '@metamask/bridge-controller';
 import { TransactionMeta } from '@metamask/transaction-controller';
 import { Hex, add0x } from '@metamask/utils';
 import { useCallback, useMemo } from 'react';
@@ -14,12 +13,11 @@ import {
   multiplyHexes,
 } from '../../../../../../../shared/lib/conversion.utils';
 import { Numeric } from '../../../../../../../shared/lib/Numeric';
-import { toHex } from '../../../../../../../shared/lib/delegation/utils';
 import { getCurrentCurrency } from '../../../../../../ducks/metamask/metamask';
 import { useFiatFormatter } from '../../../../../../hooks/useFiatFormatter';
 import { useGasFeeEstimates } from '../../../../../../hooks/useGasFeeEstimates';
 import { selectConversionRateByChainId } from '../../../../../../selectors';
-import { useDappSwapContextOptional } from '../../../../context/dapp-swap';
+import { useTransactionGasLimit } from '../../../../hooks/gas/useTransactionGasLimit';
 import { HEX_ZERO } from '../shared/constants';
 import { useEIP1559TxFees } from './useEIP1559TxFees';
 import { useSupportsEIP1559 } from './useSupportsEIP1559';
@@ -40,10 +38,6 @@ export function useFeeCalculations(transactionMeta: TransactionMeta) {
   const currentCurrency = useSelector(getCurrentCurrency);
   const { chainId } = transactionMeta;
   const fiatFormatter = useFiatFormatter();
-  const dappSwapContext = useDappSwapContextOptional();
-  const selectedQuote = dappSwapContext?.selectedQuote;
-  const isQuotedSwapDisplayedInInfo =
-    dappSwapContext?.isQuotedSwapDisplayedInInfo ?? false;
 
   const conversionRate = useSelector((state) =>
     selectConversionRateByChainId(state, chainId),
@@ -51,32 +45,8 @@ export function useFeeCalculations(transactionMeta: TransactionMeta) {
   const hasValidConversionRate =
     Number.isFinite(conversionRate) && Number(conversionRate) > 0;
 
-  let quotedGasLimit;
-  if (isQuotedSwapDisplayedInInfo) {
-    quotedGasLimit = toHex(
-      ((selectedQuote?.approval as TxData)?.gasLimit ?? 0) +
-        ((selectedQuote?.trade as TxData)?.gasLimit ?? 0),
-    ) as Hex;
-  }
-
-  // When container types are set, the gas limit has been re-estimated for the
-  // wrapped transaction, so we should use `txParams.gas` directly. Otherwise,
-  // prefer the optimized values from simulation.
-  const hasContainerTypes = (transactionMeta?.containerTypes?.length ?? 0) > 0;
-
-  // `gasUsed` is the gas limit actually used by the transaction in the
-  // simulation environment.
-  const optimizedGasLimit = hasContainerTypes
-    ? transactionMeta?.txParams?.gas || HEX_ZERO
-    : quotedGasLimit ||
-      transactionMeta?.gasUsed ||
-      // While estimating gas for the transaction we add 50% gas limit buffer.
-      // With `gasLimitNoBuffer` that buffer is removed. see PR
-      // https://github.com/MetaMask/metamask-extension/pull/29502 for more
-      // details.
-      transactionMeta?.gasLimitNoBuffer ||
-      transactionMeta?.txParams?.gas ||
-      HEX_ZERO;
+  const { gasLimit: optimizedGasLimit, quotedGasLimit } =
+    useTransactionGasLimit(transactionMeta);
 
   const getFeesFromHex = useCallback(
     (hexFee: Hex) => {

--- a/ui/pages/confirmations/components/confirm/info/hooks/useTransferRecipient.test.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useTransferRecipient.test.ts
@@ -88,6 +88,43 @@ describe('useTransferRecipient', () => {
       }),
     ).toBe(ADDRESS_2_MOCK);
   });
+
+  it('prefers txParamsOriginal.to over txParams.to when container wrapping replaced it', () => {
+    expect(
+      runHook({
+        ...TRANSACTION_METADATA_MOCK,
+        type: TransactionType.simpleSend,
+        txParams: {
+          ...TRANSACTION_METADATA_MOCK.txParams,
+          to: ADDRESS_2_MOCK,
+        },
+        txParamsOriginal: {
+          ...TRANSACTION_METADATA_MOCK.txParams,
+          to: ADDRESS_MOCK,
+        },
+      }),
+    ).toBe(ADDRESS_MOCK);
+  });
+
+  it('prefers txParamsOriginal.data over txParams.data when container wrapping replaced it', () => {
+    const originalData = genUnapprovedTokenTransferConfirmation().txParams.data;
+
+    expect(
+      runHook({
+        ...TRANSACTION_METADATA_MOCK,
+        txParams: {
+          ...TRANSACTION_METADATA_MOCK.txParams,
+          to: ADDRESS_2_MOCK,
+          data: '0xdeadbeef',
+        },
+        txParamsOriginal: {
+          ...TRANSACTION_METADATA_MOCK.txParams,
+          to: ADDRESS_2_MOCK,
+          data: originalData,
+        },
+      }),
+    ).toBe(ADDRESS_MOCK);
+  });
 });
 
 describe('useNestedTransactionTransferRecipients', () => {

--- a/ui/pages/confirmations/components/confirm/info/hooks/useTransferRecipient.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useTransferRecipient.ts
@@ -40,12 +40,16 @@ function getRecipientFromNestedTransactionMetadata(
 function getRecipientFromTransactionMetadata(
   transactionMetadata: TransactionMeta,
 ): string | undefined {
-  const { type, txParams } = transactionMetadata;
-  return getRecipientByType(
-    type as TransactionType,
-    txParams?.data ?? '',
-    txParams?.to ?? '',
-  );
+  const { type, txParams, txParamsOriginal } = transactionMetadata;
+
+  // Prefer the original params when container wrapping (e.g. enforced
+  // simulations) has replaced `to`/`data` with the delegation manager
+  // address and payload, so the UI keeps showing the user-intended
+  // recipient.
+  const data = txParamsOriginal?.data ?? txParams?.data ?? '';
+  const to = txParamsOriginal?.to ?? txParams?.to ?? '';
+
+  return getRecipientByType(type as TransactionType, data, to);
 }
 
 function getRecipientByType(

--- a/ui/pages/confirmations/components/confirm/info/shared/native-send-heading/native-send-heading.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/native-send-heading/native-send-heading.tsx
@@ -32,12 +32,13 @@ const NativeSendHeading = () => {
   const { currentConfirmation: transactionMeta } =
     useConfirmContext<TransactionMeta>();
 
-  const { chainId } = transactionMeta;
+  const { chainId, txParams, txParamsOriginal } = transactionMeta;
 
-  const nativeAssetTransferValue = calcTokenAmount(
-    transactionMeta.txParams.value as string,
-    18,
-  );
+  // Prefer the original `value` so that container wrapping (e.g. enforced
+  // simulations) does not zero out the displayed send amount.
+  const displayValue = (txParamsOriginal?.value ?? txParams.value) as string;
+
+  const nativeAssetTransferValue = calcTokenAmount(displayValue, 18);
 
   const conversionRate = useSelector((state) =>
     selectConversionRateByChainId(state, chainId),

--- a/ui/pages/confirmations/components/confirm/info/shared/transaction-details/transaction-details.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/transaction-details/transaction-details.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { Hex } from '@metamask/utils';
+import { TransactionMeta } from '@metamask/transaction-controller';
 import { toHex } from '@metamask/controller-utils';
 import {
   getMockConfirmState,
@@ -206,6 +207,77 @@ describe('Transaction Details', () => {
         const amountRow = getByTestId('transaction-details-amount-row');
         expect(amountRow).toBeInTheDocument();
       });
+
+      it('renders using txParamsOriginal.value when container wrapping zeroed txParams.value', () => {
+        const contractInteraction =
+          genUnapprovedContractInteractionConfirmation({
+            chainId: CHAIN_IDS.GOERLI,
+          }) as TransactionMeta;
+        const wrappedContractInteraction = {
+          ...contractInteraction,
+          txParamsOriginal: { ...contractInteraction.txParams },
+          txParams: {
+            ...contractInteraction.txParams,
+            value: '0x0',
+          },
+        };
+        const state = getMockConfirmStateForTransaction(
+          wrappedContractInteraction,
+          {
+            metamask: {
+              preferences: {
+                showConfirmationAdvancedDetails: true,
+              },
+            },
+          },
+        );
+        const mockStore = configureMockStore(middleware)(state);
+        const { getByTestId } = renderWithConfirmContextProvider(
+          <TransactionDetails />,
+          mockStore,
+        );
+
+        expect(
+          getByTestId('transaction-details-amount-row'),
+        ).toBeInTheDocument();
+      });
+
+      it('does not render when both txParamsOriginal.value and txParams.value are zero', () => {
+        const contractInteraction =
+          genUnapprovedContractInteractionConfirmation({
+            chainId: CHAIN_IDS.GOERLI,
+          }) as TransactionMeta;
+        const wrappedContractInteraction = {
+          ...contractInteraction,
+          txParamsOriginal: {
+            ...contractInteraction.txParams,
+            value: '0x0',
+          },
+          txParams: {
+            ...contractInteraction.txParams,
+            value: '0x0',
+          },
+        };
+        const state = getMockConfirmStateForTransaction(
+          wrappedContractInteraction,
+          {
+            metamask: {
+              preferences: {
+                showConfirmationAdvancedDetails: true,
+              },
+            },
+          },
+        );
+        const mockStore = configureMockStore(middleware)(state);
+        const { queryByTestId } = renderWithConfirmContextProvider(
+          <TransactionDetails />,
+          mockStore,
+        );
+
+        expect(
+          queryByTestId('transaction-details-amount-row'),
+        ).not.toBeInTheDocument();
+      });
     });
 
     it('display network info if there is an alert on that field', () => {
@@ -278,6 +350,44 @@ describe('Transaction Details', () => {
         expect(
           getByTestId('transaction-details-recipient-row'),
         ).toBeInTheDocument();
+      });
+
+      it('renders the txParamsOriginal.to address when container wrapping replaced txParams.to', () => {
+        const originalTo = '0x1111111111111111111111111111111111111111';
+        const delegationManager = '0x2222222222222222222222222222222222222222';
+        const contractInteraction =
+          genUnapprovedContractInteractionConfirmation() as TransactionMeta;
+        const wrappedContractInteraction = {
+          ...contractInteraction,
+          txParamsOriginal: {
+            ...contractInteraction.txParams,
+            to: originalTo,
+          },
+          txParams: {
+            ...contractInteraction.txParams,
+            to: delegationManager,
+          },
+        };
+        const state = getMockConfirmStateForTransaction(
+          wrappedContractInteraction,
+          {
+            metamask: {
+              preferences: {
+                showConfirmationAdvancedDetails: true,
+              },
+            },
+          },
+        );
+        const mockStore = configureMockStore(middleware)(state);
+        const { getByTestId } = renderWithConfirmContextProvider(
+          <TransactionDetails />,
+          mockStore,
+        );
+
+        const recipientRow = getByTestId('transaction-details-recipient-row');
+        expect(recipientRow).toBeInTheDocument();
+        expect(recipientRow).toHaveTextContent('0x11111...11111');
+        expect(recipientRow).not.toHaveTextContent('0x22222...22222');
       });
     });
 

--- a/ui/pages/confirmations/components/confirm/info/shared/transaction-details/transaction-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/transaction-details/transaction-details.tsx
@@ -59,9 +59,12 @@ export const RecipientRow = ({ recipient }: { recipient?: Hex } = {}) => {
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
   const { isUpgrade } = useIsUpgradeTransaction();
   const isDowngrade = useIsDowngradeTransaction();
-  const { nestedTransactions, txParams, chainId, id } =
+  const { nestedTransactions, txParams, txParamsOriginal, chainId, id } =
     currentConfirmation ?? {};
-  const { from, to: txTo } = txParams ?? {};
+  const { from } = txParams ?? {};
+  // Prefer the original `to` so that container wrapping (e.g. enforced
+  // simulations) does not display the delegation manager as the recipient.
+  const txTo = txParamsOriginal?.to ?? txParams?.to;
   const to = recipient ?? txTo;
 
   const isBatch =
@@ -117,7 +120,11 @@ const AmountRow = () => {
     currentConfirmation?.chainId,
   );
 
-  const value = currentConfirmation?.txParams?.value;
+  // Prefer the original `value` so that container wrapping (e.g. enforced
+  // simulations) does not zero out the displayed amount.
+  const value =
+    currentConfirmation?.txParamsOriginal?.value ??
+    currentConfirmation?.txParams?.value;
 
   if (!value || value === HEX_ZERO) {
     return null;

--- a/ui/pages/confirmations/components/confirm/info/utils.test.ts
+++ b/ui/pages/confirmations/components/confirm/info/utils.test.ts
@@ -132,6 +132,28 @@ describe('hasValueAndNativeBalanceMismatch', () => {
 
     expect(hasValueAndNativeBalanceMismatch(transaction)).toBe(true);
   });
+
+  it('prefers txParamsOriginal.value over txParams.value when container wrapping zeroed the top-level value', () => {
+    const transactionValueInDecimal = 10000000000000000;
+    const transactionValueInHex = toHex(transactionValueInDecimal);
+
+    const transaction = {
+      txParams: {
+        value: '0x0',
+      },
+      txParamsOriginal: {
+        value: transactionValueInHex,
+      },
+      simulationData: {
+        nativeBalanceChange: {
+          difference: transactionValueInHex,
+          isDecrease: true,
+        },
+      },
+    } as unknown as TransactionMeta;
+
+    expect(hasValueAndNativeBalanceMismatch(transaction)).toBe(false);
+  });
 });
 
 describe('isValidUTF8', () => {

--- a/ui/pages/confirmations/components/confirm/info/utils.ts
+++ b/ui/pages/confirmations/components/confirm/info/utils.ts
@@ -92,7 +92,10 @@ function percentageChangeWithinThreshold(
 export function hasValueAndNativeBalanceMismatch(
   transactionMeta: TransactionMeta | undefined,
 ): boolean {
-  const value = transactionMeta?.txParams?.value ?? '0x0';
+  const value =
+    transactionMeta?.txParamsOriginal?.value ??
+    transactionMeta?.txParams?.value ??
+    '0x0';
   const nativeBalanceChange =
     transactionMeta?.simulationData?.nativeBalanceChange;
   const simulatedNativeBalanceDifference =

--- a/ui/pages/confirmations/hooks/gas/useAdvancedGasFeeOption.test.ts
+++ b/ui/pages/confirmations/hooks/gas/useAdvancedGasFeeOption.test.ts
@@ -8,6 +8,7 @@ import {
 import { GasModalType } from '../../constants/gas';
 import { useConfirmContext } from '../../context/confirm';
 import { useFeeCalculations } from '../../components/confirm/info/hooks/useFeeCalculations';
+import { useTransactionGasLimit } from './useTransactionGasLimit';
 import { useAdvancedGasFeeOption } from './useAdvancedGasFeeOption';
 
 jest.mock('../../../../hooks/useI18nContext', () => ({
@@ -22,25 +23,37 @@ jest.mock('../../components/confirm/info/hooks/useFeeCalculations', () => ({
   useFeeCalculations: jest.fn(),
 }));
 
+jest.mock('./useTransactionGasLimit', () => ({
+  useTransactionGasLimit: jest.fn(),
+}));
+
 jest.mock('../transactions/useTransactionNativeTicker', () => ({
   useTransactionNativeTicker: () => 'ETH',
 }));
 
 const mockUseConfirmContext = jest.mocked(useConfirmContext);
 const mockUseFeeCalculations = jest.mocked(useFeeCalculations);
+const mockUseTransactionGasLimit = jest.mocked(useTransactionGasLimit);
 
 describe('useAdvancedGasFeeOption', () => {
   const mockSetActiveModal = jest.fn();
+  const mockCalculateGasEstimate = jest.fn().mockReturnValue({
+    currentCurrencyFee: '$1.00',
+    preciseNativeCurrencyFee: '0.001',
+  });
 
   beforeEach(() => {
     jest.clearAllMocks();
 
+    mockCalculateGasEstimate.mockClear();
     mockUseFeeCalculations.mockReturnValue({
-      calculateGasEstimate: jest.fn().mockReturnValue({
-        currentCurrencyFee: '$1.00',
-        preciseNativeCurrencyFee: '0.001',
-      }),
+      calculateGasEstimate: mockCalculateGasEstimate,
     } as unknown as ReturnType<typeof useFeeCalculations>);
+
+    mockUseTransactionGasLimit.mockReturnValue({
+      gasLimit: '0x5208',
+      quotedGasLimit: undefined,
+    });
   });
 
   it('returns advanced option with isSelected false when userFeeLevel is a standard level', () => {
@@ -143,5 +156,37 @@ describe('useAdvancedGasFeeOption', () => {
     expect(mockSetActiveModal).toHaveBeenCalledWith(
       GasModalType.AdvancedGasPriceModal,
     );
+  });
+
+  it('passes the gas limit from useTransactionGasLimit to calculateGasEstimate and tooltip', () => {
+    mockUseTransactionGasLimit.mockReturnValue({
+      gasLimit: '0x1fbd0',
+      quotedGasLimit: undefined,
+    });
+
+    mockUseConfirmContext.mockReturnValue({
+      currentConfirmation: {
+        id: '1',
+        userFeeLevel: UserFeeLevel.CUSTOM,
+        gasFeeEstimates: {},
+        gasLimitNoBuffer: '0x5208',
+        containerTypes: ['EnforcedSimulations'],
+        txParams: {
+          type: TransactionEnvelopeType.feeMarket,
+          gas: '0x1fbd0',
+          maxFeePerGas: '0x2540be400',
+          maxPriorityFeePerGas: '0x3b9aca00',
+        },
+      },
+    } as unknown as ReturnType<typeof useConfirmContext>);
+
+    const { result } = renderHook(() =>
+      useAdvancedGasFeeOption({ setActiveModal: mockSetActiveModal }),
+    );
+
+    expect(mockCalculateGasEstimate).toHaveBeenCalledWith(
+      expect.objectContaining({ gas: '0x1fbd0' }),
+    );
+    expect(result.current[0].tooltipProps?.gasLimit).toBe(0x1fbd0);
   });
 });

--- a/ui/pages/confirmations/hooks/gas/useAdvancedGasFeeOption.test.ts
+++ b/ui/pages/confirmations/hooks/gas/useAdvancedGasFeeOption.test.ts
@@ -52,7 +52,6 @@ describe('useAdvancedGasFeeOption', () => {
 
     mockUseTransactionGasLimit.mockReturnValue({
       gasLimit: '0x5208',
-      modalGasLimit: '0x5208',
       quotedGasLimit: undefined,
     });
   });
@@ -159,10 +158,9 @@ describe('useAdvancedGasFeeOption', () => {
     );
   });
 
-  it('passes the modal gas limit from useTransactionGasLimit to calculateGasEstimate and tooltip', () => {
+  it('passes the gas limit from useTransactionGasLimit to calculateGasEstimate and tooltip', () => {
     mockUseTransactionGasLimit.mockReturnValue({
-      gasLimit: '0x5208',
-      modalGasLimit: '0x1fbd0',
+      gasLimit: '0x1fbd0',
       quotedGasLimit: undefined,
     });
 

--- a/ui/pages/confirmations/hooks/gas/useAdvancedGasFeeOption.test.ts
+++ b/ui/pages/confirmations/hooks/gas/useAdvancedGasFeeOption.test.ts
@@ -52,6 +52,7 @@ describe('useAdvancedGasFeeOption', () => {
 
     mockUseTransactionGasLimit.mockReturnValue({
       gasLimit: '0x5208',
+      modalGasLimit: '0x5208',
       quotedGasLimit: undefined,
     });
   });
@@ -158,9 +159,10 @@ describe('useAdvancedGasFeeOption', () => {
     );
   });
 
-  it('passes the gas limit from useTransactionGasLimit to calculateGasEstimate and tooltip', () => {
+  it('passes the modal gas limit from useTransactionGasLimit to calculateGasEstimate and tooltip', () => {
     mockUseTransactionGasLimit.mockReturnValue({
-      gasLimit: '0x1fbd0',
+      gasLimit: '0x5208',
+      modalGasLimit: '0x1fbd0',
       quotedGasLimit: undefined,
     });
 

--- a/ui/pages/confirmations/hooks/gas/useAdvancedGasFeeOption.ts
+++ b/ui/pages/confirmations/hooks/gas/useAdvancedGasFeeOption.ts
@@ -13,6 +13,7 @@ import { useConfirmContext } from '../../context/confirm';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { useTransactionNativeTicker } from '../transactions/useTransactionNativeTicker';
 import { hexWEIToDecGWEI } from '../../../../../shared/lib/conversion.utils';
+import { useTransactionGasLimit } from './useTransactionGasLimit';
 
 const HEX_ZERO = '0x0';
 
@@ -30,7 +31,6 @@ export const useAdvancedGasFeeOption = ({
     userFeeLevel,
     txParams: {
       type: transactionEnvelopeType,
-      gas: txParamsGas,
       maxFeePerGas,
       maxPriorityFeePerGas,
       gasPrice: txParamsGasPrice,
@@ -38,6 +38,7 @@ export const useAdvancedGasFeeOption = ({
   } = transactionMeta;
 
   const { calculateGasEstimate } = useFeeCalculations(transactionMeta);
+  const { gasLimit: displayGas } = useTransactionGasLimit(transactionMeta);
 
   const onAdvancedGasFeeClick = useCallback(() => {
     const newModalType =
@@ -87,13 +88,11 @@ export const useAdvancedGasFeeOption = ({
   if (isAdvancedGasFeeSelected) {
     const feePerGas = maxFeePerGas || HEX_ZERO;
     let gasPrice = HEX_ZERO;
-    let gas = transactionMeta.gasLimitNoBuffer || HEX_ZERO;
     let shouldUseEIP1559FeeLogic = true;
     const priorityFeePerGas = maxPriorityFeePerGas || HEX_ZERO;
 
     if (transactionEnvelopeType === TransactionEnvelopeType.legacy) {
       gasPrice = txParamsGasPrice || HEX_ZERO;
-      gas = txParamsGas || HEX_ZERO;
       shouldUseEIP1559FeeLogic = false;
     }
 
@@ -101,7 +100,7 @@ export const useAdvancedGasFeeOption = ({
       calculateGasEstimate({
         feePerGas,
         priorityFeePerGas,
-        gas,
+        gas: displayGas,
         shouldUseEIP1559FeeLogic,
         gasPrice,
       });
@@ -129,10 +128,7 @@ export const useAdvancedGasFeeOption = ({
           maxPriorityFeePerGas: hexWEIToDecGWEI(
             maxPriorityFeePerGas || HEX_ZERO,
           ),
-          gasLimit: parseInt(
-            transactionMeta.gasLimitNoBuffer || txParamsGas || HEX_ZERO,
-            16,
-          ),
+          gasLimit: parseInt(displayGas, 16),
           transaction: transactionMeta as unknown as Record<string, unknown>,
         },
       },
@@ -147,7 +143,7 @@ export const useAdvancedGasFeeOption = ({
       maxFeePerGas,
       maxPriorityFeePerGas,
       transactionMeta,
-      txParamsGas,
+      displayGas,
     ],
   );
 

--- a/ui/pages/confirmations/hooks/gas/useAdvancedGasFeeOption.ts
+++ b/ui/pages/confirmations/hooks/gas/useAdvancedGasFeeOption.ts
@@ -38,7 +38,7 @@ export const useAdvancedGasFeeOption = ({
   } = transactionMeta;
 
   const { calculateGasEstimate } = useFeeCalculations(transactionMeta);
-  const { modalGasLimit: displayGas } = useTransactionGasLimit(transactionMeta);
+  const { gasLimit: displayGas } = useTransactionGasLimit(transactionMeta);
 
   const onAdvancedGasFeeClick = useCallback(() => {
     const newModalType =

--- a/ui/pages/confirmations/hooks/gas/useAdvancedGasFeeOption.ts
+++ b/ui/pages/confirmations/hooks/gas/useAdvancedGasFeeOption.ts
@@ -38,7 +38,7 @@ export const useAdvancedGasFeeOption = ({
   } = transactionMeta;
 
   const { calculateGasEstimate } = useFeeCalculations(transactionMeta);
-  const { gasLimit: displayGas } = useTransactionGasLimit(transactionMeta);
+  const { modalGasLimit: displayGas } = useTransactionGasLimit(transactionMeta);
 
   const onAdvancedGasFeeClick = useCallback(() => {
     const newModalType =

--- a/ui/pages/confirmations/hooks/gas/useDappSuggestedGasFeeOption.ts
+++ b/ui/pages/confirmations/hooks/gas/useDappSuggestedGasFeeOption.ts
@@ -13,6 +13,7 @@ import { useConfirmContext } from '../../context/confirm';
 import { useFeeCalculations } from '../../components/confirm/info/hooks/useFeeCalculations';
 import { useTransactionNativeTicker } from '../transactions/useTransactionNativeTicker';
 import { hexWEIToDecGWEI } from '../../../../../shared/lib/conversion.utils';
+import { useTransactionGasLimit } from './useTransactionGasLimit';
 
 const HEX_ZERO = '0x0';
 const MM_ORIGIN = 'metamask';
@@ -27,6 +28,7 @@ export const useDappSuggestedGasFeeOption = ({
     useConfirmContext<TransactionMeta>();
   const nativeTicker = useTransactionNativeTicker();
   const { calculateGasEstimate } = useFeeCalculations(transactionMeta);
+  const { gasLimit: displayGas } = useTransactionGasLimit(transactionMeta);
   const dispatch = useDispatch();
 
   const { dappSuggestedGasFees, id, origin, userFeeLevel } = transactionMeta;
@@ -54,7 +56,7 @@ export const useDappSuggestedGasFeeOption = ({
   if (shouldIncludeDappSuggestedGasFeeOption) {
     let feePerGas = HEX_ZERO;
     let gasPrice = HEX_ZERO;
-    let gas = transactionMeta.gasLimitNoBuffer || HEX_ZERO;
+    let gas: string = displayGas || HEX_ZERO;
     let shouldUseEIP1559FeeLogic = true;
     let priorityFeePerGas = HEX_ZERO;
 

--- a/ui/pages/confirmations/hooks/gas/useDappSuggestedGasFeeOption.ts
+++ b/ui/pages/confirmations/hooks/gas/useDappSuggestedGasFeeOption.ts
@@ -28,7 +28,7 @@ export const useDappSuggestedGasFeeOption = ({
     useConfirmContext<TransactionMeta>();
   const nativeTicker = useTransactionNativeTicker();
   const { calculateGasEstimate } = useFeeCalculations(transactionMeta);
-  const { modalGasLimit: displayGas } = useTransactionGasLimit(transactionMeta);
+  const { gasLimit: displayGas } = useTransactionGasLimit(transactionMeta);
   const dispatch = useDispatch();
 
   const { dappSuggestedGasFees, id, origin, userFeeLevel } = transactionMeta;

--- a/ui/pages/confirmations/hooks/gas/useDappSuggestedGasFeeOption.ts
+++ b/ui/pages/confirmations/hooks/gas/useDappSuggestedGasFeeOption.ts
@@ -28,7 +28,7 @@ export const useDappSuggestedGasFeeOption = ({
     useConfirmContext<TransactionMeta>();
   const nativeTicker = useTransactionNativeTicker();
   const { calculateGasEstimate } = useFeeCalculations(transactionMeta);
-  const { gasLimit: displayGas } = useTransactionGasLimit(transactionMeta);
+  const { modalGasLimit: displayGas } = useTransactionGasLimit(transactionMeta);
   const dispatch = useDispatch();
 
   const { dappSuggestedGasFees, id, origin, userFeeLevel } = transactionMeta;

--- a/ui/pages/confirmations/hooks/gas/useGasFeeEstimateLevelOptions.test.ts
+++ b/ui/pages/confirmations/hooks/gas/useGasFeeEstimateLevelOptions.test.ts
@@ -7,6 +7,7 @@ import {
 import { useGasFeeEstimates } from '../../../../hooks/useGasFeeEstimates';
 import { useConfirmContext } from '../../context/confirm';
 import { useFeeCalculations } from '../../components/confirm/info/hooks/useFeeCalculations';
+import { useTransactionGasLimit } from './useTransactionGasLimit';
 import { useGasFeeEstimateLevelOptions } from './useGasFeeEstimateLevelOptions';
 
 jest.mock('../../../../hooks/useI18nContext', () => ({
@@ -23,6 +24,10 @@ jest.mock('../../../../hooks/useGasFeeEstimates', () => ({
 
 jest.mock('../../components/confirm/info/hooks/useFeeCalculations', () => ({
   useFeeCalculations: jest.fn(),
+}));
+
+jest.mock('./useTransactionGasLimit', () => ({
+  useTransactionGasLimit: jest.fn(),
 }));
 
 jest.mock('../../../../store/actions', () => ({
@@ -44,19 +49,27 @@ jest.mock('react-redux', () => ({
 const mockUseConfirmContext = jest.mocked(useConfirmContext);
 const mockUseGasFeeEstimates = jest.mocked(useGasFeeEstimates);
 const mockUseFeeCalculations = jest.mocked(useFeeCalculations);
+const mockUseTransactionGasLimit = jest.mocked(useTransactionGasLimit);
 
 describe('useGasFeeEstimateLevelOptions', () => {
   const mockHandleCloseModals = jest.fn();
+  const mockCalculateGasEstimate = jest.fn().mockReturnValue({
+    currentCurrencyFee: '$1.00',
+    preciseNativeCurrencyFee: '0.001',
+  });
 
   beforeEach(() => {
     jest.clearAllMocks();
 
+    mockCalculateGasEstimate.mockClear();
     mockUseFeeCalculations.mockReturnValue({
-      calculateGasEstimate: jest.fn().mockReturnValue({
-        currentCurrencyFee: '$1.00',
-        preciseNativeCurrencyFee: '0.001',
-      }),
+      calculateGasEstimate: mockCalculateGasEstimate,
     } as unknown as ReturnType<typeof useFeeCalculations>);
+
+    mockUseTransactionGasLimit.mockReturnValue({
+      gasLimit: '0x5208',
+      quotedGasLimit: undefined,
+    });
   });
 
   it('returns empty array when currentConfirmation is undefined', () => {
@@ -211,5 +224,66 @@ describe('useGasFeeEstimateLevelOptions', () => {
     expect(result.current).toHaveLength(2);
     expect(result.current[0].key).toBe(GasFeeEstimateLevel.Low);
     expect(result.current[1].key).toBe(GasFeeEstimateLevel.Medium);
+  });
+
+  it('passes the gas limit from useTransactionGasLimit to calculateGasEstimate and tooltip', () => {
+    mockUseTransactionGasLimit.mockReturnValue({
+      gasLimit: '0x1fbd0',
+      quotedGasLimit: undefined,
+    });
+
+    mockUseConfirmContext.mockReturnValue({
+      currentConfirmation: {
+        id: '1',
+        chainId: '0x1',
+        networkClientId: 'mainnet',
+        userFeeLevel: 'medium',
+        gasLimitNoBuffer: '0x5208',
+        containerTypes: ['EnforcedSimulations'],
+        gasFeeEstimates: {
+          type: GasFeeEstimateType.FeeMarket,
+          [GasFeeEstimateLevel.Low]: {
+            maxFeePerGas: '0x1',
+            maxPriorityFeePerGas: '0x1',
+          },
+          [GasFeeEstimateLevel.Medium]: {
+            maxFeePerGas: '0x2',
+            maxPriorityFeePerGas: '0x2',
+          },
+          [GasFeeEstimateLevel.High]: {
+            maxFeePerGas: '0x3',
+            maxPriorityFeePerGas: '0x3',
+          },
+        },
+      },
+    } as unknown as ReturnType<typeof useConfirmContext>);
+
+    mockUseGasFeeEstimates.mockReturnValue({
+      gasFeeEstimates: {
+        [GasFeeEstimateLevel.Low]: {
+          minWaitTimeEstimate: 15000,
+          maxWaitTimeEstimate: 30000,
+        },
+        [GasFeeEstimateLevel.Medium]: {
+          minWaitTimeEstimate: 10000,
+          maxWaitTimeEstimate: 20000,
+        },
+        [GasFeeEstimateLevel.High]: {
+          minWaitTimeEstimate: 5000,
+          maxWaitTimeEstimate: 10000,
+        },
+      },
+    } as unknown as ReturnType<typeof useGasFeeEstimates>);
+
+    const { result } = renderHook(() =>
+      useGasFeeEstimateLevelOptions({
+        handleCloseModals: mockHandleCloseModals,
+      }),
+    );
+
+    expect(mockCalculateGasEstimate).toHaveBeenCalledWith(
+      expect.objectContaining({ gas: '0x1fbd0' }),
+    );
+    expect(result.current[0].tooltipProps?.gasLimit).toBe(0x1fbd0);
   });
 });

--- a/ui/pages/confirmations/hooks/gas/useGasFeeEstimateLevelOptions.test.ts
+++ b/ui/pages/confirmations/hooks/gas/useGasFeeEstimateLevelOptions.test.ts
@@ -68,7 +68,6 @@ describe('useGasFeeEstimateLevelOptions', () => {
 
     mockUseTransactionGasLimit.mockReturnValue({
       gasLimit: '0x5208',
-      modalGasLimit: '0x5208',
       quotedGasLimit: undefined,
     });
   });
@@ -227,10 +226,9 @@ describe('useGasFeeEstimateLevelOptions', () => {
     expect(result.current[1].key).toBe(GasFeeEstimateLevel.Medium);
   });
 
-  it('passes the modal gas limit from useTransactionGasLimit to calculateGasEstimate and tooltip', () => {
+  it('passes the gas limit from useTransactionGasLimit to calculateGasEstimate and tooltip', () => {
     mockUseTransactionGasLimit.mockReturnValue({
-      gasLimit: '0x5208',
-      modalGasLimit: '0x1fbd0',
+      gasLimit: '0x1fbd0',
       quotedGasLimit: undefined,
     });
 

--- a/ui/pages/confirmations/hooks/gas/useGasFeeEstimateLevelOptions.test.ts
+++ b/ui/pages/confirmations/hooks/gas/useGasFeeEstimateLevelOptions.test.ts
@@ -68,6 +68,7 @@ describe('useGasFeeEstimateLevelOptions', () => {
 
     mockUseTransactionGasLimit.mockReturnValue({
       gasLimit: '0x5208',
+      modalGasLimit: '0x5208',
       quotedGasLimit: undefined,
     });
   });
@@ -226,9 +227,10 @@ describe('useGasFeeEstimateLevelOptions', () => {
     expect(result.current[1].key).toBe(GasFeeEstimateLevel.Medium);
   });
 
-  it('passes the gas limit from useTransactionGasLimit to calculateGasEstimate and tooltip', () => {
+  it('passes the modal gas limit from useTransactionGasLimit to calculateGasEstimate and tooltip', () => {
     mockUseTransactionGasLimit.mockReturnValue({
-      gasLimit: '0x1fbd0',
+      gasLimit: '0x5208',
+      modalGasLimit: '0x1fbd0',
       quotedGasLimit: undefined,
     });
 

--- a/ui/pages/confirmations/hooks/gas/useGasFeeEstimateLevelOptions.ts
+++ b/ui/pages/confirmations/hooks/gas/useGasFeeEstimateLevelOptions.ts
@@ -19,6 +19,7 @@ import { toHumanEstimatedTimeRange } from '../../utils/time';
 import { hexWEIToDecGWEI } from '../../../../../shared/lib/conversion.utils';
 import { CURRENCY_SYMBOLS } from '../../../../../shared/constants/network';
 import { getNetworkConfigurationsByChainId } from '../../../../../shared/lib/selectors/networks';
+import { useTransactionGasLimit } from './useTransactionGasLimit';
 
 const HEX_ZERO = '0x0';
 
@@ -51,6 +52,9 @@ export const useGasFeeEstimateLevelOptions = ({
           ?.nativeCurrency,
     ) ?? CURRENCY_SYMBOLS.ETH;
   const { calculateGasEstimate } = useFeeCalculations(effectiveTransactionMeta);
+  const { gasLimit: displayGas } = useTransactionGasLimit(
+    effectiveTransactionMeta,
+  );
   const { gasFeeEstimates: networkGasFeeEstimates } = useGasFeeEstimates(
     transactionMeta?.networkClientId,
   ) as {
@@ -119,7 +123,7 @@ export const useGasFeeEstimateLevelOptions = ({
 
       let feePerGas = HEX_ZERO;
       let gasPrice = HEX_ZERO;
-      const gas = transactionMeta.gasLimitNoBuffer || HEX_ZERO;
+      const gas = displayGas || HEX_ZERO;
       let shouldUseEIP1559FeeLogic = true;
       let priorityFeePerGas = HEX_ZERO;
 

--- a/ui/pages/confirmations/hooks/gas/useGasFeeEstimateLevelOptions.ts
+++ b/ui/pages/confirmations/hooks/gas/useGasFeeEstimateLevelOptions.ts
@@ -52,7 +52,7 @@ export const useGasFeeEstimateLevelOptions = ({
           ?.nativeCurrency,
     ) ?? CURRENCY_SYMBOLS.ETH;
   const { calculateGasEstimate } = useFeeCalculations(effectiveTransactionMeta);
-  const { gasLimit: displayGas } = useTransactionGasLimit(
+  const { modalGasLimit: displayGas } = useTransactionGasLimit(
     effectiveTransactionMeta,
   );
   const { gasFeeEstimates: networkGasFeeEstimates } = useGasFeeEstimates(

--- a/ui/pages/confirmations/hooks/gas/useGasFeeEstimateLevelOptions.ts
+++ b/ui/pages/confirmations/hooks/gas/useGasFeeEstimateLevelOptions.ts
@@ -52,7 +52,7 @@ export const useGasFeeEstimateLevelOptions = ({
           ?.nativeCurrency,
     ) ?? CURRENCY_SYMBOLS.ETH;
   const { calculateGasEstimate } = useFeeCalculations(effectiveTransactionMeta);
-  const { modalGasLimit: displayGas } = useTransactionGasLimit(
+  const { gasLimit: displayGas } = useTransactionGasLimit(
     effectiveTransactionMeta,
   );
   const { gasFeeEstimates: networkGasFeeEstimates } = useGasFeeEstimates(

--- a/ui/pages/confirmations/hooks/gas/useGasPriceEstimateOption.ts
+++ b/ui/pages/confirmations/hooks/gas/useGasPriceEstimateOption.ts
@@ -17,6 +17,7 @@ import { type GasOption } from '../../types/gas';
 import { EMPTY_VALUE_STRING } from '../../constants/gas';
 import { useTransactionNativeTicker } from '../transactions/useTransactionNativeTicker';
 import { hexWEIToDecGWEI } from '../../../../../shared/lib/conversion.utils';
+import { useTransactionGasLimit } from './useTransactionGasLimit';
 
 const HEX_ZERO = '0x0';
 
@@ -30,6 +31,7 @@ export const useGasPriceEstimateOption = ({
   const { currentConfirmation: transactionMeta } =
     useConfirmContext<TransactionMeta>();
   const { calculateGasEstimate } = useFeeCalculations(transactionMeta);
+  const { gasLimit: displayGas } = useTransactionGasLimit(transactionMeta);
   const nativeTicker = useTransactionNativeTicker();
 
   const {
@@ -97,7 +99,7 @@ export const useGasPriceEstimateOption = ({
 
     let feePerGas = HEX_ZERO;
     let gasPrice = HEX_ZERO;
-    const gas = transactionMeta.gasLimitNoBuffer || HEX_ZERO;
+    const gas = displayGas || HEX_ZERO;
     let shouldUseEIP1559FeeLogic = false;
     let priorityFeePerGas = HEX_ZERO;
 
@@ -148,6 +150,7 @@ export const useGasPriceEstimateOption = ({
     onGasPriceEstimateLevelClick,
     t,
     nativeTicker,
+    displayGas,
   ]);
 
   return options;

--- a/ui/pages/confirmations/hooks/gas/useGasPriceEstimateOption.ts
+++ b/ui/pages/confirmations/hooks/gas/useGasPriceEstimateOption.ts
@@ -31,7 +31,7 @@ export const useGasPriceEstimateOption = ({
   const { currentConfirmation: transactionMeta } =
     useConfirmContext<TransactionMeta>();
   const { calculateGasEstimate } = useFeeCalculations(transactionMeta);
-  const { modalGasLimit: displayGas } = useTransactionGasLimit(transactionMeta);
+  const { gasLimit: displayGas } = useTransactionGasLimit(transactionMeta);
   const nativeTicker = useTransactionNativeTicker();
 
   const {

--- a/ui/pages/confirmations/hooks/gas/useGasPriceEstimateOption.ts
+++ b/ui/pages/confirmations/hooks/gas/useGasPriceEstimateOption.ts
@@ -31,7 +31,7 @@ export const useGasPriceEstimateOption = ({
   const { currentConfirmation: transactionMeta } =
     useConfirmContext<TransactionMeta>();
   const { calculateGasEstimate } = useFeeCalculations(transactionMeta);
-  const { gasLimit: displayGas } = useTransactionGasLimit(transactionMeta);
+  const { modalGasLimit: displayGas } = useTransactionGasLimit(transactionMeta);
   const nativeTicker = useTransactionNativeTicker();
 
   const {

--- a/ui/pages/confirmations/hooks/gas/useTransactionGasLimit.test.ts
+++ b/ui/pages/confirmations/hooks/gas/useTransactionGasLimit.test.ts
@@ -1,0 +1,135 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { type TransactionMeta } from '@metamask/transaction-controller';
+
+import { useDappSwapContextOptional } from '../../context/dapp-swap';
+import { useTransactionGasLimit } from './useTransactionGasLimit';
+
+jest.mock('../../context/dapp-swap', () => ({
+  useDappSwapContextOptional: jest.fn(),
+}));
+
+const mockUseDappSwapContextOptional = jest.mocked(useDappSwapContextOptional);
+
+const BASE_TRANSACTION_META = {
+  chainId: '0x1',
+  networkClientId: 'mainnet',
+  txParams: { gas: '0x5208' },
+} as unknown as TransactionMeta;
+
+describe('useTransactionGasLimit', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseDappSwapContextOptional.mockReturnValue(undefined);
+  });
+
+  it('prefers gasUsed when no container types are set', () => {
+    const { result } = renderHook(() =>
+      useTransactionGasLimit({
+        ...BASE_TRANSACTION_META,
+        gasUsed: '0x7530',
+        gasLimitNoBuffer: '0x6000',
+      } as unknown as TransactionMeta),
+    );
+
+    expect(result.current.gasLimit).toBe('0x7530');
+  });
+
+  it('falls back to gasLimitNoBuffer when gasUsed is missing', () => {
+    const { result } = renderHook(() =>
+      useTransactionGasLimit({
+        ...BASE_TRANSACTION_META,
+        gasLimitNoBuffer: '0x6000',
+      } as unknown as TransactionMeta),
+    );
+
+    expect(result.current.gasLimit).toBe('0x6000');
+  });
+
+  it('falls back to txParams.gas when both gasUsed and gasLimitNoBuffer are missing', () => {
+    const { result } = renderHook(() =>
+      useTransactionGasLimit(BASE_TRANSACTION_META),
+    );
+
+    expect(result.current.gasLimit).toBe('0x5208');
+  });
+
+  it('returns 0x0 when no gas fields are available', () => {
+    const { result } = renderHook(() =>
+      useTransactionGasLimit({
+        chainId: '0x1',
+        networkClientId: 'mainnet',
+        txParams: {},
+      } as unknown as TransactionMeta),
+    );
+
+    expect(result.current.gasLimit).toBe('0x0');
+  });
+
+  it('prefers txParams.gas over simulation fields when container types are set', () => {
+    const { result } = renderHook(() =>
+      useTransactionGasLimit({
+        ...BASE_TRANSACTION_META,
+        containerTypes: ['EnforcedSimulations'],
+        gasUsed: '0x7530',
+        gasLimitNoBuffer: '0x6000',
+        txParams: { gas: '0x1fbd0' },
+      } as unknown as TransactionMeta),
+    );
+
+    expect(result.current.gasLimit).toBe('0x1fbd0');
+  });
+
+  it('falls back to 0x0 when container types are set but txParams.gas is missing', () => {
+    const { result } = renderHook(() =>
+      useTransactionGasLimit({
+        ...BASE_TRANSACTION_META,
+        containerTypes: ['EnforcedSimulations'],
+        gasLimitNoBuffer: '0x6000',
+        txParams: {},
+      } as unknown as TransactionMeta),
+    );
+
+    expect(result.current.gasLimit).toBe('0x0');
+  });
+
+  it('uses quoted gas limit when a swap quote is displayed', () => {
+    mockUseDappSwapContextOptional.mockReturnValue({
+      isQuotedSwapDisplayedInInfo: true,
+      selectedQuote: {
+        approval: { gasLimit: 100 },
+        trade: { gasLimit: 50 },
+      },
+    } as unknown as ReturnType<typeof useDappSwapContextOptional>);
+
+    const { result } = renderHook(() =>
+      useTransactionGasLimit({
+        ...BASE_TRANSACTION_META,
+        gasUsed: '0x7530',
+      } as unknown as TransactionMeta),
+    );
+
+    // 100 + 50 = 150 = 0x96
+    expect(result.current.gasLimit).toBe('0x96');
+    expect(result.current.quotedGasLimit).toBe('0x96');
+  });
+
+  it('ignores quoted gas limit when container types are set', () => {
+    mockUseDappSwapContextOptional.mockReturnValue({
+      isQuotedSwapDisplayedInInfo: true,
+      selectedQuote: {
+        approval: { gasLimit: 100 },
+        trade: { gasLimit: 50 },
+      },
+    } as unknown as ReturnType<typeof useDappSwapContextOptional>);
+
+    const { result } = renderHook(() =>
+      useTransactionGasLimit({
+        ...BASE_TRANSACTION_META,
+        containerTypes: ['EnforcedSimulations'],
+        txParams: { gas: '0x1fbd0' },
+      } as unknown as TransactionMeta),
+    );
+
+    expect(result.current.gasLimit).toBe('0x1fbd0');
+  });
+});

--- a/ui/pages/confirmations/hooks/gas/useTransactionGasLimit.test.ts
+++ b/ui/pages/confirmations/hooks/gas/useTransactionGasLimit.test.ts
@@ -132,4 +132,42 @@ describe('useTransactionGasLimit', () => {
 
     expect(result.current.gasLimit).toBe('0x1fbd0');
   });
+
+  describe('modalGasLimit', () => {
+    it('prefers gasLimitNoBuffer and ignores gasUsed when no container types are set', () => {
+      const { result } = renderHook(() =>
+        useTransactionGasLimit({
+          ...BASE_TRANSACTION_META,
+          gasUsed: '0x7530',
+          gasLimitNoBuffer: '0x6000',
+        } as unknown as TransactionMeta),
+      );
+
+      expect(result.current.modalGasLimit).toBe('0x6000');
+    });
+
+    it('returns 0x0 when gasLimitNoBuffer is missing and no container types are set', () => {
+      const { result } = renderHook(() =>
+        useTransactionGasLimit({
+          ...BASE_TRANSACTION_META,
+          gasUsed: '0x7530',
+        } as unknown as TransactionMeta),
+      );
+
+      expect(result.current.modalGasLimit).toBe('0x0');
+    });
+
+    it('prefers wrapped txParams.gas when container types are set', () => {
+      const { result } = renderHook(() =>
+        useTransactionGasLimit({
+          ...BASE_TRANSACTION_META,
+          containerTypes: ['EnforcedSimulations'],
+          gasLimitNoBuffer: '0x6000',
+          txParams: { gas: '0x1fbd0' },
+        } as unknown as TransactionMeta),
+      );
+
+      expect(result.current.modalGasLimit).toBe('0x1fbd0');
+    });
+  });
 });

--- a/ui/pages/confirmations/hooks/gas/useTransactionGasLimit.test.ts
+++ b/ui/pages/confirmations/hooks/gas/useTransactionGasLimit.test.ts
@@ -132,42 +132,4 @@ describe('useTransactionGasLimit', () => {
 
     expect(result.current.gasLimit).toBe('0x1fbd0');
   });
-
-  describe('modalGasLimit', () => {
-    it('prefers gasLimitNoBuffer and ignores gasUsed when no container types are set', () => {
-      const { result } = renderHook(() =>
-        useTransactionGasLimit({
-          ...BASE_TRANSACTION_META,
-          gasUsed: '0x7530',
-          gasLimitNoBuffer: '0x6000',
-        } as unknown as TransactionMeta),
-      );
-
-      expect(result.current.modalGasLimit).toBe('0x6000');
-    });
-
-    it('returns 0x0 when gasLimitNoBuffer is missing and no container types are set', () => {
-      const { result } = renderHook(() =>
-        useTransactionGasLimit({
-          ...BASE_TRANSACTION_META,
-          gasUsed: '0x7530',
-        } as unknown as TransactionMeta),
-      );
-
-      expect(result.current.modalGasLimit).toBe('0x0');
-    });
-
-    it('prefers wrapped txParams.gas when container types are set', () => {
-      const { result } = renderHook(() =>
-        useTransactionGasLimit({
-          ...BASE_TRANSACTION_META,
-          containerTypes: ['EnforcedSimulations'],
-          gasLimitNoBuffer: '0x6000',
-          txParams: { gas: '0x1fbd0' },
-        } as unknown as TransactionMeta),
-      );
-
-      expect(result.current.modalGasLimit).toBe('0x1fbd0');
-    });
-  });
 });

--- a/ui/pages/confirmations/hooks/gas/useTransactionGasLimit.ts
+++ b/ui/pages/confirmations/hooks/gas/useTransactionGasLimit.ts
@@ -1,0 +1,61 @@
+import { TxData } from '@metamask/bridge-controller';
+import { TransactionMeta } from '@metamask/transaction-controller';
+import { Hex } from '@metamask/utils';
+
+import { toHex } from '../../../../../shared/lib/delegation/utils';
+import { useDappSwapContextOptional } from '../../context/dapp-swap';
+import { HEX_ZERO } from '../../components/confirm/info/shared/constants';
+
+/**
+ * Returns the gas limit that should be used when computing or displaying the
+ * fee for a given transaction. Extracted from `useFeeCalculations` so that
+ * gas-limit selection can be reused by the gas fee modal option hooks
+ * without pulling in the rest of the fee calculation machinery.
+ *
+ * @param transactionMeta - The transaction being displayed.
+ * @returns An object with `gasLimit` (the selected gas limit as a hex
+ * string) and `quotedGasLimit` (the swap-quoted gas limit if applicable,
+ * otherwise `undefined`; exposed for callers that still need it such as
+ * `useTransactionGasFeeEstimate`).
+ */
+export function useTransactionGasLimit(transactionMeta: TransactionMeta): {
+  gasLimit: Hex;
+  quotedGasLimit: Hex | undefined;
+} {
+  const dappSwapContext = useDappSwapContextOptional();
+  const selectedQuote = dappSwapContext?.selectedQuote;
+  const isQuotedSwapDisplayedInInfo =
+    dappSwapContext?.isQuotedSwapDisplayedInInfo ?? false;
+
+  let quotedGasLimit: Hex | undefined;
+  if (isQuotedSwapDisplayedInInfo) {
+    quotedGasLimit = toHex(
+      ((selectedQuote?.approval as TxData)?.gasLimit ?? 0) +
+        ((selectedQuote?.trade as TxData)?.gasLimit ?? 0),
+    ) as Hex;
+  }
+
+  // When container types are set (e.g. enforced simulations), the gas limit
+  // has been re-estimated for the wrapped transaction, so we use
+  // `txParams.gas` directly. Otherwise, prefer the optimized values from
+  // simulation.
+  const hasContainerTypes = (transactionMeta?.containerTypes?.length ?? 0) > 0;
+
+  // `gasUsed` is the gas limit actually used by the transaction in the
+  // simulation environment.
+  const gasLimit = (
+    hasContainerTypes
+      ? transactionMeta?.txParams?.gas || HEX_ZERO
+      : quotedGasLimit ||
+        transactionMeta?.gasUsed ||
+        // While estimating gas for the transaction we add 50% gas limit buffer.
+        // With `gasLimitNoBuffer` that buffer is removed. See PR
+        // https://github.com/MetaMask/metamask-extension/pull/29502 for more
+        // details.
+        transactionMeta?.gasLimitNoBuffer ||
+        transactionMeta?.txParams?.gas ||
+        HEX_ZERO
+  ) as Hex;
+
+  return { gasLimit, quotedGasLimit };
+}

--- a/ui/pages/confirmations/hooks/gas/useTransactionGasLimit.ts
+++ b/ui/pages/confirmations/hooks/gas/useTransactionGasLimit.ts
@@ -7,29 +7,19 @@ import { useDappSwapContextOptional } from '../../context/dapp-swap';
 import { HEX_ZERO } from '../../components/confirm/info/shared/constants';
 
 /**
- * Returns the gas limits that should be used when computing or displaying
- * fees for a given transaction. Extracted from `useFeeCalculations` so that
- * gas-limit selection can be reused by the gas fee modal option hooks
- * without pulling in the rest of the fee calculation machinery.
- *
- * Two gas limits are returned because the confirmation screen's main fee
- * row and the gas fee modal's option rows historically used slightly
- * different priority chains; this hook preserves both while adding
- * container-wrapping awareness to both.
+ * Returns the gas limit that should be used when computing or displaying
+ * the fee for a given transaction. Shared by `useFeeCalculations` and the
+ * gas fee modal option hooks so the same value is used everywhere.
  *
  * @param transactionMeta - The transaction being displayed.
- * @returns An object with `gasLimit` (full priority chain used by
- * `useFeeCalculations` to compute the displayed fee — prefers `gasUsed`
- * from simulation), `modalGasLimit` (priority used by the gas fee modal
- * option rows — prefers `gasLimitNoBuffer`) and `quotedGasLimit` (the
- * swap-quoted gas limit if applicable, otherwise `undefined`; exposed for
- * callers that still need it such as `useTransactionGasFeeEstimate`). When
- * `containerTypes` is set (e.g. enforced simulations) both `gasLimit` and
- * `modalGasLimit` resolve to the wrapped `txParams.gas`.
+ * @returns An object with `gasLimit` (the selected gas limit) and
+ * `quotedGasLimit` (the swap-quoted gas limit if applicable, otherwise
+ * `undefined`; exposed for callers that still need it such as
+ * `useTransactionGasFeeEstimate`). When `containerTypes` is set (e.g.
+ * enforced simulations) `gasLimit` resolves to the wrapped `txParams.gas`.
  */
 export function useTransactionGasLimit(transactionMeta: TransactionMeta): {
   gasLimit: Hex;
-  modalGasLimit: Hex;
   quotedGasLimit: Hex | undefined;
 } {
   const dappSwapContext = useDappSwapContextOptional();
@@ -50,13 +40,12 @@ export function useTransactionGasLimit(transactionMeta: TransactionMeta): {
   // `txParams.gas` directly. `gasUsed` / `gasLimitNoBuffer` reflect the
   // pre-wrap estimate and would understate the fee.
   const hasContainerTypes = (transactionMeta?.containerTypes?.length ?? 0) > 0;
-  const wrappedGas = (transactionMeta?.txParams?.gas || HEX_ZERO) as Hex;
 
   // `gasUsed` is the gas limit actually used by the transaction in the
   // simulation environment.
   const gasLimit = (
     hasContainerTypes
-      ? wrappedGas
+      ? transactionMeta?.txParams?.gas || HEX_ZERO
       : quotedGasLimit ||
         transactionMeta?.gasUsed ||
         // While estimating gas for the transaction we add 50% gas limit
@@ -68,11 +57,5 @@ export function useTransactionGasLimit(transactionMeta: TransactionMeta): {
         HEX_ZERO
   ) as Hex;
 
-  const modalGasLimit = (
-    hasContainerTypes
-      ? wrappedGas
-      : transactionMeta?.gasLimitNoBuffer || HEX_ZERO
-  ) as Hex;
-
-  return { gasLimit, modalGasLimit, quotedGasLimit };
+  return { gasLimit, quotedGasLimit };
 }

--- a/ui/pages/confirmations/hooks/gas/useTransactionGasLimit.ts
+++ b/ui/pages/confirmations/hooks/gas/useTransactionGasLimit.ts
@@ -7,19 +7,29 @@ import { useDappSwapContextOptional } from '../../context/dapp-swap';
 import { HEX_ZERO } from '../../components/confirm/info/shared/constants';
 
 /**
- * Returns the gas limit that should be used when computing or displaying the
- * fee for a given transaction. Extracted from `useFeeCalculations` so that
+ * Returns the gas limits that should be used when computing or displaying
+ * fees for a given transaction. Extracted from `useFeeCalculations` so that
  * gas-limit selection can be reused by the gas fee modal option hooks
  * without pulling in the rest of the fee calculation machinery.
  *
+ * Two gas limits are returned because the confirmation screen's main fee
+ * row and the gas fee modal's option rows historically used slightly
+ * different priority chains; this hook preserves both while adding
+ * container-wrapping awareness to both.
+ *
  * @param transactionMeta - The transaction being displayed.
- * @returns An object with `gasLimit` (the selected gas limit as a hex
- * string) and `quotedGasLimit` (the swap-quoted gas limit if applicable,
- * otherwise `undefined`; exposed for callers that still need it such as
- * `useTransactionGasFeeEstimate`).
+ * @returns An object with `gasLimit` (full priority chain used by
+ * `useFeeCalculations` to compute the displayed fee — prefers `gasUsed`
+ * from simulation), `modalGasLimit` (priority used by the gas fee modal
+ * option rows — prefers `gasLimitNoBuffer`) and `quotedGasLimit` (the
+ * swap-quoted gas limit if applicable, otherwise `undefined`; exposed for
+ * callers that still need it such as `useTransactionGasFeeEstimate`). When
+ * `containerTypes` is set (e.g. enforced simulations) both `gasLimit` and
+ * `modalGasLimit` resolve to the wrapped `txParams.gas`.
  */
 export function useTransactionGasLimit(transactionMeta: TransactionMeta): {
   gasLimit: Hex;
+  modalGasLimit: Hex;
   quotedGasLimit: Hex | undefined;
 } {
   const dappSwapContext = useDappSwapContextOptional();
@@ -37,25 +47,32 @@ export function useTransactionGasLimit(transactionMeta: TransactionMeta): {
 
   // When container types are set (e.g. enforced simulations), the gas limit
   // has been re-estimated for the wrapped transaction, so we use
-  // `txParams.gas` directly. Otherwise, prefer the optimized values from
-  // simulation.
+  // `txParams.gas` directly. `gasUsed` / `gasLimitNoBuffer` reflect the
+  // pre-wrap estimate and would understate the fee.
   const hasContainerTypes = (transactionMeta?.containerTypes?.length ?? 0) > 0;
+  const wrappedGas = (transactionMeta?.txParams?.gas || HEX_ZERO) as Hex;
 
   // `gasUsed` is the gas limit actually used by the transaction in the
   // simulation environment.
   const gasLimit = (
     hasContainerTypes
-      ? transactionMeta?.txParams?.gas || HEX_ZERO
+      ? wrappedGas
       : quotedGasLimit ||
         transactionMeta?.gasUsed ||
-        // While estimating gas for the transaction we add 50% gas limit buffer.
-        // With `gasLimitNoBuffer` that buffer is removed. See PR
-        // https://github.com/MetaMask/metamask-extension/pull/29502 for more
-        // details.
+        // While estimating gas for the transaction we add 50% gas limit
+        // buffer. With `gasLimitNoBuffer` that buffer is removed. See PR
+        // https://github.com/MetaMask/metamask-extension/pull/29502 for
+        // more details.
         transactionMeta?.gasLimitNoBuffer ||
         transactionMeta?.txParams?.gas ||
         HEX_ZERO
   ) as Hex;
 
-  return { gasLimit, quotedGasLimit };
+  const modalGasLimit = (
+    hasContainerTypes
+      ? wrappedGas
+      : transactionMeta?.gasLimitNoBuffer || HEX_ZERO
+  ) as Hex;
+
+  return { gasLimit, modalGasLimit, quotedGasLimit };
 }


### PR DESCRIPTION
## **Description**

Three follow-ups for enforced simulations:

1. Confirmation screen was showing the delegation manager as the recipient and zero for the send amount under enforced simulations. Fixed so the user sees what they actually intended to do.
2. Gas fee modal rows computed their displayed fee against a stale pre-wrap gas limit, so fees shown before opening the modal differed from fees shown inside it. Unified so the modal and the main screen use the same gas limit.
3. Added a `FORCE_ENABLE_SIMULATIONS` env flag that makes enforced simulations apply whenever there are balance changes, bypassing the trust signal check. Local/QA only.

## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Set `ENABLE_ENFORCED_SIMULATIONS=true` and `FORCE_ENABLE_SIMULATIONS=true` in `.metamaskrc`.
2. `yarn start`.
3. From a dApp, send a native transfer to a trusted address on a supported chain. The enforced simulations row should appear auto-enabled.
4. Confirm the recipient is the dApp-supplied address, the send amount matches the original value, and the fee shown on the confirmation matches the fee shown in the gas fee modal rows.
5. Turn `FORCE_ENABLE_SIMULATIONS` off and repeat with an untrusted recipient — behaviour should be unchanged from today.

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches transaction confirmation display and gas fee computation paths, so mistakes could mislead users about recipients, amounts, or fees. The new `FORCE_ENABLE_SIMULATIONS` flag bypasses trust-signal gating (intended non-prod) and must remain disabled in production builds.
> 
> **Overview**
> Ensures confirmations show the *user-intended* recipient and amount when enforced simulations/container wrapping rewrites `txParams` by preferring `txParamsOriginal` for `to`, `data`, and `value` (updates `useTransferRecipient`, `NativeSendHeading`, `TransactionDetails`, and mismatch detection).
> 
> Unifies gas-limit selection across the main confirmation and gas-fee modal options via new `useTransactionGasLimit`, preventing fee discrepancies when wrapping changes the effective gas limit; updates related hooks/tests to use the shared value.
> 
> Adds `FORCE_ENABLE_SIMULATIONS` env var (wired into `builds.yml` and `.metamaskrc.dist`) to force enforced simulations whenever balance changes exist by skipping trust-signal checks, with expanded unit coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 316cefb79d5bc31aad374621a7e930c3d4294e0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->