### PR TITLE
fix: exclude STX status-page from pending count cp-13.29.0

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -61,6 +61,7 @@ import {
   CorruptionHandler,
   hasVault,
 } from './lib/state-corruption/state-corruption-recovery';
+import { getAttentionRequiredApprovalCount } from './lib/approval/utils';
 import { useSplitStateStorage } from './lib/use-split-state-storage';
 import migrations from './migrations';
 import Migrator from './lib/migrator';
@@ -1989,7 +1990,9 @@ export function setupController(
     try {
       const pendingApprovalCount =
         controller.appStateController.waitingForUnlock.length +
-        controller.approvalController.getTotalApprovalCount();
+        getAttentionRequiredApprovalCount({
+          approvalController: controller.approvalController,
+        });
       return pendingApprovalCount;
     } catch (error) {
       console.error('Failed to get pending approval count:', error);

--- a/app/scripts/lib/approval/utils.test.ts
+++ b/app/scripts/lib/approval/utils.test.ts
@@ -6,8 +6,15 @@ import { Json } from '@metamask/utils';
 import { ApprovalType } from '@metamask/controller-utils';
 import { providerErrors } from '@metamask/rpc-errors';
 import { DIALOG_APPROVAL_TYPES } from '@metamask/snaps-rpc-methods';
-import { SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES } from '../../../../shared/constants/app';
-import { rejectAllApprovals, rejectOriginApprovals } from './utils';
+import {
+  SMART_TRANSACTION_CONFIRMATION_TYPES,
+  SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES,
+} from '../../../../shared/constants/app';
+import {
+  getAttentionRequiredApprovalCount,
+  rejectAllApprovals,
+  rejectOriginApprovals,
+} from './utils';
 
 const ID_MOCK = '123';
 const ID_MOCK_2 = '456';
@@ -31,6 +38,24 @@ function createApprovalControllerMock(
 }
 
 describe('Approval Utils', () => {
+  describe('getAttentionRequiredApprovalCount', () => {
+    it('excludes smart transaction status page approvals', () => {
+      const approvalController = createApprovalControllerMock([
+        { id: ID_MOCK, type: ApprovalType.Transaction },
+        {
+          id: ID_MOCK_2,
+          type: SMART_TRANSACTION_CONFIRMATION_TYPES.showSmartTransactionStatusPage,
+        },
+      ]);
+
+      expect(
+        getAttentionRequiredApprovalCount({
+          approvalController,
+        }),
+      ).toBe(1);
+    });
+  });
+
   describe('rejectAllApprovals', () => {
     it('rejects approval requests with rejected error', () => {
       const approvalController = createApprovalControllerMock([

--- a/app/scripts/lib/approval/utils.ts
+++ b/app/scripts/lib/approval/utils.ts
@@ -6,9 +6,27 @@ import { ApprovalType } from '@metamask/controller-utils';
 import { DIALOG_APPROVAL_TYPES } from '@metamask/snaps-rpc-methods';
 import { providerErrors } from '@metamask/rpc-errors';
 import { createProjectLogger, Json } from '@metamask/utils';
-import { SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES } from '../../../../shared/constants/app';
+import {
+  SMART_TRANSACTION_CONFIRMATION_TYPES,
+  SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES,
+} from '../../../../shared/constants/app';
 
 const log = createProjectLogger('approval-utils');
+
+export function getAttentionRequiredApprovalCount({
+  approvalController,
+}: {
+  approvalController: ApprovalController;
+}) {
+  const approvalRequestsById = approvalController.state.pendingApprovals ?? {};
+  const approvalRequests = Object.values(approvalRequestsById);
+
+  return approvalRequests.filter(
+    (approvalRequest) =>
+      approvalRequest.type !==
+      SMART_TRANSACTION_CONFIRMATION_TYPES.showSmartTransactionStatusPage,
+  ).length;
+}
 
 export function rejectAllApprovals({
   approvalController,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Note: STX toasts are behind a feature flag.

Updates the badge logic to exclude STX status page-only requests, since these no longer need user action.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensys.slack.com/archives/C06FXU326RL/p1777072954423729

## **Manual testing steps**

1. Open sidepanel
2. Confirm an STX transaction

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only the badge pending-count calculation by filtering out a non-actionable approval type, with a focused unit test to prevent regressions.
> 
> **Overview**
> Updates the browser badge pending-count logic to only include approvals that still require user action by excluding `SMART_TRANSACTION_CONFIRMATION_TYPES.showSmartTransactionStatusPage` from the total.
> 
> Adds `getAttentionRequiredApprovalCount` in `app/scripts/lib/approval/utils.ts`, wires it into `background.js` pending badge calculation, and covers the filter behavior with a new unit test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30e50c7502dd8a68bd13b2dc69c3ca167d6e9a3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->