### PR TITLE
fix: toAssetId rem early return if err 0x... fallback

### DIFF
--- a/shared/lib/asset-utils.test.ts
+++ b/shared/lib/asset-utils.test.ts
@@ -75,14 +75,16 @@ describe('asset-utils', () => {
       ]);
     });
 
-    it('should return undefined if getNativeAssetForChainId returns undefined for unsupported chain', () => {
+    it('should return erc20:0x... format if getNativeAssetForChainId returns undefined for unsupported chain', () => {
       const nativeAddress = '0x0000000000000000000000000000000000000000';
       const chainId = 'eip155:1231' as CaipChainId;
 
       // getNativeAssetForChainId returns undefined (not throws) for chains not in the swaps map
       // Format normalization in isEvmChainId should prevent conversion errors
       const result = toAssetId(nativeAddress, chainId);
-      expect(result).toBeUndefined();
+      expect(result).toStrictEqual(
+        'eip155:1231/erc20:0x0000000000000000000000000000000000000000',
+      );
     });
 
     it('should create Solana token asset ID correctly', () => {

--- a/shared/lib/asset-utils.ts
+++ b/shared/lib/asset-utils.ts
@@ -56,10 +56,9 @@ export const toAssetId = (
     try {
       return getNativeAssetForChainId(chainIdToUse)?.assetId;
     } catch {
-      // Return undefined for unsupported chains (e.g., custom networks)
+      // Skip error for unsupported chains (e.g., custom networks) so we obtain the assetId in another way
       // This allows the send flow to work for custom networks even if they're not in the swaps map
       // Format normalization in isEvmChainId should prevent most errors, but this is a defensive fallback
-      return undefined;
     }
   }
   if (chainIdToUse === MultichainNetworks.SOLANA) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The early `return` in case of failure in `toAssetId` caused Extension to miss out on fallback `erc20:0x...` format which then prevents it from calling Price API for the native token of most custom networks - ex: Ink, Chiliz
Removing the early `return` allows the function to reach the fallback assetId.
Tested a normal "send flow" with Injective Testnet and it worked, so I assume this `return` is not strictly required anymore.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: drop early return in `toAssetId` if error so we allow fallback assetId erc20:0x...

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/NEB-172?atlOrigin=eyJpIjoiNTM3NDhhNWUxODJlNGZjOWE2OTA3OGU5M2ZjMzJjMjkiLCJwIjoiaiJ9

## **Manual testing steps**

1. Select a custom network (ex: Ink, Chiliz)
2. Click on it's native token
3. Before the fix: Price and data OK, but no chart. After the fix, the chart appears.
4. Apply smoketest non-reg to verify ability to send tokens, including Injective Testnet

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->


### **Before**

<!-- [screenshots/recordings] -->
<img width="300" alt="image" src="https://github.com/user-attachments/assets/aa5a7c16-5b54-403b-98a1-ac3a18f8de2e" />

### **After**

<!-- [screenshots/recordings] -->
<img width="300" alt="image" src="https://github.com/user-attachments/assets/971d3f6e-732e-40c4-8dad-04c53af9ca15" />

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `toAssetId` behavior for native-address inputs on unsupported/custom EVM chains, now returning an `erc20:0x000...` CAIP asset ID instead of `undefined`, which could affect callers that previously treated this case as missing data.
> 
> **Overview**
> Fixes `toAssetId` so that when resolving a native address on an unsupported/custom chain and `getNativeAssetForChainId` errors/returns nothing, it no longer exits early and can fall back to generating an EVM `.../erc20:0x000...` asset ID (enabling downstream token/price lookups for custom networks).
> 
> Updates the unit test to assert the new fallback asset ID format instead of expecting `undefined` for unsupported chain IDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d48f7fec8fd002a8cbda553b4ca40a19b39e2bfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->