### PR TITLE
feat: tempo disable tx management for testnet moderato

### DIFF
--- a/app/scripts/lib/transaction/tempo-tx-utils.test.ts
+++ b/app/scripts/lib/transaction/tempo-tx-utils.test.ts
@@ -195,8 +195,8 @@ describe('tempo-tx-utils', () => {
     it('return true for Tempo Mainnet', () => {
       expect(isTempoChain('0x1079')).toBe(true);
     });
-    it('return true for Tempo Moderato Testnet', () => {
-      expect(isTempoChain('0xa5bf')).toBe(true);
+    it('return false for Tempo Moderato Testnet', () => {
+      expect(isTempoChain('0xa5bf')).toBe(false);
     });
     it('return false for Polygon Mainnet', () => {
       expect(isTempoChain('0x89')).toBe(false);

--- a/app/scripts/lib/transaction/tempo-tx-utils.ts
+++ b/app/scripts/lib/transaction/tempo-tx-utils.ts
@@ -26,12 +26,6 @@ const TEMPO_CONFIG: TempoConfig = {
         symbol: 'pathUSD',
       },
     },
-    '0xa5bf': {
-      defaultFeeToken: {
-        address: '0x20c0000000000000000000000000000000000000',
-        symbol: 'pathUSD',
-      },
-    },
   },
 } as const;
 

--- a/app/scripts/lib/transaction/util.test.ts
+++ b/app/scripts/lib/transaction/util.test.ts
@@ -119,7 +119,7 @@ const TEMPO_EXPECTED_TRANSACTIONS_FOR_VALID_CALLS_FIELD = [
 
 const TEMPO_FEE_TOKEN_MOCK = '0xtempoFeeToken';
 
-const TEMPO_VALID_CHAIN_ID = '0xa5bf' as Hex;
+const TEMPO_VALID_CHAIN_ID = '0x1079' as Hex;
 
 const TEMPO_TRANSACTION_PARAMS_MOCK = {
   type: '0x76' as const,
@@ -839,7 +839,7 @@ describe('Transaction Utils', () => {
       it('adds transaction with extra Tempo-specific params', async () => {
         await addDappTransaction({
           ...dappRequest,
-          chainId: '0xa5bf',
+          chainId: '0x1079',
         });
 
         expect(
@@ -868,7 +868,7 @@ describe('Transaction Utils', () => {
         await addDappTransaction({
           ...dappRequest,
           transactionParams: transactionParamsMockWithoutTo,
-          chainId: '0xa5bf',
+          chainId: '0x1079',
         });
 
         expect(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Sentinel is not enabled for Tempo Moderato Testnet on `prod`, making the 7702-leveraged flow fail on that testnet.
This PR disables Tempo tx transformation for Tempo Moderato Testnet, while preserving the asset-hiding logic.
Limitations will be the same as for Hardware Wallet: `pathUSD` will always show as fee token for all txs.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: tempo disable tx management for testnet moderato

## **Related issues**

Fixes:

## **Manual testing steps**

1. Switch to Tempo Moderato Testnet.
2. Perform a "send" of any token.
3. Observe that tx with be announced as paid with `pathUSD` regardless of user holding.
4. The tx should go through as long as the user has `pathUSD` balance.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
<img width="300"  alt="image" src="https://github.com/user-attachments/assets/0385773f-4dc4-4fd5-923d-c86fa1383948" />

### **After**

<img width="300" alt="image" src="https://github.com/user-attachments/assets/da0b8168-ac89-4ae3-a0eb-c61bb1b9ca50" />


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which chain IDs are treated as Tempo-supported, disabling Tempo-specific transaction options/batching on `0xa5bf`; incorrect chain gating could impact transaction submission behavior on that network.
> 
> **Overview**
> Disables Tempo transaction management on Tempo Moderato Testnet by removing `0xa5bf` from the Tempo per-chain configuration, making `isTempoChain` return false for that chain.
> 
> Updates unit tests to reflect the new chain gating, and switches Tempo-related transaction tests to use Tempo Mainnet (`0x1079`) when asserting Tempo-specific extra options are applied.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d47e1e9e25181d3de4170e98381599aa859f641. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->