### PR TITLE
fix: failed-transaction badge fixes

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -28,10 +28,8 @@ import {
   ENVIRONMENT_TYPE_SIDEPANEL,
   PLATFORM_FIREFOX,
   MESSAGE_TYPE,
-  POPUP_FILE,
-  POPUP_INIT_FILE,
-  SIDEPANEL_FILE,
 } from '../../shared/constants/app';
+import { AccountOverviewTabKey } from '../../shared/constants/app-state';
 import { EXTENSION_MESSAGES } from '../../shared/constants/messages';
 import { BACKGROUND_LIVENESS_METHOD } from '../../shared/constants/ui-initialization';
 import {
@@ -159,7 +157,6 @@ log.setLevel(process.env.METAMASK_DEBUG ? 'debug' : 'info', false);
 const platform = new ExtensionPlatform();
 const notificationManager = new NotificationManager();
 const isFirefox = getPlatform() === PLATFORM_FIREFOX;
-const POPUP_LAUNCH_FILE = isFirefox ? POPUP_FILE : POPUP_INIT_FILE;
 
 /**
  * Parses port connection info for routing decisions.
@@ -1611,11 +1608,7 @@ export function setupController(
   };
 
   const hasPersistentUiOpen = () => {
-    return (
-      openPopupCount > 0 ||
-      openSidePanelCount > 0 ||
-      Object.keys(openMetamaskTabsIDs).length > 0
-    );
+    return openPopupCount > 0 || openSidePanelCount > 0;
   };
 
   const isOnlyNotificationOpen = () => {
@@ -1719,7 +1712,7 @@ export function setupController(
           notificationIsOpen = false;
           // Render any failure badge that was suppressed while the notification was open
           if (failedTxCount > 0) {
-            setClientOpenOptions('activity');
+            setClientLandingTab(AccountOverviewTabKey.Activity);
           }
           updateBadge();
           const isClientOpen = isClientOpenStatus();
@@ -1895,19 +1888,11 @@ export function setupController(
     onTransactionStatusUpdated,
   );
 
-  function setClientOpenOptions(tab) {
-    const popup = tab ? `${POPUP_LAUNCH_FILE}?tab=${tab}` : POPUP_LAUNCH_FILE;
-    const sidepanelPath = tab ? `${SIDEPANEL_FILE}?tab=${tab}` : SIDEPANEL_FILE;
-
+  function setClientLandingTab(tab) {
     try {
-      if (isManifestV3) {
-        browser.action.setPopup({ popup });
-        browser.sidePanel?.setOptions?.({ path: sidepanelPath });
-      } else {
-        browser.browserAction.setPopup({ popup });
-      }
+      controller.appStateController.setDefaultHomeActiveTabName(tab ?? null);
     } catch (e) {
-      console.error('Error setting extension action URLs:', e);
+      console.error('Error setting landing tab:', e);
     }
   }
 
@@ -1942,7 +1927,7 @@ export function setupController(
 
     // Defer landing page until notification closes; close handler re-applies
     if (!isOnlyNotificationOpen()) {
-      setClientOpenOptions('activity');
+      setClientLandingTab(AccountOverviewTabKey.Activity);
     }
 
     updateBadge();
@@ -1951,7 +1936,6 @@ export function setupController(
   function clearFailedTxBadge() {
     seenFailedNonces.clear();
     failedTxCount = 0;
-    setClientOpenOptions();
     updateBadge();
   }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Follow-up fixes to the failed-transactions badge (#41984):
- Not automatically going to the activity tab on badge click
- Badge wasn't always rendering until MM tab instances were closed


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: failed-transaction badge fixes

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches background UI-state logic for badge display and landing-tab selection, which could affect when/where the extension opens after failures across popup/notification/sidepanel/fullscreen contexts.
> 
> **Overview**
> Fixes failed-transaction badge behavior by switching from dynamically rewriting popup/sidepanel URLs (via `?tab=...`) to persisting a default landing tab in app state (`setDefaultHomeActiveTabName`), ensuring badge clicks reliably land on the Activity view.
> 
> Adjusts “persistent UI open” detection so fullscreen MetaMask tabs no longer suppress the failed-tx badge; the Activity landing-tab is re-applied when a notification closes if failures occurred while it was open, and clearing the failed badge no longer resets popup URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit caaff6a6be8412719aa3f6f3beb6a70d6f897a30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->