### PR TITLE
test: add local Bitcoin node send e2e

### DIFF
--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -228,6 +228,14 @@ async function withFixtures(options, testSuite) {
           localNodes.push(localNode);
           break;
 
+        case 'bitcoin':
+          // eslint-disable-next-line n/global-require, no-case-declarations -- load this module conditionally
+          const { BitcoinNode } = require('./seeder/bitcoin/node');
+          localNode = new BitcoinNode();
+          await localNode.start(nodeOptions);
+          localNodes.push(localNode);
+          break;
+
         case 'none':
           break;
 
@@ -349,12 +357,16 @@ async function withFixtures(options, testSuite) {
       getPrivacyReport,
       getNetworkReport,
       clearNetworkReport,
-    } = await mockingSetupFunction(mockServer, testSpecificMock, {
-      chainId: localNodeOptsNormalized[0]?.options.chainId || 1337,
-      ethConversionInUsd,
-      monConversionInUsd,
-      unifiedEvmAccountsApiBalances,
-    });
+    } = await mockingSetupFunction(
+      mockServer,
+      (server) => testSpecificMock(server, { localNodes }),
+      {
+        chainId: localNodeOptsNormalized[0]?.options.chainId || 1337,
+        ethConversionInUsd,
+        monConversionInUsd,
+        unifiedEvmAccountsApiBalances,
+      },
+    );
 
     if ((await detectPort(8000)) !== 8000) {
       throw new Error(

--- a/test/e2e/helpers/bitcoin-node.test.ts
+++ b/test/e2e/helpers/bitcoin-node.test.ts
@@ -1,0 +1,99 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import {
+  bitcoinToSatoshis,
+  createEsploraTransaction,
+  scriptPubKeyToScriptHash,
+} from '../seeder/bitcoin/node';
+
+describe('BitcoinNode helpers', () => {
+  describe('bitcoinToSatoshis', () => {
+    it('converts BTC values from bitcoind RPC responses to satoshis', () => {
+      expect(bitcoinToSatoshis(1.23456789)).toBe(123456789);
+    });
+  });
+
+  describe('scriptPubKeyToScriptHash', () => {
+    it('returns the SHA-256 hash used by Esplora scripthash endpoints', () => {
+      expect(
+        scriptPubKeyToScriptHash(
+          '0014469d76e8387e11cbe9010c72ee4b748dd9152fa5',
+        ),
+      ).toBe(
+        '538c172f4f5ff9c24693359c4cdc8ee4666565326a789d5e4b2df1db7acb4721',
+      );
+    });
+  });
+
+  describe('createEsploraTransaction', () => {
+    it('maps bitcoind verbose transaction output to the Esplora transaction shape', () => {
+      const transaction = createEsploraTransaction({
+        blockhash: '0'.repeat(64),
+        confirmations: 1,
+        hash: '1'.repeat(64),
+        hex: '02000000000100',
+        locktime: 0,
+        size: 110,
+        time: 1710000000,
+        txid: '2'.repeat(64),
+        version: 2,
+        vin: [
+          {
+            sequence: 4294967295,
+            txid: '3'.repeat(64),
+            vout: 0,
+          },
+        ],
+        vout: [
+          {
+            n: 0,
+            scriptPubKey: {
+              address: 'bcrt1qg6whd6pc0cguh6gpp3ewujm53hv32ta9n4k6m7',
+              asm: '0 469d76e8387e11cbe9010c72ee4b748dd9152fa5',
+              hex: '0014469d76e8387e11cbe9010c72ee4b748dd9152fa5',
+              type: 'witness_v0_keyhash',
+            },
+            value: 0.25,
+          },
+        ],
+        vsize: 82,
+        weight: 328,
+      });
+
+      expect(transaction).toStrictEqual({
+        fee: 0,
+        locktime: 0,
+        size: 110,
+        status: {
+          block_hash: '0'.repeat(64),
+          block_time: 1710000000,
+          confirmed: true,
+        },
+        txid: '2'.repeat(64),
+        version: 2,
+        vin: [
+          {
+            is_coinbase: false,
+            prevout: null,
+            scriptsig: '',
+            scriptsig_asm: '',
+            sequence: 4294967295,
+            txid: '3'.repeat(64),
+            vout: 0,
+            witness: [],
+          },
+        ],
+        vout: [
+          {
+            scriptpubkey: '0014469d76e8387e11cbe9010c72ee4b748dd9152fa5',
+            scriptpubkey_address: 'bc1qg6whd6pc0cguh6gpp3ewujm53hv32ta9hdp252',
+            scriptpubkey_asm:
+              'OP_0 OP_PUSHBYTES_20 469d76e8387e11cbe9010c72ee4b748dd9152fa5',
+            scriptpubkey_type: 'v0_p2wpkh',
+            value: 25000000,
+          },
+        ],
+        weight: 328,
+      });
+    });
+  });
+});

--- a/test/e2e/page-objects/pages/send/bitcoin-review-tx-page.ts
+++ b/test/e2e/page-objects/pages/send/bitcoin-review-tx-page.ts
@@ -19,6 +19,10 @@ class BitcoinReviewTxPage {
         this.cancelButton,
         this.confirmButton,
       ]);
+      await this.driver.waitForSelector({
+        text: 'Transaction request',
+        tag: 'h2',
+      });
     } catch (e) {
       console.log(
         'Timeout while waiting for bitcoin review tx page to be loaded',
@@ -48,10 +52,8 @@ class BitcoinReviewTxPage {
     console.log(
       `Check if send amount ${amount} is displayed on bitcoin review tx page`,
     );
-    await this.driver.waitForSelector({
-      text: `-${amount} BTC`,
-      tag: 'p',
-    });
+    await this.waitForBodyText(`-${amount}`, 30_000);
+    await this.waitForBodyText('BTC', 30_000);
   }
 
   async checkTotalAmountIsDisplayed(total: string): Promise<void> {
@@ -62,6 +64,19 @@ class BitcoinReviewTxPage {
       text: `${total} USD`,
       tag: 'p',
     });
+  }
+
+  private async waitForBodyText(text: string, timeout: number): Promise<void> {
+    await this.driver.wait(
+      async () =>
+        Boolean(
+          await this.driver.executeScript(
+            'return document.body?.innerText.includes(arguments[0][0]);',
+            text,
+          ),
+        ),
+      timeout,
+    );
   }
 }
 

--- a/test/e2e/seeder/bitcoin/node.ts
+++ b/test/e2e/seeder/bitcoin/node.ts
@@ -1,0 +1,782 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { createHash } from 'crypto';
+import {
+  spawn,
+  execFileSync,
+  ChildProcessWithoutNullStreams,
+} from 'child_process';
+import { promises as fs } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { AddressInfo, createServer } from 'net';
+import {
+  DEFAULT_BTC_ADDRESS,
+  DEFAULT_BTC_BALANCE,
+  DEFAULT_BTC_FEE_RATE,
+} from '../../constants';
+
+const BITCOIN_WALLET_NAME = 'metamask-e2e';
+const DEFAULT_DOCKER_IMAGE = 'bitcoin/bitcoin:28.0';
+const DEFAULT_BTC_SCRIPT_PUBKEY =
+  '0014469d76e8387e11cbe9010c72ee4b748dd9152fa5';
+const MAINNET_GENESIS_BLOCK_HASH =
+  '000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f';
+
+export type BitcoinLocalNodeOptions = {
+  binaryPath?: string;
+  dockerImage?: string;
+  initialBalance?: number;
+  p2pPort?: number;
+  rpcPassword?: string;
+  rpcPort?: number;
+  rpcUser?: string;
+  useDocker?: boolean;
+};
+
+type BitcoinRpcError = {
+  code: number;
+  message: string;
+};
+
+type BitcoinRpcResponse<TResult> = {
+  error: BitcoinRpcError | null;
+  result: TResult;
+};
+
+type BitcoinBlock = {
+  bits: string;
+  difficulty: number;
+  hash: string;
+  height: number;
+  mediantime: number;
+  merkleroot: string;
+  nonce: number;
+  previousblockhash?: string;
+  size: number;
+  time: number;
+  tx: string[];
+  version: number;
+  weight: number;
+};
+
+type BitcoinScriptPubKey = {
+  address?: string;
+  asm: string;
+  desc?: string;
+  hex: string;
+  type: string;
+};
+
+export type BitcoinVerboseTransaction = {
+  blockhash?: string;
+  confirmations?: number;
+  fee?: number;
+  hash: string;
+  hex: string;
+  locktime: number;
+  size: number;
+  time?: number;
+  txid: string;
+  version: number;
+  vin: {
+    coinbase?: string;
+    sequence: number;
+    scriptSig?: {
+      asm: string;
+      hex: string;
+    };
+    txid?: string;
+    txinwitness?: string[];
+    vout?: number;
+  }[];
+  vout: {
+    n: number;
+    scriptPubKey: BitcoinScriptPubKey;
+    value: number;
+  }[];
+  vsize: number;
+  weight: number;
+};
+
+type EsploraTransactionInput = {
+  is_coinbase: boolean;
+  prevout: EsploraTransactionOutput | null;
+  scriptsig: string;
+  scriptsig_asm: string;
+  sequence: number;
+  txid?: string;
+  vout?: number;
+  witness: string[];
+};
+
+type EsploraTransactionOutput = {
+  scriptpubkey: string;
+  scriptpubkey_address?: string;
+  scriptpubkey_asm: string;
+  scriptpubkey_type: string;
+  value: number;
+};
+
+type EsploraTransaction = {
+  fee: number;
+  locktime: number;
+  size: number;
+  status: {
+    block_hash?: string;
+    block_height?: number;
+    block_time?: number;
+    confirmed: boolean;
+  };
+  txid: string;
+  version: number;
+  vin: EsploraTransactionInput[];
+  vout: EsploraTransactionOutput[];
+  weight: number;
+};
+
+type EsploraUtxo = {
+  status: EsploraTransaction['status'];
+  txid: string;
+  value: number;
+  vout: number;
+};
+
+type EsploraOutspend = {
+  spent: boolean;
+  status?: EsploraTransaction['status'];
+  txid?: string;
+  vin?: number;
+};
+
+export function bitcoinToSatoshis(value: number): number {
+  return Math.round(value * 100_000_000);
+}
+
+export function scriptPubKeyToScriptHash(scriptPubKey: string): string {
+  return createHash('sha256')
+    .update(Buffer.from(scriptPubKey, 'hex'))
+    .digest('hex');
+}
+
+export function createEsploraTransaction(
+  transaction: BitcoinVerboseTransaction,
+  options: {
+    blockHeight?: number;
+    fee?: number;
+    prevouts?: Map<string, EsploraTransactionOutput>;
+  } = {},
+): EsploraTransaction {
+  const { blockHeight, fee = 0, prevouts = new Map() } = options;
+
+  return {
+    fee,
+    locktime: transaction.locktime,
+    size: transaction.size,
+    status: {
+      ...(transaction.blockhash ? { block_hash: transaction.blockhash } : {}),
+      ...(blockHeight ? { block_height: blockHeight } : {}),
+      ...(transaction.time ? { block_time: transaction.time } : {}),
+      confirmed: Boolean(transaction.confirmations),
+    },
+    txid: transaction.txid,
+    version: transaction.version,
+    vin: transaction.vin.map((input) => {
+      const prevoutKey =
+        input.txid && input.vout !== undefined
+          ? createOutpoint(input.txid, input.vout)
+          : undefined;
+
+      return {
+        is_coinbase: Boolean(input.coinbase),
+        prevout: prevoutKey ? (prevouts.get(prevoutKey) ?? null) : null,
+        scriptsig: input.scriptSig?.hex ?? '',
+        scriptsig_asm: input.scriptSig?.asm ?? '',
+        sequence: input.sequence,
+        ...(input.txid ? { txid: input.txid } : {}),
+        ...(input.vout === undefined ? {} : { vout: input.vout }),
+        witness: input.txinwitness ?? [],
+      };
+    }),
+    vout: transaction.vout.map((output) =>
+      createEsploraTransactionOutput(output),
+    ),
+    weight: transaction.weight,
+  };
+}
+
+function createEsploraBlock(block: BitcoinBlock) {
+  return {
+    bits: Number.parseInt(block.bits, 16),
+    difficulty: block.difficulty,
+    height: block.height,
+    id: block.hash,
+    mediantime: block.mediantime,
+    merkle_root: block.merkleroot,
+    nonce: block.nonce,
+    previousblockhash: block.previousblockhash,
+    size: block.size,
+    timestamp: block.time,
+    tx_count: block.tx.length,
+    version: block.version,
+    weight: block.weight,
+  };
+}
+
+function createEsploraTransactionOutput(output: {
+  scriptPubKey: BitcoinScriptPubKey;
+  value: number;
+}): EsploraTransactionOutput {
+  const { scriptPubKey } = output;
+  return {
+    scriptpubkey: scriptPubKey.hex,
+    scriptpubkey_address:
+      scriptPubKey.hex === DEFAULT_BTC_SCRIPT_PUBKEY
+        ? DEFAULT_BTC_ADDRESS
+        : scriptPubKey.address,
+    scriptpubkey_asm: normalizeScriptPubKeyAsm(scriptPubKey),
+    scriptpubkey_type: normalizeScriptPubKeyType(scriptPubKey.type),
+    value: bitcoinToSatoshis(output.value),
+  };
+}
+
+function createOutpoint(txid: string, vout: number): string {
+  return `${txid}:${vout}`;
+}
+
+function normalizeScriptPubKeyAsm(scriptPubKey: BitcoinScriptPubKey): string {
+  if (scriptPubKey.hex.startsWith('0014')) {
+    return `OP_0 OP_PUSHBYTES_20 ${scriptPubKey.hex.slice(4)}`;
+  }
+
+  return scriptPubKey.asm;
+}
+
+function normalizeScriptPubKeyType(type: string): string {
+  if (type === 'witness_v0_keyhash') {
+    return 'v0_p2wpkh';
+  }
+
+  if (type === 'witness_v1_taproot') {
+    return 'v1_p2tr';
+  }
+
+  return type;
+}
+
+async function findAvailablePort(preferredPort?: number): Promise<number> {
+  const server = createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(preferredPort ?? 0, '127.0.0.1', resolve);
+  });
+  const { port } = server.address() as AddressInfo;
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+  return port;
+}
+
+async function wait(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export class BitcoinNode {
+  #containerName: string | undefined;
+
+  #dataDir: string | undefined;
+
+  #fundingTxId: string | undefined;
+
+  #process: ChildProcessWithoutNullStreams | undefined;
+
+  #rpcPassword = 'metamask-e2e-pass';
+
+  #rpcPort = 18443;
+
+  #rpcUser = 'metamask-e2e-user';
+
+  #stderr = '';
+
+  readonly #broadcastTxIds = new Set<string>();
+
+  readonly #targetScriptPubKey = DEFAULT_BTC_SCRIPT_PUBKEY;
+
+  async start(options: BitcoinLocalNodeOptions = {}): Promise<void> {
+    this.#rpcPort = await findAvailablePort(options.rpcPort);
+    const p2pPort = await findAvailablePort(options.p2pPort);
+    this.#rpcUser = options.rpcUser ?? this.#rpcUser;
+    this.#rpcPassword = options.rpcPassword ?? this.#rpcPassword;
+
+    if (options.useDocker ?? !options.binaryPath) {
+      this.startDockerNode(options.dockerImage ?? DEFAULT_DOCKER_IMAGE);
+    } else {
+      await this.startHostNode(options.binaryPath, p2pPort);
+    }
+
+    await this.waitForReady();
+    await this.createWallet();
+    await this.fundDefaultAccount(
+      options.initialBalance ?? DEFAULT_BTC_BALANCE,
+    );
+  }
+
+  async broadcastTransaction(rawTransaction: string): Promise<string> {
+    const txId = await this.rpc<string>('sendrawtransaction', [rawTransaction]);
+    this.#broadcastTxIds.add(txId);
+    return txId;
+  }
+
+  async getBlock(blockHash: string) {
+    const block = await this.rpc<BitcoinBlock>('getblock', [blockHash, 1]);
+    return createEsploraBlock(block);
+  }
+
+  async getBlockHash(height: number): Promise<string> {
+    if (height === 0) {
+      return MAINNET_GENESIS_BLOCK_HASH;
+    }
+
+    return await this.rpc<string>('getblockhash', [height]);
+  }
+
+  async getBlocks(): Promise<ReturnType<typeof createEsploraBlock>[]> {
+    const tipHeight = await this.getTipHeight();
+    const blockCount = Math.min(tipHeight + 1, 10);
+    const blocks = [];
+
+    for (let height = tipHeight; height > tipHeight - blockCount; height--) {
+      const blockHash = await this.rpc<string>('getblockhash', [height]);
+      const block = await this.rpc<BitcoinBlock>('getblock', [blockHash, 1]);
+      blocks.push(createEsploraBlock(block));
+    }
+
+    return blocks;
+  }
+
+  async getFeeEstimates(): Promise<Record<string, number>> {
+    return {
+      '1': DEFAULT_BTC_FEE_RATE,
+      '2': DEFAULT_BTC_FEE_RATE,
+      '3': DEFAULT_BTC_FEE_RATE,
+      '4': DEFAULT_BTC_FEE_RATE,
+      '6': DEFAULT_BTC_FEE_RATE,
+      '10': DEFAULT_BTC_FEE_RATE,
+      '144': DEFAULT_BTC_FEE_RATE,
+    };
+  }
+
+  async getOutspends(txId: string): Promise<EsploraOutspend[]> {
+    const transaction = await this.getVerboseTransaction(txId);
+
+    return await Promise.all(
+      transaction.vout.map(async (output) => {
+        const unspent = await this.rpc<unknown>('gettxout', [
+          txId,
+          output.n,
+          true,
+        ]);
+        if (unspent) {
+          return { spent: false };
+        }
+
+        const spender = await this.findSpendingTransaction(txId, output.n);
+        if (!spender) {
+          return { spent: true };
+        }
+
+        return {
+          spent: true,
+          status: spender.status,
+          txid: spender.txid,
+          vin: spender.vin.findIndex(
+            (input) => input.txid === txId && input.vout === output.n,
+          ),
+        };
+      }),
+    );
+  }
+
+  async getScriptHashTransactions(
+    scriptHash: string,
+  ): Promise<EsploraTransaction[]> {
+    if (scriptHash !== this.targetScriptHash) {
+      return [];
+    }
+
+    const txIds = [
+      ...(this.#fundingTxId ? [this.#fundingTxId] : []),
+      ...this.#broadcastTxIds,
+    ];
+
+    return await Promise.all(txIds.map((txId) => this.getTransaction(txId)));
+  }
+
+  async getScriptHashUtxos(scriptHash: string): Promise<EsploraUtxo[]> {
+    if (scriptHash !== this.targetScriptHash || !this.#fundingTxId) {
+      return [];
+    }
+
+    const transaction = await this.getVerboseTransaction(this.#fundingTxId);
+    const output = transaction.vout.find(
+      (candidate) => candidate.scriptPubKey.hex === this.#targetScriptPubKey,
+    );
+
+    if (!output) {
+      return [];
+    }
+
+    const unspent = await this.rpc<unknown>('gettxout', [
+      this.#fundingTxId,
+      output.n,
+      true,
+    ]);
+
+    if (!unspent) {
+      return [];
+    }
+
+    const esploraTransaction = await this.getTransaction(this.#fundingTxId);
+
+    return [
+      {
+        status: esploraTransaction.status,
+        txid: this.#fundingTxId,
+        value: bitcoinToSatoshis(output.value),
+        vout: output.n,
+      },
+    ];
+  }
+
+  async getTipHash(): Promise<string> {
+    const tipHeight = await this.getTipHeight();
+    return await this.rpc<string>('getblockhash', [tipHeight]);
+  }
+
+  async getTipHeight(): Promise<number> {
+    return await this.rpc<number>('getblockcount');
+  }
+
+  async getTransaction(txId: string): Promise<EsploraTransaction> {
+    const transaction = await this.getVerboseTransaction(txId);
+    const blockHeight = transaction.blockhash
+      ? await this.getBlockHeight(transaction.blockhash)
+      : undefined;
+    const prevouts = await this.getPrevouts(transaction);
+    const fee = this.calculateFee(transaction, prevouts);
+
+    return createEsploraTransaction(transaction, {
+      blockHeight,
+      fee,
+      prevouts,
+    });
+  }
+
+  async quit(): Promise<void> {
+    if (this.#containerName) {
+      try {
+        execFileSync('docker', ['rm', '-f', this.#containerName], {
+          stdio: 'pipe',
+        });
+      } catch {
+        // Already gone.
+      }
+    } else if (this.#process) {
+      try {
+        await this.rpc('stop');
+      } catch {
+        this.#process.kill();
+      }
+    }
+
+    if (this.#dataDir) {
+      await fs.rm(this.#dataDir, { force: true, recursive: true });
+    }
+  }
+
+  get targetScriptHash(): string {
+    return scriptPubKeyToScriptHash(this.#targetScriptPubKey);
+  }
+
+  private calculateFee(
+    transaction: BitcoinVerboseTransaction,
+    prevouts: Map<string, EsploraTransactionOutput>,
+  ): number {
+    if (transaction.vin.some((input) => input.coinbase)) {
+      return 0;
+    }
+
+    const inputTotal = transaction.vin.reduce((sum, input) => {
+      if (!input.txid || input.vout === undefined) {
+        return sum;
+      }
+      return (
+        sum + (prevouts.get(createOutpoint(input.txid, input.vout))?.value ?? 0)
+      );
+    }, 0);
+    const outputTotal = transaction.vout.reduce(
+      (sum, output) => sum + bitcoinToSatoshis(output.value),
+      0,
+    );
+
+    return Math.max(inputTotal - outputTotal, 0);
+  }
+
+  private async createWallet(): Promise<void> {
+    try {
+      await this.rpc('createwallet', [
+        BITCOIN_WALLET_NAME,
+        false,
+        false,
+        '',
+        false,
+        true,
+      ]);
+    } catch (error) {
+      if (
+        !(
+          error instanceof Error &&
+          error.message.includes('Database already exists')
+        )
+      ) {
+        throw error;
+      }
+    }
+  }
+
+  private async findSpendingTransaction(
+    txId: string,
+    vout: number,
+  ): Promise<EsploraTransaction | undefined> {
+    for (const candidateTxId of this.#broadcastTxIds) {
+      const transaction = await this.getTransaction(candidateTxId);
+      if (
+        transaction.vin.some(
+          (input) => input.txid === txId && input.vout === vout,
+        )
+      ) {
+        return transaction;
+      }
+    }
+
+    return undefined;
+  }
+
+  private async fundDefaultAccount(amount: number): Promise<void> {
+    const miningAddress = await this.rpc<string>(
+      'getnewaddress',
+      ['', 'bech32'],
+      true,
+    );
+    await this.rpc('generatetoaddress', [101, miningAddress]);
+
+    const decodedScript = await this.rpc<{
+      address?: string;
+      segwit?: { address?: string };
+    }>('decodescript', [this.#targetScriptPubKey]);
+    const regtestAddress =
+      decodedScript.segwit?.address ?? decodedScript.address;
+    if (!regtestAddress) {
+      throw new Error(
+        'bitcoind did not derive a regtest address for BTC script',
+      );
+    }
+
+    this.#fundingTxId = await this.rpc<string>(
+      'sendtoaddress',
+      [regtestAddress, amount],
+      true,
+    );
+    await this.rpc('generatetoaddress', [1, miningAddress]);
+  }
+
+  private async getBlockHeight(blockHash: string): Promise<number | undefined> {
+    const block = await this.rpc<BitcoinBlock>('getblock', [blockHash, 1]);
+    return block.height;
+  }
+
+  private async getPrevouts(
+    transaction: BitcoinVerboseTransaction,
+  ): Promise<Map<string, EsploraTransactionOutput>> {
+    const prevouts = new Map<string, EsploraTransactionOutput>();
+
+    for (const input of transaction.vin) {
+      if (!input.txid || input.vout === undefined) {
+        continue;
+      }
+
+      const previousTransaction = await this.getVerboseTransaction(input.txid);
+      const previousOutput = previousTransaction.vout[input.vout];
+      if (previousOutput) {
+        prevouts.set(
+          createOutpoint(input.txid, input.vout),
+          createEsploraTransactionOutput(previousOutput),
+        );
+      }
+    }
+
+    return prevouts;
+  }
+
+  private async getVerboseTransaction(
+    txId: string,
+  ): Promise<BitcoinVerboseTransaction> {
+    return await this.rpc<BitcoinVerboseTransaction>('getrawtransaction', [
+      txId,
+      true,
+    ]);
+  }
+
+  private getNodeFailureMessage(): string | undefined {
+    if (this.#process && this.#process.exitCode !== null) {
+      return `bitcoind exited early: ${this.#stderr}`;
+    }
+
+    if (!this.#containerName) {
+      return undefined;
+    }
+
+    try {
+      const running = execFileSync(
+        'docker',
+        ['inspect', '-f', '{{.State.Running}}', this.#containerName],
+        { encoding: 'utf8', stdio: 'pipe' },
+      ).trim();
+      if (running !== 'true') {
+        return `Dockerized bitcoind exited early: ${this.getNodeLogs()}`;
+      }
+    } catch (error) {
+      return `Dockerized bitcoind is unavailable: ${
+        error instanceof Error ? error.message : String(error)
+      }`;
+    }
+
+    return undefined;
+  }
+
+  private getNodeLogs(): string {
+    if (!this.#containerName) {
+      return '';
+    }
+
+    try {
+      return execFileSync('docker', ['logs', this.#containerName], {
+        encoding: 'utf8',
+        stdio: 'pipe',
+      });
+    } catch {
+      return '';
+    }
+  }
+
+  private async rpc<TResult = unknown>(
+    method: string,
+    params: unknown[] = [],
+    wallet = false,
+  ): Promise<TResult> {
+    const walletPath = wallet ? `/wallet/${BITCOIN_WALLET_NAME}` : '';
+    const response = await fetch(
+      `http://127.0.0.1:${this.#rpcPort}${walletPath}`,
+      {
+        body: JSON.stringify({
+          id: 'metamask-e2e',
+          jsonrpc: '1.0',
+          method,
+          params,
+        }),
+        headers: {
+          Authorization: `Basic ${Buffer.from(
+            `${this.#rpcUser}:${this.#rpcPassword}`,
+          ).toString('base64')}`,
+          'Content-Type': 'application/json',
+        },
+        method: 'POST',
+      },
+    );
+
+    const rpcResponse = (await response.json()) as BitcoinRpcResponse<TResult>;
+    if (!response.ok || rpcResponse.error) {
+      throw new Error(
+        `bitcoind RPC ${method} failed: ${JSON.stringify(rpcResponse.error)}`,
+      );
+    }
+
+    return rpcResponse.result;
+  }
+
+  private async waitForReady(timeoutMs = 30_000): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+
+    while (Date.now() < deadline) {
+      const failureMessage = this.getNodeFailureMessage();
+      if (failureMessage) {
+        throw new Error(failureMessage);
+      }
+
+      try {
+        await this.rpc('getblockchaininfo');
+        return;
+      } catch {
+        await wait(250);
+      }
+    }
+
+    throw new Error(
+      `bitcoind did not become ready: ${this.getNodeLogs() || this.#stderr}`,
+    );
+  }
+
+  private startDockerNode(dockerImage: string): void {
+    this.#containerName = `bitcoin-regtest-e2e-${process.pid}-${Date.now()}`;
+
+    execFileSync(
+      'docker',
+      [
+        'run',
+        '-d',
+        '--rm',
+        '--name',
+        this.#containerName,
+        '-p',
+        `127.0.0.1:${this.#rpcPort}:18443`,
+        dockerImage,
+        '-regtest',
+        '-server=1',
+        '-txindex=1',
+        '-fallbackfee=0.00001',
+        '-rpcbind=0.0.0.0',
+        '-rpcallowip=0.0.0.0/0',
+        '-rpcport=18443',
+        `-rpcuser=${this.#rpcUser}`,
+        `-rpcpassword=${this.#rpcPassword}`,
+      ],
+      { stdio: 'pipe' },
+    );
+  }
+
+  private async startHostNode(
+    binaryPath: string,
+    p2pPort: number,
+  ): Promise<void> {
+    execFileSync(binaryPath, ['-version'], { stdio: 'pipe' });
+
+    this.#dataDir = await fs.mkdtemp(join(tmpdir(), 'metamask-bitcoind-'));
+
+    this.#process = spawn(binaryPath, [
+      '-regtest',
+      '-server=1',
+      '-txindex=1',
+      '-fallbackfee=0.00001',
+      `-datadir=${this.#dataDir}`,
+      '-rpcbind=127.0.0.1',
+      '-rpcallowip=127.0.0.1',
+      `-rpcport=${this.#rpcPort}`,
+      `-port=${p2pPort}`,
+      `-rpcuser=${this.#rpcUser}`,
+      `-rpcpassword=${this.#rpcPassword}`,
+    ]);
+
+    this.#process.stderr.on('data', (data) => {
+      this.#stderr += data.toString();
+    });
+  }
+}

--- a/test/e2e/tests/btc/mocks/local-bitcoin-node-mocks.ts
+++ b/test/e2e/tests/btc/mocks/local-bitcoin-node-mocks.ts
@@ -1,0 +1,122 @@
+import { Mockttp, MockedEndpoint } from 'mockttp';
+import { BitcoinNode } from '../../../seeder/bitcoin/node';
+
+const BITCOIN_ESPLORA_URL =
+  /^https:\/\/bitcoin-mainnet\.infura\.io\/v3\/[a-f0-9]{32}\/esplora/u;
+
+function bitcoinEsploraPath(path: string): RegExp {
+  return new RegExp(`${BITCOIN_ESPLORA_URL.source}${path}$`, 'u');
+}
+
+function getPathMatch(url: string, pattern: RegExp): string | undefined {
+  return url.match(pattern)?.[1];
+}
+
+export async function proxyBitcoinBlockchainCalls(
+  mockServer: Mockttp,
+  bitcoinNode: BitcoinNode,
+): Promise<MockedEndpoint[]> {
+  return [
+    await mockServer
+      .forGet(bitcoinEsploraPath('/blocks'))
+      .always()
+      .thenCallback(async () => ({
+        json: await bitcoinNode.getBlocks(),
+        statusCode: 200,
+      })),
+
+    await mockServer
+      .forGet(bitcoinEsploraPath('/blocks/tip/height'))
+      .always()
+      .thenCallback(async () => ({
+        body: String(await bitcoinNode.getTipHeight()),
+        statusCode: 200,
+      })),
+
+    await mockServer
+      .forGet(bitcoinEsploraPath('/blocks/tip/hash'))
+      .always()
+      .thenCallback(async () => ({
+        body: await bitcoinNode.getTipHash(),
+        statusCode: 200,
+      })),
+
+    await mockServer
+      .forGet(bitcoinEsploraPath('/scripthash/([0-9a-f]{64})/txs'))
+      .always()
+      .thenCallback(async (request) => ({
+        json: await bitcoinNode.getScriptHashTransactions(
+          getPathMatch(request.url, /scripthash\/([0-9a-f]{64})\/txs/u) ?? '',
+        ),
+        statusCode: 200,
+      })),
+
+    await mockServer
+      .forGet(bitcoinEsploraPath('/scripthash/([0-9a-f]{64})/utxo'))
+      .always()
+      .thenCallback(async (request) => ({
+        json: await bitcoinNode.getScriptHashUtxos(
+          getPathMatch(request.url, /scripthash\/([0-9a-f]{64})\/utxo/u) ?? '',
+        ),
+        statusCode: 200,
+      })),
+
+    await mockServer
+      .forGet(bitcoinEsploraPath('/tx/([0-9a-f]{64})'))
+      .always()
+      .thenCallback(async (request) => ({
+        json: await bitcoinNode.getTransaction(
+          getPathMatch(request.url, /\/tx\/([0-9a-f]{64})$/u) ?? '',
+        ),
+        statusCode: 200,
+      })),
+
+    await mockServer
+      .forGet(bitcoinEsploraPath('/tx/([0-9a-f]{64})/outspends'))
+      .always()
+      .thenCallback(async (request) => ({
+        json: await bitcoinNode.getOutspends(
+          getPathMatch(request.url, /\/tx\/([0-9a-f]{64})\/outspends/u) ?? '',
+        ),
+        statusCode: 200,
+      })),
+
+    await mockServer
+      .forGet(bitcoinEsploraPath('/block/([0-9a-f]{64})'))
+      .always()
+      .thenCallback(async (request) => ({
+        json: await bitcoinNode.getBlock(
+          getPathMatch(request.url, /\/block\/([0-9a-f]{64})$/u) ?? '',
+        ),
+        statusCode: 200,
+      })),
+
+    await mockServer
+      .forGet(bitcoinEsploraPath('/block-height/(\\d+)'))
+      .always()
+      .thenCallback(async (request) => ({
+        body: await bitcoinNode.getBlockHash(
+          Number(getPathMatch(request.url, /\/block-height\/(\d+)$/u) ?? 0),
+        ),
+        statusCode: 200,
+      })),
+
+    await mockServer
+      .forGet(bitcoinEsploraPath('/fee-estimates'))
+      .always()
+      .thenCallback(async () => ({
+        json: await bitcoinNode.getFeeEstimates(),
+        statusCode: 200,
+      })),
+
+    await mockServer
+      .forPost(bitcoinEsploraPath('/tx'))
+      .always()
+      .thenCallback(async (request) => ({
+        body: await bitcoinNode.broadcastTransaction(
+          (await request.body.getText()) ?? '',
+        ),
+        statusCode: 200,
+      })),
+  ];
+}

--- a/test/e2e/tests/send/btc-send-local.spec.ts
+++ b/test/e2e/tests/send/btc-send-local.spec.ts
@@ -1,0 +1,101 @@
+import { Suite } from 'mocha';
+import { Mockttp } from 'mockttp';
+import { DEFAULT_BTC_BALANCE } from '../../constants';
+import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
+import { withFixtures } from '../../helpers';
+import { login } from '../../page-objects/flows/login.flow';
+import { switchToNetworkFromNetworkSelect } from '../../page-objects/flows/network.flow';
+import ActivityListPage from '../../page-objects/pages/home/activity-list';
+import BitcoinHomepage from '../../page-objects/pages/home/bitcoin-homepage';
+import BitcoinReviewTxPage from '../../page-objects/pages/send/bitcoin-review-tx-page';
+import SendPage from '../../page-objects/pages/send/send-page';
+import { BitcoinNode } from '../../seeder/bitcoin/node';
+import {
+  mockCurrencyExchangeRates,
+  mockExchangeRates,
+  mockFiatExchangeRates,
+  mockSolanaSpotPrices,
+  mockSupportedVsCurrencies,
+  mockTokensV2SupportedNetworks,
+  mockTokensV3Assets,
+} from '../btc/mocks';
+import { proxyBitcoinBlockchainCalls } from '../btc/mocks/local-bitcoin-node-mocks';
+import { mockPriceMulti, mockPriceMultiBtcAndSol } from '../btc/mocks/min-api';
+
+const BITCOIN_CHAIN_ID = 'bip122:000000000019d6689c085ae165831e93';
+const RECIPIENT_ADDRESS = 'bc1qsqvczpxkgvp3lw230p7jffuuqnw9pp4j5tawmf';
+
+async function mockBtcSendLocalMocks(
+  mockServer: Mockttp,
+  { localNodes }: { localNodes: unknown[] },
+) {
+  const bitcoinNode = localNodes.find(
+    (node): node is BitcoinNode => node instanceof BitcoinNode,
+  );
+  if (!bitcoinNode) {
+    throw new Error('Bitcoin local node was not started');
+  }
+
+  return [
+    await mockExchangeRates(mockServer),
+    await mockCurrencyExchangeRates(mockServer),
+    await mockFiatExchangeRates(mockServer),
+    await mockSolanaSpotPrices(mockServer),
+    await mockSupportedVsCurrencies(mockServer),
+    await mockPriceMulti(mockServer),
+    await mockPriceMultiBtcAndSol(mockServer),
+    await mockTokensV2SupportedNetworks(mockServer),
+    await mockTokensV3Assets(mockServer),
+    ...(await proxyBitcoinBlockchainCalls(mockServer, bitcoinNode)),
+  ];
+}
+
+describe('BTC Account - Send with local bitcoind', function (this: Suite) {
+  this.timeout(180_000);
+
+  it('sends BTC using a local Bitcoin regtest node', async function () {
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilderV2().build(),
+        title: this.test?.fullTitle(),
+        dappOptions: { numberOfTestDapps: 1 },
+        localNodeOptions: [
+          'anvil',
+          {
+            type: 'bitcoin',
+            options: {
+              initialBalance: DEFAULT_BTC_BALANCE,
+            },
+          },
+        ],
+        testSpecificMock: mockBtcSendLocalMocks,
+      },
+      async ({ driver }) => {
+        await login(driver);
+
+        const homePage = new BitcoinHomepage(driver);
+        await switchToNetworkFromNetworkSelect(driver, 'Popular', 'Bitcoin');
+        await homePage.checkPageIsLoaded();
+        await homePage.checkIsExpectedBitcoinBalanceDisplayed(
+          DEFAULT_BTC_BALANCE,
+        );
+
+        const sendPage = new SendPage(driver);
+        await homePage.startSendFlow();
+        await sendPage.selectToken(BITCOIN_CHAIN_ID, 'BTC');
+        await sendPage.fillRecipient(RECIPIENT_ADDRESS);
+        await sendPage.fillAmount('0.5');
+        await sendPage.pressContinueButton();
+
+        const bitcoinReviewTxPage = new BitcoinReviewTxPage(driver);
+        await bitcoinReviewTxPage.checkPageIsLoaded();
+        await bitcoinReviewTxPage.checkSendAmountIsDisplayed('0.5');
+        await bitcoinReviewTxPage.clickConfirmButton();
+
+        const activityListPage = new ActivityListPage(driver);
+        await activityListPage.checkTransactionActivityByText('Sent');
+        await activityListPage.checkWaitForTransactionStatus('pending');
+      },
+    );
+  });
+});


### PR DESCRIPTION
## **Description**

Adds a Bitcoin send E2E path that uses a local `bitcoind -regtest` node instead of static Esplora transaction fixtures.

The change introduces:

- a `BitcoinNode` E2E seeder that starts `bitcoind -regtest`, creates a wallet, mines spendable funds, funds the deterministic Bitcoin account script, and exposes Esplora-shaped data for the Bitcoin snap
- `withFixtures` support for `localNodeOptions: { type: 'bitcoin' }`
- Bitcoin Esplora mock proxies backed by the local node
- a focused send spec that completes the BTC send UI flow and broadcasts through the local node
- helper coverage for satoshi conversion, script hash derivation, and Esplora transaction mapping

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Install `bitcoind` and make sure it is available on `PATH`.
2. Build the Chrome E2E extension with `yarn build:test`.
3. Run `yarn test:e2e:single test/e2e/tests/send/btc-send-local.spec.ts --browser=chrome`.

## **Screenshots/Recordings**

<!-- ## **Screenshots/Recordings**

Not applicable; this is an E2E infrastructure/test-only change.

### **Before**

Not applicable.

### **After**

Not applicable.
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## Verification

- `yarn lint:changed:fix`
- `yarn test:unit test/e2e/helpers/bitcoin-node.test.ts --runInBand`

Not fully run locally:

- `yarn test:e2e:single test/e2e/tests/send/btc-send-local.spec.ts --browser=chrome` stopped before test execution because `dist/chrome/manifest.json` is missing in this fresh worktree.
- `yarn lint:tsc` currently fails on existing unrelated type errors in `@metamask/delegation-core` imports, `bridge-status-controller-messenger.ts`, and `ui/selectors/toast.test.ts`.
