### PR TITLE
fix: malicious alert token banners

### DIFF
--- a/ui/pages/bridge/hooks/useBridgeAlerts.test.ts
+++ b/ui/pages/bridge/hooks/useBridgeAlerts.test.ts
@@ -305,7 +305,7 @@ describe('useBridgeAlerts', () => {
             title: 'bridgeMaliciousTokenTitle',
             description: `bridgeTokenIsMaliciousModalDescription:${MOCK_TO_TOKEN.symbol}`,
             infoList: [{ title: 'Honeypot', description: null }],
-            alertModalErrorMessage: `bridgeTokenIsMaliciousModalDescription:${MOCK_TO_TOKEN.symbol}`,
+            alertModalDescriptionType: 'banner',
           },
           isConfirmationAlert: true,
           openModalOnClick: true,
@@ -339,6 +339,7 @@ describe('useBridgeAlerts', () => {
           modalProps: {
             title: 'bridgeSuspiciousTokenTitle',
             description: `bridgeTokenIsSuspiciousModalDescription:${MOCK_TO_TOKEN.symbol}`,
+            alertModalDescriptionType: 'text',
             infoList: [{ title: 'Airdrop', description: null }],
           },
           bannerAlertProps: { severity: BannerAlertSeverity.Warning },

--- a/ui/pages/bridge/hooks/useBridgeAlerts.ts
+++ b/ui/pages/bridge/hooks/useBridgeAlerts.ts
@@ -154,9 +154,7 @@ export const useBridgeAlerts = () => {
               : 'bridgeTokenIsSuspiciousModalDescription',
             [toToken.symbol],
           ),
-          alertModalErrorMessage: assetIsMalicious
-            ? t('bridgeTokenIsMaliciousModalDescription', [toToken.symbol])
-            : undefined,
+          alertModalDescriptionType: assetIsMalicious ? 'banner' : 'text',
           infoList: assetIsMalicious
             ? assetMaliciousLocalizedFeatures
             : assetSuspiciousLocalizedFeatures,

--- a/ui/pages/bridge/prepare/components/__snapshots__/bridge-alert-banner-list.test.tsx.snap
+++ b/ui/pages/bridge/prepare/components/__snapshots__/bridge-alert-banner-list.test.tsx.snap
@@ -10,29 +10,36 @@ exports[`BridgeAlertBannerList price-data-unavailable banner renders the banner 
   data-testid="bridge-banner-alerts"
 >
   <div
-    class="mm-box mm-banner-base mm-banner-alert mm-banner-alert--severity-danger mm-box--padding-3 mm-box--padding-left-2 mm-box--display-flex mm-box--gap-2 mm-box--text-align-left mm-box--background-color-error-muted mm-box--rounded-sm"
+    class="flex flex-row gap-2 items-start p-3 pl-2 bg-error-muted rounded-sm border-l-4 border-error-default"
     data-testid="bridge-price-data-unavailable"
   >
-    <span
-      class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-error-default"
-      style="mask-image: url('./images/icons/danger.svg');"
-    />
+    <svg
+      class="inline-block w-6 h-6 text-error-default"
+      fill="currentColor"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M1 21 12 2l11 19zm3.45-2h15.1L12 6zM12 18q.424 0 .713-.287c.289-.288.287-.43.287-.713s-.096-.52-.287-.712S12.283 16 12 16s-.52.096-.712.288S11 16.717 11 17s.096.52.288.713.429.287.712.287m-1-3h2v-5h-2z"
+      />
+    </svg>
     <div
-      class="mm-box mm-box--min-width-0"
+      class="min-w-0 flex-1"
     >
       <p
-        class="mm-box mm-text mm-text--body-md-medium mm-box--color-text-default"
+        class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default"
       >
         No price information
       </p>
-      <p
-        class="mm-box mm-text mm-text--body-sm mm-box--color-text-default"
+      <div
+        class="mt-1"
       >
-        We couldn't get price information for this token. Make sure the amount received is what you expect before continuing.
-      </p>
-      <p
-        class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
-      />
+        <p
+          class="text-default text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default"
+        >
+          We couldn't get price information for this token. Make sure the amount received is what you expect before continuing.
+        </p>
+      </div>
     </div>
   </div>
 </div>
@@ -50,60 +57,83 @@ exports[`BridgeAlertBannerList should render the insufficient-gas alert when ins
   data-testid="bridge-banner-alerts"
 >
   <div
-    class="mm-box mm-banner-base mm-banner-alert mm-banner-alert--severity-danger mm-box--padding-3 mm-box--padding-left-2 mm-box--display-flex mm-box--gap-2 mm-box--text-align-left mm-box--background-color-error-muted mm-box--rounded-sm"
+    class="flex flex-row gap-2 items-start p-3 pl-2 bg-error-muted rounded-sm border-l-4 border-error-default"
     data-testid="bridge-price-data-unavailable"
   >
-    <span
-      class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-error-default"
-      style="mask-image: url('./images/icons/danger.svg');"
-    />
+    <svg
+      class="inline-block w-6 h-6 text-error-default"
+      fill="currentColor"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M1 21 12 2l11 19zm3.45-2h15.1L12 6zM12 18q.424 0 .713-.287c.289-.288.287-.43.287-.713s-.096-.52-.287-.712S12.283 16 12 16s-.52.096-.712.288S11 16.717 11 17s.096.52.288.713.429.287.712.287m-1-3h2v-5h-2z"
+      />
+    </svg>
     <div
-      class="mm-box mm-box--min-width-0"
+      class="min-w-0 flex-1"
     >
       <p
-        class="mm-box mm-text mm-text--body-md-medium mm-box--color-text-default"
+        class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default"
       >
         No price information
       </p>
-      <p
-        class="mm-box mm-text mm-text--body-sm mm-box--color-text-default"
+      <div
+        class="mt-1"
       >
-        We couldn't get price information for this token. Make sure the amount received is what you expect before continuing.
-      </p>
-      <p
-        class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
-      />
+        <p
+          class="text-default text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default"
+        >
+          We couldn't get price information for this token. Make sure the amount received is what you expect before continuing.
+        </p>
+      </div>
     </div>
   </div>
   <div
-    class="mm-box mm-banner-base mm-banner-alert mm-banner-alert--severity-danger mm-box--padding-3 mm-box--padding-left-2 mm-box--display-flex mm-box--gap-2 mm-box--text-align-left mm-box--background-color-error-muted mm-box--rounded-sm"
+    class="flex flex-row gap-2 items-start p-3 pl-2 bg-error-muted rounded-sm border-l-4 border-error-default"
     data-testid="bridge-insufficient-gas"
   >
-    <span
-      class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-error-default"
-      style="mask-image: url('./images/icons/danger.svg');"
-    />
+    <svg
+      class="inline-block w-6 h-6 text-error-default"
+      fill="currentColor"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M1 21 12 2l11 19zm3.45-2h15.1L12 6zM12 18q.424 0 .713-.287c.289-.288.287-.43.287-.713s-.096-.52-.287-.712S12.283 16 12 16s-.52.096-.712.288S11 16.717 11 17s.096.52.288.713.429.287.712.287m-1-3h2v-5h-2z"
+      />
+    </svg>
     <div
-      class="mm-box mm-box--min-width-0"
+      class="min-w-0 flex-1"
     >
       <p
-        class="mm-box mm-text mm-text--body-md-medium mm-box--color-text-default"
+        class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default"
       >
         More ETH needed for gas
       </p>
-      <p
-        class="mm-box mm-text mm-text--body-sm mm-box--color-text-default"
+      <div
+        class="mt-1"
       >
-        You don't have enough ETH to pay the gas fee for this bridge. Enter a smaller amount or buy more ETH.
-      </p>
-      <p
-        class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
-      />
-      <button
-        class="mm-box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"
+        <p
+          class="text-default text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default"
+        >
+          You don't have enough ETH to pay the gas fee for this bridge. Enter a smaller amount or buy more ETH.
+        </p>
+      </div>
+      <div
+        class="mt-4"
       >
-        Buy more ETH
-      </button>
+        <button
+          class="inline-flex items-center justify-center rounded-xl px-4 font-medium min-w-20 overflow-hidden relative h-10 transition-all duration-100 ease-linear active:scale-[0.97] active:ease-[cubic-bezier(0.3,0.8,0.3,1)] bg-icon-default text-primary-inverse hover:bg-icon-default-hover active:bg-icon-default-pressed focus-visible:ring-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-default"
+          role="button"
+        >
+          <span
+            class="text-inherit text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default"
+          >
+            Buy more ETH
+          </span>
+        </button>
+      </div>
     </div>
   </div>
 </div>
@@ -121,55 +151,69 @@ exports[`BridgeAlertBannerList should render the market-closed alert when market
   data-testid="bridge-banner-alerts"
 >
   <div
-    class="mm-box mm-banner-base mm-banner-alert mm-banner-alert--severity-danger mm-box--padding-3 mm-box--padding-left-2 mm-box--display-flex mm-box--gap-2 mm-box--text-align-left mm-box--background-color-error-muted mm-box--rounded-sm"
+    class="flex flex-row gap-2 items-start p-3 pl-2 bg-error-muted rounded-sm border-l-4 border-error-default"
     data-testid="bridge-market-closed"
   >
-    <span
-      class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-error-default"
-      style="mask-image: url('./images/icons/danger.svg');"
-    />
+    <svg
+      class="inline-block w-6 h-6 text-error-default"
+      fill="currentColor"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M1 21 12 2l11 19zm3.45-2h15.1L12 6zM12 18q.424 0 .713-.287c.289-.288.287-.43.287-.713s-.096-.52-.287-.712S12.283 16 12 16s-.52.096-.712.288S11 16.717 11 17s.096.52.288.713.429.287.712.287m-1-3h2v-5h-2z"
+      />
+    </svg>
     <div
-      class="mm-box mm-box--min-width-0"
+      class="min-w-0 flex-1"
     >
       <p
-        class="mm-box mm-text mm-text--body-md-medium mm-box--color-text-default"
+        class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default"
       >
         Market closed
       </p>
-      <p
-        class="mm-box mm-text mm-text--body-sm mm-box--color-text-default"
+      <div
+        class="mt-1"
       >
-        This stock token is currently outside trading hours. Try again when the market reopens.
-      </p>
-      <p
-        class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
-      />
+        <p
+          class="text-default text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default"
+        >
+          This stock token is currently outside trading hours. Try again when the market reopens.
+        </p>
+      </div>
     </div>
   </div>
   <div
-    class="mm-box mm-banner-base mm-banner-alert mm-banner-alert--severity-danger mm-box--padding-3 mm-box--padding-left-2 mm-box--display-flex mm-box--gap-2 mm-box--text-align-left mm-box--background-color-error-muted mm-box--rounded-sm"
+    class="flex flex-row gap-2 items-start p-3 pl-2 bg-error-muted rounded-sm border-l-4 border-error-default"
     data-testid="bridge-price-data-unavailable"
   >
-    <span
-      class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-error-default"
-      style="mask-image: url('./images/icons/danger.svg');"
-    />
+    <svg
+      class="inline-block w-6 h-6 text-error-default"
+      fill="currentColor"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M1 21 12 2l11 19zm3.45-2h15.1L12 6zM12 18q.424 0 .713-.287c.289-.288.287-.43.287-.713s-.096-.52-.287-.712S12.283 16 12 16s-.52.096-.712.288S11 16.717 11 17s.096.52.288.713.429.287.712.287m-1-3h2v-5h-2z"
+      />
+    </svg>
     <div
-      class="mm-box mm-box--min-width-0"
+      class="min-w-0 flex-1"
     >
       <p
-        class="mm-box mm-text mm-text--body-md-medium mm-box--color-text-default"
+        class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default"
       >
         No price information
       </p>
-      <p
-        class="mm-box mm-text mm-text--body-sm mm-box--color-text-default"
+      <div
+        class="mt-1"
       >
-        We couldn't get price information for this token. Make sure the amount received is what you expect before continuing.
-      </p>
-      <p
-        class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
-      />
+        <p
+          class="text-default text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default"
+        >
+          We couldn't get price information for this token. Make sure the amount received is what you expect before continuing.
+        </p>
+      </div>
     </div>
   </div>
 </div>
@@ -187,55 +231,69 @@ exports[`BridgeAlertBannerList should render the market-closed alert when market
   data-testid="bridge-banner-alerts"
 >
   <div
-    class="mm-box mm-banner-base mm-banner-alert mm-banner-alert--severity-danger mm-box--padding-3 mm-box--padding-left-2 mm-box--display-flex mm-box--gap-2 mm-box--text-align-left mm-box--background-color-error-muted mm-box--rounded-sm"
+    class="flex flex-row gap-2 items-start p-3 pl-2 bg-error-muted rounded-sm border-l-4 border-error-default"
     data-testid="bridge-market-closed"
   >
-    <span
-      class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-error-default"
-      style="mask-image: url('./images/icons/danger.svg');"
-    />
+    <svg
+      class="inline-block w-6 h-6 text-error-default"
+      fill="currentColor"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M1 21 12 2l11 19zm3.45-2h15.1L12 6zM12 18q.424 0 .713-.287c.289-.288.287-.43.287-.713s-.096-.52-.287-.712S12.283 16 12 16s-.52.096-.712.288S11 16.717 11 17s.096.52.288.713.429.287.712.287m-1-3h2v-5h-2z"
+      />
+    </svg>
     <div
-      class="mm-box mm-box--min-width-0"
+      class="min-w-0 flex-1"
     >
       <p
-        class="mm-box mm-text mm-text--body-md-medium mm-box--color-text-default"
+        class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default"
       >
         Market closed
       </p>
-      <p
-        class="mm-box mm-text mm-text--body-sm mm-box--color-text-default"
+      <div
+        class="mt-1"
       >
-        This stock token is currently outside trading hours. Try again when the market reopens.
-      </p>
-      <p
-        class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
-      />
+        <p
+          class="text-default text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default"
+        >
+          This stock token is currently outside trading hours. Try again when the market reopens.
+        </p>
+      </div>
     </div>
   </div>
   <div
-    class="mm-box mm-banner-base mm-banner-alert mm-banner-alert--severity-danger mm-box--padding-3 mm-box--padding-left-2 mm-box--display-flex mm-box--gap-2 mm-box--text-align-left mm-box--background-color-error-muted mm-box--rounded-sm"
+    class="flex flex-row gap-2 items-start p-3 pl-2 bg-error-muted rounded-sm border-l-4 border-error-default"
     data-testid="bridge-price-data-unavailable"
   >
-    <span
-      class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-error-default"
-      style="mask-image: url('./images/icons/danger.svg');"
-    />
+    <svg
+      class="inline-block w-6 h-6 text-error-default"
+      fill="currentColor"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M1 21 12 2l11 19zm3.45-2h15.1L12 6zM12 18q.424 0 .713-.287c.289-.288.287-.43.287-.713s-.096-.52-.287-.712S12.283 16 12 16s-.52.096-.712.288S11 16.717 11 17s.096.52.288.713.429.287.712.287m-1-3h2v-5h-2z"
+      />
+    </svg>
     <div
-      class="mm-box mm-box--min-width-0"
+      class="min-w-0 flex-1"
     >
       <p
-        class="mm-box mm-text mm-text--body-md-medium mm-box--color-text-default"
+        class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default"
       >
         No price information
       </p>
-      <p
-        class="mm-box mm-text mm-text--body-sm mm-box--color-text-default"
+      <div
+        class="mt-1"
       >
-        We couldn't get price information for this token. Make sure the amount received is what you expect before continuing.
-      </p>
-      <p
-        class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
-      />
+        <p
+          class="text-default text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default"
+        >
+          We couldn't get price information for this token. Make sure the amount received is what you expect before continuing.
+        </p>
+      </div>
     </div>
   </div>
 </div>
@@ -253,50 +311,64 @@ exports[`BridgeAlertBannerList should render the no-quotes alert when no quotes 
   data-testid="bridge-banner-alerts"
 >
   <div
-    class="mm-box mm-banner-base mm-banner-alert mm-banner-alert--severity-danger mm-box--padding-3 mm-box--padding-left-2 mm-box--display-flex mm-box--gap-2 mm-box--text-align-left mm-box--background-color-error-muted mm-box--rounded-sm"
+    class="flex flex-row gap-2 items-start p-3 pl-2 bg-error-muted rounded-sm border-l-4 border-error-default"
     data-testid="bridge-no-quotes"
   >
-    <span
-      class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-error-default"
-      style="mask-image: url('./images/icons/danger.svg');"
-    />
-    <div
-      class="mm-box mm-box--min-width-0"
+    <svg
+      class="inline-block w-6 h-6 text-error-default"
+      fill="currentColor"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
     >
-      <p
-        class="mm-box mm-text mm-text--body-sm mm-box--color-text-default"
-      >
-        This trade route isn't available right now. Try changing the amount, network, or token and we'll find the best option.
-      </p>
-      <p
-        class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+      <path
+        d="M1 21 12 2l11 19zm3.45-2h15.1L12 6zM12 18q.424 0 .713-.287c.289-.288.287-.43.287-.713s-.096-.52-.287-.712S12.283 16 12 16s-.52.096-.712.288S11 16.717 11 17s.096.52.288.713.429.287.712.287m-1-3h2v-5h-2z"
       />
+    </svg>
+    <div
+      class="min-w-0 flex-1"
+    >
+      <div
+        class=""
+      >
+        <p
+          class="text-default text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default"
+        >
+          This trade route isn't available right now. Try changing the amount, network, or token and we'll find the best option.
+        </p>
+      </div>
     </div>
   </div>
   <div
-    class="mm-box mm-banner-base mm-banner-alert mm-banner-alert--severity-danger mm-box--padding-3 mm-box--padding-left-2 mm-box--display-flex mm-box--gap-2 mm-box--text-align-left mm-box--background-color-error-muted mm-box--rounded-sm"
+    class="flex flex-row gap-2 items-start p-3 pl-2 bg-error-muted rounded-sm border-l-4 border-error-default"
     data-testid="bridge-price-data-unavailable"
   >
-    <span
-      class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-error-default"
-      style="mask-image: url('./images/icons/danger.svg');"
-    />
+    <svg
+      class="inline-block w-6 h-6 text-error-default"
+      fill="currentColor"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M1 21 12 2l11 19zm3.45-2h15.1L12 6zM12 18q.424 0 .713-.287c.289-.288.287-.43.287-.713s-.096-.52-.287-.712S12.283 16 12 16s-.52.096-.712.288S11 16.717 11 17s.096.52.288.713.429.287.712.287m-1-3h2v-5h-2z"
+      />
+    </svg>
     <div
-      class="mm-box mm-box--min-width-0"
+      class="min-w-0 flex-1"
     >
       <p
-        class="mm-box mm-text mm-text--body-md-medium mm-box--color-text-default"
+        class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default"
       >
         No price information
       </p>
-      <p
-        class="mm-box mm-text mm-text--body-sm mm-box--color-text-default"
+      <div
+        class="mt-1"
       >
-        We couldn't get price information for this token. Make sure the amount received is what you expect before continuing.
-      </p>
-      <p
-        class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
-      />
+        <p
+          class="text-default text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default"
+        >
+          We couldn't get price information for this token. Make sure the amount received is what you expect before continuing.
+        </p>
+      </div>
     </div>
   </div>
 </div>
@@ -314,50 +386,64 @@ exports[`BridgeAlertBannerList should render the no-quotes alert when reason is 
   data-testid="bridge-banner-alerts"
 >
   <div
-    class="mm-box mm-banner-base mm-banner-alert mm-banner-alert--severity-danger mm-box--padding-3 mm-box--padding-left-2 mm-box--display-flex mm-box--gap-2 mm-box--text-align-left mm-box--background-color-error-muted mm-box--rounded-sm"
+    class="flex flex-row gap-2 items-start p-3 pl-2 bg-error-muted rounded-sm border-l-4 border-error-default"
     data-testid="bridge-no-quotes"
   >
-    <span
-      class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-error-default"
-      style="mask-image: url('./images/icons/danger.svg');"
-    />
-    <div
-      class="mm-box mm-box--min-width-0"
+    <svg
+      class="inline-block w-6 h-6 text-error-default"
+      fill="currentColor"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
     >
-      <p
-        class="mm-box mm-text mm-text--body-sm mm-box--color-text-default"
-      >
-        No quotes available. Try a smaller amount.
-      </p>
-      <p
-        class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
+      <path
+        d="M1 21 12 2l11 19zm3.45-2h15.1L12 6zM12 18q.424 0 .713-.287c.289-.288.287-.43.287-.713s-.096-.52-.287-.712S12.283 16 12 16s-.52.096-.712.288S11 16.717 11 17s.096.52.288.713.429.287.712.287m-1-3h2v-5h-2z"
       />
+    </svg>
+    <div
+      class="min-w-0 flex-1"
+    >
+      <div
+        class=""
+      >
+        <p
+          class="text-default text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default"
+        >
+          No quotes available. Try a smaller amount.
+        </p>
+      </div>
     </div>
   </div>
   <div
-    class="mm-box mm-banner-base mm-banner-alert mm-banner-alert--severity-danger mm-box--padding-3 mm-box--padding-left-2 mm-box--display-flex mm-box--gap-2 mm-box--text-align-left mm-box--background-color-error-muted mm-box--rounded-sm"
+    class="flex flex-row gap-2 items-start p-3 pl-2 bg-error-muted rounded-sm border-l-4 border-error-default"
     data-testid="bridge-price-data-unavailable"
   >
-    <span
-      class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-error-default"
-      style="mask-image: url('./images/icons/danger.svg');"
-    />
+    <svg
+      class="inline-block w-6 h-6 text-error-default"
+      fill="currentColor"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M1 21 12 2l11 19zm3.45-2h15.1L12 6zM12 18q.424 0 .713-.287c.289-.288.287-.43.287-.713s-.096-.52-.287-.712S12.283 16 12 16s-.52.096-.712.288S11 16.717 11 17s.096.52.288.713.429.287.712.287m-1-3h2v-5h-2z"
+      />
+    </svg>
     <div
-      class="mm-box mm-box--min-width-0"
+      class="min-w-0 flex-1"
     >
       <p
-        class="mm-box mm-text mm-text--body-md-medium mm-box--color-text-default"
+        class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default"
       >
         No price information
       </p>
-      <p
-        class="mm-box mm-text mm-text--body-sm mm-box--color-text-default"
+      <div
+        class="mt-1"
       >
-        We couldn't get price information for this token. Make sure the amount received is what you expect before continuing.
-      </p>
-      <p
-        class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
-      />
+        <p
+          class="text-default text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default"
+        >
+          We couldn't get price information for this token. Make sure the amount received is what you expect before continuing.
+        </p>
+      </div>
     </div>
   </div>
 </div>
@@ -375,60 +461,82 @@ exports[`BridgeAlertBannerList should render the token-security alert when token
   data-testid="bridge-banner-alerts"
 >
   <div
-    class="mm-box mm-banner-base mm-banner-alert mm-banner-alert--severity-danger mm-box--padding-3 mm-box--padding-left-2 mm-box--display-flex mm-box--gap-2 mm-box--text-align-left mm-box--background-color-error-muted mm-box--rounded-sm"
+    class="flex flex-row gap-2 items-start p-3 pl-2 bg-error-muted rounded-sm border-l-4 border-error-default"
     data-testid="bridge-token-security"
   >
-    <span
-      class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-error-default"
-      style="mask-image: url('./images/icons/danger.svg');"
-    />
+    <svg
+      class="inline-block w-6 h-6 text-error-default"
+      fill="currentColor"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M1 21 12 2l11 19zm3.45-2h15.1L12 6zM12 18q.424 0 .713-.287c.289-.288.287-.43.287-.713s-.096-.52-.287-.712S12.283 16 12 16s-.52.096-.712.288S11 16.717 11 17s.096.52.288.713.429.287.712.287m-1-3h2v-5h-2z"
+      />
+    </svg>
     <div
-      class="mm-box mm-box--min-width-0"
+      class="min-w-0 flex-1"
     >
       <p
-        class="mm-box mm-text mm-text--body-md-medium mm-box--color-text-default"
+        class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default"
       >
         USDC is a malicious token.
       </p>
-      
-      <p
-        class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
-      />
+      <div
+        class="mt-1"
+      >
+        <p
+          class="text-default text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default"
+        />
+      </div>
     </div>
     <button
-      aria-label="Close"
-      class="mm-box mm-button-icon mm-button-icon--size-sm mm-banner-base__close-button mm-box--margin-left-auto mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
+      aria-label="Close banner"
+      class="inline-flex items-center justify-center p-0 h-6 w-6 rounded-lg bg-transparent hover:bg-hover active:bg-pressed text-icon-default ml-3 self-start"
     >
-      <span
-        class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
-        style="mask-image: url('./images/icons/arrow-right.svg');"
-      />
+      <svg
+        class="inline-block w-5 h-5 text-inherit"
+        fill="currentColor"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="m8.887 22-1.775-1.775L15.337 12 7.112 3.775 8.887 2l10 10z"
+        />
+      </svg>
     </button>
   </div>
   <div
-    class="mm-box mm-banner-base mm-banner-alert mm-banner-alert--severity-danger mm-box--padding-3 mm-box--padding-left-2 mm-box--display-flex mm-box--gap-2 mm-box--text-align-left mm-box--background-color-error-muted mm-box--rounded-sm"
+    class="flex flex-row gap-2 items-start p-3 pl-2 bg-error-muted rounded-sm border-l-4 border-error-default"
     data-testid="bridge-price-data-unavailable"
   >
-    <span
-      class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-error-default"
-      style="mask-image: url('./images/icons/danger.svg');"
-    />
+    <svg
+      class="inline-block w-6 h-6 text-error-default"
+      fill="currentColor"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M1 21 12 2l11 19zm3.45-2h15.1L12 6zM12 18q.424 0 .713-.287c.289-.288.287-.43.287-.713s-.096-.52-.287-.712S12.283 16 12 16s-.52.096-.712.288S11 16.717 11 17s.096.52.288.713.429.287.712.287m-1-3h2v-5h-2z"
+      />
+    </svg>
     <div
-      class="mm-box mm-box--min-width-0"
+      class="min-w-0 flex-1"
     >
       <p
-        class="mm-box mm-text mm-text--body-md-medium mm-box--color-text-default"
+        class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default"
       >
         No price information
       </p>
-      <p
-        class="mm-box mm-text mm-text--body-sm mm-box--color-text-default"
+      <div
+        class="mt-1"
       >
-        We couldn't get price information for this token. Make sure the amount received is what you expect before continuing.
-      </p>
-      <p
-        class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
-      />
+        <p
+          class="text-default text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default"
+        >
+          We couldn't get price information for this token. Make sure the amount received is what you expect before continuing.
+        </p>
+      </div>
     </div>
   </div>
 </div>
@@ -446,55 +554,69 @@ exports[`BridgeAlertBannerList should render the tx-alert alert when tx alert is
   data-testid="bridge-banner-alerts"
 >
   <div
-    class="mm-box mm-banner-base mm-banner-alert mm-banner-alert--severity-danger mm-box--padding-3 mm-box--padding-left-2 mm-box--display-flex mm-box--gap-2 mm-box--text-align-left mm-box--background-color-error-muted mm-box--rounded-sm"
+    class="flex flex-row gap-2 items-start p-3 pl-2 bg-error-muted rounded-sm border-l-4 border-error-default"
     data-testid="bridge-tx-alert"
   >
-    <span
-      class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-error-default"
-      style="mask-image: url('./images/icons/danger.svg');"
-    />
+    <svg
+      class="inline-block w-6 h-6 text-error-default"
+      fill="currentColor"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M1 21 12 2l11 19zm3.45-2h15.1L12 6zM12 18q.424 0 .713-.287c.289-.288.287-.43.287-.713s-.096-.52-.287-.712S12.283 16 12 16s-.52.096-.712.288S11 16.717 11 17s.096.52.288.713.429.287.712.287m-1-3h2v-5h-2z"
+      />
+    </svg>
     <div
-      class="mm-box mm-box--min-width-0"
+      class="min-w-0 flex-1"
     >
       <p
-        class="mm-box mm-text mm-text--body-md-medium mm-box--color-text-default"
+        class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default"
       >
         This transaction will be reverted
       </p>
-      <p
-        class="mm-box mm-text mm-text--body-sm mm-box--color-text-default"
+      <div
+        class="mt-1"
       >
-        Tx alert description Please select a different quote.
-      </p>
-      <p
-        class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
-      />
+        <p
+          class="text-default text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default"
+        >
+          Tx alert description Please select a different quote.
+        </p>
+      </div>
     </div>
   </div>
   <div
-    class="mm-box mm-banner-base mm-banner-alert mm-banner-alert--severity-danger mm-box--padding-3 mm-box--padding-left-2 mm-box--display-flex mm-box--gap-2 mm-box--text-align-left mm-box--background-color-error-muted mm-box--rounded-sm"
+    class="flex flex-row gap-2 items-start p-3 pl-2 bg-error-muted rounded-sm border-l-4 border-error-default"
     data-testid="bridge-price-data-unavailable"
   >
-    <span
-      class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-error-default"
-      style="mask-image: url('./images/icons/danger.svg');"
-    />
+    <svg
+      class="inline-block w-6 h-6 text-error-default"
+      fill="currentColor"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M1 21 12 2l11 19zm3.45-2h15.1L12 6zM12 18q.424 0 .713-.287c.289-.288.287-.43.287-.713s-.096-.52-.287-.712S12.283 16 12 16s-.52.096-.712.288S11 16.717 11 17s.096.52.288.713.429.287.712.287m-1-3h2v-5h-2z"
+      />
+    </svg>
     <div
-      class="mm-box mm-box--min-width-0"
+      class="min-w-0 flex-1"
     >
       <p
-        class="mm-box mm-text mm-text--body-md-medium mm-box--color-text-default"
+        class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default"
       >
         No price information
       </p>
-      <p
-        class="mm-box mm-text mm-text--body-sm mm-box--color-text-default"
+      <div
+        class="mt-1"
       >
-        We couldn't get price information for this token. Make sure the amount received is what you expect before continuing.
-      </p>
-      <p
-        class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
-      />
+        <p
+          class="text-default text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default"
+        >
+          We couldn't get price information for this token. Make sure the amount received is what you expect before continuing.
+        </p>
+      </div>
     </div>
   </div>
 </div>

--- a/ui/pages/bridge/prepare/components/bridge-alert-banner-list.tsx
+++ b/ui/pages/bridge/prepare/components/bridge-alert-banner-list.tsx
@@ -6,6 +6,12 @@ import {
 } from '@metamask/bridge-controller';
 
 import {
+  BannerAlert,
+  IconName,
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react';
+import {
   getBridgeQuotes,
   getHardwareWalletName,
 } from '../../../../ducks/bridge/selectors';
@@ -19,12 +25,6 @@ import { useDismissableAlerts } from '../../hooks/useDismissableBanners';
 import { useBridgeAlerts } from '../../hooks/useBridgeAlerts';
 import { type BridgeAlert } from '../types';
 import { BridgeAlertModal } from './bridge-alert-modal';
-import {
-  BannerAlert,
-  IconName,
-  Text,
-  TextVariant,
-} from '@metamask/design-system-react';
 
 const LocalBannerAlert = ({
   alert,

--- a/ui/pages/bridge/prepare/components/bridge-alert-banner-list.tsx
+++ b/ui/pages/bridge/prepare/components/bridge-alert-banner-list.tsx
@@ -9,16 +9,7 @@ import {
   getBridgeQuotes,
   getHardwareWalletName,
 } from '../../../../ducks/bridge/selectors';
-import {
-  BannerAlert,
-  IconName,
-  Text,
-} from '../../../../components/component-library';
-import {
-  BackgroundColor,
-  TextAlign,
-  TextVariant,
-} from '../../../../helpers/constants/design-system';
+import { BackgroundColor } from '../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { Column } from '../../layout';
 import { getCurrentKeyring } from '../../../../selectors';
@@ -28,6 +19,55 @@ import { useDismissableAlerts } from '../../hooks/useDismissableBanners';
 import { useBridgeAlerts } from '../../hooks/useBridgeAlerts';
 import { type BridgeAlert } from '../types';
 import { BridgeAlertModal } from './bridge-alert-modal';
+import {
+  BannerAlert,
+  IconName,
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react';
+
+const LocalBannerAlert = ({
+  alert,
+  onClose,
+}: {
+  alert: BridgeAlert;
+  onClose?: () => void;
+}) => {
+  const bannerProps = alert.bannerAlertProps;
+  const closeButtonProps = alert.openModalOnClick
+    ? { iconProps: { name: IconName.ArrowRight } }
+    : undefined;
+
+  if (
+    bannerProps &&
+    'actionButtonLabel' in bannerProps &&
+    'actionButtonOnClick' in bannerProps
+  ) {
+    return (
+      <BannerAlert
+        data-testid={`bridge-${alert.id}`}
+        onClose={onClose}
+        closeButtonProps={closeButtonProps}
+        title={alert.title}
+        description={alert.description}
+        severity={bannerProps.severity}
+        actionButtonLabel={bannerProps.actionButtonLabel}
+        actionButtonOnClick={bannerProps.actionButtonOnClick}
+      />
+    );
+  }
+
+  return (
+    <BannerAlert
+      data-testid={`bridge-${alert.id}`}
+      onClose={onClose}
+      closeButtonProps={closeButtonProps}
+      title={alert.title}
+      description={alert.description}
+      severity={bannerProps?.severity}
+    />
+  );
+};
 
 export const BridgeAlertBannerList = ({
   quoteParams,
@@ -68,20 +108,17 @@ export const BridgeAlertBannerList = ({
           isTxSubmittable &&
           hardwareWalletName &&
           activeQuote && (
-            <BannerAlert
-              title={t('hardwareWalletSubmissionWarningTitle')}
-              textAlign={TextAlign.Left}
-            >
+            <BannerAlert title={t('hardwareWalletSubmissionWarningTitle')}>
               <ul style={{ listStyle: 'disc' }}>
                 <li>
-                  <Text variant={TextVariant.bodyMd}>
+                  <Text variant={TextVariant.BodyMd}>
                     {t('hardwareWalletSubmissionWarningStep1', [
                       hardwareWalletName,
                     ])}
                   </Text>
                 </li>
                 <li>
-                  <Text variant={TextVariant.bodyMd}>
+                  <Text variant={TextVariant.BodyMd}>
                     {t('hardwareWalletSubmissionWarningStep2', [
                       hardwareWalletName,
                     ])}
@@ -103,19 +140,10 @@ export const BridgeAlertBannerList = ({
               }
 
               return (
-                <BannerAlert
+                <LocalBannerAlert
                   key={`${alert.id}-${index}`}
-                  textAlign={TextAlign.Left}
-                  data-testid={`bridge-${alert.id}`}
+                  alert={alert}
                   onClose={onClose}
-                  closeButtonProps={
-                    alert.openModalOnClick
-                      ? { iconName: IconName.ArrowRight }
-                      : undefined
-                  }
-                  title={alert.title}
-                  description={alert.description}
-                  {...alert.bannerAlertProps}
                 />
               );
             })}

--- a/ui/pages/bridge/prepare/components/bridge-alert-modal.tsx
+++ b/ui/pages/bridge/prepare/components/bridge-alert-modal.tsx
@@ -147,7 +147,14 @@ export const BridgeAlertModal = ({
           </Column>
         </ModalHeader>
         <Column gap={3} paddingInline={4} paddingBottom={4}>
-          <Text variant={TextVariant.BodySm}>{modalDescription}</Text>
+          {activeAlert.modalProps?.alertModalDescriptionType === 'banner' ? (
+            <BannerAlert
+              severity={BannerAlertSeverity.Danger}
+              description={modalDescription}
+            />
+          ) : (
+            <Text variant={TextVariant.BodySm}>{modalDescription}</Text>
+          )}
           <Column>
             {modalInfoList?.map((item) => (
               <Row

--- a/ui/pages/bridge/prepare/types.ts
+++ b/ui/pages/bridge/prepare/types.ts
@@ -1,5 +1,5 @@
+import { BannerAlert } from '@metamask/design-system-react';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
-import { type BannerAlert } from '../../../components/component-library';
 
 type BaseDestinationAccount = {
   isExternal: boolean;
@@ -56,6 +56,11 @@ export type BridgeAlertModalProps = {
   infoList?: { title: string; description: string | null }[];
   /** Inner danger {@link BannerAlert} in the modal (e.g. malicious token or fiat loss). */
   alertModalErrorMessage?: string;
+  /**
+   * Render description either as an alert banner or plain text.
+   * @default text
+   */
+  alertModalDescriptionType?: 'banner' | 'text';
 };
 
 /** An alert transformed for display purposes */
@@ -82,10 +87,13 @@ export type BridgeAlert = MinimalBridgeAlert & {
   /** When shown as a BannerAlert, this indicates whether the alert can be dismissed by the user. */
   isDismissable?: boolean;
   /** If this is defined, the alert will be displayed as a BannerAlert with the props specified. */
-  bannerAlertProps?: Pick<
-    React.ComponentProps<typeof BannerAlert>,
-    'severity' | 'actionButtonLabel' | 'actionButtonOnClick' | 'data-testid'
-  >;
+  bannerAlertProps?:
+    | { severity?: React.ComponentProps<typeof BannerAlert>['severity'] }
+    | {
+        severity?: React.ComponentProps<typeof BannerAlert>['severity'];
+        actionButtonLabel: string;
+        actionButtonOnClick: React.MouseEventHandler<HTMLButtonElement>;
+      };
   /**
    * When set, non-undefined fields override top-level title, description, and infoList in the modal.
    * Top-level title and description still drive the inline {@link BannerAlert} list.


### PR DESCRIPTION
## **Description**

This PR makes two related improvements to bridge token security alerts:

**1. Track destination token security classification in metrics**

Adds `token_security_type_destination` (e.g. `"Malicious"`, `"Warning"`) to bridge analytics events in `prepare-bridge-page.tsx` and forwards it through `submitBridgeTx` / `submitBridgeIntent` to the bridge status controller. This gives product visibility into how often users proceed with flagged tokens.

**2. Improve malicious-token alert modal UI**

Previously, when a destination token was malicious, the alert modal rendered the same warning text twice — once as a plain `<Text>` description and again as a separate inner `BannerAlert` (`alertModalErrorMessage`). The redundancy is removed: the description is now rendered directly as a danger `BannerAlert` for malicious tokens and as plain text for suspicious tokens, controlled by a new `alertModalDescriptionType: 'banner' | 'text'` field on `BridgeAlertModalProps`.

**3. Migrate bridge alert banner list to Design System `BannerAlert`**

Replaces the legacy component-library `BannerAlert` with the `@metamask/design-system-react` one in `BridgeAlertBannerList`. The DS component uses a discriminated union for action-button props, so the inline `.map()` rendering logic was extracted into a dedicated `LocalBannerAlert` component to satisfy TypeScript. The `types.ts` `bannerAlertProps` type is updated to mirror the same union constraint.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-4436

## **Manual testing steps**

1. Go to the Bridge page and select a destination token that has a security warning (malicious or suspicious).
2. Confirm the banner alert appears in the quote list with the correct severity (danger for malicious, warning for suspicious).
3. Click the arrow button on the banner to open the alert modal.
   - For a **malicious** token: verify the description renders as a red `BannerAlert` inside the modal (not plain text).
   - For a **suspicious** token: verify the description renders as plain text.
4. Proceed with a bridge transaction and confirm the `token_security_type_destination` field appears in the analytics events (e.g. via Segment debugger or the `submitTx` call payload).

## **Screenshots/Recordings**

<!--
### **Before**

### **After**
-->
<img width="449" height="390" alt="Screenshot 2026-04-28 at 8 28 20 PM" src="https://github.com/user-attachments/assets/690e39b3-4a81-428d-b078-e3b94f021be9" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates alert rendering and types around bridge warnings, including a UI component migration; risk is moderate due to potential behavioral/styling regressions in user-facing alerts and modal presentation.
> 
> **Overview**
> Improves **bridge token security alert UX** by replacing the duplicated malicious-token modal messaging with a single description rendered either as an inline danger `BannerAlert` or plain text, controlled via new `modalProps.alertModalDescriptionType`.
> 
> Migrates `BridgeAlertBannerList` to the Design System `@metamask/design-system-react` `BannerAlert`, introducing a `LocalBannerAlert` wrapper and updating `BridgeAlert.bannerAlertProps` typings to match the DS action-button union; associated snapshots and `useBridgeAlerts` tests are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1a01942bbb7121be4e27b1322e194bd962dc541. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->