### PR TITLE
fix: guard browser.management in initInstallType (#42033)

### DIFF
--- a/app/scripts/lib/install-type.ts
+++ b/app/scripts/lib/install-type.ts
@@ -16,6 +16,13 @@ let cachedInstallType: InstallType = INSTALL_TYPE.UNKNOWN;
  * @returns A promise that resolves to the install type
  */
 export const initInstallType = async (): Promise<InstallType> => {
+  // The `management` API is only available in contexts that declare the
+  // `management` permission (background/service worker). In the offscreen
+  // document and other restricted contexts, `browser.management` is
+  // undefined, so guard before calling to avoid a TypeError.
+  if (typeof browser.management?.getSelf !== 'function') {
+    return cachedInstallType;
+  }
   try {
     const extensionInfo = await browser.management.getSelf();
     if (extensionInfo.installType) {


### PR DESCRIPTION
## **Description**

When opening \`offscreen.html\` after a fresh install, the console reports \`TypeError: Cannot read properties of undefined (reading 'getSelf')\`. The offscreen document does not declare the \`management\` permission, so \`browser.management\` is \`undefined\` in that context. \`initInstallType\` (called from \`setupSentry\` via \`bootstrap\` -> \`sentry-install\`, which is injected into every HTML page including offscreen) then trips a TypeError that the surrounding \`try/catch\` logs to the console on every install. Guard \`browser.management?.getSelf\` before calling so restricted contexts stay silent; the cached install type still resolves correctly from the background/service-worker initialization.

## **Changelog**

CHANGELOG entry: Fixed a console error on first install when opening the offscreen page (\`Cannot read properties of undefined (reading 'getSelf')\`).

## **Related issues**

Fixes: #42033

## **Manual testing steps**

1. Build and load the extension in Chrome.
2. Import a wallet for the first time.
3. Open \`chrome-extension://<id>/offscreen.html\` and inspect its console.
4. Confirm there is no \`Cannot read properties of undefined (reading 'getSelf')\` error.

## **Screenshots/Recordings**

### **Before**

Console on offscreen page logs \`TypeError: Cannot read properties of undefined (reading 'getSelf')\` (see issue #42033 recording).

### **After**

No error logged on offscreen page; install type still resolved from the service-worker context.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single defensive guard around an optional browser API; no auth, data, or behavioral changes beyond silencing errors in restricted contexts.
> 
> **Overview**
> **`initInstallType`** now checks that **`browser.management?.getSelf`** exists before calling it. Offscreen and other extension pages that load Sentry bootstrap still run **`initInstallType`**, but without the **`management`** permission they no longer throw **`Cannot read properties of undefined (reading 'getSelf')`** on fresh install.
> 
> Those contexts return the existing cached value (typically **`unknown`**) instead of hitting the API. Install type continues to be populated from the background/service worker, where **`management`** is available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4706443f684fe7abefc89185212c43fc866f34b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->