### PR TITLE
fix: Only register autolock listener once cp-13.28.0

### DIFF
--- a/app/scripts/controllers/app-state-controller.ts
+++ b/app/scripts/controllers/app-state-controller.ts
@@ -834,6 +834,17 @@ export class AppStateController extends BaseController<
     this.#onInactiveTimeout = onInactiveTimeout || (() => undefined);
     this.#timer = null;
 
+    if (isManifestV3) {
+      this.#extension.alarms.onAlarm.addListener(
+        (alarmInfo: { name: string }) => {
+          if (alarmInfo.name === AUTO_LOCK_TIMEOUT_ALARM) {
+            this.#onInactiveTimeout();
+            this.#extension.alarms.clear(AUTO_LOCK_TIMEOUT_ALARM);
+          }
+        },
+      );
+    }
+
     this.waitingForUnlock = [];
 
     messenger.subscribe(
@@ -1222,14 +1233,6 @@ export class AppStateController extends BaseController<
         delayInMinutes: timeoutToSet,
         periodInMinutes: timeoutToSet,
       });
-      this.#extension.alarms.onAlarm.addListener(
-        (alarmInfo: { name: string }) => {
-          if (alarmInfo.name === AUTO_LOCK_TIMEOUT_ALARM) {
-            this.#onInactiveTimeout();
-            this.#extension.alarms.clear(AUTO_LOCK_TIMEOUT_ALARM);
-          }
-        },
-      );
     } else {
       this.#timer = setTimeout(
         () => this.#onInactiveTimeout(),

--- a/app/scripts/controllers/app-state-controller.ts
+++ b/app/scripts/controllers/app-state-controller.ts
@@ -834,6 +834,7 @@ export class AppStateController extends BaseController<
     this.#onInactiveTimeout = onInactiveTimeout || (() => undefined);
     this.#timer = null;
 
+    // Clearing an alarm does not remove the listeners, so we only need to register the listener once.
     if (isManifestV3) {
       this.#extension.alarms.onAlarm.addListener(
         (alarmInfo: { name: string }) => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This fixes a bug where the longer the app would run, the more listeners for "auto-lock" would be registered. Every time we reset the autolock timer we would add another listener, potentially assuming that `clear()` removes the listeners, while it does not. The fix is simply to register the listener once.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug where autolocking the wallet would cause unnecessary computation

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/41930

## **Manual testing steps**

1. Enable autolock
2. Wait for the lock to timeout
3. Inspect logs
4. Repeat a couple of times and notice that it doesn't get worse each time

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches wallet auto-lock behavior in Manifest V3 by changing when the alarm listener is registered; mistakes here could prevent or duplicate auto-lock callbacks. The change is small and keeps the same callback logic, reducing risk of listener leaks over time.
> 
> **Overview**
> Fixes a Manifest V3 auto-lock bug where resetting the inactivity timer repeatedly registered additional `alarms.onAlarm` listeners.
> 
> The `AUTO_LOCK_TIMEOUT_ALARM` listener is now registered once in the `AppStateController` constructor, and the reset logic only (re)creates/clears the alarm instead of re-adding listeners, preventing accumulated callbacks and extra computation during long-running sessions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb8a5133c204b4c8c4b237a1064e7bcbc2445008. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->