### PR TITLE
fix(asset-page): hide send button for zero token balance

### DIFF
--- a/test/e2e/page-objects/pages/token-overview-page.ts
+++ b/test/e2e/page-objects/pages/token-overview-page.ts
@@ -34,8 +34,7 @@ class TokenOverviewPage {
   async checkPageIsLoaded(): Promise<void> {
     try {
       await this.driver.waitForMultipleSelectors([
-        this.sendButton,
-        // this.swapButton,
+        this.swapButton,
       ]);
     } catch (e) {
       console.log(

--- a/test/e2e/page-objects/pages/token-overview-page.ts
+++ b/test/e2e/page-objects/pages/token-overview-page.ts
@@ -32,11 +32,29 @@ class TokenOverviewPage {
   }
 
   async checkPageIsLoaded(): Promise<void> {
+    // Try send button check
     try {
-      await Promise.any([
-        this.driver.waitForSelector(this.sendButton),
-        this.driver.waitForSelector(this.swapButton),
-      ]);
+      const sendButtonFound = await this.driver.waitForSelector(
+        this.sendButton,
+      );
+
+      if (sendButtonFound) {
+        console.log('Token overview page is loaded');
+        return;
+      }
+    } catch (e) {
+      console.log('Failed to find send button, trying swap button', e);
+    }
+
+    // Fallback to swap button check
+    try {
+      const swapButtonFound = await this.driver.waitForSelector(
+        this.swapButton,
+      );
+
+      if (swapButtonFound) {
+        console.log('Token overview page is loaded');
+      }
     } catch (e) {
       console.log(
         'Timeout while waiting for Token overview page to be loaded',
@@ -44,7 +62,6 @@ class TokenOverviewPage {
       );
       throw e;
     }
-    console.log('Token overview page is loaded');
   }
 
   async clickReceive(): Promise<void> {

--- a/test/e2e/page-objects/pages/token-overview-page.ts
+++ b/test/e2e/page-objects/pages/token-overview-page.ts
@@ -33,9 +33,9 @@ class TokenOverviewPage {
 
   async checkPageIsLoaded(): Promise<void> {
     try {
-      await this.driver.waitForMultipleSelectors([
-        this.sendButton,
-        // this.swapButton,
+      await Promise.any([
+        this.driver.waitForSelector(this.sendButton),
+        this.driver.waitForSelector(this.swapButton),
       ]);
     } catch (e) {
       console.log(

--- a/test/e2e/page-objects/pages/token-overview-page.ts
+++ b/test/e2e/page-objects/pages/token-overview-page.ts
@@ -33,9 +33,7 @@ class TokenOverviewPage {
 
   async checkPageIsLoaded(): Promise<void> {
     try {
-      await this.driver.waitForMultipleSelectors([
-        this.swapButton,
-      ]);
+      await this.driver.waitForMultipleSelectors([this.swapButton]);
     } catch (e) {
       console.log(
         'Timeout while waiting for Token overview page to be loaded',

--- a/test/e2e/page-objects/pages/token-overview-page.ts
+++ b/test/e2e/page-objects/pages/token-overview-page.ts
@@ -33,7 +33,10 @@ class TokenOverviewPage {
 
   async checkPageIsLoaded(): Promise<void> {
     try {
-      await this.driver.waitForMultipleSelectors([this.swapButton]);
+      await this.driver.waitForMultipleSelectors([
+        this.sendButton,
+        // this.swapButton,
+      ]);
     } catch (e) {
       console.log(
         'Timeout while waiting for Token overview page to be loaded',

--- a/ui/pages/asset/components/__snapshots__/asset-page.test.tsx.snap
+++ b/ui/pages/asset/components/__snapshots__/asset-page.test.tsx.snap
@@ -545,25 +545,6 @@ exports[`AssetPage should render an ERC20 asset without prices 1`] = `
         </button>
         <button
           class="mm-box mm-text mm-button-base mm-button-base--size-md icon-button token-overview__button mm-text--body-md-medium mm-box--padding-0 mm-box--padding-top-3 mm-box--padding-right-2 mm-box--padding-bottom-3 mm-box--padding-left-2 mm-box--display-inline-flex mm-box--flex-direction-column mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-muted mm-box--rounded-xl"
-          data-testid="eth-overview-send"
-        >
-          <span
-            class="mm-box mm-text icon-button__label mm-text--inherit mm-text--ellipsis mm-box--color-text-default"
-          >
-            <span
-              class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-icon-alternative"
-              style="mask-image: url('./images/icons/send.svg');"
-            />
-            <span
-              class="mm-box mm-text mm-text--body-sm-medium mm-text--ellipsis mm-box--display-block mm-box--color-text-default"
-              style="margin-top: -4px;"
-            >
-              Send
-            </span>
-          </span>
-        </button>
-        <button
-          class="mm-box mm-text mm-button-base mm-button-base--size-md icon-button token-overview__button mm-text--body-md-medium mm-box--padding-0 mm-box--padding-top-3 mm-box--padding-right-2 mm-box--padding-bottom-3 mm-box--padding-left-2 mm-box--display-inline-flex mm-box--flex-direction-column mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-muted mm-box--rounded-xl"
           data-testid="token-overview-swap"
         >
           <span
@@ -965,25 +946,6 @@ exports[`AssetPage should render an ERC20 token with prices 1`] = `
               style="margin-top: -4px;"
             >
               Buy
-            </span>
-          </span>
-        </button>
-        <button
-          class="mm-box mm-text mm-button-base mm-button-base--size-md icon-button token-overview__button mm-text--body-md-medium mm-box--padding-0 mm-box--padding-top-3 mm-box--padding-right-2 mm-box--padding-bottom-3 mm-box--padding-left-2 mm-box--display-inline-flex mm-box--flex-direction-column mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-muted mm-box--rounded-xl"
-          data-testid="eth-overview-send"
-        >
-          <span
-            class="mm-box mm-text icon-button__label mm-text--inherit mm-text--ellipsis mm-box--color-text-default"
-          >
-            <span
-              class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-icon-alternative"
-              style="mask-image: url('./images/icons/send.svg');"
-            />
-            <span
-              class="mm-box mm-text mm-text--body-sm-medium mm-text--ellipsis mm-box--display-block mm-box--color-text-default"
-              style="margin-top: -4px;"
-            >
-              Send
             </span>
           </span>
         </button>

--- a/ui/pages/asset/components/asset-page.test.tsx
+++ b/ui/pages/asset/components/asset-page.test.tsx
@@ -448,6 +448,43 @@ describe('AssetPage', () => {
     );
   });
 
+  it('hides the Send button when token balance is zero', () => {
+    const { queryByTestId } = renderWithProvider(
+      <AssetPage asset={token} optionsButton={null} />,
+      store,
+    );
+
+    expect(queryByTestId('eth-overview-send')).not.toBeInTheDocument();
+  });
+
+  it('shows the Send button when token balance is greater than zero', () => {
+    (
+      getAssetsBySelectedAccountGroup as unknown as jest.Mock
+    ).mockReturnValueOnce({
+      '0x1': [
+        {
+          assetId: '0x0000000000000000000000000000000000000000',
+          rawBalance: '0x0',
+          balance: '0',
+          fiat: { balance: 0 },
+        },
+        {
+          assetId: token.address,
+          rawBalance: '0x1',
+          balance: '1',
+          fiat: { balance: 0 },
+        },
+      ],
+    });
+
+    const { queryByTestId } = renderWithProvider(
+      <AssetPage asset={token} optionsButton={null} />,
+      store,
+    );
+
+    expect(queryByTestId('eth-overview-send')).toBeInTheDocument();
+  });
+
   it('should show the Swap button if chain id is supported', async () => {
     const { queryByTestId } = renderWithProvider(
       <AssetPage asset={token} optionsButton={null} />,

--- a/ui/pages/asset/components/token-buttons.tsx
+++ b/ui/pages/asset/components/token-buttons.tsx
@@ -50,6 +50,9 @@ const TokenButtons = ({
   const navigate = useNavigate();
   const isExternalServicesEnabled = useSelector(getUseExternalServices);
   const isEvm = isEvmChainId(token.chainId);
+  const shouldShowSendButton = Boolean(
+    token.balance?.value && token.balance.value !== '0',
+  );
 
   const currentChainId = token.chainId;
 
@@ -147,23 +150,25 @@ const TokenButtons = ({
         disabled={token.isERC721 || !isBuyableChain}
       />
 
-      <IconButton
-        className="token-overview__button"
-        onClick={handleSendOnClick}
-        Icon={
-          <Icon
-            name={IconName.Send}
-            color={IconColor.iconAlternative}
-            size={IconSize.Md}
-          />
-        }
-        label={t('send')}
-        data-testid="eth-overview-send"
-        disabled={
-          token.isERC721 ||
-          (disableSendForNonEvm && !isEvm && !isExternalServicesEnabled)
-        }
-      />
+      {shouldShowSendButton ? (
+        <IconButton
+          className="token-overview__button"
+          onClick={handleSendOnClick}
+          Icon={
+            <Icon
+              name={IconName.Send}
+              color={IconColor.iconAlternative}
+              size={IconSize.Md}
+            />
+          }
+          label={t('send')}
+          data-testid="eth-overview-send"
+          disabled={
+            token.isERC721 ||
+            (disableSendForNonEvm && !isEvm && !isExternalServicesEnabled)
+          }
+        />
+      ) : null}
 
       <IconButton
         className="token-overview__button"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

On the asset details page for token assets, the Send button was always rendered even when the selected account had zero balance for that token. This could lead users into a send flow that hangs in a loading state.

This change aligns extension behavior with mobile by only rendering the Send button when the token has a positive balance in the selected account.

## **Changelog**

CHANGELOG entry: Fixed a bug where the token asset details page showed Send for zero-balance tokens.

## **Related issues**

Fixes: ASSETS-3070
Jira: https://consensyssoftware.atlassian.net/browse/ASSETS-3070
GitHub issue: N/A

## **Manual testing steps**

1. Open the extension and navigate to a token asset details page where the selected account balance is `0`.
2. Confirm the `Send` button is hidden.
3. Navigate to a token asset details page where the selected account has a positive token balance.
4. Confirm the `Send` button is visible.

## **Screenshots/Recordings**

### **Before**

[screenshots/recordings]

### **After**

https://www.loom.com/share/2d246f214c9c47799c0bd1aa7861bb46

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e1d2d03-1a0e-455b-843f-9d6554a91843"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e1d2d03-1a0e-455b-843f-9d6554a91843"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

