### PR TITLE
fix(analytics): normalize active A/B test payloads

### DIFF
--- a/.agents/skills/ab-testing-implementation/SKILL.md
+++ b/.agents/skills/ab-testing-implementation/SKILL.md
@@ -51,7 +51,8 @@ rg -n "Experiment Viewed|ExperimentViewed" app shared ui
    - Prefer allowlisted auto-enrichment on the shared MetaMetrics path.
    - Add `active_ab_tests` manually only for business events that bypass the
      shared MetaMetrics wrappers/controller path, and only when the
-     assignment is active.
+     assignment is active. Use `createActiveABTestAssignment` for manual
+     payloads so `key_value_pair` stays in sync.
    - Never add new `ab_tests:` payloads. If a legacy touchpoint cannot be
      migrated in the same change, keep the line annotated with
      `LEGACY_AB_TEST_ALLOWED` and explain why.
@@ -65,10 +66,10 @@ const experiment = useABTest('swapsSWAPS4135AbtestNumpadQuickAmounts', {
 
 const activeABTests = experiment.isActive
   ? [
-      {
-        key: 'swapsSWAPS4135AbtestNumpadQuickAmounts',
-        value: experiment.variantName,
-      },
+      createActiveABTestAssignment(
+        'swapsSWAPS4135AbtestNumpadQuickAmounts',
+        experiment.variantName,
+      ),
     ]
   : undefined;
 ```
@@ -111,6 +112,7 @@ node --import tsx .agents/skills/ab-testing-implementation/scripts/check-ab-test
 
 - `ui/hooks/useABTest.ts`
 - `ui/hooks/useABTest.test.ts`
+- `shared/lib/ab-testing/active-ab-test-assignment.ts`
 - `shared/lib/ab-testing/resolve-ab-test-assignment.ts`
 - `shared/lib/ab-testing/ab-test-analytics.ts`
 - `ui/selectors/remote-feature-flags.ts`

--- a/.agents/skills/ab-testing-implementation/scripts/check-ab-testing-compliance.ts
+++ b/.agents/skills/ab-testing-implementation/scripts/check-ab-testing-compliance.ts
@@ -28,7 +28,7 @@ Checks changed files for A/B testing implementation compliance.
 
 Rules:
   - Fail: New ab_tests payload additions in checked code diffs
-  - Fail: Malformed literal active_ab_tests objects missing key/value
+  - Fail: Malformed literal active_ab_tests objects missing key/value/key_value_pair
   - Fail: Inline useABTest variants object missing control
   - Warn: Flag key naming mismatch for Abtest keys
   - Warn: Risky A/B integration changes without test-file updates`;
@@ -186,6 +186,47 @@ function printList(title: string, items: string[]): void {
   }
 }
 
+function extractActiveABTestsPayload(
+  addedLines: string[],
+  startIndex: number,
+): string | null {
+  const line = addedLines[startIndex];
+  const match = line.match(/active_ab_tests\s*:\s*(\[|\{)/u);
+
+  if (!match) {
+    return null;
+  }
+
+  const openingCharacter = match[1];
+  const closingCharacter = openingCharacter === '[' ? ']' : '}';
+  const payloadStartIndex =
+    (match.index ?? 0) + match[0].lastIndexOf(openingCharacter);
+  let payload = line.slice(payloadStartIndex);
+  const closingIndex = payload.indexOf(closingCharacter);
+
+  if (closingIndex !== -1) {
+    return payload.slice(0, closingIndex + 1);
+  }
+
+  for (
+    let index = startIndex + 1;
+    index < addedLines.length && index <= startIndex + 8;
+    index += 1
+  ) {
+    const nextLine = addedLines[index];
+    const nextClosingIndex = nextLine.indexOf(closingCharacter);
+
+    if (nextClosingIndex !== -1) {
+      payload += `\n${nextLine.slice(0, nextClosingIndex + 1)}`;
+      break;
+    }
+
+    payload += `\n${nextLine}`;
+  }
+
+  return payload;
+}
+
 function main(): void {
   let mode: Mode | null = null;
   let filesArg = '';
@@ -315,10 +356,19 @@ function main(): void {
 
       if (/active_ab_tests\s*:/.test(line)) {
         if (/active_ab_tests\s*:\s*(\[|\{)/.test(line)) {
-          const window = addedLines.slice(index, index + 9).join('\n');
-          if (!/key\s*:/.test(window) || !/value\s*:/.test(window)) {
+          const payload = extractActiveABTestsPayload(addedLines, index) ?? '';
+          const hasLiteralAssignmentFields =
+            /key\s*:/.test(payload) ||
+            /value\s*:/.test(payload) ||
+            /key_value_pair\s*:/.test(payload);
+          const hasCompleteLiteralAssignment =
+            /key\s*:/.test(payload) &&
+            /value\s*:/.test(payload) &&
+            /key_value_pair\s*:/.test(payload);
+
+          if (hasLiteralAssignmentFields && !hasCompleteLiteralAssignment) {
             failures.push(
-              `${file}: malformed literal active_ab_tests object (expected key and value).`,
+              `${file}: malformed literal active_ab_tests object (expected key, value, and key_value_pair).`,
             );
           }
         }

--- a/app/scripts/controllers/metametrics-controller.test.ts
+++ b/app/scripts/controllers/metametrics-controller.test.ts
@@ -41,6 +41,7 @@ import {
   AB_TEST_ANALYTICS_MAPPINGS,
   clearABTestAnalyticsMappings,
 } from '../../../shared/lib/ab-testing/ab-test-analytics';
+import { createActiveABTestAssignment } from '../../../shared/lib/ab-testing/active-ab-test-assignment';
 import * as ManifestFlags from '../../../shared/lib/manifestFlags';
 import * as Utils from '../lib/util';
 import { mockNetworkState } from '../../../test/stub/networks';
@@ -992,10 +993,10 @@ describe('MetaMetricsController', function () {
               properties: expect.objectContaining({
                 // eslint-disable-next-line @typescript-eslint/naming-convention
                 active_ab_tests: [
-                  {
-                    key: TEST_BADGE_FLAG_KEY,
-                    value: 'withBadge',
-                  },
+                  createActiveABTestAssignment(
+                    TEST_BADGE_FLAG_KEY,
+                    'withBadge',
+                  ),
                 ],
               }),
             }),
@@ -1039,14 +1040,11 @@ describe('MetaMetricsController', function () {
               properties: expect.objectContaining({
                 // eslint-disable-next-line @typescript-eslint/naming-convention
                 active_ab_tests: [
-                  {
-                    key: TEST_QUICK_AMOUNTS_FLAG_KEY,
-                    value: 'treatment',
-                  },
-                  {
-                    key: TEST_LAYOUT_FLAG_KEY,
-                    value: 'control',
-                  },
+                  createActiveABTestAssignment(
+                    TEST_QUICK_AMOUNTS_FLAG_KEY,
+                    'treatment',
+                  ),
+                  createActiveABTestAssignment(TEST_LAYOUT_FLAG_KEY, 'control'),
                 ],
               }),
             }),
@@ -1089,6 +1087,8 @@ describe('MetaMetricsController', function () {
                 {
                   key: TEST_QUICK_AMOUNTS_FLAG_KEY,
                   value: 'manual-value',
+                  // eslint-disable-next-line @typescript-eslint/naming-convention
+                  key_value_pair: 'incorrect=value',
                 },
               ],
               // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -1103,14 +1103,14 @@ describe('MetaMetricsController', function () {
                 quote_count: 3,
                 // eslint-disable-next-line @typescript-eslint/naming-convention
                 active_ab_tests: [
-                  {
-                    key: TEST_QUICK_AMOUNTS_FLAG_KEY,
-                    value: 'manual-value',
-                  },
-                  {
-                    key: TEST_LAYOUT_FLAG_KEY,
-                    value: 'treatment',
-                  },
+                  createActiveABTestAssignment(
+                    TEST_QUICK_AMOUNTS_FLAG_KEY,
+                    'manual-value',
+                  ),
+                  createActiveABTestAssignment(
+                    TEST_LAYOUT_FLAG_KEY,
+                    'treatment',
+                  ),
                 ],
               }),
             }),
@@ -1181,6 +1181,103 @@ describe('MetaMetricsController', function () {
       });
     });
 
+    it('normalizes existing active_ab_tests for unmapped events without fetching feature flags', async function () {
+      const getManifestFlagsSpy = jest
+        .spyOn(ManifestFlags, 'getManifestFlags')
+        .mockReturnValue({});
+
+      await withController(({ controller }) => {
+        const spy = jest.spyOn(segmentMock, 'track');
+
+        controller.trackEvent({
+          event: 'Unrelated Event',
+          category: 'Unit Test',
+          properties: {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            active_ab_tests: [
+              {
+                key: TEST_BADGE_FLAG_KEY,
+                value: 'withBadge',
+              },
+            ],
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            test_prop: 'value',
+          },
+        });
+
+        expect(getManifestFlagsSpy).not.toHaveBeenCalled();
+        expect(spy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            properties: expect.objectContaining({
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              active_ab_tests: [
+                createActiveABTestAssignment(TEST_BADGE_FLAG_KEY, 'withBadge'),
+              ],
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              test_prop: 'value',
+            }),
+          }),
+          expect.anything(),
+        );
+      });
+    });
+
+    it('normalizes existing active_ab_tests on anonymous sensitive-property events', async function () {
+      const getManifestFlagsSpy = jest
+        .spyOn(ManifestFlags, 'getManifestFlags')
+        .mockReturnValue({});
+
+      await withController(({ controller }) => {
+        const spy = jest.spyOn(segmentMock, 'track');
+
+        controller.trackEvent({
+          event: 'Unrelated Event',
+          category: 'Unit Test',
+          properties: {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            active_ab_tests: [
+              {
+                key: TEST_BADGE_FLAG_KEY,
+                value: 'withBadge',
+              },
+            ],
+          },
+          sensitiveProperties: {
+            sensitive: 'value',
+          },
+        });
+
+        const normalizedAssignment = createActiveABTestAssignment(
+          TEST_BADGE_FLAG_KEY,
+          'withBadge',
+        );
+
+        expect(getManifestFlagsSpy).not.toHaveBeenCalled();
+        expect(spy).toHaveBeenCalledTimes(2);
+        expect(spy).toHaveBeenNthCalledWith(
+          1,
+          expect.objectContaining({
+            properties: expect.objectContaining({
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              active_ab_tests: [normalizedAssignment],
+              sensitive: 'value',
+            }),
+          }),
+          expect.anything(),
+        );
+        expect(spy).toHaveBeenNthCalledWith(
+          2,
+          expect.objectContaining({
+            properties: expect.objectContaining({
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              active_ab_tests: [normalizedAssignment],
+            }),
+          }),
+          expect.anything(),
+        );
+      });
+    });
+
     it('preserves sensitiveProperties and only enriches the identified event', async function () {
       AB_TEST_ANALYTICS_MAPPINGS.push({
         flagKey: TEST_BADGE_FLAG_KEY,
@@ -1232,10 +1329,7 @@ describe('MetaMetricsController', function () {
                 button_type: 'card',
                 // eslint-disable-next-line @typescript-eslint/naming-convention
                 active_ab_tests: [
-                  {
-                    key: TEST_BADGE_FLAG_KEY,
-                    value: 'control',
-                  },
+                  createActiveABTestAssignment(TEST_BADGE_FLAG_KEY, 'control'),
                 ],
               }),
             }),
@@ -1276,10 +1370,10 @@ describe('MetaMetricsController', function () {
               properties: expect.objectContaining({
                 // eslint-disable-next-line @typescript-eslint/naming-convention
                 active_ab_tests: [
-                  {
-                    key: TEST_QUICK_AMOUNTS_FLAG_KEY,
-                    value: 'treatment',
-                  },
+                  createActiveABTestAssignment(
+                    TEST_QUICK_AMOUNTS_FLAG_KEY,
+                    'treatment',
+                  ),
                 ],
               }),
             }),

--- a/app/scripts/controllers/metametrics-controller.ts
+++ b/app/scripts/controllers/metametrics-controller.ts
@@ -1044,14 +1044,31 @@ export class MetaMetricsController extends BaseController<
 
     let identifiedPayload = payload;
 
-    if (hasABTestAnalyticsMappingForEvent(payload.event)) {
+    const hasABTestAnalyticsMapping = hasABTestAnalyticsMappingForEvent(
+      payload.event,
+    );
+    const hasActiveABTests = payload.properties?.active_ab_tests !== undefined;
+
+    let normalizedPayload = payload;
+
+    if (hasActiveABTests) {
+      try {
+        normalizedPayload = enrichWithABTests(payload, null, []);
+      } catch {
+        normalizedPayload = payload;
+      }
+    }
+
+    identifiedPayload = normalizedPayload;
+
+    if (hasABTestAnalyticsMapping) {
       try {
         identifiedPayload = enrichWithABTests(
-          payload,
+          normalizedPayload,
           this.#getRemoteFeatureFlags(),
         );
       } catch {
-        identifiedPayload = payload;
+        identifiedPayload = normalizedPayload;
       }
     }
 
@@ -1074,7 +1091,7 @@ export class MetaMetricsController extends BaseController<
         // @ts-expect-error This property may not exist. We check for it below.
         overrideAnonymousEventNames[`${payload.event}`];
       const anonymousPayload = {
-        ...payload,
+        ...normalizedPayload,
         event: anonymousEventName ?? payload.event,
       };
 

--- a/docs/ab-testing.md
+++ b/docs/ab-testing.md
@@ -18,7 +18,8 @@ Use this order every time:
    register an `ABTestAnalyticsMapping` in background-safe shared code used by
    `shared/lib/ab-testing/ab-test-analytics.ts`.
 5. If the feature uses a custom tracking path that bypasses shared MetaMetrics
-   enrichment, attach `active_ab_tests` manually on that event.
+   enrichment, attach `active_ab_tests` manually with
+   `createActiveABTestAssignment`.
 6. Update targeted tests, the E2E feature-flag registry, and local override
    guidance when needed.
 
@@ -44,7 +45,8 @@ An A/B test is ready when all of these are true:
 - The feature reads assignment through `useABTest`
 - The variants object includes a `control` variant
 - Shared MetaMetrics events are registered for auto-enrichment when needed
-- Custom tracker events attach `active_ab_tests` manually when active
+- Custom tracker events attach `active_ab_tests` manually with
+  `createActiveABTestAssignment` when active
 - Relevant tests were added or updated when behavior or analytics wiring changed
 - The E2E feature-flag registry includes the production default value
 
@@ -141,17 +143,15 @@ trackEvent({
 ### 4. Handle bypass paths manually
 
 If an event bypasses the shared MetaMetrics enrichment path, add
-`active_ab_tests` yourself. Do not copy this pattern for `trackEvent(...)`
-calls that already flow through shared enrichment.
+`active_ab_tests` yourself with `createActiveABTestAssignment`. Do not copy
+this pattern for `trackEvent(...)` calls that already flow through shared
+enrichment.
 
 ```typescript
+import { createActiveABTestAssignment } from '../../../../shared/lib/ab-testing/active-ab-test-assignment';
+
 const activeABTests = isActive
-  ? [
-      {
-        key: FEATURE_AB_TEST_KEY,
-        value: variantName,
-      },
-    ]
+  ? [createActiveABTestAssignment(FEATURE_AB_TEST_KEY, variantName)]
   : undefined;
 
 sendCustomAnalyticsPayload({
@@ -210,7 +210,8 @@ Events are auto-enriched when:
 - and the event name is registered in background-safe shared analytics mapping
   code
 
-If an event bypasses that shared path, attach `active_ab_tests` manually.
+If an event bypasses that shared path, attach `active_ab_tests` manually with
+`createActiveABTestAssignment`.
 
 ### 3. Do not add new `ab_tests` payloads
 
@@ -219,13 +220,19 @@ If an event bypasses that shared path, attach `active_ab_tests` manually.
 Use this shape instead:
 
 ```typescript
-type ActiveABTest = Array<{ key: string; value: string }>;
+type ActiveABTest = Array<{
+  key: string;
+  value: string;
+  key_value_pair: string;
+}>;
 ```
 
 Correct:
 
 ```typescript
-active_ab_tests: [{ key: FEATURE_AB_TEST_KEY, value: variantName }];
+active_ab_tests: [
+  createActiveABTestAssignment(FEATURE_AB_TEST_KEY, variantName),
+];
 ```
 
 Incorrect:
@@ -350,6 +357,7 @@ Helpful existing files:
 
 - `ui/hooks/useABTest.ts`
 - `ui/hooks/useABTest.test.ts`
+- `shared/lib/ab-testing/active-ab-test-assignment.ts`
 - `shared/lib/ab-testing/resolve-ab-test-assignment.ts`
 - `shared/lib/ab-testing/ab-test-analytics.ts`
 - `app/scripts/controllers/metametrics-controller.ts`
@@ -362,7 +370,7 @@ No. Not when you use `useABTest`.
 
 **Do I manually attach `active_ab_tests` to every event?**  
 No. Register shared-path events for auto-enrichment. Add `active_ab_tests`
-manually only for bypass paths.
+manually only for bypass paths, and use `createActiveABTestAssignment`.
 
 **What is the fallback variant?**  
 `control`.
@@ -372,7 +380,8 @@ When the hook is using the fallback because the assignment is missing, invalid,
 or unresolved.
 
 **Do I need a per-test analytics schema key?**  
-No. Use the shared `active_ab_tests` array of `{ key, value }`.
+No. Use the shared `active_ab_tests` array of
+`{ key, value, key_value_pair }`.
 
 **Can multiple tests enrich the same event?**  
 Yes. Multiple assignments can be included in the same `active_ab_tests` array.

--- a/shared/lib/ab-testing/ab-test-analytics.test.ts
+++ b/shared/lib/ab-testing/ab-test-analytics.test.ts
@@ -6,6 +6,7 @@ import {
   getRemoteFeatureFlagsWithManifestOverrides,
   hasABTestAnalyticsMappingForEvent,
 } from './ab-test-analytics';
+import { createActiveABTestAssignment } from './active-ab-test-assignment';
 
 const TEST_BADGE_FLAG_KEY = 'testTEST338AbtestAttentionBadge';
 const TEST_QUICK_AMOUNTS_FLAG_KEY = 'testTEST4135AbtestQuickAmounts';
@@ -75,10 +76,7 @@ describe('ab-test-analytics', () => {
       expect(result.properties).toStrictEqual({
         // eslint-disable-next-line @typescript-eslint/naming-convention
         active_ab_tests: [
-          {
-            key: TEST_BADGE_FLAG_KEY,
-            value: 'withBadge',
-          },
+          createActiveABTestAssignment(TEST_BADGE_FLAG_KEY, 'withBadge'),
         ],
       });
     });
@@ -94,14 +92,8 @@ describe('ab-test-analytics', () => {
       );
 
       expect(result.properties?.active_ab_tests).toStrictEqual([
-        {
-          key: TEST_QUICK_AMOUNTS_FLAG_KEY,
-          value: 'treatment',
-        },
-        {
-          key: TEST_LAYOUT_FLAG_KEY,
-          value: 'control',
-        },
+        createActiveABTestAssignment(TEST_QUICK_AMOUNTS_FLAG_KEY, 'treatment'),
+        createActiveABTestAssignment(TEST_LAYOUT_FLAG_KEY, 'control'),
       ]);
     });
 
@@ -119,6 +111,28 @@ describe('ab-test-analytics', () => {
       ).toStrictEqual(event);
     });
 
+    it('normalizes existing active_ab_tests when the event is not allowlisted', () => {
+      const result = enrichWithABTests(
+        createEvent('Unrelated Event', {
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          active_ab_tests: [
+            {
+              key: TEST_BADGE_FLAG_KEY,
+              value: 'withBadge',
+            },
+          ],
+        }),
+        {
+          [TEST_BADGE_FLAG_KEY]: 'control',
+        },
+        TEST_ANALYTICS_MAPPINGS,
+      );
+
+      expect(result.properties?.active_ab_tests).toStrictEqual([
+        createActiveABTestAssignment(TEST_BADGE_FLAG_KEY, 'withBadge'),
+      ]);
+    });
+
     it('ignores missing and invalid flag values', () => {
       const event = createEvent('Unified SwapBridge Page Viewed');
 
@@ -134,7 +148,7 @@ describe('ab-test-analytics', () => {
       ).toStrictEqual(event);
     });
 
-    it('merges with existing active_ab_tests and preserves explicit payload values', () => {
+    it('merges with existing active_ab_tests, normalizes them, and preserves explicit payload values', () => {
       const result = enrichWithABTests(
         createEvent('Unified SwapBridge Page Viewed', {
           // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -142,6 +156,8 @@ describe('ab-test-analytics', () => {
             {
               key: TEST_QUICK_AMOUNTS_FLAG_KEY,
               value: 'manual-value',
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              key_value_pair: 'incorrect=value',
             },
           ],
           // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -159,14 +175,11 @@ describe('ab-test-analytics', () => {
         quote_count: 3,
         // eslint-disable-next-line @typescript-eslint/naming-convention
         active_ab_tests: [
-          {
-            key: TEST_QUICK_AMOUNTS_FLAG_KEY,
-            value: 'manual-value',
-          },
-          {
-            key: TEST_LAYOUT_FLAG_KEY,
-            value: 'treatment',
-          },
+          createActiveABTestAssignment(
+            TEST_QUICK_AMOUNTS_FLAG_KEY,
+            'manual-value',
+          ),
+          createActiveABTestAssignment(TEST_LAYOUT_FLAG_KEY, 'treatment'),
         ],
       });
     });
@@ -197,10 +210,7 @@ describe('ab-test-analytics', () => {
         button_type: 'card',
         // eslint-disable-next-line @typescript-eslint/naming-convention
         active_ab_tests: [
-          {
-            key: TEST_BADGE_FLAG_KEY,
-            value: 'control',
-          },
+          createActiveABTestAssignment(TEST_BADGE_FLAG_KEY, 'control'),
         ],
       });
       expect(result.sensitiveProperties).toStrictEqual({

--- a/shared/lib/ab-testing/ab-test-analytics.ts
+++ b/shared/lib/ab-testing/ab-test-analytics.ts
@@ -2,12 +2,12 @@ import type { Json } from '@metamask/utils';
 
 import type { MetaMetricsEventPayload } from '../../constants/metametrics';
 import { getManifestFlags } from '../manifestFlags';
+import {
+  createActiveABTestAssignment,
+  normalizeActiveABTestAssignments,
+  type ActiveABTestAssignment,
+} from './active-ab-test-assignment';
 import { resolveABTestAssignment } from './resolve-ab-test-assignment';
-
-export type ActiveABTestAssignment = {
-  key: string;
-  value: string;
-};
 
 export type ABTestAnalyticsMapping = {
   flagKey: string;
@@ -32,26 +32,6 @@ export function hasABTestAnalyticsMappingForEvent(
   return mappings.some((mapping) => hasEventName(mapping, eventName));
 }
 
-const isActiveABTestAssignment = (
-  value: unknown,
-): value is ActiveABTestAssignment =>
-  Boolean(
-    value &&
-      typeof value === 'object' &&
-      'key' in value &&
-      typeof value.key === 'string' &&
-      'value' in value &&
-      typeof value.value === 'string',
-  );
-
-const getExistingActiveABTests = (value: unknown): ActiveABTestAssignment[] => {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-
-  return value.filter(isActiveABTestAssignment);
-};
-
 export function getRemoteFeatureFlagsWithManifestOverrides(
   remoteFeatureFlags: Record<string, unknown> | null | undefined,
 ): Record<string, unknown> {
@@ -61,17 +41,36 @@ export function getRemoteFeatureFlagsWithManifestOverrides(
   };
 }
 
+const cloneEventWithAssignments = <TEvent extends MetaMetricsEventPayload>(
+  event: TEvent,
+  assignments: ActiveABTestAssignment[],
+): TEvent => ({
+  ...event,
+  properties: {
+    ...event.properties,
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    active_ab_tests: assignments as Json,
+  },
+});
+
 export function enrichWithABTests<TEvent extends MetaMetricsEventPayload>(
   event: TEvent,
   featureFlags: Record<string, unknown> | null | undefined,
   mappings: readonly ABTestAnalyticsMapping[] = AB_TEST_ANALYTICS_MAPPINGS,
 ): TEvent {
+  const existingAssignments = normalizeActiveABTestAssignments(
+    event.properties?.active_ab_tests,
+  );
   const relevantMappings = mappings.filter((mapping) =>
     hasEventName(mapping, event.event),
   );
 
   if (relevantMappings.length === 0) {
-    return event;
+    if (existingAssignments.length === 0) {
+      return event;
+    }
+
+    return cloneEventWithAssignments(event, existingAssignments);
   }
 
   const injectedAssignments = relevantMappings.flatMap((mapping) => {
@@ -81,16 +80,19 @@ export function enrichWithABTests<TEvent extends MetaMetricsEventPayload>(
       mapping.validVariants,
     );
 
-    return isActive ? [{ key: mapping.flagKey, value: variantName }] : [];
+    return isActive
+      ? [createActiveABTestAssignment(mapping.flagKey, variantName)]
+      : [];
   });
 
   if (injectedAssignments.length === 0) {
-    return event;
+    if (existingAssignments.length === 0) {
+      return event;
+    }
+
+    return cloneEventWithAssignments(event, existingAssignments);
   }
 
-  const existingAssignments = getExistingActiveABTests(
-    event.properties?.active_ab_tests,
-  );
   const mergedAssignments = [...existingAssignments];
   const existingKeys = new Set(existingAssignments.map(({ key }) => key));
 
@@ -103,12 +105,5 @@ export function enrichWithABTests<TEvent extends MetaMetricsEventPayload>(
     mergedAssignments.push(assignment);
   }
 
-  return {
-    ...event,
-    properties: {
-      ...event.properties,
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      active_ab_tests: mergedAssignments as Json,
-    },
-  };
+  return cloneEventWithAssignments(event, mergedAssignments);
 }

--- a/shared/lib/ab-testing/active-ab-test-assignment.test.ts
+++ b/shared/lib/ab-testing/active-ab-test-assignment.test.ts
@@ -1,0 +1,77 @@
+import {
+  createActiveABTestAssignment,
+  normalizeActiveABTestAssignments,
+} from './active-ab-test-assignment';
+
+describe('active-ab-test-assignment', () => {
+  describe('createActiveABTestAssignment', () => {
+    it('creates an assignment with a derived key_value_pair', () => {
+      expect(
+        createActiveABTestAssignment(
+          'testTEST338AbtestAttentionBadge',
+          'withBadge',
+        ),
+      ).toStrictEqual({
+        key: 'testTEST338AbtestAttentionBadge',
+        value: 'withBadge',
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        key_value_pair: 'testTEST338AbtestAttentionBadge=withBadge',
+      });
+    });
+  });
+
+  describe('normalizeActiveABTestAssignments', () => {
+    it('normalizes legacy assignments missing key_value_pair', () => {
+      expect(
+        normalizeActiveABTestAssignments([
+          {
+            key: 'testTEST338AbtestAttentionBadge',
+            value: 'withBadge',
+          },
+        ]),
+      ).toStrictEqual([
+        createActiveABTestAssignment(
+          'testTEST338AbtestAttentionBadge',
+          'withBadge',
+        ),
+      ]);
+    });
+
+    it('recomputes stale key_value_pair values', () => {
+      expect(
+        normalizeActiveABTestAssignments([
+          {
+            key: 'testTEST338AbtestAttentionBadge',
+            value: 'withBadge',
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            key_value_pair: 'incorrect=value',
+          },
+        ]),
+      ).toStrictEqual([
+        createActiveABTestAssignment(
+          'testTEST338AbtestAttentionBadge',
+          'withBadge',
+        ),
+      ]);
+    });
+
+    it('discards malformed assignments', () => {
+      expect(
+        normalizeActiveABTestAssignments([
+          null,
+          { key: 'missing-value' },
+          { value: 'missing-key' },
+          { key: 'numeric-value', value: 1 },
+          createActiveABTestAssignment('testTEST1000AbtestValid', 'control'),
+        ]),
+      ).toStrictEqual([
+        createActiveABTestAssignment('testTEST1000AbtestValid', 'control'),
+      ]);
+    });
+
+    it('returns an empty array for non-array values', () => {
+      expect(normalizeActiveABTestAssignments(undefined)).toStrictEqual([]);
+      expect(normalizeActiveABTestAssignments({})).toStrictEqual([]);
+    });
+  });
+});

--- a/shared/lib/ab-testing/active-ab-test-assignment.ts
+++ b/shared/lib/ab-testing/active-ab-test-assignment.ts
@@ -1,0 +1,67 @@
+/**
+ * Canonical `active_ab_tests` entry emitted on analytics business events.
+ */
+export type ActiveABTestAssignment = {
+  /** Canonical experiment identifier, usually the LaunchDarkly flag key. */
+  key: string;
+  /** Assigned variant name for the active experiment. */
+  value: string;
+  /** Convenience `key=value` representation derived from `key` and `value`. */
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  key_value_pair: string;
+};
+
+/**
+ * Creates a normalized `active_ab_tests` entry with a derived
+ * `key_value_pair`.
+ *
+ * @param key - Canonical experiment identifier.
+ * @param value - Assigned variant name for the active experiment.
+ * @returns A normalized active A/B test assignment.
+ */
+export function createActiveABTestAssignment(
+  key: string,
+  value: string,
+): ActiveABTestAssignment {
+  return {
+    key,
+    value,
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    key_value_pair: `${key}=${value}`,
+  };
+}
+
+const isActiveABTestAssignment = (
+  value: unknown,
+): value is Pick<ActiveABTestAssignment, 'key' | 'value'> =>
+  Boolean(
+    value &&
+      typeof value === 'object' &&
+      'key' in value &&
+      typeof value.key === 'string' &&
+      'value' in value &&
+      typeof value.value === 'string',
+  );
+
+/**
+ * Normalizes an unknown `active_ab_tests` payload into canonical entries.
+ *
+ * Legacy objects that only include `key` and `value` are upgraded by deriving
+ * `key_value_pair`. Entries without the minimum assignment shape are discarded.
+ *
+ * @param value - Unknown analytics payload value.
+ * @returns Normalized active A/B test assignments.
+ */
+export function normalizeActiveABTestAssignments(
+  value: unknown,
+): ActiveABTestAssignment[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .filter(isActiveABTestAssignment)
+    .map(({ key, value: assignmentValue }) =>
+      createActiveABTestAssignment(key, assignmentValue),
+    );
+}

--- a/test/unit-global/check-ab-testing-compliance.test.ts
+++ b/test/unit-global/check-ab-testing-compliance.test.ts
@@ -132,11 +132,11 @@ describe('check-ab-testing-compliance.ts', () => {
     expect(result.output).toContain("added 'ab_tests' payload");
   });
 
-  it('fails when literal active_ab_tests object misses key/value fields', () => {
+  it('fails when literal active_ab_tests object misses key_value_pair', () => {
     const repo = createRepo();
     appendFileSync(
       path.join(repo, 'app/sample.ts'),
-      "const payload = { active_ab_tests: [{ key: 'swapsSWAPS9999AbtestFoo' }] };\n",
+      "const payload = { active_ab_tests: [{ key: 'swapsSWAPS9999AbtestFoo', value: 'control' }] };\n",
     );
 
     const result = runChecker(repo, ['--staged']);
@@ -179,7 +179,7 @@ describe('check-ab-testing-compliance.ts', () => {
       [
         'const { variantName, isActive } = useABTest(FLAG_KEY, VARIANTS);',
         'const payload = isActive',
-        '  ? { active_ab_tests: [{ key: FLAG_KEY, value: variantName }] }',
+        '  ? { active_ab_tests: [createActiveABTestAssignment(FLAG_KEY, variantName)] }',
         '  : {};',
         '',
       ].join('\n'),
@@ -191,6 +191,57 @@ describe('check-ab-testing-compliance.ts', () => {
     expect(result.output).not.toContain(
       'inline useABTest variants object is missing control',
     );
+  });
+
+  it('passes when helper-only active_ab_tests has sibling metadata key/value fields', () => {
+    const repo = createRepo();
+    appendFileSync(
+      path.join(repo, 'app/sample.ts'),
+      "const payload = { active_ab_tests: [createActiveABTestAssignment(FLAG_KEY, variantName)], metadata: { key: 'foo', value: 'bar' } };\n",
+    );
+
+    const result = runChecker(repo, ['--staged']);
+
+    expect(result.status).toBe(0);
+    expect(result.output).not.toContain(
+      'malformed literal active_ab_tests object',
+    );
+  });
+
+  it('passes when literal active_ab_tests includes key_value_pair', () => {
+    const repo = createRepo();
+    appendFileSync(
+      path.join(repo, 'app/sample.ts'),
+      "const payload = { active_ab_tests: [{ key: 'swapsSWAPS9999AbtestFoo', value: 'control', key_value_pair: 'swapsSWAPS9999AbtestFoo=control' }] };\n",
+    );
+
+    const result = runChecker(repo, ['--staged']);
+
+    expect(result.status).toBe(0);
+    expect(result.output).not.toContain(
+      'malformed literal active_ab_tests object',
+    );
+  });
+
+  it('fails when helper-built and malformed literal entries are mixed together', () => {
+    const repo = createRepo();
+    appendFileSync(
+      path.join(repo, 'app/sample.ts'),
+      [
+        'const payload = {',
+        '  active_ab_tests: [',
+        '    createActiveABTestAssignment(FLAG_KEY, variantName),',
+        "    { key: 'swapsSWAPS9999AbtestFoo', value: 'control' },",
+        '  ],',
+        '};',
+        '',
+      ].join('\n'),
+    );
+
+    const result = runChecker(repo, ['--staged']);
+
+    expect(result.status).toBe(1);
+    expect(result.output).toContain('malformed literal active_ab_tests object');
   });
 
   it('ignores invalid A/B examples in test files', () => {


### PR DESCRIPTION
## **Description**

Ports the mobile A/B analytics payload normalization from MetaMask Mobile PR #29183 to extension.

This standardizes app-emitted `active_ab_tests` assignments so analytics payloads include the Segment schema's `key_value_pair` field in addition to `key` and `value`. The change adds a shared helper/normalizer, applies it across MetaMetrics enrichment and controller dispatch paths, and tightens the A/B compliance checker plus docs so new manual payloads use the canonical shape.

This helps PMs analyze A/B test results in Mixpanel without relying on unsupported AND filtering across separate object properties in an array. Instead of filtering for an object where `key = exampleKey` and `value = treatment`, consumers can filter on `key_value_pair = exampleKey=treatment`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: No issue - follow-up to align extension `active_ab_tests` payloads with the updated Segment schema and the equivalent MetaMask Mobile implementation in https://github.com/MetaMask/metamask-mobile/pull/29183.

## **Manual testing steps**

1. N/A - this change updates analytics payload normalization, tests, docs, and compliance tooling; it does not introduce a user-facing browser flow to manually test.

Automated verification performed:

- `yarn test:unit shared/lib/ab-testing/active-ab-test-assignment.test.ts shared/lib/ab-testing/ab-test-analytics.test.ts app/scripts/controllers/metametrics-controller.test.ts test/unit-global/check-ab-testing-compliance.test.ts --collectCoverage=false --no-watchman`
- `yarn lint:changed:fix`
- `node --import tsx .agents/skills/ab-testing-implementation/scripts/check-ab-testing-compliance.ts --staged`

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
