### PR TITLE
feat: add agent cli daemon stop command

### DIFF
--- a/.claude/skills/metamask-visual-testing/SKILL.md
+++ b/.claude/skills/metamask-visual-testing/SKILL.md
@@ -77,7 +77,7 @@ The `mm` CLI is the primary interface.
 
 | Command                 | Description                            |
 | ----------------------- | -------------------------------------- |
-| `mm launch`             | Launch MetaMask in headed Chrome       |
+| `mm launch`             | Launch MetaMask in headless Chrome     |
 | `mm cleanup`            | Stop browser and services              |
 | `mm cleanup --shutdown` | Stop browser, services, and the daemon |
 | `mm status`             | Show current daemon and session status |

--- a/package.json
+++ b/package.json
@@ -554,7 +554,7 @@
     "@metamask/auto-changelog": "^5.3.1",
     "@metamask/browser-playground": "0.6.2",
     "@metamask/build-utils": "^3.0.0",
-    "@metamask/client-mcp-core": "0.2.0",
+    "@metamask/client-mcp-core": "0.3.0",
     "@metamask/design-system-shared": "^0.16.0",
     "@metamask/eslint-config": "^13.0.0",
     "@metamask/eslint-config-jest": "^13.0.0",

--- a/test/e2e/playwright/llm-workflow/capabilities/state-snapshot.ts
+++ b/test/e2e/playwright/llm-workflow/capabilities/state-snapshot.ts
@@ -13,9 +13,7 @@ export type MetaMaskStateSnapshotCapabilityOptions = {
   defaultChainId?: number;
 };
 
-export class MetaMaskStateSnapshotCapability
-  implements StateSnapshotCapability
-{
+export class MetaMaskStateSnapshotCapability implements StateSnapshotCapability {
   private readonly defaultChainId: number;
 
   constructor(options: MetaMaskStateSnapshotCapabilityOptions = {}) {

--- a/test/e2e/playwright/llm-workflow/capabilities/state-snapshot.ts
+++ b/test/e2e/playwright/llm-workflow/capabilities/state-snapshot.ts
@@ -13,7 +13,9 @@ export type MetaMaskStateSnapshotCapabilityOptions = {
   defaultChainId?: number;
 };
 
-export class MetaMaskStateSnapshotCapability implements StateSnapshotCapability {
+export class MetaMaskStateSnapshotCapability
+  implements StateSnapshotCapability
+{
   private readonly defaultChainId: number;
 
   constructor(options: MetaMaskStateSnapshotCapabilityOptions = {}) {

--- a/test/e2e/playwright/llm-workflow/launcher/state-inspector.test.ts
+++ b/test/e2e/playwright/llm-workflow/launcher/state-inspector.test.ts
@@ -16,30 +16,58 @@ import {
   getBaseExtensionState,
 } from './state-inspector';
 
-const mockGetAccountAddress = jest.fn();
-const mockGetNetworkName = jest.fn();
 const mockGetBalance = jest.fn();
 
 jest.mock('../page-objects/home-page', () => {
   return {
     HomePage: jest.fn().mockImplementation(() => {
       return {
-        getAccountAddress: mockGetAccountAddress,
-        getNetworkName: mockGetNetworkName,
         getBalance: mockGetBalance,
       };
     }),
   };
 });
 
+const DEFAULT_METAMASK_STATE = {
+  internalAccounts: {
+    selectedAccount: 'account-1',
+    accounts: {
+      'account-1': { address: '0xABC123def456' },
+    },
+  },
+  networkConfigurationsByChainId: {
+    '0x539': {
+      name: 'Localhost 8545',
+      chainId: '0x539',
+      rpcEndpoints: [{ networkClientId: 'network-client-1' }],
+    },
+  },
+  selectedNetworkClientId: 'network-client-1',
+};
+
 function buildPage(
   currentUrl = 'chrome-extension://id/home.html',
   visibleBySelector: Record<string, boolean> = {},
   rejectSelectors: string[] = [],
+  cdpMetamaskState: unknown = null,
 ): Page {
   const rejectSet = new Set(rejectSelectors);
+  const mockCdpSend = jest.fn().mockImplementation(() => {
+    if (cdpMetamaskState === null) {
+      return Promise.resolve({ result: {} });
+    }
+    return Promise.resolve({
+      result: { value: JSON.stringify(cdpMetamaskState) },
+    });
+  });
   return {
     url: jest.fn().mockReturnValue(currentUrl),
+    context: jest.fn().mockReturnValue({
+      newCDPSession: jest.fn().mockResolvedValue({
+        send: mockCdpSend,
+        detach: jest.fn().mockResolvedValue(undefined),
+      }),
+    }),
     locator: jest.fn().mockImplementation((selector: string) => {
       return {
         isVisible: jest.fn().mockImplementation(() => {
@@ -56,8 +84,6 @@ function buildPage(
 describe('state-inspector', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockGetAccountAddress.mockResolvedValue('0xabc');
-    mockGetNetworkName.mockResolvedValue('Localhost 8545');
     mockGetBalance.mockResolvedValue('25 ETH');
   });
 
@@ -284,10 +310,13 @@ describe('state-inspector', () => {
       ).rejects.toThrow('Extension not initialized');
     });
 
-    it('returns minimal state for non-home screens', async () => {
-      const page = buildPage('chrome-extension://id/home.html#/send', {
-        '[data-testid="account-menu-icon"]': false,
-      });
+    it('returns identity fields on unlocked non-home screens via stateHooks', async () => {
+      const page = buildPage(
+        'chrome-extension://id/home.html#/send',
+        {},
+        [],
+        DEFAULT_METAMASK_STATE,
+      );
 
       const state = await getBaseExtensionState(page, {
         extensionId: 'a'.repeat(32),
@@ -296,16 +325,22 @@ describe('state-inspector', () => {
 
       expect(state.isLoaded).toBe(true);
       expect(state.extensionId).toBe('a'.repeat(32));
-      expect(state.chainId).toBe(1);
       expect(state.currentScreen).toBe('send');
-      expect(state.accountAddress).toBeNull();
-      expect(state.networkName).toBeNull();
+      expect(state.isUnlocked).toBe(true);
+      expect(state.accountAddress).toBe('0xABC123def456');
+      expect(state.networkName).toBe('Localhost 8545');
+      expect(state.chainId).toBe(1337);
       expect(state.balance).toBeNull();
       expect(HomePage).not.toHaveBeenCalled();
     });
 
-    it('returns home details when unlocked on home', async () => {
-      const page = buildPage('chrome-extension://id/home.html#/');
+    it('returns identity and balance when unlocked on home', async () => {
+      const page = buildPage(
+        'chrome-extension://id/home.html#/',
+        {},
+        [],
+        DEFAULT_METAMASK_STATE,
+      );
 
       const state = await getBaseExtensionState(page, {
         extensionId: 'b'.repeat(32),
@@ -314,10 +349,91 @@ describe('state-inspector', () => {
 
       expect(state.currentScreen).toBe('home');
       expect(state.isUnlocked).toBe(true);
-      expect(state.accountAddress).toBe('0xabc');
+      expect(state.accountAddress).toBe('0xABC123def456');
       expect(state.networkName).toBe('Localhost 8545');
+      expect(state.chainId).toBe(1337);
       expect(state.balance).toBe('25 ETH');
       expect(HomePage).toHaveBeenCalledWith(page);
+    });
+
+    it('returns null identity when CDP session fails', async () => {
+      const page = buildPage('chrome-extension://id/home.html#/');
+      (page.context().newCDPSession as jest.Mock).mockRejectedValue(
+        new Error('Page navigating'),
+      );
+
+      const state = await getBaseExtensionState(page, {
+        extensionId: 'e'.repeat(32),
+        chainId: 1337,
+      });
+
+      expect(state.accountAddress).toBeNull();
+      expect(state.networkName).toBeNull();
+      expect(state.chainId).toBe(1337);
+      expect(state.balance).toBe('25 ETH');
+    });
+
+    it('returns null identity when evaluate returns null', async () => {
+      const page = buildPage('chrome-extension://id/home.html#/', {}, [], null);
+
+      const state = await getBaseExtensionState(page, {
+        extensionId: 'f'.repeat(32),
+        chainId: 1,
+      });
+
+      expect(state.accountAddress).toBeNull();
+      expect(state.networkName).toBeNull();
+      expect(state.chainId).toBe(1);
+    });
+
+    it('parses hex chainId from Redux state to number', async () => {
+      const page = buildPage(
+        'chrome-extension://id/home.html#/',
+        {},
+        [],
+        {
+          ...DEFAULT_METAMASK_STATE,
+          networkConfigurationsByChainId: {
+            '0x1': {
+              name: 'Ethereum Mainnet',
+              chainId: '0x1',
+              rpcEndpoints: [{ networkClientId: 'network-client-1' }],
+            },
+          },
+        },
+      );
+
+      const state = await getBaseExtensionState(page, {
+        extensionId: 'g'.repeat(32),
+        chainId: 1337,
+      });
+
+      expect(state.chainId).toBe(1);
+    });
+
+    it('falls back to options.chainId when Redux chainId is null', async () => {
+      const page = buildPage(
+        'chrome-extension://id/home.html#/',
+        {},
+        [],
+        {
+          ...DEFAULT_METAMASK_STATE,
+          networkConfigurationsByChainId: {
+            '0x539': {
+              name: 'Localhost 8545',
+              chainId: null,
+              rpcEndpoints: [{ networkClientId: 'network-client-1' }],
+            },
+          },
+        },
+      );
+
+      const state = await getBaseExtensionState(page, {
+        extensionId: 'h'.repeat(32),
+        chainId: 42,
+      });
+
+      expect(state.chainId).toBe(42);
     });
 
     it('returns isUnlocked: true when URL is home even if account-menu-icon not visible', async () => {
@@ -349,6 +465,27 @@ describe('state-inspector', () => {
 
       expect(state.currentScreen).toBe('onboarding-welcome');
       expect(state.isUnlocked).toBe(false);
+    });
+
+    it('extracts identity even when locked but skips balance', async () => {
+      const page = buildPage(
+        'chrome-extension://id/home.html#/unlock',
+        {},
+        [],
+        DEFAULT_METAMASK_STATE,
+      );
+
+      const state = await getBaseExtensionState(page, {
+        extensionId: 'i'.repeat(32),
+        chainId: 1,
+      });
+
+      expect(state.isUnlocked).toBe(false);
+      expect(state.accountAddress).toBe('0xABC123def456');
+      expect(state.networkName).toBe('Localhost 8545');
+      expect(state.chainId).toBe(1337);
+      expect(state.balance).toBeNull();
+      expect(HomePage).not.toHaveBeenCalled();
     });
   });
 });

--- a/test/e2e/playwright/llm-workflow/launcher/state-inspector.test.ts
+++ b/test/e2e/playwright/llm-workflow/launcher/state-inspector.test.ts
@@ -387,21 +387,16 @@ describe('state-inspector', () => {
     });
 
     it('parses hex chainId from Redux state to number', async () => {
-      const page = buildPage(
-        'chrome-extension://id/home.html#/',
-        {},
-        [],
-        {
-          ...DEFAULT_METAMASK_STATE,
-          networkConfigurationsByChainId: {
-            '0x1': {
-              name: 'Ethereum Mainnet',
-              chainId: '0x1',
-              rpcEndpoints: [{ networkClientId: 'network-client-1' }],
-            },
+      const page = buildPage('chrome-extension://id/home.html#/', {}, [], {
+        ...DEFAULT_METAMASK_STATE,
+        networkConfigurationsByChainId: {
+          '0x1': {
+            name: 'Ethereum Mainnet',
+            chainId: '0x1',
+            rpcEndpoints: [{ networkClientId: 'network-client-1' }],
           },
         },
-      );
+      });
 
       const state = await getBaseExtensionState(page, {
         extensionId: 'g'.repeat(32),
@@ -412,21 +407,16 @@ describe('state-inspector', () => {
     });
 
     it('falls back to options.chainId when Redux chainId is null', async () => {
-      const page = buildPage(
-        'chrome-extension://id/home.html#/',
-        {},
-        [],
-        {
-          ...DEFAULT_METAMASK_STATE,
-          networkConfigurationsByChainId: {
-            '0x539': {
-              name: 'Localhost 8545',
-              chainId: null,
-              rpcEndpoints: [{ networkClientId: 'network-client-1' }],
-            },
+      const page = buildPage('chrome-extension://id/home.html#/', {}, [], {
+        ...DEFAULT_METAMASK_STATE,
+        networkConfigurationsByChainId: {
+          '0x539': {
+            name: 'Localhost 8545',
+            chainId: null,
+            rpcEndpoints: [{ networkClientId: 'network-client-1' }],
           },
         },
-      );
+      });
 
       const state = await getBaseExtensionState(page, {
         extensionId: 'h'.repeat(32),

--- a/test/e2e/playwright/llm-workflow/launcher/state-inspector.ts
+++ b/test/e2e/playwright/llm-workflow/launcher/state-inspector.ts
@@ -280,8 +280,7 @@ function resolveIdentity(metamaskState: MetamaskStateSlice): IdentityData {
   const networkConfig =
     configs.find((cfg) =>
       cfg.rpcEndpoints?.some(
-        (ep) =>
-          ep.networkClientId === metamaskState.selectedNetworkClientId,
+        (ep) => ep.networkClientId === metamaskState.selectedNetworkClientId,
       ),
     ) ?? null;
 
@@ -292,9 +291,7 @@ function resolveIdentity(metamaskState: MetamaskStateSlice): IdentityData {
   };
 }
 
-async function extractIdentityViaCDP(
-  page: Page,
-): Promise<IdentityData | null> {
+async function extractIdentityViaCDP(page: Page): Promise<IdentityData | null> {
   let cdp;
   try {
     cdp = await page.context().newCDPSession(page);

--- a/test/e2e/playwright/llm-workflow/launcher/state-inspector.ts
+++ b/test/e2e/playwright/llm-workflow/launcher/state-inspector.ts
@@ -23,6 +23,13 @@ import {
   SIGNATURE_REQUEST_PATH,
   UNLOCK_ROUTE,
 } from '../../../../../ui/helpers/constants/routes';
+import type { AccountsState } from '../../../../../ui/selectors/accounts';
+import { getMaybeSelectedInternalAccount } from '../../../../../ui/selectors/accounts';
+import type { ProviderConfigState } from '../../../../../shared/lib/selectors/networks';
+import {
+  getProviderConfig,
+  getNetworkConfigurationsByChainId,
+} from '../../../../../shared/lib/selectors/networks';
 import type { ExtensionState } from '../launcher-types';
 import { HomePage } from '../page-objects/home-page';
 
@@ -246,48 +253,42 @@ const CDP_FETCH_METAMASK_STATE = `
 })()
 `.trim();
 
-type MetamaskStateSlice = {
-  internalAccounts?: {
-    selectedAccount?: string;
-    accounts?: Record<string, { address?: string }>;
-  };
-  networkConfigurationsByChainId?: Record<
-    string,
-    {
-      name?: string;
-      chainId?: string | null;
-      rpcEndpoints?: { networkClientId?: string }[];
-    }
-  >;
-  selectedNetworkClientId?: string;
-};
-
 type IdentityData = {
   accountAddress: string | null;
   networkName: string | null;
   chainId: string | null;
 };
 
-function resolveIdentity(metamaskState: MetamaskStateSlice): IdentityData {
-  const selectedId = metamaskState.internalAccounts?.selectedAccount;
-  const account = selectedId
-    ? metamaskState.internalAccounts?.accounts?.[selectedId]
-    : null;
+// The CDP-fetched metamask slice is cast to the selector state types so that
+// identity extraction reuses the same logic as the extension UI. This keeps
+// the inspector in sync with future state-shape changes automatically.
+type SelectorState = AccountsState & ProviderConfigState;
 
-  const configs = Object.values(
-    metamaskState.networkConfigurationsByChainId ?? {},
-  );
-  const networkConfig =
-    configs.find((cfg) =>
-      cfg.rpcEndpoints?.some(
-        (ep) => ep.networkClientId === metamaskState.selectedNetworkClientId,
-      ),
-    ) ?? null;
+function resolveIdentity(
+  metamaskState: Record<string, unknown>,
+): IdentityData {
+  const state = { metamask: metamaskState } as SelectorState;
+
+  const selectedAccount = getMaybeSelectedInternalAccount(state);
+
+  let networkName: string | null = null;
+  let chainId: string | null = null;
+  try {
+    const providerConfig = getProviderConfig(state);
+    chainId = providerConfig.chainId ?? null;
+    // getProviderConfig returns nickname only for custom RPC endpoints.
+    // Fall back to the canonical network name for built-in networks.
+    const configs = getNetworkConfigurationsByChainId(state);
+    networkName =
+      providerConfig.nickname ?? configs[providerConfig.chainId]?.name ?? null;
+  } catch {
+    // getProviderConfig throws when configuration is not found
+  }
 
   return {
-    accountAddress: account?.address ?? null,
-    networkName: networkConfig?.name ?? null,
-    chainId: networkConfig?.chainId ?? null,
+    accountAddress: selectedAccount?.address ?? null,
+    networkName,
+    chainId,
   };
 }
 
@@ -314,7 +315,7 @@ async function extractIdentityViaCDP(page: Page): Promise<IdentityData | null> {
       return null;
     }
 
-    return resolveIdentity(parsed as MetamaskStateSlice);
+    return resolveIdentity(parsed as Record<string, unknown>);
   } catch {
     return null;
   } finally {

--- a/test/e2e/playwright/llm-workflow/launcher/state-inspector.ts
+++ b/test/e2e/playwright/llm-workflow/launcher/state-inspector.ts
@@ -256,7 +256,7 @@ type MetamaskStateSlice = {
     {
       name?: string;
       chainId?: string | null;
-      rpcEndpoints?: Array<{ networkClientId?: string }>;
+      rpcEndpoints?: { networkClientId?: string }[];
     }
   >;
   selectedNetworkClientId?: string;
@@ -321,7 +321,7 @@ async function extractIdentityViaCDP(
   } catch {
     return null;
   } finally {
-    await cdp?.detach().catch(() => {});
+    await cdp?.detach().catch(() => undefined);
   }
 }
 
@@ -342,7 +342,7 @@ export async function getBaseExtensionState(
 
   let accountAddress: string | null = null;
   let networkName: string | null = null;
-  let chainId: number | null = options.chainId;
+  let { chainId } = options;
   let balance: string | null = null;
 
   const identity = await extractIdentityViaCDP(page);

--- a/test/e2e/playwright/llm-workflow/launcher/state-inspector.ts
+++ b/test/e2e/playwright/llm-workflow/launcher/state-inspector.ts
@@ -234,6 +234,97 @@ export async function detectUnlockState(
     .catch(() => false);
 }
 
+// Fetches the raw metamask Redux state via stateHooks. Uses CDP
+// Runtime.evaluate directly because Playwright's page.evaluate() wrapper
+// references setInterval internally, which is blocked by LavaMoat scuttling.
+const CDP_FETCH_METAMASK_STATE = `
+(async () => {
+  const hooks = globalThis.stateHooks;
+  if (typeof hooks?.getCleanAppState !== 'function') return null;
+  const state = await hooks.getCleanAppState();
+  return JSON.stringify(state?.metamask ?? null);
+})()
+`.trim();
+
+type MetamaskStateSlice = {
+  internalAccounts?: {
+    selectedAccount?: string;
+    accounts?: Record<string, { address?: string }>;
+  };
+  networkConfigurationsByChainId?: Record<
+    string,
+    {
+      name?: string;
+      chainId?: string | null;
+      rpcEndpoints?: Array<{ networkClientId?: string }>;
+    }
+  >;
+  selectedNetworkClientId?: string;
+};
+
+type IdentityData = {
+  accountAddress: string | null;
+  networkName: string | null;
+  chainId: string | null;
+};
+
+function resolveIdentity(metamaskState: MetamaskStateSlice): IdentityData {
+  const selectedId = metamaskState.internalAccounts?.selectedAccount;
+  const account = selectedId
+    ? metamaskState.internalAccounts?.accounts?.[selectedId]
+    : null;
+
+  const configs = Object.values(
+    metamaskState.networkConfigurationsByChainId ?? {},
+  );
+  const networkConfig =
+    configs.find((cfg) =>
+      cfg.rpcEndpoints?.some(
+        (ep) =>
+          ep.networkClientId === metamaskState.selectedNetworkClientId,
+      ),
+    ) ?? null;
+
+  return {
+    accountAddress: account?.address ?? null,
+    networkName: networkConfig?.name ?? null,
+    chainId: networkConfig?.chainId ?? null,
+  };
+}
+
+async function extractIdentityViaCDP(
+  page: Page,
+): Promise<IdentityData | null> {
+  let cdp;
+  try {
+    cdp = await page.context().newCDPSession(page);
+    const result = await cdp.send('Runtime.evaluate', {
+      expression: CDP_FETCH_METAMASK_STATE,
+      awaitPromise: true,
+      returnByValue: true,
+    });
+
+    if (result.exceptionDetails || !result.result?.value) {
+      return null;
+    }
+
+    const parsed =
+      typeof result.result.value === 'string'
+        ? JSON.parse(result.result.value)
+        : result.result.value;
+
+    if (!parsed || typeof parsed !== 'object') {
+      return null;
+    }
+
+    return resolveIdentity(parsed as MetamaskStateSlice);
+  } catch {
+    return null;
+  } finally {
+    await cdp?.detach().catch(() => {});
+  }
+}
+
 export async function getBaseExtensionState(
   page: Page | undefined,
   options: {
@@ -251,14 +342,27 @@ export async function getBaseExtensionState(
 
   let accountAddress: string | null = null;
   let networkName: string | null = null;
-  const { chainId } = options;
+  let chainId: number | null = options.chainId;
   let balance: string | null = null;
 
-  if (currentScreen === 'home' && isUnlocked) {
-    const homePage = new HomePage(page);
+  const identity = await extractIdentityViaCDP(page);
 
-    accountAddress = (await homePage.getAccountAddress()) || null;
-    networkName = (await homePage.getNetworkName()) || null;
+  if (identity) {
+    accountAddress = identity.accountAddress;
+    networkName = identity.networkName;
+
+    if (identity.chainId) {
+      const parsed = Number(identity.chainId);
+      if (!Number.isNaN(parsed)) {
+        chainId = parsed;
+      }
+    }
+  }
+
+  // Balance remains DOM-based (home screen only) pending a separate
+  // investigation into extracting it from Redux state.
+  if (isUnlocked && currentScreen === 'home') {
+    const homePage = new HomePage(page);
     balance = (await homePage.getBalance()) || null;
   }
 

--- a/test/e2e/playwright/llm-workflow/launcher/state-inspector.ts
+++ b/test/e2e/playwright/llm-workflow/launcher/state-inspector.ts
@@ -264,9 +264,7 @@ type IdentityData = {
 // the inspector in sync with future state-shape changes automatically.
 type SelectorState = AccountsState & ProviderConfigState;
 
-function resolveIdentity(
-  metamaskState: Record<string, unknown>,
-): IdentityData {
+function resolveIdentity(metamaskState: Record<string, unknown>): IdentityData {
   const state = { metamask: metamaskState } as SelectorState;
 
   const selectedAccount = getMaybeSelectedInternalAccount(state);

--- a/test/e2e/playwright/llm-workflow/page-objects/home-page.ts
+++ b/test/e2e/playwright/llm-workflow/page-objects/home-page.ts
@@ -9,18 +9,6 @@ export class HomePage {
 
   private readonly sendButton: Locator;
 
-  private readonly networkPicker: Locator;
-
-  private readonly networkPickerLabel: Locator;
-
-  private readonly networkSubtitle: Locator;
-
-  private readonly networkDisplay: Locator;
-
-  private readonly addressCopyButton: Locator;
-
-  private readonly selectedAccountAddress: Locator;
-
   private readonly ethPrimaryCurrency: Locator;
 
   private readonly ethSecondaryCurrency: Locator;
@@ -37,22 +25,6 @@ export class HomePage {
       '[data-testid="account-options-menu-button"]',
     );
     this.sendButton = page.locator('[data-testid="coin-overview-send"]');
-
-    this.networkPicker = page.locator('.mm-picker-network');
-    this.networkPickerLabel = page.locator(
-      '[data-testid="picker-network-label"]',
-    );
-    this.networkSubtitle = page.locator(
-      '[data-testid="networks-subtitle-test-id"]',
-    );
-    this.networkDisplay = page.locator('[data-testid="network-display"]');
-
-    this.addressCopyButton = page.locator(
-      '[data-testid="address-copy-button-text"]',
-    );
-    this.selectedAccountAddress = page.locator(
-      '[data-testid="selected-account-address"]',
-    );
 
     this.ethPrimaryCurrency = page.locator(
       '[data-testid="eth-overview__primary-currency"]',
@@ -116,110 +88,6 @@ export class HomePage {
       }
       if (coinPrimary) {
         return coinPrimary.trim();
-      }
-
-      return '';
-    } catch {
-      return '';
-    }
-  }
-
-  /**
-   * Returns network name using fallback chain:
-   * networkPickerLabel → networkSubtitle → networkDisplay → networkPicker aria-label
-   */
-  async getNetworkName(): Promise<string> {
-    try {
-      if (
-        await this.networkPickerLabel
-          .isVisible({ timeout: 1500 })
-          .catch(() => false)
-      ) {
-        const text = await this.networkPickerLabel.textContent();
-        if (text?.trim()) {
-          return text.trim();
-        }
-      }
-
-      if (
-        await this.networkSubtitle
-          .isVisible({ timeout: 1500 })
-          .catch(() => false)
-      ) {
-        const text = await this.networkSubtitle.textContent();
-        if (text?.trim()) {
-          return text.trim();
-        }
-      }
-
-      if (
-        await this.networkDisplay
-          .isVisible({ timeout: 1500 })
-          .catch(() => false)
-      ) {
-        const text = await this.networkDisplay.textContent();
-        if (text?.trim()) {
-          return text.trim();
-        }
-      }
-
-      if (
-        await this.networkPicker.isVisible({ timeout: 1500 }).catch(() => false)
-      ) {
-        const ariaLabel = await this.networkPicker.getAttribute('aria-label');
-        if (ariaLabel?.trim()) {
-          return ariaLabel.trim();
-        }
-
-        const innerText = await this.networkPicker.innerText();
-        if (innerText?.trim()) {
-          return innerText.trim();
-        }
-      }
-
-      return '';
-    } catch {
-      return '';
-    }
-  }
-
-  /**
-   * Returns account address. May return shortened address depending on UI state.
-   * Falls back: addressCopyButton (title/data-address/text) → selectedAccountAddress
-   */
-  async getAccountAddress(): Promise<string> {
-    try {
-      if (
-        await this.addressCopyButton
-          .isVisible({ timeout: 2000 })
-          .catch(() => false)
-      ) {
-        const title = await this.addressCopyButton.getAttribute('title');
-        if (title?.startsWith('0x')) {
-          return title;
-        }
-
-        const dataAddress =
-          await this.addressCopyButton.getAttribute('data-address');
-        if (dataAddress?.startsWith('0x')) {
-          return dataAddress;
-        }
-
-        const text = await this.addressCopyButton.textContent();
-        if (text?.trim()) {
-          return text.trim();
-        }
-      }
-
-      if (
-        await this.selectedAccountAddress
-          .isVisible({ timeout: 2000 })
-          .catch(() => false)
-      ) {
-        const text = await this.selectedAccountAddress.textContent();
-        if (text?.trim()) {
-          return text.trim();
-        }
       }
 
       return '';

--- a/yarn.lock
+++ b/yarn.lock
@@ -6084,9 +6084,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/client-mcp-core@npm:0.2.0":
-  version: 0.2.0
-  resolution: "@metamask/client-mcp-core@npm:0.2.0"
+"@metamask/client-mcp-core@npm:0.3.0":
+  version: 0.3.0
+  resolution: "@metamask/client-mcp-core@npm:0.3.0"
   dependencies:
     cosmiconfig: "npm:^9.0.0"
     express: "npm:^5.2.1"
@@ -6096,7 +6096,7 @@ __metadata:
     playwright: ^1.49.0
   bin:
     mm: ./dist/cli/mm.cjs
-  checksum: 10/d5c0a56e92e21d9ef242a3ba80f452bfb1c1bfe15939bcb0790998cb7f3698f55e41a3cdced7aec4a298c724a3c1789e871bbb1d458fc25731bdd4c171b7ed84
+  checksum: 10/58f070b64ac3188e36fcb6a26d7b64e94e6cfa1ca8ebbde7fa09a8e4263150bb4e3a0a6b3e1e46e97942eaa2f8357819295898a79420c7c5ff3cfbdd30112a8c
   languageName: node
   linkType: hard
 
@@ -34121,7 +34121,7 @@ __metadata:
     "@metamask/chain-agnostic-permission": "npm:^1.5.0"
     "@metamask/claims-controller": "npm:^0.4.2"
     "@metamask/client-controller": "npm:^1.0.0"
-    "@metamask/client-mcp-core": "npm:0.2.0"
+    "@metamask/client-mcp-core": "npm:0.3.0"
     "@metamask/connectivity-controller": "npm:^0.1.0"
     "@metamask/contract-metadata": "npm:^2.5.0"
     "@metamask/controller-utils": "npm:^11.18.0"


### PR DESCRIPTION
## **Description**

Refactors the LLM workflow **state inspector** to extract wallet identity (account address, network name, chain ID) from **Redux state via CDP `Runtime.evaluate`** instead of fragile DOM scraping through page objects.

**Why:** The previous approach used `HomePage.getAccountAddress()` and `HomePage.getNetworkName()` which relied on specific DOM selectors (`[data-testid="address-copy-button-text"]`, `[data-testid="picker-network-label"]`, etc.) that only worked on the home screen and broke whenever UI layout changed. By reading directly from `stateHooks.getCleanAppState()` via a CDP session, identity extraction now works on **any screen** (send, swap, settings, etc.) and is resilient to UI changes.

Additionally:
- Upgrades `@metamask/client-mcp-core` from `0.2.0` → `0.3.0`
- Fixes a typo in the visual testing skill (`headed` → `headless`)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Run state inspector unit tests: `yarn jest test/e2e/playwright/llm-workflow/launcher/state-inspector.test.ts`
2. Verify all pass, including new cases for CDP failure fallback, hex chainId parsing, and locked-state identity extraction.

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Playwright LLM workflow state detection to rely on CDP `Runtime.evaluate` and Redux selectors for identity fields, which can be sensitive to CDP/session timing and state shape changes, though it’s limited to test tooling. Also bumps an internal CLI dependency version which may affect the `mm` daemon/CLI behavior in CI.
> 
> **Overview**
> Updates the LLM workflow `state-inspector` to extract wallet identity (**account address, network name, chain id**) from Redux via a CDP `Runtime.evaluate` call to `stateHooks.getCleanAppState()`, instead of relying on home-screen DOM scraping; balance remains DOM-based on `home` only.
> 
> Expands unit coverage for identity extraction across non-home and locked screens, plus failure/edge cases (CDP session failure, null evaluate result, hex chainId parsing and fallback). Separately, removes `HomePage` DOM helpers for address/network, bumps `@metamask/client-mcp-core` `0.2.0` → `0.3.0`, and fixes a doc typo (`headed` → `headless`) in the visual testing skill.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66637762753c5dfe68951fd3e6b2bb5bdb05202f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->