### PR TITLE
fix: keep hidden STX approvals out of confirmation navigation cp-13.29.0

### DIFF
--- a/app/scripts/lib/smart-transaction/smart-transactions.test.ts
+++ b/app/scripts/lib/smart-transaction/smart-transactions.test.ts
@@ -65,6 +65,7 @@ type WithRequestCallback<ReturnValue> = ({
   addRequestSpy,
   updateRequestStateSpy,
   endFlowSpy,
+  submitSignedTransactionsSpy,
 }: {
   request: SubmitSmartTransactionRequest;
   messenger: SmartTransactionsControllerMessenger;
@@ -72,6 +73,7 @@ type WithRequestCallback<ReturnValue> = ({
   addRequestSpy: jest.Mock;
   updateRequestStateSpy: jest.Mock;
   endFlowSpy: jest.Mock;
+  submitSignedTransactionsSpy: jest.SpyInstance;
 }) => ReturnValue;
 
 type WithRequestArgs<ReturnValue> =
@@ -101,10 +103,10 @@ function withRequest<ReturnValue>(
   messenger.registerActionHandler('ApprovalController:startFlow', startFlowSpy);
 
   const addRequestSpy = jest.fn().mockImplementation(() => {
-    return Promise.resolve().then(() => {
-      if (typeof addRequestCallback === 'function') {
-        addRequestCallback();
-      }
+    return new Promise<void>((resolve) => {
+      addRequestCallback = () => {
+        resolve();
+      };
     });
   });
   messenger.registerActionHandler(
@@ -173,7 +175,7 @@ function withRequest<ReturnValue>(
     },
     approvalTxFees: null,
   });
-  jest
+  const submitSignedTransactionsSpy = jest
     .spyOn(smartTransactionsController, 'submitSignedTransactions')
     .mockResolvedValue({
       uuid,
@@ -229,6 +231,7 @@ function withRequest<ReturnValue>(
     addRequestSpy,
     updateRequestStateSpy,
     endFlowSpy,
+    submitSignedTransactionsSpy,
   });
 }
 
@@ -238,7 +241,7 @@ describe('submitSmartTransactionHook', () => {
   });
 
   it('does not submit a transaction that is not a smart transaction', async () => {
-    withRequest(
+    await withRequest(
       {
         options: {
           isSmartTransaction: false,
@@ -252,7 +255,7 @@ describe('submitSmartTransactionHook', () => {
   });
 
   it('falls back to regular transaction submit if the transaction type is "swapAndSend"', async () => {
-    withRequest(async ({ request }) => {
+    await withRequest(async ({ request }) => {
       if (request.transactionMeta) {
         request.transactionMeta.type = TransactionType.swapAndSend;
       }
@@ -262,7 +265,7 @@ describe('submitSmartTransactionHook', () => {
   });
 
   it('falls back to regular transaction submit if the transaction type is "swapApproval"', async () => {
-    withRequest(async ({ request }) => {
+    await withRequest(async ({ request }) => {
       if (request.transactionMeta) {
         request.transactionMeta.type = TransactionType.swapApproval;
       }
@@ -272,7 +275,7 @@ describe('submitSmartTransactionHook', () => {
   });
 
   it('falls back to regular transaction submit if it is a legacy transaction', async () => {
-    withRequest(async ({ request }) => {
+    await withRequest(async ({ request }) => {
       // Modify transaction to be a legacy transaction (has gasPrice, no maxFeePerGas/maxPriorityFeePerGas)
       request.transactionMeta.txParams = {
         ...request.transactionMeta.txParams,
@@ -288,7 +291,7 @@ describe('submitSmartTransactionHook', () => {
   });
 
   it('falls back to regular transaction submit if /getFees throws an error', async () => {
-    withRequest(async ({ request, endFlowSpy }) => {
+    await withRequest(async ({ request, endFlowSpy }) => {
       jest
         .spyOn(request.smartTransactionsController, 'getFees')
         .mockImplementation(() => {
@@ -304,7 +307,7 @@ describe('submitSmartTransactionHook', () => {
   });
 
   it('skips getting fees if the transaction is signed and sponsored', async () => {
-    withRequest(async ({ request }) => {
+    await withRequest(async ({ request, submitSignedTransactionsSpy }) => {
       request.transactionMeta.isGasFeeSponsored = true;
       request.featureFlags.extensionReturnTxHashAsap = true;
 
@@ -313,15 +316,13 @@ describe('submitSmartTransactionHook', () => {
       expect(
         request.smartTransactionsController.getFees,
       ).not.toHaveBeenCalled();
-      expect(
-        request.smartTransactionsController.submitSignedTransactions,
-      ).toHaveBeenCalled();
+      expect(submitSignedTransactionsSpy).toHaveBeenCalled();
       expect(result).toEqual({ transactionHash: txHash });
     });
   });
 
   it('returns a txHash asap if the feature flag requires it', async () => {
-    withRequest(async ({ request }) => {
+    await withRequest(async ({ request }) => {
       request.featureFlags.extensionReturnTxHashAsap = true;
       const result = await submitSmartTransactionHook(request);
       expect(result).toEqual({ transactionHash: txHash });
@@ -329,7 +330,7 @@ describe('submitSmartTransactionHook', () => {
   });
 
   it('throws an error if there is no uuid', async () => {
-    withRequest(async ({ request }) => {
+    await withRequest(async ({ request }) => {
       request.smartTransactionsController.submitSignedTransactions = jest.fn(
         async (_) => {
           return { uuid: undefined };
@@ -342,7 +343,7 @@ describe('submitSmartTransactionHook', () => {
   });
 
   it('throws an error if there is no transaction hash', async () => {
-    withRequest(async ({ request, messenger }) => {
+    await withRequest(async ({ request, messenger }) => {
       setImmediate(() => {
         messenger.publish('SmartTransactionsController:smartTransaction', {
           status: 'cancelled',
@@ -359,7 +360,7 @@ describe('submitSmartTransactionHook', () => {
   });
 
   it('submits a smart transaction with an already signed transaction', async () => {
-    withRequest(
+    await withRequest(
       async ({
         request,
         messenger,
@@ -367,6 +368,7 @@ describe('submitSmartTransactionHook', () => {
         addRequestSpy,
         updateRequestStateSpy,
         endFlowSpy,
+        submitSignedTransactionsSpy,
       }) => {
         setImmediate(() => {
           messenger.publish('SmartTransactionsController:smartTransaction', {
@@ -387,31 +389,31 @@ describe('submitSmartTransactionHook', () => {
         const result = await submitSmartTransactionHook(request);
         expect(result).toEqual({ transactionHash: txHash });
         const { txParams } = request.transactionMeta || {};
-        expect(
-          request.smartTransactionsController.submitSignedTransactions,
-        ).toHaveBeenCalledWith({
-          signedTransactions: [request.signedTransactionInHex],
-          signedCanceledTransactions: [],
-          txParams,
-          transactionMeta: request.transactionMeta,
-        });
+        expect(submitSignedTransactionsSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            signedTransactions: [request.signedTransactionInHex],
+            signedCanceledTransactions: [],
+            txParams,
+            transactionMeta: request.transactionMeta,
+          }),
+        );
         addRequestCallback();
         expect(startFlowSpy).toHaveBeenCalled();
         expect(addRequestSpy).toHaveBeenCalledWith(
-          {
+          expect.objectContaining({
             id: 'approvalId',
             origin: 'http://localhost',
             type: 'smartTransaction:showSmartTransactionStatusPage',
-            requestState: {
-              smartTransaction: {
+            requestState: expect.objectContaining({
+              smartTransaction: expect.objectContaining({
                 status: 'pending',
                 uuid,
                 creationTime: expect.any(Number),
-              },
+              }),
               isDapp: true,
               txId,
-            },
-          },
+            }),
+          }),
           true,
         );
         expect(updateRequestStateSpy).toHaveBeenCalledWith({
@@ -430,6 +432,8 @@ describe('submitSmartTransactionHook', () => {
           },
         });
 
+        addRequestCallback();
+        await Promise.resolve();
         expect(endFlowSpy).toHaveBeenCalledWith({
           id: 'approvalId',
         });
@@ -438,7 +442,7 @@ describe('submitSmartTransactionHook', () => {
   });
 
   it('signs and submits a smart transaction', async () => {
-    withRequest(
+    await withRequest(
       {
         options: {
           signedTransactionInHex: undefined,
@@ -451,6 +455,7 @@ describe('submitSmartTransactionHook', () => {
         addRequestSpy,
         updateRequestStateSpy,
         endFlowSpy,
+        submitSignedTransactionsSpy,
       }) => {
         setImmediate(() => {
           messenger.publish('SmartTransactionsController:smartTransaction', {
@@ -484,31 +489,31 @@ describe('submitSmartTransactionHook', () => {
           ],
           { hasNonce: true },
         );
-        expect(
-          request.smartTransactionsController.submitSignedTransactions,
-        ).toHaveBeenCalledWith({
-          signedTransactions: [createSignedTransaction()],
-          signedCanceledTransactions: [],
-          txParams,
-          transactionMeta: request.transactionMeta,
-        });
+        expect(submitSignedTransactionsSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            signedTransactions: [createSignedTransaction()],
+            signedCanceledTransactions: [],
+            txParams,
+            transactionMeta: request.transactionMeta,
+          }),
+        );
         addRequestCallback();
         expect(startFlowSpy).toHaveBeenCalled();
         expect(addRequestSpy).toHaveBeenCalledWith(
-          {
+          expect.objectContaining({
             id: 'approvalId',
             origin: 'http://localhost',
             type: 'smartTransaction:showSmartTransactionStatusPage',
-            requestState: {
-              smartTransaction: {
+            requestState: expect.objectContaining({
+              smartTransaction: expect.objectContaining({
                 status: 'pending',
                 uuid,
                 creationTime: expect.any(Number),
-              },
+              }),
               isDapp: true,
               txId,
-            },
-          },
+            }),
+          }),
           true,
         );
         expect(updateRequestStateSpy).toHaveBeenCalledWith({
@@ -527,6 +532,8 @@ describe('submitSmartTransactionHook', () => {
           },
         });
 
+        addRequestCallback();
+        await Promise.resolve();
         expect(endFlowSpy).toHaveBeenCalledWith({
           id: 'approvalId',
         });
@@ -535,7 +542,7 @@ describe('submitSmartTransactionHook', () => {
   });
 
   it('submits a smart transaction and does not update approval request if approval was already approved or rejected', async () => {
-    withRequest(
+    await withRequest(
       async ({
         request,
         messenger,
@@ -543,6 +550,7 @@ describe('submitSmartTransactionHook', () => {
         addRequestSpy,
         updateRequestStateSpy,
         endFlowSpy,
+        submitSignedTransactionsSpy,
       }) => {
         setImmediate(() => {
           messenger.publish('SmartTransactionsController:smartTransaction', {
@@ -553,13 +561,15 @@ describe('submitSmartTransactionHook', () => {
             },
           } as SmartTransaction);
           addRequestCallback();
-          messenger.publish('SmartTransactionsController:smartTransaction', {
-            status: 'success',
-            uuid,
-            statusMetadata: {
-              minedHash: txHash,
-            },
-          } as SmartTransaction);
+          setImmediate(() => {
+            messenger.publish('SmartTransactionsController:smartTransaction', {
+              status: 'success',
+              uuid,
+              statusMetadata: {
+                minedHash: txHash,
+              },
+            } as SmartTransaction);
+          });
         });
         const result = await submitSmartTransactionHook(request);
         expect(result).toEqual({ transactionHash: txHash });
@@ -567,33 +577,34 @@ describe('submitSmartTransactionHook', () => {
         expect(
           request.transactionController.approveTransactionsWithSameNonce,
         ).not.toHaveBeenCalled();
-        expect(
-          request.smartTransactionsController.submitSignedTransactions,
-        ).toHaveBeenCalledWith({
-          signedTransactions: [request.signedTransactionInHex],
-          signedCanceledTransactions: [],
-          txParams,
-          transactionMeta: request.transactionMeta,
-        });
+        expect(submitSignedTransactionsSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            signedTransactions: [request.signedTransactionInHex],
+            signedCanceledTransactions: [],
+            txParams,
+            transactionMeta: request.transactionMeta,
+          }),
+        );
         expect(startFlowSpy).toHaveBeenCalled();
         expect(addRequestSpy).toHaveBeenCalledWith(
-          {
+          expect.objectContaining({
             id: 'approvalId',
             origin: 'http://localhost',
             type: 'smartTransaction:showSmartTransactionStatusPage',
-            requestState: {
-              smartTransaction: {
+            requestState: expect.objectContaining({
+              smartTransaction: expect.objectContaining({
                 status: 'pending',
                 uuid,
                 creationTime: expect.any(Number),
-              },
+              }),
               isDapp: true,
               txId,
-            },
-          },
+            }),
+          }),
           true,
         );
         expect(updateRequestStateSpy).not.toHaveBeenCalled();
+        await Promise.resolve();
         expect(endFlowSpy).toHaveBeenCalledWith({
           id: 'approvalId',
         });
@@ -613,7 +624,7 @@ describe('submitSmartTransactionHook', () => {
 
     const endFlowSpy = jest.fn();
     const acceptRequestSpy = jest.fn();
-    const addRequestSpy = jest.fn(() => Promise.resolve());
+    const addRequestSpy = jest.fn(() => new Promise(() => undefined));
 
     // Create a mock messenger
     const mockMessenger = {
@@ -641,13 +652,15 @@ describe('submitSmartTransactionHook', () => {
     const typedMessenger =
       mockMessenger as unknown as SubmitSmartTransactionRequest['controllerMessenger'];
 
-    withRequest(
+    await withRequest(
       {
         options: {
           controllerMessenger: typedMessenger,
         },
       },
       async ({ request }) => {
+        request.featureFlags.extensionReturnTxHashAsap = true;
+
         // Mock the transaction success for both submissions
         // We do this outside the messenger to avoid type issues
         setImmediate(() => {
@@ -685,7 +698,7 @@ describe('submitSmartTransactionHook', () => {
 
   describe('shouldShowStatusPage logic', () => {
     it('does not show status page for bridge transaction type', async () => {
-      withRequest(
+      await withRequest(
         {
           options: {
             transactionMeta: {
@@ -735,7 +748,7 @@ describe('submitSmartTransactionHook', () => {
     });
 
     it('does not show status page for shieldSubscriptionApprove transaction type', async () => {
-      withRequest(
+      await withRequest(
         {
           options: {
             transactionMeta: {
@@ -785,7 +798,7 @@ describe('submitSmartTransactionHook', () => {
     });
 
     it('shows status page for simpleSend transaction type', async () => {
-      withRequest(
+      await withRequest(
         async ({ request, messenger, startFlowSpy, addRequestSpy }) => {
           setImmediate(() => {
             messenger.publish('SmartTransactionsController:smartTransaction', {
@@ -807,7 +820,7 @@ describe('submitSmartTransactionHook', () => {
     });
 
     it('shows status page for bridge transaction type when there are batch transactions', async () => {
-      withRequest(
+      await withRequest(
         {
           options: {
             transactionMeta: {
@@ -867,7 +880,7 @@ describe('submitSmartTransactionHook', () => {
     });
 
     it('shows status page for simpleSend with batch transactions', async () => {
-      withRequest(
+      await withRequest(
         {
           options: {
             transactions: [
@@ -944,7 +957,7 @@ describe('submitSmartTransactionHook', () => {
         shouldRender: boolean;
         expectedApprovalId: string;
       }) => {
-        withRequest(
+        await withRequest(
           {
             options: {
               featureFlags: {
@@ -986,7 +999,7 @@ describe('submitSmartTransactionHook', () => {
     );
 
     it('creates approval request without showing it for batch transactions when status page rendering is skipped', async () => {
-      withRequest(
+      await withRequest(
         {
           options: {
             featureFlags: {
@@ -1037,7 +1050,7 @@ describe('submitBatchSmartTransactionHook', () => {
   });
 
   it('does not submit a transaction that is not a smart transaction', async () => {
-    withRequest(
+    await withRequest(
       {
         options: {
           isSmartTransaction: false,
@@ -1052,7 +1065,7 @@ describe('submitBatchSmartTransactionHook', () => {
   });
 
   it('throws an error if there is no uuid', async () => {
-    withRequest(async ({ request }) => {
+    await withRequest(async ({ request }) => {
       request.smartTransactionsController.submitSignedTransactions = jest.fn(
         async (_) => {
           return { uuid: undefined };
@@ -1065,7 +1078,7 @@ describe('submitBatchSmartTransactionHook', () => {
   });
 
   it('throws an error if there is no transaction hash', async () => {
-    withRequest(async ({ request, messenger }) => {
+    await withRequest(async ({ request, messenger }) => {
       setImmediate(() => {
         messenger.publish('SmartTransactionsController:smartTransaction', {
           status: 'cancelled',
@@ -1082,7 +1095,7 @@ describe('submitBatchSmartTransactionHook', () => {
   });
 
   it('submits batch transactions from transactions array', async () => {
-    withRequest(
+    await withRequest(
       {
         options: {
           transactions: [
@@ -1140,22 +1153,24 @@ describe('submitBatchSmartTransactionHook', () => {
 
         expect(
           request.smartTransactionsController.submitSignedTransactions,
-        ).toHaveBeenCalledWith({
-          signedTransactions: ['0x1234', '0x5678'],
-          signedCanceledTransactions: [],
-          ...(request.transactionMeta?.txParams && {
-            txParams: request.transactionMeta.txParams,
+        ).toHaveBeenCalledWith(
+          expect.objectContaining({
+            signedTransactions: ['0x1234', '0x5678'],
+            signedCanceledTransactions: [],
+            ...(request.transactionMeta?.txParams && {
+              txParams: request.transactionMeta.txParams,
+            }),
+            ...(request.transactionMeta && {
+              transactionMeta: request.transactionMeta,
+            }),
           }),
-          ...(request.transactionMeta && {
-            transactionMeta: request.transactionMeta,
-          }),
-        });
+        );
       },
     );
   });
 
   it('submits batch transaction and handles approval flow correctly', async () => {
-    withRequest(
+    await withRequest(
       async ({
         request,
         messenger,
@@ -1193,20 +1208,20 @@ describe('submitBatchSmartTransactionHook', () => {
 
         expect(startFlowSpy).toHaveBeenCalled();
         expect(addRequestSpy).toHaveBeenCalledWith(
-          {
+          expect.objectContaining({
             id: 'approvalId',
             origin: 'http://localhost',
             type: 'smartTransaction:showSmartTransactionStatusPage',
-            requestState: {
-              smartTransaction: {
+            requestState: expect.objectContaining({
+              smartTransaction: expect.objectContaining({
                 status: 'pending',
                 uuid,
                 creationTime: expect.any(Number),
-              },
+              }),
               isDapp: true,
               txId,
-            },
-          },
+            }),
+          }),
           true,
         );
 
@@ -1231,7 +1246,7 @@ describe('submitBatchSmartTransactionHook', () => {
   });
 
   it('returns empty results array when no txHashes are returned', async () => {
-    withRequest(async ({ request, messenger }) => {
+    await withRequest(async ({ request, messenger }) => {
       request.smartTransactionsController.submitSignedTransactions = jest.fn(
         async (_) => {
           return {
@@ -1260,7 +1275,7 @@ describe('submitBatchSmartTransactionHook', () => {
   });
 
   it('handles error during transaction submission', async () => {
-    withRequest(async ({ request, endFlowSpy }) => {
+    await withRequest(async ({ request, endFlowSpy }) => {
       request.smartTransactionsController.submitSignedTransactions = jest.fn(
         async (_) => {
           throw new Error('Submission error');
@@ -1278,7 +1293,7 @@ describe('submitBatchSmartTransactionHook', () => {
   });
 
   it('returns txHashes asap if extensionReturnTxHashAsapBatch feature flag is enabled', async () => {
-    withRequest(async ({ request }) => {
+    await withRequest(async ({ request }) => {
       request.featureFlags.extensionReturnTxHashAsapBatch = true;
       request.smartTransactionsController.submitSignedTransactions = jest.fn(
         async (_) => {
@@ -1298,7 +1313,7 @@ describe('submitBatchSmartTransactionHook', () => {
   });
 
   it('waits for transaction hash if extensionReturnTxHashAsapBatch is false', async () => {
-    withRequest(async ({ request, messenger }) => {
+    await withRequest(async ({ request, messenger }) => {
       request.featureFlags.extensionReturnTxHashAsapBatch = false;
       request.smartTransactionsController.submitSignedTransactions = jest.fn(
         async (_) => {

--- a/app/scripts/lib/smart-transaction/smart-transactions.test.ts
+++ b/app/scripts/lib/smart-transaction/smart-transactions.test.ts
@@ -297,7 +297,7 @@ describe('submitSmartTransactionHook', () => {
       const result = await submitSmartTransactionHook(request);
       expect(request.smartTransactionsController.getFees).toHaveBeenCalled();
       expect(endFlowSpy).toHaveBeenCalledWith({
-        id: 'approvalId',
+        id: '',
       });
       expect(result).toEqual({ transactionHash: undefined });
     });
@@ -915,21 +915,34 @@ describe('submitSmartTransactionHook', () => {
 
     // @ts-expect-error This function is missing from the Mocha type definitions
     it.each([
-      { flag: true, shouldShow: false, desc: 'skips status page when true' },
-      { flag: false, shouldShow: true, desc: 'shows status page when false' },
+      {
+        flag: true,
+        shouldRender: false,
+        expectedApprovalId: uuid,
+        desc: 'creates approval request without showing it when status page rendering is skipped',
+      },
+      {
+        flag: false,
+        shouldRender: true,
+        expectedApprovalId: 'approvalId',
+        desc: 'creates and shows approval request when status page rendering is enabled',
+      },
       {
         flag: undefined,
-        shouldShow: true,
-        desc: 'shows status page when undefined (backwards compatible)',
+        shouldRender: true,
+        expectedApprovalId: 'approvalId',
+        desc: 'creates and shows approval request when flag is undefined (backwards compatible)',
       },
     ])(
       '$desc',
       async ({
         flag,
-        shouldShow,
+        shouldRender,
+        expectedApprovalId,
       }: {
         flag: boolean | undefined;
-        shouldShow: boolean;
+        shouldRender: boolean;
+        expectedApprovalId: string;
       }) => {
         withRequest(
           {
@@ -954,20 +967,25 @@ describe('submitSmartTransactionHook', () => {
 
             const result = await submitSmartTransactionHook(request);
 
-            if (shouldShow) {
-              expect(startFlowSpy).toHaveBeenCalled();
-              expect(addRequestSpy).toHaveBeenCalled();
+            if (shouldRender) {
+              expect(startFlowSpy).toHaveBeenCalledWith();
             } else {
               expect(startFlowSpy).not.toHaveBeenCalled();
-              expect(addRequestSpy).not.toHaveBeenCalled();
             }
+            expect(addRequestSpy).toHaveBeenCalledWith(
+              expect.objectContaining({
+                id: expectedApprovalId,
+                type: 'smartTransaction:showSmartTransactionStatusPage',
+              }),
+              shouldRender,
+            );
             expect(result).toEqual({ transactionHash: txHash });
           },
         );
       },
     );
 
-    it('skips status page even with batch transactions when flag is true', async () => {
+    it('creates approval request without showing it for batch transactions when status page rendering is skipped', async () => {
       withRequest(
         {
           options: {
@@ -999,7 +1017,13 @@ describe('submitSmartTransactionHook', () => {
           const result = await submitSmartTransactionHook(request);
 
           expect(startFlowSpy).not.toHaveBeenCalled();
-          expect(addRequestSpy).not.toHaveBeenCalled();
+          expect(addRequestSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+              id: uuid,
+              type: 'smartTransaction:showSmartTransactionStatusPage',
+            }),
+            false,
+          );
           expect(result).toEqual({ transactionHash: txHash });
         },
       );
@@ -1248,7 +1272,7 @@ describe('submitBatchSmartTransactionHook', () => {
       );
 
       expect(endFlowSpy).toHaveBeenCalledWith({
-        id: 'approvalId',
+        id: '',
       });
     });
   });

--- a/app/scripts/lib/smart-transaction/smart-transactions.ts
+++ b/app/scripts/lib/smart-transaction/smart-transactions.ts
@@ -80,7 +80,11 @@ class SmartTransactionHook {
 
   #approvalFlowEnded: boolean;
 
+  // UI flow identifier
   #approvalFlowId: string;
+
+  // Pending approval identifier
+  #approvalRequestId: string;
 
   #chainId: Hex;
 
@@ -104,7 +108,11 @@ class SmartTransactionHook {
 
   #txParams: TransactionParams;
 
+  // Approval flow and UI rendering
   #shouldShowStatusPage: boolean;
+
+  // UI rendering only
+  #shouldRenderStatusPage: boolean;
 
   constructor(request: SubmitSmartTransactionRequest) {
     const {
@@ -118,6 +126,7 @@ class SmartTransactionHook {
       transactions,
     } = request;
     this.#approvalFlowId = '';
+    this.#approvalRequestId = '';
     this.#approvalFlowEnded = false;
     this.#transactionMeta = transactionMeta as TransactionMeta;
     this.#signedTransactionInHex = signedTransactionInHex;
@@ -140,6 +149,10 @@ class SmartTransactionHook {
     );
 
     this.#shouldShowStatusPage = legacyShowStatusPage;
+
+    this.#shouldRenderStatusPage =
+      this.#shouldShowStatusPage &&
+      !this.#featureFlags.extensionSkipTransactionStatusPage;
 
     log.info(
       '[SmartTransaction] shouldShowStatusPage:',
@@ -333,7 +346,9 @@ class SmartTransactionHook {
 
   async #processApprovalIfNeeded(uuid: string) {
     if (this.#shouldShowStatusPage) {
-      await this.#startApprovalFlow();
+      if (this.#shouldRenderStatusPage) {
+        await this.#startApprovalFlow();
+      }
 
       this.#addApprovalRequest({
         uuid,
@@ -349,6 +364,11 @@ class SmartTransactionHook {
       return;
     }
     this.#approvalFlowEnded = true;
+
+    if (!this.#shouldRenderStatusPage) {
+      return;
+    }
+
     this.#endApprovalFlow(this.#approvalFlowId);
 
     // Clear the shared approval flow ID when we end the flow
@@ -361,11 +381,15 @@ class SmartTransactionHook {
     const onApproveOrRejectWrapper = () => {
       this.#onApproveOrReject();
     };
+    this.#approvalRequestId = this.#shouldRenderStatusPage
+      ? this.#approvalFlowId
+      : uuid;
+
     this.#controllerMessenger
       .call(
         'ApprovalController:addRequest',
         {
-          id: this.#approvalFlowId,
+          id: this.#approvalRequestId,
           origin,
           type: SMART_TRANSACTION_CONFIRMATION_TYPES.showSmartTransactionStatusPage,
           requestState: {
@@ -379,7 +403,7 @@ class SmartTransactionHook {
             txId: this.#transactionMeta.id,
           },
         },
-        true,
+        this.#shouldRenderStatusPage,
       )
       .then(onApproveOrRejectWrapper, onApproveOrRejectWrapper);
   }
@@ -392,7 +416,7 @@ class SmartTransactionHook {
     return await this.#controllerMessenger.call(
       'ApprovalController:updateRequestState',
       {
-        id: this.#approvalFlowId,
+        id: this.#approvalRequestId,
         requestState: {
           smartTransaction,
           isDapp: this.#isDapp,

--- a/ui/components/app/transaction-list-item/transaction-list-item.component.js
+++ b/ui/components/app/transaction-list-item/transaction-list-item.component.js
@@ -269,6 +269,7 @@ function TransactionListItemInner({
 
     return (
       <Button
+        className="whitespace-nowrap"
         data-testid="speed-up-button"
         size={ButtonSize.Sm}
         onClick={hasCancelled ? cancelTransaction : retryTransaction}

--- a/ui/selectors/approvals.test.ts
+++ b/ui/selectors/approvals.test.ts
@@ -1,16 +1,19 @@
 import { ApprovalType } from '@metamask/controller-utils';
+import { SMART_TRANSACTION_CONFIRMATION_TYPES } from '../../shared/constants/app';
 import {
   type ApprovalsMetaMaskState,
   getApprovalFlows,
   getApprovalsByOrigin,
   getPendingApprovals,
   hasPendingApprovals,
+  selectPendingApprovalsForNavigation,
 } from './approvals';
 
 describe('approval selectors', () => {
   const mockedState = {
     metamask: {
       pendingApprovalCount: 3,
+      remoteFeatureFlags: {},
       pendingApprovals: {
         '1': {
           id: '1',
@@ -180,6 +183,85 @@ describe('approval selectors', () => {
       expect(result).toStrictEqual(
         Object.values(mockedState.metamask.pendingApprovals),
       );
+    });
+  });
+
+  describe('selectPendingApprovalsForNavigation', () => {
+    it('filters hidden smart transaction status approvals when skip flag is enabled', () => {
+      const state = {
+        metamask: {
+          ...mockedState.metamask,
+          remoteFeatureFlags: {
+            extensionSkipTransactionStatusPage: true,
+          },
+          pendingApprovals: {
+            stx: {
+              id: 'stx',
+              origin: 'origin',
+              time: Date.now() - 1,
+              type: SMART_TRANSACTION_CONFIRMATION_TYPES.showSmartTransactionStatusPage,
+              requestData: {},
+              requestState: {
+                txId: '0x1',
+                smartTransaction: { status: 'pending' },
+              },
+              expectsResult: false,
+            },
+            tx: {
+              id: 'tx',
+              origin: 'origin',
+              time: Date.now(),
+              type: ApprovalType.Transaction,
+              requestData: {},
+              requestState: null,
+              expectsResult: false,
+            },
+          },
+        },
+      };
+
+      expect(selectPendingApprovalsForNavigation(state)).toStrictEqual([
+        state.metamask.pendingApprovals.tx,
+      ]);
+    });
+
+    it('keeps smart transaction status approvals when skip flag is disabled', () => {
+      const state = {
+        metamask: {
+          ...mockedState.metamask,
+          remoteFeatureFlags: {
+            extensionSkipTransactionStatusPage: false,
+          },
+          pendingApprovals: {
+            stx: {
+              id: 'stx',
+              origin: 'origin',
+              time: Date.now() - 1,
+              type: SMART_TRANSACTION_CONFIRMATION_TYPES.showSmartTransactionStatusPage,
+              requestData: {},
+              requestState: {
+                txId: '0x1',
+                smartTransaction: { status: 'pending' },
+              },
+              expectsResult: false,
+            },
+            tx: {
+              id: 'tx',
+              origin: 'origin',
+              time: Date.now(),
+              type: ApprovalType.Transaction,
+              requestData: {},
+              requestState: null,
+              expectsResult: false,
+            },
+          },
+        },
+      };
+
+      expect(selectPendingApprovalsForNavigation(state)).toStrictEqual([
+        state.metamask.pendingApprovals.stx,
+        state.metamask.pendingApprovals.tx,
+      ]);
     });
   });
 });

--- a/ui/selectors/approvals.ts
+++ b/ui/selectors/approvals.ts
@@ -6,12 +6,16 @@ import { ApprovalType } from '@metamask/controller-utils';
 import { createSelector } from 'reselect';
 import { Json } from '@metamask/utils';
 import { createDeepEqualSelector } from '../../shared/lib/selectors/selector-creators';
+import { SMART_TRANSACTION_CONFIRMATION_TYPES } from '../../shared/constants/app';
+import { getBooleanFeatureFlag } from '../../shared/lib/remote-feature-flag-utils';
+import { getRemoteFeatureFlags } from './remote-feature-flags';
 import { EMPTY_OBJECT } from './shared';
 
 export type ApprovalsMetaMaskState = {
   metamask: {
     pendingApprovals: ApprovalControllerState['pendingApprovals'];
     approvalFlows: ApprovalControllerState['approvalFlows'];
+    remoteFeatureFlags?: Record<string, unknown>;
   };
 };
 
@@ -72,14 +76,32 @@ export const pendingApprovalsSortedSelector = createSelector(
   (approvals) => [...approvals].sort((a1, a2) => a1.time - a2.time),
 );
 
+const getSkipSmartTransactionStatusPage = createSelector(
+  getRemoteFeatureFlags,
+  (remoteFeatureFlags) =>
+    getBooleanFeatureFlag(
+      remoteFeatureFlags?.extensionSkipTransactionStatusPage,
+      false,
+    ),
+);
+
 /**
  * Returns pending approvals sorted by time for use in confirmation navigation.
  * Excludes duplicate watch asset approvals as they are combined into a single confirmation.
  */
 export const selectPendingApprovalsForNavigation = createDeepEqualSelector(
   pendingApprovalsSortedSelector,
-  (sortedPendingApprovals) =>
+  getSkipSmartTransactionStatusPage,
+  (sortedPendingApprovals, skipSmartTransactionStatusPage) =>
     sortedPendingApprovals.filter((approval, index) => {
+      if (
+        skipSmartTransactionStatusPage &&
+        approval.type ===
+          SMART_TRANSACTION_CONFIRMATION_TYPES.showSmartTransactionStatusPage
+      ) {
+        return false;
+      }
+
       if (
         isWatchNftApproval(approval) &&
         sortedPendingApprovals.findIndex(isWatchNftApproval) !== index


### PR DESCRIPTION
## **Description**

Note: this is behind a feature flag

Decouple smart transaction status approvals from confirmation navigation.

When `extensionSkipTransactionStatusPage` is enabled, STX status approvals are still created for toast tracking but will no longer be treated as navigable confirmations. This prevents the blank confirmation page that could appear during overlapping STX submissions.

Changes
- Decouple STX status approvals from the confirmation navigation selector
- Fix the "speed up" button text wrapping

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches smart transaction approval-flow IDs and confirmation navigation filtering; behavior changes are gated by `extensionSkipTransactionStatusPage` but could affect approval lifecycle and UI state ordering if misapplied.
> 
> **Overview**
> **When `extensionSkipTransactionStatusPage` is enabled, smart-transaction status approvals are now created for tracking but are not treated as navigable confirmations.**
> 
> The smart-transaction hook decouples approval *flow* vs *request* IDs: it can skip starting/ending the UI flow while still creating/updating an approval request (using the STX `uuid` as the request id when hidden). The confirmation navigation selector (`selectPendingApprovalsForNavigation`) now filters out `smartTransaction:showSmartTransactionStatusPage` approvals when the remote flag is on, with new tests covering both flag states.
> 
> Also adds a small UI tweak to keep the activity list “Speed Up” button label from wrapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 216eaff46a52324e663bddb8096620139282e656. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->