### PR TITLE
feat(passkey): TO-731 - handle passkey of google password manager in sidepanel

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5344,10 +5344,6 @@
   "passkeySetupStepVerify": {
     "message": "Validate Biometrics"
   },
-  "passkeyTroubleshoot": {
-    "message": "Trouble unlocking?",
-    "description": "Opens MetaMask in a full browser tab when passkey is unreliable in the side panel."
-  },
   "passkeyTroubleshootModalDescription": {
     "message": "Try opening the extension in a full screen window and try again.",
     "description": "Explains that unlocking with a passkey may work better in a full screen MetaMask window."
@@ -5360,9 +5356,21 @@
     "message": "Still having trouble?",
     "description": "Link text to open MetaMask support when passkey unlock troubleshooting did not help."
   },
-  "passkeyTroubleshootModalTitle": {
+  "passkeyTroubleshootUnlock": {
+    "message": "Trouble unlocking?",
+    "description": "Opens MetaMask in a full browser tab when passkey is unreliable in the side panel."
+  },
+  "passkeyTroubleshootUnlockModalTitle": {
     "message": "Trouble unlocking",
     "description": "Title for the modal shown when the user needs help unlocking with a passkey from the side panel."
+  },
+  "passkeyTroubleshootVerify": {
+    "message": "Trouble verifying?",
+    "description": "Link to open passkey troubleshooting when verifying identity (not unlock), e.g. change password or security settings in the side panel."
+  },
+  "passkeyTroubleshootVerifyModalTitle": {
+    "message": "Trouble verifying?",
+    "description": "Title for the passkey troubleshoot modal when the user needs help verifying with a passkey outside of unlock (e.g. security settings or change password)."
   },
   "passkeyTurnedOff": {
     "message": "Biometrics turned off"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -5344,10 +5344,6 @@
   "passkeySetupStepVerify": {
     "message": "Validate Biometrics"
   },
-  "passkeyTroubleshoot": {
-    "message": "Trouble unlocking?",
-    "description": "Opens MetaMask in a full browser tab when passkey is unreliable in the side panel."
-  },
   "passkeyTroubleshootModalDescription": {
     "message": "Try opening the extension in a full screen window and try again.",
     "description": "Explains that unlocking with a passkey may work better in a full screen MetaMask window."
@@ -5360,9 +5356,21 @@
     "message": "Still having trouble?",
     "description": "Link text to open MetaMask support when passkey unlock troubleshooting did not help."
   },
-  "passkeyTroubleshootModalTitle": {
+  "passkeyTroubleshootUnlock": {
+    "message": "Trouble unlocking?",
+    "description": "Opens MetaMask in a full browser tab when passkey is unreliable in the side panel."
+  },
+  "passkeyTroubleshootUnlockModalTitle": {
     "message": "Trouble unlocking",
     "description": "Title for the modal shown when the user needs help unlocking with a passkey from the side panel."
+  },
+  "passkeyTroubleshootVerify": {
+    "message": "Trouble verifying?",
+    "description": "Link to open passkey troubleshooting when verifying identity (not unlock), e.g. change password or security settings in the side panel."
+  },
+  "passkeyTroubleshootVerifyModalTitle": {
+    "message": "Trouble verifying?",
+    "description": "Title for the passkey troubleshoot modal when the user needs help verifying with a passkey outside of unlock (e.g. security settings or change password)."
   },
   "passkeyTurnedOff": {
     "message": "Biometrics turned off"

--- a/package.json
+++ b/package.json
@@ -395,7 +395,7 @@
     "@metamask/notification-services-controller": "^23.1.0",
     "@metamask/object-multiplex": "^2.0.0",
     "@metamask/obs-store": "^9.0.0",
-    "@metamask/passkey-controller": "^2.0.0",
+    "@metamask/passkey-controller": "^2.0.1",
     "@metamask/permission-controller": "^13.0.0",
     "@metamask/permission-log-controller": "^5.0.0",
     "@metamask/permissions-kernel-snap": "^1.1.0",

--- a/shared/constants/passkey.ts
+++ b/shared/constants/passkey.ts
@@ -3,19 +3,3 @@
  * so the user is not immediately prompted again when opening the wallet.
  */
 export const PASSKEY_AUTO_UNLOCK_SUPPRESSION_DURATION_MS = 1_000;
-
-/**
- * Google Password Manager (passkey authenticator model).
- * @see https://web.dev/articles/webauthn-aaguid
- * @see https://github.com/passkeydeveloper/passkey-authenticator-aaguids/blob/main/aaguid.json
- */
-export const GOOGLE_PASSWORD_MANAGER_PASSKEY_AAGUID =
-  'ea9b8d66-4d01-1d21-3ce4-b6b48cb575d4';
-
-/**
- * AAGUIDs for passkey authenticators that should not run passkey ceremonies in
- * the extension side panel; open a normal extension tab instead.
- * Add entries with a comment / issue link when a provider fails in sidepanel.
- */
-export const PASSKEY_AAGUIDS_INCOMPATIBLE_WITH_SIDEPANEL: ReadonlySet<string> =
-  new Set([GOOGLE_PASSWORD_MANAGER_PASSKEY_AAGUID]);

--- a/shared/constants/passkey.ts
+++ b/shared/constants/passkey.ts
@@ -3,3 +3,19 @@
  * so the user is not immediately prompted again when opening the wallet.
  */
 export const PASSKEY_AUTO_UNLOCK_SUPPRESSION_DURATION_MS = 1_000;
+
+/**
+ * Google Password Manager (passkey authenticator model).
+ * @see https://web.dev/articles/webauthn-aaguid
+ * @see https://github.com/passkeydeveloper/passkey-authenticator-aaguids/blob/main/aaguid.json
+ */
+export const GOOGLE_PASSWORD_MANAGER_PASSKEY_AAGUID =
+  'ea9b8d66-4d01-1d21-3ce4-b6b48cb575d4';
+
+/**
+ * AAGUIDs for passkey authenticators that should not run passkey ceremonies in
+ * the extension side panel; open a normal extension tab instead.
+ * Add entries with a comment / issue link when a provider fails in sidepanel.
+ */
+export const PASSKEY_AAGUIDS_INCOMPATIBLE_WITH_SIDEPANEL: ReadonlySet<string> =
+  new Set([GOOGLE_PASSWORD_MANAGER_PASSKEY_AAGUID]);

--- a/shared/lib/passkey/index.ts
+++ b/shared/lib/passkey/index.ts
@@ -13,7 +13,4 @@ export {
   ExtensionPasskeyErrorCode,
   translatePasskeyError,
 } from './passkey-error';
-export {
-  normalizePasskeyAaguid,
-  isPasskeyAaguidIncompatibleWithSidepanel,
-} from './passkey-sidepanel-aaguid';
+export { isPasskeyAaguidIncompatibleWithSidepanel } from './passkey-sidepanel-aaguid';

--- a/shared/lib/passkey/index.ts
+++ b/shared/lib/passkey/index.ts
@@ -13,3 +13,7 @@ export {
   ExtensionPasskeyErrorCode,
   translatePasskeyError,
 } from './passkey-error';
+export {
+  normalizePasskeyAaguid,
+  isPasskeyAaguidIncompatibleWithSidepanel,
+} from './passkey-sidepanel-aaguid';

--- a/shared/lib/passkey/passkey-sidepanel-aaguid.test.ts
+++ b/shared/lib/passkey/passkey-sidepanel-aaguid.test.ts
@@ -1,0 +1,59 @@
+import { GOOGLE_PASSWORD_MANAGER_PASSKEY_AAGUID } from '../../constants/passkey';
+import {
+  normalizePasskeyAaguid,
+  isPasskeyAaguidIncompatibleWithSidepanel,
+} from './passkey-sidepanel-aaguid';
+
+describe('normalizePasskeyAaguid', () => {
+  it('returns lowercase trimmed UUID', () => {
+    expect(
+      normalizePasskeyAaguid('  EA9B8D66-4D01-1D21-3CE4-B6B48CB575D4  '),
+    ).toBe(GOOGLE_PASSWORD_MANAGER_PASSKEY_AAGUID);
+  });
+
+  it('returns null for missing or whitespace-only', () => {
+    expect(normalizePasskeyAaguid('')).toBeNull();
+    expect(normalizePasskeyAaguid('   ')).toBeNull();
+    expect(normalizePasskeyAaguid(null)).toBeNull();
+    expect(normalizePasskeyAaguid(undefined)).toBeNull();
+  });
+
+  it('returns trimmed lowercase for any non-empty string', () => {
+    expect(normalizePasskeyAaguid('not-a-uuid')).toBe('not-a-uuid');
+    expect(normalizePasskeyAaguid('  Foo  ')).toBe('foo');
+  });
+});
+
+describe('isPasskeyAaguidIncompatibleWithSidepanel', () => {
+  it('returns true for Google Password Manager AAGUID', () => {
+    expect(
+      isPasskeyAaguidIncompatibleWithSidepanel(
+        GOOGLE_PASSWORD_MANAGER_PASSKEY_AAGUID,
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false for unknown AAGUID', () => {
+    expect(
+      isPasskeyAaguidIncompatibleWithSidepanel(
+        'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false for all-zero AAGUID', () => {
+    expect(
+      isPasskeyAaguidIncompatibleWithSidepanel(
+        '00000000-0000-0000-0000-000000000000',
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false for missing aaguid', () => {
+    expect(isPasskeyAaguidIncompatibleWithSidepanel(undefined)).toBe(false);
+  });
+
+  it('returns false for non-list string', () => {
+    expect(isPasskeyAaguidIncompatibleWithSidepanel('not-a-uuid')).toBe(false);
+  });
+});

--- a/shared/lib/passkey/passkey-sidepanel-aaguid.test.ts
+++ b/shared/lib/passkey/passkey-sidepanel-aaguid.test.ts
@@ -1,8 +1,11 @@
-import { GOOGLE_PASSWORD_MANAGER_PASSKEY_AAGUID } from '../../constants/passkey';
 import {
   normalizePasskeyAaguid,
   isPasskeyAaguidIncompatibleWithSidepanel,
 } from './passkey-sidepanel-aaguid';
+
+/** Must match private Google Password Manager AAGUID in passkey-sidepanel-aaguid.ts */
+const GOOGLE_PASSWORD_MANAGER_PASSKEY_AAGUID =
+  'ea9b8d66-4d01-1d21-3ce4-b6b48cb575d4';
 
 describe('normalizePasskeyAaguid', () => {
   it('returns lowercase trimmed UUID', () => {

--- a/shared/lib/passkey/passkey-sidepanel-aaguid.ts
+++ b/shared/lib/passkey/passkey-sidepanel-aaguid.ts
@@ -1,0 +1,37 @@
+import { PASSKEY_AAGUIDS_INCOMPATIBLE_WITH_SIDEPANEL } from '../../constants/passkey';
+
+/**
+ * Normalizes a stored passkey AAGUID for Set lookup (trim + lowercase).
+ * Returns null if the value is missing or whitespace-only.
+ * @param raw
+ */
+export function normalizePasskeyAaguid(
+  raw: string | undefined | null,
+): string | null {
+  if (raw === undefined || raw === null || typeof raw !== 'string') {
+    return null;
+  }
+  const trimmed = raw.trim().toLowerCase();
+  if (!trimmed) {
+    return null;
+  }
+  return trimmed;
+}
+
+/**
+ * True when this authenticator AAGUID is known to misbehave for passkey
+ * ceremonies inside the extension side panel (defer to a normal browser tab).
+ *
+ * Add AAGUIDs to {@link PASSKEY_AAGUIDS_INCOMPATIBLE_WITH_SIDEPANEL} only with
+ * a short comment / issue link—do not branch per provider in UI code.
+ * @param aaguid
+ */
+export function isPasskeyAaguidIncompatibleWithSidepanel(
+  aaguid: string | undefined | null,
+): boolean {
+  const normalized = normalizePasskeyAaguid(aaguid);
+  if (normalized === null) {
+    return false;
+  }
+  return PASSKEY_AAGUIDS_INCOMPATIBLE_WITH_SIDEPANEL.has(normalized);
+}

--- a/shared/lib/passkey/passkey-sidepanel-aaguid.ts
+++ b/shared/lib/passkey/passkey-sidepanel-aaguid.ts
@@ -1,4 +1,19 @@
-import { PASSKEY_AAGUIDS_INCOMPATIBLE_WITH_SIDEPANEL } from '../../constants/passkey';
+/**
+ * Google Password Manager (passkey authenticator model).
+ * Module-private; call sites should use {@link isPasskeyAaguidIncompatibleWithSidepanel}.
+ * @see https://web.dev/articles/webauthn-aaguid
+ * @see https://github.com/passkeydeveloper/passkey-authenticator-aaguids/blob/main/aaguid.json
+ */
+const GOOGLE_PASSWORD_MANAGER_PASSKEY_AAGUID =
+  'ea9b8d66-4d01-1d21-3ce4-b6b48cb575d4';
+
+/**
+ * AAGUIDs for passkey authenticators that should not run passkey ceremonies in
+ * the extension side panel; open a normal extension tab instead.
+ * Add entries with a comment / issue link when a provider fails in sidepanel.
+ */
+const PASSKEY_AAGUIDS_INCOMPATIBLE_WITH_SIDEPANEL: ReadonlySet<string> =
+  new Set([GOOGLE_PASSWORD_MANAGER_PASSKEY_AAGUID]);
 
 /**
  * Normalizes a stored passkey AAGUID for Set lookup (trim + lowercase).
@@ -22,8 +37,6 @@ export function normalizePasskeyAaguid(
  * True when this authenticator AAGUID is known to misbehave for passkey
  * ceremonies inside the extension side panel (defer to a normal browser tab).
  *
- * Add AAGUIDs to {@link PASSKEY_AAGUIDS_INCOMPATIBLE_WITH_SIDEPANEL} only with
- * a short comment / issue link—do not branch per provider in UI code.
  * @param aaguid
  */
 export function isPasskeyAaguidIncompatibleWithSidepanel(

--- a/ui/components/app/change-password/change-password.test.tsx
+++ b/ui/components/app/change-password/change-password.test.tsx
@@ -129,6 +129,9 @@ jest.mock('../../../selectors', () => ({
   getIsSocialLoginFlow: jest.fn().mockReturnValue(false),
   getIsPasskeyRegistered: jest.fn().mockReturnValue(false),
   getIsPasskeyFeatureAvailable: jest.fn().mockReturnValue(false),
+  getIsEnrolledPasskeyIncompatibleWithSidepanel: jest
+    .fn()
+    .mockReturnValue(false),
 }));
 
 describe('ChangePassword', () => {
@@ -144,6 +147,9 @@ describe('ChangePassword', () => {
     (selectors.getIsPasskeyFeatureAvailable as jest.Mock).mockReturnValue(
       false,
     );
+    (
+      selectors.getIsEnrolledPasskeyIncompatibleWithSidepanel as jest.Mock
+    ).mockReturnValue(false);
     (startPasskeyAuthentication as jest.Mock).mockResolvedValue({
       id: 'mock-credential',
     });
@@ -381,6 +387,9 @@ describe('ChangePassword', () => {
       (selectors.getIsPasskeyFeatureAvailable as jest.Mock).mockReturnValue(
         true,
       );
+      (
+        selectors.getIsEnrolledPasskeyIncompatibleWithSidepanel as jest.Mock
+      ).mockReturnValue(false);
       (startPasskeyAuthentication as jest.Mock).mockResolvedValue(
         mockAssertion,
       );
@@ -637,41 +646,36 @@ describe('ChangePassword', () => {
       ).not.toBeInTheDocument();
     });
 
-    it('shows open in full tab while passkey verification runs in the side panel', async () => {
+    it('opens change password in browser tab when sidepanel and enrolled passkey is incompatible', async () => {
+      const openExtensionInBrowser = jest.fn();
+      globalThis.platform = { openExtensionInBrowser } as never;
+
       jest
         .mocked(getEnvironmentType)
         .mockReturnValue(ENVIRONMENT_TYPE_SIDEPANEL);
-      let resolveAuth: ((value: unknown) => void) | undefined;
-      (startPasskeyAuthentication as jest.Mock).mockImplementation(
-        () =>
-          new Promise((resolve) => {
-            resolveAuth = resolve;
-          }),
+      (
+        selectors.getIsEnrolledPasskeyIncompatibleWithSidepanel as jest.Mock
+      ).mockReturnValue(true);
+
+      const { getByTestId, queryByTestId } = renderWithProvider(
+        <ChangePassword />,
+        mockStore,
       );
 
-      const { getByTestId } = renderWithProvider(<ChangePassword />, mockStore);
-
       await waitFor(() => {
-        expect(
-          getByTestId('change-password-passkey-verifying-open-full-screen'),
-        ).toBeInTheDocument();
+        expect(openExtensionInBrowser).toHaveBeenCalledWith(
+          SECURITY_PASSWORD_CHANGE_V2_ROUTE,
+          'from=sidepanel',
+        );
       });
 
-      resolveAuth?.({
-        id: 'mock-credential',
-        rawId: 'mock-credential',
-        type: 'public-key',
-        response: {
-          clientDataJSON: 'e30',
-          authenticatorData: 'AA',
-          signature: 'AA',
-        },
-        clientExtensionResults: {},
-      });
+      expect(
+        queryByTestId('change-password-passkey-verifying-open-full-screen'),
+      ).not.toBeInTheDocument();
+      expect(getByTestId('verify-current-password-input')).toBeInTheDocument();
+      expect(startPasskeyAuthentication).not.toHaveBeenCalled();
 
-      await waitFor(() => {
-        expect(getByTestId('change-password-input')).toBeInTheDocument();
-      });
+      delete (globalThis as { platform?: unknown }).platform;
     });
 
     it('opens passkey troubleshoot modal from side panel verify step and opens change password full screen from modal', async () => {

--- a/ui/components/app/change-password/change-password.tsx
+++ b/ui/components/app/change-password/change-password.tsx
@@ -483,7 +483,7 @@ const ChangePassword = ({
               className="text-center"
               onClick={() => setShowPasskeyTroubleshootModal(true)}
             >
-              {t('passkeyTroubleshoot')}
+              {t('passkeyTroubleshootVerify')}
             </TextButton>
           ) : null}
           <TextButton
@@ -565,7 +565,7 @@ const ChangePassword = ({
                       className="mt-2 flex w-full justify-start text-left"
                       onClick={() => setShowPasskeyTroubleshootModal(true)}
                     >
-                      {t('passkeyTroubleshoot')}
+                      {t('passkeyTroubleshootVerify')}
                     </TextButton>
                   ) : null}
                 </Box>
@@ -642,6 +642,7 @@ const ChangePassword = ({
       )}
       {showPasskeyTroubleshootModal ? (
         <PasskeyTroubleshootModal
+          mode="verify"
           onClose={() => setShowPasskeyTroubleshootModal(false)}
           onOpenFullScreen={openChangePasswordInFullScreen}
         />

--- a/ui/components/app/change-password/change-password.tsx
+++ b/ui/components/app/change-password/change-password.tsx
@@ -57,6 +57,7 @@ import {
   getIsPasskeyFeatureAvailable,
   getIsPasskeyRegistered,
   getIsSocialLoginFlow,
+  getIsEnrolledPasskeyIncompatibleWithSidepanel,
 } from '../../../selectors';
 import { getEnvironmentType } from '../../../../shared/lib/environment-type';
 import { ENVIRONMENT_TYPE_SIDEPANEL } from '../../../../shared/constants/app';
@@ -101,15 +102,26 @@ const ChangePassword = ({
   const isPasskeyRegistered = useSelector(getIsPasskeyRegistered);
   const isPasskeyFeatureAvailable = useSelector(getIsPasskeyFeatureAvailable);
   const isPasskeyActive = isPasskeyRegistered && isPasskeyFeatureAvailable;
+  const isEnrolledPasskeyIncompatibleWithSidepanel = useSelector(
+    getIsEnrolledPasskeyIncompatibleWithSidepanel,
+  );
+  const isSidePanel = getEnvironmentType() === ENVIRONMENT_TYPE_SIDEPANEL;
+  const mustDeferPasskeyToBrowserTab =
+    isSidePanel &&
+    isEnrolledPasskeyIncompatibleWithSidepanel &&
+    isPasskeyActive;
   const animationEventEmitter = useRef(new EventEmitter());
+  const hasDeferredPasskeyToBrowserTabRef = useRef(false);
 
   const [step, setStep] = useState(() =>
-    isPasskeyActive
+    isPasskeyActive && !mustDeferPasskeyToBrowserTab
       ? ChangePasswordSteps.VerifyPasskey
       : ChangePasswordSteps.VerifyCurrentPassword,
   );
 
-  const [isVerifyingPasskey, setIsVerifyingPasskey] = useState(isPasskeyActive);
+  const [isVerifyingPasskey, setIsVerifyingPasskey] = useState(
+    () => isPasskeyActive && !mustDeferPasskeyToBrowserTab,
+  );
 
   const [currentPassword, setCurrentPassword] = useState('');
   const [isIncorrectPasswordError, setIsIncorrectPasswordError] =
@@ -309,8 +321,6 @@ const ChangePassword = ({
     }
   }, [t]);
 
-  const isSidePanel = getEnvironmentType() === ENVIRONMENT_TYPE_SIDEPANEL;
-
   const openChangePasswordInFullScreen = useCallback(() => {
     cancelPasskeyCeremony();
     globalThis.platform?.openExtensionInBrowser?.(
@@ -319,10 +329,22 @@ const ChangePassword = ({
     );
   }, []);
 
+  useEffect(() => {
+    if (
+      !mustDeferPasskeyToBrowserTab ||
+      hasDeferredPasskeyToBrowserTabRef.current
+    ) {
+      return;
+    }
+    hasDeferredPasskeyToBrowserTabRef.current = true;
+    openChangePasswordInFullScreen();
+  }, [mustDeferPasskeyToBrowserTab, openChangePasswordInFullScreen]);
+
   // When a passkey is already enrolled, verify with WebAuthn on the dedicated step before new password.
   useEffect(() => {
     if (
       !isPasskeyActive ||
+      mustDeferPasskeyToBrowserTab ||
       step !== ChangePasswordSteps.VerifyPasskey ||
       passkeyAuthenticationResponse !== null
     ) {
@@ -364,6 +386,7 @@ const ChangePassword = ({
     };
   }, [
     isPasskeyActive,
+    mustDeferPasskeyToBrowserTab,
     passkeyAuthenticationResponse,
     step,
     performPasskeyAuthentication,
@@ -475,7 +498,9 @@ const ChangePassword = ({
           >
             {t('changePasswordPasskeyVerifyingTitle')}
           </Text>
-          {isSidePanel && isVerifyingPasskey ? (
+          {isSidePanel &&
+          isVerifyingPasskey &&
+          !mustDeferPasskeyToBrowserTab ? (
             <TextButton
               type="button"
               data-testid="change-password-passkey-verifying-open-full-screen"
@@ -557,7 +582,9 @@ const ChangePassword = ({
                       disabled={isVerifyingPasskey}
                     />
                   </Box>
-                  {isSidePanel && isVerifyingPasskey ? (
+                  {isSidePanel &&
+                  isVerifyingPasskey &&
+                  !mustDeferPasskeyToBrowserTab ? (
                     <TextButton
                       type="button"
                       data-testid="change-password-passkey-toggle-open-full-screen"

--- a/ui/components/app/passkey-troubleshoot-modal/index.ts
+++ b/ui/components/app/passkey-troubleshoot-modal/index.ts
@@ -1,1 +1,2 @@
 export { default } from './passkey-troubleshoot-modal';
+export type { PasskeyTroubleshootModalMode } from './passkey-troubleshoot-modal';

--- a/ui/components/app/passkey-troubleshoot-modal/passkey-troubleshoot-modal.tsx
+++ b/ui/components/app/passkey-troubleshoot-modal/passkey-troubleshoot-modal.tsx
@@ -26,12 +26,16 @@ import {
 } from '../../../../shared/constants/metametrics';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 
+export type PasskeyTroubleshootModalMode = 'unlock' | 'verify';
+
 type PasskeyTroubleshootModalProps = Readonly<{
+  mode: PasskeyTroubleshootModalMode;
   onClose: () => void;
   onOpenFullScreen: () => void;
 }>;
 
 export default function PasskeyTroubleshootModal({
+  mode,
   onClose,
   onOpenFullScreen,
 }: PasskeyTroubleshootModalProps) {
@@ -84,7 +88,11 @@ export default function PasskeyTroubleshootModal({
             color={TextColor.TextDefault}
             textAlign={TextAlign.Center}
           >
-            {t('passkeyTroubleshootModalTitle')}
+            {t(
+              mode === 'unlock'
+                ? 'passkeyTroubleshootUnlockModalTitle'
+                : 'passkeyTroubleshootVerifyModalTitle',
+            )}
           </Text>
         </ModalHeader>
         <Box paddingHorizontal={4}>

--- a/ui/pages/onboarding-flow/setup-passkey/setup-passkey.tsx
+++ b/ui/pages/onboarding-flow/setup-passkey/setup-passkey.tsx
@@ -169,15 +169,20 @@ export default function SetupPasskey() {
           'Onboarding passkey enrollment ceremony cancelled or timed out',
           error,
         );
-        setRegisterStepPhase(DEFAULT_PASSKEY_ENROLLMENT_STEP_PHASE);
-        setVerifyStepPhase(DEFAULT_PASSKEY_ENROLLMENT_STEP_PHASE);
+        if (isMountedRef.current) {
+          setRegisterStepPhase(DEFAULT_PASSKEY_ENROLLMENT_STEP_PHASE);
+          setVerifyStepPhase(DEFAULT_PASSKEY_ENROLLMENT_STEP_PHASE);
+        }
         return;
       }
 
       log.error('Onboarding passkey registration failed', error);
-      setEnrollmentError(
-        translatePasskeyError(error, t) ?? t('passkeyErrorRegistrationFailed'),
-      );
+      if (isMountedRef.current) {
+        setEnrollmentError(
+          translatePasskeyError(error, t) ??
+            t('passkeyErrorRegistrationFailed'),
+        );
+      }
     } finally {
       if (isMountedRef.current) {
         setIsEnrollmentInProgress(false);

--- a/ui/pages/onboarding-flow/setup-passkey/setup-passkey.tsx
+++ b/ui/pages/onboarding-flow/setup-passkey/setup-passkey.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import log from 'loglevel';
 import {
   Box,
@@ -80,6 +80,14 @@ export default function SetupPasskey() {
       DEFAULT_PASSKEY_ENROLLMENT_STEP_PHASE,
     );
   const [enrollmentError, setEnrollmentError] = useState<string | null>(null);
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
 
   const goToNextStep = useCallback(() => {
     const isFirefox = getBrowserName() === PLATFORM_FIREFOX;
@@ -151,7 +159,9 @@ export default function SetupPasskey() {
       await new Promise((resolve) => {
         setTimeout(resolve, PASSKEY_ENROLLMENT_SUCCESS_DISPLAY_MS);
       });
-      goToNextStep();
+      if (isMountedRef.current) {
+        goToNextStep();
+      }
     } catch (error) {
       // handle error
       if (isPasskeyCeremonySilentError(error)) {
@@ -169,9 +179,11 @@ export default function SetupPasskey() {
         translatePasskeyError(error, t) ?? t('passkeyErrorRegistrationFailed'),
       );
     } finally {
-      setIsEnrollmentInProgress(false);
-      setRegisterStepPhase((prev) => (prev === 'loading' ? 'idle' : prev));
-      setVerifyStepPhase((prev) => (prev === 'loading' ? 'idle' : prev));
+      if (isMountedRef.current) {
+        setIsEnrollmentInProgress(false);
+        setRegisterStepPhase((prev) => (prev === 'loading' ? 'idle' : prev));
+        setVerifyStepPhase((prev) => (prev === 'loading' ? 'idle' : prev));
+      }
     }
   }, [dispatch, t, goToNextStep]);
 

--- a/ui/pages/onboarding-flow/welcome/welcome.tsx
+++ b/ui/pages/onboarding-flow/welcome/welcome.tsx
@@ -24,11 +24,13 @@ import {
   ONBOARDING_UNLOCK_ROUTE,
   ONBOARDING_METAMETRICS,
   ONBOARDING_REVIEW_SRP_ROUTE,
+  ONBOARDING_SETUP_PASSKEY_ROUTE,
 } from '../../../helpers/constants/routes';
 import {
   getCurrentKeyring,
   getFirstTimeFlowType,
   getIsParticipateInMetaMetricsSet,
+  getIsPasskeyFeatureAvailable,
   getIsSocialLoginFlow,
 } from '../../../selectors';
 import { FirstTimeFlowType } from '../../../../shared/constants/onboarding';
@@ -97,6 +99,7 @@ export default function OnboardingWelcome() {
   const isParticipateInMetaMetricsSet = useSelector(
     getIsParticipateInMetaMetricsSet,
   );
+  const isPasskeyFeatureAvailable = useSelector(getIsPasskeyFeatureAvailable);
   const [newAccountCreationInProgress, setNewAccountCreationInProgress] =
     useState(false);
 
@@ -148,6 +151,8 @@ export default function OnboardingWelcome() {
         );
       } else if (firstTimeFlowType === FirstTimeFlowType.socialCreate) {
         navigate(ONBOARDING_COMPLETION_ROUTE, { replace: true });
+      } else if (isPasskeyFeatureAvailable) {
+        navigate(ONBOARDING_SETUP_PASSKEY_ROUTE, { replace: true });
       } else {
         navigate(ONBOARDING_REVIEW_SRP_ROUTE, { replace: true });
       }
@@ -178,6 +183,7 @@ export default function OnboardingWelcome() {
     isFireFox,
     isWalletResetInProgress,
     isSocialLoginFLow,
+    isPasskeyFeatureAvailable,
   ]);
 
   const {

--- a/ui/pages/settings-v2/security-and-password-tab/passkey-item.test.tsx
+++ b/ui/pages/settings-v2/security-and-password-tab/passkey-item.test.tsx
@@ -3,7 +3,6 @@ import { fireEvent, screen } from '@testing-library/react';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import mockState from '../../../../test/data/mock-state.json';
-import { GOOGLE_PASSWORD_MANAGER_PASSKEY_AAGUID } from '../../../../shared/constants/passkey';
 import { ENVIRONMENT_TYPE_SIDEPANEL } from '../../../../shared/constants/app';
 import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
@@ -27,6 +26,10 @@ const backgroundConnectionMock = new Proxy(
   {},
   { get: () => jest.fn().mockResolvedValue(undefined) },
 );
+
+/** Must match private Google Password Manager AAGUID in shared/lib/passkey/passkey-sidepanel-aaguid.ts */
+const GOOGLE_PASSWORD_MANAGER_PASSKEY_AAGUID =
+  'ea9b8d66-4d01-1d21-3ce4-b6b48cb575d4';
 
 describe('PasskeyItem', () => {
   const mockStore = configureMockStore([thunk])(mockState);

--- a/ui/pages/settings-v2/security-and-password-tab/passkey-item.test.tsx
+++ b/ui/pages/settings-v2/security-and-password-tab/passkey-item.test.tsx
@@ -1,11 +1,15 @@
 import React from 'react';
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import mockState from '../../../../test/data/mock-state.json';
+import { GOOGLE_PASSWORD_MANAGER_PASSKEY_AAGUID } from '../../../../shared/constants/passkey';
+import { ENVIRONMENT_TYPE_SIDEPANEL } from '../../../../shared/constants/app';
 import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import { setBackgroundConnection } from '../../../store/background-connection';
+import { SECURITY_AND_PASSWORD_ROUTE } from '../../../helpers/constants/routes';
+import * as environmentType from '../../../../shared/lib/environment-type';
 import PasskeyItem from './passkey-item';
 
 jest.mock('../../../../shared/lib/environment', () => ({
@@ -41,5 +45,39 @@ describe('PasskeyItem', () => {
     expect(
       screen.getByTestId('security-passkey-settings-toggle'),
     ).toBeInTheDocument();
+  });
+
+  it('opens security and password settings in browser when disabling in sidepanel with incompatible AAGUID', () => {
+    const openExtensionInBrowser = jest.fn();
+    globalThis.platform = { openExtensionInBrowser } as never;
+
+    jest
+      .spyOn(environmentType, 'getEnvironmentType')
+      .mockReturnValue(ENVIRONMENT_TYPE_SIDEPANEL);
+
+    const storeWithGpmPasskey = configureMockStore([thunk])({
+      ...mockState,
+      metamask: {
+        ...mockState.metamask,
+        passkeyRecord: {
+          credential: {
+            id: 'cred-id',
+            aaguid: GOOGLE_PASSWORD_MANAGER_PASSKEY_AAGUID,
+          },
+        },
+      },
+    });
+
+    renderWithProvider(<PasskeyItem />, storeWithGpmPasskey);
+
+    fireEvent.click(screen.getByTestId('security-passkey-settings-toggle'));
+
+    expect(openExtensionInBrowser).toHaveBeenCalledWith(
+      SECURITY_AND_PASSWORD_ROUTE,
+      'from=sidepanel',
+    );
+
+    delete (globalThis as { platform?: unknown }).platform;
+    jest.restoreAllMocks();
   });
 });

--- a/ui/pages/settings-v2/security-and-password-tab/passkey-item.tsx
+++ b/ui/pages/settings-v2/security-and-password-tab/passkey-item.tsx
@@ -33,6 +33,7 @@ import {
 import {
   getIsPasskeyFeatureAvailable,
   getIsPasskeyRegistered,
+  getIsEnrolledPasskeyIncompatibleWithSidepanel,
 } from '../../../selectors';
 import {
   forceUpdateMetamaskState,
@@ -53,6 +54,9 @@ const PasskeyItem = () => {
 
   const isPasskeyFeatureAvailable = useSelector(getIsPasskeyFeatureAvailable);
   const isPasskeyRegistered = useSelector(getIsPasskeyRegistered);
+  const isEnrolledPasskeyIncompatibleWithSidepanel = useSelector(
+    getIsEnrolledPasskeyIncompatibleWithSidepanel,
+  );
 
   const [isPasskeyOperationPending, setIsPasskeyOperationPending] =
     useState(false);
@@ -84,6 +88,18 @@ const PasskeyItem = () => {
 
   const removePasskey = useCallback(async () => {
     if (!isPasskeyRegistered) {
+      return;
+    }
+
+    if (
+      getEnvironmentType() === ENVIRONMENT_TYPE_SIDEPANEL &&
+      isEnrolledPasskeyIncompatibleWithSidepanel
+    ) {
+      cancelPasskeyCeremony();
+      globalThis.platform?.openExtensionInBrowser?.(
+        SECURITY_AND_PASSWORD_ROUTE,
+        'from=sidepanel',
+      );
       return;
     }
 
@@ -134,7 +150,14 @@ const PasskeyItem = () => {
     } finally {
       setIsPasskeyOperationPending(false);
     }
-  }, [dispatch, isPasskeyRegistered, navigate, t, trackEvent]);
+  }, [
+    dispatch,
+    isEnrolledPasskeyIncompatibleWithSidepanel,
+    isPasskeyRegistered,
+    navigate,
+    t,
+    trackEvent,
+  ]);
 
   const handlePasskeyToggle = useCallback(
     async (isPasskeyUnlockEnabled: boolean) => {

--- a/ui/pages/settings-v2/security-and-password-tab/passkey-item.tsx
+++ b/ui/pages/settings-v2/security-and-password-tab/passkey-item.tsx
@@ -166,7 +166,7 @@ const PasskeyItem = () => {
             className="mt-2 flex w-full justify-start text-left"
             onClick={() => setShowPasskeyTroubleshootModal(true)}
           >
-            {t('passkeyTroubleshoot')}
+            {t('passkeyTroubleshootVerify')}
           </TextButton>
         ) : null}
       </>
@@ -191,6 +191,7 @@ const PasskeyItem = () => {
       />
       {showPasskeyTroubleshootModal ? (
         <PasskeyTroubleshootModal
+          mode="verify"
           onClose={() => setShowPasskeyTroubleshootModal(false)}
           onOpenFullScreen={openSecurityAndPasswordInFullScreen}
         />

--- a/ui/pages/unlock-page/passkey/unlock-passkey-section.test.tsx
+++ b/ui/pages/unlock-page/passkey/unlock-passkey-section.test.tsx
@@ -43,6 +43,7 @@ describe('UnlockPasskeySection', () => {
     logoSection: <div data-testid="logo-mock" />,
     isPasskeyActive: true,
     passkeyAutoUnlockSuppressed: true,
+    mustDeferPasskeyToBrowserTab: false,
     isPasswordInProgress: false,
     onUnlockWithPasskey: jest.fn().mockResolvedValue(undefined),
     onUsePassword: jest.fn(),
@@ -234,6 +235,65 @@ describe('UnlockPasskeySection', () => {
         clientExtensionResults: {},
       });
       await Promise.resolve();
+    });
+  });
+
+  describe('when mustDeferPasskeyToBrowserTab', () => {
+    const openExtensionInBrowser = jest.fn();
+
+    beforeEach(() => {
+      globalThis.platform = {
+        openExtensionInBrowser,
+      } as never;
+    });
+
+    afterEach(() => {
+      delete (globalThis as { platform?: unknown }).platform;
+    });
+
+    it('does not start passkey ceremony on mount when auto unlock is not suppressed', async () => {
+      const onUnlockWithPasskey = jest.fn().mockResolvedValue(undefined);
+
+      renderWithProvider(
+        <UnlockPasskeySection
+          {...baseProps}
+          passkeyAutoUnlockSuppressed={false}
+          mustDeferPasskeyToBrowserTab
+          onUnlockWithPasskey={onUnlockWithPasskey}
+        />,
+        mockStore,
+        '/unlock',
+      );
+
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(onUnlockWithPasskey).not.toHaveBeenCalled();
+      expect(openExtensionInBrowser).not.toHaveBeenCalled();
+    });
+
+    it('opens extension in browser when primary passkey button is clicked', async () => {
+      const onUnlockWithPasskey = jest.fn().mockResolvedValue(undefined);
+
+      const { getByTestId } = renderWithProvider(
+        <UnlockPasskeySection
+          {...baseProps}
+          mustDeferPasskeyToBrowserTab
+          onUnlockWithPasskey={onUnlockWithPasskey}
+        />,
+        mockStore,
+        '/unlock',
+      );
+
+      fireEvent.click(getByTestId('unlock-passkey-button'));
+
+      expect(openExtensionInBrowser).toHaveBeenCalledWith(
+        UNLOCK_ROUTE,
+        'from=sidepanel',
+      );
+      expect(onUnlockWithPasskey).not.toHaveBeenCalled();
     });
   });
 });

--- a/ui/pages/unlock-page/passkey/unlock-passkey-section.tsx
+++ b/ui/pages/unlock-page/passkey/unlock-passkey-section.tsx
@@ -42,6 +42,7 @@ export type UnlockPasskeySectionProps = {
   logoSection: ReactNode;
   isPasskeyActive: boolean;
   passkeyAutoUnlockSuppressed: boolean;
+  mustDeferPasskeyToBrowserTab: boolean;
   isPasswordInProgress: boolean;
   onUnlockWithPasskey: (
     authenticationResponse: PasskeyAuthenticationResponse,
@@ -53,6 +54,7 @@ export const UnlockPasskeySection = ({
   logoSection,
   isPasskeyActive,
   passkeyAutoUnlockSuppressed,
+  mustDeferPasskeyToBrowserTab,
   isPasswordInProgress,
   onUnlockWithPasskey,
   onUsePassword,
@@ -65,7 +67,10 @@ export const UnlockPasskeySection = ({
   const [showTroubleshootModal, setShowTroubleshootModal] = useState(false);
 
   const [mountAutoUnlockEligible] = useState(
-    () => isPasskeyActive && !passkeyAutoUnlockSuppressed,
+    () =>
+      isPasskeyActive &&
+      !passkeyAutoUnlockSuppressed &&
+      !mustDeferPasskeyToBrowserTab,
   );
 
   const isMountedRef = useRef(true);
@@ -143,10 +148,22 @@ export const UnlockPasskeySection = ({
 
   const openUnlockInFullScreen = useCallback(() => {
     cancelPasskeyCeremony();
-    globalThis.platform.openExtensionInBrowser(UNLOCK_ROUTE, 'from=sidepanel');
+    globalThis.platform?.openExtensionInBrowser?.(
+      UNLOCK_ROUTE,
+      'from=sidepanel',
+    );
   }, []);
 
+  const handlePrimaryPasskeyAction = useCallback(() => {
+    if (mustDeferPasskeyToBrowserTab) {
+      openUnlockInFullScreen();
+      return;
+    }
+    runPasskeyUnlock();
+  }, [mustDeferPasskeyToBrowserTab, openUnlockInFullScreen, runPasskeyUnlock]);
+
   const showTroubleshoot =
+    !mustDeferPasskeyToBrowserTab &&
     getEnvironmentType() === ENVIRONMENT_TYPE_SIDEPANEL &&
     isPasskeyActive &&
     passkeyInProgress;
@@ -185,7 +202,7 @@ export const UnlockPasskeySection = ({
           isLoading={passkeyInProgress}
           data-testid="unlock-passkey-button"
           disabled={isPasswordInProgress || passkeyInProgress}
-          onClick={runPasskeyUnlock}
+          onClick={handlePrimaryPasskeyAction}
           aria-busy={passkeyInProgress}
         >
           {t('unlockWithPasskey')}

--- a/ui/pages/unlock-page/passkey/unlock-passkey-section.tsx
+++ b/ui/pages/unlock-page/passkey/unlock-passkey-section.tsx
@@ -198,13 +198,14 @@ export const UnlockPasskeySection = ({
             className="text-center"
             onClick={() => setShowTroubleshootModal(true)}
           >
-            {t('passkeyTroubleshoot')}
+            {t('passkeyTroubleshootUnlock')}
           </TextButton>
         ) : null}
       </Box>
 
       {showTroubleshootModal ? (
         <PasskeyTroubleshootModal
+          mode="unlock"
           onClose={() => setShowTroubleshootModal(false)}
           onOpenFullScreen={openUnlockInFullScreen}
         />

--- a/ui/pages/unlock-page/passkey/unlock-passkey-section.tsx
+++ b/ui/pages/unlock-page/passkey/unlock-passkey-section.tsx
@@ -154,7 +154,7 @@ export const UnlockPasskeySection = ({
     );
   }, []);
 
-  const handlePrimaryPasskeyAction = useCallback(() => {
+  const handlePasskeyUnlockAction = useCallback(() => {
     if (mustDeferPasskeyToBrowserTab) {
       openUnlockInFullScreen();
       return;
@@ -202,7 +202,7 @@ export const UnlockPasskeySection = ({
           isLoading={passkeyInProgress}
           data-testid="unlock-passkey-button"
           disabled={isPasswordInProgress || passkeyInProgress}
-          onClick={handlePrimaryPasskeyAction}
+          onClick={handlePasskeyUnlockAction}
           aria-busy={passkeyInProgress}
         >
           {t('unlockWithPasskey')}

--- a/ui/pages/unlock-page/unlock-page.component.test.tsx
+++ b/ui/pages/unlock-page/unlock-page.component.test.tsx
@@ -50,6 +50,7 @@ describe('UnlockPage component (passkey UI)', () => {
     isPopup: false,
     isWalletResetInProgress: false,
     passkeyAutoUnlockSuppressed: true,
+    mustDeferPasskeyToBrowserTab: false,
     ...overrides,
   });
 

--- a/ui/pages/unlock-page/unlock-page.component.tsx
+++ b/ui/pages/unlock-page/unlock-page.component.tsx
@@ -41,12 +41,14 @@ import Mascot from '../../components/ui/mascot';
 import {
   DEFAULT_ROUTE,
   ONBOARDING_WELCOME_ROUTE,
+  UNLOCK_ROUTE,
 } from '../../helpers/constants/routes';
 import {
   MetaMetricsContextProp,
   MetaMetricsEventCategory,
   MetaMetricsEventName,
 } from '../../../shared/constants/metametrics';
+import { cancelPasskeyCeremony } from '../../../shared/lib/passkey';
 import { isFlask, isBeta } from '../../../shared/lib/build-types';
 import { SUPPORT_LINK } from '../../../shared/lib/ui-utils';
 import { TraceName, TraceOperation } from '../../../shared/lib/trace';
@@ -82,6 +84,8 @@ type UnlockPageProps = {
   isPopup: boolean;
   isWalletResetInProgress: boolean;
   passkeyAutoUnlockSuppressed: boolean;
+  /** When true, passkey ceremony must run in a browser tab (sidepanel + incompatible AAGUID). */
+  mustDeferPasskeyToBrowserTab: boolean;
 };
 
 type UnlockPageState = {
@@ -196,6 +200,10 @@ class UnlockPage extends Component<UnlockPageProps, UnlockPageState> {
      * When true, do not auto-start WebAuthn (after UI-initiated lock; background + timer).
      */
     passkeyAutoUnlockSuppressed: PropTypes.bool,
+    /**
+     * When true, passkey unlock UI defers ceremony to a full extension tab (sidepanel + incompatible AAGUID).
+     */
+    mustDeferPasskeyToBrowserTab: PropTypes.bool,
     /**
      * Completes passkey unlock and navigates after success (same redirect rules as password onSubmit).
      */
@@ -535,6 +543,18 @@ class UnlockPage extends Component<UnlockPageProps, UnlockPageState> {
     this.setState({ isPasswordUnlockMode, error: null });
   };
 
+  handleUnlockPasskeyFromPasswordForm = () => {
+    if (this.props.mustDeferPasskeyToBrowserTab) {
+      cancelPasskeyCeremony();
+      globalThis.platform?.openExtensionInBrowser?.(
+        UNLOCK_ROUTE,
+        'from=sidepanel',
+      );
+      return;
+    }
+    this.setPasswordUnlockMode(false);
+  };
+
   onForgotPasswordOrLoginWithDiffMethods = async () => {
     const { isSocialLoginFlow, navigate, isOnboardingCompleted } = this.props;
 
@@ -705,7 +725,7 @@ class UnlockPage extends Component<UnlockPageProps, UnlockPageState> {
                   {this.props.isPasskeyActive ? (
                     <UnlockPasskeyIconButton
                       disabled={isLocked || isSubmitting}
-                      onClick={() => this.setPasswordUnlockMode(false)}
+                      onClick={this.handleUnlockPasskeyFromPasswordForm}
                     />
                   ) : null}
                 </Box>
@@ -783,6 +803,9 @@ class UnlockPage extends Component<UnlockPageProps, UnlockPageState> {
               isPasskeyActive={this.props.isPasskeyActive}
               passkeyAutoUnlockSuppressed={
                 this.props.passkeyAutoUnlockSuppressed
+              }
+              mustDeferPasskeyToBrowserTab={
+                this.props.mustDeferPasskeyToBrowserTab
               }
               isPasswordInProgress={isSubmitting}
               onUnlockWithPasskey={this.props.onUnlockWithPasskey}

--- a/ui/pages/unlock-page/unlock-page.container.ts
+++ b/ui/pages/unlock-page/unlock-page.container.ts
@@ -6,7 +6,10 @@ import type { PasskeyAuthenticationResponse } from '@metamask/passkey-controller
 // TODO: Remove restricted import
 // eslint-disable-next-line import-x/no-restricted-paths
 import { getEnvironmentType } from '../../../app/scripts/lib/util';
-import { ENVIRONMENT_TYPE_POPUP } from '../../../shared/constants/app';
+import {
+  ENVIRONMENT_TYPE_POPUP,
+  ENVIRONMENT_TYPE_SIDEPANEL,
+} from '../../../shared/constants/app';
 import { DEFAULT_ROUTE } from '../../helpers/constants/routes';
 import {
   tryUnlockMetamask,
@@ -21,6 +24,7 @@ import {
   getFirstTimeFlowType,
   getIsPasskeyFeatureAvailable,
   getIsPasskeyRegistered,
+  getIsEnrolledPasskeyIncompatibleWithSidepanel,
 } from '../../selectors';
 import {
   getCompletedOnboarding,
@@ -43,17 +47,22 @@ const mapStateToProps = (state: MetaMaskReduxState) => {
   } = state;
   const isSocialLoginFlow = getIsSocialLoginFlow(state);
   const isOnboardingCompleted = getCompletedOnboarding(state);
+  const isPasskeyActive =
+    getIsPasskeyFeatureAvailable(state) &&
+    getIsPasskeyRegistered(state) &&
+    !isSocialLoginFlow &&
+    isOnboardingCompleted;
   return {
     isUnlocked,
     isSocialLoginFlow,
     isOnboardingCompleted,
     firstTimeFlowType: getFirstTimeFlowType(state),
     isWalletResetInProgress: getIsWalletResetInProgress(state),
-    isPasskeyActive:
-      getIsPasskeyFeatureAvailable(state) &&
-      getIsPasskeyRegistered(state) &&
-      !isSocialLoginFlow &&
-      isOnboardingCompleted,
+    isPasskeyActive,
+    mustDeferPasskeyToBrowserTab:
+      getEnvironmentType() === ENVIRONMENT_TYPE_SIDEPANEL &&
+      getIsEnrolledPasskeyIncompatibleWithSidepanel(state) &&
+      isPasskeyActive,
     passkeyAutoUnlockSuppressed: getPasskeyAutoUnlockSuppressed(state),
   };
 };

--- a/ui/pages/unlock-page/unlock-page.stories.tsx
+++ b/ui/pages/unlock-page/unlock-page.stories.tsx
@@ -43,6 +43,7 @@ DefaultStory.args = {
     participateInMetaMetrics: true,
   }),
   passkeyAutoUnlockSuppressed: false,
+  mustDeferPasskeyToBrowserTab: false,
 };
 
 DefaultStory.storyName = 'Default';

--- a/ui/selectors/passkey.test.ts
+++ b/ui/selectors/passkey.test.ts
@@ -1,6 +1,8 @@
+import { GOOGLE_PASSWORD_MANAGER_PASSKEY_AAGUID } from '../../shared/constants/passkey';
 import {
   getIsPasskeyFeatureAvailable,
   getIsPasskeyRegistered,
+  getIsEnrolledPasskeyIncompatibleWithSidepanel,
 } from './selectors';
 
 jest.mock('../../shared/lib/environment', () => ({
@@ -8,6 +10,7 @@ jest.mock('../../shared/lib/environment', () => ({
 }));
 
 jest.mock('../../shared/lib/passkey', () => ({
+  ...jest.requireActual('../../shared/lib/passkey'),
   isWebAuthnSupported: jest.fn(),
 }));
 
@@ -122,5 +125,36 @@ describe('getIsPasskeyRegistered', () => {
     };
 
     expect(getIsPasskeyRegistered(state)).toBe(false);
+  });
+});
+
+describe('getIsEnrolledPasskeyIncompatibleWithSidepanel', () => {
+  it('returns true when passkey credential AAGUID is in the incompatible set', () => {
+    const state = {
+      metamask: {
+        passkeyRecord: {
+          credential: { aaguid: GOOGLE_PASSWORD_MANAGER_PASSKEY_AAGUID },
+        },
+      },
+    };
+    expect(getIsEnrolledPasskeyIncompatibleWithSidepanel(state)).toBe(true);
+  });
+
+  it('returns false when no passkey record', () => {
+    const state = { metamask: { passkeyRecord: null } };
+    expect(getIsEnrolledPasskeyIncompatibleWithSidepanel(state)).toBe(false);
+  });
+
+  it('returns false when AAGUID is unknown', () => {
+    const state = {
+      metamask: {
+        passkeyRecord: {
+          credential: {
+            aaguid: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+          },
+        },
+      },
+    };
+    expect(getIsEnrolledPasskeyIncompatibleWithSidepanel(state)).toBe(false);
   });
 });

--- a/ui/selectors/passkey.test.ts
+++ b/ui/selectors/passkey.test.ts
@@ -1,4 +1,3 @@
-import { GOOGLE_PASSWORD_MANAGER_PASSKEY_AAGUID } from '../../shared/constants/passkey';
 import {
   getIsPasskeyFeatureAvailable,
   getIsPasskeyRegistered,
@@ -43,6 +42,10 @@ const { isFirefoxBrowser } = jest.requireMock(
 const { getIsSocialLoginFlow } = jest.requireMock('./first-time-flow') as {
   getIsSocialLoginFlow: jest.Mock;
 };
+
+/** Must match private Google Password Manager AAGUID in shared/lib/passkey/passkey-sidepanel-aaguid.ts */
+const GOOGLE_PASSWORD_MANAGER_PASSKEY_AAGUID =
+  'ea9b8d66-4d01-1d21-3ce4-b6b48cb575d4';
 
 describe('getIsPasskeyFeatureAvailable', () => {
   const mockState = {} as Parameters<typeof getIsPasskeyFeatureAvailable>[0];

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -49,7 +49,10 @@ import {
 } from '../../shared/lib/selectors/assets-migration';
 import { getEnabledNetworks } from '../../shared/lib/selectors/multichain';
 import { getBooleanFeatureFlag } from '../../shared/lib/remote-feature-flag-utils';
-import { isWebAuthnSupported } from '../../shared/lib/passkey';
+import {
+  isWebAuthnSupported,
+  isPasskeyAaguidIncompatibleWithSidepanel,
+} from '../../shared/lib/passkey';
 import { getIsPasskeyFeatureEnabled } from '../../shared/lib/environment';
 import { isFirefoxBrowser } from '../../shared/lib/browser-runtime.utils';
 // TODO: Fix circular dependency
@@ -2928,6 +2931,19 @@ export function getUsePhishDetect(state) {
  */
 export function getIsPasskeyRegistered(state) {
   return Boolean(state.metamask.passkeyRecord);
+}
+
+/**
+ * True when the enrolled passkey's AAGUID is in the sidepanel-incompatible set
+ * (defer passkey flows to a normal browser tab when also in sidepanel).
+ *
+ * @param {object} state - Redux state
+ * @returns {boolean}
+ */
+export function getIsEnrolledPasskeyIncompatibleWithSidepanel(state) {
+  return isPasskeyAaguidIncompatibleWithSidepanel(
+    state.metamask.passkeyRecord?.credential?.aaguid,
+  );
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -7578,9 +7578,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/passkey-controller@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@metamask/passkey-controller@npm:2.0.0"
+"@metamask/passkey-controller@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@metamask/passkey-controller@npm:2.0.1"
   dependencies:
     "@levischuck/tiny-cbor": "npm:^0.3.3"
     "@metamask/base-controller": "npm:^9.1.0"
@@ -7589,7 +7589,7 @@ __metadata:
     "@noble/ciphers": "npm:^1.3.0"
     "@noble/curves": "npm:^1.9.2"
     "@noble/hashes": "npm:^1.8.0"
-  checksum: 10/5dbd6568f2c9dce6a9913a318220778e41722de306d5e8430d65740ead834db7edee768e62c9c70e27b2cdc05ccb6e865b6450df04a7c98e120e9b80b295dc8d
+  checksum: 10/2e2b9967ea6af51d378cad497d7bbf898eafd51946f7420a9bf12327eb1ee77e395fb52c32bc68808a9cc2cc19744ae525fead4d948fd22573e4b093178bbb9d
   languageName: node
   linkType: hard
 
@@ -34191,7 +34191,7 @@ __metadata:
     "@metamask/notification-services-controller": "npm:^23.1.0"
     "@metamask/object-multiplex": "npm:^2.0.0"
     "@metamask/obs-store": "npm:^9.0.0"
-    "@metamask/passkey-controller": "npm:^2.0.0"
+    "@metamask/passkey-controller": "npm:^2.0.1"
     "@metamask/permission-controller": "npm:^13.0.0"
     "@metamask/permission-log-controller": "npm:^5.0.0"
     "@metamask/permissions-kernel-snap": "npm:^1.1.0"


### PR DESCRIPTION
## **Description**

Google Password Manager registers passkeys with a known AAGUID that does not behave reliably for WebAuthn ceremonies inside the extension **side panel**. This change detects that AAGUID and **defers passkey flows to a normal extension tab** so enrollment, unlock, and password-change passkey steps can complete.

Also updates **passkey troubleshoot modal** copy to reflect this behavior, fixes a **state update after unmount** in the passkey unlock flow, and adds/updates **unit tests** for AAGUID normalization, selectors, and affected UI surfaces.

## **Changelog**

CHANGELOG entry: Improved passkey support when using Google Password Manager by completing passkey steps in a full extension tab instead of the side panel.

## **Related issues**

Fixes: <!-- e.g. TO-731 or GitHub issue # -->

## **Manual testing steps**

1. Build and load the extension with side panel enabled (typical Chrome MV3 dev setup).
2. **Unlock:** Use a wallet that has a passkey created with Google Password Manager; attempt unlock via passkey and confirm the flow opens/finishes in a full tab when needed (not stuck in side panel).
3. **Settings → Security:** Open passkey-related UI (e.g. passkey item / troubleshooting) and confirm messaging matches Google Password Manager / side panel behavior.
4. **Change password / setup passkey flows:** Exercise passkey steps where applicable and confirm no regressions for non–Google Password Manager authenticators (still work in side panel when compatible).
5. Rapidly navigate away during unlock/passkey UI and confirm no React warnings or broken state from updates after unmount.

## **Screenshots/Recordings**

### **Before**

<!-- Add screenshot/recording: passkey failing or trapped in side panel with GPM -->

### **After**

<!-- Add screenshot/recording: flow continuing in full tab + updated troubleshoot copy -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches passkey-based unlock and security flows and changes navigation/behavior in the sidepanel, which could affect users’ ability to unlock or manage passkeys. Logic is scoped to a specific AAGUID with added tests, reducing blast radius.
> 
> **Overview**
> Improves reliability for passkeys created by Google Password Manager by detecting its AAGUID and **deferring passkey ceremonies from the extension side panel to a full extension tab** across unlock, change-password, and passkey disable flows.
> 
> Adds `isPasskeyAaguidIncompatibleWithSidepanel` + a new selector (`getIsEnrolledPasskeyIncompatibleWithSidepanel`) to drive the defer behavior, and updates unlock/change-password UI to avoid starting WebAuthn in sidepanel when deferring (opening the relevant route in a browser tab instead).
> 
> Updates passkey troubleshoot copy to distinguish *unlock* vs *verify* contexts (new modal `mode`), routes some onboarding users to passkey setup when available, bumps `@metamask/passkey-controller` to `2.0.1`, and adds unit tests covering AAGUID normalization, selector behavior, and the new sidepanel defer cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c15010555d14a498fcb97594b709c850dc8dcecd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->