### PR TITLE
feat: hide toasts on confirmations cp-13.29.0

### DIFF
--- a/ui/components/ui/toast/toast.tsx
+++ b/ui/components/ui/toast/toast.tsx
@@ -32,6 +32,9 @@ export function Toaster() {
     <ToasterBase
       position="bottom-center"
       containerClassName="toast-container"
+      containerStyle={{
+        display: 'var(--toast-display, flex)',
+      }}
       toastOptions={{
         className: 'w-[360px] max-w-[360px] border border-border-muted',
         style: {

--- a/ui/hooks/useCssVar.ts
+++ b/ui/hooks/useCssVar.ts
@@ -1,0 +1,19 @@
+import { useMemo } from 'react';
+
+type Props = {
+  name: `--${string}`;
+  root?: HTMLElement;
+};
+
+export const useCssVar = ({ name, root }: Props) => {
+  const resolvedRoot = root ?? document.documentElement;
+
+  return useMemo(
+    () => ({
+      set: (value: string) => resolvedRoot.style.setProperty(name, value),
+      get: () => resolvedRoot.style.getPropertyValue(name),
+      remove: () => resolvedRoot.style.removeProperty(name),
+    }),
+    [name, resolvedRoot],
+  );
+};

--- a/ui/hooks/useHideToasts.ts
+++ b/ui/hooks/useHideToasts.ts
@@ -1,0 +1,21 @@
+import { useLayoutEffect } from 'react';
+import { useCssVar } from './useCssVar';
+
+const toastCssVariable = '--toast-display';
+
+export function useHideToasts() {
+  const toastDisplay = useCssVar({ name: toastCssVariable });
+
+  useLayoutEffect(() => {
+    const previousValue = toastDisplay.get();
+    toastDisplay.set('none');
+
+    return () => {
+      if (previousValue) {
+        toastDisplay.set(previousValue);
+      } else {
+        toastDisplay.remove();
+      }
+    };
+  }, [toastDisplay]);
+}

--- a/ui/pages/confirmations/confirm/confirm.tsx
+++ b/ui/pages/confirmations/confirm/confirm.tsx
@@ -19,34 +19,39 @@ import {
   GasFeeModalContextProvider,
   GasFeeModalWrapper,
 } from '../context/gas-fee-modal';
+import { useHideToasts } from '../../../hooks/useHideToasts';
 
-const Confirm: React.FC<{ confirmationId?: string }> = ({ confirmationId }) => (
-  <ConfirmContextProvider confirmationId={confirmationId}>
-    <DappSwapContextProvider>
-      <GasFeeModalContextProvider>
-        <TransactionModalContextProvider>
-          <ConfirmAlerts>
-            <>
-              <Page className="confirm_wrapper">
-                <ConfirmNav />
-                <Header />
-                <SmartTransactionsBannerAlert marginType="noTop" />
-                <ScrollToBottom>
-                  <BlockaidLoadingIndicator />
-                  <Title />
-                  <Info />
-                  <PluggableSection />
-                </ScrollToBottom>
-                <GasFeeTokenToast />
-                <Footer />
-              </Page>
-              <GasFeeModalWrapper />
-            </>
-          </ConfirmAlerts>
-        </TransactionModalContextProvider>
-      </GasFeeModalContextProvider>
-    </DappSwapContextProvider>
-  </ConfirmContextProvider>
-);
+const Confirm: React.FC<{ confirmationId?: string }> = ({ confirmationId }) => {
+  useHideToasts();
+
+  return (
+    <ConfirmContextProvider confirmationId={confirmationId}>
+      <DappSwapContextProvider>
+        <GasFeeModalContextProvider>
+          <TransactionModalContextProvider>
+            <ConfirmAlerts>
+              <>
+                <Page className="confirm_wrapper">
+                  <ConfirmNav />
+                  <Header />
+                  <SmartTransactionsBannerAlert marginType="noTop" />
+                  <ScrollToBottom>
+                    <BlockaidLoadingIndicator />
+                    <Title />
+                    <Info />
+                    <PluggableSection />
+                  </ScrollToBottom>
+                  <GasFeeTokenToast />
+                  <Footer />
+                </Page>
+                <GasFeeModalWrapper />
+              </>
+            </ConfirmAlerts>
+          </TransactionModalContextProvider>
+        </GasFeeModalContextProvider>
+      </DappSwapContextProvider>
+    </ConfirmContextProvider>
+  );
+};
 
 export default Confirm;

--- a/ui/pages/confirmations/confirmation/confirmation.js
+++ b/ui/pages/confirmations/confirmation/confirmation.js
@@ -33,6 +33,7 @@ import MetaMaskTemplateRenderer from '../../../components/app/metamask-template-
 import ConfirmationWarningModal from '../components/confirmation-warning-modal';
 import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
 import { useI18nContext } from '../../../hooks/useI18nContext';
+import { useHideToasts } from '../../../hooks/useHideToasts';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 import {
   getUnapprovedTemplatedConfirmations,
@@ -234,6 +235,8 @@ function Header({ confirmation, isSnapCustomUIDialog, onCancel }) {
 export default function ConfirmationPage({
   redirectToHomeOnZeroConfirmations = true,
 }) {
+  useHideToasts();
+
   const t = useI18nContext();
   const { trackEvent } = useContext(MetaMetricsContext);
   const dispatch = useDispatch();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Note: transaction toasts are behind a feature flag

Adds a small hook to hide global toasts on confirmation screens

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Navigate to a confirmation page while a toast is open

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that toggles a CSS variable to hide the global toast container while confirmation pages are mounted; main risk is unintended toast visibility changes if other views rely on the same variable.
> 
> **Overview**
> Hides the global `react-hot-toast` toaster while users are on confirmation flows.
> 
> This adds `useCssVar`/`useHideToasts` to set `--toast-display: none` on mount (restoring the prior value on unmount), updates the `Toaster` to respect `--toast-display`, and applies the hook in both `Confirm` and `ConfirmationPage` so confirmation screens suppress global toasts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05faab75f9c81201da700b2f699271a44fa86293. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->