### PR TITLE
fix: inlude hip3 categorization on perps market list cp-13.29.0

### DIFF
--- a/app/scripts/messenger-client-init/perps-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/perps-controller-init.test.ts
@@ -182,6 +182,32 @@ describe('PerpsControllerInit', () => {
       });
     });
 
+    /**
+     * Data-layer guard: the UI categorization filter (Stocks/Commodities/Forex)
+     * intentionally does NOT re-check the HIP-3 allowlist and trusts the
+     * controller to limit which HIP-3 markets reach the UI. If this fallback
+     * is ever weakened (e.g. set to []), markets from non-allowlisted DEXes
+     * could surface in the UI before LaunchDarkly responds. Lock it in here.
+     *
+     * See ui/pages/perps/market-list/index.tsx :: filterByType.
+     */
+    it('always wires a non-empty fallbackHip3AllowlistMarkets so the controller can gate HIP-3 markets before LD loads', () => {
+      const request = getInitRequestMock();
+      PerpsControllerInit(request);
+
+      const constructorCall = PerpsControllerMock.mock.calls[0][0];
+      expect(constructorCall.clientConfig.fallbackHip3Enabled).toBe(true);
+      expect(constructorCall.clientConfig.fallbackHip3AllowlistMarkets).toEqual(
+        ['xyz:*'],
+      );
+      expect(
+        constructorCall.clientConfig.fallbackHip3AllowlistMarkets,
+      ).not.toEqual([]);
+      expect(
+        constructorCall.clientConfig.fallbackHip3AllowlistMarkets,
+      ).not.toBeUndefined();
+    });
+
     it('passes deferEligibilityCheck true when onboarding is not complete', () => {
       const request = getInitRequestMock();
       request.persistedState.OnboardingController = {

--- a/app/scripts/messenger-client-init/perps-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/perps-controller-init.test.ts
@@ -196,16 +196,15 @@ describe('PerpsControllerInit', () => {
       PerpsControllerInit(request);
 
       const constructorCall = PerpsControllerMock.mock.calls[0][0];
-      expect(constructorCall.clientConfig.fallbackHip3Enabled).toBe(true);
-      expect(constructorCall.clientConfig.fallbackHip3AllowlistMarkets).toEqual(
-        ['xyz:*'],
-      );
-      expect(
-        constructorCall.clientConfig.fallbackHip3AllowlistMarkets,
-      ).not.toEqual([]);
-      expect(
-        constructorCall.clientConfig.fallbackHip3AllowlistMarkets,
-      ).not.toBeUndefined();
+      const { clientConfig } = constructorCall;
+      expect(clientConfig).toBeDefined();
+      if (!clientConfig) {
+        return;
+      }
+      expect(clientConfig.fallbackHip3Enabled).toBe(true);
+      expect(clientConfig.fallbackHip3AllowlistMarkets).toEqual(['xyz:*']);
+      expect(clientConfig.fallbackHip3AllowlistMarkets).not.toEqual([]);
+      expect(clientConfig.fallbackHip3AllowlistMarkets).not.toBeUndefined();
     });
 
     it('passes deferEligibilityCheck true when onboarding is not complete', () => {

--- a/ui/pages/perps/market-list/index.test.tsx
+++ b/ui/pages/perps/market-list/index.test.tsx
@@ -250,9 +250,7 @@ describe('MarketListView', () => {
         expect(screen.getByTestId('market-row-xyz-TSLA')).toBeInTheDocument();
         expect(screen.getByTestId('market-row-xyz-AAPL')).toBeInTheDocument();
         // BTC is a crypto market and should be absent
-        expect(
-          screen.queryByTestId('market-row-BTC'),
-        ).not.toBeInTheDocument();
+        expect(screen.queryByTestId('market-row-BTC')).not.toBeInTheDocument();
       });
     });
 
@@ -267,13 +265,9 @@ describe('MarketListView', () => {
       await waitFor(() => {
         // GOLD and SILVER are commodity markets in mockHip3Markets
         expect(screen.getByTestId('market-row-xyz-GOLD')).toBeInTheDocument();
-        expect(
-          screen.getByTestId('market-row-xyz-SILVER'),
-        ).toBeInTheDocument();
+        expect(screen.getByTestId('market-row-xyz-SILVER')).toBeInTheDocument();
         // BTC is crypto and should be absent
-        expect(
-          screen.queryByTestId('market-row-BTC'),
-        ).not.toBeInTheDocument();
+        expect(screen.queryByTestId('market-row-BTC')).not.toBeInTheDocument();
       });
     });
 

--- a/ui/pages/perps/market-list/index.test.tsx
+++ b/ui/pages/perps/market-list/index.test.tsx
@@ -234,6 +234,66 @@ describe('MarketListView', () => {
         expect(screen.getByTestId('filter-select-menu')).toBeInTheDocument();
       });
     });
+
+    it('shows equity markets on Stocks tab even when perpsHip3AllowlistMarkets flag is absent', async () => {
+      // mockStore has no perpsHip3AllowlistMarkets flag → allowedHip3Sources defaults to Set()
+      renderWithProvider(<MarketListView />, mockStore);
+
+      // Open filter dropdown and click Stocks
+      const filterButton = screen.getByTestId('filter-select-button');
+      fireEvent.click(filterButton);
+      await waitFor(() => screen.getByTestId('filter-select-menu'));
+      fireEvent.click(screen.getByTestId('filter-select-option-stocks'));
+
+      await waitFor(() => {
+        // TSLA and AAPL are equity markets in mockHip3Markets
+        expect(screen.getByTestId('market-row-xyz-TSLA')).toBeInTheDocument();
+        expect(screen.getByTestId('market-row-xyz-AAPL')).toBeInTheDocument();
+        // BTC is a crypto market and should be absent
+        expect(
+          screen.queryByTestId('market-row-BTC'),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    it('shows commodity markets on Commodities tab even when perpsHip3AllowlistMarkets flag is absent', async () => {
+      renderWithProvider(<MarketListView />, mockStore);
+
+      const filterButton = screen.getByTestId('filter-select-button');
+      fireEvent.click(filterButton);
+      await waitFor(() => screen.getByTestId('filter-select-menu'));
+      fireEvent.click(screen.getByTestId('filter-select-option-commodities'));
+
+      await waitFor(() => {
+        // GOLD and SILVER are commodity markets in mockHip3Markets
+        expect(screen.getByTestId('market-row-xyz-GOLD')).toBeInTheDocument();
+        expect(
+          screen.getByTestId('market-row-xyz-SILVER'),
+        ).toBeInTheDocument();
+        // BTC is crypto and should be absent
+        expect(
+          screen.queryByTestId('market-row-BTC'),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    it('shows only crypto markets on Crypto tab regardless of allowedHip3Sources', async () => {
+      renderWithProvider(<MarketListView />, mockStore);
+
+      const filterButton = screen.getByTestId('filter-select-button');
+      fireEvent.click(filterButton);
+      await waitFor(() => screen.getByTestId('filter-select-menu'));
+      fireEvent.click(screen.getByTestId('filter-select-option-crypto'));
+
+      await waitFor(() => {
+        const btcRow = screen.queryByTestId('market-row-BTC');
+        expect(btcRow).toBeInTheDocument();
+        // HIP-3 equity market should not appear under Crypto
+        expect(
+          screen.queryByTestId('market-row-xyz-TSLA'),
+        ).not.toBeInTheDocument();
+      });
+    });
   });
 
   describe('sort functionality', () => {

--- a/ui/pages/perps/market-list/index.tsx
+++ b/ui/pages/perps/market-list/index.tsx
@@ -89,14 +89,15 @@ const isUncategorizedHip3Market = (
  * Filter markets by market type
  *
  * Crypto markets have no marketSource (main DEX).
- * HIP-3 markets (stocks, commodities, forex) come from allowed DEX providers.
- * Market type is resolved using HIP3_ASSET_MARKET_TYPES mapping first,
- * then falls back to the market's own marketType property.
- * "New" category shows HIP-3 assets that haven't been categorized yet.
+ * Stocks / commodities / forex are identified purely by resolved market type —
+ * intentionally not gated on the allowlist so categories work even when the
+ * remote feature flag has not yet loaded (the controller's own fallback already
+ * limits which HIP-3 markets reach the UI).
+ * "New" category shows HIP-3 assets from allowed sources that haven't been categorized yet.
  *
  * @param markets - Array of markets to filter
  * @param filter - Market type filter
- * @param allowedHip3Sources - Set of allowed HIP-3 market sources from feature flag
+ * @param allowedHip3Sources - Set of allowed HIP-3 market sources (used for "new" tab only)
  * @returns Filtered array of markets
  */
 const filterByType = (
@@ -112,25 +113,13 @@ const filterByType = (
       return markets.filter(isCryptoMarket);
     }
     case 'stocks': {
-      return markets.filter(
-        (m) =>
-          isHip3Market(m, allowedHip3Sources) &&
-          getResolvedMarketType(m) === 'equity',
-      );
+      return markets.filter((m) => getResolvedMarketType(m) === 'equity');
     }
     case 'commodities': {
-      return markets.filter(
-        (m) =>
-          isHip3Market(m, allowedHip3Sources) &&
-          getResolvedMarketType(m) === 'commodity',
-      );
+      return markets.filter((m) => getResolvedMarketType(m) === 'commodity');
     }
     case 'forex': {
-      return markets.filter(
-        (m) =>
-          isHip3Market(m, allowedHip3Sources) &&
-          getResolvedMarketType(m) === 'forex',
-      );
+      return markets.filter((m) => getResolvedMarketType(m) === 'forex');
     }
     case 'new': {
       return markets.filter((m) =>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The Stocks, Commodities, and Forex tabs in the perps market list were rendering empty even though HIP-3 markets were visible and tradable under "All".

The filter was gating each category on isHip3Market(m, allowedHip3Sources), where allowedHip3Sources comes from the perpsHip3AllowlistMarkets LaunchDarkly flag. The UI-side selector defaults to an empty set when the flag hasn't loaded yet — so every market failed the allowlist check, leaving all three category tabs blank.

Meanwhile, the background controller has a hardcoded fallbackHip3AllowlistMarkets: ['xyz:*'], which is why the markets appear tradable under "All" but disappear when a category filter is selected.

**Fix:**

Remove the isHip3Market gate from the stocks, commodities, and forex filter cases. These tabs now filter purely on the resolved marketType (equity, commodity, forex), which is already correctly populated by the controller's transformMarketData.

This is safe because:

The controller's own allowlist already controls which HIP-3 markets reach the UI — re-checking it in the UI filter is redundant and produces a false negative when the flag is empty.
getResolvedMarketType returns undefined for crypto and unmapped markets, so no non-HIP-3 markets can bleed through.
The all, crypto, and new tab logic is unchanged.

## **Changelog**

CHANGELOG entry: fixes bug where hip3 assets weren't discoverable in search

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3096

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/b31f2b6e-b0cb-4898-94ce-aa3a2e4e46fe

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes market-category filtering logic for perps, which can affect what markets are surfaced to users if market typing or controller gating is incorrect. Added tests reduce risk by asserting both UI behavior when the LaunchDarkly allowlist flag is missing and that the controller fallback allowlist remains non-empty.
> 
> **Overview**
> Fixes the perps market list category tabs (Stocks/Commodities/Forex) rendering empty when the `perpsHip3AllowlistMarkets` remote feature flag hasn’t loaded.
> 
> The UI filter now categorizes these tabs **only by resolved market type** (equity/commodity/forex) instead of additionally gating on the allowlist set; the allowlist is still used for the *"New"* tab. New tests cover category tab rendering with the flag absent and add a guard asserting `PerpsControllerInit` always wires a **non-empty** `fallbackHip3AllowlistMarkets` so HIP-3 markets are gated before LaunchDarkly responds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa6d106c9be48ccca3150253cc0fb37c6a2d971a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->