### PR TITLE
feat: update gas token picker design

### DIFF
--- a/ui/pages/confirmations/components/confirm/info/__snapshots__/info.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/__snapshots__/info.test.tsx.snap
@@ -384,9 +384,9 @@ exports[`Info renders info section for approve request 1`] = `
             $0.08
           </p>
           <div
-            class="mm-box mm-box--margin-left-1 mm-box--padding-inline-start-1 mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-transparent mm-box--rounded-pill"
+            class="mm-box mm-box--margin-left-1 mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center"
             data-testid="selected-gas-fee-token"
-            style="cursor: default; padding-inline-end: 6px; padding: 0px;"
+            style="cursor: default;"
           >
             <div
               class=""
@@ -743,9 +743,9 @@ exports[`Info renders info section for contract interaction request 1`] = `
             $0.04
           </p>
           <div
-            class="mm-box mm-box--margin-left-1 mm-box--padding-inline-start-1 mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-transparent mm-box--rounded-pill"
+            class="mm-box mm-box--margin-left-1 mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center"
             data-testid="selected-gas-fee-token"
-            style="cursor: default; padding-inline-end: 6px; padding: 0px;"
+            style="cursor: default;"
           >
             <div
               class=""
@@ -1360,9 +1360,9 @@ exports[`Info renders info section for setApprovalForAll request 1`] = `
             $0.08
           </p>
           <div
-            class="mm-box mm-box--margin-left-1 mm-box--padding-inline-start-1 mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-transparent mm-box--rounded-pill"
+            class="mm-box mm-box--margin-left-1 mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center"
             data-testid="selected-gas-fee-token"
-            style="cursor: default; padding-inline-end: 6px; padding: 0px;"
+            style="cursor: default;"
           >
             <div
               class=""

--- a/ui/pages/confirmations/components/confirm/info/approve/__snapshots__/approve.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/approve/__snapshots__/approve.test.tsx.snap
@@ -394,9 +394,9 @@ exports[`<ApproveInfo /> renders component for approve request 1`] = `
             0.0001
           </p>
           <div
-            class="mm-box mm-box--margin-left-1 mm-box--padding-inline-start-1 mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-transparent mm-box--rounded-pill"
+            class="mm-box mm-box--margin-left-1 mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center"
             data-testid="selected-gas-fee-token"
-            style="cursor: default; padding-inline-end: 6px; padding: 0px;"
+            style="cursor: default;"
           >
             <div
               class=""

--- a/ui/pages/confirmations/components/confirm/info/base-transaction-info/__snapshots__/base-transaction-info.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/base-transaction-info/__snapshots__/base-transaction-info.test.tsx.snap
@@ -272,9 +272,9 @@ exports[`<BaseTransactionInfo /> renders component for contract interaction requ
             $0.04
           </p>
           <div
-            class="mm-box mm-box--margin-left-1 mm-box--padding-inline-start-1 mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-transparent mm-box--rounded-pill"
+            class="mm-box mm-box--margin-left-1 mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center"
             data-testid="selected-gas-fee-token"
-            style="cursor: default; padding-inline-end: 6px; padding: 0px;"
+            style="cursor: default;"
           >
             <div
               class=""

--- a/ui/pages/confirmations/components/confirm/info/native-transfer/__snapshots__/native-transfer.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/native-transfer/__snapshots__/native-transfer.test.tsx.snap
@@ -511,9 +511,9 @@ exports[`NativeTransferInfo renders correctly 1`] = `
             $0.08
           </p>
           <div
-            class="mm-box mm-box--margin-left-1 mm-box--padding-inline-start-1 mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-transparent mm-box--rounded-pill"
+            class="mm-box mm-box--margin-left-1 mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center"
             data-testid="selected-gas-fee-token"
-            style="cursor: default; padding-inline-end: 6px; padding: 0px;"
+            style="cursor: default;"
           >
             <div
               class=""

--- a/ui/pages/confirmations/components/confirm/info/nft-token-transfer/__snapshots__/nft-token-transfer.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/nft-token-transfer/__snapshots__/nft-token-transfer.test.tsx.snap
@@ -537,9 +537,9 @@ exports[`NFTTokenTransferInfo renders correctly 1`] = `
             $0.08
           </p>
           <div
-            class="mm-box mm-box--margin-left-1 mm-box--padding-inline-start-1 mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-transparent mm-box--rounded-pill"
+            class="mm-box mm-box--margin-left-1 mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center"
             data-testid="selected-gas-fee-token"
-            style="cursor: default; padding-inline-end: 6px; padding: 0px;"
+            style="cursor: default;"
           >
             <div
               class=""

--- a/ui/pages/confirmations/components/confirm/info/set-approval-for-all-info/__snapshots__/set-approval-for-all-info.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/set-approval-for-all-info/__snapshots__/set-approval-for-all-info.test.tsx.snap
@@ -386,9 +386,9 @@ exports[`<SetApprovalForAllInfo /> renders component for approve request 1`] = `
             $0.08
           </p>
           <div
-            class="mm-box mm-box--margin-left-1 mm-box--padding-inline-start-1 mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-transparent mm-box--rounded-pill"
+            class="mm-box mm-box--margin-left-1 mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center"
             data-testid="selected-gas-fee-token"
-            style="cursor: default; padding-inline-end: 6px; padding: 0px;"
+            style="cursor: default;"
           >
             <div
               class=""

--- a/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/__snapshots__/edit-gas-fees-row.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/__snapshots__/edit-gas-fees-row.test.tsx.snap
@@ -75,9 +75,9 @@ exports[`<EditGasFeesRow /> renders component 1`] = `
           </div>
         </div>
         <div
-          class="mm-box mm-box--margin-left-1 mm-box--padding-inline-start-1 mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-transparent mm-box--rounded-pill"
+          class="mm-box mm-box--margin-left-1 mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center"
           data-testid="selected-gas-fee-token"
-          style="cursor: default; padding-inline-end: 6px; padding: 0px;"
+          style="cursor: default;"
         >
           <div
             class=""

--- a/ui/pages/confirmations/components/confirm/info/shared/gas-fees-section/__snapshots__/gas-fees-section.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-fees-section/__snapshots__/gas-fees-section.test.tsx.snap
@@ -70,9 +70,9 @@ exports[`<GasFeesSection /> renders component for gas fees section 1`] = `
             $0.04
           </p>
           <div
-            class="mm-box mm-box--margin-left-1 mm-box--padding-inline-start-1 mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-transparent mm-box--rounded-pill"
+            class="mm-box mm-box--margin-left-1 mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center"
             data-testid="selected-gas-fee-token"
-            style="cursor: default; padding-inline-end: 6px; padding: 0px;"
+            style="cursor: default;"
           >
             <div
               class=""

--- a/ui/pages/confirmations/components/confirm/info/shared/selected-gas-fee-token/selected-gas-fee-token.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/selected-gas-fee-token/selected-gas-fee-token.tsx
@@ -10,8 +10,6 @@ import {
 } from '../../../../../../../components/component-library';
 import {
   AlignItems,
-  BackgroundColor,
-  BorderRadius,
   Display,
 } from '../../../../../../../helpers/constants/design-system';
 import { useConfirmContext } from '../../../../../context/confirm';
@@ -84,21 +82,12 @@ export function SelectedGasFeeToken() {
       <Box
         data-testid="selected-gas-fee-token"
         onClick={handleClick}
-        backgroundColor={
-          hasMoreThanOneGasFeeTokenToChooseFrom
-            ? BackgroundColor.backgroundMuted
-            : BackgroundColor.transparent
-        }
-        borderRadius={BorderRadius.pill}
         display={Display.InlineFlex}
         alignItems={AlignItems.center}
-        paddingInlineStart={1}
         marginLeft={1}
         gap={1}
         style={{
           cursor: hasMoreThanOneGasFeeTokenToChooseFrom ? 'pointer' : 'default',
-          paddingInlineEnd: '6px',
-          padding: hasMoreThanOneGasFeeTokenToChooseFrom ? '4px 8px' : '0px',
         }}
       >
         <GasFeeTokenIcon
@@ -109,7 +98,7 @@ export function SelectedGasFeeToken() {
         {hasMoreThanOneGasFeeTokenToChooseFrom && (
           <Icon
             data-testid="selected-gas-fee-token-arrow"
-            name={IconName.ArrowDown}
+            name={IconName.ArrowRight}
             size={IconSize.Sm}
           />
         )}

--- a/ui/pages/confirmations/components/confirm/info/token-transfer/__snapshots__/token-transfer.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/token-transfer/__snapshots__/token-transfer.test.tsx.snap
@@ -514,9 +514,9 @@ exports[`TokenTransferInfo renders correctly 1`] = `
             $0.08
           </p>
           <div
-            class="mm-box mm-box--margin-left-1 mm-box--padding-inline-start-1 mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center mm-box--background-color-transparent mm-box--rounded-pill"
+            class="mm-box mm-box--margin-left-1 mm-box--display-inline-flex mm-box--gap-1 mm-box--align-items-center"
             data-testid="selected-gas-fee-token"
-            style="cursor: default; padding-inline-end: 6px; padding: 0px;"
+            style="cursor: default;"
           >
             <div
               class=""


### PR DESCRIPTION
## **Description**

Updates the gas fee token picker (the inline dropdown trigger that opens the gas-fee-token modal) to match the new design:

- Removes the muted background pill (and the associated padding / border-radius styling).
- Switches the dropdown indicator from a down arrow (`IconName.ArrowDown`) to a right arrow (`IconName.ArrowRight`).

No behavioral changes — the click target, modal trigger condition, and a11y test ID (`selected-gas-fee-token-arrow`) are unchanged.

Design reference: [Figma — Smart account upgrades, node 1:2851](https://www.figma.com/design/zdMm61LqLR01krPCscHYoT/Smart-account-upgrades?node-id=1-2851).

## **Changelog**

CHANGELOG entry: Updated the design of the gas fee token picker.

## **Related issues**

Fixes: [CONF-1346](https://consensyssoftware.atlassian.net/browse/CONF-1346)

## **Manual testing steps**

1. Open a confirmation that exposes the gas fee token picker — e.g. a contract interaction on a chain with smart-transactions / gasless support and at least two gas fee tokens (or run the `gas-fee-tokens-smart-transactions.spec.ts` E2E fixture state).
2. Locate the gas fee token row in the gas info section.
3. Confirm the trigger renders as `[token icon] SYMBOL >` with no background pill and the arrow pointing right.
4. Click the trigger and confirm the gas fee token modal still opens.
5. Verify the trigger is hidden when there is only one gas fee token to choose from (no regression).

## **Screenshots/Recordings**

### **Before**

Inline pill with muted background and a down arrow.

### **After**

Inline text + right arrow, no background. _Screenshots to be added once visual validation completes._

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable (existing 12 unit tests in `selected-gas-fee-token.test.tsx` still pass — assertions are on the test ID, not the icon name)
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)

[CONF-1346]: https://consensyssoftware.atlassian.net/browse/CONF-1346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ