### PR TITLE
fix(perps): require single back-button click after order submission cp-13.31.0

### DIFF
--- a/ui/pages/perps/perps-order-entry-page.tsx
+++ b/ui/pages/perps/perps-order-entry-page.tsx
@@ -532,24 +532,24 @@ const PerpsOrderEntryPage: React.FC = () => {
 
     const tpInvalid = Boolean(
       tp?.trim() &&
-        !isValidTakeProfitPrice(tp, {
-          currentPrice: referencePrice,
-          direction: dir,
-        }),
+      !isValidTakeProfitPrice(tp, {
+        currentPrice: referencePrice,
+        direction: dir,
+      }),
     );
     const slInvalid = Boolean(
       sl?.trim() &&
-        !isValidStopLossPrice(sl, {
-          currentPrice: referencePrice,
-          direction: dir,
-        }),
+      !isValidStopLossPrice(sl, {
+        currentPrice: referencePrice,
+        direction: dir,
+      }),
     );
     const slLiquidationInvalid = Boolean(
       sl?.trim() &&
-        !isStopLossSafeFromLiquidation(sl, {
-          liquidationPrice,
-          direction: dir,
-        }),
+      !isStopLossSafeFromLiquidation(sl, {
+        liquidationPrice,
+        direction: dir,
+      }),
     );
 
     return tpInvalid || slInvalid || slLiquidationInvalid;

--- a/ui/pages/perps/perps-order-entry-page.tsx
+++ b/ui/pages/perps/perps-order-entry-page.tsx
@@ -532,24 +532,24 @@ const PerpsOrderEntryPage: React.FC = () => {
 
     const tpInvalid = Boolean(
       tp?.trim() &&
-      !isValidTakeProfitPrice(tp, {
-        currentPrice: referencePrice,
-        direction: dir,
-      }),
+        !isValidTakeProfitPrice(tp, {
+          currentPrice: referencePrice,
+          direction: dir,
+        }),
     );
     const slInvalid = Boolean(
       sl?.trim() &&
-      !isValidStopLossPrice(sl, {
-        currentPrice: referencePrice,
-        direction: dir,
-      }),
+        !isValidStopLossPrice(sl, {
+          currentPrice: referencePrice,
+          direction: dir,
+        }),
     );
     const slLiquidationInvalid = Boolean(
       sl?.trim() &&
-      !isStopLossSafeFromLiquidation(sl, {
-        liquidationPrice,
-        direction: dir,
-      }),
+        !isStopLossSafeFromLiquidation(sl, {
+          liquidationPrice,
+          direction: dir,
+        }),
     );
 
     return tpInvalid || slInvalid || slLiquidationInvalid;
@@ -704,8 +704,6 @@ const PerpsOrderEntryPage: React.FC = () => {
     [setPendingOrder, navigateBack],
   );
 
-
-
   const getTradeActionToastDescription = useCallback(() => {
     if (orderMode === 'modify' || !orderFormState) {
       return undefined;
@@ -729,8 +727,8 @@ const PerpsOrderEntryPage: React.FC = () => {
 
     const rawAmount = formattedPositionSize.endsWith(` ${displayAssetSymbol}`)
       ? formattedPositionSize
-        .slice(0, -` ${displayAssetSymbol}`.length)
-        .trimEnd()
+          .slice(0, -` ${displayAssetSymbol}`.length)
+          .trimEnd()
       : formattedPositionSize;
 
     if (!rawAmount) {
@@ -1118,9 +1116,9 @@ const PerpsOrderEntryPage: React.FC = () => {
       handleBackClick(
         orderFormState.type === 'market'
           ? {
-            pendingOrderSymbol: orderFormState.asset,
-            pendingOrderFilledDescription: tradeActionToastDescription,
-          }
+              pendingOrderSymbol: orderFormState.asset,
+              pendingOrderFilledDescription: tradeActionToastDescription,
+            }
           : undefined,
       );
 

--- a/ui/pages/perps/perps-order-entry-page.tsx
+++ b/ui/pages/perps/perps-order-entry-page.tsx
@@ -672,38 +672,11 @@ const PerpsOrderEntryPage: React.FC = () => {
     livePrice?.percentChange24h ?? market?.change24hPercent ?? '',
   );
 
-  const handleBackClick = useCallback(
-    (extraState?: Partial<PerpsToastRouteState>) => {
-      if (extraState?.pendingOrderSymbol) {
-        setPendingOrder({
-          symbol: extraState.pendingOrderSymbol,
-          filledDescription: extraState.pendingOrderFilledDescription,
-        });
-      }
-
-      if (!decodedSymbol) {
-        return;
-      }
-
-      const marketDetailPath = `${PERPS_MARKET_DETAIL_ROUTE}/${encodeURIComponent(
-        decodedSymbol,
-      )}`;
-
-      // Pending-order data is delivered imperatively via setPendingOrder above.
-      // Avoid route state so browser back/forward cannot replay filled toasts.
-      // Replace (not push) so the just-submitted order-entry page does not
-      // remain in history — otherwise the market-detail back button (which
-      // uses navigate(-1)) would return to a stale post-submit form.
-      navigate(marketDetailPath, { replace: true });
-    },
-    [decodedSymbol, navigate, setPendingOrder],
-  );
-
   // Visible header back button: pop the history stack so the user returns to
   // wherever they came from. Pushing marketDetailPath instead would create a
   // market-detail -> order-entry -> market-detail loop, since the
   // market-detail back button uses navigate(-1).
-  const handleBackButtonClick = useCallback(() => {
+  const navigateBack = useCallback(() => {
     if (typeof window !== 'undefined' && window.history.length > 1) {
       navigate(-1);
       return;
@@ -717,6 +690,21 @@ const PerpsOrderEntryPage: React.FC = () => {
     }
     navigate(DEFAULT_ROUTE, { replace: true });
   }, [decodedSymbol, navigate]);
+
+  const handleBackClick = useCallback(
+    (extraState?: Partial<PerpsToastRouteState>) => {
+      if (extraState?.pendingOrderSymbol) {
+        setPendingOrder({
+          symbol: extraState.pendingOrderSymbol,
+          filledDescription: extraState.pendingOrderFilledDescription,
+        });
+      }
+      navigateBack();
+    },
+    [setPendingOrder, navigateBack],
+  );
+
+
 
   const getTradeActionToastDescription = useCallback(() => {
     if (orderMode === 'modify' || !orderFormState) {
@@ -741,8 +729,8 @@ const PerpsOrderEntryPage: React.FC = () => {
 
     const rawAmount = formattedPositionSize.endsWith(` ${displayAssetSymbol}`)
       ? formattedPositionSize
-          .slice(0, -` ${displayAssetSymbol}`.length)
-          .trimEnd()
+        .slice(0, -` ${displayAssetSymbol}`.length)
+        .trimEnd()
       : formattedPositionSize;
 
     if (!rawAmount) {
@@ -1130,9 +1118,9 @@ const PerpsOrderEntryPage: React.FC = () => {
       handleBackClick(
         orderFormState.type === 'market'
           ? {
-              pendingOrderSymbol: orderFormState.asset,
-              pendingOrderFilledDescription: tradeActionToastDescription,
-            }
+            pendingOrderSymbol: orderFormState.asset,
+            pendingOrderFilledDescription: tradeActionToastDescription,
+          }
           : undefined,
       );
 
@@ -1278,7 +1266,7 @@ const PerpsOrderEntryPage: React.FC = () => {
         <Box paddingLeft={2} paddingBottom={4} paddingTop={4}>
           <Box
             data-testid="perps-order-entry-back-button"
-            onClick={handleBackButtonClick}
+            onClick={() => handleBackClick()}
             aria-label={t('back')}
             className="p-2 cursor-pointer"
           >
@@ -1350,7 +1338,7 @@ const PerpsOrderEntryPage: React.FC = () => {
       >
         <Box
           data-testid="perps-order-entry-back-button"
-          onClick={handleBackButtonClick}
+          onClick={() => handleBackClick()}
           aria-label={t('back')}
           className="w-9 shrink-0 cursor-pointer"
         >


### PR DESCRIPTION
## **Description**

After submitting a perps order, the back button in the order-entry header required two clicks to navigate away. This happened because the post-submit flow used `handleBackClick` which navigated to an explicit `marketDetailPath` via `navigate(replace)`, while the header back button used a separate `handleBackButtonClick` that called `navigate(-1)`. After submit, the explicit route push left a stale entry in the history stack, so the first `navigate(-1)` from the header button simply returned to the just-submitted page.

This PR extracts a shared `navigateBack` helper (history pop with fallback) and rewires `handleBackClick` to call it instead of pushing an explicit route. Both the header back button and the post-submit callback now go through the same code path, so a single click is enough to leave the page.

## **Changelog**

CHANGELOG entry: Fixed a bug where the back button required two clicks after submitting a perps order

## **Related issues**

Fixes: #42528

## **Manual testing steps**

1. Go to any perps market detail page
2. Open the order entry form
3. Submit a market order
4. Click the back button in the header
5. Verify you are navigated back with a single click

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI navigation refactor limited to the perps order-entry page; main risk is unintended back-navigation behavior in edge cases (no history / direct entry).
> 
> **Overview**
> Fixes the perps order-entry back button requiring two clicks after an order submission by **centralizing navigation logic**.
> 
> Introduces a shared `navigateBack` helper (history pop with safe fallbacks) and rewires `handleBackClick` and the header back button to use it, while preserving pending-order toast state via `setPendingOrder`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f26abde297af676b120532604130d12b4e24f636. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->