### PR TITLE
fix(metrics): report transaction error as non-sensitive property

### DIFF
--- a/app/scripts/lib/transaction/metrics-builders/transaction-details.ts
+++ b/app/scripts/lib/transaction/metrics-builders/transaction-details.ts
@@ -41,9 +41,6 @@ export const getTransactionDetailsMetricsProperties: TransactionMetricsBuilder =
     const finalizedExtras =
       eventName === TransactionMetaMetricsEvent.finalized
         ? {
-            ...(transactionEventPayload.error
-              ? { error: transactionEventPayload.error }
-              : {}),
             ...(transactionMeta.txReceipt?.gasUsed
               ? { gas_used: hexWEIToDecGWEI(transactionMeta.txReceipt.gasUsed) }
               : {}),
@@ -80,8 +77,16 @@ export const getTransactionDetailsMetricsProperties: TransactionMetricsBuilder =
       transactionMeta.nestedTransactions?.length,
     );
 
+    const finalizedNonSensitive =
+      eventName === TransactionMetaMetricsEvent.finalized &&
+      transactionEventPayload.error
+        ? { error: transactionEventPayload.error }
+        : {};
+
     return {
-      properties: {},
+      properties: {
+        ...finalizedNonSensitive,
+      },
       sensitiveProperties: {
         transaction_envelope_type: isEIP1559Transaction(transactionMeta)
           ? TRANSACTION_ENVELOPE_TYPE_NAMES.FEE_MARKET

--- a/app/scripts/lib/transaction/metrics.test.ts
+++ b/app/scripts/lib/transaction/metrics.test.ts
@@ -146,7 +146,8 @@ describe('transaction metrics handlers', () => {
 
     const payload = (request.trackEvent as jest.Mock).mock.calls[0][0];
     expect(payload.event).toBe(TransactionMetaMetricsEvent.finalized);
-    expect(payload.sensitiveProperties.error).toBe('boom');
+    expect(payload.properties.error).toBe('boom');
+    expect(payload.sensitiveProperties.error).toBeUndefined();
   });
 
   it('tracks finalized event for dropped and sets dropped marker', async () => {


### PR DESCRIPTION
## **Description**

The `error` property emitted on the `Transaction Finalized` event is currently classified as a sensitive property on extension while [mobile reports it as a non-sensitive property](https://github.com/MetaMask/metamask-mobile/blob/main/app/core/Engine/controllers/transaction-controller/metrics_properties/base.ts). As a consequence, on extension `error` only appears on `Transaction Finalized Anon` events, which makes it harder to investigate transaction failures in dashboards/funnels that key off the regular `Transaction Finalized` event.

This PR moves the `error` property out of `sensitiveProperties` and into the regular `properties` bag in the transaction-details metrics builder, so the extension schema matches mobile and `error` shows up on `Transaction Finalized`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [CONF-1073](https://consensyssoftware.atlassian.net/browse/CONF-1073)

## **Manual testing steps**

1. Build the extension with this branch and enable MetaMetrics.
2. Trigger a transaction failure (e.g. submit a tx that reverts on-chain or reject a hardware-wallet sign).
3. In the network/console events sent to Segment, confirm that the `Transaction Finalized` event now includes a top-level `error` property and that the corresponding `Transaction Finalized Anon` event no longer carries `error` under sensitive properties.

## **Screenshots/Recordings**

N/A — analytics-only change.

### **Before**

`error` only present on `Transaction Finalized Anon` (sensitive properties).

### **After**

`error` present on `Transaction Finalized` (non-sensitive properties), matching mobile.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)

[CONF-1073]: https://consensyssoftware.atlassian.net/browse/CONF-1073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk analytics-only change that reclassifies the transaction `error` field from `sensitiveProperties` to `properties` on `Transaction Finalized` events. Main impact is on telemetry schema/consumers and dashboards expecting the old location.
> 
> **Overview**
> Moves the `error` field for `TransactionMetaMetricsEvent.finalized` from `sensitiveProperties` into the non-sensitive `properties` payload in `transaction-details` so it appears on the standard "Transaction Finalized" event.
> 
> Updates the corresponding metrics test to assert `error` is present in `properties` and absent from `sensitiveProperties`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f6467f260d9de27f8bf03954243f5419b19dbd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->