### PR TITLE
feat(confirmations): convert enforced simulations env var to remote feature flag

### DIFF
--- a/.metamaskrc.dist
+++ b/.metamaskrc.dist
@@ -98,10 +98,6 @@ TEST_SRP_2=
 ; Entry points to connecting remain unchanged regardless of this flag.
 NEW_HARDWARE_WALLET_ONBOARDING='false'
 
-; Set this to `true` to enforce simulation balance changes by converting
-; external transactions to delegations.
-;ENABLE_ENFORCED_SIMULATIONS='true'
-
 ; Set this to `true` to force enforced simulations to apply whenever a
 ; transaction has balance changes, bypassing the trust signal check.
 ; Intended for local development and QA only.

--- a/app/scripts/lib/transaction/containers/enforced-simulations.test.ts
+++ b/app/scripts/lib/transaction/containers/enforced-simulations.test.ts
@@ -15,6 +15,7 @@ import { DELEGATOR_CONTRACTS } from '@metamask/delegation-deployments';
 import { Hex, remove0x } from '@metamask/utils';
 import { DelegationControllerSignDelegationAction } from '@metamask/delegation-controller';
 import { toHex } from '@metamask/controller-utils';
+import { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
 import { TransactionControllerInitMessenger } from '../../../messenger-client-init/messengers/transaction-controller-messenger';
 import { enforceSimulations } from './enforced-simulations';
 
@@ -64,13 +65,18 @@ describe('Enforced Simulations Utils', () => {
     TransactionControllerIsAtomicBatchSupportedAction['handler']
   > = jest.fn();
 
+  const remoteFeatureFlagGetStateMock: jest.MockedFn<
+    RemoteFeatureFlagControllerGetStateAction['handler']
+  > = jest.fn();
+
   beforeEach(() => {
     jest.resetAllMocks();
 
     const baseMessenger = new Messenger<
       MockAnyNamespace,
       | DelegationControllerSignDelegationAction
-      | TransactionControllerIsAtomicBatchSupportedAction,
+      | TransactionControllerIsAtomicBatchSupportedAction
+      | RemoteFeatureFlagControllerGetStateAction,
       never
     >({
       namespace: MOCK_ANY_NAMESPACE,
@@ -86,10 +92,16 @@ describe('Enforced Simulations Utils', () => {
       isAtomicBatchSupportedMock,
     );
 
+    baseMessenger.registerActionHandler(
+      'RemoteFeatureFlagController:getState',
+      remoteFeatureFlagGetStateMock,
+    );
+
     messenger = new Messenger<
       'TransactionControllerInitMessenger',
       | DelegationControllerSignDelegationAction
-      | TransactionControllerIsAtomicBatchSupportedAction,
+      | TransactionControllerIsAtomicBatchSupportedAction
+      | RemoteFeatureFlagControllerGetStateAction,
       never,
       typeof baseMessenger
     >({
@@ -101,10 +113,15 @@ describe('Enforced Simulations Utils', () => {
       actions: [
         'DelegationController:signDelegation',
         'TransactionController:isAtomicBatchSupported',
+        'RemoteFeatureFlagController:getState',
       ],
     });
 
     signDelegationMock.mockResolvedValue(DELEGATION_SIGNATURE_MOCK);
+    remoteFeatureFlagGetStateMock.mockReturnValue({
+      cacheTimestamp: 0,
+      remoteFeatureFlags: {},
+    });
 
     options = {
       messenger,

--- a/app/scripts/lib/transaction/containers/enforced-simulations.ts
+++ b/app/scripts/lib/transaction/containers/enforced-simulations.ts
@@ -52,7 +52,9 @@ export async function enforceSimulations({
   const from = txParams.from as Hex;
   const chainIdDecimal = hexToNumber(chainId);
   const delegationEnvironment = getDeleGatorEnvironment(chainIdDecimal);
-  const slippage = getEnforcedSimulationsSlippage();
+  const slippage = getEnforcedSimulationsSlippage(
+    messenger.call('RemoteFeatureFlagController:getState'),
+  );
 
   const caveats = generateCaveats(
     from,

--- a/app/scripts/lib/transaction/containers/enforced-simulations.ts
+++ b/app/scripts/lib/transaction/containers/enforced-simulations.ts
@@ -52,9 +52,11 @@ export async function enforceSimulations({
   const from = txParams.from as Hex;
   const chainIdDecimal = hexToNumber(chainId);
   const delegationEnvironment = getDeleGatorEnvironment(chainIdDecimal);
-  const slippage = getEnforcedSimulationsSlippage(
-    messenger.call('RemoteFeatureFlagController:getState'),
+
+  const remoteFeatureFlagState = messenger.call(
+    'RemoteFeatureFlagController:getState',
   );
+  const slippage = getEnforcedSimulationsSlippage(remoteFeatureFlagState);
 
   const caveats = generateCaveats(
     from,

--- a/builds.yml
+++ b/builds.yml
@@ -426,9 +426,6 @@ env:
   ###
   - DEEP_LINK_PUBLIC_KEY: BD8cWMMR2J33ax8hvSz8LNt99H3wGBPWuAgw+lsfWcBrw4ZtTHFnWyNkbgXglqJOoc+1OA5ZC4kW4GYU/QIeBNA=
 
-  # Enforce simulation balance changes by converting external transactions to delegations.
-  - ENABLE_ENFORCED_SIMULATIONS: false
-
   # Force enforced simulations to apply whenever a transaction has balance
   # changes, bypassing the trust signal check. Intended for local
   # development and QA only; must remain false for production builds.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "webpack:lavamoat:policy:mv3": "concurrently 'yarn webpack:lavamoat:build --generatePolicy' 'yarn webpack:lavamoat:build --generatePolicy --type flask' 'yarn webpack:lavamoat:build --generatePolicy --type beta' 'yarn webpack:lavamoat:build --generatePolicy --type experimental' --kill-others-on-fail",
     "foundryup": "yarn mm-foundryup",
     "postinstall": "yarn webpack:clearcache && yarn foundryup",
-    "env:e2e": "SEGMENT_HOST='https://api.segment.io' SEGMENT_WRITE_KEY='FAKE' ENABLE_ENFORCED_SIMULATIONS='true' yarn",
+    "env:e2e": "SEGMENT_HOST='https://api.segment.io' SEGMENT_WRITE_KEY='FAKE' yarn",
     "start": "yarn build:dev dev --apply-lavamoat=false --snow=false",
     "start:with-state": "node ./app/scripts/start-with-wallet-state.mjs",
     "start:mv2": "ENABLE_MV3=false yarn build:dev dev --apply-lavamoat=false --snow=false",

--- a/shared/lib/transaction/enforced-simulations.test.ts
+++ b/shared/lib/transaction/enforced-simulations.test.ts
@@ -4,9 +4,11 @@ import {
   TransactionMeta,
   TransactionStatus,
 } from '@metamask/transaction-controller';
+import type { RemoteFeatureFlagControllerState } from '@metamask/remote-feature-flag-controller';
 import { Hex } from '@metamask/utils';
 import { CachedScanAddressResponse, ResultType } from '../trust-signals';
 import {
+  DEFAULT_ENFORCED_SIMULATIONS_SLIPPAGE,
   EnforcedSimulationsState,
   getEnforcedSimulationsSlippage,
   isEnforcedSimulationsEligible,
@@ -80,20 +82,43 @@ function buildStateForAddresses(
   };
 }
 
+function buildRemoteFeatureFlagState(
+  flag?: { enabled?: boolean; slippage?: number },
+): RemoteFeatureFlagControllerState {
+  return {
+    cacheTimestamp: 0,
+    remoteFeatureFlags: flag
+      ? /* eslint-disable-next-line @typescript-eslint/naming-convention */
+        { confirmations_enforced_simulations: flag }
+      : {},
+  };
+}
+
 describe('enforced-simulations', () => {
   describe('getEnforcedSimulationsSlippage', () => {
-    it('returns the default slippage percentage', () => {
-      expect(getEnforcedSimulationsSlippage()).toBe(10);
+    it('returns the value from the flag when provided', () => {
+      expect(
+        getEnforcedSimulationsSlippage(
+          buildRemoteFeatureFlagState({ slippage: 25 }),
+        ),
+      ).toBe(25);
+    });
+
+    it('falls back to the default when the flag has no slippage', () => {
+      expect(
+        getEnforcedSimulationsSlippage(buildRemoteFeatureFlagState({})),
+      ).toBe(DEFAULT_ENFORCED_SIMULATIONS_SLIPPAGE);
+    });
+
+    it('falls back to the default when the flag is missing', () => {
+      expect(
+        getEnforcedSimulationsSlippage(buildRemoteFeatureFlagState()),
+      ).toBe(DEFAULT_ENFORCED_SIMULATIONS_SLIPPAGE);
     });
   });
 
   describe('getIsEnforcedSimulationsEligible', () => {
-    beforeEach(() => {
-      process.env.ENABLE_ENFORCED_SIMULATIONS = 'true';
-    });
-
     afterEach(() => {
-      delete process.env.ENABLE_ENFORCED_SIMULATIONS;
       delete process.env.FORCE_ENABLE_SIMULATIONS;
     });
 
@@ -106,27 +131,21 @@ describe('enforced-simulations', () => {
       ).toBe(true);
     });
 
-    it('returns false when env flag is not set', () => {
-      delete process.env.ENABLE_ENFORCED_SIMULATIONS;
-
-      expect(isEnforcedSimulationsEligible(BASE_TRANSACTION_META)).toBe(false);
-    });
-
     it('returns false when origin is undefined', () => {
       expect(
-        isEnforcedSimulationsEligible({
-          ...BASE_TRANSACTION_META,
-          origin: undefined,
-        }),
+        isEnforcedSimulationsEligible(
+          { ...BASE_TRANSACTION_META, origin: undefined },
+          buildState(ResultType.Benign),
+        ),
       ).toBe(false);
     });
 
     it('returns false when origin is MetaMask internal', () => {
       expect(
-        isEnforcedSimulationsEligible({
-          ...BASE_TRANSACTION_META,
-          origin: ORIGIN_METAMASK,
-        }),
+        isEnforcedSimulationsEligible(
+          { ...BASE_TRANSACTION_META, origin: ORIGIN_METAMASK },
+          buildState(ResultType.Benign),
+        ),
       ).toBe(false);
     });
 

--- a/shared/lib/transaction/enforced-simulations.test.ts
+++ b/shared/lib/transaction/enforced-simulations.test.ts
@@ -82,9 +82,10 @@ function buildStateForAddresses(
   };
 }
 
-function buildRemoteFeatureFlagState(
-  flag?: { enabled?: boolean; slippage?: number },
-): RemoteFeatureFlagControllerState {
+function buildRemoteFeatureFlagState(flag?: {
+  enabled?: boolean;
+  slippage?: number;
+}): RemoteFeatureFlagControllerState {
   return {
     cacheTimestamp: 0,
     remoteFeatureFlags: flag

--- a/shared/lib/transaction/enforced-simulations.ts
+++ b/shared/lib/transaction/enforced-simulations.ts
@@ -50,22 +50,6 @@ type FeatureFlagSource = Pick<
 >;
 
 /**
- * Reads the `confirmations_enforced_simulations` remote feature flag
- * value, returning `undefined` when the flag is absent.
- *
- * @param source - An object holding the remote feature flags.
- * @param source.remoteFeatureFlags - The remote feature flags object.
- * @returns The flag value or `undefined`.
- */
-export function getEnforcedSimulationsFlag({
-  remoteFeatureFlags,
-}: FeatureFlagSource): EnforcedSimulationsFeatureFlag | undefined {
-  return (remoteFeatureFlags as RemoteFlagsWithEnforcedSimulations)?.[
-    ENFORCED_SIMULATIONS_FEATURE_FLAG
-  ];
-}
-
-/**
  * Reads the `enabled` field from the `confirmations_enforced_simulations`
  * remote feature flag. Defaults to `false` when the flag or field is
  * absent.
@@ -143,6 +127,14 @@ export function isEnforcedSimulationsEligible(
   }
 
   return true;
+}
+
+function getEnforcedSimulationsFlag({
+  remoteFeatureFlags,
+}: FeatureFlagSource): EnforcedSimulationsFeatureFlag | undefined {
+  return (remoteFeatureFlags as RemoteFlagsWithEnforcedSimulations)?.[
+    ENFORCED_SIMULATIONS_FEATURE_FLAG
+  ];
 }
 
 function isForceEnabled(): boolean {

--- a/shared/lib/transaction/enforced-simulations.ts
+++ b/shared/lib/transaction/enforced-simulations.ts
@@ -31,17 +31,52 @@ export type EnforcedSimulationsFeatureFlag = {
   slippage?: number;
 };
 
+/**
+ * State required by the enforced simulations trust signal check.
+ */
+export type EnforcedSimulationsState = {
+  addressSecurityAlertResponses: Record<string, CachedScanAddressResponse>;
+  eip7702SupportedChains: Hex[];
+};
+
 type RemoteFlagsWithEnforcedSimulations = {
   /* eslint-disable-next-line @typescript-eslint/naming-convention */
   confirmations_enforced_simulations?: EnforcedSimulationsFeatureFlag;
 };
 
-function getEnforcedSimulationsFlag(
-  remoteFeatureFlags: RemoteFeatureFlagControllerState['remoteFeatureFlags'],
-): EnforcedSimulationsFeatureFlag | undefined {
+type FeatureFlagSource = Pick<
+  RemoteFeatureFlagControllerState,
+  'remoteFeatureFlags'
+>;
+
+/**
+ * Reads the `confirmations_enforced_simulations` remote feature flag
+ * value, returning `undefined` when the flag is absent.
+ *
+ * @param source - An object holding the remote feature flags.
+ * @param source.remoteFeatureFlags - The remote feature flags object.
+ * @returns The flag value or `undefined`.
+ */
+export function getEnforcedSimulationsFlag({
+  remoteFeatureFlags,
+}: FeatureFlagSource): EnforcedSimulationsFeatureFlag | undefined {
   return (remoteFeatureFlags as RemoteFlagsWithEnforcedSimulations)?.[
     ENFORCED_SIMULATIONS_FEATURE_FLAG
   ];
+}
+
+/**
+ * Reads the `enabled` field from the `confirmations_enforced_simulations`
+ * remote feature flag. Defaults to `false` when the flag or field is
+ * absent.
+ *
+ * @param source - An object holding the remote feature flags.
+ * @returns Whether enforced simulations are enabled.
+ */
+export function getIsEnforcedSimulationsEnabled(
+  source: FeatureFlagSource,
+): boolean {
+  return getEnforcedSimulationsFlag(source)?.enabled ?? false;
 }
 
 /**
@@ -50,26 +85,17 @@ function getEnforcedSimulationsFlag(
  * {@link DEFAULT_ENFORCED_SIMULATIONS_SLIPPAGE} when the flag or field is
  * absent.
  *
- * @param state - The remote feature flag controller state.
- * @param state.remoteFeatureFlags - The remote feature flags object.
+ * @param source - An object holding the remote feature flags.
  * @returns The slippage percentage to apply.
  */
-export function getEnforcedSimulationsSlippage({
-  remoteFeatureFlags,
-}: RemoteFeatureFlagControllerState): number {
+export function getEnforcedSimulationsSlippage(
+  source: FeatureFlagSource,
+): number {
   return (
-    getEnforcedSimulationsFlag(remoteFeatureFlags)?.slippage ??
+    getEnforcedSimulationsFlag(source)?.slippage ??
     DEFAULT_ENFORCED_SIMULATIONS_SLIPPAGE
   );
 }
-
-/**
- * State required by the enforced simulations trust signal check.
- */
-export type EnforcedSimulationsState = {
-  addressSecurityAlertResponses: Record<string, CachedScanAddressResponse>;
-  eip7702SupportedChains: Hex[];
-};
 
 /**
  * Determines whether a transaction is eligible for enforced simulations.

--- a/shared/lib/transaction/enforced-simulations.ts
+++ b/shared/lib/transaction/enforced-simulations.ts
@@ -3,6 +3,7 @@ import {
   TransactionMeta,
 } from '@metamask/transaction-controller';
 import { ORIGIN_METAMASK } from '@metamask/controller-utils';
+import type { RemoteFeatureFlagControllerState } from '@metamask/remote-feature-flag-controller';
 import { Hex } from '@metamask/utils';
 import {
   CachedScanAddressResponse,
@@ -11,7 +12,56 @@ import {
   ResultType,
 } from '../trust-signals';
 
-const DEFAULT_ENFORCED_SIMULATIONS_SLIPPAGE = 10;
+/**
+ * Default slippage percentage to apply when the
+ * `confirmations_enforced_simulations` remote feature flag does not
+ * provide a `slippage` value.
+ */
+export const DEFAULT_ENFORCED_SIMULATIONS_SLIPPAGE = 10;
+
+const ENFORCED_SIMULATIONS_FEATURE_FLAG = 'confirmations_enforced_simulations';
+
+/**
+ * Shape of the `confirmations_enforced_simulations` remote feature flag
+ * value. Both fields are optional; consumers fall back to safe defaults
+ * (disabled / {@link DEFAULT_ENFORCED_SIMULATIONS_SLIPPAGE}) when absent.
+ */
+export type EnforcedSimulationsFeatureFlag = {
+  enabled?: boolean;
+  slippage?: number;
+};
+
+type RemoteFlagsWithEnforcedSimulations = {
+  /* eslint-disable-next-line @typescript-eslint/naming-convention */
+  confirmations_enforced_simulations?: EnforcedSimulationsFeatureFlag;
+};
+
+function getEnforcedSimulationsFlag(
+  remoteFeatureFlags: RemoteFeatureFlagControllerState['remoteFeatureFlags'],
+): EnforcedSimulationsFeatureFlag | undefined {
+  return (remoteFeatureFlags as RemoteFlagsWithEnforcedSimulations)?.[
+    ENFORCED_SIMULATIONS_FEATURE_FLAG
+  ];
+}
+
+/**
+ * Reads the `slippage` field from the `confirmations_enforced_simulations`
+ * remote feature flag. Falls back to
+ * {@link DEFAULT_ENFORCED_SIMULATIONS_SLIPPAGE} when the flag or field is
+ * absent.
+ *
+ * @param state - The remote feature flag controller state.
+ * @param state.remoteFeatureFlags - The remote feature flags object.
+ * @returns The slippage percentage to apply.
+ */
+export function getEnforcedSimulationsSlippage({
+  remoteFeatureFlags,
+}: RemoteFeatureFlagControllerState): number {
+  return (
+    getEnforcedSimulationsFlag(remoteFeatureFlags)?.slippage ??
+    DEFAULT_ENFORCED_SIMULATIONS_SLIPPAGE
+  );
+}
 
 /**
  * State required by the enforced simulations trust signal check.
@@ -22,44 +72,29 @@ export type EnforcedSimulationsState = {
 };
 
 /**
- * Returns the default slippage percentage for enforced simulations.
- *
- * @returns The slippage percentage.
- */
-export function getEnforcedSimulationsSlippage(): number {
-  return DEFAULT_ENFORCED_SIMULATIONS_SLIPPAGE;
-}
-
-/**
  * Determines whether a transaction is eligible for enforced simulations.
  *
- * When state is provided and the chain supports trust signals, also
- * requires that at least one recipient address is loaded and not trusted.
- * If the chain is unsupported by trust signals, the transaction remains
- * eligible since we cannot verify trust. When state is omitted (e.g.
- * background hook), only the base eligibility checks are applied.
+ * When the chain supports trust signals, also requires that at least one
+ * recipient address is loaded and not trusted. If the chain is
+ * unsupported by trust signals, the transaction remains eligible since
+ * we cannot verify trust.
  *
  * @param transactionMeta - The transaction metadata.
- * @param state - Optional trust signal state. When provided, the trust
- * signal for the recipient must be loaded and not trusted.
+ * @param state - Trust signal state and EIP-7702 supported chains.
  * @returns Whether the transaction is eligible for enforced simulations.
  */
 export function isEnforcedSimulationsEligible(
   transactionMeta: TransactionMeta,
-  state?: EnforcedSimulationsState,
+  state: EnforcedSimulationsState,
 ): boolean {
   const { chainId, origin, simulationData } = transactionMeta;
-
-  if (!process.env.ENABLE_ENFORCED_SIMULATIONS) {
-    return false;
-  }
 
   if (!origin || origin === ORIGIN_METAMASK) {
     return false;
   }
 
   if (
-    !state?.eip7702SupportedChains?.some(
+    !state.eip7702SupportedChains?.some(
       (supported) => supported.toLowerCase() === chainId?.toLowerCase(),
     )
   ) {
@@ -77,7 +112,7 @@ export function isEnforcedSimulationsEligible(
     return true;
   }
 
-  if (state && isTrusted(transactionMeta, state)) {
+  if (isTrusted(transactionMeta, state)) {
     return false;
   }
 

--- a/test/e2e/tests/confirmations/helpers.ts
+++ b/test/e2e/tests/confirmations/helpers.ts
@@ -256,6 +256,11 @@ export async function mockEip7702FeatureFlag(mockServer: Mockttp) {
                 },
                 supportedChains: ['0xaa36a7', '0x539', '0x1'],
               },
+              // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              confirmations_enforced_simulations: {
+                enabled: true,
+              },
             },
           ],
         };

--- a/ui/pages/confirmations/components/rows/enforced-simulations-row/enforced-simulations-row.stories.tsx
+++ b/ui/pages/confirmations/components/rows/enforced-simulations-row/enforced-simulations-row.stories.tsx
@@ -1,6 +1,7 @@
 /**
- * NOTE: Requires `ENABLE_ENFORCED_SIMULATIONS=1` in `.metamaskrc` to render.
- * Without it, the eligibility check returns false and the component is empty.
+ * NOTE: Requires the `confirmations_enforced_simulations` remote feature
+ * flag to have `enabled: true` to render. Without it, the eligibility
+ * check returns false and the component is empty.
  */
 import { Meta } from '@storybook/react';
 import React from 'react';

--- a/ui/pages/confirmations/hooks/useIsEnforcedSimulationsEligible.test.ts
+++ b/ui/pages/confirmations/hooks/useIsEnforcedSimulationsEligible.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention, camelcase */
 import { TransactionMeta } from '@metamask/transaction-controller';
 import { renderHookWithConfirmContextProvider } from '../../../../test/lib/confirmations/render-helpers';
 import { getMockConfirmStateForTransaction } from '../../../../test/data/confirmations/helper';
@@ -13,9 +14,11 @@ const getIsEnforcedSimulationsEligibleMock = jest.mocked(
 
 function runHook({
   eligible = true,
+  enabled = true,
   addressSecurityAlertResponses = {},
 }: {
   eligible?: boolean;
+  enabled?: boolean;
   addressSecurityAlertResponses?: Record<string, unknown>;
 } = {}) {
   getIsEnforcedSimulationsEligibleMock.mockReturnValue(eligible);
@@ -30,6 +33,9 @@ function runHook({
     {
       metamask: {
         addressSecurityAlertResponses,
+        remoteFeatureFlags: {
+          confirmations_enforced_simulations: { enabled },
+        },
       },
     },
   );
@@ -56,7 +62,6 @@ describe('useIsEnforcedSimulationsEligible', () => {
   });
 
   it('passes transaction meta and state to eligibility function', () => {
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     const alertResponses = { someKey: { result_type: 'Benign' } };
 
     runHook({
@@ -71,5 +76,10 @@ describe('useIsEnforcedSimulationsEligible', () => {
         eip7702SupportedChains: [],
       },
     );
+  });
+
+  it('returns false and skips the eligibility check when the flag is disabled', () => {
+    expect(runHook({ enabled: false })).toBe(false);
+    expect(getIsEnforcedSimulationsEligibleMock).not.toHaveBeenCalled();
   });
 });

--- a/ui/pages/confirmations/hooks/useIsEnforcedSimulationsEligible.test.ts
+++ b/ui/pages/confirmations/hooks/useIsEnforcedSimulationsEligible.test.ts
@@ -6,7 +6,12 @@ import { genUnapprovedContractInteractionConfirmation } from '../../../../test/d
 import { isEnforcedSimulationsEligible } from '../../../../shared/lib/transaction/enforced-simulations';
 import { useIsEnforcedSimulationsEligible } from './useIsEnforcedSimulationsEligible';
 
-jest.mock('../../../../shared/lib/transaction/enforced-simulations');
+jest.mock('../../../../shared/lib/transaction/enforced-simulations', () => ({
+  ...jest.requireActual(
+    '../../../../shared/lib/transaction/enforced-simulations',
+  ),
+  isEnforcedSimulationsEligible: jest.fn(),
+}));
 
 const getIsEnforcedSimulationsEligibleMock = jest.mocked(
   isEnforcedSimulationsEligible,

--- a/ui/pages/confirmations/hooks/useIsEnforcedSimulationsEligible.ts
+++ b/ui/pages/confirmations/hooks/useIsEnforcedSimulationsEligible.ts
@@ -7,6 +7,7 @@ import {
 } from '../../../../shared/lib/transaction/enforced-simulations';
 import { getEip7702SupportedChains } from '../../../../shared/lib/eip7702-support-utils';
 import { useConfirmContext } from '../context/confirm';
+import { selectIsEnforcedSimulationsEnabled } from '../selectors/feature-flags';
 
 const EMPTY_RESPONSES: EnforcedSimulationsState['addressSecurityAlertResponses'] =
   {};
@@ -24,7 +25,9 @@ export function useIsEnforcedSimulationsEligible(): boolean {
       getEip7702SupportedChains(state.metamask),
   );
 
-  if (!currentConfirmation) {
+  const enabled = useSelector(selectIsEnforcedSimulationsEnabled);
+
+  if (!enabled || !currentConfirmation) {
     return false;
   }
 

--- a/ui/pages/confirmations/selectors/feature-flags.test.ts
+++ b/ui/pages/confirmations/selectors/feature-flags.test.ts
@@ -1,14 +1,25 @@
 /* eslint-disable @typescript-eslint/naming-convention, camelcase */
-import { selectIsMetaMaskPayDappsEnabled } from './feature-flags';
+import { DEFAULT_ENFORCED_SIMULATIONS_SLIPPAGE } from '../../../../shared/lib/transaction/enforced-simulations';
+import {
+  selectEnforcedSimulationsSlippage,
+  selectIsEnforcedSimulationsEnabled,
+  selectIsMetaMaskPayDappsEnabled,
+} from './feature-flags';
 
 type ConfirmationsPayDappsFlag = {
   enabled?: boolean;
+};
+
+type EnforcedSimulationsFlag = {
+  enabled?: boolean;
+  slippage?: number;
 };
 
 type MockState = {
   metamask: {
     remoteFeatureFlags: {
       confirmations_pay_dapps?: ConfirmationsPayDappsFlag;
+      confirmations_enforced_simulations?: EnforcedSimulationsFlag;
     };
   };
 };
@@ -20,6 +31,18 @@ const getMockState = (
     remoteFeatureFlags: {
       ...(confirmations_pay_dapps !== undefined && {
         confirmations_pay_dapps,
+      }),
+    },
+  },
+});
+
+const getMockEnforcedSimulationsState = (
+  confirmations_enforced_simulations?: EnforcedSimulationsFlag,
+): MockState => ({
+  metamask: {
+    remoteFeatureFlags: {
+      ...(confirmations_enforced_simulations !== undefined && {
+        confirmations_enforced_simulations,
       }),
     },
   },
@@ -54,6 +77,51 @@ describe('Confirmations Pay Feature Flags', () => {
         },
       };
       expect(selectIsMetaMaskPayDappsEnabled(state)).toBe(false);
+    });
+  });
+});
+
+describe('Confirmations Enforced Simulations Feature Flags', () => {
+  describe('selectIsEnforcedSimulationsEnabled', () => {
+    it('returns true when enabled is true', () => {
+      const state = getMockEnforcedSimulationsState({ enabled: true });
+      expect(selectIsEnforcedSimulationsEnabled(state)).toBe(true);
+    });
+
+    it('returns false when enabled is false', () => {
+      const state = getMockEnforcedSimulationsState({ enabled: false });
+      expect(selectIsEnforcedSimulationsEnabled(state)).toBe(false);
+    });
+
+    it('defaults to false when the flag is not set', () => {
+      const state = getMockEnforcedSimulationsState();
+      expect(selectIsEnforcedSimulationsEnabled(state)).toBe(false);
+    });
+
+    it('defaults to false when the flag is an empty object', () => {
+      const state = getMockEnforcedSimulationsState({});
+      expect(selectIsEnforcedSimulationsEnabled(state)).toBe(false);
+    });
+  });
+
+  describe('selectEnforcedSimulationsSlippage', () => {
+    it('returns the slippage value from the flag', () => {
+      const state = getMockEnforcedSimulationsState({ slippage: 25 });
+      expect(selectEnforcedSimulationsSlippage(state)).toBe(25);
+    });
+
+    it('falls back to the default when slippage is not provided', () => {
+      const state = getMockEnforcedSimulationsState({ enabled: true });
+      expect(selectEnforcedSimulationsSlippage(state)).toBe(
+        DEFAULT_ENFORCED_SIMULATIONS_SLIPPAGE,
+      );
+    });
+
+    it('falls back to the default when the flag is not set', () => {
+      const state = getMockEnforcedSimulationsState();
+      expect(selectEnforcedSimulationsSlippage(state)).toBe(
+        DEFAULT_ENFORCED_SIMULATIONS_SLIPPAGE,
+      );
     });
   });
 });

--- a/ui/pages/confirmations/selectors/feature-flags.ts
+++ b/ui/pages/confirmations/selectors/feature-flags.ts
@@ -1,7 +1,7 @@
 import { createSelector } from 'reselect';
 import {
-  DEFAULT_ENFORCED_SIMULATIONS_SLIPPAGE,
-  EnforcedSimulationsFeatureFlag,
+  getEnforcedSimulationsSlippage,
+  getIsEnforcedSimulationsEnabled,
 } from '../../../../shared/lib/transaction/enforced-simulations';
 import { getRemoteFeatureFlags } from '../../../selectors/remote-feature-flags';
 
@@ -26,24 +26,14 @@ export const selectIsMetaMaskPayDappsEnabled = createSelector(
   (flag): boolean => flag?.enabled ?? false,
 );
 
-const selectConfirmationsEnforcedSimulationsFlag = createSelector(
-  getRemoteFeatureFlags,
-  (flags) =>
-    /* eslint-disable @typescript-eslint/naming-convention */
-    (
-      flags as unknown as {
-        confirmations_enforced_simulations?: EnforcedSimulationsFeatureFlag;
-      }
-    ).confirmations_enforced_simulations,
-  /* eslint-enable @typescript-eslint/naming-convention */
-);
-
 export const selectIsEnforcedSimulationsEnabled = createSelector(
-  selectConfirmationsEnforcedSimulationsFlag,
-  (flag): boolean => flag?.enabled ?? false,
+  getRemoteFeatureFlags,
+  (remoteFeatureFlags): boolean =>
+    getIsEnforcedSimulationsEnabled({ remoteFeatureFlags }),
 );
 
 export const selectEnforcedSimulationsSlippage = createSelector(
-  selectConfirmationsEnforcedSimulationsFlag,
-  (flag): number => flag?.slippage ?? DEFAULT_ENFORCED_SIMULATIONS_SLIPPAGE,
+  getRemoteFeatureFlags,
+  (remoteFeatureFlags): number =>
+    getEnforcedSimulationsSlippage({ remoteFeatureFlags }),
 );

--- a/ui/pages/confirmations/selectors/feature-flags.ts
+++ b/ui/pages/confirmations/selectors/feature-flags.ts
@@ -1,4 +1,8 @@
 import { createSelector } from 'reselect';
+import {
+  DEFAULT_ENFORCED_SIMULATIONS_SLIPPAGE,
+  EnforcedSimulationsFeatureFlag,
+} from '../../../../shared/lib/transaction/enforced-simulations';
 import { getRemoteFeatureFlags } from '../../../selectors/remote-feature-flags';
 
 type ConfirmationsPayDappsFlag = {
@@ -20,4 +24,26 @@ const selectConfirmationsPayDappsFlag = createSelector(
 export const selectIsMetaMaskPayDappsEnabled = createSelector(
   selectConfirmationsPayDappsFlag,
   (flag): boolean => flag?.enabled ?? false,
+);
+
+const selectConfirmationsEnforcedSimulationsFlag = createSelector(
+  getRemoteFeatureFlags,
+  (flags) =>
+    /* eslint-disable @typescript-eslint/naming-convention */
+    (
+      flags as unknown as {
+        confirmations_enforced_simulations?: EnforcedSimulationsFeatureFlag;
+      }
+    ).confirmations_enforced_simulations,
+  /* eslint-enable @typescript-eslint/naming-convention */
+);
+
+export const selectIsEnforcedSimulationsEnabled = createSelector(
+  selectConfirmationsEnforcedSimulationsFlag,
+  (flag): boolean => flag?.enabled ?? false,
+);
+
+export const selectEnforcedSimulationsSlippage = createSelector(
+  selectConfirmationsEnforcedSimulationsFlag,
+  (flag): number => flag?.slippage ?? DEFAULT_ENFORCED_SIMULATIONS_SLIPPAGE,
 );


### PR DESCRIPTION
## **Description**

Replace the `ENABLE_ENFORCED_SIMULATIONS` env var and the hard-coded slippage constant with a single `confirmations_enforced_simulations` remote feature flag exposing `enabled` and `slippage`. Slippage falls back to the existing default (`10`) when the flag does not provide a value. `FORCE_ENABLE_SIMULATIONS` remains an env var since it is dev/QA only.

## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the runtime gating and configuration (slippage) for enforced simulations from a build-time env var to a remote feature flag, which can affect when transactions are wrapped into delegations and the balance-change limits applied. Risk is moderate because it touches confirmation/transaction mutation paths but preserves the dev-only force override.
> 
> **Overview**
> **Moves enforced simulations enablement/config from env vars to a remote feature flag.** The `ENABLE_ENFORCED_SIMULATIONS` build/env wiring is removed (from `.metamaskrc.dist`, `builds.yml`, and the e2e env script), and eligibility is now controlled by the `confirmations_enforced_simulations` remote flag.
> 
> **Adds remote-flag driven configuration.** `shared/lib/transaction/enforced-simulations` now reads `enabled` and `slippage` from remote feature flags (defaulting slippage to `10`), `useIsEnforcedSimulationsEligible` short-circuits when the flag is disabled, and the background `enforceSimulations` path pulls remote flag state via `RemoteFeatureFlagController:getState` to compute slippage.
> 
> **Tests/fixtures updated accordingly.** Unit tests are rewritten to pass remote flag state and to cover slippage fallbacks and disabled-flag behavior, and e2e mocks/storybook notes are updated to include the new `confirmations_enforced_simulations` flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de11f23902ccc6331cd86efc109a66ecdd56f8bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->