### PR TITLE
test: refactor withSrp to use flow and remove extra logic

### DIFF
--- a/test/e2e/flask/multi-srp/add-accounts.spec.ts
+++ b/test/e2e/flask/multi-srp/add-accounts.spec.ts
@@ -1,8 +1,12 @@
 import { Suite } from 'mocha';
 import { Driver } from '../../webdriver/driver';
+import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
+import { withFixtures } from '../../helpers';
+import { login } from '../../page-objects/flows/login.flow';
+import { importAdditionalSecretRecoveryPhrase } from '../../page-objects/flows/multi-srp.flow';
 import HeaderNavbar from '../../page-objects/pages/header-navbar';
 import AccountListPage from '../../page-objects/pages/account-list-page';
-import { mockActiveNetworks, withMultiSrp } from './common-multi-srp';
+import { mockActiveNetworks } from './common-multi-srp';
 
 const addAccountToSrp = async (driver: Driver, srpIndex: number) => {
   const headerNavbar = new HeaderNavbar(driver);
@@ -22,24 +26,30 @@ const addAccountToSrp = async (driver: Driver, srpIndex: number) => {
 
 describe('Multi SRP - Add accounts', function (this: Suite) {
   it('adds a new account for the default srp', async function () {
-    await withMultiSrp(
+    await withFixtures(
       {
+        fixtures: new FixtureBuilderV2().build(),
         title: this.test?.fullTitle(),
         testSpecificMock: mockActiveNetworks,
       },
-      async (driver: Driver) => {
+      async ({ driver }) => {
+        await login(driver);
+        await importAdditionalSecretRecoveryPhrase(driver);
         await addAccountToSrp(driver, 0);
       },
     );
   });
 
   it('adds a new account for the new srp', async function () {
-    await withMultiSrp(
+    await withFixtures(
       {
+        fixtures: new FixtureBuilderV2().build(),
         title: this.test?.fullTitle(),
         testSpecificMock: mockActiveNetworks,
       },
-      async (driver: Driver) => {
+      async ({ driver }) => {
+        await login(driver);
+        await importAdditionalSecretRecoveryPhrase(driver);
         await addAccountToSrp(driver, 1);
       },
     );

--- a/test/e2e/flask/multi-srp/common-multi-srp.ts
+++ b/test/e2e/flask/multi-srp/common-multi-srp.ts
@@ -1,76 +1,9 @@
 import { Mockttp } from 'mockttp';
-import { Driver } from '../../webdriver/driver';
-import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
-import { WALLET_PASSWORD } from '../../constants';
-import { withFixtures } from '../../helpers';
-import AccountListPage from '../../page-objects/pages/account-list-page';
-import HeaderNavbar from '../../page-objects/pages/header-navbar';
-import PrivacySettings from '../../page-objects/pages/settings/privacy-settings';
-import SettingsPage from '../../page-objects/pages/settings/settings-page';
-import HomePage from '../../page-objects/pages/home/homepage';
-import { login } from '../../page-objects/flows/login.flow';
 import { MockedEndpoint } from '../../mock-e2e';
 
-export const SECOND_TEST_E2E_SRP =
-  'bench top weekend buyer spoon side resist become detect gauge eye feed';
-
-export async function withMultiSrp(
-  {
-    title,
-    testSpecificMock,
-  }: {
-    title?: string;
-    testSpecificMock: (mockServer: Mockttp) => Promise<MockedEndpoint>;
-  },
-  test: (driver: Driver) => Promise<void>,
-  srpToUse: string = SECOND_TEST_E2E_SRP,
-) {
-  await withFixtures(
-    {
-      dappOptions: { numberOfTestDapps: 1 },
-      fixtures: new FixtureBuilderV2().build(),
-      title,
-      testSpecificMock: async (mockServer: Mockttp) => [
-        await mockActiveNetworks(mockServer),
-        await testSpecificMock(mockServer),
-      ],
-    },
-    async ({ driver }) => {
-      await login(driver);
-      const homePage = new HomePage(driver);
-      await homePage.checkPageIsLoaded();
-      const headerNavbar = new HeaderNavbar(driver);
-      await headerNavbar.openAccountMenu();
-      const accountListPage = new AccountListPage(driver);
-      await accountListPage.checkPageIsLoaded();
-      await accountListPage.startImportSecretPhrase(srpToUse);
-      await homePage.checkNewSrpAddedToastIsDisplayed();
-      await homePage.dismissSrpAddedToast();
-      await homePage.checkPageIsLoaded();
-      await test(driver);
-    },
-  );
-}
-
-export const verifySrp = async (
-  driver: Driver,
-  srp: string,
-  srpIndex: number,
-) => {
-  await new HeaderNavbar(driver).openSettingsPage();
-  const settingsPage = new SettingsPage(driver);
-  await settingsPage.checkPageIsLoaded();
-  await settingsPage.goToSecurityAndPasswordSettings();
-
-  const privacySettings = new PrivacySettings(driver);
-  await privacySettings.checkSecurityAndPasswordPageIsLoaded();
-  await privacySettings.openRevealSrpQuiz(srpIndex);
-  await privacySettings.completeRevealSrpQuiz();
-  await privacySettings.fillPasswordToRevealSrp(WALLET_PASSWORD);
-  await privacySettings.checkSrpTextIsDisplayed(srp);
-};
-
-export async function mockActiveNetworks(mockServer: Mockttp) {
+export async function mockActiveNetworks(
+  mockServer: Mockttp,
+): Promise<MockedEndpoint> {
   return await mockServer
     .forGet('https://accounts.api.cx.metamask.io/v2/activeNetworks')
     .thenCallback(() => {

--- a/test/e2e/flask/multi-srp/import-srp.spec.ts
+++ b/test/e2e/flask/multi-srp/import-srp.spec.ts
@@ -6,16 +6,16 @@ import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { WALLET_PASSWORD as testPassword } from '../../constants';
 import { withFixtures } from '../../helpers';
 import { login } from '../../page-objects/flows/login.flow';
+import {
+  importAdditionalSecretRecoveryPhrase,
+  SECOND_TEST_E2E_SRP,
+} from '../../page-objects/flows/multi-srp.flow';
 import HeaderNavbar from '../../page-objects/pages/header-navbar';
 import AccountListPage from '../../page-objects/pages/account-list-page';
 import HomePage from '../../page-objects/pages/home/homepage';
 import MultichainAccountDetailsPage from '../../page-objects/pages/multichain/multichain-account-details-page';
 import PrivacySettings from '../../page-objects/pages/settings/privacy-settings';
-import {
-  SECOND_TEST_E2E_SRP,
-  mockActiveNetworks,
-  withMultiSrp,
-} from './common-multi-srp';
+import { mockActiveNetworks } from './common-multi-srp';
 
 const TEST_SRP_WORDS_FOR_UI_TEST = [
   'ghost',
@@ -34,12 +34,15 @@ const TEST_SRP_WORDS_FOR_UI_TEST = [
 
 describe('Multi SRP - Import SRP', function (this: Suite) {
   it('successfully imports a new srp', async function () {
-    await withMultiSrp(
+    await withFixtures(
       {
+        fixtures: new FixtureBuilderV2().build(),
         title: this.test?.fullTitle(),
         testSpecificMock: mockActiveNetworks,
       },
-      async (driver: Driver) => {
+      async ({ driver }) => {
+        await login(driver);
+        await importAdditionalSecretRecoveryPhrase(driver);
         const accountListPage = new AccountListPage(driver);
         await accountListPage.checkAccountBelongsToSrp('Account 1', 2);
       },
@@ -47,12 +50,15 @@ describe('Multi SRP - Import SRP', function (this: Suite) {
   });
 
   it('successfully imports a new srp and it matches the srp imported', async function () {
-    await withMultiSrp(
+    await withFixtures(
       {
+        fixtures: new FixtureBuilderV2().build(),
         title: this.test?.fullTitle(),
         testSpecificMock: mockActiveNetworks,
       },
-      async (driver: Driver) => {
+      async ({ driver }) => {
+        await login(driver);
+        await importAdditionalSecretRecoveryPhrase(driver);
         const headerNavbar = new HeaderNavbar(driver);
         await headerNavbar.openAccountMenu();
         const accountListPage = new AccountListPage(driver);

--- a/test/e2e/flask/multi-srp/settings-reveal-srp.spec.ts
+++ b/test/e2e/flask/multi-srp/settings-reveal-srp.spec.ts
@@ -1,36 +1,44 @@
 import { Suite } from 'mocha';
-import { Driver } from '../../webdriver/driver';
+import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { E2E_SRP as FIRST_TEST_E2E_SRP } from '../../constants';
+import { withFixtures } from '../../helpers';
+import { login } from '../../page-objects/flows/login.flow';
 import {
-  mockActiveNetworks,
+  importAdditionalSecretRecoveryPhrase,
   SECOND_TEST_E2E_SRP,
-  withMultiSrp,
   verifySrp,
-} from './common-multi-srp';
+} from '../../page-objects/flows/multi-srp.flow';
+import { mockActiveNetworks } from './common-multi-srp';
 
 describe('Multi SRP - Reveal Imported SRP', function (this: Suite) {
   const firstSrpIndex = 1;
   const secondSrpIndex = 2;
 
   it('successfully exports the default SRP', async function () {
-    await withMultiSrp(
+    await withFixtures(
       {
+        fixtures: new FixtureBuilderV2().build(),
         title: this.test?.fullTitle(),
         testSpecificMock: mockActiveNetworks,
       },
-      async (driver: Driver) => {
+      async ({ driver }) => {
+        await login(driver);
+        await importAdditionalSecretRecoveryPhrase(driver);
         await verifySrp(driver, FIRST_TEST_E2E_SRP, firstSrpIndex);
       },
     );
   });
 
   it('successfully exports the imported SRP', async function () {
-    await withMultiSrp(
+    await withFixtures(
       {
+        fixtures: new FixtureBuilderV2().build(),
         title: this.test?.fullTitle(),
         testSpecificMock: mockActiveNetworks,
       },
-      async (driver: Driver) => {
+      async ({ driver }) => {
+        await login(driver);
+        await importAdditionalSecretRecoveryPhrase(driver);
         await verifySrp(driver, SECOND_TEST_E2E_SRP, secondSrpIndex);
       },
     );

--- a/test/e2e/page-objects/flows/multi-srp.flow.ts
+++ b/test/e2e/page-objects/flows/multi-srp.flow.ts
@@ -1,0 +1,50 @@
+import { Driver } from '../../webdriver/driver';
+import { WALLET_PASSWORD } from '../../constants';
+import AccountListPage from '../pages/account-list-page';
+import HeaderNavbar from '../pages/header-navbar';
+import HomePage from '../pages/home/homepage';
+import PrivacySettings from '../pages/settings/privacy-settings';
+import SettingsPage from '../pages/settings/settings-page';
+
+export const SECOND_TEST_E2E_SRP =
+  'bench top weekend buyer spoon side resist become detect gauge eye feed';
+
+/**
+ * Imports an additional secret recovery phrase from the account list after unlock.
+ *
+ * @param driver - The webdriver instance.
+ * @param srpWords - Space-separated recovery phrase words. Defaults to {@link SECOND_TEST_E2E_SRP}.
+ */
+export async function importAdditionalSecretRecoveryPhrase(
+  driver: Driver,
+  srpWords: string = SECOND_TEST_E2E_SRP,
+): Promise<void> {
+  const homePage = new HomePage(driver);
+  await homePage.checkPageIsLoaded();
+  const headerNavbar = new HeaderNavbar(driver);
+  await headerNavbar.openAccountMenu();
+  const accountListPage = new AccountListPage(driver);
+  await accountListPage.checkPageIsLoaded();
+  await accountListPage.startImportSecretPhrase(srpWords);
+  await homePage.checkNewSrpAddedToastIsDisplayed();
+  await homePage.dismissSrpAddedToast();
+  await homePage.checkPageIsLoaded();
+}
+
+export async function verifySrp(
+  driver: Driver,
+  srp: string,
+  srpIndex: number,
+): Promise<void> {
+  await new HeaderNavbar(driver).openSettingsPage();
+  const settingsPage = new SettingsPage(driver);
+  await settingsPage.checkPageIsLoaded();
+  await settingsPage.goToSecurityAndPasswordSettings();
+
+  const privacySettings = new PrivacySettings(driver);
+  await privacySettings.checkSecurityAndPasswordPageIsLoaded();
+  await privacySettings.openRevealSrpQuiz(srpIndex);
+  await privacySettings.completeRevealSrpQuiz();
+  await privacySettings.fillPasswordToRevealSrp(WALLET_PASSWORD);
+  await privacySettings.checkSrpTextIsDisplayed(srp);
+}

--- a/test/e2e/page-objects/pages/phishing-warning-page.ts
+++ b/test/e2e/page-objects/pages/phishing-warning-page.ts
@@ -28,7 +28,10 @@ class PhishingWarningPage {
     this.driver = driver;
   }
 
-  async checkPageIsLoaded(timeout: number = 10000): Promise<void> {
+  async checkPageIsLoaded(
+    options: { timeout?: number } = { timeout: 10000 },
+  ): Promise<void> {
+    const { timeout } = options;
     try {
       await this.driver.waitForSelector(this.phishingWarningPageTitle, {
         timeout,
@@ -62,7 +65,7 @@ class PhishingWarningPage {
           )) as WebElement;
           await this.driver.switchToFrame(iframe as unknown as string);
           // We set a smaller custom timeout so we can retry more times the whole flow if needed
-          await this.checkPageIsLoaded(2000);
+          await this.checkPageIsLoaded({ timeout: 2000 });
           await this.driver.clickElement(this.openWarningInNewTabLink);
           return true;
         } catch {

--- a/test/e2e/page-objects/pages/phishing-warning-page.ts
+++ b/test/e2e/page-objects/pages/phishing-warning-page.ts
@@ -28,9 +28,11 @@ class PhishingWarningPage {
     this.driver = driver;
   }
 
-  async checkPageIsLoaded(): Promise<void> {
+  async checkPageIsLoaded(timeout: number = 10000): Promise<void> {
     try {
-      await this.driver.waitForSelector(this.phishingWarningPageTitle);
+      await this.driver.waitForSelector(this.phishingWarningPageTitle, {
+        timeout,
+      });
     } catch (e) {
       console.log(
         'Timeout while waiting for Phishing Warning page to be loaded',
@@ -59,7 +61,8 @@ class PhishingWarningPage {
             this.iframeSelector,
           )) as WebElement;
           await this.driver.switchToFrame(iframe as unknown as string);
-          await this.checkPageIsLoaded();
+          // We set smaller custom timeouts so we can retry more times the whole flow if needed
+          await this.checkPageIsLoaded(2000);
           await this.driver.clickElement(this.openWarningInNewTabLink);
           return true;
         } catch {
@@ -72,7 +75,7 @@ class PhishingWarningPage {
           return false;
         }
       },
-      { interval: 1000, timeout: 20000 },
+      { interval: 1000, timeout: 10000 },
     );
   }
 

--- a/test/e2e/page-objects/pages/phishing-warning-page.ts
+++ b/test/e2e/page-objects/pages/phishing-warning-page.ts
@@ -72,7 +72,7 @@ class PhishingWarningPage {
           return false;
         }
       },
-      { interval: 1000, timeout: 10000 },
+      { interval: 1000, timeout: 20000 },
     );
   }
 

--- a/test/e2e/page-objects/pages/phishing-warning-page.ts
+++ b/test/e2e/page-objects/pages/phishing-warning-page.ts
@@ -61,7 +61,7 @@ class PhishingWarningPage {
             this.iframeSelector,
           )) as WebElement;
           await this.driver.switchToFrame(iframe as unknown as string);
-          // We set smaller custom timeouts so we can retry more times the whole flow if needed
+          // We set a smaller custom timeout so we can retry more times the whole flow if needed
           await this.checkPageIsLoaded(2000);
           await this.driver.clickElement(this.openWarningInNewTabLink);
           return true;

--- a/test/e2e/page-objects/pages/phishing-warning-page.ts
+++ b/test/e2e/page-objects/pages/phishing-warning-page.ts
@@ -28,14 +28,9 @@ class PhishingWarningPage {
     this.driver = driver;
   }
 
-  async checkPageIsLoaded(
-    options: { timeout?: number } = { timeout: 10000 },
-  ): Promise<void> {
-    const { timeout } = options;
+  async checkPageIsLoaded(): Promise<void> {
     try {
-      await this.driver.waitForSelector(this.phishingWarningPageTitle, {
-        timeout,
-      });
+      await this.driver.waitForSelector(this.phishingWarningPageTitle);
     } catch (e) {
       console.log(
         'Timeout while waiting for Phishing Warning page to be loaded',
@@ -55,31 +50,18 @@ class PhishingWarningPage {
     console.log(
       'Clicking open warning in new tab link on phishing warning page',
     );
-    // Switch to iframe and wait for content to load with waitUntil()
-    // to mitigate a race condition where we search in a stale iframe context if that's replaced on load
-    await this.driver.waitUntil(
-      async () => {
-        try {
-          const iframe = (await this.driver.findElement(
-            this.iframeSelector,
-          )) as WebElement;
-          await this.driver.switchToFrame(iframe as unknown as string);
-          // We set a smaller custom timeout so we can retry more times the whole flow if needed
-          await this.checkPageIsLoaded({ timeout: 2000 });
-          await this.driver.clickElement(this.openWarningInNewTabLink);
-          return true;
-        } catch {
-          try {
-            // Switch back to default content before retrying, in case we're stuck in the iframe context that was replaced on load
-            await this.driver.switchToDefaultContent();
-          } catch {
-            // context may already be discarded
-          }
-          return false;
-        }
-      },
-      { interval: 1000, timeout: 10000 },
-    );
+    const iframe = (await this.driver.findElement(
+      this.iframeSelector,
+    )) as WebElement;
+    await this.driver.switchToFrame(iframe as unknown as string);
+    await this.checkPageIsLoaded();
+    await this.driver.clickElement(this.openWarningInNewTabLink);
+    try {
+      // Switch back to default content before retrying, in case we're stuck in the iframe context that was replaced on load
+      await this.driver.switchToDefaultContent();
+    } catch {
+      // context may already be discarded
+    }
   }
 
   async clickProceedAnywayButton(): Promise<void> {

--- a/test/e2e/tests/phishing-controller/phishing-detection.spec.ts
+++ b/test/e2e/tests/phishing-controller/phishing-detection.spec.ts
@@ -138,7 +138,7 @@ describe('Phishing Detection', function (this: Suite) {
       );
     });
 
-    it('should display the MetaMask Phishing Detection page in an iframe and take the user to the blocked page if they continue', async function () {
+    it('should display the MetaMask Phishing Detection page in an iframe and take the user to the blocked page if they continue TEST', async function () {
       await withFixtures(
         getFixtureOptions({
           title: this.test?.fullTitle(),

--- a/test/e2e/tests/phishing-controller/phishing-detection.spec.ts
+++ b/test/e2e/tests/phishing-controller/phishing-detection.spec.ts
@@ -138,7 +138,7 @@ describe('Phishing Detection', function (this: Suite) {
       );
     });
 
-    it('should display the MetaMask Phishing Detection page in an iframe and take the user to the blocked page if they continue TEST', async function () {
+    it('should display the MetaMask Phishing Detection page in an iframe and take the user to the blocked page if they continue', async function () {
       await withFixtures(
         getFixtureOptions({
           title: this.test?.fullTitle(),

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -785,7 +785,7 @@ class Driver {
    * @returns {Promise<void>} Promise that resolves when the element stops moving.
    * @throws {Error} Throws an error if the element does not stop moving within the timeout period.
    */
-  async waitForElementToStopMoving(rawLocator, timeout = 5000) {
+  async waitForElementToStopMoving(rawLocator, timeout = 6000) {
     const startTime = Date.now();
 
     while (Date.now() - startTime < timeout) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- Remove withSrp wrapper and use withFixtures to avoid extra layer of complexity
- Move importAdditionalSecretRecoveryPhrase and verifySrp to a flow file
- Remove un-needed waitUntil wrapper in the iframe





## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Ci should pass

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timing and naming changes; low blast radius, with main risk being an overly-short timeout causing new flakiness or confusing test reporting.
> 
> **Overview**
> Improves stability of the e2e phishing-warning iframe flow by making `PhishingWarningPage.checkPageIsLoaded` accept an optional timeout and wiring that through to `waitForSelector`.
> 
> In `clickOpenWarningInNewTabLinkOnIframe`, the page-load check now uses a shorter per-attempt timeout (2s) so the surrounding `waitUntil` loop can retry within its 10s budget. The affected iframe test’s `it(...)` description was also modified (appending `TEST`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20cfc529feffd7d169784527c98afc804ef988cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->