### PR TITLE
feat(perps): add compliance gate for restricted wallets

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -82,6 +82,18 @@
     "message": "I have read and agree to the $1",
     "description": "$1 is the `terms` message"
   },
+  "accessRestrictedContactSupport": {
+    "message": "Contact support"
+  },
+  "accessRestrictedDescriptionLine1": {
+    "message": "This wallet address has been flagged during compliance screening. As a result, some MetaMask services are unavailable."
+  },
+  "accessRestrictedDescriptionLine2": {
+    "message": "If you believe this is an error, contact support to request a review."
+  },
+  "accessRestrictedTitle": {
+    "message": "Access restricted"
+  },
   "accessingYourCamera": {
     "message": "Accessing your camera..."
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -82,6 +82,18 @@
     "message": "I have read and agree to the $1",
     "description": "$1 is the `terms` message"
   },
+  "accessRestrictedContactSupport": {
+    "message": "Contact support"
+  },
+  "accessRestrictedDescriptionLine1": {
+    "message": "This wallet address has been flagged during compliance screening. As a result, some MetaMask services are unavailable."
+  },
+  "accessRestrictedDescriptionLine2": {
+    "message": "If you believe this is an error, contact support to request a review."
+  },
+  "accessRestrictedTitle": {
+    "message": "Access restricted"
+  },
   "accessingYourCamera": {
     "message": "Accessing your camera..."
   },

--- a/app/scripts/constants/sentry-state.ts
+++ b/app/scripts/constants/sentry-state.ts
@@ -149,6 +149,10 @@ export const SENTRY_BACKGROUND_STATE: SentryBackgroundControllerMasks = {
   ConnectivityController: {
     connectivityStatus: true,
   },
+  ComplianceController: {
+    walletComplianceStatusMap: false,
+    lastCheckedAt: false,
+  },
   CronjobController: {
     events: false,
   },

--- a/app/scripts/messenger-client-init/compliance-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/compliance-controller-init.test.ts
@@ -1,0 +1,74 @@
+import { ComplianceController } from '@metamask/compliance-controller';
+import { buildControllerInitRequestMock } from './test/utils';
+import { ComplianceControllerInit } from './compliance-controller-init';
+import type { ComplianceControllerMessenger } from './messengers/compliance-controller-messenger';
+
+jest.mock('@metamask/compliance-controller', () => ({
+  ComplianceController: jest.fn().mockImplementation(() => ({
+    checkWalletsCompliance: jest.fn(),
+  })),
+}));
+
+describe('ComplianceControllerInit', () => {
+  const ComplianceControllerMock = jest.mocked(ComplianceController);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates ComplianceController with persisted state', () => {
+    const persistedState = {
+      walletComplianceStatusMap: {
+        '0xblocked': {
+          address: '0xblocked',
+          blocked: true,
+          checkedAt: '2026-05-05T00:00:00.000Z',
+        },
+      },
+      lastCheckedAt: '2026-05-05T00:00:00.000Z',
+    };
+    const request = {
+      ...buildControllerInitRequestMock(),
+      controllerMessenger: {
+        call: jest.fn(),
+      } as unknown as ComplianceControllerMessenger,
+      initMessenger: undefined,
+    };
+    request.persistedState.ComplianceController = persistedState;
+
+    const result = ComplianceControllerInit(request);
+
+    expect(result.messengerClient).toBeDefined();
+    expect(result.api).toBeDefined();
+    expect(ComplianceControllerMock).toHaveBeenCalledWith({
+      messenger: request.controllerMessenger,
+      state: persistedState,
+    });
+  });
+
+  it('exposes complianceCheckWalletsCompliance through the background API', async () => {
+    const checkWalletsCompliance = jest
+      .fn()
+      .mockResolvedValue([{ address: '0xabc', blocked: false }]);
+    ComplianceControllerMock.mockImplementationOnce(
+      () =>
+        ({
+          checkWalletsCompliance,
+        }) as never,
+    );
+    const request = {
+      ...buildControllerInitRequestMock(),
+      controllerMessenger: {
+        call: jest.fn(),
+      } as unknown as ComplianceControllerMessenger,
+      initMessenger: undefined,
+    };
+
+    const { api } = ComplianceControllerInit(request);
+
+    await expect(
+      api?.complianceCheckWalletsCompliance(['0xabc']),
+    ).resolves.toEqual([{ address: '0xabc', blocked: false }]);
+    expect(checkWalletsCompliance).toHaveBeenCalledWith(['0xabc']);
+  });
+});

--- a/app/scripts/messenger-client-init/compliance-controller-init.ts
+++ b/app/scripts/messenger-client-init/compliance-controller-init.ts
@@ -1,0 +1,48 @@
+import {
+  ComplianceController,
+  type ComplianceControllerMessenger,
+  type WalletComplianceStatus,
+} from '@metamask/compliance-controller';
+import { MessengerClientInitFunction } from './types';
+
+type ComplianceBackgroundApi = {
+  complianceCheckWalletsCompliance: (
+    addresses: string[],
+  ) => Promise<WalletComplianceStatus[]>;
+};
+
+/**
+ * Initialize the ComplianceController.
+ *
+ * The controller always exists so its persisted state slot is available. Perps
+ * gates decide whether to call the API by checking the compliance feature flag.
+ *
+ * @param request - The request object.
+ * @param request.controllerMessenger - The messenger for the controller.
+ * @param request.persistedState - Persisted state to hydrate from.
+ * @returns The initialized controller and background API.
+ */
+export const ComplianceControllerInit: MessengerClientInitFunction<
+  ComplianceController,
+  ComplianceControllerMessenger
+> = ({ controllerMessenger, persistedState }) => {
+  const messengerClient = new ComplianceController({
+    messenger: controllerMessenger,
+    state: persistedState.ComplianceController,
+  });
+
+  return {
+    messengerClient,
+    api: getApi(messengerClient),
+  };
+};
+
+function getApi(
+  messengerClient: ComplianceController,
+): ComplianceBackgroundApi {
+  return {
+    complianceCheckWalletsCompliance:
+      messengerClient.checkWalletsCompliance.bind(messengerClient),
+  };
+}
+

--- a/app/scripts/messenger-client-init/compliance-controller-init.ts
+++ b/app/scripts/messenger-client-init/compliance-controller-init.ts
@@ -45,4 +45,3 @@ function getApi(
       messengerClient.checkWalletsCompliance.bind(messengerClient),
   };
 }
-

--- a/app/scripts/messenger-client-init/compliance-service-init.test.ts
+++ b/app/scripts/messenger-client-init/compliance-service-init.test.ts
@@ -1,0 +1,64 @@
+import { ComplianceService } from '@metamask/compliance-controller';
+import { ENVIRONMENT } from '../../../development/build/constants';
+import { buildControllerInitRequestMock } from './test/utils';
+import { ComplianceServiceInit } from './compliance-service-init';
+import type { ComplianceServiceMessenger } from './messengers/compliance-service-messenger';
+
+jest.mock('@metamask/compliance-controller', () => ({
+  ComplianceService: jest.fn().mockImplementation(() => ({})),
+}));
+
+describe('ComplianceServiceInit', () => {
+  const ComplianceServiceMock = jest.mocked(ComplianceService);
+  const fetchMock = jest.fn();
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+    delete process.env.METAMASK_ENVIRONMENT;
+  });
+
+  afterAll(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('creates ComplianceService with production environment for production builds', () => {
+    process.env.METAMASK_ENVIRONMENT = ENVIRONMENT.PRODUCTION;
+    const request = {
+      ...buildControllerInitRequestMock(),
+      controllerMessenger: {
+        call: jest.fn(),
+      } as unknown as ComplianceServiceMessenger,
+      initMessenger: undefined,
+    };
+
+    const result = ComplianceServiceInit(request);
+
+    expect(result.messengerClient).toBeDefined();
+    expect(ComplianceServiceMock).toHaveBeenCalledWith({
+      messenger: request.controllerMessenger,
+      fetch: expect.any(Function),
+      env: 'production',
+    });
+  });
+
+  it('creates ComplianceService with development environment outside production builds', () => {
+    process.env.METAMASK_ENVIRONMENT = ENVIRONMENT.DEVELOPMENT;
+    const request = {
+      ...buildControllerInitRequestMock(),
+      controllerMessenger: {
+        call: jest.fn(),
+      } as unknown as ComplianceServiceMessenger,
+      initMessenger: undefined,
+    };
+
+    ComplianceServiceInit(request);
+
+    expect(ComplianceServiceMock).toHaveBeenCalledWith({
+      messenger: request.controllerMessenger,
+      fetch: expect.any(Function),
+      env: 'development',
+    });
+  });
+});

--- a/app/scripts/messenger-client-init/compliance-service-init.ts
+++ b/app/scripts/messenger-client-init/compliance-service-init.ts
@@ -1,0 +1,33 @@
+import {
+  ComplianceService,
+  type ComplianceServiceMessenger,
+} from '@metamask/compliance-controller';
+import { ENVIRONMENT } from '../../../development/build/constants';
+import { MessengerClientInitFunction } from './types';
+
+function getComplianceServiceEnvironment(): 'production' | 'development' {
+  return process.env.METAMASK_ENVIRONMENT === ENVIRONMENT.PRODUCTION
+    ? 'production'
+    : 'development';
+}
+
+/**
+ * Initialize the ComplianceService.
+ *
+ * @param request - The request object.
+ * @param request.controllerMessenger - The messenger to use for the service.
+ * @returns The initialized service.
+ */
+export const ComplianceServiceInit: MessengerClientInitFunction<
+  ComplianceService,
+  ComplianceServiceMessenger
+> = ({ controllerMessenger }) => {
+  const messengerClient = new ComplianceService({
+    messenger: controllerMessenger,
+    fetch: globalThis.fetch.bind(globalThis),
+    env: getComplianceServiceEnvironment(),
+  });
+
+  return { messengerClient };
+};
+

--- a/app/scripts/messenger-client-init/compliance-service-init.ts
+++ b/app/scripts/messenger-client-init/compliance-service-init.ts
@@ -30,4 +30,3 @@ export const ComplianceServiceInit: MessengerClientInitFunction<
 
   return { messengerClient };
 };
-

--- a/app/scripts/messenger-client-init/controller-list.ts
+++ b/app/scripts/messenger-client-init/controller-list.ts
@@ -94,6 +94,10 @@ import {
   GeolocationApiService,
   GeolocationController,
 } from '@metamask/geolocation-controller';
+import {
+  ComplianceController,
+  ComplianceService,
+} from '@metamask/compliance-controller';
 import { PerpsController } from '@metamask/perps-controller';
 import { PasskeyController } from '@metamask/passkey-controller';
 import { OnboardingController } from '../controllers/onboarding';
@@ -220,6 +224,8 @@ export type MessengerClient =
   | NetworkEnablementController
   | ClaimsService
   | ClientController
+  | ComplianceController
+  | ComplianceService
   | StaticAssetsController
   | ProfileMetricsController
   | ProfileMetricsService
@@ -244,6 +250,7 @@ export type MessengerClientFlatState = AccountOrderController['state'] &
   BridgeStatusController['state'] &
   ClaimsController['state'] &
   ClientController['state'] &
+  ComplianceController['state'] &
   CronjobController['state'] &
   CurrencyRateController['state'] &
   DeFiPositionsController['state'] &

--- a/app/scripts/messenger-client-init/messengers/compliance-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/compliance-controller-messenger.ts
@@ -1,0 +1,50 @@
+import { Messenger } from '@metamask/messenger';
+import type {
+  ComplianceControllerActions,
+  ComplianceControllerEvents,
+  ComplianceServiceCheckWalletComplianceAction,
+  ComplianceServiceCheckWalletsComplianceAction,
+} from '@metamask/compliance-controller';
+import { RootMessenger } from '../../lib/messenger';
+
+type AllowedActions =
+  | ComplianceServiceCheckWalletComplianceAction
+  | ComplianceServiceCheckWalletsComplianceAction;
+
+type AllowedEvents = never;
+
+export type ComplianceControllerMessenger = ReturnType<
+  typeof getComplianceControllerMessenger
+>;
+
+/**
+ * Create a messenger restricted to the allowed actions and events of the
+ * ComplianceController.
+ *
+ * @param messenger - The root messenger used to create the restricted messenger.
+ * @returns A restricted messenger for the ComplianceController.
+ */
+export function getComplianceControllerMessenger(
+  messenger: RootMessenger<ComplianceControllerActions | AllowedActions>,
+) {
+  const complianceControllerMessenger = new Messenger<
+    'ComplianceController',
+    ComplianceControllerActions | AllowedActions,
+    ComplianceControllerEvents | AllowedEvents,
+    typeof messenger
+  >({
+    namespace: 'ComplianceController',
+    parent: messenger,
+  });
+
+  messenger.delegate({
+    messenger: complianceControllerMessenger,
+    actions: [
+      'ComplianceService:checkWalletCompliance',
+      'ComplianceService:checkWalletsCompliance',
+    ],
+  });
+
+  return complianceControllerMessenger;
+}
+

--- a/app/scripts/messenger-client-init/messengers/compliance-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/compliance-controller-messenger.ts
@@ -47,4 +47,3 @@ export function getComplianceControllerMessenger(
 
   return complianceControllerMessenger;
 }
-

--- a/app/scripts/messenger-client-init/messengers/compliance-service-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/compliance-service-messenger.ts
@@ -1,0 +1,29 @@
+import { Messenger } from '@metamask/messenger';
+import type {
+  ComplianceServiceActions,
+  ComplianceServiceEvents,
+} from '@metamask/compliance-controller';
+import { RootMessenger } from '../../lib/messenger';
+
+export type ComplianceServiceMessenger = ReturnType<
+  typeof getComplianceServiceMessenger
+>;
+
+/**
+ * Create a messenger for the ComplianceService.
+ *
+ * @param messenger - The root messenger used to create the restricted messenger.
+ * @returns A restricted messenger for the ComplianceService.
+ */
+export function getComplianceServiceMessenger(messenger: RootMessenger) {
+  return new Messenger<
+    'ComplianceService',
+    ComplianceServiceActions,
+    ComplianceServiceEvents,
+    typeof messenger
+  >({
+    namespace: 'ComplianceService',
+    parent: messenger,
+  });
+}
+

--- a/app/scripts/messenger-client-init/messengers/compliance-service-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/compliance-service-messenger.ts
@@ -26,4 +26,3 @@ export function getComplianceServiceMessenger(messenger: RootMessenger) {
     parent: messenger,
   });
 }
-

--- a/app/scripts/messenger-client-init/messengers/index.ts
+++ b/app/scripts/messenger-client-init/messengers/index.ts
@@ -211,6 +211,8 @@ import { getProfileMetricsServiceMessenger } from './profile-metrics-service-mes
 import { getStorageServiceMessenger } from './storage-service-messenger';
 import { getGeolocationApiServiceMessenger } from './geolocation-api-service-messenger';
 import { getGeolocationControllerMessenger } from './geolocation-controller-messenger';
+import { getComplianceControllerMessenger } from './compliance-controller-messenger';
+import { getComplianceServiceMessenger } from './compliance-service-messenger';
 import { getPerpsControllerMessenger } from './perps-controller-messenger';
 import { getDataDeletionServiceMessenger } from './data-deletion-service-messenger';
 import { getLegacyBackgroundApiServiceMessenger } from './legacy-background-api-service-messenger';
@@ -323,6 +325,10 @@ export type { PermissionLogControllerMessenger } from './permission-log-controll
 export { getPermissionLogControllerMessenger } from './permission-log-controller-messenger';
 export { getGeolocationApiServiceMessenger } from './geolocation-api-service-messenger';
 export { getGeolocationControllerMessenger } from './geolocation-controller-messenger';
+export type { ComplianceControllerMessenger } from './compliance-controller-messenger';
+export { getComplianceControllerMessenger } from './compliance-controller-messenger';
+export type { ComplianceServiceMessenger } from './compliance-service-messenger';
+export { getComplianceServiceMessenger } from './compliance-service-messenger';
 export type { PerpsControllerMessenger } from './perps-controller-messenger';
 export { getPerpsControllerMessenger } from './perps-controller-messenger';
 export type { PhishingControllerMessenger } from './phishing-controller-messenger';
@@ -468,6 +474,14 @@ export const MESSENGER_FACTORIES = {
   },
   ClientController: {
     getMessenger: getClientControllerMessenger,
+    getInitMessenger: noop,
+  },
+  ComplianceService: {
+    getMessenger: getComplianceServiceMessenger,
+    getInitMessenger: noop,
+  },
+  ComplianceController: {
+    getMessenger: getComplianceControllerMessenger,
     getInitMessenger: noop,
   },
   CronjobController: {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -359,6 +359,8 @@ import { TransactionControllerInit } from './messenger-client-init/confirmations
 import { TransactionPayControllerInit } from './messenger-client-init/transaction-pay-controller-init';
 import { GeolocationApiServiceInit } from './messenger-client-init/geolocation-api-service-init';
 import { GeolocationControllerInit } from './messenger-client-init/geolocation-controller-init';
+import { ComplianceServiceInit } from './messenger-client-init/compliance-service-init';
+import { ComplianceControllerInit } from './messenger-client-init/compliance-controller-init';
 import { PerpsControllerInit } from './messenger-client-init/perps-controller-init';
 import { PerpsStreamBridge } from './controllers/perps/perps-stream-bridge';
 import { PPOMControllerInit } from './messenger-client-init/confirmations/ppom-controller-init';
@@ -665,6 +667,8 @@ export default class MetamaskController extends EventEmitter {
       AccountActivityService: AccountActivityServiceInit,
       GeolocationApiService: GeolocationApiServiceInit,
       GeolocationController: GeolocationControllerInit,
+      ComplianceService: ComplianceServiceInit,
+      ComplianceController: ComplianceControllerInit,
       ...(getIsPerpsIncludedInBuild()
         ? { PerpsController: PerpsControllerInit }
         : {}),

--- a/attribution.txt
+++ b/attribution.txt
@@ -28782,6 +28782,33 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 
 ******************************
 
+@metamask/compliance-controller
+2.0.0 <https://github.com/MetaMask/core>
+MIT License
+
+Copyright (c) 2026 MetaMask
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+******************************
+
 @metamask/connectivity-controller
 0.1.0 <https://github.com/MetaMask/core>
 MIT License

--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -1135,6 +1135,17 @@
         "@metamask/base-controller": true
       }
     },
+    "@metamask/compliance-controller": {
+      "globals": {
+        "URL": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/controller-utils": true,
+        "@metamask/superstruct": true,
+        "reselect": true
+      }
+    },
     "@metamask/connectivity-controller": {
       "packages": {
         "@metamask/base-controller": true

--- a/lavamoat/browserify/experimental/policy.json
+++ b/lavamoat/browserify/experimental/policy.json
@@ -1135,6 +1135,17 @@
         "@metamask/base-controller": true
       }
     },
+    "@metamask/compliance-controller": {
+      "globals": {
+        "URL": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/controller-utils": true,
+        "@metamask/superstruct": true,
+        "reselect": true
+      }
+    },
     "@metamask/connectivity-controller": {
       "packages": {
         "@metamask/base-controller": true

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -1135,6 +1135,17 @@
         "@metamask/base-controller": true
       }
     },
+    "@metamask/compliance-controller": {
+      "globals": {
+        "URL": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/controller-utils": true,
+        "@metamask/superstruct": true,
+        "reselect": true
+      }
+    },
     "@metamask/connectivity-controller": {
       "packages": {
         "@metamask/base-controller": true

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -1135,6 +1135,17 @@
         "@metamask/base-controller": true
       }
     },
+    "@metamask/compliance-controller": {
+      "globals": {
+        "URL": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/controller-utils": true,
+        "@metamask/superstruct": true,
+        "reselect": true
+      }
+    },
     "@metamask/connectivity-controller": {
       "packages": {
         "@metamask/base-controller": true

--- a/lavamoat/build-system/policy.json
+++ b/lavamoat/build-system/policy.json
@@ -7610,7 +7610,7 @@
         "process.versions.pnp": true
       },
       "packages": {
-        "eslint-import-resolver-typescript>unrs-resolver>@unrs/resolver-binding-darwin-arm64": true
+        "eslint-import-resolver-typescript>unrs-resolver>@unrs/resolver-binding-linux-x64-gnu": true
       }
     },
     "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>unset-value": {

--- a/lavamoat/build-system/policy.json
+++ b/lavamoat/build-system/policy.json
@@ -7610,7 +7610,7 @@
         "process.versions.pnp": true
       },
       "packages": {
-        "eslint-import-resolver-typescript>unrs-resolver>@unrs/resolver-binding-linux-x64-gnu": true
+        "eslint-import-resolver-typescript>unrs-resolver>@unrs/resolver-binding-darwin-arm64": true
       }
     },
     "gulp>gulp-cli>matchdep>micromatch>snapdragon>base>cache-base>unset-value": {

--- a/lavamoat/webpack/mv2/beta/policy.json
+++ b/lavamoat/webpack/mv2/beta/policy.json
@@ -1031,6 +1031,17 @@
         "@metamask/base-controller": true
       }
     },
+    "@metamask/compliance-controller": {
+      "globals": {
+        "URL": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/controller-utils": true,
+        "@metamask/superstruct": true,
+        "reselect": true
+      }
+    },
     "@metamask/connectivity-controller": {
       "packages": {
         "@metamask/base-controller": true

--- a/lavamoat/webpack/mv2/experimental/policy.json
+++ b/lavamoat/webpack/mv2/experimental/policy.json
@@ -1031,6 +1031,17 @@
         "@metamask/base-controller": true
       }
     },
+    "@metamask/compliance-controller": {
+      "globals": {
+        "URL": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/controller-utils": true,
+        "@metamask/superstruct": true,
+        "reselect": true
+      }
+    },
     "@metamask/connectivity-controller": {
       "packages": {
         "@metamask/base-controller": true

--- a/lavamoat/webpack/mv2/flask/policy.json
+++ b/lavamoat/webpack/mv2/flask/policy.json
@@ -1031,6 +1031,17 @@
         "@metamask/base-controller": true
       }
     },
+    "@metamask/compliance-controller": {
+      "globals": {
+        "URL": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/controller-utils": true,
+        "@metamask/superstruct": true,
+        "reselect": true
+      }
+    },
     "@metamask/connectivity-controller": {
       "packages": {
         "@metamask/base-controller": true

--- a/lavamoat/webpack/mv2/main/policy.json
+++ b/lavamoat/webpack/mv2/main/policy.json
@@ -1031,6 +1031,17 @@
         "@metamask/base-controller": true
       }
     },
+    "@metamask/compliance-controller": {
+      "globals": {
+        "URL": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/controller-utils": true,
+        "@metamask/superstruct": true,
+        "reselect": true
+      }
+    },
     "@metamask/connectivity-controller": {
       "packages": {
         "@metamask/base-controller": true

--- a/lavamoat/webpack/mv3/beta/policy.json
+++ b/lavamoat/webpack/mv3/beta/policy.json
@@ -724,6 +724,12 @@
         "@metamask/controller-utils": true
       }
     },
+    "@metamask/compliance-controller": {
+      "packages": {
+        "@metamask/base-controller": true,
+        "reselect": true
+      }
+    },
     "@metamask/controller-utils": {
       "globals": {
         "Buffer.from": true,

--- a/lavamoat/webpack/mv3/experimental/policy.json
+++ b/lavamoat/webpack/mv3/experimental/policy.json
@@ -724,6 +724,12 @@
         "@metamask/controller-utils": true
       }
     },
+    "@metamask/compliance-controller": {
+      "packages": {
+        "@metamask/base-controller": true,
+        "reselect": true
+      }
+    },
     "@metamask/controller-utils": {
       "globals": {
         "Buffer.from": true,

--- a/lavamoat/webpack/mv3/flask/policy.json
+++ b/lavamoat/webpack/mv3/flask/policy.json
@@ -724,6 +724,12 @@
         "@metamask/controller-utils": true
       }
     },
+    "@metamask/compliance-controller": {
+      "packages": {
+        "@metamask/base-controller": true,
+        "reselect": true
+      }
+    },
     "@metamask/controller-utils": {
       "globals": {
         "Buffer.from": true,

--- a/lavamoat/webpack/mv3/main/policy.json
+++ b/lavamoat/webpack/mv3/main/policy.json
@@ -724,6 +724,12 @@
         "@metamask/controller-utils": true
       }
     },
+    "@metamask/compliance-controller": {
+      "packages": {
+        "@metamask/base-controller": true,
+        "reselect": true
+      }
+    },
     "@metamask/controller-utils": {
       "globals": {
         "Buffer.from": true,

--- a/package.json
+++ b/package.json
@@ -342,6 +342,7 @@
     "@metamask/chain-agnostic-permission": "^1.5.0",
     "@metamask/claims-controller": "^0.4.2",
     "@metamask/client-controller": "^1.0.0",
+    "@metamask/compliance-controller": "2.0.0",
     "@metamask/connectivity-controller": "^0.1.0",
     "@metamask/contract-metadata": "^2.5.0",
     "@metamask/controller-utils": "^11.18.0",

--- a/shared/constants/perps-events.ts
+++ b/shared/constants/perps-events.ts
@@ -58,6 +58,7 @@ export const PERPS_EVENT_VALUE = {
     FLIP_POSITION: 'flip_position',
     CREATE_TP_SL: 'create_tp_sl',
     UPDATE_TP_SL: 'update_tp_sl',
+    COMPLIANCE_BLOCK_NOTIF: 'compliance_block_notif',
   },
   INTERACTION_TYPE: {
     ORDER_TYPE_SELECTED: 'order_type_selected',

--- a/test/e2e/fixtures/default-fixture.json
+++ b/test/e2e/fixtures/default-fixture.json
@@ -834,6 +834,10 @@
       "fcmToken": "",
       "isPushEnabled": true
     },
+    "ComplianceController": {
+      "lastCheckedAt": null,
+      "walletComplianceStatusMap": {}
+    },
     "OnboardingController": {
       "completedOnboarding": true,
       "firstTimeFlowType": "import",

--- a/test/e2e/fixtures/onboarding-fixture.json
+++ b/test/e2e/fixtures/onboarding-fixture.json
@@ -590,6 +590,10 @@
       "fcmToken": "",
       "isPushEnabled": true
     },
+    "ComplianceController": {
+      "lastCheckedAt": null,
+      "walletComplianceStatusMap": {}
+    },
     "OnboardingController": {
       "completedOnboarding": false,
       "firstTimeFlowType": null,

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
@@ -120,6 +120,11 @@
   "ClaimsController": "object",
   "ClaimsService": "undefined",
   "ClientController": "object",
+  "ComplianceController": {
+    "lastCheckedAt": null,
+    "walletComplianceStatusMap": "object"
+  },
+  "ComplianceService": "undefined",
   "ConnectivityController": { "connectivityStatus": "online" },
   "CronjobController": { "events": "object" },
   "CurrencyController": {

--- a/ui/components/app/compliance/access-restricted-context.test.tsx
+++ b/ui/components/app/compliance/access-restricted-context.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MetaMetricsEventName } from '../../../../shared/constants/metametrics';
+import {
+  PERPS_EVENT_PROPERTY,
+  PERPS_EVENT_VALUE,
+} from '../../../../shared/constants/perps-events';
+import {
+  AccessRestrictedProvider,
+  useAccessRestrictedModal,
+} from './access-restricted-context';
+
+const mockTrack = jest.fn();
+
+jest.mock('../../../hooks/perps', () => ({
+  usePerpsEventTracking: () => ({ track: mockTrack }),
+}));
+
+jest.mock('./access-restricted-modal', () => ({
+  AccessRestrictedModal: ({
+    isOpen,
+    onClose,
+    onContactSupport,
+  }: {
+    isOpen: boolean;
+    onClose: () => void;
+    onContactSupport: () => void;
+  }) =>
+    isOpen ? (
+      <div data-testid="access-restricted-modal">
+        <button onClick={onClose}>Close</button>
+        <button onClick={onContactSupport}>Contact support</button>
+      </div>
+    ) : null,
+}));
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+function TestAccessRestrictedConsumer() {
+  const { showAccessRestrictedModal } = useAccessRestrictedModal();
+  return <button onClick={showAccessRestrictedModal}>Show restricted</button>;
+}
+
+describe('AccessRestrictedProvider', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    globalThis.platform = {
+      openTab: jest.fn(),
+    } as unknown as typeof globalThis.platform;
+  });
+
+  it('tracks the compliance block screen event when the modal is shown', () => {
+    render(
+      <AccessRestrictedProvider>
+        <TestAccessRestrictedConsumer />
+      </AccessRestrictedProvider>,
+    );
+
+    fireEvent.click(screen.getByText('Show restricted'));
+
+    expect(screen.getByTestId('access-restricted-modal')).toBeInTheDocument();
+    expect(mockTrack).toHaveBeenCalledWith(
+      MetaMetricsEventName.PerpsScreenViewed,
+      {
+        [PERPS_EVENT_PROPERTY.SCREEN_TYPE]:
+          PERPS_EVENT_VALUE.SCREEN_TYPE.COMPLIANCE_BLOCK_NOTIF,
+      },
+    );
+  });
+});

--- a/ui/components/app/compliance/access-restricted-context.test.tsx
+++ b/ui/components/app/compliance/access-restricted-context.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
 import { MetaMetricsEventName } from '../../../../shared/constants/metametrics';
 import {
   PERPS_EVENT_PROPERTY,
@@ -41,11 +42,18 @@ function TestAccessRestrictedConsumer() {
 }
 
 describe('AccessRestrictedProvider', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
     globalThis.platform = {
       openTab: jest.fn(),
     } as unknown as typeof globalThis.platform;
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
   });
 
   it('tracks the compliance block screen event when the modal is shown', () => {
@@ -64,6 +72,14 @@ describe('AccessRestrictedProvider', () => {
         [PERPS_EVENT_PROPERTY.SCREEN_TYPE]:
           PERPS_EVENT_VALUE.SCREEN_TYPE.COMPLIANCE_BLOCK_NOTIF,
       },
+    );
+  });
+
+  it('throws when missing access-restricted modal context is used', () => {
+    const { result } = renderHook(() => useAccessRestrictedModal());
+
+    expect(() => result.current.showAccessRestrictedModal()).toThrow(
+      'useAccessRestrictedModal must be used within AccessRestrictedProvider',
     );
   });
 });

--- a/ui/components/app/compliance/access-restricted-context.tsx
+++ b/ui/components/app/compliance/access-restricted-context.tsx
@@ -1,0 +1,87 @@
+import React, {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
+import { SUPPORT_CONFIG } from '../../../../shared/constants/perps';
+import {
+  PERPS_EVENT_PROPERTY,
+  PERPS_EVENT_VALUE,
+} from '../../../../shared/constants/perps-events';
+import { MetaMetricsEventName } from '../../../../shared/constants/metametrics';
+import { usePerpsEventTracking } from '../../../hooks/perps';
+import { AccessRestrictedModal } from './access-restricted-modal';
+
+type AccessRestrictedContextValue = {
+  showAccessRestrictedModal: () => void;
+  hideAccessRestrictedModal: () => void;
+  isAccessRestricted: boolean;
+};
+
+const AccessRestrictedContext =
+  createContext<AccessRestrictedContextValue | null>(null);
+
+const MISSING_PROVIDER_VALUE: AccessRestrictedContextValue = {
+  showAccessRestrictedModal: () => undefined,
+  hideAccessRestrictedModal: () => undefined,
+  isAccessRestricted: false,
+};
+
+export type AccessRestrictedProviderProps = {
+  children: ReactNode;
+};
+
+export const AccessRestrictedProvider = ({
+  children,
+}: AccessRestrictedProviderProps) => {
+  const [isVisible, setIsVisible] = useState(false);
+  const { track } = usePerpsEventTracking();
+
+  const showAccessRestrictedModal = useCallback(() => {
+    setIsVisible(true);
+    track(MetaMetricsEventName.PerpsScreenViewed, {
+      [PERPS_EVENT_PROPERTY.SCREEN_TYPE]:
+        PERPS_EVENT_VALUE.SCREEN_TYPE.COMPLIANCE_BLOCK_NOTIF,
+    });
+  }, [track]);
+
+  const hideAccessRestrictedModal = useCallback(() => {
+    setIsVisible(false);
+  }, []);
+
+  const handleContactSupport = useCallback(() => {
+    hideAccessRestrictedModal();
+    globalThis.platform.openTab({ url: SUPPORT_CONFIG.Url });
+  }, [hideAccessRestrictedModal]);
+
+  const value = useMemo(
+    () => ({
+      showAccessRestrictedModal,
+      hideAccessRestrictedModal,
+      isAccessRestricted: isVisible,
+    }),
+    [showAccessRestrictedModal, hideAccessRestrictedModal, isVisible],
+  );
+
+  return (
+    <AccessRestrictedContext.Provider value={value}>
+      {children}
+      <AccessRestrictedModal
+        isOpen={isVisible}
+        onClose={hideAccessRestrictedModal}
+        onContactSupport={handleContactSupport}
+      />
+    </AccessRestrictedContext.Provider>
+  );
+};
+
+export const useAccessRestrictedModal = (): AccessRestrictedContextValue => {
+  const context = useContext(AccessRestrictedContext);
+  if (!context) {
+    return MISSING_PROVIDER_VALUE;
+  }
+  return context;
+};

--- a/ui/components/app/compliance/access-restricted-context.tsx
+++ b/ui/components/app/compliance/access-restricted-context.tsx
@@ -24,9 +24,15 @@ type AccessRestrictedContextValue = {
 const AccessRestrictedContext =
   createContext<AccessRestrictedContextValue | null>(null);
 
+const throwMissingProviderError = () => {
+  throw new Error(
+    'useAccessRestrictedModal must be used within AccessRestrictedProvider',
+  );
+};
+
 const MISSING_PROVIDER_VALUE: AccessRestrictedContextValue = {
-  showAccessRestrictedModal: () => undefined,
-  hideAccessRestrictedModal: () => undefined,
+  showAccessRestrictedModal: throwMissingProviderError,
+  hideAccessRestrictedModal: throwMissingProviderError,
   isAccessRestricted: false,
 };
 

--- a/ui/components/app/compliance/access-restricted-modal.tsx
+++ b/ui/components/app/compliance/access-restricted-modal.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  Button,
+  ButtonSize,
+  ButtonVariant,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react';
+import {
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalContentSize,
+  ModalHeader,
+  ModalOverlay,
+} from '../../component-library';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+
+export type AccessRestrictedModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  onContactSupport: () => void;
+};
+
+export const AccessRestrictedModal = ({
+  isOpen,
+  onClose,
+  onContactSupport,
+}: AccessRestrictedModalProps) => {
+  const t = useI18nContext();
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      data-testid="access-restricted-modal"
+    >
+      <ModalOverlay />
+      <ModalContent size={ModalContentSize.Sm}>
+        <ModalHeader onClose={onClose}>
+          {t('accessRestrictedTitle')}
+        </ModalHeader>
+        <ModalBody>
+          <Box
+            flexDirection={BoxFlexDirection.Column}
+            alignItems={BoxAlignItems.Center}
+            gap={4}
+          >
+            <Box flexDirection={BoxFlexDirection.Column} gap={3}>
+              <Text
+                variant={TextVariant.BodyMd}
+                color={TextColor.TextAlternative}
+              >
+                {t('accessRestrictedDescriptionLine1')}
+              </Text>
+              <Text
+                variant={TextVariant.BodyMd}
+                color={TextColor.TextAlternative}
+              >
+                {t('accessRestrictedDescriptionLine2')}
+              </Text>
+            </Box>
+            <Button
+              variant={ButtonVariant.Primary}
+              size={ButtonSize.Lg}
+              isFullWidth
+              onClick={onContactSupport}
+              data-testid="access-restricted-contact-support"
+            >
+              {t('accessRestrictedContactSupport')}
+            </Button>
+          </Box>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+};
+

--- a/ui/components/app/compliance/access-restricted-modal.tsx
+++ b/ui/components/app/compliance/access-restricted-modal.tsx
@@ -79,4 +79,3 @@ export const AccessRestrictedModal = ({
     </Modal>
   );
 };
-

--- a/ui/components/app/compliance/index.ts
+++ b/ui/components/app/compliance/index.ts
@@ -1,0 +1,7 @@
+export {
+  AccessRestrictedProvider,
+  useAccessRestrictedModal,
+} from './access-restricted-context';
+export { AccessRestrictedModal } from './access-restricted-modal';
+export { useComplianceGate } from './useComplianceGate';
+

--- a/ui/components/app/compliance/index.ts
+++ b/ui/components/app/compliance/index.ts
@@ -4,4 +4,4 @@ export {
 } from './access-restricted-context';
 export { AccessRestrictedModal } from './access-restricted-modal';
 export { useComplianceGate } from './useComplianceGate';
-
+export { useSelectedAccountComplianceGate } from './useSelectedAccountComplianceGate';

--- a/ui/components/app/compliance/useComplianceGate.test.tsx
+++ b/ui/components/app/compliance/useComplianceGate.test.tsx
@@ -221,9 +221,11 @@ describe('useComplianceGate', () => {
     expect(mockShowAccessRestrictedModal).toHaveBeenCalledTimes(1);
   });
 
-  it('fails open when the compliance API rejects even if cached state is blocked', async () => {
-    mockSubmitRequestToBackground.mockRejectedValueOnce(new Error('offline'));
-    const action = jest.fn().mockReturnValue('allowed');
+  it('blocks when the background returns a cached blocked status', async () => {
+    mockSubmitRequestToBackground.mockResolvedValueOnce([
+      getStatus(ADDRESS, true),
+    ]);
+    const action = jest.fn();
     const { result } = renderHook(() => useComplianceGate(ADDRESS), {
       wrapper: getWrapper(
         getState({
@@ -234,14 +236,12 @@ describe('useComplianceGate', () => {
       ),
     });
 
-    let value: string | undefined;
     await act(async () => {
-      value = await result.current.gate(action);
+      await result.current.gate(action);
     });
 
-    expect(action).toHaveBeenCalledTimes(1);
-    expect(value).toBe('allowed');
-    expect(mockShowAccessRestrictedModal).not.toHaveBeenCalled();
+    expect(action).not.toHaveBeenCalled();
+    expect(mockShowAccessRestrictedModal).toHaveBeenCalledTimes(1);
   });
 
   it('resets stale blocked results after the address changes', async () => {

--- a/ui/components/app/compliance/useComplianceGate.test.tsx
+++ b/ui/components/app/compliance/useComplianceGate.test.tsx
@@ -195,6 +195,29 @@ describe('useComplianceGate', () => {
     expect(mockShowAccessRestrictedModal).not.toHaveBeenCalled();
   });
 
+  it('fails open when the compliance API rejects even if cached state is blocked', async () => {
+    mockSubmitRequestToBackground.mockRejectedValueOnce(new Error('offline'));
+    const action = jest.fn().mockReturnValue('allowed');
+    const { result } = renderHook(() => useComplianceGate(ADDRESS), {
+      wrapper: getWrapper(
+        getState({
+          walletComplianceStatusMap: {
+            [ADDRESS]: getStatus(ADDRESS, true),
+          },
+        }),
+      ),
+    });
+
+    let value: string | undefined;
+    await act(async () => {
+      value = await result.current.gate(action);
+    });
+
+    expect(action).toHaveBeenCalledTimes(1);
+    expect(value).toBe('allowed');
+    expect(mockShowAccessRestrictedModal).not.toHaveBeenCalled();
+  });
+
   it('resets stale blocked results after the address changes', async () => {
     mockSubmitRequestToBackground
       .mockResolvedValueOnce([getStatus(BLOCKED_ADDRESS, true)])

--- a/ui/components/app/compliance/useComplianceGate.test.tsx
+++ b/ui/components/app/compliance/useComplianceGate.test.tsx
@@ -1,0 +1,227 @@
+import React, { type PropsWithChildren } from 'react';
+import { Provider } from 'react-redux';
+import configureMockStore from 'redux-mock-store';
+import { act, renderHook } from '@testing-library/react-hooks';
+import { submitRequestToBackground } from '../../../store/background-connection';
+import { useComplianceGate } from './useComplianceGate';
+
+jest.mock('../../../store/background-connection', () => ({
+  submitRequestToBackground: jest.fn(),
+}));
+
+const mockShowAccessRestrictedModal = jest.fn();
+
+jest.mock('./access-restricted-context', () => ({
+  useAccessRestrictedModal: () => ({
+    showAccessRestrictedModal: mockShowAccessRestrictedModal,
+  }),
+}));
+
+jest.mock('../../../../shared/lib/manifestFlags', () => {
+  const manifestFlags = { remoteFeatureFlags: {} };
+  return {
+    getManifestFlags: () => manifestFlags,
+  };
+});
+
+const mockStore = configureMockStore([]);
+const mockSubmitRequestToBackground = jest.mocked(submitRequestToBackground);
+
+const ADDRESS = '0xabc';
+const BLOCKED_ADDRESS = '0xblocked';
+
+type WalletComplianceStatus = {
+  address: string;
+  blocked: boolean;
+  checkedAt: string;
+};
+
+function getState({
+  complianceEnabled = true,
+  walletComplianceStatusMap = {},
+}: {
+  complianceEnabled?: boolean;
+  walletComplianceStatusMap?: Record<string, WalletComplianceStatus>;
+} = {}) {
+  return {
+    metamask: {
+      remoteFeatureFlags: { complianceEnabled },
+      walletComplianceStatusMap,
+      lastCheckedAt: null,
+    },
+  };
+}
+
+function getWrapper(state = getState()) {
+  const store = mockStore(state);
+  return function complianceTestWrapper({
+    children,
+  }: PropsWithChildren<Record<string, unknown>>) {
+    return <Provider store={store}>{children}</Provider>;
+  };
+}
+
+function getStatus(address: string, blocked: boolean): WalletComplianceStatus {
+  return {
+    address,
+    blocked,
+    checkedAt: '2026-05-05T00:00:00.000Z',
+  };
+}
+
+function createDeferred<ResultValue>() {
+  let resolve: (value: ResultValue) => void = () => undefined;
+  let reject: (error: unknown) => void = () => undefined;
+  const promise = new Promise<ResultValue>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return { promise, resolve, reject };
+}
+
+describe('useComplianceGate', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('skips the API and runs the action when compliance is disabled', async () => {
+    const action = jest.fn().mockReturnValue('allowed');
+    const { result } = renderHook(() => useComplianceGate(ADDRESS), {
+      wrapper: getWrapper(getState({ complianceEnabled: false })),
+    });
+
+    let value: string | undefined;
+    await act(async () => {
+      value = await result.current.gate(action);
+    });
+
+    expect(mockSubmitRequestToBackground).not.toHaveBeenCalled();
+    expect(action).toHaveBeenCalledTimes(1);
+    expect(value).toBe('allowed');
+  });
+
+  it('prefetches wallet compliance when enabled', async () => {
+    mockSubmitRequestToBackground.mockResolvedValueOnce([
+      getStatus(ADDRESS, false),
+    ]);
+
+    renderHook(() => useComplianceGate(ADDRESS), {
+      wrapper: getWrapper(),
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+      'complianceCheckWalletsCompliance',
+      [[ADDRESS]],
+    );
+  });
+
+  it('blocks the action and shows access-restricted UX for a blocked result', async () => {
+    mockSubmitRequestToBackground.mockResolvedValueOnce([
+      getStatus(ADDRESS, true),
+    ]);
+    const action = jest.fn();
+    const { result } = renderHook(() => useComplianceGate(ADDRESS), {
+      wrapper: getWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.gate(action);
+    });
+
+    expect(action).not.toHaveBeenCalled();
+    expect(mockShowAccessRestrictedModal).toHaveBeenCalledTimes(1);
+  });
+
+  it('blocks when any address in an array is blocked', async () => {
+    mockSubmitRequestToBackground.mockResolvedValueOnce([
+      getStatus(ADDRESS, false),
+      getStatus(BLOCKED_ADDRESS, true),
+    ]);
+    const action = jest.fn();
+    const { result } = renderHook(
+      () => useComplianceGate([ADDRESS, BLOCKED_ADDRESS]),
+      {
+        wrapper: getWrapper(),
+      },
+    );
+
+    await act(async () => {
+      await result.current.gate(action);
+    });
+
+    expect(action).not.toHaveBeenCalled();
+    expect(mockShowAccessRestrictedModal).toHaveBeenCalledTimes(1);
+  });
+
+  it('waits for the in-flight prefetch before running the action', async () => {
+    const deferred = createDeferred<WalletComplianceStatus[]>();
+    mockSubmitRequestToBackground.mockReturnValueOnce(deferred.promise);
+    const action = jest.fn();
+    const { result } = renderHook(() => useComplianceGate(ADDRESS), {
+      wrapper: getWrapper(),
+    });
+
+    const gatePromise = result.current.gate(action);
+
+    expect(action).not.toHaveBeenCalled();
+
+    await act(async () => {
+      deferred.resolve([getStatus(ADDRESS, false)]);
+      await gatePromise;
+    });
+
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails open when the compliance API rejects', async () => {
+    mockSubmitRequestToBackground.mockRejectedValueOnce(new Error('offline'));
+    const action = jest.fn().mockReturnValue('allowed');
+    const { result } = renderHook(() => useComplianceGate(ADDRESS), {
+      wrapper: getWrapper(),
+    });
+
+    let value: string | undefined;
+    await act(async () => {
+      value = await result.current.gate(action);
+    });
+
+    expect(action).toHaveBeenCalledTimes(1);
+    expect(value).toBe('allowed');
+    expect(mockShowAccessRestrictedModal).not.toHaveBeenCalled();
+  });
+
+  it('resets stale blocked results after the address changes', async () => {
+    mockSubmitRequestToBackground
+      .mockResolvedValueOnce([getStatus(BLOCKED_ADDRESS, true)])
+      .mockResolvedValueOnce([getStatus(ADDRESS, false)]);
+    const action = jest.fn();
+    const { result, rerender } = renderHook<
+      { address: string },
+      ReturnType<typeof useComplianceGate>
+    >(
+      ({ address }) => useComplianceGate(address),
+      {
+        initialProps: { address: BLOCKED_ADDRESS },
+        wrapper: getWrapper(),
+      },
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    rerender({ address: ADDRESS });
+
+    await act(async () => {
+      await result.current.gate(action);
+    });
+
+    expect(action).toHaveBeenCalledTimes(1);
+    expect(mockShowAccessRestrictedModal).not.toHaveBeenCalled();
+  });
+});

--- a/ui/components/app/compliance/useComplianceGate.test.tsx
+++ b/ui/components/app/compliance/useComplianceGate.test.tsx
@@ -226,13 +226,10 @@ describe('useComplianceGate', () => {
     const { result, rerender } = renderHook<
       { address: string },
       ReturnType<typeof useComplianceGate>
-    >(
-      ({ address }) => useComplianceGate(address),
-      {
-        initialProps: { address: BLOCKED_ADDRESS },
-        wrapper: getWrapper(),
-      },
-    );
+    >(({ address }) => useComplianceGate(address), {
+      initialProps: { address: BLOCKED_ADDRESS },
+      wrapper: getWrapper(),
+    });
 
     await act(async () => {
       await Promise.resolve();

--- a/ui/components/app/compliance/useComplianceGate.test.tsx
+++ b/ui/components/app/compliance/useComplianceGate.test.tsx
@@ -195,6 +195,32 @@ describe('useComplianceGate', () => {
     expect(mockShowAccessRestrictedModal).not.toHaveBeenCalled();
   });
 
+  it('retries compliance checks after a rejected prefetch', async () => {
+    mockSubmitRequestToBackground
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValueOnce([getStatus(ADDRESS, true)]);
+    const firstAction = jest.fn().mockReturnValue('allowed');
+    const secondAction = jest.fn();
+    const { result } = renderHook(() => useComplianceGate(ADDRESS), {
+      wrapper: getWrapper(),
+    });
+
+    let value: string | undefined;
+    await act(async () => {
+      value = await result.current.gate(firstAction);
+    });
+
+    await act(async () => {
+      await result.current.gate(secondAction);
+    });
+
+    expect(firstAction).toHaveBeenCalledTimes(1);
+    expect(value).toBe('allowed');
+    expect(secondAction).not.toHaveBeenCalled();
+    expect(mockSubmitRequestToBackground).toHaveBeenCalledTimes(2);
+    expect(mockShowAccessRestrictedModal).toHaveBeenCalledTimes(1);
+  });
+
   it('fails open when the compliance API rejects even if cached state is blocked', async () => {
     mockSubmitRequestToBackground.mockRejectedValueOnce(new Error('offline'));
     const action = jest.fn().mockReturnValue('allowed');

--- a/ui/components/app/compliance/useComplianceGate.ts
+++ b/ui/components/app/compliance/useComplianceGate.ts
@@ -1,0 +1,101 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useSelector } from 'react-redux';
+import type { WalletComplianceStatus } from '@metamask/compliance-controller';
+import { submitRequestToBackground } from '../../../store/background-connection';
+import {
+  getIsComplianceEnabled,
+  selectAreAnyWalletsBlocked,
+} from '../../../selectors/compliance';
+import { useAccessRestrictedModal } from './access-restricted-context';
+
+type AddressInput = string | string[];
+
+export function useComplianceGate(address?: AddressInput) {
+  const addressKey = useMemo(() => {
+    if (!address) {
+      return '';
+    }
+    return Array.isArray(address) ? address.join(',') : address;
+  }, [address]);
+
+  const addresses = useMemo(
+    () => (addressKey ? addressKey.split(',').filter(Boolean) : []),
+    [addressKey],
+  );
+
+  const isComplianceEnabled = useSelector(getIsComplianceEnabled);
+  const rawIsBlocked = useSelector(selectAreAnyWalletsBlocked(addresses));
+  const { showAccessRestrictedModal } = useAccessRestrictedModal();
+  const isBlocked = isComplianceEnabled && rawIsBlocked;
+
+  const prefetchRef = useRef<Promise<WalletComplianceStatus[] | undefined> | null>(
+    null,
+  );
+  const prefetchBlockedRef = useRef(false);
+
+  const checkCompliance = useCallback(async () => {
+    if (addresses.length === 0) {
+      return undefined;
+    }
+
+    return await submitRequestToBackground<WalletComplianceStatus[]>(
+      'complianceCheckWalletsCompliance',
+      [addresses],
+    );
+  }, [addresses]);
+
+  useEffect(() => {
+    if (!isComplianceEnabled || addresses.length === 0) {
+      prefetchBlockedRef.current = false;
+      prefetchRef.current = null;
+      return;
+    }
+
+    prefetchBlockedRef.current = false;
+    const request = checkCompliance();
+    prefetchRef.current = request;
+    request
+      .then((results) => {
+        prefetchBlockedRef.current =
+          results?.some((result) => result.blocked) ?? false;
+      })
+      .catch(() => {
+        prefetchBlockedRef.current = false;
+      });
+  }, [addresses.length, checkCompliance, isComplianceEnabled]);
+
+  const gate = useCallback(
+    async <ResultValue>(
+      action: () => ResultValue | Promise<ResultValue>,
+    ): Promise<ResultValue | undefined> => {
+      if (!isComplianceEnabled) {
+        return await action();
+      }
+
+      let latestResults: WalletComplianceStatus[] | undefined;
+      try {
+        latestResults = prefetchRef.current
+          ? await prefetchRef.current
+          : await checkCompliance();
+      } catch {
+        prefetchBlockedRef.current = false;
+      }
+
+      const isLatestResultBlocked =
+        latestResults?.some((result) => result.blocked) ?? false;
+
+      if (isBlocked || prefetchBlockedRef.current || isLatestResultBlocked) {
+        showAccessRestrictedModal();
+        return undefined;
+      }
+
+      return await action();
+    },
+    [checkCompliance, isBlocked, isComplianceEnabled, showAccessRestrictedModal],
+  );
+
+  return useMemo(
+    () => ({ isComplianceEnabled, isBlocked, checkCompliance, gate }),
+    [isComplianceEnabled, isBlocked, checkCompliance, gate],
+  );
+}

--- a/ui/components/app/compliance/useComplianceGate.ts
+++ b/ui/components/app/compliance/useComplianceGate.ts
@@ -68,6 +68,9 @@ export function useComplianceGate(address?: AddressInput) {
       .catch(() => {
         if (requestIdRef.current === requestId) {
           latestSuccessfulBlockedRef.current = false;
+          if (prefetchRef.current === request) {
+            prefetchRef.current = null;
+          }
         }
       });
   }, [addresses.length, checkCompliance, isComplianceEnabled]);
@@ -81,12 +84,14 @@ export function useComplianceGate(address?: AddressInput) {
       }
 
       let latestResults: WalletComplianceStatus[] | undefined;
+      const prefetch = prefetchRef.current;
       try {
-        latestResults = prefetchRef.current
-          ? await prefetchRef.current
-          : await checkCompliance();
+        latestResults = prefetch ? await prefetch : await checkCompliance();
       } catch {
         latestSuccessfulBlockedRef.current = false;
+        if (prefetchRef.current === prefetch) {
+          prefetchRef.current = null;
+        }
       }
 
       const isLatestResultBlocked =

--- a/ui/components/app/compliance/useComplianceGate.ts
+++ b/ui/components/app/compliance/useComplianceGate.ts
@@ -28,9 +28,9 @@ export function useComplianceGate(address?: AddressInput) {
   const { showAccessRestrictedModal } = useAccessRestrictedModal();
   const isBlocked = isComplianceEnabled && rawIsBlocked;
 
-  const prefetchRef = useRef<Promise<WalletComplianceStatus[] | undefined> | null>(
-    null,
-  );
+  const prefetchRef = useRef<Promise<
+    WalletComplianceStatus[] | undefined
+  > | null>(null);
   const latestSuccessfulBlockedRef = useRef(false);
   const requestIdRef = useRef(0);
 

--- a/ui/components/app/compliance/useComplianceGate.ts
+++ b/ui/components/app/compliance/useComplianceGate.ts
@@ -31,7 +31,8 @@ export function useComplianceGate(address?: AddressInput) {
   const prefetchRef = useRef<Promise<WalletComplianceStatus[] | undefined> | null>(
     null,
   );
-  const prefetchBlockedRef = useRef(false);
+  const latestSuccessfulBlockedRef = useRef(false);
+  const requestIdRef = useRef(0);
 
   const checkCompliance = useCallback(async () => {
     if (addresses.length === 0) {
@@ -46,21 +47,28 @@ export function useComplianceGate(address?: AddressInput) {
 
   useEffect(() => {
     if (!isComplianceEnabled || addresses.length === 0) {
-      prefetchBlockedRef.current = false;
+      requestIdRef.current += 1;
+      latestSuccessfulBlockedRef.current = false;
       prefetchRef.current = null;
       return;
     }
 
-    prefetchBlockedRef.current = false;
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
+    latestSuccessfulBlockedRef.current = false;
     const request = checkCompliance();
     prefetchRef.current = request;
     request
       .then((results) => {
-        prefetchBlockedRef.current =
-          results?.some((result) => result.blocked) ?? false;
+        if (requestIdRef.current === requestId) {
+          latestSuccessfulBlockedRef.current =
+            results?.some((result) => result.blocked) ?? false;
+        }
       })
       .catch(() => {
-        prefetchBlockedRef.current = false;
+        if (requestIdRef.current === requestId) {
+          latestSuccessfulBlockedRef.current = false;
+        }
       });
   }, [addresses.length, checkCompliance, isComplianceEnabled]);
 
@@ -78,20 +86,20 @@ export function useComplianceGate(address?: AddressInput) {
           ? await prefetchRef.current
           : await checkCompliance();
       } catch {
-        prefetchBlockedRef.current = false;
+        latestSuccessfulBlockedRef.current = false;
       }
 
       const isLatestResultBlocked =
         latestResults?.some((result) => result.blocked) ?? false;
 
-      if (isBlocked || prefetchBlockedRef.current || isLatestResultBlocked) {
+      if (latestSuccessfulBlockedRef.current || isLatestResultBlocked) {
         showAccessRestrictedModal();
         return undefined;
       }
 
       return await action();
     },
-    [checkCompliance, isBlocked, isComplianceEnabled, showAccessRestrictedModal],
+    [checkCompliance, isComplianceEnabled, showAccessRestrictedModal],
   );
 
   return useMemo(

--- a/ui/components/app/compliance/useSelectedAccountComplianceGate.ts
+++ b/ui/components/app/compliance/useSelectedAccountComplianceGate.ts
@@ -1,0 +1,9 @@
+import { useSelector } from 'react-redux';
+import { getSelectedInternalAccount } from '../../../selectors/accounts';
+import { useComplianceGate } from './useComplianceGate';
+
+export function useSelectedAccountComplianceGate() {
+  const selectedAccount = useSelector(getSelectedInternalAccount);
+
+  return useComplianceGate(selectedAccount?.address ?? '');
+}

--- a/ui/components/app/perps/close-position/close-position-modal.tsx
+++ b/ui/components/app/perps/close-position/close-position-modal.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useMemo, useCallback, useEffect } from 'react';
-import { useSelector } from 'react-redux';
 import {
   Box,
   BoxBackgroundColor,
@@ -57,8 +56,7 @@ import {
   type PerpsToastKeyConfig,
 } from '../perps-toast';
 import { PerpsGeoBlockModal } from '../perps-geo-block-modal';
-import { getSelectedInternalAccount } from '../../../../selectors/accounts';
-import { useComplianceGate } from '../../compliance';
+import { useSelectedAccountComplianceGate } from '../../compliance';
 import type { Position } from '../types';
 
 type ClosePositionParams = {
@@ -253,9 +251,8 @@ export const ClosePositionModal: React.FC<ClosePositionModalProps> = ({
   sizeDecimals,
 }) => {
   const t = useI18nContext() as CloseToastTranslation;
-  const selectedAccount = useSelector(getSelectedInternalAccount);
   const { isEligible } = usePerpsEligibility();
-  const { gate } = useComplianceGate(selectedAccount?.address ?? '');
+  const { gate } = useSelectedAccountComplianceGate();
   const { track } = usePerpsEventTracking();
   const [isGeoBlockModalOpen, setIsGeoBlockModalOpen] = useState(false);
   usePerpsEventTracking({

--- a/ui/components/app/perps/close-position/close-position-modal.tsx
+++ b/ui/components/app/perps/close-position/close-position-modal.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useMemo, useCallback, useEffect } from 'react';
+import { useSelector } from 'react-redux';
 import {
   Box,
   BoxBackgroundColor,
@@ -56,6 +57,8 @@ import {
   type PerpsToastKeyConfig,
 } from '../perps-toast';
 import { PerpsGeoBlockModal } from '../perps-geo-block-modal';
+import { getSelectedInternalAccount } from '../../../../selectors/accounts';
+import { useComplianceGate } from '../../compliance';
 import type { Position } from '../types';
 
 type ClosePositionParams = {
@@ -250,7 +253,9 @@ export const ClosePositionModal: React.FC<ClosePositionModalProps> = ({
   sizeDecimals,
 }) => {
   const t = useI18nContext() as CloseToastTranslation;
+  const selectedAccount = useSelector(getSelectedInternalAccount);
   const { isEligible } = usePerpsEligibility();
+  const { gate } = useComplianceGate(selectedAccount?.address ?? '');
   const { track } = usePerpsEventTracking();
   const [isGeoBlockModalOpen, setIsGeoBlockModalOpen] = useState(false);
   usePerpsEventTracking({
@@ -363,107 +368,110 @@ export const ClosePositionModal: React.FC<ClosePositionModalProps> = ({
     if (isSubmitDisabled) {
       return;
     }
-    if (!isEligible) {
-      setIsGeoBlockModalOpen(true);
-      return;
-    }
+    await gate(async () => {
+      if (!isEligible) {
+        setIsGeoBlockModalOpen(true);
+        return;
+      }
 
-    setIsSubmitting(true);
-    setError(null);
+      setIsSubmitting(true);
+      setError(null);
 
-    replacePerpsToastByKey(
-      getCloseInProgressToastConfig({
-        isPartialClose,
-        positionSize: position.size,
-        closeSize,
-        displayName,
-        t,
-        formatNumber,
-      }),
-    );
-
-    try {
-      onClose();
-      const result = await submitRequestToBackground<{
-        success: boolean;
-        error?: string;
-      }>('perpsClosePosition', [
-        buildCloseRequestParams({
-          symbol: position.symbol,
-          currentPrice,
+      replacePerpsToastByKey(
+        getCloseInProgressToastConfig({
           isPartialClose,
+          positionSize: position.size,
           closeSize,
+          displayName,
+          t,
+          formatNumber,
         }),
-      ]);
-      if (!result.success) {
-        const message = result.error || 'Failed to close position';
+      );
+
+      try {
+        onClose();
+        const result = await submitRequestToBackground<{
+          success: boolean;
+          error?: string;
+        }>('perpsClosePosition', [
+          buildCloseRequestParams({
+            symbol: position.symbol,
+            currentPrice,
+            isPartialClose,
+            closeSize,
+          }),
+        ]);
+        if (!result.success) {
+          const message = result.error || 'Failed to close position';
+          track(MetaMetricsEventName.PerpsPositionCloseTransaction, {
+            [PERPS_EVENT_PROPERTY.ASSET]: position.symbol,
+            [PERPS_EVENT_PROPERTY.STATUS]: PERPS_EVENT_VALUE.STATUS.FAILED,
+            [PERPS_EVENT_PROPERTY.FAILURE_REASON]: message,
+            [PERPS_EVENT_PROPERTY.ERROR_MESSAGE]: message,
+            [PERPS_EVENT_PROPERTY.SIZE]: String(closeNotionalUsd),
+            [PERPS_EVENT_PROPERTY.METAMASK_FEE]: String(estimatedFees),
+          });
+          track(MetaMetricsEventName.PerpsError, {
+            [PERPS_EVENT_PROPERTY.ERROR_TYPE]:
+              PERPS_EVENT_VALUE.ERROR_TYPE.BACKEND,
+            [PERPS_EVENT_PROPERTY.ERROR_MESSAGE]: message,
+          });
+          const { errorMessage, toast } = getCloseFailureToastConfig({
+            error: new Error(message),
+            isPartialClose,
+            t,
+            formatFiat,
+          });
+          setError(errorMessage);
+          replacePerpsToastByKey(toast);
+          return;
+        }
+        track(MetaMetricsEventName.PerpsPositionCloseTransaction, {
+          [PERPS_EVENT_PROPERTY.ASSET]: position.symbol,
+          [PERPS_EVENT_PROPERTY.STATUS]: PERPS_EVENT_VALUE.STATUS.SUCCESS,
+          [PERPS_EVENT_PROPERTY.PERCENTAGE_CLOSED]: closePercent,
+          [PERPS_EVENT_PROPERTY.SIZE]: String(closeNotionalUsd),
+          [PERPS_EVENT_PROPERTY.METAMASK_FEE]: String(estimatedFees),
+        });
+        replacePerpsToastByKey(
+          getCloseSuccessToastConfig({
+            isPartialClose,
+            position,
+            t,
+            formatPercentWithMinThreshold,
+          }),
+        );
+      } catch (err) {
+        const errMessage =
+          err instanceof Error ? err.message : 'An unknown error occurred';
         track(MetaMetricsEventName.PerpsPositionCloseTransaction, {
           [PERPS_EVENT_PROPERTY.ASSET]: position.symbol,
           [PERPS_EVENT_PROPERTY.STATUS]: PERPS_EVENT_VALUE.STATUS.FAILED,
-          [PERPS_EVENT_PROPERTY.FAILURE_REASON]: message,
-          [PERPS_EVENT_PROPERTY.ERROR_MESSAGE]: message,
+          [PERPS_EVENT_PROPERTY.FAILURE_REASON]: errMessage,
+          [PERPS_EVENT_PROPERTY.ERROR_MESSAGE]: errMessage,
           [PERPS_EVENT_PROPERTY.SIZE]: String(closeNotionalUsd),
           [PERPS_EVENT_PROPERTY.METAMASK_FEE]: String(estimatedFees),
         });
         track(MetaMetricsEventName.PerpsError, {
-          [PERPS_EVENT_PROPERTY.ERROR_TYPE]:
-            PERPS_EVENT_VALUE.ERROR_TYPE.BACKEND,
-          [PERPS_EVENT_PROPERTY.ERROR_MESSAGE]: message,
+          [PERPS_EVENT_PROPERTY.ERROR_TYPE]: PERPS_EVENT_VALUE.ERROR_TYPE.BACKEND,
+          [PERPS_EVENT_PROPERTY.ERROR_MESSAGE]: errMessage,
         });
+
         const { errorMessage, toast } = getCloseFailureToastConfig({
-          error: new Error(message),
+          error: err,
           isPartialClose,
           t,
           formatFiat,
         });
         setError(errorMessage);
         replacePerpsToastByKey(toast);
-        return;
+      } finally {
+        setIsSubmitting(false);
       }
-      track(MetaMetricsEventName.PerpsPositionCloseTransaction, {
-        [PERPS_EVENT_PROPERTY.ASSET]: position.symbol,
-        [PERPS_EVENT_PROPERTY.STATUS]: PERPS_EVENT_VALUE.STATUS.SUCCESS,
-        [PERPS_EVENT_PROPERTY.PERCENTAGE_CLOSED]: closePercent,
-        [PERPS_EVENT_PROPERTY.SIZE]: String(closeNotionalUsd),
-        [PERPS_EVENT_PROPERTY.METAMASK_FEE]: String(estimatedFees),
-      });
-      replacePerpsToastByKey(
-        getCloseSuccessToastConfig({
-          isPartialClose,
-          position,
-          t,
-          formatPercentWithMinThreshold,
-        }),
-      );
-    } catch (err) {
-      const errMessage =
-        err instanceof Error ? err.message : 'An unknown error occurred';
-      track(MetaMetricsEventName.PerpsPositionCloseTransaction, {
-        [PERPS_EVENT_PROPERTY.ASSET]: position.symbol,
-        [PERPS_EVENT_PROPERTY.STATUS]: PERPS_EVENT_VALUE.STATUS.FAILED,
-        [PERPS_EVENT_PROPERTY.FAILURE_REASON]: errMessage,
-        [PERPS_EVENT_PROPERTY.ERROR_MESSAGE]: errMessage,
-        [PERPS_EVENT_PROPERTY.SIZE]: String(closeNotionalUsd),
-        [PERPS_EVENT_PROPERTY.METAMASK_FEE]: String(estimatedFees),
-      });
-      track(MetaMetricsEventName.PerpsError, {
-        [PERPS_EVENT_PROPERTY.ERROR_TYPE]: PERPS_EVENT_VALUE.ERROR_TYPE.BACKEND,
-        [PERPS_EVENT_PROPERTY.ERROR_MESSAGE]: errMessage,
-      });
-
-      const { errorMessage, toast } = getCloseFailureToastConfig({
-        error: err,
-        isPartialClose,
-        t,
-        formatFiat,
-      });
-      setError(errorMessage);
-      replacePerpsToastByKey(toast);
-    } finally {
-      setIsSubmitting(false);
-    }
+    });
   }, [
     isSubmitDisabled,
+    gate,
     isEligible,
     replacePerpsToastByKey,
     isPartialClose,

--- a/ui/components/app/perps/close-position/close-position-modal.tsx
+++ b/ui/components/app/perps/close-position/close-position-modal.tsx
@@ -450,7 +450,8 @@ export const ClosePositionModal: React.FC<ClosePositionModalProps> = ({
           [PERPS_EVENT_PROPERTY.METAMASK_FEE]: String(estimatedFees),
         });
         track(MetaMetricsEventName.PerpsError, {
-          [PERPS_EVENT_PROPERTY.ERROR_TYPE]: PERPS_EVENT_VALUE.ERROR_TYPE.BACKEND,
+          [PERPS_EVENT_PROPERTY.ERROR_TYPE]:
+            PERPS_EVENT_VALUE.ERROR_TYPE.BACKEND,
           [PERPS_EVENT_PROPERTY.ERROR_MESSAGE]: errMessage,
         });
 

--- a/ui/components/app/perps/edit-margin/edit-margin-modal-content.tsx
+++ b/ui/components/app/perps/edit-margin/edit-margin-modal-content.tsx
@@ -333,7 +333,8 @@ export const EditMarginModalContent: React.FC<EditMarginModalContentProps> = ({
           [PERPS_EVENT_PROPERTY.SIZE]: rawMarginAmount,
         });
         track(MetaMetricsEventName.PerpsError, {
-          [PERPS_EVENT_PROPERTY.ERROR_TYPE]: PERPS_EVENT_VALUE.ERROR_TYPE.BACKEND,
+          [PERPS_EVENT_PROPERTY.ERROR_TYPE]:
+            PERPS_EVENT_VALUE.ERROR_TYPE.BACKEND,
           [PERPS_EVENT_PROPERTY.ERROR_MESSAGE]: errorMessage,
         });
 

--- a/ui/components/app/perps/edit-margin/edit-margin-modal-content.tsx
+++ b/ui/components/app/perps/edit-margin/edit-margin-modal-content.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback, useEffect, useMemo } from 'react';
+import { useSelector } from 'react-redux';
 import {
   Box,
   BoxFlexDirection,
@@ -42,6 +43,8 @@ import {
 } from '../../../../../shared/constants/perps-events';
 import { PERPS_TOAST_KEYS, usePerpsToast } from '../perps-toast';
 import { PerpsGeoBlockModal } from '../perps-geo-block-modal';
+import { getSelectedInternalAccount } from '../../../../selectors/accounts';
+import { useComplianceGate } from '../../compliance';
 import type { Position, AccountState, PerpsBackgroundResult } from '../types';
 import { PerpsSlider } from '../perps-slider';
 import { getDisplayName } from '../utils';
@@ -97,7 +100,9 @@ export const EditMarginModalContent: React.FC<EditMarginModalContentProps> = ({
   onSavingChange,
 }) => {
   const t = useI18nContext();
+  const selectedAccount = useSelector(getSelectedInternalAccount);
   const { isEligible } = usePerpsEligibility();
+  const { gate } = useComplianceGate(selectedAccount?.address ?? '');
   const { replacePerpsToastByKey } = usePerpsToast();
   const { track } = usePerpsEventTracking();
   const [isGeoBlockModalOpen, setIsGeoBlockModalOpen] = useState(false);
@@ -249,109 +254,112 @@ export const EditMarginModalContent: React.FC<EditMarginModalContentProps> = ({
   );
 
   const handleSaveMargin = useCallback(async () => {
-    if (!isEligible) {
-      setIsGeoBlockModalOpen(true);
-      return;
-    }
-    if (!isValid) {
-      return;
-    }
-
-    const rawMarginAmount = marginAmount.replaceAll(',', '');
-    const amountNum = Number.parseFloat(rawMarginAmount) || 0;
-    if (amountNum <= 0) {
-      return;
-    }
-
-    setIsSaving(true);
-    onSavingChange?.(true);
-
-    try {
-      const signedAmount =
-        marginMode === 'add' ? rawMarginAmount : `-${rawMarginAmount}`;
-
-      const result = await submitRequestToBackground<PerpsBackgroundResult>(
-        'perpsUpdateMargin',
-        [
-          {
-            symbol: position.symbol,
-            amount: signedAmount,
-          },
-        ],
-      );
-
-      if (!result.success) {
-        throw new Error(result.error || 'Failed to update margin');
+    await gate(async () => {
+      if (!isEligible) {
+        setIsGeoBlockModalOpen(true);
+        return;
+      }
+      if (!isValid) {
+        return;
       }
 
-      const riskType =
-        marginMode === 'add'
-          ? PERPS_EVENT_VALUE.RISK_MANAGEMENT_TYPE.ADD_MARGIN
-          : PERPS_EVENT_VALUE.RISK_MANAGEMENT_TYPE.REMOVE_MARGIN;
-      track(MetaMetricsEventName.PerpsRiskManagement, {
-        [PERPS_EVENT_PROPERTY.ASSET]: position.symbol,
-        [PERPS_EVENT_PROPERTY.STATUS]: PERPS_EVENT_VALUE.STATUS.SUCCESS,
-        [PERPS_EVENT_PROPERTY.TYPE]: riskType,
-        [PERPS_EVENT_PROPERTY.SIZE]: rawMarginAmount,
-      });
+      const rawMarginAmount = marginAmount.replaceAll(',', '');
+      const amountNum = Number.parseFloat(rawMarginAmount) || 0;
+      if (amountNum <= 0) {
+        return;
+      }
 
-      const streamManager = getPerpsStreamManager();
-      const freshPositions = await submitRequestToBackground<PerpsPosition[]>(
-        'perpsGetPositions',
-        [{ skipCache: true }],
-      );
-      streamManager.pushPositionsWithOverrides(freshPositions);
-      const displaySymbol = getDisplayName(position.symbol);
+      setIsSaving(true);
+      onSavingChange?.(true);
 
-      replacePerpsToastByKey({
-        key:
-          marginMode === 'add'
-            ? PERPS_TOAST_KEYS.MARGIN_ADD_SUCCESS
-            : PERPS_TOAST_KEYS.MARGIN_REMOVE_SUCCESS,
-        messageParams: [`$${marginAmount}`, displaySymbol],
-      });
+      try {
+        const signedAmount =
+          marginMode === 'add' ? rawMarginAmount : `-${rawMarginAmount}`;
 
-      setMarginAmount('');
-      onClose();
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : 'An unknown error occurred';
-
-      const riskType =
-        marginMode === 'add'
-          ? PERPS_EVENT_VALUE.RISK_MANAGEMENT_TYPE.ADD_MARGIN
-          : PERPS_EVENT_VALUE.RISK_MANAGEMENT_TYPE.REMOVE_MARGIN;
-      track(MetaMetricsEventName.PerpsRiskManagement, {
-        [PERPS_EVENT_PROPERTY.ASSET]: position.symbol,
-        [PERPS_EVENT_PROPERTY.STATUS]: PERPS_EVENT_VALUE.STATUS.FAILED,
-        [PERPS_EVENT_PROPERTY.FAILURE_REASON]: errorMessage,
-        [PERPS_EVENT_PROPERTY.ERROR_MESSAGE]: errorMessage,
-        [PERPS_EVENT_PROPERTY.TYPE]: riskType,
-        [PERPS_EVENT_PROPERTY.SIZE]: rawMarginAmount,
-      });
-      track(MetaMetricsEventName.PerpsError, {
-        [PERPS_EVENT_PROPERTY.ERROR_TYPE]: PERPS_EVENT_VALUE.ERROR_TYPE.BACKEND,
-        [PERPS_EVENT_PROPERTY.ERROR_MESSAGE]: errorMessage,
-      });
-
-      const normalizedErrorMessage = errorMessage.trim();
-      const shouldUseFallbackDescription =
-        normalizedErrorMessage.length === 0 ||
-        MARGIN_FAILED_FALLBACK_ERROR_PATTERNS.some((pattern) =>
-          pattern.test(normalizedErrorMessage),
+        const result = await submitRequestToBackground<PerpsBackgroundResult>(
+          'perpsUpdateMargin',
+          [
+            {
+              symbol: position.symbol,
+              amount: signedAmount,
+            },
+          ],
         );
 
-      replacePerpsToastByKey({
-        key: PERPS_TOAST_KEYS.MARGIN_ADJUSTMENT_FAILED,
-        description: shouldUseFallbackDescription
-          ? t('perpsToastMarginAdjustmentFailedDescriptionFallback')
-          : normalizedErrorMessage,
-      });
-    } finally {
-      setIsSaving(false);
-      onSavingChange?.(false);
-    }
+        if (!result.success) {
+          throw new Error(result.error || 'Failed to update margin');
+        }
+
+        const riskType =
+          marginMode === 'add'
+            ? PERPS_EVENT_VALUE.RISK_MANAGEMENT_TYPE.ADD_MARGIN
+            : PERPS_EVENT_VALUE.RISK_MANAGEMENT_TYPE.REMOVE_MARGIN;
+        track(MetaMetricsEventName.PerpsRiskManagement, {
+          [PERPS_EVENT_PROPERTY.ASSET]: position.symbol,
+          [PERPS_EVENT_PROPERTY.STATUS]: PERPS_EVENT_VALUE.STATUS.SUCCESS,
+          [PERPS_EVENT_PROPERTY.TYPE]: riskType,
+          [PERPS_EVENT_PROPERTY.SIZE]: rawMarginAmount,
+        });
+
+        const streamManager = getPerpsStreamManager();
+        const freshPositions = await submitRequestToBackground<PerpsPosition[]>(
+          'perpsGetPositions',
+          [{ skipCache: true }],
+        );
+        streamManager.pushPositionsWithOverrides(freshPositions);
+        const displaySymbol = getDisplayName(position.symbol);
+
+        replacePerpsToastByKey({
+          key:
+            marginMode === 'add'
+              ? PERPS_TOAST_KEYS.MARGIN_ADD_SUCCESS
+              : PERPS_TOAST_KEYS.MARGIN_REMOVE_SUCCESS,
+          messageParams: [`$${marginAmount}`, displaySymbol],
+        });
+
+        setMarginAmount('');
+        onClose();
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : 'An unknown error occurred';
+
+        const riskType =
+          marginMode === 'add'
+            ? PERPS_EVENT_VALUE.RISK_MANAGEMENT_TYPE.ADD_MARGIN
+            : PERPS_EVENT_VALUE.RISK_MANAGEMENT_TYPE.REMOVE_MARGIN;
+        track(MetaMetricsEventName.PerpsRiskManagement, {
+          [PERPS_EVENT_PROPERTY.ASSET]: position.symbol,
+          [PERPS_EVENT_PROPERTY.STATUS]: PERPS_EVENT_VALUE.STATUS.FAILED,
+          [PERPS_EVENT_PROPERTY.FAILURE_REASON]: errorMessage,
+          [PERPS_EVENT_PROPERTY.ERROR_MESSAGE]: errorMessage,
+          [PERPS_EVENT_PROPERTY.TYPE]: riskType,
+          [PERPS_EVENT_PROPERTY.SIZE]: rawMarginAmount,
+        });
+        track(MetaMetricsEventName.PerpsError, {
+          [PERPS_EVENT_PROPERTY.ERROR_TYPE]: PERPS_EVENT_VALUE.ERROR_TYPE.BACKEND,
+          [PERPS_EVENT_PROPERTY.ERROR_MESSAGE]: errorMessage,
+        });
+
+        const normalizedErrorMessage = errorMessage.trim();
+        const shouldUseFallbackDescription =
+          normalizedErrorMessage.length === 0 ||
+          MARGIN_FAILED_FALLBACK_ERROR_PATTERNS.some((pattern) =>
+            pattern.test(normalizedErrorMessage),
+          );
+
+        replacePerpsToastByKey({
+          key: PERPS_TOAST_KEYS.MARGIN_ADJUSTMENT_FAILED,
+          description: shouldUseFallbackDescription
+            ? t('perpsToastMarginAdjustmentFailedDescriptionFallback')
+            : normalizedErrorMessage,
+        });
+      } finally {
+        setIsSaving(false);
+        onSavingChange?.(false);
+      }
+    });
   }, [
+    gate,
     isEligible,
     marginMode,
     marginAmount,

--- a/ui/components/app/perps/edit-margin/edit-margin-modal-content.tsx
+++ b/ui/components/app/perps/edit-margin/edit-margin-modal-content.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useCallback, useEffect, useMemo } from 'react';
-import { useSelector } from 'react-redux';
 import {
   Box,
   BoxFlexDirection,
@@ -43,8 +42,7 @@ import {
 } from '../../../../../shared/constants/perps-events';
 import { PERPS_TOAST_KEYS, usePerpsToast } from '../perps-toast';
 import { PerpsGeoBlockModal } from '../perps-geo-block-modal';
-import { getSelectedInternalAccount } from '../../../../selectors/accounts';
-import { useComplianceGate } from '../../compliance';
+import { useSelectedAccountComplianceGate } from '../../compliance';
 import type { Position, AccountState, PerpsBackgroundResult } from '../types';
 import { PerpsSlider } from '../perps-slider';
 import { getDisplayName } from '../utils';
@@ -100,9 +98,8 @@ export const EditMarginModalContent: React.FC<EditMarginModalContentProps> = ({
   onSavingChange,
 }) => {
   const t = useI18nContext();
-  const selectedAccount = useSelector(getSelectedInternalAccount);
   const { isEligible } = usePerpsEligibility();
-  const { gate } = useComplianceGate(selectedAccount?.address ?? '');
+  const { gate } = useSelectedAccountComplianceGate();
   const { replacePerpsToastByKey } = usePerpsToast();
   const { track } = usePerpsEventTracking();
   const [isGeoBlockModalOpen, setIsGeoBlockModalOpen] = useState(false);

--- a/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.tsx
+++ b/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useSelector } from 'react-redux';
 import {
   twMerge,
   TextVariant,
@@ -23,6 +24,8 @@ import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { useFormatters } from '../../../../hooks/useFormatters';
 import { usePerpsEligibility } from '../../../../hooks/perps';
 import { usePerpsLiveAccount } from '../../../../hooks/perps/stream';
+import { getSelectedInternalAccount } from '../../../../selectors/accounts';
+import { useComplianceGate } from '../../compliance';
 import { PerpsGeoBlockModal } from '../perps-geo-block-modal';
 import { PerpsControlBarSkeleton } from '../perps-skeletons';
 
@@ -71,6 +74,8 @@ export const PerpsBalanceDropdown: React.FC<PerpsBalanceDropdownProps> = ({
   const { account, isInitialLoading } = usePerpsLiveAccount();
   const { formatPercentWithMinThreshold } = useFormatters();
   const { isEligible } = usePerpsEligibility();
+  const selectedAccount = useSelector(getSelectedInternalAccount);
+  const { gate } = useComplianceGate(selectedAccount?.address ?? '');
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [isGeoBlockModalOpen, setIsGeoBlockModalOpen] = useState(false);
 
@@ -96,12 +101,16 @@ export const PerpsBalanceDropdown: React.FC<PerpsBalanceDropdownProps> = ({
   }, []);
 
   const handleAddFunds = useCallback(() => {
-    if (!isEligible) {
-      setIsGeoBlockModalOpen(true);
-      return;
-    }
-    invokePerpsBalanceAction(onAddFunds);
-  }, [isEligible, onAddFunds]);
+    gate(() => {
+      if (!isEligible) {
+        setIsGeoBlockModalOpen(true);
+        return;
+      }
+      invokePerpsBalanceAction(onAddFunds);
+    }).catch((error: unknown) => {
+      console.error(error);
+    });
+  }, [gate, isEligible, onAddFunds]);
 
   const handleWithdraw = useCallback(() => {
     invokePerpsBalanceAction(onWithdraw);

--- a/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.tsx
+++ b/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { useSelector } from 'react-redux';
 import {
   twMerge,
   TextVariant,
@@ -24,8 +23,7 @@ import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { useFormatters } from '../../../../hooks/useFormatters';
 import { usePerpsEligibility } from '../../../../hooks/perps';
 import { usePerpsLiveAccount } from '../../../../hooks/perps/stream';
-import { getSelectedInternalAccount } from '../../../../selectors/accounts';
-import { useComplianceGate } from '../../compliance';
+import { useSelectedAccountComplianceGate } from '../../compliance';
 import { PerpsGeoBlockModal } from '../perps-geo-block-modal';
 import { PerpsControlBarSkeleton } from '../perps-skeletons';
 
@@ -74,8 +72,7 @@ export const PerpsBalanceDropdown: React.FC<PerpsBalanceDropdownProps> = ({
   const { account, isInitialLoading } = usePerpsLiveAccount();
   const { formatPercentWithMinThreshold } = useFormatters();
   const { isEligible } = usePerpsEligibility();
-  const selectedAccount = useSelector(getSelectedInternalAccount);
-  const { gate } = useComplianceGate(selectedAccount?.address ?? '');
+  const { gate } = useSelectedAccountComplianceGate();
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [isGeoBlockModalOpen, setIsGeoBlockModalOpen] = useState(false);
 

--- a/ui/components/app/perps/perps-view.tsx
+++ b/ui/components/app/perps/perps-view.tsx
@@ -26,7 +26,6 @@ import {
   selectTutorialCompleted,
   setTutorialModalOpen,
 } from '../../../ducks/perps';
-import { getSelectedInternalAccount } from '../../../selectors/accounts';
 
 import { usePerpsEligibility } from '../../../hooks/perps';
 import { getTradeableBalance } from '../../../hooks/perps/getTradeableBalance';
@@ -37,7 +36,7 @@ import {
   PERPS_EVENT_PROPERTY,
   PERPS_EVENT_VALUE,
 } from '../../../../shared/constants/perps-events';
-import { useComplianceGate } from '../compliance';
+import { useSelectedAccountComplianceGate } from '../compliance';
 import { PerpsGeoBlockModal } from './perps-geo-block-modal';
 import { usePerpsDepositConfirmation } from './hooks/usePerpsDepositConfirmation';
 import { usePerpsWithdrawNavigation } from './hooks/usePerpsWithdrawNavigation';
@@ -73,9 +72,8 @@ export const PerpsView: React.FC = () => {
   const isFirstTimeUser = useSelector(selectPerpsIsFirstTimeUser);
   const isTestnet = useSelector(selectPerpsIsTestnet);
   const tutorialCompleted = useSelector(selectTutorialCompleted);
-  const selectedAccount = useSelector(getSelectedInternalAccount);
   const { isEligible } = usePerpsEligibility();
-  const { gate } = useComplianceGate(selectedAccount?.address ?? '');
+  const { gate } = useSelectedAccountComplianceGate();
   const { trigger: triggerDeposit } = usePerpsDepositConfirmation();
   const { trigger: triggerWithdraw } = usePerpsWithdrawNavigation();
   const [isCloseAllPending, setIsCloseAllPending] = useState(false);

--- a/ui/components/app/perps/perps-view.tsx
+++ b/ui/components/app/perps/perps-view.tsx
@@ -26,6 +26,7 @@ import {
   selectTutorialCompleted,
   setTutorialModalOpen,
 } from '../../../ducks/perps';
+import { getSelectedInternalAccount } from '../../../selectors/accounts';
 
 import { usePerpsEligibility } from '../../../hooks/perps';
 import { getTradeableBalance } from '../../../hooks/perps/getTradeableBalance';
@@ -36,6 +37,7 @@ import {
   PERPS_EVENT_PROPERTY,
   PERPS_EVENT_VALUE,
 } from '../../../../shared/constants/perps-events';
+import { useComplianceGate } from '../compliance';
 import { PerpsGeoBlockModal } from './perps-geo-block-modal';
 import { usePerpsDepositConfirmation } from './hooks/usePerpsDepositConfirmation';
 import { usePerpsWithdrawNavigation } from './hooks/usePerpsWithdrawNavigation';
@@ -71,7 +73,9 @@ export const PerpsView: React.FC = () => {
   const isFirstTimeUser = useSelector(selectPerpsIsFirstTimeUser);
   const isTestnet = useSelector(selectPerpsIsTestnet);
   const tutorialCompleted = useSelector(selectTutorialCompleted);
+  const selectedAccount = useSelector(getSelectedInternalAccount);
   const { isEligible } = usePerpsEligibility();
+  const { gate } = useComplianceGate(selectedAccount?.address ?? '');
   const { trigger: triggerDeposit } = usePerpsDepositConfirmation();
   const { trigger: triggerWithdraw } = usePerpsWithdrawNavigation();
   const [isCloseAllPending, setIsCloseAllPending] = useState(false);
@@ -138,35 +142,37 @@ export const PerpsView: React.FC = () => {
   }, []);
 
   const handleCloseAllPositions = useCallback(async () => {
-    if (!isEligible) {
-      setIsGeoBlockModalOpen(true);
-      return;
-    }
-    if (positions.length === 0) {
-      return;
-    }
-    setBatchActionError(null);
-    setIsCloseAllPending(true);
-    try {
-      const result = await submitRequestToBackground<BatchCloseResult>(
-        'perpsClosePositions',
-        [{ closeAll: true }],
-      );
-      if (!result?.success) {
-        setBatchActionError(t('somethingWentWrong'));
+    await gate(async () => {
+      if (!isEligible) {
+        setIsGeoBlockModalOpen(true);
         return;
       }
-      const fresh = await submitRequestToBackground<Position[]>(
-        'perpsGetPositions',
-        [],
-      );
-      applyPositionsSnapshot(fresh ?? []);
-    } catch {
-      setBatchActionError(t('somethingWentWrong'));
-    } finally {
-      setIsCloseAllPending(false);
-    }
-  }, [isEligible, applyPositionsSnapshot, positions.length, t]);
+      if (positions.length === 0) {
+        return;
+      }
+      setBatchActionError(null);
+      setIsCloseAllPending(true);
+      try {
+        const result = await submitRequestToBackground<BatchCloseResult>(
+          'perpsClosePositions',
+          [{ closeAll: true }],
+        );
+        if (!result?.success) {
+          setBatchActionError(t('somethingWentWrong'));
+          return;
+        }
+        const fresh = await submitRequestToBackground<Position[]>(
+          'perpsGetPositions',
+          [],
+        );
+        applyPositionsSnapshot(fresh ?? []);
+      } catch {
+        setBatchActionError(t('somethingWentWrong'));
+      } finally {
+        setIsCloseAllPending(false);
+      }
+    });
+  }, [gate, isEligible, applyPositionsSnapshot, positions.length, t]);
 
   const handleCancelAllOrders = useCallback(async () => {
     if (!isEligible) {

--- a/ui/components/app/perps/start-trade-cta/start-trade-cta.test.tsx
+++ b/ui/components/app/perps/start-trade-cta/start-trade-cta.test.tsx
@@ -3,13 +3,16 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { renderWithProvider } from '../../../../../test/lib/render-helpers-navigate';
 import configureStore from '../../../../store/store';
 import mockState from '../../../../../test/data/mock-state.json';
+import { AccessRestrictedProvider } from '../../compliance';
 import { StartTradeCta } from './start-trade-cta';
 
 const mockUsePerpsEligibility = jest.fn(() => ({ isEligible: true }));
+const mockTrack = jest.fn();
 const mockSubmitRequestToBackground = jest.fn();
 
 jest.mock('../../../../hooks/perps', () => ({
   usePerpsEligibility: () => mockUsePerpsEligibility(),
+  usePerpsEventTracking: () => ({ track: mockTrack }),
 }));
 
 jest.mock('../../../../store/background-connection', () => ({
@@ -27,6 +30,16 @@ const selectedAccountId = mockState.metamask.internalAccounts
 const selectedAccountAddress =
   mockState.metamask.internalAccounts.accounts[selectedAccountId].address;
 
+function renderStartTradeCta(
+  component: React.ReactElement,
+  store = mockStore,
+) {
+  return renderWithProvider(
+    <AccessRestrictedProvider>{component}</AccessRestrictedProvider>,
+    store,
+  );
+}
+
 describe('StartTradeCta', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -41,20 +54,20 @@ describe('StartTradeCta', () => {
   });
 
   it('renders the CTA button', () => {
-    renderWithProvider(<StartTradeCta />, mockStore);
+    renderStartTradeCta(<StartTradeCta />);
 
     expect(screen.getByTestId('start-new-trade-cta')).toBeInTheDocument();
   });
 
   it('displays the start new trade text', () => {
-    renderWithProvider(<StartTradeCta />, mockStore);
+    renderStartTradeCta(<StartTradeCta />);
 
     expect(screen.getByText(/start a new trade/iu)).toBeInTheDocument();
   });
 
   it('calls onPress when clicked', () => {
     const onPress = jest.fn();
-    renderWithProvider(<StartTradeCta onPress={onPress} />, mockStore);
+    renderStartTradeCta(<StartTradeCta onPress={onPress} />);
 
     const button = screen.getByTestId('start-new-trade-cta');
     fireEvent.click(button);
@@ -63,7 +76,7 @@ describe('StartTradeCta', () => {
   });
 
   it('renders without onPress callback', () => {
-    renderWithProvider(<StartTradeCta />, mockStore);
+    renderStartTradeCta(<StartTradeCta />);
 
     const button = screen.getByTestId('start-new-trade-cta');
     expect(() => fireEvent.click(button)).not.toThrow();
@@ -71,14 +84,14 @@ describe('StartTradeCta', () => {
 
   it('is clickable as a button', () => {
     const onPress = jest.fn();
-    renderWithProvider(<StartTradeCta onPress={onPress} />, mockStore);
+    renderStartTradeCta(<StartTradeCta onPress={onPress} />);
 
     const button = screen.getByTestId('start-new-trade-cta');
     expect(button).not.toBeDisabled();
   });
 
   it('renders the plus icon', () => {
-    renderWithProvider(<StartTradeCta />, mockStore);
+    renderStartTradeCta(<StartTradeCta />);
 
     const cta = screen.getByTestId('start-new-trade-cta');
     expect(cta).toBeInTheDocument();
@@ -86,7 +99,7 @@ describe('StartTradeCta', () => {
 
   it('handles multiple clicks', () => {
     const onPress = jest.fn();
-    renderWithProvider(<StartTradeCta onPress={onPress} />, mockStore);
+    renderStartTradeCta(<StartTradeCta onPress={onPress} />);
 
     const button = screen.getByTestId('start-new-trade-cta');
     fireEvent.click(button);
@@ -99,7 +112,7 @@ describe('StartTradeCta', () => {
   it('shows geo-block modal and does not call onPress when geo-blocked', () => {
     mockUsePerpsEligibility.mockReturnValue({ isEligible: false });
     const onPress = jest.fn();
-    renderWithProvider(<StartTradeCta onPress={onPress} />, mockStore);
+    renderStartTradeCta(<StartTradeCta onPress={onPress} />);
 
     fireEvent.click(screen.getByTestId('start-new-trade-cta'));
     expect(onPress).not.toHaveBeenCalled();
@@ -125,7 +138,7 @@ describe('StartTradeCta', () => {
     });
     const onPress = jest.fn();
 
-    renderWithProvider(<StartTradeCta onPress={onPress} />, blockedStore);
+    renderStartTradeCta(<StartTradeCta onPress={onPress} />, blockedStore);
 
     fireEvent.click(screen.getByTestId('start-new-trade-cta'));
 

--- a/ui/components/app/perps/start-trade-cta/start-trade-cta.test.tsx
+++ b/ui/components/app/perps/start-trade-cta/start-trade-cta.test.tsx
@@ -30,10 +30,7 @@ const selectedAccountId = mockState.metamask.internalAccounts
 const selectedAccountAddress =
   mockState.metamask.internalAccounts.accounts[selectedAccountId].address;
 
-function renderStartTradeCta(
-  component: React.ReactElement,
-  store = mockStore,
-) {
+function renderStartTradeCta(component: React.ReactElement, store = mockStore) {
   return renderWithProvider(
     <AccessRestrictedProvider>{component}</AccessRestrictedProvider>,
     store,

--- a/ui/components/app/perps/start-trade-cta/start-trade-cta.test.tsx
+++ b/ui/components/app/perps/start-trade-cta/start-trade-cta.test.tsx
@@ -1,14 +1,20 @@
 import React from 'react';
-import { fireEvent, screen } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { renderWithProvider } from '../../../../../test/lib/render-helpers-navigate';
 import configureStore from '../../../../store/store';
 import mockState from '../../../../../test/data/mock-state.json';
 import { StartTradeCta } from './start-trade-cta';
 
 const mockUsePerpsEligibility = jest.fn(() => ({ isEligible: true }));
+const mockSubmitRequestToBackground = jest.fn();
 
 jest.mock('../../../../hooks/perps', () => ({
   usePerpsEligibility: () => mockUsePerpsEligibility(),
+}));
+
+jest.mock('../../../../store/background-connection', () => ({
+  submitRequestToBackground: (...args: unknown[]) =>
+    mockSubmitRequestToBackground(...args),
 }));
 
 const mockStore = configureStore({
@@ -16,11 +22,22 @@ const mockStore = configureStore({
     ...mockState.metamask,
   },
 });
+const selectedAccountId = mockState.metamask.internalAccounts
+  .selectedAccount as keyof typeof mockState.metamask.internalAccounts.accounts;
+const selectedAccountAddress =
+  mockState.metamask.internalAccounts.accounts[selectedAccountId].address;
 
 describe('StartTradeCta', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUsePerpsEligibility.mockReturnValue({ isEligible: true });
+    mockSubmitRequestToBackground.mockResolvedValue([
+      {
+        address: selectedAccountAddress,
+        blocked: false,
+        checkedAt: '2026-05-05T00:00:00.000Z',
+      },
+    ]);
   });
 
   it('renders the CTA button', () => {
@@ -87,5 +104,37 @@ describe('StartTradeCta', () => {
     fireEvent.click(screen.getByTestId('start-new-trade-cta'));
     expect(onPress).not.toHaveBeenCalled();
     expect(screen.getByTestId('perps-geo-block-modal')).toBeInTheDocument();
+  });
+
+  it('does not call onPress when the selected wallet is compliance blocked', async () => {
+    mockSubmitRequestToBackground.mockResolvedValue([
+      {
+        address: selectedAccountAddress,
+        blocked: true,
+        checkedAt: '2026-05-05T00:00:00.000Z',
+      },
+    ]);
+    const blockedStore = configureStore({
+      metamask: {
+        ...mockState.metamask,
+        remoteFeatureFlags: {
+          ...mockState.metamask.remoteFeatureFlags,
+          complianceEnabled: true,
+        },
+      },
+    });
+    const onPress = jest.fn();
+
+    renderWithProvider(<StartTradeCta onPress={onPress} />, blockedStore);
+
+    fireEvent.click(screen.getByTestId('start-new-trade-cta'));
+
+    await waitFor(() => {
+      expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+        'complianceCheckWalletsCompliance',
+        [[selectedAccountAddress]],
+      );
+    });
+    expect(onPress).not.toHaveBeenCalled();
   });
 });

--- a/ui/components/app/perps/start-trade-cta/start-trade-cta.tsx
+++ b/ui/components/app/perps/start-trade-cta/start-trade-cta.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useCallback } from 'react';
-import { useSelector } from 'react-redux';
 import {
   Box,
   BoxFlexDirection,
@@ -16,8 +15,7 @@ import {
 } from '@metamask/design-system-react';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { usePerpsEligibility } from '../../../../hooks/perps';
-import { getSelectedInternalAccount } from '../../../../selectors/accounts';
-import { useComplianceGate } from '../../compliance';
+import { useSelectedAccountComplianceGate } from '../../compliance';
 import { PerpsGeoBlockModal } from '../perps-geo-block-modal';
 
 export type StartTradeCtaProps = {
@@ -35,8 +33,7 @@ export type StartTradeCtaProps = {
 export const StartTradeCta: React.FC<StartTradeCtaProps> = ({ onPress }) => {
   const t = useI18nContext();
   const { isEligible } = usePerpsEligibility();
-  const selectedAccount = useSelector(getSelectedInternalAccount);
-  const { gate } = useComplianceGate(selectedAccount?.address ?? '');
+  const { gate } = useSelectedAccountComplianceGate();
   const [isGeoBlockModalOpen, setIsGeoBlockModalOpen] = useState(false);
 
   const handleClick = useCallback(() => {

--- a/ui/components/app/perps/start-trade-cta/start-trade-cta.tsx
+++ b/ui/components/app/perps/start-trade-cta/start-trade-cta.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback } from 'react';
+import { useSelector } from 'react-redux';
 import {
   Box,
   BoxFlexDirection,
@@ -15,6 +16,8 @@ import {
 } from '@metamask/design-system-react';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { usePerpsEligibility } from '../../../../hooks/perps';
+import { getSelectedInternalAccount } from '../../../../selectors/accounts';
+import { useComplianceGate } from '../../compliance';
 import { PerpsGeoBlockModal } from '../perps-geo-block-modal';
 
 export type StartTradeCtaProps = {
@@ -32,15 +35,21 @@ export type StartTradeCtaProps = {
 export const StartTradeCta: React.FC<StartTradeCtaProps> = ({ onPress }) => {
   const t = useI18nContext();
   const { isEligible } = usePerpsEligibility();
+  const selectedAccount = useSelector(getSelectedInternalAccount);
+  const { gate } = useComplianceGate(selectedAccount?.address ?? '');
   const [isGeoBlockModalOpen, setIsGeoBlockModalOpen] = useState(false);
 
   const handleClick = useCallback(() => {
-    if (!isEligible) {
-      setIsGeoBlockModalOpen(true);
-      return;
-    }
-    onPress?.();
-  }, [isEligible, onPress]);
+    gate(() => {
+      if (!isEligible) {
+        setIsGeoBlockModalOpen(true);
+        return;
+      }
+      onPress?.();
+    }).catch((error: unknown) => {
+      console.error(error);
+    });
+  }, [gate, isEligible, onPress]);
 
   return (
     <>

--- a/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.tsx
+++ b/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.tsx
@@ -6,7 +6,6 @@ import React, {
   useLayoutEffect,
   useRef,
 } from 'react';
-import { useSelector } from 'react-redux';
 import {
   Box,
   BoxAlignItems,
@@ -41,10 +40,9 @@ import { usePerpsOrderFees } from '../../../../hooks/perps/usePerpsOrderFees';
 import { MetaMetricsEventName } from '../../../../../shared/constants/metametrics';
 import { submitRequestToBackground } from '../../../../store/background-connection';
 import { getPerpsStreamManager } from '../../../../providers/perps';
-import { getSelectedInternalAccount } from '../../../../selectors/accounts';
 import { usePerpsToast } from '../perps-toast';
 import { PERPS_TOAST_KEYS } from '../perps-toast/perps-toast-provider';
-import { useComplianceGate } from '../../compliance';
+import { useSelectedAccountComplianceGate } from '../../compliance';
 import type { Position, PerpsBackgroundResult } from '../types';
 import {
   normalizeTpslPrices,
@@ -108,10 +106,9 @@ export const UpdateTPSLModalContent: React.FC<UpdateTPSLModalContentProps> = ({
   onSubmitStateChange,
 }) => {
   const t = useI18nContext();
-  const selectedAccount = useSelector(getSelectedInternalAccount);
   const { track } = usePerpsEventTracking();
   const { isEligible } = usePerpsEligibility();
-  const { gate } = useComplianceGate(selectedAccount?.address ?? '');
+  const { gate } = useSelectedAccountComplianceGate();
   const { replacePerpsToastByKey } = usePerpsToast();
   const { feeRate: closingFeeRate } = usePerpsOrderFees({
     symbol: position.symbol,

--- a/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.tsx
+++ b/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.tsx
@@ -6,6 +6,7 @@ import React, {
   useLayoutEffect,
   useRef,
 } from 'react';
+import { useSelector } from 'react-redux';
 import {
   Box,
   BoxAlignItems,
@@ -40,8 +41,10 @@ import { usePerpsOrderFees } from '../../../../hooks/perps/usePerpsOrderFees';
 import { MetaMetricsEventName } from '../../../../../shared/constants/metametrics';
 import { submitRequestToBackground } from '../../../../store/background-connection';
 import { getPerpsStreamManager } from '../../../../providers/perps';
+import { getSelectedInternalAccount } from '../../../../selectors/accounts';
 import { usePerpsToast } from '../perps-toast';
 import { PERPS_TOAST_KEYS } from '../perps-toast/perps-toast-provider';
+import { useComplianceGate } from '../../compliance';
 import type { Position, PerpsBackgroundResult } from '../types';
 import {
   normalizeTpslPrices,
@@ -105,8 +108,10 @@ export const UpdateTPSLModalContent: React.FC<UpdateTPSLModalContentProps> = ({
   onSubmitStateChange,
 }) => {
   const t = useI18nContext();
+  const selectedAccount = useSelector(getSelectedInternalAccount);
   const { track } = usePerpsEventTracking();
   const { isEligible } = usePerpsEligibility();
+  const { gate } = useComplianceGate(selectedAccount?.address ?? '');
   const { replacePerpsToastByKey } = usePerpsToast();
   const { feeRate: closingFeeRate } = usePerpsOrderFees({
     symbol: position.symbol,
@@ -443,119 +448,122 @@ export const UpdateTPSLModalContent: React.FC<UpdateTPSLModalContentProps> = ({
   }, [editingSlPrice, formatEditPrice]);
 
   const handleSave = useCallback(async () => {
-    if (!isEligible) {
-      setIsGeoBlockModalOpen(true);
-      return;
-    }
-    if (!position) {
-      return;
-    }
-    setIsSaving(true);
+    await gate(async () => {
+      if (!isEligible) {
+        setIsGeoBlockModalOpen(true);
+        return;
+      }
+      if (!position) {
+        return;
+      }
+      setIsSaving(true);
 
-    const { takeProfitPrice: cleanTpPrice, stopLossPrice: cleanSlPrice } =
-      normalizeTpslPrices({
-        takeProfitPrice: editingTpPrice,
-        stopLossPrice: editingSlPrice,
-      });
+      const { takeProfitPrice: cleanTpPrice, stopLossPrice: cleanSlPrice } =
+        normalizeTpslPrices({
+          takeProfitPrice: editingTpPrice,
+          stopLossPrice: editingSlPrice,
+        });
 
-    try {
-      const result = await submitRequestToBackground<PerpsBackgroundResult>(
-        'perpsUpdatePositionTPSL',
-        [
-          {
-            symbol: position.symbol,
-            takeProfitPrice: cleanTpPrice,
-            stopLossPrice: cleanSlPrice,
-          },
-        ],
-      );
-      const derivedTpslType = deriveTpslType({
-        takeProfitPrice: cleanTpPrice,
-        stopLossPrice: cleanSlPrice,
-        hasExistingTpsl: Boolean(
-          position.takeProfitPrice || position.stopLossPrice,
-        ),
-      });
+      try {
+        const result = await submitRequestToBackground<PerpsBackgroundResult>(
+          'perpsUpdatePositionTPSL',
+          [
+            {
+              symbol: position.symbol,
+              takeProfitPrice: cleanTpPrice,
+              stopLossPrice: cleanSlPrice,
+            },
+          ],
+        );
+        const derivedTpslType = deriveTpslType({
+          takeProfitPrice: cleanTpPrice,
+          stopLossPrice: cleanSlPrice,
+          hasExistingTpsl: Boolean(
+            position.takeProfitPrice || position.stopLossPrice,
+          ),
+        });
 
-      if (!result.success) {
-        const failMessage = result.error || 'Failed to update TP/SL';
+        if (!result.success) {
+          const failMessage = result.error || 'Failed to update TP/SL';
+          track(MetaMetricsEventName.PerpsRiskManagement, {
+            [PERPS_EVENT_PROPERTY.ASSET]: position.symbol,
+            [PERPS_EVENT_PROPERTY.STATUS]: PERPS_EVENT_VALUE.STATUS.FAILED,
+            [PERPS_EVENT_PROPERTY.FAILURE_REASON]: failMessage,
+            [PERPS_EVENT_PROPERTY.ERROR_MESSAGE]: failMessage,
+            [PERPS_EVENT_PROPERTY.TYPE]: derivedTpslType,
+            [PERPS_EVENT_PROPERTY.SIZE]: position.size,
+          });
+          track(MetaMetricsEventName.PerpsError, {
+            [PERPS_EVENT_PROPERTY.ERROR_TYPE]:
+              PERPS_EVENT_VALUE.ERROR_TYPE.BACKEND,
+            [PERPS_EVENT_PROPERTY.ERROR_MESSAGE]: failMessage,
+          });
+          replacePerpsToastByKey({
+            key: PERPS_TOAST_KEYS.UPDATE_FAILED,
+            description: failMessage,
+          });
+          return;
+        }
         track(MetaMetricsEventName.PerpsRiskManagement, {
           [PERPS_EVENT_PROPERTY.ASSET]: position.symbol,
-          [PERPS_EVENT_PROPERTY.STATUS]: PERPS_EVENT_VALUE.STATUS.FAILED,
-          [PERPS_EVENT_PROPERTY.FAILURE_REASON]: failMessage,
-          [PERPS_EVENT_PROPERTY.ERROR_MESSAGE]: failMessage,
+          [PERPS_EVENT_PROPERTY.STATUS]: PERPS_EVENT_VALUE.STATUS.SUCCESS,
           [PERPS_EVENT_PROPERTY.TYPE]: derivedTpslType,
           [PERPS_EVENT_PROPERTY.SIZE]: position.size,
         });
+        const streamManager = getPerpsStreamManager();
+        streamManager.setOptimisticTPSL(
+          position.symbol,
+          cleanTpPrice,
+          cleanSlPrice,
+        );
+        const currentPositions = streamManager.positions.getCachedData();
+        const optimisticallyUpdatedPositions = currentPositions.map((p) =>
+          p.symbol === position.symbol
+            ? {
+                ...p,
+                takeProfitPrice: cleanTpPrice,
+                stopLossPrice: cleanSlPrice,
+              }
+            : p,
+        );
+        streamManager.positions.pushData(optimisticallyUpdatedPositions);
+
+        setTimeout(async () => {
+          try {
+            const freshPositions = await submitRequestToBackground<
+              PerpsPosition[]
+            >('perpsGetPositions', [{ skipCache: true }]);
+            streamManager.pushPositionsWithOverrides(freshPositions);
+          } catch (e) {
+            console.warn('[Perps] Delayed TP/SL refetch failed:', e);
+          }
+        }, 2500);
+
+        replacePerpsToastByKey({
+          key: PERPS_TOAST_KEYS.UPDATE_SUCCESS,
+        });
+        onClose();
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : 'An unknown error occurred';
         track(MetaMetricsEventName.PerpsError, {
-          [PERPS_EVENT_PROPERTY.ERROR_TYPE]:
-            PERPS_EVENT_VALUE.ERROR_TYPE.BACKEND,
-          [PERPS_EVENT_PROPERTY.ERROR_MESSAGE]: failMessage,
+          [PERPS_EVENT_PROPERTY.ERROR_TYPE]: PERPS_EVENT_VALUE.ERROR_TYPE.BACKEND,
+          [PERPS_EVENT_PROPERTY.ERROR_MESSAGE]: errorMessage,
         });
         replacePerpsToastByKey({
           key: PERPS_TOAST_KEYS.UPDATE_FAILED,
-          description: failMessage,
+          description: errorMessage,
         });
-        return;
-      }
-      track(MetaMetricsEventName.PerpsRiskManagement, {
-        [PERPS_EVENT_PROPERTY.ASSET]: position.symbol,
-        [PERPS_EVENT_PROPERTY.STATUS]: PERPS_EVENT_VALUE.STATUS.SUCCESS,
-        [PERPS_EVENT_PROPERTY.TYPE]: derivedTpslType,
-        [PERPS_EVENT_PROPERTY.SIZE]: position.size,
-      });
-      const streamManager = getPerpsStreamManager();
-      streamManager.setOptimisticTPSL(
-        position.symbol,
-        cleanTpPrice,
-        cleanSlPrice,
-      );
-      const currentPositions = streamManager.positions.getCachedData();
-      const optimisticallyUpdatedPositions = currentPositions.map((p) =>
-        p.symbol === position.symbol
-          ? {
-              ...p,
-              takeProfitPrice: cleanTpPrice,
-              stopLossPrice: cleanSlPrice,
-            }
-          : p,
-      );
-      streamManager.positions.pushData(optimisticallyUpdatedPositions);
-
-      setTimeout(async () => {
-        try {
-          const freshPositions = await submitRequestToBackground<
-            PerpsPosition[]
-          >('perpsGetPositions', [{ skipCache: true }]);
-          streamManager.pushPositionsWithOverrides(freshPositions);
-        } catch (e) {
-          console.warn('[Perps] Delayed TP/SL refetch failed:', e);
+      } finally {
+        if (isMountedRef.current) {
+          setIsSaving(false);
         }
-      }, 2500);
-
-      replacePerpsToastByKey({
-        key: PERPS_TOAST_KEYS.UPDATE_SUCCESS,
-      });
-      onClose();
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : 'An unknown error occurred';
-      track(MetaMetricsEventName.PerpsError, {
-        [PERPS_EVENT_PROPERTY.ERROR_TYPE]: PERPS_EVENT_VALUE.ERROR_TYPE.BACKEND,
-        [PERPS_EVENT_PROPERTY.ERROR_MESSAGE]: errorMessage,
-      });
-      replacePerpsToastByKey({
-        key: PERPS_TOAST_KEYS.UPDATE_FAILED,
-        description: errorMessage,
-      });
-    } finally {
-      if (isMountedRef.current) {
-        setIsSaving(false);
       }
-    }
+    });
   }, [
     editingSlPrice,
     editingTpPrice,
+    gate,
     isEligible,
     onClose,
     position,

--- a/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.tsx
+++ b/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.tsx
@@ -544,7 +544,8 @@ export const UpdateTPSLModalContent: React.FC<UpdateTPSLModalContentProps> = ({
         const errorMessage =
           error instanceof Error ? error.message : 'An unknown error occurred';
         track(MetaMetricsEventName.PerpsError, {
-          [PERPS_EVENT_PROPERTY.ERROR_TYPE]: PERPS_EVENT_VALUE.ERROR_TYPE.BACKEND,
+          [PERPS_EVENT_PROPERTY.ERROR_TYPE]:
+            PERPS_EVENT_VALUE.ERROR_TYPE.BACKEND,
           [PERPS_EVENT_PROPERTY.ERROR_MESSAGE]: errorMessage,
         });
         replacePerpsToastByKey({

--- a/ui/pages/perps/perps-layout.tsx
+++ b/ui/pages/perps/perps-layout.tsx
@@ -3,6 +3,7 @@ import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { Outlet, useLocation } from 'react-router-dom';
 import { PROVIDER_CONFIG } from '@metamask/perps-controller';
 import { PerpsToastProvider } from '../../components/app/perps';
+import { AccessRestrictedProvider } from '../../components/app/compliance';
 import { usePerpsViewActive } from '../../hooks/perps/stream/usePerpsViewActive';
 import { usePerpsLifecycleBreadcrumbs } from '../../hooks/perps/usePerpsLifecycleBreadcrumbs';
 import { submitRequestToBackground } from '../../store/background-connection';
@@ -154,8 +155,10 @@ export default function PerpsLayout() {
   }, []);
 
   return (
-    <PerpsToastProvider>
-      <Outlet />
-    </PerpsToastProvider>
+    <AccessRestrictedProvider>
+      <PerpsToastProvider>
+        <Outlet />
+      </PerpsToastProvider>
+    </AccessRestrictedProvider>
   );
 }

--- a/ui/pages/perps/perps-market-detail-page.tsx
+++ b/ui/pages/perps/perps-market-detail-page.tsx
@@ -104,7 +104,7 @@ import { UpdateTPSLModal } from '../../components/app/perps/update-tpsl';
 import { ClosePositionModal } from '../../components/app/perps/close-position';
 import { CancelOrderModal } from '../../components/app/perps/cancel-order';
 import { PerpsGeoBlockModal } from '../../components/app/perps/perps-geo-block-modal';
-import { useComplianceGate } from '../../components/app/compliance';
+import { useSelectedAccountComplianceGate } from '../../components/app/compliance';
 import type { Order } from '../../components/app/perps/types';
 import {
   PERPS_TOAST_KEYS,
@@ -270,7 +270,7 @@ const PerpsMarketDetailPage: React.FC = () => {
   const isPerpsExperienceAvailable = useSelector(getIsPerpsExperienceAvailable);
   const selectedAccount = useSelector(getSelectedInternalAccount);
   const selectedAddress = selectedAccount?.address;
-  const { gate } = useComplianceGate(selectedAddress ?? '');
+  const { gate } = useSelectedAccountComplianceGate();
   const { isEligible } = usePerpsEligibility();
   const { track } = usePerpsEventTracking();
   const {

--- a/ui/pages/perps/perps-market-detail-page.tsx
+++ b/ui/pages/perps/perps-market-detail-page.tsx
@@ -104,6 +104,7 @@ import { UpdateTPSLModal } from '../../components/app/perps/update-tpsl';
 import { ClosePositionModal } from '../../components/app/perps/close-position';
 import { CancelOrderModal } from '../../components/app/perps/cancel-order';
 import { PerpsGeoBlockModal } from '../../components/app/perps/perps-geo-block-modal';
+import { useComplianceGate } from '../../components/app/compliance';
 import type { Order } from '../../components/app/perps/types';
 import {
   PERPS_TOAST_KEYS,
@@ -269,6 +270,7 @@ const PerpsMarketDetailPage: React.FC = () => {
   const isPerpsExperienceAvailable = useSelector(getIsPerpsExperienceAvailable);
   const selectedAccount = useSelector(getSelectedInternalAccount);
   const selectedAddress = selectedAccount?.address;
+  const { gate } = useComplianceGate(selectedAddress ?? '');
   const { isEligible } = usePerpsEligibility();
   const { track } = usePerpsEventTracking();
   const {
@@ -731,26 +733,31 @@ const PerpsMarketDetailPage: React.FC = () => {
 
   const handleOpenOrder = useCallback(
     (direction: 'long' | 'short') => {
-      if (!isEligible) {
-        setIsGeoBlockModalOpen(true);
-        return;
-      }
-      if (!decodedSymbol || isLoadingAccount) {
-        return;
-      }
-      track(MetaMetricsEventName.PerpsUiInteraction, {
-        [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
-          PERPS_EVENT_VALUE.INTERACTION_TYPE.BUTTON_CLICKED,
-        [PERPS_EVENT_PROPERTY.BUTTON_TYPE]:
-          PERPS_EVENT_VALUE.BUTTON_CLICKED.TRADE,
-        [PERPS_EVENT_PROPERTY.BUTTON_LOCATION]:
-          PERPS_EVENT_VALUE.BUTTON_LOCATION.ASSET_DETAILS,
-        [PERPS_EVENT_PROPERTY.ASSET]: decodedSymbol,
-        [PERPS_EVENT_PROPERTY.DIRECTION]: direction,
+      gate(() => {
+        if (!isEligible) {
+          setIsGeoBlockModalOpen(true);
+          return;
+        }
+        if (!decodedSymbol || isLoadingAccount) {
+          return;
+        }
+        track(MetaMetricsEventName.PerpsUiInteraction, {
+          [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
+            PERPS_EVENT_VALUE.INTERACTION_TYPE.BUTTON_CLICKED,
+          [PERPS_EVENT_PROPERTY.BUTTON_TYPE]:
+            PERPS_EVENT_VALUE.BUTTON_CLICKED.TRADE,
+          [PERPS_EVENT_PROPERTY.BUTTON_LOCATION]:
+            PERPS_EVENT_VALUE.BUTTON_LOCATION.ASSET_DETAILS,
+          [PERPS_EVENT_PROPERTY.ASSET]: decodedSymbol,
+          [PERPS_EVENT_PROPERTY.DIRECTION]: direction,
+        });
+        navigate(buildOrderEntryUrl(direction, 'new'));
+      }).catch((error: unknown) => {
+        console.error(error);
       });
-      navigate(buildOrderEntryUrl(direction, 'new'));
     },
     [
+      gate,
       isEligible,
       decodedSymbol,
       isLoadingAccount,
@@ -761,43 +768,55 @@ const PerpsMarketDetailPage: React.FC = () => {
   );
 
   const handleClosePosition = useCallback(() => {
-    if (!isEligible) {
-      setIsGeoBlockModalOpen(true);
-      return;
-    }
-    if (!position) {
-      return;
-    }
-    setIsCloseModalOpen(true);
-  }, [isEligible, position]);
+    gate(() => {
+      if (!isEligible) {
+        setIsGeoBlockModalOpen(true);
+        return;
+      }
+      if (!position) {
+        return;
+      }
+      setIsCloseModalOpen(true);
+    }).catch((error: unknown) => {
+      console.error(error);
+    });
+  }, [gate, isEligible, position]);
 
   const handleOpenAddMarginModal = useCallback(() => {
-    track(MetaMetricsEventName.PerpsUiInteraction, {
-      [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
-        PERPS_EVENT_VALUE.INTERACTION_TYPE.BUTTON_CLICKED,
-      [PERPS_EVENT_PROPERTY.BUTTON_TYPE]:
-        PERPS_EVENT_VALUE.BUTTON_CLICKED.ADD_MARGIN,
-      [PERPS_EVENT_PROPERTY.BUTTON_LOCATION]:
-        PERPS_EVENT_VALUE.BUTTON_LOCATION.ASSET_DETAILS,
+    gate(() => {
+      track(MetaMetricsEventName.PerpsUiInteraction, {
+        [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
+          PERPS_EVENT_VALUE.INTERACTION_TYPE.BUTTON_CLICKED,
+        [PERPS_EVENT_PROPERTY.BUTTON_TYPE]:
+          PERPS_EVENT_VALUE.BUTTON_CLICKED.ADD_MARGIN,
+        [PERPS_EVENT_PROPERTY.BUTTON_LOCATION]:
+          PERPS_EVENT_VALUE.BUTTON_LOCATION.ASSET_DETAILS,
+      });
+      setIsModifyMenuOpen(false);
+      setIsMarginMenuOpen(false);
+      setMarginModalMode('add');
+    }).catch((error: unknown) => {
+      console.error(error);
     });
-    setIsModifyMenuOpen(false);
-    setIsMarginMenuOpen(false);
-    setMarginModalMode('add');
-  }, [track]);
+  }, [gate, track]);
 
   const handleOpenDecreaseMarginModal = useCallback(() => {
-    track(MetaMetricsEventName.PerpsUiInteraction, {
-      [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
-        PERPS_EVENT_VALUE.INTERACTION_TYPE.BUTTON_CLICKED,
-      [PERPS_EVENT_PROPERTY.BUTTON_TYPE]:
-        PERPS_EVENT_VALUE.BUTTON_CLICKED.REMOVE_MARGIN,
-      [PERPS_EVENT_PROPERTY.BUTTON_LOCATION]:
-        PERPS_EVENT_VALUE.BUTTON_LOCATION.ASSET_DETAILS,
+    gate(() => {
+      track(MetaMetricsEventName.PerpsUiInteraction, {
+        [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
+          PERPS_EVENT_VALUE.INTERACTION_TYPE.BUTTON_CLICKED,
+        [PERPS_EVENT_PROPERTY.BUTTON_TYPE]:
+          PERPS_EVENT_VALUE.BUTTON_CLICKED.REMOVE_MARGIN,
+        [PERPS_EVENT_PROPERTY.BUTTON_LOCATION]:
+          PERPS_EVENT_VALUE.BUTTON_LOCATION.ASSET_DETAILS,
+      });
+      setIsModifyMenuOpen(false);
+      setIsMarginMenuOpen(false);
+      setMarginModalMode('remove');
+    }).catch((error: unknown) => {
+      console.error(error);
     });
-    setIsModifyMenuOpen(false);
-    setIsMarginMenuOpen(false);
-    setMarginModalMode('remove');
-  }, [track]);
+  }, [gate, track]);
 
   const handleOpenReverseModal = useCallback(() => {
     setIsModifyMenuOpen(false);
@@ -805,28 +824,33 @@ const PerpsMarketDetailPage: React.FC = () => {
   }, []);
 
   const handleAddExposure = useCallback(() => {
-    if (!position || !decodedSymbol) {
-      return;
-    }
-    track(MetaMetricsEventName.PerpsUiInteraction, {
-      [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
-        PERPS_EVENT_VALUE.INTERACTION_TYPE.BUTTON_CLICKED,
-      [PERPS_EVENT_PROPERTY.BUTTON_TYPE]:
-        PERPS_EVENT_VALUE.BUTTON_CLICKED.INCREASE_EXPOSURE,
-      [PERPS_EVENT_PROPERTY.BUTTON_LOCATION]:
-        PERPS_EVENT_VALUE.BUTTON_LOCATION.ASSET_DETAILS,
-    });
-    setIsModifyMenuOpen(false);
-    if (position.leverage?.type === 'cross') {
-      replacePerpsToastByKey({
-        key: PERPS_TOAST_KEYS.INCREASE_POSITION_CROSS_MARGIN_BLOCKED,
-        description: t('perpsCrossMarginNotSupportedDescription'),
+    gate(() => {
+      if (!position || !decodedSymbol) {
+        return;
+      }
+      track(MetaMetricsEventName.PerpsUiInteraction, {
+        [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
+          PERPS_EVENT_VALUE.INTERACTION_TYPE.BUTTON_CLICKED,
+        [PERPS_EVENT_PROPERTY.BUTTON_TYPE]:
+          PERPS_EVENT_VALUE.BUTTON_CLICKED.INCREASE_EXPOSURE,
+        [PERPS_EVENT_PROPERTY.BUTTON_LOCATION]:
+          PERPS_EVENT_VALUE.BUTTON_LOCATION.ASSET_DETAILS,
       });
-      return;
-    }
-    const direction = parseFloat(position.size) >= 0 ? 'long' : 'short';
-    navigate(buildOrderEntryUrl(direction, 'modify'));
+      setIsModifyMenuOpen(false);
+      if (position.leverage?.type === 'cross') {
+        replacePerpsToastByKey({
+          key: PERPS_TOAST_KEYS.INCREASE_POSITION_CROSS_MARGIN_BLOCKED,
+          description: t('perpsCrossMarginNotSupportedDescription'),
+        });
+        return;
+      }
+      const direction = parseFloat(position.size) >= 0 ? 'long' : 'short';
+      navigate(buildOrderEntryUrl(direction, 'modify'));
+    }).catch((error: unknown) => {
+      console.error(error);
+    });
   }, [
+    gate,
     position,
     decodedSymbol,
     navigate,
@@ -837,24 +861,28 @@ const PerpsMarketDetailPage: React.FC = () => {
   ]);
 
   const handleReduceExposure = useCallback(() => {
-    if (!isEligible) {
-      setIsGeoBlockModalOpen(true);
-      return;
-    }
-    if (!position || !decodedSymbol) {
-      return;
-    }
-    track(MetaMetricsEventName.PerpsUiInteraction, {
-      [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
-        PERPS_EVENT_VALUE.INTERACTION_TYPE.BUTTON_CLICKED,
-      [PERPS_EVENT_PROPERTY.BUTTON_TYPE]:
-        PERPS_EVENT_VALUE.BUTTON_CLICKED.REDUCE_EXPOSURE,
-      [PERPS_EVENT_PROPERTY.BUTTON_LOCATION]:
-        PERPS_EVENT_VALUE.BUTTON_LOCATION.ASSET_DETAILS,
+    gate(() => {
+      if (!isEligible) {
+        setIsGeoBlockModalOpen(true);
+        return;
+      }
+      if (!position || !decodedSymbol) {
+        return;
+      }
+      track(MetaMetricsEventName.PerpsUiInteraction, {
+        [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
+          PERPS_EVENT_VALUE.INTERACTION_TYPE.BUTTON_CLICKED,
+        [PERPS_EVENT_PROPERTY.BUTTON_TYPE]:
+          PERPS_EVENT_VALUE.BUTTON_CLICKED.REDUCE_EXPOSURE,
+        [PERPS_EVENT_PROPERTY.BUTTON_LOCATION]:
+          PERPS_EVENT_VALUE.BUTTON_LOCATION.ASSET_DETAILS,
+      });
+      setIsModifyMenuOpen(false);
+      setIsCloseModalOpen(true);
+    }).catch((error: unknown) => {
+      console.error(error);
     });
-    setIsModifyMenuOpen(false);
-    setIsCloseModalOpen(true);
-  }, [isEligible, position, decodedSymbol, track]);
+  }, [gate, isEligible, position, decodedSymbol, track]);
 
   const handleOpenMarginMenu = useCallback(() => {
     track(MetaMetricsEventName.PerpsUiInteraction, {
@@ -878,8 +906,12 @@ const PerpsMarketDetailPage: React.FC = () => {
   }, []);
 
   const handleOpenTPSLModal = useCallback(() => {
-    setIsTPSLModalOpen(true);
-  }, []);
+    gate(() => {
+      setIsTPSLModalOpen(true);
+    }).catch((error: unknown) => {
+      console.error(error);
+    });
+  }, [gate]);
 
   const handleCloseTPSLModal = useCallback(() => {
     setIsTPSLModalOpen(false);
@@ -1770,11 +1802,15 @@ const PerpsMarketDetailPage: React.FC = () => {
                 variant={ButtonVariant.Secondary}
                 size={ButtonSize.Lg}
                 onClick={() => {
-                  if (!isEligible) {
-                    setIsGeoBlockModalOpen(true);
-                    return;
-                  }
-                  setIsModifyMenuOpen((prev) => !prev);
+                  gate(() => {
+                    if (!isEligible) {
+                      setIsGeoBlockModalOpen(true);
+                      return;
+                    }
+                    setIsModifyMenuOpen((prev) => !prev);
+                  }).catch((error: unknown) => {
+                    console.error(error);
+                  });
                 }}
                 className="w-full flex items-center gap-2"
                 data-testid="perps-modify-cta-button"

--- a/ui/pages/perps/perps-order-entry-page.tsx
+++ b/ui/pages/perps/perps-order-entry-page.tsx
@@ -75,6 +75,7 @@ import { getTradeableBalance } from '../../hooks/perps/getTradeableBalance';
 import { useFormatters } from '../../hooks/useFormatters';
 import { translatePerpsError } from '../../components/app/perps/utils/translate-perps-error';
 import { PerpsGeoBlockModal } from '../../components/app/perps/perps-geo-block-modal';
+import { useComplianceGate } from '../../components/app/compliance';
 import { usePerpsDepositConfirmation } from '../../components/app/perps/hooks/usePerpsDepositConfirmation';
 import { getPerpsStreamManager } from '../../providers/perps';
 import { submitRequestToBackground } from '../../store/background-connection';
@@ -236,6 +237,7 @@ const PerpsOrderEntryPage: React.FC = () => {
   const isPerpsExperienceAvailable = useSelector(getIsPerpsExperienceAvailable);
   const selectedAccount = useSelector(getSelectedInternalAccount);
   const selectedAddress = selectedAccount?.address;
+  const { gate } = useComplianceGate(selectedAddress ?? '');
   const { isEligible } = usePerpsEligibility();
   const { track } = usePerpsEventTracking();
   const [isGeoBlockModalOpen, setIsGeoBlockModalOpen] = useState(false);
@@ -1227,21 +1229,24 @@ const PerpsOrderEntryPage: React.FC = () => {
   ]);
 
   const handlePrimaryAction = useCallback(async () => {
-    if (hasNoAvailableBalance) {
-      if (!isEligible) {
-        setIsGeoBlockModalOpen(true);
-        return;
-      }
-      if (!selectedAddress || isDepositLoading) {
+    await gate(async () => {
+      if (hasNoAvailableBalance) {
+        if (!isEligible) {
+          setIsGeoBlockModalOpen(true);
+          return;
+        }
+        if (!selectedAddress || isDepositLoading) {
+          return;
+        }
+
+        await triggerDeposit();
         return;
       }
 
-      await triggerDeposit();
-      return;
-    }
-
-    await handleOrderSubmit();
+      await handleOrderSubmit();
+    });
   }, [
+    gate,
     handleOrderSubmit,
     hasNoAvailableBalance,
     isDepositLoading,

--- a/ui/pages/perps/perps-order-entry-page.tsx
+++ b/ui/pages/perps/perps-order-entry-page.tsx
@@ -75,7 +75,7 @@ import { getTradeableBalance } from '../../hooks/perps/getTradeableBalance';
 import { useFormatters } from '../../hooks/useFormatters';
 import { translatePerpsError } from '../../components/app/perps/utils/translate-perps-error';
 import { PerpsGeoBlockModal } from '../../components/app/perps/perps-geo-block-modal';
-import { useComplianceGate } from '../../components/app/compliance';
+import { useSelectedAccountComplianceGate } from '../../components/app/compliance';
 import { usePerpsDepositConfirmation } from '../../components/app/perps/hooks/usePerpsDepositConfirmation';
 import { getPerpsStreamManager } from '../../providers/perps';
 import { submitRequestToBackground } from '../../store/background-connection';
@@ -237,7 +237,7 @@ const PerpsOrderEntryPage: React.FC = () => {
   const isPerpsExperienceAvailable = useSelector(getIsPerpsExperienceAvailable);
   const selectedAccount = useSelector(getSelectedInternalAccount);
   const selectedAddress = selectedAccount?.address;
-  const { gate } = useComplianceGate(selectedAddress ?? '');
+  const { gate } = useSelectedAccountComplianceGate();
   const { isEligible } = usePerpsEligibility();
   const { track } = usePerpsEventTracking();
   const [isGeoBlockModalOpen, setIsGeoBlockModalOpen] = useState(false);

--- a/ui/selectors/compliance.test.ts
+++ b/ui/selectors/compliance.test.ts
@@ -54,12 +54,12 @@ describe('compliance selectors', () => {
     });
 
     it('accepts boolean feature flag values', () => {
-      expect(getIsComplianceEnabled(getState({ complianceEnabled: true }))).toBe(
-        true,
-      );
-      expect(getIsComplianceEnabled(getState({ complianceEnabled: false }))).toBe(
-        false,
-      );
+      expect(
+        getIsComplianceEnabled(getState({ complianceEnabled: true })),
+      ).toBe(true);
+      expect(
+        getIsComplianceEnabled(getState({ complianceEnabled: false })),
+      ).toBe(false);
     });
 
     it('accepts enabled version-gated feature flag values', () => {
@@ -139,7 +139,10 @@ describe('compliance selectors', () => {
     });
 
     it('returns the cached status map and last checked timestamp', () => {
-      const state = getState({ walletComplianceStatusMap, lastCheckedAt: checkedAt });
+      const state = getState({
+        walletComplianceStatusMap,
+        lastCheckedAt: checkedAt,
+      });
 
       expect(selectWalletComplianceStatusMap(state)).toBe(
         walletComplianceStatusMap,

--- a/ui/selectors/compliance.test.ts
+++ b/ui/selectors/compliance.test.ts
@@ -1,0 +1,150 @@
+import type { RemoteFeatureFlagControllerState } from '@metamask/remote-feature-flag-controller';
+import {
+  getIsComplianceEnabled,
+  selectAreAnyWalletsBlocked,
+  selectComplianceLastCheckedAt,
+  selectIsWalletBlocked,
+  selectWalletComplianceStatusMap,
+} from './compliance';
+
+jest.mock('../../shared/lib/manifestFlags', () => {
+  const manifestFlags = { remoteFeatureFlags: {} };
+  return {
+    getManifestFlags: () => manifestFlags,
+  };
+});
+
+const BLOCKED_ADDRESS = '0xblocked';
+const COMPLIANT_ADDRESS = '0xcompliant';
+
+type RemoteFeatureFlagValue =
+  RemoteFeatureFlagControllerState['remoteFeatureFlags'][string];
+
+function getState({
+  complianceEnabled,
+  walletComplianceStatusMap,
+  lastCheckedAt,
+}: {
+  complianceEnabled?: RemoteFeatureFlagValue;
+  walletComplianceStatusMap?: Record<
+    string,
+    { address: string; blocked: boolean; checkedAt: string }
+  >;
+  lastCheckedAt?: string | null;
+} = {}) {
+  const remoteFeatureFlags: RemoteFeatureFlagControllerState['remoteFeatureFlags'] =
+    {};
+  if (complianceEnabled !== undefined) {
+    remoteFeatureFlags.complianceEnabled = complianceEnabled;
+  }
+
+  return {
+    metamask: {
+      remoteFeatureFlags,
+      walletComplianceStatusMap,
+      lastCheckedAt,
+    },
+  };
+}
+
+describe('compliance selectors', () => {
+  describe('getIsComplianceEnabled', () => {
+    it('defaults false', () => {
+      expect(getIsComplianceEnabled(getState())).toBe(false);
+    });
+
+    it('accepts boolean feature flag values', () => {
+      expect(getIsComplianceEnabled(getState({ complianceEnabled: true }))).toBe(
+        true,
+      );
+      expect(getIsComplianceEnabled(getState({ complianceEnabled: false }))).toBe(
+        false,
+      );
+    });
+
+    it('accepts enabled version-gated feature flag values', () => {
+      expect(
+        getIsComplianceEnabled(
+          getState({
+            complianceEnabled: { enabled: true, minimumVersion: '0.0.0' },
+          }),
+        ),
+      ).toBe(true);
+    });
+
+    it('rejects disabled or invalid version-gated feature flag values', () => {
+      expect(
+        getIsComplianceEnabled(
+          getState({
+            complianceEnabled: { enabled: false, minimumVersion: '0.0.0' },
+          }),
+        ),
+      ).toBe(false);
+      expect(
+        getIsComplianceEnabled(
+          getState({
+            complianceEnabled: { enabled: true, minimumVersion: null },
+          }),
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe('wallet status selectors', () => {
+    const checkedAt = '2026-05-05T00:00:00.000Z';
+    const walletComplianceStatusMap = {
+      [BLOCKED_ADDRESS]: {
+        address: BLOCKED_ADDRESS,
+        blocked: true,
+        checkedAt,
+      },
+      [COMPLIANT_ADDRESS]: {
+        address: COMPLIANT_ADDRESS,
+        blocked: false,
+        checkedAt,
+      },
+    };
+
+    it('returns true for a cached blocked address', () => {
+      expect(
+        selectIsWalletBlocked(BLOCKED_ADDRESS)(
+          getState({ walletComplianceStatusMap }),
+        ),
+      ).toBe(true);
+    });
+
+    it('returns false for a cached compliant address', () => {
+      expect(
+        selectIsWalletBlocked(COMPLIANT_ADDRESS)(
+          getState({ walletComplianceStatusMap }),
+        ),
+      ).toBe(false);
+    });
+
+    it('returns false for unknown or missing state', () => {
+      expect(selectIsWalletBlocked('0xunknown')(getState())).toBe(false);
+      expect(
+        selectAreAnyWalletsBlocked([BLOCKED_ADDRESS])(
+          getState({ walletComplianceStatusMap: undefined }),
+        ),
+      ).toBe(false);
+    });
+
+    it('returns true when any address in an array is blocked', () => {
+      expect(
+        selectAreAnyWalletsBlocked([COMPLIANT_ADDRESS, BLOCKED_ADDRESS])(
+          getState({ walletComplianceStatusMap }),
+        ),
+      ).toBe(true);
+    });
+
+    it('returns the cached status map and last checked timestamp', () => {
+      const state = getState({ walletComplianceStatusMap, lastCheckedAt: checkedAt });
+
+      expect(selectWalletComplianceStatusMap(state)).toBe(
+        walletComplianceStatusMap,
+      );
+      expect(selectComplianceLastCheckedAt(state)).toBe(checkedAt);
+    });
+  });
+});

--- a/ui/selectors/compliance.ts
+++ b/ui/selectors/compliance.ts
@@ -1,0 +1,81 @@
+import { createSelector, type Selector } from 'reselect';
+import { memoize } from 'lodash';
+import {
+  getDefaultComplianceControllerState,
+  selectIsWalletBlocked as selectIsWalletBlockedFromComplianceState,
+  type ComplianceControllerState,
+} from '@metamask/compliance-controller';
+import { getBooleanFeatureFlag } from '../../shared/lib/remote-feature-flag-utils';
+import { getRemoteFeatureFlags } from './remote-feature-flags';
+
+const DEFAULT_COMPLIANCE_ENABLED = false;
+const DEFAULT_COMPLIANCE_STATE = getDefaultComplianceControllerState();
+
+type ComplianceState = {
+  metamask: Partial<ComplianceControllerState>;
+};
+
+export const getIsComplianceEnabled = createSelector(
+  getRemoteFeatureFlags,
+  (remoteFeatureFlags) =>
+    getBooleanFeatureFlag(
+      remoteFeatureFlags.complianceEnabled,
+      DEFAULT_COMPLIANCE_ENABLED,
+    ),
+);
+
+const getComplianceWalletComplianceStatusMap = (state: ComplianceState) =>
+  state.metamask.walletComplianceStatusMap ??
+  DEFAULT_COMPLIANCE_STATE.walletComplianceStatusMap;
+
+const getComplianceLastCheckedAtValue = (state: ComplianceState) =>
+  state.metamask.lastCheckedAt ?? DEFAULT_COMPLIANCE_STATE.lastCheckedAt;
+
+const getComplianceControllerState = createSelector(
+  getComplianceWalletComplianceStatusMap,
+  getComplianceLastCheckedAtValue,
+  (walletComplianceStatusMap, lastCheckedAt): ComplianceControllerState => ({
+    walletComplianceStatusMap,
+    lastCheckedAt,
+  }),
+);
+
+const getSelectIsWalletBlocked = memoize((address: string) =>
+  createSelector(getComplianceControllerState, (state) =>
+    selectIsWalletBlockedFromComplianceState(address)(state),
+  ),
+);
+
+export const selectIsWalletBlocked = (
+  address: string,
+): Selector<ComplianceState, boolean> => getSelectIsWalletBlocked(address);
+
+const getSelectAreAnyWalletsBlocked = memoize(
+  (addresses: string[]) =>
+    createSelector(getComplianceControllerState, (state) => {
+      if (addresses.length === 0) {
+        return false;
+      }
+
+      return addresses.some((address) =>
+        selectIsWalletBlockedFromComplianceState(address)(state),
+      );
+    }),
+  (addresses: string[]) =>
+    [...addresses].sort((a, b) => a.localeCompare(b)).join(','),
+);
+
+export const selectAreAnyWalletsBlocked = (
+  addresses: string[],
+): Selector<ComplianceState, boolean> =>
+  getSelectAreAnyWalletsBlocked(addresses);
+
+export const selectWalletComplianceStatusMap = createSelector(
+  getComplianceControllerState,
+  (state) => state.walletComplianceStatusMap,
+);
+
+export const selectComplianceLastCheckedAt = createSelector(
+  getComplianceControllerState,
+  (state) => state.lastCheckedAt,
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6100,6 +6100,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/compliance-controller@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@metamask/compliance-controller@npm:2.0.0"
+  dependencies:
+    "@metamask/base-controller": "npm:^9.0.1"
+    "@metamask/controller-utils": "npm:^11.20.0"
+    "@metamask/messenger": "npm:^1.1.0"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/utils": "npm:^11.9.0"
+    reselect: "npm:^5.1.1"
+  checksum: 10/a5052dac7860eb4cdd247ebccdb6d091092ea8564a3e8d986f0d38e0a3107ee35844c45eb2873ea7f388129603ad2a0bd9f788adc0b96a14d0987e8bedfa80bf
+  languageName: node
+  linkType: hard
+
 "@metamask/connectivity-controller@npm:^0.1.0":
   version: 0.1.0
   resolution: "@metamask/connectivity-controller@npm:0.1.0"
@@ -34122,6 +34136,7 @@ __metadata:
     "@metamask/claims-controller": "npm:^0.4.2"
     "@metamask/client-controller": "npm:^1.0.0"
     "@metamask/client-mcp-core": "npm:0.2.0"
+    "@metamask/compliance-controller": "npm:2.0.0"
     "@metamask/connectivity-controller": "npm:^0.1.0"
     "@metamask/contract-metadata": "npm:^2.5.0"
     "@metamask/controller-utils": "npm:^11.18.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Adds Perps compliance screening for selected wallet addresses, backed by `@metamask/compliance-controller`. When the `complianceEnabled` remote flag is enabled, Perps prefetches compliance status for the selected wallet and gates Mobile parity trading actions. If the latest successful compliance check reports the wallet as blocked, Extension shows the access-restricted modal before the action proceeds.

  This wires ComplianceService and ComplianceController into Extension background initialization, persists controller state, adds compliance selectors/hooks/provider UI, and applies the gate to Perps trading entry points including start trade, order entry, close position, close all positions, add/remove margin, TP/SL create/edit, exposure modification, and add funds/deposit. Cancel, cancel-all, read-only Perps screens, market browsing, activity, watchlist, tutorial, and withdraw-only flows remain ungated for Mobile parity.

Perps needs to prevent blocked wallets from accessing restricted trading flows while preserving safe exits, cancellation paths, and read-only market access. The original Jira wording suggested blocking on Perps entry, but Mobile uses action gated compliance rather than route-level blocking.

This PR follows Mobile as the product baseline: compliance checks are feature-flagged, service errors fail open, geo eligibility remains a separate guard after compliance passes, and compliance block analytics are centralized as `PERPS_SCREEN_VIEWED` with `screen_type: compliance_block_notif`.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Prevent blocked wallets from accessing restricted trading flows

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2969

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new compliance controller/service and gates multiple Perps trading actions based on remote-flagged wallet screening, which can block user flows if misconfigured or if background API wiring/state handling is wrong. Fail-open behavior on API errors mitigates availability risk but still impacts critical trading entry points when enabled.
> 
> **Overview**
> Adds compliance screening plumbing via `@metamask/compliance-controller`, wiring new `ComplianceService`/`ComplianceController` messenger clients into background initialization, persisted state, Sentry allowlist, LavaMoat policies, and test fixtures.
> 
> Introduces a UI compliance layer (`useComplianceGate`, selectors, and an `AccessRestrictedProvider`/modal) that prefetches wallet compliance status behind the `complianceEnabled` remote flag and shows an *Access restricted* support modal (with Perps metrics event `COMPLIANCE_BLOCK_NOTIF`) when a wallet is blocked.
> 
> Applies the compliance gate across key Perps trading entry points (start trade, order submit/deposit, close/close-all, margin changes, TP/SL updates, and exposure modifications) while leaving non-trading/exit paths like withdraw/cancel flows largely unaffected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9c6571e7d2364ed9769555a001076f4fc14549b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->