### PR TITLE
fix: disable incoming transactions for extension

### DIFF
--- a/app/scripts/messenger-client-init/confirmations/transaction-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/confirmations/transaction-controller-init.test.ts
@@ -189,7 +189,7 @@ describe('Transaction Controller Init', () => {
         },
       )?.isEnabled;
 
-      expect(incomingTransactionsIsEnabled?.()).toBe(true);
+      expect(incomingTransactionsIsEnabled?.()).toBe(false);
     });
 
     it('unless enabled in preferences but onboarding incomplete', () => {

--- a/app/scripts/messenger-client-init/confirmations/transaction-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/confirmations/transaction-controller-init.test.ts
@@ -177,7 +177,7 @@ describe('Transaction Controller Init', () => {
     });
   });
 
-  describe('determines incoming transactions is enabled', () => {
+  describe('determines incoming transactions is disabled', () => {
     it('when useExternalServices is enabled in preferences and onboarding complete', () => {
       const incomingTransactionsIsEnabled = testConstructorOption(
         'incomingTransactions',

--- a/app/scripts/messenger-client-init/confirmations/transaction-controller-init.ts
+++ b/app/scripts/messenger-client-init/confirmations/transaction-controller-init.ts
@@ -131,9 +131,7 @@ export const TransactionControllerInit: MessengerClientInitFunction<
     incomingTransactions: {
       client: `extension-${process.env.METAMASK_VERSION?.replace(/\./gu, '-')}`,
       includeTokenTransfers: false,
-      isEnabled: () =>
-        preferencesController().state.useExternalServices &&
-        onboardingController().state.completedOnboarding,
+      isEnabled: () => false,
       updateTransactions: true,
     },
     isAutomaticGasFeeUpdateEnabled,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Disable incoming transaction polling for extension.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**
NA

## **Manual testing steps**
NA

## **Screenshots/Recordings**
NA

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change that only disables a background polling feature and updates its unit test; minimal impact beyond losing incoming-transaction updates.
> 
> **Overview**
> Disables incoming transaction polling in the extension by making `TransactionController`'s `incomingTransactions.isEnabled` always return `false`, instead of depending on `useExternalServices` and onboarding completion.
> 
> Updates the corresponding init test to assert incoming transactions are *always disabled* regardless of preference/onboarding state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cea6359566446a4cc67739f3e088cd0b424f158b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->