### PR TITLE
feat(perps): add perps screen view to perps tab

### DIFF
--- a/shared/constants/perps-events.ts
+++ b/shared/constants/perps-events.ts
@@ -39,10 +39,13 @@ export const PERPS_EVENT_PROPERTY = {
   BUTTON_TYPE: 'button_type',
   BUTTON_LOCATION: 'button_location',
   MARKET_CATEGORY_FILTER: 'market_category_filter',
+  OPEN_POSITION: 'open_position',
+  OPEN_ORDER: 'open_order',
 } as const;
 
 export const PERPS_EVENT_VALUE = {
   SCREEN_TYPE: {
+    WALLET_HOME_PERPS_TAB: 'wallet_home_perps_tab',
     MARKET_LIST: 'market_list',
     TRADING: 'trading',
     ASSET_DETAILS: 'asset_details',
@@ -110,6 +113,7 @@ export const PERPS_EVENT_VALUE = {
   },
   SOURCE: {
     WALLET_HOME_PERPS_TAB: 'wallet_home_perps_tab',
+    HOMESCREEN_TAB: 'homescreen_tab',
     MARKET_LIST: 'market_list',
     ASSET_DETAILS: 'perps_asset_details_screen',
     DEEPLINK: 'deeplink',

--- a/ui/components/app/perps/perps-view.test.tsx
+++ b/ui/components/app/perps/perps-view.test.tsx
@@ -5,6 +5,12 @@ import configureStore from '../../../store/store';
 import mockState from '../../../../test/data/mock-state.json';
 import { usePerpsTransactionHistory } from '../../../hooks/perps/usePerpsTransactionHistory';
 import * as streamHooks from '../../../hooks/perps/stream';
+import { MetaMetricsContext } from '../../../contexts/metametrics';
+import {
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
+} from '../../../../shared/constants/metametrics';
+import { PERPS_EVENT_PROPERTY } from '../../../../shared/constants/perps-events';
 import * as mocks from './mocks';
 import { PerpsView } from './perps-view';
 import { usePerpsTabExploreData } from './hooks/usePerpsTabExploreData';
@@ -510,5 +516,66 @@ describe('PerpsView', () => {
     expect(screen.queryByTestId('explore-markets-ETH')).not.toBeInTheDocument();
     expect(screen.getByTestId('perps-watchlist-ETH')).toBeInTheDocument();
     expect(screen.queryByTestId('perps-watchlist-BTC')).not.toBeInTheDocument();
+  });
+
+  describe('analytics tracking', () => {
+    it('fires Perp Screen Viewed with wallet_home_perps_tab screen_type once loading completes', () => {
+      const mockTrackEvent = jest.fn();
+      const mockMetaMetricsContext = {
+        trackEvent: mockTrackEvent,
+        bufferedTrace: jest.fn(),
+        bufferedEndTrace: jest.fn(),
+        onboardingParentContext: { current: null },
+      };
+
+      renderWithProvider(
+        <MetaMetricsContext.Provider value={mockMetaMetricsContext}>
+          <PerpsView />
+        </MetaMetricsContext.Provider>,
+        mockStore,
+      );
+
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: MetaMetricsEventName.PerpsScreenViewed,
+          category: MetaMetricsEventCategory.Perps,
+          properties: expect.objectContaining({
+            [PERPS_EVENT_PROPERTY.SCREEN_TYPE]: 'wallet_home_perps_tab',
+            [PERPS_EVENT_PROPERTY.OPEN_POSITION]: expect.any(Number),
+            [PERPS_EVENT_PROPERTY.OPEN_ORDER]: expect.any(Number),
+            [PERPS_EVENT_PROPERTY.SOURCE]: 'homescreen_tab',
+            [PERPS_EVENT_PROPERTY.HAS_PERP_BALANCE]: true,
+          }),
+        }),
+      );
+    });
+
+    it('does not fire Perp Screen Viewed while loading', () => {
+      const mockTrackEvent = jest.fn();
+      const mockMetaMetricsContext = {
+        trackEvent: mockTrackEvent,
+        bufferedTrace: jest.fn(),
+        bufferedEndTrace: jest.fn(),
+        onboardingParentContext: { current: null },
+      };
+
+      jest.mocked(streamHooks.usePerpsLivePositions).mockReturnValue({
+        positions: mocks.mockPositions,
+        isInitialLoading: true,
+      });
+
+      renderWithProvider(
+        <MetaMetricsContext.Provider value={mockMetaMetricsContext}>
+          <PerpsView />
+        </MetaMetricsContext.Provider>,
+        mockStore,
+      );
+
+      expect(mockTrackEvent).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: MetaMetricsEventName.PerpsScreenViewed,
+        }),
+      );
+    });
   });
 });

--- a/ui/components/app/perps/perps-view.test.tsx
+++ b/ui/components/app/perps/perps-view.test.tsx
@@ -113,6 +113,10 @@ describe('PerpsView', () => {
       orders: mocks.mockOrders,
       isInitialLoading: false,
     });
+    jest.mocked(streamHooks.usePerpsLiveAccount).mockReturnValue({
+      account: mocks.mockAccountState,
+      isInitialLoading: false,
+    });
     jest.mocked(usePerpsTabExploreData).mockReturnValue({
       exploreMarkets: [...mocks.mockCryptoMarkets, ...mocks.mockHip3Markets],
       watchlistMarkets: mocks.mockCryptoMarkets.filter((market) =>
@@ -535,7 +539,12 @@ describe('PerpsView', () => {
         mockStore,
       );
 
-      expect(mockTrackEvent).toHaveBeenCalledWith(
+      const screenViewedCalls = mockTrackEvent.mock.calls.filter(
+        ([arg]) => arg?.event === MetaMetricsEventName.PerpsScreenViewed,
+      );
+
+      expect(screenViewedCalls).toHaveLength(1);
+      expect(screenViewedCalls[0][0]).toEqual(
         expect.objectContaining({
           event: MetaMetricsEventName.PerpsScreenViewed,
           category: MetaMetricsEventCategory.Perps,
@@ -561,6 +570,35 @@ describe('PerpsView', () => {
 
       jest.mocked(streamHooks.usePerpsLivePositions).mockReturnValue({
         positions: mocks.mockPositions,
+        isInitialLoading: true,
+      });
+
+      renderWithProvider(
+        <MetaMetricsContext.Provider value={mockMetaMetricsContext}>
+          <PerpsView />
+        </MetaMetricsContext.Provider>,
+        mockStore,
+      );
+
+      expect(mockTrackEvent).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: MetaMetricsEventName.PerpsScreenViewed,
+        }),
+      );
+    });
+
+    it('does not fire Perp Screen Viewed while account data is still loading', () => {
+      const mockTrackEvent = jest.fn();
+      const mockMetaMetricsContext = {
+        trackEvent: mockTrackEvent,
+        bufferedTrace: jest.fn(),
+        bufferedEndTrace: jest.fn(),
+        onboardingParentContext: { current: null },
+      };
+
+      // positions/orders/markets are ready but account hasn't arrived yet
+      jest.mocked(streamHooks.usePerpsLiveAccount).mockReturnValue({
+        account: null,
         isInitialLoading: true,
       });
 

--- a/ui/components/app/perps/perps-view.tsx
+++ b/ui/components/app/perps/perps-view.tsx
@@ -87,7 +87,7 @@ export const PerpsView: React.FC = () => {
     usePerpsLivePositions();
   const { orders: allOrders, isInitialLoading: ordersLoading } =
     usePerpsLiveOrders();
-  const { account } = usePerpsLiveAccount();
+  const { account, isInitialLoading: accountLoading } = usePerpsLiveAccount();
   const {
     exploreMarkets,
     watchlistMarkets,
@@ -203,7 +203,8 @@ export const PerpsView: React.FC = () => {
   }, [isEligible, applyOrdersSnapshot, orders.length, t]);
 
   const hasPositions = positions.length > 0;
-  const isLoading = positionsLoading || ordersLoading || marketsLoading;
+  const isLoading =
+    positionsLoading || ordersLoading || marketsLoading || accountLoading;
   const hasPerpBalance = Boolean(
     account && Number.parseFloat(account.availableBalance) > 0,
   );

--- a/ui/components/app/perps/perps-view.tsx
+++ b/ui/components/app/perps/perps-view.tsx
@@ -11,6 +11,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import {
   usePerpsLivePositions,
   usePerpsLiveOrders,
+  usePerpsLiveAccount,
 } from '../../../hooks/perps/stream';
 import { usePerpsTransactionHistory } from '../../../hooks/perps/usePerpsTransactionHistory';
 import { PERPS_RECENT_ACTIVITY_MAX_TRANSACTIONS } from '../../../../shared/constants/perps';
@@ -28,6 +29,12 @@ import {
 
 import { usePerpsEligibility } from '../../../hooks/perps';
 import { usePerpsMeasurement } from '../../../hooks/perps/usePerpsMeasurement';
+import { usePerpsEventTracking } from '../../../hooks/perps/usePerpsEventTracking';
+import { MetaMetricsEventName } from '../../../../shared/constants/metametrics';
+import {
+  PERPS_EVENT_PROPERTY,
+  PERPS_EVENT_VALUE,
+} from '../../../../shared/constants/perps-events';
 
 import { PerpsGeoBlockModal } from './perps-geo-block-modal';
 import { usePerpsDepositConfirmation } from './hooks/usePerpsDepositConfirmation';
@@ -80,6 +87,7 @@ export const PerpsView: React.FC = () => {
     usePerpsLivePositions();
   const { orders: allOrders, isInitialLoading: ordersLoading } =
     usePerpsLiveOrders();
+  const { account } = usePerpsLiveAccount();
   const {
     exploreMarkets,
     watchlistMarkets,
@@ -196,8 +204,24 @@ export const PerpsView: React.FC = () => {
 
   const hasPositions = positions.length > 0;
   const isLoading = positionsLoading || ordersLoading || marketsLoading;
+  const hasPerpBalance = Boolean(
+    account && Number.parseFloat(account.availableBalance) > 0,
+  );
 
   usePerpsMeasurement('PerpsTabLoaded', !isLoading);
+
+  usePerpsEventTracking({
+    eventName: MetaMetricsEventName.PerpsScreenViewed,
+    conditions: !isLoading,
+    properties: {
+      [PERPS_EVENT_PROPERTY.SCREEN_TYPE]:
+        PERPS_EVENT_VALUE.SCREEN_TYPE.WALLET_HOME_PERPS_TAB,
+      [PERPS_EVENT_PROPERTY.OPEN_POSITION]: positions.length,
+      [PERPS_EVENT_PROPERTY.OPEN_ORDER]: orders.length,
+      [PERPS_EVENT_PROPERTY.SOURCE]: PERPS_EVENT_VALUE.SOURCE.HOMESCREEN_TAB,
+      [PERPS_EVENT_PROPERTY.HAS_PERP_BALANCE]: hasPerpBalance,
+    },
+  });
 
   // Auto-open tutorial modal the first time a user enters the perps domain.
   // Guards on both the backend isFirstTimeUser flag (stable once propagated) and


### PR DESCRIPTION
## **Description**

The Mixpanel `Perp Screen Viewed` event was not being fired when a user lands on the Perps tab in wallet home. Every other Perps screen (market list, trading, asset details, activity, modals) already fires this event, but the top-level tab view was missing.

This PR adds the tracking call to `PerpsView` using the existing `usePerpsEventTracking` declarative hook, matching the Mobile implementation in `PerpsTabView.tsx`.

**What changed:**
- Added `WALLET_HOME_PERPS_TAB` to `PERPS_EVENT_VALUE.SCREEN_TYPE` and `HOMESCREEN_TAB` to `PERPS_EVENT_VALUE.SOURCE` in `shared/constants/perps-events.ts`, mirroring the Mobile constants.
- Added `OPEN_POSITION` and `OPEN_ORDER` property keys to `PERPS_EVENT_PROPERTY` (also absent from the extension constants until now).
- Added `usePerpsEventTracking` declarative call in `PerpsView` that fires once loading completes, with the same payload as Mobile.

**Event fired:**
```
Event:  "Perp Screen Viewed"
Properties:
  screen_type:       "wallet_home_perps_tab"
  open_position:     <number of open positions>
  open_order:        <number of open orders>
  source:            "homescreen_tab"
  has_perp_balance:  true | false
  perps_timestamp:   <unix ms>
```

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [TAT-3048](https://consensyssoftware.atlassian.net/browse/TAT-3048)

## **Manual testing steps**

1. Build the extension and open it in Chrome.
2. Complete onboarding (or use an existing wallet).
3. Navigate to the wallet home page.
4. Click the **Perps** tab.
5. Open Mixpanel (or the MetaMetrics debug view) and verify a `Perp Screen Viewed` event is fired with:
   - `screen_type: "wallet_home_perps_tab"`
   - `source: "homescreen_tab"`
   - `has_perp_balance: true/false` (depending on whether the account has a perps balance)
   - `open_position` and `open_order` matching the actual counts shown in the UI.
6. Navigate away and back to the Perps tab — confirm the event fires again (once per mount).

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[TAT-3048]: https://consensyssoftware.atlassian.net/browse/TAT-3048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new analytics constants and fires `PerpsScreenViewed` from `PerpsView` once positions/orders/markets/account finish loading, which also slightly changes the tab’s loading gating and could affect when the UI exits its skeleton state.
> 
> **Overview**
> Adds Mixpanel tracking for the Wallet Home Perps tab by emitting `MetaMetricsEventName.PerpsScreenViewed` from `PerpsView` via `usePerpsEventTracking` once all initial perps data (including account) has loaded, with properties for screen/source plus open positions/orders counts and `has_perp_balance`.
> 
> Extends `shared/constants/perps-events.ts` with new enums/keys (`WALLET_HOME_PERPS_TAB`, `HOMESCREEN_TAB`, `OPEN_POSITION`, `OPEN_ORDER`) and adds unit tests to ensure the event fires exactly once after loading and not during loading (including the new account-loading gate).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f99f58bafccbe7274e3402cfc5372a6c414dd551. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->