### PR TITLE
feat: Support ENS v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -329,7 +329,7 @@
     "@metamask/eip-5792-middleware": "3.0.3",
     "@metamask/eip-7702-internal-rpc-middleware": "^0.1.0",
     "@metamask/ens-controller": "^19.1.0",
-    "@metamask/ens-resolver-snap": "^1.1.0",
+    "@metamask/ens-resolver-snap": "^1.2.0",
     "@metamask/eth-hd-keyring": "^13.1.0",
     "@metamask/eth-json-rpc-filters": "^9.0.0",
     "@metamask/eth-json-rpc-middleware": "^23.1.0",

--- a/test/e2e/tests/transaction/ens.spec.ts
+++ b/test/e2e/tests/transaction/ens.spec.ts
@@ -9,24 +9,16 @@ import HomePage from '../../page-objects/pages/home/homepage';
 import { mockServerJsonRpc } from '../ppom/mocks/mock-server-json-rpc';
 import { mockMultiNetworkBalancePolling } from '../../mock-balance-polling/mock-balance-polling';
 import SendPage from '../../page-objects/pages/send/send-page';
+import { shortenAddress } from '../../../../ui/helpers/utils/util';
 
 describe('ENS', function (this: Suite) {
-  const sampleAddress: string = '1111111111111111111111111111111111111111';
-
-  const shortSampleAddress = '0x11111...11111';
+  const shortSampleAddress = shortenAddress(
+    '0x225f137127d9067788314bc7fcc1f36746a3c3B5',
+  );
   const chainId = 1;
 
-  // ENS Contract Addresses and Function Signatures
-  const ENSRegistryWithFallback: string =
-    '0x00000000000c2e074ec69a0dfb2997ba6c7d2e1e';
-  const resolverSignature: string = '0x0178b8bf';
-  const ensNode: string =
-    'eb4f647bea6caa36333c816d7b46fdcb05f9466ecacc140ea8c66faf15b3d9f1';
-  const resolverNodeAddress: string =
-    '226159d592e2b063810a10ebf6dcbada94ed68b8';
-  const supportsInterfaceSignature: string = '0x01ffc9a7';
-  const addressSignature: string = '0x3b3b57de';
-  const sampleEnsDomain: string = 'test.eth';
+  const UR_PROXY = '0xeeeeeeee14d718c2b47d9923deab1335e144eeee';
+  const sampleEnsDomain = 'luc.eth';
 
   async function mockInfura(mockServer: MockttpServer): Promise<void> {
     await mockMultiNetworkBalancePolling(mockServer);
@@ -35,43 +27,18 @@ describe('ENS', function (this: Suite) {
       ['eth_blockNumber'],
       ['eth_getBlockByNumber'],
       ['eth_chainId', { result: `0x${chainId}` }],
-      // 1. Get the address of the resolver for the specified node
+      // Get the address from the universal resolver
       [
         'eth_call',
         {
           params: [
             {
-              to: ENSRegistryWithFallback,
-              data: `${resolverSignature}${ensNode}`,
+              to: UR_PROXY,
+              data: '0xa1472844000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000009036c75630365746800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000243b3b57dee1e7bcf2ca33c28a806ee265cfedf02fedf1b124ca73b2203ca80cc7c91a02ad00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000014782d62617463682d676174657761793a74727565000000000000000000000000',
             },
           ],
-          result: `0x000000000000000000000000${resolverNodeAddress}`,
-        },
-      ],
-      // 2. Check supportsInterface from the public resolver
-      [
-        'eth_call',
-        {
-          params: [
-            {
-              to: `0x${resolverNodeAddress}`,
-              data: `${supportsInterfaceSignature}9061b92300000000000000000000000000000000000000000000000000000000`,
-            },
-          ],
-          result: `0x0000000000000000000000000000000000000000000000000000000000000000`,
-        },
-      ],
-      // 3. Return the address associated with an ENS
-      [
-        'eth_call',
-        {
-          params: [
-            {
-              to: `0x${resolverNodeAddress}`,
-              data: `${addressSignature}eb4f647bea6caa36333c816d7b46fdcb05f9466ecacc140ea8c66faf15b3d9f1`,
-            },
-          ],
-          result: `0x000000000000000000000000${sampleAddress}`,
+          result:
+            '0x00000000000000000000000000000000000000000000000000000000000000400000000000000000000000004976fb03c32e5b8cfe2b6ccb31c09ba78ebaba410000000000000000000000000000000000000000000000000000000000000020000000000000000000000000225f137127d9067788314bc7fcc1f36746a3c3b5',
         },
       ],
     ]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6316,10 +6316,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/ens-resolver-snap@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@metamask/ens-resolver-snap@npm:1.1.0"
-  checksum: 10/e7d636ae8934aa31e0b0ee916557e1911b37147d7a6eca74fbe3581df3652162104f190eddba6c5ae100166e79168855ac364393b57abfbc6f8bc82047d71082
+"@metamask/ens-resolver-snap@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@metamask/ens-resolver-snap@npm:1.2.0"
+  checksum: 10/abe07b3eaac4fa4daf5cf24041467183cc3d65975c77e80045e0eeb92c5bc78cd4c47c3980a35d33ed33dea92545ed3df5d7de387ee4bd7062848ccad30fd3db
   languageName: node
   linkType: hard
 
@@ -34174,7 +34174,7 @@ __metadata:
     "@metamask/eip-5792-middleware": "npm:3.0.3"
     "@metamask/eip-7702-internal-rpc-middleware": "npm:^0.1.0"
     "@metamask/ens-controller": "npm:^19.1.0"
-    "@metamask/ens-resolver-snap": "npm:^1.1.0"
+    "@metamask/ens-resolver-snap": "npm:^1.2.0"
     "@metamask/eslint-config": "npm:^13.0.0"
     "@metamask/eslint-config-jest": "npm:^13.0.0"
     "@metamask/eslint-config-mocha": "npm:^13.0.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Bump ENS Snap to the latest version which includes support for ENS v2.

The mocking of the ENS E2E had to be updated to use the new contract. It now matches the mocks used in the Snap.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added support for ENS v2

## **Related issues**

https://consensyssoftware.atlassian.net/browse/WPC-983

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only bumps `@metamask/ens-resolver-snap` from `^1.1.0` to `^1.2.0` and updates the lockfile; runtime behavior changes are confined to the updated dependency.
> 
> **Overview**
> Updates the ENS resolver Snap dependency to `@metamask/ens-resolver-snap@^1.2.0` (from `^1.1.0`) to pick up **ENS v2 support**, with corresponding `yarn.lock` changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba72254d436e5665aaf5c1f67438f4074f8e954d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->