### PR TITLE
fix: transaction toast fixes cp-13.28.0

### DIFF
--- a/ui/app/toast-listener/useSmartTransactionToasts.test.ts
+++ b/ui/app/toast-listener/useSmartTransactionToasts.test.ts
@@ -191,6 +191,50 @@ describe('useSmartTransactionToasts', () => {
     },
   );
 
+  it('stays pending during Speed Up then shows success when the replacement confirms', () => {
+    mockTransactions = [
+      {
+        approvalId: 'approval-1',
+        txId: 'tx-1',
+        smartTransactionStatus: SmartTransactionStatuses.PENDING,
+        evmStatus: TransactionStatus.submitted,
+      },
+    ];
+
+    const { rerender } = renderHook(() => useSmartTransactionToasts());
+
+    expect(mockShowPendingToast).toHaveBeenCalledWith('stx-tx-1');
+
+    // Speed Up in flight: selector is following the retry replacement, which is still submitted.
+    mockTransactions = [
+      {
+        approvalId: 'approval-1',
+        txId: 'tx-1',
+        smartTransactionStatus: SmartTransactionStatuses.PENDING,
+        evmStatus: TransactionStatus.submitted,
+      },
+    ];
+
+    rerender();
+
+    expect(mockShowFailedToast).not.toHaveBeenCalled();
+    expect(mockShowSuccessToast).not.toHaveBeenCalled();
+
+    mockTransactions = [
+      {
+        approvalId: 'approval-1',
+        txId: 'tx-1',
+        smartTransactionStatus: SmartTransactionStatuses.PENDING,
+        evmStatus: TransactionStatus.confirmed,
+      },
+    ];
+
+    rerender();
+
+    expect(mockShowSuccessToast).toHaveBeenCalledWith('stx-tx-1');
+    expect(mockResolvePendingApproval).toHaveBeenCalledWith('approval-1', true);
+  });
+
   it('shows a failed toast and resolves the approval when a pending transaction becomes unknown', () => {
     mockTransactions = [
       {

--- a/ui/app/toast-listener/useSmartTransactionToasts.test.ts
+++ b/ui/app/toast-listener/useSmartTransactionToasts.test.ts
@@ -1,5 +1,6 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { SmartTransactionStatuses } from '@metamask/smart-transactions-controller';
+import { TransactionStatus } from '@metamask/transaction-controller';
 import { useSmartTransactionToasts } from './useSmartTransactionToasts';
 
 const mockDispatch = jest.fn();
@@ -40,6 +41,7 @@ describe('useSmartTransactionToasts', () => {
     approvalId: string;
     txId: string;
     smartTransactionStatus: string | undefined;
+    evmStatus?: string | undefined;
   }[];
 
   beforeEach(() => {
@@ -121,6 +123,73 @@ describe('useSmartTransactionToasts', () => {
       value: true,
     });
   });
+
+  it('shows a failed toast when the user cancels a pending STX from the Activity tab', () => {
+    mockTransactions = [
+      {
+        approvalId: 'approval-1',
+        txId: 'tx-1',
+        smartTransactionStatus: SmartTransactionStatuses.PENDING,
+        evmStatus: TransactionStatus.submitted,
+      },
+    ];
+
+    const { rerender } = renderHook(() => useSmartTransactionToasts());
+
+    expect(mockShowPendingToast).toHaveBeenCalledWith('stx-tx-1');
+
+    mockTransactions = [
+      {
+        approvalId: 'approval-1',
+        txId: 'tx-1',
+        smartTransactionStatus: SmartTransactionStatuses.PENDING,
+        evmStatus: TransactionStatus.dropped,
+      },
+    ];
+
+    rerender();
+
+    expect(mockShowFailedToast).toHaveBeenCalledWith('stx-tx-1');
+    expect(mockResolvePendingApproval).toHaveBeenCalledWith('approval-1', true);
+  });
+
+  // @ts-expect-error This function is missing from the Mocha type definitions
+  it.each([
+    TransactionStatus.failed,
+    TransactionStatus.rejected,
+    TransactionStatus.cancelled,
+  ])(
+    'shows a failed toast when the underlying EVM tx enters terminal status %s',
+    (terminalStatus: TransactionStatus) => {
+      mockTransactions = [
+        {
+          approvalId: 'approval-1',
+          txId: 'tx-1',
+          smartTransactionStatus: SmartTransactionStatuses.PENDING,
+          evmStatus: TransactionStatus.submitted,
+        },
+      ];
+
+      const { rerender } = renderHook(() => useSmartTransactionToasts());
+
+      mockTransactions = [
+        {
+          approvalId: 'approval-1',
+          txId: 'tx-1',
+          smartTransactionStatus: SmartTransactionStatuses.PENDING,
+          evmStatus: terminalStatus,
+        },
+      ];
+
+      rerender();
+
+      expect(mockShowFailedToast).toHaveBeenCalledWith('stx-tx-1');
+      expect(mockResolvePendingApproval).toHaveBeenCalledWith(
+        'approval-1',
+        true,
+      );
+    },
+  );
 
   it('shows a failed toast and resolves the approval when a pending transaction becomes unknown', () => {
     mockTransactions = [

--- a/ui/app/toast-listener/useSmartTransactionToasts.ts
+++ b/ui/app/toast-listener/useSmartTransactionToasts.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { SmartTransactionStatuses } from '@metamask/smart-transactions-controller';
+import { TransactionStatus as EvmTransactionStatus } from '@metamask/transaction-controller';
 import { useDispatch, useSelector } from 'react-redux';
 import { type TransactionStatus } from '../../helpers/utils/transaction-display';
 import { resolvePendingApproval } from '../../store/actions';
@@ -10,7 +11,21 @@ function generateToastId(txId: string) {
   return `stx-${txId}`;
 }
 
-function mapToastStatus(status?: string): TransactionStatus | undefined {
+const failureStatuses = new Set<string>([
+  EvmTransactionStatus.failed,
+  EvmTransactionStatus.dropped,
+  EvmTransactionStatus.rejected,
+  EvmTransactionStatus.cancelled,
+]);
+
+function mapToastStatus(
+  status?: string,
+  evmStatus?: string,
+): TransactionStatus | undefined {
+  if (evmStatus && failureStatuses.has(evmStatus)) {
+    return 'failed';
+  }
+
   if (!status || status === SmartTransactionStatuses.PENDING) {
     return 'pending';
   }
@@ -27,6 +42,8 @@ function mapToastStatus(status?: string): TransactionStatus | undefined {
   ) {
     return 'failed';
   }
+
+  return undefined;
 }
 
 // Relies on pendingApprovals being managed via the SmartTransactionHook
@@ -42,7 +59,10 @@ export function useSmartTransactionToasts() {
 
     for (const tx of transactions) {
       const toastId = generateToastId(tx.txId);
-      const currentStatus = mapToastStatus(tx.smartTransactionStatus);
+      const currentStatus = mapToastStatus(
+        tx.smartTransactionStatus,
+        tx.evmStatus,
+      );
       const previousStatus = previousStatusesRef.current[toastId];
 
       nextStatuses[toastId] = currentStatus;

--- a/ui/app/toast-listener/useSmartTransactionToasts.ts
+++ b/ui/app/toast-listener/useSmartTransactionToasts.ts
@@ -22,14 +22,6 @@ function mapToastStatus(
   status?: string,
   evmStatus?: string,
 ): TransactionStatus | undefined {
-  if (evmStatus && failureStatuses.has(evmStatus)) {
-    return 'failed';
-  }
-
-  if (!status || status === SmartTransactionStatuses.PENDING) {
-    return 'pending';
-  }
-
   if (status === SmartTransactionStatuses.SUCCESS) {
     return 'success';
   }
@@ -41,6 +33,19 @@ function mapToastStatus(
     status === SmartTransactionStatuses.UNKNOWN
   ) {
     return 'failed';
+  }
+
+  // STX is pending/undefined — check the underlying EVM status to handle Cancel and Speed Up
+  if (evmStatus && failureStatuses.has(evmStatus)) {
+    return 'failed';
+  }
+
+  if (evmStatus === EvmTransactionStatus.confirmed) {
+    return 'success';
+  }
+
+  if (!status || status === SmartTransactionStatuses.PENDING) {
+    return 'pending';
   }
 
   return undefined;

--- a/ui/selectors/toast.test.ts
+++ b/ui/selectors/toast.test.ts
@@ -426,5 +426,81 @@ describe('toast selectors', () => {
         },
       ]);
     });
+
+    it('follows the replacement for a Speed Up (retry) chain', () => {
+      const state = {
+        metamask: {
+          pendingApprovals: {
+            'approval-1': {
+              id: 'approval-1',
+              type: 'smartTransaction:showSmartTransactionStatusPage',
+              requestState: {
+                txId: 'tx-1',
+                smartTransaction: { status: 'pending' },
+              },
+            },
+          },
+          transactions: [
+            {
+              id: 'tx-1',
+              status: 'dropped',
+              replacedById: 'tx-1-retry',
+            },
+            {
+              id: 'tx-1-retry',
+              status: 'submitted',
+              type: TransactionType.retry,
+            },
+          ],
+        },
+      } as unknown as SelectorState;
+
+      expect(selectSmartTransactions(state)).toStrictEqual([
+        {
+          approvalId: 'approval-1',
+          txId: 'tx-1',
+          smartTransactionStatus: 'pending',
+          evmStatus: 'submitted',
+        },
+      ]);
+    });
+
+    it('does NOT follow a cancel replacement (keeps original dropped status)', () => {
+      const state = {
+        metamask: {
+          pendingApprovals: {
+            'approval-1': {
+              id: 'approval-1',
+              type: 'smartTransaction:showSmartTransactionStatusPage',
+              requestState: {
+                txId: 'tx-1',
+                smartTransaction: { status: 'pending' },
+              },
+            },
+          },
+          transactions: [
+            {
+              id: 'tx-1',
+              status: 'dropped',
+              replacedById: 'tx-1-cancel',
+            },
+            {
+              id: 'tx-1-cancel',
+              status: 'confirmed',
+              type: TransactionType.cancel,
+            },
+          ],
+        },
+      } as unknown as SelectorState;
+
+      expect(selectSmartTransactions(state)).toStrictEqual([
+        {
+          approvalId: 'approval-1',
+          txId: 'tx-1',
+          smartTransactionStatus: 'pending',
+          evmStatus: 'dropped',
+        },
+      ]);
+    });
   });
 });

--- a/ui/selectors/toast.test.ts
+++ b/ui/selectors/toast.test.ts
@@ -392,6 +392,37 @@ describe('toast selectors', () => {
           approvalId: 'approval-1',
           txId: 'tx-1',
           smartTransactionStatus: 'pending',
+          evmStatus: undefined,
+        },
+      ]);
+    });
+
+    it('populates evmStatus from the matching TransactionController entry', () => {
+      const state = {
+        metamask: {
+          pendingApprovals: {
+            'approval-1': {
+              id: 'approval-1',
+              type: 'smartTransaction:showSmartTransactionStatusPage',
+              requestState: {
+                txId: 'tx-1',
+                smartTransaction: { status: 'pending' },
+              },
+            },
+          },
+          transactions: [
+            { id: 'tx-1', status: 'dropped' },
+            { id: 'tx-2', status: 'confirmed' },
+          ],
+        },
+      } as unknown as SelectorState;
+
+      expect(selectSmartTransactions(state)).toStrictEqual([
+        {
+          approvalId: 'approval-1',
+          txId: 'tx-1',
+          smartTransactionStatus: 'pending',
+          evmStatus: 'dropped',
         },
       ]);
     });

--- a/ui/selectors/toast.ts
+++ b/ui/selectors/toast.ts
@@ -1,3 +1,7 @@
+import {
+  TransactionStatus,
+  TransactionType,
+} from '@metamask/transaction-controller';
 import { createSelector } from 'reselect';
 import { createDeepEqualSelector } from '../../shared/lib/selectors/selector-creators';
 import { SMART_TRANSACTION_CONFIRMATION_TYPES } from '../../shared/constants/app';
@@ -142,6 +146,30 @@ type TxRequest = {
   evmStatus: string | undefined;
 };
 
+function getEffectiveEvmStatus(
+  txId: string,
+  transactions: ReturnType<typeof selectTransactions>,
+) {
+  const originalTx = transactions.find((tx) => tx.id === txId);
+  if (!originalTx) {
+    return undefined;
+  }
+
+  if (
+    originalTx.status === TransactionStatus.dropped &&
+    originalTx.replacedById
+  ) {
+    const replacement = transactions.find(
+      (tx) => tx.id === originalTx.replacedById,
+    );
+    if (replacement?.type === TransactionType.retry) {
+      return replacement.status;
+    }
+  }
+
+  return originalTx.status;
+}
+
 export const selectSmartTransactions = createDeepEqualSelector(
   getPendingApprovals,
   selectTransactions,
@@ -166,14 +194,12 @@ export const selectSmartTransactions = createDeepEqualSelector(
         continue;
       }
 
-      // Also track the EVM transaction status so we can detect failures
-      const evmTransaction = transactions.find((tx) => tx.id === txId);
-
       result.push({
         approvalId: approval.id,
         txId,
         smartTransactionStatus: smartTransaction?.status,
-        evmStatus: evmTransaction?.status,
+        // Track EVM transaction status to detect cancels and speed ups
+        evmStatus: getEffectiveEvmStatus(txId, transactions),
       });
     }
 

--- a/ui/selectors/toast.ts
+++ b/ui/selectors/toast.ts
@@ -139,11 +139,13 @@ type TxRequest = {
   approvalId: string;
   txId: string;
   smartTransactionStatus: string | undefined;
+  evmStatus: string | undefined;
 };
 
 export const selectSmartTransactions = createDeepEqualSelector(
   getPendingApprovals,
-  (pendingApprovals) => {
+  selectTransactions,
+  (pendingApprovals, transactions) => {
     const result: TxRequest[] = [];
 
     for (const approval of pendingApprovals) {
@@ -164,10 +166,14 @@ export const selectSmartTransactions = createDeepEqualSelector(
         continue;
       }
 
+      // Also track the EVM transaction status so we can detect failures
+      const evmTransaction = transactions.find((tx) => tx.id === txId);
+
       result.push({
         approvalId: approval.id,
         txId,
         smartTransactionStatus: smartTransaction?.status,
+        evmStatus: evmTransaction?.status,
       });
     }
 


### PR DESCRIPTION
## **Description**

RC fixes for smart transaction toasts:
- Canceled and Sped up transactions gets stuck in "transaction submitted" toast state

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Ensure STX is on
2. Send a token on mainnet with low gas fee
3. On Activity tab, choose Cancel or Speed up

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes toast state transitions for Smart Transactions by incorporating underlying EVM transaction status and replacement-chain logic; mistakes could cause incorrect success/failed toasts or prematurely resolve approvals.
> 
> **Overview**
> Fixes Smart Transaction toast state getting stuck by **including underlying EVM transaction status** in `selectSmartTransactions` and using it in `useSmartTransactionToasts` to derive `pending`/`success`/`failed`.
> 
> The selector now computes an `evmStatus` (optionally following `retry`/Speed Up replacements but *not* cancel replacements), and the toast hook treats terminal EVM statuses (`dropped`/`failed`/`rejected`/`cancelled`) as failures and `confirmed` as success even while STX remains `pending`.
> 
> Adds/updates unit tests covering cancel-from-activity, terminal EVM statuses, and Speed Up flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27bb23ca9fdd16db8488785d600bb424d5a1a91e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->