### PR TITLE
ci: fix lint

### DIFF
--- a/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.tsx
+++ b/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.tsx
@@ -374,10 +374,10 @@ export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
     () =>
       Boolean(
         stopLossPrice.trim() &&
-          !isStopLossSafeFromLiquidation(stopLossPrice, {
-            liquidationPrice,
-            direction,
-          }),
+        !isStopLossSafeFromLiquidation(stopLossPrice, {
+          liquidationPrice,
+          direction,
+        }),
       ),
     [stopLossPrice, liquidationPrice, direction],
   );

--- a/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.tsx
+++ b/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.tsx
@@ -299,10 +299,10 @@ export const UpdateTPSLModalContent: React.FC<UpdateTPSLModalContentProps> = ({
     () =>
       Boolean(
         editingSlPrice.trim() &&
-          !isStopLossSafeFromLiquidation(editingSlPrice, {
-            liquidationPrice,
-            direction: positionDirection,
-          }),
+        !isStopLossSafeFromLiquidation(editingSlPrice, {
+          liquidationPrice,
+          direction: positionDirection,
+        }),
       ),
     [editingSlPrice, liquidationPrice, positionDirection],
   );

--- a/ui/pages/perps/perps-order-entry-page.tsx
+++ b/ui/pages/perps/perps-order-entry-page.tsx
@@ -543,10 +543,10 @@ const PerpsOrderEntryPage: React.FC = () => {
     );
     const slLiquidationInvalid = Boolean(
       sl?.trim() &&
-        !isStopLossSafeFromLiquidation(sl, {
-          liquidationPrice,
-          direction: dir,
-        }),
+      !isStopLossSafeFromLiquidation(sl, {
+        liquidationPrice,
+        direction: dir,
+      }),
     );
 
     return tpInvalid || slInvalid || slLiquidationInvalid;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fix unlinted files

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formatting-only changes in UI validation code; no logic or data flow is altered.
> 
> **Overview**
> Cleans up lint/formatting in perps TP/SL validation by reformatting the `isStopLossSafeFromLiquidation` checks in order entry auto-close, the update TP/SL modal, and the perps order entry page.
> 
> No functional behavior is intended to change; this is a whitespace/indentation-only adjustment to satisfy linting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93123426be069be4a28355b4318683fc240bb604. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->