### PR TITLE
feat(perps): add editable close-amount USD input and normalize UI labels

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5708,7 +5708,7 @@
     "message": "Cancel order"
   },
   "perpsCandleIntervals": {
-    "message": "Candle intervals"
+    "message": "Set candle interval"
   },
   "perpsCandlePeriodDays": {
     "message": "Days"
@@ -5723,7 +5723,7 @@
     "message": "Close all"
   },
   "perpsCloseAmount": {
-    "message": "Close Amount"
+    "message": "Close amount"
   },
   "perpsCloseLong": {
     "message": "Close long"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -5708,7 +5708,7 @@
     "message": "Cancel order"
   },
   "perpsCandleIntervals": {
-    "message": "Candle intervals"
+    "message": "Set candle interval"
   },
   "perpsCandlePeriodDays": {
     "message": "Days"
@@ -5723,7 +5723,7 @@
     "message": "Close all"
   },
   "perpsCloseAmount": {
-    "message": "Close Amount"
+    "message": "Close amount"
   },
   "perpsCloseLong": {
     "message": "Close long"

--- a/ui/components/app/perps/close-position/close-position-modal.tsx
+++ b/ui/components/app/perps/close-position/close-position-modal.tsx
@@ -534,8 +534,9 @@ export const ClosePositionModal: React.FC<ClosePositionModalProps> = ({
                 >
                   <Icon
                     name={IconName.Warning}
-                    size={IconSize.Sm}
+                    size={IconSize.Md}
                     color={IconColor.WarningDefault}
+                    className="shrink-0"
                   />
                   <Text
                     variant={TextVariant.BodySm}

--- a/ui/components/app/perps/constants/chartConfig.ts
+++ b/ui/components/app/perps/constants/chartConfig.ts
@@ -39,10 +39,10 @@ export const CANDLE_PERIODS = [
   { label: '4h', value: CandlePeriod.FourHours },
   { label: '8h', value: CandlePeriod.EightHours },
   { label: '12h', value: CandlePeriod.TwelveHours },
-  { label: '1D', value: CandlePeriod.OneDay },
-  { label: '3D', value: CandlePeriod.ThreeDays },
-  { label: '1W', value: CandlePeriod.OneWeek },
-  { label: '1M', value: CandlePeriod.OneMonth },
+  { label: '1d', value: CandlePeriod.OneDay },
+  { label: '3d', value: CandlePeriod.ThreeDays },
+  { label: '1w', value: CandlePeriod.OneWeek },
+  { label: '1m', value: CandlePeriod.OneMonth },
 ] as const;
 
 // Default periods shown in the selector (others available via "More")

--- a/ui/components/app/perps/order-entry/components/close-amount-section/close-amount-section.test.tsx
+++ b/ui/components/app/perps/order-entry/components/close-amount-section/close-amount-section.test.tsx
@@ -44,9 +44,9 @@ describe('CloseAmountSection', () => {
       );
 
       expect(screen.getByText(/2\.5.*BTC/u)).toBeInTheDocument();
-      expect(screen.getByTestId('close-amount-value')).toHaveTextContent(
-        /\$56,250/u,
-      );
+      const container = screen.getByTestId('close-amount-value');
+      const input = container.querySelector('input') as HTMLInputElement;
+      expect(input.value).toMatch(/56,?250/u);
     });
 
     it('displays close amount USD based on percentage', () => {
@@ -55,9 +55,9 @@ describe('CloseAmountSection', () => {
         mockStore,
       );
 
-      expect(screen.getByTestId('close-amount-value')).toHaveTextContent(
-        /\$84,375/u,
-      );
+      const container = screen.getByTestId('close-amount-value');
+      const input = container.querySelector('input') as HTMLInputElement;
+      expect(input.value).toMatch(/84,?375/u);
     });
 
     it('displays close percentage in chip', () => {
@@ -94,9 +94,9 @@ describe('CloseAmountSection', () => {
         mockStore,
       );
 
-      expect(screen.getByTestId('close-amount-value')).toHaveTextContent(
-        /\$56,250/u,
-      );
+      const container = screen.getByTestId('close-amount-value');
+      const input = container.querySelector('input') as HTMLInputElement;
+      expect(input.value).toMatch(/56,?250/u);
       expect(screen.getByText(/50.*%/u)).toBeInTheDocument();
     });
 
@@ -106,9 +106,9 @@ describe('CloseAmountSection', () => {
         mockStore,
       );
 
-      expect(screen.getByTestId('close-amount-value')).toHaveTextContent(
-        /\$28,125/u,
-      );
+      const container = screen.getByTestId('close-amount-value');
+      const input = container.querySelector('input') as HTMLInputElement;
+      expect(input.value).toMatch(/28,?125/u);
     });
 
     it('handles negative position size (short)', () => {

--- a/ui/components/app/perps/order-entry/components/close-amount-section/close-amount-section.tsx
+++ b/ui/components/app/perps/order-entry/components/close-amount-section/close-amount-section.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import {
   Box,
   BoxBackgroundColor,
@@ -11,16 +11,17 @@ import {
   BoxJustifyContent,
   BoxAlignItems,
 } from '@metamask/design-system-react';
+import { formatPositionSize } from '../../../../../../../shared/lib/perps-formatters';
 import {
-  formatPerpsFiat,
-  formatPositionSize,
-  PRICE_RANGES_MINIMAL_VIEW,
-  PRICE_RANGES_UNIVERSAL,
-} from '../../../../../../../shared/lib/perps-formatters';
+  BorderRadius,
+  BackgroundColor,
+} from '../../../../../../helpers/constants/design-system';
+import { TextField, TextFieldSize } from '../../../../../component-library';
 import { PerpsSlider } from '../../../perps-slider';
 import { getDisplaySymbol } from '../../../utils';
 import { useI18nContext } from '../../../../../../hooks/useI18nContext';
 import type { CloseAmountSectionProps } from '../../order-entry.types';
+import { isUnsignedDecimalInput, formatNumberForInput } from '../../utils';
 
 /** Fixed width (rem) for the close-% chip so the slider row layout stays stable as digits change */
 const CLOSE_PERCENT_CHIP_WIDTH_REM = 4.75;
@@ -46,14 +47,50 @@ export const CloseAmountSection: React.FC<CloseAmountSectionProps> = ({
 }) => {
   const t = useI18nContext();
 
-  const closeAmount = useMemo(() => {
-    const size = Math.abs(parseFloat(positionSize)) || 0;
-    return (size * closePercent) / 100;
-  }, [positionSize, closePercent]);
+  const totalPositionSize = Math.abs(Number.parseFloat(positionSize)) || 0;
+  const totalNotionalUsd = totalPositionSize * currentPrice;
 
-  const closeValueUsd = useMemo(() => {
-    return closeAmount * currentPrice;
-  }, [closeAmount, currentPrice]);
+  const closeValueUsd = useMemo(
+    () => (totalNotionalUsd * closePercent) / 100,
+    [totalNotionalUsd, closePercent],
+  );
+
+  const [rawInput, setRawInput] = useState('');
+  const [isUsdInputFocused, setIsUsdInputFocused] = useState(false);
+
+  const displayValue = useMemo(
+    () => formatNumberForInput(closeValueUsd, 2),
+    [closeValueUsd],
+  );
+
+  const handleUsdInputChange = useCallback(
+    ({ target: { value } }: React.ChangeEvent<HTMLInputElement>) => {
+      if (value === '' || isUnsignedDecimalInput(value)) {
+        setRawInput(value);
+
+        const parsed = Number.parseFloat(value);
+        if (!Number.isNaN(parsed) && totalNotionalUsd > 0) {
+          const newPercent = Math.min(
+            100,
+            Math.max(0, (parsed / totalNotionalUsd) * 100),
+          );
+          onClosePercentChange(newPercent);
+        } else if (value === '' || value === '0') {
+          onClosePercentChange(0);
+        }
+      }
+    },
+    [totalNotionalUsd, onClosePercentChange],
+  );
+
+  const handleUsdInputFocus = useCallback(() => {
+    setIsUsdInputFocused(true);
+    setRawInput(formatNumberForInput(closeValueUsd, 2));
+  }, [closeValueUsd]);
+
+  const handleUsdInputBlur = useCallback(() => {
+    setIsUsdInputFocused(false);
+  }, []);
 
   const handleSliderChange = useCallback(
     (_event: React.ChangeEvent<unknown>, value: number | number[]) => {
@@ -62,8 +99,6 @@ export const CloseAmountSection: React.FC<CloseAmountSectionProps> = ({
     },
     [onClosePercentChange],
   );
-
-  const totalPositionSize = Math.abs(parseFloat(positionSize)) || 0;
 
   return (
     <Box flexDirection={BoxFlexDirection.Column} gap={3}>
@@ -84,21 +119,28 @@ export const CloseAmountSection: React.FC<CloseAmountSectionProps> = ({
         <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
           {t('perpsCloseAmount')}
         </Text>
-        <Box
-          backgroundColor={BoxBackgroundColor.BackgroundMuted}
-          className="rounded-xl"
-          padding={4}
-        >
-          <Text
-            variant={TextVariant.BodyMd}
-            fontWeight={FontWeight.Medium}
-            data-testid="close-amount-value"
-          >
-            {formatPerpsFiat(closeValueUsd, {
-              ranges: PRICE_RANGES_MINIMAL_VIEW,
-            })}
-          </Text>
-        </Box>
+        <TextField
+          size={TextFieldSize.Md}
+          value={isUsdInputFocused ? rawInput : displayValue}
+          onChange={handleUsdInputChange}
+          onFocus={handleUsdInputFocus}
+          onBlur={handleUsdInputBlur}
+          placeholder="0.00"
+          borderRadius={BorderRadius.MD}
+          borderWidth={0}
+          backgroundColor={BackgroundColor.backgroundMuted}
+          className="w-full"
+          data-testid="close-amount-value"
+          inputProps={{ inputMode: 'decimal' }}
+          startAccessory={
+            <Text
+              variant={TextVariant.BodyMd}
+              color={TextColor.TextAlternative}
+            >
+              $
+            </Text>
+          }
+        />
       </Box>
 
       <Box
@@ -138,7 +180,7 @@ export const CloseAmountSection: React.FC<CloseAmountSectionProps> = ({
             textAlign={TextAlign.Center}
             style={{ width: '100%', fontVariantNumeric: 'tabular-nums' }}
           >
-            {closePercent} %
+            {Math.round(closePercent)} %
           </Text>
         </Box>
       </Box>

--- a/ui/pages/perps/perps-market-detail-page.test.tsx
+++ b/ui/pages/perps/perps-market-detail-page.test.tsx
@@ -1028,7 +1028,7 @@ describe('PerpsMarketDetailPage', () => {
       fireEvent.click(screen.getByTestId('perps-candle-period-more'));
       fireEvent.click(screen.getByTestId('perps-candle-period-modal-1M'));
 
-      expect(screen.getByText('1M')).toBeInTheDocument();
+      expect(screen.getByText('1m')).toBeInTheDocument();
       expect(screen.getByTestId('perps-candle-period-more')).toHaveClass(
         'bg-muted',
       );


### PR DESCRIPTION
## **Description**

This PR introduces an editable USD input field for the close-position amount in the perps order entry, allowing users to type a specific dollar value instead of only using the slider. It also normalizes chart candle period labels to lowercase (`1d`, `3d`, `1w`, `1m`) for visual consistency, updates locale strings for proper sentence casing, and increases the partial-close warning icon size for better visibility.

## **Changelog**

CHANGELOG entry: Added editable USD input for close-position amount in perpetuals trading

## **Related issues**

Fixes: https://docs.google.com/document/d/1yBGt2q6Xt7zpXMZcBBDTzxjfTnPWjY6MYKxWvPyNqpw/edit?tab=t.0

## **Manual testing steps**

Feature: Editable close-position USD amount

Scenario: User types a custom USD amount to close
  Given the user has an open perpetual position
  When the user opens the close-position flow
  Then the close amount field is an editable text input prefixed with "$"
  When the user types a USD value (e.g. "500")
  Then the slider percentage updates to match the entered amount
  And when the input loses focus

Scenario: Candle period labels are lowercase
  Given the user is viewing the perps chart
  When the user opens the candle interval selector
  Then period labels for days, weeks, and months display as "1d", "3d", "1w", "1m"

Scenario: Warning icon is properly sized
  Given the user has an open position
  When a partial-close warning is displayed in the close-position modal
  Then the warning icon renders at medium size and does not shrink

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**
<img width="376" height="780" alt="Screenshot 2026-04-30 at 09 38 45" src="https://github.com/user-attachments/assets/9d557503-9903-43b3-be2e-941c10a58583" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit c9dd2255e335e136860fc01612a3045039e98420. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->