### PR TITLE
fix(perps): add header icons to margin, reverse, and close modals

### DIFF
--- a/ui/components/app/perps/close-position/close-position-modal.tsx
+++ b/ui/components/app/perps/close-position/close-position-modal.tsx
@@ -496,7 +496,21 @@ export const ClosePositionModal: React.FC<ClosePositionModalProps> = ({
       >
         <ModalOverlay />
         <ModalContent size={ModalContentSize.Sm}>
-          <ModalHeader onClose={onClose}>{t('perpsClosePosition')}</ModalHeader>
+          <ModalHeader onClose={onClose}>
+            <Box
+              flexDirection={BoxFlexDirection.Column}
+              alignItems={BoxAlignItems.Center}
+              gap={2}
+            >
+              <Icon name={IconName.CircleX} size={IconSize.Xl} />
+              <Text
+                variant={TextVariant.HeadingSm}
+                textAlign={TextAlign.Center}
+              >
+                {t('perpsClosePosition')}
+              </Text>
+            </Box>
+          </ModalHeader>
           <ModalBody>
             <Box flexDirection={BoxFlexDirection.Column} gap={4}>
               {/* Close Amount Section (input + slider) */}

--- a/ui/components/app/perps/edit-margin/edit-margin-modal.tsx
+++ b/ui/components/app/perps/edit-margin/edit-margin-modal.tsx
@@ -1,5 +1,16 @@
 import React, { useRef, useCallback, useState } from 'react';
 import {
+  Box,
+  BoxFlexDirection,
+  BoxAlignItems,
+  Text,
+  TextVariant,
+  TextAlign,
+  Icon,
+  IconName,
+  IconSize,
+} from '@metamask/design-system-react';
+import {
   PERPS_EVENT_PROPERTY,
   PERPS_EVENT_VALUE,
 } from '../../../../../shared/constants/perps-events';
@@ -80,7 +91,21 @@ export const EditMarginModal: React.FC<EditMarginModalProps> = ({
     >
       <ModalOverlay />
       <ModalContent size={ModalContentSize.Sm}>
-        <ModalHeader onClose={onClose}>{title}</ModalHeader>
+        <ModalHeader onClose={onClose}>
+          <Box
+            flexDirection={BoxFlexDirection.Column}
+            alignItems={BoxAlignItems.Center}
+            gap={2}
+          >
+            <Icon
+              name={mode === 'add' ? IconName.AddCircle : IconName.RemoveMinus}
+              size={IconSize.Xl}
+            />
+            <Text variant={TextVariant.HeadingSm} textAlign={TextAlign.Center}>
+              {title}
+            </Text>
+          </Box>
+        </ModalHeader>
         <ModalBody>
           <EditMarginModalContent
             position={position}

--- a/ui/components/app/perps/reverse-position/reverse-position-modal.tsx
+++ b/ui/components/app/perps/reverse-position/reverse-position-modal.tsx
@@ -6,8 +6,12 @@ import {
   BoxAlignItems,
   Text,
   TextVariant,
+  TextAlign,
   TextColor,
   FontWeight,
+  Icon,
+  IconName,
+  IconSize,
 } from '@metamask/design-system-react';
 import type { Position as PerpsPosition } from '@metamask/perps-controller';
 import {
@@ -191,7 +195,19 @@ export const ReversePositionModal: React.FC<ReversePositionModalProps> = ({
         <ModalOverlay />
         <ModalContent size={ModalContentSize.Sm}>
           <ModalHeader onClose={onClose}>
-            {t('perpsReversePosition')}
+            <Box
+              flexDirection={BoxFlexDirection.Column}
+              alignItems={BoxAlignItems.Center}
+              gap={2}
+            >
+              <Icon name={IconName.SwapHorizontal} size={IconSize.Xl} />
+              <Text
+                variant={TextVariant.HeadingSm}
+                textAlign={TextAlign.Center}
+              >
+                {t('perpsReversePosition')}
+              </Text>
+            </Box>
           </ModalHeader>
           <ModalBody>
             <Box flexDirection={BoxFlexDirection.Column} gap={4}>


### PR DESCRIPTION
## **Description**

The perps position modals (Add Margin, Decrease Margin, Reverse Position, Close Position) were missing the decorative header icons shown in the Figma designs. Each modal now renders a centered icon above the title text inside the `ModalHeader`, matching the design specs:

- **Add Margin** → `AddCircle` (circle with +)
- **Decrease Margin** → `RemoveMinus` (circle with −)
- **Reverse Position** → `SwapHorizontal` (bidirectional arrows)
- **Close Position** → `CircleX` (circle with ✕)

## **Changelog**

CHANGELOG entry: Added header icons to the Add Margin, Decrease Margin, Reverse Position, and Close Position modals in Perpetuals

## **Related issues**

Fixes: https://docs.google.com/document/d/1yBGt2q6Xt7zpXMZcBBDTzxjfTnPWjY6MYKxWvPyNqpw/edit?tab=t.0

## **Manual testing steps**

Feature: Perps modal header icons

Scenario: Add Margin modal displays AddCircle icon
  Given the user has an open perps position
  When they open the "Add Margin" modal
  Then a circle-with-plus icon is displayed centered above the "Add margin" title

Scenario: Decrease Margin modal displays RemoveMinus icon
  Given the user has an open perps position
  When they open the "Decrease Margin" modal
  Then a circle-with-minus icon is displayed centered above the "Decrease margin" title

Scenario: Reverse Position modal displays SwapHorizontal icon
  Given the user has an open perps position
  When they open the "Reverse Position" modal
  Then a horizontal-swap-arrows icon is displayed centered above the "Reverse position" title

Scenario: Close Position modal displays CircleX icon
  Given the user has an open perps position
  When they open the "Close Position" modal
  Then a circle-with-X icon is displayed centered above the "Close position" title

## **Screenshots/Recordings**

### **Before**

Plain text title in the modal header, no icon.

### **After**
<img width="341" height="474" alt="Screenshot 2026-04-27 at 10 18 01" src="https://github.com/user-attachments/assets/43d1c043-4422-4b32-acf9-b2e7a880124d" />
<img width="341" height="366" alt="Screenshot 2026-04-27 at 10 17 55" src="https://github.com/user-attachments/assets/c8c166e5-199a-44a1-8145-16fe1ec2754e" />
<img width="340" height="472" alt="Screenshot 2026-04-27 at 10 17 50" src="https://github.com/user-attachments/assets/ac409f76-f686-4eec-a61a-24ff905fa406" />
<img width="363" height="771" alt="Screenshot 2026-04-27 at 10 17 40" src="https://github.com/user-attachments/assets/3f531dac-2c6b-4b8b-8baf-69d05570b8b1" />

Each modal now shows a centered icon (32px) above the title, matching the Figma designs.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts modal header layout and imports; no business logic, data handling, or perps transaction flow is modified.
> 
> **Overview**
> Adds decorative header icons and centered title styling to Perps `ClosePositionModal`, `EditMarginModal` (add/decrease), and `ReversePositionModal` by replacing the plain `ModalHeader` text with a column layout containing an `Icon` plus a `HeadingSm` title.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c1e900b7878debd73cc3fdbac4b145c8d1d3f5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->