### PR TITLE
fix: conditionally render network picker in dapp control bar only if eip155 permission exists

### DIFF
--- a/ui/components/multichain/dapp-connection-control-bar/dapp-connection-control-bar.test.tsx
+++ b/ui/components/multichain/dapp-connection-control-bar/dapp-connection-control-bar.test.tsx
@@ -346,7 +346,8 @@ describe('DappConnectionControlBar', () => {
 
   describe('when connected to a dapp via a non-EVM-only provider', () => {
     const SOLANA_ACCOUNT_ID = 'a8b9c0d1-2e3f-4a5b-6c7d-8e9f0a1b2c3d';
-    const SOLANA_ACCOUNT_ADDRESS = '7S3P4HxJpyyigGzodYwHtCxZyUQe9JiBMHyRWXArAaKv';
+    const SOLANA_ACCOUNT_ADDRESS =
+      '7S3P4HxJpyyigGzodYwHtCxZyUQe9JiBMHyRWXArAaKv';
     const SOLANA_SCOPE = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
 
     const buildSolanaOnlyState = () => {

--- a/ui/components/multichain/dapp-connection-control-bar/dapp-connection-control-bar.test.tsx
+++ b/ui/components/multichain/dapp-connection-control-bar/dapp-connection-control-bar.test.tsx
@@ -88,7 +88,10 @@ const activeTab = {
   url: 'https://metamask.github.io/test-dapp/',
 };
 
-const makeCaip25Permission = (accounts: string[]) => ({
+const makeCaip25Permission = (
+  accounts: string[],
+  scope: string = 'eip155:0',
+) => ({
   'endowment:caip25': {
     parentCapability: 'endowment:caip25',
     caveats: [
@@ -97,7 +100,7 @@ const makeCaip25Permission = (accounts: string[]) => ({
         value: {
           requiredScopes: {},
           optionalScopes: {
-            'eip155:0': { accounts },
+            [scope]: { accounts },
           },
           isMultichainOrigin: false,
         },
@@ -338,6 +341,108 @@ describe('DappConnectionControlBar', () => {
           ]),
         );
       });
+    });
+  });
+
+  describe('when connected to a dapp via a non-EVM-only provider', () => {
+    const SOLANA_ACCOUNT_ID = 'a8b9c0d1-2e3f-4a5b-6c7d-8e9f0a1b2c3d';
+    const SOLANA_ACCOUNT_ADDRESS = '7S3P4HxJpyyigGzodYwHtCxZyUQe9JiBMHyRWXArAaKv';
+    const SOLANA_SCOPE = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
+
+    const buildSolanaOnlyState = () => {
+      const baseGroup =
+        mockState.metamask.accountTree.wallets[
+          'entropy:01JKAF3DSGM3AB87EM9N0K41AJ'
+        ].groups[GROUP_1_ID];
+
+      return {
+        metamask: {
+          ...mockState.metamask,
+          ...sharedMetamaskOverrides,
+          accountTree: {
+            ...mockState.metamask.accountTree,
+            selectedAccountGroup: GROUP_1_ID,
+            wallets: {
+              ...mockState.metamask.accountTree.wallets,
+              'entropy:01JKAF3DSGM3AB87EM9N0K41AJ': {
+                ...mockState.metamask.accountTree.wallets[
+                  'entropy:01JKAF3DSGM3AB87EM9N0K41AJ'
+                ],
+                groups: {
+                  [GROUP_1_ID]: {
+                    ...baseGroup,
+                    accounts: [...baseGroup.accounts, SOLANA_ACCOUNT_ID],
+                  },
+                },
+              },
+            },
+          },
+          internalAccounts: {
+            ...mockState.metamask.internalAccounts,
+            accounts: {
+              ...mockState.metamask.internalAccounts.accounts,
+              [SOLANA_ACCOUNT_ID]: {
+                address: SOLANA_ACCOUNT_ADDRESS,
+                id: SOLANA_ACCOUNT_ID,
+                metadata: {
+                  importTime: 0,
+                  name: 'Solana Account',
+                  keyring: { type: 'Snap Keyring' },
+                  lastSelected: 3000,
+                },
+                options: {},
+                methods: [],
+                scopes: [SOLANA_SCOPE],
+                type: 'solana:data-account',
+              },
+            },
+            selectedAccount: SOLANA_ACCOUNT_ID,
+          },
+          subjects: {
+            [DAPP_ORIGIN]: {
+              permissions: makeCaip25Permission(
+                [`${SOLANA_SCOPE}:${SOLANA_ACCOUNT_ADDRESS}`],
+                SOLANA_SCOPE,
+              ),
+            },
+          },
+        },
+        activeTab,
+      };
+    };
+
+    it('renders the control bar', () => {
+      const store = configureStore(buildSolanaOnlyState());
+      const { getByTestId } = renderWithProvider(
+        <DappConnectionControlBar />,
+        store,
+      );
+      expect(getByTestId('dapp-connection-control-bar')).toBeInTheDocument();
+    });
+
+    it('does not render the network picker button (avoids showing the EVM network logo on a non-EVM connection)', () => {
+      const store = configureStore(buildSolanaOnlyState());
+      const { queryByTestId } = renderWithProvider(
+        <DappConnectionControlBar />,
+        store,
+      );
+      expect(
+        queryByTestId('dapp-connection-control-bar__network-button'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('still renders the permissions and disconnect buttons', () => {
+      const store = configureStore(buildSolanaOnlyState());
+      const { getByTestId } = renderWithProvider(
+        <DappConnectionControlBar />,
+        store,
+      );
+      expect(
+        getByTestId('dapp-connection-control-bar__permissions-button'),
+      ).toBeInTheDocument();
+      expect(
+        getByTestId('dapp-connection-control-bar__disconnect-button'),
+      ).toBeInTheDocument();
     });
   });
 

--- a/ui/components/multichain/dapp-connection-control-bar/dapp-connection-control-bar.tsx
+++ b/ui/components/multichain/dapp-connection-control-bar/dapp-connection-control-bar.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
-import { NonEmptyArray } from '@metamask/utils';
+import { KnownCaipNamespace, NonEmptyArray } from '@metamask/utils';
 import {
   getAllScopesFromCaip25CaveatValue,
   isInternalAccountInPermittedAccountIds,
@@ -119,6 +119,18 @@ export const DappConnectionControlBar: React.FC = () => {
       getCaip25CaveatValueFromPermissions(existingPermissions);
     return caveatValue ? getAllScopesFromCaip25CaveatValue(caveatValue) : [];
   }, [existingPermissions]);
+
+  // The network picker is EVM-only. Only show it when the dapp has at least
+  // one EIP155 (EVM) scope in its permissions; non-EVM-only connections
+  // (e.g. Solana, Tron) should not render the network picker, as the
+  // currently selected EVM network is irrelevant to that dapp's context.
+  const hasEip155Permission = useMemo(
+    () =>
+      existingChainIds.some((scope) =>
+        scope.startsWith(`${KnownCaipNamespace.Eip155}:`),
+      ),
+    [existingChainIds],
+  );
 
   const addressesToPermit = useMemo(() => {
     if (!accountGroupInternalAccounts?.length) {
@@ -310,7 +322,7 @@ export const DappConnectionControlBar: React.FC = () => {
           ) : (
             <>
               {/* Network selector (icon-only, same size as action icons) */}
-              {dappActiveNetwork && (
+              {dappActiveNetwork && hasEip155Permission && (
                 <button
                   className="dapp-connection-control-bar__network-button flex items-center gap-1"
                   onClick={handleNetworkClick}


### PR DESCRIPTION
## **Description**

Hides the EVM network picker on the dapp connection control bar when the active dapp has no EIP-155 (EVM) permissions.

The control bar at the bottom of the wallet popup currently renders the EVM network picker — including the Ethereum logo — for any active dapp connection, regardless of which provider the dapp is actually connected through. For dapps connected via a non-EVM provider (Solana, Tron, etc.), this signals the wrong chain context to the user: the picker functionally only governs the selected EVM network, but visually claims to reflect "the network" of a connection that has no EVM scope at all.

The picker is now rendered only when the dapp's CAIP-25 permissions contain at least one `eip155:*` scope. Non-EVM-only connections render the rest of the control bar (favicon, identity, settings, disconnect) without the picker. The network picker itself, the active-network selector logic, the permissions popup, and provider/connection detection are unchanged.

Note: UX will significantly improve after https://github.com/MetaMask/metamask-extension/pull/41997 is merged, since we still allow to pick non EVM networks in this component as of now.

### What changed

1. **`DappConnectionControlBar` gates the network picker on EIP-155 presence:**
   - Added a `KnownCaipNamespace` import from `@metamask/utils`.
   - Derived a memoized `hasEip155Permission` from the existing `existingChainIds` array (the CAIP-2 scopes parsed out of the dapp's CAIP-25 caveat). It is `true` iff at least one scope's namespace is `eip155`.
   - The network picker button is now rendered only when `dappActiveNetwork && hasEip155Permission`. All other branches (favicon, identity, "Not connected" tag, Connect CTA, settings, disconnect, disconnect modal) are unchanged.

2. **Behavior matrix:**

   | Connection scopes (from CAIP-25 caveat) | Network picker rendered? |
   | --------------------------------------- | ------------------------ |
   | `eip155:0` only / mixed EVM             | yes (existing behavior)  |
   | `eip155:1` + `solana:...`               | yes (any EIP-155 present) |
   | `solana:...` only / non-EVM only        | **no** (new)             |
   | No permissions / not connected          | n/a — bar already returns `null` |

3. **Unit tests added:**
   - Generalized the existing `makeCaip25Permission` test helper to accept a custom scope (still defaults to `eip155:0`).
   - Added a `describe("when connected to a dapp via a non-EVM-only provider")` block that injects a Solana internal account into the selected account group and grants the dapp a Solana-only CAIP-25 permission. Three new assertions verify the bar still renders, the network picker button is **not** rendered, and the permissions and disconnect buttons still render.

| File                                                                                          | Change                                                                                                                                                                                                                                                                                |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `ui/components/multichain/dapp-connection-control-bar/dapp-connection-control-bar.tsx`        | Added `KnownCaipNamespace` import; added `hasEip155Permission` memo derived from `existingChainIds`; gated the network picker button render on `dappActiveNetwork && hasEip155Permission` so non-EVM-only connections no longer show an Ethereum-logo network picker.                |
| `ui/components/multichain/dapp-connection-control-bar/dapp-connection-control-bar.test.tsx`   | Generalized `makeCaip25Permission` to accept a custom scope; added a non-EVM-only-provider `describe` block that injects a Solana account into the selected group and asserts the bar renders, the network picker is hidden, and the permissions and disconnect buttons still show. |

The check uses a simple CAIP-2 prefix match (`scope.startsWith('eip155:')`) consistent with the convention used elsewhere in the codebase (e.g. `shared/lib/multichain/scope-utils.ts`). The change is purely additive on the render path — it can only hide the picker, never alter which actions or accounts are permitted.

## **Changelog**

CHANGELOG entry: The dapp connection control bar no longer renders the EVM network picker (which incorrectly displayed the Ethereum logo) when the active dapp is connected only through a non-EVM provider (Solana, Tron, etc.). The picker is now shown only when the dapp's permissions include at least one EVM (EIP-155) scope.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/WAPI-1431

## **Manual testing steps**

1. **EVM dapp — picker still renders:** open `https://metamask.github.io/test-dapp/`, click **Connect**, approve. Return to the wallet popup. Confirm the bottom control bar shows the network picker with the correct EVM network logo (e.g. Ethereum, Base, Polygon) and that clicking it opens the network selector.
2. **Non-EVM-only dapp — picker hidden:** open a Solana-only dapp (e.g. a Solana Wallet Standard test dapp) or a Tron-only dapp, connect via that provider, then return to the wallet popup. Confirm the bottom control bar shows the favicon, origin, account name, settings, and disconnect controls but **does not** render the network picker (i.e. no Ethereum logo).
3. **Mixed EVM + non-EVM origin — picker renders for the EVM network:** for an origin that has been permissioned on both an EVM network and Solana, confirm the network picker renders and reflects the currently selected EVM network.
4. **Not-connected state unchanged:** with a dapp that the active account group is not connected to, confirm the bar shows the "Not connected" tag and Connect CTA, with no picker (existing behavior).
5. **Unit tests:**
   ```bash
   yarn jest ui/components/multichain/dapp-connection-control-bar/dapp-connection-control-bar.test.tsx
   ```

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only gating change that conditionally hides the EVM network picker; no permissioning, network selection, or dispatch logic is altered. Main risk is an incorrect scope-detection edge case that could hide/show the picker unexpectedly.
> 
> **Overview**
> Updates `DappConnectionControlBar` to **only render the network picker when the connected dapp has at least one `eip155:*` CAIP-25 scope**, preventing an EVM network icon from showing for non-EVM-only connections.
> 
> Extends unit tests by generalizing the CAIP-25 permission helper to accept an arbitrary scope and adding a Solana-only connection scenario that asserts the control bar still renders while the network button is hidden and the permissions/disconnect actions remain available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2aa6e3f61cf06efb3c88d69142c05bfb8a4cd27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->