### PR TITLE
fix: guard against null account in getTokenByAccountAndAddressAndChainId cp-13.29.0

### DIFF
--- a/ui/selectors/assets.test.ts
+++ b/ui/selectors/assets.test.ts
@@ -682,7 +682,7 @@ describe('getTokenByAccountAndAddressAndChainId', () => {
   describe('when account is undefined and selectedAccountGroup is null', () => {
     it('should return null without crashing (deeplink guard)', () => {
       const mockStateNoGroup = cloneDeep(mockState);
-      mockStateNoGroup.metamask.selectedAccountGroup = null;
+      mockStateNoGroup.metamask.selectedAccountGroup = null as unknown as string;
       mockStateNoGroup.metamask.internalAccounts.selectedAccount =
         '5132883f-598e-482c-a02b-84eeaa352f5b';
 
@@ -705,7 +705,7 @@ describe('getTokenByAccountAndAddressAndChainId', () => {
       // Override the Solana account's scopes so it no longer matches the queried chain
       mockStateNoMatchingAccount.metamask.internalAccounts.accounts[
         '5132883f-598e-482c-a02b-84eeaa352f5b'
-      ].scopes = [EthScope.Eoa];
+      ].scopes = [EthScope.Eoa] as unknown as SolScope[];
 
       const result = getTokenByAccountAndAddressAndChainId(
         mockStateNoMatchingAccount,

--- a/ui/selectors/assets.test.ts
+++ b/ui/selectors/assets.test.ts
@@ -678,6 +678,45 @@ describe('getTokenByAccountAndAddressAndChainId', () => {
       });
     });
   });
+
+  describe('when account is undefined and selectedAccountGroup is null', () => {
+    it('should return null without crashing (deeplink guard)', () => {
+      const mockStateNoGroup = cloneDeep(mockState);
+      mockStateNoGroup.metamask.selectedAccountGroup = null;
+      mockStateNoGroup.metamask.internalAccounts.selectedAccount =
+        '5132883f-598e-482c-a02b-84eeaa352f5b';
+
+      const result = getTokenByAccountAndAddressAndChainId(
+        mockStateNoGroup,
+        undefined,
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501',
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+      );
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('when account is undefined and no account in the group matches the non-EVM chainId', () => {
+    it('should return null without crashing', () => {
+      const mockStateNoMatchingAccount = cloneDeep(mockState);
+      mockStateNoMatchingAccount.metamask.internalAccounts.selectedAccount =
+        '5132883f-598e-482c-a02b-84eeaa352f5b';
+      // Override the Solana account's scopes so it no longer matches the queried chain
+      mockStateNoMatchingAccount.metamask.internalAccounts.accounts[
+        '5132883f-598e-482c-a02b-84eeaa352f5b'
+      ].scopes = [EthScope.Eoa];
+
+      const result = getTokenByAccountAndAddressAndChainId(
+        mockStateNoMatchingAccount,
+        undefined,
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501',
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+      );
+
+      expect(result).toBeNull();
+    });
+  });
 });
 
 describe('getMultichainNativeAssetType', () => {

--- a/ui/selectors/assets.test.ts
+++ b/ui/selectors/assets.test.ts
@@ -682,7 +682,8 @@ describe('getTokenByAccountAndAddressAndChainId', () => {
   describe('when account is undefined and selectedAccountGroup is null', () => {
     it('should return null without crashing (deeplink guard)', () => {
       const mockStateNoGroup = cloneDeep(mockState);
-      mockStateNoGroup.metamask.selectedAccountGroup = null as unknown as string;
+      mockStateNoGroup.metamask.selectedAccountGroup =
+        null as unknown as string;
       mockStateNoGroup.metamask.internalAccounts.selectedAccount =
         '5132883f-598e-482c-a02b-84eeaa352f5b';
 

--- a/ui/selectors/assets.ts
+++ b/ui/selectors/assets.ts
@@ -531,6 +531,10 @@ export const getTokenByAccountAndAddressAndChainId = createDeepEqualSelector(
             chainId as CaipChainId,
           ));
 
+    if (!accountToUse) {
+      return null;
+    }
+
     const assetsToSearch = isEvm
       ? (getSelectedAccountTokensAcrossChains(state) as Record<
           Hex,


### PR DESCRIPTION
Prevents a crash when navigating to the Asset page via deeplink for a non-EVM chain when no account group is selected yet.

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: guard against null account in getTokenByAccountAndAddressAndChainId

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/42305

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://www.loom.com/share/c5a5f9187c6e438b9e753f6d3d263820

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk defensive change to a selector; it only alters behavior in edge cases where no suitable internal account can be resolved, returning `null` instead of potentially crashing.
> 
> **Overview**
> Prevents `getTokenByAccountAndAddressAndChainId` from crashing when it cannot resolve an `accountToUse` (e.g., deeplink into a non-EVM asset before `selectedAccountGroup` is set, or when no group account matches the requested non-EVM `chainId`).
> 
> Adds coverage in `assets.test.ts` to assert the selector returns `null` for these guard scenarios rather than throwing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f10f0c1eeb1ff527c363b42483c1ff3a36b6bbea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->