### PR TITLE
fix: parse typed data values without regex

### DIFF
--- a/shared/lib/transaction.utils.test.js
+++ b/shared/lib/transaction.utils.test.js
@@ -517,7 +517,35 @@ describe('Transaction.utils', function () {
         });
       });
 
-      describe('nested value spoofing protection', () => {
+      describe('value spoofing protection', () => {
+        it('uses the last message object when duplicate sibling message keys are present', () => {
+          const realValue = '100000000000000000000000000000';
+          const maliciousData = `{"message":{"value":100000000000000},"message":{"value":"${realValue}"}}`;
+          const result = parse(maliciousData);
+          expect(result.message.value).toBe(realValue);
+        });
+
+        it('uses JSON key decoding when duplicate sibling message keys are escaped', () => {
+          const realValue = '100000000000000000000000000000';
+          const maliciousData = `{"message":{"value":100000000000000},"messag\\u0065":{"value":"${realValue}"}}`;
+          const result = parse(maliciousData);
+          expect(result.message.value).toBe(realValue);
+        });
+
+        it('uses the last message.value when duplicate sibling value keys are present', () => {
+          const realValue = '100000000000000000000000000000';
+          const maliciousData = `{"message":{"value":100000000000000,"value":"${realValue}"}}`;
+          const result = parse(maliciousData);
+          expect(result.message.value).toBe(realValue);
+        });
+
+        it('uses JSON key decoding when duplicate sibling value keys are escaped', () => {
+          const realValue = '100000000000000000000000000000';
+          const maliciousData = `{"message":{"value":100000000000000,"valu\\u0065":"${realValue}"}}`;
+          const result = parse(maliciousData);
+          expect(result.message.value).toBe(realValue);
+        });
+
         it('ignores nested value fields and uses actual message.value (spoofing attack prevention)', () => {
           const maliciousData = JSON.stringify({
             message: {
@@ -586,6 +614,14 @@ describe('Transaction.utils', function () {
           });
           const result = parse(data);
           expect(result.message.value).toBe('123');
+        });
+
+        it('preserves bare large integers outside message.value', () => {
+          const largeAmount =
+            '1461501637330902918203684832716283019655932542975';
+          const data = `{"message":{"details":{"amount":${largeAmount}},"value":1}}`;
+          const result = parse(data);
+          expect(result.message.details.amount).toBe(largeAmount);
         });
       });
     });

--- a/shared/lib/transaction.utils.ts
+++ b/shared/lib/transaction.utils.ts
@@ -327,20 +327,117 @@ export async function determineTransactionAssetType(
   return { assetType: AssetType.native, tokenStandard: TokenStandard.none };
 }
 
-/**
- * Regex to extract large numeric values from message.value.
- * Uses [^{}]* instead of [^}]* to prevent matching nested "value" fields -
- * by excluding both { and }, the regex stops at any nested object boundary,
- * ensuring only top-level message.value is matched.
- */
-const REGEX_MESSAGE_VALUE_LARGE =
-  /"message"\s*:\s*\{[^{}]*"value"\s*:\s*(\d{15,})/u;
+const LARGE_INTEGER_DIGIT_COUNT = 15;
 
-function extractLargeMessageValue(dataToParse: string): string | undefined {
-  if (typeof dataToParse !== 'string') {
-    return undefined;
+function isDigit(character: string | undefined): boolean {
+  return character !== undefined && character >= '0' && character <= '9';
+}
+
+function isNonZeroDigit(character: string | undefined): boolean {
+  return character !== undefined && character >= '1' && character <= '9';
+}
+
+function copyJsonString(data: string, start: number): [string, number] {
+  let cursor = start + 1;
+
+  while (cursor < data.length) {
+    const character = data[cursor];
+
+    if (character === '\\') {
+      cursor += 2;
+      continue;
+    }
+
+    cursor += 1;
+
+    if (character === '"') {
+      break;
+    }
   }
-  return dataToParse.match(REGEX_MESSAGE_VALUE_LARGE)?.[1];
+
+  return [data.slice(start, cursor), cursor];
+}
+
+function copyJsonNumber(data: string, start: number): [string, number] {
+  let cursor = start;
+
+  if (data[cursor] === '-') {
+    cursor += 1;
+  }
+
+  const integerStart = cursor;
+
+  if (data[cursor] === '0') {
+    cursor += 1;
+  } else if (isNonZeroDigit(data[cursor])) {
+    while (isDigit(data[cursor])) {
+      cursor += 1;
+    }
+  } else {
+    return [data[start], start + 1];
+  }
+
+  const integerEnd = cursor;
+  let hasFractionOrExponent = false;
+
+  if (data[cursor] === '.') {
+    hasFractionOrExponent = true;
+    cursor += 1;
+
+    while (isDigit(data[cursor])) {
+      cursor += 1;
+    }
+  }
+
+  if (data[cursor] === 'e' || data[cursor] === 'E') {
+    hasFractionOrExponent = true;
+    cursor += 1;
+
+    if (data[cursor] === '+' || data[cursor] === '-') {
+      cursor += 1;
+    }
+
+    while (isDigit(data[cursor])) {
+      cursor += 1;
+    }
+  }
+
+  const rawNumber = data.slice(start, cursor);
+  const digitCount = integerEnd - integerStart;
+
+  if (!hasFractionOrExponent && digitCount >= LARGE_INTEGER_DIGIT_COUNT) {
+    return [`"${rawNumber}"`, cursor];
+  }
+
+  return [rawNumber, cursor];
+}
+
+function quoteLargeJsonIntegers(data: string): string {
+  let result = '';
+  let cursor = 0;
+
+  while (cursor < data.length) {
+    const character = data[cursor];
+
+    if (character === '"') {
+      const [jsonString, nextCursor] = copyJsonString(data, cursor);
+      result += jsonString;
+      cursor = nextCursor;
+      continue;
+    }
+
+    if (character === '-' || isDigit(character)) {
+      const [jsonNumber, nextCursor] = copyJsonNumber(data, cursor);
+      result += jsonNumber;
+      cursor = nextCursor;
+      continue;
+    }
+
+    result += character;
+    cursor += 1;
+  }
+
+  return result;
 }
 
 /**
@@ -354,8 +451,8 @@ function extractLargeMessageValue(dataToParse: string): string | undefined {
  * Note that using JSON.parse reviver cannot help since the value will be coerced by the time it
  * reaches the reviver function.
  *
- * This function has a workaround to extract the large value from the message and replace
- * the message value with the string value.
+ * This function has a workaround to quote large integer JSON tokens before parsing so
+ * they are represented as strings instead of precision-losing JavaScript numbers.
  *
  * @param dataToParse
  * @returns
@@ -364,14 +461,12 @@ export const parseTypedDataMessage = (dataToParse: DataMessageParam) => {
   const result =
     typeof dataToParse === 'object'
       ? dataToParse
-      : JSON.parse(String(dataToParse));
-
-  const messageValue = extractLargeMessageValue(String(dataToParse));
+      : JSON.parse(quoteLargeJsonIntegers(String(dataToParse)));
 
   if (result.message?.value) {
     // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    result.message.value = messageValue || String(result.message.value);
+    result.message.value = String(result.message.value);
   }
 
   return result;


### PR DESCRIPTION
## **Description**

Replaces the regex-based `message.value` extraction in typed-data parsing with a JSON-token pre-pass that preserves bare large integer values before native JSON parsing. This keeps Permit confirmation display values tied to parsed JSON semantics instead of raw-text regex matches, including sibling duplicate-key and escaped-key decoy patterns that bypassed the hardening from https://github.com/MetaMask/metamask-extension/pull/40477.

This addresses the reported regex-selected decoy display path for "EIP-712 Permit confirmation displays decoy value while signing attacker-controlled amount (bypasses PR #40477 fix, v13.26.0)" and adds regression coverage for sibling-key variants.

## **Changelog**

CHANGELOG entry: Fixed EIP-712 Permit confirmation parsing to prevent decoy spending cap values from being displayed.

## **Related issues**

Fixes: N/A
Refs: https://github.com/MetaMask/pm-security/issues/660
Refs: https://github.com/MetaMask/MetaMask-planning/issues/7056
Refs: https://github.com/MetaMask/metamask-extension/pull/40477
HackerOne: https://hackerone.com/reports/3691951
Team communications: https://consensys.slack.com/archives/C0318JSUBM3/p1777283918500609

## **Manual testing steps**

1. Run `yarn lint:changed:fix`.
2. Run `./node_modules/.bin/jest --config jest.config.js --watchman=false shared/lib/transaction.utils.test.js`.
3. Run `yarn webpack-cli build --config ./development/webpack/webpack.integration.tests.config.ts`.
4. Run `./node_modules/.bin/jest --config jest.integration.config.js --watchman=false test/integration/confirmations/signatures/permit.test.tsx`.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes security-sensitive EIP-712 typed-data parsing by introducing a custom JSON token pre-pass that rewrites numeric literals, which could affect how dapp-supplied messages are interpreted/displayed. While covered by new regression tests, any edge-case JSON formatting differences could impact signature confirmation and value rendering.
> 
> **Overview**
> Replaces the regex-based extraction of `message.value` in `parseTypedDataMessage` with a lightweight JSON token pre-pass (`quoteLargeJsonIntegers`) that **quotes large integer literals (15+ digits) before `JSON.parse`** to avoid precision loss and BigNumber failures.
> 
> This shifts spoofing resistance to match *actual JSON parsing semantics* (e.g., duplicate/escaped keys resolve to the last decoded key) and expands test coverage for sibling duplicate-key/escaped-key decoy patterns, plus a regression ensuring large integers elsewhere in the message (e.g., `message.details.amount`) are preserved as strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11ab492b10f60d6145479daea9b0f4a3ca46ff67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->