### PR TITLE
fix(confirmations): scope signing-or-submitting alert to current chain and account

### DIFF
--- a/ui/pages/confirmations/hooks/alerts/transactions/useSigningOrSubmittingAlerts.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useSigningOrSubmittingAlerts.test.ts
@@ -98,7 +98,7 @@ describe('useSigningOrSubmittingAlerts', () => {
     ).toEqual([]);
   });
 
-  it('returns alerts if transaction on different chain', () => {
+  it('returns no alerts if transaction is on a different chain', () => {
     expect(
       runHook({
         currentConfirmation: CONFIRMATION_MOCK,
@@ -110,7 +110,22 @@ describe('useSigningOrSubmittingAlerts', () => {
           },
         ],
       }),
-    ).toEqual([EXPECTED_ALERT]);
+    ).toEqual([]);
+  });
+
+  it('returns no alerts if transaction is from a different account', () => {
+    expect(
+      runHook({
+        currentConfirmation: CONFIRMATION_MOCK,
+        transactions: [
+          {
+            ...TRANSACTION_META_MOCK,
+            status: TransactionStatus.approved,
+            txParams: { from: '0xdifferentaccount' },
+          },
+        ],
+      }),
+    ).toEqual([]);
   });
 
   it('returns no alerts if transaction has alternate status', () => {

--- a/ui/pages/confirmations/hooks/alerts/transactions/useSigningOrSubmittingAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useSigningOrSubmittingAlerts.ts
@@ -43,11 +43,6 @@ export function useSigningOrSubmittingAlerts(): Alert[] {
 
   const isValidType = isCorrectDeveloperTransactionType(type);
 
-  // Only block on a previous signing/submitting transaction when it shares the
-  // current confirmation's chain and account, since transaction nonces are
-  // scoped per (chainId, from). Pending transactions on other chains or other
-  // accounts cannot affect this confirmation's nonce. The pay-token branch
-  // below intentionally still considers the pay-token chain.
   const hasSigningOrSubmittingForCurrentScope = useMemo(() => {
     if (!from) {
       return false;

--- a/ui/pages/confirmations/hooks/alerts/transactions/useSigningOrSubmittingAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useSigningOrSubmittingAlerts.ts
@@ -43,8 +43,27 @@ export function useSigningOrSubmittingAlerts(): Alert[] {
 
   const isValidType = isCorrectDeveloperTransactionType(type);
 
+  // Only block on a previous signing/submitting transaction when it shares the
+  // current confirmation's chain and account, since transaction nonces are
+  // scoped per (chainId, from). Pending transactions on other chains or other
+  // accounts cannot affect this confirmation's nonce. The pay-token branch
+  // below intentionally still considers the pay-token chain.
+  const hasSigningOrSubmittingForCurrentScope = useMemo(() => {
+    if (!from) {
+      return false;
+    }
+
+    const fromLower = from.toLowerCase();
+
+    return signingOrSubmittingTransactions.some(
+      (tx: TransactionMeta) =>
+        tx.chainId === chainId &&
+        tx.txParams?.from?.toLowerCase() === fromLower,
+    );
+  }, [signingOrSubmittingTransactions, chainId, from]);
+
   const isSigningOrSubmitting =
-    isValidType && signingOrSubmittingTransactions.length > 0;
+    isValidType && hasSigningOrSubmittingForCurrentScope;
 
   const payTokenChainId = payToken?.chainId;
   const isPayTokenOnDifferentChain =


### PR DESCRIPTION
## **Description**

The signing-or-submitting alert (`useSigningOrSubmittingAlerts`) previously blocked any new confirmation whenever **any** approved or signed transaction existed in state — regardless of chain or account.

Transaction nonces are scoped per `(chainId, from)`. A pending transaction on chain A from account X cannot affect the nonce sequence for a confirmation on chain B, or for a different account on the same chain. The cross-chain / cross-account block had no real basis and made the alert too aggressive.

The mobile implementation (`useSignedOrSubmittedAlert.ts`) already filters by `chainId` and `txParams.from`. This PR brings extension behavior in line.

The pay-token branch (which intentionally checks the *pay token* chain rather than the confirmation chain) is untouched and continues to filter by `from`.

## **Related issues**

- [CONF-1246](https://consensyssoftware.atlassian.net/browse/CONF-1246)

<!--
## **Manual testing steps**
-->

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).

<!--
## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all review feedback and is ready for merge.
-->

CHANGELOG entry: Fixed an alert that incorrectly warned about a previous signing or submitting transaction when the previous transaction was on a different chain or from a different account.

[CONF-1246]: https://consensyssoftware.atlassian.net/browse/CONF-1246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: tightens the alert gating logic to filter by `chainId` and `from`, with updated tests to prevent false-positive blocking; no new external integrations or data handling changes.
> 
> **Overview**
> The signing/submitting blocking alert in `useSigningOrSubmittingAlerts` is now **scoped to the current confirmation’s `chainId` and `txParams.from`**, instead of triggering whenever *any* approved/signed transaction exists.
> 
> Tests were updated to assert **no alert** for different-chain or different-account transactions, while keeping existing behavior for same-scope pending txs and the pay-token-chain branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 428bd0491fae1b0affbdc069d9337bf9519121d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->