### PR TITLE
fix(assets): remove NFT description placeholder fallback

### DIFF
--- a/ui/components/app/assets/nfts/nft-details/__snapshots__/nft-details.test.js.snap
+++ b/ui/components/app/assets/nfts/nft-details/__snapshots__/nft-details.test.js.snap
@@ -99,17 +99,6 @@ exports[`NFT Details should match minimal props and state snapshot 1`] = `
             </h4>
           </div>
           <div
-            class="mm-box mm-box--margin-top-2"
-          >
-            <p
-              class="mm-box mm-text mm-text--body-md mm-text--font-weight-medium mm-box--color-text-alternative"
-              data-testid="nft-details__description"
-              style="display: -webkit-box; overflow: hidden;"
-            >
-              At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio.
-            </p>
-          </div>
-          <div
             class="mm-box mm-box--margin-top-4 mm-box--margin-bottom-4 mm-box--display-flex mm-box--gap-4 mm-box--flex-wrap-wrap"
           />
           <div

--- a/ui/components/app/assets/nfts/nft-details/nft-detail-description.tsx
+++ b/ui/components/app/assets/nfts/nft-details/nft-detail-description.tsx
@@ -18,10 +18,9 @@ const NftDetailDescription = ({ value }: { value: string | null }) => {
   const { contentRef, isOverflowing } = useIsOverflowing();
   const [isOpen, setIsOpen] = useState(false);
 
-  // TEMPORARY MOCK - Remove this before committing
-  const mockDescription =
-    'At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio.';
-  const displayValue = value || mockDescription;
+  if (!value) {
+    return null;
+  }
 
   const shouldDisplayButton = isOverflowing;
 
@@ -46,7 +45,7 @@ const NftDetailDescription = ({ value }: { value: string | null }) => {
             overflow: 'hidden',
           }}
         >
-          {displayValue}
+          {value}
         </Text>
       </Box>
       {shouldDisplayButton && (

--- a/ui/components/app/assets/nfts/nft-details/nft-details.test.js
+++ b/ui/components/app/assets/nfts/nft-details/nft-details.test.js
@@ -84,6 +84,15 @@ describe('NFT Details', () => {
     });
   });
 
+  it('does not render description when nft description is missing', () => {
+    const { queryByTestId } = renderWithProvider(
+      <NftDetails {...props} />,
+      mockStore,
+    );
+
+    expect(queryByTestId('nft-details__description')).not.toBeInTheDocument();
+  });
+
   it(`should route to '/' route when the back button is clicked`, () => {
     const { queryByTestId } = renderWithProvider(
       <NftDetails {...props} />,

--- a/ui/components/app/assets/nfts/nft-details/nft-details.test.js
+++ b/ui/components/app/assets/nfts/nft-details/nft-details.test.js
@@ -74,23 +74,15 @@ describe('NFT Details', () => {
     );
     shortenAddress.mockReturnValue('0xDc738...06414');
 
-    const { container } = renderWithProvider(
+    const { container, queryByTestId } = renderWithProvider(
       <NftDetails {...props} nftChainId={CHAIN_IDS.GOERLI} />,
       mockStore,
     );
 
     await waitFor(() => {
       expect(container).toMatchSnapshot();
+      expect(queryByTestId('nft-details__description')).not.toBeInTheDocument();
     });
-  });
-
-  it('does not render description when nft description is missing', () => {
-    const { queryByTestId } = renderWithProvider(
-      <NftDetails {...props} />,
-      mockStore,
-    );
-
-    expect(queryByTestId('nft-details__description')).not.toBeInTheDocument();
   });
 
   it(`should route to '/' route when the back button is clicked`, () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

This PR fixes a regression introduced by #39504 where NFT details could display placeholder Latin text when a description is missing.

- Removes the temporary mock description fallback from `nft-detail-description.tsx`
- Returns `null` when an NFT has no description instead of rendering fallback content
- Updates `nft-details` test coverage and snapshot to verify that no description block renders for null descriptions

## **Changelog**

CHANGELOG entry: Fixed a bug where NFT details showed placeholder description text when no description metadata was available.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/pull/39504 https://consensyssoftware.atlassian.net/browse/ASSETS-3132
Related: https://consensyssoftware.atlassian.net/browse/MDP-661

## **Manual testing steps**

1. Open NFT details for an NFT with `description: null`.
2. Confirm no description block or placeholder text appears.
3. Open NFT details for an NFT with a real description.
4. Confirm description still renders and expands/collapses via Show More/Show Less.

## **Screenshots/Recordings**

### **Before**

<img width="439" height="571" alt="Screenshot 2026-04-29 at 11 33 36" src="https://github.com/user-attachments/assets/17fedadf-2ca1-4716-9fad-ca74cb018335" />


### **After**

<img width="446" height="544" alt="Screenshot 2026-04-29 at 11 35 08" src="https://github.com/user-attachments/assets/9fd24653-b033-4f69-a320-215b4c74dab5" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-603fc302-426e-46cb-8a51-496c3a4627f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-603fc302-426e-46cb-8a51-496c3a4627f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

