### PR TITLE
fix: register musd on unlock to fix fresh-install conversion bug

### DIFF
--- a/privacy-snapshot.json
+++ b/privacy-snapshot.json
@@ -6,6 +6,7 @@
   "api.devnet.solana.com",
   "api.etherscan.io",
   "api.lens.dev",
+  "api.merkl.xyz",
   "api.segment.io",
   "api.simplehash.com",
   "api.testnet.solana.com",

--- a/test/e2e/fixtures/default-fixture.json
+++ b/test/e2e/fixtures/default-fixture.json
@@ -839,12 +839,12 @@
       "firstTimeFlowType": "import",
       "seedPhraseBackedUp": null
     },
-    "PasskeyController": {
-      "passkeyRecord": null
-    },
     "PPOMController": {
       "storageMetadata": [],
       "versionInfo": []
+    },
+    "PasskeyController": {
+      "passkeyRecord": null
     },
     "PermissionController": {},
     "PermissionLogController": {
@@ -1086,7 +1086,35 @@
     "TokensController": {
       "allDetectedTokens": {},
       "allIgnoredTokens": {},
-      "allTokens": {}
+      "allTokens": {
+        "0x1": {
+          "0x5cfe73b6021e818b776b421b1c4db2474086a7e1": [
+            {
+              "address": "0xacA92E438df0B2401fF60dA7E4337B687a2435DA",
+              "decimals": 6,
+              "symbol": "MUSD"
+            }
+          ]
+        },
+        "0x38": {
+          "0x5cfe73b6021e818b776b421b1c4db2474086a7e1": [
+            {
+              "address": "0xacA92E438df0B2401fF60dA7E4337B687a2435DA",
+              "decimals": 6,
+              "symbol": "MUSD"
+            }
+          ]
+        },
+        "0xe708": {
+          "0x5cfe73b6021e818b776b421b1c4db2474086a7e1": [
+            {
+              "address": "0xacA92E438df0B2401fF60dA7E4337B687a2435DA",
+              "decimals": 6,
+              "symbol": "MUSD"
+            }
+          ]
+        }
+      }
     },
     "TransactionController": {
       "lastFetchedBlockNumbers": {},

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
@@ -388,7 +388,7 @@
   "TokensController": {
     "allDetectedTokens": {},
     "allIgnoredTokens": {},
-    "allTokens": {}
+    "allTokens": { "0x1": "object", "0x38": "object", "0xe708": "object" }
   },
   "TransactionPayController": { "transactionData": "object" },
   "TxController": {

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
@@ -108,7 +108,7 @@
     "allIgnoredTokens": {},
     "allNftContracts": "object",
     "allNfts": "object",
-    "allTokens": {},
+    "allTokens": { "0x1": "object", "0x38": "object", "0xe708": "object" },
     "announcements": "object",
     "approvalFlows": "object",
     "assetExchangeRates": "object",

--- a/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-background-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-background-state.json
@@ -277,7 +277,7 @@
     "TokensController": {
       "allDetectedTokens": {},
       "allIgnoredTokens": {},
-      "allTokens": {}
+      "allTokens": { "0x1": "object", "0x38": "object", "0xe708": "object" }
     },
     "TransactionController": {
       "lastFetchedBlockNumbers": "object",

--- a/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
@@ -292,7 +292,7 @@
     "TokensController": {
       "allDetectedTokens": {},
       "allIgnoredTokens": {},
-      "allTokens": {}
+      "allTokens": { "0x1": "object", "0x38": "object", "0xe708": "object" }
     },
     "TransactionController": {
       "lastFetchedBlockNumbers": "object",

--- a/ui/components/app/musd/EarnTransactionMonitor.tsx
+++ b/ui/components/app/musd/EarnTransactionMonitor.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { useEnsureMusdTokenRegistered } from '../../../hooks/musd/useEnsureMusdTokenRegistered';
+
+const EarnTransactionMonitor: React.FC = () => {
+  useEnsureMusdTokenRegistered();
+  return null;
+};
+
+export default EarnTransactionMonitor;

--- a/ui/components/app/musd/index.ts
+++ b/ui/components/app/musd/index.ts
@@ -17,3 +17,4 @@ export { MusdConversionToast } from './musd-conversion-toast';
 export { MusdBuyGetCta } from './musd-buy-get-cta';
 export { MusdAssetCta } from './musd-asset-cta';
 export { MusdConvertLink } from './musd-convert-link';
+export { default as EarnTransactionMonitor } from './EarnTransactionMonitor';

--- a/ui/components/app/musd/index.ts
+++ b/ui/components/app/musd/index.ts
@@ -17,4 +17,4 @@ export { MusdConversionToast } from './musd-conversion-toast';
 export { MusdBuyGetCta } from './musd-buy-get-cta';
 export { MusdAssetCta } from './musd-asset-cta';
 export { MusdConvertLink } from './musd-convert-link';
-export { default as EarnTransactionMonitor } from './EarnTransactionMonitor';
+export { default as MusdTokenMonitor } from './musd-token-monitor';

--- a/ui/components/app/musd/musd-token-monitor.test.tsx
+++ b/ui/components/app/musd/musd-token-monitor.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import MusdTokenMonitor from './musd-token-monitor';
+
+const mockUseEnsureMusdTokenRegistered = jest.fn();
+
+jest.mock('../../../hooks/musd/useEnsureMusdTokenRegistered', () => ({
+  useEnsureMusdTokenRegistered: () => mockUseEnsureMusdTokenRegistered(),
+}));
+
+describe('MusdTokenMonitor', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders nothing', () => {
+    const { container } = render(<MusdTokenMonitor />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('calls useEnsureMusdTokenRegistered on mount', () => {
+    render(<MusdTokenMonitor />);
+    expect(mockUseEnsureMusdTokenRegistered).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/components/app/musd/musd-token-monitor.tsx
+++ b/ui/components/app/musd/musd-token-monitor.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { useEnsureMusdTokenRegistered } from '../../../hooks/musd/useEnsureMusdTokenRegistered';
 
-const EarnTransactionMonitor: React.FC = () => {
+const MusdTokenMonitor: React.FC = () => {
   useEnsureMusdTokenRegistered();
   return null;
 };
 
-export default EarnTransactionMonitor;
+export default MusdTokenMonitor;

--- a/ui/hooks/musd/index.ts
+++ b/ui/hooks/musd/index.ts
@@ -67,3 +67,5 @@ export {
 } from './useMusdPaymentToken';
 
 export { isMerklClaimTransaction } from '../../components/app/musd/utils';
+
+export { useEnsureMusdTokenRegistered } from './useEnsureMusdTokenRegistered';

--- a/ui/hooks/musd/useEnsureMusdTokenRegistered.test.ts
+++ b/ui/hooks/musd/useEnsureMusdTokenRegistered.test.ts
@@ -1,0 +1,81 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useDispatch, useSelector } from 'react-redux';
+import { useEnsureMusdTokenRegistered } from './useEnsureMusdTokenRegistered';
+
+const mockEnsureMusdTokenImportedForChain = jest.fn();
+
+jest.mock('../../components/app/musd/utils', () => ({
+  ensureMusdTokenImportedForChain: (...args: unknown[]) =>
+    mockEnsureMusdTokenImportedForChain(...args),
+}));
+
+jest.mock('../../components/app/musd/constants', () => ({
+  MUSD_TOKEN_ADDRESS_BY_CHAIN: {
+    '0x1': '0xaaa',
+    '0xe708': '0xbbb',
+  },
+}));
+
+jest.mock('react-redux', () => ({
+  useDispatch: jest.fn(),
+  useSelector: jest.fn(),
+}));
+
+describe('useEnsureMusdTokenRegistered', () => {
+  const mockDispatch = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useDispatch as jest.Mock).mockReturnValue(mockDispatch);
+    mockEnsureMusdTokenImportedForChain.mockResolvedValue(undefined);
+  });
+
+  it('registers mUSD for all supported chains when flow is enabled', async () => {
+    (useSelector as jest.Mock).mockReturnValue(true);
+
+    renderHook(() => useEnsureMusdTokenRegistered());
+
+    // Allow async effect to complete
+    await new Promise(process.nextTick);
+
+    expect(mockEnsureMusdTokenImportedForChain).toHaveBeenCalledTimes(2);
+    expect(mockEnsureMusdTokenImportedForChain).toHaveBeenCalledWith(
+      '0x1',
+      mockDispatch,
+    );
+    expect(mockEnsureMusdTokenImportedForChain).toHaveBeenCalledWith(
+      '0xe708',
+      mockDispatch,
+    );
+  });
+
+  it('does not register mUSD when flow is disabled', async () => {
+    (useSelector as jest.Mock).mockReturnValue(false);
+
+    renderHook(() => useEnsureMusdTokenRegistered());
+
+    await new Promise(process.nextTick);
+
+    expect(mockEnsureMusdTokenImportedForChain).not.toHaveBeenCalled();
+  });
+
+  it('continues registering remaining chains when one fails', async () => {
+    (useSelector as jest.Mock).mockReturnValue(true);
+    jest.spyOn(console, 'warn').mockImplementation();
+
+    mockEnsureMusdTokenImportedForChain
+      .mockRejectedValueOnce(new Error('network'))
+      .mockResolvedValueOnce(undefined);
+
+    renderHook(() => useEnsureMusdTokenRegistered());
+
+    await new Promise(process.nextTick);
+
+    expect(mockEnsureMusdTokenImportedForChain).toHaveBeenCalledTimes(2);
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('[mUSD] Failed to register'),
+      expect.any(Error),
+    );
+    (console.warn as jest.Mock).mockRestore();
+  });
+});

--- a/ui/hooks/musd/useEnsureMusdTokenRegistered.ts
+++ b/ui/hooks/musd/useEnsureMusdTokenRegistered.ts
@@ -1,0 +1,44 @@
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import type { Hex } from '@metamask/utils';
+import { ensureMusdTokenImportedForChain } from '../../components/app/musd/utils';
+import { MUSD_TOKEN_ADDRESS_BY_CHAIN } from '../../components/app/musd/constants';
+import { selectIsMusdConversionFlowEnabled } from '../../selectors/musd/feature-flags';
+import type { MetaMaskReduxDispatch } from '../../store/store';
+
+const SUPPORTED_MUSD_CHAIN_IDS = Object.keys(
+  MUSD_TOKEN_ADDRESS_BY_CHAIN,
+) as Hex[];
+
+/**
+ * Registers mUSD in `TokensController.allTokens` for every supported chain
+ * once the wallet is unlocked. This is the precondition for
+ * `TokenRatesController` to fetch mUSD market data, which
+ * `TransactionPayController.parseRequiredTokens` requires to keep mUSD in
+ * `requiredTokens`. Mirrors `useEnsureMusdTokenRegistered` in mobile.
+ */
+export function useEnsureMusdTokenRegistered(): void {
+  const dispatch = useDispatch<MetaMaskReduxDispatch>();
+  const isFlowEnabled = useSelector(selectIsMusdConversionFlowEnabled);
+
+  useEffect(() => {
+    if (!isFlowEnabled) {
+      return;
+    }
+
+    (async () => {
+      for (const chainId of SUPPORTED_MUSD_CHAIN_IDS) {
+        try {
+          await ensureMusdTokenImportedForChain(chainId, dispatch);
+        } catch (error) {
+          console.warn(
+            `[mUSD] Failed to register mUSD token for chain ${chainId}:`,
+            error,
+          );
+        }
+      }
+    })().catch((error) => {
+      console.warn('[mUSD] Unexpected error registering mUSD tokens:', error);
+    });
+  }, [dispatch, isFlowEnabled]);
+}

--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -16,7 +16,7 @@ import {
   ImportTokensModal,
 } from '../../components/multichain';
 import Alerts from '../../components/app/alerts';
-import { EarnTransactionMonitor } from '../../components/app/musd';
+import { MusdTokenMonitor } from '../../components/app/musd';
 
 import {
   ASSET_ROUTE,
@@ -739,7 +739,7 @@ export default function Routes() {
       <ToastMaster />
 
       {isUnlocked ? <Toaster /> : null}
-      {isUnlocked ? <EarnTransactionMonitor /> : null}
+      {isUnlocked ? <MusdTokenMonitor /> : null}
       <Modals />
     </div>
   );

--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -16,6 +16,7 @@ import {
   ImportTokensModal,
 } from '../../components/multichain';
 import Alerts from '../../components/app/alerts';
+import { EarnTransactionMonitor } from '../../components/app/musd';
 
 import {
   ASSET_ROUTE,
@@ -738,6 +739,7 @@ export default function Routes() {
       <ToastMaster />
 
       {isUnlocked ? <Toaster /> : null}
+      {isUnlocked ? <EarnTransactionMonitor /> : null}
       <Modals />
     </div>
   );


### PR DESCRIPTION
## **Description**

POC for #42282.

When the user first enters an amount on a fresh-install mUSD conversion, `useUpdateTokenAmount` encodes it with wrong default decimals. mUSD isn't yet in `TokensController.allTokens`, so `TokenRatesController` hasn't fetched its market data, so `TransactionPayController.parseRequiredTokens` drops mUSD from `requiredTokens`, so `primaryRequiredToken?.decimals ?? 18` falls through to the fallback.

The bug self-resolves after a few seconds or on a subsequent amount change, once the per-conversion `addImportedTokens` propagates and the next parse succeeds. But the *first* amount entry is broken.

## **Solution in this PR (POC)**

Mirrors the mobile fix: register mUSD in `TokensController.allTokens` for every supported chain on unlock, well before the user navigates into the conversion flow. By the time they arrive at the confirmation, market data has been fetched and the first parse succeeds.

- Added `useEnsureMusdTokenRegistered` hook (matches mobile's hook name).
- Added `MusdTokenMonitor` render-null component that mounts the hook.
- Mounted in `routes.component.tsx` next to other post-unlock components (`Alerts`, `Toaster`), gated on `isUnlocked`.
- Hook itself gated on `selectIsMusdConversionFlowEnabled` so it's a no-op when the feature is off.

Mobile reference: [`useEnsureMusdTokenRegistered`](https://github.com/MetaMask/metamask-mobile/blob/main/app/components/UI/Earn/hooks/useEnsureMusdTokenRegistered.ts) and [`EarnTransactionMonitor`](https://github.com/MetaMask/metamask-mobile/blob/main/app/components/UI/Earn/components/EarnTransactionMonitor.tsx) (named `MusdTokenMonitor` here for accuracy since this only handles mUSD token registration, not broader Earn transaction monitoring).

## **Alternative**

https://github.com/MetaMask/core/pull/8620 seeds mUSD into `TokensController` at the core level on `KeyringController:unlock`, which would make this client-side hook unnecessary.

> ⚠️ That core PR currently hardcodes `decimals: 18` for the mUSD entry, but on-chain mUSD is **6 decimals** (see `MUSD_TOKEN.decimals = 6` in `ui/components/app/musd/constants.ts`). That needs fixing before it lands.

## **Related issues**

Fixes: #42282

## **Manual testing steps**

1. Fresh install with a wallet that has stablecoin balance on Mainnet/Linea/BSC.
2. Unlock the wallet — `MusdTokenMonitor` should mount.
3. Within ~1 second, start an mUSD conversion from a stablecoin.
4. Enter an amount and verify the encoded calldata uses the correct decimals (no wildly wrong value).
5. Repeat *without* this fix on `main` — should reproduce the bug on first amount entry.

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).

## **CHANGELOG entry**

CHANGELOG entry: Not included
