### PR TITLE
fix: use DEVICE_KEYRING_MAP for hardware account detection in pay alert

### DIFF
--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -1224,7 +1224,6 @@
       "Reselect: Identity function warnings": 3
     },
     "ui/pages/confirmations/hooks/alerts/transactions/usePayHardwareAccountAlert.test.ts": {
-      "React: Act warnings (component updates not wrapped)": 3,
       "Reselect: Identity function warnings": 3
     },
     "ui/pages/confirmations/hooks/alerts/transactions/usePendingTransactionAlerts.test.ts": {

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -1224,6 +1224,7 @@
       "Reselect: Identity function warnings": 3
     },
     "ui/pages/confirmations/hooks/alerts/transactions/usePayHardwareAccountAlert.test.ts": {
+      "React: Act warnings (component updates not wrapped)": 3,
       "Reselect: Identity function warnings": 3
     },
     "ui/pages/confirmations/hooks/alerts/transactions/usePendingTransactionAlerts.test.ts": {

--- a/ui/pages/confirmations/hooks/alerts/transactions/usePayHardwareAccountAlert.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/usePayHardwareAccountAlert.test.ts
@@ -1,5 +1,7 @@
 import { Hex } from '@metamask/utils';
 import { KeyringTypes } from '@metamask/keyring-controller';
+import { TransactionType } from '@metamask/transaction-controller';
+import { waitFor } from '@testing-library/react';
 import {
   getMockConfirmStateForTransaction,
   getMockConfirmState,
@@ -53,7 +55,26 @@ function createHardwareAccountState(keyringType: string) {
   };
 }
 
-function runHookWithTransaction(keyringType: string = 'HD Key Tree') {
+function runHookWithMusdConversion(keyringType: string = 'HD Key Tree') {
+  const transaction = {
+    ...genUnapprovedContractInteractionConfirmation({
+      address: CONTRACT_INTERACTION_SENDER_ADDRESS as Hex,
+    }),
+    type: TransactionType.musdConversion,
+  };
+
+  const state = getMockConfirmStateForTransaction(
+    transaction,
+    createHardwareAccountState(keyringType),
+  );
+
+  return renderHookWithConfirmContextProvider(
+    () => usePayHardwareAccountAlert(),
+    state,
+  );
+}
+
+function runHookWithContractInteraction(keyringType: string) {
   const transaction = genUnapprovedContractInteractionConfirmation({
     address: CONTRACT_INTERACTION_SENDER_ADDRESS as Hex,
   });
@@ -78,59 +99,52 @@ function runHookWithoutTransaction() {
   );
 }
 
+const EXPECTED_ALERT = {
+  key: AlertsName.PayHardwareAccount,
+  field: RowAlertKey.PayWith,
+  reason: 'Wallet not supported',
+  message: "Hardware wallets aren't supported.\nSwitch wallets to continue.",
+  severity: Severity.Danger,
+  isBlocking: true,
+};
+
 describe('usePayHardwareAccountAlert', () => {
-  it('returns alert if from address is a Ledger hardware wallet account', () => {
-    const { result } = runHookWithTransaction(KeyringTypes.ledger);
+  it('returns alert for Ledger account on musdConversion', async () => {
+    const { result } = runHookWithMusdConversion(KeyringTypes.ledger);
 
-    expect(result.current).toStrictEqual([
-      {
-        key: AlertsName.PayHardwareAccount,
-        field: RowAlertKey.PayWith,
-        reason: 'Wallet not supported',
-        message:
-          "Hardware wallets aren't supported.\nSwitch wallets to continue.",
-        severity: Severity.Danger,
-        isBlocking: true,
-      },
-    ]);
+    await waitFor(() => {
+      expect(result.current).toStrictEqual([EXPECTED_ALERT]);
+    });
   });
 
-  it('returns alert if from address is a Trezor hardware wallet account', () => {
-    const { result } = runHookWithTransaction(KeyringTypes.trezor);
+  it('returns alert for Trezor account on musdConversion', async () => {
+    const { result } = runHookWithMusdConversion(KeyringTypes.trezor);
 
-    expect(result.current).toStrictEqual([
-      {
-        key: AlertsName.PayHardwareAccount,
-        field: RowAlertKey.PayWith,
-        reason: 'Wallet not supported',
-        message:
-          "Hardware wallets aren't supported.\nSwitch wallets to continue.",
-        severity: Severity.Danger,
-        isBlocking: true,
-      },
-    ]);
+    await waitFor(() => {
+      expect(result.current).toStrictEqual([EXPECTED_ALERT]);
+    });
   });
 
-  it('returns alert if from address is a Lattice hardware wallet account', () => {
-    const { result } = runHookWithTransaction(KeyringTypes.lattice);
+  it('returns alert for Lattice account on musdConversion', async () => {
+    const { result } = runHookWithMusdConversion(KeyringTypes.lattice);
 
-    expect(result.current).toStrictEqual([
-      {
-        key: AlertsName.PayHardwareAccount,
-        field: RowAlertKey.PayWith,
-        reason: 'Wallet not supported',
-        message:
-          "Hardware wallets aren't supported.\nSwitch wallets to continue.",
-        severity: Severity.Danger,
-        isBlocking: true,
-      },
-    ]);
+    await waitFor(() => {
+      expect(result.current).toStrictEqual([EXPECTED_ALERT]);
+    });
   });
 
-  it('returns no alert if from address is not a hardware wallet account', () => {
-    const { result } = runHookWithTransaction('HD Key Tree');
+  it('returns no alert for non-hardware wallet account on musdConversion', () => {
+    const { result } = runHookWithMusdConversion('HD Key Tree');
 
     expect(result.current).toStrictEqual([]);
+  });
+
+  it('returns no alert for hardware wallet on contractInteraction', async () => {
+    const { result } = runHookWithContractInteraction(KeyringTypes.ledger);
+
+    await waitFor(() => {
+      expect(result.current).toStrictEqual([]);
+    });
   });
 
   it('returns no alert if there is no current confirmation', () => {

--- a/ui/pages/confirmations/hooks/alerts/transactions/usePayHardwareAccountAlert.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/usePayHardwareAccountAlert.test.ts
@@ -1,4 +1,5 @@
 import { Hex } from '@metamask/utils';
+import { KeyringTypes } from '@metamask/keyring-controller';
 import {
   getMockConfirmStateForTransaction,
   getMockConfirmState,
@@ -11,7 +12,6 @@ import { renderHookWithConfirmContextProvider } from '../../../../../../test/lib
 import { AlertsName } from '../constants';
 import { RowAlertKey } from '../../../../../components/app/confirm/info/row/constants';
 import { Severity } from '../../../../../helpers/constants/design-system';
-import { HardwareDeviceNames } from '../../../../../../shared/constants/hardware-wallets';
 import { usePayHardwareAccountAlert } from './usePayHardwareAccountAlert';
 
 const HARDWARE_ACCOUNT_ID = 'hardware-account-id';
@@ -80,7 +80,7 @@ function runHookWithoutTransaction() {
 
 describe('usePayHardwareAccountAlert', () => {
   it('returns alert if from address is a Ledger hardware wallet account', () => {
-    const { result } = runHookWithTransaction(HardwareDeviceNames.ledger);
+    const { result } = runHookWithTransaction(KeyringTypes.ledger);
 
     expect(result.current).toStrictEqual([
       {
@@ -96,7 +96,7 @@ describe('usePayHardwareAccountAlert', () => {
   });
 
   it('returns alert if from address is a Trezor hardware wallet account', () => {
-    const { result } = runHookWithTransaction(HardwareDeviceNames.trezor);
+    const { result } = runHookWithTransaction(KeyringTypes.trezor);
 
     expect(result.current).toStrictEqual([
       {
@@ -112,7 +112,7 @@ describe('usePayHardwareAccountAlert', () => {
   });
 
   it('returns alert if from address is a Lattice hardware wallet account', () => {
-    const { result } = runHookWithTransaction(HardwareDeviceNames.lattice);
+    const { result } = runHookWithTransaction(KeyringTypes.lattice);
 
     expect(result.current).toStrictEqual([
       {

--- a/ui/pages/confirmations/hooks/alerts/transactions/usePayHardwareAccountAlert.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/usePayHardwareAccountAlert.ts
@@ -17,7 +17,6 @@ import { isHardwareAccount } from '../../../../../components/app/rewards/utils/i
 const PAY_HARDWARE_ALERT_TRANSACTION_TYPES: TransactionType[] = [
   TransactionType.musdConversion,
   TransactionType.perpsDeposit,
-  TransactionType.perpsRelayDeposit,
   TransactionType.perpsWithdraw,
   TransactionType.predictDeposit,
   TransactionType.predictWithdraw,

--- a/ui/pages/confirmations/hooks/alerts/transactions/usePayHardwareAccountAlert.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/usePayHardwareAccountAlert.ts
@@ -11,7 +11,7 @@ import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { AlertsName } from '../constants';
 import { useConfirmContext } from '../../../context/confirm';
 import { getInternalAccountByAddress } from '../../../../../selectors/accounts';
-import { isHardwareAccount } from '../../../../../../shared/lib/accounts/accounts';
+import { isHardwareAccount } from '../../../../../components/app/rewards/utils/isHardwareAccount';
 
 export function usePayHardwareAccountAlert(): Alert[] {
   const t = useI18nContext();

--- a/ui/pages/confirmations/hooks/alerts/transactions/usePayHardwareAccountAlert.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/usePayHardwareAccountAlert.ts
@@ -3,6 +3,7 @@
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import type { TransactionMeta } from '@metamask/transaction-controller';
+import { TransactionType } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 import { Alert } from '../../../../../ducks/confirm-alerts/confirm-alerts';
 import { Severity } from '../../../../../helpers/constants/design-system';
@@ -13,14 +14,25 @@ import { useConfirmContext } from '../../../context/confirm';
 import { getInternalAccountByAddress } from '../../../../../selectors/accounts';
 import { isHardwareAccount } from '../../../../../components/app/rewards/utils/isHardwareAccount';
 
+const PAY_HARDWARE_ALERT_TRANSACTION_TYPES: TransactionType[] = [
+  TransactionType.musdConversion,
+];
+
 export function usePayHardwareAccountAlert(): Alert[] {
   const t = useI18nContext();
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
 
+  const transactionType = currentConfirmation?.type;
   const fromAddress = currentConfirmation?.txParams?.from as Hex | undefined;
 
+  const isApplicableType =
+    transactionType !== undefined &&
+    PAY_HARDWARE_ALERT_TRANSACTION_TYPES.includes(transactionType);
+
   const account = useSelector((state) =>
-    fromAddress ? getInternalAccountByAddress(state, fromAddress) : undefined,
+    fromAddress && isApplicableType
+      ? getInternalAccountByAddress(state, fromAddress)
+      : undefined,
   );
 
   const isHardwareWallet = account ? isHardwareAccount(account) : false;

--- a/ui/pages/confirmations/hooks/alerts/transactions/usePayHardwareAccountAlert.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/usePayHardwareAccountAlert.ts
@@ -16,6 +16,11 @@ import { isHardwareAccount } from '../../../../../components/app/rewards/utils/i
 
 const PAY_HARDWARE_ALERT_TRANSACTION_TYPES: TransactionType[] = [
   TransactionType.musdConversion,
+  TransactionType.perpsDeposit,
+  TransactionType.perpsRelayDeposit,
+  TransactionType.perpsWithdraw,
+  TransactionType.predictDeposit,
+  TransactionType.predictWithdraw,
 ];
 
 export function usePayHardwareAccountAlert(): Alert[] {
@@ -25,20 +30,18 @@ export function usePayHardwareAccountAlert(): Alert[] {
   const transactionType = currentConfirmation?.type;
   const fromAddress = currentConfirmation?.txParams?.from as Hex | undefined;
 
-  const isApplicableType =
-    transactionType !== undefined &&
-    PAY_HARDWARE_ALERT_TRANSACTION_TYPES.includes(transactionType);
-
   const account = useSelector((state) =>
-    fromAddress && isApplicableType
-      ? getInternalAccountByAddress(state, fromAddress)
-      : undefined,
+    fromAddress ? getInternalAccountByAddress(state, fromAddress) : undefined,
   );
 
   const isHardwareWallet = account ? isHardwareAccount(account) : false;
 
+  const isApplicableType =
+    transactionType !== undefined &&
+    PAY_HARDWARE_ALERT_TRANSACTION_TYPES.includes(transactionType);
+
   return useMemo(() => {
-    if (!isHardwareWallet) {
+    if (!isApplicableType || !isHardwareWallet) {
       return [];
     }
 
@@ -52,5 +55,5 @@ export function usePayHardwareAccountAlert(): Alert[] {
         isBlocking: true,
       },
     ];
-  }, [isHardwareWallet, t]);
+  }, [isApplicableType, isHardwareWallet, t]);
 }


### PR DESCRIPTION
## **Description**

`usePayHardwareAccountAlert` was importing `isHardwareAccount` from `shared/lib/accounts/accounts.ts`, which compares `account.metadata.keyring.type` against `HardwareDeviceNames` values (short names like `'ledger'`). However, `account.metadata.keyring.type` stores the full `KeyringTypes` string (e.g. `'Ledger Hardware'`), so the comparison never matched and the alert never fired for hardware wallets during mUSD conversion.

This switches the import to the `isHardwareAccount` utility from `ui/components/app/rewards/utils/isHardwareAccount.ts`, which correctly checks against `DEVICE_KEYRING_MAP` values (the actual `KeyringTypes` strings). Tests are updated to use `KeyringTypes` instead of `HardwareDeviceNames`.

## **Changelog**

CHANGELOG entry: Fixed hardware wallet detection in the pay alert so Ledger and other hardware wallets are correctly identified during mUSD conversion

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/42074
Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1140

## **Manual testing steps**

1. Connect a Ledger hardware wallet account
2. Initiate an mUSD conversion transaction
3. Verify the hardware account alert appears and the confirm button is disabled

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
<img width="1120" height="1356" alt="Screenshot 2026-04-24 at 15 51 23" src="https://github.com/user-attachments/assets/b56348fc-20d1-495f-90dd-4539d5d0e4cc" />

-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI alert logic and test updates; low risk aside from potentially changing when blocking alerts appear for the listed transaction types.
> 
> **Overview**
> Fixes hardware-wallet detection in `usePayHardwareAccountAlert` by switching to the UI `isHardwareAccount` helper that matches stored `KeyringTypes`, and gates the alert to a specific set of transaction types (`musdConversion`, `perps*`, `predict*`).
> 
> Updates tests to use `KeyringTypes`, adds coverage for mUSD conversion vs. contract interaction behavior, and stabilizes assertions via a shared expected alert and `waitFor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fca04c614d62db666e039ab9052bba7f38cc86f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->