### PR TITLE
feat(onboarding): handle outdated Telegram app with dedicated error m…

### DIFF
--- a/app/_locales/de/messages.json
+++ b/app/_locales/de/messages.json
@@ -4792,10 +4792,6 @@
   "onboardingMetametricsTitle": {
     "message": "Helfen Sie dabei, MetaMask zu verbessern"
   },
-  "onboardingOptionIcon": {
-    "message": "$1-Symbol",
-    "description": "$1 is the icon name"
-  },
   "onboardingSignInWith": {
     "message": "Mit $1 anmelden",
     "description": "$1 is the type of login used Google, Apple, etc"
@@ -6513,11 +6509,11 @@
   },
   "securitySocialLoginEnabledDescription": {
     "message": "Verwenden Sie Ihre $1-Anmeldung und Ihr MetaMask-Passwort, um Ihr Konto und Ihre geheimen Wiederherstellungsphrasen wiederherzustellen.",
-    "description": "The $1 is the text 'Google' or 'Apple'"
+    "description": "The $1 is the text 'Google' or 'Apple' or 'Telegram'"
   },
   "securitySocialLoginLabel": {
     "message": "$1 WIEDERHERSTELLUNG",
-    "description": "The $1 is the text 'Google' or 'Apple'"
+    "description": "The $1 is the text 'Google' or 'Apple' or 'Telegram'"
   },
   "securitySrpDescription": {
     "message": "Sichern Sie Ihre geheime Wiederherstellungsphrase, damit Sie nie den Zugriff auf Ihre Wallet verlieren. Bewahren Sie sie an einem sicheren Ort auf, auf den nur Sie Zugriff haben und den Sie nie vergessen werden."

--- a/app/_locales/el/messages.json
+++ b/app/_locales/el/messages.json
@@ -4792,10 +4792,6 @@
   "onboardingMetametricsTitle": {
     "message": "Βοηθήστε στη βελτίωση του MetaMask"
   },
-  "onboardingOptionIcon": {
-    "message": "εικονίδιο $1",
-    "description": "$1 is the icon name"
-  },
   "onboardingSignInWith": {
     "message": "Συνδεθείτε με το $1",
     "description": "$1 is the type of login used Google, Apple, etc"
@@ -6513,11 +6509,11 @@
   },
   "securitySocialLoginEnabledDescription": {
     "message": "Χρησιμοποιήστε τα στοιχεία σύνδεσης στο $1 και τον κωδικό πρόσβασης στο MetaMask για να ανακτήσετε τον λογαριασμό σας και τη Μυστική Φράση Ανάκτησης.",
-    "description": "The $1 is the text 'Google' or 'Apple'"
+    "description": "The $1 is the text 'Google' or 'Apple' or 'Telegram'"
   },
   "securitySocialLoginLabel": {
     "message": "ΑΝΑΚΤΗΣΗ ΜΕΣΩ $1",
-    "description": "The $1 is the text 'Google' or 'Apple'"
+    "description": "The $1 is the text 'Google' or 'Apple' or 'Telegram'"
   },
   "securitySrpDescription": {
     "message": "Δημιουργήστε αντίγραφο ασφαλείας της Μυστικής Φράσης Ανάκτησης, για να διασφαλίσετε ότι δεν θα χάσετε ποτέ πρόσβαση στο πορτοφόλι σας. Φυλάξτε την σε ασφαλές μέρος στο οποίο μόνο εσείς θα έχετε πρόσβαση και δεν θα το ξεχάσετε."

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -3843,6 +3843,15 @@
   "loginErrorSessionExpiredTitle": {
     "message": "Session has expired"
   },
+  "loginErrorTelegramOutdatedButton": {
+    "message": "Update Telegram"
+  },
+  "loginErrorTelegramOutdatedDescription": {
+    "message": "We couldn't connect to Telegram. This usually happens when your Telegram app is out of date. Please update Telegram and try again."
+  },
+  "loginErrorTelegramOutdatedTitle": {
+    "message": "Couldn't sign in with Telegram"
+  },
   "logo": {
     "message": "$1 logo",
     "description": "$1 is the name of the ticker"
@@ -5035,10 +5044,6 @@
   "onboardingMetametricsTitle": {
     "message": "Help improve MetaMask"
   },
-  "onboardingOptionIcon": {
-    "message": "$1 icon",
-    "description": "$1 is the icon name"
-  },
   "onboardingSignInWith": {
     "message": "Sign in with $1",
     "description": "$1 is the type of login used Google, Apple, etc"
@@ -5093,6 +5098,9 @@
   },
   "openWallet": {
     "message": "Open wallet"
+  },
+  "opensInNewTab": {
+    "message": "opens in new tab"
   },
   "options": {
     "message": "Options"
@@ -7104,11 +7112,11 @@
   },
   "securitySocialLoginEnabledDescription": {
     "message": "Use your $1 login and MetaMask password to recover your account and Secret Recovery Phrases.",
-    "description": "The $1 is the text 'Google' or 'Apple'"
+    "description": "The $1 is the text 'Google' or 'Apple' or 'Telegram'"
   },
   "securitySocialLoginLabel": {
     "message": "$1 RECOVERY",
-    "description": "The $1 is the text 'Google' or 'Apple'"
+    "description": "The $1 is the text 'Google' or 'Apple' or 'Telegram'"
   },
   "securitySrpDescription": {
     "message": "Back up your Secret Recovery Phrase so you never lose access to your wallet. Be sure to store it in a safe place that only you can access and won’t forget."

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -3843,6 +3843,15 @@
   "loginErrorSessionExpiredTitle": {
     "message": "Session has expired"
   },
+  "loginErrorTelegramOutdatedButton": {
+    "message": "Update Telegram"
+  },
+  "loginErrorTelegramOutdatedDescription": {
+    "message": "We couldn't connect to Telegram. This usually happens when your Telegram app is out of date. Please update Telegram and try again."
+  },
+  "loginErrorTelegramOutdatedTitle": {
+    "message": "Couldn't sign in with Telegram"
+  },
   "logo": {
     "message": "$1 logo",
     "description": "$1 is the name of the ticker"
@@ -5035,10 +5044,6 @@
   "onboardingMetametricsTitle": {
     "message": "Help improve MetaMask"
   },
-  "onboardingOptionIcon": {
-    "message": "$1 icon",
-    "description": "$1 is the icon name"
-  },
   "onboardingSignInWith": {
     "message": "Sign in with $1",
     "description": "$1 is the type of login used Google, Apple, etc"
@@ -5093,6 +5098,9 @@
   },
   "openWallet": {
     "message": "Open wallet"
+  },
+  "opensInNewTab": {
+    "message": "opens in new tab"
   },
   "options": {
     "message": "Options"
@@ -7104,11 +7112,11 @@
   },
   "securitySocialLoginEnabledDescription": {
     "message": "Use your $1 login and MetaMask password to recover your account and Secret Recovery Phrases.",
-    "description": "The $1 is the text 'Google' or 'Apple'"
+    "description": "The $1 is the text 'Google' or 'Apple' or 'Telegram'"
   },
   "securitySocialLoginLabel": {
     "message": "$1 RECOVERY",
-    "description": "The $1 is the text 'Google' or 'Apple'"
+    "description": "The $1 is the text 'Google' or 'Apple' or 'Telegram'"
   },
   "securitySrpDescription": {
     "message": "Back up your Secret Recovery Phrase so you never lose access to your wallet. Be sure to store it in a safe place that only you can access and won’t forget."

--- a/app/_locales/es_419/messages.json
+++ b/app/_locales/es_419/messages.json
@@ -4792,10 +4792,6 @@
   "onboardingMetametricsTitle": {
     "message": "Ayuda a mejorar MetaMask"
   },
-  "onboardingOptionIcon": {
-    "message": "Ícono $1",
-    "description": "$1 is the icon name"
-  },
   "onboardingSignInWith": {
     "message": "Inicia sesión con $1",
     "description": "$1 is the type of login used Google, Apple, etc"
@@ -6513,11 +6509,11 @@
   },
   "securitySocialLoginEnabledDescription": {
     "message": "Utiliza tu nombre de usuario de $1 y tu contraseña de MetaMask para recuperar tu cuenta y tus frases secretas de recuperación.",
-    "description": "The $1 is the text 'Google' or 'Apple'"
+    "description": "The $1 is the text 'Google' or 'Apple' or 'Telegram'"
   },
   "securitySocialLoginLabel": {
     "message": "RECUPERACIÓN DE $1",
-    "description": "The $1 is the text 'Google' or 'Apple'"
+    "description": "The $1 is the text 'Google' or 'Apple' or 'Telegram'"
   },
   "securitySrpDescription": {
     "message": "Haz una copia de seguridad de tu frase secreta de recuperación para no perder nunca el acceso a tu billetera. Asegúrate de guardarla en un lugar seguro al que solo tú puedas acceder y que no olvides."

--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -4792,10 +4792,6 @@
   "onboardingMetametricsTitle": {
     "message": "Aidez-nous à améliorer MetaMask"
   },
-  "onboardingOptionIcon": {
-    "message": "Icône $1",
-    "description": "$1 is the icon name"
-  },
   "onboardingSignInWith": {
     "message": "Se connecter avec $1",
     "description": "$1 is the type of login used Google, Apple, etc"
@@ -6513,11 +6509,11 @@
   },
   "securitySocialLoginEnabledDescription": {
     "message": "Utilisez votre identifiant $1 et votre mot de passe MetaMask pour récupérer votre compte et vos phrases secrètes de récupération.",
-    "description": "The $1 is the text 'Google' or 'Apple'"
+    "description": "The $1 is the text 'Google' or 'Apple' or 'Telegram'"
   },
   "securitySocialLoginLabel": {
     "message": "RÉCUPÉRATION $1",
-    "description": "The $1 is the text 'Google' or 'Apple'"
+    "description": "The $1 is the text 'Google' or 'Apple' or 'Telegram'"
   },
   "securitySrpDescription": {
     "message": "Sauvegardez votre phrase secrète de récupération pour ne jamais perdre l’accès à votre portefeuille. Veillez à la conserver dans un endroit sûr auquel personne d’autre que vous ne peut y accéder et que vous ne risquez pas d’oublier."

--- a/app/_locales/ga/messages.json
+++ b/app/_locales/ga/messages.json
@@ -3915,10 +3915,6 @@
   "onboardingMetametricsTitle": {
     "message": "Cabhraigh linn MetaMask a fheabhsú"
   },
-  "onboardingOptionIcon": {
-    "message": "Deilbhín $1",
-    "description": "$1 is the icon name"
-  },
   "onboardingSignInWith": {
     "message": "Sínigh isteach le $1",
     "description": "$1 is the type of login used Google, Apple, etc"
@@ -4909,11 +4905,11 @@
   },
   "securitySocialLoginEnabledDescription": {
     "message": "Bain úsáid as do logáil isteach $1 agus do phasfhocal MetaMask chun do chuntas agus Frásaí Aisghabhála Rúnda a aisghabháil.",
-    "description": "The $1 is the text 'Google' or 'Apple'"
+    "description": "The $1 is the text 'Google' or 'Apple' or 'Telegram'"
   },
   "securitySocialLoginLabel": {
     "message": "AISGHNÍOMH $1",
-    "description": "The $1 is the text 'Google' or 'Apple'"
+    "description": "The $1 is the text 'Google' or 'Apple' or 'Telegram'"
   },
   "securitySrpDescription": {
     "message": "Déan cúltaca de do Rún Aisghabhála Frása ionas nach gcaillfidh tú rochtain ar do sparán choíche. Bí cinnte é a stóráil in áit shábháilte nach féidir ach leatsa rochtain a fháil air agus nach ndéanfaidh tú dearmad air."

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -4792,10 +4792,6 @@
   "onboardingMetametricsTitle": {
     "message": "MetaMask को बेहतर बनाने में मदद करें"
   },
-  "onboardingOptionIcon": {
-    "message": "$1 आइकन",
-    "description": "$1 is the icon name"
-  },
   "onboardingSignInWith": {
     "message": "$1 के साथ साइन इन करें",
     "description": "$1 is the type of login used Google, Apple, etc"
@@ -6513,11 +6509,11 @@
   },
   "securitySocialLoginEnabledDescription": {
     "message": "अपने अकाउंट और सीक्रेट रिकवरी फ्रेज़ को रिकवर करने के लिए अपने $1 लॉगिन और MetaMask पासवर्ड का उपयोग करें।",
-    "description": "The $1 is the text 'Google' or 'Apple'"
+    "description": "The $1 is the text 'Google' or 'Apple' or 'Telegram'"
   },
   "securitySocialLoginLabel": {
     "message": "$1 रिकवरी",
-    "description": "The $1 is the text 'Google' or 'Apple'"
+    "description": "The $1 is the text 'Google' or 'Apple' or 'Telegram'"
   },
   "securitySrpDescription": {
     "message": "अपने सीक्रेट रिकवरी फ्रेज़ का बैकअप लें ताकि आप अपने वॉलेट तक कभी पहुँच न खोएँ। इसे किसी सुरक्षित स्थान पर रखें, जहां केवल आप ही पहुंच सकें और जिसे आप भूलें नहीं।"

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -4792,10 +4792,6 @@
   "onboardingMetametricsTitle": {
     "message": "Bantu tingkatkan MetaMask"
   },
-  "onboardingOptionIcon": {
-    "message": "Ikon $1",
-    "description": "$1 is the icon name"
-  },
   "onboardingSignInWith": {
     "message": "Masuk dengan $1",
     "description": "$1 is the type of login used Google, Apple, etc"
@@ -6513,11 +6509,11 @@
   },
   "securitySocialLoginEnabledDescription": {
     "message": "Gunakan login $1 dan kata sandi MetaMask untuk memulihkan akun dan Frasa Pemulihan Rahasia.",
-    "description": "The $1 is the text 'Google' or 'Apple'"
+    "description": "The $1 is the text 'Google' or 'Apple' or 'Telegram'"
   },
   "securitySocialLoginLabel": {
     "message": "PEMULIHAN $1",
-    "description": "The $1 is the text 'Google' or 'Apple'"
+    "description": "The $1 is the text 'Google' or 'Apple' or 'Telegram'"
   },
   "securitySrpDescription": {
     "message": "Cadangkan Frasa Pemulihan Rahasia agar Anda tidak pernah kehilangan akses ke dompet Anda. Pastikan untuk menyimpannya di tempat yang aman yang hanya dapat diakses oleh Anda dan tidak akan terlupakan."

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -4792,10 +4792,6 @@
   "onboardingMetametricsTitle": {
     "message": "MetaMaskの改善にご協力ください"
   },
-  "onboardingOptionIcon": {
-    "message": "$1アイコン",
-    "description": "$1 is the icon name"
-  },
   "onboardingSignInWith": {
     "message": "$1でサインイン",
     "description": "$1 is the type of login used Google, Apple, etc"
@@ -6513,11 +6509,11 @@
   },
   "securitySocialLoginEnabledDescription": {
     "message": "$1のログイン情報とMetaMaskのパスワードを使って、アカウントとシークレットリカバリーフレーズを復元することができます。",
-    "description": "The $1 is the text 'Google' or 'Apple'"
+    "description": "The $1 is the text 'Google' or 'Apple' or 'Telegram'"
   },
   "securitySocialLoginLabel": {
     "message": "$1の復元",
-    "description": "The $1 is the text 'Google' or 'Apple'"
+    "description": "The $1 is the text 'Google' or 'Apple' or 'Telegram'"
   },
   "securitySrpDescription": {
     "message": "ウォレットへのアクセスを失わないよう、シークレットリカバリーフレーズをバックアップしましょう。自分だけがアクセスできて、絶対に忘れないような安全な場所に保管するようにしてください。"

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -4792,10 +4792,6 @@
   "onboardingMetametricsTitle": {
     "message": "MetaMask 개선에 도움을 주세요"
   },
-  "onboardingOptionIcon": {
-    "message": "$1 아이콘",
-    "description": "$1 is the icon name"
-  },
   "onboardingSignInWith": {
     "message": "$1(으)로 로그인",
     "description": "$1 is the type of login used Google, Apple, etc"
@@ -6513,11 +6509,11 @@
   },
   "securitySocialLoginEnabledDescription": {
     "message": "$1 로그인과 MetaMask 비밀번호를 사용하여 계정과 비밀복구구문을 복구하세요.",
-    "description": "The $1 is the text 'Google' or 'Apple'"
+    "description": "The $1 is the text 'Google' or 'Apple' or 'Telegram'"
   },
   "securitySocialLoginLabel": {
     "message": "$1 복구",
-    "description": "The $1 is the text 'Google' or 'Apple'"
+    "description": "The $1 is the text 'Google' or 'Apple' or 'Telegram'"
   },
   "securitySrpDescription": {
     "message": "비밀복구구문을 백업해 두면 지갑 접근 권한을 잃지 않을 수 있습니다. 본인만 접근할 수 있고 절대 잊지 않을 안전한 장소에 보관하세요."

--- a/app/_locales/pt/messages.json
+++ b/app/_locales/pt/messages.json
@@ -4792,10 +4792,6 @@
   "onboardingMetametricsTitle": {
     "message": "Ajude-nos a melhorar a MetaMask"
   },
-  "onboardingOptionIcon": {
-    "message": "Ícone $1",
-    "description": "$1 is the icon name"
-  },
   "onboardingSignInWith": {
     "message": "Fazer login com $1",
     "description": "$1 is the type of login used Google, Apple, etc"
@@ -6513,11 +6509,11 @@
   },
   "securitySocialLoginEnabledDescription": {
     "message": "Use seu login $1 e senha da MetaMask para recuperar sua conta e suas Frases de Recuperação Secretas.",
-    "description": "The $1 is the text 'Google' or 'Apple'"
+    "description": "The $1 is the text 'Google' or 'Apple' or 'Telegram'"
   },
   "securitySocialLoginLabel": {
     "message": "RECUPERAÇÃO DE $1",
-    "description": "The $1 is the text 'Google' or 'Apple'"
+    "description": "The $1 is the text 'Google' or 'Apple' or 'Telegram'"
   },
   "securitySrpDescription": {
     "message": "Faça backup de sua Frase de Recuperação Secreta para nunca perder o acesso à sua carteira. Certifique-se de guardá-la em um local seguro que só você pode acessar e que você não vai esquecer."

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -4792,10 +4792,6 @@
   "onboardingMetametricsTitle": {
     "message": "Помогите нам улучшить MetaMask"
   },
-  "onboardingOptionIcon": {
-    "message": "Значок $1",
-    "description": "$1 is the icon name"
-  },
   "onboardingSignInWith": {
     "message": "Войти с помощью $1",
     "description": "$1 is the type of login used Google, Apple, etc"
@@ -6513,11 +6509,11 @@
   },
   "securitySocialLoginEnabledDescription": {
     "message": "Используйте свой логин $1 и пароль MetaMask для восстановления своего счета и секретных фраз для восстановления.",
-    "description": "The $1 is the text 'Google' or 'Apple'"
+    "description": "The $1 is the text 'Google' or 'Apple' or 'Telegram'"
   },
   "securitySocialLoginLabel": {
     "message": "ВОССТАНОВЛЕНИЕ $1",
-    "description": "The $1 is the text 'Google' or 'Apple'"
+    "description": "The $1 is the text 'Google' or 'Apple' or 'Telegram'"
   },
   "securitySrpDescription": {
     "message": "Сохраните свою секретную фразу для восстановления, чтобы никогда не терять доступ к своему кошельку. Обязательно сохраните ее в безопасном месте, к которому сможете получить доступ только вы и которое вы не забудете."

--- a/app/_locales/tl/messages.json
+++ b/app/_locales/tl/messages.json
@@ -4792,10 +4792,6 @@
   "onboardingMetametricsTitle": {
     "message": "Tulungan kaming mapahusay ang MetaMask"
   },
-  "onboardingOptionIcon": {
-    "message": "$1 icon",
-    "description": "$1 is the icon name"
-  },
   "onboardingSignInWith": {
     "message": "Mag-sign in gamit ang $1",
     "description": "$1 is the type of login used Google, Apple, etc"
@@ -6513,11 +6509,11 @@
   },
   "securitySocialLoginEnabledDescription": {
     "message": "Gamitin ng iyong $1 na login at password sa MetaMask para mabawi ang iyong account at mga Lihim na Parirala sa Pagbawi.",
-    "description": "The $1 is the text 'Google' or 'Apple'"
+    "description": "The $1 is the text 'Google' or 'Apple' or 'Telegram'"
   },
   "securitySocialLoginLabel": {
     "message": "PAGBAWI SA $1",
-    "description": "The $1 is the text 'Google' or 'Apple'"
+    "description": "The $1 is the text 'Google' or 'Apple' or 'Telegram'"
   },
   "securitySrpDescription": {
     "message": "I-back up ang iyong Lihim na Parirala sa Pagbawi nang sa gayon ay hindi ka mawalan ng access sa iyong wallet. Tiyaking itago ito sa isang ligtas na lugar na ikaw lamang ang may access at hindi makakalimutan."

--- a/app/_locales/tr/messages.json
+++ b/app/_locales/tr/messages.json
@@ -4792,10 +4792,6 @@
   "onboardingMetametricsTitle": {
     "message": "MetaMask'in iyileştirilmesine yardımcı olun"
   },
-  "onboardingOptionIcon": {
-    "message": "$1 simgesi",
-    "description": "$1 is the icon name"
-  },
   "onboardingSignInWith": {
     "message": "$1 ile giriş yap",
     "description": "$1 is the type of login used Google, Apple, etc"
@@ -6513,11 +6509,11 @@
   },
   "securitySocialLoginEnabledDescription": {
     "message": "$1 oturumunuzu ve MetaMask şifrenizi kullanarak hesabınızı ve Gizli Kurtarma İfadelerini kurtarabilirsiniz.",
-    "description": "The $1 is the text 'Google' or 'Apple'"
+    "description": "The $1 is the text 'Google' or 'Apple' or 'Telegram'"
   },
   "securitySocialLoginLabel": {
     "message": "$1 KURTARMA",
-    "description": "The $1 is the text 'Google' or 'Apple'"
+    "description": "The $1 is the text 'Google' or 'Apple' or 'Telegram'"
   },
   "securitySrpDescription": {
     "message": "Cüzdanınıza erişimi asla kaybetmemeniz için Gizli Kurtarma İfadenizi yedekleyin. Yalnızca sizin erişiminiz olan ve unutmayacağınız güvenli bir yerde sakladığınızdan emin olun."

--- a/app/_locales/vi/messages.json
+++ b/app/_locales/vi/messages.json
@@ -4792,10 +4792,6 @@
   "onboardingMetametricsTitle": {
     "message": "Giúp cải thiện MetaMask"
   },
-  "onboardingOptionIcon": {
-    "message": "Biểu tượng $1",
-    "description": "$1 is the icon name"
-  },
   "onboardingSignInWith": {
     "message": "Đăng nhập bằng $1",
     "description": "$1 is the type of login used Google, Apple, etc"
@@ -6513,11 +6509,11 @@
   },
   "securitySocialLoginEnabledDescription": {
     "message": "Sử dụng đăng nhập $1 và mật khẩu MetaMask của bạn để khôi phục tài khoản và Cụm từ khôi phục bí mật.",
-    "description": "The $1 is the text 'Google' or 'Apple'"
+    "description": "The $1 is the text 'Google' or 'Apple' or 'Telegram'"
   },
   "securitySocialLoginLabel": {
     "message": "KHÔI PHỤC $1",
-    "description": "The $1 is the text 'Google' or 'Apple'"
+    "description": "The $1 is the text 'Google' or 'Apple' or 'Telegram'"
   },
   "securitySrpDescription": {
     "message": "Sao lưu Cụm từ khôi phục bí mật để bạn không bao giờ mất quyền truy cập vào ví. Hãy chắc chắn lưu trữ cụm từ này ở nơi an toàn mà chỉ bạn mới có thể truy cập và không bị quên."

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -4792,10 +4792,6 @@
   "onboardingMetametricsTitle": {
     "message": "请帮助我们改进 MetaMask"
   },
-  "onboardingOptionIcon": {
-    "message": "$1 图标",
-    "description": "$1 is the icon name"
-  },
   "onboardingSignInWith": {
     "message": "使用 $1 登录",
     "description": "$1 is the type of login used Google, Apple, etc"
@@ -6513,11 +6509,11 @@
   },
   "securitySocialLoginEnabledDescription": {
     "message": "使用您的 $1 登录信息和 MetaMask 密码来恢复账户及私钥助记词。",
-    "description": "The $1 is the text 'Google' or 'Apple'"
+    "description": "The $1 is the text 'Google' or 'Apple' or 'Telegram'"
   },
   "securitySocialLoginLabel": {
     "message": "$1 找回",
-    "description": "The $1 is the text 'Google' or 'Apple'"
+    "description": "The $1 is the text 'Google' or 'Apple' or 'Telegram'"
   },
   "securitySrpDescription": {
     "message": "备份您的私钥助记词，这样您永远不会失去对钱包的访问权限。请务必将其存储在一个只有您能接触到且不会遗忘的安全位置。"

--- a/app/scripts/messenger-client-init/seedless-onboarding/oauth-service-init.ts
+++ b/app/scripts/messenger-client-init/seedless-onboarding/oauth-service-init.ts
@@ -1,5 +1,8 @@
 import browser from 'webextension-polyfill';
-import { Env as ProfileSyncEnv, getEnvUrls } from '@metamask/profile-sync-controller/sdk';
+import {
+  Env as ProfileSyncEnv,
+  getEnvUrls,
+} from '@metamask/profile-sync-controller/sdk';
 import { MessengerClientInitFunction } from '../types';
 import { OAuthService } from '../../services/oauth/oauth-service';
 import {
@@ -59,11 +62,10 @@ export const OAuthServiceInit: MessengerClientInitFunction<
       metaMetricsController.state.participateInMetaMetrics,
 
     storePendingSocialLoginProfileJwt: async (jwt: string) => {
-      const {
-        [PENDING_PROFILE_PAIRING_TOKENS_SESSION_KEY]: pendingJwts = [],
-      } = await browser.storage.session.get(
-        PENDING_PROFILE_PAIRING_TOKENS_SESSION_KEY,
-      );
+      const { [PENDING_PROFILE_PAIRING_TOKENS_SESSION_KEY]: pendingJwts = [] } =
+        await browser.storage.session.get(
+          PENDING_PROFILE_PAIRING_TOKENS_SESSION_KEY,
+        );
 
       await browser.storage.session.set({
         [PENDING_PROFILE_PAIRING_TOKENS_SESSION_KEY]: [...pendingJwts, jwt],

--- a/app/scripts/services/oauth/oauth-service.ts
+++ b/app/scripts/services/oauth/oauth-service.ts
@@ -409,7 +409,8 @@ export class OAuthService {
     const { authConnection } = loginHandler;
 
     const authCode =
-      authConnection === AuthConnection.Google || authConnection === AuthConnection.Telegram
+      authConnection === AuthConnection.Google ||
+      authConnection === AuthConnection.Telegram
         ? this.#getRedirectUrlAuthCode(redirectUrl)
         : null;
 

--- a/app/scripts/services/oauth/oidc.ts
+++ b/app/scripts/services/oauth/oidc.ts
@@ -30,10 +30,7 @@ export async function exchangeJwtBearerForOidcAccessToken(
 
   const body = new URLSearchParams();
   body.set('grant_type', 'urn:ietf:params:oauth:grant-type:jwt-bearer');
-  body.set(
-    'client_id',
-    getOidcClientId(profileSyncEnv, Platform.EXTENSION),
-  );
+  body.set('client_id', getOidcClientId(profileSyncEnv, Platform.EXTENSION));
   body.set('assertion', jwtToken);
 
   const response = await fetch(oidcTokenUrl, {

--- a/app/scripts/services/oauth/telegram-login-handler.ts
+++ b/app/scripts/services/oauth/telegram-login-handler.ts
@@ -89,6 +89,7 @@ export class TelegramLoginHandler extends BaseLoginHandler {
   /**
    * Execute the server-side token exchange chain:
    * verify -> hydra jwt-bearer -> mint
+   * @param code
    */
   async getAuthIdToken(code: string): Promise<AuthTokenResponse> {
     const verifyRes = await fetch(
@@ -136,7 +137,11 @@ export class TelegramLoginHandler extends BaseLoginHandler {
     // check if telegram profile is already synced by looking for the alias in ext field
     const authPayload = JSON.parse(decodeIdToken(verifyData?.token));
     let profileSynced = false;
-    const aliases: { alias_profile_id?: string }[] =
+    const aliases: {
+      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      alias_profile_id?: string;
+    }[] =
       authPayload?.ext?.[
         `${this.#options.authenticationServerUrl}/profile/aliases`
       ] || [];
@@ -147,7 +152,7 @@ export class TelegramLoginHandler extends BaseLoginHandler {
       }
     }
     // TODO: debug only, remove after review
-    const debug = true
+    const debug = true;
     if (!profileSynced || debug) {
       mintData.profile_pairing_token = hydraIdToken;
     }

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -1490,7 +1490,7 @@
       "error: Warning: Encountered two children with": 1
     },
     "ui/pages/onboarding-flow/welcome/welcome.test.tsx": {
-      "MetaMask: Background connection not initialized": 14,
+      "MetaMask: Background connection not initialized": 18,
       "React: State updates on unmounted components": 1
     },
     "ui/pages/permissions-connect/connect-page/connect-page.test.tsx": {

--- a/ui/pages/onboarding-flow/creation-successful/creation-successful.tsx
+++ b/ui/pages/onboarding-flow/creation-successful/creation-successful.tsx
@@ -59,7 +59,6 @@ import {
   setCompletedOnboardingWithSidepanel,
   setUseSidePanelAsDefault,
   removeDeferredDeepLink,
-  performSeedlessOnboardingProfilePair,
 } from '../../../store/actions';
 import { LottieAnimation } from '../../../components/component-library/lottie-animation';
 import { useSidePanelEnabled } from '../../../hooks/useSidePanelEnabled';

--- a/ui/pages/onboarding-flow/onboarding-flow.test.tsx
+++ b/ui/pages/onboarding-flow/onboarding-flow.test.tsx
@@ -146,6 +146,7 @@ jest.mock('../../store/actions', () => ({
   getIsSeedlessOnboardingUserAuthenticated: jest.fn(
     () => async () => Promise.resolve(false),
   ),
+  performSeedlessOnboardingProfilePair: jest.fn(() => async () => null),
 }));
 
 jest.mock('../../../shared/lib/environment', () => ({

--- a/ui/pages/onboarding-flow/welcome/fox-appear-animation.tsx
+++ b/ui/pages/onboarding-flow/welcome/fox-appear-animation.tsx
@@ -59,7 +59,7 @@ export default function FoxAppearAnimation({
     autoplay: false,
     layout: new Layout({
       fit: Fit.Contain,
-      alignment: Alignment.BottomCenter,
+      alignment: isLoader ? Alignment.Center : Alignment.BottomCenter,
     }),
   });
 

--- a/ui/pages/onboarding-flow/welcome/index.scss
+++ b/ui/pages/onboarding-flow/welcome/index.scss
@@ -78,14 +78,14 @@
     }
 
     &--loader {
+      position: relative;
       height: 550px;
       width: 550px;
       max-width: 550px;
       display: flex;
-      flex-direction: column;
       justify-content: center;
       align-items: center;
-      margin-top: -250px;
+      margin-top: -150px;
     }
   }
 
@@ -95,9 +95,12 @@
   }
 
   &__spinner {
+    position: absolute;
+    top: 70%;
+    left: 50%;
+    transform: translateX(-50%);
     width: 2rem;
     height: 2rem;
-    align-self: center;
   }
 }
 

--- a/ui/pages/onboarding-flow/welcome/login-error-modal.test.tsx
+++ b/ui/pages/onboarding-flow/welcome/login-error-modal.test.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { fireEvent } from '@testing-library/react';
+import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
+import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
+import { MetaMetricsContext } from '../../../contexts/metametrics';
+import {
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
+} from '../../../../shared/constants/metametrics';
+import LoginErrorModal from './login-error-modal';
+import { LOGIN_ERROR, LoginErrorType } from './types';
+
+const TELEGRAM_DESKTOP_UPDATE_URL = 'https://desktop.telegram.org/';
+
+const buildState = (authConnection?: string) => ({
+  metamask: {
+    internalAccounts: { accounts: {}, selectedAccount: '' },
+    metaMetricsId: '0x00000000',
+    authConnection,
+  },
+});
+
+describe('LoginErrorModal', () => {
+  const mockOnDone = jest.fn();
+  const mockTrackEvent = jest.fn();
+  const mockMetaMetricsContext = {
+    trackEvent: mockTrackEvent,
+    bufferedTrace: jest.fn(),
+    bufferedEndTrace: jest.fn(),
+    onboardingParentContext: { current: null },
+  };
+
+  const renderModal = (
+    loginError: LoginErrorType,
+    { authConnection }: { authConnection?: string } = {},
+  ) => {
+    const store = configureMockStore([thunk])(buildState(authConnection));
+
+    return renderWithProvider(
+      <MetaMetricsContext.Provider value={mockMetaMetricsContext}>
+        <LoginErrorModal onDone={mockOnDone} loginError={loginError} />
+      </MetaMetricsContext.Provider>,
+      store,
+    );
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // @ts-expect-error mocking platform
+    global.platform = { openTab: jest.fn() };
+  });
+
+  it('renders the unable-to-connect title and CTA', () => {
+    const { getByText } = renderModal(LOGIN_ERROR.UNABLE_TO_CONNECT);
+
+    expect(
+      getByText(messages.loginErrorConnectTitle.message),
+    ).toBeInTheDocument();
+    expect(
+      getByText(messages.loginErrorConnectButton.message),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the session-expired title and CTA', () => {
+    const { getByText } = renderModal(LOGIN_ERROR.SESSION_EXPIRED);
+
+    expect(
+      getByText(messages.loginErrorSessionExpiredTitle.message),
+    ).toBeInTheDocument();
+    expect(
+      getByText(messages.loginErrorSessionExpiredButton.message),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the generic title and CTA', () => {
+    const { getByText } = renderModal(LOGIN_ERROR.GENERIC);
+
+    expect(
+      getByText(messages.loginErrorGenericTitle.message),
+    ).toBeInTheDocument();
+    expect(
+      getByText(messages.loginErrorGenericButton.message),
+    ).toBeInTheDocument();
+  });
+
+  it('calls onDone when the default CTA is clicked', () => {
+    const { getByTestId } = renderModal(LOGIN_ERROR.UNABLE_TO_CONNECT);
+
+    fireEvent.click(getByTestId('login-error-modal-button'));
+
+    expect(mockOnDone).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders a RESET_WALLET description that includes the social login type', () => {
+    const { getByText } = renderModal(LOGIN_ERROR.RESET_WALLET, {
+      authConnection: 'google',
+    });
+
+    expect(getByText(/Re-login with google/iu)).toBeInTheDocument();
+  });
+
+  describe('when loginError is TELEGRAM_OUTDATED', () => {
+    it('renders the Telegram-specific title, description and Update Telegram CTA', () => {
+      const { getByText, getByTestId, queryByTestId } = renderModal(
+        LOGIN_ERROR.TELEGRAM_OUTDATED,
+      );
+
+      expect(
+        getByText(messages.loginErrorTelegramOutdatedTitle.message),
+      ).toBeInTheDocument();
+      expect(
+        getByText(messages.loginErrorTelegramOutdatedDescription.message),
+      ).toBeInTheDocument();
+      expect(
+        getByTestId('login-error-modal-update-telegram-button'),
+      ).toBeInTheDocument();
+      // The default CTA must be replaced, not added alongside.
+      expect(queryByTestId('login-error-modal-button')).not.toBeInTheDocument();
+    });
+
+    it('opens the Telegram desktop URL, tracks the event, and dismisses the modal when the CTA is clicked', () => {
+      const { getByTestId } = renderModal(LOGIN_ERROR.TELEGRAM_OUTDATED);
+
+      fireEvent.click(getByTestId('login-error-modal-update-telegram-button'));
+
+      expect(global.platform.openTab).toHaveBeenCalledWith({
+        url: TELEGRAM_DESKTOP_UPDATE_URL,
+      });
+      expect(mockTrackEvent).toHaveBeenCalledWith({
+        category: MetaMetricsEventCategory.Onboarding,
+        event: MetaMetricsEventName.SupportLinkClicked,
+        properties: {
+          url: TELEGRAM_DESKTOP_UPDATE_URL,
+          location: 'Telegram outdated modal',
+        },
+      });
+      expect(mockOnDone).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/ui/pages/onboarding-flow/welcome/login-error-modal.tsx
+++ b/ui/pages/onboarding-flow/welcome/login-error-modal.tsx
@@ -33,6 +33,8 @@ import { MetaMetricsContext } from '../../../contexts/metametrics';
 import { getSocialLoginType } from '../../../selectors';
 import { LOGIN_ERROR, LoginErrorType } from './types';
 
+const TELEGRAM_DESKTOP_UPDATE_URL = 'https://desktop.telegram.org/';
+
 type LoginErrorModalProps = {
   onDone: () => void;
   loginError: LoginErrorType;
@@ -48,12 +50,17 @@ export default function LoginErrorModal({
   const { trackEvent } = useContext(MetaMetricsContext);
   const socialLoginType = useSelector(getSocialLoginType);
 
+  const isTelegramOutdated = loginError === LOGIN_ERROR.TELEGRAM_OUTDATED;
+
   const getTitle = () => {
     if (loginError === LOGIN_ERROR.UNABLE_TO_CONNECT) {
       return t('loginErrorConnectTitle');
     }
     if (loginError === LOGIN_ERROR.SESSION_EXPIRED) {
       return t('loginErrorSessionExpiredTitle');
+    }
+    if (isTelegramOutdated) {
+      return t('loginErrorTelegramOutdatedTitle');
     }
     return t('loginErrorGenericTitle');
   };
@@ -67,6 +74,9 @@ export default function LoginErrorModal({
     }
     if (loginError === LOGIN_ERROR.RESET_WALLET && socialLoginType) {
       return t('loginErrorResetWalletDescription', [socialLoginType]);
+    }
+    if (isTelegramOutdated) {
+      return t('loginErrorTelegramOutdatedDescription');
     }
 
     return t('loginErrorGenericDescription', [
@@ -110,6 +120,19 @@ export default function LoginErrorModal({
     return t('loginErrorGenericButton');
   };
 
+  const handleUpdateTelegramClick = () => {
+    trackEvent({
+      category: MetaMetricsEventCategory.Onboarding,
+      event: MetaMetricsEventName.SupportLinkClicked,
+      properties: {
+        url: TELEGRAM_DESKTOP_UPDATE_URL,
+        location: 'Telegram outdated modal',
+      },
+    });
+    global.platform.openTab({ url: TELEGRAM_DESKTOP_UPDATE_URL });
+    onDone();
+  };
+
   return (
     <Modal isOpen onClose={onDone} data-testid="login-error-modal">
       <ModalOverlay />
@@ -133,15 +156,27 @@ export default function LoginErrorModal({
         <Box paddingLeft={4} paddingRight={4}>
           <Text variant={TextVariant.BodyMd}>{getDescription()}</Text>
           <Box marginTop={6}>
-            <Button
-              data-testid="login-error-modal-button"
-              variant={ButtonVariant.Primary}
-              size={ButtonSize.Lg}
-              onClick={onDone}
-              className="w-full"
-            >
-              {getButtonText()}
-            </Button>
+            {isTelegramOutdated ? (
+              <Button
+                data-testid="login-error-modal-update-telegram-button"
+                variant={ButtonVariant.Primary}
+                size={ButtonSize.Lg}
+                onClick={handleUpdateTelegramClick}
+                className="w-full"
+              >
+                {t('loginErrorTelegramOutdatedButton')}
+              </Button>
+            ) : (
+              <Button
+                data-testid="login-error-modal-button"
+                variant={ButtonVariant.Primary}
+                size={ButtonSize.Lg}
+                onClick={onDone}
+                className="w-full"
+              >
+                {getButtonText()}
+              </Button>
+            )}
           </Box>
         </Box>
       </ModalContent>

--- a/ui/pages/onboarding-flow/welcome/login-error-modal.tsx
+++ b/ui/pages/onboarding-flow/welcome/login-error-modal.tsx
@@ -129,7 +129,7 @@ export default function LoginErrorModal({
         location: 'Telegram outdated modal',
       },
     });
-    global.platform.openTab({ url: TELEGRAM_DESKTOP_UPDATE_URL });
+    globalThis.platform.openTab({ url: TELEGRAM_DESKTOP_UPDATE_URL });
     onDone();
   };
 

--- a/ui/pages/onboarding-flow/welcome/login-options.test.tsx
+++ b/ui/pages/onboarding-flow/welcome/login-options.test.tsx
@@ -1,0 +1,156 @@
+import React from 'react';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { fireEvent } from '@testing-library/react';
+import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
+import { enLocale as messages, tEn } from '../../../../test/lib/i18n-helpers';
+import { ThemeType } from '../../../../shared/constants/preferences';
+import LoginOptions from './login-options';
+import { LOGIN_OPTION, LOGIN_TYPE } from './types';
+
+const buildStore = () =>
+  configureMockStore([thunk])({
+    metamask: {
+      internalAccounts: { accounts: {}, selectedAccount: '' },
+      theme: ThemeType.light,
+    },
+  });
+
+describe('LoginOptions', () => {
+  const mockHandleLogin = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('when loginOption is NEW', () => {
+    it('renders create-with buttons for Google, Apple, Telegram and an SRP button', () => {
+      const { getByTestId, getByText } = renderWithProvider(
+        <LoginOptions
+          loginOption={LOGIN_OPTION.NEW}
+          handleLogin={mockHandleLogin}
+        />,
+        buildStore(),
+      );
+
+      expect(
+        getByTestId('onboarding-create-with-google-button'),
+      ).toBeInTheDocument();
+      expect(
+        getByTestId('onboarding-create-with-apple-button'),
+      ).toBeInTheDocument();
+      expect(
+        getByTestId('onboarding-create-with-telegram-button'),
+      ).toBeInTheDocument();
+      expect(
+        getByTestId('onboarding-create-with-srp-button'),
+      ).toBeInTheDocument();
+
+      expect(
+        getByText(tEn('onboardingContinueWith', ['Google'])),
+      ).toBeInTheDocument();
+      expect(
+        getByText(tEn('onboardingContinueWith', ['Apple'])),
+      ).toBeInTheDocument();
+      expect(
+        getByText(tEn('onboardingContinueWith', ['Telegram'])),
+      ).toBeInTheDocument();
+      expect(
+        getByText(messages.onboardingSrpCreate.message),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('when loginOption is EXISTING', () => {
+    it('renders import-with buttons for Google, Apple, Telegram and an SRP button', () => {
+      const { getByTestId, getByText } = renderWithProvider(
+        <LoginOptions
+          loginOption={LOGIN_OPTION.EXISTING}
+          handleLogin={mockHandleLogin}
+        />,
+        buildStore(),
+      );
+
+      expect(
+        getByTestId('onboarding-import-with-google-button'),
+      ).toBeInTheDocument();
+      expect(
+        getByTestId('onboarding-import-with-apple-button'),
+      ).toBeInTheDocument();
+      expect(
+        getByTestId('onboarding-import-with-telegram-button'),
+      ).toBeInTheDocument();
+      expect(
+        getByTestId('onboarding-import-with-srp-button'),
+      ).toBeInTheDocument();
+
+      expect(
+        getByText(tEn('onboardingSignInWith', ['Google'])),
+      ).toBeInTheDocument();
+      expect(
+        getByText(tEn('onboardingSignInWith', ['Apple'])),
+      ).toBeInTheDocument();
+      expect(
+        getByText(tEn('onboardingSignInWith', ['Telegram'])),
+      ).toBeInTheDocument();
+      expect(
+        getByText(messages.onboardingSrpImport.message),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('calls handleLogin with the correct LOGIN_TYPE for each button', () => {
+    const { getByTestId } = renderWithProvider(
+      <LoginOptions
+        loginOption={LOGIN_OPTION.NEW}
+        handleLogin={mockHandleLogin}
+      />,
+      buildStore(),
+    );
+
+    fireEvent.click(getByTestId('onboarding-create-with-google-button'));
+    fireEvent.click(getByTestId('onboarding-create-with-apple-button'));
+    fireEvent.click(getByTestId('onboarding-create-with-telegram-button'));
+    fireEvent.click(getByTestId('onboarding-create-with-srp-button'));
+
+    expect(mockHandleLogin).toHaveBeenNthCalledWith(1, LOGIN_TYPE.GOOGLE);
+    expect(mockHandleLogin).toHaveBeenNthCalledWith(2, LOGIN_TYPE.APPLE);
+    expect(mockHandleLogin).toHaveBeenNthCalledWith(3, LOGIN_TYPE.TELEGRAM);
+    expect(mockHandleLogin).toHaveBeenNthCalledWith(4, LOGIN_TYPE.SRP);
+    expect(mockHandleLogin).toHaveBeenCalledTimes(4);
+  });
+
+  it('renders Terms of Use and Privacy Notice footer links pointing to consensys.io', () => {
+    const { getByRole } = renderWithProvider(
+      <LoginOptions
+        loginOption={LOGIN_OPTION.NEW}
+        handleLogin={mockHandleLogin}
+      />,
+      buildStore(),
+    );
+
+    const termsLink = getByRole('link', {
+      name: new RegExp(messages.onboardingLoginFooterTermsOfUse.message, 'iu'),
+    });
+    const privacyLink = getByRole('link', {
+      name: new RegExp(
+        messages.onboardingLoginFooterPrivacyNotice.message,
+        'iu',
+      ),
+    });
+
+    expect(termsLink).toHaveAttribute(
+      'href',
+      'https://consensys.io/terms-of-use',
+    );
+    expect(termsLink).toHaveAttribute('target', '_blank');
+    expect(termsLink).toHaveAttribute('rel', 'noopener noreferrer');
+
+    expect(privacyLink).toHaveAttribute(
+      'href',
+      'https://consensys.io/privacy-notice',
+    );
+    expect(privacyLink).toHaveAttribute('target', '_blank');
+    expect(privacyLink).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+});

--- a/ui/pages/onboarding-flow/welcome/login-options.tsx
+++ b/ui/pages/onboarding-flow/welcome/login-options.tsx
@@ -57,7 +57,7 @@ export const SocialButton = React.forwardRef(
           className="w-full"
           gap={2}
         >
-          {icon}
+          <span aria-hidden="true">{icon}</span>
           <Box>{label}</Box>
         </Box>
       </Button>
@@ -83,76 +83,82 @@ export default function LoginOptions({
       : 'var(--color-accent02-dark)';
   }, [theme]);
 
+  const isExisting = loginOption === LOGIN_OPTION.EXISTING;
+
+  const socialOptions: {
+    name: string;
+    loginType: LoginType;
+    testIdSuffix: string;
+    icon: React.ReactNode;
+    btnClass: string;
+  }[] = [
+    {
+      name: 'Google',
+      loginType: LOGIN_TYPE.GOOGLE,
+      testIdSuffix: 'google',
+      icon: (
+        <img
+          src="images/icons/google.svg"
+          className="options-modal__social-icon"
+          alt=""
+        />
+      ),
+      btnClass: 'mb-4',
+    },
+    {
+      name: 'Apple',
+      loginType: LOGIN_TYPE.APPLE,
+      testIdSuffix: 'apple',
+      icon: (
+        <Icon
+          name={IconName.AppleLogo}
+          color={IconColor.InfoInverse}
+          size={IconSize.Lg}
+        />
+      ),
+      btnClass: 'mb-4',
+    },
+    {
+      name: 'Telegram',
+      loginType: LOGIN_TYPE.TELEGRAM,
+      testIdSuffix: 'telegram',
+      icon: (
+        <img
+          src="images/icons/telegram.svg"
+          className="options-modal__social-icon"
+          alt=""
+        />
+      ),
+      btnClass: 'mb-2',
+    },
+  ];
+
   return (
     <Box>
-      <SocialButton
-        data-testid={
-          loginOption === LOGIN_OPTION.EXISTING
-            ? 'onboarding-import-with-google-button'
-            : 'onboarding-create-with-google-button'
-        }
-        icon={
-          <img
-            src="images/icons/google.svg"
-            className="options-modal__social-icon"
-            alt={t('onboardingOptionIcon', ['Google'])}
+      {socialOptions.map(
+        ({ name, loginType, testIdSuffix, icon, btnClass }) => (
+          <SocialButton
+            key={loginType}
+            data-testid={`onboarding-${
+              isExisting ? 'import' : 'create'
+            }-with-${testIdSuffix}-button`}
+            icon={icon}
+            label={t(
+              isExisting ? 'onboardingSignInWith' : 'onboardingContinueWith',
+              [name],
+            )}
+            btnClass={btnClass}
+            onClick={() => handleLogin(loginType)}
           />
-        }
-        label={
-          loginOption === LOGIN_OPTION.EXISTING
-            ? t('onboardingSignInWith', ['Google'])
-            : t('onboardingContinueWith', ['Google'])
-        }
-        btnClass="mb-4"
-        onClick={() => handleLogin(LOGIN_TYPE.GOOGLE)}
-      />
-      <SocialButton
-        data-testid={
-          loginOption === LOGIN_OPTION.EXISTING
-            ? 'onboarding-import-with-apple-button'
-            : 'onboarding-create-with-apple-button'
-        }
-        icon={
-          <Icon
-            name={IconName.AppleLogo}
-            color={IconColor.InfoInverse}
-            size={IconSize.Lg}
-          />
-        }
-        label={
-          loginOption === LOGIN_OPTION.EXISTING
-            ? t('onboardingSignInWith', ['Apple'])
-            : t('onboardingContinueWith', ['Apple'])
-        }
-        btnClass="mb-4"
-        onClick={() => handleLogin(LOGIN_TYPE.APPLE)}
-      />
-      <SocialButton
-        data-testid={
-          loginOption === LOGIN_OPTION.EXISTING
-            ? 'onboarding-import-with-telegram-button'
-            : 'onboarding-create-with-telegram-button'
-        }
-        icon={
-          <img
-            src="images/icons/telegram.svg"
-            className="options-modal__social-icon"
-            alt={t('onboardingOptionIcon', ['Telegram'])}
-          />
-        }
-        label={
-          loginOption === LOGIN_OPTION.EXISTING
-            ? t('onboardingSignInWith', ['Telegram'])
-            : t('onboardingContinueWith', ['Telegram'])
-        }
-        btnClass="mb-2"
-        onClick={() => handleLogin(LOGIN_TYPE.TELEGRAM)}
-      />
+        ),
+      )}
       <Box
         flexDirection={BoxFlexDirection.Row}
         alignItems={BoxAlignItems.Center}
         marginBottom={4}
         className="options-modal__or"
+        role="separator"
+        aria-orientation="horizontal"
       >
         <Text
           className="w-max px-2 mx-auto relative z-[1]"
@@ -169,19 +175,15 @@ export default function LoginOptions({
       </Box>
       <Button
         data-theme={theme === ThemeType.dark ? ThemeType.light : ThemeType.dark}
-        data-testid={
-          loginOption === LOGIN_OPTION.EXISTING
-            ? 'onboarding-import-with-srp-button'
-            : 'onboarding-create-with-srp-button'
-        }
+        data-testid={`onboarding-${
+          isExisting ? 'import' : 'create'
+        }-with-srp-button`}
         variant={ButtonVariant.Primary}
         className="w-full"
         size={ButtonSize.Lg}
         onClick={() => handleLogin(LOGIN_TYPE.SRP)}
       >
-        {loginOption === LOGIN_OPTION.EXISTING
-          ? t('onboardingSrpImport')
-          : t('onboardingSrpCreate')}
+        {t(isExisting ? 'onboardingSrpImport' : 'onboardingSrpCreate')}
       </Button>
       <Text
         variant={TextVariant.BodySm}
@@ -200,6 +202,9 @@ export default function LoginOptions({
               href="https://consensys.io/terms-of-use"
               target="_blank"
               rel="noopener noreferrer"
+              aria-label={`${t('onboardingLoginFooterTermsOfUse')} (${t(
+                'opensInNewTab',
+              )})`}
             >
               {t('onboardingLoginFooterTermsOfUse')}
             </a>
@@ -213,6 +218,9 @@ export default function LoginOptions({
               href="https://consensys.io/privacy-notice"
               target="_blank"
               rel="noopener noreferrer"
+              aria-label={`${t('onboardingLoginFooterPrivacyNotice')} (${t(
+                'opensInNewTab',
+              )})`}
             >
               {t('onboardingLoginFooterPrivacyNotice')}
             </a>

--- a/ui/pages/onboarding-flow/welcome/types.ts
+++ b/ui/pages/onboarding-flow/welcome/types.ts
@@ -19,6 +19,7 @@ export const LOGIN_ERROR = {
   GENERIC: 'generic',
   SESSION_EXPIRED: 'session_expired',
   RESET_WALLET: 'reset_wallet',
+  TELEGRAM_OUTDATED: 'telegram_outdated',
 } as const;
 
 export type LoginErrorType = (typeof LOGIN_ERROR)[keyof typeof LOGIN_ERROR];

--- a/ui/pages/onboarding-flow/welcome/welcome.test.tsx
+++ b/ui/pages/onboarding-flow/welcome/welcome.test.tsx
@@ -15,6 +15,7 @@ import {
 import { PLATFORM_FIREFOX } from '../../../../shared/constants/app';
 import { ONBOARDING_CREATE_PASSWORD_ROUTE } from '../../../helpers/constants/routes';
 import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
+import { OAuthErrorMessages } from '../../../../shared/lib/error';
 import Welcome from './welcome';
 
 const mockUseNavigate = jest.fn();
@@ -44,6 +45,14 @@ jest.mock('./metamask-wordmark-animation', () => ({
     setTimeout(() => setIsAnimationComplete(true), 0);
     return <div data-testid="metamask-wordmark-animation" />;
   },
+}));
+
+jest.mock('./login-error-modal', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  __esModule: true,
+  default: ({ loginError }: { loginError: string }) => (
+    <div data-testid="login-error-modal" data-login-error={loginError} />
+  ),
 }));
 
 const mockIntersectionObserver = jest.fn();
@@ -415,6 +424,132 @@ describe('Welcome Page', () => {
       // should navigate to create password page
       expect(mockUseNavigate).toHaveBeenCalledWith(
         ONBOARDING_CREATE_PASSWORD_ROUTE,
+      );
+    });
+  });
+
+  describe('Telegram-outdated error routing', () => {
+    const triggerTelegramCreateFailure = async (errorMessage: string) => {
+      jest
+        .spyOn(Environment, 'getIsSeedlessOnboardingFeatureEnabled')
+        .mockReturnValue(true);
+      const noopThunk = () => Promise.resolve();
+      jest
+        .spyOn(Actions, 'setParticipateInMetaMetrics')
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .mockReturnValue(noopThunk as any);
+      jest
+        .spyOn(Actions, 'setFirstTimeFlowType')
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .mockReturnValue(noopThunk as any);
+      // Override the success mock from beforeEach with a rejection. We have
+      // to clear the existing queued return value first; otherwise the success
+      // thunk from beforeEach would be consumed instead of our rejection.
+      startOAuthLoginSpy.mockReset();
+      startOAuthLoginSpy.mockReturnValueOnce(
+        jest.fn().mockRejectedValueOnce(new Error(errorMessage)),
+      );
+
+      const utils = renderWithProvider(
+        <MetaMetricsContext.Provider value={mockMetaMetricsContext}>
+          <Welcome />
+        </MetaMetricsContext.Provider>,
+        mockStore,
+      );
+
+      await waitFor(() => {
+        expect(
+          utils.getByText(messages.onboardingCreateWallet.message),
+        ).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        fireEvent.click(
+          utils.getByText(messages.onboardingCreateWallet.message),
+        );
+        await new Promise((resolve) => setTimeout(resolve, 500));
+      });
+
+      await waitFor(() => {
+        expect(
+          utils.getByTestId('onboarding-create-with-telegram-button'),
+        ).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        fireEvent.click(
+          utils.getByTestId('onboarding-create-with-telegram-button'),
+        );
+      });
+
+      return utils;
+    };
+
+    const expectOutdatedAppEventTracked = () => {
+      expect(mockTrackEvent).toHaveBeenCalledWith({
+        category: MetaMetricsEventCategory.Onboarding,
+        event: MetaMetricsEventName.SocialLoginFailed,
+        properties: {
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          account_type: `${MetaMetricsEventAccountType.Default}_telegram`,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          is_rehydration: 'unknown',
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          failure_type: 'outdated_app',
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          error_category: 'telegram_app',
+        },
+      });
+    };
+
+    it('routes to TELEGRAM_OUTDATED when verify rejects with 403', async () => {
+      const { findByTestId } = await triggerTelegramCreateFailure(
+        'Telegram verify failed: 403 Forbidden',
+      );
+
+      const modal = await findByTestId('login-error-modal');
+      expect(modal).toHaveAttribute('data-login-error', 'telegram_outdated');
+      expectOutdatedAppEventTracked();
+    });
+
+    it('routes to TELEGRAM_OUTDATED when verify rejects with 404', async () => {
+      const { findByTestId } = await triggerTelegramCreateFailure(
+        'Telegram verify failed: 404 Not Found',
+      );
+
+      const modal = await findByTestId('login-error-modal');
+      expect(modal).toHaveAttribute('data-login-error', 'telegram_outdated');
+      expectOutdatedAppEventTracked();
+    });
+
+    it('routes to TELEGRAM_OUTDATED when the OAuth flow returns no redirect URL', async () => {
+      const { findByTestId } = await triggerTelegramCreateFailure(
+        OAuthErrorMessages.NO_REDIRECT_URL_FOUND_ERROR,
+      );
+
+      const modal = await findByTestId('login-error-modal');
+      expect(modal).toHaveAttribute('data-login-error', 'telegram_outdated');
+    });
+
+    it('does NOT route to TELEGRAM_OUTDATED for non-403/404 verify failures', async () => {
+      const { findByTestId } = await triggerTelegramCreateFailure(
+        'Telegram verify failed: 500 Internal Server Error',
+      );
+
+      const modal = await findByTestId('login-error-modal');
+      expect(modal).not.toHaveAttribute(
+        'data-login-error',
+        'telegram_outdated',
+      );
+
+      // The outdated_app heuristic must NOT be reported for unrelated 5xx failures.
+      expect(mockTrackEvent).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          properties: expect.objectContaining({
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            failure_type: 'outdated_app',
+          }),
+        }),
       );
     });
   });

--- a/ui/pages/onboarding-flow/welcome/welcome.tsx
+++ b/ui/pages/onboarding-flow/welcome/welcome.tsx
@@ -261,7 +261,7 @@ export default function OnboardingWelcome() {
   );
 
   const handleSocialLoginError = useCallback(
-    (error) => {
+    (error, loginType) => {
       const errorMessage =
         error instanceof Error ? error.message : 'Unknown error';
 
@@ -281,6 +281,38 @@ export default function OnboardingWelcome() {
         return;
       }
 
+      // Telegram-specific failures are most commonly caused by an outdated
+      // Telegram desktop app — the OAuth handshake happens inside Telegram's
+      // embedded webview which silently fails on old clients. Route those to
+      // a Telegram-specific modal so users know to update their Telegram app
+      // rather than seeing a generic connection error.
+      if (loginType === LOGIN_TYPE.TELEGRAM) {
+        const isTelegramVerifyFailure =
+          /Telegram verify failed:\s*(403|404)/u.test(errorMessage);
+        const isLikelyOutdatedApp =
+          isTelegramVerifyFailure ||
+          errorMessage === OAuthErrorMessages.NO_REDIRECT_URL_FOUND_ERROR;
+
+        if (isLikelyOutdatedApp) {
+          trackEvent({
+            category: MetaMetricsEventCategory.Onboarding,
+            event: MetaMetricsEventName.SocialLoginFailed,
+            properties: {
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              account_type: `${MetaMetricsEventAccountType.Default}_${LOGIN_TYPE.TELEGRAM}`,
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              is_rehydration: 'unknown',
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              failure_type: 'outdated_app',
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              error_category: 'telegram_app',
+            },
+          });
+          setLoginError(LOGIN_ERROR.TELEGRAM_OUTDATED);
+          return;
+        }
+      }
+
       if (errorMessage === OAuthErrorMessages.NO_REDIRECT_URL_FOUND_ERROR) {
         setLoginError(LOGIN_ERROR.UNABLE_TO_CONNECT);
         return;
@@ -288,7 +320,7 @@ export default function OnboardingWelcome() {
 
       setLoginError(LOGIN_ERROR.GENERIC);
     },
-    [bufferedEndTrace],
+    [bufferedEndTrace, trackEvent],
   );
 
   const onSocialLoginCreateClick = useCallback(
@@ -330,7 +362,7 @@ export default function OnboardingWelcome() {
           navigate(ONBOARDING_ACCOUNT_EXIST, { replace: true });
         }
       } catch (error) {
-        handleSocialLoginError(error);
+        handleSocialLoginError(error, socialConnectionType);
       } finally {
         setIsLoggingIn(false);
       }
@@ -384,7 +416,7 @@ export default function OnboardingWelcome() {
           navigate(ONBOARDING_UNLOCK_ROUTE, { replace: true });
         }
       } catch (error) {
-        handleSocialLoginError(error);
+        handleSocialLoginError(error, socialConnectionType);
       } finally {
         setIsLoggingIn(false);
       }

--- a/ui/pages/settings/security-tab/reveal-srp-list/reveal-srp-list.tsx
+++ b/ui/pages/settings/security-tab/reveal-srp-list/reveal-srp-list.tsx
@@ -9,20 +9,16 @@ import {
   IconName,
   IconSize,
   Text,
-} from '../../../../components/component-library';
-import { SrpList } from '../../../../components/multichain/multi-srp/srp-list/srp-list';
-import {
   TextVariant,
   TextColor,
-  TextTransform,
-  BackgroundColor,
-  Display,
-  FlexDirection,
-  AlignItems,
+  BoxFlexDirection,
+  BoxAlignItems,
   IconColor,
   FontWeight,
-  BlockSize,
-} from '../../../../helpers/constants/design-system';
+  TextTransform,
+} from '@metamask/design-system-react';
+import { SrpList } from '../../../../components/multichain/multi-srp/srp-list/srp-list';
+import { BackgroundColor } from '../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import {
   ONBOARDING_REVIEW_SRP_ROUTE,
@@ -64,15 +60,46 @@ export const RevealSrpList = () => {
     return `${maskedHostname}@${domain}`;
   };
 
+  const getSocialLoginIcon = (type: AuthConnection) => {
+    switch (type) {
+      case AuthConnection.Apple:
+        return (
+          <Icon
+            name={IconName.AppleLogo}
+            color={IconColor.IconDefault}
+            size={IconSize.Lg}
+          />
+        );
+      case AuthConnection.Google:
+        return (
+          <img
+            src="images/icons/google.svg"
+            alt="Google icon"
+            width={24}
+            height={24}
+          />
+        );
+      default:
+        return (
+          <img
+            src="images/icons/telegram.svg"
+            alt="Telegram icon"
+            width={24}
+            height={24}
+          />
+        );
+    }
+  };
+
   return (
     <Box className="srp-reveal-list">
       {isSocialLoginFlow && (
         <Box paddingTop={4} paddingLeft={4} paddingRight={4}>
           <Text
-            marginBottom={2}
-            variant={TextVariant.bodyMd}
-            color={TextColor.textAlternative}
+            variant={TextVariant.BodyMd}
+            color={TextColor.TextAlternative}
             textTransform={TextTransform.Uppercase}
+            className="mb-2"
           >
             {t('securitySocialLoginLabel', [socialLoginType])}
           </Text>
@@ -82,38 +109,25 @@ export const RevealSrpList = () => {
             border={false}
           >
             <Box
-              display={Display.Flex}
-              flexDirection={FlexDirection.Row}
-              alignItems={AlignItems.center}
+              flexDirection={BoxFlexDirection.Row}
+              alignItems={BoxAlignItems.Center}
               gap={3}
             >
               <Box
-                display={Display.Flex}
-                alignItems={AlignItems.center}
+                flexDirection={BoxFlexDirection.Row}
+                alignItems={BoxAlignItems.Center}
                 gap={2}
               >
-                {socialLoginType === AuthConnection.Apple ? (
-                  <Icon
-                    name={IconName.Apple}
-                    color={IconColor.iconDefault}
-                    size={IconSize.Lg}
-                  />
-                ) : (
-                  <img
-                    src={`images/icons/google.svg`}
-                    className="srp-reveal-list__social-icon"
-                    alt="Google icon"
-                  />
-                )}
+                {getSocialLoginIcon(socialLoginType as AuthConnection)}
               </Box>
-              <Box flexDirection={FlexDirection.Column}>
+              <Box flexDirection={BoxFlexDirection.Column}>
                 <Text fontWeight={FontWeight.Medium}>
                   {t('securitySocialLoginEnabled')}
                 </Text>
                 {socialLoginEmail && (
                   <Text
-                    variant={TextVariant.bodySm}
-                    color={TextColor.textAlternative}
+                    variant={TextVariant.BodySm}
+                    color={TextColor.TextAlternative}
                   >
                     {maskHostNameFromEmail(socialLoginEmail)}
                   </Text>
@@ -122,19 +136,15 @@ export const RevealSrpList = () => {
             </Box>
           </Card>
           <Text
-            marginTop={1}
-            variant={TextVariant.bodySm}
-            color={TextColor.textAlternative}
+            className="mt-1"
+            variant={TextVariant.BodySm}
+            color={TextColor.TextAlternative}
           >
             {t('securitySocialLoginEnabledDescription', [
               capitalize(socialLoginType),
             ])}
           </Text>
-          <Box
-            width={BlockSize.Full}
-            className="srp-reveal-list__divider"
-            marginTop={4}
-          />
+          <Box className="srp-reveal-list__divider w-full" marginTop={4} />
         </Box>
       )}
       <Box
@@ -146,9 +156,9 @@ export const RevealSrpList = () => {
         data-testid="select-srp-container"
       >
         <Text
-          marginBottom={2}
-          variant={TextVariant.bodyMd}
-          color={TextColor.textAlternative}
+          className="mb-2"
+          variant={TextVariant.BodyMd}
+          color={TextColor.TextAlternative}
           textTransform={TextTransform.Uppercase}
         >
           {t('securitySrpLabel')}


### PR DESCRIPTION
…odal and fix loader fox centering

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

When a user's Telegram Desktop app is outdated, the OAuth handshake inside Telegram's embedded webview silently fails with a `403`/`404` response. Previously, MetaMask surfaced a generic "Unable to connect" error with no guidance on how to resolve it, leaving users unable to sign in via Telegram. Additionally, the Telegram "login in progress" loader screen had two visual bugs: the fox was misaligned (off-centre due to an incorrect Rive canvas alignment), and the loading spinner appeared far below the fox's face.

- Added `TELEGRAM_OUTDATED` to the `LOGIN_ERROR` enum.
- `welcome.tsx` now detects Telegram-specific failures (`Telegram verify failed: 403|404` or `NO_REDIRECT_URL_FOUND_ERROR`) and routes them to the new error type instead of the generic modal.
- `LoginErrorModal` renders a dedicated title, description, and **"Update Telegram"** primary CTA for `TELEGRAM_OUTDATED`. Clicking it opens `https://desktop.telegram.org/` in a new tab and dismisses the modal.
- Three new `en` locale strings: `loginErrorTelegramOutdatedTitle`, `loginErrorTelegramOutdatedDescription`, `loginErrorTelegramOutdatedButton`.
- Telemetry events added:
  - `Social Login Failed` (with `failure_type: 'outdated_app'`,`error_category: 'telegram_app'`, `is_rehydration: 'unknown'`) when the outdated-app error is detected.
  - `Support Link Clicked` (with `location: 'Telegram outdated modal'`) when the "Update Telegram" CTA is clicked.
- `login-error-modal.test.tsx` — new file; covers all 5 error types, CTA dismiss behaviour, Telegram update URL, and `SupportLinkClicked` telemetry.
- `login-options.test.tsx` — new file; covers create/import mode labels & test-ids, `handleLogin` callback contract, and footer link attributes.

Jira Link: https://consensyssoftware.atlassian.net/browse/TO-704


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added a dedicated "Update Telegram" error screen shown when the user's Telegram app is too outdated to complete social login, with a direct link to download the latest Telegram Desktop client.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Start a new wallet creation flow.
2. Click **Continue with Telegram**.
3. Simulate an outdated-app scenario (e.g. use a Telegram app version that returns 403/404 on the OAuth verify endpoint).
4. Verify the **"Couldn't sign in with Telegram"** modal appears with the "Update Telegram" button.
5. Click **Update Telegram** — confirm `https://desktop.telegram.org/` opens in a new tab and the modal closes.
6. Confirm the `Social Login Failed` and `Support Link Clicked` analytics events fire in the Segment debugger.


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/e315ff83-bd16-4054-bd60-fe5b0e8ff2c9

<img width="1251" height="1042" alt="Screenshot 2026-04-29 at 1 22 21 PM" src="https://github.com/user-attachments/assets/8b6bced9-4b92-4fe7-97dd-3621d56ece7a" />
<img width="1728" height="1084" alt="Screenshot 2026-04-29 at 12 30 41 PM" src="https://github.com/user-attachments/assets/923d656d-3ffa-4203-b26f-e79df9998b76" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 50dc78d8573625ccebd63f4458ea2a503b59de90. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->