### PR TITLE
fix: fixed Sentry capture for the OAuth Provider Login error

### DIFF
--- a/app/scripts/services/oauth/oauth-service.test.ts
+++ b/app/scripts/services/oauth/oauth-service.test.ts
@@ -6,6 +6,7 @@ import {
   MessengerEvents,
   MockAnyNamespace,
 } from '@metamask/messenger';
+import browser from 'webextension-polyfill';
 import { OAuthErrorMessages } from '../../../../shared/lib/error';
 import { ENVIRONMENT } from '../../../../development/build/constants';
 import { OAuthServiceMessenger, WebAuthenticator } from './types';
@@ -18,6 +19,14 @@ type Actions = MessengerActions<OAuthServiceMessenger>;
 type Events = MessengerEvents<OAuthServiceMessenger>;
 
 type RootMessenger = Messenger<MockAnyNamespace, Actions, Events>;
+
+type OAuthServiceTestMessenger = OAuthServiceMessenger & {
+  captureException?: jest.Mock;
+};
+
+const mockBrowserRuntime = browser.runtime as typeof browser.runtime & {
+  lastError?: { message: string; stack?: string[] };
+};
 
 const DEFAULT_GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID as string;
 const DEFAULT_APPLE_CLIENT_ID = process.env.APPLE_CLIENT_ID as string;
@@ -43,14 +52,22 @@ function getOAuthLoginEnvs(): {
   };
 }
 
-function getMessenger(): OAuthServiceMessenger {
+function getMessenger({
+  captureException,
+}: {
+  captureException?: jest.Mock;
+} = {}): OAuthServiceTestMessenger {
   const rootMessenger: RootMessenger = new Messenger({
     namespace: MOCK_ANY_NAMESPACE,
   });
-  return new Messenger({
+  const messenger = new Messenger({
     namespace: 'OAuthService',
     parent: rootMessenger,
-  });
+  }) as OAuthServiceTestMessenger;
+
+  messenger.captureException = captureException;
+
+  return messenger;
 }
 
 const getRedirectUrlSpy = jest.fn().mockReturnValue(MOCK_REDIRECT_URI);
@@ -82,6 +99,8 @@ describe('OAuthService - startOAuthLogin', () => {
   });
 
   beforeEach(() => {
+    mockBrowserRuntime.lastError = undefined;
+
     // mock the fetch call to auth-server
     jest.spyOn(global, 'fetch').mockImplementation(
       jest.fn(() => {
@@ -102,6 +121,7 @@ describe('OAuthService - startOAuthLogin', () => {
   });
 
   afterEach(() => {
+    mockBrowserRuntime.lastError = undefined;
     jest.clearAllMocks();
   });
 
@@ -177,7 +197,8 @@ describe('OAuthService - startOAuthLogin', () => {
   });
 
   it('should throw an error if the state validation fails - google', async () => {
-    const messenger = getMessenger();
+    const captureException = jest.fn();
+    const messenger = getMessenger({ captureException });
 
     const oauthEnv = getOAuthLoginEnvs();
 
@@ -198,6 +219,104 @@ describe('OAuthService - startOAuthLogin', () => {
     await expect(
       oauthService.startOAuthLogin(AuthConnection.Google),
     ).rejects.toThrow(OAuthErrorMessages.INVALID_OAUTH_STATE_ERROR);
+
+    expect(captureException).toHaveBeenCalledTimes(1);
+    const sentryError = captureException.mock.calls[0][0] as Error & {
+      cause?: Error;
+    };
+
+    expect(sentryError.message).toContain(AuthConnection.Google);
+    expect(sentryError.message).not.toContain(MOCK_REDIRECT_URI);
+    expect(sentryError.cause?.message).toBe(
+      OAuthErrorMessages.INVALID_OAUTH_STATE_ERROR,
+    );
+  });
+
+  it('preserves the browser auth flow error for sentry when no redirect URL is returned', async () => {
+    const ErrorUtils =
+      jest.requireActual<typeof import('../../../../shared/lib/error')>(
+        '../../../../shared/lib/error',
+      );
+    const createSentryErrorSpy = jest.spyOn(ErrorUtils, 'createSentryError');
+    const captureException = jest.fn();
+    const messenger = getMessenger({ captureException });
+    const browserAuthFlowErrorMessage =
+      'Authorization page could not be loaded';
+    mockBrowserRuntime.lastError = {
+      message: browserAuthFlowErrorMessage,
+    };
+
+    const oauthService = new OAuthService({
+      messenger,
+      env: getOAuthLoginEnvs(),
+      webAuthenticator: {
+        ...mockWebAuthenticator,
+        launchWebAuthFlow: jest.fn().mockImplementation((_options, cb) => {
+          cb(undefined);
+        }),
+      },
+      bufferedTrace: mockBufferedTrace,
+      bufferedEndTrace: mockBufferedEndTrace,
+      trackEvent: mockTrackEvent,
+      addEventBeforeMetricsOptIn: mockAddEventBeforeMetricsOptIn,
+      getParticipateInMetaMetrics: mockGetParticipateInMetaMetrics,
+    });
+
+    await expect(
+      oauthService.startOAuthLogin(AuthConnection.Google),
+    ).rejects.toThrow(browserAuthFlowErrorMessage);
+
+    const sentryError = captureException.mock.calls[0][0] as Error & {
+      cause?: Error & { cause?: Error };
+    };
+
+    expect(sentryError.cause?.message).toBe(browserAuthFlowErrorMessage);
+    expect(sentryError.cause?.cause?.message).toBe(browserAuthFlowErrorMessage);
+    expect(sentryError.message).toContain(AuthConnection.Google);
+    expect(sentryError.message).not.toContain(MOCK_REDIRECT_URI);
+    expect(createSentryErrorSpy).toHaveBeenCalledTimes(1);
+    expect(createSentryErrorSpy).not.toHaveBeenCalledWith(
+      OAuthErrorMessages.NO_REDIRECT_URL_FOUND_ERROR,
+      expect.anything(),
+    );
+
+    createSentryErrorSpy.mockRestore();
+  });
+
+  it('falls back to the generic no redirect error when the browser reports no lastError', async () => {
+    const captureException = jest.fn();
+    const messenger = getMessenger({ captureException });
+
+    const oauthService = new OAuthService({
+      messenger,
+      env: getOAuthLoginEnvs(),
+      webAuthenticator: {
+        ...mockWebAuthenticator,
+        launchWebAuthFlow: jest.fn().mockImplementation((_options, cb) => {
+          cb(undefined);
+        }),
+      },
+      bufferedTrace: mockBufferedTrace,
+      bufferedEndTrace: mockBufferedEndTrace,
+      trackEvent: mockTrackEvent,
+      addEventBeforeMetricsOptIn: mockAddEventBeforeMetricsOptIn,
+      getParticipateInMetaMetrics: mockGetParticipateInMetaMetrics,
+    });
+
+    await expect(
+      oauthService.startOAuthLogin(AuthConnection.Google),
+    ).rejects.toThrow(OAuthErrorMessages.NO_REDIRECT_URL_FOUND_ERROR);
+
+    const sentryError = captureException.mock.calls[0][0] as Error & {
+      cause?: Error & { cause?: Error };
+    };
+
+    expect(sentryError.cause?.message).toBe(
+      OAuthErrorMessages.NO_REDIRECT_URL_FOUND_ERROR,
+    );
+    expect(sentryError.cause?.cause).toBeUndefined();
+    expect(sentryError.message).toContain(AuthConnection.Google);
+    expect(sentryError.message).not.toContain(MOCK_REDIRECT_URI);
   });
 
   describe('OAuthService:startOAuthLogin action', () => {

--- a/app/scripts/services/oauth/oauth-service.test.ts
+++ b/app/scripts/services/oauth/oauth-service.test.ts
@@ -233,10 +233,9 @@ describe('OAuthService - startOAuthLogin', () => {
   });
 
   it('preserves the browser auth flow error for sentry when no redirect URL is returned', async () => {
-    const ErrorUtils =
-      jest.requireActual<typeof import('../../../../shared/lib/error')>(
-        '../../../../shared/lib/error',
-      );
+    const ErrorUtils = jest.requireActual<
+      typeof import('../../../../shared/lib/error')
+    >('../../../../shared/lib/error');
     const createSentryErrorSpy = jest.spyOn(ErrorUtils, 'createSentryError');
     const captureException = jest.fn();
     const messenger = getMessenger({ captureException });

--- a/app/scripts/services/oauth/oauth-service.ts
+++ b/app/scripts/services/oauth/oauth-service.ts
@@ -280,10 +280,10 @@ export class OAuthService {
                   return;
                 }
                 if (browserAuthFlowError) {
-                  const message = browserAuthFlowError.message || OAuthErrorMessages.NO_REDIRECT_URL_FOUND_ERROR;
-                  const authError = new Error(
-                    message,
-                  ) as Error & {
+                  const message =
+                    browserAuthFlowError.message ||
+                    OAuthErrorMessages.NO_REDIRECT_URL_FOUND_ERROR;
+                  const authError = new Error(message) as Error & {
                     cause?: Error;
                   };
                   authError.cause = browserAuthFlowError as Error;

--- a/app/scripts/services/oauth/oauth-service.ts
+++ b/app/scripts/services/oauth/oauth-service.ts
@@ -272,13 +272,27 @@ export class OAuthService {
                   reject(error);
                 }
               } else {
+                const browserAuthFlowError = checkForLastError();
                 const userCancelledLoginError =
-                  this.#getUserCancelledLoginError();
+                  this.#getUserCancelledLoginError(browserAuthFlowError);
                 if (userCancelledLoginError) {
                   reject(userCancelledLoginError);
                   return;
                 }
-                // Throw default error for no redirect URL found
+                if (browserAuthFlowError) {
+                  const message = browserAuthFlowError.message || OAuthErrorMessages.NO_REDIRECT_URL_FOUND_ERROR;
+                  const authError = new Error(
+                    message,
+                  ) as Error & {
+                    cause?: Error;
+                  };
+                  authError.cause = browserAuthFlowError as Error;
+                  reject(authError);
+                  return;
+                }
+
+                // Fall back to the generic error when the browser API did not
+                // provide a redirect URL or a useful runtime error.
                 reject(
                   new Error(OAuthErrorMessages.NO_REDIRECT_URL_FOUND_ERROR),
                 );
@@ -312,8 +326,8 @@ export class OAuthService {
       if (!isUserCancelled) {
         this.#messenger.captureException?.(
           createSentryError(
-            TraceName.OnboardingOAuthProviderLoginError,
-            error as Error,
+            `${TraceName.OnboardingOAuthProviderLoginError} (${authConnection})`,
+            error,
           ),
         );
       }
@@ -453,8 +467,7 @@ export class OAuthService {
     return url.searchParams.get('code');
   }
 
-  #getUserCancelledLoginError(): Error | undefined {
-    const error = checkForLastError();
+  #getUserCancelledLoginError(error = checkForLastError()): Error | undefined {
     if (isUserCancelledLoginError(error)) {
       return error;
     }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR improves the error capture for the Sentry. Previously, we just throw the `NO_REDIRECT_URL_FOUND_ERROR` if redirect url isn't return from the Web Authentication API, but now we will parse the accurate error from `brower.runtime.lastError`.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Related: https://github.com/MetaMask/metamask-extension/issues/39560

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth provider login error-handling and Sentry reporting paths; risk is moderate because it changes what errors are thrown/captured during social login failures, though primarily in failure branches.
> 
> **Overview**
> Improves OAuth provider-login failure handling to preserve the underlying `browser.runtime.lastError` when the WebAuth flow returns no redirect URL, surfacing a more accurate thrown error while keeping the original browser error attached as `cause` for Sentry.
> 
> Updates Sentry reporting to include the `authConnection` in the error message (and avoid leaking the redirect URL), and adjusts `#getUserCancelledLoginError` to accept a pre-fetched runtime error. Adds/updates tests to validate the new Sentry `cause` chain and fallback behavior when no `lastError` is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e921ac8947a5c61276c39423c8ea61dd65b135b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->