### PR TITLE
fix: suppress stx toast in favor of custom musd toast cp-13.29.0

### DIFF
--- a/ui/helpers/constants/transactions.js
+++ b/ui/helpers/constants/transactions.js
@@ -34,13 +34,16 @@ export const EXCLUDED_TRANSACTION_TYPES = new Set([
 export const TOAST_EXCLUDED_TRANSACTION_TYPES = new Set([
   TransactionType.swapApproval,
   TransactionType.bridgeApproval,
-  TransactionType.bridge,
   TransactionType.shieldSubscriptionApprove,
   TransactionType.musdConversion,
   TransactionType.musdClaim,
   TransactionType.perpsDeposit,
   TransactionType.perpsDepositAndOrder,
   TransactionType.perpsWithdraw,
+]);
+
+export const TOAST_EXCLUDED_NESTED_TRANSACTION_TYPES = new Set([
+  TransactionType.musdRelayDeposit,
 ]);
 
 // Non-EVM transaction types excluded from toast notifications.

--- a/ui/selectors/toast.test.ts
+++ b/ui/selectors/toast.test.ts
@@ -427,6 +427,36 @@ describe('toast selectors', () => {
       ]);
     });
 
+    it('excludes smart transaction toasts for batches with excluded nested types', () => {
+      const state = {
+        metamask: {
+          pendingApprovals: {
+            'approval-1': {
+              id: 'approval-1',
+              type: 'smartTransaction:showSmartTransactionStatusPage',
+              requestState: {
+                txId: 'tx-1',
+                smartTransaction: { status: 'pending' },
+              },
+            },
+          },
+          transactions: [
+            {
+              id: 'tx-1',
+              status: 'submitted',
+              type: TransactionType.batch,
+              nestedTransactions: [
+                { type: TransactionType.tokenMethodApprove },
+                { type: TransactionType.musdRelayDeposit },
+              ],
+            },
+          ],
+        },
+      } as unknown as SelectorState;
+
+      expect(selectSmartTransactions(state)).toStrictEqual([]);
+    });
+
     it('follows the replacement for a Speed Up (retry) chain', () => {
       const state = {
         metamask: {

--- a/ui/selectors/toast.ts
+++ b/ui/selectors/toast.ts
@@ -1,5 +1,6 @@
 import {
   TransactionStatus,
+  type TransactionMeta,
   TransactionType,
 } from '@metamask/transaction-controller';
 import { createSelector } from 'reselect';
@@ -7,6 +8,7 @@ import { createDeepEqualSelector } from '../../shared/lib/selectors/selector-cre
 import { SMART_TRANSACTION_CONFIRMATION_TYPES } from '../../shared/constants/app';
 import type { MetaMaskReduxState } from '../store/store';
 import {
+  TOAST_EXCLUDED_NESTED_TRANSACTION_TYPES,
   TOAST_EXCLUDED_TRANSACTION_TYPES,
   TOAST_EXCLUDED_NON_EVM_TRANSACTION_TYPES,
 } from '../helpers/constants/transactions';
@@ -146,6 +148,22 @@ type TxRequest = {
   evmStatus: string | undefined;
 };
 
+function isTransactionTypeExcluded(
+  transaction: TransactionMeta | undefined,
+) {
+  const type = transaction?.type;
+  const isExcludedType = Boolean(
+    type && TOAST_EXCLUDED_TRANSACTION_TYPES.has(type),
+  );
+  const isExcludedNestedType = Boolean(transaction?.nestedTransactions?.some(
+    (nested) =>
+      nested.type &&
+      TOAST_EXCLUDED_NESTED_TRANSACTION_TYPES.has(nested.type),
+  ));
+
+  return isExcludedType || isExcludedNestedType;
+}
+
 function getEffectiveEvmStatus(
   txId: string,
   transactions: ReturnType<typeof selectTransactions>,
@@ -191,6 +209,11 @@ export const selectSmartTransactions = createDeepEqualSelector(
       };
 
       if (!txId) {
+        continue;
+      }
+
+      const transaction = transactions.find((tx) => tx.id === txId);
+      if (isTransactionTypeExcluded(transaction)) {
         continue;
       }
 

--- a/ui/selectors/toast.ts
+++ b/ui/selectors/toast.ts
@@ -148,18 +148,17 @@ type TxRequest = {
   evmStatus: string | undefined;
 };
 
-function isTransactionTypeExcluded(
-  transaction: TransactionMeta | undefined,
-) {
+function isTransactionTypeExcluded(transaction: TransactionMeta | undefined) {
   const type = transaction?.type;
   const isExcludedType = Boolean(
     type && TOAST_EXCLUDED_TRANSACTION_TYPES.has(type),
   );
-  const isExcludedNestedType = Boolean(transaction?.nestedTransactions?.some(
-    (nested) =>
-      nested.type &&
-      TOAST_EXCLUDED_NESTED_TRANSACTION_TYPES.has(nested.type),
-  ));
+  const isExcludedNestedType = Boolean(
+    transaction?.nestedTransactions?.some(
+      (nested) =>
+        nested.type && TOAST_EXCLUDED_NESTED_TRANSACTION_TYPES.has(nested.type),
+    ),
+  );
 
   return isExcludedType || isExcludedNestedType;
 }


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Note: STX toasts are behind a feature flag.

Prevents the generic STX toast from showing for mUSD flows that already have their own custom toast.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: #42069 

## **Manual testing steps**

1. From tokens list, choose a token with "Get X% mUSD Bonus"
2. Proceed
3. Observe only custom mUSD toast

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only tightens toast-eligibility filtering for smart transaction approvals and adds a unit test; no transaction execution or state mutations change.
> 
> **Overview**
> Prevents generic *smart transaction* toasts from showing when the underlying EVM transaction is a `batch` that includes certain nested mUSD-related operations.
> 
> This introduces `TOAST_EXCLUDED_NESTED_TRANSACTION_TYPES` (currently `musdRelayDeposit`) and updates `selectSmartTransactions` to skip approvals whose associated `TransactionMeta` is either an excluded top-level type or contains an excluded nested transaction type, with test coverage added for the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 732358e0868f97b57d6032f80bb7a3a861b038e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->