### PR TITLE
fix: prevent mUSD conversion decimals issue

### DIFF
--- a/ui/pages/confirmations/hooks/transactions/useUpdateTokenAmount.ts
+++ b/ui/pages/confirmations/hooks/transactions/useUpdateTokenAmount.ts
@@ -10,6 +10,7 @@ import { getTokenTransferData } from '../../utils/transaction-pay';
 import { updateEditableParams } from '../../../../store/actions';
 import { updateAtomicBatchData } from '../../../../store/controller-actions/transaction-controller';
 import { useTransactionPayPrimaryRequiredToken } from '../pay/useTransactionPayData';
+import { useTokenWithBalance } from '../tokens/useTokenWithBalance';
 
 const ERC20_ABI = ['function transfer(address to, uint256 amount)'];
 let erc20Interface: Interface | null = null;
@@ -50,7 +51,15 @@ export function useUpdateTokenAmount() {
 
   const primaryRequiredToken = useTransactionPayPrimaryRequiredToken();
 
-  const decimals = primaryRequiredToken?.decimals ?? 18;
+  // Synchronous fallback source for decimals
+
+  const recipientToken = useTokenWithBalance(
+    (to ?? '0x0') as Hex,
+    (transactionMeta?.chainId ?? '0x0') as Hex,
+  );
+
+  const decimals: number | undefined =
+    primaryRequiredToken?.decimals ?? recipientToken?.decimals;
 
   const amountRaw = useMemo(() => {
     if (!data) {
@@ -76,6 +85,11 @@ export function useUpdateTokenAmount() {
   const updateTokenAmount = useCallback(
     (amountHuman: string) => {
       if (!data || !to) {
+        return;
+      }
+
+      // Bail if decimals can't be resolved
+      if (decimals === undefined) {
         return;
       }
 


### PR DESCRIPTION

## **Description**

PoC for preventing decimal issue when mUSD conversion is loading

## **Changelog**

CHANGELOG entry: prevent mUSD conversion decimals issue

## **Related issues**

Fixes:

## **Manual testing steps**

1.  Import an SRP with a small amount of USDC and no mUSD
2. Try to convert it
3. Note that you don't get any error the first time you enter a number

## **Screenshots/Recordings**


### **Before**



### **After**

https://github.com/user-attachments/assets/2daf60a6-72ed-4c5c-980e-573e71eb301c


## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches transaction confirmation logic that rewrites ERC-20 transfer calldata; incorrect decimals handling could affect the amount encoded or prevent editing in some edge cases.
> 
> **Overview**
> Prevents token amount edits from using an incorrect default `18` decimals while required token metadata is still loading.
> 
> `useUpdateTokenAmount` now derives `decimals` from `useTransactionPayPrimaryRequiredToken()` with a synchronous fallback to `useTokenWithBalance(to, chainId)`, and **bails out** of `updateTokenAmount` if decimals cannot be resolved, avoiding encoding a wrong ERC-20 `transfer` amount.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02a313d4e7a0b297b7d6c739d755fd5ae7da43ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->