### PR TITLE
fix: update RPC navigation to direct users to the correct settings page

### DIFF
--- a/ui/components/app/network-connection-banner/network-connection-banner.test.tsx
+++ b/ui/components/app/network-connection-banner/network-connection-banner.test.tsx
@@ -115,7 +115,9 @@ describe('NetworkConnectionBanner', () => {
           chainId: '0x1',
           trackRpcUpdateFromBanner: true,
         });
-        expect(mockUseNavigate).toHaveBeenCalledWith(NETWORKS_ROUTE);
+        expect(mockUseNavigate).toHaveBeenCalledWith(
+          `${NETWORKS_ROUTE}?view=edit`,
+        );
       });
 
       it('creates a metrics event', () => {
@@ -231,7 +233,9 @@ describe('NetworkConnectionBanner', () => {
           chainId: '0x1',
           trackRpcUpdateFromBanner: true,
         });
-        expect(mockUseNavigate).toHaveBeenCalledWith(NETWORKS_ROUTE);
+        expect(mockUseNavigate).toHaveBeenCalledWith(
+          `${NETWORKS_ROUTE}?view=edit`,
+        );
       });
 
       it('creates a metrics event', () => {

--- a/ui/components/app/network-connection-banner/network-connection-banner.tsx
+++ b/ui/components/app/network-connection-banner/network-connection-banner.tsx
@@ -254,7 +254,7 @@ export const NetworkConnectionBanner = () => {
           trackRpcUpdateFromBanner: true,
         }),
       );
-      navigate(NETWORKS_ROUTE);
+      navigate(`${NETWORKS_ROUTE}?view=edit`);
     }
   }, [networkConnectionBanner, dispatch, navigate]);
 

--- a/ui/components/multichain/network-manager/components/add-network/AddNetwork.tsx
+++ b/ui/components/multichain/network-manager/components/add-network/AddNetwork.tsx
@@ -8,12 +8,14 @@ type AddNetworkProps = {
   networkFormState: ReturnType<typeof useNetworkFormState>;
   network: UpdateNetworkFields;
   isEdit?: boolean;
+  trackRpcUpdateFromBanner?: boolean;
 };
 
 export const AddNetwork: React.FC<AddNetworkProps> = ({
   networkFormState,
   network,
   isEdit = false,
+  trackRpcUpdateFromBanner,
 }) => {
   const [, setSearchParams] = useSearchParams();
   return (
@@ -28,6 +30,7 @@ export const AddNetwork: React.FC<AddNetworkProps> = ({
       }}
       networkFormState={networkFormState}
       existingNetwork={network}
+      trackRpcUpdateFromBanner={trackRpcUpdateFromBanner}
       onRpcAdd={() => {
         setSearchParams({ view: isEdit ? 'edit-rpc' : 'add-rpc' });
       }}

--- a/ui/pages/networks/networks-page.tsx
+++ b/ui/pages/networks/networks-page.tsx
@@ -104,7 +104,11 @@ export const NetworksPage = () => {
     getSelectedMultichainNetworkChainId,
   );
   const rawEditedNetwork = useSelector(getEditedNetwork);
-  const { chainId: editingChainId, editCompleted } = rawEditedNetwork ?? {};
+  const {
+    chainId: editingChainId,
+    editCompleted,
+    trackRpcUpdateFromBanner,
+  } = rawEditedNetwork ?? {};
 
   const editedNetwork = useMemo((): UpdateNetworkFields | undefined => {
     if (view === 'add') {
@@ -387,6 +391,7 @@ export const NetworksPage = () => {
             networkFormState={networkFormState}
             network={editedNetwork as UpdateNetworkFields}
             isEdit={true}
+            trackRpcUpdateFromBanner={trackRpcUpdateFromBanner}
           />
         </>
       ) : null}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI routing/state-plumbing change that only affects how users are directed from the network connection banner into the networks edit flow.
> 
> **Overview**
> Fixes the "Update RPC" action in `NetworkConnectionBanner` to navigate directly to the networks edit view by appending `?view=edit` to `NETWORKS_ROUTE`.
> 
> Plumbs `trackRpcUpdateFromBanner` from `setEditedNetwork` through `NetworksPage` into `AddNetwork`/`NetworksForm`, and updates banner tests to assert the new navigation URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77a20e5b310222ddaeaeb38afbc3c631e5ba18c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->