### PR TITLE
fix: sponsored hardware wallet send max native

### DIFF
--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -842,8 +842,8 @@
       "Test errors: Uncaught Errors": 2
     },
     "ui/pages/confirmations/components/confirm/info/native-transfer/native-transfer.test.tsx": {
-      "MetaMask: Background connection not initialized": 41,
-      "React: Act warnings (component updates not wrapped)": 14,
+      "MetaMask: Background connection not initialized": 43,
+      "React: Act warnings (component updates not wrapped)": 17,
       "Reselect: Identity function warnings": 4
     },
     "ui/pages/confirmations/components/confirm/info/nft-token-transfer/nft-token-transfer.test.tsx": {

--- a/ui/pages/confirmations/components/confirm/info/hooks/useMaxValueRefresher.test.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useMaxValueRefresher.test.ts
@@ -10,6 +10,7 @@ import {
   getCrossChainMetaMaskCachedBalances,
   selectMaxValueModeForTransaction,
 } from '../../../../../../selectors';
+import { useIsGaslessSupported } from '../../../../hooks/gas/useIsGaslessSupported';
 import { useMaxValueRefresher } from './useMaxValueRefresher';
 import { useSupportsEIP1559 } from './useSupportsEIP1559';
 
@@ -41,6 +42,7 @@ jest.mock('../../../../context/confirm', () => ({
 }));
 
 jest.mock('../../../../hooks/useTransactionEventFragment');
+jest.mock('../../../../hooks/gas/useIsGaslessSupported');
 
 jest.mock('./useSupportsEIP1559', () => ({
   useSupportsEIP1559: jest.fn(),
@@ -61,6 +63,7 @@ describe('useMaxValueRefresher', () => {
   );
   const updateEditableParamsMock = jest.mocked(updateEditableParams);
   const mockUseSearchParams = jest.mocked(useSearchParams);
+  const mockUseIsGaslessSupported = jest.mocked(useIsGaslessSupported);
 
   const baseTransactionMeta = {
     id: 'test-transaction-id',
@@ -96,6 +99,12 @@ describe('useMaxValueRefresher', () => {
 
     useTransactionEventFragmentMock.mockReturnValue({
       updateTransactionEventFragment: updateTransactionEventFragmentMock,
+    });
+
+    mockUseIsGaslessSupported.mockReturnValue({
+      isSupported: false,
+      isSmartTransaction: false,
+      pending: false,
     });
   });
 
@@ -313,6 +322,11 @@ describe('useMaxValueRefresher', () => {
       });
 
       it('calculates value as full balance if gas is sponsored', () => {
+        mockUseIsGaslessSupported.mockReturnValue({
+          isSmartTransaction: false,
+          isSupported: true,
+          pending: false,
+        });
         const transactionMeta = merge({}, baseTransactionMeta, {
           txParams: {
             gas: '0x5208', // 21000
@@ -331,6 +345,35 @@ describe('useMaxValueRefresher', () => {
           transactionMeta.id,
           {
             value: defaultBalance,
+          },
+        );
+      });
+
+      it('calculates value using maxFeePerGas if gas is sponsored on network but gasless not supported (ex: Hardware Wallet)', () => {
+        mockUseIsGaslessSupported.mockReturnValue({
+          isSmartTransaction: false,
+          // Unsupported, often because account is Hardware Wallet
+          isSupported: false,
+          pending: false,
+        });
+        const transactionMeta = merge({}, baseTransactionMeta, {
+          txParams: {
+            gas: '0x5208', // 21000
+            maxFeePerGas: '0x77359400', // 2 gwei
+          },
+          isGasFeeSponsored: true,
+        });
+
+        useConfirmContextMock.mockReturnValue({
+          currentConfirmation: transactionMeta,
+        } as unknown as ReturnType<typeof useConfirmContext>);
+
+        renderHook(() => useMaxValueRefresher());
+
+        expect(updateEditableParamsMock).toHaveBeenCalledWith(
+          transactionMeta.id,
+          {
+            value: '0x1631f457a756000',
           },
         );
       });

--- a/ui/pages/confirmations/components/confirm/info/hooks/useMaxValueRefresher.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useMaxValueRefresher.ts
@@ -20,6 +20,7 @@ import { updateEditableParams } from '../../../../../../store/actions';
 import { useConfirmContext } from '../../../../context/confirm';
 import { HEX_ZERO } from '../shared/constants';
 import { useTransactionEventFragment } from '../../../../hooks/useTransactionEventFragment';
+import { useIsGaslessSupported } from '../../../../hooks/gas/useIsGaslessSupported';
 import { useSupportsEIP1559 } from './useSupportsEIP1559';
 
 /**
@@ -46,6 +47,7 @@ export const useMaxValueRefresher = () => {
     id: transactionId,
     txParams: { from },
   } = transactionMeta;
+  const { isSupported: isGaslessSupported } = useIsGaslessSupported();
   const isMaxAmountMode = useSelector((state) =>
     selectMaxValueModeForTransaction(state, transactionMeta?.id),
   );
@@ -89,7 +91,7 @@ export const useMaxValueRefresher = () => {
 
     // Gas Sponsorship means the user has no native gas to pay at all.
     // This will allow to send the full max value of the native balance.
-    if (!transactionMeta.isGasFeeSponsored) {
+    if (!transactionMeta.isGasFeeSponsored || !isGaslessSupported) {
       gasFeeInHex = multiplyHexes(
         gas,
         supportsEIP1559 ? maxFeePerGas : gasPrice,
@@ -124,5 +126,6 @@ export const useMaxValueRefresher = () => {
     layer1GasFee,
     dispatch,
     transactionMeta,
+    isGaslessSupported,
   ]);
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

On sponsored networks, the "send max native" feature wrongly tries to send 100% of user's balance on Hardware Wallets despite Gas Sponsorship being disabled for those. This creates an out of gas situation.
The PR restores the legacy behavior of the "max" button for such specific cases (HW + gas sponsorship + send max native).

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: sponsored hardware wallet send max native

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/NEB-1132?atlOrigin=eyJpIjoiYjFiZWVkNWJlMTI5NDk5NmE4OTA2NTM5NjkzM2RlMzQiLCJwIjoiaiJ9

## **Manual testing steps**

0. Use a HW wallet account - ex: QR Code wallet
1. Go on SEI token page on SEI network
2. Click on "Send"
3. Click on the "max" button
4. Continue to Confirmation view. Notice that no error appear and that the tx executes without sponsorship.

Non-reg on regular accounts to check that sending max on SEI still sends the full balance - not Monad because of the 10 MON constraint. 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
<img width="300" alt="image" src="https://github.com/user-attachments/assets/b58d3fbb-6037-4359-b718-001dd9905e51" />


### **After**

<!-- [screenshots/recordings] -->
<img width="300" alt="image" src="https://github.com/user-attachments/assets/7df3ff05-93e6-480f-8968-ca34468dcf61" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches send-max value calculation for native transfers; mistakes here could cause failed transactions or incorrect amounts, though the change is narrowly scoped and covered by unit tests.
> 
> **Overview**
> Fixes native **Send Max** computation for gas-sponsored `simpleSend` confirmations by only treating fees as fully sponsored when `useIsGaslessSupported()` reports support; otherwise it still subtracts estimated gas (and L1 fees) from the balance (e.g., hardware-wallet accounts on sponsored networks).
> 
> Updates `useMaxValueRefresher` unit tests to mock `useIsGaslessSupported` and adds coverage for the “sponsored network but gasless unsupported” case; adjusts Jest console baseline accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83a3de5bf004d99d829050fda44ba598d031755e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->