### PR TITLE
fix(perps): use fixed width for modify menu popover

### DIFF
--- a/ui/pages/perps/perps-market-detail-page.tsx
+++ b/ui/pages/perps/perps-market-detail-page.tsx
@@ -1782,8 +1782,7 @@ const PerpsMarketDetailPage: React.FC = () => {
                 flip
                 offset={[0, 8]}
                 padding={0}
-                matchWidth
-                className="rounded-lg z-[1050]"
+                className="rounded-lg z-[1050] w-[294px]"
                 data-testid="perps-modify-menu"
               >
                 <Box flexDirection={BoxFlexDirection.Column}>


### PR DESCRIPTION
## **Description**

The perps modify menu popover was using the `matchWidth` prop, which caused it to inherit the trigger button's width. This resulted in a popover that was too narrow or inconsistently sized depending on the trigger element.

This PR removes `matchWidth` and applies a fixed `w-[294px]` width to the popover, ensuring a consistent and appropriately sized menu regardless of the trigger's dimensions.

## **Changelog**

CHANGELOG entry: Fixed the modify menu popover width on the perps market detail page

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3055

## **Manual testing steps**

1. Navigate to the Perps market detail page
2. Open a position so the modify menu trigger is visible
3. Click the modify menu trigger button
4. Verify the popover menu appears with a consistent 294px width and does not match the trigger button's width

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
<img width="371" height="768" alt="Screenshot 2026-04-30 at 10 59 43" src="https://github.com/user-attachments/assets/dbf448e9-d4d5-4509-a442-e786c540c7cc" />

-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts popover sizing; main risk is minor layout regressions in the perps modify menu on different viewports.
> 
> **Overview**
> **Fixes inconsistent sizing of the perps position “Modify” popover menu** by removing `matchWidth` behavior (which inherited the trigger button width) and applying a fixed `w-[294px]` width via `className` on the `Popover` in `perps-market-detail-page.tsx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69856b589b8ccabdd948f964abb0658b15156ef1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->