### PR TITLE
perf: fix benchmark "Missing Data" in PR Comments

### DIFF
--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -85,10 +85,9 @@ jobs:
         run: Xvfb -ac :99 -screen 0 1280x1024x16 &
         shell: bash
 
-      - name: Install AWS CLI (needed for S3 upload on main/release only)
+      - name: Install AWS CLI (needed for S3 upload)
         if: >-
           ${{
-            env.MAIN_OR_RELEASE == 'true' &&
             vars.AWS_REGION != '' &&
             vars.AWS_IAM_ROLE != '' &&
             vars.AWS_S3_BUCKET != ''
@@ -121,7 +120,6 @@ jobs:
       - name: Upload benchmark to S3
         if: >-
           ${{
-            env.MAIN_OR_RELEASE == 'true' &&
             vars.AWS_REGION != '' &&
             vars.AWS_IAM_ROLE != '' &&
             vars.AWS_S3_BUCKET != ''
@@ -200,7 +198,6 @@ jobs:
       - name: Upload benchmark to S3
         if: >-
           ${{
-            env.MAIN_OR_RELEASE == 'true' &&
             vars.AWS_REGION != '' &&
             vars.AWS_IAM_ROLE != '' &&
             vars.AWS_S3_BUCKET != ''


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Since #41477 (remove browserify from benchmark system), all PRs show ⚠️ Missing data for every benchmark category in the bot comment. The tests run and pass successfully, but no data appears in the PR comment.

Root cause: #41477 gated the S3 upload to `MAIN_OR_RELEASE == 'true'`, replacing the old `BENCHMARK_GATED` variable. Before that change, browserify benchmarks used `BENCHMARK_GATED: true` for all runs, so benchmark results were always uploaded to S3 and available via CloudFront. After the change, PR runs never upload to S3, so the announcement script gets 404s for every benchmark file and reports missing data.

This PR removes the `MAIN_OR_RELEASE` gate from the S3 upload steps in `run-benchmarks.yml`. 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="915" height="486" alt="Screenshot 2026-05-07 at 14 12 43" src="https://github.com/user-attachments/assets/aa79094b-7d9c-41c3-bcd8-80da1e4fbd03" />


<!-- [screenshots/recordings] -->

### **After**

<img width="1085" height="696" alt="Screenshot 2026-05-07 at 16 43 03" src="https://github.com/user-attachments/assets/080a3f55-d931-42b9-9174-17dbccc57b6b" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI behavior to upload benchmark artifacts to S3 on PR runs as well as main/release, which could increase AWS usage and relies on correct IAM/S3 configuration.
> 
> **Overview**
> Removes the `MAIN_OR_RELEASE` gating in `run-benchmarks.yml` so benchmark JSONs are uploaded to S3 (and the AWS CLI is installed) whenever AWS vars are configured, including on PR runs.
> 
> Keeps Sentry reporting restricted to main/release, but makes S3-backed benchmark data available for PR comment/announcement tooling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b76bf46186e1a0edfc2c3fee7a4601529d0efc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->