### PR TITLE
feat(perps): Display perpsWithdraw in confirmation UI and activity list

### DIFF
--- a/app/scripts/lib/transaction/metrics-context.test.ts
+++ b/app/scripts/lib/transaction/metrics-context.test.ts
@@ -112,4 +112,17 @@ describe('buildTransactionMetricsContext', () => {
     expect(context.transactionTypeForMetrics).toBe('perpsDeposit');
     expect(context.isContractInteraction).toBe(false);
   });
+
+  it('returns perpsWithdraw as transaction type for perps withdraw transactions', async () => {
+    const context = await buildTransactionMetricsContext({
+      transactionMeta: createTransactionMeta({
+        type: TransactionType.perpsWithdraw,
+        txParams: { data: '0xa9059cbb' },
+      }),
+      transactionMetricsRequest: createRequest(),
+    });
+
+    expect(context.transactionTypeForMetrics).toBe('perpsWithdraw');
+    expect(context.isContractInteraction).toBe(false);
+  });
 });

--- a/app/scripts/lib/transaction/metrics-context.ts
+++ b/app/scripts/lib/transaction/metrics-context.ts
@@ -107,6 +107,7 @@ function determineTransactionTypeAndContractInteraction(
     'musdConversion',
     'musdClaim',
     'perpsDeposit',
+    'perpsWithdraw',
   ];
 
   if (directTypeMappings.includes(type)) {

--- a/shared/lib/confirmation.utils.ts
+++ b/shared/lib/confirmation.utils.ts
@@ -17,6 +17,7 @@ const REDESIGN_USER_TRANSACTION_TYPES = [
   TransactionType.musdClaim,
   TransactionType.musdConversion,
   TransactionType.perpsDeposit,
+  TransactionType.perpsWithdraw,
   TransactionType.revokeDelegation,
   TransactionType.shieldSubscriptionApprove,
   TransactionType.simpleSend,

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -350,6 +350,9 @@
       "Reselect: Identity function warnings": 1,
       "error: Warning: React does not recognize": 1
     },
+    "ui/components/app/transaction-list-item/transaction-list-item.component.test.js": {
+      "React: PropTypes validation failures": 1
+    },
     "ui/components/app/transaction-list-item/transaction-list-item.component.unified-swap-bridge.test.tsx": {
       "Reselect: Identity function warnings": 1,
       "error: Error: Insufficient number of substitutions": 1

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -734,7 +734,7 @@
       "warn: No tokens found for chainId:": 1
     },
     "ui/pages/confirmations/components/activity/transaction-details-summary/transaction-details-summary.test.tsx": {
-      "warn: No tokens found for chainId:": 6
+      "warn: No tokens found for chainId:": 7
     },
     "ui/pages/confirmations/components/activity/transaction-details/transaction-details.test.tsx": {
       "warn: No tokens found for chainId:": 1

--- a/ui/components/app/transaction-list-item/transaction-list-item.component.js
+++ b/ui/components/app/transaction-list-item/transaction-list-item.component.js
@@ -110,7 +110,9 @@ function TransactionListItemInner({
   const hasGasFeeTokenSelected = Boolean(selectedGasFeeToken);
 
   const badgeChainId =
-    type === TransactionType.perpsDeposit && metamaskPay?.chainId
+    (type === TransactionType.perpsDeposit ||
+      type === TransactionType.perpsWithdraw) &&
+    metamaskPay?.chainId
       ? metamaskPay.chainId
       : chainId;
 

--- a/ui/components/app/transaction-list-item/transaction-list-item.component.test.js
+++ b/ui/components/app/transaction-list-item/transaction-list-item.component.test.js
@@ -1,5 +1,8 @@
 import { NameType } from '@metamask/name-controller';
-import { TransactionStatus } from '@metamask/transaction-controller';
+import {
+  TransactionStatus,
+  TransactionType,
+} from '@metamask/transaction-controller';
 import { act, fireEvent } from '@testing-library/react';
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -116,6 +119,7 @@ jest.mock('../../../store/actions.ts', () => ({
   updateTransactionGasFees: jest.fn().mockReturnValue({ type: 'TYPE' }),
   createCancelTransaction: jest.fn().mockReturnValue({ type: 'TYPE' }),
   createSpeedUpTransaction: jest.fn().mockReturnValue({ type: 'TYPE' }),
+  captureSingleException: jest.fn().mockReturnValue({ type: 'TYPE' }),
 }));
 
 const mockStore = configureStore();
@@ -424,6 +428,40 @@ describe('TransactionListItem', () => {
 
       expect(queryByTestId('cancel-button')).toBeInTheDocument();
       expect(queryByTestId('speed-up-button')).toBeInTheDocument();
+    });
+  });
+
+  describe('perpsWithdraw chain badge', () => {
+    beforeEach(() => {
+      useSelector.mockImplementation(
+        generateUseSelectorRouter({ balance: '2AA1EFB94E0000' }),
+      );
+      useDispatch.mockReturnValue(jest.fn());
+    });
+
+    it('renders the ChainBadge using metamaskPay.chainId (source) for perpsWithdraw', () => {
+      const perpsWithdrawGroup = {
+        ...transactionGroup,
+        initialTransaction: {
+          ...transactionGroup.initialTransaction,
+          type: TransactionType.perpsWithdraw,
+          chainId: '0x38',
+          metamaskPay: { chainId: '0x2105' },
+        },
+        primaryTransaction: {
+          ...transactionGroup.primaryTransaction,
+          type: TransactionType.perpsWithdraw,
+          chainId: '0x38',
+          metamaskPay: { chainId: '0x2105' },
+          status: TransactionStatus.confirmed,
+        },
+      };
+
+      const { getByAltText } = renderWithProvider(
+        <TransactionListItem transactionGroup={perpsWithdrawGroup} />,
+      );
+
+      expect(getByAltText('Base')).toBeInTheDocument();
     });
   });
 });

--- a/ui/helpers/constants/transactions.js
+++ b/ui/helpers/constants/transactions.js
@@ -40,6 +40,7 @@ export const TOAST_EXCLUDED_TRANSACTION_TYPES = new Set([
   TransactionType.musdClaim,
   TransactionType.perpsDeposit,
   TransactionType.perpsDepositAndOrder,
+  TransactionType.perpsWithdraw,
 ]);
 
 // Non-EVM transaction types excluded from toast notifications.

--- a/ui/helpers/utils/activity.test.ts
+++ b/ui/helpers/utils/activity.test.ts
@@ -111,6 +111,57 @@ describe('filterTransactionByChain', () => {
     });
   });
 
+  describe('perpsWithdraw transactions', () => {
+    it('returns true when source chain (metamaskPay.chainId) is in enabled chains', () => {
+      const transactionGroup = {
+        initialTransaction: {
+          type: TransactionType.perpsWithdraw,
+          chainId: CHAIN_IDS.ARBITRUM,
+          metamaskPay: {
+            chainId: CHAIN_IDS.BASE,
+          },
+        },
+      };
+
+      expect(
+        filterTransactionByChain(transactionGroup as never, [CHAIN_IDS.BASE]),
+      ).toBe(true);
+    });
+
+    it('returns false when only destination chain (Arbitrum) is enabled', () => {
+      const transactionGroup = {
+        initialTransaction: {
+          type: TransactionType.perpsWithdraw,
+          chainId: CHAIN_IDS.ARBITRUM,
+          metamaskPay: {
+            chainId: CHAIN_IDS.BASE,
+          },
+        },
+      };
+
+      expect(
+        filterTransactionByChain(transactionGroup as never, [
+          CHAIN_IDS.ARBITRUM,
+        ]),
+      ).toBe(false);
+    });
+
+    it('falls back to destination chain when no metamaskPay.chainId', () => {
+      const transactionGroup = {
+        initialTransaction: {
+          type: TransactionType.perpsWithdraw,
+          chainId: CHAIN_IDS.ARBITRUM,
+        },
+      };
+
+      expect(
+        filterTransactionByChain(transactionGroup as never, [
+          CHAIN_IDS.ARBITRUM,
+        ]),
+      ).toBe(true);
+    });
+  });
+
   describe('musdConversion transactions', () => {
     it('returns true when transaction chain is in enabled chains', () => {
       const transactionGroup = {

--- a/ui/helpers/utils/activity.ts
+++ b/ui/helpers/utils/activity.ts
@@ -23,7 +23,10 @@ export function filterTransactionByChain(
     return enabledChainIds.includes(chainId);
   }
 
-  if (type === TransactionType.perpsDeposit) {
+  if (
+    type === TransactionType.perpsDeposit ||
+    type === TransactionType.perpsWithdraw
+  ) {
     return enabledChainIds.includes(sourceChainId);
   }
 

--- a/ui/hooks/useTransactionDisplayData.js
+++ b/ui/hooks/useTransactionDisplayData.js
@@ -409,6 +409,8 @@ export function useTransactionDisplayData(transactionGroup) {
 
     if (type === TransactionType.perpsDeposit) {
       title = t('perpsDepositActivityTitle');
+    } else if (type === TransactionType.perpsWithdraw) {
+      title = t('perpsWithdrawFundsTitle');
     } else if (type === TransactionType.musdClaim) {
       title = t('musdClaimTitle');
     } else {

--- a/ui/hooks/useTransactionDisplayData.test.js
+++ b/ui/hooks/useTransactionDisplayData.test.js
@@ -249,6 +249,52 @@ describe('useTransactionDisplayData', () => {
     expect(result.current).toStrictEqual(expectedResults[0]);
   });
 
+  it('should return "Withdraw" title for a perpsWithdraw transaction', () => {
+    const perpsWithdrawGroup = {
+      nonce: '0x1',
+      initialTransaction: {
+        id: 'perps-withdraw-test',
+        time: 1700000000000,
+        status: 'confirmed',
+        chainId: CHAIN_IDS.MAINNET,
+        txParams: {
+          from: '0x9eca64466f257793eaa52fcfff5066894b76a149',
+          to: '0xabca64466f257793eaa52fcfff5066894b76a149',
+          value: '0x0',
+          data: '0xa9059cbb',
+        },
+        type: 'perpsWithdraw',
+        metamaskPay: {
+          chainId: CHAIN_IDS.MAINNET,
+          tokenAddress: '0xabca64466f257793eaa52fcfff5066894b76a149',
+        },
+      },
+      primaryTransaction: {
+        id: 'perps-withdraw-test',
+        time: 1700000000000,
+        status: 'confirmed',
+        chainId: CHAIN_IDS.MAINNET,
+        txParams: {
+          from: '0x9eca64466f257793eaa52fcfff5066894b76a149',
+          to: '0xabca64466f257793eaa52fcfff5066894b76a149',
+          value: '0x0',
+          data: '0xa9059cbb',
+        },
+        type: 'perpsWithdraw',
+      },
+      transactions: [],
+      hasRetried: false,
+      hasCancelled: false,
+    };
+
+    const { result } = renderHookWithProvider(
+      () => useTransactionDisplayData(perpsWithdrawGroup),
+      getMockState(),
+      DEFAULT_ROUTE,
+    );
+    expect(result.current.title).toBe('Withdraw');
+  });
+
   it('should return "Claim Bonus" title for a contractInteraction sent to the Merkl distributor address', () => {
     const merklClaimGroup = {
       nonce: '0x1',

--- a/ui/pages/confirmations/components/activity/transaction-details-modal/transaction-details-modal.test.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-modal/transaction-details-modal.test.tsx
@@ -107,6 +107,15 @@ describe('TransactionDetailsModal', () => {
     ).toBeInTheDocument();
   });
 
+  it('renders Withdraw title for perpsWithdraw transactions', () => {
+    const { getByRole } = render(TransactionType.perpsWithdraw);
+    expect(
+      getByRole('heading', {
+        name: messages.perpsWithdrawFundsTitle.message,
+      }),
+    ).toBeInTheDocument();
+  });
+
   it('renders TransactionDetails component', () => {
     const { getByTestId } = render();
     expect(getByTestId('transaction-details')).toBeInTheDocument();

--- a/ui/pages/confirmations/components/activity/transaction-details-modal/transaction-details-modal.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-modal/transaction-details-modal.tsx
@@ -40,6 +40,8 @@ export function TransactionDetailsModal({
         return t('musdConversionTitle');
       case TransactionType.perpsDeposit:
         return t('perpsDepositTitle');
+      case TransactionType.perpsWithdraw:
+        return t('perpsWithdrawFundsTitle');
       default:
         return t('transaction');
     }

--- a/ui/pages/confirmations/components/activity/transaction-details-summary/transaction-details-summary.test.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-summary/transaction-details-summary.test.tsx
@@ -223,6 +223,14 @@ describe('TransactionDetailsSummary', () => {
     expect(useTokenWithBalanceMock).toHaveBeenCalledWith('0x456', CHAIN_ID);
   });
 
+  it('renders a ReceiveSummaryLine for perpsWithdraw transactions', () => {
+    const { getByText } = render(TransactionType.perpsWithdraw);
+
+    expect(
+      getByText(messages.bridgeReceiveLoading.message),
+    ).toBeInTheDocument();
+  });
+
   describe('mUSD conversion summary', () => {
     it('shows relay and receive lines, filtering out approval txs', () => {
       const approvalTx = createMockTransactionMeta(

--- a/ui/pages/confirmations/components/activity/transaction-details-summary/transaction-details-summary.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-summary/transaction-details-summary.tsx
@@ -126,7 +126,8 @@ function TransactionSummaryLine({
   if (
     type === TransactionType.musdClaim ||
     type === TransactionType.musdConversion ||
-    type === TransactionType.perpsDeposit
+    type === TransactionType.perpsDeposit ||
+    type === TransactionType.perpsWithdraw
   ) {
     return (
       <ReceiveSummaryLine

--- a/ui/pages/confirmations/components/confirm/footer/footer.test.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/footer.test.tsx
@@ -1226,6 +1226,27 @@ describe('ConfirmFooter', () => {
     expect(queryByText(messages.cancel.message)).not.toBeInTheDocument();
   });
 
+  it('renders SingleActionFooter for perpsWithdraw transaction type', () => {
+    jest.spyOn(confirmContext, 'useConfirmContext').mockReturnValue({
+      currentConfirmation: {
+        ...genUnapprovedContractInteractionConfirmation(),
+        type: TransactionType.perpsWithdraw,
+      },
+      isScrollToBottomCompleted: true,
+      setIsScrollToBottomCompleted: () => undefined,
+    } as unknown as ReturnType<typeof confirmContext.useConfirmContext>);
+
+    const { getByTestId, queryByText } = render(
+      getMockContractInteractionConfirmState(),
+    );
+
+    expect(getByTestId('confirm-footer-button')).toBeInTheDocument();
+    expect(getByTestId('confirm-footer-button')).toHaveTextContent(
+      messages.perpsWithdraw.message,
+    );
+    expect(queryByText(messages.cancel.message)).not.toBeInTheDocument();
+  });
+
   describe('goBackTo navigation', () => {
     it('does not call navigateNext when cancel is clicked and goBackTo is defined', async () => {
       const navigateNextMock = jest.fn();

--- a/ui/pages/confirmations/components/confirm/footer/footer.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/footer.tsx
@@ -54,6 +54,7 @@ import { SingleActionFooter } from './single-action-footer';
 const SINGLE_ACTION_FOOTER_TYPES = [
   TransactionType.musdConversion,
   TransactionType.perpsDeposit,
+  TransactionType.perpsWithdraw,
 ];
 
 export type OnCancelHandler = ({

--- a/ui/pages/confirmations/components/confirm/footer/single-action-footer.test.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/single-action-footer.test.tsx
@@ -33,6 +33,11 @@ function genPerpsDeposit() {
   return { ...base, type: TransactionType.perpsDeposit, origin: 'metamask' };
 }
 
+function genPerpsWithdraw() {
+  const base = genUnapprovedContractInteractionConfirmation({ chainId: '0x1' });
+  return { ...base, type: TransactionType.perpsWithdraw, origin: 'metamask' };
+}
+
 function render({
   isGaslessLoading = false,
   confirmation = genMusdConversion(),
@@ -46,7 +51,8 @@ function render({
   isGaslessLoading?: boolean;
   confirmation?:
     | ReturnType<typeof genMusdConversion>
-    | ReturnType<typeof genPerpsDeposit>;
+    | ReturnType<typeof genPerpsDeposit>
+    | ReturnType<typeof genPerpsWithdraw>;
   alerts?: {
     key: string;
     severity: string;
@@ -160,6 +166,14 @@ describe('<SingleActionFooter />', () => {
 
     expect(getByTestId('confirm-footer-button')).toHaveTextContent(
       messages.addFunds.message,
+    );
+  });
+
+  it('shows Withdraw label for perpsWithdraw transaction type', () => {
+    const { getByTestId } = render({ confirmation: genPerpsWithdraw() });
+
+    expect(getByTestId('confirm-footer-button')).toHaveTextContent(
+      messages.perpsWithdraw.message,
     );
   });
 });

--- a/ui/pages/confirmations/components/confirm/footer/single-action-footer.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/single-action-footer.tsx
@@ -22,6 +22,7 @@ type ButtonState = {
 const BUTTON_TEXT_BY_TYPE: Partial<Record<TransactionType, string>> = {
   [TransactionType.musdConversion]: 'musdConvert',
   [TransactionType.perpsDeposit]: 'addFunds',
+  [TransactionType.perpsWithdraw]: 'perpsWithdraw',
 };
 
 function useSingleActionButtonState(isGaslessLoading: boolean): ButtonState {

--- a/ui/pages/confirmations/components/confirm/header/advanced-details-button.test.tsx
+++ b/ui/pages/confirmations/components/confirm/header/advanced-details-button.test.tsx
@@ -1,14 +1,31 @@
 import React from 'react';
-import { getMockTokenTransferConfirmState } from '../../../../../../test/data/confirmations/helper';
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
+import {
+  getMockConfirmStateForTransaction,
+  getMockTokenTransferConfirmState,
+} from '../../../../../../test/data/confirmations/helper';
+import { genUnapprovedContractInteractionConfirmation } from '../../../../../../test/data/confirmations/contract-interaction';
 import { renderWithConfirmContextProvider } from '../../../../../../test/lib/confirmations/render-helpers';
 import configureStore from '../../../../../store/store';
 import { AdvancedDetailsButton } from './advanced-details-button';
 
-const mockStore = getMockTokenTransferConfirmState({});
+const defaultState = getMockTokenTransferConfirmState({});
 
-const render = () => {
-  const store = configureStore(mockStore);
+const render = (state: Record<string, unknown> = defaultState) => {
+  const store = configureStore(state);
   return renderWithConfirmContextProvider(<AdvancedDetailsButton />, store);
+};
+
+const getPerpsWithdrawState = () => {
+  const base = genUnapprovedContractInteractionConfirmation({ chainId: '0x1' });
+  return getMockConfirmStateForTransaction({
+    ...base,
+    type: TransactionType.perpsWithdraw,
+    origin: 'metamask',
+  } as TransactionMeta);
 };
 
 describe('<AdvancedDetailsButton />', () => {
@@ -16,5 +33,21 @@ describe('<AdvancedDetailsButton />', () => {
     const { container } = render();
 
     expect(container).toMatchSnapshot();
+  });
+
+  it('hides the button visually for perpsWithdraw transactions', () => {
+    const { getByTestId } = render(getPerpsWithdrawState());
+
+    const button = getByTestId('header-advanced-details-button');
+    expect(button.closest('[style*="visibility"]')).toHaveStyle({
+      visibility: 'hidden',
+    });
+  });
+
+  it('keeps the button visible for non-hidden transaction types', () => {
+    const { getByTestId } = render();
+
+    const button = getByTestId('header-advanced-details-button');
+    expect(button.closest('[style*="visibility"]')).toBeNull();
   });
 });

--- a/ui/pages/confirmations/components/confirm/header/advanced-details-button.tsx
+++ b/ui/pages/confirmations/components/confirm/header/advanced-details-button.tsx
@@ -47,7 +47,8 @@ export const AdvancedDetailsButton = () => {
       style={
         currentConfirmation?.type ===
           TransactionType.shieldSubscriptionApprove ||
-        currentConfirmation?.type === TransactionType.perpsDeposit
+        currentConfirmation?.type === TransactionType.perpsDeposit ||
+        currentConfirmation?.type === TransactionType.perpsWithdraw
           ? { visibility: 'hidden' }
           : {}
       }

--- a/ui/pages/confirmations/components/confirm/header/header.test.tsx
+++ b/ui/pages/confirmations/components/confirm/header/header.test.tsx
@@ -1,12 +1,18 @@
 import { fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
 import { DefaultRootState } from 'react-redux';
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
 
 import {
+  getMockConfirmStateForTransaction,
   getMockContractInteractionConfirmState,
   getMockTokenTransferConfirmState,
   getMockTypedSignConfirmState,
 } from '../../../../../../test/data/confirmations/helper';
+import { genUnapprovedContractInteractionConfirmation } from '../../../../../../test/data/confirmations/contract-interaction';
 import { renderWithConfirmContextProvider } from '../../../../../../test/lib/confirmations/render-helpers';
 import configureStore from '../../../../../store/store';
 import { enLocale as messages } from '../../../../../../test/lib/i18n-helpers';
@@ -74,5 +80,22 @@ describe('Header', () => {
     await waitFor(() => {
       expect(queryByTestId('account-details-modal')).toBeInTheDocument();
     });
+  });
+
+  it('renders the wallet-initiated header for perpsWithdraw transactions from the wallet', () => {
+    const base = genUnapprovedContractInteractionConfirmation({
+      chainId: '0x1',
+    });
+    const state = getMockConfirmStateForTransaction({
+      ...base,
+      type: TransactionType.perpsWithdraw,
+      origin: 'metamask',
+    } as TransactionMeta);
+
+    const { getByTestId } = render(state);
+
+    expect(
+      getByTestId('wallet-initiated-header-back-button'),
+    ).toBeInTheDocument();
   });
 });

--- a/ui/pages/confirmations/components/confirm/header/header.tsx
+++ b/ui/pages/confirmations/components/confirm/header/header.tsx
@@ -27,6 +27,7 @@ const CONFIRMATIONS_WITH_ALT_HEADER = [
   ...SIMPLE_HEADER_TYPES,
   TransactionType.musdClaim,
   TransactionType.perpsDeposit,
+  TransactionType.perpsWithdraw,
   TransactionType.simpleSend,
   TransactionType.shieldSubscriptionApprove,
   TransactionType.tokenMethodSafeTransferFrom,

--- a/ui/pages/confirmations/components/confirm/header/wallet-initiated-header.test.tsx
+++ b/ui/pages/confirmations/components/confirm/header/wallet-initiated-header.test.tsx
@@ -27,6 +27,16 @@ const getPerpsDepositState = () => {
   } as TransactionMeta);
 };
 
+/** Build a confirm state for a perpsWithdraw transaction. */
+const getPerpsWithdrawState = () => {
+  const base = genUnapprovedContractInteractionConfirmation({ chainId: '0x1' });
+  return getMockConfirmStateForTransaction({
+    ...base,
+    type: TransactionType.perpsWithdraw,
+    origin: 'metamask',
+  } as TransactionMeta);
+};
+
 const render = (
   state: DefaultRootState = getMockTokenTransferConfirmState({}),
 ) => {
@@ -119,5 +129,36 @@ describe('<WalletInitiatedHeader />', () => {
     const { getByTestId } = render();
 
     expect(getByTestId('header-advanced-details-button')).toBeInTheDocument();
+  });
+
+  it('calls onCancel with navigateBackToPreviousPage for perpsWithdraw', () => {
+    const mockOnCancel = jest.fn();
+    jest.spyOn(ConfirmActions, 'useConfirmActions').mockImplementation(() => ({
+      onCancel: mockOnCancel,
+      resetTransactionState: jest.fn(),
+    }));
+
+    const { getByTestId } = render(getPerpsWithdrawState());
+    fireEvent.click(getByTestId('wallet-initiated-header-back-button'));
+
+    expect(mockOnCancel).toHaveBeenCalledWith({
+      location: 'confirmation',
+      navigateBackToPreviousPage: true,
+    });
+  });
+
+  it('shows perpsWithdrawFundsTitle as the header title for perpsWithdraw', () => {
+    const { getByText } = render(getPerpsWithdrawState());
+
+    expect(getByText(tEn('perpsWithdrawFundsTitle'))).toBeInTheDocument();
+  });
+
+  it('hides AdvancedDetailsButton visually for perpsWithdraw', () => {
+    const { getByTestId } = render(getPerpsWithdrawState());
+
+    const advancedButton = getByTestId('header-advanced-details-button');
+    expect(advancedButton.closest('[style*="visibility"]')).toHaveStyle({
+      visibility: 'hidden',
+    });
   });
 });

--- a/ui/pages/confirmations/components/confirm/header/wallet-initiated-header.tsx
+++ b/ui/pages/confirmations/components/confirm/header/wallet-initiated-header.tsx
@@ -50,7 +50,8 @@ export const WalletInitiatedHeader = () => {
 
     if (
       currentConfirmation.type === TransactionType.musdClaim ||
-      currentConfirmation.type === TransactionType.perpsDeposit
+      currentConfirmation.type === TransactionType.perpsDeposit ||
+      currentConfirmation.type === TransactionType.perpsWithdraw
     ) {
       onCancel({
         location: MetaMetricsEventLocation.Confirmation,
@@ -89,6 +90,9 @@ export const WalletInitiatedHeader = () => {
     }
     if (currentConfirmation?.type === TransactionType.perpsDeposit) {
       return t('perpsDepositFundsTitle');
+    }
+    if (currentConfirmation?.type === TransactionType.perpsWithdraw) {
+      return t('perpsWithdrawFundsTitle');
     }
     return t('review');
   };

--- a/ui/pages/confirmations/components/confirm/title/title.test.tsx
+++ b/ui/pages/confirmations/components/confirm/title/title.test.tsx
@@ -292,6 +292,7 @@ describe('ConfirmTitle', () => {
       TransactionType.musdClaim,
       TransactionType.musdConversion,
       TransactionType.perpsDeposit,
+      TransactionType.perpsWithdraw,
       TransactionType.predictDeposit,
       TransactionType.predictWithdraw,
     ])('hides alert banner for %s transaction type', (type: string) => {

--- a/ui/pages/confirmations/components/confirm/title/title.tsx
+++ b/ui/pages/confirmations/components/confirm/title/title.tsx
@@ -42,6 +42,7 @@ const TRANSACTION_TYPES_HIDE_BANNER: string[] = [
   TransactionType.musdClaim,
   TransactionType.musdConversion,
   TransactionType.perpsDeposit,
+  TransactionType.perpsWithdraw,
   TransactionType.predictDeposit,
   TransactionType.predictWithdraw,
 ];

--- a/ui/pages/confirmations/components/rows/bridge-fee-row/bridge-fee-row.test.tsx
+++ b/ui/pages/confirmations/components/rows/bridge-fee-row/bridge-fee-row.test.tsx
@@ -1,12 +1,17 @@
 import React from 'react';
 import { userEvent } from '@testing-library/user-event';
 import configureMockStore from 'redux-mock-store';
+import { TransactionType } from '@metamask/transaction-controller';
 import type {
   TransactionPayQuote,
   TransactionPayTotals,
 } from '@metamask/transaction-pay-controller';
 import type { Json } from '@metamask/utils';
-import { getMockPersonalSignConfirmState } from '../../../../../../test/data/confirmations/helper';
+import {
+  getMockConfirmStateForTransaction,
+  getMockPersonalSignConfirmState,
+} from '../../../../../../test/data/confirmations/helper';
+import { genUnapprovedContractInteractionConfirmation } from '../../../../../../test/data/confirmations/contract-interaction';
 import { renderWithConfirmContextProvider } from '../../../../../../test/lib/confirmations/render-helpers';
 import {
   useIsTransactionPayLoading,
@@ -21,12 +26,24 @@ jest.mock('../../../hooks/pay/useTransactionPayData');
 
 const mockStore = configureMockStore([]);
 
-function render(props: BridgeFeeRowProps = {}) {
-  const state = getMockPersonalSignConfirmState();
+function render(
+  props: BridgeFeeRowProps = {},
+  state: Record<string, unknown> = getMockPersonalSignConfirmState(),
+) {
   return renderWithConfirmContextProvider(
     <BridgeFeeRow {...props} />,
     mockStore(state),
   );
+}
+
+function getPerpsWithdrawState() {
+  const base = genUnapprovedContractInteractionConfirmation({ chainId: '0x1' });
+  const withdraw = {
+    ...base,
+    type: TransactionType.perpsWithdraw,
+    origin: 'metamask',
+  };
+  return getMockConfirmStateForTransaction(withdraw);
 }
 
 describe('BridgeFeeRow', () => {
@@ -182,5 +199,23 @@ describe('BridgeFeeRow', () => {
     const feeValue = getByTestId('transaction-fee-value');
     expect(feeValue).toBeInTheDocument();
     expect(feeValue).toHaveTextContent('$1.23');
+  });
+
+  it('renders Provider Fee label for perpsWithdraw transactions', () => {
+    const { getByText, queryByText } = render({}, getPerpsWithdrawState());
+
+    expect(getByText(messages.perpsWithdrawFee.message)).toBeInTheDocument();
+    expect(
+      queryByText(messages.transactionFee.message),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders Transaction fee label for non-perpsWithdraw transactions', () => {
+    const { getByText, queryByText } = render();
+
+    expect(getByText(messages.transactionFee.message)).toBeInTheDocument();
+    expect(
+      queryByText(messages.perpsWithdrawFee.message),
+    ).not.toBeInTheDocument();
   });
 });

--- a/ui/pages/confirmations/components/rows/bridge-fee-row/bridge-fee-row.test.tsx
+++ b/ui/pages/confirmations/components/rows/bridge-fee-row/bridge-fee-row.test.tsx
@@ -218,4 +218,13 @@ describe('BridgeFeeRow', () => {
       queryByText(messages.perpsWithdrawFee.message),
     ).not.toBeInTheDocument();
   });
+
+  it('renders Provider Fee label on the skeleton while loading a perpsWithdraw transaction', () => {
+    useIsTransactionPayLoadingMock.mockReturnValue(true);
+
+    const { getByTestId, getByText } = render({}, getPerpsWithdrawState());
+
+    expect(getByTestId('bridge-fee-row-skeleton')).toBeInTheDocument();
+    expect(getByText(messages.perpsWithdrawFee.message)).toBeInTheDocument();
+  });
 });

--- a/ui/pages/confirmations/components/rows/bridge-fee-row/bridge-fee-row.tsx
+++ b/ui/pages/confirmations/components/rows/bridge-fee-row/bridge-fee-row.tsx
@@ -1,5 +1,7 @@
 import React, { useMemo } from 'react';
 import { BigNumber } from 'bignumber.js';
+import type { TransactionMeta } from '@metamask/transaction-controller';
+import { TransactionType } from '@metamask/transaction-controller';
 import type { TransactionPayTotals } from '@metamask/transaction-pay-controller';
 import { Text } from '../../../../../components/component-library';
 import {
@@ -19,6 +21,10 @@ import {
 } from '../../../hooks/pay/useTransactionPayData';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { useFiatFormatter } from '../../../../../hooks/useFiatFormatter';
+import { useConfirmContext } from '../../../context/confirm';
+import { hasTransactionType } from '../../../../../../shared/lib/transactions.utils';
+
+const PROVIDER_FEE_TYPES = [TransactionType.perpsWithdraw];
 
 export type BridgeFeeRowProps = {
   variant?: ConfirmInfoRowSize;
@@ -39,6 +45,11 @@ export function BridgeFeeRow({
   const isLoading = useIsTransactionPayLoading();
   const quotes = useTransactionPayQuotes();
   const totals = useTransactionPayTotals();
+  const { currentConfirmation } = useConfirmContext<TransactionMeta>();
+
+  const feeLabel = hasTransactionType(currentConfirmation, PROVIDER_FEE_TYPES)
+    ? t('perpsWithdrawFee')
+    : t('transactionFee');
 
   const feeTotalUsd = useMemo(() => {
     if (!totals?.fees) {
@@ -61,7 +72,7 @@ export function BridgeFeeRow({
     return (
       <ConfirmInfoRowSkeleton
         data-testid="bridge-fee-row-skeleton"
-        label={t('transactionFee')}
+        label={feeLabel}
         rowVariant={variant}
       />
     );
@@ -85,7 +96,7 @@ export function BridgeFeeRow({
   return (
     <ConfirmInfoRow
       data-testid="bridge-fee-row"
-      label={t('transactionFee')}
+      label={feeLabel}
       rowVariant={variant}
       tooltip={tooltipContent}
     >

--- a/ui/pages/confirmations/constants/pay.ts
+++ b/ui/pages/confirmations/constants/pay.ts
@@ -7,4 +7,5 @@ export const PAY_TRANSACTION_TYPES = [
   TransactionType.musdClaim,
   TransactionType.musdConversion,
   TransactionType.perpsDeposit,
+  TransactionType.perpsWithdraw,
 ];

--- a/ui/pages/confirmations/hooks/pay/useTransactionPayMetrics.test.tsx
+++ b/ui/pages/confirmations/hooks/pay/useTransactionPayMetrics.test.tsx
@@ -231,6 +231,27 @@ describe('useTransactionPayMetrics', () => {
     );
   });
 
+  it('includes custom_amount use case and sending value for perpsWithdraw transactions', () => {
+    useTransactionPayTokenMock.mockReturnValue({
+      payToken: PAY_TOKEN_MOCK,
+      setPayToken: jest.fn(),
+    } as ReturnType<typeof useTransactionPayToken>);
+
+    renderHook(() => useTransactionPayMetrics(), {
+      wrapper: createWrapper(TransactionType.perpsWithdraw),
+    });
+
+    expect(upsertTransactionUIMetricsFragment).toHaveBeenCalledWith(
+      TRANSACTION_ID_MOCK,
+      {
+        properties: expect.objectContaining({
+          mm_pay_use_case: 'custom_amount',
+          simulation_sending_assets_total_value: expect.any(Number),
+        }),
+      },
+    );
+  });
+
   it('does not include custom_amount use case for non-perpsDeposit transactions', () => {
     useTransactionPayTokenMock.mockReturnValue({
       payToken: PAY_TOKEN_MOCK,

--- a/ui/pages/confirmations/hooks/pay/useTransactionPayMetrics.ts
+++ b/ui/pages/confirmations/hooks/pay/useTransactionPayMetrics.ts
@@ -70,7 +70,10 @@ export function useTransactionPayMetrics() {
 
     if (
       payToken &&
-      hasTransactionType(transactionMeta, [TransactionType.perpsDeposit])
+      hasTransactionType(transactionMeta, [
+        TransactionType.perpsDeposit,
+        TransactionType.perpsWithdraw,
+      ])
     ) {
       props.mm_pay_use_case = 'custom_amount';
       props.simulation_sending_assets_total_value = sendingValue;


### PR DESCRIPTION
## **Description**

Wires the `TransactionType.perpsWithdraw` transaction type through the redesigned confirmations and the activity list so a real perps withdrawal renders the correct header, footer, title, tooltip copy, details modal and activity filtering. Mirrors metamask-mobile [#28026](https://github.com/MetaMask/metamask-mobile/pull/28026).

Builds on top of the UI scaffold from #42043. All changes are additive — they register `perpsWithdraw` in existing switch statements / type lists; nothing fires until an actual `perpsWithdraw` transaction exists.

Key changes:

- **Confirmation chrome:** `WalletInitiatedHeader` renders "Withdraw" title + back button, `AdvancedDetailsButton` hides, `SingleActionFooter` shows the "Withdraw" CTA, alert banner hides via `TRANSACTION_TYPES_HIDE_BANNER`.
- **Fees:** `BridgeFeeRow` label switches to "Provider Fee" for `perpsWithdraw`.
- **Activity list:** `filterTransactionByChain` matches on `metamaskPay.chainId`; `TransactionListItem` uses source-chain `ChainBadge`; `useTransactionDisplayData` returns the "Withdraw" title.
- **Transaction details modal:** title is "Withdraw"; summary uses `ReceiveSummaryLine`.
- **Metrics:** `buildTransactionMetricsContext` maps `perpsWithdraw` directly, and `useTransactionPayMetrics` emits `mm_pay_use_case = custom_amount` + `simulation_sending_assets_total_value`.
- **Toasts:** `perpsWithdraw` added to `TOAST_EXCLUDED_TRANSACTION_TYPES`.
- Registers `perpsWithdraw` in `PAY_TRANSACTION_TYPES` and `REDESIGN_USER_TRANSACTION_TYPES` so the above actually activates for a `perpsWithdraw` transaction (same 1-line overlap lands in CONF-1213; rebase is a no-op).

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/MetaMask/metamask-extension/pull/PR?quickstart=1)

## **Changelog**

CHANGELOG entry: Added display support for Perps withdraw transactions in the confirmation screen and activity list

## **Related issues**

Fixes: [CONF-1214](https://consensyssoftware.atlassian.net/browse/CONF-1214)

## **Manual testing steps**

Full E2E flow requires an additional PR to submit a real withdrawal. UI can be verified end-to-end by:

1. Go to Settings → Debug → Confirmations → click **Trigger** next to **Perps Withdraw**.
2. Confirm the header shows "Withdraw" + back arrow (no avatar/addresses), Advanced Details icon is not visible, footer is a single "Withdraw" CTA (no Cancel button), and the fee row reads "Provider Fee".

## **Screenshots/Recordings**

<!--
### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[CONF-1214]: https://consensyssoftware.atlassian.net/browse/CONF-1214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: it expands the redesigned confirmations/Pay flow and activity chain filtering to include `perpsWithdraw`, which could affect how Pay-type transactions are displayed, filtered, and instrumented if type detection or `metamaskPay.chainId` is missing/mis-set.
> 
> **Overview**
> Adds end-to-end UI support for `TransactionType.perpsWithdraw` across the redesigned confirmation experience and activity list.
> 
> `perpsWithdraw` is now treated as a Pay/redesign transaction type, with updated header/footer behavior (single “Withdraw” CTA, hides advanced details, hides alert banner), correct titles in the details modal and activity display data, and receive-style summary rendering. Activity list chain badging/filtering is updated to prefer `metamaskPay.chainId` (source chain) for `perpsWithdraw`, and toast notifications exclude it.
> 
> Metrics wiring is extended so `buildTransactionMetricsContext` maps `perpsWithdraw` directly, and Pay metrics emit the same `custom_amount` use-case properties as `perpsDeposit` for withdrawals. Tests/baselines are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc19f542eaf25626c7642d5bfdac42f1bcc58828. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->