### PR TITLE
fix: unlock redirect back loop

### DIFF
--- a/ui/pages/unlock-page/unlock-page.component.tsx
+++ b/ui/pages/unlock-page/unlock-page.component.tsx
@@ -234,7 +234,7 @@ class UnlockPage extends Component<UnlockPageProps, UnlockPageState> {
         const search = fromLocation.search || '';
         redirectTo = fromLocation.pathname + search;
       }
-      navigate(redirectTo);
+      navigate(redirectTo, { replace: true });
     }
   }
 

--- a/ui/pages/unlock-page/unlock-page.container.ts
+++ b/ui/pages/unlock-page/unlock-page.container.ts
@@ -99,7 +99,7 @@ const mergeProps = (
       const search = fromLocation.search || '';
       redirectTo = fromLocation.pathname + search;
     }
-    navigate(redirectTo);
+    navigate(redirectTo, { replace: true });
   };
 
   return {

--- a/ui/pages/unlock-page/unlock-page.test.tsx
+++ b/ui/pages/unlock-page/unlock-page.test.tsx
@@ -178,7 +178,9 @@ describe('Unlock Page', () => {
     } as unknown as string);
 
     expect(mockUseNavigate).toHaveBeenCalledTimes(1);
-    expect(mockUseNavigate).toHaveBeenCalledWith(intendedPath);
+    expect(mockUseNavigate).toHaveBeenCalledWith(intendedPath, {
+      replace: true,
+    });
   });
 
   it('changes password, submits, and redirects to the specified route (from location.state)', async () => {
@@ -207,7 +209,12 @@ describe('Unlock Page', () => {
 
     expect(mockTryUnlockMetamask).toHaveBeenCalledTimes(1);
     expect(mockUseNavigate).toHaveBeenCalledTimes(1);
-    expect(mockUseNavigate).toHaveBeenCalledWith(intendedPath + intendedSearch);
+    expect(mockUseNavigate).toHaveBeenCalledWith(
+      intendedPath + intendedSearch,
+      {
+        replace: true,
+      },
+    );
   });
 
   it('should show login error modal when authentication error is thrown', async () => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes the redirect loop when auto unlocking

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: replace unlock redirect history entry

## **Related issues**

Fixes: #42004 

## **Manual testing steps**

1. Set autolock
2. Stay idle in the Accounts list
3. Unlock
4. Click Back

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts `react-router` navigation options on unlock redirects, with updated tests; main behavior change is back/forward history handling.
> 
> **Overview**
> Fixes an unlock redirect loop by changing post-unlock redirects to use `navigate(..., { replace: true })` (both for auto-unlock in `UnlockPage` and for manual unlock submit in the container), preventing an extra history entry from being added.
> 
> Updates `UnlockPage` tests to assert the new `replace: true` navigation behavior for redirects driven by `location.state.from`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d56204995b8ea77e867ec350ca5d6fa6bba0dbd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->