### PR TITLE
fix: trezor model one capabilities check and unlock check cp-13.29.0

### DIFF
--- a/ui/contexts/hardware-wallets/adapters/TrezorAdapter.test.ts
+++ b/ui/contexts/hardware-wallets/adapters/TrezorAdapter.test.ts
@@ -249,6 +249,22 @@ describe('TrezorAdapter', () => {
       );
     });
 
+    it('allows locked Model One because it unlocks during transaction signing', async () => {
+      mockGetTrezorFeatures.mockResolvedValue(
+        createMockFeaturesResponse({
+          model: 'T1B1',
+          unlocked: false,
+        }),
+      );
+
+      await expect(adapter.ensureDeviceReady()).resolves.toBe(true);
+      expect(mockOptions.onDeviceEvent).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: DeviceEvent.DeviceLocked,
+        }),
+      );
+    });
+
     it('throws DeviceNotReady when device is not initialized', async () => {
       mockGetTrezorFeatures.mockResolvedValue(
         createMockFeaturesResponse({

--- a/ui/contexts/hardware-wallets/adapters/TrezorAdapter.test.ts
+++ b/ui/contexts/hardware-wallets/adapters/TrezorAdapter.test.ts
@@ -296,7 +296,21 @@ describe('TrezorAdapter', () => {
       });
     });
 
-    it('allows Model One when required capabilities are missing', async () => {
+    it('allows Model One name when only Solana capability is missing', async () => {
+      mockGetTrezorFeatures.mockResolvedValue(
+        createMockFeaturesResponse({
+          model: 'Trezor Model One',
+          capabilities: ['Capability_Bitcoin', 'Capability_Ethereum'],
+        }),
+      );
+
+      await expect(adapter.ensureDeviceReady()).resolves.toBe(true);
+      expect(mockOptions.onDeviceEvent).not.toHaveBeenCalledWith(
+        expect.objectContaining({ error: expect.anything() }),
+      );
+    });
+
+    it('throws DeviceMissingCapability when Model One is missing a supported capability', async () => {
       mockGetTrezorFeatures.mockResolvedValue(
         createMockFeaturesResponse({
           model: 'T1B1',
@@ -304,7 +318,12 @@ describe('TrezorAdapter', () => {
         }),
       );
 
-      await expect(adapter.ensureDeviceReady()).resolves.toBe(true);
+      await expect(adapter.ensureDeviceReady()).rejects.toMatchObject({
+        code: ErrorCode.DeviceMissingCapability,
+        metadata: expect.objectContaining({
+          missingCapabilities: ['Capability_Ethereum'],
+        }),
+      });
     });
 
     it('rejects oversized messages on Model One preflight', async () => {

--- a/ui/contexts/hardware-wallets/adapters/TrezorAdapter.test.ts
+++ b/ui/contexts/hardware-wallets/adapters/TrezorAdapter.test.ts
@@ -296,6 +296,17 @@ describe('TrezorAdapter', () => {
       });
     });
 
+    it('allows Model One when required capabilities are missing', async () => {
+      mockGetTrezorFeatures.mockResolvedValue(
+        createMockFeaturesResponse({
+          model: 'T1B1',
+          capabilities: ['Capability_Bitcoin'],
+        }),
+      );
+
+      await expect(adapter.ensureDeviceReady()).resolves.toBe(true);
+    });
+
     it('rejects oversized messages on Model One preflight', async () => {
       mockGetTrezorFeatures.mockResolvedValue(
         createMockFeaturesResponse({

--- a/ui/contexts/hardware-wallets/adapters/TrezorAdapter.ts
+++ b/ui/contexts/hardware-wallets/adapters/TrezorAdapter.ts
@@ -142,7 +142,7 @@ export class TrezorAdapter implements HardwareWalletAdapter {
     try {
       const payload = await this.#fetchDeviceFeatures();
       this.#validateDeviceState(payload);
-      this.#validateCapabilities(payload.capabilities);
+      this.#validateCapabilities(payload.capabilities, payload.model);
       this.#validateModelOneMessageSize(payload.model, options);
       return true;
     } catch (error) {
@@ -198,9 +198,18 @@ export class TrezorAdapter implements HardwareWalletAdapter {
    * Validate that the device reports all required capabilities.
    *
    * @param capabilities - Raw capabilities list from device features
+   * @param model - The device model identifier
    */
-  #validateCapabilities(capabilities: unknown): void {
+  #validateCapabilities(capabilities: unknown, model: string): void {
     const missing = getMissingCapabilities(capabilities);
+
+    // NOTE: Not all Trezor models support all capabilities, so we skip validation for Model One
+    // Model one does not support solana.
+    // This is to unblock the usage of model one to send devices.
+    if (isTrezorModelOne(model)) {
+      return;
+    }
+
     if (missing.length > 0) {
       throw createHardwareWalletError(
         ErrorCode.DeviceMissingCapability,

--- a/ui/contexts/hardware-wallets/adapters/TrezorAdapter.ts
+++ b/ui/contexts/hardware-wallets/adapters/TrezorAdapter.ts
@@ -206,7 +206,7 @@ export class TrezorAdapter implements HardwareWalletAdapter {
     // NOTE: Not all Trezor models support all capabilities, so we skip validation for Model One
     // Model one does not support solana.
     // This is to unblock the usage of model one to send devices.
-    if (isTrezorModelOne(model)) {
+    if (isTrezorModelOne(model) && missing.includes('Capability_Solana')) {
       return;
     }
 

--- a/ui/contexts/hardware-wallets/adapters/TrezorAdapter.ts
+++ b/ui/contexts/hardware-wallets/adapters/TrezorAdapter.ts
@@ -203,19 +203,20 @@ export class TrezorAdapter implements HardwareWalletAdapter {
   #validateCapabilities(capabilities: unknown, model: string): void {
     const missing = getMissingCapabilities(capabilities);
 
-    // NOTE: Not all Trezor models support all capabilities, so we skip validation for Model One
-    // Model one does not support solana.
-    // This is to unblock the usage of model one to send devices.
-    if (isTrezorModelOne(model) && missing.includes('Capability_Solana')) {
-      return;
-    }
+    // Trezor Model One does not support Solana, but it must still support
+    // the other required capabilities.
+    const missingForModel = isTrezorModelOne(model)
+      ? missing.filter((capability) => capability !== 'Capability_Solana')
+      : missing;
 
-    if (missing.length > 0) {
+    if (missingForModel.length > 0) {
       throw createHardwareWalletError(
         ErrorCode.DeviceMissingCapability,
         HardwareWalletType.Trezor,
-        `Trezor device is missing required capabilities: ${missing.join(', ')}.`,
-        { metadata: { capabilities, missingCapabilities: missing } },
+        `Trezor device is missing required capabilities: ${missingForModel.join(
+          ', ',
+        )}.`,
+        { metadata: { capabilities, missingCapabilities: missingForModel } },
       );
     }
   }

--- a/ui/contexts/hardware-wallets/adapters/TrezorAdapter.ts
+++ b/ui/contexts/hardware-wallets/adapters/TrezorAdapter.ts
@@ -169,7 +169,8 @@ export class TrezorAdapter implements HardwareWalletAdapter {
    * @param payload - The device feature payload to validate
    */
   #validateDeviceState(payload: TrezorFeaturesPayload): void {
-    if (!payload.unlocked) {
+    // NOTE: Model one is always locked, it will only become unlocked when performing a transaction.
+    if (!payload.unlocked && !isTrezorModelOne(payload.model)) {
       throw createHardwareWalletError(
         ErrorCode.AuthenticationDeviceLocked,
         HardwareWalletType.Trezor,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR updates the missing solana capabilities check to allow Trezor model one perform transactions.  We also skip the unlock check for Trezor Model One because it can only be unlocked when it is about to perform a transaction. 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix trezor model one capability validation. 

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/42133

## **Manual testing steps**

1. Using a trezor model one
2. Go to a swap page
3. Perform a swap. 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes device-readiness gating for Trezor Model One by bypassing the locked-state check and treating missing Solana capability as acceptable, which could affect which devices are allowed to proceed to signing. Risk is moderate since it impacts hardware-wallet transaction flows but is narrowly scoped and covered by new tests.
> 
> **Overview**
> Updates `TrezorAdapter.ensureDeviceReady` to apply **Model One–specific validation**: locked devices no longer fail readiness for Model One, and capability validation ignores missing `Capability_Solana` for Model One while still requiring other capabilities.
> 
> Adds tests covering the new readiness behavior for locked Model One devices and for Model One capability requirements (allow missing Solana, still error on missing supported capabilities).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c1b8b213a9ba7b71f283415c53a53dbacfaa8c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->