### PR TITLE
fix: replace deprecated Callout with BannerAlert component

### DIFF
--- a/ui/pages/confirmations/confirmation/confirmation.js
+++ b/ui/pages/confirmations/confirmation/confirmation.js
@@ -46,8 +46,8 @@ import {
   getIsHardwareWalletErrorModalVisible,
 } from '../../../selectors';
 import { getNetworkConfigurationsByChainId } from '../../../../shared/lib/selectors/networks';
-import Callout from '../../../components/ui/callout';
 import { Box } from '../../../components/component-library';
+import { BannerAlert } from '@metamask/design-system-react';
 import Loading from '../../../components/ui/loading-screen';
 import SnapAuthorshipHeader from '../../../components/app/snaps/snap-authorship-header';
 import { SnapUIRenderer } from '../../../components/app/snaps/snap-ui-renderer';
@@ -623,16 +623,13 @@ export default function ConfirmationPage({
                 Object.values(alertState[pendingConfirmation.id])
                   .filter((alert) => alert.dismissed === false)
                   .map((alert, idx, filtered) => (
-                    <Callout
-                      key={alert.id}
-                      severity={alert.severity}
-                      dismiss={() => dismissAlert(alert.id)}
-                      isFirst={idx === 0}
-                      isLast={idx === filtered.length - 1}
-                      isMultiple={filtered.length > 1}
+                    <BannerAlert
+                    key={alert.id}
+                    severity={alert.severity}
+                    onClose={() => dismissAlert(alert.id)}
                     >
-                      <MetaMaskTemplateRenderer sections={alert.content} />
-                    </Callout>
+                    <MetaMaskTemplateRenderer sections={alert.content} />
+                  </BannerAlert>
                   ))
               }
               style={
@@ -656,13 +653,12 @@ export default function ConfirmationPage({
               cancelText={templatedValues.cancelText}
               loading={loading}
               submitAlerts={submitAlerts.map((alert, idx) => (
-                <Callout
+                <BannerAlert
                   key={alert.id}
                   severity={alert.severity}
-                  isFirst={idx === 0}
                 >
                   <MetaMaskTemplateRenderer sections={alert.content} />
-                </Callout>
+                </BannerAlert>
               ))}
             />
           )}


### PR DESCRIPTION
Replaces deprecated Callout component with BannerAlert from @metamask/design-system-react.

closes #20470

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that swaps alert components and updates dismiss handling; main risk is minor styling/behavior differences in alert rendering/close actions.
> 
> **Overview**
> Replaces the deprecated `Callout` usage on the confirmation page with `BannerAlert` from `@metamask/design-system-react` for both footer alerts and submit-time alerts.
> 
> Updates the dismiss/close wiring to use `onClose` (instead of `dismiss`) and removes `Callout`-specific positional props (`isFirst`, `isLast`, `isMultiple`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1947f589e55a56cba327930188dd54866399e15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->