### PR TITLE
fix: cp-13.30.0 render skeleton until pay required token resolves

### DIFF
--- a/.yarn/patches/@metamask-transaction-pay-controller-npm-20.1.0-1c84c5db4d.patch
+++ b/.yarn/patches/@metamask-transaction-pay-controller-npm-20.1.0-1c84c5db4d.patch
@@ -1,17 +1,19 @@
 diff --git a/dist/TransactionPayController.cjs b/dist/TransactionPayController.cjs
-index e077ab4e0f4c01e7ac9c848a343855283662331c..5e7c91e44876d15334bce4305fce98dee3188d17 100644
+index e077ab4e0f4c01e7ac9c848a343855283662331c..298d53f8007fa463a21db5f91f7c9292e11f399a 100644
 --- a/dist/TransactionPayController.cjs
 +++ b/dist/TransactionPayController.cjs
-@@ -58,6 +58,7 @@ class TransactionPayController extends base_controller_1.BaseController {
+@@ -57,7 +57,8 @@ class TransactionPayController extends base_controller_1.BaseController {
+         __classPrivateFieldSet(this, _TransactionPayController_getStrategy, getStrategy, "f");
          __classPrivateFieldSet(this, _TransactionPayController_getStrategies, getStrategies, "f");
          this.messenger.registerMethodActionHandlers(this, MESSENGER_EXPOSED_METHODS);
-         (0, transaction_1.pollTransactionChanges)(messenger, __classPrivateFieldGet(this, _TransactionPayController_instances, "m", _TransactionPayController_updateTransactionData).bind(this), __classPrivateFieldGet(this, _TransactionPayController_instances, "m", _TransactionPayController_removeTransactionData).bind(this));
+-        (0, transaction_1.pollTransactionChanges)(messenger, __classPrivateFieldGet(this, _TransactionPayController_instances, "m", _TransactionPayController_updateTransactionData).bind(this), __classPrivateFieldGet(this, _TransactionPayController_instances, "m", _TransactionPayController_removeTransactionData).bind(this));
++        (0, transaction_1.subscribeTransactionChanges)(messenger, __classPrivateFieldGet(this, _TransactionPayController_instances, "m", _TransactionPayController_updateTransactionData).bind(this), __classPrivateFieldGet(this, _TransactionPayController_instances, "m", _TransactionPayController_removeTransactionData).bind(this));
 +        (0, transaction_1.subscribeAssetChanges)(messenger, () => this.state, __classPrivateFieldGet(this, _TransactionPayController_instances, "m", _TransactionPayController_updateTransactionData).bind(this));
          // eslint-disable-next-line no-new
          new QuoteRefresher_1.QuoteRefresher({
              getStrategies: __classPrivateFieldGet(this, _TransactionPayController_instances, "m", _TransactionPayController_getStrategiesWithFallback).bind(this),
 diff --git a/dist/TransactionPayController.mjs b/dist/TransactionPayController.mjs
-index eb0f523321c838017a8a9d1e31e25e8ef40937cd..21eab67e0553845f97c29945e4ade3d9fa654e1d 100644
+index eb0f523321c838017a8a9d1e31e25e8ef40937cd..7e42c91fe7e355c9772e95912e1218411cdeee0f 100644
 --- a/dist/TransactionPayController.mjs
 +++ b/dist/TransactionPayController.mjs
 @@ -20,7 +20,7 @@ import { QuoteRefresher } from "./helpers/QuoteRefresher.mjs";
@@ -19,14 +21,16 @@ index eb0f523321c838017a8a9d1e31e25e8ef40937cd..21eab67e0553845f97c29945e4ade3d9
  import { updateQuotes } from "./utils/quotes.mjs";
  import { updateSourceAmounts } from "./utils/source-amounts.mjs";
 -import { pollTransactionChanges } from "./utils/transaction.mjs";
-+import { pollTransactionChanges, subscribeAssetChanges } from "./utils/transaction.mjs";
++import { subscribeAssetChanges, subscribeTransactionChanges } from "./utils/transaction.mjs";
  const MESSENGER_EXPOSED_METHODS = [
      'getDelegationTransaction',
      'getStrategy',
-@@ -56,6 +56,7 @@ export class TransactionPayController extends BaseController {
+@@ -55,7 +55,8 @@ export class TransactionPayController extends BaseController {
+         __classPrivateFieldSet(this, _TransactionPayController_getStrategy, getStrategy, "f");
          __classPrivateFieldSet(this, _TransactionPayController_getStrategies, getStrategies, "f");
          this.messenger.registerMethodActionHandlers(this, MESSENGER_EXPOSED_METHODS);
-         pollTransactionChanges(messenger, __classPrivateFieldGet(this, _TransactionPayController_instances, "m", _TransactionPayController_updateTransactionData).bind(this), __classPrivateFieldGet(this, _TransactionPayController_instances, "m", _TransactionPayController_removeTransactionData).bind(this));
+-        pollTransactionChanges(messenger, __classPrivateFieldGet(this, _TransactionPayController_instances, "m", _TransactionPayController_updateTransactionData).bind(this), __classPrivateFieldGet(this, _TransactionPayController_instances, "m", _TransactionPayController_removeTransactionData).bind(this));
++        subscribeTransactionChanges(messenger, __classPrivateFieldGet(this, _TransactionPayController_instances, "m", _TransactionPayController_updateTransactionData).bind(this), __classPrivateFieldGet(this, _TransactionPayController_instances, "m", _TransactionPayController_removeTransactionData).bind(this));
 +        subscribeAssetChanges(messenger, () => this.state, __classPrivateFieldGet(this, _TransactionPayController_instances, "m", _TransactionPayController_updateTransactionData).bind(this));
          // eslint-disable-next-line no-new
          new QuoteRefresher({
@@ -73,15 +77,164 @@ index cde5e8fe696114026edfa95d96a33d7022bb190b..5e29659c1cdc5e07a0c840fd625f184e
  export type TransactionPayControllerGetStateAction = ControllerGetStateAction<typeof CONTROLLER_NAME, TransactionPayControllerState>;
  /** Configurable properties of a transaction. */
  export type TransactionConfig = {
+diff --git a/dist/utils/required-tokens.cjs b/dist/utils/required-tokens.cjs
+index 0f607e124c3c5240d1261230c164bb206beeadad..383299274aa452dc2a2799f499cea52431e61375 100644
+--- a/dist/utils/required-tokens.cjs
++++ b/dist/utils/required-tokens.cjs
+@@ -6,7 +6,9 @@ const controller_utils_1 = require("@metamask/controller-utils");
+ const metamask_eth_abis_1 = require("@metamask/metamask-eth-abis");
+ const utils_1 = require("@metamask/utils");
+ const bignumber_js_1 = require("bignumber.js");
++const logger_1 = require("../logger.cjs");
+ const token_1 = require("./token.cjs");
++const log = (0, utils_1.createModuleLogger)(logger_1.projectLogger, 'required-tokens');
+ const FOUR_BYTE_TOKEN_TRANSFER = '0xa9059cbb';
+ /**
+  * Parse required tokens from a transaction.
+@@ -26,10 +28,8 @@ function parseRequiredTokens(transaction, messenger) {
+             .filter(Boolean);
+         return assetTokens;
+     }
+-    return [
+-        getTokenTransferToken(transaction, messenger),
+-        getGasFeeToken(transaction, messenger),
+-    ].filter(Boolean);
++    const transferToken = getTokenTransferToken(transaction, messenger);
++    return transferToken ? [transferToken] : [];
+ }
+ exports.parseRequiredTokens = parseRequiredTokens;
+ /**
+@@ -42,17 +42,26 @@ exports.parseRequiredTokens = parseRequiredTokens;
+ function getTokenTransferToken(transaction, messenger) {
+     const { data, to } = getTokenTransferData(transaction) ?? {};
+     if (!to || !data) {
++        log('No token transfer detected', {
++            transactionId: transaction.id,
++        });
+         return undefined;
+     }
+     let transferAmount;
++    let decodeError;
+     try {
+         const result = new abi_1.Interface(metamask_eth_abis_1.abiERC20).decodeFunctionData('transfer', data);
+         transferAmount = (0, controller_utils_1.toHex)(result._value);
+     }
+-    catch {
+-        // Intentionally empty
++    catch (error) {
++        decodeError = error;
+     }
+     if (transferAmount === undefined) {
++        log('Failed to decode transfer calldata', {
++            transactionId: transaction.id,
++            to,
++            error: decodeError,
++        });
+         return undefined;
+     }
+     return buildRequiredToken(transaction, to, transferAmount, messenger);
+@@ -113,6 +122,16 @@ function buildRequiredToken(transaction, tokenAddress, amountRawHex, messenger)
+     const fiatRates = (0, token_1.getTokenFiatRate)(messenger, tokenAddress, chainId);
+     const tokenBalance = (0, token_1.getTokenBalance)(messenger, from, chainId, tokenAddress);
+     if (tokenDecimals === undefined || !symbol || fiatRates === undefined) {
++        log('Missing token data', {
++            transactionId: transaction.id,
++            chainId,
++            tokenAddress,
++            missing: {
++                decimals: tokenDecimals === undefined,
++                symbol: !symbol,
++                fiatRates: fiatRates === undefined,
++            },
++        });
+         return undefined;
+     }
+     const { human: balanceHuman, raw: balanceRaw, fiat: balanceFiat, usd: balanceUsd, } = (0, token_1.computeTokenAmounts)(tokenBalance, tokenDecimals, fiatRates);
+diff --git a/dist/utils/required-tokens.mjs b/dist/utils/required-tokens.mjs
+index d9b232aeee6c12b6baacf8e0c87b3e6874ca1845..35edb78e1c65e74c42718de6cdda380bcd6896ed 100644
+--- a/dist/utils/required-tokens.mjs
++++ b/dist/utils/required-tokens.mjs
+@@ -1,9 +1,11 @@
+ import { Interface } from "@ethersproject/abi";
+ import { toHex } from "@metamask/controller-utils";
+ import { abiERC20 } from "@metamask/metamask-eth-abis";
+-import { add0x } from "@metamask/utils";
++import { add0x, createModuleLogger } from "@metamask/utils";
+ import { BigNumber } from "bignumber.js";
++import { projectLogger } from "../logger.mjs";
+ import { computeTokenAmounts, getNativeToken, getTokenBalance, getTokenFiatRate, getTokenInfo } from "./token.mjs";
++const log = createModuleLogger(projectLogger, 'required-tokens');
+ const FOUR_BYTE_TOKEN_TRANSFER = '0xa9059cbb';
+ /**
+  * Parse required tokens from a transaction.
+@@ -23,10 +25,8 @@ export function parseRequiredTokens(transaction, messenger) {
+             .filter(Boolean);
+         return assetTokens;
+     }
+-    return [
+-        getTokenTransferToken(transaction, messenger),
+-        getGasFeeToken(transaction, messenger),
+-    ].filter(Boolean);
++    const transferToken = getTokenTransferToken(transaction, messenger);
++    return transferToken ? [transferToken] : [];
+ }
+ /**
+  * Parse a required token from a token transfer.
+@@ -38,17 +38,26 @@ export function parseRequiredTokens(transaction, messenger) {
+ function getTokenTransferToken(transaction, messenger) {
+     const { data, to } = getTokenTransferData(transaction) ?? {};
+     if (!to || !data) {
++        log('No token transfer detected', {
++            transactionId: transaction.id,
++        });
+         return undefined;
+     }
+     let transferAmount;
++    let decodeError;
+     try {
+         const result = new Interface(abiERC20).decodeFunctionData('transfer', data);
+         transferAmount = toHex(result._value);
+     }
+-    catch {
+-        // Intentionally empty
++    catch (error) {
++        decodeError = error;
+     }
+     if (transferAmount === undefined) {
++        log('Failed to decode transfer calldata', {
++            transactionId: transaction.id,
++            to,
++            error: decodeError,
++        });
+         return undefined;
+     }
+     return buildRequiredToken(transaction, to, transferAmount, messenger);
+@@ -109,6 +118,16 @@ function buildRequiredToken(transaction, tokenAddress, amountRawHex, messenger)
+     const fiatRates = getTokenFiatRate(messenger, tokenAddress, chainId);
+     const tokenBalance = getTokenBalance(messenger, from, chainId, tokenAddress);
+     if (tokenDecimals === undefined || !symbol || fiatRates === undefined) {
++        log('Missing token data', {
++            transactionId: transaction.id,
++            chainId,
++            tokenAddress,
++            missing: {
++                decimals: tokenDecimals === undefined,
++                symbol: !symbol,
++                fiatRates: fiatRates === undefined,
++            },
++        });
+         return undefined;
+     }
+     const { human: balanceHuman, raw: balanceRaw, fiat: balanceFiat, usd: balanceUsd, } = computeTokenAmounts(tokenBalance, tokenDecimals, fiatRates);
 diff --git a/dist/utils/transaction.cjs b/dist/utils/transaction.cjs
-index 9274f4010142362daa258639a514f6beb4611a61..2328055898d6855b1d0d10b5f0c6ef05f1f59a56 100644
+index 9274f4010142362daa258639a514f6beb4611a61..c956b006672079f733fbbfc6865bdfdc9d132176 100644
 --- a/dist/utils/transaction.cjs
 +++ b/dist/utils/transaction.cjs
 @@ -1,10 +1,11 @@
  "use strict";
  Object.defineProperty(exports, "__esModule", { value: true });
 -exports.isPredictWithdrawTransaction = exports.collectTransactionIds = exports.updateTransaction = exports.waitForTransactionConfirmed = exports.pollTransactionChanges = exports.getTransaction = exports.FINALIZED_STATUSES = void 0;
-+exports.isPredictWithdrawTransaction = exports.collectTransactionIds = exports.updateTransaction = exports.waitForTransactionConfirmed = exports.subscribeAssetChanges = exports.pollTransactionChanges = exports.getTransaction = exports.FINALIZED_STATUSES = void 0;
++exports.isPredictWithdrawTransaction = exports.collectTransactionIds = exports.updateTransaction = exports.waitForTransactionConfirmed = exports.subscribeAssetChanges = exports.subscribeTransactionChanges = exports.getTransaction = exports.FINALIZED_STATUSES = void 0;
  const transaction_controller_1 = require("@metamask/transaction-controller");
  const utils_1 = require("@metamask/utils");
  const lodash_1 = require("lodash");
@@ -90,10 +243,28 @@ index 9274f4010142362daa258639a514f6beb4611a61..2328055898d6855b1d0d10b5f0c6ef05
  const required_tokens_1 = require("./required-tokens.cjs");
  const log = (0, utils_1.createModuleLogger)(logger_1.projectLogger, 'transaction');
  exports.FINALIZED_STATUSES = [
-@@ -51,6 +52,39 @@ function pollTransactionChanges(messenger, updateTransactionData, removeTransact
+@@ -25,13 +26,13 @@ function getTransaction(transactionId, messenger) {
+ }
+ exports.getTransaction = getTransaction;
+ /**
+- * Poll for transaction changes and update the transaction data accordingly.
++ * Subscribe to transaction changes and update the transaction data accordingly.
+  *
+  * @param messenger - Controller messenger.
+  * @param updateTransactionData - Callback to update transaction data.
+  * @param removeTransactionData - Callback to remove transaction data.
+  */
+-function pollTransactionChanges(messenger, updateTransactionData, removeTransactionData) {
++function subscribeTransactionChanges(messenger, updateTransactionData, removeTransactionData) {
+     messenger.subscribe('TransactionController:stateChange', (transactions, previousTransactions) => {
+         const newTransactions = transactions.filter((tx) => !previousTransactions?.find((prevTx) => prevTx.id === tx.id));
+         const updatedTransactions = transactions.filter((tx) => {
+@@ -50,7 +51,39 @@ function pollTransactionChanges(messenger, updateTransactionData, removeTransact
+         [...newTransactions, ...updatedTransactions].forEach((tx) => onTransactionChange(tx, messenger, updateTransactionData));
      }, (state) => state.transactions);
  }
- exports.pollTransactionChanges = pollTransactionChanges;
+-exports.pollTransactionChanges = pollTransactionChanges;
++exports.subscribeTransactionChanges = subscribeTransactionChanges;
 +/**
 + * Subscribe to asset state changes and re-parse required tokens for
 + * in-flight transactions whose tokens have not yet resolved.
@@ -126,12 +297,11 @@ index 9274f4010142362daa258639a514f6beb4611a61..2328055898d6855b1d0d10b5f0c6ef05
 +    messenger.subscribe('CurrencyRateController:stateChange', buildHandler('CurrencyRateController'));
 +}
 +exports.subscribeAssetChanges = subscribeAssetChanges;
-+
  /**
   * Wait for a transaction to be confirmed or fail.
   *
 diff --git a/dist/utils/transaction.d.cts b/dist/utils/transaction.d.cts
-index 336403441bd828ce81c40304c48207621acb4e0b..9eb3975b7a495dcaed86e57d56779087bcbb55b6 100644
+index 336403441bd828ce81c40304c48207621acb4e0b..579bc289c797d7194ef5248a0490bde564121ffe 100644
 --- a/dist/utils/transaction.d.cts
 +++ b/dist/utils/transaction.d.cts
 @@ -1,7 +1,7 @@
@@ -143,10 +313,19 @@ index 336403441bd828ce81c40304c48207621acb4e0b..9eb3975b7a495dcaed86e57d56779087
  export declare const FINALIZED_STATUSES: TransactionStatus[];
  /**
   * Retrieve transaction metadata by ID.
-@@ -19,6 +19,15 @@ export declare function getTransaction(transactionId: string, messenger: Transac
+@@ -12,13 +12,22 @@ export declare const FINALIZED_STATUSES: TransactionStatus[];
+  */
+ export declare function getTransaction(transactionId: string, messenger: TransactionPayControllerMessenger): TransactionMeta | undefined;
+ /**
+- * Poll for transaction changes and update the transaction data accordingly.
++ * Subscribe to transaction changes and update the transaction data accordingly.
+  *
+  * @param messenger - Controller messenger.
+  * @param updateTransactionData - Callback to update transaction data.
   * @param removeTransactionData - Callback to remove transaction data.
   */
- export declare function pollTransactionChanges(messenger: TransactionPayControllerMessenger, updateTransactionData: UpdateTransactionDataCallback, removeTransactionData: (transactionId: string) => void): void;
+-export declare function pollTransactionChanges(messenger: TransactionPayControllerMessenger, updateTransactionData: UpdateTransactionDataCallback, removeTransactionData: (transactionId: string) => void): void;
++export declare function subscribeTransactionChanges(messenger: TransactionPayControllerMessenger, updateTransactionData: UpdateTransactionDataCallback, removeTransactionData: (transactionId: string) => void): void;
 +/**
 + * Subscribe to asset state changes and re-parse required tokens for
 + * in-flight transactions whose tokens have not yet resolved.
@@ -160,7 +339,7 @@ index 336403441bd828ce81c40304c48207621acb4e0b..9eb3975b7a495dcaed86e57d56779087
   * Wait for a transaction to be confirmed or fail.
   *
 diff --git a/dist/utils/transaction.d.mts b/dist/utils/transaction.d.mts
-index e61bbfce52c5444b633f9348d2a8207609087cb7..1fe42e55e97572a7c93294936e5efa0c5acc4468 100644
+index e61bbfce52c5444b633f9348d2a8207609087cb7..609ce7ca5cc2468545a6232a12dac9cb2f530a8e 100644
 --- a/dist/utils/transaction.d.mts
 +++ b/dist/utils/transaction.d.mts
 @@ -1,7 +1,7 @@
@@ -172,10 +351,19 @@ index e61bbfce52c5444b633f9348d2a8207609087cb7..1fe42e55e97572a7c93294936e5efa0c
  export declare const FINALIZED_STATUSES: TransactionStatus[];
  /**
   * Retrieve transaction metadata by ID.
-@@ -19,6 +19,15 @@ export declare function getTransaction(transactionId: string, messenger: Transac
+@@ -12,13 +12,22 @@ export declare const FINALIZED_STATUSES: TransactionStatus[];
+  */
+ export declare function getTransaction(transactionId: string, messenger: TransactionPayControllerMessenger): TransactionMeta | undefined;
+ /**
+- * Poll for transaction changes and update the transaction data accordingly.
++ * Subscribe to transaction changes and update the transaction data accordingly.
+  *
+  * @param messenger - Controller messenger.
+  * @param updateTransactionData - Callback to update transaction data.
   * @param removeTransactionData - Callback to remove transaction data.
   */
- export declare function pollTransactionChanges(messenger: TransactionPayControllerMessenger, updateTransactionData: UpdateTransactionDataCallback, removeTransactionData: (transactionId: string) => void): void;
+-export declare function pollTransactionChanges(messenger: TransactionPayControllerMessenger, updateTransactionData: UpdateTransactionDataCallback, removeTransactionData: (transactionId: string) => void): void;
++export declare function subscribeTransactionChanges(messenger: TransactionPayControllerMessenger, updateTransactionData: UpdateTransactionDataCallback, removeTransactionData: (transactionId: string) => void): void;
 +/**
 + * Subscribe to asset state changes and re-parse required tokens for
 + * in-flight transactions whose tokens have not yet resolved.
@@ -189,7 +377,7 @@ index e61bbfce52c5444b633f9348d2a8207609087cb7..1fe42e55e97572a7c93294936e5efa0c
   * Wait for a transaction to be confirmed or fail.
   *
 diff --git a/dist/utils/transaction.mjs b/dist/utils/transaction.mjs
-index 2d0fa701cb7ef4a8dddb7034dcdaf06bc33c72b4..a60254ffca20ab8bcb8d1211d19c8a468c0b3f98 100644
+index 2d0fa701cb7ef4a8dddb7034dcdaf06bc33c72b4..f491ef66a25175424db6147a72faad1faced20d4 100644
 --- a/dist/utils/transaction.mjs
 +++ b/dist/utils/transaction.mjs
 @@ -3,6 +3,7 @@ import { createModuleLogger } from "@metamask/utils";
@@ -200,6 +388,22 @@ index 2d0fa701cb7ef4a8dddb7034dcdaf06bc33c72b4..a60254ffca20ab8bcb8d1211d19c8a46
  import { parseRequiredTokens } from "./required-tokens.mjs";
  const log = createModuleLogger(projectLogger, 'transaction');
  export const FINALIZED_STATUSES = [
+@@ -22,13 +23,13 @@ export function getTransaction(transactionId, messenger) {
+     return transactionControllerState.transactions.find((tx) => tx.id === transactionId);
+ }
+ /**
+- * Poll for transaction changes and update the transaction data accordingly.
++ * Subscribe to transaction changes and update the transaction data accordingly.
+  *
+  * @param messenger - Controller messenger.
+  * @param updateTransactionData - Callback to update transaction data.
+  * @param removeTransactionData - Callback to remove transaction data.
+  */
+-export function pollTransactionChanges(messenger, updateTransactionData, removeTransactionData) {
++export function subscribeTransactionChanges(messenger, updateTransactionData, removeTransactionData) {
+     messenger.subscribe('TransactionController:stateChange', (transactions, previousTransactions) => {
+         const newTransactions = transactions.filter((tx) => !previousTransactions?.find((prevTx) => prevTx.id === tx.id));
+         const updatedTransactions = transactions.filter((tx) => {
 @@ -47,6 +48,39 @@ export function pollTransactionChanges(messenger, updateTransactionData, removeT
          [...newTransactions, ...updatedTransactions].forEach((tx) => onTransactionChange(tx, messenger, updateTransactionData));
      }, (state) => state.transactions);

--- a/.yarn/patches/@metamask-transaction-pay-controller-npm-20.1.0-1c84c5db4d.patch
+++ b/.yarn/patches/@metamask-transaction-pay-controller-npm-20.1.0-1c84c5db4d.patch
@@ -1,0 +1,242 @@
+diff --git a/dist/TransactionPayController.cjs b/dist/TransactionPayController.cjs
+index e077ab4e0f4c01e7ac9c848a343855283662331c..5e7c91e44876d15334bce4305fce98dee3188d17 100644
+--- a/dist/TransactionPayController.cjs
++++ b/dist/TransactionPayController.cjs
+@@ -58,6 +58,7 @@ class TransactionPayController extends base_controller_1.BaseController {
+         __classPrivateFieldSet(this, _TransactionPayController_getStrategies, getStrategies, "f");
+         this.messenger.registerMethodActionHandlers(this, MESSENGER_EXPOSED_METHODS);
+         (0, transaction_1.pollTransactionChanges)(messenger, __classPrivateFieldGet(this, _TransactionPayController_instances, "m", _TransactionPayController_updateTransactionData).bind(this), __classPrivateFieldGet(this, _TransactionPayController_instances, "m", _TransactionPayController_removeTransactionData).bind(this));
++        (0, transaction_1.subscribeAssetChanges)(messenger, () => this.state, __classPrivateFieldGet(this, _TransactionPayController_instances, "m", _TransactionPayController_updateTransactionData).bind(this));
+         // eslint-disable-next-line no-new
+         new QuoteRefresher_1.QuoteRefresher({
+             getStrategies: __classPrivateFieldGet(this, _TransactionPayController_instances, "m", _TransactionPayController_getStrategiesWithFallback).bind(this),
+diff --git a/dist/TransactionPayController.mjs b/dist/TransactionPayController.mjs
+index eb0f523321c838017a8a9d1e31e25e8ef40937cd..21eab67e0553845f97c29945e4ade3d9fa654e1d 100644
+--- a/dist/TransactionPayController.mjs
++++ b/dist/TransactionPayController.mjs
+@@ -20,7 +20,7 @@ import { QuoteRefresher } from "./helpers/QuoteRefresher.mjs";
+ import { getStrategyOrder } from "./utils/feature-flags.mjs";
+ import { updateQuotes } from "./utils/quotes.mjs";
+ import { updateSourceAmounts } from "./utils/source-amounts.mjs";
+-import { pollTransactionChanges } from "./utils/transaction.mjs";
++import { pollTransactionChanges, subscribeAssetChanges } from "./utils/transaction.mjs";
+ const MESSENGER_EXPOSED_METHODS = [
+     'getDelegationTransaction',
+     'getStrategy',
+@@ -56,6 +56,7 @@ export class TransactionPayController extends BaseController {
+         __classPrivateFieldSet(this, _TransactionPayController_getStrategies, getStrategies, "f");
+         this.messenger.registerMethodActionHandlers(this, MESSENGER_EXPOSED_METHODS);
+         pollTransactionChanges(messenger, __classPrivateFieldGet(this, _TransactionPayController_instances, "m", _TransactionPayController_updateTransactionData).bind(this), __classPrivateFieldGet(this, _TransactionPayController_instances, "m", _TransactionPayController_removeTransactionData).bind(this));
++        subscribeAssetChanges(messenger, () => this.state, __classPrivateFieldGet(this, _TransactionPayController_instances, "m", _TransactionPayController_updateTransactionData).bind(this));
+         // eslint-disable-next-line no-new
+         new QuoteRefresher({
+             getStrategies: __classPrivateFieldGet(this, _TransactionPayController_instances, "m", _TransactionPayController_getStrategiesWithFallback).bind(this),
+diff --git a/dist/types.d.cts b/dist/types.d.cts
+index de378839765f757299b13c15a9cc5dc702d5f78d..37d657742239e8071a6b90e1b5820433ddb203bf 100644
+--- a/dist/types.d.cts
++++ b/dist/types.d.cts
+@@ -1,5 +1,5 @@
+-import type { AssetsControllerGetStateForTransactionPayAction } from "@metamask/assets-controller";
+-import type { CurrencyRateControllerActions, TokenBalancesControllerGetStateAction } from "@metamask/assets-controllers";
++import type { AssetsControllerGetStateForTransactionPayAction, AssetsControllerStateChangeEvent } from "@metamask/assets-controller";
++import type { CurrencyRateControllerActions, CurrencyRateStateChange, TokenBalancesControllerGetStateAction, TokenRatesControllerStateChangeEvent, TokensControllerStateChangeEvent } from "@metamask/assets-controllers";
+ import type { TokenRatesControllerGetStateAction } from "@metamask/assets-controllers";
+ import type { TokensControllerGetStateAction } from "@metamask/assets-controllers";
+ import type { AccountTrackerControllerGetStateAction } from "@metamask/assets-controllers";
+@@ -22,7 +22,7 @@ import type { Draft } from "immer";
+ import type { CONTROLLER_NAME, TransactionPayStrategy } from "./constants.cjs";
+ import type { TransactionPayControllerMethodActions } from "./TransactionPayController-method-action-types.cjs";
+ export type AllowedActions = AccountTrackerControllerGetStateAction | AssetsControllerGetStateForTransactionPayAction | BridgeControllerActions | BridgeStatusControllerActions | CurrencyRateControllerActions | GasFeeControllerActions | KeyringControllerGetStateAction | KeyringControllerSignTypedMessageAction | NetworkControllerFindNetworkClientIdByChainIdAction | NetworkControllerGetNetworkClientByIdAction | RampsControllerGetQuotesAction | RemoteFeatureFlagControllerGetStateAction | TokenBalancesControllerGetStateAction | TokenRatesControllerGetStateAction | TokensControllerGetStateAction | TransactionControllerAddTransactionAction | TransactionControllerAddTransactionBatchAction | TransactionControllerEstimateGasAction | TransactionControllerEstimateGasBatchAction | TransactionControllerGetGasFeeTokensAction | TransactionControllerGetStateAction | TransactionControllerUpdateTransactionAction;
+-export type AllowedEvents = BridgeStatusControllerStateChangeEvent | TransactionControllerStateChangeEvent | TransactionControllerUnapprovedTransactionAddedEvent;
++export type AllowedEvents = AssetsControllerStateChangeEvent | BridgeStatusControllerStateChangeEvent | CurrencyRateStateChange | TokenRatesControllerStateChangeEvent | TokensControllerStateChangeEvent | TransactionControllerStateChangeEvent | TransactionControllerUnapprovedTransactionAddedEvent;
+ export type TransactionPayControllerGetStateAction = ControllerGetStateAction<typeof CONTROLLER_NAME, TransactionPayControllerState>;
+ /** Configurable properties of a transaction. */
+ export type TransactionConfig = {
+diff --git a/dist/types.d.mts b/dist/types.d.mts
+index cde5e8fe696114026edfa95d96a33d7022bb190b..5e29659c1cdc5e07a0c840fd625f184edc9a23bc 100644
+--- a/dist/types.d.mts
++++ b/dist/types.d.mts
+@@ -1,5 +1,5 @@
+-import type { AssetsControllerGetStateForTransactionPayAction } from "@metamask/assets-controller";
+-import type { CurrencyRateControllerActions, TokenBalancesControllerGetStateAction } from "@metamask/assets-controllers";
++import type { AssetsControllerGetStateForTransactionPayAction, AssetsControllerStateChangeEvent } from "@metamask/assets-controller";
++import type { CurrencyRateControllerActions, CurrencyRateStateChange, TokenBalancesControllerGetStateAction, TokenRatesControllerStateChangeEvent, TokensControllerStateChangeEvent } from "@metamask/assets-controllers";
+ import type { TokenRatesControllerGetStateAction } from "@metamask/assets-controllers";
+ import type { TokensControllerGetStateAction } from "@metamask/assets-controllers";
+ import type { AccountTrackerControllerGetStateAction } from "@metamask/assets-controllers";
+@@ -22,7 +22,7 @@ import type { Draft } from "immer";
+ import type { CONTROLLER_NAME, TransactionPayStrategy } from "./constants.mjs";
+ import type { TransactionPayControllerMethodActions } from "./TransactionPayController-method-action-types.mjs";
+ export type AllowedActions = AccountTrackerControllerGetStateAction | AssetsControllerGetStateForTransactionPayAction | BridgeControllerActions | BridgeStatusControllerActions | CurrencyRateControllerActions | GasFeeControllerActions | KeyringControllerGetStateAction | KeyringControllerSignTypedMessageAction | NetworkControllerFindNetworkClientIdByChainIdAction | NetworkControllerGetNetworkClientByIdAction | RampsControllerGetQuotesAction | RemoteFeatureFlagControllerGetStateAction | TokenBalancesControllerGetStateAction | TokenRatesControllerGetStateAction | TokensControllerGetStateAction | TransactionControllerAddTransactionAction | TransactionControllerAddTransactionBatchAction | TransactionControllerEstimateGasAction | TransactionControllerEstimateGasBatchAction | TransactionControllerGetGasFeeTokensAction | TransactionControllerGetStateAction | TransactionControllerUpdateTransactionAction;
+-export type AllowedEvents = BridgeStatusControllerStateChangeEvent | TransactionControllerStateChangeEvent | TransactionControllerUnapprovedTransactionAddedEvent;
++export type AllowedEvents = AssetsControllerStateChangeEvent | BridgeStatusControllerStateChangeEvent | CurrencyRateStateChange | TokenRatesControllerStateChangeEvent | TokensControllerStateChangeEvent | TransactionControllerStateChangeEvent | TransactionControllerUnapprovedTransactionAddedEvent;
+ export type TransactionPayControllerGetStateAction = ControllerGetStateAction<typeof CONTROLLER_NAME, TransactionPayControllerState>;
+ /** Configurable properties of a transaction. */
+ export type TransactionConfig = {
+diff --git a/dist/utils/transaction.cjs b/dist/utils/transaction.cjs
+index 9274f4010142362daa258639a514f6beb4611a61..2328055898d6855b1d0d10b5f0c6ef05f1f59a56 100644
+--- a/dist/utils/transaction.cjs
++++ b/dist/utils/transaction.cjs
+@@ -1,10 +1,11 @@
+ "use strict";
+ Object.defineProperty(exports, "__esModule", { value: true });
+-exports.isPredictWithdrawTransaction = exports.collectTransactionIds = exports.updateTransaction = exports.waitForTransactionConfirmed = exports.pollTransactionChanges = exports.getTransaction = exports.FINALIZED_STATUSES = void 0;
++exports.isPredictWithdrawTransaction = exports.collectTransactionIds = exports.updateTransaction = exports.waitForTransactionConfirmed = exports.subscribeAssetChanges = exports.pollTransactionChanges = exports.getTransaction = exports.FINALIZED_STATUSES = void 0;
+ const transaction_controller_1 = require("@metamask/transaction-controller");
+ const utils_1 = require("@metamask/utils");
+ const lodash_1 = require("lodash");
+ const logger_1 = require("../logger.cjs");
++const feature_flags_1 = require("./feature-flags.cjs");
+ const required_tokens_1 = require("./required-tokens.cjs");
+ const log = (0, utils_1.createModuleLogger)(logger_1.projectLogger, 'transaction');
+ exports.FINALIZED_STATUSES = [
+@@ -51,6 +52,39 @@ function pollTransactionChanges(messenger, updateTransactionData, removeTransact
+     }, (state) => state.transactions);
+ }
+ exports.pollTransactionChanges = pollTransactionChanges;
++/**
++ * Subscribe to asset state changes and re-parse required tokens for
++ * in-flight transactions whose tokens have not yet resolved.
++ *
++ * @param messenger - Controller messenger.
++ * @param getControllerState - Callback returning the current controller state.
++ * @param updateTransactionData - Callback to update transaction data.
++ */
++function subscribeAssetChanges(messenger, getControllerState, updateTransactionData) {
++    const buildHandler = (source) => (_state, patches) => {
++        const { transactionData } = getControllerState();
++        for (const [transactionId, data] of Object.entries(transactionData)) {
++            if (data.tokens.length > 0) {
++                continue;
++            }
++            const transaction = getTransaction(transactionId, messenger);
++            if (!transaction || exports.FINALIZED_STATUSES.includes(transaction.status)) {
++                continue;
++            }
++            log('Asset data changed', { transactionId, source, patches });
++            onTransactionChange(transaction, messenger, updateTransactionData);
++        }
++    };
++    if ((0, feature_flags_1.getAssetsUnifyStateFeature)(messenger)) {
++        messenger.subscribe('AssetsController:stateChange', buildHandler('AssetsController'));
++        return;
++    }
++    messenger.subscribe('TokensController:stateChange', buildHandler('TokensController'));
++    messenger.subscribe('TokenRatesController:stateChange', buildHandler('TokenRatesController'));
++    messenger.subscribe('CurrencyRateController:stateChange', buildHandler('CurrencyRateController'));
++}
++exports.subscribeAssetChanges = subscribeAssetChanges;
++
+ /**
+  * Wait for a transaction to be confirmed or fail.
+  *
+diff --git a/dist/utils/transaction.d.cts b/dist/utils/transaction.d.cts
+index 336403441bd828ce81c40304c48207621acb4e0b..9eb3975b7a495dcaed86e57d56779087bcbb55b6 100644
+--- a/dist/utils/transaction.d.cts
++++ b/dist/utils/transaction.d.cts
+@@ -1,7 +1,7 @@
+ import { TransactionStatus } from "@metamask/transaction-controller";
+ import type { TransactionMeta } from "@metamask/transaction-controller";
+ import type { Hex } from "@metamask/utils";
+-import type { TransactionPayControllerMessenger, UpdateTransactionDataCallback } from "../types.cjs";
++import type { TransactionPayControllerMessenger, TransactionPayControllerState, UpdateTransactionDataCallback } from "../types.cjs";
+ export declare const FINALIZED_STATUSES: TransactionStatus[];
+ /**
+  * Retrieve transaction metadata by ID.
+@@ -19,6 +19,15 @@ export declare function getTransaction(transactionId: string, messenger: Transac
+  * @param removeTransactionData - Callback to remove transaction data.
+  */
+ export declare function pollTransactionChanges(messenger: TransactionPayControllerMessenger, updateTransactionData: UpdateTransactionDataCallback, removeTransactionData: (transactionId: string) => void): void;
++/**
++ * Subscribe to asset state changes and re-parse required tokens for
++ * in-flight transactions whose tokens have not yet resolved.
++ *
++ * @param messenger - Controller messenger.
++ * @param getControllerState - Callback returning the current controller state.
++ * @param updateTransactionData - Callback to update transaction data.
++ */
++export declare function subscribeAssetChanges(messenger: TransactionPayControllerMessenger, getControllerState: () => TransactionPayControllerState, updateTransactionData: UpdateTransactionDataCallback): void;
+ /**
+  * Wait for a transaction to be confirmed or fail.
+  *
+diff --git a/dist/utils/transaction.d.mts b/dist/utils/transaction.d.mts
+index e61bbfce52c5444b633f9348d2a8207609087cb7..1fe42e55e97572a7c93294936e5efa0c5acc4468 100644
+--- a/dist/utils/transaction.d.mts
++++ b/dist/utils/transaction.d.mts
+@@ -1,7 +1,7 @@
+ import { TransactionStatus } from "@metamask/transaction-controller";
+ import type { TransactionMeta } from "@metamask/transaction-controller";
+ import type { Hex } from "@metamask/utils";
+-import type { TransactionPayControllerMessenger, UpdateTransactionDataCallback } from "../types.mjs";
++import type { TransactionPayControllerMessenger, TransactionPayControllerState, UpdateTransactionDataCallback } from "../types.mjs";
+ export declare const FINALIZED_STATUSES: TransactionStatus[];
+ /**
+  * Retrieve transaction metadata by ID.
+@@ -19,6 +19,15 @@ export declare function getTransaction(transactionId: string, messenger: Transac
+  * @param removeTransactionData - Callback to remove transaction data.
+  */
+ export declare function pollTransactionChanges(messenger: TransactionPayControllerMessenger, updateTransactionData: UpdateTransactionDataCallback, removeTransactionData: (transactionId: string) => void): void;
++/**
++ * Subscribe to asset state changes and re-parse required tokens for
++ * in-flight transactions whose tokens have not yet resolved.
++ *
++ * @param messenger - Controller messenger.
++ * @param getControllerState - Callback returning the current controller state.
++ * @param updateTransactionData - Callback to update transaction data.
++ */
++export declare function subscribeAssetChanges(messenger: TransactionPayControllerMessenger, getControllerState: () => TransactionPayControllerState, updateTransactionData: UpdateTransactionDataCallback): void;
+ /**
+  * Wait for a transaction to be confirmed or fail.
+  *
+diff --git a/dist/utils/transaction.mjs b/dist/utils/transaction.mjs
+index 2d0fa701cb7ef4a8dddb7034dcdaf06bc33c72b4..a60254ffca20ab8bcb8d1211d19c8a468c0b3f98 100644
+--- a/dist/utils/transaction.mjs
++++ b/dist/utils/transaction.mjs
+@@ -3,6 +3,7 @@ import { createModuleLogger } from "@metamask/utils";
+ import $lodash from "lodash";
+ const { cloneDeep } = $lodash;
+ import { projectLogger } from "../logger.mjs";
++import { getAssetsUnifyStateFeature } from "./feature-flags.mjs";
+ import { parseRequiredTokens } from "./required-tokens.mjs";
+ const log = createModuleLogger(projectLogger, 'transaction');
+ export const FINALIZED_STATUSES = [
+@@ -47,6 +48,39 @@ export function pollTransactionChanges(messenger, updateTransactionData, removeT
+         [...newTransactions, ...updatedTransactions].forEach((tx) => onTransactionChange(tx, messenger, updateTransactionData));
+     }, (state) => state.transactions);
+ }
++
++/**
++ * Subscribe to asset state changes and re-parse required tokens for
++ * in-flight transactions whose tokens have not yet resolved.
++ *
++ * @param messenger - Controller messenger.
++ * @param getControllerState - Callback returning the current controller state.
++ * @param updateTransactionData - Callback to update transaction data.
++ */
++export function subscribeAssetChanges(messenger, getControllerState, updateTransactionData) {
++    const buildHandler = (source) => (_state, patches) => {
++        const { transactionData } = getControllerState();
++        for (const [transactionId, data] of Object.entries(transactionData)) {
++            if (data.tokens.length > 0) {
++                continue;
++            }
++            const transaction = getTransaction(transactionId, messenger);
++            if (!transaction || FINALIZED_STATUSES.includes(transaction.status)) {
++                continue;
++            }
++            log('Asset data changed', { transactionId, source, patches });
++            onTransactionChange(transaction, messenger, updateTransactionData);
++        }
++    };
++    if (getAssetsUnifyStateFeature(messenger)) {
++        messenger.subscribe('AssetsController:stateChange', buildHandler('AssetsController'));
++        return;
++    }
++    messenger.subscribe('TokensController:stateChange', buildHandler('TokensController'));
++    messenger.subscribe('TokenRatesController:stateChange', buildHandler('TokenRatesController'));
++    messenger.subscribe('CurrencyRateController:stateChange', buildHandler('CurrencyRateController'));
++}
++
+ /**
+  * Wait for a transaction to be confirmed or fail.
+  *

--- a/app/scripts/messenger-client-init/messengers/transaction-pay-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/transaction-pay-controller-messenger.ts
@@ -54,7 +54,11 @@ export function getTransactionPayControllerMessenger(
       'KeyringController:signTypedMessage',
     ],
     events: [
+      'AssetsController:stateChange',
       'BridgeStatusController:stateChange',
+      'CurrencyRateController:stateChange',
+      'TokenRatesController:stateChange',
+      'TokensController:stateChange',
       'TransactionController:stateChange',
       'TransactionController:unapprovedTransactionAdded',
     ],

--- a/package.json
+++ b/package.json
@@ -289,7 +289,8 @@
     "@metamask/snaps-controllers": "^20.0.3",
     "@metamask/messenger@npm:^0.3.0": "^1.1.1",
     "@metamask/perps-controller": "^5.0.0",
-    "@metamask/bridge-status-controller@npm:^71.1.0": "patch:@metamask/bridge-status-controller@npm%3A71.0.0#~/.yarn/patches/@metamask-bridge-status-controller-npm-71.0.0-541daf6bed.patch"
+    "@metamask/bridge-status-controller@npm:^71.1.0": "patch:@metamask/bridge-status-controller@npm%3A71.0.0#~/.yarn/patches/@metamask-bridge-status-controller-npm-71.0.0-541daf6bed.patch",
+    "@metamask/transaction-pay-controller@npm:^20.1.0": "patch:@metamask/transaction-pay-controller@npm%3A20.1.0#~/.yarn/patches/@metamask-transaction-pay-controller-npm-20.1.0-1c84c5db4d.patch"
   },
   "dependencies": {
     "@babel/runtime": "patch:@babel/runtime@npm%3A7.26.10#~/.yarn/patches/@babel-runtime-npm-7.26.10-fe8c62510a.patch",

--- a/ui/pages/confirmations/components/confirm/footer/footer.test.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/footer.test.tsx
@@ -49,6 +49,7 @@ jest.mock('../../../hooks/alerts/transactions/useInsufficientBalanceAlerts');
 jest.mock('../../../hooks/gas/useIsGaslessSupported');
 jest.mock('../../../hooks/pay/useTransactionPayData', () => ({
   useIsTransactionPayLoading: jest.fn(() => false),
+  useTransactionPayPrimaryRequiredToken: jest.fn(() => undefined),
   useTransactionPayRequiredTokens: jest.fn(() => []),
 }));
 

--- a/ui/pages/confirmations/components/confirm/footer/single-action-footer.test.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/single-action-footer.test.tsx
@@ -10,7 +10,7 @@ import configureStore from '../../../../../store/store';
 import { Severity } from '../../../../../helpers/constants/design-system';
 import {
   useIsTransactionPayLoading,
-  useTransactionPayRequiredTokens,
+  useTransactionPayPrimaryRequiredToken,
 } from '../../../hooks/pay/useTransactionPayData';
 import { SingleActionFooter } from './single-action-footer';
 
@@ -87,13 +87,10 @@ describe('<SingleActionFooter />', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     jest.mocked(useIsTransactionPayLoading).mockReturnValue(false);
-    jest
-      .mocked(useTransactionPayRequiredTokens)
-      .mockReturnValue([
-        { amountUsd: '10.00', skipIfBalance: false } as ReturnType<
-          typeof useTransactionPayRequiredTokens
-        >[number],
-      ]);
+    jest.mocked(useTransactionPayPrimaryRequiredToken).mockReturnValue({
+      amountUsd: '10.00',
+      skipIfBalance: false,
+    } as ReturnType<typeof useTransactionPayPrimaryRequiredToken>);
   });
 
   it('renders the button', () => {
@@ -179,25 +176,48 @@ describe('<SingleActionFooter />', () => {
   });
 
   it('disables button when amount is zero', () => {
-    jest
-      .mocked(useTransactionPayRequiredTokens)
-      .mockReturnValue([
-        { amountUsd: '0', skipIfBalance: false } as ReturnType<
-          typeof useTransactionPayRequiredTokens
-        >[number],
-      ]);
+    jest.mocked(useTransactionPayPrimaryRequiredToken).mockReturnValue({
+      amountUsd: '0',
+      skipIfBalance: false,
+    } as ReturnType<typeof useTransactionPayPrimaryRequiredToken>);
 
     const { getByTestId } = render();
 
     expect(getByTestId('confirm-footer-button')).toBeDisabled();
   });
 
-  it('disables button when no required tokens exist', () => {
-    jest.mocked(useTransactionPayRequiredTokens).mockReturnValue([]);
+  it('shows disabled loading when primary required token is not yet resolved', () => {
+    jest
+      .mocked(useTransactionPayPrimaryRequiredToken)
+      .mockReturnValue(undefined);
 
     const { getByTestId } = render();
 
-    expect(getByTestId('confirm-footer-button')).toBeDisabled();
+    const button = getByTestId('confirm-footer-button');
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute('aria-busy', 'true');
+  });
+
+  it('shows disabled loading over blocking alerts when awaiting required token', () => {
+    jest
+      .mocked(useTransactionPayPrimaryRequiredToken)
+      .mockReturnValue(undefined);
+
+    const { getByTestId } = render({
+      alerts: [
+        {
+          key: 'some-blocking-alert',
+          severity: Severity.Danger,
+          reason: 'Hardware wallet not supported',
+          message: 'Switch wallets to continue.',
+          isBlocking: true,
+        },
+      ],
+    });
+
+    const button = getByTestId('confirm-footer-button');
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute('aria-busy', 'true');
   });
 
   it('shows Add funds label for perpsDeposit transaction type', () => {

--- a/ui/pages/confirmations/components/confirm/footer/single-action-footer.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/single-action-footer.tsx
@@ -9,7 +9,7 @@ import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { useConfirmContext } from '../../../context/confirm';
 import {
   useIsTransactionPayLoading,
-  useTransactionPayRequiredTokens,
+  useTransactionPayPrimaryRequiredToken,
 } from '../../../hooks/pay/useTransactionPayData';
 import { FlexDirection } from '../../../../../helpers/constants/design-system';
 
@@ -33,51 +33,46 @@ function useSingleActionButtonState(isGaslessLoading: boolean): ButtonState {
 
   const { alerts } = useAlerts(transactionId);
   const isPayLoading = useIsTransactionPayLoading();
-  const requiredTokens = useTransactionPayRequiredTokens();
+  const primaryRequiredToken = useTransactionPayPrimaryRequiredToken();
 
   const blockingAlerts = useMemo(
     () => alerts.filter((a) => a.isBlocking),
     [alerts],
   );
 
-  const hasAmount = useMemo(
-    () =>
-      (requiredTokens ?? [])
-        .filter((token) => !token.skipIfBalance)
-        .reduce(
-          (acc, token) => acc.plus(new BigNumber(token.amountUsd ?? 0)),
-          new BigNumber(0),
-        )
-        .gt(0),
-    [requiredTokens],
-  );
-
   return useMemo(() => {
-    const isLoadingState = isGaslessLoading || isPayLoading;
     const i18nKey =
       (transactionType && BUTTON_TEXT_BY_TYPE[transactionType]) ?? 'confirm';
     const defaultButtonText = t(i18nKey);
 
-    const hasBlockingAlerts = blockingAlerts.length > 0;
-    const isDisabled = hasBlockingAlerts || !hasAmount;
+    const isAwaitingRequiredToken = !primaryRequiredToken;
 
+    const hasBlockingAlerts = blockingAlerts.length > 0;
     const firstAlert = blockingAlerts[0];
     const alertText =
       firstAlert?.reason ?? (firstAlert?.message as string | undefined);
 
-    const buttonText =
-      hasBlockingAlerts && alertText ? alertText : defaultButtonText;
+    const hasAmount = primaryRequiredToken
+      ? new BigNumber(primaryRequiredToken.amountUsd ?? 0).gt(0)
+      : false;
 
-    return {
-      buttonText,
-      isDisabled,
-      isLoading: isLoadingState,
-    };
+    const buttonText =
+      !isAwaitingRequiredToken && hasBlockingAlerts && alertText
+        ? alertText
+        : defaultButtonText;
+
+    const isDisabled =
+      isAwaitingRequiredToken || hasBlockingAlerts || !hasAmount;
+
+    const isLoading =
+      isAwaitingRequiredToken || isGaslessLoading || isPayLoading;
+
+    return { buttonText, isDisabled, isLoading };
   }, [
     blockingAlerts,
-    hasAmount,
     isGaslessLoading,
     isPayLoading,
+    primaryRequiredToken,
     transactionType,
     t,
   ]);
@@ -104,7 +99,7 @@ export const SingleActionFooter = ({
         className="w-full"
         data-testid="confirm-footer-button"
         disabled={isDisabled}
-        isLoading={isLoading && !isDisabled}
+        isLoading={isLoading}
         onClick={isLoading ? undefined : onSubmit}
         size={ButtonSize.Lg}
       >

--- a/ui/pages/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
+++ b/ui/pages/confirmations/components/info/custom-amount-info/custom-amount-info.test.tsx
@@ -24,8 +24,16 @@ jest.mock('../../../hooks/pay/useTransactionPayMetrics');
 jest.mock('../../../hooks/pay/useTransactionPayAvailableTokens');
 jest.mock('../../../hooks/pay/useTransactionPayData');
 jest.mock('../../transactions/custom-amount/custom-amount', () => ({
-  CustomAmount: ({ amountFiat }: { amountFiat: string }) => (
-    <div data-testid="custom-amount">{amountFiat}</div>
+  CustomAmount: ({
+    amountFiat,
+    disabled,
+  }: {
+    amountFiat: string;
+    disabled?: boolean;
+  }) => (
+    <div data-testid="custom-amount" data-disabled={String(Boolean(disabled))}>
+      {amountFiat}
+    </div>
   ),
   CustomAmountSkeleton: () => <div data-testid="custom-amount-skeleton" />,
 }));
@@ -84,31 +92,47 @@ const DEFAULT_ALERTS_HOOK_RETURN: {
   disableUpdate: false,
 };
 
-function render({
-  hasMax = false,
-  disableAutomaticToken,
-  disablePay = false,
-  hidePayTokenAmount = false,
-  availableTokens = [MOCK_AVAILABLE_TOKEN],
-  customAmountHookReturn = DEFAULT_CUSTOM_AMOUNT_HOOK_RETURN,
-  alertsHookReturn = DEFAULT_ALERTS_HOOK_RETURN,
-  isQuotesLoading = false,
-  hasQuotes = false,
-  sourceAmounts = [],
-  requiredTokens = [],
-}: {
-  hasMax?: boolean;
-  disableAutomaticToken?: boolean;
-  disablePay?: boolean;
-  hidePayTokenAmount?: boolean;
-  availableTokens?: (typeof MOCK_AVAILABLE_TOKEN)[];
-  customAmountHookReturn?: typeof DEFAULT_CUSTOM_AMOUNT_HOOK_RETURN;
-  alertsHookReturn?: typeof DEFAULT_ALERTS_HOOK_RETURN;
-  isQuotesLoading?: boolean;
-  hasQuotes?: boolean;
-  sourceAmounts?: { targetTokenAddress: string }[];
-  requiredTokens?: { address: string; skipIfBalance: boolean }[];
-} = {}) {
+const MOCK_PRIMARY_REQUIRED_TOKEN = {
+  address: '0xrequired',
+  skipIfBalance: false,
+  decimals: 18,
+};
+
+function render(
+  options: {
+    hasMax?: boolean;
+    disableAutomaticToken?: boolean;
+    disablePay?: boolean;
+    hidePayTokenAmount?: boolean;
+    availableTokens?: (typeof MOCK_AVAILABLE_TOKEN)[];
+    customAmountHookReturn?: typeof DEFAULT_CUSTOM_AMOUNT_HOOK_RETURN;
+    alertsHookReturn?: typeof DEFAULT_ALERTS_HOOK_RETURN;
+    isQuotesLoading?: boolean;
+    hasQuotes?: boolean;
+    sourceAmounts?: { targetTokenAddress: string }[];
+    requiredTokens?: { address: string; skipIfBalance: boolean }[];
+    primaryRequiredToken?: typeof MOCK_PRIMARY_REQUIRED_TOKEN | undefined;
+  } = {},
+) {
+  const {
+    hasMax = false,
+    disableAutomaticToken,
+    disablePay = false,
+    hidePayTokenAmount = false,
+    availableTokens = [MOCK_AVAILABLE_TOKEN],
+    customAmountHookReturn = DEFAULT_CUSTOM_AMOUNT_HOOK_RETURN,
+    alertsHookReturn = DEFAULT_ALERTS_HOOK_RETURN,
+    isQuotesLoading = false,
+    hasQuotes = false,
+    sourceAmounts = [],
+    requiredTokens = [],
+  } = options;
+  const primaryRequiredToken = Object.prototype.hasOwnProperty.call(
+    options,
+    'primaryRequiredToken',
+  )
+    ? options.primaryRequiredToken
+    : MOCK_PRIMARY_REQUIRED_TOKEN;
   jest
     .mocked(useTransactionCustomAmountModule.useTransactionCustomAmount)
     .mockReturnValue(customAmountHookReturn);
@@ -152,6 +176,13 @@ function render({
     .mockReturnValue(
       sourceAmounts as ReturnType<
         typeof useTransactionPayDataModule.useTransactionPaySourceAmounts
+      >,
+    );
+  jest
+    .mocked(useTransactionPayDataModule.useTransactionPayPrimaryRequiredToken)
+    .mockReturnValue(
+      primaryRequiredToken as ReturnType<
+        typeof useTransactionPayDataModule.useTransactionPayPrimaryRequiredToken
       >,
     );
 
@@ -228,6 +259,52 @@ describe('CustomAmountInfo', () => {
     });
     expect(queryByTestId('pay-token-amount')).not.toBeInTheDocument();
     expect(getByTestId('pay-with-row')).toBeInTheDocument();
+  });
+
+  describe('input disabled state', () => {
+    it('disables the input when no tokens are available', () => {
+      const { getByTestId } = render({ availableTokens: [] });
+
+      expect(getByTestId('custom-amount')).toHaveAttribute(
+        'data-disabled',
+        'true',
+      );
+    });
+  });
+
+  describe('awaiting required token', () => {
+    it('renders the skeleton when pay is enabled but no primary required token is resolved', () => {
+      const { getByTestId, queryByTestId } = render({
+        disablePay: false,
+        primaryRequiredToken: undefined,
+      });
+
+      expect(getByTestId('custom-amount-info-skeleton')).toBeInTheDocument();
+      expect(queryByTestId('custom-amount-info')).not.toBeInTheDocument();
+    });
+
+    it('does not render the skeleton when pay is disabled and no primary required token is resolved', () => {
+      const { getByTestId, queryByTestId } = render({
+        disablePay: true,
+        primaryRequiredToken: undefined,
+      });
+
+      expect(getByTestId('custom-amount-info')).toBeInTheDocument();
+      expect(
+        queryByTestId('custom-amount-info-skeleton'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders the full UI once a primary required token is resolved', () => {
+      const { getByTestId, queryByTestId } = render({
+        disablePay: false,
+      });
+
+      expect(getByTestId('custom-amount-info')).toBeInTheDocument();
+      expect(
+        queryByTestId('custom-amount-info-skeleton'),
+      ).not.toBeInTheDocument();
+    });
   });
 
   it('renders pay with row when tokens available and disablePay is false', () => {
@@ -374,6 +451,13 @@ describe('CustomAmountInfo', () => {
       jest
         .mocked(useTransactionPayDataModule.useTransactionPaySourceAmounts)
         .mockReturnValue([]);
+      jest
+        .mocked(
+          useTransactionPayDataModule.useTransactionPayPrimaryRequiredToken,
+        )
+        .mockReturnValue({ skipIfBalance: false } as ReturnType<
+          typeof useTransactionPayDataModule.useTransactionPayPrimaryRequiredToken
+        >);
 
       const state = getMockConfirmStateForTransaction(MOCK_TRANSACTION_META);
 

--- a/ui/pages/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/ui/pages/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -39,6 +39,7 @@ import { useAutomaticTransactionPayToken } from '../../../hooks/pay/useAutomatic
 import type { SetPayTokenRequest } from '../../../hooks/pay/types';
 import {
   useIsTransactionPayLoading,
+  useTransactionPayPrimaryRequiredToken,
   useTransactionPayQuotes,
 } from '../../../hooks/pay/useTransactionPayData';
 import { useTransactionPayMetrics } from '../../../hooks/pay/useTransactionPayMetrics';
@@ -95,6 +96,8 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = React.memo(
     const { currentConfirmation } = useConfirmContext<TransactionMeta>();
     const availableTokens = useTransactionPayAvailableTokens();
     const hasTokens = availableTokens.length > 0;
+    const primaryRequiredToken = useTransactionPayPrimaryRequiredToken();
+    const isAwaitingRequiredToken = !disablePay && !primaryRequiredToken;
 
     const { disableUpdate } = useTransactionCustomAmountAlerts();
 
@@ -123,7 +126,7 @@ export const CustomAmountInfo: React.FC<CustomAmountInfoProps> = React.memo(
       [updatePendingAmountPercentage],
     );
 
-    if (!currentConfirmation) {
+    if (!currentConfirmation || isAwaitingRequiredToken) {
       return <CustomAmountInfoSkeleton />;
     }
 

--- a/ui/pages/confirmations/components/info/musd-conversion-info/musd-conversion-info.test.tsx
+++ b/ui/pages/confirmations/components/info/musd-conversion-info/musd-conversion-info.test.tsx
@@ -163,6 +163,15 @@ function setupDefaultMocks({
     .mocked(useTransactionPayDataModule.useTransactionPaySourceAmounts)
     .mockReturnValue([]);
   jest
+    .mocked(useTransactionPayDataModule.useTransactionPayPrimaryRequiredToken)
+    .mockReturnValue({
+      address: '0xrequired',
+      skipIfBalance: false,
+      decimals: 18,
+    } as unknown as ReturnType<
+      typeof useTransactionPayDataModule.useTransactionPayPrimaryRequiredToken
+    >);
+  jest
     .mocked(useTransactionPayTokenModule.useTransactionPayToken)
     .mockReturnValue({
       isNative: false,

--- a/ui/pages/confirmations/hooks/transactions/useUpdateTokenAmount.test.ts
+++ b/ui/pages/confirmations/hooks/transactions/useUpdateTokenAmount.test.ts
@@ -208,7 +208,7 @@ describe('useUpdateTokenAmount', () => {
       expect(calledData).toContain('1bc16d674ec80000');
     });
 
-    it('uses 18 decimals as default when no required token found', () => {
+    it('does nothing when no primary required token resolves decimals', () => {
       const transactionMeta = createMockTransactionMeta();
       const { result } = runHook({
         transactionMeta,
@@ -219,7 +219,23 @@ describe('useUpdateTokenAmount', () => {
         result.current.updateTokenAmount('2');
       });
 
-      expect(updateEditableParamsMock).toHaveBeenCalled();
+      expect(updateEditableParamsMock).not.toHaveBeenCalled();
+      expect(updateAtomicBatchDataMock).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when only skipIfBalance required tokens are present', () => {
+      const transactionMeta = createMockTransactionMeta();
+      const { result } = runHook({
+        transactionMeta,
+        requiredTokens: [{ decimals: MOCK_DECIMALS, skipIfBalance: true }],
+      });
+
+      act(() => {
+        result.current.updateTokenAmount('2');
+      });
+
+      expect(updateEditableParamsMock).not.toHaveBeenCalled();
+      expect(updateAtomicBatchDataMock).not.toHaveBeenCalled();
     });
   });
 

--- a/ui/pages/confirmations/hooks/transactions/useUpdateTokenAmount.ts
+++ b/ui/pages/confirmations/hooks/transactions/useUpdateTokenAmount.ts
@@ -50,7 +50,7 @@ export function useUpdateTokenAmount() {
 
   const primaryRequiredToken = useTransactionPayPrimaryRequiredToken();
 
-  const decimals = primaryRequiredToken?.decimals ?? 18;
+  const decimals = primaryRequiredToken?.decimals;
 
   const amountRaw = useMemo(() => {
     if (!data) {
@@ -75,7 +75,7 @@ export function useUpdateTokenAmount() {
 
   const updateTokenAmount = useCallback(
     (amountHuman: string) => {
-      if (!data || !to) {
+      if (!data || !to || decimals === undefined) {
         return;
       }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8540,7 +8540,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-pay-controller@npm:^20.1.0":
+"@metamask/transaction-pay-controller@npm:20.1.0":
   version: 20.1.0
   resolution: "@metamask/transaction-pay-controller@npm:20.1.0"
   dependencies:
@@ -8566,6 +8566,35 @@ __metadata:
     immer: "npm:^9.0.6"
     lodash: "npm:^4.17.21"
   checksum: 10/9c4572673c8eda42eb6f92ac9891ae88a613c7f26d23bfab6bfd489388c2c7a9b1f71e1a5346d68346906b677a0b9933847065b1578683db446d72dc55521f17
+  languageName: node
+  linkType: hard
+
+"@metamask/transaction-pay-controller@patch:@metamask/transaction-pay-controller@npm%3A20.1.0#~/.yarn/patches/@metamask-transaction-pay-controller-npm-20.1.0-1c84c5db4d.patch":
+  version: 20.1.0
+  resolution: "@metamask/transaction-pay-controller@patch:@metamask/transaction-pay-controller@npm%3A20.1.0#~/.yarn/patches/@metamask-transaction-pay-controller-npm-20.1.0-1c84c5db4d.patch::version=20.1.0&hash=200727"
+  dependencies:
+    "@ethersproject/abi": "npm:^5.7.0"
+    "@ethersproject/contracts": "npm:^5.7.0"
+    "@ethersproject/providers": "npm:^5.7.0"
+    "@metamask/assets-controller": "npm:^6.2.1"
+    "@metamask/assets-controllers": "npm:^105.0.0"
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/bridge-controller": "npm:^71.0.0"
+    "@metamask/bridge-status-controller": "npm:^71.1.0"
+    "@metamask/controller-utils": "npm:^11.20.0"
+    "@metamask/gas-fee-controller": "npm:^26.1.1"
+    "@metamask/messenger": "npm:^1.2.0"
+    "@metamask/metamask-eth-abis": "npm:^3.1.1"
+    "@metamask/network-controller": "npm:^30.1.0"
+    "@metamask/ramps-controller": "npm:^13.2.0"
+    "@metamask/remote-feature-flag-controller": "npm:^4.2.0"
+    "@metamask/transaction-controller": "npm:^65.0.0"
+    "@metamask/utils": "npm:^11.9.0"
+    bignumber.js: "npm:^9.1.2"
+    bn.js: "npm:^5.2.1"
+    immer: "npm:^9.0.6"
+    lodash: "npm:^4.17.21"
+  checksum: 10/b930ba47d786cb1d960ee73aebc2fe8d5736fabba0d450e353538e7a7ab5060d21d72e5934b698c9163ebb877e61474f3e14a3d6463fceda4213438ca8ac2c69
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8571,7 +8571,7 @@ __metadata:
 
 "@metamask/transaction-pay-controller@patch:@metamask/transaction-pay-controller@npm%3A20.1.0#~/.yarn/patches/@metamask-transaction-pay-controller-npm-20.1.0-1c84c5db4d.patch":
   version: 20.1.0
-  resolution: "@metamask/transaction-pay-controller@patch:@metamask/transaction-pay-controller@npm%3A20.1.0#~/.yarn/patches/@metamask-transaction-pay-controller-npm-20.1.0-1c84c5db4d.patch::version=20.1.0&hash=200727"
+  resolution: "@metamask/transaction-pay-controller@patch:@metamask/transaction-pay-controller@npm%3A20.1.0#~/.yarn/patches/@metamask-transaction-pay-controller-npm-20.1.0-1c84c5db4d.patch::version=20.1.0&hash=a62708"
   dependencies:
     "@ethersproject/abi": "npm:^5.7.0"
     "@ethersproject/contracts": "npm:^5.7.0"
@@ -8594,7 +8594,7 @@ __metadata:
     bn.js: "npm:^5.2.1"
     immer: "npm:^9.0.6"
     lodash: "npm:^4.17.21"
-  checksum: 10/b930ba47d786cb1d960ee73aebc2fe8d5736fabba0d450e353538e7a7ab5060d21d72e5934b698c9163ebb877e61474f3e14a3d6463fceda4213438ca8ac2c69
+  checksum: 10/dddea782b115d63f122ae72fd2641c52d2a30c99ad866adcc3a695a67dfe0a989f1c17f21a6eab1ab1d414c1917bb73cf2cfaf689609e51cf972f9ca2642bd57
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

Cherry-pick of #42430 onto `release/13.30.0`.

The pay controller change (added in #42430 via a `^22.0.0` bump) is shipped here as a `yarn patch` against `20.1.0` instead, so the release branch picks up no transitive package bumps. See MetaMask/core#8714 for the upstream core fix.

## **Changelog**

CHANGELOG entry: null

## **Manual testing steps**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes confirmation UX and transaction-pay controller event subscriptions; regressions could block confirmations or mis-handle pay token parsing when asset state updates occur.
> 
> **Overview**
> Ensures confirmation flows treat Transaction Pay required-token data as an *async dependency*: the `CustomAmountInfo` panel now renders a skeleton until `useTransactionPayPrimaryRequiredToken` resolves (when Pay is enabled), and `SingleActionFooter` shows a disabled loading state until the required token is available (taking precedence over blocking-alert text).
> 
> Updates token-amount editing to **avoid defaulting decimals**: `useUpdateTokenAmount` now no-ops unless the primary required token provides `decimals`, preventing potentially incorrect ERC-20 amount encoding.
> 
> Adds a Yarn patch for `@metamask/transaction-pay-controller@20.1.0` so in-flight transactions with unresolved required tokens re-parse on asset-related `stateChange` events (Assets unified-state or legacy Tokens/TokenRates/CurrencyRate), and wires the extra events into the TransactionPay controller messenger delegation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76539e939795f40d11fd8da814e8c790d957f371. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->