### PR TITLE
fix: default stop-loss percentage input to negative

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -6121,6 +6121,10 @@
     "message": "Stop loss must be $1 $2 price",
     "description": "Validation error when stop loss price is on the wrong side of the reference price. $1 is above/below, $2 is current/entry."
   },
+  "perpsStopLossInvalidLiquidationPrice": {
+    "message": "Stop loss must be $1 liquidation price",
+    "description": "Validation error when stop loss price is on the wrong side of the liquidation price. $1 is above/below."
+  },
   "perpsSubmitting": {
     "message": "Submitting...",
     "description": "Loading text shown while an order is being submitted"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -6117,13 +6117,13 @@
     "message": "Stop loss",
     "description": "Label for stop loss price input"
   },
-  "perpsStopLossInvalidPrice": {
-    "message": "Stop loss must be $1 $2 price",
-    "description": "Validation error when stop loss price is on the wrong side of the reference price. $1 is above/below, $2 is current/entry."
-  },
   "perpsStopLossInvalidLiquidationPrice": {
     "message": "Stop loss must be $1 liquidation price",
     "description": "Validation error when stop loss price is on the wrong side of the liquidation price. $1 is above/below."
+  },
+  "perpsStopLossInvalidPrice": {
+    "message": "Stop loss must be $1 $2 price",
+    "description": "Validation error when stop loss price is on the wrong side of the reference price. $1 is above/below, $2 is current/entry."
   },
   "perpsSubmitting": {
     "message": "Submitting...",

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -6121,6 +6121,10 @@
     "message": "Stop loss must be $1 $2 price",
     "description": "Validation error when stop loss price is on the wrong side of the reference price. $1 is above/below, $2 is current/entry."
   },
+  "perpsStopLossInvalidLiquidationPrice": {
+    "message": "Stop loss must be $1 liquidation price",
+    "description": "Validation error when stop loss price is on the wrong side of the liquidation price. $1 is above/below."
+  },
   "perpsSubmitting": {
     "message": "Submitting...",
     "description": "Loading text shown while an order is being submitted"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -6117,13 +6117,13 @@
     "message": "Stop loss",
     "description": "Label for stop loss price input"
   },
-  "perpsStopLossInvalidPrice": {
-    "message": "Stop loss must be $1 $2 price",
-    "description": "Validation error when stop loss price is on the wrong side of the reference price. $1 is above/below, $2 is current/entry."
-  },
   "perpsStopLossInvalidLiquidationPrice": {
     "message": "Stop loss must be $1 liquidation price",
     "description": "Validation error when stop loss price is on the wrong side of the liquidation price. $1 is above/below."
+  },
+  "perpsStopLossInvalidPrice": {
+    "message": "Stop loss must be $1 $2 price",
+    "description": "Validation error when stop loss price is on the wrong side of the reference price. $1 is above/below, $2 is current/entry."
   },
   "perpsSubmitting": {
     "message": "Submitting...",

--- a/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.test.tsx
+++ b/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.test.tsx
@@ -519,6 +519,31 @@ describe('AutoCloseSection', () => {
       expect(onStopLossPriceChange).toHaveBeenCalledWith('44550');
     });
 
+    it('normalizes leading-zero SL RoE% input before defaulting to negative', () => {
+      // -11% RoE at leverage=10: priceChange = -11/(10*100) = -1.1% -> 45000 * 0.989 = 44505
+      const onStopLossPriceChange = jest.fn();
+      renderWithProvider(
+        <AutoCloseSection
+          {...defaultProps}
+          enabled={true}
+          direction="long"
+          currentPrice={45000}
+          leverage={10}
+          onStopLossPriceChange={onStopLossPriceChange}
+        />,
+        mockStore,
+      );
+
+      const container = screen.getByTestId('sl-percent-input');
+      const input = container.querySelector('input');
+      expect(input).not.toBeNull();
+      fireEvent.change(input as HTMLInputElement, {
+        target: { value: '011' },
+      });
+
+      expect(onStopLossPriceChange).toHaveBeenCalledWith('44505');
+    });
+
     it('preserves an explicit positive SL RoE% input', () => {
       // +10% RoE at leverage=10: priceChange = 1% -> 45000 * 1.01 = 45450
       const onStopLossPriceChange = jest.fn();

--- a/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.test.tsx
+++ b/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.test.tsx
@@ -493,7 +493,7 @@ describe('AutoCloseSection', () => {
       expect(onTakeProfitPriceChange).toHaveBeenCalledWith('45450');
     });
 
-    it('updates price when RoE% is entered for SL (long)', () => {
+    it('defaults unsigned SL RoE% input to negative for long positions', () => {
       // -10% RoE at leverage=10: priceChange = -10/(10*100) = -1% -> 45000 * 0.99 = 44550
       // Negative RoE = loss direction = SL below entry for long
       const onStopLossPriceChange = jest.fn();
@@ -513,10 +513,35 @@ describe('AutoCloseSection', () => {
       const input = container.querySelector('input');
       expect(input).not.toBeNull();
       fireEvent.change(input as HTMLInputElement, {
-        target: { value: '-10' },
+        target: { value: '10' },
       });
 
       expect(onStopLossPriceChange).toHaveBeenCalledWith('44550');
+    });
+
+    it('preserves an explicit positive SL RoE% input', () => {
+      // +10% RoE at leverage=10: priceChange = 1% -> 45000 * 1.01 = 45450
+      const onStopLossPriceChange = jest.fn();
+      renderWithProvider(
+        <AutoCloseSection
+          {...defaultProps}
+          enabled={true}
+          direction="long"
+          currentPrice={45000}
+          leverage={10}
+          onStopLossPriceChange={onStopLossPriceChange}
+        />,
+        mockStore,
+      );
+
+      const container = screen.getByTestId('sl-percent-input');
+      const input = container.querySelector('input');
+      expect(input).not.toBeNull();
+      fireEvent.change(input as HTMLInputElement, {
+        target: { value: '+10' },
+      });
+
+      expect(onStopLossPriceChange).toHaveBeenCalledWith('45450');
     });
 
     it('uses limit price as baseline when typing SL % on a limit order', () => {
@@ -756,6 +781,42 @@ describe('AutoCloseSection', () => {
 
       expect(screen.getByTestId('sl-validation-error')).toHaveTextContent(
         /below.*current/iu,
+      );
+    });
+
+    it('shows SL liquidation error when long SL is below liquidation price', () => {
+      renderWithProvider(
+        <AutoCloseSection
+          {...defaultProps}
+          enabled={true}
+          direction="long"
+          currentPrice={50000}
+          liquidationPrice={45000}
+          stopLossPrice="44000"
+        />,
+        mockStore,
+      );
+
+      expect(screen.getByTestId('sl-validation-error')).toHaveTextContent(
+        /above.*liquidation/iu,
+      );
+    });
+
+    it('shows SL liquidation error when short SL is above liquidation price', () => {
+      renderWithProvider(
+        <AutoCloseSection
+          {...defaultProps}
+          enabled={true}
+          direction="short"
+          currentPrice={50000}
+          liquidationPrice={55000}
+          stopLossPrice="56000"
+        />,
+        mockStore,
+      );
+
+      expect(screen.getByTestId('sl-validation-error')).toHaveTextContent(
+        /below.*liquidation/iu,
       );
     });
 

--- a/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.tsx
+++ b/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.tsx
@@ -24,13 +24,19 @@ import { usePerpsOrderFees } from '../../../../../../hooks/perps/usePerpsOrderFe
 import { TextField, TextFieldSize } from '../../../../../component-library';
 import ToggleButton from '../../../../../ui/toggle-button';
 import type { AutoCloseSectionProps } from '../../order-entry.types';
-import { isSignedDecimalInput, isUnsignedDecimalInput } from '../../utils';
+import { isUnsignedDecimalInput } from '../../utils';
 import {
   isValidTakeProfitPrice,
   isValidStopLossPrice,
+  isStopLossSafeFromLiquidation,
   getTakeProfitErrorDirection,
   getStopLossErrorDirection,
+  getStopLossLiquidationErrorDirection,
 } from '../../../utils/tpslValidation';
+import {
+  applyDefaultStopLossSign,
+  isSignedDecimalInput,
+} from '../../../utils/tpslInput';
 import { formatRoePercent, getPnlDisplayColor } from '../../../utils';
 
 /**
@@ -56,6 +62,7 @@ import { formatRoePercent, getPnlDisplayColor } from '../../../utils';
  * @param props.estimatedSize - Signed position size in asset units for estimated PnL
  * @param props.orderType - Order type ('market' | 'limit') for choosing the validation reference price
  * @param props.limitPrice - Limit price string used as reference price for limit-order TP/SL validation
+ * @param props.liquidationPrice - Estimated liquidation price for stop-loss safety validation
  * @param props.leverage - Leverage multiplier for RoE% calculation
  * @param props.asset - Asset symbol for fetching dynamic closing fee rates
  */
@@ -72,6 +79,7 @@ export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
   estimatedSize,
   orderType,
   limitPrice,
+  liquidationPrice,
   leverage,
   asset,
 }) => {
@@ -249,7 +257,7 @@ export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
   // Handle SL percentage input change
   const handleSlPercentChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
-      const { value } = event.target;
+      const value = applyDefaultStopLossSign(event.target.value, rawSlPercent);
       if (value === '' || isSignedDecimalInput(value)) {
         setRawSlPercent(value);
         const numValue = parseFloat(value);
@@ -261,7 +269,7 @@ export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
         }
       }
     },
-    [onStopLossPriceChange, percentToPrice],
+    [onStopLossPriceChange, percentToPrice, rawSlPercent],
   );
 
   const handleSlPercentFocus = useCallback(() => {
@@ -363,6 +371,18 @@ export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
     [stopLossPrice, validationReferencePrice, direction],
   );
 
+  const isSlLiquidationInvalid = useMemo(
+    () =>
+      Boolean(
+        stopLossPrice.trim() &&
+          !isStopLossSafeFromLiquidation(stopLossPrice, {
+            liquidationPrice,
+            direction,
+          }),
+      ),
+    [stopLossPrice, liquidationPrice, direction],
+  );
+
   const tpErrorMessage = useMemo(() => {
     if (!isTpInvalid) {
       return null;
@@ -374,14 +394,20 @@ export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
   }, [isTpInvalid, direction, priceLabel, t]);
 
   const slErrorMessage = useMemo(() => {
-    if (!isSlInvalid) {
-      return null;
+    if (isSlInvalid) {
+      return t('perpsStopLossInvalidPrice', [
+        getStopLossErrorDirection(direction),
+        priceLabel,
+      ]);
     }
-    return t('perpsStopLossInvalidPrice', [
-      getStopLossErrorDirection(direction),
-      priceLabel,
-    ]);
-  }, [isSlInvalid, direction, priceLabel, t]);
+    if (isSlLiquidationInvalid) {
+      return t('perpsStopLossInvalidPrice', [
+        getStopLossLiquidationErrorDirection(direction),
+        'liquidation',
+      ]);
+    }
+    return null;
+  }, [isSlInvalid, isSlLiquidationInvalid, direction, priceLabel, t]);
 
   return (
     <Box flexDirection={BoxFlexDirection.Column} gap={3}>
@@ -462,7 +488,10 @@ export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
                   backgroundColor={BackgroundColor.backgroundMuted}
                   className="w-full"
                   data-testid="tp-percent-input"
-                  inputProps={{ textVariant: TextVariantLegacy.bodySm }}
+                  inputProps={{
+                    textVariant: TextVariantLegacy.bodySm,
+                    inputMode: 'decimal',
+                  }}
                   endAccessory={
                     <Text
                       variant={TextVariant.BodySm}
@@ -593,7 +622,10 @@ export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
                   backgroundColor={BackgroundColor.backgroundMuted}
                   className="w-full"
                   data-testid="sl-percent-input"
-                  inputProps={{ textVariant: TextVariantLegacy.bodySm }}
+                  inputProps={{
+                    textVariant: TextVariantLegacy.bodySm,
+                    inputMode: 'decimal',
+                  }}
                   endAccessory={
                     <Text
                       variant={TextVariant.BodySm}

--- a/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.tsx
+++ b/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.tsx
@@ -38,8 +38,6 @@ import {
 } from '../../../utils/tpslInput';
 import { formatRoePercent, getPnlDisplayColor } from '../../../utils';
 
-const INPUT_TEXT_VARIANT = 'body-sm';
-
 /**
  * AutoCloseSection - Collapsible section for Take Profit and Stop Loss configuration
  *
@@ -460,7 +458,6 @@ export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
                   className="w-full"
                   data-testid="tp-price-input"
                   inputProps={{
-                    textVariant: INPUT_TEXT_VARIANT,
                     inputMode: 'decimal',
                   }}
                   startAccessory={
@@ -489,7 +486,6 @@ export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
                   className="w-full"
                   data-testid="tp-percent-input"
                   inputProps={{
-                    textVariant: INPUT_TEXT_VARIANT,
                     inputMode: 'decimal',
                   }}
                   endAccessory={
@@ -594,7 +590,6 @@ export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
                   className="w-full"
                   data-testid="sl-price-input"
                   inputProps={{
-                    textVariant: INPUT_TEXT_VARIANT,
                     inputMode: 'decimal',
                   }}
                   startAccessory={
@@ -623,7 +618,6 @@ export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
                   className="w-full"
                   data-testid="sl-percent-input"
                   inputProps={{
-                    textVariant: INPUT_TEXT_VARIANT,
                     inputMode: 'decimal',
                   }}
                   endAccessory={

--- a/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.tsx
+++ b/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.tsx
@@ -401,9 +401,8 @@ export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
       ]);
     }
     if (isSlLiquidationInvalid) {
-      return t('perpsStopLossInvalidPrice', [
+      return t('perpsStopLossInvalidLiquidationPrice', [
         getStopLossLiquidationErrorDirection(direction),
-        'liquidation',
       ]);
     }
     return null;

--- a/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.tsx
+++ b/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.tsx
@@ -17,7 +17,6 @@ import {
 import {
   BorderRadius,
   BackgroundColor,
-  TextVariant as TextVariantLegacy,
 } from '../../../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../../../hooks/useI18nContext';
 import { usePerpsOrderFees } from '../../../../../../hooks/perps/usePerpsOrderFees';
@@ -38,6 +37,8 @@ import {
   isSignedDecimalInput,
 } from '../../../utils/tpslInput';
 import { formatRoePercent, getPnlDisplayColor } from '../../../utils';
+
+const INPUT_TEXT_VARIANT = 'body-sm';
 
 /**
  * AutoCloseSection - Collapsible section for Take Profit and Stop Loss configuration
@@ -459,7 +460,7 @@ export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
                   className="w-full"
                   data-testid="tp-price-input"
                   inputProps={{
-                    textVariant: TextVariantLegacy.bodySm,
+                    textVariant: INPUT_TEXT_VARIANT,
                     inputMode: 'decimal',
                   }}
                   startAccessory={
@@ -488,7 +489,7 @@ export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
                   className="w-full"
                   data-testid="tp-percent-input"
                   inputProps={{
-                    textVariant: TextVariantLegacy.bodySm,
+                    textVariant: INPUT_TEXT_VARIANT,
                     inputMode: 'decimal',
                   }}
                   endAccessory={
@@ -593,7 +594,7 @@ export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
                   className="w-full"
                   data-testid="sl-price-input"
                   inputProps={{
-                    textVariant: TextVariantLegacy.bodySm,
+                    textVariant: INPUT_TEXT_VARIANT,
                     inputMode: 'decimal',
                   }}
                   startAccessory={
@@ -622,7 +623,7 @@ export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
                   className="w-full"
                   data-testid="sl-percent-input"
                   inputProps={{
-                    textVariant: TextVariantLegacy.bodySm,
+                    textVariant: INPUT_TEXT_VARIANT,
                     inputMode: 'decimal',
                   }}
                   endAccessory={

--- a/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.tsx
+++ b/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.tsx
@@ -257,7 +257,7 @@ export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
   // Handle SL percentage input change
   const handleSlPercentChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
-      const value = applyDefaultStopLossSign(event.target.value, rawSlPercent);
+      const value = applyDefaultStopLossSign(event.target.value);
       if (value === '' || isSignedDecimalInput(value)) {
         setRawSlPercent(value);
         const numValue = parseFloat(value);
@@ -269,7 +269,7 @@ export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
         }
       }
     },
-    [onStopLossPriceChange, percentToPrice, rawSlPercent],
+    [onStopLossPriceChange, percentToPrice],
   );
 
   const handleSlPercentFocus = useCallback(() => {

--- a/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.tsx
+++ b/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.tsx
@@ -257,7 +257,7 @@ export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
   // Handle SL percentage input change
   const handleSlPercentChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
-      const value = applyDefaultStopLossSign(event.target.value);
+      const value = applyDefaultStopLossSign(event.target.value, rawSlPercent);
       if (value === '' || isSignedDecimalInput(value)) {
         setRawSlPercent(value);
         const numValue = parseFloat(value);
@@ -269,7 +269,7 @@ export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
         }
       }
     },
-    [onStopLossPriceChange, percentToPrice],
+    [onStopLossPriceChange, percentToPrice, rawSlPercent],
   );
 
   const handleSlPercentFocus = useCallback(() => {

--- a/ui/components/app/perps/order-entry/order-entry.tsx
+++ b/ui/components/app/perps/order-entry/order-entry.tsx
@@ -362,6 +362,7 @@ export const OrderEntry: React.FC<OrderEntryProps> = ({
             estimatedSize={estimatedSize}
             orderType={formState.type}
             limitPrice={formState.limitPrice}
+            liquidationPrice={calculations.liquidationPriceRaw}
             asset={asset}
           />
         )}

--- a/ui/components/app/perps/order-entry/order-entry.types.ts
+++ b/ui/components/app/perps/order-entry/order-entry.types.ts
@@ -232,6 +232,8 @@ export type AutoCloseSectionProps = {
   orderType?: OrderType;
   /** Limit price string – used as the reference price for limit-order TP/SL validation */
   limitPrice?: string;
+  /** Estimated liquidation price – used for stop-loss safety validation */
+  liquidationPrice?: number | null;
   /** Leverage multiplier - used to convert RoE % to price change % (RoE% = priceChange% * leverage) */
   leverage: number;
   /** Asset symbol (e.g. 'BTC', 'ETH') – used to fetch dynamic closing fee rates */

--- a/ui/components/app/perps/order-entry/utils.test.ts
+++ b/ui/components/app/perps/order-entry/utils.test.ts
@@ -1,7 +1,6 @@
 import {
   formatNumberForInput,
   isDigitsOnlyInput,
-  isSignedDecimalInput,
   isUnsignedDecimalInput,
 } from './utils';
 
@@ -54,32 +53,6 @@ describe('order-entry utils', () => {
       expect(isUnsignedDecimalInput('10..2')).toBe(false);
       expect(isUnsignedDecimalInput('1-0')).toBe(false);
       expect(isUnsignedDecimalInput('a10')).toBe(false);
-    });
-  });
-
-  describe('isSignedDecimalInput', () => {
-    it('accepts signed decimal typing states', () => {
-      expect(isSignedDecimalInput('')).toBe(true);
-      expect(isSignedDecimalInput('-')).toBe(true);
-      expect(isSignedDecimalInput('-.')).toBe(true);
-      expect(isSignedDecimalInput('.')).toBe(true);
-      expect(isSignedDecimalInput('-12.5')).toBe(true);
-      expect(isSignedDecimalInput('12.5')).toBe(true);
-    });
-
-    it('accepts + prefix and intermediate states', () => {
-      expect(isSignedDecimalInput('+')).toBe(true);
-      expect(isSignedDecimalInput('+.')).toBe(true);
-      expect(isSignedDecimalInput('+12.5')).toBe(true);
-      expect(isSignedDecimalInput('+15')).toBe(true);
-    });
-
-    it('rejects invalid signed decimal values', () => {
-      expect(isSignedDecimalInput('--1')).toBe(false);
-      expect(isSignedDecimalInput('-1-2')).toBe(false);
-      expect(isSignedDecimalInput('1.2.3')).toBe(false);
-      expect(isSignedDecimalInput('1a')).toBe(false);
-      expect(isSignedDecimalInput('++1')).toBe(false);
     });
   });
 });

--- a/ui/components/app/perps/order-entry/utils.ts
+++ b/ui/components/app/perps/order-entry/utils.ts
@@ -51,31 +51,3 @@ export const isUnsignedDecimalInput = (value: string): boolean => {
   }
   return true;
 };
-
-/**
- * Linear-time signed decimal validation with optional leading sign (+ or -) and
- * optional single decimal point. Accepts intermediate states like "-", "+", "-.", "+.".
- * @param value
- */
-export const isSignedDecimalInput = (value: string): boolean => {
-  let startIndex = 0;
-  if (value.startsWith('-') || value.startsWith('+')) {
-    startIndex = 1;
-  }
-
-  let seenDecimal = false;
-  for (let index = startIndex; index < value.length; index += 1) {
-    const char = value[index];
-    if (char === '.') {
-      if (seenDecimal) {
-        return false;
-      }
-      seenDecimal = true;
-      continue;
-    }
-    if (!isDigit(char)) {
-      return false;
-    }
-  }
-  return true;
-};

--- a/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.test.tsx
+++ b/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.test.tsx
@@ -578,6 +578,24 @@ describe('UpdateTPSLModalContent', () => {
       expect(blurredValue).toMatch(/^-?\d+(\.\d+)?$/u);
     });
 
+    it('normalizes leading-zero SL percent input before defaulting to negative', () => {
+      // SOL: entry=95, leverage=10. 011 normalizes to -11% signed RoE
+      // -> 95*(1-11/1000) = 93.955
+      renderTpslModalContent({ position: positionWithoutTPSL });
+
+      const slPercentInput = screen.getAllByPlaceholderText('0')[1];
+      fireEvent.focus(slPercentInput);
+      fireEvent.change(slPercentInput, { target: { value: '011' } });
+
+      expect((slPercentInput as HTMLInputElement).value).toBe('-11');
+
+      const slPriceInput = screen.getAllByPlaceholderText(
+        '0.00',
+      )[1] as HTMLInputElement;
+      const numValue = parseFloat(slPriceInput.value.replace(/,/gu, ''));
+      expect(numValue).toBeCloseTo(93.955, 0);
+    });
+
     it('rejects non-numeric characters in TP percent input', () => {
       renderTpslModalContent({ position: positionWithoutTPSL });
 

--- a/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.test.tsx
+++ b/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.test.tsx
@@ -378,6 +378,42 @@ describe('UpdateTPSLModalContent', () => {
     });
   });
 
+  describe('validation', () => {
+    it('shows a liquidation error and disables save when long SL is below liquidation price', () => {
+      renderTpslModalContent({
+        position: {
+          ...positionWithTPSL,
+          stopLossPrice: '2300',
+        },
+        currentPrice: 2900,
+      });
+
+      expect(screen.getByTestId('sl-validation-error')).toHaveTextContent(
+        /above.*liquidation/iu,
+      );
+      expect(
+        screen.getByTestId('perps-update-tpsl-modal-submit'),
+      ).toBeDisabled();
+    });
+
+    it('shows a liquidation error and disables save when short SL is above liquidation price', () => {
+      renderTpslModalContent({
+        position: {
+          ...mockPositions[1],
+          stopLossPrice: '49000',
+        },
+        currentPrice: 47000,
+      });
+
+      expect(screen.getByTestId('sl-validation-error')).toHaveTextContent(
+        /below.*liquidation/iu,
+      );
+      expect(
+        screen.getByTestId('perps-update-tpsl-modal-submit'),
+      ).toBeDisabled();
+    });
+  });
+
   describe('percent input (RoE%)', () => {
     it('updates TP price when a RoE% value is typed', () => {
       // ETH: entry=2850, leverage=3, +50% RoE -> 2850 * (1 + 50/300) = 2850 * 1.1667 = 3325
@@ -411,20 +447,36 @@ describe('UpdateTPSLModalContent', () => {
       expect(numValue).toBeCloseTo(2375, 0);
     });
 
-    it('updates SL price when a positive RoE% is typed (SL above entry)', () => {
+    it('updates SL price when an explicit positive RoE% is typed (SL above entry)', () => {
       // SOL: entry=95, leverage=10, +15% signed RoE -> 95 * (1 + 15/1000) = 95 * 1.015 = 96.425
       renderTpslModalContent({ position: positionWithoutTPSL });
 
       const percentInputs = screen.getAllByPlaceholderText('0');
       const slPercentInput = percentInputs[1];
       fireEvent.focus(slPercentInput);
-      fireEvent.change(slPercentInput, { target: { value: '15' } });
+      fireEvent.change(slPercentInput, { target: { value: '+15' } });
 
       const slPriceInput = screen.getAllByPlaceholderText(
         '0.00',
       )[1] as HTMLInputElement;
       const numValue = parseFloat(slPriceInput.value.replace(/,/gu, ''));
       expect(numValue).toBeCloseTo(96.425, 0);
+    });
+
+    it('defaults unsigned SL RoE% input to negative', () => {
+      // SOL: entry=95, leverage=10, defaulted -10% signed RoE -> 95 * 0.99 = 94.05
+      renderTpslModalContent({ position: positionWithoutTPSL });
+
+      const percentInputs = screen.getAllByPlaceholderText('0');
+      const slPercentInput = percentInputs[1];
+      fireEvent.focus(slPercentInput);
+      fireEvent.change(slPercentInput, { target: { value: '10' } });
+
+      const slPriceInput = screen.getAllByPlaceholderText(
+        '0.00',
+      )[1] as HTMLInputElement;
+      const numValue = parseFloat(slPriceInput.value.replace(/,/gu, ''));
+      expect(numValue).toBeCloseTo(94.05, 0);
     });
 
     it('clears TP price when percent input is cleared', () => {
@@ -515,9 +567,9 @@ describe('UpdateTPSLModalContent', () => {
 
       const slPercentInput = screen.getAllByPlaceholderText('0')[1];
       fireEvent.focus(slPercentInput);
-      fireEvent.change(slPercentInput, { target: { value: '10' } });
+      fireEvent.change(slPercentInput, { target: { value: '+10' } });
 
-      expect((slPercentInput as HTMLInputElement).value).toBe('10');
+      expect((slPercentInput as HTMLInputElement).value).toBe('+10');
 
       fireEvent.blur(slPercentInput);
 

--- a/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.tsx
+++ b/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.tsx
@@ -373,7 +373,7 @@ export const UpdateTPSLModalContent: React.FC<UpdateTPSLModalContentProps> = ({
 
   const handleSlPercentInputChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
-      const value = applyDefaultStopLossSign(event.target.value, rawSlPercent);
+      const value = applyDefaultStopLossSign(event.target.value);
       if (value === '' || isSignedDecimalInput(value)) {
         setRawSlPercent(value);
         setSlPresetPercent(null);
@@ -386,7 +386,7 @@ export const UpdateTPSLModalContent: React.FC<UpdateTPSLModalContentProps> = ({
         }
       }
     },
-    [percentToPriceForEdit, rawSlPercent],
+    [percentToPriceForEdit],
   );
 
   const handleSlPercentFocus = useCallback(() => {

--- a/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.tsx
+++ b/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.tsx
@@ -805,9 +805,8 @@ export const UpdateTPSLModalContent: React.FC<UpdateTPSLModalContentProps> = ({
                   getStopLossErrorDirection(positionDirection),
                   'current',
                 ])
-              : t('perpsStopLossInvalidPrice', [
+              : t('perpsStopLossInvalidLiquidationPrice', [
                   getStopLossLiquidationErrorDirection(positionDirection),
-                  'liquidation',
                 ])}
           </Text>
         )}

--- a/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.tsx
+++ b/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.tsx
@@ -53,9 +53,15 @@ import { PerpsGeoBlockModal } from '../perps-geo-block-modal';
 import {
   isValidTakeProfitPrice,
   isValidStopLossPrice,
+  isStopLossSafeFromLiquidation,
   getTakeProfitErrorDirection,
   getStopLossErrorDirection,
+  getStopLossLiquidationErrorDirection,
 } from '../utils/tpslValidation';
+import {
+  applyDefaultStopLossSign,
+  isSignedDecimalInput,
+} from '../utils/tpslInput';
 
 // RoE (Return on Equity) preset percentages - matching mobile
 const TP_PRESETS = [10, 25, 50, 100];
@@ -139,6 +145,16 @@ export const UpdateTPSLModalContent: React.FC<UpdateTPSLModalContentProps> = ({
     }
     return Number.parseFloat(position.size) >= 0 ? 'long' : 'short';
   }, [position]);
+
+  const liquidationPrice = useMemo(() => {
+    if (!position.liquidationPrice) {
+      return null;
+    }
+    const parsed = Number.parseFloat(
+      position.liquidationPrice.replaceAll(',', ''),
+    );
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+  }, [position.liquidationPrice]);
 
   // Presets populate the input with a raw numeric string (the `$` renders as a
   // sibling icon). Use PRICE_RANGES_UNIVERSAL so BTC collapses to no decimals
@@ -279,7 +295,19 @@ export const UpdateTPSLModalContent: React.FC<UpdateTPSLModalContentProps> = ({
     [editingSlPrice, currentPrice, positionDirection],
   );
 
-  const hasInvalidTPSL = isTpInvalid || isSlInvalid;
+  const isSlLiquidationInvalid = useMemo(
+    () =>
+      Boolean(
+        editingSlPrice.replaceAll(',', '').trim() &&
+          !isStopLossSafeFromLiquidation(editingSlPrice, {
+            liquidationPrice,
+            direction: positionDirection,
+          }),
+      ),
+    [editingSlPrice, liquidationPrice, positionDirection],
+  );
+
+  const hasInvalidTPSL = isTpInvalid || isSlInvalid || isSlLiquidationInvalid;
 
   useEffect(() => {
     return () => {
@@ -317,7 +345,7 @@ export const UpdateTPSLModalContent: React.FC<UpdateTPSLModalContentProps> = ({
   const handleTpPercentInputChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       const { value } = event.target;
-      if (value === '' || /^[+-]?\d*(?:\.\d*)?$/u.test(value)) {
+      if (value === '' || isSignedDecimalInput(value)) {
         setRawTpPercent(value);
         setTpPresetPercent(null);
         const numValue = Number.parseFloat(value);
@@ -345,8 +373,8 @@ export const UpdateTPSLModalContent: React.FC<UpdateTPSLModalContentProps> = ({
 
   const handleSlPercentInputChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
-      const { value } = event.target;
-      if (value === '' || /^[+-]?\d*(?:\.\d*)?$/u.test(value)) {
+      const value = applyDefaultStopLossSign(event.target.value, rawSlPercent);
+      if (value === '' || isSignedDecimalInput(value)) {
         setRawSlPercent(value);
         setSlPresetPercent(null);
         const numValue = Number.parseFloat(value);
@@ -358,7 +386,7 @@ export const UpdateTPSLModalContent: React.FC<UpdateTPSLModalContentProps> = ({
         }
       }
     },
-    [percentToPriceForEdit],
+    [percentToPriceForEdit, rawSlPercent],
   );
 
   const handleSlPercentFocus = useCallback(() => {
@@ -766,16 +794,21 @@ export const UpdateTPSLModalContent: React.FC<UpdateTPSLModalContentProps> = ({
             </Text>
           </Box>
         )}
-        {isSlInvalid && (
+        {(isSlInvalid || isSlLiquidationInvalid) && (
           <Text
             variant={TextVariant.BodyXs}
             color={TextColor.ErrorDefault}
             data-testid="sl-validation-error"
           >
-            {t('perpsStopLossInvalidPrice', [
-              getStopLossErrorDirection(positionDirection),
-              'current',
-            ])}
+            {isSlInvalid
+              ? t('perpsStopLossInvalidPrice', [
+                  getStopLossErrorDirection(positionDirection),
+                  'current',
+                ])
+              : t('perpsStopLossInvalidPrice', [
+                  getStopLossLiquidationErrorDirection(positionDirection),
+                  'liquidation',
+                ])}
           </Text>
         )}
       </Box>

--- a/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.tsx
+++ b/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.tsx
@@ -147,7 +147,7 @@ export const UpdateTPSLModalContent: React.FC<UpdateTPSLModalContentProps> = ({
   }, [position]);
 
   const liquidationPrice = useMemo(() => {
-    if (!position.liquidationPrice) {
+    if (!position?.liquidationPrice) {
       return null;
     }
     const parsed = Number.parseFloat(

--- a/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.tsx
+++ b/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.tsx
@@ -147,7 +147,7 @@ export const UpdateTPSLModalContent: React.FC<UpdateTPSLModalContentProps> = ({
   }, [position]);
 
   const liquidationPrice = useMemo(() => {
-    if (!position?.liquidationPrice) {
+    if (!position.liquidationPrice) {
       return null;
     }
     const parsed = Number.parseFloat(
@@ -298,7 +298,7 @@ export const UpdateTPSLModalContent: React.FC<UpdateTPSLModalContentProps> = ({
   const isSlLiquidationInvalid = useMemo(
     () =>
       Boolean(
-        editingSlPrice.replaceAll(',', '').trim() &&
+        editingSlPrice.trim() &&
           !isStopLossSafeFromLiquidation(editingSlPrice, {
             liquidationPrice,
             direction: positionDirection,
@@ -373,7 +373,7 @@ export const UpdateTPSLModalContent: React.FC<UpdateTPSLModalContentProps> = ({
 
   const handleSlPercentInputChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
-      const value = applyDefaultStopLossSign(event.target.value);
+      const value = applyDefaultStopLossSign(event.target.value, rawSlPercent);
       if (value === '' || isSignedDecimalInput(value)) {
         setRawSlPercent(value);
         setSlPresetPercent(null);
@@ -386,7 +386,7 @@ export const UpdateTPSLModalContent: React.FC<UpdateTPSLModalContentProps> = ({
         }
       }
     },
-    [percentToPriceForEdit],
+    [percentToPriceForEdit, rawSlPercent],
   );
 
   const handleSlPercentFocus = useCallback(() => {

--- a/ui/components/app/perps/utils/tpslInput.test.ts
+++ b/ui/components/app/perps/utils/tpslInput.test.ts
@@ -25,26 +25,32 @@ describe('tpslInput', () => {
   });
 
   describe('applyDefaultStopLossSign', () => {
-    it('prefixes an unsigned non-zero value when the field was empty', () => {
-      expect(applyDefaultStopLossSign('10', '')).toBe('-10');
-      expect(applyDefaultStopLossSign('0.5', '')).toBe('-0.5');
+    it('prefixes an unsigned positive value', () => {
+      expect(applyDefaultStopLossSign('10')).toBe('-10');
+      expect(applyDefaultStopLossSign('0.5')).toBe('-0.5');
     });
 
     it('preserves explicit signed values', () => {
-      expect(applyDefaultStopLossSign('-10', '')).toBe('-10');
-      expect(applyDefaultStopLossSign('+10', '')).toBe('+10');
+      expect(applyDefaultStopLossSign('-10')).toBe('-10');
+      expect(applyDefaultStopLossSign('+10')).toBe('+10');
+      expect(applyDefaultStopLossSign('-.')).toBe('-.');
+      expect(applyDefaultStopLossSign('+.')).toBe('+.');
     });
 
     it('does not prefix zero or intermediate decimal states', () => {
-      expect(applyDefaultStopLossSign('0', '')).toBe('0');
-      expect(applyDefaultStopLossSign('0.', '')).toBe('0.');
-      expect(applyDefaultStopLossSign('.', '')).toBe('.');
-      expect(applyDefaultStopLossSign('', '')).toBe('');
+      expect(applyDefaultStopLossSign('0')).toBe('0');
+      expect(applyDefaultStopLossSign('0.')).toBe('0.');
+      expect(applyDefaultStopLossSign('.')).toBe('.');
+      expect(applyDefaultStopLossSign('')).toBe('');
     });
 
-    it('does not coerce edits after input has content', () => {
-      expect(applyDefaultStopLossSign('10', '-')).toBe('10');
-      expect(applyDefaultStopLossSign('10', '-10')).toBe('10');
+    it('normalizes leading zeros before applying the default sign', () => {
+      expect(applyDefaultStopLossSign('00')).toBe('0');
+      expect(applyDefaultStopLossSign('01')).toBe('-1');
+      expect(applyDefaultStopLossSign('011')).toBe('-11');
+      expect(applyDefaultStopLossSign('.1')).toBe('-0.1');
+      expect(applyDefaultStopLossSign('+011')).toBe('+11');
+      expect(applyDefaultStopLossSign('-011')).toBe('-11');
     });
   });
 });

--- a/ui/components/app/perps/utils/tpslInput.test.ts
+++ b/ui/components/app/perps/utils/tpslInput.test.ts
@@ -25,32 +25,42 @@ describe('tpslInput', () => {
   });
 
   describe('applyDefaultStopLossSign', () => {
-    it('prefixes an unsigned positive value', () => {
-      expect(applyDefaultStopLossSign('10')).toBe('-10');
-      expect(applyDefaultStopLossSign('0.5')).toBe('-0.5');
+    it('prefixes an initial unsigned positive value', () => {
+      expect(applyDefaultStopLossSign('10', '')).toBe('-10');
+      expect(applyDefaultStopLossSign('0.5', '')).toBe('-0.5');
     });
 
     it('preserves explicit signed values', () => {
-      expect(applyDefaultStopLossSign('-10')).toBe('-10');
-      expect(applyDefaultStopLossSign('+10')).toBe('+10');
-      expect(applyDefaultStopLossSign('-.')).toBe('-.');
-      expect(applyDefaultStopLossSign('+.')).toBe('+.');
+      expect(applyDefaultStopLossSign('-10', '')).toBe('-10');
+      expect(applyDefaultStopLossSign('+10', '')).toBe('+10');
+      expect(applyDefaultStopLossSign('-.', '')).toBe('-.');
+      expect(applyDefaultStopLossSign('+.', '')).toBe('+.');
     });
 
     it('does not prefix zero or intermediate decimal states', () => {
-      expect(applyDefaultStopLossSign('0')).toBe('0');
-      expect(applyDefaultStopLossSign('0.')).toBe('0.');
-      expect(applyDefaultStopLossSign('.')).toBe('.');
-      expect(applyDefaultStopLossSign('')).toBe('');
+      expect(applyDefaultStopLossSign('0', '')).toBe('0');
+      expect(applyDefaultStopLossSign('0.', '')).toBe('0.');
+      expect(applyDefaultStopLossSign('.', '')).toBe('.');
+      expect(applyDefaultStopLossSign('', '')).toBe('');
     });
 
     it('normalizes leading zeros before applying the default sign', () => {
-      expect(applyDefaultStopLossSign('00')).toBe('0');
-      expect(applyDefaultStopLossSign('01')).toBe('-1');
-      expect(applyDefaultStopLossSign('011')).toBe('-11');
-      expect(applyDefaultStopLossSign('.1')).toBe('-0.1');
-      expect(applyDefaultStopLossSign('+011')).toBe('+11');
-      expect(applyDefaultStopLossSign('-011')).toBe('-11');
+      expect(applyDefaultStopLossSign('00', '')).toBe('0');
+      expect(applyDefaultStopLossSign('01', '')).toBe('-1');
+      expect(applyDefaultStopLossSign('011', '')).toBe('-11');
+      expect(applyDefaultStopLossSign('.1', '')).toBe('-0.1');
+      expect(applyDefaultStopLossSign('+011', '')).toBe('+11');
+      expect(applyDefaultStopLossSign('-011', '')).toBe('-11');
+    });
+
+    it('defaults to negative when appending to a zero-like value', () => {
+      expect(applyDefaultStopLossSign('01', '0')).toBe('-1');
+      expect(applyDefaultStopLossSign('0.1', '0.')).toBe('-0.1');
+    });
+
+    it('does not re-prefix when a user deletes the leading minus', () => {
+      expect(applyDefaultStopLossSign('1', '-1')).toBe('1');
+      expect(applyDefaultStopLossSign('10', '-10')).toBe('10');
     });
   });
 });

--- a/ui/components/app/perps/utils/tpslInput.test.ts
+++ b/ui/components/app/perps/utils/tpslInput.test.ts
@@ -1,0 +1,48 @@
+import { applyDefaultStopLossSign, isSignedDecimalInput } from './tpslInput';
+
+describe('tpslInput', () => {
+  describe('isSignedDecimalInput', () => {
+    it('accepts signed decimal input states', () => {
+      expect(isSignedDecimalInput('')).toBe(true);
+      expect(isSignedDecimalInput('-')).toBe(true);
+      expect(isSignedDecimalInput('-.')).toBe(true);
+      expect(isSignedDecimalInput('+')).toBe(true);
+      expect(isSignedDecimalInput('+.')).toBe(true);
+      expect(isSignedDecimalInput('-12.5')).toBe(true);
+      expect(isSignedDecimalInput('+12.5')).toBe(true);
+      expect(isSignedDecimalInput('12.5')).toBe(true);
+    });
+
+    it('rejects invalid signed decimal input states', () => {
+      expect(isSignedDecimalInput('--1')).toBe(false);
+      expect(isSignedDecimalInput('++1')).toBe(false);
+      expect(isSignedDecimalInput('-1-2')).toBe(false);
+      expect(isSignedDecimalInput('1.2.3')).toBe(false);
+      expect(isSignedDecimalInput('1a')).toBe(false);
+    });
+  });
+
+  describe('applyDefaultStopLossSign', () => {
+    it('prefixes an unsigned non-zero value when the field was empty', () => {
+      expect(applyDefaultStopLossSign('10', '')).toBe('-10');
+      expect(applyDefaultStopLossSign('0.5', '')).toBe('-0.5');
+    });
+
+    it('preserves explicit signed values', () => {
+      expect(applyDefaultStopLossSign('-10', '')).toBe('-10');
+      expect(applyDefaultStopLossSign('+10', '')).toBe('+10');
+    });
+
+    it('does not prefix zero or intermediate decimal states', () => {
+      expect(applyDefaultStopLossSign('0', '')).toBe('0');
+      expect(applyDefaultStopLossSign('0.', '')).toBe('0.');
+      expect(applyDefaultStopLossSign('.', '')).toBe('.');
+      expect(applyDefaultStopLossSign('', '')).toBe('');
+    });
+
+    it('does not coerce edits after input has content', () => {
+      expect(applyDefaultStopLossSign('10', '-')).toBe('10');
+      expect(applyDefaultStopLossSign('10', '-10')).toBe('10');
+    });
+  });
+});

--- a/ui/components/app/perps/utils/tpslInput.test.ts
+++ b/ui/components/app/perps/utils/tpslInput.test.ts
@@ -8,8 +8,10 @@ describe('tpslInput', () => {
       expect(isSignedDecimalInput('-.')).toBe(true);
       expect(isSignedDecimalInput('+')).toBe(true);
       expect(isSignedDecimalInput('+.')).toBe(true);
+      expect(isSignedDecimalInput('.')).toBe(true);
       expect(isSignedDecimalInput('-12.5')).toBe(true);
       expect(isSignedDecimalInput('+12.5')).toBe(true);
+      expect(isSignedDecimalInput('+15')).toBe(true);
       expect(isSignedDecimalInput('12.5')).toBe(true);
     });
 

--- a/ui/components/app/perps/utils/tpslInput.ts
+++ b/ui/components/app/perps/utils/tpslInput.ts
@@ -46,15 +46,26 @@ const normalizeLeadingZeros = (value: string): string => {
   return `${integerPart.replace(/^0+/u, '')}${decimalPart}`;
 };
 
+const isZeroLikeInput = (value: string): boolean => {
+  const unsignedValue =
+    value.startsWith('-') || value.startsWith('+') ? value.slice(1) : value;
+
+  return unsignedValue === '' || /^[0.]*$/u.test(unsignedValue);
+};
+
 /**
- * Defaults unsigned stop-loss percentage values to negative RoE and mirrors
- * mobile keypad leading-zero behavior. Positive SL RoE remains available only
- * through an explicit "+" sign, which can be intentional when a user is locking
- * in profit on an existing position.
+ * Defaults initial unsigned stop-loss percentage values to negative RoE and
+ * mirrors mobile keypad leading-zero behavior. Positive SL RoE remains
+ * available when a user edits an existing signed value or enters an explicit
+ * "+" sign, which can be intentional when locking in profit on a position.
  *
  * @param value - The next raw input value
+ * @param previousValue - The previous controlled input value
  */
-export const applyDefaultStopLossSign = (value: string): string => {
+export const applyDefaultStopLossSign = (
+  value: string,
+  previousValue: string,
+): string => {
   if (value === '') {
     return value;
   }
@@ -78,5 +89,7 @@ export const applyDefaultStopLossSign = (value: string): string => {
     return normalizedValue;
   }
 
-  return `-${normalizedValue}`;
+  return isZeroLikeInput(previousValue)
+    ? `-${normalizedValue}`
+    : normalizedValue;
 };

--- a/ui/components/app/perps/utils/tpslInput.ts
+++ b/ui/components/app/perps/utils/tpslInput.ts
@@ -29,32 +29,54 @@ export const isSignedDecimalInput = (value: string): boolean => {
   return true;
 };
 
+const normalizeLeadingZeros = (value: string): string => {
+  const decimalIndex = value.indexOf('.');
+  const integerPart =
+    decimalIndex === -1 ? value : value.slice(0, decimalIndex);
+  const decimalPart = decimalIndex === -1 ? '' : value.slice(decimalIndex);
+
+  if (integerPart === '') {
+    return decimalPart ? `0${decimalPart}` : value;
+  }
+
+  if (/^0+$/u.test(integerPart)) {
+    return decimalPart ? `0${decimalPart}` : '0';
+  }
+
+  return `${integerPart.replace(/^0+/u, '')}${decimalPart}`;
+};
+
 /**
- * Defaults an empty stop-loss percentage field to negative RoE when the user
- * starts with an unsigned, non-zero value. This mirrors mobile's keypad
- * convenience without coercing later edits; positive SL RoE can be intentional
- * when a user is locking in profit on an existing position.
+ * Defaults unsigned stop-loss percentage values to negative RoE and mirrors
+ * mobile keypad leading-zero behavior. Positive SL RoE remains available only
+ * through an explicit "+" sign, which can be intentional when a user is locking
+ * in profit on an existing position.
  *
  * @param value - The next raw input value
- * @param previousValue - The previous controlled input value
  */
-export const applyDefaultStopLossSign = (
-  value: string,
-  previousValue: string,
-): string => {
-  if (
-    previousValue ||
-    value === '' ||
-    value.startsWith('-') ||
-    value.startsWith('+')
-  ) {
+export const applyDefaultStopLossSign = (value: string): string => {
+  if (value === '') {
     return value;
   }
 
-  const numericValue = Number.parseFloat(value);
+  const sign = value.startsWith('-') || value.startsWith('+') ? value[0] : '';
+  const unsignedValue = sign ? value.slice(1) : value;
+
+  if (unsignedValue === '' || unsignedValue === '.') {
+    return value;
+  }
+
+  const normalizedValue = normalizeLeadingZeros(unsignedValue);
+  const signedValue = sign ? `${sign}${normalizedValue}` : normalizedValue;
+
+  if (sign) {
+    return signedValue;
+  }
+
+  const numericValue = Number.parseFloat(normalizedValue);
   if (!Number.isFinite(numericValue) || numericValue <= 0) {
-    return value;
+    return normalizedValue;
   }
 
-  return `-${value}`;
+  return `-${normalizedValue}`;
 };

--- a/ui/components/app/perps/utils/tpslInput.ts
+++ b/ui/components/app/perps/utils/tpslInput.ts
@@ -1,0 +1,60 @@
+const isDigit = (char: string): boolean => char >= '0' && char <= '9';
+
+/**
+ * Linear-time signed decimal validation with optional leading sign (+ or -) and
+ * optional single decimal point. Accepts intermediate states like "-", "+", "-.", "+.".
+ *
+ * @param value - The input value to validate
+ */
+export const isSignedDecimalInput = (value: string): boolean => {
+  let startIndex = 0;
+  if (value.startsWith('-') || value.startsWith('+')) {
+    startIndex = 1;
+  }
+
+  let seenDecimal = false;
+  for (let index = startIndex; index < value.length; index += 1) {
+    const char = value[index];
+    if (char === '.') {
+      if (seenDecimal) {
+        return false;
+      }
+      seenDecimal = true;
+      continue;
+    }
+    if (!isDigit(char)) {
+      return false;
+    }
+  }
+  return true;
+};
+
+/**
+ * Defaults an empty stop-loss percentage field to negative RoE when the user
+ * starts with an unsigned, non-zero value. This mirrors mobile's keypad
+ * convenience without coercing later edits; positive SL RoE can be intentional
+ * when a user is locking in profit on an existing position.
+ *
+ * @param value - The next raw input value
+ * @param previousValue - The previous controlled input value
+ */
+export const applyDefaultStopLossSign = (
+  value: string,
+  previousValue: string,
+): string => {
+  if (
+    previousValue ||
+    value === '' ||
+    value.startsWith('-') ||
+    value.startsWith('+')
+  ) {
+    return value;
+  }
+
+  const numericValue = Number.parseFloat(value);
+  if (!Number.isFinite(numericValue) || numericValue <= 0) {
+    return value;
+  }
+
+  return `-${value}`;
+};

--- a/ui/components/app/perps/utils/tpslValidation.test.ts
+++ b/ui/components/app/perps/utils/tpslValidation.test.ts
@@ -308,10 +308,10 @@ describe('tpslValidation', () => {
         ).toBe(true);
       });
 
-      it('handles formatted prices with commas and dollar signs', () => {
+      it('handles formatted stop loss prices with commas and dollar signs', () => {
         expect(
           isStopLossSafeFromLiquidation('$45,000', {
-            liquidationPrice: '$40,000',
+            liquidationPrice: 40000,
             direction: 'long',
           }),
         ).toBe(true);

--- a/ui/components/app/perps/utils/tpslValidation.test.ts
+++ b/ui/components/app/perps/utils/tpslValidation.test.ts
@@ -1,8 +1,10 @@
 import {
   isValidTakeProfitPrice,
   isValidStopLossPrice,
+  isStopLossSafeFromLiquidation,
   getTakeProfitErrorDirection,
   getStopLossErrorDirection,
+  getStopLossLiquidationErrorDirection,
 } from './tpslValidation';
 
 describe('tpslValidation', () => {
@@ -223,6 +225,111 @@ describe('tpslValidation', () => {
 
     it('returns empty string for undefined', () => {
       expect(getStopLossErrorDirection(undefined)).toBe('');
+    });
+  });
+
+  describe('isStopLossSafeFromLiquidation', () => {
+    describe('long direction', () => {
+      it('returns true when SL is above liquidation price', () => {
+        expect(
+          isStopLossSafeFromLiquidation('45000', {
+            liquidationPrice: 40000,
+            direction: 'long',
+          }),
+        ).toBe(true);
+      });
+
+      it('returns false when SL is below liquidation price', () => {
+        expect(
+          isStopLossSafeFromLiquidation('39000', {
+            liquidationPrice: 40000,
+            direction: 'long',
+          }),
+        ).toBe(false);
+      });
+
+      it('returns false when SL equals liquidation price', () => {
+        expect(
+          isStopLossSafeFromLiquidation('40000', {
+            liquidationPrice: 40000,
+            direction: 'long',
+          }),
+        ).toBe(false);
+      });
+    });
+
+    describe('short direction', () => {
+      it('returns true when SL is below liquidation price', () => {
+        expect(
+          isStopLossSafeFromLiquidation('45000', {
+            liquidationPrice: 50000,
+            direction: 'short',
+          }),
+        ).toBe(true);
+      });
+
+      it('returns false when SL is above liquidation price', () => {
+        expect(
+          isStopLossSafeFromLiquidation('51000', {
+            liquidationPrice: 50000,
+            direction: 'short',
+          }),
+        ).toBe(false);
+      });
+
+      it('returns false when SL equals liquidation price', () => {
+        expect(
+          isStopLossSafeFromLiquidation('50000', {
+            liquidationPrice: 50000,
+            direction: 'short',
+          }),
+        ).toBe(false);
+      });
+    });
+
+    describe('edge cases', () => {
+      it('returns true when inputs are incomplete', () => {
+        expect(
+          isStopLossSafeFromLiquidation('', {
+            liquidationPrice: 40000,
+            direction: 'long',
+          }),
+        ).toBe(true);
+        expect(
+          isStopLossSafeFromLiquidation('39000', {
+            liquidationPrice: null,
+            direction: 'long',
+          }),
+        ).toBe(true);
+        expect(
+          isStopLossSafeFromLiquidation('39000', {
+            liquidationPrice: 40000,
+          }),
+        ).toBe(true);
+      });
+
+      it('handles formatted prices with commas and dollar signs', () => {
+        expect(
+          isStopLossSafeFromLiquidation('$45,000', {
+            liquidationPrice: '$40,000',
+            direction: 'long',
+          }),
+        ).toBe(true);
+      });
+    });
+  });
+
+  describe('getStopLossLiquidationErrorDirection', () => {
+    it('returns "above" for long', () => {
+      expect(getStopLossLiquidationErrorDirection('long')).toBe('above');
+    });
+
+    it('returns "below" for short', () => {
+      expect(getStopLossLiquidationErrorDirection('short')).toBe('below');
+    });
+
+    it('returns empty string for undefined', () => {
+      expect(getStopLossLiquidationErrorDirection(undefined)).toBe('');
     });
   });
 });

--- a/ui/components/app/perps/utils/tpslValidation.ts
+++ b/ui/components/app/perps/utils/tpslValidation.ts
@@ -19,7 +19,7 @@ type ValidationParams = {
 };
 
 type LiquidationValidationParams = {
-  liquidationPrice?: number | string | null;
+  liquidationPrice?: number | null;
   direction?: Direction;
 };
 
@@ -103,18 +103,13 @@ export const isStopLossSafeFromLiquidation = (
   }
 
   const slPrice = parsePrice(price);
-  const liquidationPriceValue = parsePrice(liquidationPrice);
-  if (
-    Number.isNaN(slPrice) ||
-    Number.isNaN(liquidationPriceValue) ||
-    liquidationPriceValue <= 0
-  ) {
+  if (Number.isNaN(slPrice) || liquidationPrice <= 0) {
     return true;
   }
 
   return direction === 'long'
-    ? slPrice > liquidationPriceValue
-    : slPrice < liquidationPriceValue;
+    ? slPrice > liquidationPrice
+    : slPrice < liquidationPrice;
 };
 
 /**

--- a/ui/components/app/perps/utils/tpslValidation.ts
+++ b/ui/components/app/perps/utils/tpslValidation.ts
@@ -155,5 +155,5 @@ export const getStopLossLiquidationErrorDirection = (
   if (!direction) {
     return '';
   }
-  return direction === 'long' ? 'above' : 'below';
+  return getStopLossErrorDirection(direction === 'long' ? 'short' : 'long');
 };

--- a/ui/components/app/perps/utils/tpslValidation.ts
+++ b/ui/components/app/perps/utils/tpslValidation.ts
@@ -18,6 +18,21 @@ type ValidationParams = {
   direction?: Direction;
 };
 
+type LiquidationValidationParams = {
+  liquidationPrice?: number | string | null;
+  direction?: Direction;
+};
+
+const parsePrice = (price: string | number | null | undefined): number => {
+  if (typeof price === 'number') {
+    return price;
+  }
+  if (!price) {
+    return Number.NaN;
+  }
+  return Number.parseFloat(price.replaceAll(/[$,]/gu, ''));
+};
+
 /**
  * Validates if a take profit price is on the correct side of the reference price.
  * Returns `true` when the price is valid **or** when inputs are incomplete (empty/NaN).
@@ -35,7 +50,7 @@ export const isValidTakeProfitPrice = (
     return true;
   }
 
-  const tpPrice = Number.parseFloat(price.replaceAll(/[$,]/gu, ''));
+  const tpPrice = parsePrice(price);
   if (Number.isNaN(tpPrice)) {
     return true;
   }
@@ -60,12 +75,46 @@ export const isValidStopLossPrice = (
     return true;
   }
 
-  const slPrice = Number.parseFloat(price.replaceAll(/[$,]/gu, ''));
+  const slPrice = parsePrice(price);
   if (Number.isNaN(slPrice)) {
     return true;
   }
 
   return direction === 'long' ? slPrice < currentPrice : slPrice > currentPrice;
+};
+
+/**
+ * Validates if a stop loss price is safe relative to the liquidation price.
+ * For Long positions, stop loss must be above liquidation price.
+ * For Short positions, stop loss must be below liquidation price.
+ * Returns `true` when inputs are incomplete (empty/NaN).
+ *
+ * @param price - The stop loss price string (may include `$` / `,` formatting)
+ * @param params - Object with `liquidationPrice` and `direction`
+ * @param params.liquidationPrice
+ * @param params.direction
+ */
+export const isStopLossSafeFromLiquidation = (
+  price: string,
+  { liquidationPrice, direction }: LiquidationValidationParams,
+): boolean => {
+  if (!direction || !price || !liquidationPrice) {
+    return true;
+  }
+
+  const slPrice = parsePrice(price);
+  const liquidationPriceValue = parsePrice(liquidationPrice);
+  if (
+    Number.isNaN(slPrice) ||
+    Number.isNaN(liquidationPriceValue) ||
+    liquidationPriceValue <= 0
+  ) {
+    return true;
+  }
+
+  return direction === 'long'
+    ? slPrice > liquidationPriceValue
+    : slPrice < liquidationPriceValue;
 };
 
 /**
@@ -92,4 +141,19 @@ export const getStopLossErrorDirection = (direction?: Direction): string => {
     return '';
   }
   return direction === 'long' ? 'below' : 'above';
+};
+
+/**
+ * Returns the directional word for a stop-loss liquidation validation error.
+ * Long SL must be "above"; Short SL must be "below".
+ *
+ * @param direction - Position direction
+ */
+export const getStopLossLiquidationErrorDirection = (
+  direction?: Direction,
+): string => {
+  if (!direction) {
+    return '';
+  }
+  return direction === 'long' ? 'above' : 'below';
 };

--- a/ui/pages/perps/perps-order-entry-page.test.tsx
+++ b/ui/pages/perps/perps-order-entry-page.test.tsx
@@ -798,6 +798,59 @@ describe('PerpsOrderEntryPage', () => {
         expect(screen.getByTestId('submit-order-button')).toBeDisabled();
       });
     });
+
+    it('disables submit when long auto-close stop loss is below liquidation price', async () => {
+      const store = mockStore(createMockState());
+      renderWithProvider(<PerpsOrderEntryPage />, store);
+
+      const amountContainer = screen.getByTestId('amount-input-field');
+      const amountInput = amountContainer.querySelector('input');
+      fireEvent.change(amountInput as HTMLInputElement, {
+        target: { value: '100' },
+      });
+
+      fireEvent.click(screen.getByTestId('auto-close-toggle'));
+
+      const slContainer = screen.getByTestId('sl-price-input');
+      const slInput = slContainer.querySelector('input');
+      fireEvent.change(slInput as HTMLInputElement, {
+        target: { value: '1' },
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('submit-order-button')).toBeDisabled();
+      });
+      expect(screen.getByTestId('sl-validation-error')).toHaveTextContent(
+        /above.*liquidation/iu,
+      );
+    });
+
+    it('disables submit when short auto-close stop loss is above liquidation price', async () => {
+      mockSearchParams.set('direction', 'short');
+      const store = mockStore(createMockState());
+      renderWithProvider(<PerpsOrderEntryPage />, store);
+
+      const amountContainer = screen.getByTestId('amount-input-field');
+      const amountInput = amountContainer.querySelector('input');
+      fireEvent.change(amountInput as HTMLInputElement, {
+        target: { value: '100' },
+      });
+
+      fireEvent.click(screen.getByTestId('auto-close-toggle'));
+
+      const slContainer = screen.getByTestId('sl-price-input');
+      const slInput = slContainer.querySelector('input');
+      fireEvent.change(slInput as HTMLInputElement, {
+        target: { value: '99999' },
+      });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('submit-order-button')).toBeDisabled();
+      });
+      expect(screen.getByTestId('sl-validation-error')).toHaveTextContent(
+        /below.*liquidation/iu,
+      );
+    });
   });
 
   describe('analytics tracking', () => {

--- a/ui/pages/perps/perps-order-entry-page.tsx
+++ b/ui/pages/perps/perps-order-entry-page.tsx
@@ -506,7 +506,8 @@ const PerpsOrderEntryPage: React.FC = () => {
 
   const hasInvalidTPSL = useMemo(() => {
     // In modify mode the TP/SL section is hidden and values carry over untouched,
-    // so stale prices that crossed the current market should not block submission.
+    // so stale prices that crossed the current market or liquidation price should
+    // not block submission. TP/SL edits are validated in the dedicated modal.
     if (!orderFormState?.autoCloseEnabled || orderMode === 'modify') {
       return false;
     }
@@ -524,6 +525,7 @@ const PerpsOrderEntryPage: React.FC = () => {
     const tp = orderFormState.takeProfitPrice;
     const sl = orderFormState.stopLossPrice;
     const dir = orderFormState.direction;
+    const liquidationPrice = orderCalculations?.liquidationPriceRaw;
 
     const tpInvalid = Boolean(
       tp?.trim() &&
@@ -542,13 +544,19 @@ const PerpsOrderEntryPage: React.FC = () => {
     const slLiquidationInvalid = Boolean(
       sl?.trim() &&
         !isStopLossSafeFromLiquidation(sl, {
-          liquidationPrice: orderCalculations?.liquidationPriceRaw,
+          liquidationPrice,
           direction: dir,
         }),
     );
 
     return tpInvalid || slInvalid || slLiquidationInvalid;
-  }, [orderFormState, orderType, currentPrice, orderMode, orderCalculations]);
+  }, [
+    orderFormState,
+    orderType,
+    currentPrice,
+    orderMode,
+    orderCalculations?.liquidationPriceRaw,
+  ]);
 
   const isInsufficientFunds = useMemo(() => {
     if (!orderFormState || orderMode === 'close') {

--- a/ui/pages/perps/perps-order-entry-page.tsx
+++ b/ui/pages/perps/perps-order-entry-page.tsx
@@ -98,6 +98,7 @@ import {
 import {
   isValidTakeProfitPrice,
   isValidStopLossPrice,
+  isStopLossSafeFromLiquidation,
 } from '../../components/app/perps/utils/tpslValidation';
 import { PerpsDetailPageSkeleton } from '../../components/app/perps/perps-skeletons';
 import {
@@ -538,9 +539,16 @@ const PerpsOrderEntryPage: React.FC = () => {
           direction: dir,
         }),
     );
+    const slLiquidationInvalid = Boolean(
+      sl?.trim() &&
+        !isStopLossSafeFromLiquidation(sl, {
+          liquidationPrice: orderCalculations?.liquidationPriceRaw,
+          direction: dir,
+        }),
+    );
 
-    return tpInvalid || slInvalid;
-  }, [orderFormState, orderType, currentPrice, orderMode]);
+    return tpInvalid || slInvalid || slLiquidationInvalid;
+  }, [orderFormState, orderType, currentPrice, orderMode, orderCalculations]);
 
   const isInsufficientFunds = useMemo(() => {
     if (!orderFormState || orderMode === 'close') {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

The perps stop-loss percentage input in extension already allowed signed values like `-10`, but users had to manually type the minus sign. MetaMask Mobile defaults stop-loss percentage entry to negative RoE, which better matches the common stop-loss flow and reduces the chance of misentering a stop-loss percentage as profit direction.

## Behavior Summary

  - Initial unsigned SL percentage entry now defaults to negative RoE, so `10` becomes `-10`.
  - Leading-zero SL percentage values normalize immediately, so `011` becomes `-11`, matching mobile-style keypad behavior.
  - Zero remains neutral: `0` does not become `-0`.
  - Users can still intentionally enter positive-RoE stop losses with `+10`, or by editing an existing signed value, as long as the resulting trigger price passes current/entry-side and liquidation-safety validation.
  - Stop-loss liquidation safety validation now blocks unsafe SL trigger prices in both the order form and update TP/SL modal.

## Problem

The extension flow was technically valid, but easier to misenter. Typing `10` into the stop-loss percentage field produced a positive RoE stop unless the user manually added `-`. Typing values with leading zeros, such as `011`, could also remain unsigned during entry and only normalize formatting after blur, which diverged from MetaMask Mobile’s stop-loss percentage behavior.

The stop-loss validation also did not consistently prevent stop-loss trigger prices that would be unsafe relative to liquidation. The update TP/SL modal now blocks these values, and the order form submit button now matches the visible liquidation validation error.

One margin calculation test also still asserted against the fallback balance field after the implementation moved to tradeable balance.

## Solution

This change adds mobile-aligned defaulting for stop-loss percentage input while preserving desktop editability. Initial unsigned SL percentages like `10`, `0.5`, and `011` are treated as `-10`, `-0.5`, and `-11`. Explicit signed values like `+10` and `-10` are preserved, and deleting the leading `-` from an existing value is respected so the input does not fight direct text edits.

The PR also consolidates signed TP/SL input validation into a shared helper, removes the old duplicate signed-decimal helper from order-entry utilities, adds stop-loss liquidation safety validation with a dedicated translatable error message, blocks unsafe SL values at submit time, and updates tests to cover the intended tradeable-balance and TP/SL input paths.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updated perps stop-loss inputs to default initial unsigned percentages to negative RoE, normalize leading-zero values, preserve intentional positive edits, and block liquidation-unsafe stop-loss trigger prices.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2979

## **Manual testing steps**

1. Open the perps order form and choose a market with an available liquidation price context.
2. In the stop-loss percentage field, type 10.
  - Expected: the field becomes -10.
  - Expected: the stop-loss price updates below entry/current price for a long, or above entry/current
    price for a short.
3. Clear the stop-loss percentage field and type 011.
  - Expected: the field becomes -11.
  - Expected: the calculated stop-loss price uses -11% RoE, not positive 11%.
4. Clear the field and type 0.
  - Expected: the value remains 0.
  - Expected: no negative sign is added for zero.
5. Clear the field and type 0.5.
    - Expected: the field becomes -0.5.
6. Clear the field and type +10.
  - Expected: the field remains +10.
  - Expected: the stop-loss price calculates as positive RoE, supporting intentional profit-locking stops.
7. In the edit TP/SL modal for an existing perps position, repeat the same stop-loss percentage checks:
  - 10 becomes -10
  - 011 becomes -11
  - 0 remains 0
  - +10 remains +10
8. Test liquidation validation:
  - For a long position/order, enter a stop-loss price at or below the liquidation price.
  - Expected: a stop-loss liquidation validation error is shown.
  - For a short position/order, enter a stop-loss price at or above the liquidation price.
  - Expected: the same validation error is shown.
  - For liquidation validation, also expect the submit/save action to be disabled.
9. Confirm normal valid TP/SL behavior still works:
  - Enter valid take-profit and stop-loss prices.
  - Expected: no validation errors.
  - Expected: submit/create/update action remains enabled when all other required fields are valid.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->



https://github.com/user-attachments/assets/98b7d6cb-4e7d-4a42-882a-368d59170f4e





## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches perps order-entry and TP/SL validation logic, which can affect whether orders can be submitted and how stop-loss prices are computed. Changes are well-covered by new unit/integration tests but still warrant careful UX/edge-case review.
> 
> **Overview**
> Aligns perps stop-loss RoE% input with mobile by defaulting the *first unsigned* SL percent entry to negative (e.g., `10`→`-10`), normalizing leading zeros (e.g., `011`→`-11`), and still allowing explicit positive values via `+`.
> 
> Adds liquidation-safety validation for stop-loss prices (new `perpsStopLossInvalidLiquidationPrice` i18n message and `isStopLossSafeFromLiquidation` checks) and wires it into the order-entry auto-close section, the update TP/SL modal (disabling save), and the order-entry page submit gating. Signed-decimal parsing/validation is consolidated into new shared `tpslInput` utilities, removing the older `isSignedDecimalInput` from order-entry utils, and tests are expanded accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da8dd8e92b9a90dff4f2b4d568e113d9ceb773da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->