### PR TITLE
fix: Remaining decimal issues [NOT-READY]

### DIFF
--- a/shared/lib/perps-formatters.test.ts
+++ b/shared/lib/perps-formatters.test.ts
@@ -13,6 +13,7 @@ import {
   formatPositionSize,
   formatVolume,
   formatWithSignificantDigits,
+  getPercentDecimalsForPrice,
 } from './perps-formatters';
 
 describe('perps-formatters', () => {
@@ -293,6 +294,29 @@ describe('perps-formatters', () => {
 
     it('accepts string input', () => {
       expect(formatPercentage('10')).toBe('+10.00%');
+    });
+  });
+
+  describe('getPercentDecimalsForPrice', () => {
+    it('returns 0 for high-priced assets (BTC / XYZ100, > $10k)', () => {
+      expect(getPercentDecimalsForPrice(81_500)).toBe(0);
+      expect(getPercentDecimalsForPrice(28_006)).toBe(0);
+    });
+
+    it('returns 1 for $1k–$10k assets (ETH-style)', () => {
+      expect(getPercentDecimalsForPrice(3_200)).toBe(1);
+    });
+
+    it('returns 6 for very small prices (PUMP, < $0.01)', () => {
+      expect(getPercentDecimalsForPrice(0.001834)).toBe(6);
+      expect(getPercentDecimalsForPrice(0.0000004)).toBe(6);
+    });
+
+    it('falls back to 2 for missing or invalid prices', () => {
+      expect(getPercentDecimalsForPrice(undefined)).toBe(2);
+      expect(getPercentDecimalsForPrice(null)).toBe(2);
+      expect(getPercentDecimalsForPrice(0)).toBe(2);
+      expect(getPercentDecimalsForPrice(Number.NaN)).toBe(2);
     });
   });
 

--- a/shared/lib/perps-formatters.ts
+++ b/shared/lib/perps-formatters.ts
@@ -519,6 +519,24 @@ export const formatPnl = (pnl: string | number): string => {
 };
 
 /**
+ * Look up the percent display precision for a given asset reference price.
+ * Mirrors the per-range `maximumDecimals` from PRICE_RANGES_UNIVERSAL so the
+ * percent input next to a TP/SL price field uses the same precision rules as
+ * the price field itself (BTC > $10k → 0 decimals, PUMP < $0.01 → 6 decimals).
+ *
+ * @param price - Asset reference price (entry / current). Falsy or non-finite
+ * values fall back to a 2-decimal cap to preserve legacy behaviour.
+ * @returns Maximum decimals to render for the percent.
+ */
+export const getPercentDecimalsForPrice = (price?: number | null): number => {
+  if (price === undefined || price === null || !Number.isFinite(price) || price <= 0) {
+    return 2;
+  }
+  const range = PRICE_RANGES_UNIVERSAL.find((r) => r.condition(price));
+  return range?.maximumDecimals ?? 2;
+};
+
+/**
  * Formats a percentage value with sign prefix.
  *
  * @param value - Raw percentage value (e.g., 5.25 for 5.25%, not 0.0525).

--- a/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.test.tsx
+++ b/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.test.tsx
@@ -443,11 +443,9 @@ describe('AutoCloseSection', () => {
       expect(percentInput).toHaveValue('');
     });
 
-    it('shows non-integer RoE% with 2 decimal places', () => {
-      // (45225 - 45000) / 45000 * 10 * 100 = 50%  (exact)
-      // (45112.5 - 45000) / 45000 * 10 * 100 = 25% (exact)
-      // Test a non-integer: leverage=3, entry=45000, tp=45500
-      // (500/45000)*3*100 = 3.33
+    it('rounds RoE% to the asset price precision (>$10k → 0 decimals)', () => {
+      // entry=45000 (>$10k → maxDecimals=0), leverage=3, tp=45500
+      // (500/45000)*3*100 = 3.333... → rounds to "3"
       renderWithProvider(
         <AutoCloseSection
           {...defaultProps}
@@ -462,8 +460,28 @@ describe('AutoCloseSection', () => {
 
       const container = screen.getByTestId('tp-percent-input');
       const percentInput = container.querySelector('input');
-      // (500/45000)*3*100 = 3.333... -> toFixed(2) = "3.33"
-      expect(percentInput).toHaveValue('3.33');
+      expect(percentInput).toHaveValue('3');
+    });
+
+    it('keeps sub-percent precision for very small prices (<$0.01 → 6 decimals)', () => {
+      // entry=0.001834 (<$0.01 → maxDecimals=6), leverage=3, tp=0.001835
+      // ((0.001835 - 0.001834)/0.001834)*3*100 = 0.16357...% → "0.16"
+      // The PUMP-style asset must keep enough precision to show sub-percent moves.
+      renderWithProvider(
+        <AutoCloseSection
+          {...defaultProps}
+          enabled={true}
+          direction="long"
+          currentPrice={0.001834}
+          leverage={3}
+          takeProfitPrice="0.001835"
+        />,
+        mockStore,
+      );
+
+      const container = screen.getByTestId('tp-percent-input');
+      const percentInput = container.querySelector('input');
+      expect(percentInput).toHaveValue('0.163577');
     });
   });
 

--- a/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.tsx
+++ b/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.tsx
@@ -11,6 +11,7 @@ import {
 import React, { useCallback, useMemo, useState } from 'react';
 import {
   formatPerpsFiat,
+  getPercentDecimalsForPrice,
   PRICE_RANGES_MINIMAL_VIEW,
 } from '../../../../../../../shared/lib/perps-formatters';
 
@@ -132,6 +133,7 @@ export const AutoCloseSection: React.FC<AutoCloseSectionProps> = ({
       // For long: positive when price > entry (profit). For short: negate (profit when price < entry).
       return formatRoePercent(
         direction === 'long' ? percentChange : -percentChange,
+        getPercentDecimalsForPrice(entryPrice),
       );
     },
     [entryPrice, leverage, direction],

--- a/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.tsx
+++ b/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.tsx
@@ -19,6 +19,7 @@ import {
 import type { Position as PerpsPosition } from '@metamask/perps-controller';
 import {
   formatPerpsFiat,
+  getPercentDecimalsForPrice,
   PRICE_RANGES_MINIMAL_VIEW,
   PRICE_RANGES_UNIVERSAL,
 } from '../../../../../shared/lib/perps-formatters';
@@ -67,8 +68,14 @@ import {
 const TP_PRESETS = [10, 25, 50, 100];
 const SL_PRESETS = [5, 10, 25, 50];
 
-const formatSignedRoePercent = (value: number): string => {
-  const formatted = formatRoePercent(value);
+const formatSignedRoePercent = (
+  value: number,
+  referencePrice?: number,
+): string => {
+  const formatted = formatRoePercent(
+    value,
+    getPercentDecimalsForPrice(referencePrice),
+  );
   return value > 0 && formatted !== '0' ? `+${formatted}` : formatted;
 };
 
@@ -200,6 +207,7 @@ export const UpdateTPSLModalContent: React.FC<UpdateTPSLModalContentProps> = ({
       // For long: positive when price > entry (profit). For short: negate (profit when price < entry).
       return formatSignedRoePercent(
         positionDirection === 'long' ? percentChange : -percentChange,
+        entryPriceForEdit,
       );
     },
     [entryPriceForEdit, leverageForEdit, positionDirection],
@@ -344,11 +352,11 @@ export const UpdateTPSLModalContent: React.FC<UpdateTPSLModalContentProps> = ({
       setEditingTpPrice(newPrice);
       // Preserve the exact preset value for display — avoids round-trip drift
       // caused by the price being rounded to 2 decimal places
-      const presetStr = formatSignedRoePercent(percent);
+      const presetStr = formatSignedRoePercent(percent, entryPriceForEdit);
       setRawTpPercent(presetStr);
       setTpPresetPercent(presetStr);
     },
-    [percentToPriceForEdit],
+    [percentToPriceForEdit, entryPriceForEdit],
   );
 
   const handleSlPresetClick = useCallback(

--- a/ui/components/app/perps/utils.test.ts
+++ b/ui/components/app/perps/utils.test.ts
@@ -700,5 +700,26 @@ describe('Perps Utils', () => {
       expect(formatRoePercent(-0.004)).toBe('0');
       expect(formatRoePercent(-0.001)).toBe('0');
     });
+
+    it('honours an explicit maxDecimals override (BTC-style 0 decimals)', () => {
+      expect(formatRoePercent(15.28, 0)).toBe('15');
+      expect(formatRoePercent(15.5, 0)).toBe('16');
+      expect(formatRoePercent(-32.99, 0)).toBe('-33');
+    });
+
+    it('preserves up to maxDecimals fractional digits (PUMP-style 6 decimals)', () => {
+      expect(formatRoePercent(0.000163, 6)).toBe('0.000163');
+      expect(formatRoePercent(-0.001234, 6)).toBe('-0.001234');
+    });
+
+    it('keeps integer values clean even when maxDecimals is large', () => {
+      expect(formatRoePercent(5, 6)).toBe('5');
+      expect(formatRoePercent(-100, 6)).toBe('-100');
+    });
+
+    it('treats invalid maxDecimals as the legacy 2-decimal default', () => {
+      expect(formatRoePercent(25.5, Number.NaN)).toBe('25.50');
+      expect(formatRoePercent(25.5, -1)).toBe('25.50');
+    });
   });
 });

--- a/ui/components/app/perps/utils.ts
+++ b/ui/components/app/perps/utils.ts
@@ -507,22 +507,35 @@ export function getPnlDisplayColor(pnl: number): TextColor {
 
 /**
  * Format a RoE% value for display in TP/SL inputs.
- * Always returns the absolute value: integers with no decimal ("25"),
- * non-integers with 2 decimal places ("25.50").
+ * Returns the absolute value with sign preserved for negatives. Integer results
+ * collapse to no decimals; otherwise the value is rendered with up to
+ * `maxDecimals` digits (default 2 for backward compatibility).
+ *
+ * Pass an asset-specific `maxDecimals` (typically derived from
+ * `getPercentDecimalsForPrice(entryPrice)`) so the percent input mirrors the
+ * asset's price precision: BTC/XYZ100 (>$10k) collapse to 0 decimals, PUMP
+ * (<$0.01) keeps up to 6 decimals so sub-percent moves remain visible.
  *
  * @param value - The numeric percentage value to format
+ * @param maxDecimals - Maximum decimal places (default 2)
  * @returns The formatted percentage string (sign preserved for negative values)
  * @example
  * formatRoePercent(10) => '10'
  * formatRoePercent(-25.5) => '-25.50'
- * formatRoePercent(0) => '0'
+ * formatRoePercent(15.28, 0) => '15'
+ * formatRoePercent(0.000163, 6) => '0.000163'
  */
-export const formatRoePercent = (value: number): string => {
+export const formatRoePercent = (
+  value: number,
+  maxDecimals: number = 2,
+): string => {
+  const safeMax = Number.isFinite(maxDecimals) && maxDecimals >= 0 ? Math.floor(maxDecimals) : 2;
   const abs = Math.abs(value);
-  const rounded = Math.round(abs * 100) / 100;
+  const factor = 10 ** safeMax;
+  const rounded = Math.round(abs * factor) / factor;
   const formatted = Number.isInteger(rounded)
     ? rounded.toFixed(0)
-    : rounded.toFixed(2);
+    : rounded.toFixed(safeMax);
   return value < 0 && rounded !== 0 ? `-${formatted}` : formatted;
 };
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The TP/SL percent input next to a TP/SL price field used a hardcoded 2-decimal cap (`formatRoePercent` ran `toFixed(2)` regardless of asset). That made BTC/XYZ100 show noisy fractional digits (e.g. `15.28%` instead of `15%`) and silently rounded sub-percent moves on PUMP-tier assets to `0`, hiding meaningful precision.

This PR derives the percent's `maxDecimals` from the same `PRICE_RANGES_UNIVERSAL` ranges already used to format the asset's price, then threads that into `formatRoePercent` from both the order-entry auto-close section and the position-screen TP/SL modal. BTC/XYZ100 (>$10k) collapse to 0 decimals, ETH-tier ($1k–$10k) caps at 1 decimal, PUMP (<$0.01) keeps up to 6 decimals.

A new `getPercentDecimalsForPrice(price)` helper centralises the lookup so future call sites do not have to duplicate the range logic.

## **Changelog**

CHANGELOG entry: Fixed TP/SL percent input precision so it matches the asset's price precision (no extra digits on BTC, full precision on small-priced markets like PUMP).

## **Related issues**

Fixes: [TAT-3074](https://consensyssoftware.atlassian.net/browse/TAT-3074)

## **Manual testing steps**

1. Open the extension and go to the Perps tab.
2. Navigate to `/perps/trade/BTC`, expand "Auto close", and enter any TP $ value (e.g. `85000`). The TP % field should display an integer (no decimal point).
3. Navigate to `/perps/trade/PUMP`, expand "Auto close", and enter a TP $ value within ~0.001% of the current price. The TP % field should display 3–6 decimals (e.g. `0.166484`), not `0.17` and not `0`.
4. Navigate to `/perps/trade/xyz:XYZ100` and repeat — TP % should display an integer.
5. Navigate to `/perps/trade/ETH` and enter a TP ~5% above current. TP % should display at most one decimal place.
6. Open an existing position and use the "Update TP/SL" modal — verify that price→percent conversion uses the same per-asset precision (BTC integer; PUMP 6-decimal).

## **Screenshots/Recordings**

<!-- Filled in by the gateway from evidence-manifest.json -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## **Validation Recipe**

<details>
<summary>artifacts/recipe.json</summary>

```json
{
  "schema_version": 1,
  "title": "TAT-3074: TP/SL percent precision is asset-aware",
  "description": "Verifies that the TP/SL percentage input in the order entry auto-close section uses asset-appropriate precision (derived from the same PRICE_RANGES_UNIVERSAL ranges used for prices). BTC/XYZ100 (high price, >$10k) → 0 decimals; PUMP (very small price, <$0.01) → up to 6 decimals; ETH (large, $1k-$10k) → at most 1 decimal. Each AC reads the live `tp-percent-input` DOM value and asserts the decimal count — reverting the fix flips formatRoePercent back to a hardcoded 2-decimal cap, which all four assertions reject. Visual screenshots are captured outside the recipe via direct CDP (Playwright's `page.screenshot` hangs on this slot's font-load wait); see before-/after- artifacts referenced from evidence-manifest.json.",
  "validate": {
    "workflow": {
      "pre_conditions": ["wallet.unlocked", "perps.feature_enabled"],
      "setup": [],
      "teardown": [],
      "entry": "ac1-nav-btc",
      "nodes": {
        "ac1-nav-btc": {
          "action": "ext_navigate_hash",
          "hash": "/perps/trade/BTC",
          "next": "ac1-wait-btc"
        },
        "ac1-wait-btc": {
          "action": "wait_for",
          "test_id": "auto-close-toggle",
          "timeout_ms": 15000,
          "next": "ac1-set-tp-and-read-btc"
        },
        "ac1-set-tp-and-read-btc": {
          "action": "eval_async",
          "expression": "(async()=>{const toggle=document.querySelector('[data-testid=auto-close-toggle]');if(!document.querySelector('[data-testid=tp-price-input]')){toggle&&toggle.click();await new Promise(r=>setTimeout(r,600));}const sm=window.stateHooks.getPerpsStreamManager();const mkt=sm.markets.getCachedData().find(m=>m.symbol==='BTC');const currentPrice=parseFloat(String(mkt.price).replace(/[$,]/g,''));const target=(currentPrice*1.05).toFixed(0);const tpPrice=document.querySelector('[data-testid=tp-price-input] input');const setNative=Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype,'value').set;tpPrice.focus();setNative.call(tpPrice,'');tpPrice.dispatchEvent(new Event('input',{bubbles:true}));await new Promise(r=>setTimeout(r,200));setNative.call(tpPrice,target);tpPrice.dispatchEvent(new Event('input',{bubbles:true}));await new Promise(r=>setTimeout(r,400));tpPrice.blur();await new Promise(r=>setTimeout(r,400));const tpPercent=document.querySelector('[data-testid=tp-percent-input] input');const value=tpPercent?tpPercent.value:'';const stripped=value.replace(/^[+-]/,'');const dotIdx=stripped.indexOf('.');const decimals=dotIdx===-1?0:(stripped.length-dotIdx-1);const isNumeric=/^[+-]?\\d+(\\.\\d+)?$/.test(stripped);return JSON.stringify({symbol:'BTC',currentPrice,target,percentValue:value,decimals,isNumeric});})()",
          "assert": {
            "all": [
              { "operator": "eq", "field": "symbol", "value": "BTC" },
              { "operator": "eq", "field": "isNumeric", "value": true },
              { "operator": "eq", "field": "decimals", "value": 0 }
            ]
          },
          "save_as": "ac1_btc",
          "note": "AC1: BTC TP percent has 0 decimals (matches >$10k price-range maxDecimals=0).",
          "next": "ac2-nav-pump"
        },
        "ac2-nav-pump": {
          "action": "ext_navigate_hash",
          "hash": "/perps/trade/PUMP",
          "next": "ac2-wait-pump"
        },
        "ac2-wait-pump": {
          "action": "wait_for",
          "test_id": "auto-close-toggle",
          "timeout_ms": 15000,
          "next": "ac2-set-tp-and-read-pump"
        },
        "ac2-set-tp-and-read-pump": {
          "action": "eval_async",
          "expression": "(async()=>{const toggle=document.querySelector('[data-testid=auto-close-toggle]');if(!document.querySelector('[data-testid=tp-price-input]')){toggle&&toggle.click();await new Promise(r=>setTimeout(r,600));}const sm=window.stateHooks.getPerpsStreamManager();const mkt=sm.markets.getCachedData().find(m=>m.symbol==='PUMP');const currentPrice=parseFloat(String(mkt.price).replace(/[$,]/g,''));const target=(currentPrice*1.000005).toPrecision(6);const tpPrice=document.querySelector('[data-testid=tp-price-input] input');const setNative=Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype,'value').set;tpPrice.focus();setNative.call(tpPrice,'');tpPrice.dispatchEvent(new Event('input',{bubbles:true}));await new Promise(r=>setTimeout(r,200));setNative.call(tpPrice,target);tpPrice.dispatchEvent(new Event('input',{bubbles:true}));await new Promise(r=>setTimeout(r,400));tpPrice.blur();await new Promise(r=>setTimeout(r,400));const tpPercent=document.querySelector('[data-testid=tp-percent-input] input');const value=tpPercent?tpPercent.value:'';const stripped=value.replace(/^[+-]/,'');const dotIdx=stripped.indexOf('.');const decimals=dotIdx===-1?0:(stripped.length-dotIdx-1);const isNumeric=/^[+-]?\\d+(\\.\\d+)?$/.test(stripped);return JSON.stringify({symbol:'PUMP',currentPrice,target,percentValue:value,decimals,isNumeric});})()",
          "assert": {
            "all": [
              { "operator": "eq", "field": "symbol", "value": "PUMP" },
              { "operator": "eq", "field": "isNumeric", "value": true },
              { "operator": "gte", "field": "decimals", "value": 3 },
              { "operator": "lte", "field": "decimals", "value": 6 }
            ]
          },
          "save_as": "ac2_pump",
          "note": "AC2: PUMP TP percent uses up to 6 decimals (matches <$0.01 price-range maxDecimals=6).",
          "next": "ac3-nav-xyz100"
        },
        "ac3-nav-xyz100": {
          "action": "ext_navigate_hash",
          "hash": "/perps/trade/xyz%3AXYZ100",
          "next": "ac3-wait-xyz100"
        },
        "ac3-wait-xyz100": {
          "action": "wait_for",
          "test_id": "auto-close-toggle",
          "timeout_ms": 15000,
          "next": "ac3-set-tp-and-read-xyz100"
        },
        "ac3-set-tp-and-read-xyz100": {
          "action": "eval_async",
          "expression": "(async()=>{const toggle=document.querySelector('[data-testid=auto-close-toggle]');if(!document.querySelector('[data-testid=tp-price-input]')){toggle&&toggle.click();await new Promise(r=>setTimeout(r,600));}const sm=window.stateHooks.getPerpsStreamManager();const mkt=sm.markets.getCachedData().find(m=>m.symbol==='xyz:XYZ100');const currentPrice=parseFloat(String(mkt.price).replace(/[$,]/g,''));const target=(currentPrice*1.05).toFixed(0);const tpPrice=document.querySelector('[data-testid=tp-price-input] input');const setNative=Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype,'value').set;tpPrice.focus();setNative.call(tpPrice,'');tpPrice.dispatchEvent(new Event('input',{bubbles:true}));await new Promise(r=>setTimeout(r,200));setNative.call(tpPrice,target);tpPrice.dispatchEvent(new Event('input',{bubbles:true}));await new Promise(r=>setTimeout(r,400));tpPrice.blur();await new Promise(r=>setTimeout(r,400));const tpPercent=document.querySelector('[data-testid=tp-percent-input] input');const value=tpPercent?tpPercent.value:'';const stripped=value.replace(/^[+-]/,'');const dotIdx=stripped.indexOf('.');const decimals=dotIdx===-1?0:(stripped.length-dotIdx-1);const isNumeric=/^[+-]?\\d+(\\.\\d+)?$/.test(stripped);return JSON.stringify({symbol:'xyz:XYZ100',currentPrice,target,percentValue:value,decimals,isNumeric});})()",
          "assert": {
            "all": [
              { "operator": "eq", "field": "symbol", "value": "xyz:XYZ100" },
              { "operator": "eq", "field": "isNumeric", "value": true },
              { "operator": "eq", "field": "decimals", "value": 0 }
            ]
          },
          "save_as": "ac3_xyz100",
          "note": "AC3: XYZ100 TP percent has 0 decimals (matches >$10k price-range maxDecimals=0).",
          "next": "ac4-nav-eth"
        },
        "ac4-nav-eth": {
          "action": "ext_navigate_hash",
          "hash": "/perps/trade/ETH",
          "next": "ac4-wait-eth"
        },
        "ac4-wait-eth": {
          "action": "wait_for",
          "test_id": "auto-close-toggle",
          "timeout_ms": 15000,
          "next": "ac4-set-tp-and-read-eth"
        },
        "ac4-set-tp-and-read-eth": {
          "action": "eval_async",
          "expression": "(async()=>{const toggle=document.querySelector('[data-testid=auto-close-toggle]');if(!document.querySelector('[data-testid=tp-price-input]')){toggle&&toggle.click();await new Promise(r=>setTimeout(r,600));}const sm=window.stateHooks.getPerpsStreamManager();const mkt=sm.markets.getCachedData().find(m=>m.symbol==='ETH');const currentPrice=parseFloat(String(mkt.price).replace(/[$,]/g,''));const target=(currentPrice*1.05).toFixed(2);const tpPrice=document.querySelector('[data-testid=tp-price-input] input');const setNative=Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype,'value').set;tpPrice.focus();setNative.call(tpPrice,'');tpPrice.dispatchEvent(new Event('input',{bubbles:true}));await new Promise(r=>setTimeout(r,200));setNative.call(tpPrice,target);tpPrice.dispatchEvent(new Event('input',{bubbles:true}));await new Promise(r=>setTimeout(r,400));tpPrice.blur();await new Promise(r=>setTimeout(r,400));const tpPercent=document.querySelector('[data-testid=tp-percent-input] input');const value=tpPercent?tpPercent.value:'';const stripped=value.replace(/^[+-]/,'');const dotIdx=stripped.indexOf('.');const decimals=dotIdx===-1?0:(stripped.length-dotIdx-1);const isNumeric=/^[+-]?\\d+(\\.\\d+)?$/.test(stripped);return JSON.stringify({symbol:'ETH',currentPrice,target,percentValue:value,decimals,isNumeric});})()",
          "assert": {
            "all": [
              { "operator": "eq", "field": "symbol", "value": "ETH" },
              { "operator": "eq", "field": "isNumeric", "value": true },
              { "operator": "lte", "field": "decimals", "value": 1 }
            ]
          },
          "save_as": "ac4_eth",
          "note": "AC4: ETH TP percent has at most 1 decimal (matches $1k-$10k price-range maxDecimals=1) — confirms no regression on mid-range assets.",
          "next": "teardown-end"
        },
        "teardown-end": {
          "action": "end",
          "message": "TAT-3074 TP/SL precision recipe complete."
        }
      }
    }
  }
}
```

</details>

## **Recipe Workflow**

<details>
<summary>artifacts/workflow.mmd</summary>

```mermaid
flowchart TD
  %% TAT-3074: TP/SL percent precision is asset-aware
  __entry__(["ENTRY"]) --> node_ac1_nav_btc
  node_ac1_nav_btc["ac1-nav-btc<br/>ext_navigate_hash"]
  node_ac1_wait_btc["ac1-wait-btc<br/>wait_for"]
  node_ac1_set_tp_and_read_btc["ac1-set-tp-and-read-btc<br/>eval_async"]
  node_ac2_nav_pump["ac2-nav-pump<br/>ext_navigate_hash"]
  node_ac2_wait_pump["ac2-wait-pump<br/>wait_for"]
  node_ac2_set_tp_and_read_pump["ac2-set-tp-and-read-pump<br/>eval_async"]
  node_ac3_nav_xyz100["ac3-nav-xyz100<br/>ext_navigate_hash"]
  node_ac3_wait_xyz100["ac3-wait-xyz100<br/>wait_for"]
  node_ac3_set_tp_and_read_xyz100["ac3-set-tp-and-read-xyz100<br/>eval_async"]
  node_ac4_nav_eth["ac4-nav-eth<br/>ext_navigate_hash"]
  node_ac4_wait_eth["ac4-wait-eth<br/>wait_for"]
  node_ac4_set_tp_and_read_eth["ac4-set-tp-and-read-eth<br/>eval_async"]
  node_teardown_end(["teardown-end<br/>PASS"])
  node_ac1_nav_btc --> node_ac1_wait_btc
  node_ac1_wait_btc --> node_ac1_set_tp_and_read_btc
  node_ac1_set_tp_and_read_btc --> node_ac2_nav_pump
  node_ac2_nav_pump --> node_ac2_wait_pump
  node_ac2_wait_pump --> node_ac2_set_tp_and_read_pump
  node_ac2_set_tp_and_read_pump --> node_ac3_nav_xyz100
  node_ac3_nav_xyz100 --> node_ac3_wait_xyz100
  node_ac3_wait_xyz100 --> node_ac3_set_tp_and_read_xyz100
  node_ac3_set_tp_and_read_xyz100 --> node_ac4_nav_eth
  node_ac4_nav_eth --> node_ac4_wait_eth
  node_ac4_wait_eth --> node_ac4_set_tp_and_read_eth
  node_ac4_set_tp_and_read_eth --> node_teardown_end
```

</details>


[TAT-3074]: https://consensyssoftware.atlassian.net/browse/TAT-3074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ