### PR TITLE
chore: remove tokensChainsCache usage from useTokenDetails

### DIFF
--- a/ui/pages/confirmations/components/confirm/info/hooks/useTokenDetails.test.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useTokenDetails.test.ts
@@ -1,57 +1,41 @@
 import { TransactionMeta } from '@metamask/transaction-controller';
-import { useSelector } from 'react-redux';
 import { genUnapprovedTokenTransferConfirmation } from '../../../../../../../test/data/confirmations/token-transfer';
 import mockState from '../../../../../../../test/data/mock-state.json';
 import { renderHookWithProvider } from '../../../../../../../test/lib/render-helpers-navigate';
-import { selectERC20TokensByChain } from '../../../../../../selectors';
 import { useTokenDetails } from './useTokenDetails';
-
-jest.mock('react-redux', () => ({
-  ...jest.requireActual('react-redux'),
-  useSelector: jest.fn(),
-}));
 
 const ICON_SYMBOL = 'FROG';
 const ICON_URL =
   'https://static.cx.metamask.io/api/v1/tokenIcons/1/0x0a2c375553e6965b42c135bb8b15a8914b08de0c.png';
-const MOCK_TOKEN_LIST_BY_CHAIN = (transactionMeta: TransactionMeta) => ({
-  [transactionMeta.chainId]: {
-    data: {
-      [(transactionMeta.txParams.to as string).toLowerCase()]: {
-        address: transactionMeta.txParams.to,
-        aggregators: ['CoinGecko', 'Socket', 'Coinmarketcap'],
-        decimals: 9,
-        iconUrl: ICON_URL,
-        name: 'Frog on ETH',
-        occurrences: 3,
-        symbol: ICON_SYMBOL,
-      },
-    },
-  },
-});
 
 describe('useTokenDetails', () => {
-  const useSelectorMock = useSelector as jest.Mock;
-
-  beforeEach(() => {
-    jest.resetAllMocks();
-  });
-
-  it('returns token details from the token list if it exists', () => {
+  it('returns token details from allTokens if the token is imported', () => {
     const transactionMeta = genUnapprovedTokenTransferConfirmation(
       {},
     ) as TransactionMeta;
 
-    useSelectorMock.mockImplementation((selector) => {
-      if (selector === selectERC20TokensByChain) {
-        return MOCK_TOKEN_LIST_BY_CHAIN(transactionMeta);
-      }
-      return undefined;
-    });
+    const stateWithToken = {
+      ...mockState,
+      metamask: {
+        ...mockState.metamask,
+        allTokens: {
+          [transactionMeta.chainId]: {
+            [transactionMeta.txParams.from as string]: [
+              {
+                address: transactionMeta.txParams.to,
+                symbol: ICON_SYMBOL,
+                image: ICON_URL,
+                decimals: 9,
+              },
+            ],
+          },
+        },
+      },
+    };
 
     const { result } = renderHookWithProvider(
       () => useTokenDetails(transactionMeta),
-      mockState,
+      stateWithToken,
     );
 
     expect(result.current).toEqual({
@@ -60,21 +44,22 @@ describe('useTokenDetails', () => {
     });
   });
 
-  it('returns undefined for tokenImage and "Unknown" for tokenSymbol if token is not found', () => {
+  it('returns undefined for tokenImage and "Unknown" for tokenSymbol if token is not in allTokens', () => {
     const transactionMeta = genUnapprovedTokenTransferConfirmation(
       {},
     ) as TransactionMeta;
 
-    useSelectorMock.mockImplementation((selector) => {
-      if (selector === selectERC20TokensByChain) {
-        return {};
-      }
-      return undefined;
-    });
+    const stateWithNoTokens = {
+      ...mockState,
+      metamask: {
+        ...mockState.metamask,
+        allTokens: {},
+      },
+    };
 
     const { result } = renderHookWithProvider(
       () => useTokenDetails(transactionMeta),
-      mockState,
+      stateWithNoTokens,
     );
 
     expect(result.current).toEqual({
@@ -83,30 +68,28 @@ describe('useTokenDetails', () => {
     });
   });
 
-  it('returns undefined for tokenImage and "Unknown" for tokenSymbol if chainId is not in token list', () => {
+  it('returns undefined for tokenImage and "Unknown" for tokenSymbol if chainId has no tokens', () => {
     const transactionMeta = genUnapprovedTokenTransferConfirmation(
       {},
     ) as TransactionMeta;
 
-    useSelectorMock.mockImplementation((selector) => {
-      if (selector === selectERC20TokensByChain) {
-        return {
+    const stateWithWrongChain = {
+      ...mockState,
+      metamask: {
+        ...mockState.metamask,
+        allTokens: {
           '0x999': {
-            data: {
-              '0xsomeotheraddress': {
-                iconUrl: ICON_URL,
-                symbol: ICON_SYMBOL,
-              },
-            },
+            [transactionMeta.txParams.from as string]: [
+              { address: transactionMeta.txParams.to, symbol: ICON_SYMBOL },
+            ],
           },
-        };
-      }
-      return undefined;
-    });
+        },
+      },
+    };
 
     const { result } = renderHookWithProvider(
       () => useTokenDetails(transactionMeta),
-      mockState,
+      stateWithWrongChain,
     );
 
     expect(result.current).toEqual({
@@ -115,30 +98,32 @@ describe('useTokenDetails', () => {
     });
   });
 
-  it('returns undefined for tokenImage and "Unknown" for tokenSymbol if token address is not in chain data', () => {
+  it('returns undefined for tokenImage and "Unknown" for tokenSymbol if token address does not match', () => {
     const transactionMeta = genUnapprovedTokenTransferConfirmation(
       {},
     ) as TransactionMeta;
 
-    useSelectorMock.mockImplementation((selector) => {
-      if (selector === selectERC20TokensByChain) {
-        return {
+    const stateWithDifferentToken = {
+      ...mockState,
+      metamask: {
+        ...mockState.metamask,
+        allTokens: {
           [transactionMeta.chainId]: {
-            data: {
-              '0xdifferentaddress': {
-                iconUrl: ICON_URL,
+            [transactionMeta.txParams.from as string]: [
+              {
+                address: '0xdifferentaddress',
                 symbol: ICON_SYMBOL,
+                image: ICON_URL,
               },
-            },
+            ],
           },
-        };
-      }
-      return undefined;
-    });
+        },
+      },
+    };
 
     const { result } = renderHookWithProvider(
       () => useTokenDetails(transactionMeta),
-      mockState,
+      stateWithDifferentToken,
     );
 
     expect(result.current).toEqual({

--- a/ui/pages/confirmations/components/confirm/info/hooks/useTokenDetails.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useTokenDetails.ts
@@ -1,10 +1,7 @@
 import { TransactionMeta } from '@metamask/transaction-controller';
 import { useSelector } from 'react-redux';
 import { useI18nContext } from '../../../../../../hooks/useI18nContext';
-import {
-  getAllTokens,
-  selectERC20TokensByChain,
-} from '../../../../../../selectors';
+import { getAllTokens } from '../../../../../../selectors';
 
 export const useTokenDetails = (transactionMeta: TransactionMeta) => {
   const t = useI18nContext();
@@ -12,18 +9,14 @@ export const useTokenDetails = (transactionMeta: TransactionMeta) => {
     chainId,
     txParams: { to, from },
   } = transactionMeta ?? { txParams: {} };
-  const erc20TokensByChain = useSelector(selectERC20TokensByChain);
-  const allTokens = useSelector(getAllTokens);
 
-  const erc20Token =
-    erc20TokensByChain[chainId]?.data?.[to?.toLowerCase() as string];
+  const allTokens = useSelector(getAllTokens);
   const tokenListToken = allTokens?.[chainId]?.[from as string]?.find(
     (token) => token.address?.toLowerCase() === (to?.toLowerCase() as string),
   );
 
-  const tokenImage = erc20Token?.iconUrl || tokenListToken?.image || undefined;
-  const tokenSymbol =
-    erc20Token?.symbol || tokenListToken?.symbol || t('unknown');
+  const tokenImage = tokenListToken?.image || undefined;
+  const tokenSymbol = tokenListToken?.symbol || t('unknown');
 
   return { tokenImage, tokenSymbol };
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

`useTokenDetails` is used in the token transfer confirmation screen (`send-heading.tsx`) to resolve the token's icon and symbol for the heading — e.g. "3 CAKE 🐰".

Previously the hook read from two sources:
1. `tokensChainsCache` via `selectERC20TokensByChain` — the cached API token list stored in Redux state
2. `allTokens` via `getAllTokens` — the user's imported/detected tokens

The `tokensChainsCache` lookup was redundant here. The `tokenMethodTransfer` transaction type (the only type that renders this component) is exclusively created by the MetaMask send flow. To reach that flow, the user must select a token from the asset picker, which means the token is always already present in `allTokens`. The first source could never return data that the second source didn't also have.

This PR removes the `selectERC20TokensByChain` / `tokensChainsCache` dependency from `useTokenDetails`, leaving `allTokens` as the sole source of truth. The tests are updated accordingly — replacing the `useSelector` mock with proper Redux state overrides that directly populate `allTokens`.

## **Changelog**

CHANGELOG entry: remove tokensChainsCache usage from useTokenDetails

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3175

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Manual testing steps**

1. Open MetaMask and go to the **Send** flow
2. Select an ERC-20 token you hold (e.g. USDC, CAKE) and enter a recipient and amount
3. Proceed to the confirmation screen
4. Verify the token symbol and icon appear correctly in the "Sending X TOKEN" heading
5. Verify the fiat value and all other confirmation details are unaffected
6. Confirm and verify the transaction completes normally

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this removes a redundant token metadata fallback and updates tests; impact is limited to token icon/symbol display on the send confirmation heading if `allTokens` is unexpectedly missing the token.
> 
> **Overview**
> Simplifies `useTokenDetails` to **only** resolve token symbol/icon from `allTokens` (via `getAllTokens`), removing the `selectERC20TokensByChain`/`tokensChainsCache` fallback.
> 
> Updates `useTokenDetails` tests to stop mocking `useSelector` and instead override Redux state to cover imported-token and missing-token scenarios (no tokens, wrong chain, mismatched address).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87d84278a6ddf2b1d270df8567e5a65851b7aeb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->