### PR TITLE
[NOT-READY] fix(perps): reverse position screen shows Confirm not Save

### DIFF
--- a/ui/components/app/perps/reverse-position/reverse-position-modal.test.tsx
+++ b/ui/components/app/perps/reverse-position/reverse-position-modal.test.tsx
@@ -196,10 +196,11 @@ describe('ReversePositionModal', () => {
         screen.getByTestId('perps-reverse-position-modal-cancel'),
       ).toBeInTheDocument();
       const submitButton = screen.getByTestId(
-        'perps-reverse-position-modal-save',
+        'perps-reverse-position-modal-confirm',
       );
       expect(submitButton).toBeInTheDocument();
       expect(submitButton).toHaveTextContent(messages.confirm.message);
+      expect(submitButton).not.toHaveTextContent(messages.save.message);
     });
 
     it('shows computed estimated fee', () => {
@@ -292,7 +293,7 @@ describe('ReversePositionModal', () => {
         mockStore,
       );
 
-      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-save'));
+      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-confirm'));
 
       await waitFor(() => {
         expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
@@ -332,7 +333,7 @@ describe('ReversePositionModal', () => {
 
       renderWithProvider(<ReversePositionModal {...defaultProps} />, mockStore);
 
-      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-save'));
+      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-confirm'));
 
       await waitFor(() => {
         expect(pushPositionsWithOverrides).toHaveBeenCalledWith(mockPositions);
@@ -349,7 +350,7 @@ describe('ReversePositionModal', () => {
         mockStore,
       );
 
-      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-save'));
+      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-confirm'));
 
       await waitFor(() => {
         expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
@@ -383,7 +384,7 @@ describe('ReversePositionModal', () => {
 
       renderWithProvider(<ReversePositionModal {...defaultProps} />, mockStore);
 
-      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-save'));
+      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-confirm'));
 
       await waitFor(() => {
         expect(
@@ -402,7 +403,7 @@ describe('ReversePositionModal', () => {
 
       renderWithProvider(<ReversePositionModal {...defaultProps} />, mockStore);
 
-      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-save'));
+      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-confirm'));
 
       await waitFor(() => {
         expect(
@@ -434,7 +435,7 @@ describe('ReversePositionModal', () => {
         mockStore,
       );
 
-      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-save'));
+      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-confirm'));
 
       await waitFor(() => {
         expect(
@@ -456,7 +457,7 @@ describe('ReversePositionModal', () => {
 
       renderWithProvider(<ReversePositionModal {...defaultProps} />, mockStore);
 
-      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-save'));
+      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-confirm'));
 
       await waitFor(() => {
         expect(
@@ -474,7 +475,7 @@ describe('ReversePositionModal', () => {
 
       renderWithProvider(<ReversePositionModal {...defaultProps} />, mockStore);
 
-      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-save'));
+      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-confirm'));
 
       expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith({
         key: 'perpsToastReverseInProgress',
@@ -484,7 +485,7 @@ describe('ReversePositionModal', () => {
     it('emits reverse success toast after successful flip + refresh', async () => {
       renderWithProvider(<ReversePositionModal {...defaultProps} />, mockStore);
 
-      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-save'));
+      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-confirm'));
 
       await waitFor(() => {
         expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith({
@@ -506,7 +507,7 @@ describe('ReversePositionModal', () => {
 
       renderWithProvider(<ReversePositionModal {...defaultProps} />, mockStore);
 
-      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-save'));
+      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-confirm'));
 
       await waitFor(() => {
         expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith({
@@ -526,7 +527,7 @@ describe('ReversePositionModal', () => {
 
       renderWithProvider(<ReversePositionModal {...defaultProps} />, mockStore);
 
-      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-save'));
+      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-confirm'));
 
       await waitFor(() => {
         expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith({
@@ -569,7 +570,7 @@ describe('ReversePositionModal', () => {
         mockStore,
       );
 
-      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-save'));
+      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-confirm'));
 
       await waitFor(() => {
         expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
@@ -593,12 +594,12 @@ describe('ReversePositionModal', () => {
 
       renderWithProvider(<ReversePositionModal {...defaultProps} />, mockStore);
 
-      const saveButton = screen.getByTestId(
-        'perps-reverse-position-modal-save',
+      const confirmButton = screen.getByTestId(
+        'perps-reverse-position-modal-confirm',
       );
-      expect(saveButton).toBeEnabled();
+      expect(confirmButton).toBeEnabled();
 
-      fireEvent.click(saveButton);
+      fireEvent.click(confirmButton);
 
       await waitFor(() => {
         expect(screen.getByTestId('perps-geo-block-modal')).toBeInTheDocument();

--- a/ui/components/app/perps/reverse-position/reverse-position-modal.tsx
+++ b/ui/components/app/perps/reverse-position/reverse-position-modal.tsx
@@ -296,7 +296,7 @@ export const ReversePositionModal: React.FC<ReversePositionModalProps> = ({
               disabled: isSubmitting,
             }}
             submitButtonProps={{
-              'data-testid': 'perps-reverse-position-modal-save',
+              'data-testid': 'perps-reverse-position-modal-confirm',
               children: isSubmitting ? t('perpsSubmitting') : t('confirm'),
               disabled: isSubmitting,
             }}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Aligns the reverse / flip position modal primary control with the visible **Confirm** label:

- Rename `data-testid` from `perps-reverse-position-modal-save` to `perps-reverse-position-modal-confirm`.
- Extend unit tests to assert the Confirm copy and reject the Save message, so the original `t('save')` regression cannot return silently.

The submit label was already `t('confirm')` on `main`; the old testid still implied “Save” and automation could diverge from what users see.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [TAT-2810](https://consensyssoftware.atlassian.net/browse/TAT-2810)

## **Manual testing steps**

1. Open Perps, go to a market where you have an open position.
2. Tap **Modify** on the position card, then **Reverse position**.
3. Confirm the primary button reads **Confirm** (not Save) and matches automation id `perps-reverse-position-modal-confirm`.

## **Screenshots/Recordings**

Placeholder — see task `artifacts/evidence-manifest.json` / `artifacts/report.md` for runner constraints (live `validate-recipe.js` bootstrap currently fails against `@metamask/client-mcp-core@0.2.0` in this repo).

### **Before**

N/a (copy already Confirm on main).

### **After**

N/a — unit tests cover the label contract.

## **Validation Recipe**

<details>
<summary>recipe.json</summary>

```json
{
  "title": "TAT-2810 — reverse position modal primary button reads Confirm",
  "description": "Opens the reverse / flip position confirmation modal on a market with an open position and asserts the primary action label is Confirm (not Save). Seeds a BTC short via PerpsStreamManager so the flow does not require placing a live order.",
  "schema_version": 1,
  "validate": {
    "workflow": {
      "pre_conditions": ["wallet.unlocked", "perps.feature_enabled"],
      "setup": [
        {
          "id": "setup-call-nav-perps",
          "action": "call",
          "ref": "perps/navigate-perps-tab"
        },
        {
          "id": "setup-inject-btc-position",
          "action": "eval_sync",
          "expression": "(function(){try{var sm=stateHooks.getPerpsStreamManager();if(!sm)return JSON.stringify({injected:false,reason:'no stream manager'});var position={symbol:'BTC',size:'-0.5',entryPrice:'45000.00',positionValue:'22500.00',unrealizedPnl:'-250.00',marginUsed:'1500.00',leverage:{type:'cross',value:15},liquidationPrice:'48000.00',maxLeverage:20,returnOnEquity:'-0.1667',cumulativeFunding:{allTime:'0',sinceOpen:'0',sinceChange:'0'}};sm.positions.pushData([position]);return JSON.stringify({injected:true})}catch(e){return JSON.stringify({injected:false,error:String(e&&e.message||e)})}})()",
          "assert": { "operator": "eq", "field": "injected", "value": true }
        },
        {
          "id": "setup-nav-btc-detail",
          "action": "call",
          "ref": "perps/navigate-to-market-detail",
          "params": { "symbol": "BTC" }
        }
      ],
      "teardown": [
        {
          "id": "teardown-clear-stream-positions",
          "action": "eval_sync",
          "expression": "(function(){try{var sm=stateHooks.getPerpsStreamManager();if(sm){sm.positions.pushData([])}return JSON.stringify({cleared:true})}catch(e){return JSON.stringify({cleared:false,error:String(e&&e.message||e)})}})()",
          "assert": { "operator": "eq", "field": "cleared", "value": true }
        }
      ],
      "entry": "setup-wait-modify-cta",
      "nodes": {
        "setup-wait-modify-cta": {
          "action": "wait_for",
          "test_id": "perps-modify-cta-button",
          "timeout_ms": 15000,
          "next": "ac1-open-modify-menu"
        },
        "ac1-open-modify-menu": {
          "action": "press",
          "test_id": "perps-modify-cta-button",
          "next": "ac1-wait-reverse-row"
        },
        "ac1-wait-reverse-row": {
          "action": "wait_for",
          "test_id": "perps-modify-menu-reverse-position",
          "timeout_ms": 10000,
          "next": "ac1-open-reverse-modal"
        },
        "ac1-open-reverse-modal": {
          "action": "press",
          "test_id": "perps-modify-menu-reverse-position",
          "next": "ac1-wait-reverse-modal"
        },
        "ac1-wait-reverse-modal": {
          "action": "wait_for",
          "test_id": "perps-reverse-position-modal",
          "timeout_ms": 10000,
          "next": "ac1-assert-confirm-button-label"
        },
        "ac1-assert-confirm-button-label": {
          "action": "eval_sync",
          "expression": "(function(){var btn=document.querySelector('[data-testid=\"perps-reverse-position-modal-confirm\"]');if(!btn)return JSON.stringify({found:false,label:''});var txt=(btn.textContent||'').trim().replace(/\\s+/g,' ');return JSON.stringify({found:true,label:txt})})()",
          "assert": {
            "all": [
              { "operator": "eq", "field": "found", "value": true },
              { "operator": "eq", "field": "label", "value": "Confirm" }
            ]
          },
          "save_as": "ac1_label",
          "next": "ac1-screenshot-reverse-modal"
        },
        "ac1-screenshot-reverse-modal": {
          "action": "screenshot",
          "filename": "evidence-ac1-reverse-modal-confirm-label.png",
          "note": "AC1: Reverse position modal open with primary action showing Confirm.",
          "next": "done"
        },
        "done": {
          "action": "end",
          "status": "pass"
        }
      }
    }
  }
}
```

</details>

## **Recipe Workflow**

<details>
<summary>workflow.mmd (mermaid)</summary>

```mermaid
flowchart TD
  __entry__(["ENTRY"]) --> node_setup_wait_modify_cta
  node_setup_wait_modify_cta["setup-wait-modify-cta<br/>wait_for"]
  node_ac1_open_modify_menu["ac1-open-modify-menu<br/>press"]
  node_ac1_wait_reverse_row["ac1-wait-reverse-row<br/>wait_for"]
  node_ac1_open_reverse_modal["ac1-open-reverse-modal<br/>press"]
  node_ac1_wait_reverse_modal["ac1-wait-reverse-modal<br/>wait_for"]
  node_ac1_assert_confirm_button_label["ac1-assert-confirm-button-label<br/>eval_sync"]
  node_ac1_screenshot_reverse_modal["ac1-screenshot-reverse-modal<br/>screenshot"]
  node_done(["done<br/>PASS"])
  node_setup_wait_modify_cta --> node_ac1_open_modify_menu
  node_ac1_open_modify_menu --> node_ac1_wait_reverse_row
  node_ac1_wait_reverse_row --> node_ac1_open_reverse_modal
  node_ac1_open_reverse_modal --> node_ac1_wait_reverse_modal
  node_ac1_wait_reverse_modal --> node_ac1_assert_confirm_button_label
  node_ac1_assert_confirm_button_label --> node_ac1_screenshot_reverse_modal
  node_ac1_screenshot_reverse_modal --> node_done
```

</details>

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[TAT-2810]: https://consensyssoftware.atlassian.net/browse/TAT-2810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ