### PR TITLE
fix(perps): localize chart x-axis and crosshair timestamps to user timezone cp-13.29.0

### DIFF
--- a/ui/components/app/perps/perps-candlestick-chart/chart-utils.test.ts
+++ b/ui/components/app/perps/perps-candlestick-chart/chart-utils.test.ts
@@ -1,4 +1,5 @@
 import type { CandleStick } from '@metamask/perps-controller';
+import { CandlePeriod } from '../constants/chartConfig';
 import {
   formatChartTimestamp,
   formatSingleCandleForChart,
@@ -109,7 +110,7 @@ describe('formatCandleDataForChart', () => {
   it('sorts output ascending by time', () => {
     const result = formatCandleDataForChart({
       symbol: 'ETH',
-      interval: '1h',
+      interval: CandlePeriod.OneHour,
       candles: [
         makeCandle({ time: 2_000_000_000_000 }),
         makeCandle({ time: 1_000_000_000_000 }),
@@ -121,7 +122,7 @@ describe('formatCandleDataForChart', () => {
   it('filters out invalid candles', () => {
     const result = formatCandleDataForChart({
       symbol: 'ETH',
-      interval: '1h',
+      interval: CandlePeriod.OneHour,
       candles: [makeCandle(), makeCandle({ open: 'NaN' })],
     });
     expect(result).toHaveLength(1);
@@ -137,7 +138,7 @@ describe('formatVolumeDataForChart', () => {
     const result = formatVolumeDataForChart(
       {
         symbol: 'ETH',
-        interval: '1h',
+        interval: CandlePeriod.OneHour,
         candles: [
           makeCandle({ time: 2_000_000_000_000 }),
           makeCandle({ time: 1_000_000_000_000 }),

--- a/ui/components/app/perps/perps-candlestick-chart/chart-utils.test.ts
+++ b/ui/components/app/perps/perps-candlestick-chart/chart-utils.test.ts
@@ -307,4 +307,12 @@ describe('formatChartTimestamp', () => {
     const dayOfMonth = formatChartTimestamp(FIXED_TS_SECONDS, 2, false, 'cs');
     expect(dayOfMonth).toContain(csMonthName);
   });
+
+  it('formats midnight as 00:00 not 24:00 (h23 hour-cycle)', () => {
+    clearFormatterCache();
+    const localMidnight = new Date(2025, 0, 15, 0, 0, 0, 0);
+    const midnightSeconds = Math.floor(localMidnight.getTime() / 1000);
+    const result = formatChartTimestamp(midnightSeconds, 4, false, 'en-US');
+    expect(result).toMatch(/^00:00:00$/u);
+  });
 });

--- a/ui/components/app/perps/perps-candlestick-chart/chart-utils.test.ts
+++ b/ui/components/app/perps/perps-candlestick-chart/chart-utils.test.ts
@@ -25,9 +25,6 @@ function expectedParts(locale: string) {
       FIXED_DATE,
     ),
     day: new Intl.DateTimeFormat(locale, { day: 'numeric' }).format(FIXED_DATE),
-    monthNumeric: new Intl.DateTimeFormat(locale, {
-      month: 'numeric',
-    }).format(FIXED_DATE),
     year: new Intl.DateTimeFormat(locale, { year: 'numeric' }).format(
       FIXED_DATE,
     ),
@@ -214,7 +211,7 @@ describe('formatChartTimestamp', () => {
             locale,
           );
           expect(result).toContain(parts.day);
-          expect(result).toContain(parts.monthNumeric);
+          expect(result).toContain(parts.monthShort);
         });
 
         it('3 (Time) returns 24h time, with date for non-today dates', () => {

--- a/ui/components/app/perps/perps-candlestick-chart/chart-utils.test.ts
+++ b/ui/components/app/perps/perps-candlestick-chart/chart-utils.test.ts
@@ -108,6 +108,8 @@ describe('formatCandleDataForChart', () => {
 
   it('sorts output ascending by time', () => {
     const result = formatCandleDataForChart({
+      symbol: 'ETH',
+      interval: '1h',
       candles: [
         makeCandle({ time: 2_000_000_000_000 }),
         makeCandle({ time: 1_000_000_000_000 }),
@@ -118,6 +120,8 @@ describe('formatCandleDataForChart', () => {
 
   it('filters out invalid candles', () => {
     const result = formatCandleDataForChart({
+      symbol: 'ETH',
+      interval: '1h',
       candles: [makeCandle(), makeCandle({ open: 'NaN' })],
     });
     expect(result).toHaveLength(1);
@@ -132,6 +136,8 @@ describe('formatVolumeDataForChart', () => {
   it('sorts output ascending by time', () => {
     const result = formatVolumeDataForChart(
       {
+        symbol: 'ETH',
+        interval: '1h',
         candles: [
           makeCandle({ time: 2_000_000_000_000 }),
           makeCandle({ time: 1_000_000_000_000 }),

--- a/ui/components/app/perps/perps-candlestick-chart/chart-utils.test.ts
+++ b/ui/components/app/perps/perps-candlestick-chart/chart-utils.test.ts
@@ -291,4 +291,20 @@ describe('formatChartTimestamp', () => {
     const deMonth = formatChartTimestamp(FIXED_TS_SECONDS, 1, false, 'de-DE');
     expect(enMonth).not.toBe(deMonth);
   });
+
+  it('patches bare-numeric month in Czech crosshair to abbreviated name', () => {
+    const csMonthName = new Intl.DateTimeFormat('cs', {
+      month: 'short',
+    }).format(FIXED_DATE);
+    const crosshair = formatChartTimestamp(FIXED_TS_SECONDS, null, true, 'cs');
+    expect(crosshair).toContain(csMonthName);
+  });
+
+  it('patches bare-numeric month in Czech DayOfMonth to abbreviated name', () => {
+    const csMonthName = new Intl.DateTimeFormat('cs', {
+      month: 'short',
+    }).format(FIXED_DATE);
+    const dayOfMonth = formatChartTimestamp(FIXED_TS_SECONDS, 2, false, 'cs');
+    expect(dayOfMonth).toContain(csMonthName);
+  });
 });

--- a/ui/components/app/perps/perps-candlestick-chart/chart-utils.test.ts
+++ b/ui/components/app/perps/perps-candlestick-chart/chart-utils.test.ts
@@ -1,0 +1,200 @@
+import type { CandleStick } from '@metamask/perps-controller';
+import {
+  formatChartTimestamp,
+  formatSingleCandleForChart,
+  formatSingleVolumeForChart,
+  formatCandleDataForChart,
+  formatVolumeDataForChart,
+} from './chart-utils';
+
+// Fixed UTC timestamp: 2025-03-15 14:30:00 UTC (a Saturday, unlikely to be "today")
+const FIXED_TS_SECONDS = 1742048400;
+
+const makeCandle = (
+  overrides: Partial<CandleStick> = {},
+): CandleStick =>
+  ({
+    time: 1_700_000_000_000,
+    open: '100',
+    high: '110',
+    low: '90',
+    close: '105',
+    volume: '50',
+    ...overrides,
+  }) as CandleStick;
+
+describe('formatSingleCandleForChart', () => {
+  it('converts ms timestamp to seconds and parses OHLC strings', () => {
+    const result = formatSingleCandleForChart(makeCandle());
+    expect(result).toEqual({
+      time: 1_700_000_000,
+      open: 100,
+      high: 110,
+      low: 90,
+      close: 105,
+    });
+  });
+
+  it('returns null for NaN OHLC values', () => {
+    expect(formatSingleCandleForChart(makeCandle({ open: 'bad' }))).toBeNull();
+  });
+
+  it('returns null for zero OHLC values', () => {
+    expect(formatSingleCandleForChart(makeCandle({ low: '0' }))).toBeNull();
+  });
+
+  it('returns null for negative OHLC values', () => {
+    expect(
+      formatSingleCandleForChart(makeCandle({ close: '-5' })),
+    ).toBeNull();
+  });
+});
+
+describe('formatSingleVolumeForChart', () => {
+  it('computes USD notional (volume * close) with bullish color', () => {
+    const result = formatSingleVolumeForChart(makeCandle(), '#0f0', '#f00');
+    expect(result).toEqual({
+      time: 1_700_000_000,
+      value: 50 * 105,
+      color: '#0f0',
+    });
+  });
+
+  it('uses downColor for bearish candle (close < open)', () => {
+    const result = formatSingleVolumeForChart(
+      makeCandle({ open: '110', close: '100' }),
+      '#0f0',
+      '#f00',
+    );
+    expect(result?.color).toBe('#f00');
+  });
+
+  it('returns null when volume is zero', () => {
+    expect(
+      formatSingleVolumeForChart(makeCandle({ volume: '0' }), '#0f0', '#f00'),
+    ).toBeNull();
+  });
+
+  it('returns null when volume is missing', () => {
+    expect(
+      formatSingleVolumeForChart(
+        makeCandle({ volume: undefined as unknown as string }),
+        '#0f0',
+        '#f00',
+      ),
+    ).toBeNull();
+  });
+});
+
+describe('formatCandleDataForChart', () => {
+  it('returns empty array for null/undefined data', () => {
+    expect(formatCandleDataForChart(null as never)).toEqual([]);
+    expect(formatCandleDataForChart({ candles: undefined } as never)).toEqual(
+      [],
+    );
+  });
+
+  it('sorts output ascending by time', () => {
+    const result = formatCandleDataForChart({
+      candles: [
+        makeCandle({ time: 2_000_000_000_000 }),
+        makeCandle({ time: 1_000_000_000_000 }),
+      ],
+    });
+    expect(result[0].time).toBeLessThan(result[1].time as number);
+  });
+
+  it('filters out invalid candles', () => {
+    const result = formatCandleDataForChart({
+      candles: [makeCandle(), makeCandle({ open: 'NaN' })],
+    });
+    expect(result).toHaveLength(1);
+  });
+});
+
+describe('formatVolumeDataForChart', () => {
+  it('returns empty array for null/undefined data', () => {
+    expect(formatVolumeDataForChart(null as never, '#0f0', '#f00')).toEqual([]);
+  });
+
+  it('sorts output ascending by time', () => {
+    const result = formatVolumeDataForChart(
+      {
+        candles: [
+          makeCandle({ time: 2_000_000_000_000 }),
+          makeCandle({ time: 1_000_000_000_000 }),
+        ],
+      },
+      '#0f0',
+      '#f00',
+    );
+    expect(result[0].time).toBeLessThan(result[1].time as number);
+  });
+});
+
+describe('formatChartTimestamp', () => {
+  describe('crosshair mode', () => {
+    it('returns short month, day, and 24h time', () => {
+      const result = formatChartTimestamp(FIXED_TS_SECONDS, null, true);
+      expect(result).toMatch(/Mar/);
+      expect(result).toMatch(/15/);
+      expect(result).toMatch(/\d{2}:\d{2}/u);
+    });
+  });
+
+  describe('tickMarkType as number (lightweight-charts v5 enum)', () => {
+    it('0 (Year) returns a 4-digit year', () => {
+      const result = formatChartTimestamp(FIXED_TS_SECONDS, 0);
+      expect(result).toMatch(/2025/);
+    });
+
+    it('1 (Month) returns abbreviated month name', () => {
+      const result = formatChartTimestamp(FIXED_TS_SECONDS, 1);
+      expect(result).toMatch(/Mar/);
+    });
+
+    it('2 (DayOfMonth) returns month/day', () => {
+      const result = formatChartTimestamp(FIXED_TS_SECONDS, 2);
+      expect(result).toMatch(/3\/15/u);
+    });
+
+    it('3 (Time) returns 24h time, with month/day for non-today dates', () => {
+      const result = formatChartTimestamp(FIXED_TS_SECONDS, 3);
+      expect(result).toMatch(/\d{1,2}\/\d{1,2}/u);
+      expect(result).toMatch(/\d{2}:\d{2}/u);
+    });
+
+    it('4 (TimeWithSeconds) returns HH:MM:SS', () => {
+      const result = formatChartTimestamp(FIXED_TS_SECONDS, 4);
+      expect(result).toMatch(/\d{2}:\d{2}:\d{2}/u);
+    });
+  });
+
+  describe('tickMarkType as string', () => {
+    it('"Year" returns 4-digit year', () => {
+      expect(formatChartTimestamp(FIXED_TS_SECONDS, 'Year' as never)).toMatch(
+        /2025/,
+      );
+    });
+
+    it('"Month" returns abbreviated month', () => {
+      expect(formatChartTimestamp(FIXED_TS_SECONDS, 'Month' as never)).toMatch(
+        /Mar/,
+      );
+    });
+  });
+
+  describe('fallback', () => {
+    it('null tickMarkType without crosshair returns month/day + time', () => {
+      const result = formatChartTimestamp(FIXED_TS_SECONDS, null, false);
+      expect(result).toMatch(/\d{1,2}\/\d{1,2}/u);
+      expect(result).toMatch(/\d{2}:\d{2}/u);
+    });
+
+    it('unknown numeric tickMarkType falls through to default', () => {
+      const result = formatChartTimestamp(FIXED_TS_SECONDS, 99);
+      expect(result).toMatch(/\d{1,2}\/\d{1,2}/u);
+      expect(result).toMatch(/\d{2}:\d{2}/u);
+    });
+  });
+});

--- a/ui/components/app/perps/perps-candlestick-chart/chart-utils.test.ts
+++ b/ui/components/app/perps/perps-candlestick-chart/chart-utils.test.ts
@@ -6,26 +6,33 @@ import {
   formatSingleVolumeForChart,
   formatCandleDataForChart,
   formatVolumeDataForChart,
+  clearFormatterCache,
 } from './chart-utils';
 
 // Fixed UTC timestamp: 2025-03-15 14:30:00 UTC (a Saturday, unlikely to be "today")
 const FIXED_TS_SECONDS = 1742048400;
-
-// The production formatters use the system's local timezone, so expected date
-// components must be derived in the same timezone to keep tests deterministic.
 const FIXED_DATE = new Date(FIXED_TS_SECONDS * 1000);
-const EXPECTED_MONTH_SHORT = new Intl.DateTimeFormat('en-US', {
-  month: 'short',
-}).format(FIXED_DATE);
-const EXPECTED_DAY = new Intl.DateTimeFormat('en-US', {
-  day: 'numeric',
-}).format(FIXED_DATE);
-const EXPECTED_MONTH_NUMERIC = new Intl.DateTimeFormat('en-US', {
-  month: 'numeric',
-}).format(FIXED_DATE);
-const EXPECTED_YEAR = new Intl.DateTimeFormat('en-US', {
-  year: 'numeric',
-}).format(FIXED_DATE);
+
+/**
+ * Build locale-specific expected values so assertions stay deterministic
+ * regardless of which locale is under test.
+ *
+ * @param locale - BCP 47 locale tag
+ */
+function expectedParts(locale: string) {
+  return {
+    monthShort: new Intl.DateTimeFormat(locale, { month: 'short' }).format(
+      FIXED_DATE,
+    ),
+    day: new Intl.DateTimeFormat(locale, { day: 'numeric' }).format(FIXED_DATE),
+    monthNumeric: new Intl.DateTimeFormat(locale, {
+      month: 'numeric',
+    }).format(FIXED_DATE),
+    year: new Intl.DateTimeFormat(locale, { year: 'numeric' }).format(
+      FIXED_DATE,
+    ),
+  };
+}
 
 const makeCandle = (overrides: Partial<CandleStick> = {}): CandleStick =>
   ({
@@ -152,68 +159,139 @@ describe('formatVolumeDataForChart', () => {
 });
 
 describe('formatChartTimestamp', () => {
-  describe('crosshair mode', () => {
-    it('returns short month, day, and 24h time', () => {
-      const result = formatChartTimestamp(FIXED_TS_SECONDS, null, true);
-      expect(result).toContain(EXPECTED_MONTH_SHORT);
-      expect(result).toContain(EXPECTED_DAY);
-      expect(result).toMatch(/\d{2}:\d{2}/u);
+  beforeEach(() => {
+    clearFormatterCache();
+  });
+
+  // Run every formatting assertion for two distinct locales to prove the
+  // locale parameter is actually threaded through to Intl.DateTimeFormat.
+  const locales: string[] = ['en-US', 'de-DE'];
+
+  locales.forEach((locale) => {
+    describe(`locale ${locale}`, () => {
+      const parts = expectedParts(locale);
+
+      describe('crosshair mode', () => {
+        it('returns short month, day, and 24h time', () => {
+          const result = formatChartTimestamp(
+            FIXED_TS_SECONDS,
+            null,
+            true,
+            locale,
+          );
+          expect(result).toContain(parts.monthShort);
+          expect(result).toContain(parts.day);
+          expect(result).toMatch(/\d{2}:\d{2}/u);
+        });
+      });
+
+      describe('tickMarkType as number (lightweight-charts v5 enum)', () => {
+        it('0 (Year) returns a 4-digit year', () => {
+          const result = formatChartTimestamp(
+            FIXED_TS_SECONDS,
+            0,
+            false,
+            locale,
+          );
+          expect(result).toContain(parts.year);
+        });
+
+        it('1 (Month) returns abbreviated month name', () => {
+          const result = formatChartTimestamp(
+            FIXED_TS_SECONDS,
+            1,
+            false,
+            locale,
+          );
+          expect(result).toContain(parts.monthShort);
+        });
+
+        it('2 (DayOfMonth) returns month/day', () => {
+          const result = formatChartTimestamp(
+            FIXED_TS_SECONDS,
+            2,
+            false,
+            locale,
+          );
+          expect(result).toContain(parts.day);
+          expect(result).toContain(parts.monthNumeric);
+        });
+
+        it('3 (Time) returns 24h time, with date for non-today dates', () => {
+          const result = formatChartTimestamp(
+            FIXED_TS_SECONDS,
+            3,
+            false,
+            locale,
+          );
+          expect(result).toContain(parts.day);
+          expect(result).toMatch(/\d{2}:\d{2}/u);
+        });
+
+        it('4 (TimeWithSeconds) returns HH:MM:SS', () => {
+          const result = formatChartTimestamp(
+            FIXED_TS_SECONDS,
+            4,
+            false,
+            locale,
+          );
+          expect(result).toMatch(/\d{2}:\d{2}:\d{2}/u);
+        });
+      });
+
+      describe('tickMarkType as string', () => {
+        it('"Year" returns 4-digit year', () => {
+          expect(
+            formatChartTimestamp(
+              FIXED_TS_SECONDS,
+              'Year' as never,
+              false,
+              locale,
+            ),
+          ).toContain(parts.year);
+        });
+
+        it('"Month" returns abbreviated month', () => {
+          expect(
+            formatChartTimestamp(
+              FIXED_TS_SECONDS,
+              'Month' as never,
+              false,
+              locale,
+            ),
+          ).toContain(parts.monthShort);
+        });
+      });
+
+      describe('fallback', () => {
+        it('null tickMarkType without crosshair returns date + time', () => {
+          const result = formatChartTimestamp(
+            FIXED_TS_SECONDS,
+            null,
+            false,
+            locale,
+          );
+          expect(result).toContain(parts.day);
+          expect(result).toMatch(/\d{2}:\d{2}/u);
+        });
+
+        it('unknown numeric tickMarkType falls through to default', () => {
+          const result = formatChartTimestamp(
+            FIXED_TS_SECONDS,
+            99,
+            false,
+            locale,
+          );
+          expect(result).toContain(parts.day);
+          expect(result).toMatch(/\d{2}:\d{2}/u);
+        });
+      });
     });
   });
 
-  describe('tickMarkType as number (lightweight-charts v5 enum)', () => {
-    it('0 (Year) returns a 4-digit year', () => {
-      const result = formatChartTimestamp(FIXED_TS_SECONDS, 0);
-      expect(result).toContain(EXPECTED_YEAR);
-    });
-
-    it('1 (Month) returns abbreviated month name', () => {
-      const result = formatChartTimestamp(FIXED_TS_SECONDS, 1);
-      expect(result).toContain(EXPECTED_MONTH_SHORT);
-    });
-
-    it('2 (DayOfMonth) returns month/day', () => {
-      const result = formatChartTimestamp(FIXED_TS_SECONDS, 2);
-      expect(result).toContain(`${EXPECTED_MONTH_NUMERIC}/${EXPECTED_DAY}`);
-    });
-
-    it('3 (Time) returns 24h time, with month/day for non-today dates', () => {
-      const result = formatChartTimestamp(FIXED_TS_SECONDS, 3);
-      expect(result).toMatch(/\d{1,2}\/\d{1,2}/u);
-      expect(result).toMatch(/\d{2}:\d{2}/u);
-    });
-
-    it('4 (TimeWithSeconds) returns HH:MM:SS', () => {
-      const result = formatChartTimestamp(FIXED_TS_SECONDS, 4);
-      expect(result).toMatch(/\d{2}:\d{2}:\d{2}/u);
-    });
-  });
-
-  describe('tickMarkType as string', () => {
-    it('"Year" returns 4-digit year', () => {
-      expect(formatChartTimestamp(FIXED_TS_SECONDS, 'Year' as never)).toContain(
-        EXPECTED_YEAR,
-      );
-    });
-
-    it('"Month" returns abbreviated month', () => {
-      expect(
-        formatChartTimestamp(FIXED_TS_SECONDS, 'Month' as never),
-      ).toContain(EXPECTED_MONTH_SHORT);
-    });
-  });
-
-  describe('fallback', () => {
-    it('null tickMarkType without crosshair returns month/day + time', () => {
-      const result = formatChartTimestamp(FIXED_TS_SECONDS, null, false);
-      expect(result).toMatch(/\d{1,2}\/\d{1,2}/u);
-      expect(result).toMatch(/\d{2}:\d{2}/u);
-    });
-
-    it('unknown numeric tickMarkType falls through to default', () => {
-      const result = formatChartTimestamp(FIXED_TS_SECONDS, 99);
-      expect(result).toMatch(/\d{1,2}\/\d{1,2}/u);
-      expect(result).toMatch(/\d{2}:\d{2}/u);
-    });
+  it('produces different output for different locales (month name)', () => {
+    const enMonth = formatChartTimestamp(FIXED_TS_SECONDS, 1, false, 'en-US');
+    const deMonth = formatChartTimestamp(FIXED_TS_SECONDS, 1, false, 'de-DE');
+    expect(enMonth).not.toBe(deMonth);
   });
 });

--- a/ui/components/app/perps/perps-candlestick-chart/chart-utils.test.ts
+++ b/ui/components/app/perps/perps-candlestick-chart/chart-utils.test.ts
@@ -10,9 +10,23 @@ import {
 // Fixed UTC timestamp: 2025-03-15 14:30:00 UTC (a Saturday, unlikely to be "today")
 const FIXED_TS_SECONDS = 1742048400;
 
-const makeCandle = (
-  overrides: Partial<CandleStick> = {},
-): CandleStick =>
+// The production formatters use the system's local timezone, so expected date
+// components must be derived in the same timezone to keep tests deterministic.
+const FIXED_DATE = new Date(FIXED_TS_SECONDS * 1000);
+const EXPECTED_MONTH_SHORT = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+}).format(FIXED_DATE);
+const EXPECTED_DAY = new Intl.DateTimeFormat('en-US', {
+  day: 'numeric',
+}).format(FIXED_DATE);
+const EXPECTED_MONTH_NUMERIC = new Intl.DateTimeFormat('en-US', {
+  month: 'numeric',
+}).format(FIXED_DATE);
+const EXPECTED_YEAR = new Intl.DateTimeFormat('en-US', {
+  year: 'numeric',
+}).format(FIXED_DATE);
+
+const makeCandle = (overrides: Partial<CandleStick> = {}): CandleStick =>
   ({
     time: 1_700_000_000_000,
     open: '100',
@@ -44,9 +58,7 @@ describe('formatSingleCandleForChart', () => {
   });
 
   it('returns null for negative OHLC values', () => {
-    expect(
-      formatSingleCandleForChart(makeCandle({ close: '-5' })),
-    ).toBeNull();
+    expect(formatSingleCandleForChart(makeCandle({ close: '-5' }))).toBeNull();
   });
 });
 
@@ -136,8 +148,8 @@ describe('formatChartTimestamp', () => {
   describe('crosshair mode', () => {
     it('returns short month, day, and 24h time', () => {
       const result = formatChartTimestamp(FIXED_TS_SECONDS, null, true);
-      expect(result).toMatch(/Mar/);
-      expect(result).toMatch(/15/);
+      expect(result).toContain(EXPECTED_MONTH_SHORT);
+      expect(result).toContain(EXPECTED_DAY);
       expect(result).toMatch(/\d{2}:\d{2}/u);
     });
   });
@@ -145,17 +157,17 @@ describe('formatChartTimestamp', () => {
   describe('tickMarkType as number (lightweight-charts v5 enum)', () => {
     it('0 (Year) returns a 4-digit year', () => {
       const result = formatChartTimestamp(FIXED_TS_SECONDS, 0);
-      expect(result).toMatch(/2025/);
+      expect(result).toContain(EXPECTED_YEAR);
     });
 
     it('1 (Month) returns abbreviated month name', () => {
       const result = formatChartTimestamp(FIXED_TS_SECONDS, 1);
-      expect(result).toMatch(/Mar/);
+      expect(result).toContain(EXPECTED_MONTH_SHORT);
     });
 
     it('2 (DayOfMonth) returns month/day', () => {
       const result = formatChartTimestamp(FIXED_TS_SECONDS, 2);
-      expect(result).toMatch(/3\/15/u);
+      expect(result).toContain(`${EXPECTED_MONTH_NUMERIC}/${EXPECTED_DAY}`);
     });
 
     it('3 (Time) returns 24h time, with month/day for non-today dates', () => {
@@ -172,15 +184,15 @@ describe('formatChartTimestamp', () => {
 
   describe('tickMarkType as string', () => {
     it('"Year" returns 4-digit year', () => {
-      expect(formatChartTimestamp(FIXED_TS_SECONDS, 'Year' as never)).toMatch(
-        /2025/,
+      expect(formatChartTimestamp(FIXED_TS_SECONDS, 'Year' as never)).toContain(
+        EXPECTED_YEAR,
       );
     });
 
     it('"Month" returns abbreviated month', () => {
-      expect(formatChartTimestamp(FIXED_TS_SECONDS, 'Month' as never)).toMatch(
-        /Mar/,
-      );
+      expect(
+        formatChartTimestamp(FIXED_TS_SECONDS, 'Month' as never),
+      ).toContain(EXPECTED_MONTH_SHORT);
     });
   });
 

--- a/ui/components/app/perps/perps-candlestick-chart/chart-utils.ts
+++ b/ui/components/app/perps/perps-candlestick-chart/chart-utils.ts
@@ -3,6 +3,9 @@
  *
  * Converts CandleData from @metamask/perps-controller (strings, milliseconds)
  * into the format expected by lightweight-charts (numbers, seconds).
+ *
+ * Also provides locale-aware time formatters for the chart x-axis and
+ * crosshair, matching the mobile TradingViewChartTemplate implementation.
  */
 import type { CandleData, CandleStick } from '@metamask/perps-controller';
 
@@ -33,22 +36,6 @@ export type HistogramData<TTime> = {
 };
 
 /**
- * Convert a UTC millisecond timestamp to a local-time Unix timestamp (seconds).
- *
- * Lightweight-charts renders numeric timestamps as-is on the x-axis without
- * any timezone conversion. By subtracting the JS timezone offset we shift the
- * value so the axis labels show the user's local wall-clock time. The offset
- * is computed per-timestamp to account for DST transitions.
- *
- * @param utcMs - UTC timestamp in milliseconds
- * @returns Seconds-precision timestamp adjusted to local time
- */
-function toLocalChartTime(utcMs: number): Time {
-  const offsetSeconds = new Date(utcMs).getTimezoneOffset() * 60;
-  return Math.floor(utcMs / 1000 - offsetSeconds) as Time;
-}
-
-/**
  * Convert a single CandleStick to CandlestickData for lightweight-charts.
  * Returns null if the candle has invalid (NaN or non-positive) OHLC values.
  *
@@ -58,7 +45,7 @@ function toLocalChartTime(utcMs: number): Time {
 export function formatSingleCandleForChart(
   candle: CandleStick,
 ): CandlestickData<Time> | null {
-  const timeInSeconds = toLocalChartTime(candle.time);
+  const timeInSeconds = Math.floor(candle.time / 1000) as Time;
 
   const formatted: CandlestickData<Time> = {
     time: timeInSeconds,
@@ -100,7 +87,7 @@ export function formatSingleVolumeForChart(
   upColor: string,
   downColor: string,
 ): HistogramData<Time> | null {
-  const timeInSeconds = toLocalChartTime(candle.time);
+  const timeInSeconds = Math.floor(candle.time / 1000) as Time;
   const volume = parseFloat(candle.volume || '0');
   const close = parseFloat(candle.close);
   const open = parseFloat(candle.open);
@@ -162,4 +149,142 @@ export function formatVolumeDataForChart(
     .map((candle) => formatSingleVolumeForChart(candle, upColor, downColor))
     .filter((item): item is HistogramData<Time> => item !== null)
     .sort((a, b) => (a.time as number) - (b.time as number));
+}
+
+// ---------------------------------------------------------------------------
+// Time-axis formatting (mirrors mobile TradingViewChartTemplate.tsx)
+//
+// Uses cached Intl.DateTimeFormat instances instead of Date.toLocaleString
+// to avoid silent fallback to Date.toString() in some extension contexts.
+// ---------------------------------------------------------------------------
+
+const userTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+const dateStringFormatter = new Intl.DateTimeFormat('en-US', {
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  timeZone: userTimezone,
+});
+
+const monthDayFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'numeric',
+  day: 'numeric',
+  timeZone: userTimezone,
+});
+
+const time24hFormatter = new Intl.DateTimeFormat('en-US', {
+  hour: '2-digit',
+  minute: '2-digit',
+  hour12: false,
+  timeZone: userTimezone,
+});
+
+const crosshairFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  day: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit',
+  hour12: false,
+  timeZone: userTimezone,
+});
+
+const yearFormatter = new Intl.DateTimeFormat('en-US', {
+  year: 'numeric',
+  timeZone: userTimezone,
+});
+
+const monthShortFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  timeZone: userTimezone,
+});
+
+const timeWithSecondsFormatter = new Intl.DateTimeFormat('en-US', {
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+  hour12: false,
+  timeZone: userTimezone,
+});
+
+function getDateString(date: Date): string {
+  return dateStringFormatter.format(date);
+}
+
+function isToday(date: Date): boolean {
+  return getDateString(date) === getDateString(new Date());
+}
+
+function formatMonthDay(date: Date): string {
+  return monthDayFormatter.format(date);
+}
+
+function formatTime24h(date: Date): string {
+  return time24hFormatter.format(date);
+}
+
+/**
+ * Lightweight-charts tick-mark type enum values passed to tickMarkFormatter.
+ * Mirrors TickMarkType from the library.
+ */
+type TickMarkType =
+  | 'Year'
+  | 'Month'
+  | 'DayOfMonth'
+  | 'Time'
+  | 'TimeWithSeconds';
+
+/**
+ * Smart timestamp formatter for the chart x-axis and crosshair, matching
+ * the mobile TradingViewChartTemplate implementation.
+ *
+ * Uses `Intl.DateTimeFormat` with the user's local timezone so labels always
+ * reflect local wall-clock time without needing to shift the underlying data.
+ *
+ * @param timeInSeconds - UTC timestamp in seconds (as stored by lightweight-charts)
+ * @param tickMarkType - Lightweight-charts tick type; null for crosshair
+ * @param isCrosshair - True when called from the crosshair time formatter
+ * @returns Formatted time string
+ */
+export function formatChartTimestamp(
+  timeInSeconds: number,
+  tickMarkType: TickMarkType | number | null,
+  isCrosshair = false,
+): string {
+  const date = new Date(timeInSeconds * 1000);
+
+  if (isCrosshair) {
+    return crosshairFormatter.format(date);
+  }
+
+  if (tickMarkType !== null && tickMarkType !== undefined) {
+    // lightweight-charts v5 passes numeric enum values:
+    // 0 = Year, 1 = Month, 2 = DayOfMonth, 3 = Time, 4 = TimeWithSeconds
+    const resolved =
+      typeof tickMarkType === 'number'
+        ? (['Year', 'Month', 'DayOfMonth', 'Time', 'TimeWithSeconds'][
+            tickMarkType
+          ] as TickMarkType | undefined)
+        : tickMarkType;
+
+    switch (resolved) {
+      case 'Year':
+        return yearFormatter.format(date);
+      case 'Month':
+        return monthShortFormatter.format(date);
+      case 'DayOfMonth':
+        return formatMonthDay(date);
+      case 'Time':
+        if (!isToday(date)) {
+          return `${formatMonthDay(date)} ${formatTime24h(date)}`;
+        }
+        return formatTime24h(date);
+      case 'TimeWithSeconds':
+        return timeWithSecondsFormatter.format(date);
+      default:
+        break;
+    }
+  }
+
+  return `${formatMonthDay(date)} ${formatTime24h(date)}`;
 }

--- a/ui/components/app/perps/perps-candlestick-chart/chart-utils.ts
+++ b/ui/components/app/perps/perps-candlestick-chart/chart-utils.ts
@@ -156,71 +156,102 @@ export function formatVolumeDataForChart(
 //
 // Uses cached Intl.DateTimeFormat instances instead of Date.toLocaleString
 // to avoid silent fallback to Date.toString() in some extension contexts.
+//
+// Formatters are locale-aware: the locale is threaded from lightweight-charts'
+// tickMarkFormatter callback (which sources it from navigator.language) so
+// labels respect the user's language/region preferences.
 // ---------------------------------------------------------------------------
 
 const userTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
-const dateStringFormatter = new Intl.DateTimeFormat('en-US', {
-  year: 'numeric',
-  month: '2-digit',
-  day: '2-digit',
-  timeZone: userTimezone,
-});
+type Formatters = {
+  dateString: Intl.DateTimeFormat;
+  monthDay: Intl.DateTimeFormat;
+  time24h: Intl.DateTimeFormat;
+  crosshair: Intl.DateTimeFormat;
+  year: Intl.DateTimeFormat;
+  monthShort: Intl.DateTimeFormat;
+  timeWithSeconds: Intl.DateTimeFormat;
+};
 
-const monthDayFormatter = new Intl.DateTimeFormat('en-US', {
-  month: 'numeric',
-  day: 'numeric',
-  timeZone: userTimezone,
-});
+const formatterCache = new Map<string, Formatters>();
 
-const time24hFormatter = new Intl.DateTimeFormat('en-US', {
-  hour: '2-digit',
-  minute: '2-digit',
-  hour12: false,
-  timeZone: userTimezone,
-});
-
-const crosshairFormatter = new Intl.DateTimeFormat('en-US', {
-  month: 'short',
-  day: 'numeric',
-  hour: '2-digit',
-  minute: '2-digit',
-  hour12: false,
-  timeZone: userTimezone,
-});
-
-const yearFormatter = new Intl.DateTimeFormat('en-US', {
-  year: 'numeric',
-  timeZone: userTimezone,
-});
-
-const monthShortFormatter = new Intl.DateTimeFormat('en-US', {
-  month: 'short',
-  timeZone: userTimezone,
-});
-
-const timeWithSecondsFormatter = new Intl.DateTimeFormat('en-US', {
-  hour: '2-digit',
-  minute: '2-digit',
-  second: '2-digit',
-  hour12: false,
-  timeZone: userTimezone,
-});
-
-function getDateString(date: Date): string {
-  return dateStringFormatter.format(date);
+function createFormatters(locale: string, timezone: string): Formatters {
+  return {
+    dateString: new Intl.DateTimeFormat(locale, {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      timeZone: timezone,
+    }),
+    monthDay: new Intl.DateTimeFormat(locale, {
+      month: 'numeric',
+      day: 'numeric',
+      timeZone: timezone,
+    }),
+    time24h: new Intl.DateTimeFormat(locale, {
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+      timeZone: timezone,
+    }),
+    crosshair: new Intl.DateTimeFormat(locale, {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+      timeZone: timezone,
+    }),
+    year: new Intl.DateTimeFormat(locale, {
+      year: 'numeric',
+      timeZone: timezone,
+    }),
+    monthShort: new Intl.DateTimeFormat(locale, {
+      month: 'short',
+      timeZone: timezone,
+    }),
+    timeWithSeconds: new Intl.DateTimeFormat(locale, {
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: false,
+      timeZone: timezone,
+    }),
+  };
 }
 
-function isToday(date: Date): boolean {
-  return getDateString(date) === getDateString(new Date());
+function getFormatters(locale: string): Formatters {
+  let formatters = formatterCache.get(locale);
+  if (!formatters) {
+    formatters = createFormatters(locale, userTimezone);
+    formatterCache.set(locale, formatters);
+  }
+  return formatters;
 }
 
-function formatMonthDay(date: Date): string {
-  return monthDayFormatter.format(date);
+/**
+ * Visible for testing – clears the per-locale formatter cache so tests
+ * that stub `navigator.language` start with a clean slate.
+ */
+export function clearFormatterCache(): void {
+  formatterCache.clear();
 }
 
-function formatTime24h(date: Date): string {
-  return time24hFormatter.format(date);
+function getDateString(date: Date, fmt: Formatters): string {
+  return fmt.dateString.format(date);
+}
+
+function isToday(date: Date, fmt: Formatters): boolean {
+  return getDateString(date, fmt) === getDateString(new Date(), fmt);
+}
+
+function formatMonthDay(date: Date, fmt: Formatters): string {
+  return fmt.monthDay.format(date);
+}
+
+function formatTime24h(date: Date, fmt: Formatters): string {
+  return fmt.time24h.format(date);
 }
 
 /**
@@ -244,17 +275,21 @@ type TickMarkType =
  * @param timeInSeconds - UTC timestamp in seconds (as stored by lightweight-charts)
  * @param tickMarkType - Lightweight-charts tick type; null for crosshair
  * @param isCrosshair - True when called from the crosshair time formatter
+ * @param locale - BCP 47 locale tag sourced from the lightweight-charts
+ * callback; falls back to `navigator.language` when omitted.
  * @returns Formatted time string
  */
 export function formatChartTimestamp(
   timeInSeconds: number,
   tickMarkType: TickMarkType | number | null,
   isCrosshair = false,
+  locale: string = navigator.language,
 ): string {
+  const fmt = getFormatters(locale);
   const date = new Date(timeInSeconds * 1000);
 
   if (isCrosshair) {
-    return crosshairFormatter.format(date);
+    return fmt.crosshair.format(date);
   }
 
   if (tickMarkType !== null && tickMarkType !== undefined) {
@@ -269,22 +304,22 @@ export function formatChartTimestamp(
 
     switch (resolved) {
       case 'Year':
-        return yearFormatter.format(date);
+        return fmt.year.format(date);
       case 'Month':
-        return monthShortFormatter.format(date);
+        return fmt.monthShort.format(date);
       case 'DayOfMonth':
-        return formatMonthDay(date);
+        return formatMonthDay(date, fmt);
       case 'Time':
-        if (!isToday(date)) {
-          return `${formatMonthDay(date)} ${formatTime24h(date)}`;
+        if (!isToday(date, fmt)) {
+          return `${formatMonthDay(date, fmt)} ${formatTime24h(date, fmt)}`;
         }
-        return formatTime24h(date);
+        return formatTime24h(date, fmt);
       case 'TimeWithSeconds':
-        return timeWithSecondsFormatter.format(date);
+        return fmt.timeWithSeconds.format(date);
       default:
         break;
     }
   }
 
-  return `${formatMonthDay(date)} ${formatTime24h(date)}`;
+  return `${formatMonthDay(date, fmt)} ${formatTime24h(date, fmt)}`;
 }

--- a/ui/components/app/perps/perps-candlestick-chart/chart-utils.ts
+++ b/ui/components/app/perps/perps-candlestick-chart/chart-utils.ts
@@ -185,7 +185,7 @@ function createFormatters(locale: string, timezone: string): Formatters {
       timeZone: timezone,
     }),
     monthDay: new Intl.DateTimeFormat(locale, {
-      month: 'numeric',
+      month: 'short',
       day: 'numeric',
       timeZone: timezone,
     }),

--- a/ui/components/app/perps/perps-candlestick-chart/chart-utils.ts
+++ b/ui/components/app/perps/perps-candlestick-chart/chart-utils.ts
@@ -257,24 +257,27 @@ function isToday(date: Date, fmt: Formatters): boolean {
  *
  * @param formatter - The combined DateTimeFormat instance
  * @param date - The date to format
- * @param monthName - Standalone short month name from the monthShort formatter
+ * @param fmt - Cached locale-specific formatters (used to derive the month name)
  * @returns The formatted string with month name patched in when needed
  */
 function formatWithMonthPatch(
   formatter: Intl.DateTimeFormat,
   date: Date,
-  monthName: string,
+  fmt: Formatters,
 ): string {
   const parts = formatter.formatToParts(date);
 
-  const needsPatch = parts.some(
-    (p) =>
-      p.type === 'month' &&
-      /^\d+$/u.test(p.value) &&
-      !monthName.startsWith(p.value),
+  const hasNumericMonth = parts.some(
+    (p) => p.type === 'month' && /^\d+$/u.test(p.value),
   );
 
-  if (!needsPatch) {
+  if (!hasNumericMonth) {
+    return formatter.format(date);
+  }
+
+  const monthName = fmt.monthShort.format(date);
+
+  if (parts.some((p) => p.type === 'month' && monthName.startsWith(p.value))) {
     return formatter.format(date);
   }
 
@@ -292,7 +295,7 @@ function formatWithMonthPatch(
  * @param fmt - Cached locale-specific formatters
  */
 function formatMonthDay(date: Date, fmt: Formatters): string {
-  return formatWithMonthPatch(fmt.monthDay, date, fmt.monthShort.format(date));
+  return formatWithMonthPatch(fmt.monthDay, date, fmt);
 }
 
 function formatTime24h(date: Date, fmt: Formatters): string {
@@ -334,11 +337,7 @@ export function formatChartTimestamp(
   const date = new Date(timeInSeconds * 1000);
 
   if (isCrosshair) {
-    return formatWithMonthPatch(
-      fmt.crosshair,
-      date,
-      fmt.monthShort.format(date),
-    );
+    return formatWithMonthPatch(fmt.crosshair, date, fmt);
   }
 
   if (tickMarkType !== null && tickMarkType !== undefined) {

--- a/ui/components/app/perps/perps-candlestick-chart/chart-utils.ts
+++ b/ui/components/app/perps/perps-candlestick-chart/chart-utils.ts
@@ -246,8 +246,53 @@ function isToday(date: Date, fmt: Formatters): boolean {
   return getDateString(date, fmt) === getDateString(new Date(), fmt);
 }
 
+/**
+ * Patch a formatted date string so that a bare-numeric month part is replaced
+ * with the standalone abbreviated month name.
+ *
+ * Some locales (notably Czech) have ICU data that downgrades `month: 'short'`
+ * back to a bare number when combined with other fields in a single
+ * DateTimeFormat.  We detect this via `formatToParts` and substitute the
+ * standalone short month name while preserving the locale-native ordering.
+ *
+ * @param formatter - The combined DateTimeFormat instance
+ * @param date - The date to format
+ * @param monthName - Standalone short month name from the monthShort formatter
+ * @returns The formatted string with month name patched in when needed
+ */
+function formatWithMonthPatch(
+  formatter: Intl.DateTimeFormat,
+  date: Date,
+  monthName: string,
+): string {
+  const parts = formatter.formatToParts(date);
+
+  const needsPatch = parts.some(
+    (p) =>
+      p.type === 'month' &&
+      /^\d+$/u.test(p.value) &&
+      !monthName.startsWith(p.value),
+  );
+
+  if (!needsPatch) {
+    return formatter.format(date);
+  }
+
+  return parts
+    .map((p) =>
+      p.type === 'month' && /^\d+$/u.test(p.value) ? monthName : p.value,
+    )
+    .join('');
+}
+
+/**
+ * Format a date as abbreviated month + day (e.g. "Apr 25", "25. dub.").
+ *
+ * @param date - The date to format
+ * @param fmt - Cached locale-specific formatters
+ */
 function formatMonthDay(date: Date, fmt: Formatters): string {
-  return fmt.monthDay.format(date);
+  return formatWithMonthPatch(fmt.monthDay, date, fmt.monthShort.format(date));
 }
 
 function formatTime24h(date: Date, fmt: Formatters): string {
@@ -289,7 +334,11 @@ export function formatChartTimestamp(
   const date = new Date(timeInSeconds * 1000);
 
   if (isCrosshair) {
-    return fmt.crosshair.format(date);
+    return formatWithMonthPatch(
+      fmt.crosshair,
+      date,
+      fmt.monthShort.format(date),
+    );
   }
 
   if (tickMarkType !== null && tickMarkType !== undefined) {

--- a/ui/components/app/perps/perps-candlestick-chart/chart-utils.ts
+++ b/ui/components/app/perps/perps-candlestick-chart/chart-utils.ts
@@ -247,24 +247,25 @@ function isToday(date: Date, fmt: Formatters): boolean {
 }
 
 /**
- * Patch a formatted date string so that a bare-numeric month part is replaced
- * with the standalone abbreviated month name.
+ * Format a date using the given formatter key, patching a bare-numeric month
+ * part with the standalone abbreviated month name when needed.
  *
  * Some locales (notably Czech) have ICU data that downgrades `month: 'short'`
  * back to a bare number when combined with other fields in a single
  * DateTimeFormat.  We detect this via `formatToParts` and substitute the
  * standalone short month name while preserving the locale-native ordering.
  *
- * @param formatter - The combined DateTimeFormat instance
+ * @param key - Which formatter from the cached set to use
  * @param date - The date to format
- * @param fmt - Cached locale-specific formatters (used to derive the month name)
+ * @param fmt - Cached locale-specific formatters
  * @returns The formatted string with month name patched in when needed
  */
 function formatWithMonthPatch(
-  formatter: Intl.DateTimeFormat,
+  key: keyof Formatters,
   date: Date,
   fmt: Formatters,
 ): string {
+  const formatter = fmt[key];
   const parts = formatter.formatToParts(date);
 
   const hasNumericMonth = parts.some(
@@ -295,7 +296,7 @@ function formatWithMonthPatch(
  * @param fmt - Cached locale-specific formatters
  */
 function formatMonthDay(date: Date, fmt: Formatters): string {
-  return formatWithMonthPatch(fmt.monthDay, date, fmt);
+  return formatWithMonthPatch('monthDay', date, fmt);
 }
 
 function formatTime24h(date: Date, fmt: Formatters): string {
@@ -337,7 +338,7 @@ export function formatChartTimestamp(
   const date = new Date(timeInSeconds * 1000);
 
   if (isCrosshair) {
-    return formatWithMonthPatch(fmt.crosshair, date, fmt);
+    return formatWithMonthPatch('crosshair', date, fmt);
   }
 
   if (tickMarkType !== null && tickMarkType !== undefined) {

--- a/ui/components/app/perps/perps-candlestick-chart/chart-utils.ts
+++ b/ui/components/app/perps/perps-candlestick-chart/chart-utils.ts
@@ -192,7 +192,7 @@ function createFormatters(locale: string, timezone: string): Formatters {
     time24h: new Intl.DateTimeFormat(locale, {
       hour: '2-digit',
       minute: '2-digit',
-      hour12: false,
+      hourCycle: 'h23',
       timeZone: timezone,
     }),
     crosshair: new Intl.DateTimeFormat(locale, {
@@ -200,7 +200,7 @@ function createFormatters(locale: string, timezone: string): Formatters {
       day: 'numeric',
       hour: '2-digit',
       minute: '2-digit',
-      hour12: false,
+      hourCycle: 'h23',
       timeZone: timezone,
     }),
     year: new Intl.DateTimeFormat(locale, {
@@ -215,7 +215,7 @@ function createFormatters(locale: string, timezone: string): Formatters {
       hour: '2-digit',
       minute: '2-digit',
       second: '2-digit',
-      hour12: false,
+      hourCycle: 'h23',
       timeZone: timezone,
     }),
   };

--- a/ui/components/app/perps/perps-candlestick-chart/chart-utils.ts
+++ b/ui/components/app/perps/perps-candlestick-chart/chart-utils.ts
@@ -33,6 +33,22 @@ export type HistogramData<TTime> = {
 };
 
 /**
+ * Convert a UTC millisecond timestamp to a local-time Unix timestamp (seconds).
+ *
+ * Lightweight-charts renders numeric timestamps as-is on the x-axis without
+ * any timezone conversion. By subtracting the JS timezone offset we shift the
+ * value so the axis labels show the user's local wall-clock time. The offset
+ * is computed per-timestamp to account for DST transitions.
+ *
+ * @param utcMs - UTC timestamp in milliseconds
+ * @returns Seconds-precision timestamp adjusted to local time
+ */
+function toLocalChartTime(utcMs: number): Time {
+  const offsetSeconds = new Date(utcMs).getTimezoneOffset() * 60;
+  return Math.floor(utcMs / 1000 - offsetSeconds) as Time;
+}
+
+/**
  * Convert a single CandleStick to CandlestickData for lightweight-charts.
  * Returns null if the candle has invalid (NaN or non-positive) OHLC values.
  *
@@ -42,7 +58,7 @@ export type HistogramData<TTime> = {
 export function formatSingleCandleForChart(
   candle: CandleStick,
 ): CandlestickData<Time> | null {
-  const timeInSeconds = Math.floor(candle.time / 1000) as Time;
+  const timeInSeconds = toLocalChartTime(candle.time);
 
   const formatted: CandlestickData<Time> = {
     time: timeInSeconds,
@@ -84,7 +100,7 @@ export function formatSingleVolumeForChart(
   upColor: string,
   downColor: string,
 ): HistogramData<Time> | null {
-  const timeInSeconds = Math.floor(candle.time / 1000) as Time;
+  const timeInSeconds = toLocalChartTime(candle.time);
   const volume = parseFloat(candle.volume || '0');
   const close = parseFloat(candle.close);
   const open = parseFloat(candle.open);

--- a/ui/components/app/perps/perps-candlestick-chart/perps-candlestick-chart.tsx
+++ b/ui/components/app/perps/perps-candlestick-chart/perps-candlestick-chart.tsx
@@ -24,6 +24,7 @@ import {
   formatVolumeDataForChart,
   formatSingleCandleForChart,
   formatSingleVolumeForChart,
+  formatChartTimestamp,
 } from './chart-utils';
 
 /**
@@ -279,6 +280,10 @@ const PerpsCandlestickChart = forwardRef<
             enableResize: false,
           },
         },
+        localization: {
+          timeFormatter: (time: number) =>
+            formatChartTimestamp(time, null, true),
+        },
         grid: {
           vertLines: { color: gridColor },
           horzLines: { color: gridColor },
@@ -304,6 +309,8 @@ const PerpsCandlestickChart = forwardRef<
           timeVisible: true,
           secondsVisible: false,
           borderColor: 'transparent',
+          tickMarkFormatter: (time: number, tickMarkType: number) =>
+            formatChartTimestamp(time, tickMarkType, false),
         },
         rightPriceScale: {
           borderColor: 'transparent',

--- a/ui/components/app/perps/perps-candlestick-chart/perps-candlestick-chart.tsx
+++ b/ui/components/app/perps/perps-candlestick-chart/perps-candlestick-chart.tsx
@@ -13,12 +13,14 @@ import {
   ISeriesApi,
   // @ts-expect-error suppress CommonJS vs ECMAScript error
 } from 'lightweight-charts';
+import { useSelector } from 'react-redux';
 import { brandColor } from '@metamask/design-tokens';
 import { Box } from '@metamask/design-system-react';
 import type { CandleData, CandleStick } from '@metamask/perps-controller';
 import { PRICE_THRESHOLD } from '../../../../../shared/lib/perps-formatters';
 import { CandlePeriod, ZOOM_CONFIG } from '../constants/chartConfig';
 import { useTheme } from '../../../../hooks/useTheme';
+import { getIntlLocale } from '../../../../ducks/locale/locale';
 import {
   formatCandleDataForChart,
   formatVolumeDataForChart,
@@ -158,6 +160,7 @@ const PerpsCandlestickChart = forwardRef<
   ) => {
     const theme = useTheme();
     const isDark = theme === 'dark';
+    const locale = useSelector(getIntlLocale);
 
     // Theme-aware colors matching mobile semantic tokens
     const upColor = isDark ? brandColor.lime100 : brandColor.lime500;
@@ -281,8 +284,9 @@ const PerpsCandlestickChart = forwardRef<
           },
         },
         localization: {
+          locale,
           timeFormatter: (time: number) =>
-            formatChartTimestamp(time, null, true),
+            formatChartTimestamp(time, null, true, locale),
         },
         grid: {
           vertLines: { color: gridColor },
@@ -309,8 +313,11 @@ const PerpsCandlestickChart = forwardRef<
           timeVisible: true,
           secondsVisible: false,
           borderColor: 'transparent',
-          tickMarkFormatter: (time: number, tickMarkType: number) =>
-            formatChartTimestamp(time, tickMarkType, false),
+          tickMarkFormatter: (
+            time: number,
+            tickMarkType: number,
+            chartLocale: string,
+          ) => formatChartTimestamp(time, tickMarkType, false, chartLocale),
         },
         rightPriceScale: {
           borderColor: 'transparent',
@@ -462,6 +469,7 @@ const PerpsCandlestickChart = forwardRef<
       textColor,
       gridColor,
       crosshairColor,
+      locale,
     ]);
 
     // Update chart data when candleData or selectedPeriod changes


### PR DESCRIPTION
## **Description**

The perps candlestick chart was displaying x-axis timestamps in UTC, which could confuse users whose local timezone differs. Additionally, `Date.toLocaleString()` can silently fall back to `Date.toString()` in some extension contexts, producing inconsistent formatting.

This PR introduces locale-aware time formatting for the chart x-axis tick marks and crosshair tooltip using cached `Intl.DateTimeFormat` instances tied to the user's local timezone. The implementation mirrors the mobile `TradingViewChartTemplate` approach with smart formatting based on tick mark type (year, month, day, time, time-with-seconds). Comprehensive unit tests are added for all formatter functions.

## **Changelog**

CHANGELOG entry: Fixed perps chart x-axis and crosshair timestamps to display in the user's local timezone

## **Related issues**

Jira issue: https://consensyssoftware.atlassian.net/browse/TAT-3073

## **Manual testing steps**

Feature: Perps chart x-axis displays local timezone timestamps

Scenario: Chart x-axis labels reflect the user's local timezone
  Given the user opens MetaMask and navigates to the Perps trading page
  When the candlestick chart loads with candle data
  Then the x-axis tick labels display timestamps in the user's local timezone
  And the crosshair tooltip shows a formatted date/time string (e.g. "Mar 15, 14:30")

Scenario: Different tick mark granularities render correctly
  Given the chart is displayed with enough data to show multiple time scales
  When zooming in and out on the chart
  Then year ticks show a 4-digit year (e.g. "2025")
  And month ticks show an abbreviated month name (e.g. "Mar")
  And day ticks show month/day (e.g. "Mar 15")
  And time ticks show 24h format with date prefix for non-today dates

## **Screenshots/Recordings**

N/A — formatting change only; no visual layout changes.

### **Before**

<!-- timestamps displayed in UTC -->

### **After**

<!-- timestamps displayed in user's local timezone -->
<img width="412" height="805" alt="Screenshot 2026-04-24 at 12 24 56" src="https://github.com/user-attachments/assets/26f543d6-49c6-41ab-a9f5-286901a34229" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only time label formatting changes; main risk is incorrect or inconsistent timestamp rendering for certain locales/timezones, mitigated by broad unit tests.
> 
> **Overview**
> Updates the perps candlestick chart to format x-axis tick labels and crosshair timestamps in the **user’s locale and local timezone**, wiring `lightweight-charts` `tickMarkFormatter`/`timeFormatter` through a new `formatChartTimestamp` helper.
> 
> Adds a cached `Intl.DateTimeFormat` formatter set (with a Czech month-name patch and `h23` hour-cycle to avoid `24:00`) plus `clearFormatterCache` for tests, and introduces comprehensive unit tests covering candle/volume formatting and the new timestamp formatting behavior across locales and tick-mark types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab7d49a116be9b3cfaea3ae704d7afc14f716081. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->