### PR TITLE
fix: Market max leverage is missing in market detail page

### DIFF
--- a/ui/pages/perps/perps-market-detail-page.test.tsx
+++ b/ui/pages/perps/perps-market-detail-page.test.tsx
@@ -568,9 +568,7 @@ describe('PerpsMarketDetailPage', () => {
 
       const { getByTestId } = await renderPage(store);
 
-      expect(getByTestId('perps-market-max-leverage')).toHaveTextContent(
-        '20x',
-      );
+      expect(getByTestId('perps-market-max-leverage')).toHaveTextContent('20x');
     });
 
     it('omits the market max leverage pill when max leverage is unavailable', async () => {
@@ -578,7 +576,7 @@ describe('PerpsMarketDetailPage', () => {
         markets: [
           {
             ...mockCryptoMarkets[1],
-            maxLeverage: undefined,
+            maxLeverage: '',
           },
         ],
         isInitialLoading: false,

--- a/ui/pages/perps/perps-market-detail-page.test.tsx
+++ b/ui/pages/perps/perps-market-detail-page.test.tsx
@@ -246,6 +246,10 @@ const mockLivePositions = jest.fn(() => ({
   positions: mockPositions,
   isInitialLoading: false,
 }));
+const mockLiveMarketData = jest.fn(() => ({
+  markets: [...mockCryptoMarkets, ...mockHip3Markets],
+  isInitialLoading: false,
+}));
 
 // Mock the perps stream hooks
 jest.mock('../../hooks/perps/stream', () => ({
@@ -255,10 +259,7 @@ jest.mock('../../hooks/perps/stream', () => ({
     isInitialLoading: false,
   }),
   usePerpsLiveAccount: () => mockLiveAccount(),
-  usePerpsLiveMarketData: () => ({
-    markets: [...mockCryptoMarkets, ...mockHip3Markets],
-    isInitialLoading: false,
-  }),
+  usePerpsLiveMarketData: () => mockLiveMarketData(),
   usePerpsLiveCandles: () => ({
     candleData: {
       symbol: 'ETH',
@@ -382,6 +383,10 @@ describe('PerpsMarketDetailPage', () => {
     });
     mockLivePositions.mockReturnValue({
       positions: mockPositions,
+      isInitialLoading: false,
+    });
+    mockLiveMarketData.mockReturnValue({
+      markets: [...mockCryptoMarkets, ...mockHip3Markets],
       isInitialLoading: false,
     });
     mockUsePerpsMarketFills.mockReturnValue({
@@ -556,6 +561,35 @@ describe('PerpsMarketDetailPage', () => {
 
       expect(getByTestId('perps-market-detail-price')).toBeInTheDocument();
       expect(getByText('ETH-USD')).toBeInTheDocument();
+    });
+
+    it('displays the market max leverage pill in the header', async () => {
+      const store = mockStore(createMockState(true));
+
+      const { getByTestId } = await renderPage(store);
+
+      expect(getByTestId('perps-market-max-leverage')).toHaveTextContent(
+        '20x',
+      );
+    });
+
+    it('omits the market max leverage pill when max leverage is unavailable', async () => {
+      mockLiveMarketData.mockReturnValue({
+        markets: [
+          {
+            ...mockCryptoMarkets[1],
+            maxLeverage: undefined,
+          },
+        ],
+        isInitialLoading: false,
+      });
+      const store = mockStore(createMockState(true));
+
+      await renderPage(store);
+
+      expect(
+        screen.queryByTestId('perps-market-max-leverage'),
+      ).not.toBeInTheDocument();
     });
 
     it('renders market detail page for BTC', async () => {

--- a/ui/pages/perps/perps-market-detail-page.tsx
+++ b/ui/pages/perps/perps-market-detail-page.tsx
@@ -1029,9 +1029,28 @@ const PerpsMarketDetailPage: React.FC = () => {
         {/* Token Logo */}
         <PerpsTokenLogo symbol={market.symbol} size={AvatarTokenSize.Md} />
 
-        {/* Header Content: symbol-USD, price + change */}
+        {/* Header Content: symbol-USD, max leverage, price + change */}
         <Box flexDirection={BoxFlexDirection.Column}>
-          <Text variant={TextVariant.HeadingMd}>{displayName}-USD</Text>
+          <Box
+            flexDirection={BoxFlexDirection.Row}
+            alignItems={BoxAlignItems.Center}
+            gap={1}
+          >
+            <Text variant={TextVariant.HeadingMd}>{displayName}-USD</Text>
+            {market.maxLeverage && (
+              <Box
+                className="rounded-md bg-muted px-1.5"
+                data-testid="perps-market-max-leverage"
+              >
+                <Text
+                  variant={TextVariant.BodyXs}
+                  color={TextColor.TextAlternative}
+                >
+                  {market.maxLeverage}
+                </Text>
+              </Box>
+            )}
+          </Box>
           <Box
             flexDirection={BoxFlexDirection.Row}
             alignItems={BoxAlignItems.Baseline}

--- a/ui/pages/perps/perps-market-detail-page.tsx
+++ b/ui/pages/perps/perps-market-detail-page.tsx
@@ -1039,7 +1039,7 @@ const PerpsMarketDetailPage: React.FC = () => {
             <Text variant={TextVariant.HeadingMd}>{displayName}-USD</Text>
             {market.maxLeverage && (
               <Box
-                className="rounded-md bg-muted px-1.5"
+                className="shrink-0 rounded-md bg-background-muted px-1.5"
                 data-testid="perps-market-max-leverage"
               >
                 <Text


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds the market max leverage pill to the perps market detail header. The page already receives `market.maxLeverage`; this renders it next to the market title to match the mobile market detail behavior.

The pill uses the existing Extension market-row max-leverage badge styling (`shrink-0`, `bg-background-muted`) for consistency.

## **Changelog**

CHANGELOG entry: Fixed a bug that hid max leverage on the perps market detail page

## **Related issues**

Fixes: [TAT-3104](https://consensyssoftware.atlassian.net/browse/TAT-3104)

## **Manual testing steps**

1. Unlock the wallet.
2. Open Perps and navigate to the BTC market detail page.
3. Confirm the market detail header shows BTC-USD with a max leverage pill, for example 40x.

## **Screenshots/Recordings**

Market detail header now displays the market max leverage pill.

<table>
<tr><td colspan="2"><strong>Market detail header max leverage pill — Before has no leverage pill beside BTC-USD; after shows the 40x pill.</strong></td></tr>
<tr>
<td align="center" width="50%"><em>Before</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/fixes/42404/before-evidence-ac1-max-leverage-pill.png" alt="before" width="400" /></td>
<td align="center" width="50%"><em>After</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/fixes/42404/after-evidence-ac1-max-leverage-pill.png" alt="after" width="400" /></td>
</tr>
</table>


**Video**
Videos captured the recipe before and after the fix.
<table>
<tr><td align="center" width="50%"><em>Before</em><br/><a href="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/fixes/42404/before.mp4">before.mp4</a></td>
<td align="center" width="50%"><em>After</em><br/><a href="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/fixes/42404/after.mp4">after.mp4</a></td></tr>
</table>

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## **Validation Recipe**

<details>
<summary>recipe.json</summary>

```json
{
  "title": "TAT-3104 market detail max leverage pill",
  "schema_version": 1,
  "description": "Validates that the perps BTC market detail header renders the market max leverage pill from live market metadata.",
  "validate": {
    "workflow": {
      "pre_conditions": ["wallet.unlocked"],
      "entry": "setup-nav-market",
      "nodes": {
        "setup-nav-market": {
          "action": "call",
          "ref": "perps/navigate-to-market-detail",
          "params": { "symbol": "BTC" },
          "next": "gate-read-btc-market-data"
        },
        "gate-read-btc-market-data": {
          "action": "eval_sync",
          "expression": "(function(){var sm=stateHooks.getPerpsStreamManager&&stateHooks.getPerpsStreamManager();var rows=sm?.markets?.getCachedData?.()||[];var btc=rows.find(function(m){return m.symbol==='BTC';});return JSON.stringify({hasBtc:!!btc,maxLeverage:btc&&btc.maxLeverage||null});})()",
          "assert": {
            "all": [
              { "operator": "eq", "field": "hasBtc", "value": true },
              { "operator": "eq", "field": "maxLeverage", "value": "40x" }
            ]
          },
          "save_as": "btc_market",
          "next": "ac1-assert-header-max-leverage"
        },
        "ac1-assert-header-max-leverage": {
          "action": "eval_sync",
          "expression": "(function(){var page=!!document.querySelector('[data-testid=\"perps-market-detail-page\"]');var pill=document.querySelector('[data-testid=\"perps-market-max-leverage\"]');var pillText=pill?.textContent?.trim()||null;var header=document.querySelector('[data-testid=\"perps-market-detail-page\"]')?.innerText||'';return JSON.stringify({page:page,pillText:pillText,headerIncludesPill:header.includes('40x'),hash:location.hash});})()",
          "assert": {
            "all": [
              { "operator": "eq", "field": "page", "value": true },
              { "operator": "eq", "field": "pillText", "value": "40x" },
              { "operator": "eq", "field": "headerIncludesPill", "value": true }
            ]
          },
          "save_as": "header_pill",
          "next": "ac1-screenshot-max-leverage-pill"
        },
        "ac1-screenshot-max-leverage-pill": {
          "action": "screenshot",
          "filename": "evidence-ac1-max-leverage-pill.png",
          "note": "AC1: BTC market detail header visibly shows the 40x max leverage pill",
          "next": "done"
        },
        "done": { "action": "end", "status": "pass" }
      }
    }
  }
}

```

</details>

## **Recipe Workflow**

<details>
<summary>workflow.mmd</summary>

```mermaid
flowchart TD
  %% TAT-3104 market detail max leverage pill
  __entry__(["ENTRY"]) --> node_setup_nav_market
  node_setup_nav_market[["setup-nav-market<br/>perps/navigate-to-market-detail"]]
  node_gate_read_btc_market_data["gate-read-btc-market-data<br/>eval_sync"]
  node_ac1_assert_header_max_leverage["ac1-assert-header-max-leverage<br/>eval_sync"]
  node_ac1_screenshot_max_leverage_pill["ac1-screenshot-max-leverage-pill<br/>screenshot"]
  node_done(["done<br/>PASS"])
  node_setup_nav_market --> node_gate_read_btc_market_data
  node_gate_read_btc_market_data --> node_ac1_assert_header_max_leverage
  node_ac1_assert_header_max_leverage --> node_ac1_screenshot_max_leverage_pill
  node_ac1_screenshot_max_leverage_pill --> node_done

```

</details>

[TAT-3104]: https://consensyssoftware.atlassian.net/browse/TAT-3104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that conditionally renders existing `market.maxLeverage` metadata and adds a couple of header-focused tests; no changes to trading logic or data flow.
> 
> **Overview**
> Shows the perps market’s **max leverage** next to the `SYMBOL-USD` header on `PerpsMarketDetailPage` via a new conditional pill (`data-testid="perps-market-max-leverage"`).
> 
> Updates `perps-market-detail-page.test.tsx` to use a mockable `usePerpsLiveMarketData` response and adds assertions that the pill renders when leverage is present and is omitted when it’s missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0922d6c5f697e5f834f645244a3d84f7b0a215c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->