### PR TITLE
ci: fix chicken-and-egg problem in the new yarn audit process

### DIFF
--- a/.github/rules/retry-config.jsonc
+++ b/.github/rules/retry-config.jsonc
@@ -92,6 +92,7 @@
     "No space left on device", // runner disk full
     "npm ERR! network", // npm network failure
     "OOMKilled", // Linux OOM killer terminated the process
+    "re-run this check after the baseline refresh completes", // yarn-audit-diff: ambient CVEs triggered a baseline refresh
     "read ECONNRESET", // TCP read failure (more specific than ECONNRESET alone)
     "resource temporarily unavailable", // file descriptor / process limit exhaustion
     "socket hang up", // HTTP connection dropped mid-request

--- a/.github/scripts/yarn-audit-and-triage.mts
+++ b/.github/scripts/yarn-audit-and-triage.mts
@@ -347,17 +347,23 @@ function buildSummaryAndVerdict({
       );
     }
   } else if (blockReleaseCandidate) {
+    // blockReleaseCandidate is only true when at least one moderate+
+    // prod advisory exists (see main()), so blockingProdAdvisories is
+    // guaranteed non-empty here.
+    const blockingProdAdvisories = prodAdvisories.filter((a) =>
+      BLOCKING_SEVERITIES.has(a.effectiveSeverity),
+    );
     githubAnnotate(
       'error',
-      `yarn audit FAILED: ${prodAdvisories.length} production advisor${prodAdvisories.length === 1 ? 'y' : 'ies'} on release branch — RC blocked.`,
+      `yarn audit FAILED: ${blockingProdAdvisories.length} production advisor${blockingProdAdvisories.length === 1 ? 'y' : 'ies'} (moderate+) on release branch — RC blocked.`,
     );
     verdictLines.push(
       `### yarn audit: **FAILED**`,
       '',
-      `Release branch with **${prodAdvisories.length}** production advisor${prodAdvisories.length === 1 ? 'y' : 'ies'} — release candidate blocked until resolved.`,
+      `Release branch with **${blockingProdAdvisories.length}** production advisor${blockingProdAdvisories.length === 1 ? 'y' : 'ies'} at moderate or higher severity — release candidate blocked until resolved.`,
       '',
       '```',
-      prodAdvisories.map(formatAdvisoryTree).join('\n\n'),
+      blockingProdAdvisories.map(formatAdvisoryTree).join('\n\n'),
       '```',
       '',
     );

--- a/.github/scripts/yarn-audit-diff.mts
+++ b/.github/scripts/yarn-audit-diff.mts
@@ -1,4 +1,4 @@
-import { spawnSync } from 'child_process';
+import { execFileSync, spawnSync } from 'child_process';
 import { createHash } from 'crypto';
 import { readFileSync } from 'fs';
 import { IncomingWebhook } from '@slack/webhook';
@@ -47,6 +47,326 @@ const IS_MAIN = BRANCH === 'main';
 
 function sevLabel(a: ParsedAdvisory): string {
   return (a.effectiveSeverity ?? 'unknown').toUpperCase();
+}
+
+/** Parse the PR number from GITHUB_REF, or null if not a PR event. */
+function getPrNumber(): string | null {
+  const ref = process.env.GITHUB_REF; // refs/pull/NNN/merge
+  if (!ref) {
+    return null;
+  }
+  const match = ref.match(/^refs\/pull\/(\d+)\/merge$/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Returns true when the current PR changes yarn.lock (i.e. modifies
+ * dependencies). Queries the GitHub PR files API so it works regardless
+ * of checkout depth.
+ *
+ * On non-PR events (push, schedule) this always returns true so the
+ * caller never suppresses a failure for mainline triggers.
+ */
+function prChangesYarnLock(): boolean {
+  const repo = process.env.GITHUB_REPOSITORY;
+  const prNumber = getPrNumber();
+  if (!repo || !prNumber) {
+    // Not a PR (or missing context) — treat as deps-changed.
+    return true;
+  }
+
+  try {
+    // --paginate applies jq per page, so each page emits a number.
+    // Sum them: if any page found yarn.lock the total will be > 0.
+    const raw = ghApi(
+      `repos/${repo}/pulls/${prNumber}/files?per_page=100`,
+      { paginate: true, jq: '[.[].filename] | map(select(. == "yarn.lock")) | length' },
+    ).trim();
+    const changed = raw.split(/\s+/).reduce((sum, n) => sum + Number(n), 0) > 0;
+    console.log(
+      changed
+        ? 'PR changes yarn.lock — dependency change detected.'
+        : 'PR does not change yarn.lock.',
+    );
+    return changed;
+  } catch (error) {
+    console.log(`Failed to query PR files: ${error}`);
+    // Safe default — treat as deps-changed.
+    return true;
+  }
+}
+
+/**
+ * Given a list of advisories, check whether the PR's yarn.lock diff actually
+ * touches any of the vulnerable packages. Returns true if we can confirm at
+ * least one advisory package was changed, or if we can't determine (safe
+ * fallback).
+ *
+ * This allows us to distinguish:
+ *   - yarn.lock changed AND advisory package touched → genuinely introduced
+ *   - yarn.lock changed but advisory package NOT touched → ambient CVE
+ *
+ * Uses the full PR diff (Accept: application/vnd.github.diff) instead of
+ * the files-API patch field, which is truncated for diffs > ~300 lines.
+ */
+function prChangesAdvisoryPackages(advisories: ParsedAdvisory[]): boolean {
+  const repo = process.env.GITHUB_REPOSITORY;
+  const prNumber = getPrNumber();
+  if (!repo || !prNumber || advisories.length === 0) {
+    return true; // safe fallback
+  }
+
+  // Collect the set of module names we care about.
+  const advisoryModules = new Set(advisories.map((a) => a.moduleName));
+
+  try {
+    // Fetch the full (untruncated) unified diff for this PR.
+    const fullDiff = execFileSync(
+      'gh',
+      [
+        'api',
+        `repos/${repo}/pulls/${prNumber}`,
+        '-H',
+        'Accept: application/vnd.github.diff',
+      ],
+      { encoding: 'utf-8', maxBuffer: 50 * 1024 * 1024 },
+    );
+
+    // Extract just the yarn.lock section from the full diff.
+    // The section starts with a line "diff --git a/yarn.lock b/yarn.lock"
+    // and ends at the next "diff --git" line (or EOF).
+    // Use a regex to match only at the start of a line — a plain indexOf
+    // could match the string inside another file's diff (e.g. this script
+    // itself contains that string as a literal).
+    const headerRe = /^diff --git a\/yarn\.lock b\/yarn\.lock/m;
+    const headerMatch = headerRe.exec(fullDiff);
+    if (!headerMatch) {
+      console.log(
+        'yarn.lock section not found in PR diff — assuming packages changed.',
+      );
+      return true;
+    }
+    const yarnLockStart = headerMatch.index;
+    const nextDiff = fullDiff.indexOf('\ndiff --git ', yarnLockStart + 1);
+    const yarnLockDiff =
+      nextDiff === -1
+        ? fullDiff.slice(yarnLockStart)
+        : fullDiff.slice(yarnLockStart, nextDiff);
+
+    // Extract package names from changed lines in the yarn.lock diff.
+    // Two patterns to catch:
+    //   1. Header lines:     +"package@npm:^1.0.0":  (package added/removed)
+    //   2. Resolution lines: +  resolution: "package@npm:1.0.0"  (version changed)
+    // When a package is merely updated (same version spec, new resolution),
+    // only the indented version/resolution/checksum lines are +/- lines —
+    // the header is a context line and won't have a +/- prefix.
+    const patterns: RegExp[] = [
+      /^[+-]"(.+?)@npm:/gm,                          // header lines
+      /^[+-]\s+resolution:\s+"(.+?)@npm:/gm,         // resolution lines
+    ];
+    const changedPackages = new Set<string>();
+    for (const pattern of patterns) {
+      let m: RegExpExecArray | null;
+      while ((m = pattern.exec(yarnLockDiff)) !== null) {
+        changedPackages.add(m[1]);
+      }
+    }
+
+    if (changedPackages.size === 0) {
+      console.log(
+        'Could not parse any package names from yarn.lock diff — assuming packages changed.',
+      );
+      return true;
+    }
+
+    console.log(
+      `Packages changed in yarn.lock: ${[...changedPackages].join(', ')}`,
+    );
+    console.log(`Advisory packages: ${[...advisoryModules].join(', ')}`);
+
+    const overlap = [...advisoryModules].filter((mod) =>
+      changedPackages.has(mod),
+    );
+
+    if (overlap.length > 0) {
+      console.log(`PR changes advisory package(s): ${overlap.join(', ')}`);
+      return true;
+    }
+
+    console.log(
+      'PR changes yarn.lock but does NOT touch any advisory packages — ambient CVE.',
+    );
+    return false;
+  } catch (error) {
+    console.log(`Failed to parse yarn.lock diff: ${error}`);
+    return true; // safe fallback
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Baseline refresh (PR-triggered, best-effort)
+// ---------------------------------------------------------------------------
+
+/**
+ * Re-run the health-checks job from the baseline run (already found by the
+ * workflow). This refreshes the audit baseline so subsequent PRs aren't
+ * blocked by ambient CVEs published after the last push-to-main.
+ *
+ * Best-effort: failures are logged but never fail the PR check.
+ * Requires `actions: write` permission on GITHUB_TOKEN.
+ *
+ * @returns The URL of the re-run on success, or null if skipped/failed.
+ */
+function triggerBaselineRefresh(): string | null {
+  const repo = process.env.GITHUB_REPOSITORY;
+  const serverUrl = process.env.GITHUB_SERVER_URL ?? 'https://github.com';
+  if (!repo) {
+    console.log(
+      'GITHUB_REPOSITORY not set — skipping baseline refresh trigger.',
+    );
+    return null;
+  }
+
+  try {
+    // Find a completed Main workflow run on main whose health-checks job
+    // we can re-run. We try BASELINE_RUN_ID first (the run our baseline
+    // came from), then fall back to the most recent completed run. This
+    // handles the common case where BASELINE_RUN_ID is still in progress
+    // because other jobs (lint, build, tests) take ~40 min while
+    // health-checks finishes in ~6 min.
+    const baselineRunId = process.env.BASELINE_RUN_ID;
+    const candidateRunIds: string[] = [];
+
+    if (baselineRunId) {
+      candidateRunIds.push(baselineRunId);
+    }
+
+    // Also find the most recent completed Main run as a fallback.
+    // Use per_page=25 so we don't miss the target in busy repos where
+    // other workflows (dependabot, scheduled, etc.) push it out of range.
+    const completedRunId = ghApi(
+      `repos/${repo}/actions/runs?branch=main&status=completed&per_page=25`,
+      {
+        jq: '[.workflow_runs[] | select(.name == "Main")] | first | .id // empty',
+      },
+    ).trim();
+
+    if (completedRunId && completedRunId !== baselineRunId) {
+      candidateRunIds.push(completedRunId);
+    }
+
+    // Track the first in-progress run we find — if we can't trigger a new
+    // refresh, we'll return this URL so the caller knows one is underway.
+    let inProgressUrl: string | null = null;
+
+    for (const candidateId of candidateRunIds) {
+      const runUrl = `${serverUrl}/${repo}/actions/runs/${candidateId}`;
+
+      // The re-run API requires the run to be completed.
+      const runStatus = ghApi(
+        `repos/${repo}/actions/runs/${candidateId}`,
+        { jq: '.status' },
+      ).trim();
+
+      if (runStatus !== 'completed') {
+        console.log(
+          `Run ${candidateId} is ${runStatus} — trying next candidate.`,
+        );
+        inProgressUrl ??= runUrl;
+        continue;
+      }
+
+      // Find the repository-health-checks job in this run.
+      // Use `first` to avoid concatenated JSON when multiple jobs match.
+      const raw = ghApi(
+        `repos/${repo}/actions/runs/${candidateId}/jobs?per_page=50`,
+        { jq: '[.jobs[] | select(.name | test("health"; "i")) | {id, status}] | first' },
+      ).trim();
+
+      if (!raw) {
+        console.log(
+          `Health-checks job not found in run ${candidateId} — trying next candidate.`,
+        );
+        continue;
+      }
+
+      const { id: jobId, status } = JSON.parse(raw) as {
+        id: number;
+        status: string;
+      };
+
+      // If another PR already re-ran this job, don't pile on.
+      if (status === 'queued' || status === 'in_progress') {
+        console.log(
+          `Baseline refresh already ${status.replace('_', ' ')} (job ${jobId}) — skipping.`,
+        );
+        console.log(`  → ${runUrl}`);
+        return runUrl;
+      }
+
+      // Re-run just that job — it will re-audit and upload a fresh baseline.
+      try {
+        ghApi(`repos/${repo}/actions/jobs/${jobId}/rerun`, { method: 'POST' });
+      } catch (rerunError) {
+        const msg = rerunError instanceof Error ? rerunError.message : String(rerunError);
+        if (msg.includes('409') || msg.includes('Conflict')) {
+          // Two PRs tried to re-run the same job simultaneously — harmless.
+          // The other PR's re-run is underway, so return the URL so the
+          // caller still adds the retry label.
+          console.log(`Baseline refresh already triggered by another PR (409 Conflict).`);
+          console.log(`  → ${runUrl}`);
+          return runUrl;
+        }
+        throw rerunError;
+      }
+      console.log(
+        `Triggered baseline refresh: re-running job ${jobId} from run ${candidateId}`,
+      );
+      console.log(`  → ${runUrl}`);
+      return runUrl;
+    }
+
+    if (inProgressUrl) {
+      console.log(
+        'A baseline refresh is already in progress — no additional re-run needed.',
+      );
+      console.log(`  → ${inProgressUrl}`);
+      return inProgressUrl;
+    }
+
+    console.log('No Main run found to re-run — skipping baseline refresh.');
+    return null;
+  } catch (error) {
+    // Best-effort — never fail the PR because the refresh trigger failed.
+    const msg = error instanceof Error ? error.message : String(error);
+    console.log(`Failed to trigger baseline refresh: ${msg}`);
+    return null;
+  }
+}
+
+/**
+ * Add the `retry-ci` label to the current PR so the triage system
+ * auto-retries after the baseline refresh completes.
+ *
+ * Best-effort: failures are logged but never fail the PR check.
+ * Requires `pull-requests: write` permission on GITHUB_TOKEN.
+ */
+function addRetryLabel(): void {
+  const repo = process.env.GITHUB_REPOSITORY;
+  const prNumber = getPrNumber();
+  if (!repo || !prNumber) {
+    return;
+  }
+
+  try {
+    ghApi(`repos/${repo}/issues/${prNumber}/labels`, {
+      method: 'POST',
+      body: { labels: ['retry-ci'] },
+    });
+    console.log(`Added retry-ci label to PR #${prNumber}`);
+  } catch (error) {
+    console.log(`Failed to add retry-ci label: ${error}`);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -346,12 +666,12 @@ async function main() {
     );
     return;
   }
-  // baseline may be [] if main has zero advisories — that's legitimate;
-  // every current advisory is genuinely new in that case.
 
   // ------------------------------------------------------------------
   // Diff: advisories present in current but not in baseline (by GHSA ID)
   // ------------------------------------------------------------------
+  // baseline may be [] if main has zero advisories — that's legitimate;
+  // every current advisory is genuinely new in that case.
   const isMainlineTrigger = IS_MAIN;
   const baselineIds = new Set(
     baseline.map((a) => a.id).filter((id): id is number => id !== null),
@@ -433,10 +753,7 @@ async function main() {
     treeText,
     '```',
     '',
-    'Run `yarn audit` locally to reproduce.',
-    '',
   ];
-  writeStepSummary(diffSummaryLines.join('\n'));
 
   // On push-to-main, create a GitHub tracking issue (before Slack so we can link it).
   const issueResult = maybeCreateIssue(
@@ -460,11 +777,114 @@ async function main() {
     );
   }
 
-  // On PRs, fail the step only when there are release-blocking advisories.
+  // ----------------------------------------------------------------
+  // Auto-healing flow for ambient CVEs on PRs
+  // ----------------------------------------------------------------
+  // When a new CVE is published between the last push-to-main and a PR
+  // run, the advisory appears "new" even though the PR didn't introduce
+  // it. This is an "ambient CVE." The auto-healing flow:
+  //
+  //   1. Detect: compare current audit against the baseline artifact
+  //      from the most recent push-to-main run.
+  //   2. Classify: check whether the PR's yarn.lock diff actually
+  //      touches the advisory packages (two-level check below).
+  //   3. Refresh: re-run the health-checks job on main so it uploads a
+  //      fresh baseline that includes the new advisory.
+  //   4. Retry: add the `retry-ci` label so the triage system
+  //      automatically re-runs this PR's health-checks job after the
+  //      refresh completes. On the retry, the advisory is already in
+  //      the baseline, so it no longer appears "new" and the check passes.
+  //
+  // Cross-repo (fork) PRs skip steps 3-4 because the token is read-only.
   // On push-to-main, the step always succeeds (baseline must be uploaded).
+  //
+  // Classification outcomes:
+  //   1. PR doesn't touch yarn.lock → ambient CVE, pass
+  //   2. PR touches yarn.lock but NOT the advisory packages → ambient, pass
+  //   3. PR touches yarn.lock AND the advisory packages → fail
   if (!isMainlineTrigger && blockingAdvisories.length > 0) {
-    process.exitCode = 1;
+    // Trigger a baseline refresh so subsequent runs aren't blocked by
+    // ambient CVEs. Only possible on same-repo PRs with actions:write.
+    let refreshUrl: string | null = null;
+    if (process.env.IS_CROSS_REPO_PR !== 'true') {
+      refreshUrl = triggerBaselineRefresh();
+    }
+
+    // Two-level check: does this PR change yarn.lock, and if so, does it
+    // touch any of the packages flagged by the advisories?
+    const touchesYarnLock = prChangesYarnLock();
+    const touchesAdvisoryPkgs =
+      touchesYarnLock && prChangesAdvisoryPackages(blockingAdvisories);
+
+    if (touchesAdvisoryPkgs) {
+      process.exitCode = 1;
+
+      // Rewrite summary — PR changed a package that has a CVE
+      diffSummaryLines[1] =
+        `### yarn audit: **FAILED** — ${newAdvisories.length} new advisor${newAdvisories.length === 1 ? 'y' : 'ies'}`;
+      diffSummaryLines[3] = refreshUrl
+        ? 'New advisories were found and this PR changes a package affected by a CVE. ' +
+          'If the advisories are unrelated to your changes, this check will auto-retry ' +
+          'after the baseline refresh completes (~2 min).' +
+          ' Run `yarn audit` locally to check whether these come from your dependency changes.'
+        : 'New advisories were found and this PR changes a package affected by a CVE. ' +
+          'Run `yarn audit` locally to check whether these come from your dependency changes.';
+      if (refreshUrl) {
+        diffSummaryLines.push(
+          `> **Baseline refresh triggered** — [view run](${refreshUrl})`,
+          '',
+        );
+      }
+
+      githubAnnotate(
+        'warning',
+        refreshUrl
+          ? 'New advisories found and this PR changes an affected package. ' +
+            'If the advisories are unrelated to your changes, re-run this check ' +
+            `after the baseline refresh completes (~2 min). Refresh: ${refreshUrl}`
+          : 'New advisories found and this PR changes a package affected by a CVE. ' +
+            'Run `yarn audit` locally to check whether these come from your dependency changes.',
+      );
+
+      // Add retry-ci label so triage auto-retries after the baseline refresh.
+      // Only when a refresh was actually triggered — otherwise the retry
+      // would fail identically (no fresh baseline to diff against).
+      if (refreshUrl) {
+        addRetryLabel();
+      }
+    } else {
+      // Ambient CVEs: either yarn.lock wasn't touched, or it was touched
+      // but the advisory packages themselves weren't changed.
+      const reason = touchesYarnLock
+        ? 'although this PR changes `yarn.lock`, it does not touch the affected packages'
+        : 'this PR does not change `yarn.lock`';
+      diffSummaryLines[1] =
+        `### yarn audit: **passed** (ambient) — ${blockingAdvisories.length} pre-existing advisor${blockingAdvisories.length === 1 ? 'y' : 'ies'}`;
+      diffSummaryLines[3] =
+        `New advisories were detected compared to the baseline, but ${reason}` +
+        ' — these are ambient CVEs, not introduced by this PR.';
+      if (refreshUrl) {
+        diffSummaryLines.push(
+          `> **Baseline refresh triggered** — [view run](${refreshUrl}). ` +
+            'Subsequent PRs will diff against the updated baseline.',
+          '',
+        );
+      }
+
+      githubAnnotate(
+        'warning',
+        `${blockingAdvisories.length} ambient advisor${blockingAdvisories.length === 1 ? 'y' : 'ies'} found (not introduced by this PR).` +
+          (refreshUrl ? ` Baseline refresh: ${refreshUrl}` : ''),
+      );
+    }
   }
+
+  // For mainline and genuine PR-introduced CVEs, add the local reproduce hint.
+  if (isMainlineTrigger || blockingAdvisories.length === 0) {
+    diffSummaryLines.push('Run `yarn audit` locally to reproduce.', '');
+  }
+
+  writeStepSummary(diffSummaryLines.join('\n'));
 }
 
 try {

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -139,7 +139,8 @@ jobs:
       contents: read
       id-token: write # required for S3 upload of audit baseline
       issues: write # create tracking issues for new audit advisories
-      actions: read # download audit-baseline artifact from prior push-to-main runs
+      actions: write # download baseline artifact + re-run health-checks to refresh baseline
+      pull-requests: write # add retry-ci label when ambient CVEs block a yarn.lock PR
     uses: ./.github/workflows/repository-health-checks.yml
     secrets: inherit
 

--- a/.github/workflows/repository-health-checks.yml
+++ b/.github/workflows/repository-health-checks.yml
@@ -13,6 +13,8 @@ jobs:
       BRANCH: ${{ github.head_ref || github.ref_name }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       SLACK_WEBHOOK_METAMASK_EXTENSION: ${{ secrets.SLACK_WEBHOOK_METAMASK_EXTENSION }}
+      # True only when the PR head lives in a different repository (no secrets).
+      IS_CROSS_REPO_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v3
@@ -73,29 +75,31 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            // Security: we must use an explicit push-to-main run ID when
-            // downloading the baseline artifact. If we omit run-id,
-            // actions/download-artifact defaults to the current run only.
-            // If we searched all runs without the branch+event filter, a PR
-            // branch run could upload a poisoned audit-baseline artifact that
-            // whitelists arbitrary GHSA IDs, causing the diff to report zero
-            // new advisories.
-            const { data } = await github.rest.actions.listWorkflowRuns({
+            // Artifact-first search: find the audit-baseline artifact from
+            // the most recent main-branch run. Using the artifact API avoids
+            // race conditions with re-runs — a re-run of an older run may
+            // upload a newer artifact, but we always prefer the highest
+            // run ID (latest workflow run) to stay on the newest commit.
+            //
+            // Security: filter to head_branch === 'main' so a PR branch
+            // can never supply a poisoned baseline.
+            const { data } = await github.rest.actions.listArtifactsForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              workflow_id: 'main.yml',
-              branch: 'main',
-              event: 'push',
-              status: 'completed',
-              per_page: 1,
+              name: 'audit-baseline',
+              per_page: 20,
             });
-            const run = data.workflow_runs[0];
-            if (!run) {
-              core.setFailed('No completed push-to-main run found for main.yml');
+            const baseline = data.artifacts
+              .filter(a => a.workflow_run?.head_branch === 'main')
+              .sort((a, b) => b.workflow_run.id - a.workflow_run.id)[0];
+            if (!baseline) {
+              core.setFailed('No audit-baseline artifact found from a main-branch run');
               return;
             }
-            core.info(`Using baseline from run ${run.id} (${run.html_url})`);
-            core.setOutput('run-id', String(run.id));
+            const runId = baseline.workflow_run.id;
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${runId}`;
+            core.info(`Using baseline from run ${runId} (${runUrl})`);
+            core.setOutput('run-id', String(runId));
 
       - name: Audit -- download baseline
         id: download-baseline
@@ -122,6 +126,8 @@ jobs:
       # check when new production moderate+ advisories are found.
       - name: Audit -- diff against baseline
         if: ${{ !cancelled() && steps.download-baseline.outcome == 'success' }}
+        env:
+          BASELINE_RUN_ID: ${{ steps.find-baseline-run.outputs.run-id }}
         run: |
           yarn tsx .github/scripts/yarn-audit-diff.mts
 
@@ -131,7 +137,7 @@ jobs:
         if: >-
           ${{
             !cancelled()
-            && github.event_name == 'push'
+            && (github.event_name == 'push' || github.event_name == 'schedule')
             && github.ref == 'refs/heads/main'
           }}
         run: mv .tmp/audit-current.json .tmp/audit-baseline.json
@@ -140,7 +146,7 @@ jobs:
         if: >-
           ${{
             !cancelled()
-            && github.event_name == 'push'
+            && (github.event_name == 'push' || github.event_name == 'schedule')
             && github.ref == 'refs/heads/main'
           }}
         uses: actions/upload-artifact@v7
@@ -152,7 +158,7 @@ jobs:
         if: >-
           ${{
             !cancelled()
-            && github.event_name == 'push'
+            && (github.event_name == 'push' || github.event_name == 'schedule')
             && github.ref == 'refs/heads/main'
             && github.repository == 'MetaMask/metamask-extension'
             && vars.AWS_REGION


### PR DESCRIPTION
## **Description**

When we implemented #41804, we left a gap in the system that we didn't foresee. When a new CVE (yarn audit advisory) appears, it causes a chicken-and-egg problem.

**Every open PR** fails the audit check (as it worked before #41804), and is waiting for branch `main` to run and pick up the new CVE baseline. But branch `main` won't run unless we get very lucky timing and a PR was just about to merge.

So far, what has happened every time is @HowardBraham has done a manual re-run of just the `repository-health-checks` job of the last `main` branch run.  This @HowardBraham manual re-run is what causes the Slack message to be posted to #metamask-extension, the issues to be opened to this repo, and the PRs to clear up.

This PR automates that process to be an auto-healing flow with four stages:

1. **Detect** — Compare the current audit against the baseline artifact from the most recent push-to-main run.
2. **Classify** — Two-level check: does the PR change `yarn.lock`, and if so, does it actually touch the advisory packages?
   - PR doesn't touch `yarn.lock` → ambient CVE, **pass**
   - PR touches `yarn.lock` but NOT the advisory packages → ambient CVE, **pass**
   - PR touches `yarn.lock` AND the advisory packages → genuinely introduced, **fail**
3. **Refresh** — Re-run the `repository-health-checks` job on `main` so it uploads a fresh baseline that includes the new advisory.
4. **Retry** — Add the `retry-ci` label so the triage system automatically re-runs this PR's health-checks after the refresh completes. On the retry, the advisory is already in the baseline, so the check passes.

Cross-repo (fork) PRs skip steps 3–4 because the token is read-only. Messaging accurately reflects this: no mention of auto-retry, just "Run `yarn audit` locally."

### Testing

Tested on fork `consensys-test/metamask-extension-howard` with 9 test scenarios:

| Test | Scenario | Result |
|------|----------|--------|
| T1 | Push-to-main: no new advisories → pass | ✅ |
| T2 | Push-to-main: new advisories → Slack + issue | ✅ |
| T3 | PR: no yarn.lock change, ambient CVEs → pass (ambient) | ✅ |
| T4 | PR: yarn.lock change but not advisory packages → pass (ambient) | ✅ |
| T5 | PR: yarn.lock change touching advisory packages → fail | ✅ |
| T6 | Cron: overnight CVE detection → Slack alert | ✅ |
| T7 | Baseline refresh deduplication (job already running) | ✅ |
| T8 | End-to-end auto-retry loop: fail → refresh → retry → pass | ✅ |
| T9 | Cross-repo PR: fail with correct messaging (no refresh, no retry) | ✅ |

## **Changelog**

CHANGELOG entry: null

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**
[skip-e2e]-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI security/audit gating and GitHub Actions permissions, including auto re-running jobs and labeling PRs, which could affect merge blocking behavior and workflow safety if misconfigured.
> 
> **Overview**
> Adds an *auto-healing* path for new `yarn audit` advisories that are **not introduced by a PR** (ambient CVEs): the diff step now detects whether the PR actually touched affected packages, and when not, passes the check while best-effort triggering a main-branch baseline refresh and applying `retry-ci` for automatic re-runs.
> 
> Updates baseline selection to be artifact-based (latest `audit-baseline` from `main`), expands baseline publishing to scheduled runs, and adjusts release-branch failure messaging to count only moderate+ production advisories. CI permissions are widened (`actions: write`, `pull-requests: write`) and retry classification gains a new transient pattern for the baseline-refresh retry message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77161a29ca4277c9677869d82b08c134dc2ed8e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->