### PR TITLE
fix: skip connect for qr wallets

### DIFF
--- a/ui/contexts/hardware-wallets/useHardwareFooter.test.ts
+++ b/ui/contexts/hardware-wallets/useHardwareFooter.test.ts
@@ -201,7 +201,7 @@ describe('useHardwareFooter', () => {
       expect(result.current.isHardwareWalletReady).toBe(true);
     });
 
-    it('returns not ready for QR wallet when camera permission is not granted', () => {
+    it('returns ready for the QR wallet footer when camera permission has not been granted yet', () => {
       mockConnectionState.status = ConnectionStatus.Disconnected;
       (useHardwareWalletConfig as jest.Mock).mockReturnValue({
         isHardwareWalletAccount: true,
@@ -212,10 +212,10 @@ describe('useHardwareFooter', () => {
 
       const { result } = renderUseHardwareFooter();
 
-      expect(result.current.isHardwareWalletReady).toBe(false);
+      expect(result.current.isHardwareWalletReady).toBe(true);
     });
 
-    it('returns not ready for QR wallet when camera permission state is unknown', () => {
+    it('returns ready for the QR wallet footer when camera permission state is unknown', () => {
       mockConnectionState.status = ConnectionStatus.Disconnected;
       (useHardwareWalletConfig as jest.Mock).mockReturnValue({
         isHardwareWalletAccount: true,
@@ -226,7 +226,7 @@ describe('useHardwareFooter', () => {
 
       const { result } = renderUseHardwareFooter();
 
-      expect(result.current.isHardwareWalletReady).toBe(false);
+      expect(result.current.isHardwareWalletReady).toBe(true);
     });
 
     it('returns not ready for Ledger even when camera permission is granted', () => {

--- a/ui/contexts/hardware-wallets/useHardwareFooter.ts
+++ b/ui/contexts/hardware-wallets/useHardwareFooter.ts
@@ -17,7 +17,6 @@ import {
 } from './rpcErrorUtils';
 import {
   ConnectionStatus,
-  HardwareConnectionPermissionState,
   HardwareWalletType,
   type EnsureDeviceReadyOptions,
 } from './types';
@@ -73,11 +72,7 @@ export const useHardwareFooter = ({
   const inE2e =
     process.env.IN_TEST && process.env.JEST_WORKER_ID === 'undefined';
   const { connectionState } = useHardwareWalletState();
-  const {
-    isHardwareWalletAccount,
-    walletType,
-    hardwareConnectionPermissionState,
-  } = useHardwareWalletConfig();
+  const { isHardwareWalletAccount, walletType } = useHardwareWalletConfig();
   const { ensureDeviceReady } = useHardwareWalletActions();
   const { showErrorModal } = useHardwareWalletError();
   const [hasPreflightSucceeded, setHasPreflightSucceeded] = useState(false);
@@ -133,22 +128,16 @@ export const useHardwareFooter = ({
       return true;
     }
 
-    // QR wallets don't need a physical device connection.
-    // Camera permission is the only prerequisite.
-    // When already granted, skip the "Connect QR"
-    // step and let the Confirm button run the preflight inline.
-    if (
-      walletType === HardwareWalletType.Qr &&
-      hardwareConnectionPermissionState ===
-        HardwareConnectionPermissionState.Granted
-    ) {
+    // QR wallets don't need a physical device connection before showing the
+    // primary footer CTA. The Confirm action still runs ensureDeviceReady,
+    // which handles camera permission before signing.
+    if (walletType === HardwareWalletType.Qr) {
       return true;
     }
 
     return isHardwareConnectionReadyForConfirmFooter(connectionState.status);
   }, [
     connectionState.status,
-    hardwareConnectionPermissionState,
     hasPreflightSucceeded,
     inE2e,
     isHardwareWalletAccount,

--- a/ui/pages/bridge/prepare/bridge-cta-button.test.tsx
+++ b/ui/pages/bridge/prepare/bridge-cta-button.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import '@testing-library/jest-dom';
 import {
   QuoteResponse,
   RequestStatus,
@@ -329,7 +330,59 @@ describe('BridgeCTAButton', () => {
     expect(getByRole('button')).not.toBeDisabled();
   });
 
-  // @ts-expect-error: each is a valid test function in jest
+  it('should render swap label for QR hardware wallet when disconnected', () => {
+    mockUseHardwareWalletConfig.mockReturnValue({
+      ...baseHardwareWalletConfig,
+      isHardwareWalletAccount: true,
+      walletType: HardwareWalletType.Qr,
+    });
+    mockUseHardwareWalletState.mockReturnValue({
+      connectionState: { status: ConnectionStatus.Disconnected },
+    });
+
+    const mockStore = createBridgeMockStore({
+      featureFlagOverrides: {
+        bridgeConfig: {
+          chainRanking: [
+            { chainId: formatChainIdToCaip(CHAIN_IDS.MAINNET) },
+            { chainId: formatChainIdToCaip(CHAIN_IDS.OPTIMISM) },
+            { chainId: formatChainIdToCaip(CHAIN_IDS.LINEA_MAINNET) },
+          ],
+        },
+      },
+      bridgeSliceOverrides: {
+        fromTokenInputValue: '1',
+        fromToken: toBridgeToken(getNativeAssetForChainId(CHAIN_IDS.MAINNET)),
+        toToken: toBridgeToken(
+          getNativeAssetForChainId(CHAIN_IDS.LINEA_MAINNET),
+        ),
+      },
+      bridgeStateOverrides: {
+        quotes: mockBridgeQuotesNativeErc20 as unknown as QuoteResponse[],
+        quotesLastFetched: Date.now(),
+        quotesLoadingStatus: RequestStatus.FETCHED,
+      },
+    });
+
+    const { getByText, queryByText, getByRole } = renderWithProvider(
+      <HardwareWalletProvider>
+        <BridgeCTAButton
+          onFetchNewQuotes={jest.fn()}
+          onOpenAlertModals={mockOnOpenPriceImpactWarningModal}
+          onOpenRecipientModal={jest.fn()}
+          onOpenMarketClosedModal={jest.fn()}
+        />
+      </HardwareWalletProvider>,
+      configureStore(mockStore),
+    );
+
+    const button = getByRole('button') as HTMLButtonElement;
+
+    expect(getByText(messages.swap.message)).toBeTruthy();
+    expect(queryByText('Connect QR')).toBeNull();
+    expect(button.disabled).toBe(false);
+  });
+
   it.each([
     {
       description: 'no alert modal is provided',
@@ -480,8 +533,17 @@ describe('BridgeCTAButton', () => {
     expect(container).toMatchSnapshot();
   });
 
-  // @ts-expect-error: each is a valid test function in jest
-  it.each([
+  it.each<
+    [
+      status: 'disable' | 'enable',
+      description: string,
+      validationErrors: Record<string, boolean>,
+      buttonLabel?: string,
+      bridgeStateOverrides?: Record<string, unknown>,
+      bridgeSliceOverrides?: Record<string, unknown>,
+      propOverrides?: Record<string, unknown>,
+    ]
+  >([
     ['disable', 'there is a tx alert', { isTxAlertPresent: true }],
     [
       'disable',
@@ -577,7 +639,6 @@ describe('BridgeCTAButton', () => {
     },
   );
 
-  // @ts-expect-error: each is a valid test function in jest
   it.each([
     ['market is closed (no quotes)', 'Market closed'],
     [
@@ -589,9 +650,14 @@ describe('BridgeCTAButton', () => {
     'should render the component when quotes are loading and %s',
     async (
       _: string,
-      bridgeSliceOverrides: Record<string, unknown> = {},
+      bridgeSliceOverridesOrLabel: string | Record<string, unknown> = {},
       propOverrides: Record<string, unknown> = {},
     ) => {
+      const bridgeSliceOverrides =
+        typeof bridgeSliceOverridesOrLabel === 'string'
+          ? {}
+          : bridgeSliceOverridesOrLabel;
+
       const mockStore = createBridgeMockStore({
         bridgeSliceOverrides: {
           fromTokenInputValue: '1',
@@ -637,8 +703,14 @@ describe('BridgeCTAButton', () => {
     },
   );
 
-  // @ts-expect-error: each is a valid test function in jest
-  it.each([
+  it.each<
+    [
+      description: string,
+      buttonLabel: string,
+      bridgeStateOverrides: Record<string, unknown>,
+      wasTxDeclined?: boolean,
+    ]
+  >([
     [
       'quote is expired (no quotes)',
       'Get new quote',
@@ -673,7 +745,7 @@ describe('BridgeCTAButton', () => {
     async (
       _: string,
       buttonLabel: string,
-      bridgeStateOverrides: Record<string, boolean>,
+      bridgeStateOverrides: Record<string, unknown>,
       wasTxDeclined: boolean = false,
     ) => {
       const mockStore = createBridgeMockStore({
@@ -813,7 +885,6 @@ describe('BridgeCTAButton', () => {
     `);
   });
 
-  // @ts-expect-error: each is a valid test function in jest
   it.each([
     { priceImpact: '0.253', expectedOpenModalCalls: 1 }, // error
     { priceImpact: '0', expectedOpenModalCalls: 0 }, // neither

--- a/ui/pages/bridge/prepare/bridge-cta-button.test.tsx
+++ b/ui/pages/bridge/prepare/bridge-cta-button.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import '@testing-library/jest-dom';
 import {
   QuoteResponse,
   RequestStatus,
@@ -383,6 +382,7 @@ describe('BridgeCTAButton', () => {
     expect(button.disabled).toBe(false);
   });
 
+  // @ts-expect-error: each is a valid test function in jest
   it.each([
     {
       description: 'no alert modal is provided',
@@ -533,17 +533,8 @@ describe('BridgeCTAButton', () => {
     expect(container).toMatchSnapshot();
   });
 
-  it.each<
-    [
-      status: 'disable' | 'enable',
-      description: string,
-      validationErrors: Record<string, boolean>,
-      buttonLabel?: string,
-      bridgeStateOverrides?: Record<string, unknown>,
-      bridgeSliceOverrides?: Record<string, unknown>,
-      propOverrides?: Record<string, unknown>,
-    ]
-  >([
+  // @ts-expect-error: each is a valid test function in jest
+  it.each([
     ['disable', 'there is a tx alert', { isTxAlertPresent: true }],
     [
       'disable',
@@ -639,6 +630,7 @@ describe('BridgeCTAButton', () => {
     },
   );
 
+  // @ts-expect-error: each is a valid test function in jest
   it.each([
     ['market is closed (no quotes)', 'Market closed'],
     [
@@ -650,14 +642,9 @@ describe('BridgeCTAButton', () => {
     'should render the component when quotes are loading and %s',
     async (
       _: string,
-      bridgeSliceOverridesOrLabel: string | Record<string, unknown> = {},
+      bridgeSliceOverrides: Record<string, unknown> = {},
       propOverrides: Record<string, unknown> = {},
     ) => {
-      const bridgeSliceOverrides =
-        typeof bridgeSliceOverridesOrLabel === 'string'
-          ? {}
-          : bridgeSliceOverridesOrLabel;
-
       const mockStore = createBridgeMockStore({
         bridgeSliceOverrides: {
           fromTokenInputValue: '1',
@@ -703,14 +690,8 @@ describe('BridgeCTAButton', () => {
     },
   );
 
-  it.each<
-    [
-      description: string,
-      buttonLabel: string,
-      bridgeStateOverrides: Record<string, unknown>,
-      wasTxDeclined?: boolean,
-    ]
-  >([
+  // @ts-expect-error: each is a valid test function in jest
+  it.each([
     [
       'quote is expired (no quotes)',
       'Get new quote',
@@ -745,7 +726,7 @@ describe('BridgeCTAButton', () => {
     async (
       _: string,
       buttonLabel: string,
-      bridgeStateOverrides: Record<string, unknown>,
+      bridgeStateOverrides: Record<string, boolean>,
       wasTxDeclined: boolean = false,
     ) => {
       const mockStore = createBridgeMockStore({
@@ -885,6 +866,7 @@ describe('BridgeCTAButton', () => {
     `);
   });
 
+  // @ts-expect-error: each is a valid test function in jest
   it.each([
     { priceImpact: '0.253', expectedOpenModalCalls: 1 }, // error
     { priceImpact: '0', expectedOpenModalCalls: 0 }, // neither

--- a/ui/pages/bridge/prepare/bridge-cta-button.tsx
+++ b/ui/pages/bridge/prepare/bridge-cta-button.tsx
@@ -22,6 +22,7 @@ import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useIsTxSubmittable } from '../../../hooks/bridge/useIsTxSubmittable';
 import {
   ConnectionStatus,
+  HardwareWalletType,
   useHardwareWalletConfig,
   useHardwareWalletState,
 } from '../../../contexts/hardware-wallets';
@@ -83,10 +84,16 @@ export const BridgeCTAButton = ({
     if (!isHardwareWalletAccount) {
       return true;
     }
+    // QR wallets don't need a physical device connection before showing the
+    // primary CTA. Submitting still runs ensureDeviceReady, which handles
+    // camera permission before signing.
+    if (walletType === HardwareWalletType.Qr) {
+      return true;
+    }
     return [ConnectionStatus.Connected, ConnectionStatus.Ready].includes(
       connectionState.status,
     );
-  }, [connectionState.status, isHardwareWalletAccount]);
+  }, [connectionState.status, isHardwareWalletAccount, walletType]);
 
   /**
    * Defines the behavior of the CTA button based on the current state


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

QR hardware wallets no longer require the "Connect QR" step before showing the confirm footer — the isHardwareWalletReady check now returns true for all QR wallets unconditionally, since camera permission is already handled by ensureDeviceReady when the user taps Confirm. This removes the hardwareConnectionPermissionState dependency from useHardwareFooter and updates the related tests to expect the footer as ready regardless of permission state.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Skip connect qr for QR accounts. 

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1731?atlOrigin=eyJpIjoiOWQxZjhhODJlN2I1NDM0Yzg1NGRiODIyNTU4OGQ4ZmMiLCJwIjoiaiJ9

## **Manual testing steps**

1. Go to a dapp transaction with a qr account
2. See that the footer says confirm and not `Connect QR`


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted UI readiness logic change limited to QR hardware wallets; main risk is behavioral regression in when QR permission prompts occur, covered by updated tests.
> 
> **Overview**
> QR hardware wallets are now considered *ready* for primary CTAs without requiring a prior “Connect QR” step; camera permission is deferred to `ensureDeviceReady` when the user submits.
> 
> This updates `useHardwareFooter` to drop `hardwareConnectionPermissionState` from readiness logic and always return ready for `HardwareWalletType.Qr`, and aligns the bridge swap CTA (`BridgeCTAButton`) to show the normal Swap action (not a connect prompt) for disconnected QR accounts. Tests were updated/added to assert readiness and labeling behavior across QR permission states and bridge disconnected scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f4a73866a026c8bceccd9682e88d0b770fe0b08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->