### PR TITLE
feat: enhance transaction metrics tracking for retries and quotes

### DIFF
--- a/app/scripts/lib/transaction/metrics-context.test.ts
+++ b/app/scripts/lib/transaction/metrics-context.test.ts
@@ -125,4 +125,46 @@ describe('buildTransactionMetricsContext', () => {
     expect(context.transactionTypeForMetrics).toBe('perps_withdraw');
     expect(context.isContractInteraction).toBe(false);
   });
+
+  describe('retry transactions', () => {
+    it('returns snake_case transaction type for retried perps deposit transactions', async () => {
+      const context = await buildTransactionMetricsContext({
+        transactionMeta: createTransactionMeta({
+          type: TransactionType.retry,
+          originalType: TransactionType.perpsDeposit,
+          txParams: { data: '0xa9059cbb' },
+        }),
+        transactionMetricsRequest: createRequest(),
+      });
+
+      expect(context.transactionTypeForMetrics).toBe('perps_deposit');
+    });
+
+    it('returns snake_case transaction type for retried mUSD conversion transactions', async () => {
+      const context = await buildTransactionMetricsContext({
+        transactionMeta: createTransactionMeta({
+          type: TransactionType.retry,
+          originalType: TransactionType.musdConversion,
+          txParams: { data: '0xa9059cbb' },
+        }),
+        transactionMetricsRequest: createRequest(),
+      });
+
+      expect(context.transactionTypeForMetrics).toBe('musd_conversion');
+    });
+
+    it('returns mm_swap as transaction type for retried swap transactions', async () => {
+      const context = await buildTransactionMetricsContext({
+        transactionMeta: createTransactionMeta({
+          type: TransactionType.retry,
+          originalType: TransactionType.swap,
+          txParams: { data: '0xa9059cbb' },
+        }),
+        transactionMetricsRequest: createRequest(),
+      });
+
+      expect(context.transactionTypeForMetrics).toBe('mm_swap');
+      expect(context.isContractInteraction).toBe(true);
+    });
+  });
 });

--- a/app/scripts/lib/transaction/metrics-context.ts
+++ b/app/scripts/lib/transaction/metrics-context.ts
@@ -118,10 +118,7 @@ function determineTransactionTypeAndContractInteraction(
   }
 
   if (type === 'retry' && originalType) {
-    return {
-      transactionType: originalType,
-      isContractInteraction,
-    };
+    return determineTransactionTypeAndContractInteraction(originalType);
   }
 
   if (isContractInteraction) {

--- a/shared/types/metametrics.ts
+++ b/shared/types/metametrics.ts
@@ -2,7 +2,7 @@ import type { Provider } from '@metamask/network-controller';
 import type { FetchGasFeeEstimateOptions } from '@metamask/gas-fee-controller';
 import type { SmartTransaction } from '@metamask/smart-transactions-controller';
 import type { TransactionMeta } from '@metamask/transaction-controller';
-import type { TransactionPayControllerState } from '@metamask/transaction-pay-controller';
+import type { TransactionData } from '@metamask/transaction-pay-controller';
 import type { Hex } from 'viem';
 import {
   PaymentType,
@@ -17,9 +17,6 @@ import type { HardwareKeyringType } from '../constants/hardware-wallets';
 import type { SnapAndHardwareMessenger } from '../../app/scripts/lib/snap-keyring/metrics';
 import { ShieldMetricsSourceEnum } from '../constants/subscriptions';
 import type { ScanAddressResponse } from '../lib/trust-signals';
-
-// TODO: Replace with direct `TransactionData` import once exported from @metamask/transaction-pay-controller
-type TransactionData = TransactionPayControllerState['transactionData'][string];
 
 export type TransactionMetricsRequest = {
   getTransactionUIMetricsFragment: (

--- a/ui/pages/confirmations/hooks/pay/useTransactionPayMetrics.ts
+++ b/ui/pages/confirmations/hooks/pay/useTransactionPayMetrics.ts
@@ -30,7 +30,7 @@ export function useTransactionPayMetrics() {
   const totals = useTransactionPayTotals();
   const tokens = useTransactionPayAvailableTokens();
 
-  const hasQuotes = (quotes?.length ?? 0) > 0;
+  const hasQuotes = Boolean(quotes?.length);
   if (hasQuotes && !hasLoadedQuoteRef.current) {
     hasLoadedQuoteRef.current = true;
   }

--- a/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
+++ b/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmount.test.ts
@@ -415,7 +415,7 @@ describe('useTransactionCustomAmount', () => {
   });
 
   describe('mm_pay_amount_input_type tracking', () => {
-    it('dispatches mm_pay_amount_input_type as manual and mm_pay_quote_requested as false when updatePendingAmount is called', () => {
+    it('dispatches mm_pay_amount_input_type as manual without mm_pay_quote_requested when updatePendingAmount is called', () => {
       const { result } = runHook();
 
       act(() => {
@@ -425,11 +425,56 @@ describe('useTransactionCustomAmount', () => {
       expect(upsertTransactionUIMetricsFragment).toHaveBeenCalledWith(
         MOCK_TRANSACTION_META.id,
         {
-          properties: expect.objectContaining({
+          properties: {
             mm_pay_amount_input_type: 'manual',
-            mm_pay_quote_requested: false,
-          }),
+          },
         },
+      );
+    });
+
+    it('dispatches mm_pay_quote_requested as true after debounce when manual input triggers a quote refresh', () => {
+      const { result } = runHook();
+
+      act(() => {
+        result.current.updatePendingAmount('50');
+      });
+
+      jest.mocked(upsertTransactionUIMetricsFragment).mockClear();
+
+      act(() => {
+        jest.advanceTimersByTime(500);
+      });
+
+      expect(upsertTransactionUIMetricsFragment).toHaveBeenCalledWith(
+        MOCK_TRANSACTION_META.id,
+        {
+          properties: {
+            mm_pay_quote_requested: true,
+          },
+        },
+      );
+    });
+
+    it('does not dispatch mm_pay_quote_requested after debounce when disableUpdate is true', () => {
+      const { result } = runHook({ disableUpdate: true });
+
+      act(() => {
+        result.current.updatePendingAmount('50');
+      });
+
+      jest.mocked(upsertTransactionUIMetricsFragment).mockClear();
+
+      act(() => {
+        jest.advanceTimersByTime(500);
+      });
+
+      expect(upsertTransactionUIMetricsFragment).not.toHaveBeenCalledWith(
+        MOCK_TRANSACTION_META.id,
+        expect.objectContaining({
+          properties: expect.objectContaining({
+            mm_pay_quote_requested: expect.anything(),
+          }),
+        }),
       );
     });
 

--- a/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmount.ts
+++ b/ui/pages/confirmations/hooks/transactions/useTransactionCustomAmount.ts
@@ -65,6 +65,16 @@ export function useTransactionCustomAmount({
       setAmountHumanDebounced(value);
       if (!disableUpdate) {
         updateTokenAmountCallback(value);
+        // Emitted only after the debounce actually triggers a quote refresh
+        // via updateEditableParams -> TransactionPayController:stateChange.
+        if (transactionId) {
+          upsertTransactionUIMetricsFragment(transactionId, {
+            properties: {
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              mm_pay_quote_requested: true,
+            },
+          });
+        }
       }
     }, DEBOUNCE_DELAY);
 
@@ -75,7 +85,7 @@ export function useTransactionCustomAmount({
     return () => {
       debouncedFn.cancel();
     };
-  }, [disableUpdate, updateTokenAmountCallback]);
+  }, [disableUpdate, transactionId, updateTokenAmountCallback]);
 
   const primaryRequiredToken = useTransactionPayPrimaryRequiredToken();
 
@@ -160,8 +170,6 @@ export function useTransactionCustomAmount({
           properties: {
             // eslint-disable-next-line @typescript-eslint/naming-convention
             mm_pay_amount_input_type: 'manual',
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            mm_pay_quote_requested: false,
           },
         });
       }


### PR DESCRIPTION
## **Description**

Follow-up to #42251 addressing review feedback ([CONF-1335](https://consensyssoftware.atlassian.net/browse/CONF-1335)).

The original PR added missing `mm_pay_*` analytics properties and converted `transaction_type` to snake_case, but two reviewer-flagged bugs remained and a couple of nits were left for a follow-up:

1. **Retry transactions emit camelCase `transaction_type`** — the snake_case mapping in `metrics-context.ts` did not apply when `type === 'retry'`, so retries of `perpsDeposit`, `musdConversion`, etc. were still surfacing as camelCase, defeating the purpose of the original fix.
2. **`mm_pay_quote_requested` was inaccurate for manual amount input** — `updatePendingAmount` synchronously emitted `mm_pay_quote_requested: false`, but ~500ms later the debounced `updateTokenAmountCallback` does in fact trigger a quote refresh via `updateEditableParams` -> `TransactionController:stateChange` -> `TransactionPayController` quote refetch.
3. **`TransactionData` indexed-access workaround** — `@metamask/transaction-pay-controller` now exports the type directly (companion [MetaMask/core#8630](https://github.com/MetaMask/core/pull/8630) merged), so the local alias and TODO can go.
4. **`hasQuotes` nit** — `(quotes?.length ?? 0) > 0` simplified to `Boolean(quotes?.length)`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [CONF-1335](https://consensyssoftware.atlassian.net/browse/CONF-1335)

Follow-up to: #42251

## **Manual testing steps**

1. Enable MetaMetrics opt-in.
2. **Retry snake_case `transaction_type`:**
   1. Trigger a perps deposit (or any `perpsDeposit`/`musdConversion`/`perpsWithdraw`/`musdClaim`).
   2. Force a retry (e.g. submit with a low gas price and use the speed-up flow).
   3. In the Segment debugger, confirm the retry's `transaction_type` is snake_case (`perps_deposit`, etc.) and not camelCase.
3. **`mm_pay_quote_requested` accuracy:**
   1. Open a confirmation that uses MM Pay (e.g. perps deposit).
   2. Type a manual amount in the amount input.
   3. Wait ~500ms for debounce, then approve.
   4. In Segment, confirm `mm_pay_amount_input_type: 'manual'` is set, and `mm_pay_quote_requested: true` is also set (no longer `false`).
   5. Repeat using the percentage buttons (25%/50%/MAX) — `mm_pay_amount_input_type` reflects the percentage and `mm_pay_quote_requested: true` is still set.
4. **No regressions:**
   1. For a non-retry, non-MM-Pay transaction, confirm `transaction_type` and `mm_pay_*` properties are unchanged from #42251 behavior.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[CONF-1335]: https://consensyssoftware.atlassian.net/browse/CONF-1335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CONF-1335]: https://consensyssoftware.atlassian.net/browse/CONF-1335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk analytics-only changes, but they touch transaction-type normalization and add an extra metrics upsert on the debounced quote-refresh path which could affect event volume/timing.
> 
> **Overview**
> **Improves transaction metrics normalization and MM Pay analytics accuracy.** Retry transactions now reuse the same transaction-type mapping logic as their `originalType`, ensuring `transaction_type` is consistently snake_case (and correctly reports `mm_swap`/contract-interaction for retried swaps), with new unit tests covering these cases.
> 
> **Aligns `mm_pay_quote_requested` with actual quote refresh behavior.** Manual amount entry now only logs `mm_pay_amount_input_type: 'manual'` immediately, and emits `mm_pay_quote_requested: true` only when the debounced update actually triggers a quote refresh (and not when `disableUpdate` is set); tests were updated/added accordingly. Also cleans up types by importing `TransactionData` directly and simplifies a small `hasQuotes` check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34bb21e8d6a443f2dbb7c08d23f49165835f595d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->