### PR TITLE
perf: fix the swap benchmark test when run against real servers

### DIFF
--- a/test/e2e/benchmarks/mocks/performance-mocks.ts
+++ b/test/e2e/benchmarks/mocks/performance-mocks.ts
@@ -555,10 +555,10 @@ export function userStorageHostMock(server: Mockttp): Promise<MockedEndpoint> {
   const existingInterceptor = (server as unknown as Record<string, unknown>)
     .__passThroughInterceptor as PassThroughInterceptor | undefined;
   setPassThroughInterceptor(server, (req) => {
-    if (
-      req.method === 'GET' &&
-      req.url.includes('user-storage.api.cx.metamask.io')
-    ) {
+    if (req.url.includes('user-storage.api.cx.metamask.io')) {
+      if (req.method === 'PUT' || req.method === 'DELETE') {
+        return { response: { statusCode: 204 } };
+      }
       return { response: { statusCode: 200, json: null } };
     }
     return existingInterceptor?.(req) ?? null;

--- a/test/e2e/benchmarks/mocks/swap-mocks.ts
+++ b/test/e2e/benchmarks/mocks/swap-mocks.ts
@@ -14,7 +14,11 @@
 
 import type { Mockttp } from 'mockttp';
 import { setPassThroughInterceptor } from '../../mock-e2e-pass-through';
-import { BRIDGE_FEATURE_FLAGS, CLIENT_CONFIG_FLAGS } from './mock-responses';
+import {
+  BRIDGE_FEATURE_FLAGS,
+  CLIENT_CONFIG_FLAGS,
+  solanaGetBalanceResponse,
+} from './mock-responses';
 import swapQuoteSolUsdc from './swap-quote-sol-usdc.json';
 
 /**
@@ -43,6 +47,10 @@ export function registerSwapInterceptor(mockServer: Mockttp): void {
   const sseBody = buildSseResponseBody([swapQuoteSolUsdc]);
 
   setPassThroughInterceptor(mockServer, (req) => {
+    if (req.url.includes('solana-mainnet.infura.io')) {
+      return { response: solanaGetBalanceResponse() };
+    }
+
     // Bridge feature flags (enables SSE + Solana chain)
     if (req.url.includes('bridge.api.cx.metamask.io/featureFlags')) {
       return {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
In `run-benchmarks / chrome-webpack-userJourneyTransactions` and it has failed pipeline in main:
https://github.com/MetaMask/metamask-extension/actions/runs/25450795047/job/74668180221
https://github.com/MetaMask/metamask-extension/actions/runs/25450411451/job/74666806573
https://github.com/MetaMask/metamask-extension/actions/runs/25445142329/job/74648241527

error message:
```
Failure on testcase: 'benchmark-swap-power-user', for more information see the artifacts tab in CI

Error: failed to batch upsert user storage for path 'addressBook'. HTTP error message: undefined, error: rate limit exceeded
Legacy syncing failed for wallet: failed to get user storage for path 'multichain_accounts_wallets.wallet'. HTTP error message: undefined, error: rate limit exceeded


-----Received an error from Chrome-----
SES_UNHANDLED_REJECTION: -32603, undefined, Legacy syncing failed for wallet: failed to get us…or message: undefined, error: rate limit exceeded
SES_UNHANDLED_REJECTION: Page unmounted
SES_UNHANDLED_REJECTION: -32603, undefined, failed to batch upsert user storage for path 'addr…or message: undefined, error: rate limit exceeded
----------End of Chrome error----------
```


The swap benchmark uses a fixture wallet with no real SOL on mainnet. In pass-through mode, Solana RPC calls were not intercepted, so the real API returned 0 balance and the UI blocked the swap. To fix this, we can mock all `solana-mainnet.infura.io` requests to return 50 SOL, which is enough to pass the gas check.

Also the address book sync sends `PUT` requests to `user-storage.api.cx.metamask.io` in the background. The existing mock only blocked `GET` requests, so `PUT/DELETE` leaked to the live server and got rate-limited. The fix is to extend the interceptor to cover all HTTP methods, returning 204 for `PUT/DELETE`.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. run `yarn start:test`
2. mock real server test by `GITHUB_REF_NAME=main yarn test:e2e:benchmark test/e2e/benchmarks/flows/user-journey/swap.ts --iterations 1`
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
<img width="1769" height="815" alt="Screenshot 2026-05-06 at 22 56 54" src="https://github.com/user-attachments/assets/f6768530-badf-40fc-9850-f1d39026d945" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are confined to e2e benchmark mocks, but they can affect pass-through test fidelity by intercepting additional live-network requests.
> 
> **Overview**
> Fixes swap benchmark pass-through runs against real servers by intercepting all `solana-mainnet.infura.io` requests in `swap-mocks.ts` and returning a mocked `getBalance` response so the gas check can pass.
> 
> Hardens the `user-storage.api.cx.metamask.io` pass-through interceptor in `performance-mocks.ts` to also handle background `PUT`/`DELETE` calls (returning `204`) instead of letting them hit the live service and get rate-limited.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 952afa546b8bda919d7df7375984b7d120e75060. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->