### PR TITLE
fix: show "Confirm" copy for Ledger when transport is connected

### DIFF
--- a/ui/contexts/hardware-wallets/index.ts
+++ b/ui/contexts/hardware-wallets/index.ts
@@ -11,7 +11,10 @@ export {
   useHardwareWalletError,
 } from './HardwareWalletErrorProvider';
 export { ConnectionState } from './connectionState';
-export { useHardwareFooter } from './useHardwareFooter';
+export {
+  useHardwareFooter,
+  isHardwareConnectionReadyForConfirmFooter,
+} from './useHardwareFooter';
 export type { SubmitPreflightCheckOptions } from './useHardwareFooter';
 export { useHardwareWalletMetrics } from './useHardwareWalletMetrics';
 export * from './errors';

--- a/ui/contexts/hardware-wallets/useHardwareFooter.test.ts
+++ b/ui/contexts/hardware-wallets/useHardwareFooter.test.ts
@@ -163,6 +163,14 @@ describe('useHardwareFooter', () => {
       expect(result.current.shouldRunHardwareWalletPreflight).toBe(true);
     });
 
+    it('treats Connected transport as ready for footer CTA before ensureDeviceReady', () => {
+      mockConnectionState.status = ConnectionStatus.Connected;
+
+      const { result } = renderUseHardwareFooter();
+
+      expect(result.current.isHardwareWalletReady).toBe(true);
+    });
+
     it('returns preflight disabled in e2e mode', () => {
       process.env.IN_TEST = 'true';
       process.env.JEST_WORKER_ID = 'undefined';
@@ -221,7 +229,8 @@ describe('useHardwareFooter', () => {
       });
 
       expect(isReady).toBe(false);
-      expect(result.current.isHardwareWalletReady).toBe(false);
+      // Transport remains connected; footer still shows Confirm so the user can retry.
+      expect(result.current.isHardwareWalletReady).toBe(true);
     });
 
     it('returns true without calling the device check in e2e mode', async () => {
@@ -303,7 +312,8 @@ describe('useHardwareFooter', () => {
         });
       });
 
-      expect(result.current.isHardwareWalletReady).toBe(false);
+      // Transport is still up; confirm CTA stays enabled and preflight runs again on submit.
+      expect(result.current.isHardwareWalletReady).toBe(true);
     });
 
     it('resets a successful preflight when the device disconnects', async () => {

--- a/ui/contexts/hardware-wallets/useHardwareFooter.ts
+++ b/ui/contexts/hardware-wallets/useHardwareFooter.ts
@@ -24,6 +24,21 @@ type UseHardwareFooterArgs = {
   onUserRejectedHardwareWalletError: () => Promise<void>;
 };
 
+/**
+ * Returns true when the transport is established (`Connected`) or when a full
+ * readiness probe has succeeded (`Ready`). `Connected` alone is enough to show
+ * the primary "Confirm" CTA: `ensureDeviceReady` still runs on submit before signing.
+ *
+ * @param status - Current `ConnectionStatus` from hardware wallet context.
+ */
+export function isHardwareConnectionReadyForConfirmFooter(
+  status: ConnectionStatus,
+): boolean {
+  return (
+    status === ConnectionStatus.Ready || status === ConnectionStatus.Connected
+  );
+}
+
 export type SubmitPreflightCheckOptions = {
   /**
    * When true, runs hardware-wallet Connect-CTA metrics before device readiness (e.g. dedicated “Connect device” button).
@@ -109,7 +124,7 @@ export const useHardwareFooter = ({
       return true;
     }
 
-    return ConnectionStatus.Ready === connectionState.status;
+    return isHardwareConnectionReadyForConfirmFooter(connectionState.status);
   }, [
     connectionState.status,
     hasPreflightSucceeded,

--- a/ui/pages/confirmations/components/confirm/footer/footer.test.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/footer.test.tsx
@@ -685,6 +685,26 @@ describe('ConfirmFooter', () => {
   });
 
   describe('hardware wallet handling', () => {
+    it('renders confirm button when hardware wallet transport is connected', () => {
+      mockUseHardwareWalletConfig.mockReturnValue({
+        isHardwareWalletAccount: true,
+        walletType: HardwareWalletType.Ledger,
+      });
+      mockUseHardwareWalletState.mockReturnValue({
+        connectionState: { status: ConnectionStatus.Connected },
+      });
+      mockUseHardwareWalletError.mockReturnValue({
+        showErrorModal: showHardwareWalletErrorModalMock,
+        dismissErrorModal: dismissHardwareWalletErrorModalMock,
+        setErrorModalSuppressed: setErrorModalSuppressedMock,
+        isDeviceConnected: true,
+      });
+
+      const { getByTestId, queryByTestId } = render();
+      expect(getByTestId('confirm-footer-button')).toBeInTheDocument();
+      expect(queryByTestId('reconnect-hardware-wallet-button')).toBeNull();
+    });
+
     it('renders confirm button when hardware wallet is ready', () => {
       mockUseHardwareWalletConfig.mockReturnValue({
         isHardwareWalletAccount: true,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Footer readiness now treats "Connected" the same as "Ready" for showing the primary "Confirm" button. `ensureDeviceReady` still runs when the user submits, so signing and error handling are unchanged; only the misleading label is fixed.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed confirmation footer showing "Connect Ledger" when a Ledger transport was already connected; the primary action now shows "Confirm" in that state.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Import or select a Ledger account.
2. From a dapp like uniswap, trigger a signature/transaction request. On the MetaMask confirmation screen, before clicking the primary button: confirm the primary CTA reads "Confirm", not "Connect Ledger".
3. Click "Confirm" and complete the flow on the Ledger (Ethereum app, approve signature). Confirm the request completes successfully.
4. Regression: unplug the Ledger or revoke WebHID permission, open another signature request, and confirm the UI can still surface a connect / reconnect style path when there is no working transport (expect not to be stuck showing Confirm as if everything were fine—behavior should match truly disconnected / error states).

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/fda63f6c-2b49-4589-824c-7610fef90760

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/UX change that broadens the "ready" state for the confirmation footer; signing safety is still gated by `ensureDeviceReady` on submit, but the CTA display logic changes for hardware wallets.
> 
> **Overview**
> Confirmation footer hardware-wallet readiness now treats `ConnectionStatus.Connected` the same as `Ready` for enabling/showing the primary **Confirm** CTA, avoiding a misleading "Connect Ledger" state when the transport is already established.
> 
> This introduces `isHardwareConnectionReadyForConfirmFooter` (exported via the hardware-wallet context index) and updates unit tests to assert the confirm button remains available across preflight failures and confirmation changes while the transport stays connected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4483ce8395251dbe4276d6378e235929b7394c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->