### PR TITLE
[NOT-READY] fix: Button copy says "Save" instead of "Confirm" in reverse position screen

### DIFF
--- a/ui/components/app/perps/reverse-position/reverse-position-modal.test.tsx
+++ b/ui/components/app/perps/reverse-position/reverse-position-modal.test.tsx
@@ -196,10 +196,11 @@ describe('ReversePositionModal', () => {
         screen.getByTestId('perps-reverse-position-modal-cancel'),
       ).toBeInTheDocument();
       const submitButton = screen.getByTestId(
-        'perps-reverse-position-modal-save',
+        'perps-reverse-position-modal-confirm',
       );
       expect(submitButton).toBeInTheDocument();
       expect(submitButton).toHaveTextContent(messages.confirm.message);
+      expect(submitButton).not.toHaveTextContent(messages.save.message);
     });
 
     it('shows computed estimated fee', () => {
@@ -292,7 +293,7 @@ describe('ReversePositionModal', () => {
         mockStore,
       );
 
-      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-save'));
+      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-confirm'));
 
       await waitFor(() => {
         expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
@@ -332,7 +333,7 @@ describe('ReversePositionModal', () => {
 
       renderWithProvider(<ReversePositionModal {...defaultProps} />, mockStore);
 
-      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-save'));
+      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-confirm'));
 
       await waitFor(() => {
         expect(pushPositionsWithOverrides).toHaveBeenCalledWith(mockPositions);
@@ -349,7 +350,7 @@ describe('ReversePositionModal', () => {
         mockStore,
       );
 
-      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-save'));
+      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-confirm'));
 
       await waitFor(() => {
         expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
@@ -383,7 +384,7 @@ describe('ReversePositionModal', () => {
 
       renderWithProvider(<ReversePositionModal {...defaultProps} />, mockStore);
 
-      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-save'));
+      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-confirm'));
 
       await waitFor(() => {
         expect(
@@ -402,7 +403,7 @@ describe('ReversePositionModal', () => {
 
       renderWithProvider(<ReversePositionModal {...defaultProps} />, mockStore);
 
-      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-save'));
+      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-confirm'));
 
       await waitFor(() => {
         expect(
@@ -434,7 +435,7 @@ describe('ReversePositionModal', () => {
         mockStore,
       );
 
-      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-save'));
+      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-confirm'));
 
       await waitFor(() => {
         expect(
@@ -456,7 +457,7 @@ describe('ReversePositionModal', () => {
 
       renderWithProvider(<ReversePositionModal {...defaultProps} />, mockStore);
 
-      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-save'));
+      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-confirm'));
 
       await waitFor(() => {
         expect(
@@ -474,7 +475,7 @@ describe('ReversePositionModal', () => {
 
       renderWithProvider(<ReversePositionModal {...defaultProps} />, mockStore);
 
-      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-save'));
+      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-confirm'));
 
       expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith({
         key: 'perpsToastReverseInProgress',
@@ -484,7 +485,7 @@ describe('ReversePositionModal', () => {
     it('emits reverse success toast after successful flip + refresh', async () => {
       renderWithProvider(<ReversePositionModal {...defaultProps} />, mockStore);
 
-      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-save'));
+      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-confirm'));
 
       await waitFor(() => {
         expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith({
@@ -506,7 +507,7 @@ describe('ReversePositionModal', () => {
 
       renderWithProvider(<ReversePositionModal {...defaultProps} />, mockStore);
 
-      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-save'));
+      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-confirm'));
 
       await waitFor(() => {
         expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith({
@@ -526,7 +527,7 @@ describe('ReversePositionModal', () => {
 
       renderWithProvider(<ReversePositionModal {...defaultProps} />, mockStore);
 
-      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-save'));
+      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-confirm'));
 
       await waitFor(() => {
         expect(mockReplacePerpsToastByKey).toHaveBeenCalledWith({
@@ -569,7 +570,7 @@ describe('ReversePositionModal', () => {
         mockStore,
       );
 
-      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-save'));
+      fireEvent.click(screen.getByTestId('perps-reverse-position-modal-confirm'));
 
       await waitFor(() => {
         expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
@@ -594,7 +595,7 @@ describe('ReversePositionModal', () => {
       renderWithProvider(<ReversePositionModal {...defaultProps} />, mockStore);
 
       const saveButton = screen.getByTestId(
-        'perps-reverse-position-modal-save',
+        'perps-reverse-position-modal-confirm',
       );
       expect(saveButton).toBeEnabled();
 

--- a/ui/components/app/perps/reverse-position/reverse-position-modal.tsx
+++ b/ui/components/app/perps/reverse-position/reverse-position-modal.tsx
@@ -296,7 +296,7 @@ export const ReversePositionModal: React.FC<ReversePositionModalProps> = ({
               disabled: isSubmitting,
             }}
             submitButtonProps={{
-              'data-testid': 'perps-reverse-position-modal-save',
+              'data-testid': 'perps-reverse-position-modal-confirm',
               children: isSubmitting ? t('perpsSubmitting') : t('confirm'),
               disabled: isSubmitting,
             }}


### PR DESCRIPTION
## **Description**

Aligns the reverse-position modal primary button `data-testid` with its rendered label. The button label has been `t('confirm')` ("Confirm") since `33e4eb1c42`, but the testid still read `perps-reverse-position-modal-save` — a stale leftover from when the children prop was `t('save')`. Renaming to `perps-reverse-position-modal-confirm` removes the inconsistency, and the unit test now also asserts that the rendered text is not "Save" so the bug cannot silently regress.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [TAT-2810](https://consensyssoftware.atlassian.net/browse/TAT-2810)

## **Manual testing steps**

1. Unlock the wallet and open the Perps tab.
2. Open an existing position's market detail screen.
3. Open the **Modify** menu and select **Reverse position**.
4. Verify the primary action button reads **Confirm** (not "Save").

## **Screenshots/Recordings**

### **Before**

<!-- gateway: replaced from evidence-manifest.json -->

### **After**

<!-- gateway: replaced from evidence-manifest.json -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## **Validation Recipe**

<details>
<summary>recipe.json</summary>

```json
{
  "title": "TAT-2810 — Reverse position confirm button label",
  "schema_version": 1,
  "validate": {
    "workflow": {
      "pre_conditions": ["wallet.unlocked", "perps.open_position"],
      "entry": "setup-prime-perps",
      "nodes": {
        "setup-prime-perps": {
          "action": "call",
          "ref": "perps/navigate-perps-tab",
          "next": "setup-resolve-symbol"
        },
        "setup-resolve-symbol": {
          "action": "eval_async",
          "expression": "(async()=>{const p=await window.stateHooks.submitRequestToBackground('perpsGetPositions',[]);const sym=(p&&p[0]&&p[0].symbol)||'BTC';return JSON.stringify({symbol:sym,count:(p||[]).length});})()",
          "save_as": "pos",
          "assert": {
            "all": [
              { "field": "count", "operator": "gt", "value": 0 }
            ]
          },
          "next": "setup-navigate-detail"
        },
        "setup-navigate-detail": {
          "action": "ext_navigate_hash",
          "hash": "perps/market/{{vars.pos.symbol}}",
          "next": "setup-wait-detail"
        },
        "setup-wait-detail": {
          "action": "wait_for",
          "test_id": "perps-market-detail-page",
          "timeout_ms": 10000,
          "next": "setup-open-modify-menu"
        },
        "setup-open-modify-menu": {
          "action": "press",
          "test_id": "perps-modify-cta-button",
          "next": "setup-wait-modify-menu"
        },
        "setup-wait-modify-menu": {
          "action": "wait_for",
          "test_id": "perps-modify-menu-reverse-position",
          "timeout_ms": 5000,
          "next": "setup-open-reverse-modal"
        },
        "setup-open-reverse-modal": {
          "action": "press",
          "test_id": "perps-modify-menu-reverse-position",
          "next": "setup-wait-reverse-button"
        },
        "setup-wait-reverse-button": {
          "action": "wait_for",
          "expression": "JSON.stringify({found:!!document.querySelector('[data-testid^=\"perps-reverse-position-modal-\"][data-testid$=\"-confirm\"]')||!!document.querySelector('[data-testid=\"perps-reverse-position-modal-save\"]')})",
          "timeout_ms": 5000,
          "assert": { "all": [{ "field": "found", "operator": "eq", "value": true }] },
          "next": "ac1-read-button-text"
        },
        "ac1-read-button-text": {
          "action": "eval_sync",
          "expression": "(()=>{const el=document.querySelector('[data-testid^=\"perps-reverse-position-modal-\"][data-testid$=\"-confirm\"]')||document.querySelector('[data-testid=\"perps-reverse-position-modal-save\"]');if(!el)return JSON.stringify({found:false});const txt=(el.textContent||'').trim();return JSON.stringify({found:true,testid:el.getAttribute('data-testid'),text:txt,isConfirm:txt==='Confirm',isSave:txt==='Save'});})()",
          "save_as": "btn",
          "assert": {
            "all": [
              { "field": "found", "operator": "eq", "value": true },
              { "field": "text", "operator": "eq", "value": "Confirm" },
              { "field": "isSave", "operator": "eq", "value": false },
              { "field": "testid", "operator": "eq", "value": "perps-reverse-position-modal-confirm" }
            ]
          },
          "next": "ac1-screenshot-confirm-button"
        },
        "ac1-screenshot-confirm-button": {
          "action": "screenshot",
          "filename": "evidence-ac1-confirm-button",
          "note": "AC1: reverse position modal primary button reads 'Confirm', not 'Save'.",
          "next": "teardown-close-modal"
        },
        "teardown-close-modal": {
          "action": "press",
          "test_id": "perps-reverse-position-modal-cancel",
          "next": "done"
        },
        "done": { "action": "end", "status": "pass" }
      }
    }
  }
}
```

</details>

## **Recipe Workflow**

<details>
<summary>workflow.mmd</summary>

```mermaid
flowchart TD
  %% TAT-2810 — Reverse position confirm button label
  __entry__(["ENTRY"]) --> node_setup_prime_perps
  node_setup_prime_perps[["setup-prime-perps<br/>perps/navigate-perps-tab"]]
  node_setup_resolve_symbol["setup-resolve-symbol<br/>eval_async"]
  node_setup_navigate_detail["setup-navigate-detail<br/>ext_navigate_hash"]
  node_setup_wait_detail["setup-wait-detail<br/>wait_for"]
  node_setup_open_modify_menu["setup-open-modify-menu<br/>press"]
  node_setup_wait_modify_menu["setup-wait-modify-menu<br/>wait_for"]
  node_setup_open_reverse_modal["setup-open-reverse-modal<br/>press"]
  node_setup_wait_reverse_button["setup-wait-reverse-button<br/>wait_for"]
  node_ac1_read_button_text["ac1-read-button-text<br/>eval_sync"]
  node_ac1_screenshot_confirm_button["ac1-screenshot-confirm-button<br/>screenshot"]
  node_teardown_close_modal["teardown-close-modal<br/>press"]
  node_done(["done<br/>PASS"])
  node_setup_prime_perps --> node_setup_resolve_symbol
  node_setup_resolve_symbol --> node_setup_navigate_detail
  node_setup_navigate_detail --> node_setup_wait_detail
  node_setup_wait_detail --> node_setup_open_modify_menu
  node_setup_open_modify_menu --> node_setup_wait_modify_menu
  node_setup_wait_modify_menu --> node_setup_open_reverse_modal
  node_setup_open_reverse_modal --> node_setup_wait_reverse_button
  node_setup_wait_reverse_button --> node_ac1_read_button_text
  node_ac1_read_button_text --> node_ac1_screenshot_confirm_button
  node_ac1_screenshot_confirm_button --> node_teardown_close_modal
  node_teardown_close_modal --> node_done
```

</details>


[TAT-2810]: https://consensyssoftware.atlassian.net/browse/TAT-2810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ