### PR TITLE
fix: gassless txs gettransactionbyhash to return nonce

### DIFF
--- a/app/scripts/lib/util.test.js
+++ b/app/scripts/lib/util.test.js
@@ -722,6 +722,47 @@ describe('app utils', () => {
       const result = formatTxMetaForRpcResult(txMeta);
       expect(result).toStrictEqual(expectedResult);
     });
+
+    it('should correctly format the tx meta object (gassless)', () => {
+      const txMeta = {
+        id: 1,
+        status: TransactionStatus.unapproved,
+        txParams: {
+          from: '0xc684832530fcbddae4b4230a47e991ddcec2831d',
+          to: '0x1678a085c290ebd122dc42cba69373b5953b831d',
+          gasPrice: '0x77359400',
+          gas: '0x7b0d',
+        },
+        type: TransactionType.simpleSend,
+        origin: 'other',
+        chainId: '0x5',
+        time: 1624408066355,
+        hash: '0x4bcb6cd6b182209585f8ad140260ddb35c81a575dd40f508d9767e652a9f60e7',
+        r: '0x4c3111e42ed5eec3dcecba1e234700f387e8693c373c61c3e54a762a26f1570e',
+        s: '0x18bfc4eeb7ebcfacc3bd59ea100a6834ea3265e65945dbec69aa2a06564fafff',
+        v: '0x29',
+      };
+      const expectedResult = {
+        accessList: null,
+        blockHash: null,
+        blockNumber: null,
+        from: '0xc684832530fcbddae4b4230a47e991ddcec2831d',
+        gas: '0x7b0d',
+        hash: '0x4bcb6cd6b182209585f8ad140260ddb35c81a575dd40f508d9767e652a9f60e7',
+        input: '0x',
+        gasPrice: '0x77359400',
+        nonce: '0x0',
+        r: '0x4c3111e42ed5eec3dcecba1e234700f387e8693c373c61c3e54a762a26f1570e',
+        s: '0x18bfc4eeb7ebcfacc3bd59ea100a6834ea3265e65945dbec69aa2a06564fafff',
+        to: '0x1678a085c290ebd122dc42cba69373b5953b831d',
+        transactionIndex: null,
+        type: TransactionEnvelopeType.legacy,
+        v: '0x29',
+        value: '0x0',
+      };
+      const result = formatTxMetaForRpcResult(txMeta);
+      expect(result).toStrictEqual(expectedResult);
+    });
   });
 
   describe('getMethodDataName', () => {

--- a/app/scripts/lib/util.ts
+++ b/app/scripts/lib/util.ts
@@ -552,7 +552,7 @@ export function formatTxMetaForRpcResult(
     gas,
     from,
     hash,
-    nonce: `${nonce}`,
+    nonce: nonce ? `${nonce}` : '0x0',
     // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     input: data || '0x',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

- Gasless transactions - when user chooses ERC20 as fee token - yields transactions that get stored without `nonce` field.
- Although we handle the absence of nonce is our own code, when a dApp requests such a transaction using ` eth_getTransactionByHash`, we return a result with `{ ... , nonce: 'undefined' }` which will crash some dApps parser (when they expect a number or hex string).
- This causes somes dApps - like stargate.finance - to systematically show a tx failure status in their UI for gasless transactions. This breaks "approve + act" UX because approval is considered as failed. The feature works but users can get confused and may have to refresh the page in some dApps.
- Since Tempo leverages those transactions for all interactions, this issue is more impactful for that chain, hence the need for a fix.

--> The following PR proposes to simply return `0x0` as `nonce` when it is missing. This has been tested to be working on stargate.finance.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: returns `nonce: '0x0'` when eth_getTransactionByHash is called for a gasless tx

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/NEB-949?atlOrigin=eyJpIjoiMGRlYTA0MjdiOTFjNGE2ZGFhY2Q0ODM5NmI1NmE3NzkiLCJwIjoiaiJ9

## **Manual testing steps**

1. Go to https://stargate.finance/?srcChain=tempo&srcToken=0x20C000000000000000000000b9537d11c60E8b50&dstChain=base&dstToken=0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913
2. Perform a `0.01` USDC.e transfer from Tempo to Base
3. Observe status on stargate.finance dApp for both approval tx and execution tx.
4. Success status is shown on the dApp - while previous version shown errors in stargate.finance dApp

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="600" alt="image" src="https://github.com/user-attachments/assets/0245b7fe-c7fe-473e-8e68-a9ded190e2fa" />

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
<img width="600" alt="image" src="https://github.com/user-attachments/assets/a1b96dc5-02c0-4a6b-887e-fe0d3b837ebe" />

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small formatting change to RPC transaction results that only affects cases where `txParams.nonce` is missing, with a focused unit test added to lock in behavior.
> 
> **Overview**
> Fixes `formatTxMetaForRpcResult` to return `nonce: '0x0'` when `txParams.nonce` is absent (e.g., gasless/fee-token transactions), avoiding `'undefined'` in `eth_getTransactionByHash` responses.
> 
> Adds a unit test covering the missing-nonce (“gasless”) case to ensure the RPC-formatted transaction meta includes the default nonce.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ed7bab1444d0d67ba03d3f0c788ffc8305f9e91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->