### PR TITLE
fix: NFTs in Send flow overlapping

### DIFF
--- a/ui/pages/confirmations/components/UI/asset/asset.test.tsx
+++ b/ui/pages/confirmations/components/UI/asset/asset.test.tsx
@@ -200,4 +200,22 @@ describe('NFTAsset', () => {
 
     expect(getByText('Native SegWit')).toBeInTheDocument();
   });
+
+  it('renders fallback when both image and collection imageUrl are missing', () => {
+    mockUseNftImageUrl.mockReturnValue('');
+    const assetWithoutImages = {
+      ...mockNFTERC721Asset,
+      image: undefined,
+      collection: {
+        name: 'Test Collection',
+        imageUrl: undefined,
+      },
+    };
+    const { getByTestId } = render(<Asset asset={assetWithoutImages} />);
+
+    expect(getByTestId('nft-asset')).toBeInTheDocument();
+    // Verify that the AvatarToken fallback is rendered instead of null
+    const avatarToken = getByTestId('nft-asset').querySelector('.mm-avatar-token');
+    expect(avatarToken).toBeInTheDocument();
+  });
 });

--- a/ui/pages/confirmations/components/UI/asset/asset.tsx
+++ b/ui/pages/confirmations/components/UI/asset/asset.tsx
@@ -90,7 +90,14 @@ const NftAsset = ({ asset, onClick, isSelected }: AssetProps) => {
                 objectFit: 'cover',
               }}
             />
-          ) : null}
+          ) : (
+            <AvatarToken
+              size={AvatarTokenSize.Md}
+              src=""
+              name={name || collection?.name || '?'}
+              showHalo={false}
+            />
+          )}
         </BadgeWrapper>
       </Box>
       <Box


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Perfect! I have successfully implemented the fix for the NFT overlapping issue. Here's the summary:



The fix addresses the core issue by ensuring NFTs always render something with consistent dimensions, preventing the virtual list layout breaking that caused overlapping. The `AvatarToken` component provides a robust fallback system that displays the first character of the NFT name or collection name, or '?' if neither is available, maintaining the expected 32x32 pixel size that fits within the 70px item height expectation.

## **Changelog**

CHANGELOG entry: Fixed perfect! I have successfully implemented the fix for the NFT overlapping issue. Here's the summary:



The fix addresses the core issue by ensuring NFTs always render something with consistent dimensions, preventing the virtual list layout breaking that caused overlapping. The `AvatarToken` component provides a robust fallback system that displays the first character of the NFT name or collection name, or '?' if neither is available, maintaining the expected 32x32 pixel size that fits within the 70px item height expectation

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/40669

## **Manual testing steps**

1. Hold at least two NFTs, with at least one missing a generated image in the NFTs tab.
2. Click Send.
3. Scroll down to the NFTs section.
4. Notice the NFTs are overlapping in the Send flow.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.