### PR TITLE
fix: Add improvements to QR error tracking mechanisms

### DIFF
--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -1214,6 +1214,8 @@ export enum MetaMetricsHardwareWalletRecoveryErrorType {
   DeviceDisconnected = 'Device Disconnected',
   EthereumAppNotOpened = 'Ethereum App Not Opened',
   BlindSigningNotEnabled = 'Blind Signing Not Enabled',
+  CameraPermissionDenied = 'Camera Permission Denied',
+  CameraPermissionPromptDismissed = 'Camera Permission Prompt Dismissed',
   GenericError = 'Generic Error',
 }
 

--- a/shared/lib/hardware-wallet-recovery-metrics.test.ts
+++ b/shared/lib/hardware-wallet-recovery-metrics.test.ts
@@ -94,6 +94,24 @@ describe('hardware-wallet-recovery-metrics', () => {
       ).toBe(MetaMetricsHardwareWalletRecoveryErrorType.EthereumAppNotOpened);
     });
 
+    it('maps camera permission denied to CameraPermissionDenied', () => {
+      expect(
+        mapHardwareWalletRecoveryErrorType({
+          code: ErrorCode.PermissionCameraDenied,
+        }),
+      ).toBe(MetaMetricsHardwareWalletRecoveryErrorType.CameraPermissionDenied);
+    });
+
+    it('maps camera permission prompt dismissed to CameraPermissionPromptDismissed', () => {
+      expect(
+        mapHardwareWalletRecoveryErrorType({
+          code: ErrorCode.PermissionCameraPromptDismissed,
+        }),
+      ).toBe(
+        MetaMetricsHardwareWalletRecoveryErrorType.CameraPermissionPromptDismissed,
+      );
+    });
+
     it('maps unrecognized codes to GenericError', () => {
       expect(
         mapHardwareWalletRecoveryErrorType({ code: ErrorCode.Unknown }),

--- a/shared/lib/hardware-wallet-recovery-metrics.ts
+++ b/shared/lib/hardware-wallet-recovery-metrics.ts
@@ -267,6 +267,10 @@ export function mapHardwareWalletRecoveryErrorType(
       return MetaMetricsHardwareWalletRecoveryErrorType.EthereumAppNotOpened;
     case ErrorCode.DeviceStateBlindSignNotSupported:
       return MetaMetricsHardwareWalletRecoveryErrorType.BlindSigningNotEnabled;
+    case ErrorCode.PermissionCameraDenied:
+      return MetaMetricsHardwareWalletRecoveryErrorType.CameraPermissionDenied;
+    case ErrorCode.PermissionCameraPromptDismissed:
+      return MetaMetricsHardwareWalletRecoveryErrorType.CameraPermissionPromptDismissed;
     default:
       return MetaMetricsHardwareWalletRecoveryErrorType.GenericError;
   }

--- a/ui/components/app/modals/hardware-wallet-error-modal/hardware-wallet-error-modal.test.tsx
+++ b/ui/components/app/modals/hardware-wallet-error-modal/hardware-wallet-error-modal.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention, camelcase -- Segment analytics payload keys use snake_case */
 import React from 'react';
 import { render, fireEvent, waitFor, act } from '@testing-library/react';
 import { Provider } from 'react-redux';
@@ -17,7 +18,11 @@ import {
 import { getMockContractInteractionConfirmState } from '../../../../../test/data/confirmations/helper';
 import { ENVIRONMENT_TYPE_FULLSCREEN } from '../../../../../shared/constants/app';
 import { getEnvironmentType } from '../../../../../shared/lib/environment-type';
-import { MetaMetricsEventName } from '../../../../../shared/constants/metametrics';
+import {
+  MetaMetricsEventName,
+  MetaMetricsHardwareWalletDeviceType,
+  MetaMetricsHardwareWalletRecoveryErrorType,
+} from '../../../../../shared/constants/metametrics';
 import { MetaMetricsContext } from '../../../../contexts/metametrics';
 import { createHardwareWalletError } from '../../../../contexts/hardware-wallets/errors';
 import { HardwareWalletType } from '../../../../contexts/hardware-wallets/types';
@@ -91,12 +96,9 @@ const createTestError = (
   code: ErrorCode,
   message: string,
   userMessage?: string,
+  walletType: HardwareWalletType = HardwareWalletType.Ledger,
 ): HardwareWalletErrorType => {
-  return createHardwareWalletError(
-    code,
-    'ledger' as HardwareWalletType,
-    userMessage || message,
-  );
+  return createHardwareWalletError(code, walletType, userMessage || message);
 };
 
 const metricsProviderValue = {
@@ -527,6 +529,103 @@ describe('HardwareWalletErrorModal', () => {
       );
 
       expect(getByTestId('qr-camera-firefox-instructions')).toBeInTheDocument();
+    });
+
+    describe('MetaMetrics tracking', () => {
+      it('tracks PermissionCameraDenied with CameraPermissionDenied error_type', async () => {
+        mockUseHardwareWalletConfig.mockReturnValue({
+          walletType: HardwareWalletType.Qr,
+        });
+        const error = createTestError(
+          ErrorCode.PermissionCameraDenied,
+          'Camera denied',
+          'Camera access denied.',
+          HardwareWalletType.Qr,
+        );
+
+        renderWithMetrics(<HardwareWalletErrorModal error={error} />);
+
+        await waitFor(() => {
+          const modalViewed = mockTrackEvent.mock.calls.filter(
+            (call) =>
+              call[0].event ===
+              MetaMetricsEventName.HardwareWalletRecoveryModalViewed,
+          );
+          expect(modalViewed).toHaveLength(1);
+          expect(modalViewed[0][0].properties).toMatchObject({
+            device_type: MetaMetricsHardwareWalletDeviceType.QrHardware,
+            error_type:
+              MetaMetricsHardwareWalletRecoveryErrorType.CameraPermissionDenied,
+            error_code: 'PermissionCameraDenied',
+            error_type_view_count: 1,
+          });
+        });
+      });
+
+      it('tracks PermissionCameraPromptDismissed with CameraPermissionPromptDismissed error_type', async () => {
+        mockUseHardwareWalletConfig.mockReturnValue({
+          walletType: HardwareWalletType.Qr,
+        });
+        const error = createTestError(
+          ErrorCode.PermissionCameraPromptDismissed,
+          'Prompt dismissed',
+          'Prompt dismissed.',
+          HardwareWalletType.Qr,
+        );
+
+        renderWithMetrics(<HardwareWalletErrorModal error={error} />);
+
+        await waitFor(() => {
+          const modalViewed = mockTrackEvent.mock.calls.filter(
+            (call) =>
+              call[0].event ===
+              MetaMetricsEventName.HardwareWalletRecoveryModalViewed,
+          );
+          expect(modalViewed).toHaveLength(1);
+          expect(modalViewed[0][0].properties).toMatchObject({
+            device_type: MetaMetricsHardwareWalletDeviceType.QrHardware,
+            error_type:
+              MetaMetricsHardwareWalletRecoveryErrorType.CameraPermissionPromptDismissed,
+            error_code: 'PermissionCameraPromptDismissed',
+            error_type_view_count: 1,
+          });
+        });
+      });
+
+      it('tracks CTA clicked with correct QR camera error_type on retry', async () => {
+        mockUseHardwareWalletConfig.mockReturnValue({
+          walletType: HardwareWalletType.Qr,
+        });
+        const error = createTestError(
+          ErrorCode.PermissionCameraDenied,
+          'Camera denied',
+          'Camera access denied.',
+          HardwareWalletType.Qr,
+        );
+
+        const { getByTestId } = renderWithMetrics(
+          <HardwareWalletErrorModal error={error} />,
+        );
+
+        await act(async () => {
+          fireEvent.click(getByTestId('qr-camera-blocked-continue'));
+        });
+
+        await waitFor(() => {
+          const ctaClicked = mockTrackEvent.mock.calls.filter(
+            (call) =>
+              call[0].event ===
+              MetaMetricsEventName.HardwareWalletRecoveryCtaClicked,
+          );
+          expect(ctaClicked).toHaveLength(1);
+          expect(ctaClicked[0][0].properties).toMatchObject({
+            device_type: MetaMetricsHardwareWalletDeviceType.QrHardware,
+            error_type:
+              MetaMetricsHardwareWalletRecoveryErrorType.CameraPermissionDenied,
+            error_code: 'PermissionCameraDenied',
+          });
+        });
+      });
     });
 
     describe('Continue button delegates to handleContinueWithPermissionCheck', () => {

--- a/ui/components/app/qr-hardware-popover/base-reader-utils.test.ts
+++ b/ui/components/app/qr-hardware-popover/base-reader-utils.test.ts
@@ -1,0 +1,154 @@
+/* eslint-disable @typescript-eslint/naming-convention, camelcase -- Segment analytics payload keys use snake_case */
+import { ErrorCode, HardwareWalletError } from '@metamask/hw-wallet-sdk';
+import {
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
+  MetaMetricsHardwareWalletDeviceType,
+  MetaMetricsHardwareWalletRecoveryErrorType,
+  MetaMetricsHardwareWalletRecoveryLocation,
+} from '../../../../shared/constants/metametrics';
+import { HARDWARE_WALLET_RECOVERY_SEGMENT_PAYLOAD_KEYS } from '../../../../shared/lib/hardware-wallet-recovery-metrics';
+import { CameraReadyState } from './base-reader.types';
+import {
+  cameraReadyStateToErrorCode,
+  createQrCameraSyntheticError,
+  buildQrCameraRecoveryTrackEventArgs,
+} from './base-reader-utils';
+
+describe('base-reader-utils', () => {
+  describe('cameraReadyStateToErrorCode', () => {
+    it('maps CameraAccessBlocked to PermissionCameraDenied', () => {
+      expect(
+        cameraReadyStateToErrorCode(CameraReadyState.CameraAccessBlocked),
+      ).toBe(ErrorCode.PermissionCameraDenied);
+    });
+
+    it('maps CameraAccessNeeded to PermissionCameraPromptDismissed', () => {
+      expect(
+        cameraReadyStateToErrorCode(CameraReadyState.CameraAccessNeeded),
+      ).toBe(ErrorCode.PermissionCameraPromptDismissed);
+    });
+
+    it('returns null for AccessingCamera', () => {
+      expect(
+        cameraReadyStateToErrorCode(CameraReadyState.AccessingCamera),
+      ).toBeNull();
+    });
+
+    it('returns null for Ready', () => {
+      expect(cameraReadyStateToErrorCode(CameraReadyState.Ready)).toBeNull();
+    });
+  });
+
+  describe('createQrCameraSyntheticError', () => {
+    it('returns a HardwareWalletError with the given error code', () => {
+      const error = createQrCameraSyntheticError(
+        ErrorCode.PermissionCameraDenied,
+      );
+      expect(error).toBeInstanceOf(HardwareWalletError);
+      expect(error.code).toBe(ErrorCode.PermissionCameraDenied);
+    });
+
+    it('attaches QR wallet type in metadata', () => {
+      const error = createQrCameraSyntheticError(
+        ErrorCode.PermissionCameraPromptDismissed,
+      );
+      expect((error.metadata as { walletType?: string })?.walletType).toBe(
+        'qr',
+      );
+    });
+  });
+
+  describe('buildQrCameraRecoveryTrackEventArgs', () => {
+    it('returns correct category and event name', () => {
+      const args = buildQrCameraRecoveryTrackEventArgs(
+        MetaMetricsEventName.HardwareWalletRecoveryModalViewed,
+        ErrorCode.PermissionCameraDenied,
+        1,
+      );
+      expect(args.category).toBe(MetaMetricsEventCategory.Accounts);
+      expect(args.event).toBe(
+        MetaMetricsEventName.HardwareWalletRecoveryModalViewed,
+      );
+    });
+
+    it('sets QR-specific constants in properties', () => {
+      const { properties } = buildQrCameraRecoveryTrackEventArgs(
+        MetaMetricsEventName.HardwareWalletRecoveryModalViewed,
+        ErrorCode.PermissionCameraDenied,
+        1,
+      );
+      expect(properties.device_type).toBe(
+        MetaMetricsHardwareWalletDeviceType.QrHardware,
+      );
+      expect(properties.device_model).toBe('N/A');
+      expect(properties.location).toBe(
+        MetaMetricsHardwareWalletRecoveryLocation.Connection,
+      );
+    });
+
+    it('derives CameraPermissionDenied error_type for PermissionCameraDenied', () => {
+      const { properties } = buildQrCameraRecoveryTrackEventArgs(
+        MetaMetricsEventName.HardwareWalletRecoveryModalViewed,
+        ErrorCode.PermissionCameraDenied,
+        1,
+      );
+      expect(properties.error_type).toBe(
+        MetaMetricsHardwareWalletRecoveryErrorType.CameraPermissionDenied,
+      );
+      expect(properties.error_code).toBe('PermissionCameraDenied');
+    });
+
+    it('derives CameraPermissionPromptDismissed error_type for PermissionCameraPromptDismissed', () => {
+      const { properties } = buildQrCameraRecoveryTrackEventArgs(
+        MetaMetricsEventName.HardwareWalletRecoveryCtaClicked,
+        ErrorCode.PermissionCameraPromptDismissed,
+        3,
+      );
+      expect(properties.error_type).toBe(
+        MetaMetricsHardwareWalletRecoveryErrorType.CameraPermissionPromptDismissed,
+      );
+      expect(properties.error_code).toBe('PermissionCameraPromptDismissed');
+    });
+
+    it('passes through the error_type_view_count', () => {
+      const { properties } = buildQrCameraRecoveryTrackEventArgs(
+        MetaMetricsEventName.HardwareWalletRecoveryModalViewed,
+        ErrorCode.PermissionCameraDenied,
+        5,
+      );
+      expect(properties.error_type_view_count).toBe(5);
+    });
+
+    it('produces only the canonical Segment payload keys', () => {
+      const { properties } = buildQrCameraRecoveryTrackEventArgs(
+        MetaMetricsEventName.HardwareWalletRecoverySuccessModalViewed,
+        ErrorCode.PermissionCameraDenied,
+        1,
+      );
+      expect(Object.keys(properties).sort()).toStrictEqual(
+        [...HARDWARE_WALLET_RECOVERY_SEGMENT_PAYLOAD_KEYS].sort(),
+      );
+    });
+
+    it('works with different event names', () => {
+      const ctaArgs = buildQrCameraRecoveryTrackEventArgs(
+        MetaMetricsEventName.HardwareWalletRecoveryCtaClicked,
+        ErrorCode.PermissionCameraDenied,
+        2,
+      );
+      expect(ctaArgs.event).toBe(
+        MetaMetricsEventName.HardwareWalletRecoveryCtaClicked,
+      );
+
+      const successArgs = buildQrCameraRecoveryTrackEventArgs(
+        MetaMetricsEventName.HardwareWalletRecoverySuccessModalViewed,
+        ErrorCode.PermissionCameraPromptDismissed,
+        1,
+      );
+      expect(successArgs.event).toBe(
+        MetaMetricsEventName.HardwareWalletRecoverySuccessModalViewed,
+      );
+    });
+  });
+});

--- a/ui/components/app/qr-hardware-popover/base-reader-utils.ts
+++ b/ui/components/app/qr-hardware-popover/base-reader-utils.ts
@@ -1,0 +1,88 @@
+import { ErrorCode, type HardwareWalletError } from '@metamask/hw-wallet-sdk';
+import type { Json } from '@metamask/utils';
+import {
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
+  MetaMetricsHardwareWalletDeviceType,
+  MetaMetricsHardwareWalletRecoveryLocation,
+} from '../../../../shared/constants/metametrics';
+import {
+  buildHardwareWalletRecoverySegmentProperties,
+  mapHardwareWalletRecoveryErrorType,
+} from '../../../../shared/lib/hardware-wallet-recovery-metrics';
+import {
+  createHardwareWalletError,
+  HardwareWalletType,
+} from '../../../contexts/hardware-wallets';
+import {
+  CameraReadyState,
+  type CameraReadyStateValue,
+} from './base-reader.types';
+
+/**
+ * Maps a {@link CameraReadyState} error state to the corresponding
+ * {@link ErrorCode} for MetaMetrics tracking.
+ *
+ * @param state - The current camera readiness state.
+ * @returns The matching {@link ErrorCode}, or `null` for non-error states.
+ */
+export function cameraReadyStateToErrorCode(
+  state: CameraReadyStateValue,
+): ErrorCode | null {
+  switch (state) {
+    case CameraReadyState.CameraAccessBlocked:
+      return ErrorCode.PermissionCameraDenied;
+    case CameraReadyState.CameraAccessNeeded:
+      return ErrorCode.PermissionCameraPromptDismissed;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Creates a synthetic {@link HardwareWalletError} for a QR camera error state.
+ *
+ * @param errorCode - The SDK error code representing the camera permission issue.
+ * @returns A `HardwareWalletError` instance with QR wallet metadata.
+ */
+export function createQrCameraSyntheticError(
+  errorCode: ErrorCode,
+): HardwareWalletError {
+  return createHardwareWalletError(errorCode, HardwareWalletType.Qr);
+}
+
+/**
+ * Builds a complete `trackEvent` argument for a QR camera recovery event.
+ *
+ * Encapsulates all the QR-specific constants (`device_type`, `device_model`,
+ * `location`) and the synthetic error construction, so callers only need to
+ * supply the event name, the camera error code, and the current view count.
+ *
+ * @param eventName - The Segment event name to fire.
+ * @param errorCode - The SDK error code representing the camera permission issue.
+ * @param errorTypeViewCount - The current monotonic view count for this error type.
+ * @returns A ready-to-use `trackEvent` argument.
+ */
+export function buildQrCameraRecoveryTrackEventArgs(
+  eventName: MetaMetricsEventName,
+  errorCode: ErrorCode,
+  errorTypeViewCount: number,
+): {
+  category: string;
+  event: MetaMetricsEventName;
+  properties: Record<string, Json>;
+} {
+  const syntheticError = createQrCameraSyntheticError(errorCode);
+  return {
+    category: MetaMetricsEventCategory.Accounts,
+    event: eventName,
+    properties: buildHardwareWalletRecoverySegmentProperties({
+      location: MetaMetricsHardwareWalletRecoveryLocation.Connection,
+      deviceType: MetaMetricsHardwareWalletDeviceType.QrHardware,
+      deviceModel: 'N/A',
+      errorType: mapHardwareWalletRecoveryErrorType(syntheticError),
+      errorTypeViewCount,
+      error: syntheticError,
+    }),
+  };
+}

--- a/ui/components/app/qr-hardware-popover/base-reader.test.tsx
+++ b/ui/components/app/qr-hardware-popover/base-reader.test.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { act, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import WebcamUtils from '../../../helpers/utils/webcam-utils';
@@ -13,6 +13,7 @@ import {
   ENVIRONMENT_TYPE_FULLSCREEN,
   ENVIRONMENT_TYPE_POPUP,
 } from '../../../../shared/constants/app';
+import { MetaMetricsEventName } from '../../../../shared/constants/metametrics';
 import { getEnvironmentType } from '../../../../shared/lib/environment-type';
 import type { BaseReaderProps } from './base-reader.types';
 import BaseReader from './base-reader';
@@ -796,5 +797,273 @@ describe('BaseReader', () => {
     });
     // checkStatus called twice: initial failure + retry
     expect(mockCheckStatus).toHaveBeenCalledTimes(2);
+  });
+
+  // ---- MetaMetrics tracking -----------------------------------------------
+
+  describe('MetaMetrics tracking', () => {
+    const mockTrackEvent = jest.fn().mockResolvedValue(undefined);
+
+    function renderWithMetrics(ui: React.ReactElement) {
+      return renderWithProvider(
+        ui,
+        undefined,
+        '/',
+        render,
+        () => mockTrackEvent,
+      );
+    }
+
+    beforeEach(() => {
+      mockTrackEvent.mockClear();
+    });
+
+    it('fires ModalViewed when entering blocked state', async () => {
+      mockEnhancedReader.mockImplementation(
+        () => null as unknown as React.ReactElement,
+      );
+      mockCheckStatus.mockResolvedValue({
+        permissions: false,
+        environmentReady: true,
+      });
+      mockQueryCameraPermission.mockResolvedValue({
+        state: 'denied',
+        permissionStatus: {
+          state: 'denied',
+          addEventListener: jest.fn(),
+        } as unknown as PermissionStatus,
+      });
+
+      await act(async () => {
+        renderWithMetrics(<BaseReader {...defaultProps} />);
+      });
+
+      const modalViewed = mockTrackEvent.mock.calls.filter(
+        (call: unknown[]) =>
+          (call[0] as { event: string }).event ===
+          MetaMetricsEventName.HardwareWalletRecoveryModalViewed,
+      );
+      expect(modalViewed).toHaveLength(1);
+      expect(modalViewed[0][0].properties.error_type_view_count).toBe(1);
+    });
+
+    it('fires ModalViewed when entering needed state', async () => {
+      mockEnhancedReader.mockImplementation(
+        () => null as unknown as React.ReactElement,
+      );
+      mockCheckStatus.mockResolvedValue({
+        permissions: true,
+        environmentReady: true,
+      });
+      mockQueryCameraPermission.mockResolvedValue({
+        state: 'prompt',
+        permissionStatus: {
+          state: 'prompt',
+          addEventListener: jest.fn(),
+        } as unknown as PermissionStatus,
+      });
+      const notAllowed = new Error('denied');
+      notAllowed.name = 'NotAllowedError';
+      mockRequestVideoStream.mockRejectedValueOnce(notAllowed);
+
+      await act(async () => {
+        renderWithMetrics(<BaseReader {...defaultProps} />);
+      });
+
+      const modalViewed = mockTrackEvent.mock.calls.filter(
+        (call: unknown[]) =>
+          (call[0] as { event: string }).event ===
+          MetaMetricsEventName.HardwareWalletRecoveryModalViewed,
+      );
+      expect(modalViewed).toHaveLength(1);
+      expect(modalViewed[0][0].properties.error_type_view_count).toBe(1);
+    });
+
+    it('fires CtaClicked when Continue is clicked on blocked UI', async () => {
+      mockEnhancedReader.mockImplementation(
+        () => null as unknown as React.ReactElement,
+      );
+      mockCheckStatus.mockResolvedValue({
+        permissions: false,
+        environmentReady: true,
+      });
+      mockQueryCameraPermission.mockResolvedValue({
+        state: 'denied',
+        permissionStatus: {
+          state: 'denied',
+          addEventListener: jest.fn(),
+        } as unknown as PermissionStatus,
+      });
+
+      await act(async () => {
+        renderWithMetrics(<BaseReader {...defaultProps} />);
+      });
+
+      await act(async () => {
+        await userEvent.click(screen.getByTestId('qr-camera-blocked-continue'));
+      });
+
+      const ctaClicked = mockTrackEvent.mock.calls.filter(
+        (call: unknown[]) =>
+          (call[0] as { event: string }).event ===
+          MetaMetricsEventName.HardwareWalletRecoveryCtaClicked,
+      );
+      expect(ctaClicked).toHaveLength(1);
+    });
+
+    it('fires CtaClicked when Continue is clicked on needed UI', async () => {
+      mockEnhancedReader.mockImplementation(
+        () => null as unknown as React.ReactElement,
+      );
+      mockCheckStatus.mockResolvedValue({
+        permissions: true,
+        environmentReady: true,
+      });
+      mockQueryCameraPermission.mockResolvedValue({
+        state: 'prompt',
+        permissionStatus: {
+          state: 'prompt',
+          addEventListener: jest.fn(),
+        } as unknown as PermissionStatus,
+      });
+      const notAllowed = new Error('denied');
+      notAllowed.name = 'NotAllowedError';
+      mockRequestVideoStream.mockRejectedValueOnce(notAllowed);
+
+      await act(async () => {
+        renderWithMetrics(<BaseReader {...defaultProps} />);
+      });
+
+      mockRequestVideoStream.mockRejectedValueOnce(notAllowed);
+      await act(async () => {
+        await userEvent.click(
+          screen.getByTestId('qr-camera-access-needed-continue'),
+        );
+      });
+
+      const ctaClicked = mockTrackEvent.mock.calls.filter(
+        (call: unknown[]) =>
+          (call[0] as { event: string }).event ===
+          MetaMetricsEventName.HardwareWalletRecoveryCtaClicked,
+      );
+      expect(ctaClicked).toHaveLength(1);
+    });
+
+    it('fires SuccessModalViewed when camera recovers from an error state', async () => {
+      mockEnhancedReader.mockImplementation(
+        () => null as unknown as React.ReactElement,
+      );
+      mockCheckStatus.mockResolvedValue({
+        permissions: false,
+        environmentReady: true,
+      });
+      mockQueryCameraPermission.mockResolvedValue({
+        state: 'denied',
+        permissionStatus: {
+          state: 'denied',
+          addEventListener: jest.fn(),
+        } as unknown as PermissionStatus,
+      });
+
+      await act(async () => {
+        renderWithMetrics(<BaseReader {...defaultProps} />);
+      });
+
+      mockQueryCameraPermission.mockResolvedValueOnce({
+        state: 'granted',
+        permissionStatus: null,
+      });
+      mockRequestVideoStream.mockResolvedValueOnce(
+        mockStream as unknown as MediaStream,
+      );
+      await act(async () => {
+        await userEvent.click(screen.getByTestId('qr-camera-blocked-continue'));
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(messages.QRHardwareScanInstructions.message),
+        ).toBeInTheDocument();
+      });
+
+      const successViewed = mockTrackEvent.mock.calls.filter(
+        (call: unknown[]) =>
+          (call[0] as { event: string }).event ===
+          MetaMetricsEventName.HardwareWalletRecoverySuccessModalViewed,
+      );
+      expect(successViewed).toHaveLength(1);
+    });
+
+    it('increments error_type_view_count when error state transitions', async () => {
+      mockEnhancedReader.mockImplementation(
+        () => null as unknown as React.ReactElement,
+      );
+      mockCheckStatus.mockResolvedValue({
+        permissions: true,
+        environmentReady: true,
+      });
+      mockQueryCameraPermission.mockResolvedValue({
+        state: 'prompt',
+        permissionStatus: {
+          state: 'prompt',
+          addEventListener: jest.fn(),
+        } as unknown as PermissionStatus,
+      });
+      const notAllowed = new Error('denied');
+      notAllowed.name = 'NotAllowedError';
+      mockRequestVideoStream.mockRejectedValueOnce(notAllowed);
+
+      await act(async () => {
+        renderWithMetrics(<BaseReader {...defaultProps} />);
+      });
+
+      mockRequestVideoStream.mockRejectedValueOnce(notAllowed);
+      mockQueryCameraPermission.mockResolvedValueOnce({
+        state: 'denied',
+        permissionStatus: {
+          state: 'denied',
+          addEventListener: jest.fn(),
+        } as unknown as PermissionStatus,
+      });
+      await act(async () => {
+        await userEvent.click(
+          screen.getByTestId('qr-camera-access-needed-continue'),
+        );
+      });
+
+      await screen.findByTestId('qr-camera-access-blocked');
+
+      const modalViewed = mockTrackEvent.mock.calls.filter(
+        (call: unknown[]) =>
+          (call[0] as { event: string }).event ===
+          MetaMetricsEventName.HardwareWalletRecoveryModalViewed,
+      );
+      expect(modalViewed).toHaveLength(2);
+      expect(modalViewed[0][0].properties.error_type_view_count).toBe(1);
+      expect(modalViewed[1][0].properties.error_type_view_count).toBe(2);
+    });
+
+    it('does not fire tracking events when permission is already granted', async () => {
+      mockEnhancedReader.mockImplementation(
+        () => null as unknown as React.ReactElement,
+      );
+      mockCheckStatus.mockResolvedValue({
+        permissions: true,
+        environmentReady: true,
+      });
+      mockQueryCameraPermission.mockResolvedValue({
+        state: 'granted',
+        permissionStatus: null,
+      });
+
+      await act(async () => {
+        renderWithMetrics(<BaseReader {...defaultProps} />);
+      });
+
+      expect(
+        screen.getByText(messages.QRHardwareScanInstructions.message),
+      ).toBeInTheDocument();
+      expect(mockTrackEvent).not.toHaveBeenCalled();
+    });
   });
 });

--- a/ui/components/app/qr-hardware-popover/base-reader.tsx
+++ b/ui/components/app/qr-hardware-popover/base-reader.tsx
@@ -19,7 +19,13 @@
  *
  * @see CameraReadyState for the state machine definition.
  */
-import React, { useEffect, useRef, useState, useCallback } from 'react';
+import React, {
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  useCallback,
+} from 'react';
 import log from 'loglevel';
 import { URDecoder } from '@ngraveio/bc-ur';
 import { ENVIRONMENT_TYPE_FULLSCREEN } from '../../../../shared/constants/app';
@@ -29,6 +35,8 @@ import {
   getMozExtensionOriginForDisplay,
   isFirefoxBrowser,
 } from '../../../../shared/lib/browser-runtime.utils';
+import { MetaMetricsEventName } from '../../../../shared/constants/metametrics';
+import { MetaMetricsContext } from '../../../contexts/metametrics';
 import WebcamUtils from '../../../helpers/utils/webcam-utils';
 import PageContainerFooter from '../../ui/page-container/page-container-footer/page-container-footer.component';
 import { useI18nContext } from '../../../hooks/useI18nContext';
@@ -43,6 +51,10 @@ import {
   type CameraReadyStateValue,
   type WebcamError,
 } from './base-reader.types';
+import {
+  cameraReadyStateToErrorCode,
+  buildQrCameraRecoveryTrackEventArgs,
+} from './base-reader-utils';
 import EnhancedReader from './enhanced-reader';
 
 // ---------------------------------------------------------------------------
@@ -105,6 +117,7 @@ const BaseReader = ({
   setErrorTitle,
 }: BaseReaderProps) => {
   const t = useI18nContext();
+  const { trackEvent } = useContext(MetaMetricsContext);
 
   const [readyState, setReadyState] = useState<CameraReadyStateValue>(
     CameraReadyState.AccessingCamera,
@@ -115,10 +128,64 @@ const BaseReader = ({
   const [permissionActionLoading, setPermissionActionLoading] = useState(false);
 
   const mountedRef = useRef(false);
+  const errorTypeViewCountRef = useRef(0);
+  const lastTrackedReadyStateRef = useRef<CameraReadyStateValue | null>(null);
+  const prevErrorReadyStateRef = useRef<CameraReadyStateValue | null>(null);
   const {
     attach: attachPermissionListener,
     cleanup: cleanupPermissionListener,
   } = usePermissionChangeListener();
+
+  // ---- MetaMetrics tracking -----------------------------------------------
+  // `readyState` is set asynchronously from multiple code paths (initial
+  // permission query, getUserMedia rejection, Continue-button retry, and the
+  // PermissionStatus change listener). A reactive `useEffect` is the only
+  // way to reliably track every transition without duplicating fire-once
+  // guards inside each handler.
+
+  useEffect(() => {
+    const errorCode = cameraReadyStateToErrorCode(readyState);
+
+    if (errorCode === null) {
+      if (
+        readyState === CameraReadyState.Ready &&
+        prevErrorReadyStateRef.current !== null
+      ) {
+        const prevErrorCode = cameraReadyStateToErrorCode(
+          prevErrorReadyStateRef.current,
+        );
+        if (prevErrorCode !== null) {
+          trackEvent(
+            buildQrCameraRecoveryTrackEventArgs(
+              MetaMetricsEventName.HardwareWalletRecoverySuccessModalViewed,
+              prevErrorCode,
+              errorTypeViewCountRef.current,
+            ),
+          );
+        }
+        prevErrorReadyStateRef.current = null;
+        errorTypeViewCountRef.current = 0;
+        lastTrackedReadyStateRef.current = null;
+      }
+      return;
+    }
+
+    prevErrorReadyStateRef.current = readyState;
+
+    if (lastTrackedReadyStateRef.current === readyState) {
+      return;
+    }
+    lastTrackedReadyStateRef.current = readyState;
+    errorTypeViewCountRef.current += 1;
+
+    trackEvent(
+      buildQrCameraRecoveryTrackEventArgs(
+        MetaMetricsEventName.HardwareWalletRecoveryModalViewed,
+        errorCode,
+        errorTypeViewCountRef.current,
+      ),
+    );
+  }, [readyState, trackEvent]);
 
   // ---- camera helpers -----------------------------------------------------
 
@@ -272,11 +339,26 @@ const BaseReader = ({
 
   // ---- "Continue" handlers for camera-access error states -----------------
 
+  const trackCameraRecoveryCtaClicked = useCallback(() => {
+    const errorCode = cameraReadyStateToErrorCode(readyState);
+    if (errorCode === null) {
+      return;
+    }
+    trackEvent(
+      buildQrCameraRecoveryTrackEventArgs(
+        MetaMetricsEventName.HardwareWalletRecoveryCtaClicked,
+        errorCode,
+        errorTypeViewCountRef.current,
+      ),
+    );
+  }, [readyState, trackEvent]);
+
   /**
    * Handler for the "needed" (prompt-dismissed) Continue button.
    * Re-requests camera access via `getUserMedia`.
    */
   const handleCameraAccessNeededContinue = useCallback(async () => {
+    trackCameraRecoveryCtaClicked();
     setPermissionActionLoading(true);
     try {
       const stream = await WebcamUtils.requestVideoStream();
@@ -304,13 +386,18 @@ const BaseReader = ({
         setPermissionActionLoading(false);
       }
     }
-  }, [cleanupPermissionListener, reconcileNotAllowedPermission]);
+  }, [
+    cleanupPermissionListener,
+    reconcileNotAllowedPermission,
+    trackCameraRecoveryCtaClicked,
+  ]);
 
   /**
    * Handler for the "blocked" Continue button.
    * Re-checks the permission state; if no longer denied, acquires the camera.
    */
   const handleCameraAccessBlockedContinue = useCallback(async () => {
+    trackCameraRecoveryCtaClicked();
     setPermissionActionLoading(true);
     try {
       const { state } = await WebcamUtils.queryCameraPermission();
@@ -335,7 +422,11 @@ const BaseReader = ({
         setPermissionActionLoading(false);
       }
     }
-  }, [cleanupPermissionListener, reconcileNotAllowedPermission]);
+  }, [
+    cleanupPermissionListener,
+    reconcileNotAllowedPermission,
+    trackCameraRecoveryCtaClicked,
+  ]);
 
   /**
    * Opens the Chromium camera site-settings page in a new tab.


### PR DESCRIPTION
## **Description**
Add improvements that enable us to track `errorType` for QR hardware wallet recovery flow and different states of camera permission access.

Given that we were missing the same tracking patterns in QR hardware wallet onboarding process, these are also added on this PR.

## **Changelog**
<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->
CHANGELOG entry: null

## **Related issues**
Fixes: n/a

## **Manual testing steps**
1. Try to trigger QR hardware wallet recovery flow by denying camera access in different ways (set to BLOCK or ASK, or dismiss prompt, etc.).
2. Check events sent to Segment on local Segment interceptor in terminal (`* node development/mock-segment.js`).

## **Screenshots/Recordings**

### **Before**
<img width="694" height="722" alt="Screenshot 2026-05-06 at 23 43 49" src="https://github.com/user-attachments/assets/85a61a9f-c118-4bdc-8583-b6fb90ce8100" />
<img width="647" height="246" alt="Screenshot 2026-05-06 at 23 42 28" src="https://github.com/user-attachments/assets/6b06bbad-04e1-40a4-b513-b79e04443f0c" />

### **After**
<img width="695" height="247" alt="Screenshot 2026-05-06 at 23 54 42" src="https://github.com/user-attachments/assets/fc82fd7e-4e0c-4267-ac3b-e12bcf751d8e" />
<img width="704" height="721" alt="Screenshot 2026-05-06 at 23 56 00" src="https://github.com/user-attachments/assets/05aa4bf8-ca40-4182-aabb-1d59f2f73ae9" />
<img width="656" height="482" alt="Screenshot 2026-05-07 at 00 32 51" src="https://github.com/user-attachments/assets/93cdbdb0-6482-4770-9270-746705ec57a8" />
<img width="702" height="248" alt="Screenshot 2026-05-07 at 00 33 12" src="https://github.com/user-attachments/assets/6181b37f-78bd-4679-8bb9-7b9c84774082" />

## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.