### PR TITLE
feat(perps): make Perps Withdraw to any token submission work

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5326,6 +5326,14 @@
     "message": "You'll receive",
     "description": "Row label on the Perps Withdraw confirmation showing the net receive amount after fees"
   },
+  "perpsWithdrawTooltip": {
+    "message": "MetaMask will swap to your desired token for you. No MetaMask fee applies when you swap to mUSD.",
+    "description": "Tooltip shown on the Transaction fee row of the Perps Withdraw confirmation"
+  },
+  "providerFee": {
+    "message": "Provider fee",
+    "description": "Label used in the Transaction fee tooltip for the provider (bridge/relay) fee, e.g. in Perps Withdraw"
+  },
   "payWithModalTitle": {
     "message": "Pay with",
     "description": "Title for the pay with modal that allows users to select which token to pay transaction fees with"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5318,6 +5318,10 @@
     "message": "Pay with",
     "description": "Label for pay with row showing which token is used to pay transaction fees"
   },
+  "withdrawTo": {
+    "message": "Withdraw to",
+    "description": "Label for pay with row in withdrawal flows showing the destination token"
+  },
   "payWithModalTitle": {
     "message": "Pay with",
     "description": "Title for the pay with modal that allows users to select which token to pay transaction fees with"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5318,22 +5318,6 @@
     "message": "Pay with",
     "description": "Label for pay with row showing which token is used to pay transaction fees"
   },
-  "withdrawTo": {
-    "message": "Receive",
-    "description": "Label for pay with row in withdrawal flows showing the destination token"
-  },
-  "youllReceive": {
-    "message": "You'll receive",
-    "description": "Row label on the Perps Withdraw confirmation showing the net receive amount after fees"
-  },
-  "perpsWithdrawTooltip": {
-    "message": "MetaMask will swap to your desired token for you. No MetaMask fee applies when you swap to mUSD.",
-    "description": "Tooltip shown on the Transaction fee row of the Perps Withdraw confirmation"
-  },
-  "providerFee": {
-    "message": "Provider fee",
-    "description": "Label used in the Transaction fee tooltip for the provider (bridge/relay) fee, e.g. in Perps Withdraw"
-  },
   "payWithModalTitle": {
     "message": "Pay with",
     "description": "Title for the pay with modal that allows users to select which token to pay transaction fees with"
@@ -6384,6 +6368,10 @@
   },
   "perpsWithdrawToastSuccessTitle": {
     "message": "Withdrawal submitted"
+  },
+  "perpsWithdrawTooltip": {
+    "message": "MetaMask will swap to your desired token for you. No MetaMask fee applies when you swap to mUSD.",
+    "description": "Tooltip shown on the Transaction fee row of the Perps Withdraw confirmation"
   },
   "perpsYouReceive": {
     "message": "You receive"
@@ -9900,6 +9888,10 @@
   "willApproveAmountForSwapping": {
     "message": "Approves token for swap."
   },
+  "withdrawTo": {
+    "message": "Receive",
+    "description": "Label for pay with row in withdrawal flows showing the destination token"
+  },
   "withdrawing": {
     "message": "Withdrawing"
   },
@@ -9932,6 +9924,10 @@
   "youSent": {
     "message": "You sent",
     "description": "Label indicating the amount and asset the user sent."
+  },
+  "youllReceive": {
+    "message": "You'll receive",
+    "description": "Row label on the Perps Withdraw confirmation showing the net receive amount after fees"
   },
   "yourActivity": {
     "message": "Your activity"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5319,7 +5319,7 @@
     "description": "Label for pay with row showing which token is used to pay transaction fees"
   },
   "withdrawTo": {
-    "message": "Withdraw to",
+    "message": "Receive",
     "description": "Label for pay with row in withdrawal flows showing the destination token"
   },
   "payWithModalTitle": {

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5322,6 +5322,10 @@
     "message": "Receive",
     "description": "Label for pay with row in withdrawal flows showing the destination token"
   },
+  "youllReceive": {
+    "message": "You'll receive",
+    "description": "Row label on the Perps Withdraw confirmation showing the net receive amount after fees"
+  },
   "payWithModalTitle": {
     "message": "Pay with",
     "description": "Title for the pay with modal that allows users to select which token to pay transaction fees with"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -5326,6 +5326,14 @@
     "message": "You'll receive",
     "description": "Row label on the Perps Withdraw confirmation showing the net receive amount after fees"
   },
+  "perpsWithdrawTooltip": {
+    "message": "MetaMask will swap to your desired token for you. No MetaMask fee applies when you swap to mUSD.",
+    "description": "Tooltip shown on the Transaction fee row of the Perps Withdraw confirmation"
+  },
+  "providerFee": {
+    "message": "Provider fee",
+    "description": "Label used in the Transaction fee tooltip for the provider (bridge/relay) fee, e.g. in Perps Withdraw"
+  },
   "payWithModalTitle": {
     "message": "Pay with",
     "description": "Title for the pay with modal that allows users to select which token to pay transaction fees with"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -5318,6 +5318,10 @@
     "message": "Pay with",
     "description": "Label for pay with row showing which token is used to pay transaction fees"
   },
+  "withdrawTo": {
+    "message": "Receive",
+    "description": "Label for pay with row in withdrawal flows showing the destination token"
+  },
   "payWithModalTitle": {
     "message": "Pay with",
     "description": "Title for the pay with modal that allows users to select which token to pay transaction fees with"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -5318,22 +5318,6 @@
     "message": "Pay with",
     "description": "Label for pay with row showing which token is used to pay transaction fees"
   },
-  "withdrawTo": {
-    "message": "Receive",
-    "description": "Label for pay with row in withdrawal flows showing the destination token"
-  },
-  "youllReceive": {
-    "message": "You'll receive",
-    "description": "Row label on the Perps Withdraw confirmation showing the net receive amount after fees"
-  },
-  "perpsWithdrawTooltip": {
-    "message": "MetaMask will swap to your desired token for you. No MetaMask fee applies when you swap to mUSD.",
-    "description": "Tooltip shown on the Transaction fee row of the Perps Withdraw confirmation"
-  },
-  "providerFee": {
-    "message": "Provider fee",
-    "description": "Label used in the Transaction fee tooltip for the provider (bridge/relay) fee, e.g. in Perps Withdraw"
-  },
   "payWithModalTitle": {
     "message": "Pay with",
     "description": "Title for the pay with modal that allows users to select which token to pay transaction fees with"
@@ -6384,6 +6368,10 @@
   },
   "perpsWithdrawToastSuccessTitle": {
     "message": "Withdrawal submitted"
+  },
+  "perpsWithdrawTooltip": {
+    "message": "MetaMask will swap to your desired token for you. No MetaMask fee applies when you swap to mUSD.",
+    "description": "Tooltip shown on the Transaction fee row of the Perps Withdraw confirmation"
   },
   "perpsYouReceive": {
     "message": "You receive"
@@ -9900,6 +9888,10 @@
   "willApproveAmountForSwapping": {
     "message": "Approves token for swap."
   },
+  "withdrawTo": {
+    "message": "Receive",
+    "description": "Label for pay with row in withdrawal flows showing the destination token"
+  },
   "withdrawing": {
     "message": "Withdrawing"
   },
@@ -9932,6 +9924,10 @@
   "youSent": {
     "message": "You sent",
     "description": "Label indicating the amount and asset the user sent."
+  },
+  "youllReceive": {
+    "message": "You'll receive",
+    "description": "Row label on the Perps Withdraw confirmation showing the net receive amount after fees"
   },
   "yourActivity": {
     "message": "Your activity"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -5322,6 +5322,10 @@
     "message": "Receive",
     "description": "Label for pay with row in withdrawal flows showing the destination token"
   },
+  "youllReceive": {
+    "message": "You'll receive",
+    "description": "Row label on the Perps Withdraw confirmation showing the net receive amount after fees"
+  },
   "payWithModalTitle": {
     "message": "Pay with",
     "description": "Title for the pay with modal that allows users to select which token to pay transaction fees with"

--- a/app/scripts/messenger-client-init/transaction-pay-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/transaction-pay-controller-init.test.ts
@@ -49,4 +49,65 @@ describe('TransactionPayControllerInit', () => {
       state: undefined,
     });
   });
+
+  describe('api.setTransactionPayPostQuote', () => {
+    function initApi() {
+      const { api, messengerClient } =
+        TransactionPayControllerInit(getInitRequestMock());
+      const setTransactionConfigMock = jest.mocked(
+        messengerClient.setTransactionConfig,
+      );
+      return { api, setTransactionConfigMock };
+    }
+
+    it('flips `isPostQuote` and `isHyperliquidSource` when isHyperliquidSource is set', () => {
+      const { api, setTransactionConfigMock } = initApi();
+
+      api.setTransactionPayPostQuote('tx-1', { isHyperliquidSource: true });
+
+      expect(setTransactionConfigMock).toHaveBeenCalledWith(
+        'tx-1',
+        expect.any(Function),
+      );
+
+      const updater = setTransactionConfigMock.mock.calls[0][1];
+      const config: {
+        isPostQuote?: boolean;
+        isHyperliquidSource?: boolean;
+      } = {};
+      updater(config as never);
+
+      expect(config).toEqual({ isPostQuote: true, isHyperliquidSource: true });
+    });
+
+    it('only sets `isPostQuote` when no options are provided', () => {
+      const { api, setTransactionConfigMock } = initApi();
+
+      api.setTransactionPayPostQuote('tx-2');
+
+      const updater = setTransactionConfigMock.mock.calls[0][1];
+      const config: {
+        isPostQuote?: boolean;
+        isHyperliquidSource?: boolean;
+      } = {};
+      updater(config as never);
+
+      expect(config).toEqual({ isPostQuote: true });
+    });
+
+    it('does not set `isHyperliquidSource` when explicitly false', () => {
+      const { api, setTransactionConfigMock } = initApi();
+
+      api.setTransactionPayPostQuote('tx-3', { isHyperliquidSource: false });
+
+      const updater = setTransactionConfigMock.mock.calls[0][1];
+      const config: {
+        isPostQuote?: boolean;
+        isHyperliquidSource?: boolean;
+      } = {};
+      updater(config as never);
+
+      expect(config).toEqual({ isPostQuote: true });
+    });
+  });
 });

--- a/app/scripts/messenger-client-init/transaction-pay-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/transaction-pay-controller-init.test.ts
@@ -54,6 +54,9 @@ describe('TransactionPayControllerInit', () => {
     function initApi() {
       const { api, messengerClient } =
         TransactionPayControllerInit(getInitRequestMock());
+      if (!api) {
+        throw new Error('Expected init result to expose an api');
+      }
       const setTransactionConfigMock = jest.mocked(
         messengerClient.setTransactionConfig,
       );

--- a/app/scripts/messenger-client-init/transaction-pay-controller-init.ts
+++ b/app/scripts/messenger-client-init/transaction-pay-controller-init.ts
@@ -55,6 +55,17 @@ function getApi(
         config.isMaxAmount = isMaxAmount;
       });
     },
+    setTransactionPayPostQuote: (
+      transactionId: string,
+      options: { isHyperliquidSource?: boolean } = {},
+    ) => {
+      messengerClient.setTransactionConfig(transactionId, (config) => {
+        config.isPostQuote = true;
+        if (options.isHyperliquidSource) {
+          config.isHyperliquidSource = true;
+        }
+      });
+    },
     updateTransactionPaymentToken:
       messengerClient.updatePaymentToken.bind(messengerClient),
   };

--- a/shared/lib/transactions.utils.test.ts
+++ b/shared/lib/transactions.utils.test.ts
@@ -3,7 +3,11 @@ import {
   TransactionMeta,
   TransactionType,
 } from '@metamask/transaction-controller';
-import { isBatchTransaction, hasTransactionType } from './transactions.utils';
+import {
+  isBatchTransaction,
+  hasTransactionType,
+  isPerpsWithdrawTransaction,
+} from './transactions.utils';
 
 describe('Transactions utils', () => {
   describe('isBatchTransaction', () => {
@@ -110,6 +114,40 @@ describe('Transactions utils', () => {
       expect(hasTransactionType(transactionMeta, [TransactionType.swap])).toBe(
         false,
       );
+    });
+  });
+
+  describe('isPerpsWithdrawTransaction', () => {
+    it('returns true when type is perpsWithdraw', () => {
+      const transactionMeta = {
+        type: TransactionType.perpsWithdraw,
+      } as TransactionMeta;
+
+      expect(isPerpsWithdrawTransaction(transactionMeta)).toBe(true);
+    });
+
+    it('returns true when a nested transaction is perpsWithdraw', () => {
+      const transactionMeta = {
+        type: TransactionType.simpleSend,
+        nestedTransactions: [
+          { type: TransactionType.tokenMethodApprove },
+          { type: TransactionType.perpsWithdraw },
+        ],
+      } as unknown as TransactionMeta;
+
+      expect(isPerpsWithdrawTransaction(transactionMeta)).toBe(true);
+    });
+
+    it('returns false for unrelated types (e.g. perpsDeposit)', () => {
+      const transactionMeta = {
+        type: TransactionType.perpsDeposit,
+      } as TransactionMeta;
+
+      expect(isPerpsWithdrawTransaction(transactionMeta)).toBe(false);
+    });
+
+    it('returns false when transactionMeta is undefined', () => {
+      expect(isPerpsWithdrawTransaction(undefined)).toBe(false);
     });
   });
 });

--- a/shared/lib/transactions.utils.ts
+++ b/shared/lib/transactions.utils.ts
@@ -39,3 +39,24 @@ export function hasTransactionType(
     ) ?? false
   );
 }
+
+const PERPS_WITHDRAW_TYPES: TransactionType[] = [TransactionType.perpsWithdraw];
+
+/**
+ * Checks whether the given transaction is a Perps withdraw, either directly
+ * via `type` or via any `nestedTransactions` entry.
+ *
+ * Mirrors `isTransactionPayWithdraw` from metamask-mobile and gives callers
+ * a single place to reason about "is this a perps withdraw flow" instead of
+ * sprinkling `hasTransactionType(tx, [TransactionType.perpsWithdraw])` and
+ * ad-hoc `WITHDRAW_TYPES` lists across the codebase.
+ *
+ * @param transactionMeta - The transaction metadata to check.
+ * @returns Whether the transaction (or any of its nested transactions) is a
+ * Perps withdraw.
+ */
+export function isPerpsWithdrawTransaction(
+  transactionMeta: TransactionMeta | undefined,
+): boolean {
+  return hasTransactionType(transactionMeta, PERPS_WITHDRAW_TYPES);
+}

--- a/ui/pages/confirmations/components/confirm/info/perps-withdraw-info/perps-withdraw-info.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/perps-withdraw-info/perps-withdraw-info.test.tsx
@@ -12,6 +12,14 @@ jest.mock('../../../../hooks/tokens/useAddToken', () => ({
   useAddToken: jest.fn(),
 }));
 
+// `useTransactionPayPostQuote` reads the current confirmation via
+// `useConfirmContext`, which throws without a `ConfirmContextProvider`.
+// The hook itself is exercised in its own unit tests; mock it out here so
+// `PerpsWithdrawInfo` can render under the lighter `renderWithProvider`.
+jest.mock('../../../../hooks/pay/useTransactionPayPostQuote', () => ({
+  useTransactionPayPostQuote: jest.fn(),
+}));
+
 jest.mock('../../../info/custom-amount-info', () => ({
   CustomAmountInfo: jest.fn(({ children }) => (
     <div data-testid="custom-amount-info-mock">{children}</div>

--- a/ui/pages/confirmations/components/confirm/info/perps-withdraw-info/perps-withdraw-info.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/perps-withdraw-info/perps-withdraw-info.test.tsx
@@ -20,6 +20,15 @@ jest.mock('../../../../hooks/pay/useTransactionPayPostQuote', () => ({
   useTransactionPayPostQuote: jest.fn(),
 }));
 
+// `usePerpsLiveAccount` boots the perps stream manager which fires an
+// async background RPC ("perpsInit"). In a stripped-down test render that
+// produces a "Background connection not initialized" warning and an
+// out-of-act `setIsReady` update. Stub it — the only thing this test cares
+// about is that `PerpsWithdrawInfo` forwards the right props.
+jest.mock('../../../../../../hooks/perps/stream', () => ({
+  usePerpsLiveAccount: () => ({ account: null, isInitialLoading: false }),
+}));
+
 jest.mock('../../../info/custom-amount-info', () => ({
   CustomAmountInfo: jest.fn(({ children }) => (
     <div data-testid="custom-amount-info-mock">{children}</div>

--- a/ui/pages/confirmations/components/confirm/info/perps-withdraw-info/perps-withdraw-info.tsx
+++ b/ui/pages/confirmations/components/confirm/info/perps-withdraw-info/perps-withdraw-info.tsx
@@ -4,6 +4,7 @@ import { useTransactionPayPostQuote } from '../../../../hooks/pay/useTransaction
 import { CustomAmountInfo } from '../../../info/custom-amount-info';
 import { PerpsWithdrawBalance } from '../../../perps-confirmations/perps-withdraw-balance';
 import { PERPS_CURRENCY, ARBITRUM_USDC } from '../../../../constants/perps';
+import { usePerpsLiveAccount } from '../../../../../../hooks/perps/stream';
 
 export const PerpsWithdrawInfo = () => {
   useAddToken({
@@ -15,11 +16,22 @@ export const PerpsWithdrawInfo = () => {
 
   useTransactionPayPostQuote();
 
+  // Source the balance for the custom-amount percentage buttons from the
+  // user's Perps available balance (gasless / withdraw-from-Perps flow). The
+  // shared `useTransactionCustomAmount` hook stays decoupled from the perps
+  // stream by accepting an explicit `balanceUsdOverride`.
+  const { account } = usePerpsLiveAccount();
+  const balanceUsdOverride = parseFloat(account?.availableBalance ?? '0') || 0;
+
   return (
     // Percentage buttons (25/50/75/Max) are intentionally hidden for MVP —
     // not passing `hasMax` so they never render. Re-enable by passing
     // `hasMax` (and optionally a `percentages` override) when ready.
-    <CustomAmountInfo currency={PERPS_CURRENCY} hidePayTokenAmount>
+    <CustomAmountInfo
+      balanceUsdOverride={balanceUsdOverride}
+      currency={PERPS_CURRENCY}
+      hidePayTokenAmount
+    >
       <PerpsWithdrawBalance />
     </CustomAmountInfo>
   );

--- a/ui/pages/confirmations/components/confirm/info/perps-withdraw-info/perps-withdraw-info.tsx
+++ b/ui/pages/confirmations/components/confirm/info/perps-withdraw-info/perps-withdraw-info.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useAddToken } from '../../../../hooks/tokens/useAddToken';
+import { useTransactionPayPostQuote } from '../../../../hooks/pay/useTransactionPayPostQuote';
 import { CustomAmountInfo } from '../../../info/custom-amount-info';
 import { PerpsWithdrawBalance } from '../../../perps-confirmations/perps-withdraw-balance';
 import { PERPS_CURRENCY, ARBITRUM_USDC } from '../../../../constants/perps';
@@ -11,6 +12,8 @@ export const PerpsWithdrawInfo = () => {
     symbol: ARBITRUM_USDC.symbol,
     tokenAddress: ARBITRUM_USDC.address,
   });
+
+  useTransactionPayPostQuote();
 
   return (
     // Percentage buttons (25/50/75/Max) are intentionally hidden for MVP —

--- a/ui/pages/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/ui/pages/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -254,7 +254,7 @@ function BottomContainer({ amountFiat }: { amountFiat: string }) {
   const { hideResults } = useTransactionCustomAmountAlerts();
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
 
-  const isWithdraw = isPerpsWithdrawTransaction(currentConfirmation);
+  const isPerpsWithdraw = isPerpsWithdrawTransaction(currentConfirmation);
 
   if (!isResultReady || hideResults) {
     return null;
@@ -269,7 +269,7 @@ function BottomContainer({ amountFiat }: { amountFiat: string }) {
     >
       <BridgeFeeRow variant={ConfirmInfoRowSize.Small} />
       <BridgeTimeRow rowVariant={ConfirmInfoRowSize.Small} />
-      {isWithdraw ? (
+      {isPerpsWithdraw ? (
         <ReceiveRow
           inputAmountUsd={amountFiat}
           variant={ConfirmInfoRowSize.Small}

--- a/ui/pages/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/ui/pages/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -49,6 +49,13 @@ import { useI18nContext } from '../../../../../hooks/useI18nContext';
 /* eslint-disable @typescript-eslint/naming-convention */
 
 export type CustomAmountInfoProps = {
+  /**
+   * Optional caller-provided balance (USD) used as the source for the
+   * percentage buttons. Takes precedence over the default `payToken.balanceUsd`.
+   * Used by flows (e.g. Perps Withdraw) whose balance comes from a different
+   * source than the selected pay token.
+   */
+  balanceUsdOverride?: number;
   children?: ReactNode;
   currency?: string;
   /**
@@ -68,6 +75,7 @@ export type CustomAmountInfoProps = {
 
 export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = React.memo(
   ({
+    balanceUsdOverride,
     children,
     currency,
     disableAutomaticToken,
@@ -95,7 +103,11 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = React.memo(
       amountHuman,
       updatePendingAmount,
       updatePendingAmountPercentage,
-    } = useTransactionCustomAmount({ currency, disableUpdate });
+    } = useTransactionCustomAmount({
+      balanceUsdOverride,
+      currency,
+      disableUpdate,
+    });
 
     const handleAmountChange = useCallback(
       (value: string) => {

--- a/ui/pages/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/ui/pages/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -44,6 +44,7 @@ import {
 import { useTransactionPayMetrics } from '../../../hooks/pay/useTransactionPayMetrics';
 import { useTransactionPayAvailableTokens } from '../../../hooks/pay/useTransactionPayAvailableTokens';
 import { useConfirmContext } from '../../../context/confirm';
+import { useI18nContext } from '../../../../../hooks/useI18nContext';
 
 /* eslint-disable @typescript-eslint/naming-convention */
 
@@ -250,6 +251,7 @@ function CenterContainerSkeleton() {
 }
 
 function BottomContainer({ amountFiat }: { amountFiat: string }) {
+  const t = useI18nContext();
   const isResultReady = useIsResultReady();
   const { hideResults } = useTransactionCustomAmountAlerts();
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
@@ -267,7 +269,12 @@ function BottomContainer({ amountFiat }: { amountFiat: string }) {
       gap={2}
       paddingBottom={4}
     >
-      <BridgeFeeRow variant={ConfirmInfoRowSize.Small} />
+      <BridgeFeeRow
+        variant={ConfirmInfoRowSize.Small}
+        tooltipDescription={
+          isPerpsWithdraw ? t('perpsWithdrawTooltip') : undefined
+        }
+      />
       <BridgeTimeRow rowVariant={ConfirmInfoRowSize.Small} />
       {isPerpsWithdraw ? (
         <ReceiveRow

--- a/ui/pages/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/ui/pages/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -32,7 +32,7 @@ import {
   PercentageButtonsSkeleton,
 } from '../../percentage-buttons';
 import { ReceiveRow } from '../../rows/receive-row/receive-row';
-import { hasTransactionType } from '../../../../../../shared/lib/transactions.utils';
+import { isPerpsWithdrawTransaction } from '../../../../../../shared/lib/transactions.utils';
 import { useTransactionCustomAmount } from '../../../hooks/transactions/useTransactionCustomAmount';
 import { useTransactionCustomAmountAlerts } from '../../../hooks/transactions/useTransactionCustomAmountAlerts';
 import { useAutomaticTransactionPayToken } from '../../../hooks/pay/useAutomaticTransactionPayToken';
@@ -249,17 +249,12 @@ function CenterContainerSkeleton() {
   );
 }
 
-const WITHDRAW_TRANSACTION_TYPES = [TransactionType.perpsWithdraw];
-
 function BottomContainer({ amountFiat }: { amountFiat: string }) {
   const isResultReady = useIsResultReady();
   const { hideResults } = useTransactionCustomAmountAlerts();
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
 
-  const isWithdraw = hasTransactionType(
-    currentConfirmation,
-    WITHDRAW_TRANSACTION_TYPES,
-  );
+  const isWithdraw = isPerpsWithdrawTransaction(currentConfirmation);
 
   if (!isResultReady || hideResults) {
     return null;

--- a/ui/pages/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/ui/pages/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode, useCallback } from 'react';
 import type { TransactionMeta } from '@metamask/transaction-controller';
+import { TransactionType } from '@metamask/transaction-controller';
 import { Box, Text } from '../../../../../components/component-library';
 import {
   Display,
@@ -30,6 +31,8 @@ import {
   PercentageButtons,
   PercentageButtonsSkeleton,
 } from '../../percentage-buttons';
+import { ReceiveRow } from '../../rows/receive-row/receive-row';
+import { hasTransactionType } from '../../../../../../shared/lib/transactions.utils';
 import { useTransactionCustomAmount } from '../../../hooks/transactions/useTransactionCustomAmount';
 import { useTransactionCustomAmountAlerts } from '../../../hooks/transactions/useTransactionCustomAmountAlerts';
 import { useAutomaticTransactionPayToken } from '../../../hooks/pay/useAutomaticTransactionPayToken';
@@ -132,7 +135,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = React.memo(
         >
           {children}
         </CenterContainer>
-        {overrideBottomContent ?? <BottomContainer />}
+        {overrideBottomContent ?? <BottomContainer amountFiat={amountFiat} />}
       </Box>
     );
   },
@@ -246,9 +249,17 @@ function CenterContainerSkeleton() {
   );
 }
 
-function BottomContainer() {
+const WITHDRAW_TRANSACTION_TYPES = [TransactionType.perpsWithdraw];
+
+function BottomContainer({ amountFiat }: { amountFiat: string }) {
   const isResultReady = useIsResultReady();
   const { hideResults } = useTransactionCustomAmountAlerts();
+  const { currentConfirmation } = useConfirmContext<TransactionMeta>();
+
+  const isWithdraw = hasTransactionType(
+    currentConfirmation,
+    WITHDRAW_TRANSACTION_TYPES,
+  );
 
   if (!isResultReady || hideResults) {
     return null;
@@ -263,7 +274,14 @@ function BottomContainer() {
     >
       <BridgeFeeRow variant={ConfirmInfoRowSize.Small} />
       <BridgeTimeRow rowVariant={ConfirmInfoRowSize.Small} />
-      <TotalRow variant={ConfirmInfoRowSize.Small} />
+      {isWithdraw ? (
+        <ReceiveRow
+          inputAmountUsd={amountFiat}
+          variant={ConfirmInfoRowSize.Small}
+        />
+      ) : (
+        <TotalRow variant={ConfirmInfoRowSize.Small} />
+      )}
     </Box>
   );
 }

--- a/ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.test.tsx
+++ b/ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen, fireEvent } from '@testing-library/react';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
 import { TransactionType } from '@metamask/transaction-controller';
 import { renderWithProvider } from '../../../../../../test/lib/render-helpers-navigate';
 import { enLocale as messages } from '../../../../../../test/lib/i18n-helpers';
@@ -13,6 +13,10 @@ import {
   useMusdPaymentToken,
 } from '../../../../../hooks/musd';
 import { useConfirmContext } from '../../../context/confirm';
+import {
+  addToken,
+  findNetworkClientIdByChainId,
+} from '../../../../../store/actions';
 import { PayWithModal } from './pay-with-modal';
 
 jest.mock('../../../hooks/pay/useTransactionPayToken');
@@ -22,6 +26,22 @@ jest.mock('../../../../../hooks/musd');
 jest.mock('../../../context/confirm', () => ({
   useConfirmContext: jest.fn(),
 }));
+jest.mock('../../../../../store/actions', () => ({
+  addToken: jest.fn(),
+  findNetworkClientIdByChainId: jest.fn(),
+}));
+
+// Zero-balance non-native token used to exercise the perpsWithdraw addToken
+// import branch.
+const PERPS_WITHDRAW_TOKEN = {
+  address: '0xaaa0000000000000000000000000000000000aaa',
+  chainId: '0xa4b1',
+  isNative: false,
+  rawBalance: '0x0',
+  symbol: 'BNB',
+  decimals: 18,
+  image: './bnb.png',
+};
 
 jest.mock('../../send/asset', () => ({
   Asset: ({
@@ -30,11 +50,7 @@ jest.mock('../../send/asset', () => ({
     hideNfts,
     includeNoBalance,
   }: {
-    onAssetSelect?: (token: {
-      address: string;
-      chainId: string;
-      disabled?: boolean;
-    }) => void;
+    onAssetSelect?: (token: Record<string, unknown>) => void;
     tokenFilter?: (tokens: unknown[]) => unknown[];
     hideNfts?: boolean;
     includeNoBalance?: boolean;
@@ -64,6 +80,12 @@ jest.mock('../../send/asset', () => ({
           }
         >
           Select Disabled Token
+        </button>
+        <button
+          data-testid="select-perps-withdraw-token"
+          onClick={() => onAssetSelect?.(PERPS_WITHDRAW_TOKEN)}
+        >
+          Select Perps Withdraw Token
         </button>
       </div>
     );
@@ -252,6 +274,81 @@ describe('PayWithModal', () => {
         chainId: '0x1',
       });
       expect(onMusdPaymentTokenChangeMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('perpsWithdraw destination token import', () => {
+    const addTokenMock = jest.mocked(addToken);
+    const findNetworkClientIdByChainIdMock = jest.mocked(
+      findNetworkClientIdByChainId,
+    );
+
+    beforeEach(() => {
+      useConfirmContextMock.mockReturnValue({
+        currentConfirmation: {
+          type: TransactionType.perpsWithdraw,
+        },
+      } as ReturnType<typeof useConfirmContext>);
+
+      findNetworkClientIdByChainIdMock.mockResolvedValue('arbitrum-client');
+      // `addToken` is a thunk; `dispatch(thunk)` returns whatever the thunk
+      // returns. The component awaits the dispatch, so a resolved jest.fn
+      // wrapped as a thunk-returning jest.fn is enough.
+      addTokenMock.mockReturnValue(jest.fn().mockResolvedValue(undefined));
+    });
+
+    it('imports a zero-balance non-native token before calling setPayToken', async () => {
+      renderModal({ isOpen: true, onClose: onCloseMock });
+
+      fireEvent.click(screen.getByTestId('select-perps-withdraw-token'));
+
+      await waitFor(() => {
+        expect(setPayTokenMock).toHaveBeenCalledWith({
+          address: PERPS_WITHDRAW_TOKEN.address,
+          chainId: PERPS_WITHDRAW_TOKEN.chainId,
+        });
+      });
+
+      expect(findNetworkClientIdByChainIdMock).toHaveBeenCalledWith(
+        PERPS_WITHDRAW_TOKEN.chainId,
+      );
+      expect(addTokenMock).toHaveBeenCalledWith(
+        {
+          address: PERPS_WITHDRAW_TOKEN.address,
+          symbol: PERPS_WITHDRAW_TOKEN.symbol,
+          decimals: PERPS_WITHDRAW_TOKEN.decimals,
+          networkClientId: 'arbitrum-client',
+          image: PERPS_WITHDRAW_TOKEN.image,
+        },
+        true,
+      );
+      expect(onCloseMock).toHaveBeenCalled();
+    });
+
+    it('keeps the modal open and skips setPayToken when token import fails', async () => {
+      const consoleErrorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => undefined);
+
+      addTokenMock.mockReturnValue(
+        jest.fn().mockRejectedValue(new Error('network down')),
+      );
+
+      renderModal({ isOpen: true, onClose: onCloseMock });
+
+      fireEvent.click(screen.getByTestId('select-perps-withdraw-token'));
+
+      await waitFor(() => {
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          'Failed to import withdraw destination token',
+          expect.any(Error),
+        );
+      });
+
+      expect(setPayTokenMock).not.toHaveBeenCalled();
+      expect(onCloseMock).not.toHaveBeenCalled();
+
+      consoleErrorSpy.mockRestore();
     });
   });
 });

--- a/ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.test.tsx
+++ b/ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.test.tsx
@@ -3,6 +3,8 @@ import { screen, fireEvent } from '@testing-library/react';
 import { TransactionType } from '@metamask/transaction-controller';
 import { renderWithProvider } from '../../../../../../test/lib/render-helpers-navigate';
 import { enLocale as messages } from '../../../../../../test/lib/i18n-helpers';
+import mockState from '../../../../../../test/data/mock-state.json';
+import configureStore from '../../../../../store/store';
 import { useTransactionPayToken } from '../../../hooks/pay/useTransactionPayToken';
 import { useTransactionPayRequiredTokens } from '../../../hooks/pay/useTransactionPayData';
 import { getAvailableTokens } from '../../../utils/transaction-pay';
@@ -70,6 +72,13 @@ jest.mock('../../send/asset', () => ({
 
 const CHAIN_ID_MOCK = '0x1';
 
+// `PayWithModal` calls `useDispatch()` for the perpsWithdraw `addToken`
+// import path, so the component needs a redux store at render time. The
+// non-perpsWithdraw test cases never actually dispatch — a default mock-state
+// store is enough to satisfy the hook.
+const renderModal = (props: { isOpen: boolean; onClose: () => void }) =>
+  renderWithProvider(<PayWithModal {...props} />, configureStore(mockState));
+
 describe('PayWithModal', () => {
   const setPayTokenMock = jest.fn();
   const onMusdPaymentTokenChangeMock = jest.fn();
@@ -124,7 +133,7 @@ describe('PayWithModal', () => {
   });
 
   it('renders modal with header', () => {
-    renderWithProvider(<PayWithModal isOpen={true} onClose={onCloseMock} />);
+    renderModal({ isOpen: true, onClose: onCloseMock });
 
     expect(
       screen.getByText(messages.payWithModalTitle.message),
@@ -132,7 +141,7 @@ describe('PayWithModal', () => {
   });
 
   it('renders Asset component with correct props', () => {
-    renderWithProvider(<PayWithModal isOpen={true} onClose={onCloseMock} />);
+    renderModal({ isOpen: true, onClose: onCloseMock });
 
     expect(screen.getByTestId('asset-component')).toBeInTheDocument();
     expect(screen.getByTestId('hide-nfts')).toHaveTextContent('true');
@@ -140,7 +149,7 @@ describe('PayWithModal', () => {
   });
 
   it('calls onClose when close button is clicked', () => {
-    renderWithProvider(<PayWithModal isOpen={true} onClose={onCloseMock} />);
+    renderModal({ isOpen: true, onClose: onCloseMock });
 
     const closeButton = screen.getByLabelText(messages.close.message);
     fireEvent.click(closeButton);
@@ -149,7 +158,7 @@ describe('PayWithModal', () => {
   });
 
   it('calls setPayToken and closes modal when token is selected', () => {
-    renderWithProvider(<PayWithModal isOpen={true} onClose={onCloseMock} />);
+    renderModal({ isOpen: true, onClose: onCloseMock });
 
     const selectButton = screen.getByTestId('select-token');
     fireEvent.click(selectButton);
@@ -162,7 +171,7 @@ describe('PayWithModal', () => {
   });
 
   it('filters tokens using getAvailableTokens with payToken and requiredTokens', () => {
-    renderWithProvider(<PayWithModal isOpen={true} onClose={onCloseMock} />);
+    renderModal({ isOpen: true, onClose: onCloseMock });
 
     expect(getAvailableTokensMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -176,7 +185,7 @@ describe('PayWithModal', () => {
   });
 
   it('does not render when isOpen is false', () => {
-    renderWithProvider(<PayWithModal isOpen={false} onClose={onCloseMock} />);
+    renderModal({ isOpen: false, onClose: onCloseMock });
 
     expect(
       screen.queryByText(messages.payWith.message),
@@ -184,7 +193,7 @@ describe('PayWithModal', () => {
   });
 
   it('does not call setPayToken when disabled token is selected', () => {
-    renderWithProvider(<PayWithModal isOpen={true} onClose={onCloseMock} />);
+    renderModal({ isOpen: true, onClose: onCloseMock });
 
     const selectDisabledButton = screen.getByTestId('select-disabled-token');
     fireEvent.click(selectDisabledButton);
@@ -203,7 +212,7 @@ describe('PayWithModal', () => {
     });
 
     it('calls onMusdPaymentTokenChange instead of setPayToken for mUSD conversions', () => {
-      renderWithProvider(<PayWithModal isOpen={true} onClose={onCloseMock} />);
+      renderModal({ isOpen: true, onClose: onCloseMock });
 
       fireEvent.click(screen.getByTestId('select-token'));
 
@@ -215,7 +224,7 @@ describe('PayWithModal', () => {
     });
 
     it('closes modal after mUSD token selection', () => {
-      renderWithProvider(<PayWithModal isOpen={true} onClose={onCloseMock} />);
+      renderModal({ isOpen: true, onClose: onCloseMock });
 
       fireEvent.click(screen.getByTestId('select-token'));
 
@@ -223,7 +232,7 @@ describe('PayWithModal', () => {
     });
 
     it('does not call onMusdPaymentTokenChange when disabled token is selected', () => {
-      renderWithProvider(<PayWithModal isOpen={true} onClose={onCloseMock} />);
+      renderModal({ isOpen: true, onClose: onCloseMock });
 
       fireEvent.click(screen.getByTestId('select-disabled-token'));
 
@@ -234,7 +243,7 @@ describe('PayWithModal', () => {
 
   describe('non-mUSD token selection', () => {
     it('calls setPayToken and not onMusdPaymentTokenChange for non-mUSD transactions', () => {
-      renderWithProvider(<PayWithModal isOpen={true} onClose={onCloseMock} />);
+      renderModal({ isOpen: true, onClose: onCloseMock });
 
       fireEvent.click(screen.getByTestId('select-token'));
 

--- a/ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
+++ b/ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from 'react';
+import { useDispatch } from 'react-redux';
 import { Hex } from '@metamask/utils';
 import {
   TransactionMeta,
@@ -22,14 +23,22 @@ import {
   useMusdPaymentToken,
 } from '../../../../../hooks/musd';
 import { useConfirmContext } from '../../../context/confirm';
+import {
+  addToken,
+  findNetworkClientIdByChainId,
+} from '../../../../../store/actions';
+import { hasTransactionType } from '../../../../../../shared/lib/transactions.utils';
 
 export type PayWithModalProps = {
   isOpen: boolean;
   onClose: () => void;
 };
 
+const WITHDRAW_TRANSACTION_TYPES = [TransactionType.perpsWithdraw];
+
 export const PayWithModal = ({ isOpen, onClose }: PayWithModalProps) => {
   const t = useI18nContext();
+  const dispatch = useDispatch();
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
   const { payToken, setPayToken } = useTransactionPayToken();
   const requiredTokens = useTransactionPayRequiredTokens();
@@ -42,12 +51,17 @@ export const PayWithModal = ({ isOpen, onClose }: PayWithModalProps) => {
   const { onPaymentTokenChange: onMusdPaymentTokenChange } =
     useMusdPaymentToken();
 
+  const isWithdraw = hasTransactionType(
+    currentConfirmation,
+    WITHDRAW_TRANSACTION_TYPES,
+  );
+
   const handleClose = useCallback(() => {
     onClose();
   }, [onClose]);
 
   const handleTokenSelect = useCallback(
-    (token: AssetType) => {
+    async (token: AssetType) => {
       if (token.disabled) {
         return;
       }
@@ -64,15 +78,48 @@ export const PayWithModal = ({ isOpen, onClose }: PayWithModalProps) => {
         return;
       }
 
-      // Default behavior for other transaction types
+      // Withdraw flows (e.g. Perps Withdraw) let the user pick a destination
+      // token they don't necessarily hold. TransactionPayController requires
+      // the token to be tracked by TokensController before `updatePaymentToken`
+      // can resolve its metadata, otherwise it throws "Payment token not
+      // found" and the selection silently fails. Ensure the token is imported
+      // first, then update the pay token.
+      if (
+        isWithdraw &&
+        !token.isNative &&
+        (token.rawBalance === '0x0' || !token.rawBalance)
+      ) {
+        try {
+          const networkClientId = await findNetworkClientIdByChainId(
+            tokenSelection.chainId,
+          );
+          await dispatch(
+            addToken(
+              {
+                address: tokenSelection.address,
+                symbol: token.symbol,
+                decimals: Number(token.decimals ?? 18),
+                networkClientId,
+                image: token.image,
+              },
+              true,
+            ),
+          );
+        } catch (error) {
+          console.error('Failed to import withdraw destination token', error);
+        }
+      }
+
       setPayToken(tokenSelection);
       handleClose();
     },
     [
-      handleClose,
-      setPayToken,
-      onMusdPaymentTokenChange,
       currentConfirmation?.type,
+      dispatch,
+      handleClose,
+      isWithdraw,
+      onMusdPaymentTokenChange,
+      setPayToken,
     ],
   );
 

--- a/ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
+++ b/ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
@@ -27,14 +27,12 @@ import {
   addToken,
   findNetworkClientIdByChainId,
 } from '../../../../../store/actions';
-import { hasTransactionType } from '../../../../../../shared/lib/transactions.utils';
+import { isPerpsWithdrawTransaction } from '../../../../../../shared/lib/transactions.utils';
 
 export type PayWithModalProps = {
   isOpen: boolean;
   onClose: () => void;
 };
-
-const WITHDRAW_TRANSACTION_TYPES = [TransactionType.perpsWithdraw];
 
 export const PayWithModal = ({ isOpen, onClose }: PayWithModalProps) => {
   const t = useI18nContext();
@@ -51,10 +49,7 @@ export const PayWithModal = ({ isOpen, onClose }: PayWithModalProps) => {
   const { onPaymentTokenChange: onMusdPaymentTokenChange } =
     useMusdPaymentToken();
 
-  const isWithdraw = hasTransactionType(
-    currentConfirmation,
-    WITHDRAW_TRANSACTION_TYPES,
-  );
+  const isWithdraw = isPerpsWithdrawTransaction(currentConfirmation);
 
   const handleClose = useCallback(() => {
     onClose();

--- a/ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
+++ b/ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
@@ -101,7 +101,12 @@ export const PayWithModal = ({ isOpen, onClose }: PayWithModalProps) => {
             ),
           );
         } catch (error) {
+          // `setPayToken` resolves the token via `TokensController`. If the
+          // import failed, the controller will throw "Payment token not
+          // found", leaving the user with a silently broken selection.
+          // Keep the modal open so they can retry or pick a different token.
           console.error('Failed to import withdraw destination token', error);
+          return;
         }
       }
 

--- a/ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
+++ b/ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
@@ -49,7 +49,7 @@ export const PayWithModal = ({ isOpen, onClose }: PayWithModalProps) => {
   const { onPaymentTokenChange: onMusdPaymentTokenChange } =
     useMusdPaymentToken();
 
-  const isWithdraw = isPerpsWithdrawTransaction(currentConfirmation);
+  const isPerpsWithdraw = isPerpsWithdrawTransaction(currentConfirmation);
 
   const handleClose = useCallback(() => {
     onClose();
@@ -80,7 +80,7 @@ export const PayWithModal = ({ isOpen, onClose }: PayWithModalProps) => {
       // found" and the selection silently fails. Ensure the token is imported
       // first, then update the pay token.
       if (
-        isWithdraw &&
+        isPerpsWithdraw &&
         !token.isNative &&
         (token.rawBalance === '0x0' || !token.rawBalance)
       ) {
@@ -112,7 +112,7 @@ export const PayWithModal = ({ isOpen, onClose }: PayWithModalProps) => {
       currentConfirmation?.type,
       dispatch,
       handleClose,
-      isWithdraw,
+      isPerpsWithdraw,
       onMusdPaymentTokenChange,
       setPayToken,
     ],

--- a/ui/pages/confirmations/components/rows/bridge-fee-row/bridge-fee-row.test.tsx
+++ b/ui/pages/confirmations/components/rows/bridge-fee-row/bridge-fee-row.test.tsx
@@ -244,8 +244,6 @@ describe('BridgeFeeRow', () => {
       content.includes(`${messages.networkFee.message}:`),
     );
     expect(tooltip.textContent).toContain(`${messages.providerFee.message}:`);
-    expect(tooltip.textContent).not.toContain(
-      `${messages.bridgeFee.message}:`,
-    );
+    expect(tooltip.textContent).not.toContain(`${messages.bridgeFee.message}:`);
   });
 });

--- a/ui/pages/confirmations/components/rows/bridge-fee-row/bridge-fee-row.test.tsx
+++ b/ui/pages/confirmations/components/rows/bridge-fee-row/bridge-fee-row.test.tsx
@@ -213,30 +213,39 @@ describe('BridgeFeeRow', () => {
     expect(feeValue).toHaveTextContent('$1.23');
   });
 
-  it('renders Provider Fee label for perpsWithdraw transactions', () => {
-    const { getByText, queryByText } = render({}, getPerpsWithdrawState());
+  it('renders Transaction fee row label for perpsWithdraw transactions', () => {
+    // The row label is intentionally "Transaction fee" for all flows; the
+    // perps-specific "Provider fee" terminology only appears inside the
+    // tooltip body (covered by the tooltip test below).
+    const { getByText } = render(
+      { variant: ConfirmInfoRowSize.Small },
+      getPerpsWithdrawState(),
+    );
 
-    expect(getByText(messages.perpsWithdrawFee.message)).toBeInTheDocument();
-    expect(
-      queryByText(messages.transactionFee.message),
-    ).not.toBeInTheDocument();
+    expect(getByText(messages.transactionFee.message)).toBeInTheDocument();
   });
 
   it('renders Transaction fee label for non-perpsWithdraw transactions', () => {
-    const { getByText, queryByText } = render();
+    const { getByText } = render();
 
     expect(getByText(messages.transactionFee.message)).toBeInTheDocument();
-    expect(
-      queryByText(messages.perpsWithdrawFee.message),
-    ).not.toBeInTheDocument();
   });
 
-  it('renders Provider Fee label on the skeleton while loading a perpsWithdraw transaction', () => {
-    useIsTransactionPayLoadingMock.mockReturnValue(true);
+  it('uses the "Provider fee" tooltip line for perpsWithdraw transactions', async () => {
+    const user = userEvent.setup();
+    const { getByTestId, findByText } = render(
+      { variant: ConfirmInfoRowSize.Small },
+      getPerpsWithdrawState(),
+    );
 
-    const { getByTestId, getByText } = render({}, getPerpsWithdrawState());
+    await user.hover(getByTestId('bridge-fee-row-tooltip'));
 
-    expect(getByTestId('bridge-fee-row-skeleton')).toBeInTheDocument();
-    expect(getByText(messages.perpsWithdrawFee.message)).toBeInTheDocument();
+    const tooltip = await findByText((content) =>
+      content.includes(`${messages.networkFee.message}:`),
+    );
+    expect(tooltip.textContent).toContain(`${messages.providerFee.message}:`);
+    expect(tooltip.textContent).not.toContain(
+      `${messages.bridgeFee.message}:`,
+    );
   });
 });

--- a/ui/pages/confirmations/components/rows/bridge-fee-row/bridge-fee-row.tsx
+++ b/ui/pages/confirmations/components/rows/bridge-fee-row/bridge-fee-row.tsx
@@ -46,13 +46,6 @@ export function BridgeFeeRow({
 
   const isPerpsWithdraw = isPerpsWithdrawTransaction(currentConfirmation);
 
-  // When a caller hasn't supplied a tooltipDescription, fall back to the
-  // perpsWithdraw description so the Perps Withdraw confirmation mirrors
-  // mobile's Transaction fee tooltip copy.
-  const resolvedTooltipDescription =
-    tooltipDescription ??
-    (isPerpsWithdraw ? t('perpsWithdrawTooltip') : undefined);
-
   const feeLabel = t('transactionFee');
 
   const feeTotalUsd = useMemo(() => {
@@ -87,7 +80,7 @@ export function BridgeFeeRow({
   let tooltipContent: string | undefined;
   if (hasQuotes && totals) {
     tooltipContent = renderTooltipContent({
-      description: resolvedTooltipDescription,
+      description: tooltipDescription,
       t,
       totals,
       formatFiat,

--- a/ui/pages/confirmations/components/rows/bridge-fee-row/bridge-fee-row.tsx
+++ b/ui/pages/confirmations/components/rows/bridge-fee-row/bridge-fee-row.tsx
@@ -44,13 +44,14 @@ export function BridgeFeeRow({
   const totals = useTransactionPayTotals();
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
 
-  const isWithdraw = isPerpsWithdrawTransaction(currentConfirmation);
+  const isPerpsWithdraw = isPerpsWithdrawTransaction(currentConfirmation);
 
   // When a caller hasn't supplied a tooltipDescription, fall back to the
   // perpsWithdraw description so the Perps Withdraw confirmation mirrors
   // mobile's Transaction fee tooltip copy.
   const resolvedTooltipDescription =
-    tooltipDescription ?? (isWithdraw ? t('perpsWithdrawTooltip') : undefined);
+    tooltipDescription ??
+    (isPerpsWithdraw ? t('perpsWithdrawTooltip') : undefined);
 
   const feeLabel = t('transactionFee');
 
@@ -93,7 +94,7 @@ export function BridgeFeeRow({
       metamaskFeeFormatted: metamaskFeeUsd,
       /** Matches prior behavior: MetaMask fee was only shown for Small variant (body row). */
       includeMetamaskFee: isSmall,
-      useProviderFeeLabel: isWithdraw,
+      useProviderFeeLabel: isPerpsWithdraw,
     });
   }
 

--- a/ui/pages/confirmations/components/rows/bridge-fee-row/bridge-fee-row.tsx
+++ b/ui/pages/confirmations/components/rows/bridge-fee-row/bridge-fee-row.tsx
@@ -1,7 +1,5 @@
 import React, { useMemo } from 'react';
 import { BigNumber } from 'bignumber.js';
-import type { TransactionMeta } from '@metamask/transaction-controller';
-import { TransactionType } from '@metamask/transaction-controller';
 import type { TransactionPayTotals } from '@metamask/transaction-pay-controller';
 import { Text } from '../../../../../components/component-library';
 import {
@@ -21,10 +19,6 @@ import {
 } from '../../../hooks/pay/useTransactionPayData';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { useFiatFormatter } from '../../../../../hooks/useFiatFormatter';
-import { useConfirmContext } from '../../../context/confirm';
-import { hasTransactionType } from '../../../../../../shared/lib/transactions.utils';
-
-const PROVIDER_FEE_TYPES = [TransactionType.perpsWithdraw];
 
 export type BridgeFeeRowProps = {
   variant?: ConfirmInfoRowSize;
@@ -45,11 +39,8 @@ export function BridgeFeeRow({
   const isLoading = useIsTransactionPayLoading();
   const quotes = useTransactionPayQuotes();
   const totals = useTransactionPayTotals();
-  const { currentConfirmation } = useConfirmContext<TransactionMeta>();
 
-  const feeLabel = hasTransactionType(currentConfirmation, PROVIDER_FEE_TYPES)
-    ? t('perpsWithdrawFee')
-    : t('transactionFee');
+  const feeLabel = t('transactionFee');
 
   const feeTotalUsd = useMemo(() => {
     if (!totals?.fees) {

--- a/ui/pages/confirmations/components/rows/bridge-fee-row/bridge-fee-row.tsx
+++ b/ui/pages/confirmations/components/rows/bridge-fee-row/bridge-fee-row.tsx
@@ -1,5 +1,7 @@
 import React, { useMemo } from 'react';
 import { BigNumber } from 'bignumber.js';
+import type { TransactionMeta } from '@metamask/transaction-controller';
+import { TransactionType } from '@metamask/transaction-controller';
 import type { TransactionPayTotals } from '@metamask/transaction-pay-controller';
 import { Text } from '../../../../../components/component-library';
 import {
@@ -19,6 +21,8 @@ import {
 } from '../../../hooks/pay/useTransactionPayData';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { useFiatFormatter } from '../../../../../hooks/useFiatFormatter';
+import { useConfirmContext } from '../../../context/confirm';
+import { hasTransactionType } from '../../../../../../shared/lib/transactions.utils';
 
 export type BridgeFeeRowProps = {
   variant?: ConfirmInfoRowSize;
@@ -28,6 +32,8 @@ export type BridgeFeeRowProps = {
    */
   tooltipDescription?: string;
 };
+
+const WITHDRAW_TYPES = [TransactionType.perpsWithdraw];
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export function BridgeFeeRow({
@@ -39,6 +45,15 @@ export function BridgeFeeRow({
   const isLoading = useIsTransactionPayLoading();
   const quotes = useTransactionPayQuotes();
   const totals = useTransactionPayTotals();
+  const { currentConfirmation } = useConfirmContext<TransactionMeta>();
+
+  const isWithdraw = hasTransactionType(currentConfirmation, WITHDRAW_TYPES);
+
+  // When a caller hasn't supplied a tooltipDescription, fall back to the
+  // perpsWithdraw description so the Perps Withdraw confirmation mirrors
+  // mobile's Transaction fee tooltip copy.
+  const resolvedTooltipDescription =
+    tooltipDescription ?? (isWithdraw ? t('perpsWithdrawTooltip') : undefined);
 
   const feeLabel = t('transactionFee');
 
@@ -74,13 +89,14 @@ export function BridgeFeeRow({
   let tooltipContent: string | undefined;
   if (hasQuotes && totals) {
     tooltipContent = renderTooltipContent({
-      description: tooltipDescription,
+      description: resolvedTooltipDescription,
       t,
       totals,
       formatFiat,
       metamaskFeeFormatted: metamaskFeeUsd,
       /** Matches prior behavior: MetaMask fee was only shown for Small variant (body row). */
       includeMetamaskFee: isSmall,
+      useProviderFeeLabel: isWithdraw,
     });
   }
 
@@ -116,6 +132,8 @@ type RenderTooltipContentArgs = {
   formatFiat: ReturnType<typeof useFiatFormatter>;
   metamaskFeeFormatted: string;
   includeMetamaskFee: boolean;
+  /** Render the provider fee as "Provider fee" (withdraw flows) instead of "Bridge fee". */
+  useProviderFeeLabel?: boolean;
 };
 
 function renderTooltipContent({
@@ -125,12 +143,13 @@ function renderTooltipContent({
   formatFiat,
   metamaskFeeFormatted,
   includeMetamaskFee,
+  useProviderFeeLabel,
 }: RenderTooltipContentArgs): string {
   const networkFee = new BigNumber(totals.fees.sourceNetwork.estimate.usd).plus(
     totals.fees.targetNetwork.usd,
   );
 
-  const bridgeFeeUsd = new BigNumber(totals.fees.provider.usd);
+  const providerFeeUsd = new BigNumber(totals.fees.provider.usd);
 
   const lines: string[] = [];
 
@@ -141,7 +160,9 @@ function renderTooltipContent({
 
   lines.push(
     `${t('networkFee')}: ${formatFiat(networkFee.toNumber())}`,
-    `${t('bridgeFee')}: ${formatFiat(bridgeFeeUsd.toNumber())}`,
+    `${useProviderFeeLabel ? t('providerFee') : t('bridgeFee')}: ${formatFiat(
+      providerFeeUsd.toNumber(),
+    )}`,
   );
 
   if (includeMetamaskFee) {

--- a/ui/pages/confirmations/components/rows/bridge-fee-row/bridge-fee-row.tsx
+++ b/ui/pages/confirmations/components/rows/bridge-fee-row/bridge-fee-row.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo } from 'react';
 import { BigNumber } from 'bignumber.js';
 import type { TransactionMeta } from '@metamask/transaction-controller';
-import { TransactionType } from '@metamask/transaction-controller';
 import type { TransactionPayTotals } from '@metamask/transaction-pay-controller';
 import { Text } from '../../../../../components/component-library';
 import {
@@ -22,7 +21,7 @@ import {
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { useFiatFormatter } from '../../../../../hooks/useFiatFormatter';
 import { useConfirmContext } from '../../../context/confirm';
-import { hasTransactionType } from '../../../../../../shared/lib/transactions.utils';
+import { isPerpsWithdrawTransaction } from '../../../../../../shared/lib/transactions.utils';
 
 export type BridgeFeeRowProps = {
   variant?: ConfirmInfoRowSize;
@@ -32,8 +31,6 @@ export type BridgeFeeRowProps = {
    */
   tooltipDescription?: string;
 };
-
-const WITHDRAW_TYPES = [TransactionType.perpsWithdraw];
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export function BridgeFeeRow({
@@ -47,7 +44,7 @@ export function BridgeFeeRow({
   const totals = useTransactionPayTotals();
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
 
-  const isWithdraw = hasTransactionType(currentConfirmation, WITHDRAW_TYPES);
+  const isWithdraw = isPerpsWithdrawTransaction(currentConfirmation);
 
   // When a caller hasn't supplied a tooltipDescription, fall back to the
   // perpsWithdraw description so the Perps Withdraw confirmation mirrors

--- a/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.tsx
+++ b/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.tsx
@@ -49,7 +49,7 @@ type PayWithRowContentProps = {
   canEdit: boolean;
   from: string | undefined;
   onOpenModal: () => void;
-  isWithdraw: boolean;
+  isPerpsWithdraw: boolean;
 };
 
 type PayWithRowPillProps = PayWithRowContentProps & {
@@ -100,7 +100,7 @@ export function PayWithRow({
 
   const canEdit = fromAccount ? !isHardwareAccount(fromAccount) : true;
 
-  const isWithdraw = isPerpsWithdrawTransaction(currentConfirmation);
+  const isPerpsWithdraw = isPerpsWithdrawTransaction(currentConfirmation);
 
   const handleOpenModal = useCallback(() => {
     if (canEdit) {
@@ -135,7 +135,7 @@ export function PayWithRow({
     canEdit,
     from,
     onOpenModal: handleOpenModal,
-    isWithdraw,
+    isPerpsWithdraw,
   };
 
   const isSmall = variant === ConfirmInfoRowSize.Small;
@@ -166,7 +166,7 @@ function PayWithRowInline({
   from,
   onOpenModal,
   ownerId,
-  isWithdraw,
+  isPerpsWithdraw,
 }: PayWithRowContentProps & { ownerId: string }) {
   const t = useI18nContext();
 
@@ -175,7 +175,7 @@ function PayWithRowInline({
       alertKey={RowAlertKey.PayWith}
       ownerId={ownerId}
       data-testid="pay-with-row"
-      label={isWithdraw ? t('withdrawTo') : t('payWith')}
+      label={isPerpsWithdraw ? t('withdrawTo') : t('payWith')}
       rowVariant={ConfirmInfoRowSize.Default}
     >
       <Box
@@ -225,7 +225,7 @@ function PayWithRowPill({
   canEdit,
   from,
   onOpenModal,
-  isWithdraw,
+  isPerpsWithdraw,
 }: PayWithRowPillProps) {
   const t = useI18nContext();
 
@@ -257,7 +257,7 @@ function PayWithRowPill({
         color={TextColor.textDefault}
         data-testid="pay-with-symbol"
       >
-        {`${isWithdraw ? t('withdrawTo') : t('payWith')} ${displayToken.symbol}`}
+        {`${isPerpsWithdraw ? t('withdrawTo') : t('payWith')} ${displayToken.symbol}`}
       </Text>
       <Text
         variant={TextVariant.bodyMdMedium}

--- a/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.tsx
+++ b/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.tsx
@@ -1,12 +1,9 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import React, { useCallback, useMemo, useState } from 'react';
-import {
-  TransactionMeta,
-  TransactionType,
-} from '@metamask/transaction-controller';
+import { TransactionMeta } from '@metamask/transaction-controller';
 import { useSelector } from 'react-redux';
 import { BigNumber } from 'bignumber.js';
-import { hasTransactionType } from '../../../../../../shared/lib/transactions.utils';
+import { isPerpsWithdrawTransaction } from '../../../../../../shared/lib/transactions.utils';
 
 import {
   Box,
@@ -103,9 +100,7 @@ export function PayWithRow({
 
   const canEdit = fromAccount ? !isHardwareAccount(fromAccount) : true;
 
-  const isWithdraw = hasTransactionType(currentConfirmation, [
-    TransactionType.perpsWithdraw,
-  ]);
+  const isWithdraw = isPerpsWithdrawTransaction(currentConfirmation);
 
   const handleOpenModal = useCallback(() => {
     if (canEdit) {

--- a/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.tsx
+++ b/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.tsx
@@ -1,8 +1,12 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import React, { useCallback, useMemo, useState } from 'react';
-import { TransactionMeta } from '@metamask/transaction-controller';
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
 import { useSelector } from 'react-redux';
 import { BigNumber } from 'bignumber.js';
+import { hasTransactionType } from '../../../../../../shared/lib/transactions.utils';
 
 import {
   Box,
@@ -48,6 +52,7 @@ type PayWithRowContentProps = {
   canEdit: boolean;
   from: string | undefined;
   onOpenModal: () => void;
+  isWithdraw: boolean;
 };
 
 type PayWithRowPillProps = PayWithRowContentProps & {
@@ -98,6 +103,10 @@ export function PayWithRow({
 
   const canEdit = fromAccount ? !isHardwareAccount(fromAccount) : true;
 
+  const isWithdraw = hasTransactionType(currentConfirmation, [
+    TransactionType.perpsWithdraw,
+  ]);
+
   const handleOpenModal = useCallback(() => {
     if (canEdit) {
       setIsModalOpen(true);
@@ -131,6 +140,7 @@ export function PayWithRow({
     canEdit,
     from,
     onOpenModal: handleOpenModal,
+    isWithdraw,
   };
 
   const isSmall = variant === ConfirmInfoRowSize.Small;
@@ -161,6 +171,7 @@ function PayWithRowInline({
   from,
   onOpenModal,
   ownerId,
+  isWithdraw,
 }: PayWithRowContentProps & { ownerId: string }) {
   const t = useI18nContext();
 
@@ -169,7 +180,7 @@ function PayWithRowInline({
       alertKey={RowAlertKey.PayWith}
       ownerId={ownerId}
       data-testid="pay-with-row"
-      label={t('payWith')}
+      label={isWithdraw ? t('withdrawTo') : t('payWith')}
       rowVariant={ConfirmInfoRowSize.Default}
     >
       <Box
@@ -219,6 +230,7 @@ function PayWithRowPill({
   canEdit,
   from,
   onOpenModal,
+  isWithdraw,
 }: PayWithRowPillProps) {
   const t = useI18nContext();
 
@@ -250,7 +262,7 @@ function PayWithRowPill({
         color={TextColor.textDefault}
         data-testid="pay-with-symbol"
       >
-        {`${t('payWith')} ${displayToken.symbol}`}
+        {`${isWithdraw ? t('withdrawTo') : t('payWith')} ${displayToken.symbol}`}
       </Text>
       <Text
         variant={TextVariant.bodyMdMedium}

--- a/ui/pages/confirmations/components/rows/receive-row/index.ts
+++ b/ui/pages/confirmations/components/rows/receive-row/index.ts
@@ -1,0 +1,2 @@
+export { ReceiveRow } from './receive-row';
+export type { ReceiveRowProps } from './receive-row';

--- a/ui/pages/confirmations/components/rows/receive-row/receive-row.test.tsx
+++ b/ui/pages/confirmations/components/rows/receive-row/receive-row.test.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import configureMockStore from 'redux-mock-store';
+import type {
+  TransactionPayQuote,
+  TransactionPayTotals,
+} from '@metamask/transaction-pay-controller';
+import type { Json } from '@metamask/utils';
+import { getMockPersonalSignConfirmState } from '../../../../../../test/data/confirmations/helper';
+import { renderWithConfirmContextProvider } from '../../../../../../test/lib/confirmations/render-helpers';
+import {
+  useIsTransactionPayLoading,
+  useTransactionPayQuotes,
+  useTransactionPayTotals,
+} from '../../../hooks/pay/useTransactionPayData';
+import { enLocale as messages } from '../../../../../../test/lib/i18n-helpers';
+import { ConfirmInfoRowSize } from '../../../../../components/app/confirm/info/row/row';
+import { ReceiveRow, ReceiveRowProps } from './receive-row';
+
+jest.mock('../../../hooks/pay/useTransactionPayData');
+
+const mockStore = configureMockStore([]);
+
+function render(
+  props: Partial<ReceiveRowProps> = {},
+  state: Record<string, unknown> = getMockPersonalSignConfirmState(),
+) {
+  return renderWithConfirmContextProvider(
+    <ReceiveRow inputAmountUsd="10" {...props} />,
+    mockStore(state),
+  );
+}
+
+describe('ReceiveRow', () => {
+  const useTransactionPayTotalsMock = jest.mocked(useTransactionPayTotals);
+  const useTransactionPayQuotesMock = jest.mocked(useTransactionPayQuotes);
+  const useIsTransactionPayLoadingMock = jest.mocked(
+    useIsTransactionPayLoading,
+  );
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    useTransactionPayTotalsMock.mockReturnValue({
+      fees: {
+        provider: { usd: '1.00' },
+        sourceNetwork: { estimate: { usd: '0.20' } },
+        targetNetwork: { usd: '0.05' },
+        metaMask: { usd: '0.25' },
+      },
+    } as TransactionPayTotals);
+
+    useIsTransactionPayLoadingMock.mockReturnValue(false);
+
+    useTransactionPayQuotesMock.mockReturnValue([
+      {} as TransactionPayQuote<Json>,
+    ]);
+  });
+
+  it('renders the youllReceive label', () => {
+    const { getByText } = render();
+
+    expect(getByText(messages.youllReceive.message)).toBeInTheDocument();
+  });
+
+  it('renders skeleton with label when loading', () => {
+    useIsTransactionPayLoadingMock.mockReturnValue(true);
+
+    const { getByTestId, queryByTestId, getByText } = render();
+
+    expect(getByTestId('receive-row-skeleton')).toBeInTheDocument();
+    expect(queryByTestId('receive-row')).not.toBeInTheDocument();
+    expect(getByText(messages.youllReceive.message)).toBeInTheDocument();
+  });
+
+  it('computes input minus all fees (provider + sourceNetwork + targetNetwork + metaMask)', () => {
+    const { getByTestId } = render({ inputAmountUsd: '10' });
+
+    // 10 - (1.00 + 0.20 + 0.05 + 0.25) = 8.50
+    expect(getByTestId('receive-value')).toHaveTextContent('$8.50');
+  });
+
+  it('treats a missing metaMask fee as zero', () => {
+    useTransactionPayTotalsMock.mockReturnValue({
+      fees: {
+        provider: { usd: '1.00' },
+        sourceNetwork: { estimate: { usd: '0.20' } },
+        targetNetwork: { usd: '0.05' },
+      },
+    } as TransactionPayTotals);
+
+    const { getByTestId } = render({ inputAmountUsd: '10' });
+
+    // 10 - (1.00 + 0.20 + 0.05) = 8.75
+    expect(getByTestId('receive-value')).toHaveTextContent('$8.75');
+  });
+
+  it('clamps the receive amount to 0 when fees exceed the input', () => {
+    const { getByTestId } = render({ inputAmountUsd: '0.10' });
+
+    expect(getByTestId('receive-value')).toHaveTextContent('$0.00');
+  });
+
+  it('renders an empty value when there are no quotes', () => {
+    useTransactionPayQuotesMock.mockReturnValue([]);
+
+    const { getByTestId } = render();
+
+    expect(getByTestId('receive-value')).toHaveTextContent('');
+  });
+
+  it('renders an empty value when totals are not available', () => {
+    useTransactionPayTotalsMock.mockReturnValue(
+      undefined as unknown as TransactionPayTotals,
+    );
+
+    const { getByTestId } = render();
+
+    expect(getByTestId('receive-value')).toHaveTextContent('');
+  });
+
+  it('uses Text component (Small variant) instead of ConfirmInfoRowText', () => {
+    const { getByTestId } = render({ variant: ConfirmInfoRowSize.Small });
+
+    const value = getByTestId('receive-value');
+    expect(value).toBeInTheDocument();
+    expect(value).toHaveTextContent('$8.50');
+  });
+});

--- a/ui/pages/confirmations/components/rows/receive-row/receive-row.tsx
+++ b/ui/pages/confirmations/components/rows/receive-row/receive-row.tsx
@@ -1,0 +1,114 @@
+import React, { useMemo } from 'react';
+import { BigNumber } from 'bignumber.js';
+import { Box, Text } from '../../../../../components/component-library';
+import {
+  TextColor,
+  TextVariant,
+} from '../../../../../helpers/constants/design-system';
+import {
+  ConfirmInfoRow,
+  ConfirmInfoRowSize,
+  ConfirmInfoRowSkeleton,
+} from '../../../../../components/app/confirm/info/row/row';
+import { ConfirmInfoRowText } from '../../../../../components/app/confirm/info/row/text';
+import {
+  useIsTransactionPayLoading,
+  useTransactionPayQuotes,
+  useTransactionPayTotals,
+} from '../../../hooks/pay/useTransactionPayData';
+import { useI18nContext } from '../../../../../hooks/useI18nContext';
+import { useFiatFormatter } from '../../../../../hooks/useFiatFormatter';
+
+export type ReceiveRowProps = {
+  /** The user's input amount in USD / fiat */
+  inputAmountUsd: string;
+  variant?: ConfirmInfoRowSize;
+};
+
+/**
+ * Row that displays "You'll receive" for withdrawal-style confirmations
+ * (e.g. Perps Withdraw). Calculates: input - (provider + sourceNetwork +
+ * targetNetwork + metamask) fees.
+ *
+ * Mirrors the mobile `ReceiveRow`.
+ *
+ * @param options0
+ * @param options0.inputAmountUsd
+ * @param options0.variant
+ */
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export function ReceiveRow({
+  inputAmountUsd,
+  variant = ConfirmInfoRowSize.Default,
+}: ReceiveRowProps) {
+  const t = useI18nContext();
+  const formatFiat = useFiatFormatter();
+  const isLoading = useIsTransactionPayLoading();
+  const totals = useTransactionPayTotals();
+  const quotes = useTransactionPayQuotes();
+
+  const hasQuotes = Boolean(quotes?.length);
+
+  const receiveUsd = useMemo(() => {
+    if (
+      !totals ||
+      inputAmountUsd === null ||
+      inputAmountUsd === undefined ||
+      !hasQuotes
+    ) {
+      return '';
+    }
+
+    const inputUsd = new BigNumber(inputAmountUsd || '0');
+    const providerFee = new BigNumber(totals.fees?.provider?.usd ?? 0);
+    const sourceNetworkFee = new BigNumber(
+      totals.fees?.sourceNetwork?.estimate?.usd ?? 0,
+    );
+    const targetNetworkFee = new BigNumber(
+      totals.fees?.targetNetwork?.usd ?? 0,
+    );
+    const metaMaskFee = new BigNumber(totals.fees?.metaMask?.usd ?? 0);
+
+    const totalFees = providerFee
+      .plus(sourceNetworkFee)
+      .plus(targetNetworkFee)
+      .plus(metaMaskFee);
+    const youReceive = inputUsd.minus(totalFees);
+
+    return formatFiat(
+      (youReceive.gte(0) ? youReceive : new BigNumber(0)).toNumber(),
+    );
+  }, [hasQuotes, inputAmountUsd, totals, formatFiat]);
+
+  const isSmall = variant === ConfirmInfoRowSize.Small;
+  const textVariant = isSmall ? TextVariant.bodyMd : TextVariant.bodyMdMedium;
+
+  if (isLoading) {
+    return (
+      <Box data-testid="receive-row-skeleton">
+        <ConfirmInfoRowSkeleton
+          label={t('youllReceive')}
+          rowVariant={variant}
+        />
+      </Box>
+    );
+  }
+
+  return (
+    <Box data-testid="receive-row">
+      <ConfirmInfoRow label={t('youllReceive')} rowVariant={variant}>
+        {isSmall ? (
+          <Text
+            variant={textVariant}
+            color={TextColor.textAlternative}
+            data-testid="receive-value"
+          >
+            {receiveUsd}
+          </Text>
+        ) : (
+          <ConfirmInfoRowText text={receiveUsd} data-testid="receive-value" />
+        )}
+      </ConfirmInfoRow>
+    </Box>
+  );
+}

--- a/ui/pages/confirmations/components/rows/receive-row/receive-row.tsx
+++ b/ui/pages/confirmations/components/rows/receive-row/receive-row.tsx
@@ -42,7 +42,13 @@ export function ReceiveRow({
   variant = ConfirmInfoRowSize.Default,
 }: ReceiveRowProps) {
   const t = useI18nContext();
-  const formatFiat = useFiatFormatter();
+  // The fee values from `TransactionPayController` (`provider.usd`,
+  // `sourceNetwork.estimate.usd`, etc.) are explicitly USD-denominated, and
+  // the input is sourced from the `usd`-currency `useTransactionCustomAmount`
+  // path used by Perps Withdraw. Force USD formatting so the displayed
+  // currency symbol matches the numerical value even if the user has set a
+  // non-USD primary currency.
+  const formatFiat = useFiatFormatter({ overrideCurrency: 'usd' });
   const isLoading = useIsTransactionPayLoading();
   const totals = useTransactionPayTotals();
   const quotes = useTransactionPayQuotes();

--- a/ui/pages/confirmations/components/transactions/custom-amount/custom-amount.test.tsx
+++ b/ui/pages/confirmations/components/transactions/custom-amount/custom-amount.test.tsx
@@ -138,13 +138,13 @@ describe('CustomAmount', () => {
     expect(amountElement).toHaveStyle({ fontSize: '64px' });
   });
 
-  it('does not include decimal separators when calculating input width', () => {
+  it('counts decimal separators as half a character when calculating input width', () => {
     const store = mockStore(getMockState());
 
     renderWithProvider(<CustomAmount amountFiat="1.33" />, store);
 
     const amountElement = screen.getByTestId('custom-amount-input');
-    expect(amountElement).toHaveStyle({ width: '3ch' });
+    expect(amountElement).toHaveStyle({ width: '3.5ch' });
   });
 });
 

--- a/ui/pages/confirmations/components/transactions/custom-amount/custom-amount.tsx
+++ b/ui/pages/confirmations/components/transactions/custom-amount/custom-amount.tsx
@@ -94,7 +94,12 @@ export const CustomAmount: React.FC<CustomAmountProps> = React.memo(
     const currency = currencyProp ?? selectedCurrency;
     const fiatSymbol = getCurrencySymbol(currency);
     const amountLength = amountFiat.length;
-    const amountCharacterLength = amountFiat.replaceAll(/[.,]/gu, '').length;
+    const decimalSeparatorCount = (amountFiat.match(/[.,]/gu) || []).length;
+    // Decimal separators visually take roughly half the width of a digit in
+    // proportional fonts, so account for them as 0.5ch each. Counting them
+    // as a full ch over-allocates (visible cursor gap); counting them as 0
+    // under-allocates (text gets clipped when overflowing the input).
+    const amountWidth = amountLength - decimalSeparatorCount * 0.5;
 
     const showLoader = isLoading || (isMaxAmount && isQuotesLoading);
 
@@ -150,7 +155,7 @@ export const CustomAmount: React.FC<CustomAmountProps> = React.memo(
               border: 'none',
               background: 'transparent',
               outline: 'none',
-              width: `${Math.max(1, amountCharacterLength)}ch`,
+              width: `${Math.max(1, amountWidth)}ch`,
               cursor: disabled ? 'default' : 'text',
             } as React.CSSProperties
           }

--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.ts
@@ -1,6 +1,9 @@
 'use no memo';
 
-import { TransactionMeta } from '@metamask/transaction-controller';
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import {
@@ -11,12 +14,18 @@ import { Alert } from '../../../../../ducks/confirm-alerts/confirm-alerts';
 import { Severity } from '../../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { getUseTransactionSimulations } from '../../../../../selectors';
+import { hasTransactionType } from '../../../../../../shared/lib/transactions.utils';
 import { useConfirmContext } from '../../../context/confirm';
 import { useIsGaslessSupported } from '../../gas/useIsGaslessSupported';
 import { useHasInsufficientBalance } from '../../useHasInsufficientBalance';
 import { useTransactionPayHasSourceAmount } from '../../pay/useTransactionPayHasSourceAmount';
 import { useTransactionPayPrimaryRequiredToken } from '../../pay/useTransactionPayData';
 import { useTransactionPayToken } from '../../pay/useTransactionPayToken';
+
+// Transaction types where the user's wallet balance doesn't pay for gas (gasless
+// flows like Perps withdraw via HyperLiquid -> Relay), so the "insufficient
+// balance" alert should be suppressed even when the native balance is low.
+const IGNORE_TYPES = [TransactionType.perpsWithdraw];
 
 export function useInsufficientBalanceAlerts({
   ignoreGasFeeToken,
@@ -27,6 +36,7 @@ export function useInsufficientBalanceAlerts({
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
   const { selectedGasFeeToken, gasFeeTokens, excludeNativeTokenForFee } =
     currentConfirmation ?? {};
+  const isIgnoredType = hasTransactionType(currentConfirmation, IGNORE_TYPES);
   const { hasInsufficientBalance, nativeCurrency } =
     useHasInsufficientBalance();
   const isSimulationEnabled = useSelector(getUseTransactionSimulations);
@@ -81,7 +91,8 @@ export function useInsufficientBalanceAlerts({
     isSimulationComplete &&
     hasNoGasFeeTokenSelected &&
     shouldCheckGaslessConditions &&
-    !isSponsoredTransaction;
+    !isSponsoredTransaction &&
+    !isIgnoredType;
 
   return useMemo(() => {
     if (!showAlert) {

--- a/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useInsufficientBalanceAlerts.ts
@@ -1,9 +1,6 @@
 'use no memo';
 
-import {
-  TransactionMeta,
-  TransactionType,
-} from '@metamask/transaction-controller';
+import { TransactionMeta } from '@metamask/transaction-controller';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import {
@@ -14,18 +11,13 @@ import { Alert } from '../../../../../ducks/confirm-alerts/confirm-alerts';
 import { Severity } from '../../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { getUseTransactionSimulations } from '../../../../../selectors';
-import { hasTransactionType } from '../../../../../../shared/lib/transactions.utils';
+import { isPerpsWithdrawTransaction } from '../../../../../../shared/lib/transactions.utils';
 import { useConfirmContext } from '../../../context/confirm';
 import { useIsGaslessSupported } from '../../gas/useIsGaslessSupported';
 import { useHasInsufficientBalance } from '../../useHasInsufficientBalance';
 import { useTransactionPayHasSourceAmount } from '../../pay/useTransactionPayHasSourceAmount';
 import { useTransactionPayPrimaryRequiredToken } from '../../pay/useTransactionPayData';
 import { useTransactionPayToken } from '../../pay/useTransactionPayToken';
-
-// Transaction types where the user's wallet balance doesn't pay for gas (gasless
-// flows like Perps withdraw via HyperLiquid -> Relay), so the "insufficient
-// balance" alert should be suppressed even when the native balance is low.
-const IGNORE_TYPES = [TransactionType.perpsWithdraw];
 
 export function useInsufficientBalanceAlerts({
   ignoreGasFeeToken,
@@ -36,7 +28,10 @@ export function useInsufficientBalanceAlerts({
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
   const { selectedGasFeeToken, gasFeeTokens, excludeNativeTokenForFee } =
     currentConfirmation ?? {};
-  const isIgnoredType = hasTransactionType(currentConfirmation, IGNORE_TYPES);
+  // Gasless flows (Perps Withdraw via HyperLiquid -> Relay) don't use the
+  // user's native balance for gas, so suppress the "insufficient balance"
+  // alert even when native balance is low.
+  const isIgnoredType = isPerpsWithdrawTransaction(currentConfirmation);
   const { hasInsufficientBalance, nativeCurrency } =
     useHasInsufficientBalance();
   const isSimulationEnabled = useSelector(getUseTransactionSimulations);

--- a/ui/pages/confirmations/hooks/pay/useTransactionPayPostQuote.test.ts
+++ b/ui/pages/confirmations/hooks/pay/useTransactionPayPostQuote.test.ts
@@ -1,4 +1,7 @@
-import { TransactionMeta, TransactionType } from '@metamask/transaction-controller';
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
 import { renderHook } from '@testing-library/react-hooks';
 import { useConfirmContext } from '../../context/confirm';
 import { setPostQuote } from '../../../../store/controller-actions/transaction-pay-controller';

--- a/ui/pages/confirmations/hooks/pay/useTransactionPayPostQuote.test.ts
+++ b/ui/pages/confirmations/hooks/pay/useTransactionPayPostQuote.test.ts
@@ -119,4 +119,49 @@ describe('useTransactionPayPostQuote', () => {
 
     consoleErrorSpy.mockRestore();
   });
+
+  it('retries setPostQuote when the transaction id returns to a previously-failed value', async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    // First call (tx-7) fails; subsequent calls succeed.
+    setPostQuoteMock.mockRejectedValueOnce(new Error('boom'));
+    setPostQuoteMock.mockResolvedValue(undefined);
+
+    mockConfirmation({
+      id: 'tx-7',
+      type: TransactionType.perpsWithdraw,
+    });
+
+    const { rerender } = renderHook(() => useTransactionPayPostQuote());
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(setPostQuoteMock).toHaveBeenCalledTimes(1);
+
+    // Switch to a different transaction so the deps change away.
+    mockConfirmation({
+      id: 'tx-8',
+      type: TransactionType.perpsWithdraw,
+    });
+    rerender();
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(setPostQuoteMock).toHaveBeenCalledTimes(2);
+
+    // Switching back to tx-7 should retry — the previous rejection must
+    // have cleared the in-flight ref, otherwise the dispatch is silently
+    // skipped and the tx stays un-configured.
+    mockConfirmation({
+      id: 'tx-7',
+      type: TransactionType.perpsWithdraw,
+    });
+    rerender();
+
+    expect(setPostQuoteMock).toHaveBeenCalledTimes(3);
+    expect(setPostQuoteMock).toHaveBeenLastCalledWith('tx-7', {
+      isHyperliquidSource: true,
+    });
+
+    consoleErrorSpy.mockRestore();
+  });
 });

--- a/ui/pages/confirmations/hooks/pay/useTransactionPayPostQuote.test.ts
+++ b/ui/pages/confirmations/hooks/pay/useTransactionPayPostQuote.test.ts
@@ -1,0 +1,119 @@
+import { TransactionMeta, TransactionType } from '@metamask/transaction-controller';
+import { renderHook } from '@testing-library/react-hooks';
+import { useConfirmContext } from '../../context/confirm';
+import { setPostQuote } from '../../../../store/controller-actions/transaction-pay-controller';
+import { useTransactionPayPostQuote } from './useTransactionPayPostQuote';
+
+jest.mock('../../context/confirm', () => ({
+  useConfirmContext: jest.fn(),
+}));
+
+jest.mock('../../../../store/controller-actions/transaction-pay-controller');
+
+const useConfirmContextMock = jest.mocked(useConfirmContext);
+const setPostQuoteMock = jest.mocked(setPostQuote);
+
+function mockConfirmation(transactionMeta: Partial<TransactionMeta> | null) {
+  useConfirmContextMock.mockReturnValue({
+    currentConfirmation: transactionMeta as TransactionMeta,
+  } as ReturnType<typeof useConfirmContext>);
+}
+
+describe('useTransactionPayPostQuote', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    setPostQuoteMock.mockResolvedValue(undefined);
+  });
+
+  it('calls setPostQuote with isHyperliquidSource for a perpsWithdraw transaction', () => {
+    mockConfirmation({
+      id: 'tx-1',
+      type: TransactionType.perpsWithdraw,
+    });
+
+    renderHook(() => useTransactionPayPostQuote());
+
+    expect(setPostQuoteMock).toHaveBeenCalledTimes(1);
+    expect(setPostQuoteMock).toHaveBeenCalledWith('tx-1', {
+      isHyperliquidSource: true,
+    });
+  });
+
+  it('does not call setPostQuote for non-perpsWithdraw transactions', () => {
+    mockConfirmation({
+      id: 'tx-2',
+      type: TransactionType.perpsDeposit,
+    });
+
+    renderHook(() => useTransactionPayPostQuote());
+
+    expect(setPostQuoteMock).not.toHaveBeenCalled();
+  });
+
+  it('does not call setPostQuote when there is no current confirmation', () => {
+    mockConfirmation(null);
+
+    renderHook(() => useTransactionPayPostQuote());
+
+    expect(setPostQuoteMock).not.toHaveBeenCalled();
+  });
+
+  it('does not call setPostQuote again on re-render for the same transaction id', () => {
+    mockConfirmation({
+      id: 'tx-3',
+      type: TransactionType.perpsWithdraw,
+    });
+
+    const { rerender } = renderHook(() => useTransactionPayPostQuote());
+    rerender();
+    rerender();
+
+    expect(setPostQuoteMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls setPostQuote again when the transaction id changes', () => {
+    mockConfirmation({
+      id: 'tx-4',
+      type: TransactionType.perpsWithdraw,
+    });
+
+    const { rerender } = renderHook(() => useTransactionPayPostQuote());
+    expect(setPostQuoteMock).toHaveBeenCalledTimes(1);
+    expect(setPostQuoteMock).toHaveBeenLastCalledWith('tx-4', {
+      isHyperliquidSource: true,
+    });
+
+    mockConfirmation({
+      id: 'tx-5',
+      type: TransactionType.perpsWithdraw,
+    });
+    rerender();
+
+    expect(setPostQuoteMock).toHaveBeenCalledTimes(2);
+    expect(setPostQuoteMock).toHaveBeenLastCalledWith('tx-5', {
+      isHyperliquidSource: true,
+    });
+  });
+
+  it('catches errors from setPostQuote without throwing', async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    setPostQuoteMock.mockRejectedValue(new Error('boom'));
+    mockConfirmation({
+      id: 'tx-6',
+      type: TransactionType.perpsWithdraw,
+    });
+
+    expect(() => renderHook(() => useTransactionPayPostQuote())).not.toThrow();
+
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Failed to set post-quote config',
+      expect.any(Error),
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/ui/pages/confirmations/hooks/pay/useTransactionPayPostQuote.ts
+++ b/ui/pages/confirmations/hooks/pay/useTransactionPayPostQuote.ts
@@ -1,0 +1,36 @@
+import { useEffect, useRef } from 'react';
+import {
+  type TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
+import { useConfirmContext } from '../../context/confirm';
+import { setPostQuote } from '../../../../store/controller-actions/transaction-pay-controller';
+import { hasTransactionType } from '../../../../../shared/lib/transactions.utils';
+
+/**
+ * Configures TransactionPayController to use post-quote mode for withdrawal
+ * flows that need it (e.g. Perps withdraw via HyperLiquid -> Relay).
+ */
+export function useTransactionPayPostQuote(): void {
+  const { currentConfirmation } = useConfirmContext<TransactionMeta>();
+  const transactionId = currentConfirmation?.id;
+  const isSet = useRef<string | null>(null);
+
+  const isPerpsWithdraw = hasTransactionType(currentConfirmation, [
+    TransactionType.perpsWithdraw,
+  ]);
+
+  useEffect(() => {
+    if (!transactionId || isSet.current === transactionId || !isPerpsWithdraw) {
+      return;
+    }
+
+    setPostQuote(transactionId, { isHyperliquidSource: true }).catch(
+      (error) => {
+        console.error('Failed to set post-quote config', error);
+      },
+    );
+
+    isSet.current = transactionId;
+  }, [isPerpsWithdraw, transactionId]);
+}

--- a/ui/pages/confirmations/hooks/pay/useTransactionPayPostQuote.ts
+++ b/ui/pages/confirmations/hooks/pay/useTransactionPayPostQuote.ts
@@ -20,12 +20,19 @@ export function useTransactionPayPostQuote(): void {
       return;
     }
 
+    // Mark in-flight synchronously so a strict-mode double-mount does not
+    // dispatch twice. On rejection, reset the marker so a future deps
+    // change (e.g. user navigates away and back) can retry instead of
+    // being permanently stuck with an un-configured post-quote tx.
+    isSet.current = transactionId;
+
     setPostQuote(transactionId, { isHyperliquidSource: true }).catch(
       (error) => {
         console.error('Failed to set post-quote config', error);
+        if (isSet.current === transactionId) {
+          isSet.current = null;
+        }
       },
     );
-
-    isSet.current = transactionId;
   }, [isPerpsWithdraw, transactionId]);
 }

--- a/ui/pages/confirmations/hooks/pay/useTransactionPayPostQuote.ts
+++ b/ui/pages/confirmations/hooks/pay/useTransactionPayPostQuote.ts
@@ -1,11 +1,8 @@
 import { useEffect, useRef } from 'react';
-import {
-  type TransactionMeta,
-  TransactionType,
-} from '@metamask/transaction-controller';
+import type { TransactionMeta } from '@metamask/transaction-controller';
 import { useConfirmContext } from '../../context/confirm';
 import { setPostQuote } from '../../../../store/controller-actions/transaction-pay-controller';
-import { hasTransactionType } from '../../../../../shared/lib/transactions.utils';
+import { isPerpsWithdrawTransaction } from '../../../../../shared/lib/transactions.utils';
 
 /**
  * Configures TransactionPayController to use post-quote mode for withdrawal
@@ -16,9 +13,7 @@ export function useTransactionPayPostQuote(): void {
   const transactionId = currentConfirmation?.id;
   const isSet = useRef<string | null>(null);
 
-  const isPerpsWithdraw = hasTransactionType(currentConfirmation, [
-    TransactionType.perpsWithdraw,
-  ]);
+  const isPerpsWithdraw = isPerpsWithdrawTransaction(currentConfirmation);
 
   useEffect(() => {
     if (!transactionId || isSet.current === transactionId || !isPerpsWithdraw) {

--- a/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmount.ts
+++ b/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmount.ts
@@ -1,13 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { debounce, type DebouncedFunc } from 'lodash';
 import { BigNumber } from 'bignumber.js';
-import {
-  type TransactionMeta,
-  TransactionType,
-} from '@metamask/transaction-controller';
+import type { TransactionMeta } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 import { setIsMaxAmount } from '../../../../store/controller-actions/transaction-pay-controller';
-import { hasTransactionType } from '../../../../../shared/lib/transactions.utils';
+import { isPerpsWithdrawTransaction } from '../../../../../shared/lib/transactions.utils';
 import { usePerpsLiveAccount } from '../../../../hooks/perps/stream';
 import { useTokenFiatRate } from '../tokens/useTokenFiatRates';
 import { useConfirmContext } from '../../context/confirm';
@@ -208,7 +205,7 @@ function useTokenBalance() {
   const { payToken } = useTransactionPayToken();
   const { account } = usePerpsLiveAccount();
 
-  if (hasTransactionType(transactionMeta, [TransactionType.perpsWithdraw])) {
+  if (isPerpsWithdrawTransaction(transactionMeta)) {
     const available = account?.availableBalance;
     return available ? parseFloat(available) || 0 : 0;
   }

--- a/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmount.ts
+++ b/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmount.ts
@@ -4,8 +4,6 @@ import { BigNumber } from 'bignumber.js';
 import type { TransactionMeta } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 import { setIsMaxAmount } from '../../../../store/controller-actions/transaction-pay-controller';
-import { isPerpsWithdrawTransaction } from '../../../../../shared/lib/transactions.utils';
-import { usePerpsLiveAccount } from '../../../../hooks/perps/stream';
 import { useTokenFiatRate } from '../tokens/useTokenFiatRates';
 import { useConfirmContext } from '../../context/confirm';
 import { useTransactionPayToken } from '../pay/useTransactionPayToken';
@@ -22,7 +20,19 @@ const DEBOUNCE_DELAY = 500;
 export function useTransactionCustomAmount({
   currency,
   disableUpdate = false,
-}: { currency?: string; disableUpdate?: boolean } = {}) {
+  balanceUsdOverride,
+}: {
+  currency?: string;
+  disableUpdate?: boolean;
+  /**
+   * Optional caller-provided balance (USD) used as the source for
+   * `updatePendingAmountPercentage`. When provided, takes precedence over the
+   * default `payToken.balanceUsd`. Lets callers like Perps Withdraw supply a
+   * non-pay-token balance (e.g. Perps available balance) without coupling the
+   * shared hook to those flows.
+   */
+  balanceUsdOverride?: number;
+} = {}) {
   const [isInputChanged, setInputChanged] = useState(false);
   const [hasInput, setHasInput] = useState(false);
   const [amountHumanDebounced, setAmountHumanDebounced] = useState('0');
@@ -35,7 +45,7 @@ export function useTransactionCustomAmount({
   const tokenAddress = getTokenAddress(transactionMeta);
   const tokenFiatRate =
     useTokenFiatRate(tokenAddress, chainId as Hex, currency) ?? 1;
-  const balanceUsd = useTokenBalance();
+  const balanceUsd = useTokenBalance(balanceUsdOverride);
 
   const { updateTokenAmount: updateTokenAmountCallback } =
     useUpdateTokenAmount();
@@ -199,15 +209,11 @@ export function useTransactionCustomAmount({
   };
 }
 
-function useTokenBalance() {
-  const { currentConfirmation: transactionMeta } =
-    useConfirmContext<TransactionMeta>();
+function useTokenBalance(balanceUsdOverride?: number) {
   const { payToken } = useTransactionPayToken();
-  const { account } = usePerpsLiveAccount();
 
-  if (isPerpsWithdrawTransaction(transactionMeta)) {
-    const available = account?.availableBalance;
-    return available ? parseFloat(available) || 0 : 0;
+  if (balanceUsdOverride !== undefined) {
+    return balanceUsdOverride;
   }
 
   const payTokenBalanceUsd = new BigNumber(

--- a/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmount.ts
+++ b/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmount.ts
@@ -1,9 +1,14 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { debounce, type DebouncedFunc } from 'lodash';
 import { BigNumber } from 'bignumber.js';
-import type { TransactionMeta } from '@metamask/transaction-controller';
+import {
+  type TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 import { setIsMaxAmount } from '../../../../store/controller-actions/transaction-pay-controller';
+import { hasTransactionType } from '../../../../../shared/lib/transactions.utils';
+import { usePerpsLiveAccount } from '../../../../hooks/perps/stream';
 import { useTokenFiatRate } from '../tokens/useTokenFiatRates';
 import { useConfirmContext } from '../../context/confirm';
 import { useTransactionPayToken } from '../pay/useTransactionPayToken';
@@ -198,7 +203,15 @@ export function useTransactionCustomAmount({
 }
 
 function useTokenBalance() {
+  const { currentConfirmation: transactionMeta } =
+    useConfirmContext<TransactionMeta>();
   const { payToken } = useTransactionPayToken();
+  const { account } = usePerpsLiveAccount();
+
+  if (hasTransactionType(transactionMeta, [TransactionType.perpsWithdraw])) {
+    const available = account?.availableBalance;
+    return available ? parseFloat(available) || 0 : 0;
+  }
 
   const payTokenBalanceUsd = new BigNumber(
     payToken?.balanceUsd ?? 0,

--- a/ui/store/controller-actions/transaction-pay-controller.test.ts
+++ b/ui/store/controller-actions/transaction-pay-controller.test.ts
@@ -2,6 +2,7 @@ import * as BackgroundConnectionModule from '../background-connection';
 import {
   updateTransactionPaymentToken,
   setIsMaxAmount,
+  setPostQuote,
 } from './transaction-pay-controller';
 
 jest.mock('../background-connection');
@@ -78,6 +79,27 @@ describe('transaction-pay-controller actions', () => {
       const result = await setIsMaxAmount('tx-123', true);
 
       expect(result).toBeUndefined();
+    });
+  });
+
+  describe('setPostQuote', () => {
+    it('forwards transactionId and options to submitRequestToBackground', async () => {
+      await setPostQuote('tx-99', { isHyperliquidSource: true });
+
+      expect(mockSubmitRequestToBackground).toHaveBeenCalledTimes(1);
+      expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+        'setTransactionPayPostQuote',
+        ['tx-99', { isHyperliquidSource: true }],
+      );
+    });
+
+    it('defaults options to an empty object when omitted', async () => {
+      await setPostQuote('tx-100');
+
+      expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+        'setTransactionPayPostQuote',
+        ['tx-100', {}],
+      );
     });
   });
 });

--- a/ui/store/controller-actions/transaction-pay-controller.ts
+++ b/ui/store/controller-actions/transaction-pay-controller.ts
@@ -28,3 +28,13 @@ export async function setIsMaxAmount(
     isMaxAmount,
   ]);
 }
+
+export async function setPostQuote(
+  transactionId: string,
+  options: { isHyperliquidSource?: boolean } = {},
+): Promise<void> {
+  return await submitRequestToBackground('setTransactionPayPostQuote', [
+    transactionId,
+    options,
+  ]);
+}


### PR DESCRIPTION
## **Description**

Mirrors mobile PR. Makes the Perps Withdraw → any-token confirmation work end-to-end:

- Wires `TransactionPayController` post-quote / `isHyperliquidSource` mode for `perpsWithdraw` via a new `setTransactionPayPostQuote` background API + `useTransactionPayPostQuote` hook called from `PerpsWithdrawInfo`.
- Sources the % amount balance from `PerpsController.accountState.availableBalance` for `perpsWithdraw`, and suppresses the insufficient-native-balance alert (gasless flow).
- Persists destination token selection in the Pay-With picker by importing zero-balance non-native tokens into `TokensController` before calling `setPayToken` (mirrors mobile #28599).
- Replaces the bottom "Total" row with a "You'll receive" row that nets fees out of input.
- Renames "Bridge fee" → "Provider fee" (with mobile-parity tooltip / mUSD-swap description), "Withdraw to" → "Receive", and "Available Perps balance" → "Available balance" for `perpsWithdraw`.
- Introduces an `isPerpsWithdrawTransaction` helper to dedupe inline `WITHDRAW_TYPES` checks across confirmation files.
- Fixes the custom-amount input width clipping decimal amounts like `0.4` / `1.33` by counting separators as half-width instead of zero (regression from #41838).

The flow is reachable today via the developer menu's "Perps Withdraw" trigger button. Wiring the production "Withdraw" button is split out into CONF-1216, the blocking insufficient-Perps-balance alert is in CONF-1217, and activity-row destination-token display + TX Details polish is a separate follow-up.

## **Changelog**

CHANGELOG entry: Make Perps Withdraw to any token submission work

## **Related issues**

Fixes: [CONF-1215](https://consensyssoftware.atlassian.net/browse/CONF-1215)

## **Manual testing steps**

1. Build and load the extension; unlock with a Perps-enabled account that holds some HyperLiquid balance.
2. Open the confirmations developer menu and tap **Perps Withdraw**.
3. Verify the confirmation opens with `$0.00`, "Available balance: $X.XX", and a Receive picker defaulting to Arbitrum USDC (default token will come from feature flags / last used token logic soon).
4. Type a decimal fiat amount (e.g. `0.4`, `1.33`, `12.50`) — confirm the input fits without clipping the leading digit.
5. Tap the Receive picker → switch to a non-USDC token you don't hold (e.g. BNB on BSC). Verify the picker closes with the new token applied (not the previous USDC selection).
6. Verify the "You'll receive" row appears (instead of "Total"), the "Provider fee" tooltip wording matches mobile, and the "Transaction fee" row is shown.
7. Hit Confirm. Verify the transaction completes via the HyperLiquid → Relay path and lands as a successful `perpsWithdraw` in Activity.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[CONF-1215]: https://consensyssoftware.atlassian.net/browse/CONF-1215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches confirmation/transaction-pay behavior and token-import side effects for a new withdraw path; incorrect gating or fee/net calculations could break token selection or show wrong receive/fee values, but changes are scoped and well-tested.
> 
> **Overview**
> Enables the Perps Withdraw confirmation flow to submit successfully by wiring a new Transaction Pay post-quote background API (`setTransactionPayPostQuote`/`setPostQuote`) and a `useTransactionPayPostQuote` hook that auto-configures `perpsWithdraw` transactions (incl. Hyperliquid source flag).
> 
> Updates the confirmation UI/logic for `perpsWithdraw`: sources custom-amount balance from the perps available balance via a `balanceUsdOverride`, suppresses insufficient-native-balance alerts for this gasless flow, relabels the pay-token picker to **Receive**, and ensures destination-token selection works by importing zero-balance non-native tokens before calling `setPayToken`.
> 
> Improves fee/total presentation by keeping the row label as “Transaction fee” while showing “Provider fee” in the tooltip for perps withdrawals, and replaces the bottom `Total` row with a new `ReceiveRow` (“You’ll receive”) that nets all fees from the user’s input. Also fixes custom-amount input width for decimal values by treating separators as half-width, and adds an `isPerpsWithdrawTransaction` helper plus associated tests and i18n strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33a2d815cbab11fa3d11b331ed0dffa1ddeda36d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->