### PR TITLE
fix: trezor preflight device check cp-13.29.0

### DIFF
--- a/ui/contexts/hardware-wallets/adapters/TrezorAdapter.test.ts
+++ b/ui/contexts/hardware-wallets/adapters/TrezorAdapter.test.ts
@@ -1,11 +1,7 @@
 import { ErrorCode, HardwareWalletError } from '@metamask/hw-wallet-sdk';
 import { DeviceEvent, type HardwareWalletAdapterOptions } from '../types';
 import * as webConnectionUtils from '../webConnectionUtils';
-import {
-  getMissingCapabilities,
-  isTrezorModelOne,
-  isTrezorModelUsingTrezorSuite,
-} from './trezorUtils';
+import { getMissingCapabilities, isTrezorModelOne } from './trezorUtils';
 import { TrezorAdapter } from './TrezorAdapter';
 
 jest.mock('../webConnectionUtils', () => ({
@@ -246,21 +242,6 @@ describe('TrezorAdapter', () => {
 });
 
 describe('trezorUtils', () => {
-  describe('isTrezorModelUsingTrezorSuite', () => {
-    it('returns true for safe 7', () => {
-      expect(isTrezorModelUsingTrezorSuite('safe 7')).toBe(true);
-    });
-
-    it('returns true for Safe 7 (case insensitive)', () => {
-      expect(isTrezorModelUsingTrezorSuite('Safe 7')).toBe(true);
-    });
-
-    it('returns false for other models', () => {
-      expect(isTrezorModelUsingTrezorSuite('T')).toBe(false);
-      expect(isTrezorModelUsingTrezorSuite('1')).toBe(false);
-    });
-  });
-
   describe('getMissingCapabilities', () => {
     it('returns empty array when all capabilities are present', () => {
       expect(

--- a/ui/contexts/hardware-wallets/adapters/TrezorAdapter.test.ts
+++ b/ui/contexts/hardware-wallets/adapters/TrezorAdapter.test.ts
@@ -1,10 +1,4 @@
-import {
-  Category,
-  ErrorCode,
-  HardwareWalletError,
-  Severity,
-} from '@metamask/hw-wallet-sdk';
-import { getTrezorFeatures } from '../../../store/actions';
+import { ErrorCode, HardwareWalletError } from '@metamask/hw-wallet-sdk';
 import { DeviceEvent, type HardwareWalletAdapterOptions } from '../types';
 import * as webConnectionUtils from '../webConnectionUtils';
 import {
@@ -14,19 +8,12 @@ import {
 } from './trezorUtils';
 import { TrezorAdapter } from './TrezorAdapter';
 
-jest.mock('../../../store/actions', () => ({
-  getTrezorFeatures: jest.fn(),
-}));
-
 jest.mock('../webConnectionUtils', () => ({
   ...jest.requireActual('../webConnectionUtils'),
   getConnectedTrezorDevices: jest.fn(),
   isWebUsbAvailable: jest.fn(),
 }));
 
-const mockGetTrezorFeatures = getTrezorFeatures as jest.MockedFunction<
-  typeof getTrezorFeatures
->;
 const mockGetConnectedTrezorDevices =
   webConnectionUtils.getConnectedTrezorDevices as jest.MockedFunction<
     typeof webConnectionUtils.getConnectedTrezorDevices
@@ -35,33 +22,6 @@ const mockIsWebUsbAvailable =
   webConnectionUtils.isWebUsbAvailable as jest.MockedFunction<
     typeof webConnectionUtils.isWebUsbAvailable
   >;
-
-type TrezorFeaturesPayload = {
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  session_id: string | null;
-  model: string;
-  initialized: boolean;
-  capabilities: string[];
-  unlocked: boolean;
-};
-
-const createMockFeaturesResponse = (
-  payload: Partial<TrezorFeaturesPayload> = {},
-) => ({
-  payload: {
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    session_id: 'session-id',
-    model: 'T',
-    initialized: true,
-    capabilities: [
-      'Capability_Bitcoin',
-      'Capability_Solana',
-      'Capability_Ethereum',
-    ],
-    unlocked: true,
-    ...payload,
-  },
-});
 
 describe('TrezorAdapter', () => {
   let adapter: TrezorAdapter;
@@ -88,7 +48,6 @@ describe('TrezorAdapter', () => {
       .mockImplementation(() => undefined);
     mockIsWebUsbAvailable.mockReturnValue(true);
     mockGetConnectedTrezorDevices.mockResolvedValue([{} as USBDevice]);
-    mockGetTrezorFeatures.mockResolvedValue(createMockFeaturesResponse());
 
     adapter = new TrezorAdapter(mockOptions);
   });
@@ -213,187 +172,73 @@ describe('TrezorAdapter', () => {
       expect(result).toBe(true);
       expect(adapter.isConnected()).toBe(true);
       expect(mockGetConnectedTrezorDevices).toHaveBeenCalled();
-      expect(mockGetTrezorFeatures).toHaveBeenCalled();
     });
 
-    it('allows null session for models that use Trezor Suite', async () => {
-      mockGetTrezorFeatures.mockResolvedValue(
-        createMockFeaturesResponse({
-          model: 'safe 7',
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          session_id: null,
-        }),
-      );
+    it('returns true without reconnecting when already connected', async () => {
+      await adapter.connect();
+      mockGetConnectedTrezorDevices.mockClear();
 
-      await expect(adapter.ensureDeviceReady()).resolves.toBe(true);
+      const result = await adapter.ensureDeviceReady();
+
+      expect(result).toBe(true);
+      expect(mockGetConnectedTrezorDevices).not.toHaveBeenCalled();
     });
+  });
 
-    it('throws AuthenticationDeviceLocked when device is locked', async () => {
-      mockGetTrezorFeatures.mockResolvedValue(
-        createMockFeaturesResponse({
-          unlocked: false,
-        }),
-      );
+  describe('validateCapabilities', () => {
+    it('throws DeviceMissingCapability when a required capability is missing', () => {
+      expect(() =>
+        adapter.validateCapabilities(
+          ['Capability_Bitcoin', 'Capability_Ethereum'],
+          'T',
+        ),
+      ).toThrow(HardwareWalletError);
 
-      await expect(adapter.ensureDeviceReady()).rejects.toMatchObject({
-        code: ErrorCode.AuthenticationDeviceLocked,
-      });
-
-      expect(mockOptions.onDeviceEvent).toHaveBeenCalledWith(
+      expect(() =>
+        adapter.validateCapabilities(
+          ['Capability_Bitcoin', 'Capability_Ethereum'],
+          'T',
+        ),
+      ).toThrow(
         expect.objectContaining({
-          event: DeviceEvent.DeviceLocked,
-          error: expect.objectContaining({
-            code: ErrorCode.AuthenticationDeviceLocked,
+          code: ErrorCode.DeviceMissingCapability,
+          metadata: expect.objectContaining({
+            missingCapabilities: ['Capability_Solana'],
           }),
         }),
       );
     });
 
-    it('allows locked Model One because it unlocks during transaction signing', async () => {
-      mockGetTrezorFeatures.mockResolvedValue(
-        createMockFeaturesResponse({
-          model: 'T1B1',
-          unlocked: false,
-        }),
-      );
+    it('allows Model One when only Solana capability is missing', () => {
+      expect(() =>
+        adapter.validateCapabilities(
+          ['Capability_Bitcoin', 'Capability_Ethereum'],
+          'Trezor Model One',
+        ),
+      ).not.toThrow();
+    });
 
-      await expect(adapter.ensureDeviceReady()).resolves.toBe(true);
-      expect(mockOptions.onDeviceEvent).not.toHaveBeenCalledWith(
+    it('throws DeviceMissingCapability when Model One is missing a supported capability', () => {
+      expect(() =>
+        adapter.validateCapabilities(['Capability_Bitcoin'], 'T1B1'),
+      ).toThrow(
         expect.objectContaining({
-          event: DeviceEvent.DeviceLocked,
+          code: ErrorCode.DeviceMissingCapability,
+          metadata: expect.objectContaining({
+            missingCapabilities: ['Capability_Ethereum'],
+          }),
         }),
       );
     });
 
-    it('throws DeviceNotReady when device is not initialized', async () => {
-      mockGetTrezorFeatures.mockResolvedValue(
-        createMockFeaturesResponse({
-          initialized: false,
-        }),
-      );
-
-      await expect(adapter.ensureDeviceReady()).rejects.toMatchObject({
-        code: ErrorCode.DeviceNotReady,
-      });
-
-      expect(mockOptions.onDeviceEvent).toHaveBeenCalledWith(
+    it('includes the raw capabilities in missing capability error metadata', () => {
+      expect(() =>
+        adapter.validateCapabilities('Capability_Bitcoin', 'T'),
+      ).toThrow(
         expect.objectContaining({
-          event: DeviceEvent.Disconnected,
-          error: expect.objectContaining({ code: ErrorCode.DeviceNotReady }),
-        }),
-      );
-      expect(adapter.isConnected()).toBe(false);
-    });
-
-    it('throws ConnectionClosed when session is missing for legacy models', async () => {
-      mockGetTrezorFeatures.mockResolvedValue(
-        createMockFeaturesResponse({
-          model: 'T',
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          session_id: null,
-        }),
-      );
-
-      await expect(adapter.ensureDeviceReady()).rejects.toMatchObject({
-        code: ErrorCode.ConnectionClosed,
-      });
-      expect(adapter.isConnected()).toBe(false);
-    });
-
-    it('throws DeviceMissingCapability when required capability is missing', async () => {
-      mockGetTrezorFeatures.mockResolvedValue(
-        createMockFeaturesResponse({
-          capabilities: ['Capability_Bitcoin', 'Capability_Ethereum'],
-        }),
-      );
-
-      await expect(adapter.ensureDeviceReady()).rejects.toMatchObject({
-        code: ErrorCode.DeviceMissingCapability,
-      });
-    });
-
-    it('allows Model One name when only Solana capability is missing', async () => {
-      mockGetTrezorFeatures.mockResolvedValue(
-        createMockFeaturesResponse({
-          model: 'Trezor Model One',
-          capabilities: ['Capability_Bitcoin', 'Capability_Ethereum'],
-        }),
-      );
-
-      await expect(adapter.ensureDeviceReady()).resolves.toBe(true);
-      expect(mockOptions.onDeviceEvent).not.toHaveBeenCalledWith(
-        expect.objectContaining({ error: expect.anything() }),
-      );
-    });
-
-    it('throws DeviceMissingCapability when Model One is missing a supported capability', async () => {
-      mockGetTrezorFeatures.mockResolvedValue(
-        createMockFeaturesResponse({
-          model: 'T1B1',
-          capabilities: ['Capability_Bitcoin'],
-        }),
-      );
-
-      await expect(adapter.ensureDeviceReady()).rejects.toMatchObject({
-        code: ErrorCode.DeviceMissingCapability,
-        metadata: expect.objectContaining({
-          missingCapabilities: ['Capability_Ethereum'],
-        }),
-      });
-    });
-
-    it('rejects oversized messages on Model One preflight', async () => {
-      mockGetTrezorFeatures.mockResolvedValue(
-        createMockFeaturesResponse({
-          model: '1',
-        }),
-      );
-
-      await expect(
-        adapter.ensureDeviceReady({ preflightMessageBytes: 1025 }),
-      ).rejects.toMatchObject({
-        code: ErrorCode.DeviceMissingCapability,
-      });
-    });
-
-    it('emits Disconnected and resets state for ConnectionClosed errors', async () => {
-      await adapter.connect();
-      expect(adapter.isConnected()).toBe(true);
-
-      const connectionClosedError = new HardwareWalletError(
-        'Connection closed',
-        {
-          code: ErrorCode.ConnectionClosed,
-          severity: Severity.Err,
-          category: Category.Connection,
-          userMessage: 'Connection closed',
-        },
-      );
-      mockGetTrezorFeatures.mockRejectedValue(connectionClosedError);
-
-      await expect(adapter.ensureDeviceReady()).rejects.toBe(
-        connectionClosedError,
-      );
-
-      expect(mockOptions.onDeviceEvent).toHaveBeenCalledWith({
-        event: DeviceEvent.Disconnected,
-        error: connectionClosedError,
-      });
-      expect(adapter.isConnected()).toBe(false);
-    });
-
-    it('wraps unknown errors as HardwareWalletError', async () => {
-      mockGetTrezorFeatures.mockRejectedValue(
-        new Error('feature fetch failed'),
-      );
-
-      await expect(adapter.ensureDeviceReady()).rejects.toThrow(
-        HardwareWalletError,
-      );
-      expect(mockOptions.onDeviceEvent).toHaveBeenCalledWith(
-        expect.objectContaining({
-          event: DeviceEvent.Disconnected,
-          error: expect.any(HardwareWalletError),
+          metadata: expect.objectContaining({
+            capabilities: 'Capability_Bitcoin',
+          }),
         }),
       );
     });

--- a/ui/contexts/hardware-wallets/adapters/TrezorAdapter.test.ts
+++ b/ui/contexts/hardware-wallets/adapters/TrezorAdapter.test.ts
@@ -238,6 +238,15 @@ describe('TrezorAdapter', () => {
         }),
       );
     });
+
+    it('does not throw when all required capabilities are present', () => {
+      expect(() =>
+        adapter.validateCapabilities(
+          ['Capability_Bitcoin', 'Capability_Solana', 'Capability_Ethereum'],
+          'T',
+        ),
+      ).not.toThrow();
+    });
   });
 });
 

--- a/ui/contexts/hardware-wallets/adapters/TrezorAdapter.ts
+++ b/ui/contexts/hardware-wallets/adapters/TrezorAdapter.ts
@@ -1,11 +1,9 @@
 import { ErrorCode, HardwareWalletError } from '@metamask/hw-wallet-sdk';
-import { getTrezorFeatures } from '../../../store/actions';
 import { createHardwareWalletError, getDeviceEventForError } from '../errors';
 import { toHardwareWalletError } from '../rpcErrorUtils';
 import {
   DeviceEvent,
   HardwareWalletType,
-  type EnsureDeviceReadyOptions,
   type HardwareWalletAdapter,
   type HardwareWalletAdapterOptions,
 } from '../types';
@@ -13,27 +11,7 @@ import {
   getConnectedTrezorDevices,
   isWebUsbAvailable,
 } from '../webConnectionUtils';
-import {
-  getMissingCapabilities,
-  isTrezorModelOne,
-  isTrezorModelUsingTrezorSuite,
-} from './trezorUtils';
-
-const TREZOR_MODEL_ONE_MAX_MESSAGE_BYTES = 1024;
-
-const CONNECTION_RESET_ERROR_CODES: ReadonlySet<ErrorCode> = new Set([
-  ErrorCode.DeviceDisconnected,
-  ErrorCode.ConnectionClosed,
-]);
-
-type TrezorFeaturesPayload = {
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  session_id: string | null;
-  model: string;
-  initialized: boolean;
-  capabilities: string[];
-  unlocked: boolean;
-};
+import { getMissingCapabilities, isTrezorModelOne } from './trezorUtils';
 
 /**
  * Trezor adapter implementation.
@@ -140,16 +118,6 @@ export class TrezorAdapter implements HardwareWalletAdapter {
   }
 
   /**
-   * Fetch the device feature payload from the Trezor Connect session.
-   *
-   * @returns Normalized feature payload (model, sessionId, capabilities, etc.)
-   */
-  async #fetchDeviceFeatures(): Promise<TrezorFeaturesPayload> {
-    const features = await getTrezorFeatures();
-    return features.payload;
-  }
-
-  /**
    * Validate that the device reports all required capabilities.
    *
    * @param capabilities - Raw capabilities list from device features
@@ -173,36 +141,6 @@ export class TrezorAdapter implements HardwareWalletAdapter {
         )}.`,
         { metadata: { capabilities, missingCapabilities: missingForModel } },
       );
-    }
-  }
-
-  /**
-   * Handle errors during ensureDeviceReady by emitting device events
-   * and resetting connection state when appropriate.
-   *
-   * @param error - The error caught during device readiness check
-   */
-  #handleDeviceReadyError(error: unknown): void {
-    const hwError =
-      error instanceof HardwareWalletError
-        ? error
-        : toHardwareWalletError(error, HardwareWalletType.Trezor);
-
-    const deviceEvent = getDeviceEventForError(
-      hwError.code,
-      DeviceEvent.Disconnected,
-    );
-
-    this.options.onDeviceEvent({
-      event: deviceEvent,
-      error: hwError,
-    });
-
-    if (
-      CONNECTION_RESET_ERROR_CODES.has(hwError.code) ||
-      deviceEvent === DeviceEvent.Disconnected
-    ) {
-      this.connected = false;
     }
   }
 

--- a/ui/contexts/hardware-wallets/adapters/TrezorAdapter.ts
+++ b/ui/contexts/hardware-wallets/adapters/TrezorAdapter.ts
@@ -102,12 +102,13 @@ export class TrezorAdapter implements HardwareWalletAdapter {
   }
 
   /**
-   * Verify the device is ready for operations.
+   * Ensure the device is connected and ready for signing operations.
    *
-   * Note: Unlike Ledger, Trezor doesn't require checking for a specific app being open.
-   * The device just needs to be connected and unlocked, which is verified during signing operations.
+   * This only verifies a USB connection is present. All other device checks
+   * (lock state, initialization, session, capabilities) are handled by the
+   * Trezor Connect SDK during the actual signing flow.
    *
-   * @returns true if device is ready
+   * @returns true if the device is connected.
    */
   async ensureDeviceReady(): Promise<boolean> {
     if (!this.isConnected()) {

--- a/ui/contexts/hardware-wallets/adapters/TrezorAdapter.ts
+++ b/ui/contexts/hardware-wallets/adapters/TrezorAdapter.ts
@@ -129,28 +129,14 @@ export class TrezorAdapter implements HardwareWalletAdapter {
    * Note: Unlike Ledger, Trezor doesn't require checking for a specific app being open.
    * The device just needs to be connected and unlocked, which is verified during signing operations.
    *
-   * @param options - Optional preflight checks (e.g. message size limits)
    * @returns true if device is ready
    */
-  async ensureDeviceReady(
-    options?: EnsureDeviceReadyOptions,
-  ): Promise<boolean> {
+  async ensureDeviceReady(): Promise<boolean> {
     if (!this.isConnected()) {
       await this.connect();
     }
 
-    try {
-      const payload = await this.#fetchDeviceFeatures();
-      this.#validateDeviceState(payload);
-      this.#validateCapabilities(payload.capabilities, payload.model);
-      this.#validateModelOneMessageSize(payload.model, options);
-      return true;
-    } catch (error) {
-      this.#handleDeviceReadyError(error);
-      throw error instanceof HardwareWalletError
-        ? error
-        : toHardwareWalletError(error, HardwareWalletType.Trezor);
-    }
+    return true;
   }
 
   /**
@@ -164,44 +150,12 @@ export class TrezorAdapter implements HardwareWalletAdapter {
   }
 
   /**
-   * Validate unlocked, initialized, and session state from device features.
-   *
-   * @param payload - The device feature payload to validate
-   */
-  #validateDeviceState(payload: TrezorFeaturesPayload): void {
-    // NOTE: Model one is always locked, it will only become unlocked when performing a transaction.
-    if (!payload.unlocked && !isTrezorModelOne(payload.model)) {
-      throw createHardwareWalletError(
-        ErrorCode.AuthenticationDeviceLocked,
-        HardwareWalletType.Trezor,
-        'Trezor is not unlocked. Please unlock your device.',
-      );
-    }
-
-    if (!payload.initialized) {
-      throw createHardwareWalletError(
-        ErrorCode.DeviceNotReady,
-        HardwareWalletType.Trezor,
-        'Trezor is not initialized.',
-      );
-    }
-
-    if (!payload.session_id && !isTrezorModelUsingTrezorSuite(payload.model)) {
-      throw createHardwareWalletError(
-        ErrorCode.ConnectionClosed,
-        HardwareWalletType.Trezor,
-        'Trezor session not established. Please reconnect your device.',
-      );
-    }
-  }
-
-  /**
    * Validate that the device reports all required capabilities.
    *
    * @param capabilities - Raw capabilities list from device features
    * @param model - The device model identifier
    */
-  #validateCapabilities(capabilities: unknown, model: string): void {
+  validateCapabilities(capabilities: unknown, model: string): void {
     const missing = getMissingCapabilities(capabilities);
 
     // Trezor Model One does not support Solana, but it must still support
@@ -218,30 +172,6 @@ export class TrezorAdapter implements HardwareWalletAdapter {
           ', ',
         )}.`,
         { metadata: { capabilities, missingCapabilities: missingForModel } },
-      );
-    }
-  }
-
-  /**
-   * Validate preflight message size for Trezor Model One devices.
-   *
-   * @param model - The device model identifier
-   * @param options - The ensureDeviceReady options containing preflightMessageBytes
-   */
-  #validateModelOneMessageSize(
-    model: string,
-    options?: EnsureDeviceReadyOptions,
-  ): void {
-    if (
-      options?.preflightMessageBytes &&
-      isTrezorModelOne(model) &&
-      options.preflightMessageBytes > TREZOR_MODEL_ONE_MAX_MESSAGE_BYTES
-    ) {
-      throw createHardwareWalletError(
-        ErrorCode.DeviceMissingCapability,
-        HardwareWalletType.Trezor,
-        `Trezor Model One does not support signing messages larger than ${TREZOR_MODEL_ONE_MAX_MESSAGE_BYTES} bytes.`,
-        { metadata: { preflightMessageBytes: options.preflightMessageBytes } },
       );
     }
   }

--- a/ui/contexts/hardware-wallets/adapters/trezorUtils.ts
+++ b/ui/contexts/hardware-wallets/adapters/trezorUtils.ts
@@ -2,23 +2,12 @@
  * Utility functions for Trezor adapter validation and device checks.
  */
 
-const TREZOR_MODELS_USING_TREZOR_SUITE = new Set(['safe 7']);
-
 const REQUIRED_TREZOR_CAPABILITIES = [
   'Capability_Bitcoin',
   'Capability_Solana',
   'Capability_Ethereum',
 ] as const;
 type RequiredTrezorCapability = (typeof REQUIRED_TREZOR_CAPABILITIES)[number];
-
-/**
- * Check whether a Trezor model uses Trezor Suite (no popup-based sessions).
- *
- * @param model - The model identifier returned by the device features
- * @returns True if the model communicates via Trezor Suite instead of popups
- */
-export const isTrezorModelUsingTrezorSuite = (model: string): boolean =>
-  TREZOR_MODELS_USING_TREZOR_SUITE.has(model.toLowerCase());
 
 /**
  * Determine which required capabilities are absent from the device's reported set.


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This fixes the trezor preflight to skip the capabilities check that added friction to the signing. 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Removes the interactive check from the trezor preflight.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/42269

## **Manual testing steps**

1. Use a trezor account
2. Start a dapp transaction
3.  Disconnect the device
4. Click connect and see the hardware wallet error modal
5. Plug in and unlock the device
6. See confirm and no sdk/iframe popup appear

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/18981b4c-567d-4b64-9b8c-0d1e23123193



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hardware-wallet preflight behavior for Trezor, which can affect when/where user-facing errors surface during signing. While the change is scoped, it alters connection/readiness assumptions in a critical flow.
> 
> **Overview**
> Simplifies Trezor preflight readiness checks so `ensureDeviceReady` only verifies a WebUSB connection (connects if needed) and no longer fetches/validates device features (lock state, initialization, session, message-size limits, or capabilities), leaving those checks to Trezor Connect during signing.
> 
> Removes the Trezor Suite model/session handling helper and rewrites tests to match the new behavior, while keeping capability validation as a standalone `validateCapabilities` method with updated coverage and metadata assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ded58ad4282dcba57ad678a470c5cdd84fdf7dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->