### PR TITLE
fix: added scroll to manage srp settings page

### DIFF
--- a/ui/components/multichain/multi-srp/srp-list/index.scss
+++ b/ui/components/multichain/multi-srp/srp-list/index.scss
@@ -4,11 +4,6 @@
   &__container {
     max-height: 500px;
     overflow-y: auto;
-
-    &--settings {
-      max-height: unset;
-      overflow-y: visible;
-    }
   }
 
   &__divider {

--- a/ui/components/multichain/multi-srp/srp-list/srp-card.test.tsx
+++ b/ui/components/multichain/multi-srp/srp-list/srp-card.test.tsx
@@ -53,7 +53,10 @@ const mockSecondHdKeyring = {
   },
 };
 
-const render = (shouldTriggerBackup: boolean) => {
+const render = (
+  shouldTriggerBackup: boolean,
+  { isSettingsPage = false }: { isSettingsPage?: boolean } = {},
+) => {
   const store = configureMockStore([thunk])({
     ...mockState,
     metamask: {
@@ -70,6 +73,7 @@ const render = (shouldTriggerBackup: boolean) => {
       walletId={mockWalletId}
       shouldTriggerBackup={shouldTriggerBackup}
       onActionComplete={mocks.onActionComplete}
+      isSettingsPage={isSettingsPage}
     />,
     store,
   );
@@ -102,5 +106,13 @@ describe('SrpCard', () => {
     fireEvent.click(keyring);
 
     expect(mocks.onActionComplete).toHaveBeenCalledWith(firstKeyringId, true);
+  });
+
+  it('renders expanded account rows on settings page', () => {
+    const { getByText } = render(false, { isSettingsPage: true });
+
+    fireEvent.click(getByText(messages.SrpListShowSingleAccount.message));
+
+    expect(getByText('Mock Account 1')).toBeInTheDocument();
   });
 });

--- a/ui/components/multichain/multi-srp/srp-list/srp-list.tsx
+++ b/ui/components/multichain/multi-srp/srp-list/srp-list.tsx
@@ -28,9 +28,18 @@ export const SrpList = ({
   return (
     <Box
       className={classnames('srp-list__container', {
-        'srp-list__container--settings': isSettingsPage,
+        'min-h-0': isSettingsPage,
       })}
       padding={isSettingsPage ? 0 : 4}
+      style={
+        isSettingsPage
+          ? {
+              maxHeight: '100%',
+              minHeight: 0,
+              overflowY: 'auto',
+            }
+          : undefined
+      }
       data-testid="srp-list"
     >
       {entropyWalletIds.map((walletId, index) => {

--- a/ui/pages/settings/security-tab/reveal-srp-list/reveal-srp-list.tsx
+++ b/ui/pages/settings/security-tab/reveal-srp-list/reveal-srp-list.tsx
@@ -65,7 +65,7 @@ export const RevealSrpList = () => {
   };
 
   return (
-    <Box className="srp-reveal-list">
+    <Box className="srp-reveal-list h-full min-h-0 overflow-y-auto">
       {isSocialLoginFlow && (
         <Box paddingTop={4} paddingLeft={4} paddingRight={4}>
           <Text


### PR DESCRIPTION
This PR fixes the scroll in the srp settings page when user has a long list of accounts

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: #42148 

## **Manual testing steps**

1. Import an SRP with multiple accounts (>30)
2. Go to Security and password > Manage wallet recovery
3. Click Show accounts
4. check scroll is working properly

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/9d3795b3-cb0d-44de-a0b9-d30c46e50616



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that tweaks container sizing/overflow behavior for SRP lists; main risk is unintended layout/scroll regressions in other views using `SrpList`.
> 
> **Overview**
> Fixes SRP management page scrolling by changing how the SRP list containers size and overflow.
> 
> `SrpList` drops the SCSS `--settings` modifier and instead applies settings-specific `maxHeight/minHeight` + `overflowY: auto` (and `min-h-0`) so long account lists scroll correctly. The security settings `RevealSrpList` wrapper is also made scrollable (`h-full min-h-0 overflow-y-auto`).
> 
> Updates `SrpCard` tests to pass `isSettingsPage` through the shared render helper and adds coverage that account rows expand correctly on the settings page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cbf336fb3a24406e78ebfd8ea15a5aae109912d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->