### PR TITLE
fix: orphaned smart transaction pending toasts cp-13.29.0

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -161,6 +161,7 @@ import {
   POLLING_TOKEN_ENVIRONMENT_TYPES,
   MESSAGE_TYPE,
   PLATFORM_FIREFOX,
+  SMART_TRANSACTION_CONFIRMATION_TYPES,
 } from '../../shared/constants/app';
 import {
   MetaMetricsEventCategory,
@@ -5676,6 +5677,44 @@ export default class MetamaskController extends EventEmitter {
       this.accountsController.getSelectedAccount().address;
 
     const globalChainId = this.#getGlobalChainId();
+
+    const matchingSmartTransactionApprovals = Object.values(
+      this.approvalController.state.pendingApprovals ?? {},
+    ).filter((approval) => {
+      if (
+        approval.type !==
+        SMART_TRANSACTION_CONFIRMATION_TYPES.showSmartTransactionStatusPage
+      ) {
+        return false;
+      }
+
+      const txId = approval.requestState?.txId;
+      if (typeof txId !== 'string') {
+        return false;
+      }
+
+      const transaction = this.txController.state.transactions.find(
+        ({ id }) => id === txId,
+      );
+
+      return (
+        transaction?.chainId === globalChainId &&
+        isEqualCaseInsensitive(transaction.txParams?.from, selectedAddress)
+      );
+    });
+
+    for (const approval of matchingSmartTransactionApprovals) {
+      try {
+        this.approvalController.rejectRequest(
+          approval.id,
+          new Error('Transaction activity reset'),
+        );
+      } catch (error) {
+        if (!(error instanceof ApprovalRequestNotFoundError)) {
+          throw error;
+        }
+      }
+    }
 
     this.txController.wipeTransactions({
       address: selectedAddress,

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -2903,6 +2903,88 @@ describe('MetaMaskController', () => {
           ignoreNetwork: false,
         });
       });
+
+      it('rejects matching smart transaction status page approvals when wiping activity', async () => {
+        const selectedAddressMock =
+          '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc';
+
+        jest
+          .spyOn(metamaskController.accountsController, 'getSelectedAccount')
+          .mockReturnValue({ address: selectedAddressMock });
+
+        metamaskController.txController.update((state) => {
+          state.transactions = [
+            {
+              id: 'matching-tx',
+              chainId: CHAIN_IDS.MAINNET,
+              txParams: {
+                from: selectedAddressMock,
+              },
+            },
+            {
+              id: 'other-chain-tx',
+              chainId: CHAIN_IDS.LINEA_MAINNET,
+              txParams: {
+                from: selectedAddressMock,
+              },
+            },
+            {
+              id: 'other-address-tx',
+              chainId: CHAIN_IDS.MAINNET,
+              txParams: {
+                from: '0x1111111111111111111111111111111111111111',
+              },
+            },
+          ];
+        });
+
+        metamaskController.approvalController.update((state) => {
+          state.pendingApprovals = {
+            matchingApproval: {
+              id: 'matching-approval',
+              type: 'smartTransaction:showSmartTransactionStatusPage',
+              requestState: {
+                txId: 'matching-tx',
+              },
+            },
+            otherChainApproval: {
+              id: 'other-chain-approval',
+              type: 'smartTransaction:showSmartTransactionStatusPage',
+              requestState: {
+                txId: 'other-chain-tx',
+              },
+            },
+            otherAddressApproval: {
+              id: 'other-address-approval',
+              type: 'smartTransaction:showSmartTransactionStatusPage',
+              requestState: {
+                txId: 'other-address-tx',
+              },
+            },
+            otherApprovalType: {
+              id: 'other-approval-type',
+              type: 'eth_signTypedData',
+              requestState: {
+                txId: 'matching-tx',
+              },
+            },
+          };
+        });
+
+        jest.spyOn(metamaskController.approvalController, 'rejectRequest');
+
+        await metamaskController.resetAccount();
+
+        expect(
+          metamaskController.approvalController.rejectRequest,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          metamaskController.approvalController.rejectRequest,
+        ).toHaveBeenCalledWith(
+          'matching-approval',
+          new Error('Transaction activity reset'),
+        );
+      });
     });
 
     describe('#removeAccount', () => {

--- a/ui/app/toast-listener/shared.tsx
+++ b/ui/app/toast-listener/shared.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { toast } from 'react-hot-toast';
-import type { TransactionMeta } from '@metamask/transaction-controller';
 import {
   useTransactionDisplay,
   type TransactionStatus,
@@ -24,6 +23,10 @@ export function showSuccessToast(id: string) {
 
 export function showFailedToast(id: string) {
   toast.error(<ToastContent status="failed" />, { id });
+}
+
+export function dismissToast(id: string) {
+  toast.dismiss(id);
 }
 
 export function showToast(id: string, status: ToastStatus) {

--- a/ui/app/toast-listener/useSmartTransactionToasts.test.ts
+++ b/ui/app/toast-listener/useSmartTransactionToasts.test.ts
@@ -15,6 +15,7 @@ const mockResolvePendingApproval = jest.fn(
 const mockShowPendingToast = jest.fn();
 const mockShowSuccessToast = jest.fn();
 const mockShowFailedToast = jest.fn();
+const mockDismissToast = jest.fn();
 
 jest.mock('react-redux', () => ({
   useDispatch: () => mockDispatch,
@@ -34,6 +35,7 @@ jest.mock('./shared', () => ({
   showPendingToast: (...args: [string]) => mockShowPendingToast(...args),
   showSuccessToast: (...args: [string]) => mockShowSuccessToast(...args),
   showFailedToast: (...args: [string]) => mockShowFailedToast(...args),
+  dismissToast: (...args: [string]) => mockDismissToast(...args),
 }));
 
 describe('useSmartTransactionToasts', () => {
@@ -263,5 +265,25 @@ describe('useSmartTransactionToasts', () => {
       approvalId: 'approval-1',
       value: true,
     });
+  });
+
+  it('dismisses a pending toast when the smart transaction disappears', () => {
+    mockTransactions = [
+      {
+        approvalId: 'approval-1',
+        txId: 'tx-1',
+        smartTransactionStatus: SmartTransactionStatuses.PENDING,
+      },
+    ];
+
+    const { rerender } = renderHook(() => useSmartTransactionToasts());
+
+    expect(mockShowPendingToast).toHaveBeenCalledWith('stx-tx-1');
+
+    mockTransactions = [];
+
+    rerender();
+
+    expect(mockDismissToast).toHaveBeenCalledWith('stx-tx-1');
   });
 });

--- a/ui/app/toast-listener/useSmartTransactionToasts.ts
+++ b/ui/app/toast-listener/useSmartTransactionToasts.ts
@@ -5,7 +5,12 @@ import { useDispatch, useSelector } from 'react-redux';
 import { type TransactionStatus } from '../../helpers/utils/transaction-display';
 import { resolvePendingApproval } from '../../store/actions';
 import { selectSmartTransactions } from '../../selectors/toast';
-import { showFailedToast, showPendingToast, showSuccessToast } from './shared';
+import {
+  dismissToast,
+  showFailedToast,
+  showPendingToast,
+  showSuccessToast,
+} from './shared';
 
 function generateToastId(txId: string) {
   return `stx-${txId}`;
@@ -90,6 +95,15 @@ export function useSmartTransactionToasts() {
       if (currentStatus === 'failed') {
         showFailedToast(toastId);
         dispatch(resolvePendingApproval(tx.approvalId, true));
+      }
+    }
+
+    for (const [toastId, previousStatus] of Object.entries(
+      previousStatusesRef.current,
+    )) {
+      // Dismiss pending toasts that are no longer in the transactions list
+      if (previousStatus === 'pending' && !(toastId in nextStatuses)) {
+        dismissToast(toastId);
       }
     }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Note: STX toasts are behind a feature flag.

Fixes orphaned STX toasts after clicking Delete Activity and nonce data in Settings. 

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/42109

## **Manual testing steps**

1. Send a transaction with very low gas on STX network (Ethereum, Base, Arbitrum, Polygon)
2. Notice the transaction is pending
3. Go to Settings Developer Tools
4. Click Delete Activity and nonce data

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `resetAccount()` to actively reject certain pending smart-transaction approvals and updates toast handling to dismiss pending toasts when their backing transaction disappears, which could affect approval/toast lifecycles if matching logic is off.
> 
> **Overview**
> Fixes orphaned Smart Transaction UX state after wiping activity.
> 
> `resetAccount()` now finds pending approvals for `showSmartTransactionStatusPage` that match the current account+chain and rejects them before wiping transactions/smart transactions.
> 
> The smart-transaction toast listener now dismisses *pending* toasts when the corresponding smart-transaction entry disappears, and adds coverage for both behaviors in tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cb321b03ea9eddff9ca9886539423cde3b3e05a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->