### PR TITLE
feat(confirmations): support flagged Perps withdraw tokens and fees

### DIFF
--- a/shared/lib/transactions.utils.test.ts
+++ b/shared/lib/transactions.utils.test.ts
@@ -6,6 +6,8 @@ import {
 import {
   isBatchTransaction,
   hasTransactionType,
+  getPostQuoteWithdrawTransactionType,
+  isPostQuoteWithdrawTransaction,
   isPerpsWithdrawTransaction,
 } from './transactions.utils';
 
@@ -148,6 +150,53 @@ describe('Transactions utils', () => {
 
     it('returns false when transactionMeta is undefined', () => {
       expect(isPerpsWithdrawTransaction(undefined)).toBe(false);
+    });
+  });
+
+  describe('getPostQuoteWithdrawTransactionType', () => {
+    it('returns perpsWithdraw when type is perpsWithdraw', () => {
+      const transactionMeta = {
+        type: TransactionType.perpsWithdraw,
+      } as TransactionMeta;
+
+      expect(getPostQuoteWithdrawTransactionType(transactionMeta)).toBe(
+        TransactionType.perpsWithdraw,
+      );
+    });
+
+    it('returns perpsWithdraw when a nested transaction is perpsWithdraw', () => {
+      const transactionMeta = {
+        type: TransactionType.batch,
+        nestedTransactions: [{ type: TransactionType.perpsWithdraw }],
+      } as unknown as TransactionMeta;
+
+      expect(getPostQuoteWithdrawTransactionType(transactionMeta)).toBe(
+        TransactionType.perpsWithdraw,
+      );
+    });
+
+    it('returns undefined for unrelated transaction types', () => {
+      const transactionMeta = {
+        type: TransactionType.simpleSend,
+      } as TransactionMeta;
+
+      expect(getPostQuoteWithdrawTransactionType(transactionMeta)).toBe(
+        undefined,
+      );
+    });
+  });
+
+  describe('isPostQuoteWithdrawTransaction', () => {
+    it('returns true when the transaction has a post-quote withdraw type', () => {
+      const transactionMeta = {
+        type: TransactionType.perpsWithdraw,
+      } as TransactionMeta;
+
+      expect(isPostQuoteWithdrawTransaction(transactionMeta)).toBe(true);
+    });
+
+    it('returns false when transactionMeta is undefined', () => {
+      expect(isPostQuoteWithdrawTransaction(undefined)).toBe(false);
     });
   });
 });

--- a/shared/lib/transactions.utils.ts
+++ b/shared/lib/transactions.utils.ts
@@ -40,7 +40,42 @@ export function hasTransactionType(
   );
 }
 
+export const POST_QUOTE_WITHDRAW_TRANSACTION_TYPES = [
+  TransactionType.perpsWithdraw,
+] as const;
+
 const PERPS_WITHDRAW_TYPES: TransactionType[] = [TransactionType.perpsWithdraw];
+
+/**
+ * Returns the matching post-quote withdraw transaction type.
+ *
+ * Keep this list-backed helper close to `hasTransactionType` so future
+ * post-quote withdraw flows can opt into the same token-list behavior by
+ * adding their transaction type to `POST_QUOTE_WITHDRAW_TRANSACTION_TYPES`.
+ *
+ * @param transactionMeta - The transaction metadata to check.
+ * @returns The matching post-quote withdraw transaction type, if any.
+ */
+export function getPostQuoteWithdrawTransactionType(
+  transactionMeta: TransactionMeta | undefined,
+): TransactionType | undefined {
+  return POST_QUOTE_WITHDRAW_TRANSACTION_TYPES.find((transactionType) =>
+    hasTransactionType(transactionMeta, [transactionType]),
+  );
+}
+
+/**
+ * Checks whether the given transaction is a post-quote withdraw transaction,
+ * either directly via `type` or via any `nestedTransactions` entry.
+ *
+ * @param transactionMeta - The transaction metadata to check.
+ * @returns Whether the transaction is a post-quote withdraw.
+ */
+export function isPostQuoteWithdrawTransaction(
+  transactionMeta: TransactionMeta | undefined,
+): boolean {
+  return Boolean(getPostQuoteWithdrawTransactionType(transactionMeta));
+}
 
 /**
  * Checks whether the given transaction is a Perps withdraw, either directly

--- a/ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.test.tsx
+++ b/ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.test.tsx
@@ -7,7 +7,7 @@ import mockState from '../../../../../../test/data/mock-state.json';
 import configureStore from '../../../../../store/store';
 import { useTransactionPayToken } from '../../../hooks/pay/useTransactionPayToken';
 import { useTransactionPayRequiredTokens } from '../../../hooks/pay/useTransactionPayData';
-import { useWithdrawTokenFilter } from '../../../hooks/pay/useWithdrawTokenFilter';
+import { usePostQuoteWithdrawTokenFilter } from '../../../hooks/pay/useWithdrawTokenFilter';
 import { getAvailableTokens } from '../../../utils/transaction-pay';
 import {
   useMusdConversionTokens,
@@ -115,7 +115,9 @@ describe('PayWithModal', () => {
   const useMusdConversionTokensMock = jest.mocked(useMusdConversionTokens);
   const useMusdPaymentTokenMock = jest.mocked(useMusdPaymentToken);
   const useConfirmContextMock = jest.mocked(useConfirmContext);
-  const useWithdrawTokenFilterMock = jest.mocked(useWithdrawTokenFilter);
+  const usePostQuoteWithdrawTokenFilterMock = jest.mocked(
+    usePostQuoteWithdrawTokenFilter,
+  );
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -125,7 +127,7 @@ describe('PayWithModal', () => {
     } as ReturnType<typeof useConfirmContext>);
 
     getAvailableTokensMock.mockImplementation(({ tokens }) => tokens as never);
-    useWithdrawTokenFilterMock.mockReturnValue({
+    usePostQuoteWithdrawTokenFilterMock.mockReturnValue({
       filterTokens: (tokens) => tokens,
       isFilterApplied: false,
     });
@@ -336,7 +338,7 @@ describe('PayWithModal', () => {
       const withdrawTokenFilterMock = jest
         .fn()
         .mockReturnValue([PERPS_WITHDRAW_TOKEN]);
-      useWithdrawTokenFilterMock.mockReturnValue({
+      usePostQuoteWithdrawTokenFilterMock.mockReturnValue({
         filterTokens: withdrawTokenFilterMock,
         isFilterApplied: true,
       });

--- a/ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.test.tsx
+++ b/ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.test.tsx
@@ -130,6 +130,7 @@ describe('PayWithModal', () => {
     usePostQuoteWithdrawTokenFilterMock.mockReturnValue({
       filterTokens: (tokens) => tokens,
       isFilterApplied: false,
+      isTokenAllowed: () => false,
     });
     useTransactionPayRequiredTokensMock.mockReturnValue([]);
     useMusdConversionTokensMock.mockReturnValue({
@@ -341,6 +342,7 @@ describe('PayWithModal', () => {
       usePostQuoteWithdrawTokenFilterMock.mockReturnValue({
         filterTokens: withdrawTokenFilterMock,
         isFilterApplied: true,
+        isTokenAllowed: () => true,
       });
 
       renderModal({ isOpen: true, onClose: onCloseMock });

--- a/ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.test.tsx
+++ b/ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.test.tsx
@@ -7,6 +7,7 @@ import mockState from '../../../../../../test/data/mock-state.json';
 import configureStore from '../../../../../store/store';
 import { useTransactionPayToken } from '../../../hooks/pay/useTransactionPayToken';
 import { useTransactionPayRequiredTokens } from '../../../hooks/pay/useTransactionPayData';
+import { useWithdrawTokenFilter } from '../../../hooks/pay/useWithdrawTokenFilter';
 import { getAvailableTokens } from '../../../utils/transaction-pay';
 import {
   useMusdConversionTokens,
@@ -21,6 +22,7 @@ import { PayWithModal } from './pay-with-modal';
 
 jest.mock('../../../hooks/pay/useTransactionPayToken');
 jest.mock('../../../hooks/pay/useTransactionPayData');
+jest.mock('../../../hooks/pay/useWithdrawTokenFilter');
 jest.mock('../../../utils/transaction-pay');
 jest.mock('../../../../../hooks/musd');
 jest.mock('../../../context/confirm', () => ({
@@ -113,6 +115,7 @@ describe('PayWithModal', () => {
   const useMusdConversionTokensMock = jest.mocked(useMusdConversionTokens);
   const useMusdPaymentTokenMock = jest.mocked(useMusdPaymentToken);
   const useConfirmContextMock = jest.mocked(useConfirmContext);
+  const useWithdrawTokenFilterMock = jest.mocked(useWithdrawTokenFilter);
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -122,6 +125,10 @@ describe('PayWithModal', () => {
     } as ReturnType<typeof useConfirmContext>);
 
     getAvailableTokensMock.mockImplementation(({ tokens }) => tokens as never);
+    useWithdrawTokenFilterMock.mockReturnValue({
+      filterTokens: (tokens) => tokens,
+      isFilterApplied: false,
+    });
     useTransactionPayRequiredTokensMock.mockReturnValue([]);
     useMusdConversionTokensMock.mockReturnValue({
       filterTokens: (tokens) => tokens,
@@ -323,6 +330,21 @@ describe('PayWithModal', () => {
         true,
       );
       expect(onCloseMock).toHaveBeenCalled();
+    });
+
+    it('uses the withdraw token filter without applying the regular available-token filter', () => {
+      const withdrawTokenFilterMock = jest
+        .fn()
+        .mockReturnValue([PERPS_WITHDRAW_TOKEN]);
+      useWithdrawTokenFilterMock.mockReturnValue({
+        filterTokens: withdrawTokenFilterMock,
+        isFilterApplied: true,
+      });
+
+      renderModal({ isOpen: true, onClose: onCloseMock });
+
+      expect(withdrawTokenFilterMock).toHaveBeenCalledWith([]);
+      expect(getAvailableTokensMock).not.toHaveBeenCalled();
     });
 
     it('keeps the modal open and skips setPayToken when token import fails', async () => {

--- a/ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
+++ b/ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
@@ -22,6 +22,7 @@ import {
   useMusdConversionTokens,
   useMusdPaymentToken,
 } from '../../../../../hooks/musd';
+import { useWithdrawTokenFilter } from '../../../hooks/pay/useWithdrawTokenFilter';
 import { useConfirmContext } from '../../../context/confirm';
 import {
   addToken,
@@ -44,6 +45,10 @@ export const PayWithModal = ({ isOpen, onClose }: PayWithModalProps) => {
   const { filterTokens: musdTokenFilter } = useMusdConversionTokens({
     transactionType: currentConfirmation?.type,
   });
+  const {
+    filterTokens: withdrawTokenFilter,
+    isFilterApplied: isWithdrawTokenFilterApplied,
+  } = useWithdrawTokenFilter();
 
   // Use the mUSD-specific payment token handler for same-chain enforcement
   const { onPaymentTokenChange: onMusdPaymentTokenChange } =
@@ -125,13 +130,24 @@ export const PayWithModal = ({ isOpen, onClose }: PayWithModalProps) => {
 
   const tokenFilter = useCallback(
     (tokens: AssetType[]) => {
+      if (isPerpsWithdraw && isWithdrawTokenFilterApplied) {
+        return withdrawTokenFilter(tokens);
+      }
+
       let available = getAvailableTokens({ payToken, requiredTokens, tokens });
 
       available = musdTokenFilter(available);
 
       return available;
     },
-    [payToken, requiredTokens, musdTokenFilter],
+    [
+      isPerpsWithdraw,
+      isWithdrawTokenFilterApplied,
+      musdTokenFilter,
+      payToken,
+      requiredTokens,
+      withdrawTokenFilter,
+    ],
   );
 
   return (

--- a/ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
+++ b/ui/pages/confirmations/components/modals/pay-with-modal/pay-with-modal.tsx
@@ -22,13 +22,13 @@ import {
   useMusdConversionTokens,
   useMusdPaymentToken,
 } from '../../../../../hooks/musd';
-import { useWithdrawTokenFilter } from '../../../hooks/pay/useWithdrawTokenFilter';
+import { usePostQuoteWithdrawTokenFilter } from '../../../hooks/pay/useWithdrawTokenFilter';
 import { useConfirmContext } from '../../../context/confirm';
 import {
   addToken,
   findNetworkClientIdByChainId,
 } from '../../../../../store/actions';
-import { isPerpsWithdrawTransaction } from '../../../../../../shared/lib/transactions.utils';
+import { isPostQuoteWithdrawTransaction } from '../../../../../../shared/lib/transactions.utils';
 
 export type PayWithModalProps = {
   isOpen: boolean;
@@ -46,15 +46,16 @@ export const PayWithModal = ({ isOpen, onClose }: PayWithModalProps) => {
     transactionType: currentConfirmation?.type,
   });
   const {
-    filterTokens: withdrawTokenFilter,
-    isFilterApplied: isWithdrawTokenFilterApplied,
-  } = useWithdrawTokenFilter();
+    filterTokens: postQuoteWithdrawTokenFilter,
+    isFilterApplied: isPostQuoteWithdrawTokenFilterApplied,
+  } = usePostQuoteWithdrawTokenFilter();
 
   // Use the mUSD-specific payment token handler for same-chain enforcement
   const { onPaymentTokenChange: onMusdPaymentTokenChange } =
     useMusdPaymentToken();
 
-  const isPerpsWithdraw = isPerpsWithdrawTransaction(currentConfirmation);
+  const isPostQuoteWithdraw =
+    isPostQuoteWithdrawTransaction(currentConfirmation);
 
   const handleClose = useCallback(() => {
     onClose();
@@ -85,7 +86,7 @@ export const PayWithModal = ({ isOpen, onClose }: PayWithModalProps) => {
       // found" and the selection silently fails. Ensure the token is imported
       // first, then update the pay token.
       if (
-        isPerpsWithdraw &&
+        isPostQuoteWithdraw &&
         !token.isNative &&
         (token.rawBalance === '0x0' || !token.rawBalance)
       ) {
@@ -122,7 +123,7 @@ export const PayWithModal = ({ isOpen, onClose }: PayWithModalProps) => {
       currentConfirmation?.type,
       dispatch,
       handleClose,
-      isPerpsWithdraw,
+      isPostQuoteWithdraw,
       onMusdPaymentTokenChange,
       setPayToken,
     ],
@@ -130,8 +131,8 @@ export const PayWithModal = ({ isOpen, onClose }: PayWithModalProps) => {
 
   const tokenFilter = useCallback(
     (tokens: AssetType[]) => {
-      if (isPerpsWithdraw && isWithdrawTokenFilterApplied) {
-        return withdrawTokenFilter(tokens);
+      if (isPostQuoteWithdraw && isPostQuoteWithdrawTokenFilterApplied) {
+        return postQuoteWithdrawTokenFilter(tokens);
       }
 
       let available = getAvailableTokens({ payToken, requiredTokens, tokens });
@@ -141,12 +142,12 @@ export const PayWithModal = ({ isOpen, onClose }: PayWithModalProps) => {
       return available;
     },
     [
-      isPerpsWithdraw,
-      isWithdrawTokenFilterApplied,
+      isPostQuoteWithdraw,
+      isPostQuoteWithdrawTokenFilterApplied,
       musdTokenFilter,
       payToken,
+      postQuoteWithdrawTokenFilter,
       requiredTokens,
-      withdrawTokenFilter,
     ],
   );
 

--- a/ui/pages/confirmations/components/rows/bridge-fee-row/bridge-fee-row.test.tsx
+++ b/ui/pages/confirmations/components/rows/bridge-fee-row/bridge-fee-row.test.tsx
@@ -246,4 +246,97 @@ describe('BridgeFeeRow', () => {
     expect(tooltip.textContent).toContain(`${messages.providerFee.message}:`);
     expect(tooltip.textContent).not.toContain(`${messages.bridgeFee.message}:`);
   });
+
+  describe('MetaMask fee value', () => {
+    it('renders the MetaMask fee value in the tooltip when ≥ $0.01', async () => {
+      useTransactionPayTotalsMock.mockReturnValue({
+        fees: {
+          provider: { usd: '1.00' },
+          metaMask: { usd: '0.50' },
+          sourceNetwork: { estimate: { usd: '0.20' } },
+          targetNetwork: { usd: '0.03' },
+        },
+      } as TransactionPayTotals);
+
+      const user = userEvent.setup();
+      const { getByTestId, findByText } = render({
+        variant: ConfirmInfoRowSize.Small,
+      });
+
+      await user.hover(getByTestId('bridge-fee-row-tooltip'));
+
+      const tooltip = await findByText((content) =>
+        content.includes(`${messages.metamaskFee.message}:`),
+      );
+      expect(tooltip.textContent).toContain(
+        `${messages.metamaskFee.message}: $0.50`,
+      );
+    });
+
+    it('renders "<$0.01" in the tooltip when MetaMask fee is sub-cent but > 0', async () => {
+      useTransactionPayTotalsMock.mockReturnValue({
+        fees: {
+          provider: { usd: '0.04' },
+          metaMask: { usd: '0.004347' },
+          sourceNetwork: { estimate: { usd: '0' } },
+          targetNetwork: { usd: '0' },
+        },
+      } as TransactionPayTotals);
+
+      const user = userEvent.setup();
+      const { getByTestId, findByText } = render({
+        variant: ConfirmInfoRowSize.Small,
+      });
+
+      await user.hover(getByTestId('bridge-fee-row-tooltip'));
+
+      const tooltip = await findByText((content) =>
+        content.includes(`${messages.metamaskFee.message}:`),
+      );
+      expect(tooltip.textContent).toContain(
+        `${messages.metamaskFee.message}: <$0.01`,
+      );
+    });
+
+    it('renders "$0.00" in the tooltip when MetaMask fee is exactly 0', async () => {
+      useTransactionPayTotalsMock.mockReturnValue({
+        fees: {
+          provider: { usd: '1.00' },
+          metaMask: { usd: '0' },
+          sourceNetwork: { estimate: { usd: '0.20' } },
+          targetNetwork: { usd: '0.03' },
+        },
+      } as TransactionPayTotals);
+
+      const user = userEvent.setup();
+      const { getByTestId, findByText } = render({
+        variant: ConfirmInfoRowSize.Small,
+      });
+
+      await user.hover(getByTestId('bridge-fee-row-tooltip'));
+
+      const tooltip = await findByText((content) =>
+        content.includes(`${messages.metamaskFee.message}:`),
+      );
+      expect(tooltip.textContent).toContain(
+        `${messages.metamaskFee.message}: $0.00`,
+      );
+    });
+
+    it('includes the MetaMask fee in the Transaction fee total', () => {
+      useTransactionPayTotalsMock.mockReturnValue({
+        fees: {
+          provider: { usd: '0.042058' },
+          metaMask: { usd: '0.004347' },
+          sourceNetwork: { estimate: { usd: '0' } },
+          targetNetwork: { usd: '0' },
+        },
+      } as TransactionPayTotals);
+
+      const { getByTestId } = render();
+
+      // 0.042058 + 0.004347 = 0.046405 → rounds to $0.05
+      expect(getByTestId('transaction-fee-value')).toHaveTextContent('$0.05');
+    });
+  });
 });

--- a/ui/pages/confirmations/components/rows/bridge-fee-row/bridge-fee-row.tsx
+++ b/ui/pages/confirmations/components/rows/bridge-fee-row/bridge-fee-row.tsx
@@ -54,13 +54,22 @@ export function BridgeFeeRow({
     }
 
     const totalFee = new BigNumber(totals.fees.provider.usd)
+      .plus(totals.fees.metaMask?.usd ?? '0')
       .plus(totals.fees.sourceNetwork.estimate.usd)
       .plus(totals.fees.targetNetwork.usd);
 
     return formatFiat(totalFee.toNumber());
   }, [totals, formatFiat]);
 
-  const metamaskFeeUsd = useMemo(() => formatFiat(0), [formatFiat]);
+  const metamaskFeeUsd = useMemo(() => {
+    const raw = new BigNumber(totals?.fees?.metaMask?.usd ?? '0');
+    // Show "<$0.01" when fee is positive but rounds to $0.00 so users can see
+    // the fee is actually collected (Intl.NumberFormat uses 2 decimal places).
+    if (raw.gt(0) && raw.lt('0.01')) {
+      return `<${formatFiat(0.01)}`;
+    }
+    return formatFiat(raw.toNumber());
+  }, [totals, formatFiat]);
 
   const isSmall = variant === ConfirmInfoRowSize.Small;
   const textVariant = isSmall ? TextVariant.bodyMd : TextVariant.bodyMdMedium;

--- a/ui/pages/confirmations/hooks/pay/useAutomaticTransactionPayToken.test.tsx
+++ b/ui/pages/confirmations/hooks/pay/useAutomaticTransactionPayToken.test.tsx
@@ -12,10 +12,12 @@ import { useTransactionPayToken } from './useTransactionPayToken';
 import { useTransactionPayRequiredTokens } from './useTransactionPayData';
 import { useTransactionPayAvailableTokens } from './useTransactionPayAvailableTokens';
 import type { SetPayTokenRequest } from './types';
+import { useWithdrawTokenFilter } from './useWithdrawTokenFilter';
 
 jest.mock('./useTransactionPayToken');
 jest.mock('./useTransactionPayData');
 jest.mock('./useTransactionPayAvailableTokens');
+jest.mock('./useWithdrawTokenFilter');
 jest.mock('../../../../selectors', () => ({
   getHardwareWalletType: jest.fn(() => null),
 }));
@@ -95,6 +97,7 @@ describe('useAutomaticTransactionPayToken', () => {
   const useTransactionPayRequiredTokensMock = jest.mocked(
     useTransactionPayRequiredTokens,
   );
+  const useWithdrawTokenFilterMock = jest.mocked(useWithdrawTokenFilter);
 
   const setPayTokenMock = jest.fn();
 
@@ -114,6 +117,10 @@ describe('useAutomaticTransactionPayToken', () => {
     ]);
 
     useTransactionPayAvailableTokensMock.mockReturnValue([]);
+    useWithdrawTokenFilterMock.mockReturnValue({
+      filterTokens: (tokens) => tokens,
+      isFilterApplied: false,
+    });
   });
 
   it('selects first token', () => {
@@ -265,6 +272,38 @@ describe('useAutomaticTransactionPayToken', () => {
     expect(setPayTokenMock).toHaveBeenCalledWith({
       address: PREFERRED_TOKEN_ADDRESS_MOCK,
       chainId: PREFERRED_CHAIN_ID_MOCK,
+    });
+  });
+
+  it('selects the first allowlisted withdraw token when the preferred token is not allowlisted', () => {
+    useTransactionPayAvailableTokensMock.mockReturnValue([
+      {
+        address: TOKEN_ADDRESS_1_MOCK,
+        chainId: CHAIN_ID_1_MOCK,
+      },
+    ] as Asset[]);
+    useWithdrawTokenFilterMock.mockReturnValue({
+      filterTokens: () =>
+        [
+          {
+            address: TOKEN_ADDRESS_2_MOCK,
+            chainId: CHAIN_ID_2_MOCK,
+          },
+        ] as Asset[],
+      isFilterApplied: true,
+    });
+
+    renderHookWithProvider({
+      transactionType: TransactionType.perpsWithdraw,
+      preferredToken: {
+        address: PREFERRED_TOKEN_ADDRESS_MOCK as Hex,
+        chainId: PREFERRED_CHAIN_ID_MOCK as Hex,
+      },
+    });
+
+    expect(setPayTokenMock).toHaveBeenCalledWith({
+      address: TOKEN_ADDRESS_2_MOCK,
+      chainId: CHAIN_ID_2_MOCK,
     });
   });
 

--- a/ui/pages/confirmations/hooks/pay/useAutomaticTransactionPayToken.test.tsx
+++ b/ui/pages/confirmations/hooks/pay/useAutomaticTransactionPayToken.test.tsx
@@ -122,6 +122,7 @@ describe('useAutomaticTransactionPayToken', () => {
     usePostQuoteWithdrawTokenFilterMock.mockReturnValue({
       filterTokens: (tokens) => tokens,
       isFilterApplied: false,
+      isTokenAllowed: () => false,
     });
   });
 
@@ -293,6 +294,7 @@ describe('useAutomaticTransactionPayToken', () => {
           },
         ] as Asset[],
       isFilterApplied: true,
+      isTokenAllowed: () => false,
     });
 
     renderHookWithProvider({
@@ -306,6 +308,41 @@ describe('useAutomaticTransactionPayToken', () => {
     expect(setPayTokenMock).toHaveBeenCalledWith({
       address: TOKEN_ADDRESS_2_MOCK,
       chainId: CHAIN_ID_2_MOCK,
+    });
+  });
+
+  it('selects an allowlisted preferred withdraw token before enrichment adds it to the token list', () => {
+    useTransactionPayAvailableTokensMock.mockReturnValue([
+      {
+        address: TOKEN_ADDRESS_1_MOCK,
+        chainId: CHAIN_ID_1_MOCK,
+      },
+    ] as Asset[]);
+    usePostQuoteWithdrawTokenFilterMock.mockReturnValue({
+      filterTokens: () =>
+        [
+          {
+            address: TOKEN_ADDRESS_2_MOCK,
+            chainId: CHAIN_ID_2_MOCK,
+          },
+        ] as Asset[],
+      isFilterApplied: true,
+      isTokenAllowed: (chainId, address) =>
+        chainId.toLowerCase() === PREFERRED_CHAIN_ID_MOCK &&
+        address.toLowerCase() === PREFERRED_TOKEN_ADDRESS_MOCK,
+    });
+
+    renderHookWithProvider({
+      transactionType: TransactionType.perpsWithdraw,
+      preferredToken: {
+        address: PREFERRED_TOKEN_ADDRESS_MOCK as Hex,
+        chainId: PREFERRED_CHAIN_ID_MOCK as Hex,
+      },
+    });
+
+    expect(setPayTokenMock).toHaveBeenCalledWith({
+      address: PREFERRED_TOKEN_ADDRESS_MOCK,
+      chainId: PREFERRED_CHAIN_ID_MOCK,
     });
   });
 

--- a/ui/pages/confirmations/hooks/pay/useAutomaticTransactionPayToken.test.tsx
+++ b/ui/pages/confirmations/hooks/pay/useAutomaticTransactionPayToken.test.tsx
@@ -12,7 +12,7 @@ import { useTransactionPayToken } from './useTransactionPayToken';
 import { useTransactionPayRequiredTokens } from './useTransactionPayData';
 import { useTransactionPayAvailableTokens } from './useTransactionPayAvailableTokens';
 import type { SetPayTokenRequest } from './types';
-import { useWithdrawTokenFilter } from './useWithdrawTokenFilter';
+import { usePostQuoteWithdrawTokenFilter } from './useWithdrawTokenFilter';
 
 jest.mock('./useTransactionPayToken');
 jest.mock('./useTransactionPayData');
@@ -97,7 +97,9 @@ describe('useAutomaticTransactionPayToken', () => {
   const useTransactionPayRequiredTokensMock = jest.mocked(
     useTransactionPayRequiredTokens,
   );
-  const useWithdrawTokenFilterMock = jest.mocked(useWithdrawTokenFilter);
+  const usePostQuoteWithdrawTokenFilterMock = jest.mocked(
+    usePostQuoteWithdrawTokenFilter,
+  );
 
   const setPayTokenMock = jest.fn();
 
@@ -117,7 +119,7 @@ describe('useAutomaticTransactionPayToken', () => {
     ]);
 
     useTransactionPayAvailableTokensMock.mockReturnValue([]);
-    useWithdrawTokenFilterMock.mockReturnValue({
+    usePostQuoteWithdrawTokenFilterMock.mockReturnValue({
       filterTokens: (tokens) => tokens,
       isFilterApplied: false,
     });
@@ -282,7 +284,7 @@ describe('useAutomaticTransactionPayToken', () => {
         chainId: CHAIN_ID_1_MOCK,
       },
     ] as Asset[]);
-    useWithdrawTokenFilterMock.mockReturnValue({
+    usePostQuoteWithdrawTokenFilterMock.mockReturnValue({
       filterTokens: () =>
         [
           {

--- a/ui/pages/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
+++ b/ui/pages/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
@@ -10,6 +10,7 @@ import { useTransactionPayToken } from './useTransactionPayToken';
 import { useTransactionPayRequiredTokens } from './useTransactionPayData';
 import { useTransactionPayAvailableTokens } from './useTransactionPayAvailableTokens';
 import type { SetPayTokenRequest } from './types';
+import { useWithdrawTokenFilter } from './useWithdrawTokenFilter';
 
 export function useAutomaticTransactionPayToken({
   disable = false,
@@ -22,11 +23,23 @@ export function useAutomaticTransactionPayToken({
   const isUpdated = useRef<string | undefined>(undefined);
   const { payToken, setPayToken } = useTransactionPayToken();
   const requiredTokens = useTransactionPayRequiredTokens();
-  const tokens = useTransactionPayAvailableTokens();
+  const availableTokens = useTransactionPayAvailableTokens();
 
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
   const transactionId = currentConfirmation?.id;
   const isWithdraw = isPerpsWithdrawTransaction(currentConfirmation);
+  const {
+    filterTokens: withdrawTokenFilter,
+    isFilterApplied: isWithdrawTokenFilterApplied,
+  } = useWithdrawTokenFilter();
+
+  const tokens = useMemo(
+    () =>
+      isWithdrawTokenFilterApplied
+        ? withdrawTokenFilter(availableTokens)
+        : availableTokens,
+    [availableTokens, isWithdrawTokenFilterApplied, withdrawTokenFilter],
+  );
 
   const tokensWithBalance = useMemo(
     () => tokens.filter((t) => !t.disabled),
@@ -57,6 +70,7 @@ export function useAutomaticTransactionPayToken({
     const automaticToken = getBestToken({
       isHardwareWallet,
       isWithdraw,
+      isWithdrawTokenFilterApplied,
       targetToken,
       tokens: tokensWithBalance,
       preferredToken,
@@ -76,6 +90,7 @@ export function useAutomaticTransactionPayToken({
     disable,
     isHardwareWallet,
     isWithdraw,
+    isWithdrawTokenFilterApplied,
     payToken,
     preferredToken,
     requiredTokens,
@@ -89,12 +104,14 @@ export function useAutomaticTransactionPayToken({
 function getBestToken({
   isHardwareWallet,
   isWithdraw,
+  isWithdrawTokenFilterApplied,
   preferredToken,
   targetToken,
   tokens,
 }: {
   isHardwareWallet: boolean;
   isWithdraw: boolean;
+  isWithdrawTokenFilterApplied: boolean;
   preferredToken?: SetPayTokenRequest;
   targetToken?: { address: Hex; chainId: Hex };
   tokens: Asset[];
@@ -110,10 +127,23 @@ function getBestToken({
     return targetTokenFallback;
   }
 
-  // For withdraws `preferredToken` is the destination — honour it even if
-  // the user has no wallet balance of it.
+  // Without a withdraw allowlist, `preferredToken` is the destination: honor it
+  // even if the user has no wallet balance of it.
   if (isWithdraw && preferredToken) {
-    return preferredToken;
+    if (!isWithdrawTokenFilterApplied) {
+      return preferredToken;
+    }
+
+    const preferredTokenAvailable = tokens.some(
+      (token) =>
+        token.address?.toLowerCase() === preferredToken.address.toLowerCase() &&
+        String(token.chainId)?.toLowerCase() ===
+          preferredToken.chainId.toLowerCase(),
+    );
+
+    if (preferredTokenAvailable) {
+      return preferredToken;
+    }
   }
 
   if (preferredToken) {
@@ -127,6 +157,10 @@ function getBestToken({
     if (preferredTokenAvailable) {
       return preferredToken;
     }
+  }
+
+  if (isWithdrawTokenFilterApplied && tokens.length === 0) {
+    return undefined;
   }
 
   if (tokens?.length) {

--- a/ui/pages/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
+++ b/ui/pages/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
@@ -121,7 +121,10 @@ function getBestToken({
   isHardwareWallet: boolean;
   isPostQuoteWithdraw: boolean;
   isPostQuoteWithdrawTokenFilterApplied: boolean;
-  isPostQuoteWithdrawTokenAllowed: (chainId: string, address: string) => boolean;
+  isPostQuoteWithdrawTokenAllowed: (
+    chainId: string,
+    address: string,
+  ) => boolean;
   preferredToken?: SetPayTokenRequest;
   targetToken?: { address: Hex; chainId: Hex };
   tokens: Asset[];

--- a/ui/pages/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
+++ b/ui/pages/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
@@ -3,14 +3,14 @@ import { useSelector } from 'react-redux';
 import type { TransactionMeta } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 import { getHardwareWalletType } from '../../../../selectors';
-import { isPerpsWithdrawTransaction } from '../../../../../shared/lib/transactions.utils';
+import { isPostQuoteWithdrawTransaction } from '../../../../../shared/lib/transactions.utils';
 import { Asset } from '../../types/send';
 import { useConfirmContext } from '../../context/confirm';
 import { useTransactionPayToken } from './useTransactionPayToken';
 import { useTransactionPayRequiredTokens } from './useTransactionPayData';
 import { useTransactionPayAvailableTokens } from './useTransactionPayAvailableTokens';
 import type { SetPayTokenRequest } from './types';
-import { useWithdrawTokenFilter } from './useWithdrawTokenFilter';
+import { usePostQuoteWithdrawTokenFilter } from './useWithdrawTokenFilter';
 
 export function useAutomaticTransactionPayToken({
   disable = false,
@@ -27,18 +27,23 @@ export function useAutomaticTransactionPayToken({
 
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
   const transactionId = currentConfirmation?.id;
-  const isWithdraw = isPerpsWithdrawTransaction(currentConfirmation);
+  const isPostQuoteWithdraw =
+    isPostQuoteWithdrawTransaction(currentConfirmation);
   const {
-    filterTokens: withdrawTokenFilter,
-    isFilterApplied: isWithdrawTokenFilterApplied,
-  } = useWithdrawTokenFilter();
+    filterTokens: postQuoteWithdrawTokenFilter,
+    isFilterApplied: isPostQuoteWithdrawTokenFilterApplied,
+  } = usePostQuoteWithdrawTokenFilter();
 
   const tokens = useMemo(
     () =>
-      isWithdrawTokenFilterApplied
-        ? withdrawTokenFilter(availableTokens)
+      isPostQuoteWithdrawTokenFilterApplied
+        ? postQuoteWithdrawTokenFilter(availableTokens)
         : availableTokens,
-    [availableTokens, isWithdrawTokenFilterApplied, withdrawTokenFilter],
+    [
+      availableTokens,
+      isPostQuoteWithdrawTokenFilterApplied,
+      postQuoteWithdrawTokenFilter,
+    ],
   );
 
   const tokensWithBalance = useMemo(
@@ -69,8 +74,8 @@ export function useAutomaticTransactionPayToken({
 
     const automaticToken = getBestToken({
       isHardwareWallet,
-      isWithdraw,
-      isWithdrawTokenFilterApplied,
+      isPostQuoteWithdraw,
+      isPostQuoteWithdrawTokenFilterApplied,
       targetToken,
       tokens: tokensWithBalance,
       preferredToken,
@@ -89,8 +94,8 @@ export function useAutomaticTransactionPayToken({
   }, [
     disable,
     isHardwareWallet,
-    isWithdraw,
-    isWithdrawTokenFilterApplied,
+    isPostQuoteWithdraw,
+    isPostQuoteWithdrawTokenFilterApplied,
     payToken,
     preferredToken,
     requiredTokens,
@@ -103,15 +108,15 @@ export function useAutomaticTransactionPayToken({
 
 function getBestToken({
   isHardwareWallet,
-  isWithdraw,
-  isWithdrawTokenFilterApplied,
+  isPostQuoteWithdraw,
+  isPostQuoteWithdrawTokenFilterApplied,
   preferredToken,
   targetToken,
   tokens,
 }: {
   isHardwareWallet: boolean;
-  isWithdraw: boolean;
-  isWithdrawTokenFilterApplied: boolean;
+  isPostQuoteWithdraw: boolean;
+  isPostQuoteWithdrawTokenFilterApplied: boolean;
   preferredToken?: SetPayTokenRequest;
   targetToken?: { address: Hex; chainId: Hex };
   tokens: Asset[];
@@ -127,10 +132,10 @@ function getBestToken({
     return targetTokenFallback;
   }
 
-  // Without a withdraw allowlist, `preferredToken` is the destination: honor it
-  // even if the user has no wallet balance of it.
-  if (isWithdraw && preferredToken) {
-    if (!isWithdrawTokenFilterApplied) {
+  // Without a post-quote withdraw allowlist, `preferredToken` is the
+  // destination: honor it even if the user has no wallet balance of it.
+  if (isPostQuoteWithdraw && preferredToken) {
+    if (!isPostQuoteWithdrawTokenFilterApplied) {
       return preferredToken;
     }
 
@@ -159,7 +164,7 @@ function getBestToken({
     }
   }
 
-  if (isWithdrawTokenFilterApplied && tokens.length === 0) {
+  if (isPostQuoteWithdrawTokenFilterApplied && tokens.length === 0) {
     return undefined;
   }
 

--- a/ui/pages/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
+++ b/ui/pages/confirmations/hooks/pay/useAutomaticTransactionPayToken.ts
@@ -32,6 +32,7 @@ export function useAutomaticTransactionPayToken({
   const {
     filterTokens: postQuoteWithdrawTokenFilter,
     isFilterApplied: isPostQuoteWithdrawTokenFilterApplied,
+    isTokenAllowed: isPostQuoteWithdrawTokenAllowed,
   } = usePostQuoteWithdrawTokenFilter();
 
   const tokens = useMemo(
@@ -76,6 +77,7 @@ export function useAutomaticTransactionPayToken({
       isHardwareWallet,
       isPostQuoteWithdraw,
       isPostQuoteWithdrawTokenFilterApplied,
+      isPostQuoteWithdrawTokenAllowed,
       targetToken,
       tokens: tokensWithBalance,
       preferredToken,
@@ -96,6 +98,7 @@ export function useAutomaticTransactionPayToken({
     isHardwareWallet,
     isPostQuoteWithdraw,
     isPostQuoteWithdrawTokenFilterApplied,
+    isPostQuoteWithdrawTokenAllowed,
     payToken,
     preferredToken,
     requiredTokens,
@@ -110,6 +113,7 @@ function getBestToken({
   isHardwareWallet,
   isPostQuoteWithdraw,
   isPostQuoteWithdrawTokenFilterApplied,
+  isPostQuoteWithdrawTokenAllowed,
   preferredToken,
   targetToken,
   tokens,
@@ -117,6 +121,7 @@ function getBestToken({
   isHardwareWallet: boolean;
   isPostQuoteWithdraw: boolean;
   isPostQuoteWithdrawTokenFilterApplied: boolean;
+  isPostQuoteWithdrawTokenAllowed: (chainId: string, address: string) => boolean;
   preferredToken?: SetPayTokenRequest;
   targetToken?: { address: Hex; chainId: Hex };
   tokens: Asset[];
@@ -139,19 +144,15 @@ function getBestToken({
       return preferredToken;
     }
 
-    const preferredTokenAvailable = tokens.some(
-      (token) =>
-        token.address?.toLowerCase() === preferredToken.address.toLowerCase() &&
-        String(token.chainId)?.toLowerCase() ===
-          preferredToken.chainId.toLowerCase(),
-    );
-
-    if (preferredTokenAvailable) {
+    if (
+      isPostQuoteWithdrawTokenAllowed(
+        preferredToken.chainId,
+        preferredToken.address,
+      )
+    ) {
       return preferredToken;
     }
-  }
-
-  if (preferredToken) {
+  } else if (preferredToken) {
     const preferredTokenAvailable = tokens.some(
       (token) =>
         token.address?.toLowerCase() === preferredToken.address.toLowerCase() &&

--- a/ui/pages/confirmations/hooks/pay/usePerpsWithdrawDefaultToken.test.tsx
+++ b/ui/pages/confirmations/hooks/pay/usePerpsWithdrawDefaultToken.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 import { renderHook } from '@testing-library/react-hooks';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
@@ -15,8 +16,10 @@ const mockStore = configureStore([]);
 
 const TOKEN_ADDRESS_1 = '0x1111111111111111111111111111111111111111' as Hex;
 const TOKEN_ADDRESS_2 = '0x2222222222222222222222222222222222222222' as Hex;
+const TOKEN_ADDRESS_3 = '0x3333333333333333333333333333333333333333' as Hex;
 const CHAIN_ID_1 = '0xa4b1' as Hex; // arbitrum
 const CHAIN_ID_2 = '0x38' as Hex; // bsc
+const CHAIN_ID_3 = '0x1' as Hex; // mainnet
 
 function makeTx(overrides: Partial<TransactionMeta>): TransactionMeta {
   return {
@@ -28,8 +31,14 @@ function makeTx(overrides: Partial<TransactionMeta>): TransactionMeta {
   } as TransactionMeta;
 }
 
-function renderHookWithState(transactions: TransactionMeta[]) {
-  const store = mockStore({ metamask: { transactions } });
+function renderHookWithState({
+  remoteFeatureFlags = {},
+  transactions,
+}: {
+  remoteFeatureFlags?: Record<string, unknown>;
+  transactions: TransactionMeta[];
+}) {
+  const store = mockStore({ metamask: { remoteFeatureFlags, transactions } });
   const wrapper = ({ children }: { children: React.ReactNode }) => (
     <Provider store={store}>{children}</Provider>
   );
@@ -38,7 +47,7 @@ function renderHookWithState(transactions: TransactionMeta[]) {
 
 describe('usePerpsWithdrawDefaultToken', () => {
   it('falls back to native Arbitrum USDC when there are no transactions', () => {
-    const { result } = renderHookWithState([]);
+    const { result } = renderHookWithState({ transactions: [] });
 
     expect(result.current).toStrictEqual({
       address: ARBITRUM_USDC.address,
@@ -46,15 +55,44 @@ describe('usePerpsWithdrawDefaultToken', () => {
     });
   });
 
+  it('falls back to the feature-flagged Perps Withdraw token when there are no transactions', () => {
+    const { result } = renderHookWithState({
+      remoteFeatureFlags: {
+        confirmations_pay_tokens: {
+          preferredTokens: {
+            default: {},
+            overrides: {
+              perpsWithdraw: [
+                {
+                  address: TOKEN_ADDRESS_3,
+                  chainId: CHAIN_ID_3,
+                  name: 'mUSD',
+                },
+              ],
+            },
+          },
+        },
+      },
+      transactions: [],
+    });
+
+    expect(result.current).toStrictEqual({
+      address: TOKEN_ADDRESS_3,
+      chainId: CHAIN_ID_3,
+    });
+  });
+
   it('falls back to native Arbitrum USDC when no confirmed perpsWithdraw exists', () => {
-    const { result } = renderHookWithState([
-      makeTx({
-        id: 'tx-1',
-        time: 100,
-        type: TransactionType.simpleSend,
-        metamaskPay: { tokenAddress: TOKEN_ADDRESS_1, chainId: CHAIN_ID_1 },
-      }),
-    ]);
+    const { result } = renderHookWithState({
+      transactions: [
+        makeTx({
+          id: 'tx-1',
+          time: 100,
+          type: TransactionType.simpleSend,
+          metamaskPay: { tokenAddress: TOKEN_ADDRESS_1, chainId: CHAIN_ID_1 },
+        }),
+      ],
+    });
 
     expect(result.current).toStrictEqual({
       address: ARBITRUM_USDC.address,
@@ -63,20 +101,37 @@ describe('usePerpsWithdrawDefaultToken', () => {
   });
 
   it('returns the metamaskPay token of the latest confirmed direct perpsWithdraw', () => {
-    const { result } = renderHookWithState([
-      makeTx({
-        id: 'old',
-        time: 100,
-        type: TransactionType.perpsWithdraw,
-        metamaskPay: { tokenAddress: TOKEN_ADDRESS_1, chainId: CHAIN_ID_1 },
-      }),
-      makeTx({
-        id: 'new',
-        time: 200,
-        type: TransactionType.perpsWithdraw,
-        metamaskPay: { tokenAddress: TOKEN_ADDRESS_2, chainId: CHAIN_ID_2 },
-      }),
-    ]);
+    const { result } = renderHookWithState({
+      remoteFeatureFlags: {
+        confirmations_pay_tokens: {
+          preferredTokens: {
+            overrides: {
+              perpsWithdraw: [
+                {
+                  address: TOKEN_ADDRESS_3,
+                  chainId: CHAIN_ID_3,
+                  name: 'mUSD',
+                },
+              ],
+            },
+          },
+        },
+      },
+      transactions: [
+        makeTx({
+          id: 'old',
+          time: 100,
+          type: TransactionType.perpsWithdraw,
+          metamaskPay: { tokenAddress: TOKEN_ADDRESS_1, chainId: CHAIN_ID_1 },
+        }),
+        makeTx({
+          id: 'new',
+          time: 200,
+          type: TransactionType.perpsWithdraw,
+          metamaskPay: { tokenAddress: TOKEN_ADDRESS_2, chainId: CHAIN_ID_2 },
+        }),
+      ],
+    });
 
     expect(result.current).toStrictEqual({
       address: TOKEN_ADDRESS_2,
@@ -85,17 +140,19 @@ describe('usePerpsWithdrawDefaultToken', () => {
   });
 
   it('matches perpsWithdraw declared as a nested transaction inside a batch', () => {
-    const { result } = renderHookWithState([
-      makeTx({
-        id: 'batch',
-        time: 100,
-        type: TransactionType.batch,
-        nestedTransactions: [
-          { type: TransactionType.perpsWithdraw },
-        ] as TransactionMeta['nestedTransactions'],
-        metamaskPay: { tokenAddress: TOKEN_ADDRESS_1, chainId: CHAIN_ID_1 },
-      }),
-    ]);
+    const { result } = renderHookWithState({
+      transactions: [
+        makeTx({
+          id: 'batch',
+          time: 100,
+          type: TransactionType.batch,
+          nestedTransactions: [
+            { type: TransactionType.perpsWithdraw },
+          ] as TransactionMeta['nestedTransactions'],
+          metamaskPay: { tokenAddress: TOKEN_ADDRESS_1, chainId: CHAIN_ID_1 },
+        }),
+      ],
+    });
 
     expect(result.current).toStrictEqual({
       address: TOKEN_ADDRESS_1,
@@ -104,21 +161,23 @@ describe('usePerpsWithdrawDefaultToken', () => {
   });
 
   it('ignores unconfirmed perpsWithdraw transactions', () => {
-    const { result } = renderHookWithState([
-      makeTx({
-        id: 'unapproved',
-        time: 200,
-        status: TransactionStatus.unapproved,
-        type: TransactionType.perpsWithdraw,
-        metamaskPay: { tokenAddress: TOKEN_ADDRESS_2, chainId: CHAIN_ID_2 },
-      }),
-      makeTx({
-        id: 'confirmed',
-        time: 100,
-        type: TransactionType.perpsWithdraw,
-        metamaskPay: { tokenAddress: TOKEN_ADDRESS_1, chainId: CHAIN_ID_1 },
-      }),
-    ]);
+    const { result } = renderHookWithState({
+      transactions: [
+        makeTx({
+          id: 'unapproved',
+          time: 200,
+          status: TransactionStatus.unapproved,
+          type: TransactionType.perpsWithdraw,
+          metamaskPay: { tokenAddress: TOKEN_ADDRESS_2, chainId: CHAIN_ID_2 },
+        }),
+        makeTx({
+          id: 'confirmed',
+          time: 100,
+          type: TransactionType.perpsWithdraw,
+          metamaskPay: { tokenAddress: TOKEN_ADDRESS_1, chainId: CHAIN_ID_1 },
+        }),
+      ],
+    });
 
     expect(result.current).toStrictEqual({
       address: TOKEN_ADDRESS_1,
@@ -127,13 +186,15 @@ describe('usePerpsWithdrawDefaultToken', () => {
   });
 
   it('ignores perpsWithdraw transactions missing metamaskPay metadata', () => {
-    const { result } = renderHookWithState([
-      makeTx({
-        id: 'no-pay-meta',
-        time: 200,
-        type: TransactionType.perpsWithdraw,
-      }),
-    ]);
+    const { result } = renderHookWithState({
+      transactions: [
+        makeTx({
+          id: 'no-pay-meta',
+          time: 200,
+          type: TransactionType.perpsWithdraw,
+        }),
+      ],
+    });
 
     expect(result.current).toStrictEqual({
       address: ARBITRUM_USDC.address,

--- a/ui/pages/confirmations/hooks/pay/usePerpsWithdrawDefaultToken.ts
+++ b/ui/pages/confirmations/hooks/pay/usePerpsWithdrawDefaultToken.ts
@@ -9,7 +9,9 @@ import {
   selectTransactions,
   type TransactionState,
 } from '../../../../selectors/transactionController';
+import type { RemoteFeatureFlagsState } from '../../../../selectors/remote-feature-flags';
 import { hasTransactionType } from '../../../../../shared/lib/transactions.utils';
+import { selectPreferredPayToken } from '../../selectors/feature-flags';
 import { ARBITRUM_USDC } from '../../constants/perps';
 import type { SetPayTokenRequest } from './types';
 
@@ -18,16 +20,20 @@ const ARBITRUM_USDC_FALLBACK: SetPayTokenRequest = {
   chainId: ARBITRUM_USDC.chainId,
 };
 
+type PerpsWithdrawDefaultTokenState = TransactionState & RemoteFeatureFlagsState;
+
 /**
  * Default destination token for Perps Withdraw: last confirmed
- * `perpsWithdraw`'s `metamaskPay`, else native Arbitrum USDC.
- *
- * TODO: replace the hardcoded fallback with the `metamask_pay_tokens`
- * remote flag once exposed in the extension.
+ * `perpsWithdraw`'s `metamaskPay`, else the remote-configured preference,
+ * else native Arbitrum USDC.
  */
 export function usePerpsWithdrawDefaultToken(): SetPayTokenRequest {
-  const transactions = useSelector((state: TransactionState) =>
+  const transactions = useSelector((state: PerpsWithdrawDefaultTokenState) =>
     selectTransactions(state),
+  );
+  const preferredToken = useSelector(
+    (state: PerpsWithdrawDefaultTokenState) =>
+      selectPreferredPayToken(state, TransactionType.perpsWithdraw),
   );
 
   return useMemo(() => {
@@ -40,7 +46,12 @@ export function usePerpsWithdrawDefaultToken(): SetPayTokenRequest {
     );
 
     if (matching.length === 0) {
-      return ARBITRUM_USDC_FALLBACK;
+      return preferredToken
+        ? {
+            address: preferredToken.address,
+            chainId: preferredToken.chainId,
+          }
+        : ARBITRUM_USDC_FALLBACK;
     }
 
     const latest = matching.reduce((acc, tx) =>
@@ -51,5 +62,5 @@ export function usePerpsWithdrawDefaultToken(): SetPayTokenRequest {
       address: latest.metamaskPay?.tokenAddress as Hex,
       chainId: latest.metamaskPay?.chainId as Hex,
     };
-  }, [transactions]);
+  }, [preferredToken, transactions]);
 }

--- a/ui/pages/confirmations/hooks/pay/usePerpsWithdrawDefaultToken.ts
+++ b/ui/pages/confirmations/hooks/pay/usePerpsWithdrawDefaultToken.ts
@@ -20,7 +20,8 @@ const ARBITRUM_USDC_FALLBACK: SetPayTokenRequest = {
   chainId: ARBITRUM_USDC.chainId,
 };
 
-type PerpsWithdrawDefaultTokenState = TransactionState & RemoteFeatureFlagsState;
+type PerpsWithdrawDefaultTokenState = TransactionState &
+  RemoteFeatureFlagsState;
 
 /**
  * Default destination token for Perps Withdraw: last confirmed
@@ -31,9 +32,8 @@ export function usePerpsWithdrawDefaultToken(): SetPayTokenRequest {
   const transactions = useSelector((state: PerpsWithdrawDefaultTokenState) =>
     selectTransactions(state),
   );
-  const preferredToken = useSelector(
-    (state: PerpsWithdrawDefaultTokenState) =>
-      selectPreferredPayToken(state, TransactionType.perpsWithdraw),
+  const preferredToken = useSelector((state: PerpsWithdrawDefaultTokenState) =>
+    selectPreferredPayToken(state, TransactionType.perpsWithdraw),
   );
 
   return useMemo(() => {

--- a/ui/pages/confirmations/hooks/pay/useWithdrawTokenFilter.test.tsx
+++ b/ui/pages/confirmations/hooks/pay/useWithdrawTokenFilter.test.tsx
@@ -1,0 +1,175 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import {
+  TransactionType,
+  type TransactionMeta,
+} from '@metamask/transaction-controller';
+import { getNativeTokenAddress } from '@metamask/assets-controllers';
+import { ConfirmContext } from '../../context/confirm';
+import type { Asset } from '../../types/send';
+import { useSendTokens } from '../send/useSendTokens';
+import { useWithdrawTokenFilter } from './useWithdrawTokenFilter';
+
+jest.mock('../send/useSendTokens');
+
+const mockStore = configureStore([]);
+const mockUseSendTokens = jest.mocked(useSendTokens);
+
+const ALL_TOKENS_MOCK = [
+  {
+    address: '0xaaa',
+    balance: '1',
+    chainId: '0x1',
+    symbol: 'TKNA',
+  },
+  {
+    address: '0xbbb',
+    balance: '0',
+    chainId: '0x1',
+    symbol: 'TKNB',
+  },
+] as Asset[];
+
+function renderUseWithdrawTokenFilter({
+  type = TransactionType.perpsWithdraw,
+  postQuoteFlags = {
+    default: { enabled: false },
+  },
+}: {
+  type?: TransactionType;
+  postQuoteFlags?: Record<string, unknown>;
+} = {}) {
+  const store = mockStore({
+    metamask: {
+      remoteFeatureFlags: {
+        confirmations_pay_post_quote: postQuoteFlags,
+      },
+    },
+  });
+
+  const confirmContextValue = {
+    currentConfirmation: {
+      id: 'tx-id',
+      type,
+      txParams: {},
+    } as TransactionMeta,
+    isScrollToBottomCompleted: true,
+    setIsScrollToBottomCompleted: jest.fn(),
+  };
+
+  const wrapper = ({ children }: React.PropsWithChildren<unknown>) => (
+    <Provider store={store}>
+      <ConfirmContext.Provider value={confirmContextValue as never}>
+        {children}
+      </ConfirmContext.Provider>
+    </Provider>
+  );
+
+  return renderHook(() => useWithdrawTokenFilter(), { wrapper });
+}
+
+describe('useWithdrawTokenFilter', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseSendTokens.mockReturnValue(ALL_TOKENS_MOCK);
+  });
+
+  it('returns passed-in tokens unchanged for non-withdraw transaction types', () => {
+    const { result } = renderUseWithdrawTokenFilter({
+      type: TransactionType.simpleSend,
+    });
+    const input = [ALL_TOKENS_MOCK[0]];
+
+    expect(result.current.filterTokens(input)).toBe(input);
+    expect(result.current.isFilterApplied).toBe(false);
+    expect(mockUseSendTokens).toHaveBeenCalledWith({
+      enabled: false,
+      includeNoBalance: false,
+      tokenFilter: undefined,
+      enrichTokenRequests: [],
+    });
+  });
+
+  it('returns passed-in tokens unchanged when no allowlist is configured', () => {
+    const { result } = renderUseWithdrawTokenFilter({
+      postQuoteFlags: {
+        perpsWithdraw: { enabled: true },
+      },
+    });
+    const input = [ALL_TOKENS_MOCK[0]];
+
+    expect(result.current.filterTokens(input)).toBe(input);
+    expect(result.current.isFilterApplied).toBe(false);
+    expect(mockUseSendTokens).toHaveBeenCalledWith({
+      enabled: false,
+      includeNoBalance: false,
+      tokenFilter: undefined,
+      enrichTokenRequests: [],
+    });
+  });
+
+  it('returns allowlisted wallet tokens for perps withdraw', () => {
+    const { result } = renderUseWithdrawTokenFilter({
+      postQuoteFlags: {
+        perpsWithdraw: {
+          enabled: true,
+          tokens: { '0x1': ['0xaaa'] },
+        },
+      },
+    });
+
+    expect(result.current.filterTokens([])).toBe(ALL_TOKENS_MOCK);
+    expect(result.current.isFilterApplied).toBe(true);
+    expect(mockUseSendTokens).toHaveBeenCalledWith({
+      enabled: true,
+      includeNoBalance: true,
+      tokenFilter: expect.any(Function),
+      enrichTokenRequests: [
+        {
+          address: '0xaaa',
+          chainId: '0x1',
+        },
+      ],
+    });
+  });
+
+  it('passes a case-insensitive tokenFilter for allowlisted tokens', () => {
+    renderUseWithdrawTokenFilter({
+      postQuoteFlags: {
+        perpsWithdraw: {
+          enabled: true,
+          tokens: { '0x1': ['0xAAA'] },
+        },
+      },
+    });
+
+    const filter = mockUseSendTokens.mock.calls[0][0]?.tokenFilter;
+
+    expect(filter?.('0x1', '0xaaa')).toBe(true);
+    expect(filter?.('0X1', '0xAAA')).toBe(true);
+    expect(filter?.('0x1', '0xbbb')).toBe(false);
+  });
+
+  it('matches native tokens via zero address without requesting enrichment', () => {
+    renderUseWithdrawTokenFilter({
+      postQuoteFlags: {
+        perpsWithdraw: {
+          enabled: true,
+          tokens: {
+            '0x1': ['0x0000000000000000000000000000000000000000'],
+          },
+        },
+      },
+    });
+
+    const args = mockUseSendTokens.mock.calls[0][0];
+    const filter = args?.tokenFilter;
+    const nativeAddress = getNativeTokenAddress('0x1');
+
+    expect(filter?.('0x1', nativeAddress)).toBe(true);
+    expect(args?.enrichTokenRequests).toEqual([]);
+  });
+});

--- a/ui/pages/confirmations/hooks/pay/useWithdrawTokenFilter.test.tsx
+++ b/ui/pages/confirmations/hooks/pay/useWithdrawTokenFilter.test.tsx
@@ -90,7 +90,6 @@ describe('usePostQuoteWithdrawTokenFilter', () => {
     expect(result.current.filterTokens(input)).toBe(input);
     expect(result.current.isFilterApplied).toBe(false);
     expect(mockUseSendTokens).toHaveBeenCalledWith({
-      enabled: false,
       includeNoBalance: false,
       tokenFilter: undefined,
       enrichTokenRequests: [],
@@ -108,7 +107,6 @@ describe('usePostQuoteWithdrawTokenFilter', () => {
     expect(result.current.filterTokens(input)).toBe(input);
     expect(result.current.isFilterApplied).toBe(false);
     expect(mockUseSendTokens).toHaveBeenCalledWith({
-      enabled: false,
       includeNoBalance: false,
       tokenFilter: undefined,
       enrichTokenRequests: [],
@@ -128,7 +126,6 @@ describe('usePostQuoteWithdrawTokenFilter', () => {
     expect(result.current.filterTokens([])).toBe(ALL_TOKENS_MOCK);
     expect(result.current.isFilterApplied).toBe(true);
     expect(mockUseSendTokens).toHaveBeenCalledWith({
-      enabled: true,
       includeNoBalance: true,
       tokenFilter: expect.any(Function),
       enrichTokenRequests: [

--- a/ui/pages/confirmations/hooks/pay/useWithdrawTokenFilter.test.tsx
+++ b/ui/pages/confirmations/hooks/pay/useWithdrawTokenFilter.test.tsx
@@ -113,6 +113,26 @@ describe('usePostQuoteWithdrawTokenFilter', () => {
     });
   });
 
+  it('returns passed-in tokens unchanged when the allowlist is disabled', () => {
+    const { result } = renderUsePostQuoteWithdrawTokenFilter({
+      postQuoteFlags: {
+        perpsWithdraw: {
+          enabled: false,
+          tokens: { '0x1': ['0xaaa'] },
+        },
+      },
+    });
+    const input = [ALL_TOKENS_MOCK[0]];
+
+    expect(result.current.filterTokens(input)).toBe(input);
+    expect(result.current.isFilterApplied).toBe(false);
+    expect(mockUseSendTokens).toHaveBeenCalledWith({
+      includeNoBalance: false,
+      tokenFilter: undefined,
+      enrichTokenRequests: [],
+    });
+  });
+
   it('returns allowlisted wallet tokens for perps withdraw', () => {
     const { result } = renderUsePostQuoteWithdrawTokenFilter({
       postQuoteFlags: {

--- a/ui/pages/confirmations/hooks/pay/useWithdrawTokenFilter.test.tsx
+++ b/ui/pages/confirmations/hooks/pay/useWithdrawTokenFilter.test.tsx
@@ -89,6 +89,7 @@ describe('usePostQuoteWithdrawTokenFilter', () => {
 
     expect(result.current.filterTokens(input)).toBe(input);
     expect(result.current.isFilterApplied).toBe(false);
+    expect(result.current.isTokenAllowed('0x1', '0xaaa')).toBe(false);
     expect(mockUseSendTokens).toHaveBeenCalledWith({
       includeNoBalance: false,
       tokenFilter: undefined,
@@ -106,6 +107,7 @@ describe('usePostQuoteWithdrawTokenFilter', () => {
 
     expect(result.current.filterTokens(input)).toBe(input);
     expect(result.current.isFilterApplied).toBe(false);
+    expect(result.current.isTokenAllowed('0x1', '0xaaa')).toBe(false);
     expect(mockUseSendTokens).toHaveBeenCalledWith({
       includeNoBalance: false,
       tokenFilter: undefined,
@@ -126,6 +128,7 @@ describe('usePostQuoteWithdrawTokenFilter', () => {
 
     expect(result.current.filterTokens(input)).toBe(input);
     expect(result.current.isFilterApplied).toBe(false);
+    expect(result.current.isTokenAllowed('0x1', '0xaaa')).toBe(false);
     expect(mockUseSendTokens).toHaveBeenCalledWith({
       includeNoBalance: false,
       tokenFilter: undefined,
@@ -145,6 +148,8 @@ describe('usePostQuoteWithdrawTokenFilter', () => {
 
     expect(result.current.filterTokens([])).toBe(ALL_TOKENS_MOCK);
     expect(result.current.isFilterApplied).toBe(true);
+    expect(result.current.isTokenAllowed('0x1', '0xaaa')).toBe(true);
+    expect(result.current.isTokenAllowed('0x1', '0xbbb')).toBe(false);
     expect(mockUseSendTokens).toHaveBeenCalledWith({
       includeNoBalance: true,
       tokenFilter: expect.any(Function),

--- a/ui/pages/confirmations/hooks/pay/useWithdrawTokenFilter.test.tsx
+++ b/ui/pages/confirmations/hooks/pay/useWithdrawTokenFilter.test.tsx
@@ -11,7 +11,7 @@ import { getNativeTokenAddress } from '@metamask/assets-controllers';
 import { ConfirmContext } from '../../context/confirm';
 import type { Asset } from '../../types/send';
 import { useSendTokens } from '../send/useSendTokens';
-import { useWithdrawTokenFilter } from './useWithdrawTokenFilter';
+import { usePostQuoteWithdrawTokenFilter } from './useWithdrawTokenFilter';
 
 jest.mock('../send/useSendTokens');
 
@@ -33,12 +33,14 @@ const ALL_TOKENS_MOCK = [
   },
 ] as Asset[];
 
-function renderUseWithdrawTokenFilter({
+function renderUsePostQuoteWithdrawTokenFilter({
+  transactionMeta,
   type = TransactionType.perpsWithdraw,
   postQuoteFlags = {
     default: { enabled: false },
   },
 }: {
+  transactionMeta?: TransactionMeta;
   type?: TransactionType;
   postQuoteFlags?: Record<string, unknown>;
 } = {}) {
@@ -51,11 +53,13 @@ function renderUseWithdrawTokenFilter({
   });
 
   const confirmContextValue = {
-    currentConfirmation: {
-      id: 'tx-id',
-      type,
-      txParams: {},
-    } as TransactionMeta,
+    currentConfirmation:
+      transactionMeta ??
+      ({
+        id: 'tx-id',
+        type,
+        txParams: {},
+      } as TransactionMeta),
     isScrollToBottomCompleted: true,
     setIsScrollToBottomCompleted: jest.fn(),
   };
@@ -68,17 +72,17 @@ function renderUseWithdrawTokenFilter({
     </Provider>
   );
 
-  return renderHook(() => useWithdrawTokenFilter(), { wrapper });
+  return renderHook(() => usePostQuoteWithdrawTokenFilter(), { wrapper });
 }
 
-describe('useWithdrawTokenFilter', () => {
+describe('usePostQuoteWithdrawTokenFilter', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseSendTokens.mockReturnValue(ALL_TOKENS_MOCK);
   });
 
   it('returns passed-in tokens unchanged for non-withdraw transaction types', () => {
-    const { result } = renderUseWithdrawTokenFilter({
+    const { result } = renderUsePostQuoteWithdrawTokenFilter({
       type: TransactionType.simpleSend,
     });
     const input = [ALL_TOKENS_MOCK[0]];
@@ -94,7 +98,7 @@ describe('useWithdrawTokenFilter', () => {
   });
 
   it('returns passed-in tokens unchanged when no allowlist is configured', () => {
-    const { result } = renderUseWithdrawTokenFilter({
+    const { result } = renderUsePostQuoteWithdrawTokenFilter({
       postQuoteFlags: {
         perpsWithdraw: { enabled: true },
       },
@@ -112,7 +116,7 @@ describe('useWithdrawTokenFilter', () => {
   });
 
   it('returns allowlisted wallet tokens for perps withdraw', () => {
-    const { result } = renderUseWithdrawTokenFilter({
+    const { result } = renderUsePostQuoteWithdrawTokenFilter({
       postQuoteFlags: {
         perpsWithdraw: {
           enabled: true,
@@ -137,7 +141,7 @@ describe('useWithdrawTokenFilter', () => {
   });
 
   it('passes a case-insensitive tokenFilter for allowlisted tokens', () => {
-    renderUseWithdrawTokenFilter({
+    renderUsePostQuoteWithdrawTokenFilter({
       postQuoteFlags: {
         perpsWithdraw: {
           enabled: true,
@@ -154,7 +158,7 @@ describe('useWithdrawTokenFilter', () => {
   });
 
   it('matches native tokens via zero address without requesting enrichment', () => {
-    renderUseWithdrawTokenFilter({
+    renderUsePostQuoteWithdrawTokenFilter({
       postQuoteFlags: {
         perpsWithdraw: {
           enabled: true,
@@ -171,5 +175,32 @@ describe('useWithdrawTokenFilter', () => {
 
     expect(filter?.('0x1', nativeAddress)).toBe(true);
     expect(args?.enrichTokenRequests).toEqual([]);
+  });
+
+  it('uses the matching post-quote withdraw type from nested transactions', () => {
+    renderUsePostQuoteWithdrawTokenFilter({
+      transactionMeta: {
+        id: 'tx-id',
+        type: TransactionType.batch,
+        txParams: {},
+        nestedTransactions: [{ type: TransactionType.perpsWithdraw }],
+      } as unknown as TransactionMeta,
+      postQuoteFlags: {
+        default: {
+          enabled: true,
+          tokens: { '0x1': ['0xbbb'] },
+        },
+        overrides: {
+          perpsWithdraw: {
+            tokens: { '0x1': ['0xaaa'] },
+          },
+        },
+      },
+    });
+
+    const filter = mockUseSendTokens.mock.calls[0][0]?.tokenFilter;
+
+    expect(filter?.('0x1', '0xaaa')).toBe(true);
+    expect(filter?.('0x1', '0xbbb')).toBe(false);
   });
 });

--- a/ui/pages/confirmations/hooks/pay/useWithdrawTokenFilter.ts
+++ b/ui/pages/confirmations/hooks/pay/useWithdrawTokenFilter.ts
@@ -64,7 +64,6 @@ export function usePostQuoteWithdrawTokenFilter(): WithdrawTokenFilterResult {
   }, [allowlist, isFilterApplied]);
 
   const walletTokens = useSendTokens({
-    enabled: isFilterApplied,
     includeNoBalance: isFilterApplied,
     tokenFilter,
     enrichTokenRequests,

--- a/ui/pages/confirmations/hooks/pay/useWithdrawTokenFilter.ts
+++ b/ui/pages/confirmations/hooks/pay/useWithdrawTokenFilter.ts
@@ -2,12 +2,9 @@ import { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { getNativeTokenAddress } from '@metamask/assets-controllers';
 import { isNativeAddress } from '@metamask/bridge-controller';
-import {
-  TransactionType,
-  type TransactionMeta,
-} from '@metamask/transaction-controller';
+import type { TransactionMeta } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
-import { isPerpsWithdrawTransaction } from '../../../../../shared/lib/transactions.utils';
+import { getPostQuoteWithdrawTransactionType } from '../../../../../shared/lib/transactions.utils';
 import { selectPayQuoteConfig } from '../../selectors/feature-flags';
 import { useConfirmContext } from '../../context/confirm';
 import type { Asset } from '../../types/send';
@@ -19,23 +16,22 @@ type WithdrawTokenFilterResult = {
 };
 
 /**
- * Returns a token filter for withdraw transactions backed by the
+ * Returns a token filter for post-quote withdraw transactions backed by the
  * `confirmations_pay_post_quote` remote feature flag.
  */
-export function useWithdrawTokenFilter(): WithdrawTokenFilterResult {
+export function usePostQuoteWithdrawTokenFilter(): WithdrawTokenFilterResult {
   const { currentConfirmation } = useConfirmContext<
     TransactionMeta | undefined
   >();
-  const isWithdraw = isPerpsWithdrawTransaction(currentConfirmation);
-  const transactionType = isWithdraw
-    ? TransactionType.perpsWithdraw
-    : currentConfirmation?.type;
+  const postQuoteWithdrawTransactionType =
+    getPostQuoteWithdrawTransactionType(currentConfirmation);
+  const isPostQuoteWithdraw = Boolean(postQuoteWithdrawTransactionType);
 
   const config = useSelector((state) =>
-    selectPayQuoteConfig(state, transactionType),
+    selectPayQuoteConfig(state, postQuoteWithdrawTransactionType),
   );
   const allowlist = config.tokens;
-  const isFilterApplied = isWithdraw && Boolean(allowlist);
+  const isFilterApplied = isPostQuoteWithdraw && Boolean(allowlist);
 
   const tokenFilter = useMemo(() => {
     if (!isFilterApplied || !allowlist) {
@@ -89,6 +85,8 @@ export function useWithdrawTokenFilter(): WithdrawTokenFilterResult {
     [filterTokens, isFilterApplied],
   );
 }
+
+export const useWithdrawTokenFilter = usePostQuoteWithdrawTokenFilter;
 
 function buildAllowlistLookup(
   allowlist: Record<Hex, Hex[]>,

--- a/ui/pages/confirmations/hooks/pay/useWithdrawTokenFilter.ts
+++ b/ui/pages/confirmations/hooks/pay/useWithdrawTokenFilter.ts
@@ -35,7 +35,8 @@ export function usePostQuoteWithdrawTokenFilter(): WithdrawTokenFilterResult {
     selectPayQuoteConfig(state, postQuoteWithdrawTransactionType),
   );
   const allowlist = config.tokens;
-  const isFilterApplied = isPostQuoteWithdraw && Boolean(allowlist);
+  const isFilterApplied =
+    isPostQuoteWithdraw && config.enabled === true && Boolean(allowlist);
 
   const tokenFilter = useMemo(() => {
     if (!isFilterApplied || !allowlist) {

--- a/ui/pages/confirmations/hooks/pay/useWithdrawTokenFilter.ts
+++ b/ui/pages/confirmations/hooks/pay/useWithdrawTokenFilter.ts
@@ -16,6 +16,7 @@ import { useSendTokens, type EnrichTokenRequest } from '../send/useSendTokens';
 type WithdrawTokenFilterResult = {
   filterTokens: (tokens: Asset[]) => Asset[];
   isFilterApplied: boolean;
+  isTokenAllowed: (chainId: string, address: string) => boolean;
 };
 
 /**
@@ -81,12 +82,19 @@ export function usePostQuoteWithdrawTokenFilter(): WithdrawTokenFilterResult {
     [isFilterApplied, walletTokens],
   );
 
+  const isTokenAllowed = useCallback(
+    (chainId: string, address: string): boolean =>
+      Boolean(isFilterApplied && tokenFilter?.(chainId, address)),
+    [isFilterApplied, tokenFilter],
+  );
+
   return useMemo(
     () => ({
       filterTokens,
       isFilterApplied,
+      isTokenAllowed,
     }),
-    [filterTokens, isFilterApplied],
+    [filterTokens, isFilterApplied, isTokenAllowed],
   );
 }
 

--- a/ui/pages/confirmations/hooks/pay/useWithdrawTokenFilter.ts
+++ b/ui/pages/confirmations/hooks/pay/useWithdrawTokenFilter.ts
@@ -1,0 +1,119 @@
+import { useCallback, useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { getNativeTokenAddress } from '@metamask/assets-controllers';
+import { isNativeAddress } from '@metamask/bridge-controller';
+import {
+  TransactionType,
+  type TransactionMeta,
+} from '@metamask/transaction-controller';
+import type { Hex } from '@metamask/utils';
+import { isPerpsWithdrawTransaction } from '../../../../../shared/lib/transactions.utils';
+import { selectPayQuoteConfig } from '../../selectors/feature-flags';
+import { useConfirmContext } from '../../context/confirm';
+import type { Asset } from '../../types/send';
+import {
+  useSendTokens,
+  type EnrichTokenRequest,
+} from '../send/useSendTokens';
+
+type WithdrawTokenFilterResult = {
+  filterTokens: (tokens: Asset[]) => Asset[];
+  isFilterApplied: boolean;
+};
+
+/**
+ * Returns a token filter for withdraw transactions backed by the
+ * `confirmations_pay_post_quote` remote feature flag.
+ */
+export function useWithdrawTokenFilter(): WithdrawTokenFilterResult {
+  const { currentConfirmation } = useConfirmContext<
+    TransactionMeta | undefined
+  >();
+  const isWithdraw = isPerpsWithdrawTransaction(currentConfirmation);
+  const transactionType = isWithdraw
+    ? TransactionType.perpsWithdraw
+    : currentConfirmation?.type;
+
+  const config = useSelector((state) =>
+    selectPayQuoteConfig(state, transactionType),
+  );
+  const allowlist = config.tokens;
+  const isFilterApplied = isWithdraw && Boolean(allowlist);
+
+  const tokenFilter = useMemo(() => {
+    if (!isFilterApplied || !allowlist) {
+      return undefined;
+    }
+
+    const lookup = buildAllowlistLookup(allowlist);
+
+    return (chainId: string, address: string): boolean =>
+      lookup.get(chainId.toLowerCase())?.has(address.toLowerCase()) ?? false;
+  }, [allowlist, isFilterApplied]);
+
+  const enrichTokenRequests = useMemo((): EnrichTokenRequest[] => {
+    if (!isFilterApplied || !allowlist) {
+      return [];
+    }
+
+    return Object.entries(allowlist).flatMap(([chainId, addresses]) =>
+      addresses
+        .filter((address) => !isNativeAddress(address.toLowerCase()))
+        .map((address) => ({
+          chainId: chainId as Hex,
+          address,
+        })),
+    );
+  }, [allowlist, isFilterApplied]);
+
+  const walletTokens = useSendTokens({
+    enabled: isFilterApplied,
+    includeNoBalance: isFilterApplied,
+    tokenFilter,
+    enrichTokenRequests,
+  });
+
+  const filterTokens = useCallback(
+    (tokens: Asset[]): Asset[] => {
+      if (!isFilterApplied) {
+        return tokens;
+      }
+
+      return walletTokens;
+    },
+    [isFilterApplied, walletTokens],
+  );
+
+  return useMemo(
+    () => ({
+      filterTokens,
+      isFilterApplied,
+    }),
+    [filterTokens, isFilterApplied],
+  );
+}
+
+function buildAllowlistLookup(
+  allowlist: Record<Hex, Hex[]>,
+): Map<string, Set<string>> {
+  const lookup = new Map<string, Set<string>>();
+
+  for (const [chainId, addresses] of Object.entries(allowlist)) {
+    const lowerChainId = chainId.toLowerCase();
+    const addressSet = new Set<string>();
+
+    for (const address of addresses) {
+      const lowerAddress = address.toLowerCase();
+      addressSet.add(lowerAddress);
+
+      if (isNativeAddress(lowerAddress)) {
+        const nativeAddress = getNativeTokenAddress(lowerChainId as Hex);
+        addressSet.add(nativeAddress.toLowerCase());
+      }
+    }
+
+    lookup.set(lowerChainId, addressSet);
+  }
+
+  return lookup;
+}

--- a/ui/pages/confirmations/hooks/pay/useWithdrawTokenFilter.ts
+++ b/ui/pages/confirmations/hooks/pay/useWithdrawTokenFilter.ts
@@ -4,7 +4,10 @@ import { getNativeTokenAddress } from '@metamask/assets-controllers';
 import { isNativeAddress } from '@metamask/bridge-controller';
 import type { TransactionMeta } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
-import { getPostQuoteWithdrawTransactionType } from '../../../../../shared/lib/transactions.utils';
+import {
+  getPostQuoteWithdrawTransactionType,
+  isPostQuoteWithdrawTransaction,
+} from '../../../../../shared/lib/transactions.utils';
 import { selectPayQuoteConfig } from '../../selectors/feature-flags';
 import { useConfirmContext } from '../../context/confirm';
 import type { Asset } from '../../types/send';
@@ -25,7 +28,8 @@ export function usePostQuoteWithdrawTokenFilter(): WithdrawTokenFilterResult {
   >();
   const postQuoteWithdrawTransactionType =
     getPostQuoteWithdrawTransactionType(currentConfirmation);
-  const isPostQuoteWithdraw = Boolean(postQuoteWithdrawTransactionType);
+  const isPostQuoteWithdraw =
+    isPostQuoteWithdrawTransaction(currentConfirmation);
 
   const config = useSelector((state) =>
     selectPayQuoteConfig(state, postQuoteWithdrawTransactionType),

--- a/ui/pages/confirmations/hooks/pay/useWithdrawTokenFilter.ts
+++ b/ui/pages/confirmations/hooks/pay/useWithdrawTokenFilter.ts
@@ -11,10 +11,7 @@ import { isPerpsWithdrawTransaction } from '../../../../../shared/lib/transactio
 import { selectPayQuoteConfig } from '../../selectors/feature-flags';
 import { useConfirmContext } from '../../context/confirm';
 import type { Asset } from '../../types/send';
-import {
-  useSendTokens,
-  type EnrichTokenRequest,
-} from '../send/useSendTokens';
+import { useSendTokens, type EnrichTokenRequest } from '../send/useSendTokens';
 
 type WithdrawTokenFilterResult = {
   filterTokens: (tokens: Asset[]) => Asset[];

--- a/ui/pages/confirmations/hooks/send/useSendTokens.test.ts
+++ b/ui/pages/confirmations/hooks/send/useSendTokens.test.ts
@@ -114,26 +114,6 @@ describe('useSendTokens', () => {
     mockFetchAssetMetadataForAssetIds.mockResolvedValue({});
   });
 
-  it('skips token list construction when disabled', async () => {
-    const { result } = renderHookWithProvider(
-      () =>
-        useSendTokens({
-          enabled: false,
-          includeNoBalance: true,
-          enrichTokenRequests: [
-            {
-              address: '0x1111111111111111111111111111111111111111',
-              chainId: '0x1',
-            },
-          ],
-        }),
-      mockState,
-    );
-
-    expect(result.current).toEqual([]);
-    expect(mockFetchAssetMetadataForAssetIds).not.toHaveBeenCalled();
-  });
-
   it('includes testnet assets with non-zero raw balance', async () => {
     const testNetAssetData = [
       {

--- a/ui/pages/confirmations/hooks/send/useSendTokens.test.ts
+++ b/ui/pages/confirmations/hooks/send/useSendTokens.test.ts
@@ -236,15 +236,46 @@ describe('useSendTokens', () => {
 
     await waitFor(() => {
       expect(
-        result.current.find((asset) => asset.address === enrichedAddress),
+        result.current.find(
+          (asset: Asset) => asset.address === enrichedAddress,
+        ),
       ).toBeDefined();
     });
 
     const enrichedAsset = result.current.find(
-      (asset) => asset.address === enrichedAddress,
+      (asset: Asset) => asset.address === enrichedAddress,
     );
     expect(enrichedAsset?.symbol).toBe('DAI');
     expect(enrichedAsset?.rawBalance).toBe('0x0');
+  });
+
+  it('handles metadata enrichment aborts without rejecting', async () => {
+    const abortError = new Error('Aborted');
+    abortError.name = 'AbortError';
+
+    mockFetchAssetMetadataForAssetIds.mockRejectedValueOnce(abortError);
+
+    const { result } = renderHookWithProvider(
+      () =>
+        useSendTokens({
+          enrichTokenRequests: [
+            {
+              address: '0x1111111111111111111111111111111111111111',
+              chainId: '0x1',
+            },
+          ],
+          includeNoBalance: true,
+        }),
+      mockState,
+    );
+
+    await waitFor(() => {
+      expect(mockFetchAssetMetadataForAssetIds).toHaveBeenCalled();
+    });
+
+    expect(result.current.some((asset: Asset) => asset.symbol === 'DAI')).toBe(
+      false,
+    );
   });
 
   it('sorts assets by fiat balance descending', async () => {

--- a/ui/pages/confirmations/hooks/send/useSendTokens.test.ts
+++ b/ui/pages/confirmations/hooks/send/useSendTokens.test.ts
@@ -1,4 +1,6 @@
 import { useSelector } from 'react-redux';
+import { waitFor } from '@testing-library/react';
+import type { Hex } from '@metamask/utils';
 
 import { renderHookWithProvider } from '../../../../../test/lib/render-helpers-navigate';
 import mockState from '../../../../../test/data/mock-state.json';
@@ -6,6 +8,7 @@ import { getAssetsBySelectedAccountGroup } from '../../../../selectors/assets';
 import * as useFiatFormatterModule from '../../../../hooks/useFiatFormatter';
 import { AssetStandard, type Asset } from '../../types/send';
 import * as useChainNetworkNameAndImageModule from '../useChainNetworkNameAndImage';
+import * as assetUtils from '../../../../../shared/lib/asset-utils';
 import { useSendTokens } from './useSendTokens';
 
 jest.mock('react-redux', () => ({
@@ -15,6 +18,10 @@ jest.mock('react-redux', () => ({
 
 jest.mock('../useChainNetworkNameAndImage');
 jest.mock('../../../../hooks/useFiatFormatter');
+jest.mock('../../../../../shared/lib/asset-utils', () => ({
+  ...jest.requireActual('../../../../../shared/lib/asset-utils'),
+  fetchAssetMetadataForAssetIds: jest.fn(),
+}));
 
 const mockUseSelector = jest.mocked(useSelector);
 const mockUseChainNetworkNameAndImageMap = jest.mocked(
@@ -22,6 +29,9 @@ const mockUseChainNetworkNameAndImageMap = jest.mocked(
 );
 const mockUseFiatFormatter = jest.mocked(
   useFiatFormatterModule.useFiatFormatter,
+);
+const mockFetchAssetMetadataForAssetIds = jest.mocked(
+  assetUtils.fetchAssetMetadataForAssetIds,
 );
 
 describe('useSendTokens', () => {
@@ -101,6 +111,27 @@ describe('useSendTokens', () => {
     mockUseChainNetworkNameAndImageMap.mockReturnValue(mockChainNetworkMap);
     mockUseFiatFormatter.mockReturnValue(mockFormatter);
     mockFormatter.mockReturnValue('$1,000.00');
+    mockFetchAssetMetadataForAssetIds.mockResolvedValue({});
+  });
+
+  it('skips token list construction when disabled', async () => {
+    const { result } = renderHookWithProvider(
+      () =>
+        useSendTokens({
+          enabled: false,
+          includeNoBalance: true,
+          enrichTokenRequests: [
+            {
+              address: '0x1111111111111111111111111111111111111111',
+              chainId: '0x1',
+            },
+          ],
+        }),
+      mockState,
+    );
+
+    expect(result.current).toEqual([]);
+    expect(mockFetchAssetMetadataForAssetIds).not.toHaveBeenCalled();
   });
 
   it('includes testnet assets with non-zero raw balance', async () => {
@@ -155,6 +186,65 @@ describe('useSendTokens', () => {
       (asset: Asset) => asset.symbol === 'ZERO',
     );
     expect(zeroBalanceAsset).toBeDefined();
+  });
+
+  it('filters tokens by chain ID and address when tokenFilter is provided', async () => {
+    const { result } = renderHookWithProvider(
+      () =>
+        useSendTokens({
+          includeNoBalance: true,
+          tokenFilter: (chainId, address) =>
+            chainId === '0x1' && address.toLowerCase() === '0xusdc',
+        }),
+      mockState,
+    );
+
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].symbol).toBe('USDC');
+  });
+
+  it('enriches allowlisted tokens that are not in the wallet asset list', async () => {
+    const enrichedAddress = '0x1111111111111111111111111111111111111111';
+    const enrichedChainId = '0x1' as Hex;
+    const enrichedAssetId = assetUtils.toAssetId(
+      enrichedAddress,
+      enrichedChainId,
+    );
+
+    mockFetchAssetMetadataForAssetIds.mockResolvedValue({
+      [enrichedAssetId as string]: {
+        assetId: enrichedAssetId,
+        decimals: 18,
+        name: 'Dai Stablecoin',
+        symbol: 'DAI',
+      },
+    } as never);
+
+    const { result } = renderHookWithProvider(
+      () =>
+        useSendTokens({
+          enrichTokenRequests: [
+            {
+              address: enrichedAddress,
+              chainId: enrichedChainId,
+            },
+          ],
+          includeNoBalance: true,
+        }),
+      mockState,
+    );
+
+    await waitFor(() => {
+      expect(
+        result.current.find((asset) => asset.address === enrichedAddress),
+      ).toBeDefined();
+    });
+
+    const enrichedAsset = result.current.find(
+      (asset) => asset.address === enrichedAddress,
+    );
+    expect(enrichedAsset?.symbol).toBe('DAI');
+    expect(enrichedAsset?.rawBalance).toBe('0x0');
   });
 
   it('sorts assets by fiat balance descending', async () => {

--- a/ui/pages/confirmations/hooks/send/useSendTokens.ts
+++ b/ui/pages/confirmations/hooks/send/useSendTokens.ts
@@ -28,18 +28,15 @@ export type EnrichTokenRequest = {
 };
 
 type UseSendTokensOptions = {
-  enabled?: boolean;
   includeNoBalance?: boolean;
   tokenFilter?: (chainId: string, address: string) => boolean;
   enrichTokenRequests?: EnrichTokenRequest[];
 };
 
 const EMPTY_ENRICH_TOKEN_REQUESTS: EnrichTokenRequest[] = [];
-const EMPTY_ASSETS: Asset[] = [];
 
 export const useSendTokens = (options: UseSendTokensOptions = {}): Asset[] => {
   const {
-    enabled = true,
     includeNoBalance = false,
     tokenFilter,
     enrichTokenRequests = EMPTY_ENRICH_TOKEN_REQUESTS,
@@ -50,20 +47,13 @@ export const useSendTokens = (options: UseSendTokensOptions = {}): Asset[] => {
     Record<CaipAssetType, AssetMetadata>
   >({});
 
-  const flatAssets = useMemo(
-    () => (enabled ? Object.values(assets).flat() : EMPTY_ASSETS),
-    [assets, enabled],
-  );
+  const flatAssets = useMemo(() => Object.values(assets).flat(), [assets]);
 
   const enrichAssetIds = useMemo(() => {
-    if (!enabled) {
-      return [];
-    }
-
     return enrichTokenRequests
       .map(({ address, chainId }) => toAssetId(address, chainId))
       .filter((assetId): assetId is CaipAssetType => Boolean(assetId));
-  }, [enabled, enrichTokenRequests]);
+  }, [enrichTokenRequests]);
 
   const enrichAssetIdsKey = useMemo(
     () => enrichAssetIds.join(','),
@@ -101,10 +91,6 @@ export const useSendTokens = (options: UseSendTokensOptions = {}): Asset[] => {
   }, [enrichAssetIds, enrichAssetIdsKey]);
 
   const assetsWithBalance = useMemo(() => {
-    if (!enabled) {
-      return EMPTY_ASSETS;
-    }
-
     return flatAssets.filter((asset) => {
       if (tokenFilter) {
         const chainId = String(asset.chainId ?? '');
@@ -122,13 +108,9 @@ export const useSendTokens = (options: UseSendTokensOptions = {}): Asset[] => {
       const haveBalance = asset.rawBalance !== '0x0';
       return asset.isNative || haveBalance;
     });
-  }, [enabled, flatAssets, includeNoBalance, tokenFilter]);
+  }, [flatAssets, includeNoBalance, tokenFilter]);
 
   const processedAssets = useMemo<Asset[]>(() => {
-    if (!enabled) {
-      return EMPTY_ASSETS;
-    }
-
     const processedWalletAssets: Asset[] = assetsWithBalance.map((asset) => {
       const chainNetworkNameAndImage = chainNetworkNAmeAndImageMap.get(
         asset.chainId as Hex,
@@ -222,7 +204,6 @@ export const useSendTokens = (options: UseSendTokensOptions = {}): Asset[] => {
   }, [
     assetsWithBalance,
     chainNetworkNAmeAndImageMap,
-    enabled,
     enrichAssetIds.length,
     enrichTokenRequests,
     enrichedTokensMetadata,

--- a/ui/pages/confirmations/hooks/send/useSendTokens.ts
+++ b/ui/pages/confirmations/hooks/send/useSendTokens.ts
@@ -55,11 +55,6 @@ export const useSendTokens = (options: UseSendTokensOptions = {}): Asset[] => {
       .filter((assetId): assetId is CaipAssetType => Boolean(assetId));
   }, [enrichTokenRequests]);
 
-  const enrichAssetIdsKey = useMemo(
-    () => enrichAssetIds.join(','),
-    [enrichAssetIds],
-  );
-
   useEffect(() => {
     let cancelled = false;
 
@@ -88,7 +83,7 @@ export const useSendTokens = (options: UseSendTokensOptions = {}): Asset[] => {
       cancelled = true;
       abortController.abort();
     };
-  }, [enrichAssetIds, enrichAssetIdsKey]);
+  }, [enrichAssetIds]);
 
   const assetsWithBalance = useMemo(() => {
     return flatAssets.filter((asset) => {
@@ -210,7 +205,7 @@ export const useSendTokens = (options: UseSendTokensOptions = {}): Asset[] => {
   ]);
 
   return useMemo(() => {
-    return processedAssets.sort(
+    return [...processedAssets].sort(
       (a, b) => (b.fiat?.balance ?? 0) - (a.fiat?.balance ?? 0),
     );
   }, [processedAssets]);

--- a/ui/pages/confirmations/hooks/send/useSendTokens.ts
+++ b/ui/pages/confirmations/hooks/send/useSendTokens.ts
@@ -1,7 +1,6 @@
 import { useSelector } from 'react-redux';
 import { useEffect, useMemo, useState } from 'react';
 import { getNativeTokenAddress } from '@metamask/assets-controllers';
-import { EthAccountType } from '@metamask/keyring-api';
 import {
   isCaipAssetType,
   parseCaipAssetType,
@@ -83,13 +82,17 @@ export const useSendTokens = (options: UseSendTokensOptions = {}): Asset[] => {
 
     const abortController = new AbortController();
 
-    fetchAssetMetadataForAssetIds(enrichAssetIds, abortController.signal).then(
-      (metadata) => {
+    fetchAssetMetadataForAssetIds(enrichAssetIds, abortController.signal)
+      .then((metadata) => {
         if (!cancelled) {
           setEnrichedTokensMetadata(metadata ?? {});
         }
-      },
-    );
+      })
+      .catch((error) => {
+        if (!cancelled && !isAbortError(error)) {
+          setEnrichedTokensMetadata({});
+        }
+      });
 
     return () => {
       cancelled = true;
@@ -121,12 +124,12 @@ export const useSendTokens = (options: UseSendTokensOptions = {}): Asset[] => {
     });
   }, [enabled, flatAssets, includeNoBalance, tokenFilter]);
 
-  const processedAssets = useMemo(() => {
+  const processedAssets = useMemo<Asset[]>(() => {
     if (!enabled) {
       return EMPTY_ASSETS;
     }
 
-    const processedWalletAssets = assetsWithBalance.map((asset) => {
+    const processedWalletAssets: Asset[] = assetsWithBalance.map((asset) => {
       const chainNetworkNameAndImage = chainNetworkNAmeAndImageMap.get(
         asset.chainId as Hex,
       );
@@ -147,7 +150,8 @@ export const useSendTokens = (options: UseSendTokensOptions = {}): Asset[] => {
         image: imageSource,
         networkImage: chainNetworkNameAndImage?.networkImage,
         networkName: chainNetworkNameAndImage?.networkName,
-        shortenedBalance: asset.balance,
+        shortenedBalance:
+          asset.balance === undefined ? undefined : String(asset.balance),
         standard: asset.isNative ? AssetStandard.Native : AssetStandard.ERC20,
       };
     });
@@ -165,16 +169,16 @@ export const useSendTokens = (options: UseSendTokensOptions = {}): Asset[] => {
       ),
     );
 
-    const enrichedAssets = enrichTokenRequests
-      .map(({ address, chainId }) => {
+    const enrichedAssets = enrichTokenRequests.reduce<Asset[]>(
+      (result, { address, chainId }) => {
         const assetId = toAssetId(address, chainId);
         if (!assetId) {
-          return undefined;
+          return result;
         }
 
         const tokenKey = `${chainId.toLowerCase()}:${address.toLowerCase()}`;
         if (existingTokenKeys.has(tokenKey)) {
-          return undefined;
+          return result;
         }
 
         const metadata =
@@ -182,15 +186,13 @@ export const useSendTokens = (options: UseSendTokensOptions = {}): Asset[] => {
           enrichedTokensMetadata[assetId.toLowerCase() as CaipAssetType];
 
         if (!metadata?.symbol && !metadata?.name) {
-          return undefined;
+          return result;
         }
 
-        const chainNetworkNameAndImage = chainNetworkNAmeAndImageMap.get(
-          chainId,
-        );
+        const chainNetworkNameAndImage =
+          chainNetworkNAmeAndImageMap.get(chainId);
 
-        return {
-          accountType: EthAccountType.Eoa,
+        result.push({
           address: address.toLowerCase(),
           assetId,
           balance: '0',
@@ -209,9 +211,12 @@ export const useSendTokens = (options: UseSendTokensOptions = {}): Asset[] => {
           shortenedBalance: '0',
           standard: AssetStandard.ERC20,
           symbol: metadata.symbol,
-        } satisfies Asset;
-      })
-      .filter((asset): asset is Asset => Boolean(asset));
+        });
+
+        return result;
+      },
+      [],
+    );
 
     return [...processedWalletAssets, ...enrichedAssets];
   }, [
@@ -250,4 +255,8 @@ function getTokenFilterAddress(asset: Asset): string | undefined {
   }
 
   return asset.assetId;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
 }

--- a/ui/pages/confirmations/hooks/send/useSendTokens.ts
+++ b/ui/pages/confirmations/hooks/send/useSendTokens.ts
@@ -1,38 +1,132 @@
 import { useSelector } from 'react-redux';
-import { useMemo } from 'react';
-import { Hex } from '@metamask/utils';
+import { useEffect, useMemo, useState } from 'react';
+import { getNativeTokenAddress } from '@metamask/assets-controllers';
+import { EthAccountType } from '@metamask/keyring-api';
+import {
+  isCaipAssetType,
+  parseCaipAssetType,
+  type CaipAssetType,
+  type Hex,
+} from '@metamask/utils';
 
 import {
   CHAIN_ID_TOKEN_IMAGE_MAP,
   CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP,
 } from '../../../../../shared/constants/network';
+import {
+  fetchAssetMetadataForAssetIds,
+  getAssetImageUrl,
+  toAssetId,
+  type AssetMetadata,
+} from '../../../../../shared/lib/asset-utils';
 import { getAssetsBySelectedAccountGroup } from '../../../../selectors/assets';
 import { AssetStandard, type Asset } from '../../types/send';
 import { useChainNetworkNameAndImageMap } from '../useChainNetworkNameAndImage';
 
-type UseSendTokensOptions = {
-  includeNoBalance?: boolean;
+export type EnrichTokenRequest = {
+  chainId: Hex;
+  address: string;
 };
 
+type UseSendTokensOptions = {
+  enabled?: boolean;
+  includeNoBalance?: boolean;
+  tokenFilter?: (chainId: string, address: string) => boolean;
+  enrichTokenRequests?: EnrichTokenRequest[];
+};
+
+const EMPTY_ENRICH_TOKEN_REQUESTS: EnrichTokenRequest[] = [];
+const EMPTY_ASSETS: Asset[] = [];
+
 export const useSendTokens = (options: UseSendTokensOptions = {}): Asset[] => {
-  const { includeNoBalance = false } = options;
+  const {
+    enabled = true,
+    includeNoBalance = false,
+    tokenFilter,
+    enrichTokenRequests = EMPTY_ENRICH_TOKEN_REQUESTS,
+  } = options;
   const chainNetworkNAmeAndImageMap = useChainNetworkNameAndImageMap();
   const assets = useSelector(getAssetsBySelectedAccountGroup);
+  const [enrichedTokensMetadata, setEnrichedTokensMetadata] = useState<
+    Record<CaipAssetType, AssetMetadata>
+  >({});
 
-  const flatAssets = useMemo(() => Object.values(assets).flat(), [assets]);
+  const flatAssets = useMemo(
+    () => (enabled ? Object.values(assets).flat() : EMPTY_ASSETS),
+    [assets, enabled],
+  );
+
+  const enrichAssetIds = useMemo(() => {
+    if (!enabled) {
+      return [];
+    }
+
+    return enrichTokenRequests
+      .map(({ address, chainId }) => toAssetId(address, chainId))
+      .filter((assetId): assetId is CaipAssetType => Boolean(assetId));
+  }, [enabled, enrichTokenRequests]);
+
+  const enrichAssetIdsKey = useMemo(
+    () => enrichAssetIds.join(','),
+    [enrichAssetIds],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (enrichAssetIds.length === 0) {
+      setEnrichedTokensMetadata((current) =>
+        Object.keys(current).length === 0 ? current : {},
+      );
+      return undefined;
+    }
+
+    const abortController = new AbortController();
+
+    fetchAssetMetadataForAssetIds(enrichAssetIds, abortController.signal).then(
+      (metadata) => {
+        if (!cancelled) {
+          setEnrichedTokensMetadata(metadata ?? {});
+        }
+      },
+    );
+
+    return () => {
+      cancelled = true;
+      abortController.abort();
+    };
+  }, [enrichAssetIds, enrichAssetIdsKey]);
 
   const assetsWithBalance = useMemo(() => {
-    if (includeNoBalance) {
-      return flatAssets;
+    if (!enabled) {
+      return EMPTY_ASSETS;
     }
+
     return flatAssets.filter((asset) => {
+      if (tokenFilter) {
+        const chainId = String(asset.chainId ?? '');
+        const address = getTokenFilterAddress(asset);
+
+        if (!chainId || !address || !tokenFilter(chainId, address)) {
+          return false;
+        }
+      }
+
+      if (includeNoBalance) {
+        return true;
+      }
+
       const haveBalance = asset.rawBalance !== '0x0';
       return asset.isNative || haveBalance;
     });
-  }, [flatAssets, includeNoBalance]);
+  }, [enabled, flatAssets, includeNoBalance, tokenFilter]);
 
   const processedAssets = useMemo(() => {
-    return assetsWithBalance.map((asset) => {
+    if (!enabled) {
+      return EMPTY_ASSETS;
+    }
+
+    const processedWalletAssets = assetsWithBalance.map((asset) => {
       const chainNetworkNameAndImage = chainNetworkNAmeAndImageMap.get(
         asset.chainId as Hex,
       );
@@ -57,7 +151,77 @@ export const useSendTokens = (options: UseSendTokensOptions = {}): Asset[] => {
         standard: asset.isNative ? AssetStandard.Native : AssetStandard.ERC20,
       };
     });
-  }, [assetsWithBalance, chainNetworkNAmeAndImageMap]);
+
+    if (enrichAssetIds.length === 0) {
+      return processedWalletAssets;
+    }
+
+    const existingTokenKeys = new Set(
+      processedWalletAssets.map(
+        (token) =>
+          `${String(token.chainId ?? '').toLowerCase()}:${String(
+            token.address ?? '',
+          ).toLowerCase()}`,
+      ),
+    );
+
+    const enrichedAssets = enrichTokenRequests
+      .map(({ address, chainId }) => {
+        const assetId = toAssetId(address, chainId);
+        if (!assetId) {
+          return undefined;
+        }
+
+        const tokenKey = `${chainId.toLowerCase()}:${address.toLowerCase()}`;
+        if (existingTokenKeys.has(tokenKey)) {
+          return undefined;
+        }
+
+        const metadata =
+          enrichedTokensMetadata[assetId] ??
+          enrichedTokensMetadata[assetId.toLowerCase() as CaipAssetType];
+
+        if (!metadata?.symbol && !metadata?.name) {
+          return undefined;
+        }
+
+        const chainNetworkNameAndImage = chainNetworkNAmeAndImageMap.get(
+          chainId,
+        );
+
+        return {
+          accountType: EthAccountType.Eoa,
+          address: address.toLowerCase(),
+          assetId,
+          balance: '0',
+          chainId,
+          decimals: metadata.decimals,
+          fiat: {
+            balance: 0,
+            currency: 'USD',
+          },
+          image: getAssetImageUrl(assetId, chainId) ?? '',
+          isNative: false,
+          name: metadata.name,
+          networkImage: chainNetworkNameAndImage?.networkImage,
+          networkName: chainNetworkNameAndImage?.networkName,
+          rawBalance: '0x0' as Hex,
+          shortenedBalance: '0',
+          standard: AssetStandard.ERC20,
+          symbol: metadata.symbol,
+        } satisfies Asset;
+      })
+      .filter((asset): asset is Asset => Boolean(asset));
+
+    return [...processedWalletAssets, ...enrichedAssets];
+  }, [
+    assetsWithBalance,
+    chainNetworkNAmeAndImageMap,
+    enabled,
+    enrichAssetIds.length,
+    enrichTokenRequests,
+    enrichedTokensMetadata,
+  ]);
 
   return useMemo(() => {
     return processedAssets.sort(
@@ -65,3 +229,25 @@ export const useSendTokens = (options: UseSendTokensOptions = {}): Asset[] => {
     );
   }, [processedAssets]);
 };
+
+function getTokenFilterAddress(asset: Asset): string | undefined {
+  const chainId = String(asset.chainId ?? '');
+
+  if (asset.isNative && chainId) {
+    try {
+      return getNativeTokenAddress(chainId as Hex);
+    } catch {
+      return asset.address;
+    }
+  }
+
+  if (asset.address) {
+    return String(asset.address);
+  }
+
+  if (asset.assetId && isCaipAssetType(asset.assetId)) {
+    return parseCaipAssetType(asset.assetId).assetReference;
+  }
+
+  return asset.assetId;
+}

--- a/ui/pages/confirmations/selectors/feature-flags.test.ts
+++ b/ui/pages/confirmations/selectors/feature-flags.test.ts
@@ -5,6 +5,7 @@ import {
   selectIsEnforcedSimulationsEnabled,
   selectIsMetaMaskPayDappsEnabled,
   selectPayQuoteConfig,
+  selectPreferredPayToken,
 } from './feature-flags';
 
 type ConfirmationsPayDappsFlag = {
@@ -27,12 +28,29 @@ type PayPostQuoteFlag = {
   perpsWithdraw?: PayPostQuoteConfig;
 };
 
+type PreferredPayToken = {
+  address?: string;
+  chainId?: string;
+  name?: string;
+};
+
+type PreferredTokensConfig = {
+  default?: PreferredPayToken[] | Record<string, PreferredPayToken[]>;
+  overrides?: Record<string, PreferredPayToken[]>;
+  perpsWithdraw?: PreferredPayToken[];
+};
+
+type PayTokensFlag = {
+  preferredTokens?: PreferredTokensConfig;
+};
+
 type MockState = {
   metamask: {
     remoteFeatureFlags: {
       confirmations_pay_dapps?: ConfirmationsPayDappsFlag;
       confirmations_enforced_simulations?: EnforcedSimulationsFlag;
       confirmations_pay_post_quote?: PayPostQuoteFlag;
+      confirmations_pay_tokens?: PayTokensFlag;
     };
   };
 };
@@ -68,6 +86,18 @@ const getMockPayPostQuoteState = (
     remoteFeatureFlags: {
       ...(confirmations_pay_post_quote !== undefined && {
         confirmations_pay_post_quote,
+      }),
+    },
+  },
+});
+
+const getMockPayTokensState = (
+  confirmations_pay_tokens?: PayTokensFlag,
+): MockState => ({
+  metamask: {
+    remoteFeatureFlags: {
+      ...(confirmations_pay_tokens !== undefined && {
+        confirmations_pay_tokens,
       }),
     },
   },
@@ -175,6 +205,64 @@ describe('Confirmations Pay Feature Flags', () => {
         enabled: false,
         tokens: undefined,
       });
+    });
+  });
+
+  describe('selectPreferredPayToken', () => {
+    it('returns the first transaction override token from the resolved config', () => {
+      const state = getMockPayTokensState({
+        preferredTokens: {
+          default: {},
+          overrides: {
+            perpsWithdraw: [
+              {
+                address: '0x1111111111111111111111111111111111111111',
+                chainId: '0x1',
+                name: 'mUSD',
+              },
+              {
+                address: '0x2222222222222222222222222222222222222222',
+                chainId: '0xa4b1',
+                name: 'USDC',
+              },
+            ],
+          },
+        },
+      });
+
+      expect(selectPreferredPayToken(state, 'perpsWithdraw')).toStrictEqual({
+        address: '0x1111111111111111111111111111111111111111',
+        chainId: '0x1',
+        name: 'mUSD',
+      });
+    });
+
+    it('supports direct transaction config', () => {
+      const state = getMockPayTokensState({
+        preferredTokens: {
+          perpsWithdraw: [
+            {
+              address: '0x3333333333333333333333333333333333333333',
+              chainId: '0x38',
+            },
+          ],
+        },
+      });
+
+      expect(selectPreferredPayToken(state, 'perpsWithdraw')).toStrictEqual({
+        address: '0x3333333333333333333333333333333333333333',
+        chainId: '0x38',
+      });
+    });
+
+    it('returns undefined when no preferred token is configured', () => {
+      const state = getMockPayTokensState({
+        preferredTokens: {
+          default: {},
+        },
+      });
+
+      expect(selectPreferredPayToken(state, 'perpsWithdraw')).toBeUndefined();
     });
   });
 });

--- a/ui/pages/confirmations/selectors/feature-flags.test.ts
+++ b/ui/pages/confirmations/selectors/feature-flags.test.ts
@@ -4,6 +4,7 @@ import {
   selectEnforcedSimulationsSlippage,
   selectIsEnforcedSimulationsEnabled,
   selectIsMetaMaskPayDappsEnabled,
+  selectPayQuoteConfig,
 } from './feature-flags';
 
 type ConfirmationsPayDappsFlag = {
@@ -15,11 +16,23 @@ type EnforcedSimulationsFlag = {
   slippage?: number;
 };
 
+type PayPostQuoteConfig = {
+  enabled?: boolean;
+  tokens?: Record<string, string[]>;
+};
+
+type PayPostQuoteFlag = {
+  default?: PayPostQuoteConfig;
+  overrides?: Record<string, PayPostQuoteConfig>;
+  perpsWithdraw?: PayPostQuoteConfig;
+};
+
 type MockState = {
   metamask: {
     remoteFeatureFlags: {
       confirmations_pay_dapps?: ConfirmationsPayDappsFlag;
       confirmations_enforced_simulations?: EnforcedSimulationsFlag;
+      confirmations_pay_post_quote?: PayPostQuoteFlag;
     };
   };
 };
@@ -43,6 +56,18 @@ const getMockEnforcedSimulationsState = (
     remoteFeatureFlags: {
       ...(confirmations_enforced_simulations !== undefined && {
         confirmations_enforced_simulations,
+      }),
+    },
+  },
+});
+
+const getMockPayPostQuoteState = (
+  confirmations_pay_post_quote?: PayPostQuoteFlag,
+): MockState => ({
+  metamask: {
+    remoteFeatureFlags: {
+      ...(confirmations_pay_post_quote !== undefined && {
+        confirmations_pay_post_quote,
       }),
     },
   },
@@ -77,6 +102,79 @@ describe('Confirmations Pay Feature Flags', () => {
         },
       };
       expect(selectIsMetaMaskPayDappsEnabled(state)).toBe(false);
+    });
+  });
+
+  describe('selectPayQuoteConfig', () => {
+    it('returns the default post-quote config when no transaction override is set', () => {
+      const state = getMockPayPostQuoteState({
+        default: {
+          enabled: true,
+          tokens: {
+            '0xa4b1': ['0xaf88d065e77c8cc2239327c5edb3a432268e5831'],
+          },
+        },
+      });
+
+      expect(selectPayQuoteConfig(state, 'perpsWithdraw')).toStrictEqual({
+        enabled: true,
+        tokens: {
+          '0xa4b1': ['0xaf88d065e77c8cc2239327c5edb3a432268e5831'],
+        },
+      });
+    });
+
+    it('merges mobile-compatible overrides with the default config', () => {
+      const state = getMockPayPostQuoteState({
+        default: {
+          enabled: true,
+          tokens: {
+            '0xa4b1': ['0xaf88d065e77c8cc2239327c5edb3a432268e5831'],
+          },
+        },
+        overrides: {
+          perpsWithdraw: {
+            tokens: {
+              '0x38': ['0x55d398326f99059ff775485246999027b3197955'],
+            },
+          },
+        },
+      });
+
+      expect(selectPayQuoteConfig(state, 'perpsWithdraw')).toStrictEqual({
+        enabled: true,
+        tokens: {
+          '0x38': ['0x55d398326f99059ff775485246999027b3197955'],
+        },
+      });
+    });
+
+    it('supports direct transaction config at perpsWithdraw.tokens', () => {
+      const state = getMockPayPostQuoteState({
+        default: { enabled: false },
+        perpsWithdraw: {
+          enabled: true,
+          tokens: {
+            '0x38': ['0x55d398326f99059ff775485246999027b3197955'],
+          },
+        },
+      });
+
+      expect(selectPayQuoteConfig(state, 'perpsWithdraw')).toStrictEqual({
+        enabled: true,
+        tokens: {
+          '0x38': ['0x55d398326f99059ff775485246999027b3197955'],
+        },
+      });
+    });
+
+    it('defaults to disabled when the post-quote flag is not set', () => {
+      const state = getMockPayPostQuoteState();
+
+      expect(selectPayQuoteConfig(state, 'perpsWithdraw')).toStrictEqual({
+        enabled: false,
+        tokens: undefined,
+      });
     });
   });
 });

--- a/ui/pages/confirmations/selectors/feature-flags.ts
+++ b/ui/pages/confirmations/selectors/feature-flags.ts
@@ -24,6 +24,25 @@ type RawPayPostQuoteFlag = {
     | undefined;
 };
 
+export type PreferredPayToken = {
+  address: Hex;
+  chainId: Hex;
+  name?: string;
+};
+
+type PreferredTokensConfig = {
+  default?: PreferredPayToken[] | Record<string, PreferredPayToken[]>;
+  overrides?: Record<string, PreferredPayToken[]>;
+  [transactionType: string]:
+    | PreferredPayToken[]
+    | Record<string, PreferredPayToken[]>
+    | undefined;
+};
+
+type RawPayTokensFlag = {
+  preferredTokens?: PreferredTokensConfig;
+};
+
 const selectConfirmationsPayDappsFlag = createSelector(
   getRemoteFeatureFlags,
   (flags) =>
@@ -50,6 +69,18 @@ const selectPayPostQuoteFlag = createSelector(
         confirmations_pay_post_quote?: RawPayPostQuoteFlag;
       }
     ).confirmations_pay_post_quote,
+  /* eslint-enable @typescript-eslint/naming-convention */
+);
+
+const selectPayTokensFlag = createSelector(
+  getRemoteFeatureFlags,
+  (flags) =>
+    /* eslint-disable @typescript-eslint/naming-convention */
+    (
+      flags as unknown as {
+        confirmations_pay_tokens?: RawPayTokensFlag;
+      }
+    ).confirmations_pay_tokens,
   /* eslint-enable @typescript-eslint/naming-convention */
 );
 
@@ -88,6 +119,21 @@ export const selectPayQuoteConfig = createSelector(
   },
 );
 
+export const selectPreferredPayToken = createSelector(
+  [
+    selectPayTokensFlag,
+    (_state, transactionType?: string) => transactionType,
+  ],
+  (flag, transactionType): PreferredPayToken | undefined => {
+    const preferredTokens = getPreferredTokensForTransaction(
+      flag?.preferredTokens,
+      transactionType,
+    );
+
+    return preferredTokens?.[0];
+  },
+);
+
 export const selectIsEnforcedSimulationsEnabled = createSelector(
   getRemoteFeatureFlags,
   (remoteFeatureFlags): boolean =>
@@ -99,3 +145,41 @@ export const selectEnforcedSimulationsSlippage = createSelector(
   (remoteFeatureFlags): number =>
     getEnforcedSimulationsSlippage({ remoteFeatureFlags }),
 );
+
+function getPreferredTokensForTransaction(
+  config?: PreferredTokensConfig,
+  transactionType?: string,
+): PreferredPayToken[] | undefined {
+  if (!config) {
+    return undefined;
+  }
+
+  const defaultTokens = normalizePreferredPayTokens(config.default);
+  const transactionTokens = transactionType
+    ? normalizePreferredPayTokens(
+        config.overrides?.[transactionType] ?? config[transactionType],
+      )
+    : undefined;
+
+  return transactionTokens ?? defaultTokens;
+}
+
+function normalizePreferredPayTokens(
+  value?: PreferredPayToken[] | Record<string, PreferredPayToken[]>,
+): PreferredPayToken[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const tokens = value.filter(isPreferredPayToken);
+  return tokens.length ? tokens : undefined;
+}
+
+function isPreferredPayToken(value: unknown): value is PreferredPayToken {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as PreferredPayToken).address === 'string' &&
+    typeof (value as PreferredPayToken).chainId === 'string'
+  );
+}

--- a/ui/pages/confirmations/selectors/feature-flags.ts
+++ b/ui/pages/confirmations/selectors/feature-flags.ts
@@ -120,10 +120,7 @@ export const selectPayQuoteConfig = createSelector(
 );
 
 export const selectPreferredPayToken = createSelector(
-  [
-    selectPayTokensFlag,
-    (_state, transactionType?: string) => transactionType,
-  ],
+  [selectPayTokensFlag, (_state, transactionType?: string) => transactionType],
   (flag, transactionType): PreferredPayToken | undefined => {
     const preferredTokens = getPreferredTokensForTransaction(
       flag?.preferredTokens,

--- a/ui/pages/confirmations/selectors/feature-flags.ts
+++ b/ui/pages/confirmations/selectors/feature-flags.ts
@@ -1,4 +1,5 @@
 import { createSelector } from 'reselect';
+import type { Hex } from '@metamask/utils';
 import {
   getEnforcedSimulationsSlippage,
   getIsEnforcedSimulationsEnabled,
@@ -7,6 +8,20 @@ import { getRemoteFeatureFlags } from '../../../selectors/remote-feature-flags';
 
 type ConfirmationsPayDappsFlag = {
   enabled?: boolean;
+};
+
+export type PayPostQuoteConfig = {
+  enabled?: boolean;
+  tokens?: Record<Hex, Hex[]>;
+};
+
+type RawPayPostQuoteFlag = {
+  default?: PayPostQuoteConfig;
+  overrides?: Record<string, PayPostQuoteConfig>;
+  [transactionType: string]:
+    | PayPostQuoteConfig
+    | Record<string, PayPostQuoteConfig>
+    | undefined;
 };
 
 const selectConfirmationsPayDappsFlag = createSelector(
@@ -24,6 +39,53 @@ const selectConfirmationsPayDappsFlag = createSelector(
 export const selectIsMetaMaskPayDappsEnabled = createSelector(
   selectConfirmationsPayDappsFlag,
   (flag): boolean => flag?.enabled ?? false,
+);
+
+const selectPayPostQuoteFlag = createSelector(
+  getRemoteFeatureFlags,
+  (flags) =>
+    /* eslint-disable @typescript-eslint/naming-convention */
+    (
+      flags as unknown as {
+        confirmations_pay_post_quote?: RawPayPostQuoteFlag;
+      }
+    ).confirmations_pay_post_quote,
+  /* eslint-enable @typescript-eslint/naming-convention */
+);
+
+/**
+ * Resolves the effective post-quote config for a given transaction type.
+ * Transaction-specific config may be supplied either as
+ * `overrides[transactionType]` (mobile-compatible) or directly at
+ * `[transactionType]` (for example, `perpsWithdraw.tokens`).
+ * @param _state
+ * @param transactionType
+ */
+export const selectPayQuoteConfig = createSelector(
+  [
+    selectPayPostQuoteFlag,
+    (_state, transactionType?: string) => transactionType,
+  ],
+  (flag, transactionType): PayPostQuoteConfig => {
+    const defaultConfig: PayPostQuoteConfig = {
+      enabled: flag?.default?.enabled ?? false,
+      tokens: flag?.default?.tokens,
+    };
+
+    const transactionConfig = transactionType
+      ? (flag?.overrides?.[transactionType] ??
+        (flag?.[transactionType] as PayPostQuoteConfig | undefined))
+      : undefined;
+
+    if (!transactionConfig) {
+      return defaultConfig;
+    }
+
+    return {
+      enabled: transactionConfig.enabled ?? defaultConfig.enabled,
+      tokens: transactionConfig.tokens ?? defaultConfig.tokens,
+    };
+  },
 );
 
 export const selectIsEnforcedSimulationsEnabled = createSelector(


### PR DESCRIPTION
## **Description**

This PR updates the confirmations Perps Withdraw flow to support remotely configured withdraw destination tokens.

It adds support for:
- Filtering Perps Withdraw destination tokens using `confirmations_pay_post_quote`
- Showing allowlisted zero-balance destination tokens in the token picker
- Defaulting Perps Withdraw to `confirmations_pay_tokens.preferredTokens.overrides.perpsWithdraw` when the user has no prior confirmed Perps Withdraw
- Preserving the last confirmed Perps Withdraw token as the default when one exists
- Including the MetaMask fee in the displayed withdraw fee total and tooltip

## **Changelog**

CHANGELOG entry: Fixed Perps Withdraw token defaults and fee display

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1332

## **Manual testing steps**

1. Configure `confirmations_pay_post_quote` with a Perps Withdraw token allowlist.
2. Configure `confirmations_pay_tokens.preferredTokens.overrides.perpsWithdraw` with a default token.
3. Open a Perps Withdraw confirmation for a user with no previous confirmed Perps Withdraw transaction.
4. Confirm the withdraw destination token defaults to the configured preferred token.
5. Select a different allowlisted token and complete a Perps Withdraw.
6. Open another Perps Withdraw confirmation and confirm the latest confirmed withdraw token is used as the default.
7. Confirm the transaction fee row includes the MetaMask fee when present.

<!--
## **Screenshots/Recordings**



### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches confirmations pay-token selection/filtering and fee display logic, so misconfiguration or edge cases could block token selection or show incorrect totals; changes are gated by remote flags and covered by tests.
> 
> **Overview**
> Adds **post-quote withdraw** support for remotely allowlisted destination tokens. New helpers (`getPostQuoteWithdrawTransactionType`, `isPostQuoteWithdrawTransaction`) and a `usePostQuoteWithdrawTokenFilter` hook apply `confirmations_pay_post_quote` allowlists (including native-token handling) and can bypass the standard available-token filter in `PayWithModal`.
> 
> Extends `useSendTokens` to support `tokenFilter` plus *metadata enrichment* for allowlisted tokens not already in the wallet list, enabling zero-balance destination tokens to appear. Updates automatic/default token selection so Perps Withdraw can default to `confirmations_pay_tokens.preferredTokens` when there’s no prior confirmed withdraw, while still preferring the most recent confirmed withdraw token.
> 
> Updates the confirmations fee row to **include MetaMask fees in the total** and display a formatted MetaMask fee line (including sub-cent `"<$0.01"`) in the tooltip; adds/updates unit tests across the above behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 190745c423a60e83ddd917c43392b9553b44e468. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->