### PR TITLE
fix: Cannot use +/- to define TP/SL thresholds

### DIFF
--- a/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.test.tsx
+++ b/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.test.tsx
@@ -268,9 +268,13 @@ describe('UpdateTPSLModalContent', () => {
       const tpInput = screen.getAllByPlaceholderText(
         '0.00',
       )[0] as HTMLInputElement;
+      const tpPercentInput = screen.getByTestId(
+        'perps-update-tpsl-tp-percent-input',
+      ) as HTMLInputElement;
       const numValue = parseFloat(tpInput.value.replace(/,/gu, ''));
       expect(numValue).toBeGreaterThan(0);
       expect(numValue).toBeCloseTo(3087.5, 0);
+      expect(tpPercentInput.value).toBe('+25');
     });
 
     it('sets SL price correctly for a -25% RoE preset on a long position', () => {

--- a/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.test.tsx
+++ b/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.test.tsx
@@ -463,6 +463,32 @@ describe('UpdateTPSLModalContent', () => {
       expect(numValue).toBeCloseTo(96.425, 0);
     });
 
+    it('preserves the positive sign after blurring an explicit positive SL RoE%', () => {
+      renderTpslModalContent({ position: positionWithoutTPSL });
+
+      const slPercentInput = screen.getByTestId(
+        'perps-update-tpsl-sl-percent-input',
+      ) as HTMLInputElement;
+      fireEvent.focus(slPercentInput);
+      fireEvent.change(slPercentInput, { target: { value: '+15' } });
+      fireEvent.blur(slPercentInput);
+
+      expect(slPercentInput.value).toMatch(/^\+/u);
+    });
+
+    it('preserves the negative sign after blurring an explicit negative TP RoE%', () => {
+      renderTpslModalContent({ position: positionWithoutTPSL });
+
+      const tpPercentInput = screen.getByTestId(
+        'perps-update-tpsl-tp-percent-input',
+      ) as HTMLInputElement;
+      fireEvent.focus(tpPercentInput);
+      fireEvent.change(tpPercentInput, { target: { value: '-15' } });
+      fireEvent.blur(tpPercentInput);
+
+      expect(tpPercentInput.value).toMatch(/^-/u);
+    });
+
     it('defaults unsigned SL RoE% input to negative', () => {
       // SOL: entry=95, leverage=10, defaulted -10% signed RoE -> 95 * 0.99 = 94.05
       renderTpslModalContent({ position: positionWithoutTPSL });
@@ -562,7 +588,7 @@ describe('UpdateTPSLModalContent', () => {
     it('shows raw input while SL percent is focused and formatted value after blur', () => {
       // SOL: entry=95, leverage=10. Typing +10 (SL above entry for lock-in-profit scenario)
       // -> price = 95*(1+10/1000) = 95.95 -> blur shows priceToPercent("95.95") for long
-      // -> (95.95-95)/95*10*100 = 10 -> "10" (positive, no sign)
+      // -> (95.95-95)/95*10*100 = 10 -> "+10"
       renderTpslModalContent({ position: positionWithoutTPSL });
 
       const slPercentInput = screen.getAllByPlaceholderText('0')[1];
@@ -574,8 +600,8 @@ describe('UpdateTPSLModalContent', () => {
       fireEvent.blur(slPercentInput);
 
       const blurredValue = (slPercentInput as HTMLInputElement).value;
-      // After blur, shows signed RoE: positive percent stays positive (no sign prefix)
-      expect(blurredValue).toMatch(/^-?\d+(\.\d+)?$/u);
+      // After blur, shows signed RoE: positive percent keeps the explicit profit sign.
+      expect(blurredValue).toMatch(/^\+\d+(\.\d+)?$/u);
     });
 
     it('normalizes leading-zero SL percent input before defaulting to negative', () => {
@@ -637,7 +663,7 @@ describe('UpdateTPSLModalContent', () => {
       // price = 95 * (1 + 25/1000) = 95 * 1.025 = 97.375 -> formatted as "97.38"
       // priceToPercent('97.38', long): (97.38-95)/95 * 10 * 100 = 25.05 -> "25.05"
       const blurredValue = (tpPercentInput as HTMLInputElement).value;
-      expect(blurredValue).toMatch(/^-?\d+(\.\d+)?$/u);
+      expect(blurredValue).toMatch(/^[+-]?\d+(\.\d+)?$/u);
     });
   });
 

--- a/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.tsx
+++ b/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.tsx
@@ -67,6 +67,11 @@ import {
 const TP_PRESETS = [10, 25, 50, 100];
 const SL_PRESETS = [5, 10, 25, 50];
 
+const formatSignedRoePercent = (value: number): string => {
+  const formatted = formatRoePercent(value);
+  return value > 0 && formatted !== '0' ? `+${formatted}` : formatted;
+};
+
 export type UpdateTPSLSubmitState = {
   onSubmit: () => void;
   isSaving: boolean;
@@ -190,7 +195,7 @@ export const UpdateTPSLModalContent: React.FC<UpdateTPSLModalContentProps> = ({
       const diff = priceNum - entryPriceForEdit;
       const percentChange = (diff / entryPriceForEdit) * leverageForEdit * 100;
       // For long: positive when price > entry (profit). For short: negate (profit when price < entry).
-      return formatRoePercent(
+      return formatSignedRoePercent(
         positionDirection === 'long' ? percentChange : -percentChange,
       );
     },
@@ -602,6 +607,7 @@ export const UpdateTPSLModalContent: React.FC<UpdateTPSLModalContentProps> = ({
               backgroundColor={BackgroundColor.backgroundMuted}
               className="w-full"
               disabled={isSaving}
+              testId="perps-update-tpsl-tp-price-input"
               startAccessory={
                 <Text
                   variant={TextVariant.BodyMd}
@@ -629,6 +635,7 @@ export const UpdateTPSLModalContent: React.FC<UpdateTPSLModalContentProps> = ({
               backgroundColor={BackgroundColor.backgroundMuted}
               className="w-full"
               disabled={isSaving}
+              testId="perps-update-tpsl-tp-percent-input"
               endAccessory={
                 <Text
                   variant={TextVariant.BodyMd}
@@ -731,6 +738,7 @@ export const UpdateTPSLModalContent: React.FC<UpdateTPSLModalContentProps> = ({
               backgroundColor={BackgroundColor.backgroundMuted}
               className="w-full"
               disabled={isSaving}
+              testId="perps-update-tpsl-sl-price-input"
               startAccessory={
                 <Text
                   variant={TextVariant.BodyMd}
@@ -758,6 +766,7 @@ export const UpdateTPSLModalContent: React.FC<UpdateTPSLModalContentProps> = ({
               backgroundColor={BackgroundColor.backgroundMuted}
               className="w-full"
               disabled={isSaving}
+              testId="perps-update-tpsl-sl-percent-input"
               endAccessory={
                 <Text
                   variant={TextVariant.BodyMd}

--- a/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.tsx
+++ b/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.tsx
@@ -327,7 +327,7 @@ export const UpdateTPSLModalContent: React.FC<UpdateTPSLModalContentProps> = ({
       setEditingTpPrice(newPrice);
       // Preserve the exact preset value for display — avoids round-trip drift
       // caused by the price being rounded to 2 decimal places
-      const presetStr = String(percent);
+      const presetStr = formatSignedRoePercent(percent);
       setRawTpPercent(presetStr);
       setTpPresetPercent(presetStr);
     },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes TP/SL RoE percent inputs in the Perps Auto close modal so signed values remain clear after the trigger price is recalculated. Explicit positive SL values such as `+15` now keep the `+` sign after blur, explicit negative TP values keep the `-` sign, and unsigned long SL input continues to default negative.

## **Changelog**

CHANGELOG entry: Fixed a bug that caused Perps TP/SL RoE signs to disappear or default incorrectly in the Auto close modal

## **Related issues**

Fixes: [TAT-2947](https://consensyssoftware.atlassian.net/browse/TAT-2947)

## **Manual testing steps**

1. Open a long Perps position and open the Auto close modal.
2. Enter `+15` in the Stop loss percent input, then blur the field and confirm it still displays a positive sign.
3. Enter `-15` in the Take profit percent input, then blur the field and confirm it still displays a negative sign.
4. Enter `5` in the Stop loss percent input for the long position and confirm it defaults to `-5`.

## **Screenshots/Recordings**

<table>
<tr><td align="center" width="50%"><strong>Screenshots/evidence Ac1 Positive Sl Sign 1777549444578</strong><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/fixes/42284/screenshots/evidence-ac1-positive-sl-sign-1777549444578.png" alt="Screenshots/evidence Ac1 Positive Sl Sign 1777549444578" width="400" /></td><td align="center" width="50%"><strong>Screenshots/evidence Ac2 Negative Tp Sign 1777549444703</strong><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/fixes/42284/screenshots/evidence-ac2-negative-tp-sign-1777549444703.png" alt="Screenshots/evidence Ac2 Negative Tp Sign 1777549444703" width="400" /></td></tr>
<tr><td align="center" width="50%"><strong>Screenshots/evidence Ac3 Unsigned Sl Negative 1777549444827</strong><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/fixes/42284/screenshots/evidence-ac3-unsigned-sl-negative-1777549444827.png" alt="Screenshots/evidence Ac3 Unsigned Sl Negative 1777549444827" width="400" /></td><td align="center" width="50%"><strong>Screenshots/long Position ETH 1777549444115</strong><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/fixes/42284/screenshots/long-position-ETH-1777549444115.png" alt="Screenshots/long Position ETH 1777549444115" width="400" /><br/><sub>caption confidence: LOW — generic filename — no state-specific suffix</sub></td></tr>
</table>

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## **Validation Recipe**

<details>
<summary>recipe.json</summary>

```json
{
  "schema_version": 1,
  "title": "TAT-2947 — TP/SL RoE sign entry",
  "description": "Validates signed RoE input in the Perps Auto close modal for TP/SL thresholds.",
  "validate": {
    "workflow": {
      "pre_conditions": ["wallet.unlocked", "perps.feature_enabled"],
      "entry": "setup-close-stale-modal",
      "nodes": {
        "setup-close-stale-modal": {
          "action": "key_press",
          "key": "Escape",
          "next": "setup-open-long-position"
        },
        "setup-open-long-position": {
          "action": "call",
          "ref": "perps/open-long-position",
          "params": { "symbol": "ETH", "side": "long", "amount": "10" },
          "next": "setup-scroll-auto-close"
        },
        "setup-scroll-auto-close": {
          "action": "scroll",
          "test_id": "perps-auto-close-row",
          "next": "setup-open-auto-close"
        },
        "setup-open-auto-close": {
          "action": "press",
          "test_id": "perps-auto-close-row",
          "next": "setup-wait-auto-close-modal"
        },
        "setup-wait-auto-close-modal": {
          "action": "wait_for",
          "expression": "!!(document.querySelector('[data-testid=\"perps-update-tpsl-tp-percent-input\"]') && document.querySelector('[data-testid=\"perps-update-tpsl-sl-percent-input\"]') && document.querySelector('[data-testid=\"perps-update-tpsl-tp-price-input\"]') && document.querySelector('[data-testid=\"perps-update-tpsl-sl-price-input\"]'))",
          "timeout_ms": 10000,
          "next": "ac1-enter-positive-sl"
        },
        "ac1-enter-positive-sl": {
          "action": "eval_sync",
          "expression": "(function(){const slPrice=document.querySelector('[data-testid=\"perps-update-tpsl-sl-price-input\"]'); const slPercent=document.querySelector('[data-testid=\"perps-update-tpsl-sl-percent-input\"]'); const setter=Object.getOwnPropertyDescriptor(HTMLInputElement.prototype,'value').set; setter.call(slPrice,''); slPrice.dispatchEvent(new Event('input',{bubbles:true})); slPrice.dispatchEvent(new Event('change',{bubbles:true})); slPercent.focus(); setter.call(slPercent,'+15'); slPercent.dispatchEvent(new Event('input',{bubbles:true})); slPercent.dispatchEvent(new Event('change',{bubbles:true})); slPercent.blur(); return JSON.stringify({slPercent:slPercent.value, slPrice:slPrice.value, hasPositiveSign:slPercent.value.startsWith('+')});})()",
          "assert": { "operator": "eq", "field": "hasPositiveSign", "value": true },
          "save_as": "ac1_positive_sl",
          "next": "ac1-screenshot-positive-sl"
        },
        "ac1-screenshot-positive-sl": {
          "action": "screenshot",
          "filename": "evidence-ac1-positive-sl-sign",
          "note": "AC1: SL RoE entered as +15 remains visibly positive after blur.",
          "next": "ac2-enter-negative-tp"
        },
        "ac2-enter-negative-tp": {
          "action": "eval_sync",
          "expression": "(function(){const tpPrice=document.querySelector('[data-testid=\"perps-update-tpsl-tp-price-input\"]'); const tpPercent=document.querySelector('[data-testid=\"perps-update-tpsl-tp-percent-input\"]'); const setter=Object.getOwnPropertyDescriptor(HTMLInputElement.prototype,'value').set; setter.call(tpPrice,''); tpPrice.dispatchEvent(new Event('input',{bubbles:true})); tpPrice.dispatchEvent(new Event('change',{bubbles:true})); tpPercent.focus(); setter.call(tpPercent,'-15'); tpPercent.dispatchEvent(new Event('input',{bubbles:true})); tpPercent.dispatchEvent(new Event('change',{bubbles:true})); tpPercent.blur(); return JSON.stringify({tpPercent:tpPercent.value, tpPrice:tpPrice.value, hasNegativeSign:tpPercent.value.startsWith('-')});})()",
          "assert": { "operator": "eq", "field": "hasNegativeSign", "value": true },
          "save_as": "ac2_negative_tp",
          "next": "ac2-screenshot-negative-tp"
        },
        "ac2-screenshot-negative-tp": {
          "action": "screenshot",
          "filename": "evidence-ac2-negative-tp-sign",
          "note": "AC2: TP RoE entered as -15 remains visibly negative after blur.",
          "next": "ac3-enter-unsigned-sl"
        },
        "ac3-enter-unsigned-sl": {
          "action": "eval_sync",
          "expression": "(function(){const slPrice=document.querySelector('[data-testid=\"perps-update-tpsl-sl-price-input\"]'); const slPercent=document.querySelector('[data-testid=\"perps-update-tpsl-sl-percent-input\"]'); const setter=Object.getOwnPropertyDescriptor(HTMLInputElement.prototype,'value').set; setter.call(slPrice,''); slPrice.dispatchEvent(new Event('input',{bubbles:true})); slPrice.dispatchEvent(new Event('change',{bubbles:true})); slPercent.focus(); setter.call(slPercent,'5'); slPercent.dispatchEvent(new Event('input',{bubbles:true})); slPercent.dispatchEvent(new Event('change',{bubbles:true})); return JSON.stringify({slPercent:slPercent.value, slPrice:slPrice.value, defaultedNegative:slPercent.value.startsWith('-')});})()",
          "assert": { "operator": "eq", "field": "defaultedNegative", "value": true },
          "save_as": "ac3_unsigned_sl",
          "next": "ac3-screenshot-unsigned-sl"
        },
        "ac3-screenshot-unsigned-sl": {
          "action": "screenshot",
          "filename": "evidence-ac3-unsigned-sl-negative",
          "note": "AC3: unsigned SL RoE input 5 defaults to a negative -5 value for a long position.",
          "next": "done"
        },
        "done": {
          "action": "end",
          "status": "pass",
          "message": "TP/SL signed RoE inputs preserve explicit signs and default unsigned long SL values negative."
        }
      }
    }
  }
}
```
</details>

## **Recipe Workflow**

<details>
<summary>workflow.mmd</summary>

```mermaid
flowchart TD
  %% TAT-2947 — TP/SL RoE sign entry
  __entry__(["ENTRY"]) --> node_setup_close_stale_modal
  node_setup_close_stale_modal["setup-close-stale-modal<br/>key_press"]
  node_setup_open_long_position[["setup-open-long-position<br/>perps/open-long-position"]]
  node_setup_scroll_auto_close["setup-scroll-auto-close<br/>scroll"]
  node_setup_open_auto_close["setup-open-auto-close<br/>press"]
  node_setup_wait_auto_close_modal["setup-wait-auto-close-modal<br/>wait_for"]
  node_ac1_enter_positive_sl["ac1-enter-positive-sl<br/>eval_sync"]
  node_ac1_screenshot_positive_sl["ac1-screenshot-positive-sl<br/>screenshot"]
  node_ac2_enter_negative_tp["ac2-enter-negative-tp<br/>eval_sync"]
  node_ac2_screenshot_negative_tp["ac2-screenshot-negative-tp<br/>screenshot"]
  node_ac3_enter_unsigned_sl["ac3-enter-unsigned-sl<br/>eval_sync"]
  node_ac3_screenshot_unsigned_sl["ac3-screenshot-unsigned-sl<br/>screenshot"]
  node_done(["done<br/>PASS"])
  node_setup_close_stale_modal --> node_setup_open_long_position
  node_setup_open_long_position --> node_setup_scroll_auto_close
  node_setup_scroll_auto_close --> node_setup_open_auto_close
  node_setup_open_auto_close --> node_setup_wait_auto_close_modal
  node_setup_wait_auto_close_modal --> node_ac1_enter_positive_sl
  node_ac1_enter_positive_sl --> node_ac1_screenshot_positive_sl
  node_ac1_screenshot_positive_sl --> node_ac2_enter_negative_tp
  node_ac2_enter_negative_tp --> node_ac2_screenshot_negative_tp
  node_ac2_screenshot_negative_tp --> node_ac3_enter_unsigned_sl
  node_ac3_enter_unsigned_sl --> node_ac3_screenshot_unsigned_sl
  node_ac3_screenshot_unsigned_sl --> node_done
```
</details>

[TAT-2947]: https://consensyssoftware.atlassian.net/browse/TAT-2947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-visible TP/SL percent formatting and preset display in a trading/risk-management flow; while logic is small, incorrect sign handling could mislead users about profit vs loss thresholds.
> 
> **Overview**
> Updates the Perps Auto Close (TP/SL) modal to **format RoE% values as explicitly signed** (e.g., `+10` for profit) when deriving percent from a trigger price, preventing the `+` sign from disappearing after blur/recalculation.
> 
> Adds stable `testId`s for TP/SL price and percent fields, adjusts TP preset percent display to include `+`, and expands unit tests to assert sign preservation for explicit positive SL and explicit negative TP inputs (plus updated blur-format expectations).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 313dbd1f5ee7e025fa4bd941de2cc567ed292e13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

