### PR TITLE
test: fix flaky test `Settings Redirects to ENS domains when user inputs ENS into address bar`

### DIFF
--- a/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
+++ b/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
@@ -1,4 +1,5 @@
 import { MockedEndpoint, MockttpServer } from 'mockttp';
+import { NetworkStatus } from '@metamask/network-controller';
 import { getCleanAppState, tinyDelayMs, withFixtures } from '../../helpers';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import HeaderNavbar from '../../page-objects/pages/header-navbar';
@@ -7,6 +8,8 @@ import PrivacySettings from '../../page-objects/pages/settings/privacy-settings'
 import SettingsPage from '../../page-objects/pages/settings/settings-page';
 import { login } from '../../page-objects/flows/login.flow';
 import { NETWORK_CLIENT_ID } from '../../constants';
+import { CHAIN_IDS } from '../../../../shared/constants/network';
+import { getCurrentChainId } from '../../../../shared/lib/selectors/networks';
 
 describe('Settings', function () {
   const ENS_NAME = 'metamask.eth';
@@ -34,6 +37,11 @@ describe('Settings', function () {
       {
         fixtures: new FixtureBuilderV2()
           .withSelectedNetwork(NETWORK_CLIENT_ID.MAINNET)
+          .withEnabledNetworks({
+            eip155: {
+              '0x1': true,
+            },
+          })
           .build(),
         title: this.test?.fullTitle(),
         testSpecificMock: mockEns,
@@ -44,22 +52,32 @@ describe('Settings', function () {
       async ({ driver }) => {
         await driver.navigate();
 
-        // Wait for the live controller state (via Redux) to confirm the
-        // ipfsGateway and useAddressBarEnsResolution settings are active and mainnet is selected.
-        // Unlike getPersistedState (which reads IndexedDB fixture data
-        // immediately), getCleanAppState reflects the running controller
-        // state that has been synced to the UI after background init.
+        // Wait for live UI Redux to match what the ENS webRequest handler needs.
+        // selectedNetworkClientId alone is not enough: webRequestDidFail always
+        // calls getCurrentChainId() (via getProviderConfig) before IN_TEST logic;
+        // that throws until NetworkController state is fully hydrated.
         await driver.wait(async () => {
           const uiState = await getCleanAppState(driver);
-          return (
-            uiState?.metamask?.ipfsGateway === 'dweb.link' &&
-            uiState?.metamask?.useAddressBarEnsResolution === true &&
-            uiState?.metamask?.selectedNetworkClientId ===
-              NETWORK_CLIENT_ID.MAINNET
-          );
+          const m = uiState?.metamask;
+          if (
+            m?.ipfsGateway !== 'dweb.link' ||
+            m?.useAddressBarEnsResolution !== true ||
+            m?.selectedNetworkClientId !== NETWORK_CLIENT_ID.MAINNET
+          ) {
+            return false;
+          }
+          if (
+            m.networksMetadata?.[NETWORK_CLIENT_ID.MAINNET]?.status !==
+            NetworkStatus.Available
+          ) {
+            return false;
+          }
+          try {
+            return getCurrentChainId({ metamask: m }) === CHAIN_IDS.MAINNET;
+          } catch {
+            return false;
+          }
         }, 10000);
-
-        await driver.delay(2000);
 
         const loginPage = new LoginPage(driver);
         await loginPage.checkPageIsLoaded();

--- a/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
+++ b/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
@@ -36,11 +36,6 @@ describe('Settings', function () {
       {
         fixtures: new FixtureBuilderV2()
           .withSelectedNetwork(NETWORK_CLIENT_ID.MAINNET)
-          .withEnabledNetworks({
-            eip155: {
-              '0x1': true,
-            },
-          })
           .build(),
         title: this.test?.fullTitle(),
         testSpecificMock: mockEns,
@@ -57,25 +52,28 @@ describe('Settings', function () {
         // immediately), getCleanAppState reflects the running controller
         // state that has been synced to the UI after background init.
         // Wait until NetworkController state resolves to mainnet.
-        await driver.waitUntil(async () => {
-          const uiState = await getCleanAppState(driver);
-          const m = uiState?.metamask;
-          if (
-            m?.ipfsGateway !== 'dweb.link' ||
-            m?.useAddressBarEnsResolution !== true
-          ) {
-            return false;
-          }
-          try {
-            return getCurrentChainId({ metamask: m }) === CHAIN_IDS.MAINNET;
-          } catch {
-            return false;
-          }
-        }, {
-          interval: 1000,
-          timeout: 10000,
-          stableFor: 1000,
-        });
+        await driver.waitUntil(
+          async () => {
+            const uiState = await getCleanAppState(driver);
+            const m = uiState?.metamask;
+            if (
+              m?.ipfsGateway !== 'dweb.link' ||
+              m?.useAddressBarEnsResolution !== true
+            ) {
+              return false;
+            }
+            try {
+              return getCurrentChainId({ metamask: m }) === CHAIN_IDS.MAINNET;
+            } catch {
+              return false;
+            }
+          },
+          {
+            interval: 1000,
+            stableFor: 1000,
+            timeout: 10000,
+          },
+        );
 
         const loginPage = new LoginPage(driver);
         await loginPage.checkPageIsLoaded();

--- a/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
+++ b/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
@@ -57,7 +57,7 @@ describe('Settings', function () {
         // immediately), getCleanAppState reflects the running controller
         // state that has been synced to the UI after background init.
         // Wait until NetworkController state resolves to mainnet.
-        await driver.wait(async () => {
+        await driver.waitUntil(async () => {
           const uiState = await getCleanAppState(driver);
           const m = uiState?.metamask;
           if (
@@ -71,7 +71,11 @@ describe('Settings', function () {
           } catch {
             return false;
           }
-        }, 10000);
+        }, {
+          interval: 1000,
+          timeout: 10000,
+          stableFor: 1000,
+        });
 
         const loginPage = new LoginPage(driver);
         await loginPage.checkPageIsLoaded();

--- a/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
+++ b/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
@@ -1,5 +1,4 @@
 import { MockedEndpoint, MockttpServer } from 'mockttp';
-import { NetworkStatus } from '@metamask/network-controller';
 import { getCleanAppState, tinyDelayMs, withFixtures } from '../../helpers';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import HeaderNavbar from '../../page-objects/pages/header-navbar';
@@ -57,28 +56,15 @@ describe('Settings', function () {
         // Unlike getPersistedState (which reads IndexedDB fixture data
         // immediately), getCleanAppState reflects the running controller
         // state that has been synced to the UI after background init.
-        // Wait for Mainnet to be fully initialized
+        // Wait until NetworkController state resolves to mainnet.
         await driver.wait(async () => {
           const uiState = await getCleanAppState(driver);
-          const m = uiState?.metamask;
-          if (
-            m?.ipfsGateway !== 'dweb.link' ||
-            m?.useAddressBarEnsResolution !== true ||
-            m?.selectedNetworkClientId !== NETWORK_CLIENT_ID.MAINNET
-          ) {
-            return false;
-          }
-          if (
-            m.networksMetadata?.[NETWORK_CLIENT_ID.MAINNET]?.status !==
-            NetworkStatus.Available
-          ) {
-            return false;
-          }
-          try {
-            return getCurrentChainId({ metamask: m }) === CHAIN_IDS.MAINNET;
-          } catch {
-            return false;
-          }
+          return (
+            uiState?.metamask?.ipfsGateway === 'dweb.link' &&
+            uiState?.metamask?.useAddressBarEnsResolution === true &&
+            getCurrentChainId({ metamask: uiState?.metamask }) ===
+              CHAIN_IDS.MAINNET
+          );
         }, 10000);
 
         const loginPage = new LoginPage(driver);

--- a/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
+++ b/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
@@ -34,6 +34,11 @@ describe('Settings', function () {
       {
         fixtures: new FixtureBuilderV2()
           .withSelectedNetwork(NETWORK_CLIENT_ID.MAINNET)
+          .withEnabledNetworks({
+            eip155: {
+              '0x1': true,
+            },
+          })
           .build(),
         title: this.test?.fullTitle(),
         testSpecificMock: mockEns,

--- a/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
+++ b/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
@@ -59,12 +59,18 @@ describe('Settings', function () {
         // Wait until NetworkController state resolves to mainnet.
         await driver.wait(async () => {
           const uiState = await getCleanAppState(driver);
-          return (
-            uiState?.metamask?.ipfsGateway === 'dweb.link' &&
-            uiState?.metamask?.useAddressBarEnsResolution === true &&
-            getCurrentChainId({ metamask: uiState?.metamask }) ===
-              CHAIN_IDS.MAINNET
-          );
+          const m = uiState?.metamask;
+          if (
+            m?.ipfsGateway !== 'dweb.link' ||
+            m?.useAddressBarEnsResolution !== true
+          ) {
+            return false;
+          }
+          try {
+            return getCurrentChainId({ metamask: m }) === CHAIN_IDS.MAINNET;
+          } catch {
+            return false;
+          }
         }, 10000);
 
         const loginPage = new LoginPage(driver);

--- a/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
+++ b/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
@@ -70,7 +70,7 @@ describe('Settings', function () {
           },
           {
             interval: 1000,
-            stableFor: 1000,
+            stableFor: 2000,
             timeout: 10000,
           },
         );

--- a/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
+++ b/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
@@ -34,11 +34,6 @@ describe('Settings', function () {
       {
         fixtures: new FixtureBuilderV2()
           .withSelectedNetwork(NETWORK_CLIENT_ID.MAINNET)
-          .withEnabledNetworks({
-            eip155: {
-              '0x1': true,
-            },
-          })
           .build(),
         title: this.test?.fullTitle(),
         testSpecificMock: mockEns,
@@ -63,6 +58,8 @@ describe('Settings', function () {
               NETWORK_CLIENT_ID.MAINNET
           );
         }, 10000);
+
+        await driver.delay(2000);
 
         const loginPage = new LoginPage(driver);
         await loginPage.checkPageIsLoaded();

--- a/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
+++ b/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
@@ -45,7 +45,7 @@ describe('Settings', function () {
         await driver.navigate();
 
         // Wait for the live controller state (via Redux) to confirm the
-        // ipfsGateway and useAddressBarEnsResolution settings are active.
+        // ipfsGateway and useAddressBarEnsResolution settings are active and mainnet is selected.
         // Unlike getPersistedState (which reads IndexedDB fixture data
         // immediately), getCleanAppState reflects the running controller
         // state that has been synced to the UI after background init.
@@ -53,7 +53,9 @@ describe('Settings', function () {
           const uiState = await getCleanAppState(driver);
           return (
             uiState?.metamask?.ipfsGateway === 'dweb.link' &&
-            uiState?.metamask?.useAddressBarEnsResolution === true
+            uiState?.metamask?.useAddressBarEnsResolution === true &&
+            uiState?.metamask?.selectedNetworkClientId ===
+              NETWORK_CLIENT_ID.MAINNET
           );
         }, 10000);
 

--- a/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
+++ b/test/e2e/tests/settings/ipfs-ens-resolution.spec.ts
@@ -52,10 +52,12 @@ describe('Settings', function () {
       async ({ driver }) => {
         await driver.navigate();
 
-        // Wait for live UI Redux to match what the ENS webRequest handler needs.
-        // selectedNetworkClientId alone is not enough: webRequestDidFail always
-        // calls getCurrentChainId() (via getProviderConfig) before IN_TEST logic;
-        // that throws until NetworkController state is fully hydrated.
+        // Wait for the live controller state (via Redux) to confirm the
+        // ipfsGateway and useAddressBarEnsResolution settings are active.
+        // Unlike getPersistedState (which reads IndexedDB fixture data
+        // immediately), getCleanAppState reflects the running controller
+        // state that has been synced to the UI after background init.
+        // Wait for Mainnet to be fully initialized
         await driver.wait(async () => {
           const uiState = await getCleanAppState(driver);
           const m = uiState?.metamask;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The ENS resolution test is flaky as sometimes the domain is not resolved. The domain resolution feature is enabled when we are on mainnet, so we now wait until we have the correct network before trying the domain resolution, to mitigate the race condition.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that add an explicit mainnet precondition to reduce race-related flakes, without modifying production logic.
> 
> **Overview**
> Deflakes the `ipfs-ens-resolution` e2e test by explicitly selecting **Mainnet** in fixtures and waiting for controller/UI state to stabilize on `CHAIN_IDS.MAINNET` before opening the ENS URL.
> 
> Replaces the previous simple Redux-state poll with a `waitUntil` that also checks `getCurrentChainId(...)` (with stability/timeout settings) to avoid race conditions where ENS resolution isn’t enabled yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8777b0802e3ea69eae588f1d928262f88769fcc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->