### PR TITLE
fix(rewards): sync controller and data service with mobile

### DIFF
--- a/app/scripts/controllers/rewards/rewards-controller.test.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.test.ts
@@ -459,15 +459,19 @@ describe('RewardsController', () => {
       });
     });
 
-    it('should throw error if current tier is not found', async () => {
+    it('should return null tier state if current tier is not found', async () => {
       await withController({ isDisabled: false }, ({ controller }) => {
-        expect(() => {
-          controller.calculateTierStatus(
-            MOCK_SEASON_TIERS,
-            'invalid-tier',
-            100,
-          );
-        }).toThrow('Current tier invalid-tier not found in season tiers');
+        const tierStatus = controller.calculateTierStatus(
+          MOCK_SEASON_TIERS,
+          'invalid-tier',
+          100,
+        );
+
+        expect(tierStatus).toEqual({
+          currentTier: null,
+          nextTier: null,
+          nextTierPointsNeeded: null,
+        });
       });
     });
   });
@@ -2889,6 +2893,48 @@ describe('RewardsController', () => {
         },
       );
     });
+
+    it('should mark GB as blocked region', async () => {
+      await withController(
+        { isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (actionType === 'RewardsDataService:fetchGeoLocation') {
+              return Promise.resolve('GB');
+            }
+            return undefined;
+          });
+
+          const result = await controller.getGeoRewardsMetadata();
+
+          expect(result).toEqual({
+            geoLocation: 'GB',
+            optinAllowedForGeo: false,
+          });
+        },
+      );
+    });
+
+    it('should mark GI as blocked region', async () => {
+      await withController(
+        { isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (actionType === 'RewardsDataService:fetchGeoLocation') {
+              return Promise.resolve('GI');
+            }
+            return undefined;
+          });
+
+          const result = await controller.getGeoRewardsMetadata();
+
+          expect(result).toEqual({
+            geoLocation: 'GI',
+            optinAllowedForGeo: false,
+          });
+        },
+      );
+    });
   });
 
   describe('validateReferralCode', () => {
@@ -3641,7 +3687,7 @@ describe('RewardsController', () => {
       });
     });
 
-    it('should force fresh check for opted-in accounts WITHOUT subscriptionId checked more than 60 minutes ago', async () => {
+    it('should use cached data for opted-in accounts WITHOUT subscriptionId regardless of staleness', async () => {
       const state: Partial<RewardsControllerState> = {
         rewardsAccounts: {
           [MOCK_CAIP_ACCOUNT]: {
@@ -3650,7 +3696,7 @@ describe('RewardsController', () => {
             subscriptionId: null, // Opted in but missing subscriptionId
             perpsFeeDiscount: null,
             lastPerpsDiscountRateFetched: null,
-            lastFreshOptInStatusCheck: Date.now() - 1000 * 60 * 61, // 61 minutes ago (exceeds 60 minute threshold)
+            lastFreshOptInStatusCheck: Date.now() - 1000 * 60 * 61, // 61 minutes ago
           },
         },
       };
@@ -3667,10 +3713,10 @@ describe('RewardsController', () => {
           addressToAccountMap,
         );
 
-        // Should force fresh check because opted-in but no subscriptionId and stale cache
-        expect(result.cachedOptInResults).toEqual([null]);
+        // hasOptedIn is true so stale-cache check only applies to hasOptedIn === false
+        expect(result.cachedOptInResults).toEqual([true]);
         expect(result.cachedSubscriptionIds).toEqual([null]);
-        expect(result.addressesNeedingFresh).toEqual([MOCK_ACCOUNT_ADDRESS]);
+        expect(result.addressesNeedingFresh).toEqual([]);
       });
     });
 
@@ -3740,7 +3786,7 @@ describe('RewardsController', () => {
       });
     });
 
-    it('should force fresh check for opted-in accounts WITHOUT subscriptionId and no lastFreshOptInStatusCheck', async () => {
+    it('should use cached data for opted-in accounts WITHOUT subscriptionId even without lastFreshOptInStatusCheck', async () => {
       const state: Partial<RewardsControllerState> = {
         rewardsAccounts: {
           [MOCK_CAIP_ACCOUNT]: {
@@ -3766,10 +3812,10 @@ describe('RewardsController', () => {
           addressToAccountMap,
         );
 
-        // Should force fresh check because opted-in without subscriptionId and never checked fresh
-        expect(result.cachedOptInResults).toEqual([null]);
+        // Should use cached data because only hasOptedIn === false triggers a fresh recheck
+        expect(result.cachedOptInResults).toEqual([true]);
         expect(result.cachedSubscriptionIds).toEqual([null]);
-        expect(result.addressesNeedingFresh).toEqual([MOCK_ACCOUNT_ADDRESS]);
+        expect(result.addressesNeedingFresh).toEqual([]);
       });
     });
   });

--- a/app/scripts/controllers/rewards/rewards-controller.test.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.test.ts
@@ -172,6 +172,7 @@ const MOCK_SEASON_METADATA: SeasonMetadataDto = {
   startDate: new Date('2024-01-01T00:00:00.000Z'),
   endDate: new Date('2024-12-31T23:59:59.999Z'),
   tiers: MOCK_SEASON_TIERS,
+  activityTypes: [],
 };
 
 const MOCK_SEASON_STATE: SeasonStateDto = {

--- a/app/scripts/controllers/rewards/rewards-controller.test.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.test.ts
@@ -2475,7 +2475,7 @@ describe('RewardsController', () => {
 
           expect(result).toBeDefined();
           expect(result?.balance.total).toBe(250);
-          expect(result?.tier.currentTier.id).toBe('tier-2');
+          expect(result?.tier.currentTier?.id).toBe('tier-2');
         },
       );
     });
@@ -6465,7 +6465,7 @@ describe('Hardware Wallet Support for Rewards', () => {
           expect(result).toBeDefined();
           expect(result?.balance.total).toBe(250);
           expect(result?.balance.updatedAt).toBeDefined();
-          expect(result?.tier.currentTier.id).toBe('tier-2');
+          expect(result?.tier.currentTier?.id).toBe('tier-2');
           expect(result?.tier.nextTier?.id).toBe('tier-3');
           expect(result?.tier.nextTierPointsNeeded).toBe(250);
         },
@@ -6639,7 +6639,7 @@ describe('Hardware Wallet Support for Rewards', () => {
 
           expect(result).toBeDefined();
           expect(result?.balance.total).toBe(50);
-          expect(result?.tier.currentTier.id).toBe('tier-1');
+          expect(result?.tier.currentTier?.id).toBe('tier-1');
           expect(result?.tier.nextTier?.id).toBe('tier-2');
           expect(result?.tier.nextTierPointsNeeded).toBe(50); // 100 - 50
         },

--- a/app/scripts/controllers/rewards/rewards-controller.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.ts
@@ -53,7 +53,7 @@ import { signTronRewardsMessage } from './utils/tron-snap';
 import { sortAccounts } from './utils/sortAccounts';
 import { isHardwareAccount } from './utils/isHardwareAccount';
 
-export const DEFAULT_BLOCKED_REGIONS = ['UK'];
+export const DEFAULT_BLOCKED_REGIONS = ['UK', 'GB', 'GI'];
 
 const controllerName = 'RewardsController';
 
@@ -412,9 +412,14 @@ export class RewardsController extends BaseController<
     // Find current tier
     const currentTier = sortedTiers.find((tier) => tier.id === currentTierId);
     if (!currentTier) {
-      throw new Error(
-        `Current tier ${currentTierId} not found in season tiers`,
+      log.warn(
+        `Current tier ${currentTierId} not found in season tiers, skip calculating tier status`,
       );
+      return {
+        currentTier: null,
+        nextTier: null,
+        nextTierPointsNeeded: null,
+      };
     }
 
     // Find next tier (first tier with more points needed than current tier)
@@ -763,6 +768,7 @@ export class RewardsController extends BaseController<
             );
             if (subscriptionId && !successAccount) {
               successAccount = account;
+              break;
             }
           } catch {
             // Continue to next account
@@ -1131,6 +1137,7 @@ export class RewardsController extends BaseController<
           subscriptionId: subscription?.id || null,
           perpsFeeDiscount: null, // Default value, will be updated when fetched
           lastPerpsDiscountRateFetched: null,
+          lastFreshOptInStatusCheck: Date.now(),
         };
         state.rewardsAccounts[account] = accountState;
         if (shouldBecomeActiveAccount) {
@@ -1204,11 +1211,7 @@ export class RewardsController extends BaseController<
               !accountState.lastFreshOptInStatusCheck ||
               Date.now() - accountState.lastFreshOptInStatusCheck >
                 NOT_OPTED_IN_OIS_STALE_CACHE_THRESHOLD_MS;
-            if (
-              (accountState.hasOptedIn === false ||
-                (accountState.hasOptedIn && !accountState.subscriptionId)) &&
-              shouldRecheckFresh
-            ) {
+            if (accountState.hasOptedIn === false && shouldRecheckFresh) {
               // Force a fresh check for this not-opted-in account
               addressesNeedingFresh.push(address);
               continue;

--- a/app/scripts/controllers/rewards/rewards-controller.types.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.types.ts
@@ -393,6 +393,11 @@ export type SeasonMetadataDto = {
    * The tiers for the season
    */
   tiers: SeasonTierDto[];
+
+  /**
+   * The activity types that earn points in this season
+   */
+  activityTypes: string[];
 };
 
 /**

--- a/app/scripts/controllers/rewards/rewards-data-service.test.ts
+++ b/app/scripts/controllers/rewards/rewards-data-service.test.ts
@@ -1641,13 +1641,13 @@ describe('RewardsDataService', () => {
         json: jest.fn().mockResolvedValue({
           current: {
             id: 'season-1',
-            startDate: '2023-06-01T00:00:00Z',
-            endDate: '2023-08-31T23:59:59Z',
+            startDate: '2030-06-01T00:00:00Z',
+            endDate: '2030-08-31T23:59:59Z',
           },
           next: {
             id: 'season-2',
-            startDate: '2023-09-01T00:00:00Z',
-            endDate: '2023-11-30T23:59:59Z',
+            startDate: '2030-09-01T00:00:00Z',
+            endDate: '2030-11-30T23:59:59Z',
           },
         }),
       } as unknown as Response;
@@ -1681,8 +1681,8 @@ describe('RewardsDataService', () => {
           current: null,
           next: {
             id: 'season-2',
-            startDate: '2023-09-01T00:00:00Z',
-            endDate: '2023-11-30T23:59:59Z',
+            startDate: '2030-09-01T00:00:00Z',
+            endDate: '2030-11-30T23:59:59Z',
           },
         }),
       } as unknown as Response;
@@ -1702,8 +1702,8 @@ describe('RewardsDataService', () => {
         json: jest.fn().mockResolvedValue({
           current: {
             id: 'season-1',
-            startDate: '2023-06-01T00:00:00Z',
-            endDate: '2023-08-31T23:59:59Z',
+            startDate: '2030-06-01T00:00:00Z',
+            endDate: '2030-08-31T23:59:59Z',
           },
           next: null,
         }),
@@ -1716,6 +1716,32 @@ describe('RewardsDataService', () => {
       expect(result.current).toBeDefined();
       expect(result.current?.id).toBe('season-1');
       expect(result.next).toBeNull();
+    });
+
+    it('coerces an ended current season to previous', async () => {
+      const mockResponse = {
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          current: {
+            id: 'season-1',
+            startDate: '2023-06-01T00:00:00Z',
+            endDate: '2023-08-31T23:59:59Z', // in the past
+          },
+          next: {
+            id: 'season-2',
+            startDate: '2030-09-01T00:00:00Z',
+            endDate: '2030-11-30T23:59:59Z',
+          },
+        }),
+      } as unknown as Response;
+
+      mockFetch.mockResolvedValue(mockResponse);
+
+      const result = await service.getDiscoverSeasons();
+
+      expect(result.current).toBeNull();
+      expect(result.previous?.id).toBe('season-1');
+      expect(result.next?.id).toBe('season-2');
     });
 
     it('throws error when response is not ok', async () => {
@@ -1798,6 +1824,25 @@ describe('RewardsDataService', () => {
 
       expect(result.startDate).toBeInstanceOf(Date);
       expect(result.endDate).toBeInstanceOf(Date);
+    });
+
+    it('defaults activityTypes to empty array when missing from response', async () => {
+      const mockResponse = {
+        ok: true,
+        json: jest.fn().mockResolvedValue({
+          id: mockSeasonId,
+          name: 'Summer Season',
+          startDate: '2023-06-01T00:00:00Z',
+          endDate: '2023-08-31T23:59:59Z',
+          // activityTypes intentionally omitted
+        }),
+      } as unknown as Response;
+
+      mockFetch.mockResolvedValue(mockResponse);
+
+      const result = await service.getSeasonMetadata(mockSeasonId);
+
+      expect(result.activityTypes).toEqual([]);
     });
 
     it('throws error when response is not ok', async () => {

--- a/app/scripts/controllers/rewards/rewards-data-service.ts
+++ b/app/scripts/controllers/rewards/rewards-data-service.ts
@@ -618,6 +618,19 @@ export class RewardsDataService {
       }
     }
 
+    // If current season's end date has already passed, coerce it to previous
+    if (data.current?.endDate) {
+      const endDate =
+        data.current.endDate instanceof Date
+          ? data.current.endDate
+          : new Date(data.current.endDate);
+
+      if (endDate <= new Date()) {
+        data.previous = data.current;
+        data.current = null;
+      }
+    }
+
     return data as DiscoverSeasonsDto;
   }
 
@@ -647,6 +660,10 @@ export class RewardsDataService {
     }
     if (data.endDate) {
       data.endDate = new Date(data.endDate);
+    }
+
+    if (!Array.isArray(data.activityTypes)) {
+      data.activityTypes = [];
     }
 
     return data as SeasonMetadataDto;

--- a/shared/types/rewards.ts
+++ b/shared/types/rewards.ts
@@ -52,7 +52,7 @@ export type SeasonStatusBalanceDtoState = {
 };
 
 export type SeasonTierState = {
-  currentTier: SeasonTierDtoState;
+  currentTier: SeasonTierDtoState | null;
   nextTier: SeasonTierDtoState | null;
   nextTierPointsNeeded: number | null;
 };


### PR DESCRIPTION
## Summary

Syncs the extension's `RewardsController` and `RewardsDataService` with the latest mobile implementation for the functions shared between both platforms.

- **`DEFAULT_BLOCKED_REGIONS`** — expanded from `['UK']` to `['UK', 'GB', 'GI']` to match mobile
- **`calculateTierStatus`** — returns graceful `null` tier state instead of throwing when the current tier ID isn't found in the tiers list; `SeasonTierState.currentTier` made nullable accordingly
- **`handleAuthenticationTrigger`** — breaks out of the silent auth loop after the first successful account, matching mobile's behaviour
- **`checkOptInStatusAgainstCache`** — removed the extra `(hasOptedIn && !subscriptionId)` condition that forced a fresh API call for opted-in accounts missing a subscriptionId; mobile only forces a recheck for `hasOptedIn === false`
- **`performSilentAuth`** — sets `lastFreshOptInStatusCheck: Date.now()` in the `finally` block so every auth attempt (success or failure) stamps the cache, matching mobile
- **`getDiscoverSeasons`** — adds end-date coercion: if the current season's `endDate` has already passed, it is moved to `previous` and `current` is nulled out
- **`getSeasonMetadata`** — adds a defensive guard ensuring `activityTypes` is always an array even if the API omits the field

## Changelog

CHANGELOG entry: null

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches rewards eligibility and caching/auth flows (silent auth selection, opt-in freshness checks, tier calculation), which could change user-visible rewards state and network call patterns. Changes are localized but affect core rewards status computation.
> 
> **Overview**
> Aligns extension rewards behavior with mobile by expanding `DEFAULT_BLOCKED_REGIONS` (now includes `GB`/`GI`) and adding `activityTypes` to `SeasonMetadataDto` (defaulting to `[]` when missing).
> 
> Makes season status handling more resilient: `calculateTierStatus` now logs and returns a *null tier state* instead of throwing when the current tier isn’t found (with `SeasonTierState.currentTier` made nullable), and `getDiscoverSeasons` reclassifies an already-ended `current` season as `previous`.
> 
> Refines opt-in/auth caching logic: breaks out after the first successful silent auth account, stamps `lastFreshOptInStatusCheck` on auth attempts, and only forces fresh opt-in checks for *not opted-in* accounts (no longer for opted-in accounts missing `subscriptionId`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bafc69d681be04154e8bb2206c1ebc6ab10e43b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->