### PR TITLE
feat(perps): add Clear buttons for TP/SL inputs in order entry

### DIFF
--- a/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.test.tsx
+++ b/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.test.tsx
@@ -338,11 +338,7 @@ describe('AutoCloseSection', () => {
 
     it('does not show SL clear button when stopLossPrice is empty', () => {
       renderWithProvider(
-        <AutoCloseSection
-          {...defaultProps}
-          enabled={true}
-          stopLossPrice=""
-        />,
+        <AutoCloseSection {...defaultProps} enabled={true} stopLossPrice="" />,
         mockStore,
       );
 

--- a/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.test.tsx
+++ b/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.test.tsx
@@ -279,6 +279,120 @@ describe('AutoCloseSection', () => {
     });
   });
 
+  describe('clear buttons', () => {
+    it('shows TP clear button when takeProfitPrice is set', () => {
+      renderWithProvider(
+        <AutoCloseSection
+          {...defaultProps}
+          enabled={true}
+          takeProfitPrice="50000"
+        />,
+        mockStore,
+      );
+
+      expect(screen.getByTestId('tp-clear-button')).toBeInTheDocument();
+    });
+
+    it('does not show TP clear button when takeProfitPrice is empty', () => {
+      renderWithProvider(
+        <AutoCloseSection
+          {...defaultProps}
+          enabled={true}
+          takeProfitPrice=""
+        />,
+        mockStore,
+      );
+
+      expect(screen.queryByTestId('tp-clear-button')).not.toBeInTheDocument();
+    });
+
+    it('calls onTakeProfitPriceChange with empty string when TP clear is clicked', () => {
+      const onTakeProfitPriceChange = jest.fn();
+      renderWithProvider(
+        <AutoCloseSection
+          {...defaultProps}
+          enabled={true}
+          takeProfitPrice="50000"
+          onTakeProfitPriceChange={onTakeProfitPriceChange}
+        />,
+        mockStore,
+      );
+
+      fireEvent.click(screen.getByTestId('tp-clear-button'));
+
+      expect(onTakeProfitPriceChange).toHaveBeenCalledWith('');
+    });
+
+    it('shows SL clear button when stopLossPrice is set', () => {
+      renderWithProvider(
+        <AutoCloseSection
+          {...defaultProps}
+          enabled={true}
+          stopLossPrice="40000"
+        />,
+        mockStore,
+      );
+
+      expect(screen.getByTestId('sl-clear-button')).toBeInTheDocument();
+    });
+
+    it('does not show SL clear button when stopLossPrice is empty', () => {
+      renderWithProvider(
+        <AutoCloseSection
+          {...defaultProps}
+          enabled={true}
+          stopLossPrice=""
+        />,
+        mockStore,
+      );
+
+      expect(screen.queryByTestId('sl-clear-button')).not.toBeInTheDocument();
+    });
+
+    it('calls onStopLossPriceChange with empty string when SL clear is clicked', () => {
+      const onStopLossPriceChange = jest.fn();
+      renderWithProvider(
+        <AutoCloseSection
+          {...defaultProps}
+          enabled={true}
+          stopLossPrice="40000"
+          onStopLossPriceChange={onStopLossPriceChange}
+        />,
+        mockStore,
+      );
+
+      fireEvent.click(screen.getByTestId('sl-clear-button'));
+
+      expect(onStopLossPriceChange).toHaveBeenCalledWith('');
+    });
+
+    it('shows TP pnl row when takeProfitPrice has whitespace-only value (no clear button)', () => {
+      renderWithProvider(
+        <AutoCloseSection
+          {...defaultProps}
+          enabled={true}
+          takeProfitPrice="   "
+        />,
+        mockStore,
+      );
+
+      expect(screen.queryByTestId('tp-clear-button')).not.toBeInTheDocument();
+    });
+
+    it('shows SL pnl row when stopLossPrice has whitespace-only value (no clear button)', () => {
+      renderWithProvider(
+        <AutoCloseSection
+          {...defaultProps}
+          enabled={true}
+          stopLossPrice="   "
+        />,
+        mockStore,
+      );
+
+      expect(screen.queryByTestId('sl-clear-button')).not.toBeInTheDocument();
+    });
+  });
+
   describe('percentage calculation (RoE: priceChange% * leverage)', () => {
     it('calculates RoE% for long TP position', () => {
       // (49500 - 45000) / 45000 * 10 * 100 = 100%

--- a/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.tsx
+++ b/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.tsx
@@ -508,6 +508,21 @@ export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
                 {tpErrorMessage}
               </Text>
             )}
+            {Boolean(takeProfitPrice.trim()) && (
+              <button
+                type="button"
+                className="cursor-pointer self-start bg-transparent border-none p-0"
+                onClick={() => onTakeProfitPriceChange('')}
+                data-testid="tp-clear-button"
+              >
+                <Text
+                  variant={TextVariant.BodyXs}
+                  color={TextColor.PrimaryDefault}
+                >
+                  {t('clear')}
+                </Text>
+              </button>
+            )}
           </Box>
 
           {/* Stop Loss Section */}
@@ -613,6 +628,21 @@ export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
               >
                 {slErrorMessage}
               </Text>
+            )}
+            {Boolean(stopLossPrice.trim()) && (
+              <button
+                type="button"
+                className="cursor-pointer self-start bg-transparent border-none p-0"
+                onClick={() => onStopLossPriceChange('')}
+                data-testid="sl-clear-button"
+              >
+                <Text
+                  variant={TextVariant.BodyXs}
+                  color={TextColor.PrimaryDefault}
+                >
+                  {t('clear')}
+                </Text>
+              </button>
             )}
           </Box>
         </Box>

--- a/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.tsx
+++ b/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.tsx
@@ -474,29 +474,54 @@ export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
                 />
               </Box>
             </Box>
-            {estimatedPnlAtTp !== null && (
+            {(Boolean(takeProfitPrice.trim()) || estimatedPnlAtTp !== null) && (
               <Box
                 flexDirection={BoxFlexDirection.Row}
                 justifyContent={BoxJustifyContent.Between}
                 alignItems={BoxAlignItems.Center}
                 data-testid="auto-close-estimated-tp-pnl-row"
               >
-                <Text
-                  variant={TextVariant.BodyXs}
-                  color={TextColor.TextAlternative}
-                >
-                  {t('perpsEstimatedPnlAtTakeProfit')}
-                </Text>
-                <Text
-                  variant={TextVariant.BodyXs}
-                  fontWeight={FontWeight.Medium}
-                  color={getPnlDisplayColor(estimatedPnlAtTp)}
-                >
-                  {estimatedPnlAtTp >= 0 ? '+' : '-'}
-                  {formatPerpsFiat(Math.abs(estimatedPnlAtTp), {
-                    ranges: PRICE_RANGES_MINIMAL_VIEW,
-                  })}
-                </Text>
+                {takeProfitPrice.trim() ? (
+                  <button
+                    type="button"
+                    className="cursor-pointer bg-transparent border-none p-0"
+                    onClick={() => onTakeProfitPriceChange('')}
+                    data-testid="tp-clear-button"
+                  >
+                    <Text
+                      variant={TextVariant.BodyXs}
+                      color={TextColor.PrimaryDefault}
+                    >
+                      {t('clear')}
+                    </Text>
+                  </button>
+                ) : (
+                  <Box />
+                )}
+                {estimatedPnlAtTp !== null && (
+                  <Box
+                    flexDirection={BoxFlexDirection.Row}
+                    alignItems={BoxAlignItems.Center}
+                    gap={1}
+                  >
+                    <Text
+                      variant={TextVariant.BodyXs}
+                      color={TextColor.TextAlternative}
+                    >
+                      {t('perpsEstimatedPnlAtTakeProfit')}
+                    </Text>
+                    <Text
+                      variant={TextVariant.BodyXs}
+                      fontWeight={FontWeight.Medium}
+                      color={getPnlDisplayColor(estimatedPnlAtTp)}
+                    >
+                      {estimatedPnlAtTp >= 0 ? '+' : '-'}
+                      {formatPerpsFiat(Math.abs(estimatedPnlAtTp), {
+                        ranges: PRICE_RANGES_MINIMAL_VIEW,
+                      })}
+                    </Text>
+                  </Box>
+                )}
               </Box>
             )}
             {tpErrorMessage && (
@@ -507,21 +532,6 @@ export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
               >
                 {tpErrorMessage}
               </Text>
-            )}
-            {Boolean(takeProfitPrice.trim()) && (
-              <button
-                type="button"
-                className="cursor-pointer self-start bg-transparent border-none p-0"
-                onClick={() => onTakeProfitPriceChange('')}
-                data-testid="tp-clear-button"
-              >
-                <Text
-                  variant={TextVariant.BodyXs}
-                  color={TextColor.PrimaryDefault}
-                >
-                  {t('clear')}
-                </Text>
-              </button>
             )}
           </Box>
 
@@ -595,29 +605,54 @@ export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
                 />
               </Box>
             </Box>
-            {estimatedPnlAtSl !== null && (
+            {(Boolean(stopLossPrice.trim()) || estimatedPnlAtSl !== null) && (
               <Box
                 flexDirection={BoxFlexDirection.Row}
                 justifyContent={BoxJustifyContent.Between}
                 alignItems={BoxAlignItems.Center}
                 data-testid="auto-close-estimated-sl-pnl-row"
               >
-                <Text
-                  variant={TextVariant.BodyXs}
-                  color={TextColor.TextAlternative}
-                >
-                  {t('perpsEstimatedPnlAtStopLoss')}
-                </Text>
-                <Text
-                  variant={TextVariant.BodyXs}
-                  fontWeight={FontWeight.Medium}
-                  color={getPnlDisplayColor(estimatedPnlAtSl)}
-                >
-                  {estimatedPnlAtSl >= 0 ? '+' : '-'}
-                  {formatPerpsFiat(Math.abs(estimatedPnlAtSl), {
-                    ranges: PRICE_RANGES_MINIMAL_VIEW,
-                  })}
-                </Text>
+                {stopLossPrice.trim() ? (
+                  <button
+                    type="button"
+                    className="cursor-pointer bg-transparent border-none p-0"
+                    onClick={() => onStopLossPriceChange('')}
+                    data-testid="sl-clear-button"
+                  >
+                    <Text
+                      variant={TextVariant.BodyXs}
+                      color={TextColor.PrimaryDefault}
+                    >
+                      {t('clear')}
+                    </Text>
+                  </button>
+                ) : (
+                  <Box />
+                )}
+                {estimatedPnlAtSl !== null && (
+                  <Box
+                    flexDirection={BoxFlexDirection.Row}
+                    alignItems={BoxAlignItems.Center}
+                    gap={1}
+                  >
+                    <Text
+                      variant={TextVariant.BodyXs}
+                      color={TextColor.TextAlternative}
+                    >
+                      {t('perpsEstimatedPnlAtStopLoss')}
+                    </Text>
+                    <Text
+                      variant={TextVariant.BodyXs}
+                      fontWeight={FontWeight.Medium}
+                      color={getPnlDisplayColor(estimatedPnlAtSl)}
+                    >
+                      {estimatedPnlAtSl >= 0 ? '+' : '-'}
+                      {formatPerpsFiat(Math.abs(estimatedPnlAtSl), {
+                        ranges: PRICE_RANGES_MINIMAL_VIEW,
+                      })}
+                    </Text>
+                  </Box>
+                )}
               </Box>
             )}
             {slErrorMessage && (
@@ -628,21 +663,6 @@ export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
               >
                 {slErrorMessage}
               </Text>
-            )}
-            {Boolean(stopLossPrice.trim()) && (
-              <button
-                type="button"
-                className="cursor-pointer self-start bg-transparent border-none p-0"
-                onClick={() => onStopLossPriceChange('')}
-                data-testid="sl-clear-button"
-              >
-                <Text
-                  variant={TextVariant.BodyXs}
-                  color={TextColor.PrimaryDefault}
-                >
-                  {t('clear')}
-                </Text>
-              </button>
             )}
           </Box>
         </Box>


### PR DESCRIPTION
## **Description**

Add "Clear" buttons to the Take Profit and Stop Loss input sections in the perps order entry Auto Close panel. Each button appears only when the user has entered a value in the respective TP/SL field, and clicking it resets both the price and derived percentage back to empty.

The layout is structured so the "Clear" button sits on the left side, while the "Est. P&L at take profit" / "Est. P&L at stop loss" label and value are grouped together on the right side of the same row.

## **Changelog**

CHANGELOG entry: Added Clear buttons for Take Profit and Stop Loss inputs in the perps order entry screen

## **Related issues**

Fixes: https://docs.google.com/document/d/1yBGt2q6Xt7zpXMZcBBDTzxjfTnPWjY6MYKxWvPyNqpw/edit?tab=t.0

## **Manual testing steps**

Feature: Clear button for Take Profit / Stop Loss

Scenario: Clear button appears when TP has a value
  Given I am on the perps order entry page with Auto Close enabled
  When I enter a value in the Take Profit price or percent field
  Then a "Clear" button appears on the left below the Take Profit inputs
  And the "Est. P&L at take profit" label and value appear on the right

Scenario: Clear button clears TP value
  Given the Take Profit field has a value and the Clear button is visible
  When I click the "Clear" button below Take Profit
  Then the Take Profit price and percent fields are reset to empty
  And the Clear button disappears

Scenario: Clear button appears when SL has a value
  Given I am on the perps order entry page with Auto Close enabled
  When I enter a value in the Stop Loss price or percent field
  Then a "Clear" button appears on the left below the Stop Loss inputs
  And the "Est. P&L at stop loss" label and value appear on the right

Scenario: Clear button clears SL value
  Given the Stop Loss field has a value and the Clear button is visible
  When I click the "Clear" button below Stop Loss
  Then the Stop Loss price and percent fields are reset to empty
  And the Clear button disappears

Scenario: Clear button is hidden when field is empty
  Given the Take Profit or Stop Loss field is empty
  Then no "Clear" button is shown for that section

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

<img width="353" height="782" alt="Screenshot 2026-04-27 at 14 45 48" src="https://github.com/user-attachments/assets/d2cb1cf6-f66a-401a-b74a-e8b973db21fc" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds new click targets and slightly adjusts conditional rendering for the TP/SL PnL row; minimal chance of regressions outside the Auto Close panel.
> 
> **Overview**
> Adds **"Clear" buttons** to the perps order entry Auto Close TP/SL sections, shown only when the corresponding `takeProfitPrice`/`stopLossPrice` is non-empty (post-`trim()`), and wired to reset the value via `onTakeProfitPriceChange('')` / `onStopLossPriceChange('')`.
> 
> Updates the TP/SL estimated PnL row rendering so it can remain visible when PnL is available, while placing the clear action on the left and grouping the PnL label/value on the right; expands tests to cover visibility and click behavior (including whitespace-only values).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea6ce8bef1c0d482fdc5602bf3cccda91952780c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->