### PR TITLE
fix: flaky tests `Critical errors...` and `Multi SRP - Import SRP...`

### DIFF
--- a/test/e2e/page-objects/pages/critical-error-page.ts
+++ b/test/e2e/page-objects/pages/critical-error-page.ts
@@ -122,7 +122,8 @@ class CriticalErrorPage {
       );
 
       // Wait for the UI to receive state and finish launching.
-      await this.driver.waitForControllersLoaded(30_000);
+      await this.driver.delay(5000);
+      await this.driver.waitForControllersLoaded();
       // Now safe to close extra tabs (service worker has finished handoff / fallback).
       await this.driver.closeAllOtherTabs();
     } else {

--- a/test/e2e/page-objects/pages/critical-error-page.ts
+++ b/test/e2e/page-objects/pages/critical-error-page.ts
@@ -90,47 +90,17 @@ class CriticalErrorPage {
       await alert.accept();
 
       // runtime.reload() kills extension tabs, so the driver's current window
-      // handle is stale. Wait for the reload, then reattach to a surviving tab.
+      // handle is stale. Wait for the reload, then reattach to the extension UI
+      // once the background has completed the restoring-tab handoff.
       await this.driver.delay(3000);
-      const handles = await this.driver.driver.getAllWindowHandles();
-      await this.driver.driver.switchTo().window(handles[0]);
-
-      await this.waitForPageAfterExtensionReload({
-        timeoutMs: 30_000,
-        waitForLoadingLogoToDisappear: false,
-      });
-
-      // The service worker handoff runs asynchronously after runtime.reload():
-      // it reads the restore session from storage.local, converts the
-      // metamask.io/restoring tab to home.html, then clears the key. We must
-      // wait for that key to be cleared before closing extra tabs — otherwise
-      // we kill the restoring tab before the service worker can hand it off,
-      // causing a fallback that opens a second home.html tab.
-      await this.driver.waitUntil(
-        async () => {
-          const cleared = await this.driver.executeScript(`
-            return new Promise(resolve => {
-              const b = globalThis.browser ?? globalThis.chrome;
-              b.storage.local.get('criticalErrorRestore', (data) => {
-                resolve(!data.criticalErrorRestore);
-              });
-            });
-          `);
-          return Boolean(cleared);
-        },
-        { interval: 300, timeout: 30_000 },
-      );
-
-      // TEMP DIAGNOSTIC: extra delay to verify hypothesis that the SW handoff
-      // (initBackground + handoffRestoringTabToExtension) is still in flight
-      // when we reach this point — the storage key is cleared BEFORE handoff
-      // in app/scripts/background.js initOrRestoreBackground, so the waitUntil
-      // above can return while initBackground/handoff is still running.
-      // If this delay makes the test stop being flaky, the race is confirmed.
-      await this.driver.delay(10_000);
-
-      // Now safe to close extra tabs (service worker has finished handoff / fallback).
-      await this.driver.closeAllOtherTabs();
+      try {
+        await this.driver.switchToWindowWithTitle(
+          WINDOW_TITLES.ExtensionInFullScreenView,
+        );
+      } catch {
+        await this.driver.openNewPage('about:blank');
+        await this.driver.navigate();
+      }
     } else {
       await alert.dismiss();
     }

--- a/test/e2e/page-objects/pages/critical-error-page.ts
+++ b/test/e2e/page-objects/pages/critical-error-page.ts
@@ -121,6 +121,14 @@ class CriticalErrorPage {
         { interval: 300, timeout: 30_000 },
       );
 
+      // TEMP DIAGNOSTIC: extra delay to verify hypothesis that the SW handoff
+      // (initBackground + handoffRestoringTabToExtension) is still in flight
+      // when we reach this point — the storage key is cleared BEFORE handoff
+      // in app/scripts/background.js initOrRestoreBackground, so the waitUntil
+      // above can return while initBackground/handoff is still running.
+      // If this delay makes the test stop being flaky, the race is confirmed.
+      await this.driver.delay(10_000);
+
       // Now safe to close extra tabs (service worker has finished handoff / fallback).
       await this.driver.closeAllOtherTabs();
     } else {

--- a/test/e2e/page-objects/pages/critical-error-page.ts
+++ b/test/e2e/page-objects/pages/critical-error-page.ts
@@ -115,10 +115,10 @@ class CriticalErrorPage {
         { interval: 300, timeout: 30_000 },
       );
 
-      // TEMP DIAGNOSTIC: The restore session key is cleared before the service
-      // worker completes initBackground + handoffRestoringTabToExtension. This
-      // delay gives that handoff time to finish before closing extra tabs.
-      await this.driver.delay(10_000);
+      // The restore session key is cleared before the service worker finishes
+      // initializing. Wait for the UI to receive state and finish launching
+      // before closing extra tabs.
+      await this.driver.waitForControllersLoaded(30_000);
 
       await this.driver.closeAllOtherTabs();
     } else {

--- a/test/e2e/page-objects/pages/critical-error-page.ts
+++ b/test/e2e/page-objects/pages/critical-error-page.ts
@@ -100,6 +100,12 @@ class CriticalErrorPage {
         waitForLoadingLogoToDisappear: false,
       });
 
+      // The service worker handoff runs asynchronously after runtime.reload():
+      // it reads the restore session from storage.local, converts the
+      // metamask.io/restoring tab to home.html, then clears the key. We must
+      // wait for that key to be cleared before closing extra tabs — otherwise
+      // we kill the restoring tab before the service worker can hand it off,
+      // causing a fallback that opens a second home.html tab.
       await this.driver.waitUntil(
         async () => {
           const cleared = await this.driver.executeScript(`
@@ -115,11 +121,9 @@ class CriticalErrorPage {
         { interval: 300, timeout: 30_000 },
       );
 
-      // The restore session key is cleared before the service worker finishes
-      // initializing. Wait for the UI to receive state and finish launching
-      // before closing extra tabs.
+      // Wait for the UI to receive state and finish launching.
       await this.driver.waitForControllersLoaded(30_000);
-
+      // Now safe to close extra tabs (service worker has finished handoff / fallback).
       await this.driver.closeAllOtherTabs();
     } else {
       await alert.dismiss();

--- a/test/e2e/page-objects/pages/critical-error-page.ts
+++ b/test/e2e/page-objects/pages/critical-error-page.ts
@@ -90,17 +90,37 @@ class CriticalErrorPage {
       await alert.accept();
 
       // runtime.reload() kills extension tabs, so the driver's current window
-      // handle is stale. Wait for the reload, then reattach to the extension UI
-      // once the background has completed the restoring-tab handoff.
+      // handle is stale. Wait for the reload, then reattach to a surviving tab.
       await this.driver.delay(3000);
-      try {
-        await this.driver.switchToWindowWithTitle(
-          WINDOW_TITLES.ExtensionInFullScreenView,
-        );
-      } catch {
-        await this.driver.openNewPage('about:blank');
-        await this.driver.navigate();
-      }
+      const handles = await this.driver.driver.getAllWindowHandles();
+      await this.driver.driver.switchTo().window(handles[0]);
+
+      await this.waitForPageAfterExtensionReload({
+        timeoutMs: 30_000,
+        waitForLoadingLogoToDisappear: false,
+      });
+
+      await this.driver.waitUntil(
+        async () => {
+          const cleared = await this.driver.executeScript(`
+            return new Promise(resolve => {
+              const b = globalThis.browser ?? globalThis.chrome;
+              b.storage.local.get('criticalErrorRestore', (data) => {
+                resolve(!data.criticalErrorRestore);
+              });
+            });
+          `);
+          return Boolean(cleared);
+        },
+        { interval: 300, timeout: 30_000 },
+      );
+
+      // TEMP DIAGNOSTIC: The restore session key is cleared before the service
+      // worker completes initBackground + handoffRestoringTabToExtension. This
+      // delay gives that handoff time to finish before closing extra tabs.
+      await this.driver.delay(10_000);
+
+      await this.driver.closeAllOtherTabs();
     } else {
       await alert.dismiss();
     }

--- a/test/e2e/page-objects/pages/home/homepage.ts
+++ b/test/e2e/page-objects/pages/home/homepage.ts
@@ -569,7 +569,7 @@ class HomePage {
 
   async dismissSrpAddedToast(): Promise<void> {
     console.log('Dismiss SRP added toast');
-    await this.driver.clickElementSafe(this.srpAddedToastCloseButton, 3000);
+    await this.driver.clickElementSafe(this.srpAddedToastCloseButton, 5000);
   }
 
   async checkNoSurveyToastIsDisplayed(): Promise<void> {

--- a/test/e2e/page-objects/pages/home/homepage.ts
+++ b/test/e2e/page-objects/pages/home/homepage.ts
@@ -569,7 +569,7 @@ class HomePage {
 
   async dismissSrpAddedToast(): Promise<void> {
     console.log('Dismiss SRP added toast');
-    await this.driver.clickElementSafe(this.srpAddedToastCloseButton, 5000);
+    await this.driver.clickElementSafe(this.srpAddedToastCloseButton, 8000);
   }
 
   async checkNoSurveyToastIsDisplayed(): Promise<void> {

--- a/test/e2e/page-objects/pages/home/homepage.ts
+++ b/test/e2e/page-objects/pages/home/homepage.ts
@@ -569,7 +569,8 @@ class HomePage {
 
   async dismissSrpAddedToast(): Promise<void> {
     console.log('Dismiss SRP added toast');
-    await this.driver.clickElement(this.srpAddedToastCloseButton);
+    // The toast can take some time to appear
+    await this.driver.clickElementSafe(this.srpAddedToastCloseButton, 15_000);
   }
 
   async checkNoSurveyToastIsDisplayed(): Promise<void> {

--- a/test/e2e/page-objects/pages/home/homepage.ts
+++ b/test/e2e/page-objects/pages/home/homepage.ts
@@ -569,7 +569,7 @@ class HomePage {
 
   async dismissSrpAddedToast(): Promise<void> {
     console.log('Dismiss SRP added toast');
-    await this.driver.clickElementSafe(this.srpAddedToastCloseButton, 8000);
+    await this.driver.clickElement(this.srpAddedToastCloseButton);
   }
 
   async checkNoSurveyToastIsDisplayed(): Promise<void> {

--- a/test/e2e/tests/critical-errors/critical-errors.spec.ts
+++ b/test/e2e/tests/critical-errors/critical-errors.spec.ts
@@ -21,7 +21,7 @@ import {
 const BACKGROUND_CONNECTION_TIMEOUT = 15_000;
 
 describe('Critical errors', function (this: Suite) {
-  this.timeout(200_000); // We set a higher timeout because of the slow nature of these tests
+  this.timeout(120_000);
   it('shows critical error screen when background is unresponsive', async function () {
     await withFixtures(
       {

--- a/test/e2e/tests/critical-errors/critical-errors.spec.ts
+++ b/test/e2e/tests/critical-errors/critical-errors.spec.ts
@@ -21,7 +21,7 @@ import {
 const BACKGROUND_CONNECTION_TIMEOUT = 15_000;
 
 describe('Critical errors', function (this: Suite) {
-  this.timeout(180_000); // This test is very long, so we need an unusually high timeout
+  this.timeout(180_000); // We set a higher timeout because of the slow nature of these tests
   it('shows critical error screen when background is unresponsive', async function () {
     await withFixtures(
       {

--- a/test/e2e/tests/critical-errors/critical-errors.spec.ts
+++ b/test/e2e/tests/critical-errors/critical-errors.spec.ts
@@ -129,7 +129,6 @@ describe('Critical errors', function (this: Suite) {
   });
 
   it('shows critical error screen when background takes over 16 seconds to sync state, and allows user to restore accounts', async function () {
-    this.timeout(120_000);
     await withFixtures(
       {
         ...getConfig(this.test?.fullTitle(), {

--- a/test/e2e/tests/critical-errors/critical-errors.spec.ts
+++ b/test/e2e/tests/critical-errors/critical-errors.spec.ts
@@ -21,7 +21,7 @@ import {
 const BACKGROUND_CONNECTION_TIMEOUT = 15_000;
 
 describe('Critical errors', function (this: Suite) {
-  this.timeout(180_000); // We set a higher timeout because of the slow nature of these tests
+  this.timeout(200_000); // We set a higher timeout because of the slow nature of these tests
   it('shows critical error screen when background is unresponsive', async function () {
     await withFixtures(
       {

--- a/test/e2e/tests/critical-errors/critical-errors.spec.ts
+++ b/test/e2e/tests/critical-errors/critical-errors.spec.ts
@@ -21,6 +21,7 @@ import {
 const BACKGROUND_CONNECTION_TIMEOUT = 15_000;
 
 describe('Critical errors', function (this: Suite) {
+  this.timeout(120_000); // This test is very long, so we need an unusually high timeout
   it('shows critical error screen when background is unresponsive', async function () {
     await withFixtures(
       {
@@ -83,7 +84,6 @@ describe('Critical errors', function (this: Suite) {
   });
 
   it('shows critical error screen when background takes over 16 seconds to initialize, and allows user to restore accounts', async function () {
-    this.timeout(120_000);
     await withFixtures(
       {
         ...getConfig(this.test?.fullTitle(), {

--- a/test/e2e/tests/critical-errors/critical-errors.spec.ts
+++ b/test/e2e/tests/critical-errors/critical-errors.spec.ts
@@ -21,7 +21,7 @@ import {
 const BACKGROUND_CONNECTION_TIMEOUT = 15_000;
 
 describe('Critical errors', function (this: Suite) {
-  this.timeout(120_000); // This test is very long, so we need an unusually high timeout
+  this.timeout(180_000); // This test is very long, so we need an unusually high timeout
   it('shows critical error screen when background is unresponsive', async function () {
     await withFixtures(
       {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The test sometimes fails with all windows closed (no artifacts).

After clicking Attempt recovery, the extension calls runtime.reload(). The test waited for criticalErrorRestore to be cleared from storage.local, then immediately called closeAllOtherTabs(). However, that storage key is cleared before the service worker has fully finished initBackground(...) and the restoring-tab handoff. So the test could close tabs while the background was still initializing / handing off the restore tab, leaving Selenium attached to a stale or unstable browser target. That caused the test to hang until Mocha’s 200s timeout.

Now after the restore key is cleared, the test now waits for waitForControllersLoaded before closing extra tabs. This waits until the extension UI has received initial state and added .controller-loaded, which means the background is ready enough for the UI to proceed. Only then do we close other tabs

<img width="905" height="292" alt="image" src="https://github.com/user-attachments/assets/bae30ac0-9c1b-4124-a0cd-c6ca6edb9a80" />


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci (note: quality gate was enabled so the tests were run extra times on each build

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are confined to E2E test code and only adjust synchronization/timeouts; main risk is slightly longer CI runtime if waits are too conservative.
> 
> **Overview**
> Reduces E2E flakiness around critical error recovery by waiting for the post-`runtime.reload()` UI to fully initialize (`waitForControllersLoaded`, plus a short delay) before closing extra tabs after the restore handoff.
> 
> Also relaxes timing in the SRP import flow by increasing the close-button click timeout for the “SRP added” toast, and makes the `critical-errors` test suite use a consistent 120s Mocha timeout (removing per-test overrides).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e2e4d951a1fbac8d6cc4b51538d23e4a92f0f7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->