### PR TITLE
release: Bump main version to 13.32.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metamask-crx",
-  "version": "13.31.0",
+  "version": "13.32.0",
   "private": true,
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Version Bump After Release

This PR bumps the main branch version from 13.31.0 to 13.32.0 after cutting the release branch.

### Why this is needed:
- **Nightly builds**: Each nightly build needs to be one minor version ahead of the current release candidate
- **Version conflicts**: Prevents conflicts between nightlies and release candidates
- **Platform alignment**: Maintains version alignment between MetaMask mobile and extension
- **Update systems**: Ensures nightlies are accepted by app stores and browser update systems

### What changed:
- Version bumped from `13.31.0` to `13.32.0`
- Platform: `extension`
- Files updated by `set-semvar-version.sh` script


CHANGELOG entry: null

### Next steps:
This PR should be **manually reviewed and merged by the release manager** to maintain proper version flow.

### Related:
- Release version: 13.31.0
- Release branch: release/13.31.0
- Platform: extension
- Test mode: false

---
*This PR was manually created to mirror the automated `create-platform-release-pr.sh` script output, because the [Auto Create Release PR run](https://github.com/MetaMask/metamask-extension/actions/runs/25516421334) failed at the changelog step before reaching the version-bump step (see [#42366](https://github.com/MetaMask/metamask-extension/pull/42366) — `approvedGitRepositories` requires Yarn ≥ 4.14, but `github-tools` pins Yarn 4.5.1).*

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a metadata-only `package.json` version bump with no runtime or build logic changes.
> 
> **Overview**
> Updates `package.json` to bump the extension version from `13.31.0` to `13.32.0` to keep `main` ahead of the release branch for nightly builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b83a3eedfce0d46e869d51f01054b44e5db989b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->