### PR TITLE
ci: more closing the Pattern Gap in the Merge Queue Retry system

### DIFF
--- a/.github/rules/retry-config.jsonc
+++ b/.github/rules/retry-config.jsonc
@@ -65,36 +65,40 @@
   // retryableOnTransientError job fails and its logs match any of these,
   // it will be marked jobRetryable=true.
   "transientErrorPatterns": [
-    "429 Too Many Requests",
-    "502 Bad Gateway",
-    "503 Service Unavailable",
-    "API rate limit exceeded",
-    "Anvil exited: Error: Address already in use",
-    "Authentication failed for",
-    "Could not resolve host",
-    "EAI_AGAIN",
-    "ECONNREFUSED",
-    "ECONNRESET",
-    "ENOTFOUND",
-    "ENOMEM",
-    "ESOCKETTIMEDOUT",
-    "ETIMEDOUT",
-    "Exceeded timeout of \\d+ ms for a test",
-    "fatal: unable to access",
-    "git.* failed with exit code 128",
-    "heap out of memory",
-    "JavaScript heap out of memory",
-    "net::ERR_",
-    "No space left on device",
-    "npm ERR! network",
-    "OOMKilled",
-    "read ECONNRESET",
-    "resource temporarily unavailable",
-    "socket hang up",
-    "vkCreateInstance failed with VK_ERROR_INCOMPATIBLE_DRIVER",
-    "VulkanError.cpp",
-    "write EPIPE",
-    "Yarn is terminating due to an unexpected empty event loop"
+    "429 Too Many Requests", // HTTP rate-limiting from npm registry, GitHub API, etc.
+    "500 Internal Server Error", // upstream server error (registry, API)
+    "502 Bad Gateway", // load-balancer/proxy failure between runner and upstream
+    "503 Service Unavailable", // upstream service temporarily down
+    "504 Gateway Time-out", // upstream timed out behind a proxy/LB
+    "API rate limit exceeded", // GitHub REST API rate limit
+    "Anvil exited: Error: Address already in use", // port collision starting Foundry local chain
+    "Authentication failed for", // transient git auth failure cloning repos
+    "Back off \\d+(\\.\\d+)? seconds before retry", // npm registry throttle (e.g. "Back off 16.402 seconds before retry")
+    "Command failed after \\d+ attempts", // Prepare dependencies: yarn install retries exhausted
+    "Could not resolve host", // DNS resolution failure
+    "EAI_AGAIN", // Node.js DNS lookup timed out
+    "ECONNREFUSED", // TCP connection refused (service not listening)
+    "ECONNRESET", // TCP connection reset by peer
+    "ENOTFOUND", // Node.js DNS name not found
+    "ENOMEM", // OS-level out-of-memory
+    "ESOCKETTIMEDOUT", // Node.js socket timeout (npm/yarn downloads)
+    "ETIMEDOUT", // TCP connection timed out
+    "Exceeded timeout of \\d+ ms for a test", // Jest test timeout (flaky slow test)
+    "fatal: unable to access", // git clone/fetch network failure
+    "git.* failed with exit code 128", // git op failed (auth, network, corrupt pack)
+    "heap out of memory", // V8 heap exhaustion (generic form)
+    "JavaScript heap out of memory", // Node.js OOM crash
+    "net::ERR_", // Chromium network errors in E2E (ERR_CONNECTION_REFUSED, etc.)
+    "No space left on device", // runner disk full
+    "npm ERR! network", // npm network failure
+    "OOMKilled", // Linux OOM killer terminated the process
+    "read ECONNRESET", // TCP read failure (more specific than ECONNRESET alone)
+    "resource temporarily unavailable", // file descriptor / process limit exhaustion
+    "socket hang up", // HTTP connection dropped mid-request
+    "vkCreateInstance failed with VK_ERROR_INCOMPATIBLE_DRIVER", // GPU driver issue on runner for headless Chrome
+    "VulkanError.cpp", // GPU driver crash in headless Chrome
+    "write EPIPE", // broken pipe — receiving process terminated
+    "Yarn is terminating due to an unexpected empty event loop" // Yarn bug: event loop drains unexpectedly mid-install
   ],
 
   // Patterns that indicate deterministic failures — errors that will never
@@ -102,12 +106,27 @@
   // Checked against annotations + log tail when no transient pattern matched
   // and the structural annotation check did not fire.
   "deterministicErrorPatterns": [
-    "BASELINE VIOLATIONS DETECTED",
-    "Code style issues found",
-    "NEW FILES \\(not in baseline\\)",
-    "Test Suites:.*failed",
-    "Working tree dirty",
-    "snapshots? failed",
-    "✖ \\d+ problems? \\("
+    "BASELINE VIOLATIONS DETECTED", // lint-baseline.mts: new violations added to already-baselined files
+    "Can't walk dependency graph", // Browserify build: broken import/require chain
+    "Cannot find module", // Node.js require/import of missing package or path
+    "Code style issues found", // oxlint --check or ESLint formatting rule failure
+    "compiled with \\d+ errors?", // Webpack build errors
+    "doesn't seem to be present in your lockfile", // Yarn: package missing from yarn.lock (needs `yarn install`)
+    "Error occurred when checking code style", // oxfmt parse error checking formatting
+    "Failed to build the preview", // Storybook: Webpack compilation error building story preview
+    "Format issues found in above \\d+ files", // Prettier or oxfmt --check: files need reformatting
+    "Invalid code fence parameters", // build: malformed code fence in source (BEGIN:, END:)
+    "LavaMoat - required node builtin package not in allowlist", // LavaMoat policy: dependency uses disallowed Node.js builtin
+    "Lint errors encountered for transformed file", // Browserify build: ESLint errors in post-transform output
+    "Module not found", // Webpack: import of nonexistent module
+    "no platform directories.*found in dist", // build verification: platform folders missing from output
+    "NEW FILES \\(not in baseline\\)", // lint-baseline.mts: new files with violations not yet baselined
+    "shellcheck reported issue", // actionlint/shellcheck: shell script issues in workflow YAML
+    "SyntaxError: Unexpected token", // JS/TS parse error (bad syntax in source)
+    "Test Suites:.*failed", // Jest summary line: one or more test suites failed
+    "Working tree dirty", // git working tree has uncommitted changes after a build/generate step
+    "snapshots? failed", // Jest snapshot assertion mismatch
+    "✖ failing tests:", // Node.js test runner (node --test) summary of failures
+    "✖ \\d+ problems? \\(" // ESLint summary: "✖ N problems (X errors, Y warnings)"
   ]
 }

--- a/.github/scripts/classify-failures.mts
+++ b/.github/scripts/classify-failures.mts
@@ -49,13 +49,14 @@
  *   - Sends a structured log to Sentry (when SENTRY_DSN_PERFORMANCE is set)
  */
 
-import { readFileSync, appendFileSync } from 'node:fs';
+import { appendFileSync, readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
-import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { parseArgs } from 'node:util';
-import { getGitHubToken } from './shared/github-token.mts';
 import { ghApi } from './shared/gh-api.mts';
+import { getGitHubToken } from './shared/github-token.mts';
+import { stripJsonComments } from './shared/json-tools.mts';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -214,22 +215,6 @@ async function flushSentry(
 // ---------------------------------------------------------------------------
 // Config
 // ---------------------------------------------------------------------------
-
-/**
- * Strip full-line // comments and trailing commas from JSONC for JSON.parse().
- *
- * Limitations (acceptable for our config file):
- *   - Does NOT handle // inside string values (no URLs in values).
- *   - Trailing-comma regex operates on full text, so ,] or ,} inside a
- *     string value would be corrupted. No current patterns contain these.
- */
-function stripJsonComments(jsonc: string): string {
-  return jsonc
-    .split('\n')
-    .filter((line) => !line.trim().startsWith('//'))
-    .join('\n')
-    .replace(/,\s*([\]}])/g, '$1');
-}
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const configPath = join(scriptDir, '..', 'rules', 'retry-config.jsonc');
@@ -472,15 +457,20 @@ function classifyJob(job: Job): JobClassification {
   // path + line number), this is a compiler/linter error — deterministic
   // by nature. This catches ALL TypeScript, ESLint, and Stylelint errors
   // without needing to enumerate every possible error message.
-  const sourceFileAnnotation = annotations.find(
-    (a) =>
-      a.path &&
-      a.path !== '.github' &&
-      a.start_line != null &&
-      a.start_line > 0 &&
-      a.message?.trim() &&
-      !/^Process completed with exit code \d+/.test(a.message.trim()),
-  );
+  // Prefer "failure"-level annotations over "warning"-level ones —
+  // warnings (e.g. React Hook missing dependency) don't cause the job
+  // to fail and shouldn't be reported as the root cause.
+  const isSourceAnnotation = (a: (typeof annotations)[number]) =>
+    a.path &&
+    a.path !== '.github' &&
+    a.start_line != null &&
+    a.start_line > 0 &&
+    a.message?.trim() &&
+    !/^Process completed with exit code \d+/.test(a.message.trim());
+  const sourceFileAnnotation =
+    annotations.find(
+      (a) => isSourceAnnotation(a) && a.annotation_level === 'failure',
+    ) ?? annotations.find(isSourceAnnotation);
   if (sourceFileAnnotation) {
     return {
       jobName,
@@ -488,8 +478,7 @@ function classifyJob(job: Job): JobClassification {
       category,
       jobRetryable: false,
       reason: `Deterministic: code error in ${sourceFileAnnotation.path}:${sourceFileAnnotation.start_line}`,
-      errorSnippet:
-        fallbackSnippet ?? sourceFileAnnotation.message!.trim().slice(0, 200),
+      errorSnippet: sourceFileAnnotation.message!.trim().slice(0, 200),
       unmatched,
       deterministic: true,
     };
@@ -507,7 +496,7 @@ function classifyJob(job: Job): JobClassification {
         category,
         jobRetryable: false,
         reason: `Deterministic: ${deterministicMatch[0]}`,
-        errorSnippet: fallbackSnippet ?? deterministicMatch[0],
+        errorSnippet: deterministicMatch[0],
         unmatched,
         deterministic: true,
       };
@@ -1028,8 +1017,17 @@ console.log('\n' + report);
 // ---------------------------------------------------------------------------
 // Create Check Run on the triggering commit
 //
-// TODO: This is untestable in a fork repo, and we won't really know if this works
-// until we merge it and see it run in the real repo.
+// This creates a "Triage and Retry System" check on the PR's Checks tab:
+//   - conclusion=neutral  → appears under "N neutral check(s)", visible
+//     separately from the 190+ successful checks.
+//   - conclusion=failure  → appears in the red "N failed check(s)" section
+//     at the top of the page.
+//
+// The check is attributed to "CLA Signature Bot" in the PR Checks tab
+// because GitHub groups check runs by app/check-suite, and the CLA bot's
+// suite appears to claim this check. Using a dedicated GitHub App token
+// instead of github.token might fix the attribution, but it's not worth
+// the extra workflow step just for cosmetics.
 // ---------------------------------------------------------------------------
 
 if (process.env.CI === 'true' && REPO === 'MetaMask/metamask-extension') {

--- a/.github/scripts/shared/json-tools.mts
+++ b/.github/scripts/shared/json-tools.mts
@@ -1,0 +1,51 @@
+/**
+ * json-tools.mts
+ *
+ * Minimal JSONC (JSON with Comments) parser.
+ * Zero npm dependencies — safe to import from dependency-free CI scripts.
+ *
+ * Supports:
+ *  - Full-line `// …` comments
+ *  - Inline `// …` comments (outside quoted strings)
+ *  - Trailing commas before `]` or `}`
+ *
+ * Does NOT support `/* … *​/` block comments.
+ */
+
+/**
+ * Strip `//` comments and trailing commas from a JSONC string so it
+ * can be passed to `JSON.parse()`.
+ */
+export function stripJsonComments(jsonc: string): string {
+  return jsonc
+    .split('\n')
+    .map((line) => {
+      // Remove full-line comments
+      if (line.trim().startsWith('//')) return '';
+      // Remove inline comments: find '//' outside of quoted strings.
+      // Walk through the line tracking whether we're inside a string.
+      let inString = false;
+      let escaped = false;
+      for (let i = 0; i < line.length; i++) {
+        const ch = line[i];
+        if (escaped) {
+          escaped = false;
+          continue;
+        }
+        if (ch === '\\') {
+          escaped = true;
+          continue;
+        }
+        if (ch === '"') {
+          inString = !inString;
+          continue;
+        }
+        if (!inString && ch === '/' && line[i + 1] === '/') {
+          return line.slice(0, i);
+        }
+      }
+      return line;
+    })
+    .join('\n')
+    .replace(/,\s*([\]}])/g, '$1');
+}


### PR DESCRIPTION
## **Description**

1. **New patterns** — Added a lot of `transientErrorPatterns` and `deterministicErrorPatterns` to `retry-config.jsonc`, put comments on every line (wooo JSONC!)
1. **Extract `stripJsonComments` to shared module** — moved to `json-tools.mts`
2. **Prefer failure-level annotations** — source-file annotation lookup now picks `annotation_level === 'failure'` first, falling back to any level (avoids reporting a warning as the root cause)
3. **Fix errorSnippet priority** — deterministic/annotation matches now report their own matched text instead of falling through to the log-tail fallback (which produced junk snippets like `error: [Subject].`)

## **Changelog**

CHANGELOG entry: null

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**
[skip-e2e]-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI retry classification logic and its pattern config; mistakes could cause incorrect auto-retry decisions or misleading root-cause snippets, but changes are localized to GitHub Actions tooling.
> 
> **Overview**
> Expands `retry-config.jsonc` with a larger, commented set of **transient** and **deterministic** failure patterns to better classify flaky infra/network issues vs. true code failures.
> 
> Updates `classify-failures.mts` to (1) use a shared JSONC helper (`stripJsonComments`) from a new `shared/json-tools.mts` module, (2) prefer `annotation_level === "failure"` when selecting source-file annotations, and (3) ensure deterministic matches report their own `errorSnippet` instead of falling back to log-tail heuristics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 319d62b02b80e8cdfefd4cfd2f629fc48ac62e0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->