### PR TITLE
fix: size MM Pay amount input to actual rendered text to stop decimal clipping

### DIFF
--- a/ui/pages/confirmations/components/transactions/custom-amount/custom-amount.test.tsx
+++ b/ui/pages/confirmations/components/transactions/custom-amount/custom-amount.test.tsx
@@ -138,13 +138,24 @@ describe('CustomAmount', () => {
     expect(amountElement).toHaveStyle({ fontSize: '64px' });
   });
 
-  it('does not include decimal separators when calculating input width', () => {
+  it('mirrors the typed value in a hidden sizer span so the input width matches the rendered text exactly', () => {
     const store = mockStore(getMockState());
 
     renderWithProvider(<CustomAmount amountFiat="1.33" />, store);
 
-    const amountElement = screen.getByTestId('custom-amount-input');
-    expect(amountElement).toHaveStyle({ width: '3ch' });
+    const sizer = screen.getByTestId('custom-amount-input-sizer');
+    expect(sizer).toHaveTextContent('1.33');
+    expect(sizer).toHaveStyle({ visibility: 'hidden' });
+    expect(sizer).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('falls back to "0" in the sizer when amount is empty so the input keeps a visible width', () => {
+    const store = mockStore(getMockState());
+
+    renderWithProvider(<CustomAmount amountFiat="" />, store);
+
+    const sizer = screen.getByTestId('custom-amount-input-sizer');
+    expect(sizer).toHaveTextContent('0');
   });
 });
 

--- a/ui/pages/confirmations/components/transactions/custom-amount/custom-amount.tsx
+++ b/ui/pages/confirmations/components/transactions/custom-amount/custom-amount.tsx
@@ -94,7 +94,6 @@ export const CustomAmount: React.FC<CustomAmountProps> = React.memo(
     const currency = currencyProp ?? selectedCurrency;
     const fiatSymbol = getCurrencySymbol(currency);
     const amountLength = amountFiat.length;
-    const amountCharacterLength = amountFiat.replaceAll(/[.,]/gu, '').length;
 
     const showLoader = isLoading || (isMaxAmount && isQuotesLoading);
 
@@ -133,28 +132,45 @@ export const CustomAmount: React.FC<CustomAmountProps> = React.memo(
         >
           {fiatSymbol}
         </Text>
-        <input
-          data-testid="custom-amount-input"
-          type="text"
-          inputMode="decimal"
-          value={amountFiat}
-          onChange={handleChange}
-          disabled={disabled}
-          style={
-            {
+        <span style={{ position: 'relative', display: 'inline-block' }}>
+          <span
+            data-testid="custom-amount-input-sizer"
+            aria-hidden="true"
+            style={{
               fontSize,
               lineHeight,
               fontWeight: 500,
-              color: textColor ? `var(--color-${textColor})` : 'inherit',
-              textAlign: 'left',
-              border: 'none',
-              background: 'transparent',
-              outline: 'none',
-              width: `${Math.max(1, amountCharacterLength)}ch`,
-              cursor: disabled ? 'default' : 'text',
-            } as React.CSSProperties
-          }
-        />
+              visibility: 'hidden',
+              whiteSpace: 'pre',
+            }}
+          >
+            {amountFiat || '0'}
+          </span>
+          <input
+            data-testid="custom-amount-input"
+            type="text"
+            inputMode="decimal"
+            value={amountFiat}
+            onChange={handleChange}
+            disabled={disabled}
+            style={
+              {
+                position: 'absolute',
+                inset: 0,
+                fontSize,
+                lineHeight,
+                fontWeight: 500,
+                color: textColor ? `var(--color-${textColor})` : 'inherit',
+                textAlign: 'left',
+                border: 'none',
+                background: 'transparent',
+                outline: 'none',
+                padding: 0,
+                cursor: disabled ? 'default' : 'text',
+              } as React.CSSProperties
+            }
+          />
+        </span>
       </Box>
     );
   },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The `width` of the MetaMask Pay custom amount input was computed in `ch` units derived from the typed value. Two prior implementations both produced visible bugs:
- `${amountFiat.replaceAll(/[.,]/gu, '').length}ch` — stripping decimal separators when sizing meant the input was undersized whenever the user typed a `.` or `,`, **clipping** the value (e.g. typing `0.31` rendered a clipped `0.31` because the input was only `3ch` wide). Introduced in #41838.
- `${amountFiat.length}ch` — counting all characters fixed the clipping but oversized the input, because `1ch` is the width of the digit `0` and `.` / `,` are narrower. The cursor sat in a visible gap past the last digit.
This PR removes both heuristics and instead pairs the `<input>` with a hidden mirror `<span>` overlay sibling that renders the same value with the same `font-size`, `line-height` and `font-weight`, then positions the input absolutely (`inset: 0`) on top of it. The input width therefore always matches the exact rendered glyph width of the typed value — no clipping when typing decimals, no visible cursor gap, no per-character heuristic to keep in sync with the font.
**Affected flows**
- mUSD conversion (`Convert and get 3%`)
- MetaMask Pay deposit (`Add funds`)
**Why a mirror span instead of a `ResizeObserver` / canvas-measure / character-table approach**
- Pure CSS, zero JS measurement, zero re-layout work.
- Always correct regardless of font / locale / theme — the browser renders the same glyphs in both elements with identical typography.
- No additional rules to keep in sync between `getFontSize` / `getLineHeight` and width calculation.



<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug where typing a decimal point in the amount input on MetaMask Pay screens caused the rendered value to be visually clipped

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1194

## **Manual testing steps**

1. Open a MetaMask Pay flow with a custom amount input — for example mUSD `Convert and get 3%` or MM Pay `Add funds`.
2. With the input focused, type `0.31`.
3. Confirm the full value `0.31` is visible and **not clipped**, and the caret sits immediately after the final digit (no visible gap).
4. Repeat with `0.` (typing only the separator) — the `.` should remain visible.
5. Repeat with a longer amount such as `12345678.90` — value renders fully and the caret sits flush after the last digit.
6. Sanity check: a regular integer amount such as `100` still renders correctly with no extra trailing space.



## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="567" height="1085" alt="not-aligned" src="https://github.com/user-attachments/assets/27137df5-5187-40d7-9d69-b6b3b32167b9" />


<!-- [screenshots/recordings] -->

### **After**

<img width="567" height="1081" alt="algined" src="https://github.com/user-attachments/assets/ffcb143a-bfab-4d6d-9470-587523d0171b" />

[aligned.webm](https://github.com/user-attachments/assets/2910153c-744a-4d26-9913-84a981c936a6)


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
