### PR TITLE
feat: show enforced simulations errors in activity and transaction details

### DIFF
--- a/.metamaskrc.dist
+++ b/.metamaskrc.dist
@@ -101,4 +101,4 @@ NEW_HARDWARE_WALLET_ONBOARDING='false'
 ; Set this to `true` to force enforced simulations to apply whenever a
 ; transaction has balance changes, bypassing the trust signal check.
 ; Intended for local development and QA only.
-;FORCE_ENABLE_SIMULATIONS='true'
+;FORCE_ENFORCED_SIMULATIONS='true'

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -9560,7 +9560,7 @@
     "message": "Transaction failed"
   },
   "transactionProtectedByEnforcedSimulations": {
-    "message": "This transaction was protected by enforced simulations. The on-chain protection prevented an unexpected change to your balances and reverted the transaction. No funds were lost.",
+    "message": "This transaction was protected. We canceled it to prevent unexpected fund loss.",
     "description": "Banner shown in the transaction details view when a failed transaction reverted because an enforced-simulations caveat enforcer rejected it."
   },
   "transactionFee": {

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -9559,10 +9559,6 @@
   "transactionFailed": {
     "message": "Transaction failed"
   },
-  "transactionProtectedByEnforcedSimulations": {
-    "message": "This transaction was protected. We canceled it to prevent unexpected fund loss.",
-    "description": "Banner shown in the transaction details view when a failed transaction reverted because an enforced-simulations caveat enforcer rejected it."
-  },
   "transactionFee": {
     "message": "Transaction fee"
   },
@@ -9596,6 +9592,10 @@
   },
   "transactionIncludesTypes": {
     "message": "This transaction includes: $1."
+  },
+  "transactionProtectedByEnforcedSimulations": {
+    "message": "This transaction was protected. We canceled it to prevent unexpected fund loss.",
+    "description": "Banner shown in the transaction details view when a failed transaction reverted because an enforced-simulations caveat enforcer rejected it."
   },
   "transactionSettings": {
     "message": "Transaction settings"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -9559,6 +9559,10 @@
   "transactionFailed": {
     "message": "Transaction failed"
   },
+  "transactionProtectedByEnforcedSimulations": {
+    "message": "This transaction was protected by enforced simulations. The on-chain protection prevented an unexpected change to your balances and reverted the transaction. No funds were lost.",
+    "description": "Banner shown in the transaction details view when a failed transaction reverted because an enforced-simulations caveat enforcer rejected it."
+  },
   "transactionFee": {
     "message": "Transaction fee"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -9593,6 +9593,10 @@
   "transactionIncludesTypes": {
     "message": "This transaction includes: $1."
   },
+  "transactionProtectedByEnforcedSimulations": {
+    "message": "This transaction was protected. We cancelled it to prevent unexpected fund loss.",
+    "description": "Banner shown in the transaction details view when a failed transaction reverted because an enforced-simulations caveat enforcer rejected it."
+  },
   "transactionSettings": {
     "message": "Transaction settings"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -9594,7 +9594,7 @@
     "message": "This transaction includes: $1."
   },
   "transactionProtectedByEnforcedSimulations": {
-    "message": "This transaction was protected. We cancelled it to prevent unexpected fund loss.",
+    "message": "This transaction was protected. We canceled it to prevent unexpected fund loss.",
     "description": "Banner shown in the transaction details view when a failed transaction reverted because an enforced-simulations caveat enforcer rejected it."
   },
   "transactionSettings": {

--- a/builds.yml
+++ b/builds.yml
@@ -428,7 +428,7 @@ env:
   # Force enforced simulations to apply whenever a transaction has balance
   # changes, bypassing the trust signal check. Intended for local
   # development and QA only; must remain false for production builds.
-  - FORCE_ENABLE_SIMULATIONS: false
+  - FORCE_ENFORCED_SIMULATIONS: false
 
   # OAuth (Social login)
   - GOOGLE_CLIENT_ID_REF

--- a/shared/lib/transaction/enforced-simulations.test.ts
+++ b/shared/lib/transaction/enforced-simulations.test.ts
@@ -120,7 +120,7 @@ describe('enforced-simulations', () => {
 
   describe('getIsEnforcedSimulationsEligible', () => {
     afterEach(() => {
-      delete process.env.FORCE_ENABLE_SIMULATIONS;
+      delete process.env.FORCE_ENFORCED_SIMULATIONS;
     });
 
     it('returns true when all conditions are met', () => {
@@ -410,9 +410,9 @@ describe('enforced-simulations', () => {
       });
     });
 
-    describe('with FORCE_ENABLE_SIMULATIONS', () => {
+    describe('with FORCE_ENFORCED_SIMULATIONS', () => {
       beforeEach(() => {
-        process.env.FORCE_ENABLE_SIMULATIONS = 'true';
+        process.env.FORCE_ENFORCED_SIMULATIONS = 'true';
       });
 
       it('returns true even when recipient is trusted', () => {
@@ -465,7 +465,7 @@ describe('enforced-simulations', () => {
       });
 
       it('is ignored when value is not the string "true"', () => {
-        process.env.FORCE_ENABLE_SIMULATIONS = '1';
+        process.env.FORCE_ENFORCED_SIMULATIONS = '1';
 
         expect(
           isEnforcedSimulationsEligible(

--- a/shared/lib/transaction/enforced-simulations.ts
+++ b/shared/lib/transaction/enforced-simulations.ts
@@ -65,14 +65,14 @@ export function getIsEnforcedSimulationsEnabled(
 
 /**
  * Whether enforced simulations are force-enabled via the
- * `FORCE_ENABLE_SIMULATIONS` build flag. When `true`, callers should
+ * `FORCE_ENFORCED_SIMULATIONS` build flag. When `true`, callers should
  * skip the remote feature flag check and bypass trust signals.
  * Intended for local development and QA only.
  *
  * @returns Whether enforced simulations are force-enabled.
  */
 export function isEnforcedSimulationsForceEnabled(): boolean {
-  return process.env.FORCE_ENABLE_SIMULATIONS?.toString() === 'true';
+  return process.env.FORCE_ENFORCED_SIMULATIONS?.toString() === 'true';
 }
 
 /**

--- a/shared/lib/transaction/enforced-simulations.ts
+++ b/shared/lib/transaction/enforced-simulations.ts
@@ -64,6 +64,18 @@ export function getIsEnforcedSimulationsEnabled(
 }
 
 /**
+ * Whether enforced simulations are force-enabled via the
+ * `FORCE_ENABLE_SIMULATIONS` build flag. When `true`, callers should
+ * skip the remote feature flag check and bypass trust signals.
+ * Intended for local development and QA only.
+ *
+ * @returns Whether enforced simulations are force-enabled.
+ */
+export function isEnforcedSimulationsForceEnabled(): boolean {
+  return process.env.FORCE_ENABLE_SIMULATIONS?.toString() === 'true';
+}
+
+/**
  * Reads the `slippage` field from the `confirmations_enforced_simulations`
  * remote feature flag. Falls back to
  * {@link DEFAULT_ENFORCED_SIMULATIONS_SLIPPAGE} when the flag or field is
@@ -115,10 +127,7 @@ export function isEnforcedSimulationsEligible(
     return false;
   }
 
-  // When forcing is enabled, skip the trust signal check so enforced
-  // simulations always applies as long as balance changes are present.
-  // Intended for local development and QA only.
-  if (isForceEnabled()) {
+  if (isEnforcedSimulationsForceEnabled()) {
     return true;
   }
 
@@ -135,10 +144,6 @@ function getEnforcedSimulationsFlag({
   return (remoteFeatureFlags as RemoteFlagsWithEnforcedSimulations)?.[
     ENFORCED_SIMULATIONS_FEATURE_FLAG
   ];
-}
-
-function isForceEnabled(): boolean {
-  return process.env.FORCE_ENABLE_SIMULATIONS === 'true';
 }
 
 function isTrusted(

--- a/ui/components/app/transaction-list-item-details/transaction-list-item-details.component.js
+++ b/ui/components/app/transaction-list-item-details/transaction-list-item-details.component.js
@@ -9,10 +9,7 @@ import {
   BannerAlertSeverity,
   Text,
 } from '../../component-library';
-import {
-  TextColor,
-  TextVariant,
-} from '../../../helpers/constants/design-system';
+import { TextVariant } from '../../../helpers/constants/design-system';
 import SenderToRecipient from '../../ui/sender-to-recipient';
 import { DEFAULT_VARIANT } from '../../ui/sender-to-recipient/sender-to-recipient.constants';
 import TransactionBreakdown from '../transaction-breakdown';
@@ -182,7 +179,7 @@ export default class TransactionListItemDetails extends PureComponent {
           {isProtectedByEnforcedSimulations && (
             <BannerAlert
               severity={BannerAlertSeverity.Info}
-              marginBottom={4}
+              marginInline={4}
               data-testid="transaction-protected-by-enforced-simulations"
             >
               <Text variant={TextVariant.bodySm}>
@@ -231,12 +228,12 @@ export default class TransactionListItemDetails extends PureComponent {
               <div>{t('status')}</div>
               <div>
                 {isProtectedByEnforcedSimulations ? (
-                  <Text
-                    color={TextColor.successDefault}
+                  <span
+                    className="transaction-status-label transaction-status-label--confirmed"
                     data-testid="transaction-protected-status-pill"
                   >
                     {t('cancelled')}
-                  </Text>
+                  </span>
                 ) : (
                   <TransactionStatus />
                 )}

--- a/ui/components/app/transaction-list-item-details/transaction-list-item-details.component.js
+++ b/ui/components/app/transaction-list-item-details/transaction-list-item-details.component.js
@@ -7,7 +7,12 @@ import { Button, ButtonSize } from '@metamask/design-system-react';
 import {
   BannerAlert,
   BannerAlertSeverity,
+  Text,
 } from '../../component-library';
+import {
+  TextColor,
+  TextVariant,
+} from '../../../helpers/constants/design-system';
 import SenderToRecipient from '../../ui/sender-to-recipient';
 import { DEFAULT_VARIANT } from '../../ui/sender-to-recipient/sender-to-recipient.constants';
 import TransactionBreakdown from '../transaction-breakdown';
@@ -174,6 +179,17 @@ export default class TransactionListItemDetails extends PureComponent {
     return (
       <Popover title={title} onClose={onClose}>
         <div className="transaction-list-item-details">
+          {isProtectedByEnforcedSimulations && (
+            <BannerAlert
+              severity={BannerAlertSeverity.Info}
+              marginBottom={4}
+              data-testid="transaction-protected-by-enforced-simulations"
+            >
+              <Text variant={TextVariant.bodySm}>
+                {t('transactionProtectedByEnforcedSimulations')}
+              </Text>
+            </BannerAlert>
+          )}
           <div className="transaction-list-item-details__operations">
             <div className="flex gap-2">
               {showSpeedUp && (
@@ -214,7 +230,16 @@ export default class TransactionListItemDetails extends PureComponent {
             >
               <div>{t('status')}</div>
               <div>
-                <TransactionStatus />
+                {isProtectedByEnforcedSimulations ? (
+                  <Text
+                    color={TextColor.successDefault}
+                    data-testid="transaction-protected-status-pill"
+                  >
+                    {t('cancelled')}
+                  </Text>
+                ) : (
+                  <TransactionStatus />
+                )}
               </div>
             </div>
             <div className="transaction-list-item-details__tx-hash gap-1">
@@ -246,15 +271,6 @@ export default class TransactionListItemDetails extends PureComponent {
             </div>
           </div>
           <div className="transaction-list-item-details__body">
-            {isProtectedByEnforcedSimulations && (
-              <BannerAlert
-                severity={BannerAlertSeverity.Info}
-                marginBottom={4}
-                data-testid="transaction-protected-by-enforced-simulations"
-              >
-                {t('transactionProtectedByEnforcedSimulations')}
-              </BannerAlert>
-            )}
             <div className="transaction-list-item-details__sender-to-recipient-header">
               <div>{t('from')}</div>
               <div>{t('to')}</div>

--- a/ui/components/app/transaction-list-item-details/transaction-list-item-details.component.js
+++ b/ui/components/app/transaction-list-item-details/transaction-list-item-details.component.js
@@ -3,16 +3,18 @@ import PropTypes from 'prop-types';
 import copyToClipboard from 'copy-to-clipboard';
 import { getBlockExplorerLink } from '@metamask/etherscan-link';
 import { TransactionType } from '@metamask/transaction-controller';
-import { Button, ButtonSize } from '@metamask/design-system-react';
 import {
   BannerAlert,
   BannerAlertSeverity,
+  Button,
+  ButtonSize,
   Text,
-} from '../../component-library';
-import { TextVariant } from '../../../helpers/constants/design-system';
+  TextVariant,
+} from '@metamask/design-system-react';
 import SenderToRecipient from '../../ui/sender-to-recipient';
 import { DEFAULT_VARIANT } from '../../ui/sender-to-recipient/sender-to-recipient.constants';
 import TransactionBreakdown from '../transaction-breakdown';
+import TransactionStatusLabel from '../transaction-status-label/transaction-status-label';
 import Tooltip from '../../ui/tooltip';
 import CancelButton from '../cancel-button';
 import Popover from '../../ui/popover';
@@ -179,10 +181,10 @@ export default class TransactionListItemDetails extends PureComponent {
           {isProtectedByEnforcedSimulations && (
             <BannerAlert
               severity={BannerAlertSeverity.Info}
-              marginInline={4}
+              className="mx-4"
               data-testid="transaction-protected-by-enforced-simulations"
             >
-              <Text variant={TextVariant.bodySm}>
+              <Text variant={TextVariant.BodySm}>
                 {t('transactionProtectedByEnforcedSimulations')}
               </Text>
             </BannerAlert>
@@ -228,12 +230,11 @@ export default class TransactionListItemDetails extends PureComponent {
               <div>{t('status')}</div>
               <div>
                 {isProtectedByEnforcedSimulations ? (
-                  <span
-                    className="transaction-status-label transaction-status-label--confirmed"
-                    data-testid="transaction-protected-status-pill"
-                  >
-                    {t('cancelled')}
-                  </span>
+                  <TransactionStatusLabel
+                    statusOnly
+                    label={t('cancelled')}
+                    tooltip={t('transactionProtectedByEnforcedSimulations')}
+                  />
                 ) : (
                   <TransactionStatus />
                 )}

--- a/ui/components/app/transaction-list-item-details/transaction-list-item-details.component.js
+++ b/ui/components/app/transaction-list-item-details/transaction-list-item-details.component.js
@@ -4,6 +4,10 @@ import copyToClipboard from 'copy-to-clipboard';
 import { getBlockExplorerLink } from '@metamask/etherscan-link';
 import { TransactionType } from '@metamask/transaction-controller';
 import { Button, ButtonSize } from '@metamask/design-system-react';
+import {
+  BannerAlert,
+  BannerAlertSeverity,
+} from '../../component-library';
 import SenderToRecipient from '../../ui/sender-to-recipient';
 import { DEFAULT_VARIANT } from '../../ui/sender-to-recipient/sender-to-recipient.constants';
 import TransactionBreakdown from '../transaction-breakdown';
@@ -51,6 +55,7 @@ export default class TransactionListItemDetails extends PureComponent {
     chainId: PropTypes.string,
     networkConfiguration: PropTypes.object,
     isHardwareWalletAccount: PropTypes.bool,
+    isProtectedByEnforcedSimulations: PropTypes.bool,
   };
 
   state = {
@@ -158,6 +163,7 @@ export default class TransactionListItemDetails extends PureComponent {
       transactionStatus: TransactionStatus,
       blockExplorerLinkText,
       isHardwareWalletAccount,
+      isProtectedByEnforcedSimulations,
     } = this.props;
     const {
       primaryTransaction: transaction,
@@ -240,6 +246,15 @@ export default class TransactionListItemDetails extends PureComponent {
             </div>
           </div>
           <div className="transaction-list-item-details__body">
+            {isProtectedByEnforcedSimulations && (
+              <BannerAlert
+                severity={BannerAlertSeverity.Info}
+                marginBottom={4}
+                data-testid="transaction-protected-by-enforced-simulations"
+              >
+                {t('transactionProtectedByEnforcedSimulations')}
+              </BannerAlert>
+            )}
             <div className="transaction-list-item-details__sender-to-recipient-header">
               <div>{t('from')}</div>
               <div>{t('to')}</div>

--- a/ui/components/app/transaction-list-item-details/transaction-list-item-details.container.js
+++ b/ui/components/app/transaction-list-item-details/transaction-list-item-details.container.js
@@ -1,6 +1,5 @@
 import { connect } from 'react-redux';
 import { compose } from 'redux';
-import { TransactionStatus } from '@metamask/transaction-controller';
 import withRouterHooks from '../../../helpers/higher-order-components/with-router-hooks/with-router-hooks';
 import { getNetworkConfigurationsByChainId } from '../../../../shared/lib/selectors/networks';
 import { isProtectedByEnforcedSimulations } from '../../../pages/confirmations/utils/confirm';
@@ -33,13 +32,9 @@ const mapStateToProps = (state, ownProps) => {
   const networkConfiguration = getNetworkConfigurationsByChainId(state);
   const isCustomNetwork = getIsCustomNetwork(state);
 
-  const primaryTransaction = transactionGroup?.primaryTransaction;
-  const isProtected =
-    primaryTransaction?.status === TransactionStatus.failed &&
-    isProtectedByEnforcedSimulations({
-      errorMessage: primaryTransaction?.error?.message,
-      data: primaryTransaction?.txParams?.data,
-    });
+  const isProtected = isProtectedByEnforcedSimulations(
+    transactionGroup?.primaryTransaction,
+  );
 
   return {
     rpcPrefs,

--- a/ui/components/app/transaction-list-item-details/transaction-list-item-details.container.js
+++ b/ui/components/app/transaction-list-item-details/transaction-list-item-details.container.js
@@ -3,6 +3,7 @@ import { compose } from 'redux';
 import { TransactionStatus } from '@metamask/transaction-controller';
 import withRouterHooks from '../../../helpers/higher-order-components/with-router-hooks/with-router-hooks';
 import { getNetworkConfigurationsByChainId } from '../../../../shared/lib/selectors/networks';
+import { isProtectedByEnforcedSimulations } from '../../../pages/confirmations/utils/confirm';
 import {
   getAccountName,
   getAddressBook,
@@ -14,11 +15,6 @@ import {
 import { isHardwareWallet } from '../../../../shared/lib/selectors/keyring';
 import { tryReverseResolveAddress } from '../../../store/actions';
 import TransactionListItemDetails from './transaction-list-item-details.component';
-
-// DelegationFramework caveat enforcers revert with `Error(string)` messages of
-// the form `<EnforcerName>:<reason>` (Solidity convention). Detect any such
-// message generically rather than hard-coding the list of enforcer names.
-const CAVEAT_ENFORCER_REVERT_PATTERN = /^[A-Z][A-Za-z0-9]*Enforcer:/u;
 
 const mapStateToProps = (state, ownProps) => {
   const { senderAddress, transactionGroup } = ownProps;
@@ -38,11 +34,12 @@ const mapStateToProps = (state, ownProps) => {
   const isCustomNetwork = getIsCustomNetwork(state);
 
   const primaryTransaction = transactionGroup?.primaryTransaction;
-  const receiptRevertMessage = primaryTransaction?.revert?.receipt?.message;
-  const isProtectedByEnforcedSimulations =
+  const isProtected =
     primaryTransaction?.status === TransactionStatus.failed &&
-    typeof receiptRevertMessage === 'string' &&
-    CAVEAT_ENFORCER_REVERT_PATTERN.test(receiptRevertMessage);
+    isProtectedByEnforcedSimulations({
+      errorMessage: primaryTransaction?.error?.message,
+      data: primaryTransaction?.txParams?.data,
+    });
 
   return {
     rpcPrefs,
@@ -51,7 +48,7 @@ const mapStateToProps = (state, ownProps) => {
     isCustomNetwork,
     blockExplorerLinkText: getBlockExplorerLinkText(state),
     isHardwareWalletAccount: isHardwareWallet(state),
-    isProtectedByEnforcedSimulations,
+    isProtectedByEnforcedSimulations: isProtected,
   };
 };
 

--- a/ui/components/app/transaction-list-item-details/transaction-list-item-details.container.js
+++ b/ui/components/app/transaction-list-item-details/transaction-list-item-details.container.js
@@ -1,5 +1,6 @@
 import { connect } from 'react-redux';
 import { compose } from 'redux';
+import { TransactionStatus } from '@metamask/transaction-controller';
 import withRouterHooks from '../../../helpers/higher-order-components/with-router-hooks/with-router-hooks';
 import { getNetworkConfigurationsByChainId } from '../../../../shared/lib/selectors/networks';
 import {
@@ -14,8 +15,13 @@ import { isHardwareWallet } from '../../../../shared/lib/selectors/keyring';
 import { tryReverseResolveAddress } from '../../../store/actions';
 import TransactionListItemDetails from './transaction-list-item-details.component';
 
+// DelegationFramework caveat enforcers revert with `Error(string)` messages of
+// the form `<EnforcerName>:<reason>` (Solidity convention). Detect any such
+// message generically rather than hard-coding the list of enforcer names.
+const CAVEAT_ENFORCER_REVERT_PATTERN = /^[A-Z][A-Za-z0-9]*Enforcer:/u;
+
 const mapStateToProps = (state, ownProps) => {
-  const { senderAddress } = ownProps;
+  const { senderAddress, transactionGroup } = ownProps;
   const addressBook = getAddressBook(state);
   const accounts = getInternalAccounts(state);
   const senderAccountName = getAccountName(accounts, senderAddress);
@@ -31,6 +37,13 @@ const mapStateToProps = (state, ownProps) => {
   const networkConfiguration = getNetworkConfigurationsByChainId(state);
   const isCustomNetwork = getIsCustomNetwork(state);
 
+  const primaryTransaction = transactionGroup?.primaryTransaction;
+  const receiptRevertMessage = primaryTransaction?.revert?.receipt?.message;
+  const isProtectedByEnforcedSimulations =
+    primaryTransaction?.status === TransactionStatus.failed &&
+    typeof receiptRevertMessage === 'string' &&
+    CAVEAT_ENFORCER_REVERT_PATTERN.test(receiptRevertMessage);
+
   return {
     rpcPrefs,
     networkConfiguration,
@@ -38,6 +51,7 @@ const mapStateToProps = (state, ownProps) => {
     isCustomNetwork,
     blockExplorerLinkText: getBlockExplorerLinkText(state),
     isHardwareWalletAccount: isHardwareWallet(state),
+    isProtectedByEnforcedSimulations,
   };
 };
 

--- a/ui/components/app/transaction-status-label/transaction-status-label.js
+++ b/ui/components/app/transaction-status-label/transaction-status-label.js
@@ -56,13 +56,15 @@ export default function TransactionStatusLabel({
   isEarliestNonce,
   className,
   statusOnly,
+  label,
+  tooltip,
 }) {
   const t = useI18nContext();
   const statusKey = getStatusKey(status, isEarliestNonce);
-  const tooltipText = error?.rpc?.message || error?.message;
-  let statusText = statusKey && t(statusKey);
+  const tooltipText = tooltip ?? error?.rpc?.message ?? error?.message;
+  let statusText = label ?? (statusKey && t(statusKey));
 
-  if (statusKey === TransactionStatus.confirmed && !statusOnly) {
+  if (!label && statusKey === TransactionStatus.confirmed && !statusOnly) {
     statusText = date;
   }
 
@@ -72,9 +74,10 @@ export default function TransactionStatusLabel({
       title={tooltipText}
       wrapperClassName={classnames(
         'transaction-status-label',
-        `transaction-status-label--${statusKey}`,
+        label ? 'transaction-status-label--confirmed' : undefined,
+        !label && `transaction-status-label--${statusKey}`,
         className,
-        statusToClassNameHash[statusKey],
+        !label && statusToClassNameHash[statusKey],
       )}
     >
       {statusText}
@@ -89,4 +92,6 @@ TransactionStatusLabel.propTypes = {
   error: PropTypes.object,
   isEarliestNonce: PropTypes.bool,
   statusOnly: PropTypes.bool,
+  label: PropTypes.string,
+  tooltip: PropTypes.string,
 };

--- a/ui/components/app/transaction-status-label/transaction-status-label.js
+++ b/ui/components/app/transaction-status-label/transaction-status-label.js
@@ -61,7 +61,7 @@ export default function TransactionStatusLabel({
 }) {
   const t = useI18nContext();
   const statusKey = getStatusKey(status, isEarliestNonce);
-  const tooltipText = tooltip ?? error?.rpc?.message ?? error?.message;
+  const tooltipText = tooltip || error?.rpc?.message || error?.message;
   let statusText = label ?? (statusKey && t(statusKey));
 
   if (!label && statusKey === TransactionStatus.confirmed && !statusOnly) {

--- a/ui/components/app/transaction-status-label/transaction-status-label.test.js
+++ b/ui/components/app/transaction-status-label/transaction-status-label.test.js
@@ -13,11 +13,7 @@ jest.mock('../../../hooks/useI18nContext', () => ({
 jest.mock('../../ui/tooltip', () => ({
   __esModule: true,
   default: ({ children, title, wrapperClassName }) => (
-    <div
-      data-testid="tooltip"
-      data-title={title}
-      className={wrapperClassName}
-    >
+    <div data-testid="tooltip" data-title={title} className={wrapperClassName}>
       {children}
     </div>
   ),

--- a/ui/components/app/transaction-status-label/transaction-status-label.test.js
+++ b/ui/components/app/transaction-status-label/transaction-status-label.test.js
@@ -12,7 +12,15 @@ jest.mock('../../../hooks/useI18nContext', () => ({
 // Mock the Tooltip component
 jest.mock('../../ui/tooltip', () => ({
   __esModule: true,
-  default: ({ children }) => <div data-testid="tooltip">{children}</div>,
+  default: ({ children, title, wrapperClassName }) => (
+    <div
+      data-testid="tooltip"
+      data-title={title}
+      className={wrapperClassName}
+    >
+      {children}
+    </div>
+  ),
 }));
 
 describe('TransactionStatusLabel Component', () => {
@@ -152,5 +160,41 @@ describe('TransactionStatusLabel Component', () => {
 
     render(<TransactionStatusLabel {...props} />);
     expect(screen.getByText(TransactionStatus.confirmed)).toBeInTheDocument();
+  });
+
+  it('label overrides the displayed text', () => {
+    render(
+      <TransactionStatusLabel
+        status={TransactionStatus.confirmed}
+        label="cancelled"
+      />,
+    );
+    expect(screen.getByText('cancelled')).toBeInTheDocument();
+  });
+
+  it('label applies confirmed class regardless of status', () => {
+    render(
+      <TransactionStatusLabel
+        status={TransactionStatus.failed}
+        label="cancelled"
+      />,
+    );
+    expect(screen.getByTestId('tooltip').className).toContain(
+      'transaction-status-label--confirmed',
+    );
+    expect(screen.getByTestId('tooltip').className).not.toContain(
+      'transaction-status-label--failed',
+    );
+  });
+
+  it('tooltip prop overrides the tooltip text', () => {
+    render(
+      <TransactionStatusLabel
+        status={TransactionStatus.failed}
+        error={{ message: 'original error' }}
+        tooltip="custom tooltip"
+      />,
+    );
+    expect(screen.getByTestId('tooltip').dataset.title).toBe('custom tooltip');
   });
 });

--- a/ui/components/multichain/activity-v2/activity-details-modal-adapter.tsx
+++ b/ui/components/multichain/activity-v2/activity-details-modal-adapter.tsx
@@ -185,10 +185,10 @@ const TransactionDetailsWrapper = ({
       isEarliestNonce={false}
       onCancel={noop}
       transactionStatus={() => {
+        const primary = syntheticGroup.primaryTransaction;
         const failureMessage =
           displayedStatusKey === 'failed'
-            ? localTransactionMeta?.error?.message ??
-              localTransactionMeta?.revert?.receipt?.message
+            ? primary.error?.message ?? primary.revert?.receipt?.message
             : undefined;
         return (
           <TransactionStatusLabel

--- a/ui/components/multichain/activity-v2/activity-details-modal-adapter.tsx
+++ b/ui/components/multichain/activity-v2/activity-details-modal-adapter.tsx
@@ -1,6 +1,9 @@
 import React, { useEffect, useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import { TransactionType } from '@metamask/transaction-controller';
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
 import { toHex } from '@metamask/controller-utils';
 import { Hex } from 'viem';
 import type {
@@ -15,6 +18,7 @@ import { formatDateWithYearContext } from '../../../helpers/utils/util';
 import LegacyTransactionListItemDetails from '../../app/transaction-list-item-details';
 import TransactionStatusLabel from '../../app/transaction-status-label/transaction-status-label';
 import { getSelectedAddress } from '../../../selectors/selectors';
+import { selectTransactionByHash } from '../../../selectors/transactionController';
 import { formatUnits } from '../../../../shared/lib/unit';
 import { useBridgeActivityData } from '../../../hooks/bridge/useBridgeActivityData';
 import { useGetTitle } from './hooks';
@@ -27,6 +31,7 @@ const noop = () => {};
 function buildSyntheticTransactionGroup(
   transaction: TransactionViewModel,
   selectedAddress?: string,
+  localTransactionMeta?: TransactionMeta,
 ): TransactionGroup {
   const rawNonce = transaction.txParams?.nonce;
   const nonce =
@@ -66,6 +71,12 @@ function buildSyntheticTransactionGroup(
     sourceTokenAddress,
     sourceTokenAmount,
     destinationTokenSymbol,
+    // Surface local TransactionController fields (revert reasons, error) onto
+    // the synthetic primary transaction so legacy details components — e.g.
+    // the "protected by enforced simulations" banner — can read them. The
+    // Accounts API view model doesn't carry these fields.
+    revert: localTransactionMeta?.revert ?? transaction.revert,
+    error: localTransactionMeta?.error ?? transaction.error,
   };
 
   return {
@@ -92,9 +103,17 @@ const TransactionDetailsWrapper = ({
   onClose: () => void;
 }) => {
   const selectedAddress = useSelector(getSelectedAddress);
+  const localTransactionMeta = useSelector((state) =>
+    selectTransactionByHash(state, transaction.hash),
+  );
   const syntheticGroup = useMemo(
-    () => buildSyntheticTransactionGroup(transaction, selectedAddress),
-    [transaction, selectedAddress],
+    () =>
+      buildSyntheticTransactionGroup(
+        transaction,
+        selectedAddress,
+        localTransactionMeta,
+      ),
+    [transaction, selectedAddress, localTransactionMeta],
   );
   const displayData = useTransactionDisplayData(syntheticGroup);
   const title = useGetTitle(transaction);
@@ -165,15 +184,22 @@ const TransactionDetailsWrapper = ({
       showSpeedUp={false}
       isEarliestNonce={false}
       onCancel={noop}
-      transactionStatus={() => (
-        <TransactionStatusLabel
-          isEarliestNonce={false}
-          error={undefined}
-          date={date}
-          status={displayedStatusKey}
-          statusOnly
-        />
-      )}
+      transactionStatus={() => {
+        const failureMessage =
+          displayedStatusKey === 'failed'
+            ? localTransactionMeta?.error?.message ??
+              localTransactionMeta?.revert?.receipt?.message
+            : undefined;
+        return (
+          <TransactionStatusLabel
+            isEarliestNonce={false}
+            error={failureMessage ? { message: failureMessage } : undefined}
+            date={date}
+            status={displayedStatusKey}
+            statusOnly
+          />
+        );
+      }}
       chainId={chainId}
     />
   );

--- a/ui/components/multichain/activity-v2/activity-details-modal-adapter.tsx
+++ b/ui/components/multichain/activity-v2/activity-details-modal-adapter.tsx
@@ -1,9 +1,6 @@
 import React, { useEffect, useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import {
-  TransactionMeta,
-  TransactionType,
-} from '@metamask/transaction-controller';
+import { TransactionType } from '@metamask/transaction-controller';
 import { toHex } from '@metamask/controller-utils';
 import { Hex } from 'viem';
 import type {
@@ -18,7 +15,6 @@ import { formatDateWithYearContext } from '../../../helpers/utils/util';
 import LegacyTransactionListItemDetails from '../../app/transaction-list-item-details';
 import TransactionStatusLabel from '../../app/transaction-status-label/transaction-status-label';
 import { getSelectedAddress } from '../../../selectors/selectors';
-import { selectTransactionByHash } from '../../../selectors/transactionController';
 import { formatUnits } from '../../../../shared/lib/unit';
 import { useBridgeActivityData } from '../../../hooks/bridge/useBridgeActivityData';
 import { useGetTitle } from './hooks';
@@ -31,7 +27,6 @@ const noop = () => {};
 function buildSyntheticTransactionGroup(
   transaction: TransactionViewModel,
   selectedAddress?: string,
-  localTransactionMeta?: TransactionMeta,
 ): TransactionGroup {
   const rawNonce = transaction.txParams?.nonce;
   const nonce =
@@ -71,12 +66,6 @@ function buildSyntheticTransactionGroup(
     sourceTokenAddress,
     sourceTokenAmount,
     destinationTokenSymbol,
-    // Surface local TransactionController fields (revert reasons, error) onto
-    // the synthetic primary transaction so legacy details components — e.g.
-    // the "protected by enforced simulations" banner — can read them. The
-    // Accounts API view model doesn't carry these fields.
-    revert: localTransactionMeta?.revert ?? transaction.revert,
-    error: localTransactionMeta?.error ?? transaction.error,
   };
 
   return {
@@ -103,17 +92,9 @@ const TransactionDetailsWrapper = ({
   onClose: () => void;
 }) => {
   const selectedAddress = useSelector(getSelectedAddress);
-  const localTransactionMeta = useSelector((state) =>
-    selectTransactionByHash(state, transaction.hash),
-  );
   const syntheticGroup = useMemo(
-    () =>
-      buildSyntheticTransactionGroup(
-        transaction,
-        selectedAddress,
-        localTransactionMeta,
-      ),
-    [transaction, selectedAddress, localTransactionMeta],
+    () => buildSyntheticTransactionGroup(transaction, selectedAddress),
+    [transaction, selectedAddress],
   );
   const displayData = useTransactionDisplayData(syntheticGroup);
   const title = useGetTitle(transaction);
@@ -184,22 +165,15 @@ const TransactionDetailsWrapper = ({
       showSpeedUp={false}
       isEarliestNonce={false}
       onCancel={noop}
-      transactionStatus={() => {
-        const primary = syntheticGroup.primaryTransaction;
-        const failureMessage =
-          displayedStatusKey === 'failed'
-            ? primary.error?.message ?? primary.revert?.receipt?.message
-            : undefined;
-        return (
-          <TransactionStatusLabel
-            isEarliestNonce={false}
-            error={failureMessage ? { message: failureMessage } : undefined}
-            date={date}
-            status={displayedStatusKey}
-            statusOnly
-          />
-        );
-      }}
+      transactionStatus={() => (
+        <TransactionStatusLabel
+          isEarliestNonce={false}
+          error={syntheticGroup.primaryTransaction.error}
+          date={date}
+          status={displayedStatusKey}
+          statusOnly
+        />
+      )}
       chainId={chainId}
     />
   );

--- a/ui/components/multichain/activity-v2/activity-list-item.tsx
+++ b/ui/components/multichain/activity-v2/activity-list-item.tsx
@@ -7,6 +7,7 @@ import { useFormatters } from '../../../hooks/useFormatters';
 import type { TransactionViewModel } from '../../../../shared/lib/multichain/types';
 import { getCurrentCurrency } from '../../../ducks/metamask/metamask';
 import { useBridgeActivityData } from '../../../hooks/bridge/useBridgeActivityData';
+import { selectTransactionByHash } from '../../../selectors/transactionController';
 import { ChainBadge } from '../../app/chain-badge/chain-badge';
 import { getPrimaryAmount } from './helpers';
 import { useGetTitle, useFiatAmount } from './hooks';
@@ -36,6 +37,17 @@ export const ActivityListItem = ({ transaction, onClick }: Props) => {
       ? TransactionStatus.failed
       : TransactionStatus.confirmed;
 
+  const localTransactionMeta = useSelector((state) =>
+    selectTransactionByHash(state, transaction.hash),
+  );
+
+  const failureMessage =
+    transactionStatus === TransactionStatus.failed
+      ? localTransactionMeta?.error?.message ??
+        localTransactionMeta?.revert?.receipt?.message
+      : undefined;
+  const failureError = failureMessage ? { message: failureMessage } : undefined;
+
   return (
     <Box
       className="px-4 py-3 bg-background-default cursor-pointer hover:bg-hover activity-list-item"
@@ -58,7 +70,11 @@ export const ActivityListItem = ({ transaction, onClick }: Props) => {
             {title}
           </Text>
           <div className="text-s-body-sm font-medium">
-            <TransactionStatusLabel status={transactionStatus} statusOnly />
+            <TransactionStatusLabel
+              status={transactionStatus}
+              error={failureError}
+              statusOnly
+            />
           </div>
         </div>
 

--- a/ui/components/multichain/activity-v2/activity-list-item.tsx
+++ b/ui/components/multichain/activity-v2/activity-list-item.tsx
@@ -3,21 +3,17 @@ import { useSelector } from 'react-redux';
 import { Box, Text, TextVariant } from '@metamask/design-system-react';
 import { TransactionStatus } from '@metamask/transaction-controller';
 import TransactionStatusLabel from '../../app/transaction-status-label/transaction-status-label';
+import Tooltip from '../../ui/tooltip';
 import { useFormatters } from '../../../hooks/useFormatters';
 import type { TransactionViewModel } from '../../../../shared/lib/multichain/types';
 import { getCurrentCurrency } from '../../../ducks/metamask/metamask';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useBridgeActivityData } from '../../../hooks/bridge/useBridgeActivityData';
-import { selectTransactionByHash } from '../../../selectors/transactionController';
+import { isProtectedByEnforcedSimulations } from '../../../pages/confirmations/utils/confirm';
 import { ChainBadge } from '../../app/chain-badge/chain-badge';
 import { getPrimaryAmount } from './helpers';
 import { useGetTitle, useFiatAmount } from './hooks';
 import { ActivityTxIcon } from './activity-tx-icon';
-
-// DelegationFramework caveat enforcers revert with `Error(string)` messages of
-// the form `<EnforcerName>:<reason>` (Solidity convention). Detect any such
-// message generically rather than hard-coding the list of enforcer names.
-const CAVEAT_ENFORCER_REVERT_PATTERN = /^[A-Z][A-Za-z0-9]*Enforcer:/u;
 
 type Props = {
   transaction: TransactionViewModel;
@@ -44,19 +40,16 @@ export const ActivityListItem = ({ transaction, onClick }: Props) => {
       ? TransactionStatus.failed
       : TransactionStatus.confirmed;
 
-  const localTransactionMeta = useSelector((state) =>
-    selectTransactionByHash(state, transaction.hash),
-  );
-
-  const receiptRevertMessage = localTransactionMeta?.revert?.receipt?.message;
-  const isProtectedByEnforcedSimulations =
+  const isProtected =
     transactionStatus === TransactionStatus.failed &&
-    typeof receiptRevertMessage === 'string' &&
-    CAVEAT_ENFORCER_REVERT_PATTERN.test(receiptRevertMessage);
+    isProtectedByEnforcedSimulations({
+      errorMessage: transaction.error?.message,
+      data: transaction.txParams?.data,
+    });
 
   const failureMessage =
     transactionStatus === TransactionStatus.failed
-      ? localTransactionMeta?.error?.message ?? receiptRevertMessage
+      ? transaction.error?.message
       : undefined;
   const failureError = failureMessage ? { message: failureMessage } : undefined;
 
@@ -82,13 +75,18 @@ export const ActivityListItem = ({ transaction, onClick }: Props) => {
             {title}
           </Text>
           <div className="text-s-body-sm font-medium">
-            {isProtectedByEnforcedSimulations ? (
-              <Text
-                className="text-success-default"
-                data-testid="activity-list-item-protected-status"
+            {isProtected ? (
+              <Tooltip
+                position="top"
+                title={t('transactionProtectedByEnforcedSimulations')}
               >
-                {t('cancelled')}
-              </Text>
+                <span
+                  className="text-success-default"
+                  data-testid="activity-list-item-protected-status"
+                >
+                  {t('cancelled')}
+                </span>
+              </Tooltip>
             ) : (
               <TransactionStatusLabel
                 status={transactionStatus}

--- a/ui/components/multichain/activity-v2/activity-list-item.tsx
+++ b/ui/components/multichain/activity-v2/activity-list-item.tsx
@@ -40,12 +40,7 @@ export const ActivityListItem = ({ transaction, onClick }: Props) => {
       ? TransactionStatus.failed
       : TransactionStatus.confirmed;
 
-  const isProtected =
-    transactionStatus === TransactionStatus.failed &&
-    isProtectedByEnforcedSimulations({
-      errorMessage: transaction.error?.message,
-      data: transaction.txParams?.data,
-    });
+  const isProtected = isProtectedByEnforcedSimulations(transaction);
 
   const failureMessage =
     transactionStatus === TransactionStatus.failed

--- a/ui/components/multichain/activity-v2/activity-list-item.tsx
+++ b/ui/components/multichain/activity-v2/activity-list-item.tsx
@@ -6,6 +6,7 @@ import TransactionStatusLabel from '../../app/transaction-status-label/transacti
 import { useFormatters } from '../../../hooks/useFormatters';
 import type { TransactionViewModel } from '../../../../shared/lib/multichain/types';
 import { getCurrentCurrency } from '../../../ducks/metamask/metamask';
+import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useBridgeActivityData } from '../../../hooks/bridge/useBridgeActivityData';
 import { selectTransactionByHash } from '../../../selectors/transactionController';
 import { ChainBadge } from '../../app/chain-badge/chain-badge';
@@ -13,12 +14,18 @@ import { getPrimaryAmount } from './helpers';
 import { useGetTitle, useFiatAmount } from './hooks';
 import { ActivityTxIcon } from './activity-tx-icon';
 
+// DelegationFramework caveat enforcers revert with `Error(string)` messages of
+// the form `<EnforcerName>:<reason>` (Solidity convention). Detect any such
+// message generically rather than hard-coding the list of enforcer names.
+const CAVEAT_ENFORCER_REVERT_PATTERN = /^[A-Z][A-Za-z0-9]*Enforcer:/u;
+
 type Props = {
   transaction: TransactionViewModel;
   onClick?: () => void;
 };
 
 export const ActivityListItem = ({ transaction, onClick }: Props) => {
+  const t = useI18nContext();
   const { formatTokenAmount, formatCurrencyWithMinThreshold } = useFormatters();
   const currentCurrency = useSelector(getCurrentCurrency);
   const title = useGetTitle(transaction);
@@ -41,10 +48,15 @@ export const ActivityListItem = ({ transaction, onClick }: Props) => {
     selectTransactionByHash(state, transaction.hash),
   );
 
+  const receiptRevertMessage = localTransactionMeta?.revert?.receipt?.message;
+  const isProtectedByEnforcedSimulations =
+    transactionStatus === TransactionStatus.failed &&
+    typeof receiptRevertMessage === 'string' &&
+    CAVEAT_ENFORCER_REVERT_PATTERN.test(receiptRevertMessage);
+
   const failureMessage =
     transactionStatus === TransactionStatus.failed
-      ? localTransactionMeta?.error?.message ??
-        localTransactionMeta?.revert?.receipt?.message
+      ? localTransactionMeta?.error?.message ?? receiptRevertMessage
       : undefined;
   const failureError = failureMessage ? { message: failureMessage } : undefined;
 
@@ -70,11 +82,20 @@ export const ActivityListItem = ({ transaction, onClick }: Props) => {
             {title}
           </Text>
           <div className="text-s-body-sm font-medium">
-            <TransactionStatusLabel
-              status={transactionStatus}
-              error={failureError}
-              statusOnly
-            />
+            {isProtectedByEnforcedSimulations ? (
+              <Text
+                className="text-success-default"
+                data-testid="activity-list-item-protected-status"
+              >
+                {t('cancelled')}
+              </Text>
+            ) : (
+              <TransactionStatusLabel
+                status={transactionStatus}
+                error={failureError}
+                statusOnly
+              />
+            )}
           </div>
         </div>
 

--- a/ui/components/multichain/activity-v2/activity-list-item.tsx
+++ b/ui/components/multichain/activity-v2/activity-list-item.tsx
@@ -3,7 +3,6 @@ import { useSelector } from 'react-redux';
 import { Box, Text, TextVariant } from '@metamask/design-system-react';
 import { TransactionStatus } from '@metamask/transaction-controller';
 import TransactionStatusLabel from '../../app/transaction-status-label/transaction-status-label';
-import Tooltip from '../../ui/tooltip';
 import { useFormatters } from '../../../hooks/useFormatters';
 import type { TransactionViewModel } from '../../../../shared/lib/multichain/types';
 import { getCurrentCurrency } from '../../../ducks/metamask/metamask';
@@ -69,26 +68,21 @@ export const ActivityListItem = ({ transaction, onClick }: Props) => {
           >
             {title}
           </Text>
-          <div className="text-s-body-sm font-medium">
-            {isProtected ? (
-              <Tooltip
-                position="top"
-                title={t('transactionProtectedByEnforcedSimulations')}
-              >
-                <span
-                  className="text-success-default"
-                  data-testid="activity-list-item-protected-status"
-                >
-                  {t('cancelled')}
-                </span>
-              </Tooltip>
-            ) : (
-              <TransactionStatusLabel
-                status={transactionStatus}
-                error={failureError}
-                statusOnly
-              />
-            )}
+          <div
+            className="text-s-body-sm font-medium"
+            data-testid="activity-list-item-protected-status"
+          >
+            <TransactionStatusLabel
+              status={transactionStatus}
+              error={failureError}
+              statusOnly
+              label={isProtected ? t('cancelled') : undefined}
+              tooltip={
+                isProtected
+                  ? t('transactionProtectedByEnforcedSimulations')
+                  : undefined
+              }
+            />
           </div>
         </div>
 

--- a/ui/components/multichain/activity-v2/activity-list.tsx
+++ b/ui/components/multichain/activity-v2/activity-list.tsx
@@ -30,6 +30,7 @@ import { noAdjustmentsScroll } from '../../ui/virtualized-list/virtualized-list'
 import {
   mergeAllTransactionsByTime,
   groupAndFlattenMergedTransactions,
+  enrichApiWithLocal,
   filterLocalNotInApi,
   matchesApiTransaction,
   matchesLocalTransaction,
@@ -91,7 +92,10 @@ export const ActivityList = ({ filter }: Props) => {
 
   // Prepare the filtered transaction sources before merging them for rendering.
   const transactionSources = useMemo(() => {
-    let evmTransactions = data?.pages?.flatMap((page) => page.data ?? []) ?? [];
+    let evmTransactions = enrichApiWithLocal(
+      data?.pages?.flatMap((page) => page.data ?? []) ?? [],
+      localTransactions,
+    );
 
     // Filter local transactions by converting hex chainId to CAIP-2
     let filteredLocalTransactions = filterLocalNotInApi(

--- a/ui/components/multichain/activity-v2/helpers.test.ts
+++ b/ui/components/multichain/activity-v2/helpers.test.ts
@@ -13,6 +13,7 @@ import type {
   TransactionViewModel,
 } from '../../../../shared/lib/multichain/types';
 import {
+  enrichApiWithLocal,
   getPrimaryAmount,
   calculateFiatFromMarketRates,
   mergeAllTransactionsByTime,
@@ -485,5 +486,68 @@ describe('resolveTransactionType', () => {
       }),
     );
     expect(result).toBe(TransactionType.swap);
+  });
+});
+
+describe('enrichApiWithLocal', () => {
+  function makeApi(
+    overrides: Partial<TransactionViewModel> & { id: string },
+  ): TransactionViewModel {
+    return overrides as TransactionViewModel;
+  }
+
+  it('overlays local error, revert, and txParams.data onto matching API entries', () => {
+    const apiTx = makeApi({
+      id: 'api-1',
+      hash: '0xABC',
+      error: { name: 'Error', message: 'Transaction failed' },
+      txParams: { data: '0x', from: '0x0', to: '0x0' },
+    });
+    const localGroup = makeLocalGroup({
+      time: 1,
+      hash: '0xabc',
+      error: {
+        name: 'OnChainFailureError',
+        message: 'Transaction failed on-chain: NativeBalanceChangeEnforcer:x',
+      },
+      revert: { receipt: { message: 'NativeBalanceChangeEnforcer:x' } },
+      txParams: {
+        data: '0xcef6d20900',
+        from: '0x0',
+        to: '0x0',
+        nonce: '0x0',
+      },
+    });
+
+    const [enriched] = enrichApiWithLocal([apiTx], [localGroup]);
+
+    expect(enriched.error?.message).toBe(
+      'Transaction failed on-chain: NativeBalanceChangeEnforcer:x',
+    );
+    expect(enriched.revert?.receipt?.message).toBe(
+      'NativeBalanceChangeEnforcer:x',
+    );
+    expect(enriched.txParams?.data).toBe('0xcef6d20900');
+  });
+
+  it('returns the API entry unchanged when no local match exists', () => {
+    const apiTx = makeApi({
+      id: 'api-1',
+      hash: '0xabc',
+      error: { name: 'Error', message: 'Transaction failed' },
+    });
+    const [enriched] = enrichApiWithLocal([apiTx], []);
+    expect(enriched).toBe(apiTx);
+  });
+
+  it('matches hashes case-insensitively', () => {
+    const apiTx = makeApi({ id: 'api-1', hash: '0xAbCdEf' });
+    const localGroup = makeLocalGroup({
+      time: 1,
+      hash: '0xabcdef',
+      error: { name: 'Error', message: 'rich' },
+    });
+    const [enriched] = enrichApiWithLocal([apiTx], [localGroup]);
+    expect(enriched.error?.message).toBe('rich');
   });
 });

--- a/ui/components/multichain/activity-v2/helpers.ts
+++ b/ui/components/multichain/activity-v2/helpers.ts
@@ -90,6 +90,41 @@ export function filterLocalNotInApi(
   });
 }
 
+// Enrich API view models with richer fields from matching local TransactionMeta
+// entries. The Accounts API doesn't return on-chain revert reasons or full
+// `txParams.data`, so when the wallet originated the transaction we overlay the
+// local copy's `error`, `revert`, and `txParams.data` onto the view model.
+// Mirrors `filterLocalNotInApi`'s hash-based pairing.
+export function enrichApiWithLocal(
+  apiTransactions: TransactionViewModel[],
+  localGroups: TransactionGroup[],
+): TransactionViewModel[] {
+  const localByHash = new Map<string, TransactionGroup['primaryTransaction']>();
+  for (const group of localGroups) {
+    const hash = group.primaryTransaction.hash?.toLowerCase();
+    if (hash) {
+      localByHash.set(hash, group.primaryTransaction);
+    }
+  }
+
+  return apiTransactions.map((tx) => {
+    const hash = tx.hash?.toLowerCase();
+    const local = hash ? localByHash.get(hash) : undefined;
+    if (!local) {
+      return tx;
+    }
+    return {
+      ...tx,
+      ...(local.error ? { error: local.error } : {}),
+      ...(local.revert ? { revert: local.revert } : {}),
+      txParams: {
+        ...tx.txParams,
+        ...(local.txParams?.data ? { data: local.txParams.data } : {}),
+      },
+    };
+  });
+}
+
 type MergedItem =
   | { type: 'local'; group: TransactionGroup; time: number; nonce: number }
   | { type: 'completed'; tx: TransactionViewModel; time: number; nonce: number }

--- a/ui/components/multichain/activity-v2/helpers.ts
+++ b/ui/components/multichain/activity-v2/helpers.ts
@@ -90,11 +90,18 @@ export function filterLocalNotInApi(
   });
 }
 
-// Enrich API view models with richer fields from matching local TransactionMeta
-// entries. The Accounts API doesn't return on-chain revert reasons or full
-// `txParams.data`, so when the wallet originated the transaction we overlay the
-// local copy's `error`, `revert`, and `txParams.data` onto the view model.
-// Mirrors `filterLocalNotInApi`'s hash-based pairing.
+/**
+ * Overlay richer local TransactionController fields onto matching API view
+ * models. The Accounts API doesn't return on-chain revert reasons or full
+ * `txParams.data`, so when the wallet originated the transaction we copy the
+ * local `TransactionMeta`'s `error`, `revert`, and `txParams.data` onto the
+ * API view model. Pairing is by hash, mirroring `filterLocalNotInApi`.
+ *
+ * @param apiTransactions - View models built from the Accounts API response.
+ * @param localGroups - Local transaction groups from the TransactionController.
+ * @returns The API view models, with local fields overlaid where a matching
+ * local entry exists. Entries without a local match are returned unchanged.
+ */
 export function enrichApiWithLocal(
   apiTransactions: TransactionViewModel[],
   localGroups: TransactionGroup[],

--- a/ui/pages/confirmations/hooks/useIsEnforcedSimulationsEligible.ts
+++ b/ui/pages/confirmations/hooks/useIsEnforcedSimulationsEligible.ts
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux';
 import {
   EnforcedSimulationsState,
   isEnforcedSimulationsEligible,
+  isEnforcedSimulationsForceEnabled,
 } from '../../../../shared/lib/transaction/enforced-simulations';
 import { getEip7702SupportedChains } from '../../../../shared/lib/eip7702-support-utils';
 import { useConfirmContext } from '../context/confirm';
@@ -27,7 +28,7 @@ export function useIsEnforcedSimulationsEligible(): boolean {
 
   const enabled = useSelector(selectIsEnforcedSimulationsEnabled);
 
-  if (!enabled || !currentConfirmation) {
+  if ((!enabled && !isEnforcedSimulationsForceEnabled()) || !currentConfirmation) {
     return false;
   }
 

--- a/ui/pages/confirmations/hooks/useIsEnforcedSimulationsEligible.ts
+++ b/ui/pages/confirmations/hooks/useIsEnforcedSimulationsEligible.ts
@@ -28,7 +28,10 @@ export function useIsEnforcedSimulationsEligible(): boolean {
 
   const enabled = useSelector(selectIsEnforcedSimulationsEnabled);
 
-  if ((!enabled && !isEnforcedSimulationsForceEnabled()) || !currentConfirmation) {
+  if (
+    (!enabled && !isEnforcedSimulationsForceEnabled()) ||
+    !currentConfirmation
+  ) {
     return false;
   }
 

--- a/ui/pages/confirmations/utils/confirm.test.ts
+++ b/ui/pages/confirmations/utils/confirm.test.ts
@@ -1,4 +1,8 @@
-import { TransactionType } from '@metamask/transaction-controller';
+import {
+  type TransactionMeta,
+  TransactionStatus,
+  TransactionType,
+} from '@metamask/transaction-controller';
 
 import {
   orderSignatureMsg,
@@ -149,85 +153,86 @@ describe('confirm util', () => {
   describe('isProtectedByEnforcedSimulations', () => {
     const REDEEM_DELEGATIONS_DATA = '0xcef6d20900000000';
 
-    it('returns true when error message matches an enforcer prefix and data has the redeemDelegations selector', () => {
-      expect(
-        isProtectedByEnforcedSimulations({
-          errorMessage: 'NativeBalanceChangeEnforcer:hasnt-decreased-enough',
-          data: REDEEM_DELEGATIONS_DATA,
-        }),
-      ).toBe(true);
-    });
+    function makeFailedTx(
+      overrides: {
+        revertMessage?: string;
+        data?: string;
+        status?: TransactionStatus;
+      } = {},
+    ): TransactionMeta {
+      const {
+        revertMessage = 'NativeBalanceChangeEnforcer:hasnt-decreased-enough',
+        data = REDEEM_DELEGATIONS_DATA,
+        status = TransactionStatus.failed,
+      } = overrides;
+      return {
+        status,
+        revert: revertMessage
+          ? { receipt: { message: revertMessage } }
+          : undefined,
+        txParams: { data },
+      } as unknown as TransactionMeta;
+    }
 
-    it('returns true when error message has TC on-chain prefix before the enforcer', () => {
-      expect(
-        isProtectedByEnforcedSimulations({
-          errorMessage:
-            'Transaction failed on-chain: ERC20BalanceChangeEnforcer:balance-out-of-range',
-          data: REDEEM_DELEGATIONS_DATA,
-        }),
-      ).toBe(true);
+    it('returns true when status is failed, receipt revert matches an enforcer prefix and data has the redeemDelegations selector', () => {
+      expect(isProtectedByEnforcedSimulations(makeFailedTx())).toBe(true);
     });
 
     it('returns true regardless of the enforcer name (generic match)', () => {
       expect(
-        isProtectedByEnforcedSimulations({
-          errorMessage: 'SomeNewEnforcer:reason',
-          data: REDEEM_DELEGATIONS_DATA,
-        }),
+        isProtectedByEnforcedSimulations(
+          makeFailedTx({ revertMessage: 'SomeNewEnforcer:reason' }),
+        ),
       ).toBe(true);
     });
 
     it('matches the redeemDelegations selector case-insensitively', () => {
       expect(
-        isProtectedByEnforcedSimulations({
-          errorMessage: 'NativeBalanceChangeEnforcer:reason',
-          data: '0xCEF6D20900000000',
-        }),
+        isProtectedByEnforcedSimulations(
+          makeFailedTx({ data: '0xCEF6D20900000000' }),
+        ),
       ).toBe(true);
+    });
+
+    it('returns false when status is not failed', () => {
+      expect(
+        isProtectedByEnforcedSimulations(
+          makeFailedTx({ status: TransactionStatus.confirmed }),
+        ),
+      ).toBe(false);
+    });
+
+    it('returns false when transactionMeta is undefined', () => {
+      expect(isProtectedByEnforcedSimulations(undefined)).toBe(false);
     });
 
     it('returns false when the data does not start with the redeemDelegations selector', () => {
       expect(
-        isProtectedByEnforcedSimulations({
-          errorMessage: 'NativeBalanceChangeEnforcer:reason',
-          data: '0xa9059cbb00000000',
-        }),
+        isProtectedByEnforcedSimulations(
+          makeFailedTx({ data: '0xa9059cbb00000000' }),
+        ),
       ).toBe(false);
     });
 
-    it('returns false when error message lacks an enforcer prefix', () => {
+    it('returns false when receipt revert reason lacks an enforcer prefix', () => {
       expect(
-        isProtectedByEnforcedSimulations({
-          errorMessage: 'Transaction failed on-chain: insufficient funds',
-          data: REDEEM_DELEGATIONS_DATA,
-        }),
+        isProtectedByEnforcedSimulations(
+          makeFailedTx({ revertMessage: 'insufficient funds' }),
+        ),
       ).toBe(false);
     });
 
-    it('returns false when errorMessage is undefined', () => {
+    it('returns false when revert.receipt is missing', () => {
       expect(
-        isProtectedByEnforcedSimulations({
-          errorMessage: undefined,
-          data: REDEEM_DELEGATIONS_DATA,
-        }),
+        isProtectedByEnforcedSimulations(makeFailedTx({ revertMessage: '' })),
       ).toBe(false);
     });
 
-    it('returns false when data is undefined', () => {
+    it('does not match a revert reason starting with a lowercase letter', () => {
       expect(
-        isProtectedByEnforcedSimulations({
-          errorMessage: 'NativeBalanceChangeEnforcer:reason',
-          data: undefined,
-        }),
-      ).toBe(false);
-    });
-
-    it('does not match a string starting with a lowercase letter', () => {
-      expect(
-        isProtectedByEnforcedSimulations({
-          errorMessage: 'nativeBalanceChangeEnforcer:reason',
-          data: REDEEM_DELEGATIONS_DATA,
-        }),
+        isProtectedByEnforcedSimulations(
+          makeFailedTx({ revertMessage: 'nativeBalanceChangeEnforcer:reason' }),
+        ),
       ).toBe(false);
     });
   });

--- a/ui/pages/confirmations/utils/confirm.test.ts
+++ b/ui/pages/confirmations/utils/confirm.test.ts
@@ -9,6 +9,7 @@ import { SignatureRequestType } from '../types/confirm';
 import {
   isOrderSignatureRequest,
   isPermitSignatureRequest,
+  isProtectedByEnforcedSimulations,
   isSignatureTransactionType,
   parseSanitizeTypedDataMessage,
   isValidASCIIURL,
@@ -142,6 +143,92 @@ describe('confirm util', () => {
       expect(stripProtocol('http://localhost:8545')).toStrictEqual(
         'localhost:8545',
       );
+    });
+  });
+
+  describe('isProtectedByEnforcedSimulations', () => {
+    const REDEEM_DELEGATIONS_DATA = '0xcef6d20900000000';
+
+    it('returns true when error message matches an enforcer prefix and data has the redeemDelegations selector', () => {
+      expect(
+        isProtectedByEnforcedSimulations({
+          errorMessage: 'NativeBalanceChangeEnforcer:hasnt-decreased-enough',
+          data: REDEEM_DELEGATIONS_DATA,
+        }),
+      ).toBe(true);
+    });
+
+    it('returns true when error message has TC on-chain prefix before the enforcer', () => {
+      expect(
+        isProtectedByEnforcedSimulations({
+          errorMessage:
+            'Transaction failed on-chain: ERC20BalanceChangeEnforcer:balance-out-of-range',
+          data: REDEEM_DELEGATIONS_DATA,
+        }),
+      ).toBe(true);
+    });
+
+    it('returns true regardless of the enforcer name (generic match)', () => {
+      expect(
+        isProtectedByEnforcedSimulations({
+          errorMessage: 'SomeNewEnforcer:reason',
+          data: REDEEM_DELEGATIONS_DATA,
+        }),
+      ).toBe(true);
+    });
+
+    it('matches the redeemDelegations selector case-insensitively', () => {
+      expect(
+        isProtectedByEnforcedSimulations({
+          errorMessage: 'NativeBalanceChangeEnforcer:reason',
+          data: '0xCEF6D20900000000',
+        }),
+      ).toBe(true);
+    });
+
+    it('returns false when the data does not start with the redeemDelegations selector', () => {
+      expect(
+        isProtectedByEnforcedSimulations({
+          errorMessage: 'NativeBalanceChangeEnforcer:reason',
+          data: '0xa9059cbb00000000',
+        }),
+      ).toBe(false);
+    });
+
+    it('returns false when error message lacks an enforcer prefix', () => {
+      expect(
+        isProtectedByEnforcedSimulations({
+          errorMessage: 'Transaction failed on-chain: insufficient funds',
+          data: REDEEM_DELEGATIONS_DATA,
+        }),
+      ).toBe(false);
+    });
+
+    it('returns false when errorMessage is undefined', () => {
+      expect(
+        isProtectedByEnforcedSimulations({
+          errorMessage: undefined,
+          data: REDEEM_DELEGATIONS_DATA,
+        }),
+      ).toBe(false);
+    });
+
+    it('returns false when data is undefined', () => {
+      expect(
+        isProtectedByEnforcedSimulations({
+          errorMessage: 'NativeBalanceChangeEnforcer:reason',
+          data: undefined,
+        }),
+      ).toBe(false);
+    });
+
+    it('does not match a string starting with a lowercase letter', () => {
+      expect(
+        isProtectedByEnforcedSimulations({
+          errorMessage: 'nativeBalanceChangeEnforcer:reason',
+          data: REDEEM_DELEGATIONS_DATA,
+        }),
+      ).toBe(false);
     });
   });
 });

--- a/ui/pages/confirmations/utils/confirm.ts
+++ b/ui/pages/confirmations/utils/confirm.ts
@@ -128,6 +128,20 @@ export const stripProtocol = (urlString: string): string => {
   return urlString.replace(/^\w+:\/\//u, '');
 };
 
+/**
+ * Detect whether a transaction was reverted on-chain by an enforced-simulations
+ * caveat enforcer (the DelegationFramework "protection" mechanism).
+ *
+ * Returns true when `data` is a `redeemDelegations` call AND `errorMessage`
+ * matches the Solidity `<EnforcerName>:<reason>` revert format. The error
+ * message check tolerates an optional `Transaction failed on-chain: ` prefix
+ * injected by `OnChainFailureError`.
+ *
+ * @param options - The options object.
+ * @param options.errorMessage - `transactionMeta.error.message` (or any string carrying the receipt revert reason).
+ * @param options.data - `transactionMeta.txParams.data` for the failed transaction.
+ * @returns Whether the transaction was reverted by an enforced-simulations caveat enforcer.
+ */
 export function isProtectedByEnforcedSimulations({
   errorMessage,
   data,

--- a/ui/pages/confirmations/utils/confirm.ts
+++ b/ui/pages/confirmations/utils/confirm.ts
@@ -13,6 +13,14 @@ export const SIGNATURE_TRANSACTION_TYPES = [
   TransactionType.signTypedData,
 ];
 
+// DelegationFramework caveat enforcers revert with `Error(string)` messages of
+// the form `<EnforcerName>:<reason>` (Solidity convention). The TC may prefix
+// `Transaction failed on-chain: ` to that message, so match anywhere in the
+// string rather than only at the start.
+const CAVEAT_ENFORCER_REVERT_PATTERN = /(?:^|\s)[A-Z][A-Za-z0-9]*Enforcer:/u;
+
+const REDEEM_DELEGATIONS_SELECTOR = '0xcef6d209';
+
 export const isSignatureTransactionType = (request?: Record<string, unknown>) =>
   request &&
   SIGNATURE_TRANSACTION_TYPES.includes(request.type as TransactionType);
@@ -119,3 +127,22 @@ export const toPunycodeURL = (urlString: string): string | undefined => {
 export const stripProtocol = (urlString: string): string => {
   return urlString.replace(/^\w+:\/\//u, '');
 };
+
+export function isProtectedByEnforcedSimulations({
+  errorMessage,
+  data,
+}: {
+  errorMessage?: string;
+  data?: string;
+}): boolean {
+  if (
+    !data ||
+    !data.toLowerCase().startsWith(REDEEM_DELEGATIONS_SELECTOR) ||
+    !errorMessage ||
+    !CAVEAT_ENFORCER_REVERT_PATTERN.test(errorMessage)
+  ) {
+    return false;
+  }
+
+  return true;
+}

--- a/ui/pages/confirmations/utils/confirm.ts
+++ b/ui/pages/confirmations/utils/confirm.ts
@@ -1,4 +1,8 @@
-import { TransactionType } from '@metamask/transaction-controller';
+import {
+  TransactionMeta,
+  TransactionStatus,
+  TransactionType,
+} from '@metamask/transaction-controller';
 import {
   PRIMARY_TYPES_ORDER,
   PRIMARY_TYPES_PERMIT,
@@ -14,10 +18,8 @@ export const SIGNATURE_TRANSACTION_TYPES = [
 ];
 
 // DelegationFramework caveat enforcers revert with `Error(string)` messages of
-// the form `<EnforcerName>:<reason>` (Solidity convention). The TC may prefix
-// `Transaction failed on-chain: ` to that message, so match anywhere in the
-// string rather than only at the start.
-const CAVEAT_ENFORCER_REVERT_PATTERN = /(?:^|\s)[A-Z][A-Za-z0-9]*Enforcer:/u;
+// the form `<EnforcerName>:<reason>` (Solidity convention).
+const CAVEAT_ENFORCER_REVERT_PATTERN = /^[A-Z][A-Za-z0-9]*Enforcer:/u;
 
 const REDEEM_DELEGATIONS_SELECTOR = '0xcef6d209';
 
@@ -132,28 +134,28 @@ export const stripProtocol = (urlString: string): string => {
  * Detect whether a transaction was reverted on-chain by an enforced-simulations
  * caveat enforcer (the DelegationFramework "protection" mechanism).
  *
- * Returns true when `data` is a `redeemDelegations` call AND `errorMessage`
- * matches the Solidity `<EnforcerName>:<reason>` revert format. The error
- * message check tolerates an optional `Transaction failed on-chain: ` prefix
- * injected by `OnChainFailureError`.
+ * Returns true when the transaction failed AND its `txParams.data` is a
+ * `redeemDelegations` call AND its decoded receipt revert reason matches the
+ * Solidity `<EnforcerName>:<reason>` revert format.
  *
- * @param options - The options object.
- * @param options.errorMessage - `transactionMeta.error.message` (or any string carrying the receipt revert reason).
- * @param options.data - `transactionMeta.txParams.data` for the failed transaction.
+ * @param transactionMeta - The transaction metadata. May be undefined.
  * @returns Whether the transaction was reverted by an enforced-simulations caveat enforcer.
  */
-export function isProtectedByEnforcedSimulations({
-  errorMessage,
-  data,
-}: {
-  errorMessage?: string;
-  data?: string;
-}): boolean {
+export function isProtectedByEnforcedSimulations(
+  transactionMeta?: TransactionMeta,
+): boolean {
+  if (!transactionMeta || transactionMeta.status !== TransactionStatus.failed) {
+    return false;
+  }
+
+  const data = transactionMeta.txParams?.data;
+  const revertMessage = transactionMeta.revert?.receipt?.message;
+
   if (
     !data ||
     !data.toLowerCase().startsWith(REDEEM_DELEGATIONS_SELECTOR) ||
-    !errorMessage ||
-    !CAVEAT_ENFORCER_REVERT_PATTERN.test(errorMessage)
+    !revertMessage ||
+    !CAVEAT_ENFORCER_REVERT_PATTERN.test(revertMessage)
   ) {
     return false;
   }

--- a/ui/selectors/transactionController.ts
+++ b/ui/selectors/transactionController.ts
@@ -60,14 +60,3 @@ export const selectUnapprovedTransactionById = createSelector(
       : undefined,
 );
 
-export const selectTransactionByHash = (
-  state: unknown,
-  hash: string | undefined,
-): TransactionMeta | undefined => {
-  if (!hash) {
-    return undefined;
-  }
-  const transactions = selectTransactions(state as TransactionState);
-  const lower = hash.toLowerCase();
-  return transactions.find((tx) => tx.hash?.toLowerCase() === lower);
-};

--- a/ui/selectors/transactionController.ts
+++ b/ui/selectors/transactionController.ts
@@ -59,3 +59,15 @@ export const selectUnapprovedTransactionById = createSelector(
         )
       : undefined,
 );
+
+export const selectTransactionByHash = (
+  state: unknown,
+  hash: string | undefined,
+): TransactionMeta | undefined => {
+  if (!hash) {
+    return undefined;
+  }
+  const transactions = selectTransactions(state as TransactionState);
+  const lower = hash.toLowerCase();
+  return transactions.find((tx) => tx.hash?.toLowerCase() === lower);
+};

--- a/ui/selectors/transactionController.ts
+++ b/ui/selectors/transactionController.ts
@@ -59,4 +59,3 @@ export const selectUnapprovedTransactionById = createSelector(
         )
       : undefined,
 );
-


### PR DESCRIPTION
## **Description**

When a transaction is protected by enforced simulations (a DelegationFramework caveat enforcer rejects a `redeemDelegations` call on-chain), the UI previously showed "Failed" with no explanation. This PR surfaces the protection as a first-class UI state:

**Cancelled status for enforcer-reverted transactions**
Transactions where `txParams.data` begins with the `redeemDelegations` selector and the receipt revert reason matches the `<EnforcerName>:<reason>` Solidity convention are now detected by a new `isProtectedByEnforcedSimulations` util. In both the legacy transaction-details popover and Activity v2 list items, these transactions display a "Cancelled" pill (styled as confirmed/success) rather than "Failed".

**Enforced simulations error banner**
A `BannerAlert` is rendered at the top of the legacy `transaction-list-item-details` popover whenever `isProtectedByEnforcedSimulations` is true, with the message: _"This transaction was protected. We canceled it to prevent unexpected fund loss."_ Activity v2 list items surface the same text as a hover tooltip on the "Cancelled" label.

**Activity v2 — enriching Accounts API entries with local TransactionMeta**
The Accounts API view model carries no local TransactionController fields (`error`, `revert`, `txParams.data`), so the protected-transaction detection would silently miss API-backed entries. A new `enrichApiWithLocal` helper matches API transactions to their local counterpart by hash and merges those fields in before rendering. The modal adapter also now forwards `error` through to `TransactionStatusLabel` so failure tooltips work for API-backed entries too.

**Dev/QA flag rename**
`FORCE_ENABLE_SIMULATIONS` → `FORCE_ENFORCED_SIMULATIONS` across `.metamaskrc.dist`, `builds.yml`, and the shared lib. The private `isForceEnabled` function is replaced by a public `isEnforcedSimulationsForceEnabled()` export so the eligibility hook can reference it directly without re-reading the env var inline.

## **Changelog**

CHANGELOG entry: Show enforced-simulations protection state ("Cancelled" status + info banner) in transaction details and Activity v2; rename `FORCE_ENABLE_SIMULATIONS` dev flag.

## **Related issues**

- [CONF-1081](https://consensyssoftware.atlassian.net/browse/CONF-1081)
- [CONF-1082](https://consensyssoftware.atlassian.net/browse/CONF-1082)

## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**

<img width="320" height="236" alt="Screenshot 2026-05-14 at 14 51 57" src="https://github.com/user-attachments/assets/d27515e1-07ea-45ef-b44c-d2c285c82eae" />

<img width="412" height="103" alt="Screenshot 2026-05-15 at 09 27 13" src="https://github.com/user-attachments/assets/f02a4915-2ccb-4c3b-a0a4-9770fc53d81a" />

<img width="401" height="99" alt="Screenshot 2026-05-14 at 14 51 34" src="https://github.com/user-attachments/assets/6360633c-a05f-4c01-a4e9-a2b55d9abb05" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[CONF-1081]: https://consensyssoftware.atlassian.net/browse/CONF-1081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to new transaction-status classification logic and API/local transaction data merging that can change how failures are displayed. Also renames an environment/build flag used for QA overrides, which could break setups if missed.
> 
> **Overview**
> Adds a new enforced-simulations *protection* UI state: failed `redeemDelegations` transactions whose on-chain revert reason matches an enforcer pattern are detected via `isProtectedByEnforcedSimulations` and shown as **Cancelled** (with an info banner/tooltip) instead of generic **Failed** in both the legacy transaction details popover and Activity v2 list items.
> 
> Improves Activity v2 fidelity by overlaying local `TransactionController` fields (`error`, `revert`, `txParams.data`) onto matching Accounts API transactions via `enrichApiWithLocal`, and ensures `TransactionStatusLabel` can be overridden with custom `label`/`tooltip` and receive real errors for better tooltips.
> 
> Renames the dev/QA build flag `FORCE_ENABLE_SIMULATIONS` to `FORCE_ENFORCED_SIMULATIONS`, exposes `isEnforcedSimulationsForceEnabled()`, and wires the confirmations eligibility hook to allow force-enabling even when the remote flag is off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bd9ec11b3b10d3f26dadfd812b67767bcb50e53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->