### PR TITLE
fix: grant KeyringController:getState to TransactionPayController messengers cp-13.30.0

### DIFF
--- a/app/scripts/messenger-client-init/messengers/transaction-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/transaction-controller-messenger.ts
@@ -13,6 +13,7 @@ import {
 } from '@metamask/bridge-status-controller';
 import { DelegationControllerSignDelegationAction } from '@metamask/delegation-controller';
 import {
+  KeyringControllerGetStateAction,
   KeyringControllerSignEip7702AuthorizationAction,
   KeyringControllerSignTypedMessageAction,
 } from '@metamask/keyring-controller';
@@ -120,6 +121,7 @@ type InitMessengerActions =
   | DelegationControllerSignDelegationAction
   | InstitutionalSnapControllerPublishHookAction
   | InstitutionalSnapControllerBeforeCheckPendingTransactionHookAction
+  | KeyringControllerGetStateAction
   | KeyringControllerSignEip7702AuthorizationAction
   | KeyringControllerSignTypedMessageAction
   | NetworkControllerFindNetworkClientIdByChainIdAction
@@ -199,6 +201,7 @@ export function getTransactionControllerInitMessenger(
       'DelegationController:signDelegation',
       'InstitutionalSnapController:beforeCheckPendingTransactionHook',
       'InstitutionalSnapController:publishHook',
+      'KeyringController:getState',
       'KeyringController:signEip7702Authorization',
       'KeyringController:signTypedMessage',
       'NetworkController:findNetworkClientIdByChainId',

--- a/app/scripts/messenger-client-init/messengers/transaction-pay-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/transaction-pay-controller-messenger.ts
@@ -50,6 +50,7 @@ export function getTransactionPayControllerMessenger(
       'TransactionController:getGasFeeTokens',
       'TransactionController:getState',
       'TransactionController:updateTransaction',
+      'KeyringController:getState',
       'KeyringController:signTypedMessage',
     ],
     events: [


### PR DESCRIPTION
## **Description**

Yesterday's bump of `@metamask/transaction-pay-controller` from `^19.2.2` to `^20.1.0` (#42290) crossed a major version that introduced a new required messenger permission (per the controller's `20.0.0` CHANGELOG):

> **BREAKING:** Fix mUSD conversion for hardware wallets on EIP-7702 chains by gating relay and Across 7702 paths on the account keyring type via `KeyringController:getState`. The `TransactionPayControllerMessenger` now requires `KeyringController:getState` permission.

The bump PR updated `package.json` and LavaMoat policies but did not delegate `KeyringController:getState` to either of the messengers the controller uses. Calling `accountSupports7702()` (used both on every quote refresh AND on every submit through `TransactionPayPublishHook`) now throws:

~~~
A handler for KeyringController:getState has not been registered
~~~

The error is swallowed by the controller's internal `.catch(noop)`, so the symptoms are silent and varied:

- Perps Withdraw, Perps Deposit, Predict Withdraw, mUSD conversion: quotes never resolve, so `transactionData[txId].quotes` stays `undefined` → no Transaction fee / Provider fee / You'll receive rows render, and the bottom button stays enabled regardless of input.
- Submission of any MetaMask Pay flow fails with the error toast shown in the screenshot below.

This fix grants `KeyringController:getState` to both messengers the controller relies on:

- `TransactionPayControllerMessenger` — used for quote fetching (`updateQuotes` → `accountSupports7702`).
- `TransactionControllerInitMessenger` — passed into `TransactionPayPublishHook`, which calls `accountSupports7702` again at submit time.

Mirrors the same change that's already in the mobile app for the same controller bump.

Both `AllowedActions` types in `@metamask/transaction-pay-controller` and `@metamask/transaction-controller` already include `KeyringControllerGetStateAction`, so this is purely a runtime delegate fix — no type changes needed beyond extending our local `InitMessengerActions` union.

This should also be cherry-picked back to `release/13.29.0` since the broken bump shipped on that branch.

## **Changelog**

CHANGELOG entry: Fixed MetaMask Pay quote fetching and submission, which silently failed because the controller messengers were missing the `KeyringController:getState` permission

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check out `main` (current state), build, open any MetaMask Pay confirmation (e.g. Perps Withdraw or Perps Deposit via the developer menu) — observe that the Transaction fee, Provider fee, and You'll receive rows never appear, and that submitting a Perps Deposit fails with `A handler for KeyringController:getState has not been registered`.
2. Check out this branch, rebuild.
3. Open the same confirmation. Verify the Relay quote endpoint is hit (Network tab) and that the fee rows + receive row populate within ~1s of typing an amount.
4. Switch the receive token in the picker (e.g. USDC → BNB) and verify quotes refresh for the new destination.
5. Submit a Perps Deposit and verify it goes through without the `KeyringController:getState` error.

## **Screenshots/Recordings**

### **Before**

Submission error toast on `main`:

![KeyringController:getState handler not registered](https://github.com/user-attachments/assets/<UPLOAD_BEFORE_SCREENSHOT_HERE>)

<!--
### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands messenger permissions to allow `KeyringController:getState`, which is required for MetaMask Pay quote/submit paths; low code-change surface but touches transaction/pay runtime behavior and controller permissioning.
> 
> **Overview**
> Fixes MetaMask Pay quote fetching and submission by delegating the newly-required `KeyringController:getState` permission to the messengers used by the pay flow.
> 
> This updates both `transaction-pay-controller-messenger.ts` and the `TransactionControllerInit` messenger in `transaction-controller-messenger.ts` to include `KeyringControllerGetStateAction` in the allowed action types and to delegate the `'KeyringController:getState'` action at runtime, preventing missing-handler errors after the `@metamask/transaction-pay-controller` major bump.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07f4634e2eec54d032bd4560b4c9b96a586e7c36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->