### PR TITLE
fix: keep opted-in hardware confirmations open during signing

### DIFF
--- a/ui/contexts/hardware-wallets/index.ts
+++ b/ui/contexts/hardware-wallets/index.ts
@@ -13,6 +13,11 @@ export {
 export { ConnectionState } from './connectionState';
 export { useHardwareFooter } from './useHardwareFooter';
 export type { SubmitPreflightCheckOptions } from './useHardwareFooter';
+export {
+  getHardwareWalletSigningBehavior,
+  useHardwareWalletSigningBehavior,
+} from './useHardwareWalletSigningBehavior';
+export type { HardwareWalletSigningBehavior } from './useHardwareWalletSigningBehavior';
 export { useHardwareWalletMetrics } from './useHardwareWalletMetrics';
 export * from './errors';
 export * from './types';

--- a/ui/contexts/hardware-wallets/useHardwareWalletSigningBehavior.test.ts
+++ b/ui/contexts/hardware-wallets/useHardwareWalletSigningBehavior.test.ts
@@ -1,0 +1,29 @@
+import { HardwareWalletType } from './types';
+import { getHardwareWalletSigningBehavior } from './useHardwareWalletSigningBehavior';
+
+describe('getHardwareWalletSigningBehavior', () => {
+  it.each([
+    undefined,
+    null,
+    HardwareWalletType.Unknown,
+    HardwareWalletType.Ledger,
+    HardwareWalletType.Trezor,
+    HardwareWalletType.OneKey,
+    HardwareWalletType.Qr,
+  ])(
+    'does not keep the confirmation open during signing for %s',
+    (walletType) => {
+      expect(getHardwareWalletSigningBehavior(walletType)).toStrictEqual({
+        keepConfirmationOpenDuringSigning: false,
+      });
+    },
+  );
+
+  it('keeps the confirmation open during signing for configured wallet types', () => {
+    expect(
+      getHardwareWalletSigningBehavior(HardwareWalletType.Lattice),
+    ).toStrictEqual({
+      keepConfirmationOpenDuringSigning: true,
+    });
+  });
+});

--- a/ui/contexts/hardware-wallets/useHardwareWalletSigningBehavior.ts
+++ b/ui/contexts/hardware-wallets/useHardwareWalletSigningBehavior.ts
@@ -1,0 +1,32 @@
+import { useHardwareWalletConfig } from './HardwareWalletContext';
+import { HardwareWalletType } from './types';
+
+export type HardwareWalletSigningBehavior = {
+  keepConfirmationOpenDuringSigning: boolean;
+};
+
+const DEFAULT_SIGNING_BEHAVIOR: HardwareWalletSigningBehavior = {
+  keepConfirmationOpenDuringSigning: false,
+};
+
+const SIGNING_BEHAVIOR_BY_WALLET_TYPE: Partial<
+  Record<HardwareWalletType, HardwareWalletSigningBehavior>
+> = {
+  [HardwareWalletType.Lattice]: {
+    keepConfirmationOpenDuringSigning: true,
+  },
+};
+
+export function getHardwareWalletSigningBehavior(
+  walletType?: HardwareWalletType | null,
+): HardwareWalletSigningBehavior {
+  return walletType
+    ? (SIGNING_BEHAVIOR_BY_WALLET_TYPE[walletType] ?? DEFAULT_SIGNING_BEHAVIOR)
+    : DEFAULT_SIGNING_BEHAVIOR;
+}
+
+export function useHardwareWalletSigningBehavior(): HardwareWalletSigningBehavior {
+  const { walletType } = useHardwareWalletConfig();
+
+  return getHardwareWalletSigningBehavior(walletType);
+}

--- a/ui/pages/confirmations/components/confirm/footer/footer.test.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/footer.test.tsx
@@ -61,6 +61,7 @@ const mockUseHardwareWalletState = jest.fn();
 const mockUseHardwareWalletConfig = jest.fn();
 const mockUseHardwareWalletActions = jest.fn();
 const mockUseHardwareWalletError = jest.fn();
+const mockUseHardwareWalletSigningBehavior = jest.fn();
 const mockIsHardwareWalletError = jest.fn();
 const mockIsUserRejectedHardwareWalletError = jest.fn();
 const mockGetEnvironmentType = jest.fn();
@@ -153,6 +154,8 @@ jest.mock('../../../../../contexts/hardware-wallets', () => ({
   useHardwareWalletConfig: () => mockUseHardwareWalletConfig(),
   useHardwareWalletActions: () => mockUseHardwareWalletActions(),
   useHardwareWalletError: () => mockUseHardwareWalletError(),
+  useHardwareWalletSigningBehavior: () =>
+    mockUseHardwareWalletSigningBehavior(),
   isHardwareWalletError: (...args: unknown[]) =>
     mockIsHardwareWalletError(...args),
   isUserRejectedHardwareWalletError: (...args: unknown[]) =>
@@ -253,6 +256,7 @@ describe('ConfirmFooter', () => {
     mockUseHardwareWalletConfig.mockReset();
     mockUseHardwareWalletActions.mockReset();
     mockUseHardwareWalletError.mockReset();
+    mockUseHardwareWalletSigningBehavior.mockReset();
     mockIsHardwareWalletError.mockReset();
     mockIsUserRejectedHardwareWalletError.mockReset();
     mockTrackHardwareWalletRecoveryConnectCtaClicked.mockReset();
@@ -274,6 +278,9 @@ describe('ConfirmFooter', () => {
       showErrorModal: showHardwareWalletErrorModalMock,
       dismissErrorModal: dismissHardwareWalletErrorModalMock,
       setErrorModalSuppressed: setErrorModalSuppressedMock,
+    });
+    mockUseHardwareWalletSigningBehavior.mockReturnValue({
+      keepConfirmationOpenDuringSigning: false,
     });
     mockIsHardwareWalletError.mockReturnValue(false);
     mockIsUserRejectedHardwareWalletError.mockReturnValue(false);
@@ -906,6 +913,40 @@ describe('ConfirmFooter', () => {
       expect(dismissHardwareWalletErrorModalMock).toHaveBeenCalledTimes(1);
     });
 
+    it('waits for result when hardware preflight applies without a wallet type', async () => {
+      const resolveSpy = jest
+        .spyOn(Actions, 'resolvePendingApproval')
+        .mockImplementation(() => jest.fn().mockResolvedValue(undefined));
+
+      mockUseHardwareWalletConfig.mockReturnValue({
+        isHardwareWalletAccount: true,
+        walletType: null,
+      });
+      mockUseHardwareWalletState.mockReturnValue({
+        connectionState: { status: ConnectionStatus.Ready },
+      });
+
+      const { getByTestId } = render(
+        getMockPersonalSignConfirmStateForRequest({
+          ...unapprovedPersonalSignMsg,
+          msgParams: {
+            from: '0xc42edfcc21ed14dda456aa0756c153f7985d8813',
+          },
+        } as SignatureRequestType),
+      );
+
+      fireEvent.click(getByTestId('confirm-footer-button'));
+
+      await waitFor(() => {
+        expect(resolveSpy).toHaveBeenCalled();
+      });
+
+      expect(resolveSpy).toHaveBeenCalledWith(expect.any(String), undefined, {
+        fromAddress: '0xc42edfcc21ed14dda456aa0756c153f7985d8813',
+        waitForResult: true,
+      });
+    });
+
     it('navigates to next confirmation on hardware wallet rejection in sidepanel', async () => {
       const hardwareError = new Error('User rejected');
       mockGetEnvironmentType.mockReturnValue(ENVIRONMENT_TYPE_SIDEPANEL);
@@ -1103,6 +1144,62 @@ describe('ConfirmFooter', () => {
     it('renders the "confirm" button when there are no alerts', () => {
       const { getByText } = render();
       expect(getByText(messages.confirm.message)).toBeInTheDocument();
+    });
+
+    it('disables the "confirm" button while loading when signing behavior is configured to wait', () => {
+      mockUseHardwareWalletConfig.mockReturnValue({
+        isHardwareWalletAccount: true,
+        walletType: HardwareWalletType.Ledger,
+      });
+      mockUseHardwareWalletState.mockReturnValue({
+        connectionState: { status: ConnectionStatus.Ready },
+      });
+      mockUseHardwareWalletSigningBehavior.mockReturnValue({
+        keepConfirmationOpenDuringSigning: true,
+      });
+      const state = getMockPersonalSignConfirmState();
+      const { getByTestId } = render({
+        ...state,
+        appState: {
+          ...state.appState,
+          isLoading: true,
+        },
+      });
+
+      expect(getByTestId('confirm-footer-button')).toBeDisabled();
+    });
+
+    it('does not disable the software wallet "confirm" button while the app is loading', () => {
+      const state = getMockPersonalSignConfirmState();
+      const { getByTestId } = render({
+        ...state,
+        appState: {
+          ...state.appState,
+          isLoading: true,
+        },
+      });
+
+      expect(getByTestId('confirm-footer-button')).not.toBeDisabled();
+    });
+
+    it('does not disable the non-opted-in hardware wallet "confirm" button while the app is loading', () => {
+      mockUseHardwareWalletConfig.mockReturnValue({
+        isHardwareWalletAccount: true,
+        walletType: HardwareWalletType.Ledger,
+      });
+      mockUseHardwareWalletState.mockReturnValue({
+        connectionState: { status: ConnectionStatus.Ready },
+      });
+      const state = getMockPersonalSignConfirmState();
+      const { getByTestId } = render({
+        ...state,
+        appState: {
+          ...state.appState,
+          isLoading: true,
+        },
+      });
+
+      expect(getByTestId('confirm-footer-button')).not.toBeDisabled();
     });
 
     it('sets the alert modal visible when the review alerts button is clicked', () => {

--- a/ui/pages/confirmations/components/confirm/footer/footer.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/footer.tsx
@@ -3,7 +3,7 @@ import {
   TransactionType,
 } from '@metamask/transaction-controller';
 import React, { useCallback, useEffect, useState } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { PRODUCT_TYPES } from '@metamask/subscription-controller';
 import { useNavigate } from 'react-router-dom';
 import { MetaMetricsEventLocation } from '../../../../../../shared/constants/metametrics';
@@ -44,8 +44,10 @@ import { getConfirmationSender } from '../utils';
 import { useUserSubscriptions } from '../../../../../hooks/subscription/useSubscription';
 import {
   useHardwareFooter,
+  useHardwareWalletSigningBehavior,
   useHardwareWalletError,
 } from '../../../../../contexts/hardware-wallets';
+import { getAppIsLoading } from '../../../../../selectors';
 import OriginThrottleModal from './origin-throttle-modal';
 import ShieldFooterAgreement from './shield-footer-agreement';
 import ShieldFooterCoverageIndicator from './shield-footer-coverage-indicator/shield-footer-coverage-indicator';
@@ -244,6 +246,7 @@ const Footer = () => {
   const currentConfirmationId = currentConfirmation?.id;
   const t = useI18nContext();
   const { isGaslessLoading } = useIsGaslessLoading();
+  const appIsLoading = useSelector(getAppIsLoading);
 
   const { from: fromAddress } = getConfirmationSender(currentConfirmation);
   const { shouldThrottleOrigin } = useOriginThrottling();
@@ -290,6 +293,8 @@ const Footer = () => {
     currentConfirmationId,
     onUserRejectedHardwareWalletError,
   });
+  const { keepConfirmationOpenDuringSigning } =
+    useHardwareWalletSigningBehavior();
 
   useEffect(() => {
     const shouldSuppressHardwareWalletErrors =
@@ -302,8 +307,15 @@ const Footer = () => {
     shouldRunHardwareWalletPreflight,
   ]);
 
+  const shouldKeepConfirmationOpenDuringSigning =
+    appIsLoading &&
+    keepConfirmationOpenDuringSigning &&
+    shouldRunHardwareWalletPreflight;
+
   const isConfirmDisabled =
-    (!isScrollToBottomCompleted && !isSignature) || isGaslessLoading;
+    (!isScrollToBottomCompleted && !isSignature) ||
+    isGaslessLoading ||
+    shouldKeepConfirmationOpenDuringSigning;
 
   const shouldShowReconnectButton =
     shouldRunHardwareWalletPreflight &&
@@ -343,11 +355,13 @@ const Footer = () => {
 
       const resolveApprovalWithHardwareWalletHandling =
         withHardwareWalletModalHandling(async () => {
-          const resolveApprovalOptions = walletType
+          const shouldWaitForHardwareResult =
+            Boolean(walletType) || shouldRunHardwareWalletPreflight;
+          const resolveApprovalOptions = shouldWaitForHardwareResult
             ? {
                 fromAddress,
                 waitForResult: true,
-                walletType,
+                ...(walletType ? { walletType } : {}),
               }
             : {
                 fromAddress,

--- a/ui/pages/confirmations/context/confirm/index.test.tsx
+++ b/ui/pages/confirmations/context/confirm/index.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { renderHook } from '@testing-library/react-hooks';
+import { TransactionType } from '@metamask/transaction-controller';
 import { Provider } from 'react-redux';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
@@ -8,6 +9,7 @@ import mockState from '../../../../../test/data/mock-state.json';
 import { ConfirmContextProvider, useConfirmContext } from '.';
 
 const mockNavigate = jest.fn();
+const mockUseHardwareWalletSigningBehavior = jest.fn();
 
 let mockWindowSearch = '';
 
@@ -45,11 +47,21 @@ jest.mock('../../hooks/useSyncConfirmPath', () => {
   };
 });
 
+jest.mock('../../../../contexts/hardware-wallets', () => ({
+  ...jest.requireActual('../../../../contexts/hardware-wallets'),
+  useHardwareWalletSigningBehavior: () =>
+    mockUseHardwareWalletSigningBehavior(),
+}));
+
 const middleware = [thunk];
 
-function createStore() {
+function createStore({ isLoading = false }: { isLoading?: boolean } = {}) {
   return configureMockStore(middleware)({
     ...mockState,
+    appState: {
+      ...mockState.appState,
+      isLoading,
+    },
     metamask: {
       ...mockState.metamask,
       pendingApprovals: {},
@@ -58,15 +70,26 @@ function createStore() {
 }
 
 function renderContextProvider(store: ReturnType<typeof createStore>) {
-  return renderHook(() => useConfirmContext(), {
-    wrapper: ({ children }: { children: React.ReactElement }) => (
-      <Provider store={store}>
-        <ConfirmContextProvider>
-          {children as React.ReactElement}
-        </ConfirmContextProvider>
-      </Provider>
-    ),
-  });
+  return renderHook(
+    ({ reduxStore }: { reduxStore: ReturnType<typeof createStore> }) =>
+      useConfirmContext(),
+    {
+      initialProps: { reduxStore: store },
+      wrapper: ({
+        children,
+        reduxStore,
+      }: {
+        children: React.ReactElement;
+        reduxStore: ReturnType<typeof createStore>;
+      }) => (
+        <Provider store={reduxStore}>
+          <ConfirmContextProvider>
+            {children as React.ReactElement}
+          </ConfirmContextProvider>
+        </Provider>
+      ),
+    },
+  );
 }
 
 describe('ConfirmContextProvider', () => {
@@ -74,7 +97,13 @@ describe('ConfirmContextProvider', () => {
     jest.clearAllMocks();
     mockWindowSearch = '';
     window.history.replaceState({}, '', '/');
-    mockCurrentConfirmation = { id: 'test-id', type: 'transaction' };
+    mockCurrentConfirmation = {
+      id: 'test-id',
+      type: TransactionType.simpleSend,
+    };
+    mockUseHardwareWalletSigningBehavior.mockReturnValue({
+      keepConfirmationOpenDuringSigning: false,
+    });
   });
 
   it('navigates to DEFAULT_ROUTE when confirmation disappears and no goBackTo', () => {
@@ -163,5 +192,58 @@ describe('ConfirmContextProvider', () => {
     window.history.replaceState({}, '', '/');
     rerender();
     expect(result.current.goBackTo).toBe('/asset/keep');
+  });
+
+  it('keeps the last confirmation while loading when signing behavior is configured to wait', () => {
+    mockUseHardwareWalletSigningBehavior.mockReturnValue({
+      keepConfirmationOpenDuringSigning: true,
+    });
+    const loadingStore = createStore({ isLoading: true });
+    const { result, rerender } = renderContextProvider(loadingStore);
+
+    mockCurrentConfirmation = undefined;
+    rerender({ reduxStore: loadingStore });
+
+    expect(result.current.currentConfirmation).toStrictEqual({
+      id: 'test-id',
+      type: TransactionType.simpleSend,
+    });
+    expect(mockNavigate).not.toHaveBeenCalled();
+
+    const idleStore = createStore({ isLoading: false });
+    rerender({ reduxStore: idleStore });
+
+    expect(mockNavigate).toHaveBeenCalledWith(DEFAULT_ROUTE, {
+      replace: true,
+    });
+  });
+
+  it('does not keep the last software wallet confirmation while loading', () => {
+    const loadingStore = createStore({ isLoading: true });
+    const { result, rerender } = renderContextProvider(loadingStore);
+
+    mockCurrentConfirmation = undefined;
+    rerender({ reduxStore: loadingStore });
+
+    expect(result.current.currentConfirmation).toBeUndefined();
+    expect(mockNavigate).toHaveBeenCalledWith(DEFAULT_ROUTE, {
+      replace: true,
+    });
+  });
+
+  it('does not keep the last confirmation while loading when signing behavior is configured not to wait', () => {
+    mockUseHardwareWalletSigningBehavior.mockReturnValue({
+      keepConfirmationOpenDuringSigning: false,
+    });
+    const loadingStore = createStore({ isLoading: true });
+    const { result, rerender } = renderContextProvider(loadingStore);
+
+    mockCurrentConfirmation = undefined;
+    rerender({ reduxStore: loadingStore });
+
+    expect(result.current.currentConfirmation).toBeUndefined();
+    expect(mockNavigate).toHaveBeenCalledWith(DEFAULT_ROUTE, {
+      replace: true,
+    });
   });
 });

--- a/ui/pages/confirmations/context/confirm/index.tsx
+++ b/ui/pages/confirmations/context/confirm/index.tsx
@@ -7,9 +7,12 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import type { TransactionType } from '@metamask/transaction-controller';
 import { useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 
+import { isCorrectDeveloperTransactionType } from '../../../../../shared/lib/confirmation.utils';
+import { useHardwareWalletSigningBehavior } from '../../../../contexts/hardware-wallets';
 import { usePrevious } from '../../../../hooks/usePrevious';
 import { getIsHardwareWalletErrorModalVisible } from '../../../../selectors';
 import useCurrentConfirmation from '../../hooks/useCurrentConfirmation';
@@ -17,6 +20,7 @@ import { useConfirmationNavigationOptions } from '../../hooks/useConfirmationNav
 import useSyncConfirmPath from '../../hooks/useSyncConfirmPath';
 import { DEFAULT_ROUTE } from '../../../../helpers/constants/routes';
 import { Confirmation } from '../../types/confirm';
+import { isSignatureTransactionType } from '../../utils';
 
 export type ConfirmContextType = {
   /** @deprecated Use useTransactionMetadataRequest or useSignatureRequest hooks instead. */
@@ -41,16 +45,40 @@ export const ConfirmContextProvider: React.FC<{
   const [goBackTo] = useState(goBackFromUrl);
   const [isScrollToBottomCompleted, setIsScrollToBottomCompleted] =
     useState(true);
+  const isLoading = useSelector(
+    (state: { appState?: { isLoading?: boolean } }) =>
+      Boolean(state.appState?.isLoading),
+  );
   const { currentConfirmation: currentConfirmationFromHook } =
     useCurrentConfirmation(confirmationId);
+  const previousConfirmation = usePrevious(currentConfirmationFromHook);
+  const { keepConfirmationOpenDuringSigning } =
+    useHardwareWalletSigningBehavior();
+  const confirmationForLoading =
+    currentConfirmationFromHook ?? previousConfirmation;
+  const isTransactionOrSignatureConfirmation = Boolean(
+    isSignatureTransactionType(confirmationForLoading) ||
+      isCorrectDeveloperTransactionType(
+        confirmationForLoading?.type as TransactionType,
+      ),
+  );
+  const shouldKeepConfirmationOpenDuringSigning =
+    isLoading &&
+    keepConfirmationOpenDuringSigning &&
+    isTransactionOrSignatureConfirmation;
   const currentConfirmation =
-    currentConfirmationOverride ?? currentConfirmationFromHook;
+    currentConfirmationOverride ??
+    currentConfirmationFromHook ??
+    (shouldKeepConfirmationOpenDuringSigning
+      ? previousConfirmation
+      : undefined);
 
   useSyncConfirmPath(
-    currentConfirmationOverride === undefined ? currentConfirmation : undefined,
+    currentConfirmationOverride === undefined
+      ? currentConfirmationFromHook
+      : undefined,
   );
   const navigate = useNavigate();
-  const previousConfirmation = usePrevious(currentConfirmation);
   const shouldNavigateHomeRef = useRef(false);
   const isHardwareWalletErrorModalVisible = useSelector(
     getIsHardwareWalletErrorModalVisible,
@@ -65,21 +93,26 @@ export const ConfirmContextProvider: React.FC<{
     if (currentConfirmationOverride !== undefined) {
       return;
     }
-    if (previousConfirmation && !currentConfirmation) {
+    if (previousConfirmation && !currentConfirmationFromHook) {
       shouldNavigateHomeRef.current = true;
     }
 
-    if (shouldNavigateHomeRef.current && !isHardwareWalletErrorModalVisible) {
+    if (
+      shouldNavigateHomeRef.current &&
+      !isHardwareWalletErrorModalVisible &&
+      !shouldKeepConfirmationOpenDuringSigning
+    ) {
       shouldNavigateHomeRef.current = false;
       navigate(goBackTo ?? DEFAULT_ROUTE, { replace: true });
     }
   }, [
     currentConfirmationOverride,
     previousConfirmation,
-    currentConfirmation,
+    currentConfirmationFromHook,
     navigate,
     goBackTo,
     isHardwareWalletErrorModalVisible,
+    shouldKeepConfirmationOpenDuringSigning,
   ]);
 
   const value = useMemo(

--- a/ui/pages/confirmations/hooks/alerts/transactions/useSigningOrSubmittingAlerts.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useSigningOrSubmittingAlerts.test.ts
@@ -147,6 +147,18 @@ describe('useSigningOrSubmittingAlerts', () => {
     expect(alerts).toEqual([EXPECTED_ALERT]);
   });
 
+  it('returns no alert if the current confirmation is signing', () => {
+    const alerts = runHook({
+      currentConfirmation: {
+        ...CONFIRMATION_MOCK,
+        status: TransactionStatus.signed,
+      },
+      transactions: [],
+    });
+
+    expect(alerts).toEqual([]);
+  });
+
   it('returns alert if approved transaction', () => {
     const alerts = runHook({
       currentConfirmation: CONFIRMATION_MOCK,

--- a/ui/pages/confirmations/hooks/alerts/transactions/useSigningOrSubmittingAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useSigningOrSubmittingAlerts.ts
@@ -28,7 +28,7 @@ const PENDING_STATUSES = [
 export function useSigningOrSubmittingAlerts(): Alert[] {
   const t = useI18nContext();
   const { currentConfirmation } = useConfirmContext();
-  const { type, chainId, txParams } = (currentConfirmation ?? {}) as
+  const { id, type, chainId, txParams } = (currentConfirmation ?? {}) as
     | TransactionMeta
     | Record<string, never>;
   const from = txParams?.from;
@@ -43,8 +43,13 @@ export function useSigningOrSubmittingAlerts(): Alert[] {
 
   const isValidType = isCorrectDeveloperTransactionType(type);
 
+  const otherSigningOrSubmittingTransactions =
+    signingOrSubmittingTransactions.filter(
+      (tx: TransactionMeta) => tx.id !== id,
+    );
+
   const isSigningOrSubmitting =
-    isValidType && signingOrSubmittingTransactions.length > 0;
+    isValidType && otherSigningOrSubmittingTransactions.length > 0;
 
   const payTokenChainId = payToken?.chainId;
   const isPayTokenOnDifferentChain =
@@ -57,11 +62,12 @@ export function useSigningOrSubmittingAlerts(): Alert[] {
 
     return allTransactions.some(
       (tx: TransactionMeta) =>
+        tx.id !== id &&
         tx.chainId === payTokenChainId &&
         tx.txParams?.from?.toLowerCase() === from.toLowerCase() &&
         PENDING_STATUSES.includes(tx.status),
     );
-  }, [allTransactions, payTokenChainId, isPayTokenOnDifferentChain, from]);
+  }, [allTransactions, payTokenChainId, isPayTokenOnDifferentChain, from, id]);
 
   const showAlert = isSigningOrSubmitting || hasPendingTransactionOnPayChain;
 

--- a/ui/pages/confirmations/hooks/transactions/useTransactionConfirm.test.ts
+++ b/ui/pages/confirmations/hooks/transactions/useTransactionConfirm.test.ts
@@ -22,7 +22,10 @@ import {
   attemptCloseNotificationPopup,
   updateAndApproveTx,
 } from '../../../../store/actions';
-import { useHardwareWalletError } from '../../../../contexts/hardware-wallets';
+import {
+  useHardwareWalletError,
+  useHardwareWalletSigningBehavior,
+} from '../../../../contexts/hardware-wallets';
 import * as DappSwapContext from '../../context/dapp-swap';
 import { useGaslessSupportedSmartTransactions } from '../gas/useGaslessSupportedSmartTransactions';
 import { useIsGaslessSupported } from '../gas/useIsGaslessSupported';
@@ -43,6 +46,9 @@ jest.mock('../../../../contexts/hardware-wallets', () => ({
     dismissErrorModal: jest.fn(),
     isErrorModalVisible: false,
     setErrorModalSuppressed: jest.fn(),
+  })),
+  useHardwareWalletSigningBehavior: jest.fn(() => ({
+    keepConfirmationOpenDuringSigning: false,
   })),
   isHardwareWalletError: (...args: unknown[]) =>
     mockIsHardwareWalletError(...args),
@@ -113,6 +119,9 @@ describe('useTransactionConfirm', () => {
   const attemptCloseNotificationPopupMock = jest.mocked(
     attemptCloseNotificationPopup,
   );
+  const useHardwareWalletSigningBehaviorMock = jest.mocked(
+    useHardwareWalletSigningBehavior,
+  );
   const useHardwareWalletErrorMock = jest.mocked(useHardwareWalletError);
   const useIsGaslessSupportedMock = jest.mocked(useIsGaslessSupported);
   const useGaslessSupportedSmartTransactionsMock = jest.mocked(
@@ -164,6 +173,9 @@ describe('useTransactionConfirm', () => {
       isErrorModalVisible: false,
       setErrorModalSuppressed: jest.fn(),
     });
+    useHardwareWalletSigningBehaviorMock.mockReturnValue({
+      keepConfirmationOpenDuringSigning: false,
+    });
   });
 
   afterEach(() => {
@@ -176,6 +188,34 @@ describe('useTransactionConfirm', () => {
     await onTransactionConfirm();
 
     expect(updateAndApproveTxMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows loading while approving a transaction configured to keep the confirmation open', async () => {
+    useHardwareWalletSigningBehaviorMock.mockReturnValue({
+      keepConfirmationOpenDuringSigning: true,
+    });
+
+    const { onTransactionConfirm } = runHook();
+
+    await onTransactionConfirm();
+
+    expect(updateAndApproveTxMock).toHaveBeenCalledWith(
+      expect.any(Object),
+      false,
+      '',
+    );
+  });
+
+  it('preserves loading behavior for transactions not configured to keep the confirmation open', async () => {
+    const { onTransactionConfirm } = runHook();
+
+    await onTransactionConfirm();
+
+    expect(updateAndApproveTxMock).toHaveBeenCalledWith(
+      expect.any(Object),
+      true,
+      '',
+    );
   });
 
   it('updates custom nonce', async () => {

--- a/ui/pages/confirmations/hooks/transactions/useTransactionConfirm.ts
+++ b/ui/pages/confirmations/hooks/transactions/useTransactionConfirm.ts
@@ -16,6 +16,7 @@ import {
   isHardwareWalletError,
   isUserRejectedHardwareWalletError,
   useHardwareWalletError,
+  useHardwareWalletSigningBehavior,
 } from '../../../../contexts/hardware-wallets';
 import { useShieldConfirm } from './useShieldConfirm';
 import { useDappSwapActions } from './dapp-swap-comparison/useDappSwapActions';
@@ -23,6 +24,8 @@ import { useDappSwapActions } from './dapp-swap-comparison/useDappSwapActions';
 export function useTransactionConfirm() {
   const dispatch = useDispatch();
   const { showErrorModal } = useHardwareWalletError();
+  const { keepConfirmationOpenDuringSigning } =
+    useHardwareWalletSigningBehavior();
   const customNonceValue = useSelector(getCustomNonceValue);
   const selectedGasFeeToken = useSelectedGasFeeToken();
   const { currentConfirmation: transactionMeta } =
@@ -104,7 +107,13 @@ export function useTransactionConfirm() {
     // navigate to shield settings page first before approving transaction to wait for subscription creation there
     handleShieldSubscriptionApprovalTransactionAfterConfirm(newTransactionMeta);
     try {
-      await dispatch(updateAndApproveTx(newTransactionMeta, true, ''));
+      await dispatch(
+        updateAndApproveTx(
+          newTransactionMeta,
+          !keepConfirmationOpenDuringSigning,
+          '',
+        ),
+      );
       onDappSwapCompleted();
       return true;
     } catch (error) {
@@ -128,6 +137,7 @@ export function useTransactionConfirm() {
     customNonceValue,
     isGaslessSupportedSTX,
     dispatch,
+    keepConfirmationOpenDuringSigning,
     showErrorModal,
     handleSmartTransaction,
     handleGasless7702,


### PR DESCRIPTION
## **Description**

Keeps the confirmation screen open during device signing for hardware wallets that explicitly opt into this behavior.

**Key changes:**
- Added a generic hardware wallet signing behavior capability: `keepConfirmationOpenDuringSigning`
- Enabled the behavior for Lattice through the capability map, without adding Lattice-specific flow logic
- Updated confirmation routing/footer behavior to wait only when the capability is enabled
- Preserved existing behavior for software wallets and other integrated hardware wallets
- Prevented the current signing transaction from triggering the “previous transaction is still being signed or submitted” alert

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Build the extension (`yarn dist`)
2. Load the extension in browser
3. Connect a Lattice hardware wallet
4. Start a send transaction from a Lattice account
5. Confirm that the confirmation screen remains open while signing on the device
6. Verify software wallets and other hardware wallets keep their existing confirmation behavior

## **Screenshots/Recordings**
https://www.loom.com/share/9e7378d3132f403f8e98c77dd3bcc98e

## **Pre-merge author checklist**

- [x] I've followed MetaMask Extension Coding Standards
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using JSDoc format if applicable
- [ ] I've applied the right labels on the PR

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR
- [ ] I confirm that this PR addresses the described behavior and includes necessary testing evidence
