### PR TITLE
test: cover perps tradeable margin balance fallback

### DIFF
--- a/ui/hooks/perps/usePerpsMarginCalculations.test.ts
+++ b/ui/hooks/perps/usePerpsMarginCalculations.test.ts
@@ -11,19 +11,47 @@ describe('usePerpsMarginCalculations', () => {
   const account = mockAccountState;
 
   describe('add mode', () => {
-    it('returns available balance as maxAmount', () => {
+    const accountWithTradeableBalance = {
+      ...mockAccountState,
+      availableBalance: '10125.00',
+      availableToTradeBalance: '9000.00',
+    };
+
+    const accountWithoutTradeableBalance = {
+      ...mockAccountState,
+      availableBalance: '10125.00',
+      availableToTradeBalance: undefined,
+    };
+
+    it('returns tradeable balance as maxAmount when available', () => {
       const { result } = renderHook(() =>
         usePerpsMarginCalculations({
           position,
           currentPrice,
-          account,
+          account: accountWithTradeableBalance,
           mode: 'add',
           amount: '0',
         }),
       );
 
       expect(result.current.maxAmount).toBe(
-        parseFloat(mockAccountState.availableBalance),
+        Number.parseFloat(accountWithTradeableBalance.availableToTradeBalance),
+      );
+    });
+
+    it('falls back to available balance as maxAmount when tradeable balance is absent', () => {
+      const { result } = renderHook(() =>
+        usePerpsMarginCalculations({
+          position,
+          currentPrice,
+          account: accountWithoutTradeableBalance,
+          mode: 'add',
+          amount: '0',
+        }),
+      );
+
+      expect(result.current.maxAmount).toBe(
+        Number.parseFloat(accountWithoutTradeableBalance.availableBalance),
       );
     });
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Updates the `usePerpsMarginCalculations` add-mode tests to cover the intended tradeable balance behavior explicitly.

The hook now calculates addable margin through `getTradeableBalance(account)`, which should prefer `availableToTradeBalance` and fall back to `availableBalance` when the tradeable balance is absent. The previous test asserted against `availableBalance` while the shared mock had identical values for both fields, so it could pass even if the priority logic regressed.

This change adds distinct test fixtures for the preferred and fallback paths, ensuring regressions in unified-account tradeable balance handling are caught.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that tighten assertions around `availableToTradeBalance` vs `availableBalance` selection in add-margin mode.
> 
> **Overview**
> Strengthens `usePerpsMarginCalculations` add-mode coverage by introducing distinct account fixtures so `maxAmount` **prefers** `availableToTradeBalance` and **falls back** to `availableBalance` when the tradeable field is missing.
> 
> This replaces the prior single assertion that could pass even if the priority logic regressed because the shared mock values were identical.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb6b67dc1d36f78bc030abc06179db1d486df7df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->