### PR TITLE
feat(perps): Add Perps Withdraw button into Developer Options, show new Perps Withdraw UI

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5529,7 +5529,7 @@
     "description": "is the available balance amount"
   },
   "perpsAvailableBalance": {
-    "message": "Available Perps balance: "
+    "message": "Available balance: "
   },
   "perpsAvailableToAdd": {
     "message": "Available to add"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -5529,7 +5529,7 @@
     "description": "is the available balance amount"
   },
   "perpsAvailableBalance": {
-    "message": "Available Perps balance: "
+    "message": "Available balance: "
   },
   "perpsAvailableToAdd": {
     "message": "Available to add"

--- a/shared/lib/confirmation.utils.test.ts
+++ b/shared/lib/confirmation.utils.test.ts
@@ -17,6 +17,10 @@ describe('confirmation.utils', () => {
       TransactionType.tokenMethodTransferFrom,
       TransactionType.tokenMethodSafeTransferFrom,
       TransactionType.simpleSend,
+      TransactionType.musdClaim,
+      TransactionType.musdConversion,
+      TransactionType.perpsDeposit,
+      TransactionType.perpsWithdraw,
     ];
 
     const unsupportedTransactionType = TransactionType.swap;

--- a/shared/lib/confirmation.utils.ts
+++ b/shared/lib/confirmation.utils.ts
@@ -17,6 +17,7 @@ const REDESIGN_USER_TRANSACTION_TYPES = [
   TransactionType.musdClaim,
   TransactionType.musdConversion,
   TransactionType.perpsDeposit,
+  TransactionType.perpsWithdraw,
   TransactionType.revokeDelegation,
   TransactionType.shieldSubscriptionApprove,
   TransactionType.simpleSend,

--- a/ui/pages/confirmations/components/confirm/info/info.tsx
+++ b/ui/pages/confirmations/components/confirm/info/info.tsx
@@ -17,6 +17,7 @@ import { CustomAmountInfoSkeleton } from '../../info/custom-amount-info';
 import { MusdClaimInfo } from '../../info/musd-claim-info';
 import { MusdConversionInfo } from '../../info/musd-conversion-info';
 import { PerpsDepositInfo } from './perps-deposit-info';
+import { PerpsWithdrawInfo } from './perps-withdraw-info';
 import ApproveInfo from './approve/approve';
 import BaseTransactionInfo from './base-transaction-info/base-transaction-info';
 import NativeTransferInfo from './native-transfer/native-transfer';
@@ -162,6 +163,7 @@ const Info = () => {
       [TransactionType.musdClaim]: () => MusdClaimInfo,
       [TransactionType.musdConversion]: () => MusdConversionInfo,
       [TransactionType.perpsDeposit]: () => PerpsDepositInfo,
+      [TransactionType.perpsWithdraw]: () => PerpsWithdrawInfo,
     }),
     [currentConfirmation],
   );

--- a/ui/pages/confirmations/components/confirm/info/perps-withdraw-info/index.ts
+++ b/ui/pages/confirmations/components/confirm/info/perps-withdraw-info/index.ts
@@ -1,0 +1,1 @@
+export { PerpsWithdrawInfo } from './perps-withdraw-info';

--- a/ui/pages/confirmations/components/confirm/info/perps-withdraw-info/perps-withdraw-info.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/perps-withdraw-info/perps-withdraw-info.test.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import configureStore from '../../../../../../store/store';
+import mockState from '../../../../../../../test/data/mock-state.json';
+import { renderWithProvider } from '../../../../../../../test/lib/render-helpers-navigate';
+import { useAddToken } from '../../../../hooks/tokens/useAddToken';
+import { CustomAmountInfo } from '../../../info/custom-amount-info';
+import { ARBITRUM_USDC, PERPS_CURRENCY } from '../../../../constants/perps';
+import { PerpsWithdrawInfo } from './perps-withdraw-info';
+
+jest.mock('../../../../hooks/tokens/useAddToken', () => ({
+  useAddToken: jest.fn(),
+}));
+
+jest.mock('../../../info/custom-amount-info', () => ({
+  CustomAmountInfo: jest.fn(({ children }) => (
+    <div data-testid="custom-amount-info-mock">{children}</div>
+  )),
+}));
+
+jest.mock('../../../perps-confirmations/perps-withdraw-balance', () => ({
+  PerpsWithdrawBalance: () => <div data-testid="perps-withdraw-balance-mock" />,
+}));
+
+const useAddTokenMock = jest.mocked(useAddToken);
+const customAmountInfoMock = jest.mocked(CustomAmountInfo);
+
+describe('PerpsWithdrawInfo', () => {
+  beforeEach(() => {
+    useAddTokenMock.mockReset();
+    customAmountInfoMock.mockClear();
+  });
+
+  it('registers Arbitrum USDC via useAddToken', () => {
+    renderWithProvider(<PerpsWithdrawInfo />, configureStore(mockState));
+
+    expect(useAddTokenMock).toHaveBeenCalledWith({
+      chainId: ARBITRUM_USDC.chainId,
+      decimals: ARBITRUM_USDC.decimals,
+      symbol: ARBITRUM_USDC.symbol,
+      tokenAddress: ARBITRUM_USDC.address,
+    });
+  });
+
+  it('renders CustomAmountInfo with the Perps currency and hidePayTokenAmount', () => {
+    renderWithProvider(<PerpsWithdrawInfo />, configureStore(mockState));
+
+    expect(customAmountInfoMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        currency: PERPS_CURRENCY,
+        hidePayTokenAmount: true,
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('renders the PerpsWithdrawBalance child inside CustomAmountInfo', () => {
+    renderWithProvider(<PerpsWithdrawInfo />, configureStore(mockState));
+
+    expect(
+      screen.getByTestId('perps-withdraw-balance-mock'),
+    ).toBeInTheDocument();
+  });
+
+  it('does not pass hasMax (percentage buttons hidden for MVP)', () => {
+    renderWithProvider(<PerpsWithdrawInfo />, configureStore(mockState));
+
+    expect(customAmountInfoMock).toHaveBeenCalledWith(
+      expect.not.objectContaining({ hasMax: true }),
+      expect.anything(),
+    );
+  });
+});

--- a/ui/pages/confirmations/components/confirm/info/perps-withdraw-info/perps-withdraw-info.tsx
+++ b/ui/pages/confirmations/components/confirm/info/perps-withdraw-info/perps-withdraw-info.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { useAddToken } from '../../../../hooks/tokens/useAddToken';
+import { CustomAmountInfo } from '../../../info/custom-amount-info';
+import { PerpsWithdrawBalance } from '../../../perps-confirmations/perps-withdraw-balance';
+import { PERPS_CURRENCY, ARBITRUM_USDC } from '../../../../constants/perps';
+
+export const PerpsWithdrawInfo = () => {
+  useAddToken({
+    chainId: ARBITRUM_USDC.chainId,
+    decimals: ARBITRUM_USDC.decimals,
+    symbol: ARBITRUM_USDC.symbol,
+    tokenAddress: ARBITRUM_USDC.address,
+  });
+
+  return (
+    <CustomAmountInfo currency={PERPS_CURRENCY} hasMax hidePayTokenAmount>
+      <PerpsWithdrawBalance />
+    </CustomAmountInfo>
+  );
+};

--- a/ui/pages/confirmations/components/confirm/info/perps-withdraw-info/perps-withdraw-info.tsx
+++ b/ui/pages/confirmations/components/confirm/info/perps-withdraw-info/perps-withdraw-info.tsx
@@ -13,7 +13,10 @@ export const PerpsWithdrawInfo = () => {
   });
 
   return (
-    <CustomAmountInfo currency={PERPS_CURRENCY} hasMax hidePayTokenAmount>
+    // Percentage buttons (25/50/75/Max) are intentionally hidden for MVP —
+    // not passing `hasMax` so they never render. Re-enable by passing
+    // `hasMax` (and optionally a `percentages` override) when ready.
+    <CustomAmountInfo currency={PERPS_CURRENCY} hidePayTokenAmount>
       <PerpsWithdrawBalance />
     </CustomAmountInfo>
   );

--- a/ui/pages/confirmations/components/developer/confirmations-developer-options/confirmations-developer-options.tsx
+++ b/ui/pages/confirmations/components/developer/confirmations-developer-options/confirmations-developer-options.tsx
@@ -4,6 +4,7 @@ import { Text } from '../../../../../components/component-library';
 import { TextColor } from '../../../../../helpers/constants/design-system';
 import { MusdConversionButton } from '../musd-conversion-button';
 import { PerpsDepositButton } from '../perps-deposit-button';
+import { PerpsWithdrawButton } from '../perps-withdraw-button';
 
 export const ConfirmationsDeveloperOptions = () => {
   return (
@@ -24,6 +25,7 @@ export const ConfirmationsDeveloperOptions = () => {
       <div className="settings-page__content-padded">
         <MusdConversionButton />
         <PerpsDepositButton />
+        <PerpsWithdrawButton />
       </div>
     </>
   );

--- a/ui/pages/confirmations/components/developer/musd-conversion-button/musd-conversion-button.tsx
+++ b/ui/pages/confirmations/components/developer/musd-conversion-button/musd-conversion-button.tsx
@@ -1,8 +1,6 @@
 import React, { useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
 import type { Hex } from '@metamask/utils';
-import { Interface } from '@ethersproject/abi';
-import { BigNumber } from 'bignumber.js';
 import { TransactionType } from '@metamask/transaction-controller';
 
 import {
@@ -16,23 +14,7 @@ import {
   ConfirmationLoader,
   useConfirmationNavigation,
 } from '../../../hooks/useConfirmationNavigation';
-
-const ERC20_ABI = ['function transfer(address to, uint256 amount)'];
-const erc20Interface = new Interface(ERC20_ABI);
-
-const generateERC20TransferData = (
-  recipient: Hex,
-  amount: string,
-  decimals: number,
-): Hex => {
-  const multiplier = new BigNumber(10).pow(decimals);
-  const amountRaw = new BigNumber(amount).times(multiplier);
-
-  return erc20Interface.encodeFunctionData('transfer', [
-    recipient,
-    `0x${amountRaw.toString(16)}`,
-  ]) as Hex;
-};
+import { generateERC20TransferData } from '../utils';
 
 export const MusdConversionButton = () => {
   const { navigateToTransaction } = useConfirmationNavigation();

--- a/ui/pages/confirmations/components/developer/perps-deposit-button/perps-deposit-button.tsx
+++ b/ui/pages/confirmations/components/developer/perps-deposit-button/perps-deposit-button.tsx
@@ -1,8 +1,6 @@
 import React, { useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
 import type { Hex } from '@metamask/utils';
-import { Interface } from '@ethersproject/abi';
-import { BigNumber } from 'bignumber.js';
 import { TransactionType } from '@metamask/transaction-controller';
 
 import {
@@ -20,23 +18,7 @@ import {
   ConfirmationLoader,
   useConfirmationNavigation,
 } from '../../../hooks/useConfirmationNavigation';
-
-const ERC20_ABI = ['function transfer(address to, uint256 amount)'];
-const erc20Interface = new Interface(ERC20_ABI);
-
-const generateERC20TransferData = (
-  recipient: Hex,
-  amount: string,
-  decimals: number,
-): Hex => {
-  const multiplier = new BigNumber(10).pow(decimals);
-  const amountRaw = new BigNumber(amount).times(multiplier);
-
-  return erc20Interface.encodeFunctionData('transfer', [
-    recipient,
-    `0x${amountRaw.toString(16)}`,
-  ]) as Hex;
-};
+import { generateERC20TransferData } from '../utils';
 
 export const PerpsDepositButton = () => {
   const { navigateToTransaction } = useConfirmationNavigation();

--- a/ui/pages/confirmations/components/developer/perps-withdraw-button/index.ts
+++ b/ui/pages/confirmations/components/developer/perps-withdraw-button/index.ts
@@ -1,0 +1,1 @@
+export { PerpsWithdrawButton } from './perps-withdraw-button';

--- a/ui/pages/confirmations/components/developer/perps-withdraw-button/perps-withdraw-button.test.tsx
+++ b/ui/pages/confirmations/components/developer/perps-withdraw-button/perps-withdraw-button.test.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { TransactionType } from '@metamask/transaction-controller';
+import configureStore from '../../../../../store/store';
+import mockState from '../../../../../../test/data/mock-state.json';
+import { renderWithProvider } from '../../../../../../test/lib/render-helpers-navigate';
+import {
+  addTransaction,
+  findNetworkClientIdByChainId,
+} from '../../../../../store/actions';
+import { getSelectedInternalAccount } from '../../../../../selectors';
+import {
+  ConfirmationLoader,
+  useConfirmationNavigation,
+} from '../../../hooks/useConfirmationNavigation';
+import { ARBITRUM_USDC } from '../../../constants/perps';
+import { CHAIN_IDS } from '../../../../../../shared/constants/network';
+import { PerpsWithdrawButton } from './perps-withdraw-button';
+
+jest.mock('../../../../../store/actions', () => ({
+  addTransaction: jest.fn(),
+  findNetworkClientIdByChainId: jest.fn(),
+}));
+
+jest.mock('../../../../../selectors', () => {
+  const actual = jest.requireActual('../../../../../selectors');
+  return {
+    ...actual,
+    getSelectedInternalAccount: jest.fn(),
+  };
+});
+
+jest.mock('../../../hooks/useConfirmationNavigation', () => {
+  const actual = jest.requireActual('../../../hooks/useConfirmationNavigation');
+  return {
+    ...actual,
+    useConfirmationNavigation: jest.fn(),
+  };
+});
+
+const addTransactionMock = jest.mocked(addTransaction);
+const findNetworkClientIdByChainIdMock = jest.mocked(
+  findNetworkClientIdByChainId,
+);
+const getSelectedInternalAccountMock = jest.mocked(getSelectedInternalAccount);
+const useConfirmationNavigationMock = jest.mocked(useConfirmationNavigation);
+
+const MOCK_ACCOUNT_ADDRESS = '0x1234567890123456789012345678901234567890';
+const MOCK_NETWORK_CLIENT_ID = 'arbitrum-mainnet';
+const MOCK_TX_ID = 'withdraw-tx-id';
+
+function renderButton() {
+  return renderWithProvider(<PerpsWithdrawButton />, configureStore(mockState));
+}
+
+describe('PerpsWithdrawButton', () => {
+  const navigateToTransactionMock = jest.fn();
+  const navigateToTransactionsMock = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    getSelectedInternalAccountMock.mockReturnValue({
+      address: MOCK_ACCOUNT_ADDRESS,
+    } as never);
+    findNetworkClientIdByChainIdMock.mockResolvedValue(
+      MOCK_NETWORK_CLIENT_ID as never,
+    );
+    addTransactionMock.mockResolvedValue({ id: MOCK_TX_ID } as never);
+    useConfirmationNavigationMock.mockReturnValue({
+      navigateToTransaction: navigateToTransactionMock,
+      navigateToTransactions: navigateToTransactionsMock,
+    } as never);
+  });
+
+  it('renders the Perps Withdraw developer button', () => {
+    renderButton();
+
+    expect(screen.getByText('Perps Withdraw')).toBeInTheDocument();
+    expect(
+      screen.getByText('Triggers a Perps withdraw confirmation.'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Trigger' })).toBeInTheDocument();
+  });
+
+  it('creates a perpsWithdraw transaction on Arbitrum and navigates to it', async () => {
+    renderButton();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Trigger' }));
+
+    await waitFor(() => {
+      expect(addTransactionMock).toHaveBeenCalledTimes(1);
+    });
+
+    expect(findNetworkClientIdByChainIdMock).toHaveBeenCalledWith(
+      CHAIN_IDS.ARBITRUM,
+    );
+
+    expect(addTransactionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: MOCK_ACCOUNT_ADDRESS,
+        to: ARBITRUM_USDC.address,
+        value: '0x0',
+      }),
+      {
+        networkClientId: MOCK_NETWORK_CLIENT_ID,
+        type: TransactionType.perpsWithdraw,
+      },
+    );
+
+    expect(navigateToTransactionMock).toHaveBeenCalledWith(MOCK_TX_ID, {
+      loader: ConfirmationLoader.CustomAmount,
+    });
+  });
+
+  it('does not call addTransaction when there is no selected account', () => {
+    getSelectedInternalAccountMock.mockReturnValue(undefined as never);
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    renderButton();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Trigger' }));
+
+    expect(addTransactionMock).not.toHaveBeenCalled();
+    expect(navigateToTransactionMock).not.toHaveBeenCalled();
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/ui/pages/confirmations/components/developer/perps-withdraw-button/perps-withdraw-button.tsx
+++ b/ui/pages/confirmations/components/developer/perps-withdraw-button/perps-withdraw-button.tsx
@@ -1,0 +1,98 @@
+import React, { useCallback, useState } from 'react';
+import { useSelector } from 'react-redux';
+import type { Hex } from '@metamask/utils';
+import { Interface } from '@ethersproject/abi';
+import { BigNumber } from 'bignumber.js';
+import { TransactionType } from '@metamask/transaction-controller';
+
+import {
+  addTransaction,
+  findNetworkClientIdByChainId,
+} from '../../../../../store/actions';
+import { getSelectedInternalAccount } from '../../../../../selectors';
+import { CHAIN_IDS } from '../../../../../../shared/constants/network';
+import { DeveloperButton } from '../developer-button';
+import { ARBITRUM_USDC } from '../../../constants/perps';
+import {
+  ConfirmationLoader,
+  useConfirmationNavigation,
+} from '../../../hooks/useConfirmationNavigation';
+
+const ERC20_ABI = ['function transfer(address to, uint256 amount)'];
+const erc20Interface = new Interface(ERC20_ABI);
+
+const generateERC20TransferData = (
+  recipient: Hex,
+  amount: string,
+  decimals: number,
+): Hex => {
+  const multiplier = new BigNumber(10).pow(decimals);
+  const amountRaw = new BigNumber(amount).times(multiplier);
+
+  return erc20Interface.encodeFunctionData('transfer', [
+    recipient,
+    `0x${amountRaw.toString(16)}`,
+  ]) as Hex;
+};
+
+export const PerpsWithdrawButton = () => {
+  const { navigateToTransaction } = useConfirmationNavigation();
+  const selectedAccount = useSelector(getSelectedInternalAccount);
+  const [hasTriggered, setHasTriggered] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleTrigger = useCallback(async () => {
+    if (!selectedAccount?.address) {
+      console.error('No selected account');
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      const networkClientId = await findNetworkClientIdByChainId(
+        CHAIN_IDS.ARBITRUM,
+      );
+
+      const transferData = generateERC20TransferData(
+        ARBITRUM_USDC.address,
+        '0',
+        ARBITRUM_USDC.decimals,
+      );
+
+      const txMeta = await addTransaction(
+        {
+          from: selectedAccount.address as Hex,
+          to: ARBITRUM_USDC.address,
+          data: transferData,
+          value: '0x0',
+        },
+        {
+          networkClientId,
+          type: TransactionType.perpsWithdraw,
+        },
+      );
+
+      setHasTriggered(true);
+
+      navigateToTransaction(txMeta.id, {
+        loader: ConfirmationLoader.CustomAmount,
+      });
+    } catch (error) {
+      console.error('Failed to create perps withdraw transaction', error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [navigateToTransaction, selectedAccount?.address]);
+
+  return (
+    <DeveloperButton
+      title="Perps Withdraw"
+      description="Triggers a Perps withdraw confirmation."
+      buttonLabel={isLoading ? 'Loading...' : 'Trigger'}
+      onPress={handleTrigger}
+      hasTriggered={hasTriggered}
+      disabled={isLoading}
+    />
+  );
+};

--- a/ui/pages/confirmations/components/developer/perps-withdraw-button/perps-withdraw-button.tsx
+++ b/ui/pages/confirmations/components/developer/perps-withdraw-button/perps-withdraw-button.tsx
@@ -1,8 +1,6 @@
 import React, { useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
 import type { Hex } from '@metamask/utils';
-import { Interface } from '@ethersproject/abi';
-import { BigNumber } from 'bignumber.js';
 import { TransactionType } from '@metamask/transaction-controller';
 
 import {
@@ -17,23 +15,7 @@ import {
   ConfirmationLoader,
   useConfirmationNavigation,
 } from '../../../hooks/useConfirmationNavigation';
-
-const ERC20_ABI = ['function transfer(address to, uint256 amount)'];
-const erc20Interface = new Interface(ERC20_ABI);
-
-const generateERC20TransferData = (
-  recipient: Hex,
-  amount: string,
-  decimals: number,
-): Hex => {
-  const multiplier = new BigNumber(10).pow(decimals);
-  const amountRaw = new BigNumber(amount).times(multiplier);
-
-  return erc20Interface.encodeFunctionData('transfer', [
-    recipient,
-    `0x${amountRaw.toString(16)}`,
-  ]) as Hex;
-};
+import { generateERC20TransferData } from '../utils';
 
 export const PerpsWithdrawButton = () => {
   const { navigateToTransaction } = useConfirmationNavigation();
@@ -54,8 +36,11 @@ export const PerpsWithdrawButton = () => {
         CHAIN_IDS.ARBITRUM,
       );
 
+      // Placeholder 0-USDC transfer: the real withdraw flow uses a Hyperliquid
+      // signed withdraw action, not an on-chain ERC-20 transfer. Recipient is
+      // the user's own address since withdrawn USDC ultimately returns to them.
       const transferData = generateERC20TransferData(
-        ARBITRUM_USDC.address,
+        selectedAccount.address as Hex,
         '0',
         ARBITRUM_USDC.decimals,
       );

--- a/ui/pages/confirmations/components/developer/utils.test.ts
+++ b/ui/pages/confirmations/components/developer/utils.test.ts
@@ -1,0 +1,64 @@
+import type { Hex } from '@metamask/utils';
+import { parseStandardTokenTransactionData } from '../../../../../shared/lib/transaction.utils';
+import { generateERC20TransferData } from './utils';
+
+const MOCK_RECIPIENT = '0x1234567890123456789012345678901234567890' as Hex;
+const TRANSFER_SELECTOR = '0xa9059cbb';
+
+describe('generateERC20TransferData', () => {
+  it('starts with the ERC-20 `transfer(address,uint256)` selector', () => {
+    const data = generateERC20TransferData(MOCK_RECIPIENT, '1', 6);
+
+    expect(data.startsWith(TRANSFER_SELECTOR)).toBe(true);
+    expect(data).toMatch(/^0x[0-9a-f]+$/iu);
+  });
+
+  it('encodes the recipient address left-padded to 32 bytes', () => {
+    const data = generateERC20TransferData(MOCK_RECIPIENT, '0', 6);
+
+    const recipientWithoutPrefix = MOCK_RECIPIENT.toLowerCase().slice(2);
+    expect(data.toLowerCase()).toContain(
+      `000000000000000000000000${recipientWithoutPrefix}`,
+    );
+  });
+
+  it('encodes a zero amount as 32 bytes of zeros (developer-scaffold case)', () => {
+    const data = generateERC20TransferData(MOCK_RECIPIENT, '0', 6);
+
+    expect(data).toBe(
+      `${TRANSFER_SELECTOR}` +
+        `000000000000000000000000${MOCK_RECIPIENT.slice(
+          2,
+        ).toLowerCase()}0000000000000000000000000000000000000000000000000000000000000000`,
+    );
+  });
+
+  it('scales a whole amount by the token decimals (1 USDC → 1_000_000)', () => {
+    const data = generateERC20TransferData(MOCK_RECIPIENT, '1', 6);
+    const parsed = parseStandardTokenTransactionData(data);
+
+    expect(parsed?.name).toBe('transfer');
+    expect(parsed?.args?.[1]?.toString()).toBe('1000000');
+  });
+
+  it('scales a fractional amount by the token decimals (0.5 USDC → 500_000)', () => {
+    const data = generateERC20TransferData(MOCK_RECIPIENT, '0.5', 6);
+    const parsed = parseStandardTokenTransactionData(data);
+
+    expect(parsed?.args?.[1]?.toString()).toBe('500000');
+  });
+
+  it('scales by 10^decimals for 18-decimal tokens (2 MUSD → 2e18)', () => {
+    const data = generateERC20TransferData(MOCK_RECIPIENT, '2', 18);
+    const parsed = parseStandardTokenTransactionData(data);
+
+    expect(parsed?.args?.[1]?.toString()).toBe('2000000000000000000');
+  });
+
+  it('round-trips the recipient through parseStandardTokenTransactionData', () => {
+    const data = generateERC20TransferData(MOCK_RECIPIENT, '1', 6);
+    const parsed = parseStandardTokenTransactionData(data);
+
+    expect(parsed?.args?.[0]?.toLowerCase()).toBe(MOCK_RECIPIENT.toLowerCase());
+  });
+});

--- a/ui/pages/confirmations/components/developer/utils.ts
+++ b/ui/pages/confirmations/components/developer/utils.ts
@@ -1,0 +1,32 @@
+import type { Hex } from '@metamask/utils';
+import { Interface } from '@ethersproject/abi';
+import { BigNumber } from 'bignumber.js';
+
+const ERC20_ABI = ['function transfer(address to, uint256 amount)'];
+const erc20Interface = new Interface(ERC20_ABI);
+
+/**
+ * Encodes an ERC-20 `transfer(address,uint256)` call for the developer-only
+ * trigger buttons (Perps Deposit / Perps Withdraw / MUSD Conversion).
+ *
+ * Takes a human-readable amount (e.g. `'0'`, `'1.5'`) and scales it by the
+ * token's decimals before encoding.
+ *
+ * @param recipient - ERC-20 transfer recipient.
+ * @param amount - Human-readable amount as a decimal string.
+ * @param decimals - Token decimals used to scale `amount` to its raw integer form.
+ * @returns Encoded `transfer(recipient, rawAmount)` calldata.
+ */
+export const generateERC20TransferData = (
+  recipient: Hex,
+  amount: string,
+  decimals: number,
+): Hex => {
+  const multiplier = new BigNumber(10).pow(decimals);
+  const amountRaw = new BigNumber(amount).times(multiplier);
+
+  return erc20Interface.encodeFunctionData('transfer', [
+    recipient,
+    `0x${amountRaw.toString(16)}`,
+  ]) as Hex;
+};

--- a/ui/pages/confirmations/components/perps-confirmations/perps-withdraw-balance/index.ts
+++ b/ui/pages/confirmations/components/perps-confirmations/perps-withdraw-balance/index.ts
@@ -1,0 +1,1 @@
+export { PerpsWithdrawBalance } from './perps-withdraw-balance';

--- a/ui/pages/confirmations/components/perps-confirmations/perps-withdraw-balance/perps-withdraw-balance.test.tsx
+++ b/ui/pages/confirmations/components/perps-confirmations/perps-withdraw-balance/perps-withdraw-balance.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import configureStore from '../../../../../store/store';
+import mockState from '../../../../../../test/data/mock-state.json';
+import { renderWithProvider } from '../../../../../../test/lib/render-helpers-navigate';
+import { enLocale as messages } from '../../../../../../test/lib/i18n-helpers';
+import { usePerpsLiveAccount } from '../../../../../hooks/perps/stream';
+import { PerpsWithdrawBalance } from './perps-withdraw-balance';
+
+jest.mock('../../../../../hooks/perps/stream', () => ({
+  usePerpsLiveAccount: jest.fn(),
+}));
+
+const usePerpsLiveAccountMock = jest.mocked(usePerpsLiveAccount);
+
+function renderBalance() {
+  const store = configureStore(mockState);
+  return renderWithProvider(<PerpsWithdrawBalance />, store);
+}
+
+describe('PerpsWithdrawBalance', () => {
+  beforeEach(() => {
+    usePerpsLiveAccountMock.mockReset();
+  });
+
+  it('renders the formatted Perps available balance', () => {
+    usePerpsLiveAccountMock.mockReturnValue({
+      account: { availableBalance: '1232.39' } as never,
+      isInitialLoading: false,
+    });
+
+    renderBalance();
+
+    expect(
+      screen.getByText(
+        new RegExp(
+          `${messages.perpsAvailableBalance.message}\\$1,232\\.39`,
+          'u',
+        ),
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('renders $0.00 when the live account has no balance', () => {
+    usePerpsLiveAccountMock.mockReturnValue({
+      account: null,
+      isInitialLoading: false,
+    });
+
+    renderBalance();
+
+    expect(
+      screen.getByText(
+        new RegExp(`${messages.perpsAvailableBalance.message}\\$0\\.00`, 'u'),
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/ui/pages/confirmations/components/perps-confirmations/perps-withdraw-balance/perps-withdraw-balance.tsx
+++ b/ui/pages/confirmations/components/perps-confirmations/perps-withdraw-balance/perps-withdraw-balance.tsx
@@ -1,0 +1,42 @@
+import React, { useMemo } from 'react';
+
+import { Box, Text } from '../../../../../components/component-library';
+import {
+  AlignItems,
+  Display,
+  FlexDirection,
+  JustifyContent,
+  TextColor,
+  TextVariant,
+} from '../../../../../helpers/constants/design-system';
+import { useI18nContext } from '../../../../../hooks/useI18nContext';
+import { useFormatters } from '../../../../../hooks/useFormatters';
+import { usePerpsLiveAccount } from '../../../../../hooks/perps/stream';
+
+export const PerpsWithdrawBalance = () => {
+  const t = useI18nContext();
+  const { formatCurrency } = useFormatters();
+  const { account } = usePerpsLiveAccount();
+
+  const balanceFormatted = useMemo(() => {
+    const value = parseFloat(account?.availableBalance ?? '0') || 0;
+    return formatCurrency(value, 'USD');
+  }, [account?.availableBalance, formatCurrency]);
+
+  return (
+    <Box
+      display={Display.Flex}
+      flexDirection={FlexDirection.Row}
+      justifyContent={JustifyContent.center}
+      alignItems={AlignItems.center}
+      paddingBottom={2}
+    >
+      <Text
+        variant={TextVariant.bodyMdMedium}
+        color={TextColor.textAlternative}
+      >
+        {`${t('perpsAvailableBalance')}${balanceFormatted}`}
+      </Text>
+    </Box>
+  );
+};

--- a/ui/pages/confirmations/constants/pay.ts
+++ b/ui/pages/confirmations/constants/pay.ts
@@ -7,4 +7,5 @@ export const PAY_TRANSACTION_TYPES = [
   TransactionType.musdClaim,
   TransactionType.musdConversion,
   TransactionType.perpsDeposit,
+  TransactionType.perpsWithdraw,
 ];

--- a/ui/pages/settings/developer-options-tab/__snapshots__/developer-options-tab.test.tsx.snap
+++ b/ui/pages/settings/developer-options-tab/__snapshots__/developer-options-tab.test.tsx.snap
@@ -676,6 +676,45 @@ exports[`Develop options tab should match snapshot 1`] = `
           </div>
         </div>
       </div>
+      <div
+        class="mm-box settings-page__content-row mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-row mm-box--justify-content-space-between"
+      >
+        <div
+          class="settings-page__content-item"
+        >
+          <span>
+            Perps Withdraw
+          </span>
+          <div
+            class="settings-page__content-description"
+          >
+            Triggers a Perps withdraw confirmation.
+          </div>
+        </div>
+        <div
+          class="settings-page__content-item-col"
+        >
+          <button
+            class="mm-box mm-text mm-button-base mm-button-base--size-md mm-button-primary mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-inverse mm-box--background-color-icon-default mm-box--rounded-xl"
+          >
+            Trigger
+          </button>
+        </div>
+        <div
+          class="settings-page__content-item-col"
+        >
+          <div
+            class="mm-box mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--align-items-center"
+            style="height: 40px; width: 40px;"
+          >
+            <span
+              class="mm-box settings-page-developer-options__icon-check mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-success-default"
+              hidden=""
+              style="mask-image: url('./images/icons/check.svg');"
+            />
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## **Description**

Adds the UI-only scaffolding for the new Perps Withdraw confirmation flow on the extension, mirroring metamask-mobile [#27792](https://github.com/MetaMask/metamask-mobile/pull/27792). A new "Perps Withdraw" button in Settings → Developer Options → Confirmations creates a `TransactionType.perpsWithdraw` transaction on Arbitrum USDC and navigates into a `CustomAmountInfo`-based confirmation page that shows the user's available Perps balance.

This is the UI foundation — the end-to-end withdrawal execution (HyperLiquid signatures, Relay submission, post-quote config, gasless alerts, activity display, feature-flagged entry from the Perps tab, toasts, etc.) will follow in subsequent PRs.

Key changes:

- New `PerpsWithdrawButton`, `PerpsWithdrawInfo`, `PerpsWithdrawBalance` components (mirrors the `PerpsDepositButton` / `PerpsDepositInfo` pattern).
- Registers `TransactionType.perpsWithdraw` in `info.tsx` `ConfirmationInfoComponentMap`, `PAY_TRANSACTION_TYPES`, and `REDESIGN_USER_TRANSACTION_TYPES` (the last one guards against an infinite-skeleton regression).
- Percentage buttons (25/50/75/Max) are intentionally hidden for now.

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/PR?quickstart=1)

## **Changelog**

CHANGELOG entry: Added a Developer Options entry to trigger the new Perps Withdraw confirmation UI

## **Related issues**

Fixes: [CONF-1213](https://consensyssoftware.atlassian.net/browse/CONF-1213)

## **Manual testing steps**

1. Enable Developer Options in Settings.
2. Go to Settings → Debug → Confirmations.
3. Click **Trigger** next to **Perps Withdraw**.
4. Verify the confirmation renders: "Withdraw" title, `$0` amount input, "Available balance: $X.XX" below, and the Receive-token row — with no 25/50/75/Max buttons (hidden for MVP).

## **Screenshots/Recordings**

### **Before**

### **After**
<img width="376" height="521" alt="image" src="https://github.com/user-attachments/assets/a9166440-5b8b-4820-96ea-3c205af3e6bc" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[CONF-1213]: https://consensyssoftware.atlassian.net/browse/CONF-1213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `perpsWithdraw` transaction type into the redesigned confirmation and Pay flows, plus new UI components and a developer trigger; risk is moderate because it changes transaction-type routing for confirmations but is otherwise UI-only scaffolding.
> 
> **Overview**
> Adds UI-only scaffolding for a new **Perps Withdraw** confirmation flow. This introduces a Developer Options button that creates a `TransactionType.perpsWithdraw` Arbitrum USDC transaction and navigates into a `CustomAmountInfo`-based confirmation view showing the live Perps *available balance*.
> 
> Wires `perpsWithdraw` into the redesigned confirmation type allowlist and `PAY_TRANSACTION_TYPES`, adds shared developer utility `generateERC20TransferData` (refactoring existing buttons to use it), and updates i18n copy from “Available Perps balance” to “Available balance” with new unit/component tests and snapshot updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a6a89cdbfe1532c10f852451d3d0a94fa2a7279. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->