### PR TITLE
chore: land fallback transaction on activity tab

### DIFF
--- a/app/scripts/messenger-client-init/confirmations/transaction-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/confirmations/transaction-controller-init.test.ts
@@ -3,6 +3,12 @@ import { NetworkController } from '@metamask/network-controller';
 import { it as jestIt } from '@jest/globals';
 import { ORIGIN_METAMASK } from '@metamask/controller-utils';
 import {
+  ActionConstraint,
+  Messenger,
+  MockAnyNamespace,
+  MOCK_ANY_NAMESPACE,
+} from '@metamask/messenger';
+import {
   TransactionMeta,
   TransactionType,
   TransactionController,
@@ -14,6 +20,8 @@ import {
   PublishBatchHookTransaction,
 } from '@metamask/transaction-controller';
 import { TransactionPayPublishHook } from '@metamask/transaction-pay-controller';
+import type { AccountOverviewTabKey } from '../../../../shared/constants/app-state';
+import type { AppStateControllerSetDefaultHomeActiveTabNameAction } from '../../controllers/app-state-controller-method-action-types';
 import {
   getTransactionControllerInitMessenger,
   getTransactionControllerMessenger,
@@ -65,15 +73,25 @@ function buildInitRequestMock(): jest.Mocked<
     TransactionControllerInitMessenger
   >
 > {
-  const baseControllerMessenger = getRootMessenger();
+  const baseControllerMessenger = new Messenger<
+    MockAnyNamespace,
+    AppStateControllerSetDefaultHomeActiveTabNameAction | ActionConstraint,
+    never
+  >({
+    namespace: MOCK_ANY_NAMESPACE,
+  });
+  baseControllerMessenger.registerActionHandler(
+    'AppStateController:setDefaultHomeActiveTabName',
+    (_defaultHomeActiveTabName: AccountOverviewTabKey | null) => undefined,
+  );
 
   const requestMock = {
     ...buildControllerInitRequestMock(),
     controllerMessenger: getTransactionControllerMessenger(
-      baseControllerMessenger,
+      baseControllerMessenger as never,
     ),
     initMessenger: getTransactionControllerInitMessenger(
-      baseControllerMessenger,
+      baseControllerMessenger as never,
     ),
   };
 

--- a/app/scripts/messenger-client-init/confirmations/transaction-controller-init.ts
+++ b/app/scripts/messenger-client-init/confirmations/transaction-controller-init.ts
@@ -18,6 +18,7 @@ import {
   TransactionPayPublishHook,
 } from '@metamask/transaction-pay-controller';
 import { Hex } from '@metamask/utils';
+import { AccountOverviewTabKey } from '../../../../shared/constants/app-state';
 import { trace } from '../../../../shared/lib/trace';
 import { hasTransactionType } from '../../../../shared/lib/transactions.utils';
 import { getIsSmartTransaction } from '../../../../shared/lib/selectors';
@@ -447,11 +448,13 @@ export async function publishHook({
     transactionMeta.txParams?.from,
     keyringController,
   );
+  let attemptedHook = false;
 
   if (
     keyringSupports7702 &&
     (!isSmartTransaction || !sendBundleSupport || isExternalSign)
   ) {
+    attemptedHook = true;
     const hook = new Delegation7702PublishHook({
       messenger: initMessenger,
     }).getHook();
@@ -480,6 +483,7 @@ export async function publishHook({
     isSmartTransaction &&
     (sendBundleSupport || transactionMeta.selectedGasFeeToken === undefined)
   ) {
+    attemptedHook = true;
     const result = await submitSmartTransactionHook({
       transactionMeta,
       signedTransactionInHex: signedTx as Hex,
@@ -509,6 +513,19 @@ export async function publishHook({
     // else, fall back to regular regular transaction submission
   }
 
+  if (attemptedHook) {
+    try {
+      await initMessenger.call(
+        'AppStateController:setDefaultHomeActiveTabName',
+        AccountOverviewTabKey.Activity,
+      );
+    } catch (error) {
+      console.error(
+        'Failed to set default home active tab for fallback transaction',
+        error,
+      );
+    }
+  }
   // Default: fall back to regular transaction submission
   return { transactionHash: undefined };
 }

--- a/app/scripts/messenger-client-init/messengers/transaction-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/transaction-controller-messenger.ts
@@ -58,6 +58,7 @@ import {
 } from '@metamask/transaction-pay-controller';
 import { RootMessenger } from '../../lib/messenger';
 import { AppStateControllerGetStateAction } from '../../controllers/app-state-controller';
+import { AppStateControllerSetDefaultHomeActiveTabNameAction } from '../../controllers/app-state-controller-method-action-types';
 import { SubscriptionServiceSubmitSubscriptionSponsorshipIntentAction } from '../../services/subscription/types';
 import {
   InstitutionalSnapControllerBeforeCheckPendingTransactionHookAction,
@@ -112,6 +113,7 @@ type InitMessengerActions =
   | AccountTrackerControllerGetStateAction
   | ApprovalControllerActions
   | AppStateControllerGetStateAction
+  | AppStateControllerSetDefaultHomeActiveTabNameAction
   | AuthenticationController.AuthenticationControllerGetBearerTokenAction
   | BridgeStatusControllerActions
   | CurrencyRateControllerActions
@@ -189,6 +191,7 @@ export function getTransactionControllerInitMessenger(
       'ApprovalController:startFlow',
       'ApprovalController:updateRequestState',
       'AppStateController:getState',
+      'AppStateController:setDefaultHomeActiveTabName',
       'AuthenticationController:getBearerToken',
       'BridgeStatusController:getState',
       'BridgeStatusController:submitTx',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This updates the smart transaction fallback path so that when it falls back to a regular submission, the user lands on the Activity tab instead of the default home tab

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: chore: land fallback transaction on Activity tab

## **Related issues**

Fixes:

## **Manual testing steps**

1. Click Send
2. Choose Linea ETH and recipient (falls back to regular flow as of time of writing)
3. Ensure there is sufficient ETH so it is not batched


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the transaction publish hook flow by adding a UI-side messenger call on fallback paths; while guarded and non-fatal, it could affect navigation or error handling during submission.
> 
> **Overview**
> When a transaction *attempts* a `Delegation7702PublishHook` or smart transaction submission hook but fails to obtain a `transactionHash` and falls back to regular submission, the init code now asks `AppStateController` to set the default home tab to `AccountOverviewTabKey.Activity` (errors are caught/logged).
> 
> Wires `AppStateController:setDefaultHomeActiveTabName` into the transaction init messenger’s allowed actions, and updates the init tests to use a typed `@metamask/messenger` instance with a registered handler for that action instead of `getRootMessenger()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6d75a359bfcc2ce88163e6241cd1e3837f13100. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->