### PR TITLE
fix(perps): persist candle period selection across navigation and sessions

### DIFF
--- a/app/scripts/controllers/preferences-controller.test.ts
+++ b/app/scripts/controllers/preferences-controller.test.ts
@@ -525,6 +525,12 @@ describe('preferences controller', () => {
       );
     });
 
+    it('stores perpsSelectedCandlePeriod as a string preference', () => {
+      const { controller } = setupController({});
+      controller.setPreference('perpsSelectedCandlePeriod', '1h');
+      expect(controller.getPreferences().perpsSelectedCandlePeriod).toBe('1h');
+    });
+
     it('enables side panel default when disabling full screen view', () => {
       const { controller: defaultController } = setupController({});
       const { controller } = setupController({

--- a/app/scripts/controllers/preferences-controller.ts
+++ b/app/scripts/controllers/preferences-controller.ts
@@ -105,6 +105,7 @@ export type Preferences = {
   };
   useNativeCurrencyAsPrimaryCurrency: boolean;
   useSidePanelAsDefault?: boolean;
+  perpsSelectedCandlePeriod?: string;
 };
 
 // Omitting properties that already exist in the PreferencesState, as part of the preferences property.

--- a/ui/pages/perps/perps-market-detail-page.test.tsx
+++ b/ui/pages/perps/perps-market-detail-page.test.tsx
@@ -1037,6 +1037,126 @@ describe('PerpsMarketDetailPage', () => {
       );
     });
 
+    it('restores persisted candle period from preferences on mount', async () => {
+      const state = createMockState(true);
+      const store = mockStore({
+        ...state,
+        metamask: {
+          ...state.metamask,
+          preferences: {
+            ...state.metamask.preferences,
+            perpsSelectedCandlePeriod: '15m',
+          },
+        },
+      });
+
+      await renderPage(store);
+
+      expect(screen.getByTestId('perps-candle-period-15m')).toHaveClass(
+        'bg-muted',
+      );
+      expect(screen.getByTestId('perps-candle-period-5m')).not.toHaveClass(
+        'bg-muted',
+      );
+    });
+
+    it('restores a non-default persisted period and highlights More button', async () => {
+      const state = createMockState(true);
+      const store = mockStore({
+        ...state,
+        metamask: {
+          ...state.metamask,
+          preferences: {
+            ...state.metamask.preferences,
+            perpsSelectedCandlePeriod: '1h',
+          },
+        },
+      });
+
+      await renderPage(store);
+
+      expect(screen.getByTestId('perps-candle-period-more')).toHaveClass(
+        'bg-muted',
+      );
+      expect(screen.getByTestId('perps-candle-period-5m')).not.toHaveClass(
+        'bg-muted',
+      );
+    });
+
+    it('defaults to 5min when persisted candle period is invalid', async () => {
+      const state = createMockState(true);
+      const store = mockStore({
+        ...state,
+        metamask: {
+          ...state.metamask,
+          preferences: {
+            ...state.metamask.preferences,
+            perpsSelectedCandlePeriod: 'invalid-period',
+          },
+        },
+      });
+
+      await renderPage(store);
+
+      expect(screen.getByTestId('perps-candle-period-5m')).toHaveClass(
+        'bg-muted',
+      );
+    });
+
+    it('defaults to 5min when perpsSelectedCandlePeriod is not set', async () => {
+      const store = mockStore(createMockState(true));
+
+      await renderPage(store);
+
+      expect(screen.getByTestId('perps-candle-period-5m')).toHaveClass(
+        'bg-muted',
+      );
+    });
+
+    it('persists candle period selection via setPreference background call', async () => {
+      const store = mockStore(createMockState(true));
+
+      await renderPage(store);
+
+      fireEvent.click(screen.getByTestId('perps-candle-period-more'));
+      fireEvent.click(screen.getByTestId('perps-candle-period-modal-30m'));
+
+      expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+        'setPreference',
+        ['perpsSelectedCandlePeriod', '30m'],
+      );
+    });
+
+    it('persists candle period when selecting a default period button', async () => {
+      const store = mockStore(createMockState(true));
+
+      await renderPage(store);
+
+      fireEvent.click(screen.getByTestId('perps-candle-period-15m'));
+
+      expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+        'setPreference',
+        ['perpsSelectedCandlePeriod', '15m'],
+      );
+    });
+
+    it('updates chart even if preference save fails', async () => {
+      mockSubmitRequestToBackground.mockImplementation((method: string) => {
+        if (method === 'setPreference') {
+          return Promise.reject(new Error('save failed'));
+        }
+        return Promise.resolve({ success: true });
+      });
+      const store = mockStore(createMockState(true));
+
+      await renderPage(store);
+
+      fireEvent.click(screen.getByTestId('perps-candle-period-more'));
+      fireEvent.click(screen.getByTestId('perps-candle-period-modal-30m'));
+
+      expect(screen.getByText('30min')).toBeInTheDocument();
+    });
+
     it('closes the candle period modal when the close button is clicked', async () => {
       const store = mockStore(createMockState(true));
 

--- a/ui/pages/perps/perps-market-detail-page.tsx
+++ b/ui/pages/perps/perps-market-detail-page.tsx
@@ -45,6 +45,7 @@ import {
 } from '../../../shared/constants/perps-events';
 import { getIsPerpsExperienceAvailable } from '../../selectors/perps/feature-flags';
 import { getSelectedInternalAccount } from '../../selectors/accounts';
+import { getPreferences } from '../../selectors';
 import { useI18nContext } from '../../hooks/useI18nContext';
 import { useTheme } from '../../hooks/useTheme';
 import {
@@ -484,10 +485,19 @@ const PerpsMarketDetailPage: React.FC = () => {
     });
   }, [decodedSymbol, allOrders, position]);
 
-  // Candle period state and chart ref
-  const [selectedPeriod, setSelectedPeriod] = useState<CandlePeriod>(
-    CandlePeriod.FiveMinutes,
-  );
+  // Candle period: persisted in PreferencesController across sessions/markets.
+  // Local override gives instant UI feedback; background save persists for next visit.
+  const { perpsSelectedCandlePeriod: persistedCandlePeriod } = useSelector(
+    getPreferences,
+  ) as { perpsSelectedCandlePeriod?: string };
+  const resolvedPersistedPeriod =
+    persistedCandlePeriod &&
+    Object.values(CandlePeriod).includes(persistedCandlePeriod as CandlePeriod)
+      ? (persistedCandlePeriod as CandlePeriod)
+      : CandlePeriod.FiveMinutes;
+  const [localPeriodOverride, setLocalPeriodOverride] =
+    useState<CandlePeriod | null>(null);
+  const selectedPeriod = localPeriodOverride ?? resolvedPersistedPeriod;
   const chartRef = useRef<PerpsCandlestickChartRef>(null);
 
   // Live candle data from CandleStreamChannel
@@ -690,8 +700,13 @@ const PerpsMarketDetailPage: React.FC = () => {
   // 5. MOBILE REFERENCE: See usePerpsLiveCandles hook, CandleStreamChannel,
   // and HyperLiquidClientService.subscribeToCandles() in the mobile app.
   const handlePeriodChange = useCallback((period: CandlePeriod) => {
-    setSelectedPeriod(period);
-    // Apply default zoom when period changes
+    setLocalPeriodOverride(period);
+    submitRequestToBackground('setPreference', [
+      'perpsSelectedCandlePeriod',
+      period,
+    ]).catch(() => {
+      // Preference save is best-effort; chart still updates via local state.
+    });
     if (chartRef.current) {
       chartRef.current.applyZoom(ZOOM_CONFIG.DEFAULT_CANDLES, true);
     }


### PR DESCRIPTION
## **Description**

The selected candle period (e.g. 1H, 4H, 1D) on the Perps market detail chart was stored as local React state (`useState`), causing it to reset to the default (5m) every time the user navigated away and returned to the page.

This PR persists the user's candle period selection in `PreferencesController` via the existing `setPreference` mechanism. A local state override provides instant UI feedback on selection, while the background save ensures the preference survives:

- Navigation away and back to the market detail page
- Switching between different markets
- Closing and reopening the extension

No state migration is required since the new field is optional and falls back to the existing default (`CandlePeriod.FiveMinutes`) when absent.

## **Changelog**

CHANGELOG entry: Fixed the candle period selection resetting to default when navigating away from the Perps market detail page

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3043

## **Manual testing steps**

Feature: Candle period selection persistence on Perps market detail page

Scenario: Selection persists across navigation
  Given the wallet is unlocked and the user is on the Perps tab
  When the user opens any market detail page (e.g. BTC)
  And selects a non-default candle period (e.g. 4H)
  And navigates back to the Perps home screen
  And reopens the same market detail page
  Then the candle period is still set to 4H

Scenario: Selection persists when switching markets
  Given the user has selected 1D on the BTC market detail page
  When the user navigates back and opens the ETH market detail page
  Then the candle period is still set to 1D

Scenario: Selection persists across extension sessions
  Given the user has selected 1H on any market detail page
  When the user closes and reopens the extension
  And navigates to any Perps market detail page
  Then the candle period is still set to 1H

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new optional string preference and wires the perps chart to read/write it; main risk is minor UX regression if period validation or background `setPreference` calls behave unexpectedly.
> 
> **Overview**
> Persists the Perps market detail chart candle interval by storing `perpsSelectedCandlePeriod` in `PreferencesController` and restoring it on page mount (with validation + fallback to `5m`).
> 
> Updates the candle-period change handler to optimistically update local UI state while best-effort saving via background `setPreference`, and adds unit tests covering restore, invalid/missing values, persistence calls, and save-failure behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6b6f2cf8aed560fb0b279d563241d3df6a22aa3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->