### PR TITLE
fix: issue in event queuing

### DIFF
--- a/app/scripts/controllers/metametrics-controller.ts
+++ b/app/scripts/controllers/metametrics-controller.ts
@@ -905,8 +905,15 @@ export class MetaMetricsController extends BaseController<
       this.clearEventsAfterMetricsOptIn();
       this.trackTracesAfterMetricsOptIn();
       this.clearTracesAfterMetricsOptIn();
-    } else if (this.state.marketingCampaignCookieId) {
-      this.setMarketingCampaignCookieId(null);
+    } else {
+      if (participateInMetaMetrics === false) {
+        // Drop any UI-buffered pre-submit events/traces; they must not be sent after opt-out.
+        this.clearEventsAfterMetricsOptIn();
+        this.clearTracesAfterMetricsOptIn();
+      }
+      if (this.state.marketingCampaignCookieId) {
+        this.setMarketingCampaignCookieId(null);
+      }
     }
 
     if (

--- a/ui/contexts/metametrics.test.tsx
+++ b/ui/contexts/metametrics.test.tsx
@@ -41,19 +41,15 @@ const renderProvider = ({
 }) => {
   const store = mockStore(state);
 
-  const TestComponent = ({
-    eventName,
-  }: {
-    eventName: MetaMetricsEventName;
-  }) => {
+  const TestComponent = () => {
     const { trackEvent } = useContext(MetaMetricsContext);
 
     useEffect(() => {
       trackEvent({
         category: MetaMetricsEventCategory.Onboarding,
-        event: eventName,
+        event,
       });
-    }, [eventName, trackEvent]);
+    }, [event, trackEvent]);
 
     return null;
   };
@@ -64,7 +60,7 @@ const renderProvider = ({
         path: '*',
         element: (
           <MetaMetricsProvider>
-            <TestComponent eventName={event} />
+            <TestComponent />
           </MetaMetricsProvider>
         ),
       },

--- a/ui/contexts/metametrics.test.tsx
+++ b/ui/contexts/metametrics.test.tsx
@@ -1,5 +1,5 @@
-import React, { useContext, useEffect } from 'react';
-import { render, waitFor } from '@testing-library/react';
+import React, { useContext, useEffect, useState } from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
 import configureMockStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
 import { createMemoryRouter, RouterProvider } from 'react-router-dom';
@@ -41,17 +41,32 @@ const renderProvider = ({
 }) => {
   const store = mockStore(state);
 
-  const TestComponent = () => {
+  const TestComponent = ({
+    eventName,
+  }: {
+    eventName: MetaMetricsEventName;
+  }) => {
     const { trackEvent } = useContext(MetaMetricsContext);
+    const [trackSettled, setTrackSettled] = useState(false);
 
     useEffect(() => {
+      let cancelled = false;
       trackEvent({
         category: MetaMetricsEventCategory.Onboarding,
-        event,
+        event: eventName,
+      }).finally(() => {
+        if (!cancelled) {
+          setTrackSettled(true);
+        }
       });
-    }, [event, trackEvent]);
+      return () => {
+        cancelled = true;
+      };
+    }, [eventName, trackEvent]);
 
-    return null;
+    return trackSettled ? (
+      <span data-testid="metametrics-provider-track-settled" />
+    ) : null;
   };
 
   const router = createMemoryRouter(
@@ -60,7 +75,7 @@ const renderProvider = ({
         path: '*',
         element: (
           <MetaMetricsProvider>
-            <TestComponent />
+            <TestComponent eventName={event} />
           </MetaMetricsProvider>
         ),
       },
@@ -157,6 +172,27 @@ describe('MetaMetricsProvider', () => {
       );
     });
 
+    expect(mockedSubmitRequestToBackground).not.toHaveBeenCalled();
+  });
+
+  it('does not buffer normal events when the user has opted out of MetaMetrics', async () => {
+    renderProvider({
+      event: MetaMetricsEventName.AnalyticsPreferenceSelected,
+      state: {
+        metamask: {
+          participateInMetaMetrics: false,
+          metaMetricsId: '0x123',
+        },
+      },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('metametrics-provider-track-settled'),
+      ).toBeInTheDocument();
+    });
+
+    expect(mockedTrackMetaMetricsEvent).not.toHaveBeenCalled();
     expect(mockedSubmitRequestToBackground).not.toHaveBeenCalled();
   });
 });

--- a/ui/contexts/metametrics.test.tsx
+++ b/ui/contexts/metametrics.test.tsx
@@ -1,5 +1,5 @@
-import React, { useContext, useEffect, useState } from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import React, { useContext, useEffect } from 'react';
+import { act, render, waitFor } from '@testing-library/react';
 import configureMockStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
 import { createMemoryRouter, RouterProvider } from 'react-router-dom';
@@ -47,26 +47,15 @@ const renderProvider = ({
     eventName: MetaMetricsEventName;
   }) => {
     const { trackEvent } = useContext(MetaMetricsContext);
-    const [trackSettled, setTrackSettled] = useState(false);
 
     useEffect(() => {
-      let cancelled = false;
       trackEvent({
         category: MetaMetricsEventCategory.Onboarding,
         event: eventName,
-      }).finally(() => {
-        if (!cancelled) {
-          setTrackSettled(true);
-        }
       });
-      return () => {
-        cancelled = true;
-      };
     }, [eventName, trackEvent]);
 
-    return trackSettled ? (
-      <span data-testid="metametrics-provider-track-settled" />
-    ) : null;
+    return null;
   };
 
   const router = createMemoryRouter(
@@ -186,10 +175,8 @@ describe('MetaMetricsProvider', () => {
       },
     });
 
-    await waitFor(() => {
-      expect(
-        screen.getByTestId('metametrics-provider-track-settled'),
-      ).toBeInTheDocument();
+    await act(async () => {
+      await Promise.resolve();
     });
 
     expect(mockedTrackMetaMetricsEvent).not.toHaveBeenCalled();

--- a/ui/contexts/metametrics.tsx
+++ b/ui/contexts/metametrics.tsx
@@ -37,7 +37,11 @@ import {
   type MetaMetricsEventPayload,
 } from '../../shared/constants/metametrics';
 import { useSegmentContext } from '../hooks/useSegmentContext';
-import { getMetaMetricsId, getParticipateInMetaMetrics } from '../selectors';
+import {
+  getIsParticipateInMetaMetricsSet,
+  getMetaMetricsId,
+  getParticipateInMetaMetrics,
+} from '../selectors';
 import {
   generateActionId,
   submitRequestToBackground,
@@ -144,10 +148,15 @@ type MetaMetricsProviderProps = {
 export function MetaMetricsProvider({ children }: MetaMetricsProviderProps) {
   const location = useLocation();
   const context = useSegmentContext();
+  const isParticipateInMetaMetricsSet = useSelector(
+    getIsParticipateInMetaMetricsSet,
+  );
   const isMetricsEnabled = useSelector(getParticipateInMetaMetrics);
   const metaMetricsId = useSelector(getMetaMetricsId);
-  // Buffer events until the background has minted the MetaMetrics ID used to submit them.
   const canTrackImmediately = isMetricsEnabled && Boolean(metaMetricsId);
+  // Buffer events until we know whether or not we can submit them.
+  const canMaybeTrackLater =
+    !isParticipateInMetaMetricsSet || (isMetricsEnabled && !metaMetricsId);
 
   const onboardingParentContext = useRef<TraceParentContext>(null);
 
@@ -185,14 +194,18 @@ export function MetaMetricsProvider({ children }: MetaMetricsProviderProps) {
       ) {
         // If metrics are enabled, track immediately
         trackMetaMetricsEvent(fullPayload as MetaMetricsEventPayload, options);
-      } else {
-        // If metrics are not enabled, buffer the event
+      } else if (canMaybeTrackLater) {
         await submitRequestToBackground('addEventBeforeMetricsOptIn', [
           { ...fullPayload, actionId: generateActionId() },
         ]);
       }
     },
-    [addContextPropsIntoEventProperties, canTrackImmediately, context],
+    [
+      addContextPropsIntoEventProperties,
+      canMaybeTrackLater,
+      canTrackImmediately,
+      context,
+    ],
   );
 
   const bufferedTrace: UITraceMethod = useCallback((request, fn) => {


### PR DESCRIPTION
## **Description**

MetaMetricsProvider should not call `addEventBeforeMetricsOptIn` after user has completed MetaMetrics onboarding. 

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/40496

## **Manual testing steps**

See Loom video

## **Screenshots/Recordings**

See this Loom video: https://www.loom.com/share/2f23b4c544274a2f81a20750522eedfc

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes event/trace buffering and queue-clearing around MetaMetrics consent, which is privacy-sensitive and could affect whether telemetry is retained or sent. Scope is limited to consent gating logic with added unit coverage.
> 
> **Overview**
> Fixes MetaMetrics queuing so **UI events are only buffered when consent is unknown or metrics are enabled but `metaMetricsId` hasn’t been minted**, and are *not* buffered once a user has explicitly opted out.
> 
> On opt-out, the background `MetaMetricsController` now **clears any queued pre-consent events/traces** (and still clears the marketing campaign cookie) to prevent later submission. Adds a unit test ensuring normal events are neither tracked nor queued when `participateInMetaMetrics` is `false`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f8ae100f22e5569b4ad1b5bc67caed7c041bba4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->