### PR TITLE
ci: find reusable builds from merge commit instead of PR head

### DIFF
--- a/.github/workflows/get-requirements.yml
+++ b/.github/workflows/get-requirements.yml
@@ -191,28 +191,6 @@ jobs:
             core.setOutput('build-hash', buildHash);
             core.info(`-> Build-source hash: ${buildHash}`);
 
-      # Post the hash as a commit status so future runs can look it up by SHA.
-      # This is an optimization for future runs — failure must not block current CI.
-      - name: Post build-source-hash commit status
-        if: ${{ steps.compute-build-hash.outputs.build-hash }}
-        continue-on-error: true
-        uses: actions/github-script@v8
-        env:
-          BUILD_HASH: ${{ steps.compute-build-hash.outputs.build-hash }}
-          HEAD_COMMIT_HASH: ${{ env.HEAD_COMMIT_HASH }}
-        with:
-          script: |
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: process.env.HEAD_COMMIT_HASH,
-              state: 'success',
-              context: 'build-source-hash',
-              description: process.env.BUILD_HASH,
-              target_url: `${process.env.GITHUB_SERVER_URL}/${context.repo.owner}/${context.repo.repo}/actions/runs/${process.env.RUN_ID}`,
-            });
-            core.info(`Posted build-source-hash: ${process.env.BUILD_HASH}`);
-
       # Check for build override tags in commit message or PR labels.
       # [force-builds] / force-builds label → always build fresh.
       # [skip-builds] / skip-builds label → always reuse from base branch (skip hash check).
@@ -362,6 +340,31 @@ jobs:
             } catch (err) {
               core.warning(`Build reuse lookup failed: ${err.message}. Builds will run fresh.`);
             }
+
+      # Post the hash as a commit status so future runs can look it up by SHA.
+      # This must run AFTER "Find reusable builds" to avoid self-poisoning:
+      # getCombinedStatusForRef returns only the latest status per context, so
+      # posting first would overwrite a prior run's hash on the same PR head SHA,
+      # causing the finder to see our own hash and incorrectly match a stale build.
+      - name: Post build-source-hash commit status
+        if: ${{ steps.compute-build-hash.outputs.build-hash }}
+        continue-on-error: true
+        uses: actions/github-script@v8
+        env:
+          BUILD_HASH: ${{ steps.compute-build-hash.outputs.build-hash }}
+          HEAD_COMMIT_HASH: ${{ env.HEAD_COMMIT_HASH }}
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: process.env.HEAD_COMMIT_HASH,
+              state: 'success',
+              context: 'build-source-hash',
+              description: process.env.BUILD_HASH,
+              target_url: `${process.env.GITHUB_SERVER_URL}/${context.repo.owner}/${context.repo.repo}/actions/runs/${process.env.RUN_ID}`,
+            });
+            core.info(`Posted build-source-hash: ${process.env.BUILD_HASH}`);
 
       - id: filter
         if: ${{ steps.check-skip-merge-queue.outputs.up-to-date != 'true' }}

--- a/.github/workflows/get-requirements.yml
+++ b/.github/workflows/get-requirements.yml
@@ -107,9 +107,10 @@ jobs:
 
       # Compute a content hash of all build-affecting source files.
       # Used to detect when builds can be reused from a prior run.
-      # IMPORTANT: We hash from HEAD_COMMIT_HASH (the PR head), not the merge
-      # commit that actions/checkout creates. This ensures the hash is stable
-      # across pushes even when the base branch advances.
+      # IMPORTANT: We hash from GITHUB_SHA (the merge commit for PRs, the
+      # pushed commit for pushes). This ensures the hash captures the merged
+      # tree that will actually be built and tested, so builds are never
+      # reused when the base branch has gained build-affecting changes.
       #
       # Uses a DENYLIST approach: we exclude paths known NOT to affect builds.
       # This is safer than an allowlist — if a new build-affecting file is
@@ -152,7 +153,7 @@ jobs:
             const eslintPattern = /^\.eslintrc(\.[a-z.-]+)?\.js$/;
 
             const { stdout: tree } = await exec.getExecOutput(
-              'git', ['ls-tree', '-r', process.env.HEAD_COMMIT_HASH],
+              'git', ['ls-tree', '-r', 'HEAD'],
               { silent: true },
             );
             const kept = tree.split('\n').filter(line => {
@@ -175,7 +176,7 @@ jobs:
             // the build-command values it passes to run-build.yml DO affect
             // output. Extract and sort them so only command changes bust the hash.
             const { stdout: mainYml } = await exec.getExecOutput(
-              'git', ['show', `${process.env.HEAD_COMMIT_HASH}:.github/workflows/main.yml`],
+              'git', ['show', `HEAD:.github/workflows/main.yml`],
               { silent: true },
             );
             const buildCommands = (mainYml.match(/build-command: .+/g) ?? [])


### PR DESCRIPTION
## **Description**

Fixes the problem seen in this run, https://github.com/MetaMask/metamask-extension/actions/runs/24776297620/job/72495504369, where a migration hit branch `main` and the E2E dist tests started failing.

Now computing the build hash from the merge ref instead of the PR head.

## **Changelog**

CHANGELOG entry: null

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI build-reuse logic and commit-status ordering; mistakes could cause stale artifacts to be reused or force unnecessary rebuilds across PRs.
> 
> **Overview**
> Updates `get-requirements.yml` so the build-source hash is computed from the checked-out `HEAD` (the PR merge commit / push SHA) rather than the PR head SHA, preventing reuse when the base branch introduces build-affecting changes.
> 
> Moves posting of the `build-source-hash` commit status to *after* the reusable-build lookup to avoid overwriting a prior run’s status on the same SHA and incorrectly matching against stale builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 107aeb00d1eeee07e868ee6e551135434a9792e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->