### PR TITLE
feat: token order input interactivity

### DIFF
--- a/ui/components/app/perps/order-entry/components/amount-input/amount-input.test.tsx
+++ b/ui/components/app/perps/order-entry/components/amount-input/amount-input.test.tsx
@@ -348,6 +348,97 @@ describe('AmountInput', () => {
 
       expect(onAmountChange).not.toHaveBeenCalled();
     });
+
+    it('preserves leading "0" in the field while the user continues typing', () => {
+      const onAmountChange = jest.fn();
+      renderWithProvider(
+        <AmountInput
+          {...defaultProps}
+          onAmountChange={onAmountChange}
+          currentPrice={45000}
+        />,
+        mockStore,
+      );
+
+      const container = screen.getByTestId('amount-input-token-field');
+      const input = container.querySelector('input') as HTMLInputElement;
+
+      fireEvent.focus(input);
+
+      // Step 1: type "0" — partial; USD clears but field keeps "0"
+      fireEvent.change(input, { target: { value: '0' } });
+      expect(input).toHaveValue('0');
+      expect(onAmountChange).toHaveBeenLastCalledWith('');
+
+      // Step 2: type "0." — field keeps "0."
+      fireEvent.change(input, { target: { value: '0.' } });
+      expect(input).toHaveValue('0.');
+
+      // Step 3: type "0.5" — field shows "0.5" and USD is computed
+      fireEvent.change(input, { target: { value: '0.5' } });
+      expect(input).toHaveValue('0.5');
+      // 0.5 × 45000 = 22500
+      expect(onAmountChange).toHaveBeenLastCalledWith('22500.00');
+    });
+
+    it('clears USD when the token field is backspaced to empty', () => {
+      const onAmountChange = jest.fn();
+      renderWithProvider(
+        <AmountInput
+          {...defaultProps}
+          onAmountChange={onAmountChange}
+          currentPrice={50000}
+        />,
+        mockStore,
+      );
+
+      const container = screen.getByTestId('amount-input-token-field');
+      const input = container.querySelector('input') as HTMLInputElement;
+
+      fireEvent.focus(input);
+      // Enter a valid token amount
+      fireEvent.change(input, { target: { value: '0.1' } });
+      expect(onAmountChange).toHaveBeenLastCalledWith('5000.00');
+
+      // Clear the field
+      fireEvent.change(input, { target: { value: '' } });
+      expect(input).toHaveValue('');
+      expect(onAmountChange).toHaveBeenLastCalledWith('');
+    });
+
+    it('shows un-grouped value for large token amounts so backspace edits work', () => {
+      // 450000 USDC / price 1 = 450000 tokens
+      // Without useGrouping:false this would be "450,000" which isUnsignedDecimalInput rejects
+      renderWithProvider(
+        <AmountInput {...defaultProps} amount="450000" currentPrice={1} />,
+        mockStore,
+      );
+
+      const container = screen.getByTestId('amount-input-token-field');
+      const input = container.querySelector('input');
+      // Must not contain a comma — value must be plain digits
+      expect(input?.value).not.toContain(',');
+      expect(input).toHaveValue('450000');
+    });
+
+    it('syncs token field from external amount change when not editing', () => {
+      const { rerender } = renderWithProvider(
+        <AmountInput {...defaultProps} amount="" currentPrice={50000} />,
+        mockStore,
+      );
+
+      const container = screen.getByTestId('amount-input-token-field');
+      const input = container.querySelector('input');
+      expect(input).toHaveValue('');
+
+      // Simulate external update (e.g. slider or USD field changed amount)
+      rerender(
+        <AmountInput {...defaultProps} amount="5000" currentPrice={50000} />,
+      );
+
+      // 5000 / 50000 = 0.1
+      expect(input).toHaveValue('0.1');
+    });
   });
 
   describe('percent input', () => {

--- a/ui/components/app/perps/order-entry/components/amount-input/amount-input.tsx
+++ b/ui/components/app/perps/order-entry/components/amount-input/amount-input.tsx
@@ -11,13 +11,7 @@ import {
   IconSize,
   IconColor,
 } from '@metamask/design-system-react';
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import {
   BorderRadius,
@@ -90,16 +84,14 @@ export const AmountInput: React.FC<AmountInputProps> = ({
 
   // Local draft for the token input so intermediate values (e.g. "0", "0.") are
   // preserved while the user is actively typing.
+  const [isEditingToken, setIsEditingToken] = useState(false);
   const [tokenInputValue, setTokenInputValue] = useState(unGroupedTokenDisplay);
-  const isEditingTokenRef = useRef(false);
 
-  // Keep the token input in sync with external state changes (slider, USD field,
-  // percent pill) unless the user is currently typing in the token field.
-  useEffect(() => {
-    if (!isEditingTokenRef.current) {
-      setTokenInputValue(unGroupedTokenDisplay);
-    }
-  }, [unGroupedTokenDisplay]);
+  // When not editing, derive the displayed token value from the current amount
+  // rather than syncing via an effect — avoids a stale intermediate render.
+  const displayedTokenValue = isEditingToken
+    ? tokenInputValue
+    : unGroupedTokenDisplay;
 
   const formatAmount = useCallback(
     (value: number): string => value.toFixed(2),
@@ -196,13 +188,13 @@ export const AmountInput: React.FC<AmountInputProps> = ({
   );
 
   const handleTokenFocus = useCallback(() => {
-    isEditingTokenRef.current = true;
-  }, []);
+    setTokenInputValue(unGroupedTokenDisplay);
+    setIsEditingToken(true);
+  }, [unGroupedTokenDisplay]);
 
   const handleTokenBlur = useCallback(() => {
-    isEditingTokenRef.current = false;
-    setTokenInputValue(unGroupedTokenDisplay);
-  }, [unGroupedTokenDisplay]);
+    setIsEditingToken(false);
+  }, []);
 
   const handleSliderChange = useCallback(
     (_event: React.ChangeEvent<unknown>, value: number | number[]) => {
@@ -340,7 +332,7 @@ export const AmountInput: React.FC<AmountInputProps> = ({
         <Box className="flex-1 min-w-0">
           <TextField
             size={TextFieldSize.Md}
-            value={tokenInputValue}
+            value={displayedTokenValue}
             onChange={handleTokenAmountChange}
             onFocus={handleTokenFocus}
             onBlur={handleTokenBlur}

--- a/ui/components/app/perps/order-entry/components/amount-input/amount-input.tsx
+++ b/ui/components/app/perps/order-entry/components/amount-input/amount-input.tsx
@@ -29,7 +29,11 @@ import { TextField, TextFieldSize } from '../../../../../component-library';
 import { PerpsSlider } from '../../../perps-slider';
 import { getDisplaySymbol } from '../../../utils';
 import type { AmountInputProps } from '../../order-entry.types';
-import { isDigitsOnlyInput, isUnsignedDecimalInput } from '../../utils';
+import {
+  formatNumberForInput,
+  isDigitsOnlyInput,
+  isUnsignedDecimalInput,
+} from '../../utils';
 
 /**
  * AmountInput - Size section with dual USD/token inputs and percentage slider
@@ -76,17 +80,14 @@ export const AmountInput: React.FC<AmountInputProps> = ({
     return currentPrice > 0 ? numAmount / currentPrice : null;
   }, [amount, currentPrice]);
 
-  // Un-grouped so the string is always editable by isUnsignedDecimalInput (no commas).
+  // Uses a locale-neutral formatter (always ".") so the value is always
+  // editable by isUnsignedDecimalInput regardless of the user's locale.
   const unGroupedTokenDisplay = useMemo(() => {
     if (tokenAmount === null || tokenAmount === 0) {
       return '';
     }
-    return formatNumber(tokenAmount, {
-      useGrouping: false,
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 6,
-    });
-  }, [tokenAmount, formatNumber]);
+    return formatNumberForInput(tokenAmount);
+  }, [tokenAmount]);
 
   // Local draft for the token input so intermediate values (e.g. "0", "0.") are
   // preserved while the user is actively typing.

--- a/ui/components/app/perps/order-entry/components/amount-input/amount-input.tsx
+++ b/ui/components/app/perps/order-entry/components/amount-input/amount-input.tsx
@@ -11,7 +11,13 @@ import {
   IconSize,
   IconColor,
 } from '@metamask/design-system-react';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 import {
   BorderRadius,
@@ -70,15 +76,30 @@ export const AmountInput: React.FC<AmountInputProps> = ({
     return currentPrice > 0 ? numAmount / currentPrice : null;
   }, [amount, currentPrice]);
 
-  const tokenDisplayValue = useMemo(() => {
+  // Un-grouped so the string is always editable by isUnsignedDecimalInput (no commas).
+  const unGroupedTokenDisplay = useMemo(() => {
     if (tokenAmount === null || tokenAmount === 0) {
       return '';
     }
     return formatNumber(tokenAmount, {
+      useGrouping: false,
       minimumFractionDigits: 0,
       maximumFractionDigits: 6,
     });
   }, [tokenAmount, formatNumber]);
+
+  // Local draft for the token input so intermediate values (e.g. "0", "0.") are
+  // preserved while the user is actively typing.
+  const [tokenInputValue, setTokenInputValue] = useState(unGroupedTokenDisplay);
+  const isEditingTokenRef = useRef(false);
+
+  // Keep the token input in sync with external state changes (slider, USD field,
+  // percent pill) unless the user is currently typing in the token field.
+  useEffect(() => {
+    if (!isEditingTokenRef.current) {
+      setTokenInputValue(unGroupedTokenDisplay);
+    }
+  }, [unGroupedTokenDisplay]);
 
   const formatAmount = useCallback(
     (value: number): string => value.toFixed(2),
@@ -131,31 +152,37 @@ export const AmountInput: React.FC<AmountInputProps> = ({
   const handleTokenAmountChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       const { value } = event.target;
-      if (value === '' || isUnsignedDecimalInput(value)) {
-        if (value === '' || value === '.') {
-          onAmountChange('');
-          onBalancePercentChange(0);
-          setPercentInputValue('0');
-          return;
-        }
-        const numToken = parseFloat(value);
-        if (isNaN(numToken) || numToken <= 0 || currentPrice === 0) {
-          onAmountChange('');
-          onBalancePercentChange(0);
-          setPercentInputValue('0');
-          return;
-        }
-        const usdSize = numToken * currentPrice;
-        onAmountChange(formatAmount(usdSize));
-        const maxSize = availableBalance * leverage;
-        if (maxSize > 0) {
-          const pct = Math.min(Math.round((usdSize / maxSize) * 100), 100);
-          onBalancePercentChange(pct);
-          setPercentInputValue(String(pct));
-        } else {
-          onBalancePercentChange(0);
-          setPercentInputValue('0');
-        }
+      if (value !== '' && !isUnsignedDecimalInput(value)) {
+        return;
+      }
+
+      // Always update the local draft so partial inputs like "0", "0.", "0.0"
+      // are preserved in the field while the user is still typing.
+      setTokenInputValue(value);
+
+      if (value === '' || value === '.') {
+        onAmountChange('');
+        onBalancePercentChange(0);
+        setPercentInputValue('0');
+        return;
+      }
+      const numToken = parseFloat(value);
+      if (!Number.isFinite(numToken) || numToken <= 0 || currentPrice === 0) {
+        onAmountChange('');
+        onBalancePercentChange(0);
+        setPercentInputValue('0');
+        return;
+      }
+      const usdSize = numToken * currentPrice;
+      onAmountChange(formatAmount(usdSize));
+      const maxSize = availableBalance * leverage;
+      if (maxSize > 0) {
+        const pct = Math.min(Math.round((usdSize / maxSize) * 100), 100);
+        onBalancePercentChange(pct);
+        setPercentInputValue(String(pct));
+      } else {
+        onBalancePercentChange(0);
+        setPercentInputValue('0');
       }
     },
     [
@@ -168,9 +195,14 @@ export const AmountInput: React.FC<AmountInputProps> = ({
     ],
   );
 
-  const handleTokenBlur = useCallback(() => {
-    // Token value is derived from amount; no need to sync back on blur
+  const handleTokenFocus = useCallback(() => {
+    isEditingTokenRef.current = true;
   }, []);
+
+  const handleTokenBlur = useCallback(() => {
+    isEditingTokenRef.current = false;
+    setTokenInputValue(unGroupedTokenDisplay);
+  }, [unGroupedTokenDisplay]);
 
   const handleSliderChange = useCallback(
     (_event: React.ChangeEvent<unknown>, value: number | number[]) => {
@@ -308,8 +340,9 @@ export const AmountInput: React.FC<AmountInputProps> = ({
         <Box className="flex-1 min-w-0">
           <TextField
             size={TextFieldSize.Md}
-            value={tokenDisplayValue}
+            value={tokenInputValue}
             onChange={handleTokenAmountChange}
+            onFocus={handleTokenFocus}
             onBlur={handleTokenBlur}
             placeholder="0"
             borderRadius={BorderRadius.MD}

--- a/ui/components/app/perps/order-entry/utils.test.ts
+++ b/ui/components/app/perps/order-entry/utils.test.ts
@@ -1,10 +1,31 @@
 import {
+  formatNumberForInput,
   isDigitsOnlyInput,
   isSignedDecimalInput,
   isUnsignedDecimalInput,
 } from './utils';
 
 describe('order-entry utils', () => {
+  describe('formatNumberForInput', () => {
+    it('always uses "." as decimal separator regardless of locale', () => {
+      expect(formatNumberForInput(0.5)).toBe('0.5');
+      expect(formatNumberForInput(1234.567)).toBe('1234.567');
+    });
+
+    it('never uses grouping separators', () => {
+      expect(formatNumberForInput(1000000)).toBe('1000000');
+    });
+
+    it('respects maximumFractionDigits', () => {
+      expect(formatNumberForInput(1.123456789, 2)).toBe('1.12');
+    });
+
+    it('produces output accepted by isUnsignedDecimalInput', () => {
+      [0.5, 1234.567, 0.000001, 100].forEach((n) => {
+        expect(isUnsignedDecimalInput(formatNumberForInput(n))).toBe(true);
+      });
+    });
+  });
   describe('isDigitsOnlyInput', () => {
     it('accepts digit-only values', () => {
       expect(isDigitsOnlyInput('')).toBe(true);

--- a/ui/components/app/perps/order-entry/utils.ts
+++ b/ui/components/app/perps/order-entry/utils.ts
@@ -1,6 +1,23 @@
 const isDigit = (char: string): boolean => char >= '0' && char <= '9';
 
 /**
+ * Formats a number for use in editable input fields. Always uses "." as the
+ * decimal separator regardless of the user's locale, ensuring compatibility
+ * with isUnsignedDecimalInput validation.
+ * @param value - The number to format
+ * @param maximumFractionDigits - Maximum fractional digits (default 6)
+ */
+export const formatNumberForInput = (
+  value: number,
+  maximumFractionDigits = 6,
+): string =>
+  new Intl.NumberFormat('en-US', {
+    useGrouping: false,
+    minimumFractionDigits: 0,
+    maximumFractionDigits,
+  }).format(value);
+
+/**
  * Linear-time digit check for integer-style inputs.
  * @param value
  */


### PR DESCRIPTION
## **Description**

Token side of the order input was non-interactive, meaning that users could only input orders as dollar amounts. This PR introduces that interactivity so that users can enter either/both amounts. Updating one input will correspond with a "connected" update with the other.

## **Changelog**

CHANGELOG entry: Make order input for token amount interactive

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3002

## **Manual testing steps**

Enter an order with either: dollar amount, token amount, or slider. All elements should update in unison.

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/31974490-d225-4b4e-ad24-90098f941b07

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches order sizing input logic and formatting, which can affect calculated USD size/percent values; changes are localized and covered by new tests but could impact edge-case entry behavior across locales.
> 
> **Overview**
> Enables fully interactive token-side sizing in perps order entry by making the token input behave like a real editable field (preserving intermediate typing states like `0`/`0.`), while keeping USD size and percent slider calculations in sync.
> 
> Introduces `formatNumberForInput` to render token values in a locale-neutral, non-grouped `.`-decimal format so validation/backspace editing works for large amounts, and adds focused unit tests covering partial input preservation, clearing behavior, large-number formatting, and external amount-to-token resync when not editing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ffda826d25c2194654d3b5e5b7b76f4ab99228c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->