### PR TITLE
fix: Websocket connection error on benign account switch

### DIFF
--- a/app/scripts/controllers/perps/infrastructure.test.ts
+++ b/app/scripts/controllers/perps/infrastructure.test.ts
@@ -226,6 +226,136 @@ describe('createPerpsInfrastructure', () => {
         expect(mockCaptureException).toHaveBeenCalledWith(error);
       });
     });
+
+    describe('when error is a benign disconnect race', () => {
+      it('does not call captureException for a direct TERMINATED_BY_USER code', () => {
+        setupSentryScope();
+        const { logger } = createPerpsInfrastructure(getDeps());
+
+        const error = Object.assign(new Error('reconnect error'), {
+          name: 'ReconnectingWebSocketError',
+          code: 'TERMINATED_BY_USER',
+        });
+
+        logger.error(error);
+
+        expect(mockCaptureException).not.toHaveBeenCalled();
+      });
+
+      it('does not call captureException when TERMINATED_BY_USER is nested via cause', () => {
+        setupSentryScope();
+        const { logger } = createPerpsInfrastructure(getDeps());
+
+        // Real-world shape: WebSocketRequestError { cause: ReconnectingWebSocketError { code } }
+        const cause = Object.assign(new Error('Error when reconnecting WebSocket: TERMINATED_BY_USER'), {
+          name: 'ReconnectingWebSocketError',
+          code: 'TERMINATED_BY_USER',
+        });
+        const error = Object.assign(new Error('Failed to establish WebSocket connection'), {
+          name: 'WebSocketRequestError',
+          cause,
+        });
+
+        logger.error(error);
+
+        expect(mockCaptureException).not.toHaveBeenCalled();
+      });
+
+      it('does not call captureException when matched by ReconnectingWebSocketError name alone', () => {
+        setupSentryScope();
+        const { logger } = createPerpsInfrastructure(getDeps());
+
+        const error = Object.assign(new Error('reconnect error'), {
+          name: 'ReconnectingWebSocketError',
+        });
+
+        logger.error(error);
+
+        expect(mockCaptureException).not.toHaveBeenCalled();
+      });
+
+      it('does not call captureException for WebSocketRequestError("WebSocket connection closed")', () => {
+        setupSentryScope();
+        const { logger } = createPerpsInfrastructure(getDeps());
+
+        // Shape produced when the HL SDK drains its pending request queue on socket close
+        const error = Object.assign(new Error('WebSocket connection closed'), {
+          name: 'WebSocketRequestError',
+        });
+
+        logger.error(error);
+
+        expect(mockCaptureException).not.toHaveBeenCalled();
+      });
+
+      it('does not touch Sentry scope when suppressing', () => {
+        const mockScope = setupSentryScope();
+        const { logger } = createPerpsInfrastructure(getDeps());
+
+        const cause = Object.assign(new Error('TERMINATED_BY_USER'), {
+          name: 'ReconnectingWebSocketError',
+          code: 'TERMINATED_BY_USER',
+        });
+        const error = Object.assign(new Error('WS error'), {
+          name: 'WebSocketRequestError',
+          cause,
+        });
+
+        logger.error(error, { tags: { feature: 'perps' } });
+
+        expect(mockScope.setTag).not.toHaveBeenCalled();
+        expect(mockScope.setContext).not.toHaveBeenCalled();
+        expect(mockScope.setExtras).not.toHaveBeenCalled();
+        expect(mockCaptureException).not.toHaveBeenCalled();
+      });
+
+      it('does not touch Sentry scope for WebSocket connection closed error', () => {
+        const mockScope = setupSentryScope();
+        const { logger } = createPerpsInfrastructure(getDeps());
+
+        const error = Object.assign(new Error('WebSocket connection closed'), {
+          name: 'WebSocketRequestError',
+        });
+
+        logger.error(error, { tags: { feature: 'perps' } });
+
+        expect(mockScope.setTag).not.toHaveBeenCalled();
+        expect(mockScope.setContext).not.toHaveBeenCalled();
+        expect(mockScope.setExtras).not.toHaveBeenCalled();
+        expect(mockCaptureException).not.toHaveBeenCalled();
+      });
+
+      it('still calls captureException for errors with a different ReconnectingWebSocket code', () => {
+        setupSentryScope();
+        const { logger } = createPerpsInfrastructure(getDeps());
+
+        const cause = Object.assign(new Error('Error when reconnecting WebSocket: UNKNOWN_ERROR'), {
+          name: 'ReconnectingWebSocketError',
+          code: 'UNKNOWN_ERROR',
+        });
+        const error = Object.assign(new Error('Failed to establish WebSocket connection'), {
+          name: 'WebSocketRequestError',
+          cause,
+        });
+
+        logger.error(error);
+
+        expect(mockCaptureException).toHaveBeenCalledWith(error);
+      });
+
+      it('still calls captureException for WebSocketRequestError with a different message', () => {
+        setupSentryScope();
+        const { logger } = createPerpsInfrastructure(getDeps());
+
+        const error = Object.assign(new Error('Failed to close WebSocket connection'), {
+          name: 'WebSocketRequestError',
+        });
+
+        logger.error(error);
+
+        expect(mockCaptureException).toHaveBeenCalledWith(error);
+      });
+    });
   });
 
   describe('performance', () => {

--- a/app/scripts/controllers/perps/infrastructure.test.ts
+++ b/app/scripts/controllers/perps/infrastructure.test.ts
@@ -263,9 +263,7 @@ describe('createPerpsInfrastructure', () => {
 
           // Real-world shape: WebSocketRequestError { cause: ReconnectingWebSocketError { code } }
           const cause = Object.assign(
-            new Error(
-              'Error when reconnecting WebSocket: TERMINATED_BY_USER',
-            ),
+            new Error('Error when reconnecting WebSocket: TERMINATED_BY_USER'),
             {
               name: 'ReconnectingWebSocketError',
               code: 'TERMINATED_BY_USER',

--- a/app/scripts/controllers/perps/infrastructure.test.ts
+++ b/app/scripts/controllers/perps/infrastructure.test.ts
@@ -247,14 +247,20 @@ describe('createPerpsInfrastructure', () => {
         const { logger } = createPerpsInfrastructure(getDeps());
 
         // Real-world shape: WebSocketRequestError { cause: ReconnectingWebSocketError { code } }
-        const cause = Object.assign(new Error('Error when reconnecting WebSocket: TERMINATED_BY_USER'), {
-          name: 'ReconnectingWebSocketError',
-          code: 'TERMINATED_BY_USER',
-        });
-        const error = Object.assign(new Error('Failed to establish WebSocket connection'), {
-          name: 'WebSocketRequestError',
-          cause,
-        });
+        const cause = Object.assign(
+          new Error('Error when reconnecting WebSocket: TERMINATED_BY_USER'),
+          {
+            name: 'ReconnectingWebSocketError',
+            code: 'TERMINATED_BY_USER',
+          },
+        );
+        const error = Object.assign(
+          new Error('Failed to establish WebSocket connection'),
+          {
+            name: 'WebSocketRequestError',
+            cause,
+          },
+        );
 
         logger.error(error);
 
@@ -329,14 +335,20 @@ describe('createPerpsInfrastructure', () => {
         setupSentryScope();
         const { logger } = createPerpsInfrastructure(getDeps());
 
-        const cause = Object.assign(new Error('Error when reconnecting WebSocket: UNKNOWN_ERROR'), {
-          name: 'ReconnectingWebSocketError',
-          code: 'UNKNOWN_ERROR',
-        });
-        const error = Object.assign(new Error('Failed to establish WebSocket connection'), {
-          name: 'WebSocketRequestError',
-          cause,
-        });
+        const cause = Object.assign(
+          new Error('Error when reconnecting WebSocket: UNKNOWN_ERROR'),
+          {
+            name: 'ReconnectingWebSocketError',
+            code: 'UNKNOWN_ERROR',
+          },
+        );
+        const error = Object.assign(
+          new Error('Failed to establish WebSocket connection'),
+          {
+            name: 'WebSocketRequestError',
+            cause,
+          },
+        );
 
         logger.error(error);
 
@@ -347,9 +359,12 @@ describe('createPerpsInfrastructure', () => {
         setupSentryScope();
         const { logger } = createPerpsInfrastructure(getDeps());
 
-        const error = Object.assign(new Error('Failed to close WebSocket connection'), {
-          name: 'WebSocketRequestError',
-        });
+        const error = Object.assign(
+          new Error('Failed to close WebSocket connection'),
+          {
+            name: 'WebSocketRequestError',
+          },
+        );
 
         logger.error(error);
 

--- a/app/scripts/controllers/perps/infrastructure.test.ts
+++ b/app/scripts/controllers/perps/infrastructure.test.ts
@@ -47,12 +47,15 @@ describe('createPerpsInfrastructure', () => {
   const mockSetStorageItem = jest.fn();
   const mockRemoveStorageItem = jest.fn();
 
-  function getDeps(): InfrastructureDeps {
+  function getDeps(
+    overrides?: Partial<InfrastructureDeps>,
+  ): InfrastructureDeps {
     return {
       trackEvent: mockTrackEvent,
       getStorageItem: mockGetStorageItem,
       setStorageItem: mockSetStorageItem,
       removeStorageItem: mockRemoveStorageItem,
+      ...overrides,
     };
   }
 
@@ -228,147 +231,186 @@ describe('createPerpsInfrastructure', () => {
     });
 
     describe('when error is a benign disconnect race', () => {
-      it('does not call captureException for a direct TERMINATED_BY_USER code', () => {
-        setupSentryScope();
-        const { logger } = createPerpsInfrastructure(getDeps());
-
-        const error = Object.assign(new Error('reconnect error'), {
+      function makeBenignError() {
+        return Object.assign(new Error('reconnect error'), {
           name: 'ReconnectingWebSocketError',
           code: 'TERMINATED_BY_USER',
         });
+      }
 
-        logger.error(error);
+      describe('while disconnect is in progress (isDisconnecting = true)', () => {
+        function getDisconnectingDeps() {
+          return getDeps({ isDisconnecting: () => true });
+        }
 
-        expect(mockCaptureException).not.toHaveBeenCalled();
-      });
+        it('does not call captureException for a direct TERMINATED_BY_USER code', () => {
+          setupSentryScope();
+          const { logger } = createPerpsInfrastructure(getDisconnectingDeps());
 
-      it('does not call captureException when TERMINATED_BY_USER is nested via cause', () => {
-        setupSentryScope();
-        const { logger } = createPerpsInfrastructure(getDeps());
-
-        // Real-world shape: WebSocketRequestError { cause: ReconnectingWebSocketError { code } }
-        const cause = Object.assign(
-          new Error('Error when reconnecting WebSocket: TERMINATED_BY_USER'),
-          {
+          const error = Object.assign(new Error('reconnect error'), {
             name: 'ReconnectingWebSocketError',
             code: 'TERMINATED_BY_USER',
-          },
-        );
-        const error = Object.assign(
-          new Error('Failed to establish WebSocket connection'),
-          {
-            name: 'WebSocketRequestError',
-            cause,
-          },
-        );
+          });
 
-        logger.error(error);
+          logger.error(error);
 
-        expect(mockCaptureException).not.toHaveBeenCalled();
-      });
-
-      it('does not call captureException when matched by ReconnectingWebSocketError name alone', () => {
-        setupSentryScope();
-        const { logger } = createPerpsInfrastructure(getDeps());
-
-        const error = Object.assign(new Error('reconnect error'), {
-          name: 'ReconnectingWebSocketError',
+          expect(mockCaptureException).not.toHaveBeenCalled();
         });
 
-        logger.error(error);
+        it('does not call captureException when TERMINATED_BY_USER is nested via cause', () => {
+          setupSentryScope();
+          const { logger } = createPerpsInfrastructure(getDisconnectingDeps());
 
-        expect(mockCaptureException).not.toHaveBeenCalled();
-      });
+          // Real-world shape: WebSocketRequestError { cause: ReconnectingWebSocketError { code } }
+          const cause = Object.assign(
+            new Error(
+              'Error when reconnecting WebSocket: TERMINATED_BY_USER',
+            ),
+            {
+              name: 'ReconnectingWebSocketError',
+              code: 'TERMINATED_BY_USER',
+            },
+          );
+          const error = Object.assign(
+            new Error('Failed to establish WebSocket connection'),
+            {
+              name: 'WebSocketRequestError',
+              cause,
+            },
+          );
 
-      it('does not call captureException for WebSocketRequestError("WebSocket connection closed")', () => {
-        setupSentryScope();
-        const { logger } = createPerpsInfrastructure(getDeps());
+          logger.error(error);
 
-        // Shape produced when the HL SDK drains its pending request queue on socket close
-        const error = Object.assign(new Error('WebSocket connection closed'), {
-          name: 'WebSocketRequestError',
+          expect(mockCaptureException).not.toHaveBeenCalled();
         });
 
-        logger.error(error);
+        it('does not call captureException when matched by ReconnectingWebSocketError name alone', () => {
+          setupSentryScope();
+          const { logger } = createPerpsInfrastructure(getDisconnectingDeps());
 
-        expect(mockCaptureException).not.toHaveBeenCalled();
-      });
-
-      it('does not touch Sentry scope when suppressing', () => {
-        const mockScope = setupSentryScope();
-        const { logger } = createPerpsInfrastructure(getDeps());
-
-        const cause = Object.assign(new Error('TERMINATED_BY_USER'), {
-          name: 'ReconnectingWebSocketError',
-          code: 'TERMINATED_BY_USER',
-        });
-        const error = Object.assign(new Error('WS error'), {
-          name: 'WebSocketRequestError',
-          cause,
-        });
-
-        logger.error(error, { tags: { feature: 'perps' } });
-
-        expect(mockScope.setTag).not.toHaveBeenCalled();
-        expect(mockScope.setContext).not.toHaveBeenCalled();
-        expect(mockScope.setExtras).not.toHaveBeenCalled();
-        expect(mockCaptureException).not.toHaveBeenCalled();
-      });
-
-      it('does not touch Sentry scope for WebSocket connection closed error', () => {
-        const mockScope = setupSentryScope();
-        const { logger } = createPerpsInfrastructure(getDeps());
-
-        const error = Object.assign(new Error('WebSocket connection closed'), {
-          name: 'WebSocketRequestError',
-        });
-
-        logger.error(error, { tags: { feature: 'perps' } });
-
-        expect(mockScope.setTag).not.toHaveBeenCalled();
-        expect(mockScope.setContext).not.toHaveBeenCalled();
-        expect(mockScope.setExtras).not.toHaveBeenCalled();
-        expect(mockCaptureException).not.toHaveBeenCalled();
-      });
-
-      it('still calls captureException for errors with a different ReconnectingWebSocket code', () => {
-        setupSentryScope();
-        const { logger } = createPerpsInfrastructure(getDeps());
-
-        const cause = Object.assign(
-          new Error('Error when reconnecting WebSocket: UNKNOWN_ERROR'),
-          {
+          const error = Object.assign(new Error('reconnect error'), {
             name: 'ReconnectingWebSocketError',
-            code: 'UNKNOWN_ERROR',
-          },
-        );
-        const error = Object.assign(
-          new Error('Failed to establish WebSocket connection'),
-          {
+          });
+
+          logger.error(error);
+
+          expect(mockCaptureException).not.toHaveBeenCalled();
+        });
+
+        it('does not call captureException for WebSocketRequestError("WebSocket connection closed")', () => {
+          setupSentryScope();
+          const { logger } = createPerpsInfrastructure(getDisconnectingDeps());
+
+          // Shape produced when the HL SDK drains its pending request queue on socket close
+          const error = Object.assign(
+            new Error('WebSocket connection closed'),
+            {
+              name: 'WebSocketRequestError',
+            },
+          );
+
+          logger.error(error);
+
+          expect(mockCaptureException).not.toHaveBeenCalled();
+        });
+
+        it('does not touch Sentry scope when suppressing', () => {
+          const mockScope = setupSentryScope();
+          const { logger } = createPerpsInfrastructure(getDisconnectingDeps());
+
+          const cause = Object.assign(new Error('TERMINATED_BY_USER'), {
+            name: 'ReconnectingWebSocketError',
+            code: 'TERMINATED_BY_USER',
+          });
+          const error = Object.assign(new Error('WS error'), {
             name: 'WebSocketRequestError',
             cause,
-          },
-        );
+          });
 
-        logger.error(error);
+          logger.error(error, { tags: { feature: 'perps' } });
 
-        expect(mockCaptureException).toHaveBeenCalledWith(error);
+          expect(mockScope.setTag).not.toHaveBeenCalled();
+          expect(mockScope.setContext).not.toHaveBeenCalled();
+          expect(mockScope.setExtras).not.toHaveBeenCalled();
+          expect(mockCaptureException).not.toHaveBeenCalled();
+        });
+
+        it('suppresses regardless of the error context (write or read)', () => {
+          setupSentryScope();
+          const { logger } = createPerpsInfrastructure(getDisconnectingDeps());
+          const error = makeBenignError();
+
+          // Even a write context like placeOrder is suppressed during disconnect
+          logger.error(error, {
+            context: { name: 'TradingService', data: { method: 'placeOrder' } },
+          });
+
+          expect(mockCaptureException).not.toHaveBeenCalled();
+        });
       });
 
-      it('still calls captureException for WebSocketRequestError with a different message', () => {
-        setupSentryScope();
-        const { logger } = createPerpsInfrastructure(getDeps());
+      describe('while disconnect is NOT in progress (isDisconnecting = false)', () => {
+        it('still calls captureException for errors with a different ReconnectingWebSocket code', () => {
+          setupSentryScope();
+          const { logger } = createPerpsInfrastructure(getDeps());
 
-        const error = Object.assign(
-          new Error('Failed to close WebSocket connection'),
-          {
-            name: 'WebSocketRequestError',
-          },
-        );
+          const cause = Object.assign(
+            new Error('Error when reconnecting WebSocket: UNKNOWN_ERROR'),
+            {
+              name: 'ReconnectingWebSocketError',
+              code: 'UNKNOWN_ERROR',
+            },
+          );
+          const error = Object.assign(
+            new Error('Failed to establish WebSocket connection'),
+            {
+              name: 'WebSocketRequestError',
+              cause,
+            },
+          );
 
-        logger.error(error);
+          logger.error(error);
 
-        expect(mockCaptureException).toHaveBeenCalledWith(error);
+          expect(mockCaptureException).toHaveBeenCalledWith(error);
+        });
+
+        it('still calls captureException for WebSocketRequestError with a different message', () => {
+          setupSentryScope();
+          const { logger } = createPerpsInfrastructure(getDeps());
+
+          const error = Object.assign(
+            new Error('Failed to close WebSocket connection'),
+            {
+              name: 'WebSocketRequestError',
+            },
+          );
+
+          logger.error(error);
+
+          expect(mockCaptureException).toHaveBeenCalledWith(error);
+        });
+
+        it('reports benign-shaped errors to Sentry when no disconnect is active', () => {
+          setupSentryScope();
+          const { logger } = createPerpsInfrastructure(getDeps());
+          const error = makeBenignError();
+
+          logger.error(error);
+
+          expect(mockCaptureException).toHaveBeenCalledWith(error);
+        });
+
+        it('reports benign-shaped errors to Sentry when isDisconnecting is not provided', () => {
+          setupSentryScope();
+          const deps = getDeps();
+          delete deps.isDisconnecting;
+          const { logger } = createPerpsInfrastructure(deps);
+          const error = makeBenignError();
+
+          logger.error(error);
+
+          expect(mockCaptureException).toHaveBeenCalledWith(error);
+        });
       });
     });
   });

--- a/app/scripts/controllers/perps/infrastructure.ts
+++ b/app/scripts/controllers/perps/infrastructure.ts
@@ -67,6 +67,30 @@ function createLogger(deps: InfrastructureDeps): PerpsLogger {
       // Suppress benign WS-close errors only while our own disconnect() is
       // active (account switch in progress). Outside that window the same
       // error shapes indicate real connectivity problems and must reach Sentry.
+      //
+      // KNOWN TRADEOFF: this guard intentionally suppresses every benign-shaped
+      // error during the disconnect window, including write-context errors
+      // (placeOrder, editOrder, cancelOrder, closePosition, updateMargin,
+      // flipPosition, withdraw, ...). We accept this for two reasons:
+      //
+      //   1. Account switches generate a high volume of in-flight read/stream
+      //      cancellations whose error shape is indistinguishable from a true
+      //      write race at this layer. Reporting them clutters both the dev
+      //      console (captureException -> console.error) and the Sentry inbox
+      //      enough to drown out real signal. We verified empirically that
+      //      gating on `options.context.data.method` to let write-path errors
+      //      through produced many false positives during normal account
+      //      switches without surfacing actionable failures.
+      //   2. Writes that genuinely race with `disconnect()` are observable to
+      //      the user via the UI (orders surface success/failure inline and
+      //      withdrawals via transaction state) and to the team via product
+      //      reports, so we are not relying on Sentry as the primary signal
+      //      for "did the order go through?" during account switches.
+      //
+      // If that invariant changes (e.g. writes start being issued from
+      // non-user-initiated paths during disconnect, or UI surfacing weakens),
+      // tighten this guard by gating on `options.context.data.method` against
+      // the upstream write-method names so write contexts bypass suppression.
       if (
         isBenignDisconnectError(error) &&
         (deps.isDisconnecting?.() ?? false)

--- a/app/scripts/controllers/perps/infrastructure.ts
+++ b/app/scripts/controllers/perps/infrastructure.ts
@@ -50,17 +50,27 @@ export type InfrastructureDeps = {
   }>;
   setStorageItem: (key: string, value: string) => Promise<void>;
   removeStorageItem: (key: string) => Promise<void>;
+  /**
+   * Returns true while a self-initiated disconnect() is in progress (e.g.
+   * during an account switch). Used to suppress benign WS-race errors that
+   * are guaranteed to be side-effects of our own teardown rather than real
+   * failures.
+   */
+  isDisconnecting?: () => boolean;
 };
 
 const debugLog = createProjectLogger('perps');
 
-function createLogger(): PerpsLogger {
+function createLogger(deps: InfrastructureDeps): PerpsLogger {
   return {
     error: (error, options) => {
-      // Benign disconnect-race errors are always side-effects of our own
-      // disconnect() during account switches — never real connection failures.
-      // Route these to the debug log and skip Sentry/console entirely.
-      if (isBenignDisconnectError(error)) {
+      // Suppress benign WS-close errors only while our own disconnect() is
+      // active (account switch in progress). Outside that window the same
+      // error shapes indicate real connectivity problems and must reach Sentry.
+      if (
+        isBenignDisconnectError(error) &&
+        (deps.isDisconnecting?.() ?? false)
+      ) {
         debugLog('Suppressed benign perps WS disconnect race', error, options);
         return;
       }
@@ -309,7 +319,7 @@ export function createPerpsInfrastructure(
   deps: InfrastructureDeps,
 ): PerpsPlatformDependencies {
   return {
-    logger: createLogger(),
+    logger: createLogger(deps),
     debugLogger: createDebugLogger(),
     metrics: createMetrics(deps),
     performance: createPerformance(),

--- a/app/scripts/controllers/perps/infrastructure.ts
+++ b/app/scripts/controllers/perps/infrastructure.ts
@@ -37,6 +37,7 @@ import {
 } from '../../../../shared/constants/metametrics';
 import { captureException } from '../../../../shared/lib/sentry';
 import { validatedVersionGatedFeatureFlag } from '../../../../shared/lib/feature-flags/version-gating';
+import { isBenignDisconnectError } from './perps-error-utils';
 
 /**
  * Dependencies required to wire {@link createPerpsInfrastructure} to extension services.
@@ -56,6 +57,13 @@ const debugLog = createProjectLogger('perps');
 function createLogger(): PerpsLogger {
   return {
     error: (error, options) => {
+      // Benign disconnect-race errors are always side-effects of our own
+      // disconnect() during account switches — never real connection failures.
+      // Route these to the debug log and skip Sentry/console entirely.
+      if (isBenignDisconnectError(error)) {
+        debugLog('Suppressed benign perps WS disconnect race', error, options);
+        return;
+      }
       const withScope = globalThis.sentry?.withScope;
       if (!withScope) {
         captureException(error);

--- a/app/scripts/controllers/perps/perps-error-utils.ts
+++ b/app/scripts/controllers/perps/perps-error-utils.ts
@@ -1,0 +1,50 @@
+/**
+ * Returns true when `err` (or any error in its `cause` chain) is a benign
+ * WebSocket disconnect side-effect of our own `PerpsController.disconnect()`.
+ *
+ * Two error shapes are treated as benign:
+ *
+ * 1. `ReconnectingWebSocketError { code: 'TERMINATED_BY_USER' }` (from
+ *    `@nktkas/rews`) — emitted when `close()` is called explicitly.  Typically
+ *    surfaces as `WebSocketRequestError { cause: ReconnectingWebSocketError }`.
+ *
+ * 2. `WebSocketRequestError { message: 'WebSocket connection closed' }` (from
+ *    `@nktkas/hyperliquid` `_postRequest.js`) — thrown when the socket's
+ *    `close`/`error` event drains the pending request queue mid-disconnect.
+ *
+ * Neither indicates a real connectivity problem; both are race side-effects of
+ * account switches where `disconnect()` fires while a request is in-flight.
+ * The chain walk (max 5 levels) handles nested `cause` references.
+ *
+ * @param err - The value thrown.
+ */
+export function isBenignDisconnectError(err: unknown): boolean {
+  let cur: unknown = err;
+  for (let i = 0; cur !== null && cur !== undefined && i < 5; i += 1) {
+    const e = cur as {
+      name?: unknown;
+      code?: unknown;
+      message?: unknown;
+      cause?: unknown;
+    };
+    // Shape 1a: ReconnectingWebSocketError with explicit TERMINATED_BY_USER code
+    if (e?.code === 'TERMINATED_BY_USER') {
+      return true;
+    }
+    // Shape 1b: ReconnectingWebSocketError without any code (defensive fallback —
+    // explicit close is the only expected path from our own disconnect())
+    if (e?.name === 'ReconnectingWebSocketError' && !e?.code) {
+      return true;
+    }
+    // Shape 2: in-flight request queue drained when socket closes
+    // Hard-coded message produced at exactly one call site in _postRequest.js
+    if (
+      e?.name === 'WebSocketRequestError' &&
+      e?.message === 'WebSocket connection closed'
+    ) {
+      return true;
+    }
+    cur = e?.cause;
+  }
+  return false;
+}

--- a/app/scripts/controllers/perps/perps-error-utils.ts
+++ b/app/scripts/controllers/perps/perps-error-utils.ts
@@ -5,12 +5,12 @@
  * Two error shapes are treated as benign:
  *
  * 1. `ReconnectingWebSocketError { code: 'TERMINATED_BY_USER' }` (from
- *    `@nktkas/rews`) — emitted when `close()` is called explicitly.  Typically
- *    surfaces as `WebSocketRequestError { cause: ReconnectingWebSocketError }`.
+ * `@nktkas/rews`) — emitted when `close()` is called explicitly.  Typically
+ * surfaces as `WebSocketRequestError { cause: ReconnectingWebSocketError }`.
  *
  * 2. `WebSocketRequestError { message: 'WebSocket connection closed' }` (from
- *    `@nktkas/hyperliquid` `_postRequest.js`) — thrown when the socket's
- *    `close`/`error` event drains the pending request queue mid-disconnect.
+ * `@nktkas/hyperliquid` `_postRequest.js`) — thrown when the socket's
+ * `close`/`error` event drains the pending request queue mid-disconnect.
  *
  * Neither indicates a real connectivity problem; both are race side-effects of
  * account switches where `disconnect()` fires while a request is in-flight.

--- a/app/scripts/messenger-client-init/perps-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/perps-controller-init.test.ts
@@ -295,6 +295,7 @@ describe('PerpsControllerInit', () => {
         getStorageItem: expect.any(Function),
         setStorageItem: expect.any(Function),
         removeStorageItem: expect.any(Function),
+        isDisconnecting: expect.any(Function),
       });
     });
 

--- a/app/scripts/messenger-client-init/perps-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/perps-controller-init.test.ts
@@ -871,8 +871,9 @@ describe('PerpsControllerInit', () => {
             const fn = (
               messengerClient as unknown as Record<string, jest.Mock>
             )[controllerMethod];
-            fn.mockRejectedValueOnce(new Error('CLIENT_NOT_INITIALIZED'))
-              .mockResolvedValueOnce(undefined);
+            fn.mockRejectedValueOnce(
+              new Error('CLIENT_NOT_INITIALIZED'),
+            ).mockResolvedValueOnce(undefined);
 
             await (api as Record<string, CallableFunction>)[apiMethod]();
 
@@ -915,11 +916,10 @@ describe('PerpsControllerInit', () => {
 
         it('perpsDepositWithConfirmation still retries on CLIENT_NOT_INITIALIZED (pre-send)', async () => {
           const { api, messengerClient } = initWithApi();
-          (messengerClient.state as unknown as Record<string, string>).lastDepositTransactionId =
-            'tx-retry';
           (
-            messengerClient.depositWithConfirmation as jest.Mock
-          )
+            messengerClient.state as unknown as Record<string, string>
+          ).lastDepositTransactionId = 'tx-retry';
+          (messengerClient.depositWithConfirmation as jest.Mock)
             .mockRejectedValueOnce(new Error('CLIENT_NOT_INITIALIZED'))
             .mockResolvedValueOnce(undefined);
 
@@ -930,9 +930,9 @@ describe('PerpsControllerInit', () => {
           );
 
           expect(messengerClient.init).toHaveBeenCalledTimes(1);
-          expect(
-            messengerClient.depositWithConfirmation,
-          ).toHaveBeenCalledTimes(2);
+          expect(messengerClient.depositWithConfirmation).toHaveBeenCalledTimes(
+            2,
+          );
           expect(result).toBe('tx-retry');
         });
       });

--- a/app/scripts/messenger-client-init/perps-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/perps-controller-init.test.ts
@@ -726,96 +726,215 @@ describe('PerpsControllerInit', () => {
         });
       }
 
-      it('retries perpsGetPositions after TERMINATED_BY_USER and succeeds', async () => {
-        const { api, messengerClient } = initWithApi();
-        const getPositions = messengerClient.getPositions as jest.Mock;
-        getPositions
-          .mockRejectedValueOnce(makeTerminatedByUserError())
-          .mockResolvedValueOnce([{ symbol: 'ETH' }]);
+      describe('read methods retry on benign disconnect errors', () => {
+        it('retries perpsGetPositions after TERMINATED_BY_USER and succeeds', async () => {
+          const { api, messengerClient } = initWithApi();
+          const getPositions = messengerClient.getPositions as jest.Mock;
+          getPositions
+            .mockRejectedValueOnce(makeTerminatedByUserError())
+            .mockResolvedValueOnce([{ symbol: 'ETH' }]);
 
-        const result = await api.perpsGetPositions();
+          const result = await api.perpsGetPositions();
 
-        expect(messengerClient.init).toHaveBeenCalledTimes(1);
-        expect(getPositions).toHaveBeenCalledTimes(2);
-        expect(result).toEqual([{ symbol: 'ETH' }]);
+          expect(messengerClient.init).toHaveBeenCalledTimes(1);
+          expect(getPositions).toHaveBeenCalledTimes(2);
+          expect(result).toEqual([{ symbol: 'ETH' }]);
+        });
+
+        it('retries perpsGetUserHistory (provider passthrough) after TERMINATED_BY_USER', async () => {
+          const { api, messengerClient } = initWithApi();
+          const getUserHistory = messengerClient.getActiveProvider()
+            .getUserHistory as jest.Mock;
+          getUserHistory
+            .mockRejectedValueOnce(makeTerminatedByUserError())
+            .mockResolvedValueOnce([{ id: 'h1' }]);
+
+          const result = await api.perpsGetUserHistory({ startTime: 0 });
+
+          expect(messengerClient.init).toHaveBeenCalledTimes(1);
+          expect(result).toEqual([{ id: 'h1' }]);
+        });
+
+        it('retries perpsGetPositions after WebSocket connection closed and succeeds', async () => {
+          const { api, messengerClient } = initWithApi();
+          const getPositions = messengerClient.getPositions as jest.Mock;
+          getPositions
+            .mockRejectedValueOnce(makeConnectionClosedError())
+            .mockResolvedValueOnce([{ symbol: 'BTC' }]);
+
+          const result = await api.perpsGetPositions();
+
+          expect(messengerClient.init).toHaveBeenCalledTimes(1);
+          expect(getPositions).toHaveBeenCalledTimes(2);
+          expect(result).toEqual([{ symbol: 'BTC' }]);
+        });
+
+        it('retries perpsGetUserHistory after WebSocket connection closed and succeeds', async () => {
+          const { api, messengerClient } = initWithApi();
+          const getUserHistory = messengerClient.getActiveProvider()
+            .getUserHistory as jest.Mock;
+          getUserHistory
+            .mockRejectedValueOnce(makeConnectionClosedError())
+            .mockResolvedValueOnce([{ id: 'h2' }]);
+
+          const result = await api.perpsGetUserHistory({ startTime: 0 });
+
+          expect(messengerClient.init).toHaveBeenCalledTimes(1);
+          expect(result).toEqual([{ id: 'h2' }]);
+        });
+
+        it('does not retry when the cause code is not TERMINATED_BY_USER', async () => {
+          const { api, messengerClient } = initWithApi();
+          const getPositions = messengerClient.getPositions as jest.Mock;
+          const cause = Object.assign(
+            new Error('Error when reconnecting WebSocket: UNKNOWN_ERROR'),
+            { name: 'ReconnectingWebSocketError', code: 'UNKNOWN_ERROR' },
+          );
+          const wsError = Object.assign(
+            new Error('Failed to establish WebSocket connection'),
+            { name: 'WebSocketRequestError', cause },
+          );
+          getPositions.mockRejectedValueOnce(wsError);
+
+          await expect(api.perpsGetPositions()).rejects.toThrow(
+            'Failed to establish WebSocket connection',
+          );
+          expect(messengerClient.init).not.toHaveBeenCalled();
+          expect(getPositions).toHaveBeenCalledTimes(1);
+        });
+
+        it('does not retry for a WebSocketRequestError with a different message', async () => {
+          const { api, messengerClient } = initWithApi();
+          const getPositions = messengerClient.getPositions as jest.Mock;
+          const wsError = Object.assign(
+            new Error('Failed to close WebSocket connection'),
+            { name: 'WebSocketRequestError' },
+          );
+          getPositions.mockRejectedValueOnce(wsError);
+
+          await expect(api.perpsGetPositions()).rejects.toThrow(
+            'Failed to close WebSocket connection',
+          );
+          expect(messengerClient.init).not.toHaveBeenCalled();
+          expect(getPositions).toHaveBeenCalledTimes(1);
+        });
       });
 
-      it('retries perpsGetUserHistory (provider passthrough) after TERMINATED_BY_USER', async () => {
-        const { api, messengerClient } = initWithApi();
-        const getUserHistory = messengerClient.getActiveProvider()
-          .getUserHistory as jest.Mock;
-        getUserHistory
-          .mockRejectedValueOnce(makeTerminatedByUserError())
-          .mockResolvedValueOnce([{ id: 'h1' }]);
+      describe('write methods do not retry on benign disconnect errors', () => {
+        // [apiMethod, controllerMethod] pairs for all guarded mutations
+        const writeMethods: [string, string][] = [
+          ['perpsPlaceOrder', 'placeOrder'],
+          ['perpsClosePosition', 'closePosition'],
+          ['perpsClosePositions', 'closePositions'],
+          ['perpsEditOrder', 'editOrder'],
+          ['perpsCancelOrder', 'cancelOrder'],
+          ['perpsCancelOrders', 'cancelOrders'],
+          ['perpsUpdatePositionTPSL', 'updatePositionTPSL'],
+          ['perpsUpdateMargin', 'updateMargin'],
+          ['perpsFlipPosition', 'flipPosition'],
+          ['perpsWithdraw', 'withdraw'],
+          ['perpsUpdateWithdrawalStatus', 'updateWithdrawalStatus'],
+          ['perpsUpdateWithdrawalProgress', 'updateWithdrawalProgress'],
+        ];
 
-        const result = await api.perpsGetUserHistory({ startTime: 0 });
+        for (const [apiMethod, controllerMethod] of writeMethods) {
+          it(`${apiMethod} surfaces "WebSocket connection closed" without retry`, async () => {
+            const { api, messengerClient } = initWithApi();
+            const fn = (
+              messengerClient as unknown as Record<string, jest.Mock>
+            )[controllerMethod];
+            fn.mockRejectedValueOnce(makeConnectionClosedError());
 
-        expect(messengerClient.init).toHaveBeenCalledTimes(1);
-        expect(result).toEqual([{ id: 'h1' }]);
-      });
+            await expect(
+              (api as Record<string, CallableFunction>)[apiMethod](),
+            ).rejects.toThrow('WebSocket connection closed');
+            expect(messengerClient.init).not.toHaveBeenCalled();
+            expect(fn).toHaveBeenCalledTimes(1);
+          });
 
-      it('retries perpsGetPositions after WebSocket connection closed and succeeds', async () => {
-        const { api, messengerClient } = initWithApi();
-        const getPositions = messengerClient.getPositions as jest.Mock;
-        getPositions
-          .mockRejectedValueOnce(makeConnectionClosedError())
-          .mockResolvedValueOnce([{ symbol: 'BTC' }]);
+          it(`${apiMethod} surfaces TERMINATED_BY_USER without retry`, async () => {
+            const { api, messengerClient } = initWithApi();
+            const fn = (
+              messengerClient as unknown as Record<string, jest.Mock>
+            )[controllerMethod];
+            fn.mockRejectedValueOnce(makeTerminatedByUserError());
 
-        const result = await api.perpsGetPositions();
+            await expect(
+              (api as Record<string, CallableFunction>)[apiMethod](),
+            ).rejects.toThrow();
+            expect(messengerClient.init).not.toHaveBeenCalled();
+            expect(fn).toHaveBeenCalledTimes(1);
+          });
 
-        expect(messengerClient.init).toHaveBeenCalledTimes(1);
-        expect(getPositions).toHaveBeenCalledTimes(2);
-        expect(result).toEqual([{ symbol: 'BTC' }]);
-      });
+          it(`${apiMethod} still retries on CLIENT_NOT_INITIALIZED (pre-send)`, async () => {
+            const { api, messengerClient } = initWithApi();
+            const fn = (
+              messengerClient as unknown as Record<string, jest.Mock>
+            )[controllerMethod];
+            fn.mockRejectedValueOnce(new Error('CLIENT_NOT_INITIALIZED'))
+              .mockResolvedValueOnce(undefined);
 
-      it('retries perpsGetUserHistory after WebSocket connection closed and succeeds', async () => {
-        const { api, messengerClient } = initWithApi();
-        const getUserHistory = messengerClient.getActiveProvider()
-          .getUserHistory as jest.Mock;
-        getUserHistory
-          .mockRejectedValueOnce(makeConnectionClosedError())
-          .mockResolvedValueOnce([{ id: 'h2' }]);
+            await (api as Record<string, CallableFunction>)[apiMethod]();
 
-        const result = await api.perpsGetUserHistory({ startTime: 0 });
+            expect(messengerClient.init).toHaveBeenCalledTimes(1);
+            expect(fn).toHaveBeenCalledTimes(2);
+          });
+        }
 
-        expect(messengerClient.init).toHaveBeenCalledTimes(1);
-        expect(result).toEqual([{ id: 'h2' }]);
-      });
+        it('perpsDepositWithConfirmation surfaces "WebSocket connection closed" without retry', async () => {
+          const { api, messengerClient } = initWithApi();
+          (
+            messengerClient.depositWithConfirmation as jest.Mock
+          ).mockRejectedValueOnce(makeConnectionClosedError());
 
-      it('does not retry when the cause code is not TERMINATED_BY_USER', async () => {
-        const { api, messengerClient } = initWithApi();
-        const getPositions = messengerClient.getPositions as jest.Mock;
-        const cause = Object.assign(
-          new Error('Error when reconnecting WebSocket: UNKNOWN_ERROR'),
-          { name: 'ReconnectingWebSocketError', code: 'UNKNOWN_ERROR' },
-        );
-        const wsError = Object.assign(
-          new Error('Failed to establish WebSocket connection'),
-          { name: 'WebSocketRequestError', cause },
-        );
-        getPositions.mockRejectedValueOnce(wsError);
+          await expect(
+            api.perpsDepositWithConfirmation(
+              ...([] as unknown as Parameters<
+                typeof messengerClient.depositWithConfirmation
+              >),
+            ),
+          ).rejects.toThrow('WebSocket connection closed');
+          expect(messengerClient.init).not.toHaveBeenCalled();
+        });
 
-        await expect(api.perpsGetPositions()).rejects.toThrow(
-          'Failed to establish WebSocket connection',
-        );
-        expect(messengerClient.init).not.toHaveBeenCalled();
-        expect(getPositions).toHaveBeenCalledTimes(1);
-      });
+        it('perpsDepositWithConfirmation surfaces TERMINATED_BY_USER without retry', async () => {
+          const { api, messengerClient } = initWithApi();
+          (
+            messengerClient.depositWithConfirmation as jest.Mock
+          ).mockRejectedValueOnce(makeTerminatedByUserError());
 
-      it('does not retry for a WebSocketRequestError with a different message', async () => {
-        const { api, messengerClient } = initWithApi();
-        const getPositions = messengerClient.getPositions as jest.Mock;
-        const wsError = Object.assign(
-          new Error('Failed to close WebSocket connection'),
-          { name: 'WebSocketRequestError' },
-        );
-        getPositions.mockRejectedValueOnce(wsError);
+          await expect(
+            api.perpsDepositWithConfirmation(
+              ...([] as unknown as Parameters<
+                typeof messengerClient.depositWithConfirmation
+              >),
+            ),
+          ).rejects.toThrow();
+          expect(messengerClient.init).not.toHaveBeenCalled();
+        });
 
-        await expect(api.perpsGetPositions()).rejects.toThrow(
-          'Failed to close WebSocket connection',
-        );
-        expect(messengerClient.init).not.toHaveBeenCalled();
-        expect(getPositions).toHaveBeenCalledTimes(1);
+        it('perpsDepositWithConfirmation still retries on CLIENT_NOT_INITIALIZED (pre-send)', async () => {
+          const { api, messengerClient } = initWithApi();
+          (messengerClient.state as unknown as Record<string, string>).lastDepositTransactionId =
+            'tx-retry';
+          (
+            messengerClient.depositWithConfirmation as jest.Mock
+          )
+            .mockRejectedValueOnce(new Error('CLIENT_NOT_INITIALIZED'))
+            .mockResolvedValueOnce(undefined);
+
+          const result = await api.perpsDepositWithConfirmation(
+            ...([] as unknown as Parameters<
+              typeof messengerClient.depositWithConfirmation
+            >),
+          );
+
+          expect(messengerClient.init).toHaveBeenCalledTimes(1);
+          expect(
+            messengerClient.depositWithConfirmation,
+          ).toHaveBeenCalledTimes(2);
+          expect(result).toBe('tx-retry');
+        });
       });
     });
   });

--- a/app/scripts/messenger-client-init/perps-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/perps-controller-init.test.ts
@@ -707,5 +707,116 @@ describe('PerpsControllerInit', () => {
       expect(placeOrder).toHaveBeenCalledTimes(2);
       expect(result).toEqual({ orderId: '123' });
     });
+
+    describe('benign disconnect-race recovery', () => {
+      function makeTerminatedByUserError() {
+        const cause = Object.assign(
+          new Error('Error when reconnecting WebSocket: TERMINATED_BY_USER'),
+          { name: 'ReconnectingWebSocketError', code: 'TERMINATED_BY_USER' },
+        );
+        return Object.assign(
+          new Error('Failed to establish WebSocket connection'),
+          { name: 'WebSocketRequestError', cause },
+        );
+      }
+
+      function makeConnectionClosedError() {
+        return Object.assign(new Error('WebSocket connection closed'), {
+          name: 'WebSocketRequestError',
+        });
+      }
+
+      it('retries perpsGetPositions after TERMINATED_BY_USER and succeeds', async () => {
+        const { api, messengerClient } = initWithApi();
+        const getPositions = messengerClient.getPositions as jest.Mock;
+        getPositions
+          .mockRejectedValueOnce(makeTerminatedByUserError())
+          .mockResolvedValueOnce([{ symbol: 'ETH' }]);
+
+        const result = await api.perpsGetPositions();
+
+        expect(messengerClient.init).toHaveBeenCalledTimes(1);
+        expect(getPositions).toHaveBeenCalledTimes(2);
+        expect(result).toEqual([{ symbol: 'ETH' }]);
+      });
+
+      it('retries perpsGetUserHistory (provider passthrough) after TERMINATED_BY_USER', async () => {
+        const { api, messengerClient } = initWithApi();
+        const getUserHistory = messengerClient.getActiveProvider()
+          .getUserHistory as jest.Mock;
+        getUserHistory
+          .mockRejectedValueOnce(makeTerminatedByUserError())
+          .mockResolvedValueOnce([{ id: 'h1' }]);
+
+        const result = await api.perpsGetUserHistory({ startTime: 0 });
+
+        expect(messengerClient.init).toHaveBeenCalledTimes(1);
+        expect(result).toEqual([{ id: 'h1' }]);
+      });
+
+      it('retries perpsGetPositions after WebSocket connection closed and succeeds', async () => {
+        const { api, messengerClient } = initWithApi();
+        const getPositions = messengerClient.getPositions as jest.Mock;
+        getPositions
+          .mockRejectedValueOnce(makeConnectionClosedError())
+          .mockResolvedValueOnce([{ symbol: 'BTC' }]);
+
+        const result = await api.perpsGetPositions();
+
+        expect(messengerClient.init).toHaveBeenCalledTimes(1);
+        expect(getPositions).toHaveBeenCalledTimes(2);
+        expect(result).toEqual([{ symbol: 'BTC' }]);
+      });
+
+      it('retries perpsGetUserHistory after WebSocket connection closed and succeeds', async () => {
+        const { api, messengerClient } = initWithApi();
+        const getUserHistory = messengerClient.getActiveProvider()
+          .getUserHistory as jest.Mock;
+        getUserHistory
+          .mockRejectedValueOnce(makeConnectionClosedError())
+          .mockResolvedValueOnce([{ id: 'h2' }]);
+
+        const result = await api.perpsGetUserHistory({ startTime: 0 });
+
+        expect(messengerClient.init).toHaveBeenCalledTimes(1);
+        expect(result).toEqual([{ id: 'h2' }]);
+      });
+
+      it('does not retry when the cause code is not TERMINATED_BY_USER', async () => {
+        const { api, messengerClient } = initWithApi();
+        const getPositions = messengerClient.getPositions as jest.Mock;
+        const cause = Object.assign(
+          new Error('Error when reconnecting WebSocket: UNKNOWN_ERROR'),
+          { name: 'ReconnectingWebSocketError', code: 'UNKNOWN_ERROR' },
+        );
+        const wsError = Object.assign(
+          new Error('Failed to establish WebSocket connection'),
+          { name: 'WebSocketRequestError', cause },
+        );
+        getPositions.mockRejectedValueOnce(wsError);
+
+        await expect(api.perpsGetPositions()).rejects.toThrow(
+          'Failed to establish WebSocket connection',
+        );
+        expect(messengerClient.init).not.toHaveBeenCalled();
+        expect(getPositions).toHaveBeenCalledTimes(1);
+      });
+
+      it('does not retry for a WebSocketRequestError with a different message', async () => {
+        const { api, messengerClient } = initWithApi();
+        const getPositions = messengerClient.getPositions as jest.Mock;
+        const wsError = Object.assign(
+          new Error('Failed to close WebSocket connection'),
+          { name: 'WebSocketRequestError' },
+        );
+        getPositions.mockRejectedValueOnce(wsError);
+
+        await expect(api.perpsGetPositions()).rejects.toThrow(
+          'Failed to close WebSocket connection',
+        );
+        expect(messengerClient.init).not.toHaveBeenCalled();
+        expect(getPositions).toHaveBeenCalledTimes(1);
+      });
+    });
   });
 });

--- a/app/scripts/messenger-client-init/perps-controller-init.ts
+++ b/app/scripts/messenger-client-init/perps-controller-init.ts
@@ -357,9 +357,7 @@ function getApi(messengerClient: PerpsController): PerpsBackgroundApi {
       messengerClient.getWithdrawalProgress.bind(messengerClient),
 
     // -- Data fetches (read-guard: init errors + benign disconnect) --
-    perpsGetPositions: read(
-      messengerClient.getPositions.bind(messengerClient),
-    ),
+    perpsGetPositions: read(messengerClient.getPositions.bind(messengerClient)),
     perpsGetMarkets: read(messengerClient.getMarkets.bind(messengerClient)),
     perpsGetMarketDataWithPrices: read(
       messengerClient.getMarketDataWithPrices.bind(messengerClient),

--- a/app/scripts/messenger-client-init/perps-controller-init.ts
+++ b/app/scripts/messenger-client-init/perps-controller-init.ts
@@ -217,36 +217,32 @@ type PerpsBackgroundApi = {
 };
 
 /**
- * Wrap a controller method so that transient initialization and WebSocket
- * disconnect-race errors trigger `controller.init()` and a single retry.
- *
- * Retried error conditions:
- * - `CLIENT_NOT_INITIALIZED` / `CLIENT_REINITIALIZING` — provider not yet
- * ready between `perpsDisconnect → perpsInit` during account switches.
- * - Benign WS disconnect-race errors (`TERMINATED_BY_USER`, in-flight queue
- * drained on socket close) — our own `disconnect()` closed the socket while
- * a request was in-flight. By the time `init()` resolves the controller has
- * rebuilt the provider with the new account and the retry runs against a
- * fresh, ready WebSocket.
- *
- * Every wrapped method is self-healing without any UI-side awareness.
- * @param controller
- * @param fn
+ * Returns true when the error proves the request never left the client.
+ * Both codes are thrown before any frame is written to the socket, so
+ * retrying is idempotent for reads and writes alike.
+ */
+function isPreSendInitError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return (
+    message.includes('CLIENT_NOT_INITIALIZED') ||
+    message.includes('CLIENT_REINITIALIZING')
+  );
+}
+
+/**
+ * Core retry wrapper: calls `controller.init()` then retries once when
+ * `shouldRetry` matches the thrown error.
  */
 function withAutoInit<TArgs extends unknown[], TResult>(
   controller: PerpsController,
   fn: (...args: TArgs) => TResult,
+  shouldRetry: (err: unknown) => boolean,
 ): (...args: TArgs) => Promise<Awaited<TResult>> {
   return async (...args: TArgs): Promise<Awaited<TResult>> => {
     try {
       return await fn(...args);
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      if (
-        message.includes('CLIENT_NOT_INITIALIZED') ||
-        message.includes('CLIENT_REINITIALIZING') ||
-        isBenignDisconnectError(err)
-      ) {
+      if (shouldRetry(err)) {
         await controller.init();
         return await fn(...args);
       }
@@ -255,53 +251,84 @@ function withAutoInit<TArgs extends unknown[], TResult>(
   };
 }
 
+/**
+ * Guard for read-only / idempotent methods.
+ *
+ * Retries on both pre-send init errors (`CLIENT_NOT_INITIALIZED` /
+ * `CLIENT_REINITIALIZING`) and benign WS disconnect-race errors
+ * (`TERMINATED_BY_USER`, in-flight queue drained on socket close).
+ * Re-submitting a fetch after `init()` rebinds the provider is always safe.
+ */
+function guardRead<TArgs extends unknown[], TResult>(
+  controller: PerpsController,
+  fn: (...args: TArgs) => TResult,
+) {
+  return withAutoInit(
+    controller,
+    fn,
+    (err) => isPreSendInitError(err) || isBenignDisconnectError(err),
+  );
+}
+
+/**
+ * Guard for write / mutation methods (orders, withdrawals, margin, deposits).
+ *
+ * Only retries on `CLIENT_NOT_INITIALIZED` / `CLIENT_REINITIALIZING`, which
+ * are thrown *before* any frame reaches the broker.
+ *
+ * `WebSocketRequestError("WebSocket connection closed")` and
+ * `TERMINATED_BY_USER` errors can be thrown *after* the request was written
+ * to the socket. Retrying those could:
+ *  - Submit the same trade, withdrawal, or margin change twice.
+ *  - Submit against a different account if `init()` rebinds the provider.
+ *
+ * Benign disconnect-race errors are therefore intentionally excluded here.
+ */
+function guardWrite<TArgs extends unknown[], TResult>(
+  controller: PerpsController,
+  fn: (...args: TArgs) => TResult,
+) {
+  return withAutoInit(controller, fn, isPreSendInitError);
+}
+
 function getApi(messengerClient: PerpsController): PerpsBackgroundApi {
-  const guard = <TArgs extends unknown[], TResult>(
+  const read = <TArgs extends unknown[], TResult>(
     fn: (...args: TArgs) => TResult,
-  ) => withAutoInit(messengerClient, fn);
+  ) => guardRead(messengerClient, fn);
+
+  const write = <TArgs extends unknown[], TResult>(
+    fn: (...args: TArgs) => TResult,
+  ) => guardWrite(messengerClient, fn);
 
   return {
     // -- Lifecycle (no guard — IS the init itself) --
     perpsInit: messengerClient.init.bind(messengerClient),
     perpsDisconnect: messengerClient.disconnect.bind(messengerClient),
 
-    // -- Trading mutations (guarded) --
-    perpsPlaceOrder: guard(messengerClient.placeOrder.bind(messengerClient)),
-    perpsClosePosition: guard(
+    // -- Trading mutations (write-guard: no benign-disconnect retry) --
+    perpsPlaceOrder: write(messengerClient.placeOrder.bind(messengerClient)),
+    perpsClosePosition: write(
       messengerClient.closePosition.bind(messengerClient),
     ),
-    perpsClosePositions: guard(
+    perpsClosePositions: write(
       messengerClient.closePositions.bind(messengerClient),
     ),
-    perpsEditOrder: guard(messengerClient.editOrder.bind(messengerClient)),
-    perpsCancelOrder: guard(messengerClient.cancelOrder.bind(messengerClient)),
-    perpsCancelOrders: guard(
+    perpsEditOrder: write(messengerClient.editOrder.bind(messengerClient)),
+    perpsCancelOrder: write(messengerClient.cancelOrder.bind(messengerClient)),
+    perpsCancelOrders: write(
       messengerClient.cancelOrders.bind(messengerClient),
     ),
-    perpsUpdatePositionTPSL: guard(
+    perpsUpdatePositionTPSL: write(
       messengerClient.updatePositionTPSL.bind(messengerClient),
     ),
-    perpsUpdateMargin: guard(
+    perpsUpdateMargin: write(
       messengerClient.updateMargin.bind(messengerClient),
     ),
-    perpsFlipPosition: guard(
+    perpsFlipPosition: write(
       messengerClient.flipPosition.bind(messengerClient),
     ),
-    perpsWithdraw: guard(messengerClient.withdraw.bind(messengerClient)),
-    perpsValidateWithdrawal: guard(
-      messengerClient.validateWithdrawal.bind(messengerClient),
-    ),
-    perpsGetWithdrawalRoutes:
-      messengerClient.getWithdrawalRoutes.bind(messengerClient),
-    perpsUpdateWithdrawalStatus: guard(
-      messengerClient.updateWithdrawalStatus.bind(messengerClient),
-    ),
-    perpsUpdateWithdrawalProgress: guard(
-      messengerClient.updateWithdrawalProgress.bind(messengerClient),
-    ),
-    perpsGetWithdrawalProgress:
-      messengerClient.getWithdrawalProgress.bind(messengerClient),
-    perpsDepositWithConfirmation: guard(
+    perpsWithdraw: write(messengerClient.withdraw.bind(messengerClient)),
+    perpsDepositWithConfirmation: write(
       async (
         ...args: Parameters<typeof messengerClient.depositWithConfirmation>
       ) => {
@@ -312,38 +339,55 @@ function getApi(messengerClient: PerpsController): PerpsBackgroundApi {
       },
     ),
 
-    // -- Data fetches (guarded) --
-    perpsGetPositions: guard(
+    // -- Withdrawal helpers --
+    // validateWithdrawal is a read (no side effect on broker)
+    perpsValidateWithdrawal: read(
+      messengerClient.validateWithdrawal.bind(messengerClient),
+    ),
+    perpsGetWithdrawalRoutes:
+      messengerClient.getWithdrawalRoutes.bind(messengerClient),
+    // updateWithdrawalStatus / updateWithdrawalProgress post to the broker
+    perpsUpdateWithdrawalStatus: write(
+      messengerClient.updateWithdrawalStatus.bind(messengerClient),
+    ),
+    perpsUpdateWithdrawalProgress: write(
+      messengerClient.updateWithdrawalProgress.bind(messengerClient),
+    ),
+    perpsGetWithdrawalProgress:
+      messengerClient.getWithdrawalProgress.bind(messengerClient),
+
+    // -- Data fetches (read-guard: init errors + benign disconnect) --
+    perpsGetPositions: read(
       messengerClient.getPositions.bind(messengerClient),
     ),
-    perpsGetMarkets: guard(messengerClient.getMarkets.bind(messengerClient)),
-    perpsGetMarketDataWithPrices: guard(
+    perpsGetMarkets: read(messengerClient.getMarkets.bind(messengerClient)),
+    perpsGetMarketDataWithPrices: read(
       messengerClient.getMarketDataWithPrices.bind(messengerClient),
     ),
-    perpsGetOrderFills: guard(
+    perpsGetOrderFills: read(
       messengerClient.getOrderFills.bind(messengerClient),
     ),
-    perpsGetOrders: guard(messengerClient.getOrders.bind(messengerClient)),
-    perpsGetOpenOrders: guard(
+    perpsGetOrders: read(messengerClient.getOrders.bind(messengerClient)),
+    perpsGetOpenOrders: read(
       messengerClient.getOpenOrders.bind(messengerClient),
     ),
-    perpsGetFunding: guard(messengerClient.getFunding.bind(messengerClient)),
-    perpsGetAccountState: guard(
+    perpsGetFunding: read(messengerClient.getFunding.bind(messengerClient)),
+    perpsGetAccountState: read(
       messengerClient.getAccountState.bind(messengerClient),
     ),
-    perpsGetHistoricalPortfolio: guard(
+    perpsGetHistoricalPortfolio: read(
       messengerClient.getHistoricalPortfolio.bind(messengerClient),
     ),
-    perpsFetchHistoricalCandles: guard(
+    perpsFetchHistoricalCandles: read(
       messengerClient.fetchHistoricalCandles.bind(messengerClient),
     ),
-    perpsCalculateFees: guard(
+    perpsCalculateFees: read(
       messengerClient.calculateFees.bind(messengerClient),
     ),
-    perpsCalculateLiquidationPrice: guard(
+    perpsCalculateLiquidationPrice: read(
       messengerClient.calculateLiquidationPrice.bind(messengerClient),
     ),
-    perpsGetAvailableDexs: guard(
+    perpsGetAvailableDexs: read(
       messengerClient.getAvailableDexs.bind(messengerClient),
     ),
 
@@ -390,8 +434,8 @@ function getApi(messengerClient: PerpsController): PerpsBackgroundApi {
     perpsGetOrderBookGrouping:
       messengerClient.getOrderBookGrouping.bind(messengerClient),
 
-    // -- Provider passthrough (guarded) --
-    perpsGetUserHistory: guard(
+    // -- Provider passthrough (read-guard) --
+    perpsGetUserHistory: read(
       async (params: {
         startTime?: number;
         endTime?: number;
@@ -400,7 +444,7 @@ function getApi(messengerClient: PerpsController): PerpsBackgroundApi {
         return messengerClient.getActiveProvider().getUserHistory(params);
       },
     ),
-    perpsGetUserNonFundingLedgerUpdates: guard(
+    perpsGetUserNonFundingLedgerUpdates: read(
       async (params?: {
         startTime?: number;
         endTime?: number;

--- a/app/scripts/messenger-client-init/perps-controller-init.ts
+++ b/app/scripts/messenger-client-init/perps-controller-init.ts
@@ -220,6 +220,7 @@ type PerpsBackgroundApi = {
  * Returns true when the error proves the request never left the client.
  * Both codes are thrown before any frame is written to the socket, so
  * retrying is idempotent for reads and writes alike.
+ * @param err
  */
 function isPreSendInitError(err: unknown): boolean {
   const message = err instanceof Error ? err.message : String(err);
@@ -232,6 +233,9 @@ function isPreSendInitError(err: unknown): boolean {
 /**
  * Core retry wrapper: calls `controller.init()` then retries once when
  * `shouldRetry` matches the thrown error.
+ * @param controller
+ * @param fn
+ * @param shouldRetry
  */
 function withAutoInit<TArgs extends unknown[], TResult>(
   controller: PerpsController,
@@ -260,8 +264,6 @@ function withAutoInit<TArgs extends unknown[], TResult>(
  * Re-submitting a fetch after `init()` rebinds the provider is always safe.
  * @param controller
  * @param fn
- * @param controller
- * @param fn
  */
 function guardRead<TArgs extends unknown[], TResult>(
   controller: PerpsController,
@@ -287,8 +289,6 @@ function guardRead<TArgs extends unknown[], TResult>(
  * - Submit against a different account if `init()` rebinds the provider.
  *
  * Benign disconnect-race errors are therefore intentionally excluded here.
- * @param controller
- * @param fn
  * @param controller
  * @param fn
  */

--- a/app/scripts/messenger-client-init/perps-controller-init.ts
+++ b/app/scripts/messenger-client-init/perps-controller-init.ts
@@ -7,6 +7,7 @@ import {
 import { SERVICE_NAME as STORAGE_SERVICE_NAME } from '@metamask/storage-service';
 import type { MetaMetricsEventPayload } from '../../../shared/constants/metametrics';
 import { createPerpsInfrastructure } from '../controllers/perps/infrastructure';
+import { isBenignDisconnectError } from '../controllers/perps/perps-error-utils';
 import { MessengerClientInitFunction } from './types';
 import { PerpsControllerMessenger } from './messengers/perps-controller-messenger';
 
@@ -216,13 +217,19 @@ type PerpsBackgroundApi = {
 };
 
 /**
- * Wrap a controller method so that CLIENT_NOT_INITIALIZED /
- * CLIENT_REINITIALIZING errors trigger `controller.init()` and a retry.
+ * Wrap a controller method so that transient initialization and WebSocket
+ * disconnect-race errors trigger `controller.init()` and a single retry.
  *
- * During account switches, `perpsDisconnect → perpsInit` runs async.
- * Any provider-dependent call during that gap throws one of these errors.
- * This wrapper catches them once, re-initializes, and retries — making
- * every wrapped method self-healing without any UI-side awareness.
+ * Retried error conditions:
+ * - `CLIENT_NOT_INITIALIZED` / `CLIENT_REINITIALIZING` — provider not yet
+ *   ready between `perpsDisconnect → perpsInit` during account switches.
+ * - Benign WS disconnect-race errors (`TERMINATED_BY_USER`, in-flight queue
+ *   drained on socket close) — our own `disconnect()` closed the socket while
+ *   a request was in-flight. By the time `init()` resolves the controller has
+ *   rebuilt the provider with the new account and the retry runs against a
+ *   fresh, ready WebSocket.
+ *
+ * Every wrapped method is self-healing without any UI-side awareness.
  * @param controller
  * @param fn
  */
@@ -237,7 +244,8 @@ function withAutoInit<TArgs extends unknown[], TResult>(
       const message = err instanceof Error ? err.message : String(err);
       if (
         message.includes('CLIENT_NOT_INITIALIZED') ||
-        message.includes('CLIENT_REINITIALIZING')
+        message.includes('CLIENT_REINITIALIZING') ||
+        isBenignDisconnectError(err)
       ) {
         await controller.init();
         return await fn(...args);

--- a/app/scripts/messenger-client-init/perps-controller-init.ts
+++ b/app/scripts/messenger-client-init/perps-controller-init.ts
@@ -258,6 +258,10 @@ function withAutoInit<TArgs extends unknown[], TResult>(
  * `CLIENT_REINITIALIZING`) and benign WS disconnect-race errors
  * (`TERMINATED_BY_USER`, in-flight queue drained on socket close).
  * Re-submitting a fetch after `init()` rebinds the provider is always safe.
+ * @param controller
+ * @param fn
+ * @param controller
+ * @param fn
  */
 function guardRead<TArgs extends unknown[], TResult>(
   controller: PerpsController,
@@ -279,10 +283,14 @@ function guardRead<TArgs extends unknown[], TResult>(
  * `WebSocketRequestError("WebSocket connection closed")` and
  * `TERMINATED_BY_USER` errors can be thrown *after* the request was written
  * to the socket. Retrying those could:
- *  - Submit the same trade, withdrawal, or margin change twice.
- *  - Submit against a different account if `init()` rebinds the provider.
+ * - Submit the same trade, withdrawal, or margin change twice.
+ * - Submit against a different account if `init()` rebinds the provider.
  *
  * Benign disconnect-race errors are therefore intentionally excluded here.
+ * @param controller
+ * @param fn
+ * @param controller
+ * @param fn
  */
 function guardWrite<TArgs extends unknown[], TResult>(
   controller: PerpsController,

--- a/app/scripts/messenger-client-init/perps-controller-init.ts
+++ b/app/scripts/messenger-client-init/perps-controller-init.ts
@@ -222,12 +222,12 @@ type PerpsBackgroundApi = {
  *
  * Retried error conditions:
  * - `CLIENT_NOT_INITIALIZED` / `CLIENT_REINITIALIZING` — provider not yet
- *   ready between `perpsDisconnect → perpsInit` during account switches.
+ * ready between `perpsDisconnect → perpsInit` during account switches.
  * - Benign WS disconnect-race errors (`TERMINATED_BY_USER`, in-flight queue
- *   drained on socket close) — our own `disconnect()` closed the socket while
- *   a request was in-flight. By the time `init()` resolves the controller has
- *   rebuilt the provider with the new account and the retry runs against a
- *   fresh, ready WebSocket.
+ * drained on socket close) — our own `disconnect()` closed the socket while
+ * a request was in-flight. By the time `init()` resolves the controller has
+ * rebuilt the provider with the new account and the retry runs against a
+ * fresh, ready WebSocket.
  *
  * Every wrapped method is self-healing without any UI-side awareness.
  * @param controller

--- a/app/scripts/messenger-client-init/perps-controller-init.ts
+++ b/app/scripts/messenger-client-init/perps-controller-init.ts
@@ -54,6 +54,7 @@ export const PerpsControllerInit: MessengerClientInitFunction<
   const trackEvent = (payload: MetaMetricsEventPayload) => {
     controllerMessenger.call('MetaMetricsController:trackEvent', payload);
   };
+  let isDisconnecting = false;
   const infrastructure = createPerpsInfrastructure({
     trackEvent,
     getStorageItem: (key: string) =>
@@ -75,6 +76,7 @@ export const PerpsControllerInit: MessengerClientInitFunction<
         storageNamespace,
         key,
       ),
+    isDisconnecting: () => isDisconnecting,
   });
   const fallbackBlockedRegions = getFallbackBlockedRegions();
   const hyperLiquidBuilderAddresses = getHyperLiquidBuilderAddresses();
@@ -107,7 +109,15 @@ export const PerpsControllerInit: MessengerClientInitFunction<
     deferEligibilityCheck: !completedOnboarding || !useExternalServices,
   });
 
-  const api = getApi(messengerClient);
+  const api = getApi(
+    messengerClient,
+    () => {
+      isDisconnecting = true;
+    },
+    () => {
+      isDisconnecting = false;
+    },
+  );
 
   return { messengerClient, api };
 };
@@ -299,7 +309,11 @@ function guardWrite<TArgs extends unknown[], TResult>(
   return withAutoInit(controller, fn, isPreSendInitError);
 }
 
-function getApi(messengerClient: PerpsController): PerpsBackgroundApi {
+function getApi(
+  messengerClient: PerpsController,
+  onDisconnectStart: () => void,
+  onDisconnectEnd: () => void,
+): PerpsBackgroundApi {
   const read = <TArgs extends unknown[], TResult>(
     fn: (...args: TArgs) => TResult,
   ) => guardRead(messengerClient, fn);
@@ -311,7 +325,16 @@ function getApi(messengerClient: PerpsController): PerpsBackgroundApi {
   return {
     // -- Lifecycle (no guard — IS the init itself) --
     perpsInit: messengerClient.init.bind(messengerClient),
-    perpsDisconnect: messengerClient.disconnect.bind(messengerClient),
+    perpsDisconnect: async (
+      ...args: Parameters<typeof messengerClient.disconnect>
+    ) => {
+      onDisconnectStart();
+      try {
+        return await messengerClient.disconnect(...args);
+      } finally {
+        onDisconnectEnd();
+      }
+    },
 
     // -- Trading mutations (write-guard: no benign-disconnect retry) --
     perpsPlaceOrder: write(messengerClient.placeOrder.bind(messengerClient)),


### PR DESCRIPTION
## **Description**

Fixes benign websocket connection errors being surfaced in console on user actions like account switch, where we are purposefully handling a full disconnect/reconnect lifecycle.

This is a client side change, to update in core required.

## **Changelog**

CHANGELOG entry: fixes websocket connection console errors on user initiated actions like account switch

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/41880
Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2976

## **Manual testing steps**

1. Go to Perps
2. Switch accounts
3. Websocket errors should not be surfaced in console

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/3e67f0dc-d916-4839-ad38-5f100c6c2358

### **After**

https://github.com/user-attachments/assets/ade287c2-5819-4fa3-aedf-d3fb741458f1

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error reporting and retry behavior around Perps WebSocket disconnect/reconnect flows; misclassification could hide real connectivity issues or change when API calls re-init, though write retries are intentionally constrained to pre-send errors to avoid duplicate submissions.
> 
> **Overview**
> Reduces noisy Perps WebSocket errors during user-initiated account switches by adding `isBenignDisconnectError` detection and suppressing Sentry reporting *only while* a tracked `disconnect()` is in progress.
> 
> Refactors the Perps background API auto-retry wrapper to distinguish **read** vs **write** calls: read-only methods now re-`init()` and retry once on benign disconnect-race errors (in addition to `CLIENT_NOT_INITIALIZED/REINITIALIZING`), while mutation methods retry *only* on pre-send init errors to avoid duplicating trades/withdrawals.
> 
> Adds extensive unit coverage for the new suppression/guard behavior, including nested `cause` error shapes and ensuring Sentry scope isn’t touched when suppressed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8f796491e48052a0eb21045db3d034e319ce27a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->