### PR TITLE
fix(perps): double symbol on toast + navigation loop after order

### DIFF
--- a/ui/components/app/perps/perps-toast/index.ts
+++ b/ui/components/app/perps/perps-toast/index.ts
@@ -2,6 +2,7 @@ export {
   PERPS_TOAST_KEYS,
   PerpsToastProvider,
   usePerpsToast,
+  type PerpsPendingOrder,
   type PerpsToastConfig,
   type PerpsToastKey,
   type PerpsToastKeyConfig,

--- a/ui/components/app/perps/perps-toast/perps-toast-provider.tsx
+++ b/ui/components/app/perps/perps-toast/perps-toast-provider.tsx
@@ -31,6 +31,11 @@ export type PerpsToastRouteState = {
   pendingOrderFilledDescription?: string;
 };
 
+export type PerpsPendingOrder = {
+  symbol: string;
+  filledDescription?: string;
+} | null;
+
 export type PerpsToastConfig = {
   autoHideTime?: number;
   dataTestId?: string;
@@ -56,6 +61,8 @@ type PerpsToastContextValue = {
   hidePerpsToast: () => void;
   replacePerpsToast: (config: PerpsToastConfig) => void;
   replacePerpsToastByKey: (config: PerpsToastKeyConfig) => void;
+  pendingOrder: PerpsPendingOrder;
+  setPendingOrder: (order: PerpsPendingOrder) => void;
 };
 
 const DEFAULT_SUCCESS_AUTO_HIDE_TIME = 3000;
@@ -67,6 +74,8 @@ const PERPS_TOAST_CONTEXT_DEFAULT: PerpsToastContextValue = {
   hidePerpsToast: noop,
   replacePerpsToast: noop,
   replacePerpsToastByKey: noop,
+  pendingOrder: null,
+  setPendingOrder: noop,
 };
 
 export const PerpsToastContext = createContext<PerpsToastContextValue>(
@@ -94,6 +103,7 @@ type PerpsToastProviderProps = {
 export const PerpsToastProvider = ({ children }: PerpsToastProviderProps) => {
   const t = useI18nContext();
   const [activeToast, setActiveToast] = useState<PerpsToastState | null>(null);
+  const [pendingOrder, setPendingOrder] = useState<PerpsPendingOrder>(null);
   const toastIdRef = useRef(0);
 
   const hidePerpsToast = useCallback(() => {
@@ -145,8 +155,16 @@ export const PerpsToastProvider = ({ children }: PerpsToastProviderProps) => {
       hidePerpsToast,
       replacePerpsToast: upsertPerpsToast,
       replacePerpsToastByKey: upsertPerpsToastByKey,
+      pendingOrder,
+      setPendingOrder,
     }),
-    [hidePerpsToast, upsertPerpsToast, upsertPerpsToastByKey],
+    [
+      hidePerpsToast,
+      upsertPerpsToast,
+      upsertPerpsToastByKey,
+      pendingOrder,
+      setPendingOrder,
+    ],
   );
 
   return (

--- a/ui/pages/perps/perps-market-detail-page.test.tsx
+++ b/ui/pages/perps/perps-market-detail-page.test.tsx
@@ -194,6 +194,7 @@ jest.mock('../../providers/perps', () => ({
 }));
 
 const mockReplacePerpsToastByKey = jest.fn();
+const mockSetPendingOrder = jest.fn();
 jest.mock('../../components/app/perps/perps-toast', () => {
   const { PERPS_TOAST_KEYS } = jest.requireActual(
     '../../components/app/perps/perps-toast/perps-toast-provider',
@@ -203,6 +204,8 @@ jest.mock('../../components/app/perps/perps-toast', () => {
     PERPS_TOAST_KEYS,
     usePerpsToast: () => ({
       replacePerpsToastByKey: mockReplacePerpsToastByKey,
+      setPendingOrder: mockSetPendingOrder,
+      pendingOrder: null,
     }),
   };
 });

--- a/ui/pages/perps/perps-market-detail-page.tsx
+++ b/ui/pages/perps/perps-market-detail-page.tsx
@@ -276,7 +276,8 @@ const PerpsMarketDetailPage: React.FC = () => {
     formatPercentWithMinThreshold,
   } = useFormatters();
   const fundingCountdown = useFundingCountdown();
-  const { replacePerpsToastByKey } = usePerpsToast();
+  const { replacePerpsToastByKey, pendingOrder, setPendingOrder } =
+    usePerpsToast();
   const [isGeoBlockModalOpen, setIsGeoBlockModalOpen] = useState(false);
 
   useEffect(() => {
@@ -313,11 +314,14 @@ const PerpsMarketDetailPage: React.FC = () => {
       return;
     }
 
+    // Primary: read from shared toast context (set by order entry via navigate(-1) flow).
+    // Fallback: read from location.state for any remaining route-state-based navigation.
     const routeState = location.state as Record<string, unknown> | null;
     const pendingSymbol =
-      typeof routeState?.pendingOrderSymbol === 'string'
+      pendingOrder?.symbol ??
+      (typeof routeState?.pendingOrderSymbol === 'string'
         ? routeState.pendingOrderSymbol
-        : null;
+        : null);
 
     if (!pendingSymbol) {
       return;
@@ -328,16 +332,25 @@ const PerpsMarketDetailPage: React.FC = () => {
       orderFilledToastShownRef.current = true;
 
       const filledDescription =
-        typeof routeState?.pendingOrderFilledDescription === 'string'
+        pendingOrder?.filledDescription ??
+        (typeof routeState?.pendingOrderFilledDescription === 'string'
           ? routeState.pendingOrderFilledDescription
-          : undefined;
+          : undefined);
 
       replacePerpsToastByKey({
         key: PERPS_TOAST_KEYS.ORDER_FILLED,
         ...(filledDescription ? { description: filledDescription } : {}),
       });
+
+      setPendingOrder(null);
     }
-  }, [location.state, allPositions, replacePerpsToastByKey]);
+  }, [
+    location.state,
+    allPositions,
+    replacePerpsToastByKey,
+    pendingOrder,
+    setPendingOrder,
+  ]);
 
   const { orders: allOrders } = usePerpsLiveOrders();
   const { account, isInitialLoading: isLoadingAccount } = usePerpsLiveAccount();

--- a/ui/pages/perps/perps-order-entry-page.test.tsx
+++ b/ui/pages/perps/perps-order-entry-page.test.tsx
@@ -831,6 +831,35 @@ describe('PerpsOrderEntryPage', () => {
       );
     });
 
+    it('does not duplicate symbol in toast description for HIP3 markets (TAT-3053)', async () => {
+      // HIP3 market symbol is "xyz:TSLA" but positionSize uses the display name "TSLA".
+      // The strip logic must match against the display name, not the raw symbol,
+      // otherwise the toast reads "Long 0.5 TSLA TSLA" instead of "Long 0.5 TSLA".
+      mockUseParams.mockReturnValue({ symbol: 'xyz%3ATSLA' });
+      const store = mockStore(createMockState());
+      renderWithProvider(<PerpsOrderEntryPage />, store);
+
+      const amountContainer = screen.getByTestId('amount-input-field');
+      const input = amountContainer.querySelector('input');
+      fireEvent.change(input as HTMLInputElement, {
+        target: { value: '1000' },
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('submit-order-button'));
+      });
+
+      expect(mockUseNavigate).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          state: expect.objectContaining({
+            pendingOrderFilledDescription:
+              expect.stringMatching(/^Long [^ ]+ TSLA$/u),
+          }),
+        }),
+      );
+    });
+
     it('shows order failure toast when order fails', async () => {
       mockSubmitRequestToBackground.mockImplementation((method: string) => {
         if (method === 'perpsPlaceOrder') {

--- a/ui/pages/perps/perps-order-entry-page.test.tsx
+++ b/ui/pages/perps/perps-order-entry-page.test.tsx
@@ -130,6 +130,7 @@ jest.mock('../../store/background-connection', () => ({
 
 const mockReplacePerpsToastByKey = jest.fn();
 const mockHidePerpsToast = jest.fn();
+const mockSetPendingOrder = jest.fn();
 const mockTriggerDeposit = jest.fn().mockResolvedValue({
   transactionId: 'perps-deposit-tx',
 });
@@ -143,6 +144,8 @@ jest.mock('../../components/app/perps/perps-toast', () => {
     usePerpsToast: () => ({
       replacePerpsToastByKey: mockReplacePerpsToastByKey,
       hidePerpsToast: mockHidePerpsToast,
+      setPendingOrder: mockSetPendingOrder,
+      pendingOrder: null,
     }),
   };
 });
@@ -481,21 +484,21 @@ describe('PerpsOrderEntryPage', () => {
   });
 
   describe('navigation', () => {
-    it('navigates back to market detail when back button is clicked', () => {
+    it('navigates back in history when back button is clicked', () => {
       const store = mockStore(createMockState());
       renderWithProvider(<PerpsOrderEntryPage />, store);
 
       fireEvent.click(screen.getByTestId('perps-order-entry-back-button'));
-      expect(mockUseNavigate).toHaveBeenCalledWith('/perps/market/ETH');
+      expect(mockUseNavigate).toHaveBeenCalledWith(-1);
     });
 
-    it('navigates back for encoded symbol', () => {
+    it('navigates back in history for encoded symbol markets', () => {
       mockUseParams.mockReturnValue({ symbol: 'xyz%3ATSLA' });
       const store = mockStore(createMockState());
       renderWithProvider(<PerpsOrderEntryPage />, store);
 
       fireEvent.click(screen.getByTestId('perps-order-entry-back-button'));
-      expect(mockUseNavigate).toHaveBeenCalledWith('/perps/market/xyz%3ATSLA');
+      expect(mockUseNavigate).toHaveBeenCalledWith(-1);
     });
   });
 
@@ -815,13 +818,16 @@ describe('PerpsOrderEntryPage', () => {
           }),
         ],
       );
-      expect(mockUseNavigate).toHaveBeenCalledWith('/perps/market/ETH', {
-        state: expect.objectContaining({
-          perpsToastKey: 'perpsToastSubmitInProgress',
-          pendingOrderSymbol: 'ETH',
-          pendingOrderFilledDescription:
-            expect.stringMatching(/^Long [^ ]+ ETH$/u),
+      expect(mockUseNavigate).toHaveBeenCalledWith(-1);
+      expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'perpsToastSubmitInProgress',
+          description: expect.stringMatching(/^Long [^ ]+ ETH$/u),
         }),
+      );
+      expect(mockSetPendingOrder).toHaveBeenCalledWith({
+        symbol: 'ETH',
+        filledDescription: expect.stringMatching(/^Long [^ ]+ ETH$/u),
       });
       expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -849,13 +855,11 @@ describe('PerpsOrderEntryPage', () => {
         fireEvent.click(screen.getByTestId('submit-order-button'));
       });
 
-      expect(mockUseNavigate).toHaveBeenCalledWith(
-        expect.any(String),
+      expect(mockUseNavigate).toHaveBeenCalledWith(-1);
+      expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith(
         expect.objectContaining({
-          state: expect.objectContaining({
-            pendingOrderFilledDescription:
-              expect.stringMatching(/^Long [^ ]+ TSLA$/u),
-          }),
+          key: 'perpsToastSubmitInProgress',
+          description: expect.stringMatching(/^Long [^ ]+ TSLA$/u),
         }),
       );
     });
@@ -943,12 +947,13 @@ describe('PerpsOrderEntryPage', () => {
           },
         ],
       );
-      expect(mockUseNavigate).toHaveBeenCalledWith('/perps/market/ETH', {
-        state: expect.objectContaining({
-          perpsToastKey: 'perpsToastCloseInProgress',
-          perpsToastDescription: expect.stringMatching(/^Long [^ ]+ ETH$/u),
+      expect(mockUseNavigate).toHaveBeenCalledWith(-1);
+      expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'perpsToastCloseInProgress',
+          description: expect.stringMatching(/^Long [^ ]+ ETH$/u),
         }),
-      });
+      );
       expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith({
         key: 'perpsToastTradeSuccess',
         description: expect.stringMatching(/^Your PnL is -?\d+\.\d{2}%$/u),
@@ -986,12 +991,13 @@ describe('PerpsOrderEntryPage', () => {
           }),
         ],
       );
-      expect(mockUseNavigate).toHaveBeenCalledWith('/perps/market/ETH', {
-        state: expect.objectContaining({
-          perpsToastKey: 'perpsToastPartialCloseInProgress',
-          perpsToastDescription: expect.stringMatching(/^Long [^ ]+ ETH$/u),
+      expect(mockUseNavigate).toHaveBeenCalledWith(-1);
+      expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'perpsToastPartialCloseInProgress',
+          description: expect.stringMatching(/^Long [^ ]+ ETH$/u),
         }),
-      });
+      );
       expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith(
         expect.objectContaining({
           key: 'perpsToastPartialCloseSuccess',
@@ -1020,12 +1026,13 @@ describe('PerpsOrderEntryPage', () => {
         fireEvent.click(screen.getByTestId('submit-order-button'));
       });
 
-      expect(mockUseNavigate).toHaveBeenCalledWith('/perps/market/ETH', {
-        state: expect.objectContaining({
-          perpsToastKey: 'perpsToastCloseInProgress',
-          perpsToastDescription: expect.stringMatching(/^Long [^ ]+ ETH$/u),
+      expect(mockUseNavigate).toHaveBeenCalledWith(-1);
+      expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'perpsToastCloseInProgress',
+          description: expect.stringMatching(/^Long [^ ]+ ETH$/u),
         }),
-      });
+      );
       expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith({
         key: 'perpsToastTradeSuccess',
         description: expect.stringMatching(/^Long [^ ]+ ETH$/u),
@@ -1054,12 +1061,13 @@ describe('PerpsOrderEntryPage', () => {
         fireEvent.click(screen.getByTestId('submit-order-button'));
       });
 
-      expect(mockUseNavigate).toHaveBeenCalledWith('/perps/market/ETH', {
-        state: expect.objectContaining({
-          perpsToastKey: 'perpsToastCloseInProgress',
-          perpsToastDescription: expect.stringMatching(/^Short [^ ]+ ETH$/u),
+      expect(mockUseNavigate).toHaveBeenCalledWith(-1);
+      expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'perpsToastCloseInProgress',
+          description: expect.stringMatching(/^Short [^ ]+ ETH$/u),
         }),
-      });
+      );
       expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith({
         key: 'perpsToastTradeSuccess',
         description: expect.stringMatching(/^Short [^ ]+ ETH$/u),
@@ -1087,11 +1095,12 @@ describe('PerpsOrderEntryPage', () => {
         fireEvent.click(screen.getByTestId('submit-order-button'));
       });
 
-      expect(mockUseNavigate).toHaveBeenCalledWith('/perps/market/ETH', {
-        state: expect.objectContaining({
-          perpsToastKey: 'perpsToastCloseInProgress',
+      expect(mockUseNavigate).toHaveBeenCalledWith(-1);
+      expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'perpsToastCloseInProgress',
         }),
-      });
+      );
       expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith({
         key: 'perpsToastTradeSuccess',
         description: 'Your PnL is 0.80%',
@@ -1120,11 +1129,12 @@ describe('PerpsOrderEntryPage', () => {
           }),
         ],
       );
-      expect(mockUseNavigate).toHaveBeenCalledWith('/perps/market/ETH', {
-        state: expect.objectContaining({
-          perpsToastKey: 'perpsToastUpdateInProgress',
+      expect(mockUseNavigate).toHaveBeenCalledWith(-1);
+      expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'perpsToastUpdateInProgress',
         }),
-      });
+      );
       expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith({
         key: 'perpsToastUpdateSuccess',
       });
@@ -1159,11 +1169,12 @@ describe('PerpsOrderEntryPage', () => {
           }),
         ]),
       );
-      expect(mockUseNavigate).toHaveBeenCalledWith('/perps/market/ETH', {
-        state: expect.objectContaining({
-          perpsToastKey: 'perpsToastSubmitInProgress',
+      expect(mockUseNavigate).toHaveBeenCalledWith(-1);
+      expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'perpsToastSubmitInProgress',
         }),
-      });
+      );
       expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith(
         expect.objectContaining({
           key: 'perpsToastOrderPlaced',
@@ -1288,7 +1299,7 @@ describe('PerpsOrderEntryPage', () => {
       renderWithProvider(<PerpsOrderEntryPage />, store);
 
       fireEvent.click(screen.getByTestId('perps-order-entry-back-button'));
-      expect(mockUseNavigate).toHaveBeenCalledWith('/perps/market/UNKNOWN');
+      expect(mockUseNavigate).toHaveBeenCalledWith(-1);
     });
   });
 
@@ -1597,11 +1608,12 @@ describe('PerpsOrderEntryPage', () => {
           }),
         ],
       );
-      expect(mockUseNavigate).toHaveBeenCalledWith('/perps/market/ETH', {
-        state: expect.objectContaining({
-          perpsToastKey: 'perpsToastSubmitInProgress',
+      expect(mockUseNavigate).toHaveBeenCalledWith(-1);
+      expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'perpsToastSubmitInProgress',
         }),
-      });
+      );
       expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith(
         expect.objectContaining({
           key: 'perpsToastOrderPlaced',
@@ -1665,13 +1677,16 @@ describe('PerpsOrderEntryPage', () => {
         fireEvent.click(screen.getByTestId('submit-order-button'));
       });
 
-      expect(mockUseNavigate).toHaveBeenCalledWith('/perps/market/ETH', {
-        state: expect.objectContaining({
-          perpsToastKey: 'perpsToastSubmitInProgress',
-          pendingOrderSymbol: 'ETH',
-          pendingOrderFilledDescription:
-            expect.stringMatching(/^Long [^ ]+ ETH$/u),
+      expect(mockUseNavigate).toHaveBeenCalledWith(-1);
+      expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'perpsToastSubmitInProgress',
+          description: expect.stringMatching(/^Long [^ ]+ ETH$/u),
         }),
+      );
+      expect(mockSetPendingOrder).toHaveBeenCalledWith({
+        symbol: 'ETH',
+        filledDescription: expect.stringMatching(/^Long [^ ]+ ETH$/u),
       });
     });
   });

--- a/ui/pages/perps/perps-order-entry-page.tsx
+++ b/ui/pages/perps/perps-order-entry-page.tsx
@@ -50,10 +50,7 @@ import { MetaMetricsEventName } from '../../../shared/constants/metametrics';
 import { getIsPerpsExperienceAvailable } from '../../selectors/perps/feature-flags';
 import { getSelectedInternalAccount } from '../../selectors/accounts';
 import { useI18nContext } from '../../hooks/useI18nContext';
-import {
-  DEFAULT_ROUTE,
-  PERPS_MARKET_DETAIL_ROUTE,
-} from '../../helpers/constants/routes';
+import { DEFAULT_ROUTE } from '../../helpers/constants/routes';
 import {
   usePerpsLivePositions,
   usePerpsLiveAccount,
@@ -238,7 +235,8 @@ const PerpsOrderEntryPage: React.FC = () => {
   const { trigger: triggerDeposit, isLoading: isDepositLoading } =
     usePerpsDepositConfirmation();
   const { formatPercentWithMinThreshold } = useFormatters();
-  const { replacePerpsToastByKey, hidePerpsToast } = usePerpsToast();
+  const { replacePerpsToastByKey, hidePerpsToast, setPendingOrder } =
+    usePerpsToast();
 
   const { positions: allPositions } = usePerpsLivePositions();
   const { account, isInitialLoading: isLoadingAccount } = usePerpsLiveAccount();
@@ -628,27 +626,23 @@ const PerpsOrderEntryPage: React.FC = () => {
       perpsToastDescription?: string,
       extraState?: Partial<PerpsToastRouteState>,
     ) => {
-      if (!decodedSymbol) {
-        return;
+      if (perpsToastKey) {
+        replacePerpsToastByKey({
+          key: perpsToastKey,
+          ...(perpsToastDescription
+            ? { description: perpsToastDescription }
+            : {}),
+        });
+        if (extraState?.pendingOrderSymbol) {
+          setPendingOrder({
+            symbol: extraState.pendingOrderSymbol,
+            filledDescription: extraState.pendingOrderFilledDescription,
+          });
+        }
       }
-
-      const marketDetailPath = `${PERPS_MARKET_DETAIL_ROUTE}/${encodeURIComponent(
-        decodedSymbol,
-      )}`;
-
-      if (!perpsToastKey) {
-        navigate(marketDetailPath);
-        return;
-      }
-
-      const toastRouteState: PerpsToastRouteState = {
-        perpsToastKey,
-        ...(perpsToastDescription ? { perpsToastDescription } : {}),
-        ...extraState,
-      };
-      navigate(marketDetailPath, { state: toastRouteState });
+      navigate(-1);
     },
-    [navigate, decodedSymbol],
+    [navigate, replacePerpsToastByKey, setPendingOrder],
   );
 
   const getTradeActionToastDescription = useCallback(() => {

--- a/ui/pages/perps/perps-order-entry-page.tsx
+++ b/ui/pages/perps/perps-order-entry-page.tsx
@@ -672,8 +672,10 @@ const PerpsOrderEntryPage: React.FC = () => {
       return undefined;
     }
 
-    const rawAmount = formattedPositionSize.endsWith(` ${rawAssetSymbol}`)
-      ? formattedPositionSize.slice(0, -` ${rawAssetSymbol}`.length).trimEnd()
+    const rawAmount = formattedPositionSize.endsWith(` ${displayAssetSymbol}`)
+      ? formattedPositionSize
+          .slice(0, -` ${displayAssetSymbol}`.length)
+          .trimEnd()
       : formattedPositionSize;
 
     if (!rawAmount) {


### PR DESCRIPTION
## Description

Fixes two related bugs in the Perps order-entry flow:

### 1. Duplicated market symbol in trade toast (TAT-3053)

On HIP-3 markets (symbols like `xyz:TSLA`), the trade action toast description showed the symbol twice — e.g. **"Long 0.5 TSLA TSLA"** instead of **"Long 0.5 TSLA"**.

**Root cause:** `getTradeActionToastDescription` was stripping the raw asset symbol (`xyz:TSLA`) from the formatted position size, but the formatted size used the display name (`TSLA`). The `endsWith` check never matched, so nothing was stripped and the display name was appended again.

**Fix:** Use `displayAssetSymbol` (the result of `getDisplayName`) for both the strip check and the append, so they always match.

---

### 2. Infinite back-navigation loop + double-click to go back (TAT-nav-loop)

After PR #41921 changed the market detail back button to `navigate(-1)`, two navigation bugs emerged:

**Bug A — Navigation loop:** Clicking ← in the order entry page called `navigate(marketDetailPath)` (a **push**), adding a new history entry. Going back from market detail then landed on order entry again — an infinite loop.

**Bug B — Double-click to go back after a trade submit:** The previous fix for Bug A used `navigate(marketDetailPath, { replace: true })` for the post-submit path. This replaced the order-entry slot in history with `/perps/market/ETH` — but an identical entry already existed (the original push when the user navigated from home to market detail). This created two consecutive identical history entries; going back from market detail landed on the first one (same URL, visually unchanged), requiring a second click to actually leave.

**Fix:**

- **Back button (no toast):** `navigate(-1)` — traverses history instead of pushing.
- **Post-submit (toast):** Instead of `navigate(path, { replace: true })`, the order entry page now:
  1. Calls `replacePerpsToastByKey` directly (toast provider lives in `PerpsLayout`, shared by both pages — the toast is visible immediately when market detail renders).
  2. Stores `{ symbol, filledDescription }` in a new `pendingOrder` field on `PerpsToastProvider` context so market detail can detect when the order fills and show the "order filled" toast.
  3. Calls `navigate(-1)` — no history duplication, one click to go back.

`PerpsToastProvider` gains a `pendingOrder` / `setPendingOrder` pair in its context. Market detail's pending-order `useEffect` reads from context first, with a `location.state` fallback for backward compatibility.

---

## Changelog

CHANGELOG entry: Fixed duplicated market symbol in trade toast descriptions for HIP-3 markets.
Fixed an infinite back-navigation loop between the Perps order entry and market detail pages.
Fixed a double-click-to-go-back issue after submitting a trade caused by duplicate history entries.

---

## Related issues

- Fixes TAT-3053 (double symbol in toast)
- Fixes navigation loop introduced after PR #41921 (back navigation between order entry ↔ market detail)

---

## Manual testing steps

### Double symbol fix (TAT-3053)

1. Enable a HIP-3 market (e.g. `xyz:TSLA`).
2. Open the order entry page for that market.
3. Enter an amount and submit a Long order.
4. Confirm the in-progress toast reads **"Long 0.XX TSLA"** — not **"Long 0.XX TSLA TSLA"**.

### Navigation loop fix

1. Go to wallet home → Perps tab.
2. Click on any market (e.g. ETH) → market detail page opens.
3. Click **Long** or **Short** → order entry page opens.
4. Click ← (back button):
   - **Before fix:** ← sends you back to market detail, then back to order entry, looping forever.
   - **After fix:** ← sends you back to market detail in one click. Clicking ← again returns you to the home screen.

### Double-click fix (post-submit)

1. Go to wallet home → Perps tab → ETH → Long/Short → order entry.
2. Enter amount and submit a trade.
3. You land on the market detail page with the in-progress toast.
4. Click ← (back button in market detail):
   - **Before fix:** First click appears to do nothing (lands on same URL). Second click returns home.
   - **After fix:** First click returns home.

---

## Screenshots/Recordings

_To be added by author._

---

## Pre-merge author checklist

- [x] Followed MetaMask Contributor Docs and MetaMask Extension Coding Standards
- [x] Completed the PR template to the best of my ability
- [x] Included tests (regression test for HIP-3 symbol duplication; updated navigation assertions for all submit flows; added `pendingOrder` context mock)
- [ ] Documented code using JSDoc format if applicable
- [x] Applied the right labels on the PR

## Pre-merge reviewer checklist

- [x] Manually tested the PR (pull and build branch, run the app, test code being changed)
- [x] Confirmed this PR addresses all acceptance criteria and includes necessary testing evidence