### PR TITLE
fix: flaky test `Multi SRP - Import SRP successfully imports a new srp and it matches the srp imported`

### DIFF
--- a/test/e2e/page-objects/pages/home/homepage.ts
+++ b/test/e2e/page-objects/pages/home/homepage.ts
@@ -564,7 +564,7 @@ class HomePage {
 
   async dismissSrpAddedToast(): Promise<void> {
     console.log('Dismiss SRP added toast');
-    await this.driver.clickElement(this.srpAddedToastCloseButton);
+    await this.driver.clickElementSafe(this.srpAddedToastCloseButton, 5000);
   }
 
   async checkNoSurveyToastIsDisplayed(): Promise<void> {

--- a/test/e2e/page-objects/pages/home/homepage.ts
+++ b/test/e2e/page-objects/pages/home/homepage.ts
@@ -564,7 +564,7 @@ class HomePage {
 
   async dismissSrpAddedToast(): Promise<void> {
     console.log('Dismiss SRP added toast');
-    await this.driver.clickElementSafe(this.srpAddedToastCloseButton, 3000);
+    await this.driver.clickElementSafe(this.srpAddedToastCloseButton, 5000);
   }
 
   async checkNoSurveyToastIsDisplayed(): Promise<void> {

--- a/test/e2e/page-objects/pages/home/homepage.ts
+++ b/test/e2e/page-objects/pages/home/homepage.ts
@@ -564,7 +564,7 @@ class HomePage {
 
   async dismissSrpAddedToast(): Promise<void> {
     console.log('Dismiss SRP added toast');
-    await this.driver.clickElementSafe(this.srpAddedToastCloseButton, 5000);
+    await this.driver.clickElement(this.srpAddedToastCloseButton);
   }
 
   async checkNoSurveyToastIsDisplayed(): Promise<void> {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The test is flaky as sometimes we get the ElementClickInterceptedError when trying to reveal the SRP, because the Wallet imported toast is still present.

We do have a previous step where we close the toast using clickElementSafe, however this only waited 3 seconds for the toast to appear. If it didn't appear within those seconds it moved on to the next step, meaning the toast could appear a bit later and then obscure the button.

Increasing a bit the timeout fixes the issue, as we now give it more time for the toast to appear.
We cannot use the regular clickElement as the toast auto-closes, so it might be the case that the toast autoclosed before we could click it, so then the test would fail, that's why we use clickElementSafe.

```
ElementClickInterceptedError: Element <button class="inline-flex items-center justify-center rounded-xl px-4 font-medium min-w-20 overflow-hidden relative h-12 transition-all duration-100 ease-linear active:scale-[0.97] active:ease-[cubic-bezier(0.3,0.8,0.3,1)] bg-icon-default text-primary-inverse hover:bg-icon-default-hover active:bg-icon-default-pressed focus-visible:ring-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-default w-full"> is not clickable at point (576,780) because another element <div class="go2072408551 w-[360px] max-w-[360px] border border-border-muted"> obscures it
```

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="1152" height="836" alt="image" src="https://github.com/user-attachments/assets/85665e06-3dc6-46e1-95e2-3bdb2f754c06" />

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts an E2E page-object timeout, which may slightly increase test runtime but doesn’t affect production code paths.
> 
> **Overview**
> Makes the `Multi SRP` E2E flow less flaky by increasing the `clickElementSafe` wait when dismissing the “Wallet imported” (`new-srp-added`) toast on the homepage, reducing cases where a late-appearing toast intercepts subsequent clicks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0533f33e6266c3406a2af34ea078b8a0d5bbe295. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->