### PR TITLE
feat: prevent toast overlapping CTA footer

### DIFF
--- a/ui/components/multichain/toast/index.scss
+++ b/ui/components/multichain/toast/index.scss
@@ -36,8 +36,15 @@
 /* react-hot-toast override */
 .toast-container {
   view-transition-name: toast;
+  /* Matches default duration of 300ms minus 70ms for exit animation delay */
+  transition: bottom 230ms cubic-bezier(.21,1.02,.73,1);
 
   [role=status] {
     justify-content: flex-start;
   }
+}
+
+/* Lift the toaster above fixed CTA footers */
+:root:has(.multichain-page-footer, .dapp-connection-control-bar) {
+  --toaster-bottom-offset: 80px;
 }

--- a/ui/components/multichain/toast/index.scss
+++ b/ui/components/multichain/toast/index.scss
@@ -36,8 +36,9 @@
 /* react-hot-toast override */
 .toast-container {
   view-transition-name: toast;
+
   /* Matches default duration of 300ms minus 70ms for exit animation delay */
-  transition: bottom 230ms cubic-bezier(.21,1.02,.73,1);
+  transition: bottom 230ms cubic-bezier(0.21, 1.02, 0.73, 1);
 
   [role=status] {
     justify-content: flex-start;

--- a/ui/components/multichain/toast/index.scss
+++ b/ui/components/multichain/toast/index.scss
@@ -46,6 +46,6 @@
 }
 
 /* Lift the toaster above fixed CTA footers */
-:root:has(.multichain-page-footer, .dapp-connection-control-bar) {
+:root:has(.cta-footer, .multichain-page-footer, .dapp-connection-control-bar) {
   --toaster-bottom-offset: 80px;
 }

--- a/ui/components/ui/toast/toast.tsx
+++ b/ui/components/ui/toast/toast.tsx
@@ -34,6 +34,7 @@ export function Toaster() {
       containerClassName="toast-container"
       containerStyle={{
         display: 'var(--toast-display, flex)',
+        bottom: 'var(--toaster-bottom-offset, 16px)',
       }}
       toastOptions={{
         className: 'w-[360px] max-w-[360px] border border-border-muted',

--- a/ui/pages/keychains/password-prompt.tsx
+++ b/ui/pages/keychains/password-prompt.tsx
@@ -92,7 +92,7 @@ export function PasswordPrompt({
       <Box
         gap={4}
         data-testid="reveal-seed-password-footer"
-        className="w-full mt-auto"
+        className="w-full mt-auto cta-footer"
       >
         <Button
           size={ButtonSize.Lg}

--- a/ui/pages/multi-srp/import-srp/__snapshots__/import-srp.test.tsx.snap
+++ b/ui/pages/multi-srp/import-srp/__snapshots__/import-srp.test.tsx.snap
@@ -142,7 +142,7 @@ exports[`ImportSrp renders matches snapshot 1`] = `
         </div>
       </div>
       <div
-        class="w-full"
+        class="w-full multichain-page-footer"
       >
         <button
           class="inline-flex items-center justify-center rounded-xl px-4 font-medium min-w-20 overflow-hidden relative h-12 transition-all duration-100 ease-linear active:scale-[0.97] active:ease-[cubic-bezier(0.3,0.8,0.3,1)] bg-icon-default text-primary-inverse hover:bg-icon-default-hover active:bg-icon-default-pressed focus-visible:ring-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-default w-full import-srp__continue-button"

--- a/ui/pages/multi-srp/import-srp/__snapshots__/import-srp.test.tsx.snap
+++ b/ui/pages/multi-srp/import-srp/__snapshots__/import-srp.test.tsx.snap
@@ -142,7 +142,7 @@ exports[`ImportSrp renders matches snapshot 1`] = `
         </div>
       </div>
       <div
-        class="w-full multichain-page-footer"
+        class="w-full cta-footer"
       >
         <button
           class="inline-flex items-center justify-center rounded-xl px-4 font-medium min-w-20 overflow-hidden relative h-12 transition-all duration-100 ease-linear active:scale-[0.97] active:ease-[cubic-bezier(0.3,0.8,0.3,1)] bg-icon-default text-primary-inverse hover:bg-icon-default-hover active:bg-icon-default-pressed focus-visible:ring-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-default w-full import-srp__continue-button"

--- a/ui/pages/multi-srp/import-srp/import-srp.tsx
+++ b/ui/pages/multi-srp/import-srp/import-srp.tsx
@@ -18,7 +18,7 @@ import {
 } from '../../../store/actions';
 import { setShowNewSrpAddedToast } from '../../../components/app/toast-master/utils';
 import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
-import { Footer, Header, Page } from '../../../components/multichain/pages/page';
+import { Header, Page } from '../../../components/multichain/pages/page';
 import {
   getIsSocialLoginFlow,
   getMetaMaskHdKeyrings,
@@ -123,7 +123,7 @@ export const ImportSrp = () => {
         setSecretRecoveryPhrase={setSecretRecoveryPhrase}
         onClearCallback={() => setSrpError('')}
       />
-      <Footer>
+      <Box className="w-full multichain-page-footer">
         <Button
           size={ButtonSize.Lg}
           data-testid="import-srp-confirm"
@@ -133,7 +133,7 @@ export const ImportSrp = () => {
         >
           {t('continue')}
         </Button>
-      </Footer>
+      </Box>
     </Page>
   );
 };

--- a/ui/pages/multi-srp/import-srp/import-srp.tsx
+++ b/ui/pages/multi-srp/import-srp/import-srp.tsx
@@ -18,7 +18,7 @@ import {
 } from '../../../store/actions';
 import { setShowNewSrpAddedToast } from '../../../components/app/toast-master/utils';
 import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
-import { Header, Page } from '../../../components/multichain/pages/page';
+import { Footer, Header, Page } from '../../../components/multichain/pages/page';
 import {
   getIsSocialLoginFlow,
   getMetaMaskHdKeyrings,
@@ -123,7 +123,7 @@ export const ImportSrp = () => {
         setSecretRecoveryPhrase={setSecretRecoveryPhrase}
         onClearCallback={() => setSrpError('')}
       />
-      <Box className="w-full">
+      <Footer>
         <Button
           size={ButtonSize.Lg}
           data-testid="import-srp-confirm"
@@ -133,7 +133,7 @@ export const ImportSrp = () => {
         >
           {t('continue')}
         </Button>
-      </Box>
+      </Footer>
     </Page>
   );
 };

--- a/ui/pages/multi-srp/import-srp/import-srp.tsx
+++ b/ui/pages/multi-srp/import-srp/import-srp.tsx
@@ -123,7 +123,7 @@ export const ImportSrp = () => {
         setSecretRecoveryPhrase={setSecretRecoveryPhrase}
         onClearCallback={() => setSrpError('')}
       />
-      <Box className="w-full multichain-page-footer">
+      <Box className="w-full cta-footer">
         <Button
           size={ButtonSize.Lg}
           data-testid="import-srp-confirm"


### PR DESCRIPTION


## **Description**

Lifts the toast above CTA footers using a CSS driven approach

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: feat: prevent toast overlapping CTA footer

## **Related issues**

Fixes:

## **Manual testing steps**

1. Trigger a toast
2. Navigate to a page with a footer CTA (ie. connect to a Dapp)

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**


https://github.com/user-attachments/assets/fd7a436c-f62a-4e52-aa07-59010719fd61


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts toast positioning via CSS variables and adds a new `cta-footer` hook; main risk is unintended layout/position changes on pages that match the new `:has(...)` selector.
> 
> **Overview**
> Prevents bottom-center `react-hot-toast` toasts from overlapping fixed footer CTAs by driving the toaster’s `bottom` offset via a new CSS variable (`--toaster-bottom-offset`) and animating bottom-position changes.
> 
> Adds a `cta-footer` class to CTA footer containers (e.g., password prompt and SRP import) so `:root:has(...)` can detect these pages and lift the toaster; updates the SRP import snapshot accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a223945d460d43cf60798b32750f8130b3c333b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->