### PR TITLE
fix: TPSL from order screen routes to auto-close section [NOT-READY]

### DIFF
--- a/ui/components/app/perps/utils/orderUtils.test.ts
+++ b/ui/components/app/perps/utils/orderUtils.test.ts
@@ -4,6 +4,7 @@ import {
   shouldDisplayOrderInMarketDetailsOrders,
   buildDisplayOrdersWithSyntheticTpsl,
   normalizeMarketDetailsOrders,
+  findFullPositionTpslPricesFromOrders,
   formatOrderLabel,
 } from './orderUtils';
 
@@ -343,6 +344,168 @@ describe('orderUtils', () => {
         orders: [limitOrder],
       });
       expect(result).toHaveLength(3);
+    });
+
+    it('excludes orphan normalTpsl trigger orders whose parent has filled', () => {
+      const orphanTp = makeOrder({
+        orderId: 'orphan-tp',
+        parentOrderId: 'filled-parent',
+        reduceOnly: true,
+        isTrigger: true,
+        isPositionTpsl: false,
+        symbol: 'ETH',
+        side: 'sell',
+        size: '1.0',
+        originalSize: '1.0',
+        triggerPrice: '3200.00',
+        detailedOrderType: 'Take Profit Limit',
+      });
+      const orphanSl = makeOrder({
+        orderId: 'orphan-sl',
+        parentOrderId: 'filled-parent',
+        reduceOnly: true,
+        isTrigger: true,
+        isPositionTpsl: false,
+        symbol: 'ETH',
+        side: 'sell',
+        size: '1.0',
+        originalSize: '1.0',
+        triggerPrice: '2800.00',
+        detailedOrderType: 'Stop Market',
+      });
+      const position = makePosition({ symbol: 'ETH', size: '1.0' });
+      const result = normalizeMarketDetailsOrders({
+        orders: [orphanTp, orphanSl],
+        existingPosition: position,
+      });
+      expect(result).toHaveLength(0);
+    });
+
+    it('keeps normalTpsl trigger orders while their parent is still open', () => {
+      const parent = makeOrder({
+        orderId: 'parent-1',
+        side: 'buy',
+        size: '1.0',
+        originalSize: '1.0',
+        reduceOnly: false,
+      });
+      const childTp = makeOrder({
+        orderId: 'child-tp',
+        parentOrderId: 'parent-1',
+        reduceOnly: true,
+        isTrigger: true,
+        isPositionTpsl: false,
+        symbol: 'ETH',
+        side: 'sell',
+        size: '1.0',
+        originalSize: '1.0',
+        triggerPrice: '3200.00',
+        detailedOrderType: 'Take Profit Limit',
+      });
+      const position = makePosition({ symbol: 'ETH', size: '1.0' });
+      const result = normalizeMarketDetailsOrders({
+        orders: [parent, childTp],
+        existingPosition: position,
+      });
+      expect(result.map((o) => o.orderId).sort()).toStrictEqual(
+        ['child-tp', 'parent-1'].sort(),
+      );
+    });
+  });
+
+  describe('findFullPositionTpslPricesFromOrders', () => {
+    it('returns empty object when no position', () => {
+      const order = makeOrder({
+        reduceOnly: true,
+        isTrigger: true,
+        triggerPrice: '3200.00',
+      });
+      expect(findFullPositionTpslPricesFromOrders([order])).toStrictEqual({});
+    });
+
+    it('extracts TP/SL prices from orphan triggers matching position size', () => {
+      const orphanTp = makeOrder({
+        orderId: 'orphan-tp',
+        parentOrderId: 'filled-parent',
+        reduceOnly: true,
+        isTrigger: true,
+        isPositionTpsl: false,
+        symbol: 'ETH',
+        side: 'sell',
+        size: '1.0',
+        originalSize: '1.0',
+        triggerPrice: '3200.00',
+        detailedOrderType: 'Take Profit Limit',
+      });
+      const orphanSl = makeOrder({
+        orderId: 'orphan-sl',
+        parentOrderId: 'filled-parent',
+        reduceOnly: true,
+        isTrigger: true,
+        isPositionTpsl: false,
+        symbol: 'ETH',
+        side: 'sell',
+        size: '1.0',
+        originalSize: '1.0',
+        triggerPrice: '2800.00',
+        detailedOrderType: 'Stop Market',
+      });
+      const position = makePosition({ symbol: 'ETH', size: '1.0' });
+      const result = findFullPositionTpslPricesFromOrders(
+        [orphanTp, orphanSl],
+        position,
+      );
+      expect(result).toStrictEqual({
+        takeProfitPrice: '3200.00',
+        stopLossPrice: '2800.00',
+      });
+    });
+
+    it('ignores normalTpsl triggers whose parent is still open', () => {
+      const parent = makeOrder({ orderId: 'parent-1' });
+      const child = makeOrder({
+        orderId: 'child-tp',
+        parentOrderId: 'parent-1',
+        reduceOnly: true,
+        isTrigger: true,
+        isPositionTpsl: false,
+        symbol: 'ETH',
+        side: 'sell',
+        size: '1.0',
+        originalSize: '1.0',
+        triggerPrice: '3200.00',
+        detailedOrderType: 'Take Profit Limit',
+      });
+      const position = makePosition({ symbol: 'ETH', size: '1.0' });
+      expect(
+        findFullPositionTpslPricesFromOrders([parent, child], position),
+      ).toStrictEqual({
+        takeProfitPrice: undefined,
+        stopLossPrice: undefined,
+      });
+    });
+
+    it('ignores orphan triggers whose size does not match the position', () => {
+      const orphan = makeOrder({
+        orderId: 'orphan-tp',
+        parentOrderId: 'filled-parent',
+        reduceOnly: true,
+        isTrigger: true,
+        isPositionTpsl: false,
+        symbol: 'ETH',
+        side: 'sell',
+        size: '0.5',
+        originalSize: '0.5',
+        triggerPrice: '3200.00',
+        detailedOrderType: 'Take Profit Limit',
+      });
+      const position = makePosition({ symbol: 'ETH', size: '1.0' });
+      expect(
+        findFullPositionTpslPricesFromOrders([orphan], position),
+      ).toStrictEqual({
+        takeProfitPrice: undefined,
+        stopLossPrice: undefined,
+      });
     });
   });
 

--- a/ui/components/app/perps/utils/orderUtils.ts
+++ b/ui/components/app/perps/utils/orderUtils.ts
@@ -305,12 +305,46 @@ export const buildDisplayOrdersWithSyntheticTpsl = (
   return displayOrders;
 };
 
+const isOrphanFullPositionTpslOrder = (
+  order: Order,
+  position: Position | undefined,
+  openOrderIds: Set<string>,
+): boolean => {
+  if (!position) {
+    return false;
+  }
+  if (!order.reduceOnly || order.isTrigger !== true) {
+    return false;
+  }
+  if (order.isPositionTpsl !== false) {
+    return false;
+  }
+  if (!order.parentOrderId || openOrderIds.has(order.parentOrderId)) {
+    return false;
+  }
+  if (
+    order.symbol !== position.symbol ||
+    !isClosingSideForPosition(order, position)
+  ) {
+    return false;
+  }
+  const orderSize = getAbsoluteOrderSize(order);
+  const positionSize = getAbsolutePositionSize(position);
+  if (!orderSize || !positionSize) {
+    return false;
+  }
+  return orderSize.minus(positionSize).abs().lte(FULL_POSITION_SIZE_TOLERANCE);
+};
+
 /**
  * Normalizes orders for the Perps Market Details > Orders section.
  *
  * Composes display-order enrichment (synthetic TP/SL rows) with visibility
  * filtering: reduce-only orders associated with the full position are excluded
- * because they are surfaced in the auto-close section instead.
+ * because they are surfaced in the auto-close section instead. Also excludes
+ * orphaned `normalTpsl` triggers (parent already filled, `isPositionTpsl: false`,
+ * size matches the position) — those originate from order-entry TP/SL on a new
+ * position and become de-facto position-bound TP/SL after the parent fills.
  *
  * @param options0 - Options object
  * @param options0.orders - The orders to normalize
@@ -326,10 +360,65 @@ export const normalizeMarketDetailsOrders = ({
   existingPosition?: Position;
 }): Order[] => {
   const ordersWithSyntheticTpsl = buildDisplayOrdersWithSyntheticTpsl(orders);
+  const openOrderIds = new Set(orders.map((order) => order.orderId));
 
-  return ordersWithSyntheticTpsl.filter((order) =>
-    shouldDisplayOrderInMarketDetailsOrders(order, existingPosition),
-  );
+  return ordersWithSyntheticTpsl.filter((order) => {
+    if (!shouldDisplayOrderInMarketDetailsOrders(order, existingPosition)) {
+      return false;
+    }
+    return !isOrphanFullPositionTpslOrder(
+      order,
+      existingPosition,
+      openOrderIds,
+    );
+  });
+};
+
+/**
+ * Extracts position-bound TP/SL prices from orphaned `normalTpsl` trigger
+ * orders when the controller did not populate `position.takeProfitPrice` /
+ * `stopLossPrice`.
+ *
+ * Order-entry TP/SL on a new position is submitted with `normalTpsl` grouping;
+ * after the parent market order fills, the resulting reduce-only triggers
+ * survive as orphans flagged `isPositionTpsl: false`. The HyperLiquid provider
+ * only resolves position-bound TP/SL prices from `isPositionTpsl === true`
+ * orders, so the auto-close section sees `undefined` for these prices unless
+ * we recover them from the orphans here.
+ *
+ * @param orders - All open orders for the market.
+ * @param position - The current position (if any).
+ * @returns Effective `takeProfitPrice` / `stopLossPrice` for the auto-close
+ * section. Empty object when no orphans match.
+ */
+export const findFullPositionTpslPricesFromOrders = (
+  orders: Order[],
+  position?: Position,
+): { takeProfitPrice?: string; stopLossPrice?: string } => {
+  if (!position) {
+    return {};
+  }
+  const openOrderIds = new Set(orders.map((order) => order.orderId));
+  let takeProfitPrice: string | undefined;
+  let stopLossPrice: string | undefined;
+
+  for (const order of orders) {
+    if (!isOrphanFullPositionTpslOrder(order, position, openOrderIds)) {
+      continue;
+    }
+    const triggerPrice = order.triggerPrice ?? order.price;
+    if (!triggerPrice) {
+      continue;
+    }
+    const detailedType = (order.detailedOrderType ?? '').toLowerCase();
+    if (detailedType.includes('take profit')) {
+      takeProfitPrice ??= triggerPrice;
+    } else if (detailedType.includes('stop')) {
+      stopLossPrice ??= triggerPrice;
+    }
+  }
+
+  return { takeProfitPrice, stopLossPrice };
 };
 
 /**

--- a/ui/pages/perps/perps-market-detail-page.tsx
+++ b/ui/pages/perps/perps-market-detail-page.tsx
@@ -92,7 +92,10 @@ import {
   formatPerpsFiatMinimal,
   formatPerpsFiatUniversal,
 } from '../../components/app/perps/utils/formatPerpsDisplayPrice';
-import { normalizeMarketDetailsOrders } from '../../components/app/perps/utils/orderUtils';
+import {
+  normalizeMarketDetailsOrders,
+  findFullPositionTpslPricesFromOrders,
+} from '../../components/app/perps/utils/orderUtils';
 import { PerpsDetailPageSkeleton } from '../../components/app/perps/perps-skeletons';
 import { Skeleton } from '../../components/component-library/skeleton';
 import { Popover, PopoverPosition } from '../../components/component-library';
@@ -463,28 +466,44 @@ const PerpsMarketDetailPage: React.FC = () => {
     positionRef.current = position;
   }, [position]);
 
-  // Filter and sort open orders for this market, then normalize for display.
-  // Normalization adds synthetic TP/SL rows for parent orders when no matching
-  // real trigger exists. Full-position TP/SL is excluded from this list — it
-  // appears in the auto-close section above (driven by position.takeProfitPrice
-  // / stopLossPrice).
-  const orders = useMemo(() => {
+  // Open orders for this market sorted by timestamp. Used both as the raw
+  // input to `normalizeMarketDetailsOrders` and to recover TP/SL prices from
+  // orphan triggers when the controller did not populate them on the position.
+  const marketOrders = useMemo(() => {
     if (!decodedSymbol) {
       return [];
     }
-    const marketOrders = allOrders
+    return allOrders
       .filter(
         (order) =>
           order.symbol.toLowerCase() === decodedSymbol.toLowerCase() &&
           order.status === 'open',
       )
       .sort((a, b) => (b.timestamp || 0) - (a.timestamp || 0));
+  }, [decodedSymbol, allOrders]);
 
-    return normalizeMarketDetailsOrders({
-      orders: marketOrders,
-      existingPosition: position,
-    });
-  }, [decodedSymbol, allOrders, position]);
+  const orders = useMemo(
+    () =>
+      normalizeMarketDetailsOrders({
+        orders: marketOrders,
+        existingPosition: position,
+      }),
+    [marketOrders, position],
+  );
+
+  // Recover position-bound TP/SL prices from orphaned `normalTpsl` triggers
+  // when the controller did not populate `position.takeProfitPrice` /
+  // `stopLossPrice`. See orderUtils.findFullPositionTpslPricesFromOrders.
+  const { takeProfitPrice: orphanTakeProfitPrice, stopLossPrice: orphanStopLossPrice } =
+    useMemo(
+      () => findFullPositionTpslPricesFromOrders(marketOrders, position),
+      [marketOrders, position],
+    );
+
+  const effectiveTakeProfitPrice =
+    position?.takeProfitPrice ?? orphanTakeProfitPrice;
+  const effectiveStopLossPrice =
+    position?.stopLossPrice ?? orphanStopLossPrice;
 
   // Candle period state and chart ref
   const [selectedPeriod, setSelectedPeriod] = useState<CandlePeriod>(
@@ -594,8 +613,8 @@ const PerpsMarketDetailPage: React.FC = () => {
     // Position-specific lines (only when user has an open position)
     if (position) {
       // Take Profit line — matches mobile `success.default`
-      if (position.takeProfitPrice) {
-        const tpPrice = parsePerpsDisplayPrice(position.takeProfitPrice);
+      if (effectiveTakeProfitPrice) {
+        const tpPrice = parsePerpsDisplayPrice(effectiveTakeProfitPrice);
         if (!isNaN(tpPrice) && tpPrice > 0) {
           lines.push({
             price: tpPrice,
@@ -621,8 +640,8 @@ const PerpsMarketDetailPage: React.FC = () => {
 
       // Stop Loss line — matches mobile `background.alternative`
       // Intentionally subtle: SL is a reference marker, not a danger indicator like Liq.
-      if (position.stopLossPrice) {
-        const slPrice = parsePerpsDisplayPrice(position.stopLossPrice);
+      if (effectiveStopLossPrice) {
+        const slPrice = parsePerpsDisplayPrice(effectiveStopLossPrice);
         if (!isNaN(slPrice) && slPrice > 0) {
           lines.push({
             price: slPrice,
@@ -649,7 +668,13 @@ const PerpsMarketDetailPage: React.FC = () => {
     }
 
     return lines;
-  }, [position, chartCurrentPrice, isDark]);
+  }, [
+    position,
+    chartCurrentPrice,
+    isDark,
+    effectiveTakeProfitPrice,
+    effectiveStopLossPrice,
+  ]);
 
   // Handle candle period change
   //
@@ -1337,8 +1362,8 @@ const PerpsMarketDetailPage: React.FC = () => {
                       variant={TextVariant.BodyMd}
                       fontWeight={FontWeight.Medium}
                     >
-                      {position.takeProfitPrice
-                        ? formatPerpsFiatUniversal(position.takeProfitPrice)
+                      {effectiveTakeProfitPrice
+                        ? formatPerpsFiatUniversal(effectiveTakeProfitPrice)
                         : '-'}
                     </Text>
                     <Text
@@ -1351,8 +1376,8 @@ const PerpsMarketDetailPage: React.FC = () => {
                       variant={TextVariant.BodyMd}
                       fontWeight={FontWeight.Medium}
                     >
-                      {position.stopLossPrice
-                        ? formatPerpsFiatUniversal(position.stopLossPrice)
+                      {effectiveStopLossPrice
+                        ? formatPerpsFiatUniversal(effectiveStopLossPrice)
                         : '-'}
                     </Text>
                   </Box>


### PR DESCRIPTION
## **Description**

A position-level TPSL set from the order-entry screen on a new perps position was rendered in the Orders list of the market detail page while the auto-close section sat empty. PR #42292 covered the case where the order returns `isPositionTpsl: true`, but the SDK submits TPSL on a new market order with `normalTpsl` grouping, so after the parent market fills the resulting reduce-only triggers survive as orphans flagged `isPositionTpsl: false`. `HyperLiquidProvider.getPositions` only resolves `position.takeProfitPrice`/`stopLossPrice` from `isPositionTpsl === true` orders, so the auto-close row read `undefined`; meanwhile `isOrderAssociatedWithFullPosition` early-returned `false` for the explicit-`false` flag, leaving the orphans visible in the Orders list.

`normalizeMarketDetailsOrders` now also filters orphan reduce-only triggers whose parent has filled and whose size matches the position, and a new `findFullPositionTpslPricesFromOrders` helper recovers their trigger prices so the auto-close row can render the effective TP/SL when `position.takeProfitPrice`/`stopLossPrice` are undefined. The chart price-line layer uses the same effective values to keep the TP/Entry/SL overlay consistent with the auto-close row.

## **Changelog**

CHANGELOG entry: Fixed a perps bug where a position-level TPSL set from the order-entry screen appeared in the Orders list of the market detail page instead of the auto-close section.

## **Related issues**

Fixes: [TAT-3075](https://consensyssoftware.atlassian.net/browse/TAT-3075)

## **Manual testing steps**

1. Unlock MetaMask and open the Perps tab.
2. Pick a market (e.g. BTC) and open the order-entry screen.
3. Expand the auto-close section, set a TP and/or SL, and submit a market order so a position opens with a position-level TPSL.
4. Navigate to `/perps/market/<symbol>`.
5. Verify the Auto close row shows the TP and SL prices.
6. Verify the Orders list does NOT contain a row for the position-level TPSL.
7. Place a limit order with order-level TPSL on the same market without a position. Verify the synthetic TP/SL rows appear in the Orders list and the Auto close row is hidden.

## **Screenshots/Recordings**

### **Before**

<!-- replaced via evidence-manifest.json by the gateway when artifacts are uploaded -->

### **After**

<!-- replaced via evidence-manifest.json by the gateway when artifacts are uploaded -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## **Validation Recipe**

<details>
<summary>recipe.json</summary>

```json
{
  "title": "TAT-3075 — orphan positionTPSL routes to auto-close, not order section",
  "description": "Validates that an orphaned reduce-only TP/SL trigger (parent filled, isPositionTpsl=false) is treated as positionTPSL on the market detail page: it must appear in the auto-close section and must NOT appear in the orders list. Also validates the order-level TP/SL converse on a market with no position. Mock data is injected via stateHooks so the test runs without real funds.",
  "schema_version": 1,
  "validate": {
    "workflow": {
      "pre_conditions": ["wallet.unlocked", "perps.feature_enabled"],
      "setup": [],
      "teardown": [
        {
          "id": "teardown-clear-injections",
          "action": "eval_sync",
          "expression": "(function(){try{var sm=stateHooks.getPerpsStreamManager();if(sm){sm.positions.pushData([]);sm.orders.pushData([]);}return JSON.stringify({cleared:true})}catch(e){return JSON.stringify({cleared:false,error:String(e&&e.message||e)})}})()",
          "assert": { "operator": "eq", "field": "cleared", "value": true }
        }
      ],
      "entry": "setup-nav-detail-btc",
      "nodes": {
        "setup-nav-detail-btc": {
          "action": "call",
          "ref": "perps/navigate-to-market-detail",
          "params": { "symbol": "BTC" },
          "next": "setup-wait-detail"
        },
        "setup-wait-detail": {
          "action": "wait_for",
          "test_id": "perps-market-detail-page",
          "timeout_ms": 10000,
          "next": "ac1-inject-orphan-positiontpsl"
        },
        "ac1-inject-orphan-positiontpsl": {
          "action": "eval_sync",
          "expression": "(function(){try{var sm=stateHooks.getPerpsStreamManager();if(!sm){return JSON.stringify({injected:false,error:'no stream manager'})}var pos={symbol:'BTC',size:'0.5',entryPrice:'80000',positionValue:'40000',unrealizedPnl:'0',marginUsed:'2000',leverage:{type:'isolated',value:20,rawUsd:'-38000'},liquidationPrice:'56000',maxLeverage:40,returnOnEquity:'0',cumulativeFunding:{allTime:'0',sinceOpen:'0',sinceChange:'0'},takeProfitCount:1,stopLossCount:1};var tp={orderId:'tat3075-orphan-tp',symbol:'BTC',side:'sell',orderType:'limit',size:'0.5',originalSize:'0.5',price:'99000',filledSize:'0',remainingSize:'0.5',status:'open',timestamp:Date.now(),detailedOrderType:'Take Profit Limit',isTrigger:true,reduceOnly:true,isPositionTpsl:false,parentOrderId:'tat3075-filled-parent-gone',triggerPrice:'99000'};var sl={orderId:'tat3075-orphan-sl',symbol:'BTC',side:'sell',orderType:'market',size:'0.5',originalSize:'0.5',price:'70000',filledSize:'0',remainingSize:'0.5',status:'open',timestamp:Date.now(),detailedOrderType:'Stop Market',isTrigger:true,reduceOnly:true,isPositionTpsl:false,parentOrderId:'tat3075-filled-parent-gone',triggerPrice:'70000'};sm.positions.pushData([pos]);sm.orders.pushData([tp,sl]);return JSON.stringify({injected:true})}catch(e){return JSON.stringify({injected:false,error:String(e&&e.message||e)})}})()",
          "assert": { "operator": "eq", "field": "injected", "value": true },
          "next": "ac1-wait-auto-close-row"
        },
        "ac1-wait-auto-close-row": {
          "action": "wait_for",
          "test_id": "perps-auto-close-row",
          "timeout_ms": 5000,
          "next": "ac1-scroll-auto-close"
        },
        "ac1-scroll-auto-close": {
          "action": "eval_sync",
          "expression": "(function(){var row=document.querySelector('[data-testid=\"perps-auto-close-row\"]');if(row){try{row.scrollIntoView({block:'center'})}catch(e){}}return JSON.stringify({scrolled:Boolean(row)})})()",
          "assert": { "operator": "eq", "field": "scrolled", "value": true },
          "next": "ac1-assert-auto-close-shows-tpsl"
        },
        "ac1-assert-auto-close-shows-tpsl": {
          "action": "eval_sync",
          "expression": "(function(){var row=document.querySelector('[data-testid=\"perps-auto-close-row\"]');if(!row)return JSON.stringify({rendered:false,hasTp:false,hasSl:false});var t=row.textContent||'';return JSON.stringify({rendered:true,hasTp:t.indexOf('99,000')>=0||t.indexOf('99000')>=0,hasSl:t.indexOf('70,000')>=0||t.indexOf('70000')>=0,text:t.replace(/\\s+/g,' ').slice(0,200)})})()",
          "assert": {
            "all": [
              { "operator": "eq", "field": "rendered", "value": true },
              { "operator": "eq", "field": "hasTp", "value": true },
              { "operator": "eq", "field": "hasSl", "value": true }
            ]
          },
          "next": "ac1-assert-orphan-not-in-orders-list"
        },
        "ac1-assert-orphan-not-in-orders-list": {
          "action": "eval_sync",
          "expression": "(function(){var tp=document.querySelector('[data-testid=\"order-card-tat3075-orphan-tp\"]');var sl=document.querySelector('[data-testid=\"order-card-tat3075-orphan-sl\"]');return JSON.stringify({tpInOrders:Boolean(tp),slInOrders:Boolean(sl)})})()",
          "assert": {
            "all": [
              { "operator": "eq", "field": "tpInOrders", "value": false },
              { "operator": "eq", "field": "slInOrders", "value": false }
            ]
          },
          "next": "ac2-clear-and-inject-orderlevel-tpsl"
        },
        "ac2-clear-and-inject-orderlevel-tpsl": {
          "action": "eval_sync",
          "expression": "(function(){try{var sm=stateHooks.getPerpsStreamManager();if(!sm){return JSON.stringify({injected:false,error:'no stream manager'})}sm.positions.pushData([]);var parent={orderId:'tat3075-orderlevel-parent',symbol:'BTC',side:'buy',orderType:'limit',size:'0.5',originalSize:'0.5',price:'80000',filledSize:'0',remainingSize:'0.5',status:'open',timestamp:Date.now(),detailedOrderType:'Limit',isTrigger:false,reduceOnly:false,takeProfitPrice:'99000',stopLossPrice:'70000'};sm.orders.pushData([parent]);return JSON.stringify({injected:true})}catch(e){return JSON.stringify({injected:false,error:String(e&&e.message||e)})}})()",
          "assert": { "operator": "eq", "field": "injected", "value": true },
          "next": "ac2-wait-parent"
        },
        "ac2-wait-parent": {
          "action": "wait_for",
          "test_id": "order-card-tat3075-orderlevel-parent",
          "timeout_ms": 5000,
          "next": "ac2-scroll-parent"
        },
        "ac2-scroll-parent": {
          "action": "eval_sync",
          "expression": "(function(){var card=document.querySelector('[data-testid=\"order-card-tat3075-orderlevel-parent\"]');if(card){try{card.scrollIntoView({block:'center'})}catch(e){}}return JSON.stringify({scrolled:Boolean(card)})})()",
          "assert": { "operator": "eq", "field": "scrolled", "value": true },
          "next": "ac2-assert-orderlevel-tpsl-in-orders"
        },
        "ac2-assert-orderlevel-tpsl-in-orders": {
          "action": "eval_sync",
          "expression": "(function(){var parent=document.querySelector('[data-testid=\"order-card-tat3075-orderlevel-parent\"]');var tp=document.querySelector('[data-testid=\"order-card-tat3075-orderlevel-parent-synthetic-tp\"]');var sl=document.querySelector('[data-testid=\"order-card-tat3075-orderlevel-parent-synthetic-sl\"]');var auto=document.querySelector('[data-testid=\"perps-auto-close-row\"]');return JSON.stringify({parentInOrders:Boolean(parent),syntheticTpInOrders:Boolean(tp),syntheticSlInOrders:Boolean(sl),autoCloseRendered:Boolean(auto)})})()",
          "assert": {
            "all": [
              { "operator": "eq", "field": "parentInOrders", "value": true },
              { "operator": "eq", "field": "syntheticTpInOrders", "value": true },
              { "operator": "eq", "field": "syntheticSlInOrders", "value": true },
              { "operator": "eq", "field": "autoCloseRendered", "value": false }
            ]
          },
          "next": "done"
        },
        "done": { "action": "end", "status": "pass" }
      }
    }
  }
}
```

</details>

## **Recipe Workflow**

<details>
<summary>workflow.mmd</summary>

```mermaid
flowchart TD
  %% TAT-3075 — orphan positionTPSL routes to auto-close, not order section
  __entry__(["ENTRY"]) --> node_setup_nav_detail_btc
  node_setup_nav_detail_btc[["setup-nav-detail-btc<br/>perps/navigate-to-market-detail"]]
  node_setup_wait_detail["setup-wait-detail<br/>wait_for"]
  node_ac1_inject_orphan_positiontpsl["ac1-inject-orphan-positiontpsl<br/>eval_sync"]
  node_ac1_wait_auto_close_row["ac1-wait-auto-close-row<br/>wait_for"]
  node_ac1_scroll_auto_close["ac1-scroll-auto-close<br/>eval_sync"]
  node_ac1_assert_auto_close_shows_tpsl["ac1-assert-auto-close-shows-tpsl<br/>eval_sync"]
  node_ac1_assert_orphan_not_in_orders_list["ac1-assert-orphan-not-in-orders-list<br/>eval_sync"]
  node_ac2_clear_and_inject_orderlevel_tpsl["ac2-clear-and-inject-orderlevel-tpsl<br/>eval_sync"]
  node_ac2_wait_parent["ac2-wait-parent<br/>wait_for"]
  node_ac2_scroll_parent["ac2-scroll-parent<br/>eval_sync"]
  node_ac2_assert_orderlevel_tpsl_in_orders["ac2-assert-orderlevel-tpsl-in-orders<br/>eval_sync"]
  node_done(["done<br/>PASS"])
  node_setup_nav_detail_btc --> node_setup_wait_detail
  node_setup_wait_detail --> node_ac1_inject_orphan_positiontpsl
  node_ac1_inject_orphan_positiontpsl --> node_ac1_wait_auto_close_row
  node_ac1_wait_auto_close_row --> node_ac1_scroll_auto_close
  node_ac1_scroll_auto_close --> node_ac1_assert_auto_close_shows_tpsl
  node_ac1_assert_auto_close_shows_tpsl --> node_ac1_assert_orphan_not_in_orders_list
  node_ac1_assert_orphan_not_in_orders_list --> node_ac2_clear_and_inject_orderlevel_tpsl
  node_ac2_clear_and_inject_orderlevel_tpsl --> node_ac2_wait_parent
  node_ac2_wait_parent --> node_ac2_scroll_parent
  node_ac2_scroll_parent --> node_ac2_assert_orderlevel_tpsl_in_orders
  node_ac2_assert_orderlevel_tpsl_in_orders --> node_done
```

</details>


[TAT-3075]: https://consensyssoftware.atlassian.net/browse/TAT-3075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ