### PR TITLE
feat(perps): show destination token in Perps Withdraw Activity and Transaction Details

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5321,10 +5321,6 @@
     "message": "Pay with",
     "description": "Label for pay with row showing which token is used to pay transaction fees"
   },
-  "perpsWithdrawActivityTitle": {
-    "message": "Perps withdraw",
-    "description": "Title shown in the Activity list for a Perps withdraw transaction"
-  },
   "payWithModalTitle": {
     "message": "Pay with",
     "description": "Title for the pay with modal that allows users to select which token to pay transaction fees with"
@@ -6324,6 +6320,10 @@
   "perpsWithdraw": {
     "message": "Withdraw"
   },
+  "perpsWithdrawActivityTitle": {
+    "message": "Perps withdraw",
+    "description": "Title shown in the Activity list for a Perps withdraw transaction"
+  },
   "perpsWithdrawEstimatedTime": {
     "message": "Estimated time"
   },
@@ -6496,6 +6496,10 @@
   },
   "provide": {
     "message": "Provide"
+  },
+  "providerFee": {
+    "message": "Provider fee",
+    "description": "Label used in the Transaction fee tooltip for the provider (bridge/relay) fee, e.g. in Perps Withdraw"
   },
   "publicAddress": {
     "message": "Public address"
@@ -6703,8 +6707,16 @@
   "receiveCrypto": {
     "message": "Receive crypto"
   },
+  "receiveToken": {
+    "message": "Receive token",
+    "description": "Row label on the Transaction Details page for withdrawal flows (e.g. Perps Withdraw), showing which token the user receives"
+  },
   "received": {
     "message": "Received"
+  },
+  "receivedTotal": {
+    "message": "Received total",
+    "description": "Row label on the Transaction Details page for withdrawal flows (e.g. Perps Withdraw), showing the net amount received after fees"
   },
   "receivingAddress": {
     "message": "Receiving address",

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5321,6 +5321,10 @@
     "message": "Pay with",
     "description": "Label for pay with row showing which token is used to pay transaction fees"
   },
+  "perpsWithdrawActivityTitle": {
+    "message": "Perps withdraw",
+    "description": "Title shown in the Activity list for a Perps withdraw transaction"
+  },
   "payWithModalTitle": {
     "message": "Pay with",
     "description": "Title for the pay with modal that allows users to select which token to pay transaction fees with"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -6320,6 +6320,10 @@
   "perpsWithdraw": {
     "message": "Withdraw"
   },
+  "perpsWithdrawActivityTitle": {
+    "message": "Perps withdraw",
+    "description": "Title shown in the Activity list for a Perps withdraw transaction"
+  },
   "perpsWithdrawEstimatedTime": {
     "message": "Estimated time"
   },
@@ -6492,6 +6496,10 @@
   },
   "provide": {
     "message": "Provide"
+  },
+  "providerFee": {
+    "message": "Provider fee",
+    "description": "Label used in the Transaction fee tooltip for the provider (bridge/relay) fee, e.g. in Perps Withdraw"
   },
   "publicAddress": {
     "message": "Public address"
@@ -6699,8 +6707,16 @@
   "receiveCrypto": {
     "message": "Receive crypto"
   },
+  "receiveToken": {
+    "message": "Receive token",
+    "description": "Row label on the Transaction Details page for withdrawal flows (e.g. Perps Withdraw), showing which token the user receives"
+  },
   "received": {
     "message": "Received"
+  },
+  "receivedTotal": {
+    "message": "Received total",
+    "description": "Row label on the Transaction Details page for withdrawal flows (e.g. Perps Withdraw), showing the net amount received after fees"
   },
   "receivingAddress": {
     "message": "Receiving address",

--- a/ui/hooks/useTransactionDisplayData.js
+++ b/ui/hooks/useTransactionDisplayData.js
@@ -450,29 +450,16 @@ export function useTransactionDisplayData(transactionGroup) {
       ? metamaskPay?.chainId
       : initialTransaction.chainId;
 
-    let targetTokenSymbol;
-
-    // Detect native destinations first (e.g. BNB on BNB chain) — they are not
-    // in the ERC-20 token list keyed by address, so look up the native ticker
-    // from the network config instead.
-    const nativeAddressForTargetChain =
-      targetLookupChainId &&
-      getNativeTokenAddress(targetLookupChainId).toLowerCase();
-    const isNativeTarget =
-      targetLookupChainId &&
-      targetLookupAddress &&
-      targetLookupAddress === nativeAddressForTargetChain;
-
-    if (isNativeTarget) {
-      const nativeInfo = getNativeTokenInfo(
+    const { symbol: targetTokenSymbol, isNative: isNativeTarget } =
+      resolveTargetToken({
+        address: targetLookupAddress,
+        chainId: targetLookupChainId,
         networkConfigurationsByChainId,
-        targetLookupChainId,
-      );
-      targetTokenSymbol = nativeInfo?.symbol;
-    } else if (targetLookupAddress && targetLookupChainId) {
-      const targetToken =
-        tokenListAllChains?.[targetLookupChainId]?.data?.[targetLookupAddress];
-      targetTokenSymbol = targetToken?.symbol;
+        tokenListAllChains,
+      });
+
+    if (targetTokenSymbol) {
+      primarySuffix = targetTokenSymbol;
     }
 
     if (isPostQuote) {
@@ -482,24 +469,14 @@ export function useTransactionDisplayData(transactionGroup) {
       // `getPostQuoteDisplay` (app/components/UI/TransactionElement/utils.js)
       // renders the Activity row.
       const fiatUsd = parseFloat(metamaskPay?.targetFiat ?? '');
-      const nativeCurrency =
-        networkConfigurationsByChainId?.[targetLookupChainId]?.nativeCurrency;
-      const nativeUsdRate =
-        currencyRates?.[nativeCurrency]?.usdConversionRate ?? 0;
-
-      let tokenUsdRate = nativeUsdRate;
-      if (!isNativeTarget && targetLookupAddress && targetLookupChainId) {
-        let checksumAddress;
-        try {
-          checksumAddress = toChecksumHexAddress(targetLookupAddress);
-        } catch {
-          checksumAddress = undefined;
-        }
-        const tokenPrice =
-          checksumAddress &&
-          marketData?.[targetLookupChainId]?.[checksumAddress]?.price;
-        tokenUsdRate = tokenPrice ? tokenPrice * nativeUsdRate : 0;
-      }
+      const tokenUsdRate = getDestinationTokenUsdRate({
+        address: targetLookupAddress,
+        chainId: targetLookupChainId,
+        isNative: isNativeTarget,
+        marketData,
+        currencyRates,
+        networkConfigurationsByChainId,
+      });
 
       const hasValidInputs =
         Number.isFinite(fiatUsd) && fiatUsd > 0 && tokenUsdRate > 0;
@@ -507,15 +484,9 @@ export function useTransactionDisplayData(transactionGroup) {
         ? fiatUsd / tokenUsdRate
         : undefined;
 
-      if (targetTokenSymbol) {
-        primarySuffix = targetTokenSymbol;
-      }
-
-      if (receivedAmount !== undefined) {
-        primaryDisplayValue =
-          receivedAmount >= 1
-            ? receivedAmount.toFixed(2)
-            : receivedAmount.toPrecision(4);
+      const formattedReceived = formatPostQuoteReceivedAmount(receivedAmount);
+      if (formattedReceived !== undefined) {
+        primaryDisplayValue = formattedReceived;
       } else if (metamaskPay?.targetFiat) {
         primaryDisplayValue = metamaskPay.targetFiat;
       }
@@ -523,14 +494,9 @@ export function useTransactionDisplayData(transactionGroup) {
       if (metamaskPay?.targetFiat) {
         secondaryDisplayValue = fiatFormatter(fiatUsd);
       }
-    } else {
-      if (targetTokenSymbol) {
-        primarySuffix = targetTokenSymbol;
-      }
-      if (metamaskPay?.targetFiat) {
-        primaryDisplayValue = metamaskPay.targetFiat;
-        secondaryDisplayValue = fiatFormatter(Number(metamaskPay.targetFiat));
-      }
+    } else if (metamaskPay?.targetFiat) {
+      primaryDisplayValue = metamaskPay.targetFiat;
+      secondaryDisplayValue = fiatFormatter(Number(metamaskPay.targetFiat));
     }
   } else {
     dispatch(
@@ -590,4 +556,104 @@ export function useTransactionDisplayData(transactionGroup) {
         : secondaryCurrency,
     isPending,
   };
+}
+
+/**
+ * Resolves the destination token's symbol and native flag from a token
+ * address + chain ID. Native targets (e.g. BNB on BNB chain) are not in the
+ * ERC-20 token list keyed by address, so they need a separate lookup via the
+ * network configuration.
+ *
+ * @param {object} args
+ * @param {string|undefined} args.address - Lower-cased token address.
+ * @param {string|undefined} args.chainId - Hex chain ID.
+ * @param {object|undefined} args.networkConfigurationsByChainId - Map keyed by chain ID.
+ * @param {object|undefined} args.tokenListAllChains - ERC-20 token lists keyed by chain ID.
+ * @returns {{ symbol: string|undefined, isNative: boolean }}
+ */
+function resolveTargetToken({
+  address,
+  chainId,
+  networkConfigurationsByChainId,
+  tokenListAllChains,
+}) {
+  if (!address || !chainId) {
+    return { symbol: undefined, isNative: false };
+  }
+
+  const nativeAddress = getNativeTokenAddress(chainId).toLowerCase();
+  const isNative = address === nativeAddress;
+
+  if (isNative) {
+    const nativeInfo = getNativeTokenInfo(
+      networkConfigurationsByChainId,
+      chainId,
+    );
+    return { symbol: nativeInfo?.symbol, isNative: true };
+  }
+
+  const targetToken = tokenListAllChains?.[chainId]?.data?.[address];
+  return { symbol: targetToken?.symbol, isNative: false };
+}
+
+/**
+ * Returns the USD value of 1 unit of the destination token, or 0 when it
+ * cannot be determined. Native targets use the chain's native USD rate
+ * directly; ERC-20 targets multiply the token's native-denominated price
+ * (from market data) by the native USD rate.
+ *
+ * @param {object} args
+ * @param {string|undefined} args.address - Lower-cased token address.
+ * @param {string|undefined} args.chainId - Hex chain ID.
+ * @param {boolean} args.isNative - Whether the destination is the chain's native token.
+ * @param {object|undefined} args.marketData - Market data keyed by chain ID, then by checksum address.
+ * @param {object|undefined} args.currencyRates - Currency rates keyed by native currency symbol.
+ * @param {object|undefined} args.networkConfigurationsByChainId - Map keyed by chain ID.
+ * @returns {number} USD per 1 token, or 0 if unavailable.
+ */
+function getDestinationTokenUsdRate({
+  address,
+  chainId,
+  isNative,
+  marketData,
+  currencyRates,
+  networkConfigurationsByChainId,
+}) {
+  const nativeCurrency =
+    networkConfigurationsByChainId?.[chainId]?.nativeCurrency;
+  const nativeUsdRate = currencyRates?.[nativeCurrency]?.usdConversionRate ?? 0;
+
+  if (isNative) {
+    return nativeUsdRate;
+  }
+
+  if (!address || !chainId) {
+    return 0;
+  }
+
+  let checksumAddress;
+  try {
+    checksumAddress = toChecksumHexAddress(address);
+  } catch {
+    checksumAddress = undefined;
+  }
+
+  const tokenPrice =
+    checksumAddress && marketData?.[chainId]?.[checksumAddress]?.price;
+  return tokenPrice ? tokenPrice * nativeUsdRate : 0;
+}
+
+/**
+ * Formats a destination token amount for the Activity row's primary display
+ * value. Mirrors mobile's `getPostQuoteDisplay`: amounts >= 1 use 2 decimals,
+ * smaller amounts use 4 significant figures.
+ *
+ * @param {number|undefined} amount - Token amount in token units (not wei).
+ * @returns {string|undefined}
+ */
+function formatPostQuoteReceivedAmount(amount) {
+  if (amount === undefined) {
+    return undefined;
+  }
+  return amount >= 1 ? amount.toFixed(2) : amount.toPrecision(4);
 }

--- a/ui/hooks/useTransactionDisplayData.js
+++ b/ui/hooks/useTransactionDisplayData.js
@@ -117,6 +117,11 @@ export function useTransactionDisplayData(transactionGroup) {
   const marketData = useSelector(getMarketData);
   const currencyRates = useSelector(getCurrencyRates);
   const fiatFormatter = useFiatFormatter();
+  // For post-quote pay flows (e.g. Perps Withdraw) the values surfaced
+  // through `metamaskPay` (`targetFiat`, fee `*.usd`) are explicitly USD,
+  // so use a USD-pinned formatter when rendering them — even if the user
+  // has selected a different display currency.
+  const usdFormatter = useFiatFormatter({ overrideCurrency: 'usd' });
 
   const t = useI18nContext();
 
@@ -281,6 +286,12 @@ export function useTransactionDisplayData(transactionGroup) {
   // used to display fiat amount of tx. initialized to either tokenFiatAmount or undefined
   // but can later be modified if dealing with a swap
   let secondaryDisplayValue = isTokenCategory ? tokenFiatAmount : undefined;
+  // when set, replaces the `useCurrencyDisplay`-formatted `primaryCurrency`.
+  // Used by the post-quote fallback path (e.g. Perps Withdraw without rate
+  // data) so we can render a fiat string without `useCurrencyDisplay`
+  // auto-appending the chain native ticker (which would misleadingly read
+  // as "$50 worth of ETH/BNB" instead of "$50").
+  let primaryCurrencyOverride;
 
   let title;
 
@@ -458,10 +469,6 @@ export function useTransactionDisplayData(transactionGroup) {
         tokenListAllChains,
       });
 
-    if (targetTokenSymbol) {
-      primarySuffix = targetTokenSymbol;
-    }
-
     if (isPostQuote) {
       // Post-quote withdrawals (e.g. Perps Withdraw): the completed tx does
       // not carry a destination-token amount; derive it from targetFiat /
@@ -486,15 +493,25 @@ export function useTransactionDisplayData(transactionGroup) {
 
       const formattedReceived = formatPostQuoteReceivedAmount(receivedAmount);
       if (formattedReceived !== undefined) {
+        // Successful conversion — render in destination-token units.
         primaryDisplayValue = formattedReceived;
+        if (targetTokenSymbol) {
+          primarySuffix = targetTokenSymbol;
+        }
       } else if (metamaskPay?.targetFiat) {
-        primaryDisplayValue = metamaskPay.targetFiat;
+        // Rate unavailable — render the USD value directly via the override
+        // so `useCurrencyDisplay` doesn't auto-append the chain native
+        // ticker (which would falsely render "$50" as "50 ETH" / "50 BNB").
+        primaryCurrencyOverride = usdFormatter(fiatUsd);
       }
 
       if (metamaskPay?.targetFiat) {
-        secondaryDisplayValue = fiatFormatter(fiatUsd);
+        secondaryDisplayValue = usdFormatter(fiatUsd);
       }
     } else if (metamaskPay?.targetFiat) {
+      if (targetTokenSymbol) {
+        primarySuffix = targetTokenSymbol;
+      }
       primaryDisplayValue = metamaskPay.targetFiat;
       secondaryDisplayValue = fiatFormatter(Number(metamaskPay.targetFiat));
     }
@@ -541,10 +558,12 @@ export function useTransactionDisplayData(transactionGroup) {
     recipientAddress = to;
   }
 
+  const resolvedPrimaryCurrency =
+    type === TransactionType.swap && isPending ? '' : primaryCurrency;
+
   return {
     title,
-    primaryCurrency:
-      type === TransactionType.swap && isPending ? '' : primaryCurrency,
+    primaryCurrency: primaryCurrencyOverride ?? resolvedPrimaryCurrency,
     recipientAddress,
     secondaryCurrency:
       (isTokenCategory && !tokenFiatAmount) ||
@@ -648,11 +667,15 @@ function getDestinationTokenUsdRate({
  * value. Mirrors mobile's `getPostQuoteDisplay`: amounts >= 1 use 2 decimals,
  * smaller amounts use 4 significant figures.
  *
+ * Returns `undefined` for any non-finite input (NaN, ±Infinity) to avoid
+ * `RangeError` from `toFixed`/`toPrecision` — this can happen when
+ * `tokenUsdRate` is small enough that `fiatUsd / tokenUsdRate` overflows.
+ *
  * @param {number|undefined} amount - Token amount in token units (not wei).
  * @returns {string|undefined}
  */
 function formatPostQuoteReceivedAmount(amount) {
-  if (amount === undefined) {
+  if (amount === undefined || !Number.isFinite(amount)) {
     return undefined;
   }
   return amount >= 1 ? amount.toFixed(2) : amount.toPrecision(4);

--- a/ui/hooks/useTransactionDisplayData.js
+++ b/ui/hooks/useTransactionDisplayData.js
@@ -508,12 +508,18 @@ export function useTransactionDisplayData(transactionGroup) {
       if (metamaskPay?.targetFiat) {
         secondaryDisplayValue = usdFormatter(fiatUsd);
       }
-    } else if (metamaskPay?.targetFiat) {
+    } else {
+      // Non-post-quote pay flows (perpsDeposit, musdClaim, musdConversion):
+      // mirror pre-refactor behavior — set the destination-token suffix
+      // whenever a target token is resolvable, independently of whether
+      // metamaskPay.targetFiat is present.
       if (targetTokenSymbol) {
         primarySuffix = targetTokenSymbol;
       }
-      primaryDisplayValue = metamaskPay.targetFiat;
-      secondaryDisplayValue = fiatFormatter(Number(metamaskPay.targetFiat));
+      if (metamaskPay?.targetFiat) {
+        primaryDisplayValue = metamaskPay.targetFiat;
+        secondaryDisplayValue = fiatFormatter(Number(metamaskPay.targetFiat));
+      }
     }
   } else {
     dispatch(

--- a/ui/hooks/useTransactionDisplayData.js
+++ b/ui/hooks/useTransactionDisplayData.js
@@ -2,12 +2,18 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useEffect, useRef, useState } from 'react';
 import { TransactionType } from '@metamask/transaction-controller';
 import BigNumber from 'bignumber.js';
+import { getNativeTokenAddress } from '@metamask/assets-controllers';
 import {
   getAllTokens,
+  getCurrencyRates,
   getKnownMethodData,
+  getMarketData,
+  getNativeTokenInfo,
   getSelectedAddress,
   selectERC20TokensByChain,
 } from '../selectors';
+import { getNetworkConfigurationsByChainId } from '../../shared/lib/selectors/networks';
+import { toChecksumHexAddress } from '../../shared/lib/hexstring-utils';
 import {
   getStatusKey,
   getTransactionTypeTitle,
@@ -105,6 +111,11 @@ export function useTransactionDisplayData(transactionGroup) {
   const selectedAddress = useSelector(getSelectedAddress);
   const knownNfts = useSelector(getNfts);
   const tokenListAllChains = useSelector(selectERC20TokensByChain);
+  const networkConfigurationsByChainId = useSelector(
+    getNetworkConfigurationsByChainId,
+  );
+  const marketData = useSelector(getMarketData);
+  const currencyRates = useSelector(getCurrencyRates);
   const fiatFormatter = useFiatFormatter();
 
   const t = useI18nContext();
@@ -400,8 +411,15 @@ export function useTransactionDisplayData(transactionGroup) {
     secondaryDisplayValue = bridgeTokenDisplayData.displayCurrencyAmount;
   } else if (PAY_TRANSACTION_TYPES.includes(type)) {
     const { metamaskPay } = initialTransaction;
-    const sourceTokenAddress = metamaskPay?.tokenAddress?.toLowerCase();
-    const sourceChainId = metamaskPay?.chainId;
+    const isPostQuote = metamaskPay?.isPostQuote === true;
+
+    // For post-quote flows (e.g. perpsWithdraw) `metamaskPay.tokenAddress` +
+    // `metamaskPay.chainId` describe the DESTINATION token the user receives,
+    // not the source. For regular pay flows they describe the source token.
+    const sourceTokenAddress = isPostQuote
+      ? undefined
+      : metamaskPay?.tokenAddress?.toLowerCase();
+    const sourceChainId = isPostQuote ? undefined : metamaskPay?.chainId;
     const sourceToken =
       sourceTokenAddress &&
       sourceChainId &&
@@ -410,7 +428,7 @@ export function useTransactionDisplayData(transactionGroup) {
     if (type === TransactionType.perpsDeposit) {
       title = t('perpsDepositActivityTitle');
     } else if (type === TransactionType.perpsWithdraw) {
-      title = t('perpsWithdrawFundsTitle');
+      title = t('perpsWithdrawActivityTitle');
     } else if (type === TransactionType.musdClaim) {
       title = t('musdClaimTitle');
     } else {
@@ -420,21 +438,99 @@ export function useTransactionDisplayData(transactionGroup) {
     }
 
     prefix = '';
-    const targetTokenAddress = to?.toLowerCase();
 
-    const targetToken =
-      targetTokenAddress &&
-      tokenListAllChains?.[initialTransaction.chainId]?.data?.[
-        targetTokenAddress
-      ];
+    // For post-quote flows, resolve the destination token via metamaskPay
+    // (the tx's own `to` field is a placeholder ERC-20 transfer used purely
+    // to drive the confirmation UI). Otherwise fall back to the legacy
+    // `to` + initialTransaction.chainId lookup used by deposit flows.
+    const targetLookupAddress = isPostQuote
+      ? metamaskPay?.tokenAddress?.toLowerCase()
+      : to?.toLowerCase();
+    const targetLookupChainId = isPostQuote
+      ? metamaskPay?.chainId
+      : initialTransaction.chainId;
 
-    if (targetToken?.symbol) {
-      primarySuffix = targetToken.symbol;
+    let targetTokenSymbol;
+
+    // Detect native destinations first (e.g. BNB on BNB chain) — they are not
+    // in the ERC-20 token list keyed by address, so look up the native ticker
+    // from the network config instead.
+    const nativeAddressForTargetChain =
+      targetLookupChainId &&
+      getNativeTokenAddress(targetLookupChainId).toLowerCase();
+    const isNativeTarget =
+      targetLookupChainId &&
+      targetLookupAddress &&
+      targetLookupAddress === nativeAddressForTargetChain;
+
+    if (isNativeTarget) {
+      const nativeInfo = getNativeTokenInfo(
+        networkConfigurationsByChainId,
+        targetLookupChainId,
+      );
+      targetTokenSymbol = nativeInfo?.symbol;
+    } else if (targetLookupAddress && targetLookupChainId) {
+      const targetToken =
+        tokenListAllChains?.[targetLookupChainId]?.data?.[targetLookupAddress];
+      targetTokenSymbol = targetToken?.symbol;
     }
 
-    if (metamaskPay?.targetFiat) {
-      primaryDisplayValue = metamaskPay.targetFiat;
-      secondaryDisplayValue = fiatFormatter(Number(metamaskPay.targetFiat));
+    if (isPostQuote) {
+      // Post-quote withdrawals (e.g. Perps Withdraw): the completed tx does
+      // not carry a destination-token amount; derive it from targetFiat /
+      // destinationTokenUsdRate, the same way mobile's
+      // `getPostQuoteDisplay` (app/components/UI/TransactionElement/utils.js)
+      // renders the Activity row.
+      const fiatUsd = parseFloat(metamaskPay?.targetFiat ?? '');
+      const nativeCurrency =
+        networkConfigurationsByChainId?.[targetLookupChainId]?.nativeCurrency;
+      const nativeUsdRate =
+        currencyRates?.[nativeCurrency]?.usdConversionRate ?? 0;
+
+      let tokenUsdRate = nativeUsdRate;
+      if (!isNativeTarget && targetLookupAddress && targetLookupChainId) {
+        let checksumAddress;
+        try {
+          checksumAddress = toChecksumHexAddress(targetLookupAddress);
+        } catch {
+          checksumAddress = undefined;
+        }
+        const tokenPrice =
+          checksumAddress &&
+          marketData?.[targetLookupChainId]?.[checksumAddress]?.price;
+        tokenUsdRate = tokenPrice ? tokenPrice * nativeUsdRate : 0;
+      }
+
+      const hasValidInputs =
+        Number.isFinite(fiatUsd) && fiatUsd > 0 && tokenUsdRate > 0;
+      const receivedAmount = hasValidInputs
+        ? fiatUsd / tokenUsdRate
+        : undefined;
+
+      if (targetTokenSymbol) {
+        primarySuffix = targetTokenSymbol;
+      }
+
+      if (receivedAmount !== undefined) {
+        primaryDisplayValue =
+          receivedAmount >= 1
+            ? receivedAmount.toFixed(2)
+            : receivedAmount.toPrecision(4);
+      } else if (metamaskPay?.targetFiat) {
+        primaryDisplayValue = metamaskPay.targetFiat;
+      }
+
+      if (metamaskPay?.targetFiat) {
+        secondaryDisplayValue = fiatFormatter(fiatUsd);
+      }
+    } else {
+      if (targetTokenSymbol) {
+        primarySuffix = targetTokenSymbol;
+      }
+      if (metamaskPay?.targetFiat) {
+        primaryDisplayValue = metamaskPay.targetFiat;
+        secondaryDisplayValue = fiatFormatter(Number(metamaskPay.targetFiat));
+      }
     }
   } else {
     dispatch(

--- a/ui/hooks/useTransactionDisplayData.test.js
+++ b/ui/hooks/useTransactionDisplayData.test.js
@@ -249,7 +249,7 @@ describe('useTransactionDisplayData', () => {
     expect(result.current).toStrictEqual(expectedResults[0]);
   });
 
-  it('should return "Withdraw" title for a perpsWithdraw transaction', () => {
+  it('should return "Perps withdraw" title for a perpsWithdraw transaction', () => {
     const perpsWithdrawGroup = {
       nonce: '0x1',
       initialTransaction: {
@@ -292,7 +292,7 @@ describe('useTransactionDisplayData', () => {
       getMockState(),
       DEFAULT_ROUTE,
     );
-    expect(result.current.title).toBe('Withdraw');
+    expect(result.current.title).toBe('Perps withdraw');
   });
 
   it('should return "Claim Bonus" title for a contractInteraction sent to the Merkl distributor address', () => {

--- a/ui/hooks/useTransactionDisplayData.test.js
+++ b/ui/hooks/useTransactionDisplayData.test.js
@@ -295,6 +295,136 @@ describe('useTransactionDisplayData', () => {
     expect(result.current.title).toBe('Perps withdraw');
   });
 
+  describe('post-quote pay flows (e.g. Perps Withdraw)', () => {
+    const NATIVE_ADDRESS = '0x0000000000000000000000000000000000000000';
+    const ERC20_ADDRESS = '0xdac17f958d2ee523a2206206994597c13d831ec7';
+
+    function buildPostQuoteGroup({ tokenAddress, targetFiat }) {
+      const tx = {
+        id: 'perps-withdraw-post-quote',
+        time: 1700000000000,
+        status: 'confirmed',
+        chainId: CHAIN_IDS.MAINNET,
+        txParams: {
+          from: '0x9eca64466f257793eaa52fcfff5066894b76a149',
+          to: '0xabca64466f257793eaa52fcfff5066894b76a149',
+          value: '0x0',
+          data: '0xa9059cbb',
+        },
+        type: 'perpsWithdraw',
+        metamaskPay: {
+          isPostQuote: true,
+          chainId: CHAIN_IDS.MAINNET,
+          tokenAddress,
+          targetFiat,
+        },
+      };
+      return {
+        nonce: '0x1',
+        initialTransaction: tx,
+        primaryTransaction: tx,
+        transactions: [],
+        hasRetried: false,
+        hasCancelled: false,
+      };
+    }
+
+    function buildPostQuoteState({ withErc20Token, withMarketData } = {}) {
+      const base = getMockState();
+      return {
+        ...base,
+        metamask: {
+          ...base.metamask,
+          currencyRates: {
+            ETH: { conversionRate: 3000, usdConversionRate: 3000 },
+          },
+          marketData: withMarketData
+            ? {
+                [CHAIN_IDS.MAINNET]: {
+                  // marketData is keyed by checksummed address
+                  '0xdAC17F958D2ee523a2206206994597C13D831ec7': {
+                    price: 0.000333,
+                  },
+                },
+              }
+            : {},
+          tokensChainsCache: withErc20Token
+            ? {
+                ...base.metamask.tokensChainsCache,
+                [CHAIN_IDS.MAINNET]: {
+                  data: {
+                    [ERC20_ADDRESS]: {
+                      address: ERC20_ADDRESS,
+                      symbol: 'USDT',
+                      decimals: 6,
+                    },
+                  },
+                },
+              }
+            : base.metamask.tokensChainsCache,
+        },
+      };
+    }
+
+    it('renders destination native symbol and derived amount when target is native', () => {
+      const { result } = renderHookWithProvider(
+        () =>
+          useTransactionDisplayData(
+            buildPostQuoteGroup({
+              tokenAddress: NATIVE_ADDRESS,
+              targetFiat: '0.27',
+            }),
+          ),
+        buildPostQuoteState(),
+        DEFAULT_ROUTE,
+      );
+
+      // 0.27 / 3000 = 0.00009 -> toPrecision(4) = "0.00009000"
+      expect(result.current.primaryCurrency).toBe('0.00009000 ETH');
+    });
+
+    it('renders destination ERC-20 symbol and derived amount when target is an ERC-20 with market data', () => {
+      const { result } = renderHookWithProvider(
+        () =>
+          useTransactionDisplayData(
+            buildPostQuoteGroup({
+              tokenAddress: ERC20_ADDRESS,
+              targetFiat: '100',
+            }),
+          ),
+        buildPostQuoteState({ withErc20Token: true, withMarketData: true }),
+        DEFAULT_ROUTE,
+      );
+
+      // tokenUsdRate = 0.000333 * 3000 = 0.999
+      // 100 / 0.999 ≈ 100.10 -> toFixed(2) = "100.10"
+      expect(result.current.primaryCurrency).toBe('100.10 USDT');
+    });
+
+    it('renders the USD value (and no destination-token symbol) when the destination token rate is unavailable', () => {
+      const { result } = renderHookWithProvider(
+        () =>
+          useTransactionDisplayData(
+            buildPostQuoteGroup({
+              tokenAddress: ERC20_ADDRESS,
+              targetFiat: '50',
+            }),
+          ),
+        buildPostQuoteState({ withErc20Token: true }),
+        DEFAULT_ROUTE,
+      );
+
+      // No marketData -> tokenUsdRate = 0 -> receivedAmount undefined.
+      // The fallback uses the USD-pinned formatter for both primary and
+      // secondary, bypassing `useCurrencyDisplay`'s default behavior of
+      // appending the chain native ticker (which would misleadingly
+      // render "$50" as "50 ETH" / "50 BNB").
+      expect(result.current.primaryCurrency).toBe('$50.00');
+      expect(result.current.primaryCurrency).not.toContain('USDT');
+      expect(result.current.primaryCurrency).not.toContain('ETH');
+    });
+  });
+
   it('should return "Claim Bonus" title for a contractInteraction sent to the Merkl distributor address', () => {
     const merklClaimGroup = {
       nonce: '0x1',

--- a/ui/pages/confirmations/components/activity/transaction-details-bridge-fee-row/transaction-details-bridge-fee-row.test.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-bridge-fee-row/transaction-details-bridge-fee-row.test.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
-import { TransactionStatus } from '@metamask/transaction-controller';
+import {
+  TransactionStatus,
+  TransactionType,
+} from '@metamask/transaction-controller';
 import { renderWithProvider } from '../../../../../../test/lib/render-helpers-navigate';
 import { TransactionDetailsProvider } from '../transaction-details-context';
 import { TransactionDetailsBridgeFeeRow } from './transaction-details-bridge-fee-row';
@@ -16,12 +19,16 @@ const mockState = {
   },
 };
 
-function createMockTransactionMeta(bridgeFeeFiat?: string) {
+function createMockTransactionMeta(
+  bridgeFeeFiat?: string,
+  type?: TransactionType,
+) {
   return {
     id: 'test-id',
     chainId: '0x1',
     status: TransactionStatus.confirmed,
     time: Date.now(),
+    type,
     txParams: {
       from: '0x123',
       to: '0x456',
@@ -30,10 +37,10 @@ function createMockTransactionMeta(bridgeFeeFiat?: string) {
   };
 }
 
-function render(bridgeFeeFiat?: string) {
+function render(bridgeFeeFiat?: string, type?: TransactionType) {
   return renderWithProvider(
     <TransactionDetailsProvider
-      transactionMeta={createMockTransactionMeta(bridgeFeeFiat) as never}
+      transactionMeta={createMockTransactionMeta(bridgeFeeFiat, type) as never}
     >
       <TransactionDetailsBridgeFeeRow />
     </TransactionDetailsProvider>,
@@ -52,5 +59,23 @@ describe('TransactionDetailsBridgeFeeRow', () => {
     expect(
       getByTestId('transaction-details-bridge-fee-row'),
     ).toBeInTheDocument();
+  });
+
+  it('renders "Bridge fee" label for non-perpsWithdraw transactions', () => {
+    const { getByText, queryByText } = render(
+      '2.50',
+      TransactionType.perpsDeposit,
+    );
+    expect(getByText('Bridge fee')).toBeInTheDocument();
+    expect(queryByText('Provider fee')).not.toBeInTheDocument();
+  });
+
+  it('renders "Provider fee" label for perpsWithdraw transactions', () => {
+    const { getByText, queryByText } = render(
+      '2.50',
+      TransactionType.perpsWithdraw,
+    );
+    expect(getByText('Provider fee')).toBeInTheDocument();
+    expect(queryByText('Bridge fee')).not.toBeInTheDocument();
   });
 });

--- a/ui/pages/confirmations/components/activity/transaction-details-bridge-fee-row/transaction-details-bridge-fee-row.test.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-bridge-fee-row/transaction-details-bridge-fee-row.test.tsx
@@ -4,8 +4,7 @@ import {
   TransactionStatus,
   TransactionType,
 } from '@metamask/transaction-controller';
-// eslint-disable-next-line import-x/no-restricted-paths
-import messages from '../../../../../../app/_locales/en/messages.json';
+import { enLocale as messages } from '../../../../../../test/lib/i18n-helpers';
 import { renderWithProvider } from '../../../../../../test/lib/render-helpers-navigate';
 import { TransactionDetailsProvider } from '../transaction-details-context';
 import { TransactionDetailsBridgeFeeRow } from './transaction-details-bridge-fee-row';

--- a/ui/pages/confirmations/components/activity/transaction-details-bridge-fee-row/transaction-details-bridge-fee-row.test.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-bridge-fee-row/transaction-details-bridge-fee-row.test.tsx
@@ -4,6 +4,8 @@ import {
   TransactionStatus,
   TransactionType,
 } from '@metamask/transaction-controller';
+// eslint-disable-next-line import-x/no-restricted-paths
+import messages from '../../../../../../app/_locales/en/messages.json';
 import { renderWithProvider } from '../../../../../../test/lib/render-helpers-navigate';
 import { TransactionDetailsProvider } from '../transaction-details-context';
 import { TransactionDetailsBridgeFeeRow } from './transaction-details-bridge-fee-row';
@@ -66,8 +68,8 @@ describe('TransactionDetailsBridgeFeeRow', () => {
       '2.50',
       TransactionType.perpsDeposit,
     );
-    expect(getByText('Bridge fee')).toBeInTheDocument();
-    expect(queryByText('Provider fee')).not.toBeInTheDocument();
+    expect(getByText(messages.bridgeFee.message)).toBeInTheDocument();
+    expect(queryByText(messages.providerFee.message)).not.toBeInTheDocument();
   });
 
   it('renders "Provider fee" label for perpsWithdraw transactions', () => {
@@ -75,7 +77,7 @@ describe('TransactionDetailsBridgeFeeRow', () => {
       '2.50',
       TransactionType.perpsWithdraw,
     );
-    expect(getByText('Provider fee')).toBeInTheDocument();
-    expect(queryByText('Bridge fee')).not.toBeInTheDocument();
+    expect(getByText(messages.providerFee.message)).toBeInTheDocument();
+    expect(queryByText(messages.bridgeFee.message)).not.toBeInTheDocument();
   });
 });

--- a/ui/pages/confirmations/components/activity/transaction-details-bridge-fee-row/transaction-details-bridge-fee-row.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-bridge-fee-row/transaction-details-bridge-fee-row.tsx
@@ -1,10 +1,12 @@
 import React, { useMemo } from 'react';
+import { TransactionType } from '@metamask/transaction-controller';
 import { Text } from '../../../../../components/component-library';
 import { TextVariant } from '../../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { useFiatFormatter } from '../../../../../hooks/useFiatFormatter';
 import { TransactionDetailsRow } from '../transaction-details-row';
 import { useTransactionDetails } from '../transaction-details-context';
+import { hasTransactionType } from '../../../../../../shared/lib/transactions.utils';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export function TransactionDetailsBridgeFeeRow() {
@@ -26,9 +28,14 @@ export function TransactionDetailsBridgeFeeRow() {
     return null;
   }
 
+  const isWithdraw = hasTransactionType(transactionMeta, [
+    TransactionType.perpsWithdraw,
+  ]);
+  const label = isWithdraw ? t('providerFee') : t('bridgeFee');
+
   return (
     <TransactionDetailsRow
-      label={t('bridgeFee')}
+      label={label}
       data-testid="transaction-details-bridge-fee-row"
     >
       <Text variant={TextVariant.bodyMd}>{bridgeFeeFormatted}</Text>

--- a/ui/pages/confirmations/components/activity/transaction-details-paid-with-row/transaction-details-paid-with-row.test.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-paid-with-row/transaction-details-paid-with-row.test.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
-import { TransactionStatus } from '@metamask/transaction-controller';
+import {
+  TransactionStatus,
+  TransactionType,
+} from '@metamask/transaction-controller';
 import { renderWithProvider } from '../../../../../../test/lib/render-helpers-navigate';
 import { useTokenWithBalance } from '../../../hooks/tokens/useTokenWithBalance';
 import { TransactionDetailsProvider } from '../transaction-details-context';
@@ -34,12 +37,17 @@ const mockState = {
   },
 };
 
-function createMockTransactionMeta(chainId?: string, tokenAddress?: string) {
+function createMockTransactionMeta(
+  chainId?: string,
+  tokenAddress?: string,
+  type?: TransactionType,
+) {
   return {
     id: 'test-id',
     chainId: CHAIN_ID,
     status: TransactionStatus.confirmed,
     time: Date.now(),
+    type,
     txParams: {
       from: '0x123',
       to: '0x456',
@@ -49,11 +57,15 @@ function createMockTransactionMeta(chainId?: string, tokenAddress?: string) {
   };
 }
 
-function render(chainId?: string, tokenAddress?: string) {
+function render(
+  chainId?: string,
+  tokenAddress?: string,
+  type?: TransactionType,
+) {
   return renderWithProvider(
     <TransactionDetailsProvider
       transactionMeta={
-        createMockTransactionMeta(chainId, tokenAddress) as never
+        createMockTransactionMeta(chainId, tokenAddress, type) as never
       }
     >
       <TransactionDetailsPaidWithRow />
@@ -111,5 +123,45 @@ describe('TransactionDetailsPaidWithRow', () => {
     });
     const { getByText } = render(CHAIN_ID, TOKEN_ADDRESS);
     expect(getByText(TOKEN_SYMBOL)).toBeInTheDocument();
+  });
+
+  it('renders "Paid with" label for non-perpsWithdraw transactions', () => {
+    useTokenWithBalanceMock.mockReturnValue({
+      address: TOKEN_ADDRESS,
+      symbol: TOKEN_SYMBOL,
+      decimals: 6,
+      chainId: CHAIN_ID,
+      balance: '0',
+      balanceFiat: '$0.00',
+      balanceRaw: '0',
+      tokenFiatAmount: 0,
+    });
+    const { getByText, queryByText } = render(
+      CHAIN_ID,
+      TOKEN_ADDRESS,
+      TransactionType.perpsDeposit,
+    );
+    expect(getByText('Paid with')).toBeInTheDocument();
+    expect(queryByText('Receive token')).not.toBeInTheDocument();
+  });
+
+  it('renders "Receive token" label for perpsWithdraw transactions', () => {
+    useTokenWithBalanceMock.mockReturnValue({
+      address: TOKEN_ADDRESS,
+      symbol: TOKEN_SYMBOL,
+      decimals: 6,
+      chainId: CHAIN_ID,
+      balance: '0',
+      balanceFiat: '$0.00',
+      balanceRaw: '0',
+      tokenFiatAmount: 0,
+    });
+    const { getByText, queryByText } = render(
+      CHAIN_ID,
+      TOKEN_ADDRESS,
+      TransactionType.perpsWithdraw,
+    );
+    expect(getByText('Receive token')).toBeInTheDocument();
+    expect(queryByText('Paid with')).not.toBeInTheDocument();
   });
 });

--- a/ui/pages/confirmations/components/activity/transaction-details-paid-with-row/transaction-details-paid-with-row.test.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-paid-with-row/transaction-details-paid-with-row.test.tsx
@@ -4,6 +4,8 @@ import {
   TransactionStatus,
   TransactionType,
 } from '@metamask/transaction-controller';
+// eslint-disable-next-line import-x/no-restricted-paths
+import messages from '../../../../../../app/_locales/en/messages.json';
 import { renderWithProvider } from '../../../../../../test/lib/render-helpers-navigate';
 import { useTokenWithBalance } from '../../../hooks/tokens/useTokenWithBalance';
 import { TransactionDetailsProvider } from '../transaction-details-context';
@@ -141,8 +143,8 @@ describe('TransactionDetailsPaidWithRow', () => {
       TOKEN_ADDRESS,
       TransactionType.perpsDeposit,
     );
-    expect(getByText('Paid with')).toBeInTheDocument();
-    expect(queryByText('Receive token')).not.toBeInTheDocument();
+    expect(getByText(messages.paidWith.message)).toBeInTheDocument();
+    expect(queryByText(messages.receiveToken.message)).not.toBeInTheDocument();
   });
 
   it('renders "Receive token" label for perpsWithdraw transactions', () => {
@@ -161,7 +163,7 @@ describe('TransactionDetailsPaidWithRow', () => {
       TOKEN_ADDRESS,
       TransactionType.perpsWithdraw,
     );
-    expect(getByText('Receive token')).toBeInTheDocument();
-    expect(queryByText('Paid with')).not.toBeInTheDocument();
+    expect(getByText(messages.receiveToken.message)).toBeInTheDocument();
+    expect(queryByText(messages.paidWith.message)).not.toBeInTheDocument();
   });
 });

--- a/ui/pages/confirmations/components/activity/transaction-details-paid-with-row/transaction-details-paid-with-row.test.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-paid-with-row/transaction-details-paid-with-row.test.tsx
@@ -4,8 +4,7 @@ import {
   TransactionStatus,
   TransactionType,
 } from '@metamask/transaction-controller';
-// eslint-disable-next-line import-x/no-restricted-paths
-import messages from '../../../../../../app/_locales/en/messages.json';
+import { enLocale as messages } from '../../../../../../test/lib/i18n-helpers';
 import { renderWithProvider } from '../../../../../../test/lib/render-helpers-navigate';
 import { useTokenWithBalance } from '../../../hooks/tokens/useTokenWithBalance';
 import { TransactionDetailsProvider } from '../transaction-details-context';

--- a/ui/pages/confirmations/components/activity/transaction-details-paid-with-row/transaction-details-paid-with-row.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-paid-with-row/transaction-details-paid-with-row.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Hex } from '@metamask/utils';
+import { TransactionType } from '@metamask/transaction-controller';
 import { Text, Box } from '../../../../../components/component-library';
 import {
   Display,
@@ -12,6 +13,7 @@ import { TransactionDetailsRow } from '../transaction-details-row';
 import { useTransactionDetails } from '../transaction-details-context';
 import { useTokenWithBalance } from '../../../hooks/tokens/useTokenWithBalance';
 import { TokenIcon } from '../../token-icon';
+import { hasTransactionType } from '../../../../../../shared/lib/transactions.utils';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export function TransactionDetailsPaidWithRow() {
@@ -30,9 +32,14 @@ export function TransactionDetailsPaidWithRow() {
     return null;
   }
 
+  const isWithdraw = hasTransactionType(transactionMeta, [
+    TransactionType.perpsWithdraw,
+  ]);
+  const label = isWithdraw ? t('receiveToken') : t('paidWith');
+
   return (
     <TransactionDetailsRow
-      label={t('paidWith')}
+      label={label}
       data-testid="transaction-details-paid-with-row"
     >
       <Box

--- a/ui/pages/confirmations/components/activity/transaction-details-total-row/transaction-details-total-row.test.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-total-row/transaction-details-total-row.test.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
-import { TransactionStatus } from '@metamask/transaction-controller';
+import {
+  TransactionStatus,
+  TransactionType,
+} from '@metamask/transaction-controller';
 import { renderWithProvider } from '../../../../../../test/lib/render-helpers-navigate';
 import { TransactionDetailsProvider } from '../transaction-details-context';
 import { TransactionDetailsTotalRow } from './transaction-details-total-row';
@@ -16,24 +19,38 @@ const mockState = {
   },
 };
 
-function createMockTransactionMeta(totalFiat?: string) {
+function createMockTransactionMeta({
+  totalFiat,
+  targetFiat,
+  type,
+}: {
+  totalFiat?: string;
+  targetFiat?: string;
+  type?: TransactionType;
+} = {}) {
   return {
     id: 'test-id',
     chainId: '0x1',
     status: TransactionStatus.confirmed,
     time: Date.now(),
+    type,
     txParams: {
       from: '0x123',
       to: '0x456',
     },
-    metamaskPay: totalFiat ? { totalFiat } : undefined,
+    metamaskPay:
+      totalFiat || targetFiat ? { totalFiat, targetFiat } : undefined,
   };
 }
 
-function render(totalFiat?: string) {
+function render(args: {
+  totalFiat?: string;
+  targetFiat?: string;
+  type?: TransactionType;
+} = {}) {
   return renderWithProvider(
     <TransactionDetailsProvider
-      transactionMeta={createMockTransactionMeta(totalFiat) as never}
+      transactionMeta={createMockTransactionMeta(args) as never}
     >
       <TransactionDetailsTotalRow />
     </TransactionDetailsProvider>,
@@ -53,7 +70,30 @@ describe('TransactionDetailsTotalRow', () => {
   });
 
   it('renders formatted total when totalFiat is provided', () => {
-    const { queryByText } = render('150.75');
+    const { queryByText } = render({ totalFiat: '150.75' });
     expect(queryByText('-')).not.toBeInTheDocument();
+  });
+
+  it('renders "Total" label and uses totalFiat for non-perpsWithdraw transactions', () => {
+    const { getByText, queryByText } = render({
+      totalFiat: '150.75',
+      targetFiat: '100',
+      type: TransactionType.perpsDeposit,
+    });
+    expect(getByText('Total')).toBeInTheDocument();
+    expect(queryByText('Received total')).not.toBeInTheDocument();
+    expect(getByText('$150.75')).toBeInTheDocument();
+  });
+
+  it('renders "Received total" label and uses targetFiat for perpsWithdraw transactions', () => {
+    const { getByText, queryByText } = render({
+      totalFiat: '150.75',
+      targetFiat: '100',
+      type: TransactionType.perpsWithdraw,
+    });
+    expect(getByText('Received total')).toBeInTheDocument();
+    expect(queryByText('Total')).not.toBeInTheDocument();
+    expect(getByText('$100.00')).toBeInTheDocument();
+    expect(queryByText('$150.75')).not.toBeInTheDocument();
   });
 });

--- a/ui/pages/confirmations/components/activity/transaction-details-total-row/transaction-details-total-row.test.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-total-row/transaction-details-total-row.test.tsx
@@ -4,8 +4,7 @@ import {
   TransactionStatus,
   TransactionType,
 } from '@metamask/transaction-controller';
-// eslint-disable-next-line import-x/no-restricted-paths
-import messages from '../../../../../../app/_locales/en/messages.json';
+import { enLocale as messages } from '../../../../../../test/lib/i18n-helpers';
 import { renderWithProvider } from '../../../../../../test/lib/render-helpers-navigate';
 import { TransactionDetailsProvider } from '../transaction-details-context';
 import { TransactionDetailsTotalRow } from './transaction-details-total-row';

--- a/ui/pages/confirmations/components/activity/transaction-details-total-row/transaction-details-total-row.test.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-total-row/transaction-details-total-row.test.tsx
@@ -4,6 +4,8 @@ import {
   TransactionStatus,
   TransactionType,
 } from '@metamask/transaction-controller';
+// eslint-disable-next-line import-x/no-restricted-paths
+import messages from '../../../../../../app/_locales/en/messages.json';
 import { renderWithProvider } from '../../../../../../test/lib/render-helpers-navigate';
 import { TransactionDetailsProvider } from '../transaction-details-context';
 import { TransactionDetailsTotalRow } from './transaction-details-total-row';
@@ -43,11 +45,13 @@ function createMockTransactionMeta({
   };
 }
 
-function render(args: {
-  totalFiat?: string;
-  targetFiat?: string;
-  type?: TransactionType;
-} = {}) {
+function render(
+  args: {
+    totalFiat?: string;
+    targetFiat?: string;
+    type?: TransactionType;
+  } = {},
+) {
   return renderWithProvider(
     <TransactionDetailsProvider
       transactionMeta={createMockTransactionMeta(args) as never}
@@ -80,8 +84,8 @@ describe('TransactionDetailsTotalRow', () => {
       targetFiat: '100',
       type: TransactionType.perpsDeposit,
     });
-    expect(getByText('Total')).toBeInTheDocument();
-    expect(queryByText('Received total')).not.toBeInTheDocument();
+    expect(getByText(messages.total.message)).toBeInTheDocument();
+    expect(queryByText(messages.receivedTotal.message)).not.toBeInTheDocument();
     expect(getByText('$150.75')).toBeInTheDocument();
   });
 
@@ -91,8 +95,8 @@ describe('TransactionDetailsTotalRow', () => {
       targetFiat: '100',
       type: TransactionType.perpsWithdraw,
     });
-    expect(getByText('Received total')).toBeInTheDocument();
-    expect(queryByText('Total')).not.toBeInTheDocument();
+    expect(getByText(messages.receivedTotal.message)).toBeInTheDocument();
+    expect(queryByText(messages.total.message)).not.toBeInTheDocument();
     expect(getByText('$100.00')).toBeInTheDocument();
     expect(queryByText('$150.75')).not.toBeInTheDocument();
   });

--- a/ui/pages/confirmations/components/activity/transaction-details-total-row/transaction-details-total-row.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-total-row/transaction-details-total-row.tsx
@@ -1,10 +1,12 @@
 import React, { useMemo } from 'react';
+import { TransactionType } from '@metamask/transaction-controller';
 import { Text } from '../../../../../components/component-library';
 import { TextVariant } from '../../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { useFiatFormatter } from '../../../../../hooks/useFiatFormatter';
 import { TransactionDetailsRow } from '../transaction-details-row';
 import { useTransactionDetails } from '../transaction-details-context';
+import { hasTransactionType } from '../../../../../../shared/lib/transactions.utils';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export function TransactionDetailsTotalRow() {
@@ -13,18 +15,29 @@ export function TransactionDetailsTotalRow() {
   const fiatFormatter = useFiatFormatter();
 
   const { metamaskPay } = transactionMeta;
-  const { totalFiat: payTotal } = metamaskPay || {};
+  const { totalFiat: payTotal, targetFiat } = metamaskPay || {};
+
+  const isWithdraw = hasTransactionType(transactionMeta, [
+    TransactionType.perpsWithdraw,
+  ]);
+
+  // For withdrawal flows (e.g. Perps Withdraw), surface the amount the user
+  // actually received (targetFiat) rather than the "pay total" (input + fees).
+  // Mirrors the mobile "Received total" row.
+  const amountSource = isWithdraw ? targetFiat : payTotal;
 
   const totalFormatted = useMemo(() => {
-    if (!payTotal) {
+    if (!amountSource) {
       return null;
     }
-    return fiatFormatter(Number(payTotal));
-  }, [fiatFormatter, payTotal]);
+    return fiatFormatter(Number(amountSource));
+  }, [fiatFormatter, amountSource]);
+
+  const label = isWithdraw ? t('receivedTotal') : t('total');
 
   return (
     <TransactionDetailsRow
-      label={t('total')}
+      label={label}
       data-testid="transaction-details-total-row"
     >
       <Text variant={TextVariant.bodyMd}>{totalFormatted ?? '-'}</Text>

--- a/ui/pages/confirmations/components/activity/transaction-details/transaction-details.test.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details/transaction-details.test.tsx
@@ -210,4 +210,18 @@ describe('TransactionDetails', () => {
       ).toBeInTheDocument();
     });
   });
+
+  describe('summary section visibility', () => {
+    it('renders summary section for perpsDeposit transactions', () => {
+      const { getByTestId } = render(TransactionType.perpsDeposit, true);
+      expect(getByTestId('transaction-details-summary')).toBeInTheDocument();
+    });
+
+    it('hides summary section for perpsWithdraw transactions', () => {
+      const { queryByTestId } = render(TransactionType.perpsWithdraw, true);
+      expect(
+        queryByTestId('transaction-details-summary'),
+      ).not.toBeInTheDocument();
+    });
+  });
 });

--- a/ui/pages/confirmations/components/activity/transaction-details/transaction-details.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details/transaction-details.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { TransactionType } from '@metamask/transaction-controller';
 import { Box } from '../../../../../components/component-library';
 import {
   Display,
@@ -15,11 +16,17 @@ import { TransactionDetailsBridgeFeeRow } from '../transaction-details-bridge-fe
 import { TransactionDetailsTotalRow } from '../transaction-details-total-row';
 import { TransactionDetailsSummary } from '../transaction-details-summary';
 import { useTransactionDetails } from '../transaction-details-context';
+import { hasTransactionType } from '../../../../../../shared/lib/transactions.utils';
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export function TransactionDetails() {
   const { transactionMeta } = useTransactionDetails();
   const hasPaymentDetails = Boolean(transactionMeta.metamaskPay);
+  // Summary is hidden for Perps Withdraw post-MVP; a tailored summary can
+  // replace the generic one later.
+  const hideSummary = hasTransactionType(transactionMeta, [
+    TransactionType.perpsWithdraw,
+  ]);
 
   return (
     <Box
@@ -62,17 +69,21 @@ export function TransactionDetails() {
         </>
       )}
 
-      <ConfirmInfoRowDivider />
+      {!hideSummary && (
+        <>
+          <ConfirmInfoRowDivider />
 
-      <Box
-        display={Display.Flex}
-        flexDirection={FlexDirection.Column}
-        gap={3}
-        paddingTop={2}
-        paddingBottom={2}
-      >
-        <TransactionDetailsSummary />
-      </Box>
+          <Box
+            display={Display.Flex}
+            flexDirection={FlexDirection.Column}
+            gap={3}
+            paddingTop={2}
+            paddingBottom={2}
+          >
+            <TransactionDetailsSummary />
+          </Box>
+        </>
+      )}
     </Box>
   );
 }


### PR DESCRIPTION
## **Description**

Mirrors mobile PR. Tailors the Activity row and Transaction Details modal so a Perps Withdraw renders as a withdrawal instead of a USDC payment.

Non-withdraw flows (`perpsDeposit`, mUSD conversion, etc.) are unchanged.

## **Changelog**

CHANGELOG entry: Updated Perps Withdraw activity rows to show the destination token and amount, and tailored the Transaction Details modal as well

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1315

## **Manual testing steps**

1. Build and load this branch (with CONF-1215 also merged or rebased in).
2. Trigger a Perps Withdraw confirmation (developer menu → "Perps Withdraw" until CONF-1216 wires the production button).
3. Pick a non-USDC destination token (e.g. **BNB on BSC**) and confirm at e.g. `$0.50`.
4. Wait for the tx to confirm.
5. Open the **Activity** tab. Verify the row shows:
   - Title: `Perps withdraw`
   - Primary: `<amount> BNB` (e.g. `0.0005805 BNB`)
   - Secondary: `$0.50`
6. Tap the activity row to open the **Transaction Details** modal. Verify:
   - No "Summary" section at the bottom.
   - Row label `Receive token` (with BNB icon + "BNB" symbol).
   - Row label `Provider fee` (instead of `Bridge fee`).
   - Row label `Received total` showing the net USD received (matching the Activity row's secondary value).
7. Trigger a `perpsDeposit` (or any non-withdraw pay flow) and verify the Activity row + Transaction Details copy is unchanged (`Paid with` / `Bridge fee` / `Total`, Summary visible).

<!--
## **Screenshots/Recordings**

### **Before**

### **After**

-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes transaction display/labeling logic and introduces rate-based derived amounts for post-quote withdraws; incorrect/missing market/rate data could lead to misleading Activity values, though fallback formatting is explicitly handled.
> 
> **Overview**
> Perps Withdraw transactions are now rendered as *withdrawals* rather than generic pay transactions in both the Activity list and the Transaction Details modal.
> 
> In `useTransactionDisplayData`, post-quote `metamaskPay` flows (notably `perpsWithdraw`) now resolve the **destination token** from `metamaskPay.chainId/tokenAddress`, derive the received token amount from `targetFiat` + USD rates (with a USD-only fallback when rates are missing), and change the Activity title to the new `perpsWithdrawActivityTitle`.
> 
> Transaction Details copy is tailored for `perpsWithdraw`: labels switch to `Receive token`, `Provider fee`, and `Received total` (using `targetFiat` instead of `totalFiat`), and the generic Summary section is hidden. New i18n strings were added and tests updated/added to cover the new withdraw-specific behavior and rate fallback paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c84348533b007c9793d6d0d3754663468ad55e84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->