### PR TITLE
fix: Cannot use +/- to define TP/SL thresholds

### DIFF
--- a/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.test.tsx
+++ b/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.test.tsx
@@ -510,6 +510,81 @@ describe('AutoCloseSection', () => {
 
       expect(onStopLossPriceChange).toHaveBeenCalledWith('2970');
     });
+
+    it('treats unsigned SL % input as loss magnitude on a long position', () => {
+      // Regression for TAT-2947: typing "5" (no sign) in SL on a long should
+      // yield SL below entry (loss direction), not above. Auto-negation is
+      // applied so the unsigned input matches the SL preset semantics.
+      // -5% RoE at 10x from $45,000: SL = $45,000 * 0.995 = $44,775
+      const onStopLossPriceChange = jest.fn();
+      renderWithProvider(
+        <AutoCloseSection
+          {...defaultProps}
+          enabled={true}
+          direction="long"
+          currentPrice={45000}
+          leverage={10}
+          onStopLossPriceChange={onStopLossPriceChange}
+        />,
+        mockStore,
+      );
+
+      const container = screen.getByTestId('sl-percent-input');
+      const input = container.querySelector('input');
+      expect(input).not.toBeNull();
+      fireEvent.change(input as HTMLInputElement, { target: { value: '5' } });
+
+      expect(onStopLossPriceChange).toHaveBeenCalledWith('44775');
+    });
+
+    it('treats unsigned SL % input as loss magnitude on a short position', () => {
+      // Short SL is loss when price goes UP. Unsigned "5" → -5% RoE → price above entry.
+      // -5% RoE on short at 10x from $45,000: SL = $45,000 * (1 - -(-5/1000)) = $45,225
+      const onStopLossPriceChange = jest.fn();
+      renderWithProvider(
+        <AutoCloseSection
+          {...defaultProps}
+          enabled={true}
+          direction="short"
+          currentPrice={45000}
+          leverage={10}
+          onStopLossPriceChange={onStopLossPriceChange}
+        />,
+        mockStore,
+      );
+
+      const container = screen.getByTestId('sl-percent-input');
+      const input = container.querySelector('input');
+      expect(input).not.toBeNull();
+      fireEvent.change(input as HTMLInputElement, { target: { value: '5' } });
+
+      expect(onStopLossPriceChange).toHaveBeenCalledWith('45225');
+    });
+
+    it('honors explicit "+" sign on SL % input to allow profit-side stop on a long', () => {
+      // Explicit "+" preserves profit-direction interpretation for the rare
+      // "lock in profit" SL on an already-winning position (covered by ticket).
+      // +5% RoE at 10x from $45,000: SL = $45,000 * 1.005 = $45,225 (above current).
+      const onStopLossPriceChange = jest.fn();
+      renderWithProvider(
+        <AutoCloseSection
+          {...defaultProps}
+          enabled={true}
+          direction="long"
+          currentPrice={45000}
+          leverage={10}
+          onStopLossPriceChange={onStopLossPriceChange}
+        />,
+        mockStore,
+      );
+
+      const container = screen.getByTestId('sl-percent-input');
+      const input = container.querySelector('input');
+      expect(input).not.toBeNull();
+      fireEvent.change(input as HTMLInputElement, { target: { value: '+5' } });
+
+      expect(onStopLossPriceChange).toHaveBeenCalledWith('45225');
+    });
   });
 
   describe('percent input focus/blur behavior (no decimal insertion)', () => {

--- a/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.tsx
+++ b/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.tsx
@@ -247,6 +247,9 @@ export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
   }, [onStopLossPriceChange, stopLossPrice]);
 
   // Handle SL percentage input change
+  // Unsigned input is treated as the loss magnitude (negative RoE) so a long
+  // typing "5" yields a stop loss below entry. Explicit "+"/"-" overrides the
+  // default for the rare case of a profit-side SL on an already winning position.
   const handleSlPercentChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       const { value } = event.target;
@@ -256,7 +259,9 @@ export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
         if (value === '' || value === '-' || value === '+') {
           onStopLossPriceChange('');
         } else if (!isNaN(numValue)) {
-          const newPrice = percentToPrice(numValue);
+          const startsWithSign = value.startsWith('+') || value.startsWith('-');
+          const signedPercent = startsWithSign ? numValue : -Math.abs(numValue);
+          const newPrice = percentToPrice(signedPercent);
           onStopLossPriceChange(newPrice);
         }
       }

--- a/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.test.tsx
+++ b/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.test.tsx
@@ -411,8 +411,27 @@ describe('UpdateTPSLModalContent', () => {
       expect(numValue).toBeCloseTo(2375, 0);
     });
 
-    it('updates SL price when a positive RoE% is typed (SL above entry)', () => {
-      // SOL: entry=95, leverage=10, +15% signed RoE -> 95 * (1 + 15/1000) = 95 * 1.015 = 96.425
+    it('updates SL price when an explicit positive RoE% is typed (profit-side SL above entry)', () => {
+      // SOL: entry=95, leverage=10. Explicit "+15" overrides the SL auto-negation
+      // and produces a profit-side SL above entry: 95 * (1 + 15/1000) = 96.425.
+      renderTpslModalContent({ position: positionWithoutTPSL });
+
+      const percentInputs = screen.getAllByPlaceholderText('0');
+      const slPercentInput = percentInputs[1];
+      fireEvent.focus(slPercentInput);
+      fireEvent.change(slPercentInput, { target: { value: '+15' } });
+
+      const slPriceInput = screen.getAllByPlaceholderText(
+        '0.00',
+      )[1] as HTMLInputElement;
+      const numValue = parseFloat(slPriceInput.value.replace(/,/gu, ''));
+      expect(numValue).toBeCloseTo(96.425, 0);
+    });
+
+    it('treats unsigned SL % input as loss magnitude on a long (TAT-2947)', () => {
+      // SOL: entry=95, leverage=10. Typing "15" (no sign) on a long should be
+      // interpreted as a loss (-15% RoE) — SL below entry, not above.
+      // 95 * (1 - 15/1000) = 95 * 0.985 = 93.575
       renderTpslModalContent({ position: positionWithoutTPSL });
 
       const percentInputs = screen.getAllByPlaceholderText('0');
@@ -424,7 +443,7 @@ describe('UpdateTPSLModalContent', () => {
         '0.00',
       )[1] as HTMLInputElement;
       const numValue = parseFloat(slPriceInput.value.replace(/,/gu, ''));
-      expect(numValue).toBeCloseTo(96.425, 0);
+      expect(numValue).toBeCloseTo(93.575, 0);
     });
 
     it('clears TP price when percent input is cleared', () => {
@@ -508,9 +527,9 @@ describe('UpdateTPSLModalContent', () => {
     });
 
     it('shows raw input while SL percent is focused and formatted value after blur', () => {
-      // SOL: entry=95, leverage=10. Typing +10 (SL above entry for lock-in-profit scenario)
-      // -> price = 95*(1+10/1000) = 95.95 -> blur shows priceToPercent("95.95") for long
-      // -> (95.95-95)/95*10*100 = 10 -> "10" (positive, no sign)
+      // SOL: entry=95, leverage=10. Typing "10" (unsigned) is treated as a loss
+      // (-10% RoE) so the SL price drops below entry: 95*(1-10/1000) = 94.05.
+      // Blur recomputes priceToPercent("94.05") = (94.05-95)/95*10*100 = -10 → "-10".
       renderTpslModalContent({ position: positionWithoutTPSL });
 
       const slPercentInput = screen.getAllByPlaceholderText('0')[1];
@@ -522,8 +541,8 @@ describe('UpdateTPSLModalContent', () => {
       fireEvent.blur(slPercentInput);
 
       const blurredValue = (slPercentInput as HTMLInputElement).value;
-      // After blur, shows signed RoE: positive percent stays positive (no sign prefix)
-      expect(blurredValue).toMatch(/^-?\d+(\.\d+)?$/u);
+      // After blur, shows signed RoE with the loss-direction "-" prefix.
+      expect(blurredValue).toBe('-10');
     });
 
     it('rejects non-numeric characters in TP percent input', () => {
@@ -823,6 +842,25 @@ describe('UpdateTPSLModalContent', () => {
       });
 
       fireEvent.click(screen.getByText('-10%'));
+
+      const slInput = screen.getAllByPlaceholderText(
+        '0.00',
+      )[1] as HTMLInputElement;
+      const numValue = parseFloat(slInput.value.replace(/,/gu, ''));
+      expect(numValue).toBeCloseTo(45300, 0);
+    });
+
+    it('treats unsigned SL % input as loss magnitude on a short (TAT-2947)', () => {
+      // BTC short: entry=45000, leverage=15. Typing "10" (no sign) on a short
+      // should be a loss → SL above entry: 45000 * (1 + 10/(15*100)) = 45300.
+      renderTpslModalContent({
+        position: shortPosition,
+        currentPrice: 45000,
+      });
+
+      const slPercentInput = screen.getAllByPlaceholderText('0')[1];
+      fireEvent.focus(slPercentInput);
+      fireEvent.change(slPercentInput, { target: { value: '10' } });
 
       const slInput = screen.getAllByPlaceholderText(
         '0.00',

--- a/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.tsx
+++ b/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.tsx
@@ -343,6 +343,11 @@ export const UpdateTPSLModalContent: React.FC<UpdateTPSLModalContentProps> = ({
     setTpPresetPercent(null);
   }, []);
 
+  // Unsigned input is treated as the loss magnitude (negative RoE) so a long
+  // typing "5" yields a stop loss below entry, mirroring the preset semantics
+  // and matching mobile (`PerpsTPSLView` auto-prepends "-" for unsigned SL
+  // input). Explicit "+"/"-" still overrides for the rare profit-side SL on an
+  // already winning position called out in the original ticket.
   const handleSlPercentInputChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       const { value } = event.target;
@@ -353,7 +358,9 @@ export const UpdateTPSLModalContent: React.FC<UpdateTPSLModalContentProps> = ({
         if (value === '' || value === '-' || value === '+') {
           setEditingSlPrice('');
         } else if (!Number.isNaN(numValue)) {
-          const newPrice = percentToPriceForEdit(numValue);
+          const startsWithSign = value.startsWith('+') || value.startsWith('-');
+          const signedPercent = startsWithSign ? numValue : -Math.abs(numValue);
+          const newPrice = percentToPriceForEdit(signedPercent);
           setEditingSlPrice(newPrice);
         }
       }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

On the perps order entry trade screen and the update-TP/SL modal, typing an unsigned number (e.g. `5`) into the Stop Loss percent field was interpreted as a positive RoE (profit direction). For a long position this produced a stop loss above current price and the SL validator surfaced a "stop loss must be below price" error. The fix auto-negates unsigned SL percent input (treating it as loss magnitude, mirroring mobile's `PerpsTPSLView` keypad) and preserves explicit `+`/`-` overrides for the rare profit-side SL on an already-winning position called out in the original ticket. SL preset clicks already negated correctly; only the typing path diverged. The TP path is intentionally unchanged — unsigned `5` keeps profit-direction semantics there.

## **Changelog**

CHANGELOG entry: Fixed an issue where typing a stop loss percentage on a perps order without an explicit "+"/"-" sign produced a stop loss on the wrong side of the entry price.

## **Related issues**

Fixes: [TAT-2947](https://consensyssoftware.atlassian.net/browse/TAT-2947)

## **Manual testing steps**

1. Open the extension and navigate to Perps → ETH market → Long.
2. Enable Auto Close on the order entry trade screen.
3. In the Stop Loss row, type `5` (no sign) into the percent field and tab away.
4. Verify the SL price is strictly below the current ETH price and the percent field shows `-5`.
5. Type `+5` into the same SL percent field — verify the SL price jumps above current (explicit sign override still works for a profit-side stop on a winning position).
6. In the Take Profit row, type `5` (no sign) — verify the TP price is above current price (unchanged behavior).
7. Repeat steps 1-4 with a Short order and confirm the SL price is above current (loss direction for a short).

## **Screenshots/Recordings**

<!-- Replaced by the gateway from artifacts/evidence-manifest.json. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## **Validation Recipe**

<details>
<summary>artifacts/recipe.json</summary>

```json
{
  "schema_version": 1,
  "title": "TAT-2947 — TP/SL +/- input semantics on order entry auto-close",
  "description": "Validates that an unsigned percent value typed into SL is interpreted as a loss (negative RoE) on a long position, and that the displayed SL percent retains its sign after blur. Also verifies TP keeps positive (profit) semantics.",
  "validate": {
    "workflow": {
      "pre_conditions": [
        "wallet.unlocked",
        "perps.feature_enabled",
        "perps.ready_to_trade"
      ],
      "setup": [
        { "id": "setup-prime", "action": "call", "ref": "perps/prime-perps-state" }
      ],
      "entry": "setup-snapshot-eth-price",
      "nodes": {
        "setup-snapshot-eth-price": {
          "action": "eval_async",
          "expression": "(async()=>{var r=await stateHooks.submitRequestToBackground('perpsGetMarketDataWithPrices',[]);var eth=(r||[]).find(function(m){return m&&m.symbol==='ETH'});var raw=eth?String(eth.price||''):'';var price=Number.parseFloat(raw.replace(/[$,]/g,''));return JSON.stringify({price:price,ok:Number.isFinite(price)&&price>0})})()",
          "assert": { "operator": "eq", "field": "ok", "value": true },
          "save_as": "eth_price",
          "next": "setup-nav-trade"
        },
        "setup-nav-trade": {
          "action": "navigate",
          "target": "PerpsOrderEntry",
          "params": { "symbol": "ETH", "direction": "long" },
          "next": "setup-wait-order-entry"
        },
        "setup-wait-order-entry": {
          "action": "wait_for",
          "test_id": "perps-order-entry-page",
          "timeout_ms": 15000,
          "next": "setup-toggle-auto-close"
        },
        "setup-toggle-auto-close": {
          "action": "eval_sync",
          "expression": "(function(){var el=document.querySelector('[data-testid=\"auto-close-toggle\"]');if(!el)return JSON.stringify({clicked:false,reason:'no-toggle'});el.click();return JSON.stringify({clicked:true})})()",
          "assert": { "operator": "eq", "field": "clicked", "value": true },
          "next": "setup-wait-sl-field"
        },
        "setup-wait-sl-field": {
          "action": "wait_for",
          "test_id": "sl-percent-input",
          "timeout_ms": 5000,
          "next": "ac1-type-sl-percent"
        },
        "ac1-type-sl-percent": {
          "action": "set_input",
          "test_id": "sl-percent-input",
          "value": "5",
          "next": "ac1-settle-sl"
        },
        "ac1-settle-sl": {
          "action": "wait_for",
          "expression": "(function(){var el=document.querySelector('[data-testid=\"sl-price-input\"] input');return !!(el&&el.value&&Number.parseFloat(el.value)>0)})()",
          "timeout_ms": 4000,
          "assert": { "operator": "truthy" },
          "next": "ac1-blur-sl-percent"
        },
        "ac1-blur-sl-percent": {
          "action": "eval_sync",
          "expression": "(function(){var el=document.querySelector('[data-testid=\"sl-percent-input\"] input');if(el){el.blur();}return JSON.stringify({blurred:!!el})})()",
          "assert": { "operator": "eq", "field": "blurred", "value": true },
          "next": "ac1-assert-sl-below-current"
        },
        "ac1-assert-sl-below-current": {
          "action": "eval_sync",
          "expression": "(function(){var priceEl=document.querySelector('[data-testid=\"sl-price-input\"] input');var slPrice=priceEl?Number.parseFloat((priceEl.value||'').replace(/[$,]/g,'')):NaN;var current={{vars.eth_price.price}};var below=Number.isFinite(slPrice)&&slPrice>0&&slPrice<current;return JSON.stringify({slPrice:slPrice,currentPrice:current,below:below})})()",
          "save_as": "ac1_sl",
          "assert": { "operator": "eq", "field": "below", "value": true },
          "next": "ac1-screenshot"
        },
        "ac1-screenshot": {
          "action": "screenshot",
          "filename": "evidence-ac1-sl-below-current",
          "note": "AC1: After typing '5' in SL percent on a long ETH order, sl-price-input is below current ETH price (loss direction).",
          "next": "ac3-assert-sl-percent-signed"
        },
        "ac3-assert-sl-percent-signed": {
          "action": "eval_sync",
          "expression": "(function(){var el=document.querySelector('[data-testid=\"sl-percent-input\"] input');var v=el?(el.value||''):'';return JSON.stringify({value:v,startsWithMinus:v.indexOf('-')===0})})()",
          "save_as": "ac3_sl_pct",
          "assert": { "operator": "eq", "field": "startsWithMinus", "value": true },
          "next": "ac3-screenshot"
        },
        "ac3-screenshot": {
          "action": "screenshot",
          "filename": "evidence-ac3-sl-percent-signed",
          "note": "AC3: SL percent field shows leading '-' after blur (sign does not disappear).",
          "next": "ac2-type-tp-percent"
        },
        "ac2-type-tp-percent": {
          "action": "set_input",
          "test_id": "tp-percent-input",
          "value": "5",
          "next": "ac2-settle-tp"
        },
        "ac2-settle-tp": {
          "action": "wait_for",
          "expression": "(function(){var el=document.querySelector('[data-testid=\"tp-price-input\"] input');return !!(el&&el.value&&Number.parseFloat(el.value)>0)})()",
          "timeout_ms": 4000,
          "assert": { "operator": "truthy" },
          "next": "ac2-blur-tp"
        },
        "ac2-blur-tp": {
          "action": "eval_sync",
          "expression": "(function(){var el=document.querySelector('[data-testid=\"tp-percent-input\"] input');if(el){el.blur();}return JSON.stringify({blurred:!!el})})()",
          "assert": { "operator": "eq", "field": "blurred", "value": true },
          "next": "ac2-assert-tp-above-current"
        },
        "ac2-assert-tp-above-current": {
          "action": "eval_sync",
          "expression": "(function(){var priceEl=document.querySelector('[data-testid=\"tp-price-input\"] input');var tpPrice=priceEl?Number.parseFloat((priceEl.value||'').replace(/[$,]/g,'')):NaN;var current={{vars.eth_price.price}};var above=Number.isFinite(tpPrice)&&tpPrice>0&&tpPrice>current;return JSON.stringify({tpPrice:tpPrice,currentPrice:current,above:above})})()",
          "save_as": "ac2_tp",
          "assert": { "operator": "eq", "field": "above", "value": true },
          "next": "ac2-screenshot"
        },
        "ac2-screenshot": {
          "action": "screenshot",
          "filename": "evidence-ac2-tp-above-current",
          "note": "AC2: After typing '5' in TP percent on a long ETH order, tp-price-input is above current ETH price (profit direction).",
          "next": "done"
        },
        "done": { "action": "end", "status": "pass" }
      }
    }
  }
}
```

</details>

## **Recipe Workflow**

<details>
<summary>artifacts/workflow.mmd</summary>

```mermaid
flowchart TD
  %% TAT-2947 — TP/SL +/- input semantics on order entry auto-close
  __entry__(["ENTRY"]) --> node_setup_snapshot_eth_price
  node_setup_snapshot_eth_price["setup-snapshot-eth-price<br/>eval_async"]
  node_setup_nav_trade["setup-nav-trade<br/>navigate"]
  node_setup_wait_order_entry["setup-wait-order-entry<br/>wait_for"]
  node_setup_toggle_auto_close["setup-toggle-auto-close<br/>eval_sync"]
  node_setup_wait_sl_field["setup-wait-sl-field<br/>wait_for"]
  node_ac1_type_sl_percent["ac1-type-sl-percent<br/>set_input"]
  node_ac1_settle_sl["ac1-settle-sl<br/>wait_for"]
  node_ac1_blur_sl_percent["ac1-blur-sl-percent<br/>eval_sync"]
  node_ac1_assert_sl_below_current["ac1-assert-sl-below-current<br/>eval_sync"]
  node_ac1_screenshot["ac1-screenshot<br/>screenshot"]
  node_ac3_assert_sl_percent_signed["ac3-assert-sl-percent-signed<br/>eval_sync"]
  node_ac3_screenshot["ac3-screenshot<br/>screenshot"]
  node_ac2_type_tp_percent["ac2-type-tp-percent<br/>set_input"]
  node_ac2_settle_tp["ac2-settle-tp<br/>wait_for"]
  node_ac2_blur_tp["ac2-blur-tp<br/>eval_sync"]
  node_ac2_assert_tp_above_current["ac2-assert-tp-above-current<br/>eval_sync"]
  node_ac2_screenshot["ac2-screenshot<br/>screenshot"]
  node_done(["done<br/>PASS"])
  node_setup_snapshot_eth_price --> node_setup_nav_trade
  node_setup_nav_trade --> node_setup_wait_order_entry
  node_setup_wait_order_entry --> node_setup_toggle_auto_close
  node_setup_toggle_auto_close --> node_setup_wait_sl_field
  node_setup_wait_sl_field --> node_ac1_type_sl_percent
  node_ac1_type_sl_percent --> node_ac1_settle_sl
  node_ac1_settle_sl --> node_ac1_blur_sl_percent
  node_ac1_blur_sl_percent --> node_ac1_assert_sl_below_current
  node_ac1_assert_sl_below_current --> node_ac1_screenshot
  node_ac1_screenshot --> node_ac3_assert_sl_percent_signed
  node_ac3_assert_sl_percent_signed --> node_ac3_screenshot
  node_ac3_screenshot --> node_ac2_type_tp_percent
  node_ac2_type_tp_percent --> node_ac2_settle_tp
  node_ac2_settle_tp --> node_ac2_blur_tp
  node_ac2_blur_tp --> node_ac2_assert_tp_above_current
  node_ac2_assert_tp_above_current --> node_ac2_screenshot
  node_ac2_screenshot --> node_done
```

</details>


[TAT-2947]: https://consensyssoftware.atlassian.net/browse/TAT-2947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ