### PR TITLE
test: fix unpredictable number of Accounts due to the Sync feature in performance tests

### DIFF
--- a/app/scripts/migrations/167.ts
+++ b/app/scripts/migrations/167.ts
@@ -60,13 +60,5 @@ function transformState(
     userStorageControllerState.isAccountSyncingEnabled = true;
   }
 
-  // If we are using `yarn start:with-state` or running an E2E test with generateWalletState, disable all syncing
-  if (process.env.WITH_STATE || getManifestFlags().testing?.disableSync) {
-    userStorageControllerState.isBackupAndSyncEnabled = false;
-    userStorageControllerState.isAccountSyncingEnabled = false;
-    userStorageControllerState.isProfileSyncingEnabled = false;
-    userStorageControllerState.isContactSyncingEnabled = false;
-  }
-
   return state;
 }

--- a/app/scripts/migrations/167.ts
+++ b/app/scripts/migrations/167.ts
@@ -1,6 +1,5 @@
 import { cloneDeep } from 'lodash';
 import { hasProperty, isObject } from '@metamask/utils';
-import { getManifestFlags } from '../../../shared/lib/manifestFlags';
 
 type VersionedData = {
   meta: { version: number };

--- a/shared/lib/manifestFlags.ts
+++ b/shared/lib/manifestFlags.ts
@@ -92,10 +92,6 @@ export type ManifestFlags = {
      */
     disableSmartTransactionsOverride?: boolean;
     /**
-     * Whether to disable all of the syncing features that get automatically enabled in migrations 158 and 167
-     */
-    disableSync?: boolean;
-    /**
      * Simulate a delay to how quickly the background responds to the UI. Set this to `true` to
      * make the background completely unresponsive.
      */

--- a/test/e2e/benchmarks/flows/startup/power-user-home.ts
+++ b/test/e2e/benchmarks/flows/startup/power-user-home.ts
@@ -63,9 +63,11 @@ async function measurePagePowerUser(
         // Confirm the number of accounts in the account list
         await new HeaderNavbar(driver).openAccountMenu();
         const accountListPage = new AccountListPage(driver);
-        await accountListPage.checkNumberOfAvailableAccounts(
-          WITH_STATE_POWER_USER.withAccounts,
-        );
+
+        // Wait for Account Sync to finish.
+        // We cannot wait for a specific account to appear as Account Sync can cause
+        // a different number of accounts loaded than the one we inject with fixtures
+        await accountListPage.waitUntilSyncingIsCompleted();
         await accountListPage.checkAccountDisplayedInAccountList(
           `Account ${WITH_STATE_POWER_USER.withAccounts}`,
         );

--- a/test/e2e/benchmarks/flows/startup/power-user-home.ts
+++ b/test/e2e/benchmarks/flows/startup/power-user-home.ts
@@ -37,12 +37,11 @@ async function measurePagePowerUser(
   await withFixtures(
     {
       title,
-      fixtures: (
-        await generateWalletState(WITH_STATE_POWER_USER, true)
-      ).build(),
+      fixtures: (await generateWalletState(WITH_STATE_POWER_USER, true))
+        .withSyncDisabled()
+        .build(),
       manifestFlags: {
         testing: {
-          disableSync: true,
           infuraProjectId: process.env.INFURA_PROJECT_ID,
         },
       },

--- a/test/e2e/benchmarks/flows/startup/power-user-home.ts
+++ b/test/e2e/benchmarks/flows/startup/power-user-home.ts
@@ -65,7 +65,7 @@ async function measurePagePowerUser(
         const accountListPage = new AccountListPage(driver);
 
         // Wait for Account Sync to finish.
-        // We cannot wait for a specific account to appear as Account Sync can cause
+        // We cannot wait for a specific account number to appear as Account Sync can cause
         // a different number of accounts loaded than the one we inject with fixtures
         await accountListPage.waitUntilSyncingIsCompleted();
         await accountListPage.checkAccountDisplayedInAccountList(

--- a/test/e2e/benchmarks/flows/startup/power-user-home.ts
+++ b/test/e2e/benchmarks/flows/startup/power-user-home.ts
@@ -9,6 +9,7 @@ import { withFixtures } from '../../../helpers';
 import { login } from '../../../page-objects/flows/login.flow';
 import AccountListPage from '../../../page-objects/pages/account-list-page';
 import HeaderNavbar from '../../../page-objects/pages/header-navbar';
+import { userStorageHostMock } from '../../mocks/performance-mocks';
 import { mockNotificationServices } from '../../../tests/notifications/mocks';
 import {
   BENCHMARK_PERSONA,
@@ -37,9 +38,9 @@ async function measurePagePowerUser(
   await withFixtures(
     {
       title,
-      fixtures: (await generateWalletState(WITH_STATE_POWER_USER, true))
-        .withSyncDisabled()
-        .build(),
+      fixtures: (
+        await generateWalletState(WITH_STATE_POWER_USER, true)
+      ).build(),
       manifestFlags: {
         testing: {
           infuraProjectId: process.env.INFURA_PROJECT_ID,
@@ -50,6 +51,7 @@ async function measurePagePowerUser(
       extendedTimeoutMultiplier: 3,
       testSpecificMock: async (server: Mockttp) => {
         await mockNotificationServices(server);
+        await userStorageHostMock(server);
       },
     },
     async ({ driver, getNetworkReport, clearNetworkReport }) => {
@@ -64,9 +66,10 @@ async function measurePagePowerUser(
         const accountListPage = new AccountListPage(driver);
 
         // Wait for Account Sync to finish.
-        // We cannot wait for a specific account number to appear as Account Sync can cause
-        // a different number of accounts loaded than the one we inject with fixtures
         await accountListPage.waitUntilSyncingIsCompleted();
+        await accountListPage.checkNumberOfAvailableAccounts(
+          WITH_STATE_POWER_USER.withAccounts,
+        );
         await accountListPage.checkAccountDisplayedInAccountList(
           `Account ${WITH_STATE_POWER_USER.withAccounts}`,
         );

--- a/test/e2e/benchmarks/flows/user-journey/asset-details.ts
+++ b/test/e2e/benchmarks/flows/user-journey/asset-details.ts
@@ -64,7 +64,7 @@ export async function runAssetDetailsBenchmark(): Promise<BenchmarkRunResult> {
         const accountListPage = new AccountListPage(driver);
 
         // Wait for Account Sync to finish.
-        // We cannot wait for a specific account to appear as Account Sync can cause
+        // We cannot wait for a specific account number to appear as Account Sync can cause
         // a different number of accounts loaded than the one we inject with fixtures
         await accountListPage.waitUntilSyncingIsCompleted();
         await accountListPage.checkAccountDisplayedInAccountList(

--- a/test/e2e/benchmarks/flows/user-journey/asset-details.ts
+++ b/test/e2e/benchmarks/flows/user-journey/asset-details.ts
@@ -40,12 +40,11 @@ export async function runAssetDetailsBenchmark(): Promise<BenchmarkRunResult> {
     await withFixtures(
       {
         title: testTitle,
-        fixtures: (
-          await generateWalletState(WITH_STATE_POWER_USER, true)
-        ).build(),
+        fixtures: (await generateWalletState(WITH_STATE_POWER_USER, true))
+          .withSyncDisabled()
+          .build(),
         manifestFlags: {
           testing: {
-            disableSync: true,
             infuraProjectId: process.env.INFURA_PROJECT_ID,
           },
         },

--- a/test/e2e/benchmarks/flows/user-journey/asset-details.ts
+++ b/test/e2e/benchmarks/flows/user-journey/asset-details.ts
@@ -62,9 +62,11 @@ export async function runAssetDetailsBenchmark(): Promise<BenchmarkRunResult> {
         const headerNavbar = new HeaderNavbar(driver);
         await headerNavbar.openAccountMenu();
         const accountListPage = new AccountListPage(driver);
-        await accountListPage.checkNumberOfAvailableAccounts(
-          WITH_STATE_POWER_USER.withAccounts,
-        );
+
+        // Wait for Account Sync to finish.
+        // We cannot wait for a specific account to appear as Account Sync can cause
+        // a different number of accounts loaded than the one we inject with fixtures
+        await accountListPage.waitUntilSyncingIsCompleted();
         await accountListPage.checkAccountDisplayedInAccountList(
           `Account ${WITH_STATE_POWER_USER.withAccounts}`,
         );

--- a/test/e2e/benchmarks/flows/user-journey/asset-details.ts
+++ b/test/e2e/benchmarks/flows/user-journey/asset-details.ts
@@ -40,9 +40,9 @@ export async function runAssetDetailsBenchmark(): Promise<BenchmarkRunResult> {
     await withFixtures(
       {
         title: testTitle,
-        fixtures: (await generateWalletState(WITH_STATE_POWER_USER, true))
-          .withSyncDisabled()
-          .build(),
+        fixtures: (
+          await generateWalletState(WITH_STATE_POWER_USER, true)
+        ).build(),
         manifestFlags: {
           testing: {
             infuraProjectId: process.env.INFURA_PROJECT_ID,
@@ -63,9 +63,10 @@ export async function runAssetDetailsBenchmark(): Promise<BenchmarkRunResult> {
         const accountListPage = new AccountListPage(driver);
 
         // Wait for Account Sync to finish.
-        // We cannot wait for a specific account number to appear as Account Sync can cause
-        // a different number of accounts loaded than the one we inject with fixtures
         await accountListPage.waitUntilSyncingIsCompleted();
+        await accountListPage.checkNumberOfAvailableAccounts(
+          WITH_STATE_POWER_USER.withAccounts,
+        );
         await accountListPage.checkAccountDisplayedInAccountList(
           `Account ${WITH_STATE_POWER_USER.withAccounts}`,
         );

--- a/test/e2e/benchmarks/flows/user-journey/import-srp-home.ts
+++ b/test/e2e/benchmarks/flows/user-journey/import-srp-home.ts
@@ -51,10 +51,10 @@ export async function runImportSrpHomeBenchmark(): Promise<BenchmarkRunResult> {
         title: testTitle,
         fixtures: (await generateWalletState(WITH_STATE_POWER_USER, true))
           .withEnabledNetworks(ALL_POPULAR_NETWORKS)
+          .withSyncDisabled()
           .build(),
         manifestFlags: {
           testing: {
-            disableSync: true,
             infuraProjectId: process.env.INFURA_PROJECT_ID,
           },
         },

--- a/test/e2e/benchmarks/flows/user-journey/import-srp-home.ts
+++ b/test/e2e/benchmarks/flows/user-journey/import-srp-home.ts
@@ -51,7 +51,6 @@ export async function runImportSrpHomeBenchmark(): Promise<BenchmarkRunResult> {
         title: testTitle,
         fixtures: (await generateWalletState(WITH_STATE_POWER_USER, true))
           .withEnabledNetworks(ALL_POPULAR_NETWORKS)
-          .withSyncDisabled()
           .build(),
         manifestFlags: {
           testing: {

--- a/test/e2e/benchmarks/flows/user-journey/onboarding-import-wallet.ts
+++ b/test/e2e/benchmarks/flows/user-journey/onboarding-import-wallet.ts
@@ -55,7 +55,6 @@ export async function runOnboardingImportWalletBenchmark(): Promise<BenchmarkRun
         title: testTitle,
         manifestFlags: {
           testing: {
-            disableSync: true,
             infuraProjectId: process.env.INFURA_PROJECT_ID,
           },
         },
@@ -64,6 +63,7 @@ export async function runOnboardingImportWalletBenchmark(): Promise<BenchmarkRun
         extendedTimeoutMultiplier: 3,
         fixtures: new FixtureBuilderV2({ onboarding: true })
           .withEnabledNetworks(ALL_POPULAR_NETWORKS)
+          .withSyncDisabled()
           .build(),
         testSpecificMock: async (server: Mockttp) => {
           if (shouldUseMockedRequests()) {

--- a/test/e2e/benchmarks/flows/user-journey/onboarding-import-wallet.ts
+++ b/test/e2e/benchmarks/flows/user-journey/onboarding-import-wallet.ts
@@ -33,6 +33,7 @@ import {
   getCommonMocks,
   benchmarkPassThroughInterceptor,
   mockBenchmarkEndpoints,
+  userStorageHostMock,
 } from '../../mocks/performance-mocks';
 import { shouldUseMockedRequests } from '../../utils/mock-config';
 import {
@@ -66,9 +67,12 @@ export async function runOnboardingImportWalletBenchmark(): Promise<BenchmarkRun
           .build(),
         testSpecificMock: async (server: Mockttp) => {
           if (shouldUseMockedRequests()) {
-            return mockBenchmarkEndpoints(server);
+            const endpoints = await mockBenchmarkEndpoints(server);
+            await userStorageHostMock(server);
+            return endpoints;
           }
           setPassThroughInterceptor(server, benchmarkPassThroughInterceptor);
+          await userStorageHostMock(server);
           return Promise.all(getCommonMocks(server));
         },
       },

--- a/test/e2e/benchmarks/flows/user-journey/onboarding-import-wallet.ts
+++ b/test/e2e/benchmarks/flows/user-journey/onboarding-import-wallet.ts
@@ -63,7 +63,6 @@ export async function runOnboardingImportWalletBenchmark(): Promise<BenchmarkRun
         extendedTimeoutMultiplier: 3,
         fixtures: new FixtureBuilderV2({ onboarding: true })
           .withEnabledNetworks(ALL_POPULAR_NETWORKS)
-          .withSyncDisabled()
           .build(),
         testSpecificMock: async (server: Mockttp) => {
           if (shouldUseMockedRequests()) {

--- a/test/e2e/benchmarks/flows/user-journey/onboarding-new-wallet.ts
+++ b/test/e2e/benchmarks/flows/user-journey/onboarding-new-wallet.ts
@@ -49,7 +49,6 @@ export async function runOnboardingNewWalletBenchmark(): Promise<BenchmarkRunRes
         title: testTitle,
         manifestFlags: {
           testing: {
-            disableSync: true,
             infuraProjectId: process.env.INFURA_PROJECT_ID,
           },
         },
@@ -58,6 +57,7 @@ export async function runOnboardingNewWalletBenchmark(): Promise<BenchmarkRunRes
         extendedTimeoutMultiplier: 3,
         fixtures: new FixtureBuilderV2({ onboarding: true })
           .withEnabledNetworks(ALL_POPULAR_NETWORKS)
+          .withSyncDisabled()
           .build(),
         testSpecificMock: getTestSpecificMock(),
       },

--- a/test/e2e/benchmarks/flows/user-journey/onboarding-new-wallet.ts
+++ b/test/e2e/benchmarks/flows/user-journey/onboarding-new-wallet.ts
@@ -57,7 +57,6 @@ export async function runOnboardingNewWalletBenchmark(): Promise<BenchmarkRunRes
         extendedTimeoutMultiplier: 3,
         fixtures: new FixtureBuilderV2({ onboarding: true })
           .withEnabledNetworks(ALL_POPULAR_NETWORKS)
-          .withSyncDisabled()
           .build(),
         testSpecificMock: getTestSpecificMock(),
       },

--- a/test/e2e/benchmarks/flows/user-journey/send-transactions.ts
+++ b/test/e2e/benchmarks/flows/user-journey/send-transactions.ts
@@ -46,7 +46,6 @@ export async function runSendTransactionsBenchmark(): Promise<BenchmarkRunResult
         title: testTitle,
         fixtures: (await generateWalletState(WITH_STATE_POWER_USER, true))
           .withEnabledNetworks(ALL_POPULAR_NETWORKS)
-          .withSyncDisabled()
           .build(),
         manifestFlags: {
           testing: {

--- a/test/e2e/benchmarks/flows/user-journey/send-transactions.ts
+++ b/test/e2e/benchmarks/flows/user-journey/send-transactions.ts
@@ -46,10 +46,10 @@ export async function runSendTransactionsBenchmark(): Promise<BenchmarkRunResult
         title: testTitle,
         fixtures: (await generateWalletState(WITH_STATE_POWER_USER, true))
           .withEnabledNetworks(ALL_POPULAR_NETWORKS)
+          .withSyncDisabled()
           .build(),
         manifestFlags: {
           testing: {
-            disableSync: true,
             infuraProjectId: process.env.INFURA_PROJECT_ID,
           },
         },

--- a/test/e2e/benchmarks/flows/user-journey/solana-asset-details.ts
+++ b/test/e2e/benchmarks/flows/user-journey/solana-asset-details.ts
@@ -41,7 +41,6 @@ export async function runSolanaAssetDetailsBenchmark(): Promise<BenchmarkRunResu
         title: testTitle,
         fixtures: (await generateWalletState(WITH_STATE_POWER_USER, true))
           .withEnabledNetworks(ALL_POPULAR_NETWORKS)
-          .withSyncDisabled()
           .build(),
         manifestFlags: {
           testing: {

--- a/test/e2e/benchmarks/flows/user-journey/solana-asset-details.ts
+++ b/test/e2e/benchmarks/flows/user-journey/solana-asset-details.ts
@@ -41,10 +41,10 @@ export async function runSolanaAssetDetailsBenchmark(): Promise<BenchmarkRunResu
         title: testTitle,
         fixtures: (await generateWalletState(WITH_STATE_POWER_USER, true))
           .withEnabledNetworks(ALL_POPULAR_NETWORKS)
+          .withSyncDisabled()
           .build(),
         manifestFlags: {
           testing: {
-            disableSync: true,
             infuraProjectId: process.env.INFURA_PROJECT_ID,
           },
         },

--- a/test/e2e/benchmarks/flows/user-journey/swap.ts
+++ b/test/e2e/benchmarks/flows/user-journey/swap.ts
@@ -48,7 +48,6 @@ export async function runSwapBenchmark(): Promise<BenchmarkRunResult> {
         title: testTitle,
         fixtures: (await generateWalletState(WITH_STATE_POWER_USER, true))
           .withEnabledNetworks(ALL_POPULAR_NETWORKS)
-          .withSyncDisabled()
           .build(),
         manifestFlags: {
           testing: {

--- a/test/e2e/benchmarks/flows/user-journey/swap.ts
+++ b/test/e2e/benchmarks/flows/user-journey/swap.ts
@@ -48,10 +48,10 @@ export async function runSwapBenchmark(): Promise<BenchmarkRunResult> {
         title: testTitle,
         fixtures: (await generateWalletState(WITH_STATE_POWER_USER, true))
           .withEnabledNetworks(ALL_POPULAR_NETWORKS)
+          .withSyncDisabled()
           .build(),
         manifestFlags: {
           testing: {
-            disableSync: true,
             infuraProjectId: process.env.INFURA_PROJECT_ID,
           },
         },

--- a/test/e2e/benchmarks/mocks/performance-mocks.ts
+++ b/test/e2e/benchmarks/mocks/performance-mocks.ts
@@ -547,7 +547,7 @@ export function getCommonMocks(server: Mockttp): Promise<MockedEndpoint>[] {
 
 export function userStorageHostMock(server: Mockttp): Promise<MockedEndpoint> {
   const endpointPromise = server
-    .forAnyRequest()
+    .forGet()
     .forHost('user-storage.api.cx.metamask.io')
     .always()
     .thenCallback(() => ({ statusCode: 200, json: null }));
@@ -555,7 +555,10 @@ export function userStorageHostMock(server: Mockttp): Promise<MockedEndpoint> {
   const existingInterceptor = (server as unknown as Record<string, unknown>)
     .__passThroughInterceptor as PassThroughInterceptor | undefined;
   setPassThroughInterceptor(server, (req) => {
-    if (req.url.includes('user-storage.api.cx.metamask.io')) {
+    if (
+      req.method === 'GET' &&
+      req.url.includes('user-storage.api.cx.metamask.io')
+    ) {
       return { response: { statusCode: 200, json: null } };
     }
     return existingInterceptor?.(req) ?? null;

--- a/test/e2e/benchmarks/mocks/performance-mocks.ts
+++ b/test/e2e/benchmarks/mocks/performance-mocks.ts
@@ -5,6 +5,10 @@
  */
 import { Mockttp, MockedEndpoint, RequestRuleBuilder } from 'mockttp';
 import { AuthenticationController } from '@metamask/profile-sync-controller';
+import {
+  setPassThroughInterceptor,
+  type PassThroughInterceptor,
+} from '../../mock-e2e-pass-through';
 import { POWER_USER_PRICES } from './price-data';
 import { buildSseResponseBody } from './swap-mocks';
 import bridgeNetworkTokens from './bridge-network-tokens.json';
@@ -539,6 +543,25 @@ export function getCommonMocks(server: Mockttp): Promise<MockedEndpoint>[] {
         return { statusCode: 200, json: { signature: 'mock-signature' } };
       }),
   ];
+}
+
+export function userStorageHostMock(server: Mockttp): Promise<MockedEndpoint> {
+  const endpointPromise = server
+    .forAnyRequest()
+    .forHost('user-storage.api.cx.metamask.io')
+    .always()
+    .thenCallback(() => ({ statusCode: 200, json: null }));
+
+  const existingInterceptor = (server as unknown as Record<string, unknown>)
+    .__passThroughInterceptor as PassThroughInterceptor | undefined;
+  setPassThroughInterceptor(server, (req) => {
+    if (req.url.includes('user-storage.api.cx.metamask.io')) {
+      return { response: { statusCode: 200, json: null } };
+    }
+    return existingInterceptor?.(req) ?? null;
+  });
+
+  return endpointPromise;
 }
 
 const SOLANA_URL_REGEX = /^https:\/\/solana-mainnet\.infura\.io\/v3\/.*/u;

--- a/test/e2e/benchmarks/utils/mock-config.ts
+++ b/test/e2e/benchmarks/utils/mock-config.ts
@@ -1,5 +1,8 @@
 import { Mockttp, MockedEndpoint } from 'mockttp';
-import { mockBenchmarkEndpoints } from '../mocks/performance-mocks';
+import {
+  mockBenchmarkEndpoints,
+  userStorageHostMock,
+} from '../mocks/performance-mocks';
 
 /**
  * Check if mocked requests should be used for performance benchmarks.
@@ -25,13 +28,23 @@ export function shouldUseMockedRequests(): boolean {
  * that need specific mocks (e.g. onboarding-import-wallet) should provide
  * their own testSpecificMock.
  *
+ * Always registers `userStorageHostMock` so the user-storage / account sync
+ * API never reaches a live server during benchmarks, regardless of branch.
+ *
  * @returns A function that accepts a mockttp server and returns mocked endpoints.
  */
 export function getTestSpecificMock(): (
   server: Mockttp,
 ) => Promise<MockedEndpoint[]> {
   if (shouldUseMockedRequests()) {
-    return async (server: Mockttp) => mockBenchmarkEndpoints(server);
+    return async (server: Mockttp) => {
+      const endpoints = await mockBenchmarkEndpoints(server);
+      await userStorageHostMock(server);
+      return endpoints;
+    };
   }
-  return async () => [];
+  return async (server: Mockttp) => {
+    await userStorageHostMock(server);
+    return [];
+  };
 }

--- a/test/e2e/fixtures/fixture-builder-v2.ts
+++ b/test/e2e/fixtures/fixture-builder-v2.ts
@@ -387,14 +387,6 @@ class FixtureBuilderV2 {
                               CUSTOM METHODS
      ==================================================================
   */
-  withSyncDisabled(): this {
-    return this.withUserStorageController({
-      isAccountSyncingEnabled: false,
-      isBackupAndSyncEnabled: false,
-      isContactSyncingEnabled: false,
-    });
-  }
-
   withAccountsControllerAdditionalAccountVault(): this {
     // Account sorting for permitted accounts (e.g. `eth_accounts`) now reads
     // `lastSelected` from the matching `AccountGroup` in `AccountTreeController`
@@ -1227,6 +1219,14 @@ class FixtureBuilderV2 {
       preferences: {
         smartTransactionsOptInStatus: false,
       },
+    });
+  }
+
+  withSyncDisabled(): this {
+    return this.withUserStorageController({
+      isAccountSyncingEnabled: false,
+      isBackupAndSyncEnabled: false,
+      isContactSyncingEnabled: false,
     });
   }
 

--- a/test/e2e/fixtures/fixture-builder-v2.ts
+++ b/test/e2e/fixtures/fixture-builder-v2.ts
@@ -25,6 +25,7 @@ import type {
   PermissionConstraint,
   PermissionControllerState,
 } from '@metamask/permission-controller';
+import type { UserStorageControllerState } from '@metamask/profile-sync-controller/user-storage';
 import {
   type NetworkMetadata,
   type NetworkState,
@@ -377,10 +378,23 @@ class FixtureBuilderV2 {
     return this;
   }
 
+  withUserStorageController(data: Partial<UserStorageControllerState>): this {
+    merge(this.fixture.data.UserStorageController, data);
+    return this;
+  }
+
   /* ==================================================================
                               CUSTOM METHODS
      ==================================================================
   */
+  withSyncDisabled(): this {
+    return this.withUserStorageController({
+      isAccountSyncingEnabled: false,
+      isBackupAndSyncEnabled: false,
+      isContactSyncingEnabled: false,
+    });
+  }
+
   withAccountsControllerAdditionalAccountVault(): this {
     // Account sorting for permitted accounts (e.g. `eth_accounts`) now reads
     // `lastSelected` from the matching `AccountGroup` in `AccountTreeController`

--- a/test/e2e/page-objects/pages/account-list-page.ts
+++ b/test/e2e/page-objects/pages/account-list-page.ts
@@ -192,11 +192,6 @@ class AccountListPage {
     tag: 'button',
   };
 
-  private readonly syncingMessage = {
-    text: 'Syncing...',
-    tag: 'div',
-  };
-
   private readonly watchAccountAddressInput =
     'input#address-input[type="text"]';
 
@@ -422,10 +417,8 @@ class AccountListPage {
    */
   async waitUntilSyncingIsCompleted(): Promise<void> {
     console.log(`Check that account syncing not displayed in account list`);
-    // We add a guard because the syncing message may take some time to appear and then disappear
-    await this.driver.assertElementNotPresent(this.syncingMessage, {
-      waitAtLeastGuard: 5000,
-    });
+    await this.checkAddWalletButttonIsDisplayed();
+    await this.driver.assertElementNotPresent(this.syncingMessage);
   }
 
   /**

--- a/test/e2e/page-objects/pages/account-list-page.ts
+++ b/test/e2e/page-objects/pages/account-list-page.ts
@@ -417,7 +417,7 @@ class AccountListPage {
    */
   async waitUntilSyncingIsCompleted(): Promise<void> {
     console.log(`Check that account syncing not displayed in account list`);
-    await this.checkAddWalletButttonIsDisplayed();
+    await this.checkAddWalletButtonIsDisplayed();
     await this.driver.assertElementNotPresent(this.syncingMessage);
   }
 
@@ -920,7 +920,7 @@ class AccountListPage {
     await this.driver.waitForSelector(this.walletDetailsButton);
   }
 
-  async checkAddWalletButttonIsDisplayed(): Promise<void> {
+  async checkAddWalletButtonIsDisplayed(): Promise<void> {
     console.log('Check add wallet button is displayed');
     await this.driver.waitForSelector(this.addMultichainWalletButton);
   }

--- a/test/e2e/page-objects/pages/account-list-page.ts
+++ b/test/e2e/page-objects/pages/account-list-page.ts
@@ -192,6 +192,11 @@ class AccountListPage {
     tag: 'button',
   };
 
+  private readonly syncingMessage = {
+    text: 'Syncing...',
+    tag: 'div',
+  };
+
   private readonly watchAccountAddressInput =
     'input#address-input[type="text"]';
 
@@ -417,9 +422,9 @@ class AccountListPage {
    */
   async waitUntilSyncingIsCompleted(): Promise<void> {
     console.log(`Check that account syncing not displayed in account list`);
-    await this.driver.assertElementNotPresent({
-      css: this.addMultichainAccountButton,
-      text: 'Syncing',
+    // We add a guard because the syncing message may take some time to appear and then disappear
+    await this.driver.assertElementNotPresent(this.syncingMessage, {
+      waitAtLeastGuard: 5000,
     });
   }
 

--- a/test/e2e/tests/multichain-accounts/multichain-account-list-menu.spec.ts
+++ b/test/e2e/tests/multichain-accounts/multichain-account-list-menu.spec.ts
@@ -60,7 +60,7 @@ describe('Multichain Accounts - Account tree', function (this: Suite) {
           'Account 1',
           'Wallet 2',
         );
-        await accountListPage.checkAddWalletButttonIsDisplayed();
+        await accountListPage.checkAddWalletButtonIsDisplayed();
 
         await accountListPage.checkMultichainAccountBalanceDisplayed({
           account: 'Account 1',
@@ -127,7 +127,7 @@ describe('Multichain Accounts - Account tree', function (this: Suite) {
         // Ensure that wallet information is displayed
         await accountListPage.checkWalletDisplayedInAccountListMenu('Wallet 1');
         await accountListPage.checkWalletDisplayedInAccountListMenu('Ledger');
-        await accountListPage.checkAddWalletButttonIsDisplayed();
+        await accountListPage.checkAddWalletButtonIsDisplayed();
 
         // The balance is not loaded for a non-selected account (which was never selected before)
         await accountListPage.checkMultichainAccountBalanceDisplayed({


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Some benchmark started failing the account number assertion, after migrated to FixtureBuilderV2:

`Number of all accounts: 64 is equal to 30? false`

The number of Accounts is initially 30, as expected. However, we have the Account Sync feature enabled, meaning a request will be made to the live endpoint, and this can causes more accounts being added.
This number can change anytime, as anytime a new extra account is added using that SRP with the Account Sync feature On, will cause that whenever we perfrom that flow again, more accounts are synced.


This problem started when we switcht to FixtureBuilderV2, because there we use the latest wallet state, meaning we don't run migrations. This caused that the disabling account sync in the migration using manifest flags, now takes no effect and it's dead code.


The agreed solution with the @MetaMask/extension-platform team was to keep the feature enabled (as it's enabled by default in the wallet) but add a mock, so we ensure the number of accounts is always the same (30) and no new accounts are added because of the account sync feature.




## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check benchmark test logs

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/2e2f9620-2ce7-48f8-9a28-a17ffbe0ac3f


### **After**

<img width="551" height="181" alt="image" src="https://github.com/user-attachments/assets/97f7aa9a-87a3-4c9d-870e-ee1ebd4abef4" />



https://github.com/user-attachments/assets/0340c531-bc82-43cc-8c75-9ae811c31205



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to E2E/benchmark harnesses and a migration/manifest testing flag cleanup; main product behavior is unaffected. Risk is mainly that benchmarks could miss regressions if the new user-storage mock is too permissive or intercept logic is incomplete.
> 
> **Overview**
> Performance benchmarks no longer rely on a `manifestFlags.testing.disableSync` switch to prevent Account Sync side effects. Instead, they **always mock `user-storage.api.cx.metamask.io`** via a new `userStorageHostMock` (including pass-through interception) so benchmark runs never hit live sync endpoints and account counts remain deterministic.
> 
> Bench flows that assert account counts now explicitly **wait for sync UI to finish** (`waitUntilSyncingIsCompleted`) before checking accounts. Supporting test utilities were updated: `disableSync` was removed from `ManifestFlags`, migration `167` dropped the conditional sync-disable block, `FixtureBuilderV2` gained `withUserStorageController` plus a `withSyncDisabled` helper, and a typo fix renamed `checkAddWalletButttonIsDisplayed` to `checkAddWalletButtonIsDisplayed`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93bf12cbe724b5e73dbbb3bcf1ac3ff8ab08498d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->