### PR TITLE
fix(firefox): inject inpage.js via declarative content_scripts world: MAIN

### DIFF
--- a/app/manifest/v2/_base.json
+++ b/app/manifest/v2/_base.json
@@ -31,8 +31,15 @@
   "content_scripts": [
     {
       "matches": ["file://*/*", "http://*/*", "https://*/*"],
-      "js": ["scripts/contentscript.js", "scripts/inpage.js"],
+      "js": ["scripts/contentscript.js"],
       "run_at": "document_start",
+      "all_frames": true
+    },
+    {
+      "matches": ["file://*/*", "http://*/*", "https://*/*"],
+      "js": ["scripts/inpage.js"],
+      "run_at": "document_start",
+      "world": "MAIN",
       "all_frames": true
     },
     {

--- a/app/manifest/v2/firefox.json
+++ b/app/manifest/v2/firefox.json
@@ -2,7 +2,7 @@
   "applications": {
     "gecko": {
       "id": "webextension@metamask.io",
-      "strict_min_version": "115.0"
+      "strict_min_version": "128.0"
     }
   },
   "browser_action": {

--- a/development/webpack/webpack.config.ts
+++ b/development/webpack/webpack.config.ts
@@ -207,8 +207,15 @@ const plugins: WebpackPluginInstance[] = [
     ],
   }),
 ];
-// MV2 requires self-injection
-if (MANIFEST_VERSION === 2) {
+// MV2 requires self-injection for browsers without `world: "MAIN"` content
+// script support. Firefox 128+ supports `world: "MAIN"` declaratively in MV2,
+// so we skip self-injection for Firefox builds and let `inpage.js` ship as
+// raw code, loaded into the page main world via a declarative content script
+// (mirrors the MV3 manifest shape). This avoids the inline-script CSP issue
+// on dApps with strict `script-src` policies. See PR description for context.
+const isFirefoxBuild =
+  args.browser.includes('firefox') || args.browser.includes('all');
+if (MANIFEST_VERSION === 2 && !isFirefoxBuild) {
   const { SelfInjectPlugin } = require('./utils/plugins/SelfInjectPlugin');
   plugins.push(new SelfInjectPlugin({ test: /^scripts\/inpage\.js$/u }));
 }

--- a/development/webpack/webpack.config.ts
+++ b/development/webpack/webpack.config.ts
@@ -207,18 +207,20 @@ const plugins: WebpackPluginInstance[] = [
     ],
   }),
 ];
-// MV2 requires self-injection for browsers without `world: "MAIN"` content
-// script support. Firefox 128+ supports `world: "MAIN"` declaratively in MV2,
-// so we skip self-injection for Firefox builds and let `inpage.js` ship as
-// raw code, loaded into the page main world via a declarative content script
-// (mirrors the MV3 manifest shape). This avoids the inline-script CSP issue
-// on dApps with strict `script-src` policies. See PR description for context.
-const isFirefoxBuild =
-  args.browser.includes('firefox') || args.browser.includes('all');
-if (MANIFEST_VERSION === 2 && !isFirefoxBuild) {
-  const { SelfInjectPlugin } = require('./utils/plugins/SelfInjectPlugin');
-  plugins.push(new SelfInjectPlugin({ test: /^scripts\/inpage\.js$/u }));
-}
+// SelfInjectPlugin previously wrapped `inpage.js` in a content-script trick
+// that creates a `<script>` element with the inpage source as `textContent`
+// and appends it to the page DOM. Firefox enforces the page's CSP on that
+// element, so dApps with strict `script-src` (no `'unsafe-inline'`) silently
+// broke for MetaMask Firefox users.
+//
+// Our MV2 build is Firefox-only in practice (every consumer of an `mv2-*`
+// build artifact in CI is `e2e-firefox.yml` or the Firefox MV2 release jobs
+// in `publish-release-from-release-head.yml`; the `chrome` MV2 dist that
+// `index.js` happens to produce is never loaded). Firefox 128+ supports
+// `content_scripts[].world: "MAIN"` declaratively in MV2, so we now ship
+// `inpage.js` as raw code and load it into the page main world via the
+// declarative content_scripts entry in `app/manifest/v2/_base.json` — same
+// shape as our MV3 manifest. No more inline injection, no CSP race.
 if (args.lavamoat) {
   const {
     lavamoatPlugin,

--- a/development/webpack/webpack.config.ts
+++ b/development/webpack/webpack.config.ts
@@ -207,20 +207,10 @@ const plugins: WebpackPluginInstance[] = [
     ],
   }),
 ];
-// SelfInjectPlugin previously wrapped `inpage.js` in a content-script trick
-// that creates a `<script>` element with the inpage source as `textContent`
-// and appends it to the page DOM. Firefox enforces the page's CSP on that
-// element, so dApps with strict `script-src` (no `'unsafe-inline'`) silently
-// broke for MetaMask Firefox users.
-//
-// Our MV2 build is Firefox-only in practice (every consumer of an `mv2-*`
-// build artifact in CI is `e2e-firefox.yml` or the Firefox MV2 release jobs
-// in `publish-release-from-release-head.yml`; the `chrome` MV2 dist that
-// `index.js` happens to produce is never loaded). Firefox 128+ supports
-// `content_scripts[].world: "MAIN"` declaratively in MV2, so we now ship
-// `inpage.js` as raw code and load it into the page main world via the
-// declarative content_scripts entry in `app/manifest/v2/_base.json` — same
-// shape as our MV3 manifest. No more inline injection, no CSP race.
+// `inpage.js` is loaded into the page main world via the declarative
+// `content_scripts[].world: "MAIN"` entry in `app/manifest/v2/_base.json`
+// (Firefox 128+) and `app/manifest/v3/_base.json` (Chrome). See
+// https://github.com/MetaMask/metamask-extension/pull/42222 for context.
 if (args.lavamoat) {
   const {
     lavamoatPlugin,

--- a/development/webpack/webpack.config.ts
+++ b/development/webpack/webpack.config.ts
@@ -210,7 +210,7 @@ const plugins: WebpackPluginInstance[] = [
 // `inpage.js` is loaded into the page main world via the declarative
 // `content_scripts[].world: "MAIN"` entry in `app/manifest/v2/_base.json`
 // (Firefox 128+) and `app/manifest/v3/_base.json` (Chrome). See
-// https://github.com/MetaMask/metamask-extension/pull/42222 for context.
+// https://github.com/MetaMask/metamask-extension/pull/42227 for context.
 if (args.lavamoat) {
   const {
     lavamoatPlugin,


### PR DESCRIPTION
## **Description**

**Draft / for evaluation.** Filing this so other engineers can pull the branch, build the Firefox artifact, and feel the difference on a strict-CSP dApp.

### Problem

[Lido reported](https://consensys.slack.com/archives/C03TAEX1D97/p1777029471609619) that MetaMask + Firefox stops working on dApps with strict CSP (no `'unsafe-inline'` in `script-src`). Reproducible at https://stake-hoodi.testnet.fi/.

### Root cause

On Firefox we ship MV2. In MV2, `inpage.js` is processed by [`SelfInjectPlugin`](https://github.com/MetaMask/metamask-extension/blob/main/development/webpack/utils/plugins/SelfInjectPlugin/index.ts#L115-L162) into a wrapper that does:

```js
{let d=document,s=d.createElement('script');s.textContent="<inpage source>";d.documentElement.appendChild(s).remove()}
```

That runs in the content-script isolated world, but the resulting `<script>` element it injects into the page DOM is treated as a **page script** by Firefox and subject to the page's CSP. Chrome MV2 historically tolerated this; Firefox enforces it. Our Chrome build is unaffected because Chrome ships MV3 and uses declarative `content_scripts[].world: "MAIN"` instead.

### Fix

Mirror the MV3 manifest shape in MV2. Firefox 128+ supports `content_scripts[].world: "MAIN"` declaratively in MV2 — scripts loaded this way run extension-privileged in the page main world and are **not** subject to page CSP. Same behavior as Chrome's MV3 path.

The diff is small:

1. **`app/manifest/v2/_base.json`** — split `scripts/inpage.js` out of the existing content_scripts entry into a new entry with `"world": "MAIN"` and `"run_at": "document_start"`. Identical shape to [`app/manifest/v3/_base.json`](https://github.com/MetaMask/metamask-extension/blob/main/app/manifest/v3/_base.json#L38-L56).
2. **`app/manifest/v2/firefox.json`** — bump `strict_min_version` from `115.0` to `128.0` (required for `world: "MAIN"`). FF 128 is the current ESR (Jul 2024); ESR 115 EOL'd Oct 2024.
3. **`development/webpack/webpack.config.ts`** — drop `SelfInjectPlugin` entirely. Confirmed by auditing CI that MV2 is Firefox-only in practice: every consumer of an `mv2-*` build artifact is `e2e-firefox.yml` or the Firefox MV2 release jobs in `publish-release-from-release-head.yml`. `e2e-chrome.yml` exclusively uses non-mv2 artifacts. The chrome MV2 dist that the build system happens to produce (because `browserPlatforms` defaults to `['firefox', 'chrome']`) is never loaded.

### Why not the imperative `scripting.executeScript` approach?

Lido's original [suggestion](https://consensys.slack.com/archives/C03TAEX1D97/p1777029471609619) was `browser.scripting.executeScript({ files: ['inpage.js'], world: 'MAIN' })` from background. That works (FF 102+ for MV2, `world: "MAIN"` since FF 128) and is the natural **fallback** if declarative `content_scripts[].world` turns out to be unsupported in Firefox MV2. But declarative is strictly better:

- No content-script→background→executeScript round-trip → no race vs `document_start`.
- No additional code surface; just a manifest change.
- Same shape we already use on Chrome MV3, so the cognitive load is zero.

If MV2 declarative `world: MAIN` is actually broken in Firefox (despite MDN listing the property without a version restriction), the fallback is straightforward — see "Fallback path" below.

### Race-condition analysis

We did a pass through how common detection libraries handle a late `window.ethereum` (since the imperative fallback would introduce a 50–300ms delay vs `document_start`):

- ✅ EIP-6963 handshake (RainbowKit, ConnectKit, modern wagmi): explicitly designed for this; race-tolerant by spec.
- ✅ `@metamask/detect-provider`: 3000ms timeout listening for `ethereum#initialized`.
- ✅ User-click-driven flows: Connect Wallet button is clicked well after inpage settles.
- ⚠️ wagmi `injected()` `isAuthorized()` reconnect-on-mount: bails immediately if `window.ethereum` missing. Mitigated by `unstable_shimAsyncInject` opt-in.
- ❌ Synchronous `window.ethereum` reads at top-of-page module load: rare in modern dApps, breaks under imperative path.

**With this PR's declarative path, none of this matters** — the script runs at `document_start` before any page script. We're including the analysis in case we end up on the imperative fallback.

## **Changelog**

CHANGELOG entry: Fixed an issue where MetaMask on Firefox failed to inject `window.ethereum` on dApps with a strict Content-Security-Policy (no `'unsafe-inline'` in `script-src`).

## **Related issues**

Fixes: WAPI-1463

Slack thread: https://consensys.slack.com/archives/C03TAEX1D97/p1777029471609619

## **Manual testing steps**

1. Build the Firefox artifact: `yarn build --browser firefox`. Confirm the dist `manifest.json` includes the new `world: "MAIN"` content_scripts entry for `inpage.js` and that `dist/firefox/scripts/inpage.js` ships as raw inpage code (not wrapped by SelfInjectPlugin — should look like the source of `app/scripts/inpage.js`, not a `createElement('script')` one-liner).
2. Load the built extension in Firefox 128+ (`about:debugging` → "This Firefox" → Load Temporary Add-on).
3. Visit https://stake-hoodi.testnet.fi/, click "Connect Wallet" → "MetaMask". Should connect normally, no CSP violation in the dev console.
4. Sanity-check on a permissive-CSP dApp (e.g., https://app.uniswap.org/) — connect should still work end-to-end.
5. Sanity-check that `window.ethereum` is set at page-load time (open DevTools console on any allowed dApp before any user interaction; `window.ethereum.isMetaMask` should be `true`).
6. Sanity-check Chrome MV3 build is unaffected: `yarn build --browser chrome`, load it, smoke-test connect on the same dApps.

## **Screenshots/Recordings**

### **Before**

CSP violation on Firefox at https://stake-hoodi.testnet.fi/:
```
Content-Security-Policy: The page's settings blocked an inline script (script-src-elem)
```
"No wallets detected" message.

### **After**

(To be added when reviewers test the build.)

## **Fallback path**

If Firefox MV2 declarative `content_scripts[].world: "MAIN"` is **not** honored (script silently doesn't run, or manifest fails validation), switch to dynamic registration. Replace the second content_scripts entry above with a background-side call:

```js
// In app/scripts/background.js (or equivalent), Firefox-only path:
if (typeof browser !== 'undefined' && browser.scripting?.registerContentScripts) {
  await browser.scripting.registerContentScripts([{
    id: 'metamask-inpage',
    js: ['scripts/inpage.js'],
    matches: ['file://*/*', 'http://*/*', 'https://*/*'],
    runAt: 'document_start',
    world: 'MAIN',
    allFrames: true,
  }]).catch(() => { /* already registered or unsupported */ });
}
```

This is functionally equivalent and well-supported on Firefox MV2 (FF 102+ for the API, FF 128+ for `world: 'MAIN'`).

## **Known limitations of this draft**

- **Bumping Firefox min version to 128.** ESR 115 users (a small but nonzero population) lose support entirely. We should confirm with the support team that this is acceptable before merging.
- **`SelfInjectPlugin` becomes dead code in webpack but the file is left in place.** Could be removed in a follow-up cleanup (the plugin and its tests are still useful documentation for future MV2-on-other-browsers work, if that ever comes back).
- **No tests added.** This is a manifest/build change; existing webpack and manifest tests use isolated fixtures and aren't affected. If we want runtime-level tests (e.g., e2e against a strict-CSP fixture page), happy to add as a follow-up.
- **MV3-on-Firefox is the long-term direction.** This PR doesn't change that — it just fixes the immediate CSP regression on the current MV2 Firefox build.

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
