### PR TITLE
ci: clarify the concepts of IS_CROSS_REPO_PR and forks

### DIFF
--- a/.github/scripts/yarn-audit-diff.mts
+++ b/.github/scripts/yarn-audit-diff.mts
@@ -795,7 +795,7 @@ async function main() {
   //      refresh completes. On the retry, the advisory is already in
   //      the baseline, so it no longer appears "new" and the check passes.
   //
-  // Cross-repo (fork) PRs skip steps 3-4 because the token is read-only.
+  // Cross-repo PRs skip steps 3-4 because the token is read-only.
   // On push-to-main, the step always succeeds (baseline must be uploaded).
   //
   // Classification outcomes:

--- a/.github/workflows/add-team-label.yml
+++ b/.github/workflows/add-team-label.yml
@@ -9,9 +9,10 @@ jobs:
   add-team-label:
     name: Add team label
     runs-on: ubuntu-latest
+    # Only same-repo PRs — TEAM_LABEL_TOKEN is not available to cross-repo PRs.
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: Add team label
-        if: ${{ !github.event.pull_request.head.repo.fork }}
         uses: MetaMask/github-tools/.github/actions/add-team-label@v1
         with:
           team-label-token: ${{ secrets.TEAM_LABEL_TOKEN }}

--- a/.github/workflows/ci-status-gate.yml
+++ b/.github/workflows/ci-status-gate.yml
@@ -166,10 +166,10 @@ jobs:
       # in the wrong suite — one the merge queue doesn't monitor. Commit
       # statuses have no suites, so they always work reliably.
       - name: Post commit status
-        # Fork PRs receive a read-only token — createCommitStatus would throw
+        # Cross-repo PRs receive a read-only token — createCommitStatus would throw
         # "Resource not accessible by integration". Commit statuses are for
-        # the merge queue and branch protection; fork PRs don't need them.
-        # On non-PR events (merge_group, push) the fork check is irrelevant.
+        # the merge queue and branch protection; cross-repo PRs don't need them.
+        # On non-PR events (merge_group, push) this check is irrelevant.
         if: >-
           ${{
             !cancelled() &&

--- a/.github/workflows/e2e-chrome.yml
+++ b/.github/workflows/e2e-chrome.yml
@@ -70,8 +70,9 @@ jobs:
       matrix-total: ${{ strategy.job-total }}
 
   test-e2e-chrome-dist:
-    # This if statement is equivalent to !IS_FORK
-    if: ${{ !(github.event.pull_request.head.repo.fork || github.event.repository.fork) }}
+    # Skip for cross-repo PRs — dist tests need secrets not available to external contributors.
+    # Deliberately allowed on fork repos so our test-forks can test the workflows if they set the secrets.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     uses: ./.github/workflows/run-e2e.yml
     with:
       test-suite-name: test-e2e-chrome-dist
@@ -148,8 +149,9 @@ jobs:
       matrix-total: ${{ strategy.job-total }}
 
   test-e2e-chrome-dist-webpack:
-    # This if statement is equivalent to !IS_FORK
-    if: ${{ !(github.event.pull_request.head.repo.fork || github.event.repository.fork) }}
+    # Skip for cross-repo PRs — dist tests need secrets not available to external contributors.
+    # Deliberately allowed on fork repos so our test-forks can test the workflows if they set the secrets.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     uses: ./.github/workflows/run-e2e.yml
     with:
       test-suite-name: test-e2e-chrome-dist-webpack

--- a/.github/workflows/e2e-firefox.yml
+++ b/.github/workflows/e2e-firefox.yml
@@ -50,8 +50,9 @@ jobs:
       matrix-total: ${{ strategy.job-total }}
 
   test-e2e-firefox-dist:
-    # This if statement is equivalent to !IS_FORK
-    if: ${{ !(github.event.pull_request.head.repo.fork || github.event.repository.fork) }}
+    # Skip for cross-repo PRs — dist tests need secrets not available to external contributors.
+    # Deliberately allowed on fork repos so our test-forks can test the workflows if they set the secrets.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     uses: ./.github/workflows/run-e2e.yml
     with:
       test-suite-name: test-e2e-firefox-dist
@@ -90,8 +91,9 @@ jobs:
       matrix-total: ${{ strategy.job-total }}
 
   test-e2e-firefox-dist-webpack:
-    # This if statement is equivalent to !IS_FORK
-    if: ${{ !(github.event.pull_request.head.repo.fork || github.event.repository.fork) }}
+    # Skip for cross-repo PRs — dist tests need secrets not available to external contributors.
+    # Deliberately allowed on fork repos so our test-forks can test the workflows if they set the secrets.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     uses: ./.github/workflows/run-e2e.yml
     with:
       test-suite-name: test-e2e-firefox-dist-webpack

--- a/.github/workflows/get-requirements.yml
+++ b/.github/workflows/get-requirements.yml
@@ -49,10 +49,7 @@ env:
   # Note: merge_group events only target `main` (no merge queue on `stable`),
   # so the fallback to 'main' is correct for that case too.
   BASE_BRANCH: ${{ github.event.pull_request.base.ref || (startsWith(github.ref_name, 'release/') && 'stable') || 'main' }}
-  # WARNING: always 'true' on fork repos — see IS_CROSS_REPO_PR below.
-  IS_FORK: ${{ github.event.pull_request.head.repo.fork || github.event.repository.fork }}
-  # True only for PRs whose head branch lives in a different repository.
-  # Unlike IS_FORK, this is false for same-repo work on a forked repository.
+  # True only for PRs whose head branch lives in a different repository (security gating).
   IS_CROSS_REPO_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
   EVENT_NAME: ${{ github.event_name }}
   PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -97,7 +94,7 @@ jobs:
         run: |
           echo "SKIP=false" >> "$GITHUB_OUTPUT"
 
-          # Ignore the [skip-e2e] tag for cross-repo fork PRs (untrusted commit messages)
+          # Ignore the [skip-e2e] tag for cross-repo PRs (untrusted commit messages)
           if [[ "$IS_CROSS_REPO_PR" != "true" ]] && { [[ "$EVENT_NAME" == "pull_request" ]] || [[ "$EVENT_NAME" == "merge_group" ]] || [[ "$BRANCH" == trigger-ci-* ]]; }; then
             if git show --format='%B' --no-patch "${HEAD_COMMIT_HASH}" | grep --fixed-strings --quiet '[skip-e2e]'; then
               echo "SKIP=true" >> "$GITHUB_OUTPUT"
@@ -454,13 +451,14 @@ jobs:
         if: ${{ steps.set-skip-everything.outputs.skip-everything != 'true' }}
         run: echo "needs-unit-and-integration=true" >> "$GITHUB_OUTPUT"
 
-      # This is very simple right now (and equivalent to !IS_FORK && !skip-everything), but is built to have future complexity
+      # This is very simple right now, but is built to have future complexity
       - name: Compute needs-releases flag
         id: set-needs-releases
-        # Do not do releases on a fork
+        # Skip on cross-repo PRs — releases need secrets not available to external contributors.
+        # Deliberately allowed on fork repos so our test-forks can test the workflows if they set the secrets.
         if: >-
           ${{
-            env.IS_FORK == 'false' &&
+            env.IS_CROSS_REPO_PR != 'true' &&
             env.EVENT_NAME != 'merge_group' &&
             steps.set-skip-everything.outputs.skip-everything != 'true'
           }}
@@ -469,10 +467,11 @@ jobs:
       # This is very simple right now, but is built to have future complexity
       - name: Compute needs-benchmarks flag
         id: set-needs-benchmarks
-        # Do not run benchmarks on a fork or in the merge queue
+        # Skip on cross-repo PRs — benchmarks need secrets not available to external contributors.
+        # Deliberately allowed on fork repos so our test-forks can test the workflows if they set the secrets.
         if: >-
           ${{
-            env.IS_FORK == 'false' &&
+            env.IS_CROSS_REPO_PR != 'true' &&
             env.EVENT_NAME != 'merge_group' &&
             steps.set-skip-everything.outputs.skip-everything != 'true'
           }}

--- a/.github/workflows/identify-codeowners.yml
+++ b/.github/workflows/identify-codeowners.yml
@@ -14,11 +14,11 @@ concurrency:
 
 jobs:
   identify-codeowners:
-    # Avoid running on forks since we need to write a PR comment
+    # Avoid running on cross-repo PRs since we need to write a PR comment
     # Avoid running on release branches and bot PRs
     if: >-
       ${{
-        !(github.event.pull_request.head.repo.fork || github.event.repository.fork)
+        github.event.pull_request.head.repo.full_name == github.repository
         && !startsWith(github.head_ref, 'release/')
         && github.event.pull_request.user.login != 'metamaskbot'
         && github.event.pull_request.user.login != 'runway-github[bot]'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,9 +29,6 @@ env:
   # For a `pull_request` event, the branch is `github.head_ref``.
   # For a `push` event, the branch is `github.ref_name`.
   BRANCH: ${{ github.head_ref || github.ref_name }}
-  # For a `pull_request` event, the fork is `github.event.pull_request.head.repo.fork`.
-  # For a `push` event, the fork is `github.event.repository.fork`.
-  IS_FORK: ${{ github.event.pull_request.head.repo.fork || github.event.repository.fork }}
   # For a `pull_request` event, the head commit hash is `github.event.pull_request.head.sha`.
   # For a `push` event, the head commit hash is `github.sha`.
   HEAD_COMMIT_HASH: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -408,12 +405,16 @@ jobs:
     name: SonarCloud
     needs:
       - run-tests
+    # Run SonarCloud on same-repo PRs and pushes to main on the canonical repo.
     if: >-
       ${{
         !cancelled() &&
-        (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'main')) &&
         needs.run-tests.result == 'success' &&
-        !(github.event.pull_request.head.repo.fork || github.event.repository.fork)
+        !github.event.repository.fork &&
+        (
+          (github.event_name == 'push' && github.ref_name == 'main') ||
+          (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+        )
       }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -464,7 +465,8 @@ jobs:
         run: yarn tsx test/e2e/mv3-perf-stats/bundle-size.ts --out test-artifacts/chrome
 
       - name: Record bundle size at commit
-        if: ${{ env.BRANCH == 'main' && env.IS_FORK == 'false'}}
+        # Skip on fork repos — only record stats on the canonical repository.
+        if: ${{ env.BRANCH == 'main' && !github.event.repository.fork }}
         run: ./.github/scripts/bundle-stats-commit.sh
 
       - name: Upload 'bundle-size' to S3
@@ -615,10 +617,21 @@ jobs:
 
   trigger-regression-validation:
     name: Trigger Regression Validation
-    # Only run for release branches, not forks.
+    # Guard: three conditions must all be true.
+    #  1. Release branch — only release/* branches need regression validation.
+    #  2. Not a fork repo — fork repos don't have the release-ci environment
+    #     or its METAMASK_REGRESSION_TRIGGER_TEST secret.
+    #  3. Not a cross-repo PR — GitHub withholds environment secrets from PRs
+    #     whose head branch lives in a different repository, so the job would
+    #     fail trying to read the dispatch token.
     # Build reuse is banned on release/* branches (in get-requirements.yml),
     # so build-dist-browserify always runs here — no !cancelled() needed.
-    if: ${{ (startsWith(github.head_ref || github.ref_name, 'release/') && !(github.event.pull_request.head.repo.fork || github.event.repository.fork)) }}
+    if: >-
+      ${{
+        startsWith(github.head_ref || github.ref_name, 'release/')
+        && !github.event.repository.fork
+        && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+      }}
     needs:
       - get-requirements
       - build-dist-webpack

--- a/.github/workflows/repository-health-checks.yml
+++ b/.github/workflows/repository-health-checks.yml
@@ -47,7 +47,7 @@ jobs:
         run: yarn --check-resolutions
 
       # --- Baseline download (PR, push-to-main, and cron) ---
-      # When the download fails (first rollout, expired artifact, or fork PR
+      # When the download fails (first rollout, expired artifact, or cross-repo PR
       # with read-only token), NO_BASELINE=true tells the triage script to
       # fall back to the same criteria as the package.json `audit` script:
       #   yarn audit --environment production --severity moderate

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -301,6 +301,7 @@ jobs:
 
   # Pushes benchmark results to extension_benchmark_stats (performance_data.json) for
   # historical comparison in PR comments. Runs on main/release branch pushes only.
+  # Skip on fork repos — only store stats on the canonical repository.
   store-benchmark-stats:
     name: store-benchmark-stats (main/release only)
     continue-on-error: true
@@ -312,7 +313,7 @@ jobs:
         !cancelled() &&
         github.event_name == 'push' &&
         (github.ref_name == 'main' || startsWith(github.ref, 'refs/heads/release/')) &&
-        !(github.event.pull_request.head.repo.fork || github.event.repository.fork)
+        !github.event.repository.fork
       }}
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -70,6 +70,10 @@ jobs:
       # For a `pull_request` event, the head commit hash is `github.event.pull_request.head.sha`.
       # For a `push` event, the head commit hash is `github.sha`.
       HEAD_COMMIT_HASH: ${{ github.event.pull_request.head.sha || github.sha }}
+      # True when the repository itself is a fork (policy/feature gating).
+      IS_FORK: ${{ github.event.repository.fork }}
+      # True for PRs whose head branch lives in a different repository (security gating).
+      IS_CROSS_REPO_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
       MATRIX_INDEX: ${{ inputs.matrix-index }}
       MATRIX_TOTAL: ${{ inputs.matrix-total }}
       JOB_NAME: ${{ inputs.test-suite-name }}${{ inputs.matrix-total > 1 && format(' ({0})', inputs.matrix-index) || '' }}

--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -67,9 +67,6 @@ jobs:
       # For a `pull_request` event, the branch is `github.head_ref``.
       # For a `push` event, the branch is `github.ref_name`.
       BRANCH: ${{ github.head_ref || github.ref_name }}
-      # For a `pull_request` event, the fork is `github.event.pull_request.head.repo.fork`.
-      # For a `push` event, the fork is `github.event.repository.fork`.
-      IS_FORK: ${{ github.event.pull_request.head.repo.fork || github.event.repository.fork }}
       # For a `pull_request` event, the head commit hash is `github.event.pull_request.head.sha`.
       # For a `push` event, the head commit hash is `github.sha`.
       HEAD_COMMIT_HASH: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/triage-and-retry-system.yml
+++ b/.github/workflows/triage-and-retry-system.yml
@@ -1,7 +1,7 @@
 # Classify and retry failed main.yml workflow runs.
 #
 # Triggered by `workflow_run` on every main.yml completion. Skips successes
-# and fork runs at the job level.
+# and cross-repo runs at the job level.
 #
 # For failures, it:
 #   1. Classifies each failed job (jobRetryable) and derives an overall
@@ -72,7 +72,7 @@ jobs:
     #
     # Pseudocode:
     #   if run.conclusion not in ['failure','cancelled'] → skip
-    #   if run.repo != run.head_repo          → skip (fork — no permissions)
+    #   if run.repo != run.head_repo          → skip (cross-repo — no permissions)
     #   if run.event == 'merge_group'         → run  (label-gated retry via PR)
     #   if run.event == 'pull_request'        → run  (label-gated retry via PR)
     #   if run.event == 'push'

--- a/.github/workflows/update-attributions.yml
+++ b/.github/workflows/update-attributions.yml
@@ -5,18 +5,18 @@ on:
     types: created
 
 jobs:
-  is-fork-pull-request:
-    name: Determine whether this issue comment was on a pull request from a fork
+  is-cross-repo-pr:
+    name: Determine whether this PR is cross-repo
     if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '@metamaskbot update-attributions') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     outputs:
-      IS_FORK: ${{ steps.is-fork.outputs.IS_FORK }}
+      IS_CROSS_REPO_PR: ${{ steps.is-cross-repo.outputs.IS_CROSS_REPO_PR }}
     steps:
       - uses: actions/checkout@v6
-      - name: Determine whether this PR is from a fork
-        id: is-fork
-        run: echo "IS_FORK=$(gh pr view --json isCrossRepository --jq '.isCrossRepository' "${PR_NUMBER}" )" >> "$GITHUB_OUTPUT"
+      - name: Determine whether this PR is cross-repo
+        id: is-cross-repo
+        run: echo "IS_CROSS_REPO_PR=$(gh pr view --json isCrossRepository --jq '.isCrossRepository' "${PR_NUMBER}" )" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.issue.number }}
@@ -25,9 +25,9 @@ jobs:
     name: React to the comment
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: is-fork-pull-request
-    # Early exit if this is a fork, since later steps are skipped for forks
-    if: ${{ needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
+    needs: is-cross-repo-pr
+    # Skip cross-repo PRs — later steps need write access to push commits.
+    if: ${{ needs.is-cross-repo-pr.outputs.IS_CROSS_REPO_PR == 'false' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -48,9 +48,9 @@ jobs:
     name: Prepare dependencies
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: is-fork-pull-request
-    # Early exit if this is a fork, since later steps are skipped for forks
-    if: ${{ needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
+    needs: is-cross-repo-pr
+    # Skip cross-repo PRs — later steps need write access to push commits.
+    if: ${{ needs.is-cross-repo-pr.outputs.IS_CROSS_REPO_PR == 'false' }}
     outputs:
       COMMIT_SHA: ${{ steps.commit-sha.outputs.COMMIT_SHA }}
     steps:
@@ -76,9 +76,9 @@ jobs:
     timeout-minutes: 30
     needs:
       - prepare
-      - is-fork-pull-request
-    # Early exit if this is a fork, since later steps are skipped for forks
-    if: ${{ needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
+      - is-cross-repo-pr
+    # Skip cross-repo PRs — later steps need write access to push commits.
+    if: ${{ needs.is-cross-repo-pr.outputs.IS_CROSS_REPO_PR == 'false' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -106,9 +106,9 @@ jobs:
     timeout-minutes: 30
     needs:
       - prepare
-      - is-fork-pull-request
+      - is-cross-repo-pr
       - update-attributions
-    if: ${{ needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
+    if: ${{ needs.is-cross-repo-pr.outputs.IS_CROSS_REPO_PR == 'false' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -164,9 +164,9 @@ jobs:
     timeout-minutes: 30
     needs:
       - commit-updated-attributions
-      - is-fork-pull-request
-    # Early exit if this is a fork, since later steps are skipped for forks
-    if: ${{ needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
+      - is-cross-repo-pr
+    # Skip cross-repo PRs — later steps need write access to push commits.
+    if: ${{ needs.is-cross-repo-pr.outputs.IS_CROSS_REPO_PR == 'false' }}
     outputs:
       PASSED: ${{ steps.set-output.outputs.PASSED }}
     steps:
@@ -176,11 +176,11 @@ jobs:
 
   failure-comment:
     name: Comment about the attributions update failure
-    if: ${{ !cancelled() && needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
+    if: ${{ !cancelled() && needs.is-cross-repo-pr.outputs.IS_CROSS_REPO_PR == 'false' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs:
-      - is-fork-pull-request
+      - is-cross-repo-pr
       - check-status
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/update-e2e-fixtures.yml
+++ b/.github/workflows/update-e2e-fixtures.yml
@@ -6,19 +6,19 @@ on:
       - created
 
 jobs:
-  is-fork-pull-request:
-    name: Determine whether this issue comment was on a pull request from a fork
+  is-cross-repo-pr:
+    name: Determine whether this PR is cross-repo
     if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '@metamaskbot update-e2e-fixture') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     outputs:
-      IS_FORK: ${{ steps.is-fork.outputs.IS_FORK }}
+      IS_CROSS_REPO_PR: ${{ steps.is-cross-repo.outputs.IS_CROSS_REPO_PR }}
     steps:
       - uses: actions/checkout@v6
 
-      - name: Determine whether this PR is from a fork
-        id: is-fork
-        run: echo "IS_FORK=$(gh pr view --json isCrossRepository --jq '.isCrossRepository' "${PR_NUMBER}" )" >> "$GITHUB_OUTPUT"
+      - name: Determine whether this PR is cross-repo
+        id: is-cross-repo
+        run: echo "IS_CROSS_REPO_PR=$(gh pr view --json isCrossRepository --jq '.isCrossRepository' "${PR_NUMBER}" )" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.issue.number }}
@@ -27,8 +27,8 @@ jobs:
     name: React to the comment
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: is-fork-pull-request
-    if: ${{ needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
+    needs: is-cross-repo-pr
+    if: ${{ needs.is-cross-repo-pr.outputs.IS_CROSS_REPO_PR == 'false' }}
     environment: default-branch
     steps:
       - name: Checkout repository
@@ -51,8 +51,8 @@ jobs:
     name: Prepare dependencies
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: is-fork-pull-request
-    if: ${{ needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
+    needs: is-cross-repo-pr
+    if: ${{ needs.is-cross-repo-pr.outputs.IS_CROSS_REPO_PR == 'false' }}
     environment: default-branch
     outputs:
       COMMIT_SHA: ${{ steps.commit-sha.outputs.COMMIT_SHA }}
@@ -210,9 +210,9 @@ jobs:
     timeout-minutes: 30
     needs:
       - prepare
-      - is-fork-pull-request
+      - is-cross-repo-pr
       - update-fixtures
-    if: ${{ needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
+    if: ${{ needs.is-cross-repo-pr.outputs.IS_CROSS_REPO_PR == 'false' }}
     environment: default-branch
     steps:
       - name: Checkout repository
@@ -270,9 +270,9 @@ jobs:
     name: Check whether the fixtures update succeeded
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: ${{ !cancelled() && needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
+    if: ${{ !cancelled() && needs.is-cross-repo-pr.outputs.IS_CROSS_REPO_PR == 'false' }}
     needs:
-      - is-fork-pull-request
+      - is-cross-repo-pr
       - commit-updated-fixtures
     outputs:
       PASSED: ${{ steps.set-output.outputs.PASSED }}
@@ -288,11 +288,11 @@ jobs:
 
   failure-comment:
     name: Comment about the fixtures update failure
-    if: ${{ !cancelled() && needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
+    if: ${{ !cancelled() && needs.is-cross-repo-pr.outputs.IS_CROSS_REPO_PR == 'false' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs:
-      - is-fork-pull-request
+      - is-cross-repo-pr
       - check-status
     environment: default-branch
     steps:

--- a/.github/workflows/update-lavamoat-policies.yml
+++ b/.github/workflows/update-lavamoat-policies.yml
@@ -21,7 +21,7 @@ jobs:
       PR_NUMBER: ${{ github.event.issue.number }}
       COMMENT_ID: ${{ github.event.comment.id }}
     outputs:
-      IS_FORK: ${{ steps.is-fork.outputs.IS_FORK }}
+      IS_CROSS_REPO_PR: ${{ steps.is-cross-repo.outputs.IS_CROSS_REPO_PR }}
       RUN_ID: ${{ steps.find-ci-run.outputs.RUN_ID }}
       NO_CI_RUN: ${{ steps.find-ci-run.outputs.NO_CI_RUN }}
       VALIDATION_PENDING: ${{ steps.find-ci-run.outputs.VALIDATION_PENDING }}
@@ -29,12 +29,12 @@ jobs:
       VALIDATION_FAILED: ${{ steps.find-ci-run.outputs.VALIDATION_FAILED }}
       FAILED_JOBS: ${{ steps.find-ci-run.outputs.FAILED_JOBS }}
     steps:
-      - name: Determine whether this PR is from a fork
-        id: is-fork
-        run: echo "IS_FORK=$(gh pr view "${PR_NUMBER}" --repo "${REPO}" --json isCrossRepository --jq '.isCrossRepository')" >> "$GITHUB_OUTPUT"
+      - name: Determine whether this PR is cross-repo
+        id: is-cross-repo
+        run: echo "IS_CROSS_REPO_PR=$(gh pr view "${PR_NUMBER}" --repo "${REPO}" --json isCrossRepository --jq '.isCrossRepository')" >> "$GITHUB_OUTPUT"
 
       - name: React to the comment
-        if: ${{ steps.is-fork.outputs.IS_FORK == 'false' }}
+        if: ${{ steps.is-cross-repo.outputs.IS_CROSS_REPO_PR == 'false' }}
         run: |
           gh api \
             --method POST \
@@ -44,7 +44,7 @@ jobs:
             -f content='+1'
 
       - name: Find CI run for PR head commit
-        if: ${{ steps.is-fork.outputs.IS_FORK == 'false' }}
+        if: ${{ steps.is-cross-repo.outputs.IS_CROSS_REPO_PR == 'false' }}
         id: find-ci-run
         run: |
           HEAD_SHA=$(gh pr view "${PR_NUMBER}" --repo "${REPO}" --json headRefOid --jq '.headRefOid')
@@ -104,7 +104,7 @@ jobs:
   apply-and-commit:
     name: Apply policy diffs and commit
     needs: prepare
-    if: ${{ !cancelled() && needs.prepare.outputs.IS_FORK == 'false' }}
+    if: ${{ !cancelled() && needs.prepare.outputs.IS_CROSS_REPO_PR == 'false' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:

--- a/test/e2e/tests/notifications/notification-items.spec.ts
+++ b/test/e2e/tests/notifications/notification-items.spec.ts
@@ -41,7 +41,14 @@ async function mockFeatureFlagsWithoutAutoEnableNotifications(server: Mockttp) {
 
 describe('Notification List - View Items and Details', function () {
   it('find each notification type we support, and navigates to their details page', async function () {
-    if (process.env.IS_FORK === 'true') {
+    // Feature announcements are fetched from Contentful, which requires CONTENTFUL_ACCESS_SPACE_ID
+    // and CONTENTFUL_ACCESS_TOKEN baked in at build time (run-build.yml). Fork repos and
+    // cross-repo PRs don't have these secrets, so the built extension uses placeholder values,
+    // never contacts Contentful, and this test times out waiting for announcement items.
+    if (
+      process.env.IS_FORK === 'true' ||
+      process.env.IS_CROSS_REPO_PR === 'true'
+    ) {
       this.skip();
     }
     await withFixtures(


### PR DESCRIPTION
## **Description**

We previously used this line (and similar) many times in the repo
```
IS_FORK: ${{ github.event.pull_request.head.repo.fork || github.event.repository.fork }}
```

But really there are two separate concepts to think about.

1) Is this an untrusted cross-repo PR where the HEAD lives in a different repo than the base, and secrets won't be available?
```
IS_CROSS_REPO_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
```

2) Is this the upstream canonical repo (MetaMask/metamask-extension)?
```
!github.event.repository.fork
```

## **Changelog**

CHANGELOG entry: null

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**
[skip-e2e]-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tweaks conditional execution across many GitHub Actions workflows to distinguish cross-repo PRs from forked repositories; mistakes could inadvertently skip required CI or attempt secret-requiring steps without permissions.
> 
> **Overview**
> **Clarifies and standardizes CI gating** by separating *cross-repo PR* detection (`head.repo.full_name != github.repository`) from *running in a forked repository* (`github.event.repository.fork`), replacing prior mixed `IS_FORK` checks.
> 
> This updates multiple workflows to **skip secret/write-required jobs only for cross-repo PRs** (e.g., team labeling, codeowner commenting, commit status posting, releases/benchmarks flags, dist E2E suites, and regression-validation dispatch), while keeping behavior for forked repos explicit (e.g., only recording/storing stats on the canonical repo).
> 
> Also updates the yarn-audit auto-healing comments/gating terminology and makes `notification-items.spec.ts` skip when either `IS_FORK` or `IS_CROSS_REPO_PR` is true to avoid timeouts when Contentful secrets aren’t available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 442aeedb6e9719787e41a8bcc7f7a75089c6dd12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->