### PR TITLE
test: clenaup workarounds due to old Fixture usage in 105.ts migration file

### DIFF
--- a/app/scripts/migrations/105.ts
+++ b/app/scripts/migrations/105.ts
@@ -68,18 +68,12 @@ function findInternalAccountByAddress(
 // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function createDefaultAccountsController(state: Record<string, any>) {
-  // FIXME: Our e2e tests are always going through this migration, which makes it
-  // impossible to define default accounts in our fixtures as they are getting
-  // overwritten here.
-  // So we check for existing state before creating a default one.
-  if (!state.AccountsController) {
-    state.AccountsController = {
-      internalAccounts: {
-        accounts: {},
-        selectedAccount: '',
-      },
-    };
-  }
+  state.AccountsController = {
+    internalAccounts: {
+      accounts: {},
+      selectedAccount: '',
+    },
+  };
 }
 
 function createInternalAccountsForAccountsController(
@@ -100,30 +94,24 @@ function createInternalAccountsForAccountsController(
       random: sha256(hexToBytes(identity.address)).slice(0, 16),
     });
 
-    // FIXME: Our e2e tests are always going through this migration, which makes it
-    // impossible to define default accounts in our fixtures as they are getting
-    // overwritten here.
-    // So we check for existing state before creating a default one.
-    if (!state.AccountsController.internalAccounts.accounts[expectedId]) {
-      state.AccountsController.internalAccounts.accounts[expectedId] = {
-        address: identity.address,
-        id: expectedId,
-        options: {},
-        metadata: {
-          name: identity.name,
-          lastSelected: identity.lastSelected ?? undefined,
-          importTime: 0,
-          keyring: {
-            // This is default HD Key Tree type because the keyring is encrypted
-            // during migration, the type will get updated when the during the
-            // initial updateAccounts call.
-            type: 'HD Key Tree',
-          },
+    state.AccountsController.internalAccounts.accounts[expectedId] = {
+      address: identity.address,
+      id: expectedId,
+      options: {},
+      metadata: {
+        name: identity.name,
+        lastSelected: identity.lastSelected ?? undefined,
+        importTime: 0,
+        keyring: {
+          // This is default HD Key Tree type because the keyring is encrypted
+          // during migration, the type will get updated when the during the
+          // initial updateAccounts call.
+          type: 'HD Key Tree',
         },
-        methods: ETH_EOA_METHODS,
-        type: EthAccountType.Eoa,
-      };
-    }
+      },
+      methods: ETH_EOA_METHODS,
+      type: EthAccountType.Eoa,
+    };
   });
 }
 
@@ -143,35 +131,26 @@ function createSelectedAccountForAccountsController(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   state: Record<string, any>,
 ) {
-  // FIXME: Our e2e tests are always going through this migration, which makes it
-  // impossible to define default accounts in our fixtures as they are getting
-  // overwritten here.
-  // So we check for existing state before creating a default one.
-  if (!state.AccountsController.internalAccounts.selectedAccount) {
-    let selectedAddress = state.PreferencesController?.selectedAddress;
+  let selectedAddress = state.PreferencesController?.selectedAddress;
 
-    if (typeof selectedAddress !== 'string') {
-      global.sentry?.captureException?.(
-        new Error(
-          `state.PreferencesController?.selectedAddress is ${selectedAddress}`,
-        ),
-      );
-
-      // Get the first account if selectedAddress is not a string
-      selectedAddress = getFirstAddress(state);
-    }
-
-    const selectedAccount = findInternalAccountByAddress(
-      state,
-      selectedAddress,
+  if (typeof selectedAddress !== 'string') {
+    global.sentry?.captureException?.(
+      new Error(
+        `state.PreferencesController?.selectedAddress is ${selectedAddress}`,
+      ),
     );
-    if (selectedAccount) {
-      // Required in case there was no address selected
-      state.PreferencesController.selectedAddress = selectedAccount.address;
-      state.AccountsController.internalAccounts = {
-        ...state.AccountsController.internalAccounts,
-        selectedAccount: selectedAccount.id,
-      };
-    }
+
+    // Get the first account if selectedAddress is not a string
+    selectedAddress = getFirstAddress(state);
+  }
+
+  const selectedAccount = findInternalAccountByAddress(state, selectedAddress);
+  if (selectedAccount) {
+    // Required in case there was no address selected
+    state.PreferencesController.selectedAddress = selectedAccount.address;
+    state.AccountsController.internalAccounts = {
+      ...state.AccountsController.internalAccounts,
+      selectedAccount: selectedAccount.id,
+    };
   }
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Our e2e don't run migrations anymore, as they always use the latest fixture state, with FixtureBuilderV2, so we can remove old workarounds

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This changes migration `105` to always overwrite `AccountsController` state (accounts and selection), which could affect users upgrading from very old states if they had pre-populated `AccountsController` data. Scope is limited to a single migration file but touches persisted account/selection state.
> 
> **Overview**
> Migration `105` no longer preserves any pre-existing `AccountsController` state: it now always initializes `AccountsController.internalAccounts` from scratch and always writes internal accounts for each `PreferencesController.identity`.
> 
> The selected account logic is also simplified to *always* derive and set `internalAccounts.selectedAccount` (and backfill `PreferencesController.selectedAddress`) based on `selectedAddress`/first identity, rather than skipping when a selection already exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c03ebc2b259dfd906a3d1b31af565c5cfe1a5743. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->