### PR TITLE
fix(analytics): use boolean for `has_perp_balance` in all perps events cp-13.29.0

### DIFF
--- a/ui/pages/perps/market-list/index.tsx
+++ b/ui/pages/perps/market-list/index.tsx
@@ -192,7 +192,7 @@ export const MarketListView: React.FC = () => {
         PERPS_EVENT_VALUE.SCREEN_TYPE.MARKET_LIST,
       [PERPS_EVENT_PROPERTY.SOURCE]:
         PERPS_EVENT_VALUE.SOURCE.WALLET_HOME_PERPS_TAB,
-      [PERPS_EVENT_PROPERTY.HAS_PERP_BALANCE]: hasPerpBalance ? 'yes' : 'no',
+      [PERPS_EVENT_PROPERTY.HAS_PERP_BALANCE]: hasPerpBalance,
       [PERPS_EVENT_PROPERTY.MARKET_CATEGORY_FILTER]: selectedFilter,
     },
   });

--- a/ui/pages/perps/perps-market-detail-page.tsx
+++ b/ui/pages/perps/perps-market-detail-page.tsx
@@ -377,7 +377,7 @@ const PerpsMarketDetailPage: React.FC = () => {
         [PERPS_EVENT_PROPERTY.ASSET]: decodedSymbol,
       }),
       [PERPS_EVENT_PROPERTY.SOURCE]: PERPS_EVENT_VALUE.SOURCE.MARKET_LIST,
-      [PERPS_EVENT_PROPERTY.HAS_PERP_BALANCE]: hasPerpBalance ? 'yes' : 'no',
+      [PERPS_EVENT_PROPERTY.HAS_PERP_BALANCE]: hasPerpBalance,
     },
     resetKey: decodedSymbol,
   });

--- a/ui/pages/perps/perps-order-entry-page.tsx
+++ b/ui/pages/perps/perps-order-entry-page.tsx
@@ -258,9 +258,7 @@ const PerpsOrderEntryPage: React.FC = () => {
       ...(decodedSymbol && { [PERPS_EVENT_PROPERTY.ASSET]: decodedSymbol }),
       [PERPS_EVENT_PROPERTY.SOURCE]: PERPS_EVENT_VALUE.SOURCE.ASSET_DETAILS,
       [PERPS_EVENT_PROPERTY.HAS_PERP_BALANCE]:
-        account && Number.parseFloat(account.availableBalance) > 0
-          ? 'yes'
-          : 'no',
+        account !== null && Number.parseFloat(account.availableBalance) > 0,
     },
     resetKey: decodedSymbol,
   });


### PR DESCRIPTION
## **Description**

The `has_perp_balance` property in the `Perp Screen Viewed` analytics event was inconsistently typed across different perps screens:

- `wallet_home_perps_tab` emitted a **boolean** (`true` / `false`)
- `asset_details`, `trading`, and `market_list` emitted a **string** (`'yes'` / `'no'`)

This inconsistency makes downstream analytics filtering and aggregation unreliable.

**Solution:** Unified all four emission sites to consistently use a **boolean** value, matching the existing behavior in `perps-view.tsx`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/42145

## **Manual testing steps**

1. Open the extension in fullscreen
2. Navigate to the Perps tab on the home screen
3. Observe the `Perp Screen Viewed` event — `has_perp_balance` should be a boolean (`true` or `false`)
4. Click on any market in the market list
5. Observe the `Perp Screen Viewed` event for `asset_details` — `has_perp_balance` should be a boolean
6. Click Long or Short on an asset
7. Observe the `Perp Screen Viewed` event for `trading` — `has_perp_balance` should be a boolean

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk analytics-only change that adjusts the type of a single event property; main risk is downstream dashboards expecting the old `'yes'/'no'` strings.
> 
> **Overview**
> Standardizes the `PerpsScreenViewed` analytics payload so `has_perp_balance` is emitted as a **boolean** across perps screens.
> 
> This updates the market list, market detail, and order entry pages to stop sending `'yes'/'no'` strings and instead send `true/false` based on `account.availableBalance`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbc25bdc9401f5684ea5c369340bf0935d9c21c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->