### PR TITLE
fix(perps): gate Perps tab on Basic Functionality to prevent WebSocket when disabled cp-13.29.0

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5642,6 +5642,9 @@
   "perps": {
     "message": "Perps"
   },
+  "perpsBasicFunctionalityOff": {
+    "message": "This feature isn't available while basic functionality is turned off."
+  },
   "perps24hVolume": {
     "message": "24h Volume"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5642,9 +5642,6 @@
   "perps": {
     "message": "Perps"
   },
-  "perpsBasicFunctionalityOff": {
-    "message": "This feature isn't available while basic functionality is turned off."
-  },
   "perps24hVolume": {
     "message": "24h Volume"
   },
@@ -5697,6 +5694,9 @@
   "perpsAvailableToTrade": {
     "message": "Available to trade",
     "description": "Label for the available balance that can be used for trading"
+  },
+  "perpsBasicFunctionalityOff": {
+    "message": "This feature isn't available while basic functionality is turned off."
   },
   "perpsBatchCancelFailed": {
     "message": "Failed to cancel one or more orders. Try again."

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -5695,6 +5695,9 @@
     "message": "Available to trade",
     "description": "Label for the available balance that can be used for trading"
   },
+  "perpsBasicFunctionalityOff": {
+    "message": "This feature isn't available while basic functionality is turned off."
+  },
   "perpsBatchCancelFailed": {
     "message": "Failed to cancel one or more orders. Try again."
   },

--- a/ui/components/app/perps/index.ts
+++ b/ui/components/app/perps/index.ts
@@ -2,6 +2,7 @@ export { PerpsBalanceDropdown } from './perps-balance-dropdown';
 export type { PerpsBalanceDropdownProps } from './perps-balance-dropdown';
 export { PerpsRecentActivity } from './perps-recent-activity';
 export type { PerpsRecentActivityProps } from './perps-recent-activity';
+export { PerpsTab } from './perps-tab';
 export { PerpsView } from './perps-view';
 export { PerpsViewStreamBoundary } from './perps-view-stream-boundary';
 export { PerpsToastProvider, usePerpsToast } from './perps-toast';

--- a/ui/components/app/perps/perps-tab.test.tsx
+++ b/ui/components/app/perps/perps-tab.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import mockState from '../../../../test/data/mock-state.json';
+import configureStore from '../../../store/store';
+import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
+import { PerpsTab } from './perps-tab';
+
+jest.mock('./perps-view-stream-boundary', () => ({
+  PerpsViewStreamBoundary: ({ children }: { children: React.ReactNode }) =>
+    children,
+}));
+
+jest.mock('./perps-view', () => ({
+  PerpsView: () => <div data-testid="perps-view-mock">Perps</div>,
+}));
+
+jest.mock('./perps-toast', () => ({
+  PerpsToastProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+describe('PerpsTab', () => {
+  it('renders the "basic functionality off" empty state when useExternalServices is false', () => {
+    const store = configureStore({
+      metamask: {
+        ...mockState.metamask,
+        useExternalServices: false,
+      },
+    });
+
+    const { queryByTestId } = renderWithProvider(<PerpsTab />, store);
+
+    expect(queryByTestId('perps-basic-functionality-off')).not.toBeNull();
+    expect(queryByTestId('perps-view-mock')).toBeNull();
+  });
+
+  it('renders the perps view when useExternalServices is true', () => {
+    const store = configureStore({
+      metamask: {
+        ...mockState.metamask,
+        useExternalServices: true,
+      },
+    });
+
+    const { queryByTestId } = renderWithProvider(<PerpsTab />, store);
+
+    expect(queryByTestId('perps-basic-functionality-off')).toBeNull();
+    expect(queryByTestId('perps-view-mock')).not.toBeNull();
+  });
+});

--- a/ui/components/app/perps/perps-tab.test.tsx
+++ b/ui/components/app/perps/perps-tab.test.tsx
@@ -86,11 +86,26 @@ describe('PerpsTab', () => {
     );
   });
 
-  it('does not call perpsDisconnect on initial render with useExternalServices false', () => {
+  it('calls perpsDisconnect on initial render when useExternalServices is false', () => {
     const store = configureStore({
       metamask: {
         ...mockState.metamask,
         useExternalServices: false,
+      },
+    });
+
+    renderWithProvider(<PerpsTab />, store);
+
+    expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+      'perpsDisconnect',
+    );
+  });
+
+  it('does not call perpsDisconnect when useExternalServices is true', () => {
+    const store = configureStore({
+      metamask: {
+        ...mockState.metamask,
+        useExternalServices: true,
       },
     });
 

--- a/ui/components/app/perps/perps-tab.test.tsx
+++ b/ui/components/app/perps/perps-tab.test.tsx
@@ -1,8 +1,14 @@
 import React from 'react';
+import { act } from '@testing-library/react';
 import mockState from '../../../../test/data/mock-state.json';
 import configureStore from '../../../store/store';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
+import { submitRequestToBackground } from '../../../store/background-connection';
 import { PerpsTab } from './perps-tab';
+
+jest.mock('../../../store/background-connection', () => ({
+  submitRequestToBackground: jest.fn().mockResolvedValue(undefined),
+}));
 
 jest.mock('./perps-view-stream-boundary', () => ({
   PerpsViewStreamBoundary: ({ children }: { children: React.ReactNode }) =>
@@ -17,7 +23,16 @@ jest.mock('./perps-toast', () => ({
   PerpsToastProvider: ({ children }: { children: React.ReactNode }) => children,
 }));
 
+const mockSubmitRequestToBackground =
+  submitRequestToBackground as jest.MockedFunction<
+    typeof submitRequestToBackground
+  >;
+
 describe('PerpsTab', () => {
+  beforeEach(() => {
+    mockSubmitRequestToBackground.mockClear();
+  });
+
   it('renders the "basic functionality off" empty state when useExternalServices is false', () => {
     const store = configureStore({
       metamask: {
@@ -44,5 +59,45 @@ describe('PerpsTab', () => {
 
     expect(queryByTestId('perps-basic-functionality-off')).toBeNull();
     expect(queryByTestId('perps-view-mock')).not.toBeNull();
+  });
+
+  it('calls perpsDisconnect when useExternalServices toggles from true to false', () => {
+    const store = configureStore({
+      metamask: {
+        ...mockState.metamask,
+        useExternalServices: true,
+      },
+    });
+
+    renderWithProvider(<PerpsTab />, store);
+
+    act(() => {
+      store.dispatch({
+        type: 'UPDATE_METAMASK_STATE',
+        value: {
+          ...mockState.metamask,
+          useExternalServices: false,
+        },
+      });
+    });
+
+    expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+      'perpsDisconnect',
+    );
+  });
+
+  it('does not call perpsDisconnect on initial render with useExternalServices false', () => {
+    const store = configureStore({
+      metamask: {
+        ...mockState.metamask,
+        useExternalServices: false,
+      },
+    });
+
+    renderWithProvider(<PerpsTab />, store);
+
+    expect(mockSubmitRequestToBackground).not.toHaveBeenCalledWith(
+      'perpsDisconnect',
+    );
   });
 });

--- a/ui/components/app/perps/perps-tab.tsx
+++ b/ui/components/app/perps/perps-tab.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
+import { getUseExternalServices } from '../../../selectors';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import { SETTINGS_ROUTE } from '../../../helpers/constants/routes';
+import ErrorBoundary from '../error-boundary/error-boundary';
+import { TabEmptyState } from '../../ui/tab-empty-state';
+import { PerpsView } from './perps-view';
+import { PerpsViewStreamBoundary } from './perps-view-stream-boundary';
+import { PerpsToastProvider } from './perps-toast';
+
+/**
+ * Perps tab content for the account overview.
+ *
+ * When Basic Functionality (useExternalServices) is off, renders an
+ * informational empty state instead of mounting the stream boundary,
+ * which prevents the background WebSocket connection from opening.
+ */
+export function PerpsTab() {
+  const useExternalServices = useSelector(getUseExternalServices);
+  const navigate = useNavigate();
+  const t = useI18nContext();
+
+  if (!useExternalServices) {
+    return (
+      <TabEmptyState
+        icon={
+          <img
+            alt="MetaMask logo"
+            src="./images/logo/metamask-fox.svg"
+            style={{ width: 64, height: 64 }}
+          />
+        }
+        description={t('basicFunctionalityRequired_description')}
+        actionButtonText={t('basicFunctionalityRequired_reviewInSettings')}
+        onAction={() => navigate(SETTINGS_ROUTE)}
+        className="mx-auto mt-5 mb-6"
+        data-testid="perps-basic-functionality-off"
+      />
+    );
+  }
+
+  return (
+    <PerpsToastProvider>
+      <ErrorBoundary key="perps">
+        <PerpsViewStreamBoundary>
+          <PerpsView />
+        </PerpsViewStreamBoundary>
+      </ErrorBoundary>
+    </PerpsToastProvider>
+  );
+}

--- a/ui/components/app/perps/perps-tab.tsx
+++ b/ui/components/app/perps/perps-tab.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import {
@@ -38,14 +38,12 @@ export function PerpsTab() {
   const navigate = useNavigate();
   const t = useI18nContext();
 
-  const prevExternalServices = useRef(useExternalServices);
   useEffect(() => {
-    if (prevExternalServices.current && !useExternalServices) {
+    if (!useExternalServices) {
       submitRequestToBackground('perpsDisconnect').catch((err: unknown) => {
         console.debug('[PerpsTab] perpsDisconnect failed:', err);
       });
     }
-    prevExternalServices.current = useExternalServices;
   }, [useExternalServices]);
 
   if (!useExternalServices) {

--- a/ui/components/app/perps/perps-tab.tsx
+++ b/ui/components/app/perps/perps-tab.tsx
@@ -15,7 +15,7 @@ import {
 } from '@metamask/design-system-react';
 import { getUseExternalServices } from '../../../selectors';
 import { useI18nContext } from '../../../hooks/useI18nContext';
-import { SETTINGS_ROUTE } from '../../../helpers/constants/routes';
+import { PRIVACY_ROUTE } from '../../../helpers/constants/routes';
 import ErrorBoundary from '../error-boundary/error-boundary';
 import { PerpsView } from './perps-view';
 import { PerpsViewStreamBoundary } from './perps-view-stream-boundary';
@@ -54,7 +54,7 @@ export function PerpsTab() {
         </Text>
         <Button
           variant={ButtonVariant.Secondary}
-          onClick={() => navigate(SETTINGS_ROUTE)}
+          onClick={() => navigate(PRIVACY_ROUTE)}
         >
           {t('basicFunctionalityRequired_reviewInSettings')}
         </Button>

--- a/ui/components/app/perps/perps-tab.tsx
+++ b/ui/components/app/perps/perps-tab.tsx
@@ -50,7 +50,7 @@ export function PerpsTab() {
           textAlign={TextAlign.Center}
           className="max-w-64"
         >
-          {t('basicFunctionalityRequired_description')}
+          {t('perpsBasicFunctionalityOff')}
         </Text>
         <Button
           variant={ButtonVariant.Secondary}

--- a/ui/components/app/perps/perps-tab.tsx
+++ b/ui/components/app/perps/perps-tab.tsx
@@ -1,11 +1,22 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxJustifyContent,
+  Button,
+  ButtonVariant,
+  Text,
+  TextAlign,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react';
 import { getUseExternalServices } from '../../../selectors';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { SETTINGS_ROUTE } from '../../../helpers/constants/routes';
 import ErrorBoundary from '../error-boundary/error-boundary';
-import { TabEmptyState } from '../../ui/tab-empty-state';
 import { PerpsView } from './perps-view';
 import { PerpsViewStreamBoundary } from './perps-view-stream-boundary';
 import { PerpsToastProvider } from './perps-toast';
@@ -24,20 +35,30 @@ export function PerpsTab() {
 
   if (!useExternalServices) {
     return (
-      <TabEmptyState
-        icon={
-          <img
-            alt="MetaMask logo"
-            src="./images/logo/metamask-fox.svg"
-            style={{ width: 64, height: 64 }}
-          />
-        }
-        description={t('basicFunctionalityRequired_description')}
-        actionButtonText={t('basicFunctionalityRequired_reviewInSettings')}
-        onAction={() => navigate(SETTINGS_ROUTE)}
-        className="mx-auto mt-5 mb-6"
+      <Box
+        flexDirection={BoxFlexDirection.Column}
+        alignItems={BoxAlignItems.Center}
+        justifyContent={BoxJustifyContent.Center}
+        gap={4}
+        paddingTop={10}
+        paddingBottom={10}
         data-testid="perps-basic-functionality-off"
-      />
+      >
+        <Text
+          variant={TextVariant.BodyMd}
+          color={TextColor.TextAlternative}
+          textAlign={TextAlign.Center}
+          className="max-w-64"
+        >
+          {t('basicFunctionalityRequired_description')}
+        </Text>
+        <Button
+          variant={ButtonVariant.Secondary}
+          onClick={() => navigate(SETTINGS_ROUTE)}
+        >
+          {t('basicFunctionalityRequired_reviewInSettings')}
+        </Button>
+      </Box>
     );
   }
 

--- a/ui/components/app/perps/perps-tab.tsx
+++ b/ui/components/app/perps/perps-tab.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import {
@@ -16,6 +16,7 @@ import {
 import { getUseExternalServices } from '../../../selectors';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { PRIVACY_ROUTE } from '../../../helpers/constants/routes';
+import { submitRequestToBackground } from '../../../store/background-connection';
 import ErrorBoundary from '../error-boundary/error-boundary';
 import { PerpsView } from './perps-view';
 import { PerpsViewStreamBoundary } from './perps-view-stream-boundary';
@@ -27,11 +28,25 @@ import { PerpsToastProvider } from './perps-toast';
  * When Basic Functionality (useExternalServices) is off, renders an
  * informational empty state instead of mounting the stream boundary,
  * which prevents the background WebSocket connection from opening.
+ *
+ * If the user toggles Basic Functionality off while the Perps tab is
+ * mounted, we also call perpsDisconnect to tear down the background
+ * WebSocket so it doesn't linger until the next page reload.
  */
 export function PerpsTab() {
   const useExternalServices = useSelector(getUseExternalServices);
   const navigate = useNavigate();
   const t = useI18nContext();
+
+  const prevExternalServices = useRef(useExternalServices);
+  useEffect(() => {
+    if (prevExternalServices.current && !useExternalServices) {
+      submitRequestToBackground('perpsDisconnect').catch((err: unknown) => {
+        console.debug('[PerpsTab] perpsDisconnect failed:', err);
+      });
+    }
+    prevExternalServices.current = useExternalServices;
+  }, [useExternalServices]);
 
   if (!useExternalServices) {
     return (

--- a/ui/components/multichain/account-overview/account-overview-tabs.test.tsx
+++ b/ui/components/multichain/account-overview/account-overview-tabs.test.tsx
@@ -12,13 +12,6 @@ import {
 import { CHAIN_IDS } from '../../../../shared/constants/network';
 import { AccountOverviewTabs } from './account-overview-tabs';
 
-const mockGetIsPerpsExperienceAvailable = jest.fn().mockReturnValue(false);
-jest.mock('../../../selectors/perps', () => ({
-  ...jest.requireActual('../../../selectors/perps'),
-  getIsPerpsExperienceAvailable: (...args: unknown[]) =>
-    mockGetIsPerpsExperienceAvailable(...args),
-}));
-
 jest.mock('../../../store/actions', () => ({
   setDefaultHomeActiveTabName: jest.fn(),
 }));

--- a/ui/components/multichain/account-overview/account-overview-tabs.test.tsx
+++ b/ui/components/multichain/account-overview/account-overview-tabs.test.tsx
@@ -12,6 +12,13 @@ import {
 import { CHAIN_IDS } from '../../../../shared/constants/network';
 import { AccountOverviewTabs } from './account-overview-tabs';
 
+const mockGetIsPerpsExperienceAvailable = jest.fn().mockReturnValue(false);
+jest.mock('../../../selectors/perps', () => ({
+  ...jest.requireActual('../../../selectors/perps'),
+  getIsPerpsExperienceAvailable: (...args: unknown[]) =>
+    mockGetIsPerpsExperienceAvailable(...args),
+}));
+
 jest.mock('../../../store/actions', () => ({
   setDefaultHomeActiveTabName: jest.fn(),
 }));
@@ -40,6 +47,10 @@ jest.mock('../../app/assets/defi-list/defi-tab', () => ({
   // eslint-disable-next-line @typescript-eslint/naming-convention
   __esModule: true,
   default: () => null,
+}));
+
+jest.mock('../../app/perps/perps-tab', () => ({
+  PerpsTab: () => <div data-testid="perps-tab-mock">PerpsTab</div>,
 }));
 
 describe('AccountOverviewTabs - event metrics', () => {

--- a/ui/components/multichain/account-overview/account-overview-tabs.tsx
+++ b/ui/components/multichain/account-overview/account-overview-tabs.tsx
@@ -30,9 +30,7 @@ import {
 import AssetList from '../../app/assets/asset-list';
 import DeFiTab from '../../app/assets/defi-list/defi-tab';
 import NftsTab from '../../app/assets/nfts/nfts-tab';
-import { PerpsView } from '../../app/perps/perps-view';
-import { PerpsViewStreamBoundary } from '../../app/perps/perps-view-stream-boundary';
-import { PerpsToastProvider } from '../../app/perps/perps-toast';
+import { PerpsTab } from '../../app/perps/perps-tab';
 import { Tab, Tabs } from '../../ui/tabs';
 import { useTokenBalances } from '../../../hooks/useTokenBalances';
 import { ActivityList } from '../activity-v2/activity-list';
@@ -179,13 +177,7 @@ export const AccountOverviewTabs = ({
           tabKey={AccountOverviewTabKey.Perps}
           data-testid="account-overview__perps-tab"
         >
-          <PerpsToastProvider>
-            <ErrorBoundary key="perps">
-              <PerpsViewStreamBoundary>
-                <PerpsView />
-              </PerpsViewStreamBoundary>
-            </ErrorBoundary>
-          </PerpsToastProvider>
+          <PerpsTab />
         </Tab>
       )}
 


### PR DESCRIPTION
## **Description**

The Perps tab in the account overview (home page) opened a WebSocket connection via `PerpsViewStreamBoundary` even when Basic Functionality (`useExternalServices`) was turned off. The full-page Perps routes (`/perps/*`) correctly block this via the `RequireBasicFunctionality` route guard, but the home tab bypassed it since it's not part of that route subtree.

This PR:
- Extracts a new `PerpsTab` component that checks `useExternalServices` before mounting the stream boundary
- When Basic Functionality is off, renders an informational message ("This feature isn't available while basic functionality is turned off.") with a button to navigate to Settings — instead of opening the WebSocket
- Simplifies `AccountOverviewTabs` by delegating all Perps tab logic to `PerpsTab`

## **Changelog**

CHANGELOG entry: Fixed Perps tab opening a WebSocket connection when basic functionality was turned off

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/42242

## **Manual testing steps**

1. Open MetaMask and go to Settings > Security
2. Turn off "Basic Functionality"
3. Go back to the home screen and click the **Perps** tab
4. Verify the tab shows a message saying the feature isn't available with basic functionality off, along with a "Review in settings" button
5. Verify no WebSocket connection is opened (check DevTools Network tab)
6. Turn Basic Functionality back on
7. Click the Perps tab again and verify it loads normally with live data

## **Screenshots/Recordings**

### **Before**

### **After**
<img width="368" height="781" alt="Screenshot 2026-04-29 at 10 46 52" src="https://github.com/user-attachments/assets/9975ace0-9f84-44bc-854b-6b50c3c3322f" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when Perps streaming mounts and adds a background `perpsDisconnect` call on state changes; incorrect gating could inadvertently block Perps or cause extra background messaging.
> 
> **Overview**
> Prevents the Account Overview **Perps** tab from opening/keeping a background WebSocket when *Basic Functionality* (`useExternalServices`) is disabled by introducing a new `PerpsTab` wrapper.
> 
> `PerpsTab` renders an empty-state message with a Settings link when disabled, and triggers `perpsDisconnect` when disabled (including when toggled off while mounted). `AccountOverviewTabs` is simplified to render `PerpsTab`, and new i18n copy plus unit tests cover the gating and disconnect behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0824d5e4fe7cecba6d7a549cded6338e1e688e19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->