### PR TITLE
fix: Fix event delegation in UI messenger

### DIFF
--- a/test/lib/mock-ui-messenger.ts
+++ b/test/lib/mock-ui-messenger.ts
@@ -1,8 +1,8 @@
-import {
+import type {
+  ActionConstraint,
   ActionHandler,
+  EventConstraint,
   Messenger,
-  MOCK_ANY_NAMESPACE,
-  MockAnyNamespace,
 } from '@metamask/messenger';
 import type {
   UIMessenger,
@@ -10,21 +10,24 @@ import type {
   UIMessengerEvents,
 } from '../../ui/messengers/ui-messenger';
 
-/**
- * Maps each UIMessenger action type string to its handler function type.
- */
-export type UIMessengerActionHandlersByType = {
-  [Action in UIMessengerActions as Action['type']]: Action['handler'];
+type DelegateeMessenger = Messenger<string, ActionConstraint, EventConstraint>;
+
+type DelegateArgs = {
+  actions?: UIMessengerActions['type'][];
+  events?: UIMessengerEvents['type'][];
+  messenger: DelegateeMessenger;
 };
 
 /**
  * Create a UI messenger for testing with the specified action handlers.
  *
- * This creates a real Messenger instance with a fake namespace and registers
- * the provided action handlers on it.
+ * This creates a mock UIMessenger that registers the provided action handlers
+ * directly on any messenger delegated to it, bypassing the background
+ * connection. Events are not subscribed to since there is no background
+ * connection in tests.
  *
  * @param actionHandlers - A map of action type strings to handler functions.
- * @returns A messenger with the specified action handlers registered.
+ * @returns A mock UI messenger with the specified action handlers.
  * @example
  * ```typescript
  * const addNetwork = jest.fn().mockResolvedValue({ chainId: '0x1' });
@@ -38,23 +41,31 @@ export function createMockUIMessenger<
 >(actionHandlers?: {
   [Action in Actions as Action['type']]: Action['handler'];
 }): UIMessenger {
-  const messenger = new Messenger<
-    MockAnyNamespace,
-    UIMessengerActions,
-    UIMessengerEvents
-  >({
-    namespace: MOCK_ANY_NAMESPACE,
-  });
+  return {
+    async delegate({ actions = [], messenger }: DelegateArgs) {
+      for (const actionType of actions) {
+        const handler =
+          (
+            actionHandlers as Record<
+              string,
+              ActionHandler<UIMessengerActions, UIMessengerActions['type']>
+            >
+          )?.[actionType] ??
+          (() => {
+            throw new Error(
+              `No handler registered for action "${String(actionType)}"`,
+            );
+          });
 
-  for (const [actionType, handler] of Object.entries(actionHandlers ?? {})) {
-    messenger.registerActionHandler(
-      actionType as Actions['type'],
-      handler as ActionHandler<Actions, Actions['type']>,
-    );
-  }
+        messenger._internalRegisterDelegatedActionHandler(actionType, handler);
+      }
+      // No background connection in tests — events are not subscribed to.
+    },
 
-  // UIMessenger is a subclass of Messenger that includes private fields.
-  // We don't want to create a real UIMessenger instance above, we want to make
-  // a "fake" one, but we want TypeScript to think this is a real one.
-  return messenger as UIMessenger;
+    async revoke({ actions = [], messenger }: DelegateArgs) {
+      for (const actionType of actions) {
+        messenger._internalUnregisterDelegatedActionHandler(actionType);
+      }
+    },
+  } as unknown as UIMessenger;
 }

--- a/test/lib/mock-ui-messenger.ts
+++ b/test/lib/mock-ui-messenger.ts
@@ -12,9 +12,12 @@ import type {
 
 type DelegateeMessenger = Messenger<string, ActionConstraint, EventConstraint>;
 
-type DelegateArgs = {
-  actions?: UIMessengerActions['type'][];
-  events?: UIMessengerEvents['type'][];
+type DelegateArgs<
+  Actions extends UIMessengerActions,
+  Events extends UIMessengerEvents,
+> = {
+  actions?: Actions['type'][];
+  events?: Events['type'][];
   messenger: DelegateeMessenger;
 };
 
@@ -38,31 +41,28 @@ type DelegateArgs = {
  */
 export function createMockUIMessenger<
   Actions extends UIMessengerActions = never,
+  Events extends UIMessengerEvents = never,
 >(actionHandlers?: {
   [Action in Actions as Action['type']]: Action['handler'];
 }): UIMessenger {
   return {
-    async delegate({ actions = [], messenger }: DelegateArgs) {
+    async delegate({ actions = [], messenger }: DelegateArgs<Actions, Events>) {
       for (const actionType of actions) {
         const handler =
-          (
-            actionHandlers as Record<
-              string,
-              ActionHandler<UIMessengerActions, UIMessengerActions['type']>
-            >
-          )?.[actionType] ??
+          actionHandlers?.[actionType] ??
           (() => {
             throw new Error(
-              `No handler registered for action "${String(actionType)}"`,
+              `No handler registered for action "${String(actionType)}".`,
             );
           });
 
         messenger._internalRegisterDelegatedActionHandler(actionType, handler);
       }
+
       // No background connection in tests — events are not subscribed to.
     },
 
-    async revoke({ actions = [], messenger }: DelegateArgs) {
+    async revoke({ actions = [], messenger }: DelegateArgs<Actions, Events>) {
       for (const actionType of actions) {
         messenger._internalUnregisterDelegatedActionHandler(actionType);
       }

--- a/ui/messengers/route-messenger.test.ts
+++ b/ui/messengers/route-messenger.test.ts
@@ -51,7 +51,7 @@ describe('createRouteMessenger', () => {
 
     expect(MessengerSpy).toHaveBeenCalledWith({
       namespace: 'SomePathRoute',
-      parent: uiMessenger,
+      captureException: expect.any(Function),
     });
   });
 

--- a/ui/messengers/route-messenger.ts
+++ b/ui/messengers/route-messenger.ts
@@ -1,4 +1,5 @@
 import { Messenger } from '@metamask/messenger';
+import { captureException } from '../../shared/lib/sentry';
 import type {
   UIMessenger,
   UIMessengerActions,
@@ -115,18 +116,24 @@ export function createRouteMessenger<
     UIMessengerEvents
   >({
     namespace: getRouteMessengerNamespace(path),
-    parent: uiMessenger,
+    captureException,
   });
 
   if (actions.length === 0 && events.length === 0) {
     throw new Error('There are no actions or events to delegate.');
   }
 
-  uiMessenger.delegate({
-    messenger: routeMessenger,
-    actions,
-    events,
-  });
+  uiMessenger
+    .delegate({
+      messenger: routeMessenger,
+      actions,
+      events,
+    })
+    .catch((error) => {
+      // Delegation should never fail, but if it does, we should at least
+      // capture the error so that it can be investigated and fixed.
+      captureException(error);
+    });
 
   return routeMessenger;
 }

--- a/ui/messengers/ui-messenger.test.ts
+++ b/ui/messengers/ui-messenger.test.ts
@@ -1,0 +1,295 @@
+import {
+  Messenger,
+  MOCK_ANY_NAMESPACE,
+  type MockAnyNamespace,
+} from '@metamask/messenger';
+import {
+  submitRequestToBackground,
+  subscribeToMessengerEvent,
+} from '../store/background-connection';
+import {
+  UIMessenger,
+  type UIMessengerActions,
+  type UIMessengerEvents,
+} from './ui-messenger';
+
+jest.mock('../store/background-connection', () => ({
+  submitRequestToBackground: jest.fn(),
+  subscribeToMessengerEvent: jest.fn(),
+}));
+
+const mockSubmitRequestToBackground = jest.mocked(submitRequestToBackground);
+const mockSubscribeToMessengerEvent = jest.mocked(subscribeToMessengerEvent);
+
+/**
+ * Create a delegatee messenger for testing. Uses MOCK_ANY_NAMESPACE to avoid
+ * namespace restrictions.
+ */
+function createDelegatee() {
+  return new Messenger<MockAnyNamespace, UIMessengerActions, UIMessengerEvents>(
+    { namespace: MOCK_ANY_NAMESPACE },
+  );
+}
+
+describe('UIMessenger', () => {
+  let uiMessenger: UIMessenger;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    uiMessenger = new UIMessenger();
+    mockSubmitRequestToBackground.mockResolvedValue(undefined);
+    mockSubscribeToMessengerEvent.mockResolvedValue(jest.fn());
+  });
+
+  describe('delegate', () => {
+    describe('actions', () => {
+      it('registers a handler on the delegatee that routes to the background', async () => {
+        const delegatee = createDelegatee();
+        mockSubmitRequestToBackground.mockResolvedValue('result');
+
+        await uiMessenger.delegate({
+          actions: ['SnapController:installSnaps'],
+          messenger: delegatee,
+        });
+
+        const result = await delegatee.call(
+          'SnapController:installSnaps',
+          { 'npm:my-snap': {} },
+        );
+
+        expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+          'messengerCall',
+          ['SnapController:installSnaps', [{ 'npm:my-snap': {} }]],
+        );
+        expect(result).toBe('result');
+      });
+
+      it('throws if an excluded action is called', async () => {
+        const delegatee = createDelegatee();
+
+        await uiMessenger.delegate({
+          actions: ['KeyringController:addKeyring'],
+          messenger: delegatee,
+        });
+
+        expect(() =>
+          delegatee.call('KeyringController:addKeyring'),
+        ).toThrow(
+          'The action "KeyringController:addKeyring" has not been exposed to the UI.',
+        );
+      });
+
+      it('throws if the same action is delegated to the same messenger twice', async () => {
+        const delegatee = createDelegatee();
+
+        await uiMessenger.delegate({
+          actions: ['SnapController:installSnaps'],
+          messenger: delegatee,
+        });
+
+        await expect(
+          uiMessenger.delegate({
+            actions: ['SnapController:installSnaps'],
+            messenger: delegatee,
+          }),
+        ).rejects.toThrow(
+          'The action "SnapController:installSnaps" has already been delegated to this messenger.',
+        );
+      });
+
+      it('allows the same action to be delegated to different messengers', async () => {
+        const delegatee1 = createDelegatee();
+        const delegatee2 = createDelegatee();
+
+        await expect(
+          Promise.all([
+            uiMessenger.delegate({
+              actions: ['SnapController:installSnaps'],
+              messenger: delegatee1,
+            }),
+            uiMessenger.delegate({
+              actions: ['SnapController:installSnaps'],
+              messenger: delegatee2,
+            }),
+          ]),
+        ).resolves.not.toThrow();
+      });
+    });
+
+    describe('events', () => {
+      it('subscribes to the event via the background connection', async () => {
+        const delegatee = createDelegatee();
+
+        await uiMessenger.delegate({
+          events: ['SnapController:snapInstalled'],
+          messenger: delegatee,
+        });
+
+        expect(mockSubscribeToMessengerEvent).toHaveBeenCalledWith(
+          'SnapController:snapInstalled',
+          expect.any(Function),
+        );
+      });
+
+      it('publishes background events to the delegatee', async () => {
+        const delegatee = createDelegatee();
+        const handler = jest.fn();
+        delegatee.subscribe('SnapController:snapInstalled', handler);
+
+        let capturedCallback!: (...args: unknown[]) => void;
+        mockSubscribeToMessengerEvent.mockImplementation(
+          async (_event, callback) => {
+            capturedCallback = callback as (...args: unknown[]) => void;
+            return jest.fn();
+          },
+        );
+
+        await uiMessenger.delegate({
+          events: ['SnapController:snapInstalled'],
+          messenger: delegatee,
+        });
+
+        const payload = { snapId: 'npm:my-snap', version: '1.0.0' };
+        capturedCallback(payload);
+
+        expect(handler).toHaveBeenCalledWith(payload);
+      });
+
+      it('throws if the same event is delegated to the same messenger twice', async () => {
+        const delegatee = createDelegatee();
+
+        await uiMessenger.delegate({
+          events: ['SnapController:snapInstalled'],
+          messenger: delegatee,
+        });
+
+        await expect(
+          uiMessenger.delegate({
+            events: ['SnapController:snapInstalled'],
+            messenger: delegatee,
+          }),
+        ).rejects.toThrow(
+          "The event 'SnapController:snapInstalled' has already been delegated to this messenger",
+        );
+      });
+
+      it('creates independent background subscriptions for different messengers', async () => {
+        const delegatee1 = createDelegatee();
+        const delegatee2 = createDelegatee();
+
+        await uiMessenger.delegate({
+          events: ['SnapController:snapInstalled'],
+          messenger: delegatee1,
+        });
+        await uiMessenger.delegate({
+          events: ['SnapController:snapInstalled'],
+          messenger: delegatee2,
+        });
+
+        expect(mockSubscribeToMessengerEvent).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
+
+  describe('revoke', () => {
+    describe('actions', () => {
+      it('unregisters the action handler from the delegatee', async () => {
+        const delegatee = createDelegatee();
+
+        await uiMessenger.delegate({
+          actions: ['SnapController:installSnaps'],
+          messenger: delegatee,
+        });
+        await uiMessenger.revoke({
+          actions: ['SnapController:installSnaps'],
+          messenger: delegatee,
+        });
+
+        expect(() =>
+          delegatee.call('SnapController:installSnaps', { 'npm:my-snap': {} }),
+        ).toThrow();
+      });
+
+      it('silently ignores actions that have not been delegated', async () => {
+        const delegatee = createDelegatee();
+
+        await expect(
+          uiMessenger.revoke({
+            actions: ['SnapController:installSnaps'],
+            messenger: delegatee,
+          }),
+        ).resolves.not.toThrow();
+      });
+
+      it('allows re-delegation after revoking', async () => {
+        const delegatee = createDelegatee();
+
+        await uiMessenger.delegate({
+          actions: ['SnapController:installSnaps'],
+          messenger: delegatee,
+        });
+        await uiMessenger.revoke({
+          actions: ['SnapController:installSnaps'],
+          messenger: delegatee,
+        });
+
+        await expect(
+          uiMessenger.delegate({
+            actions: ['SnapController:installSnaps'],
+            messenger: delegatee,
+          }),
+        ).resolves.not.toThrow();
+      });
+    });
+
+    describe('events', () => {
+      it('calls the unsubscribe function for the event', async () => {
+        const delegatee = createDelegatee();
+        const mockUnsubscribe = jest.fn().mockResolvedValue(undefined);
+        mockSubscribeToMessengerEvent.mockResolvedValue(mockUnsubscribe);
+
+        await uiMessenger.delegate({
+          events: ['SnapController:snapInstalled'],
+          messenger: delegatee,
+        });
+        await uiMessenger.revoke({
+          events: ['SnapController:snapInstalled'],
+          messenger: delegatee,
+        });
+
+        expect(mockUnsubscribe).toHaveBeenCalled();
+      });
+
+      it('allows re-delegation after revoking', async () => {
+        const delegatee = createDelegatee();
+
+        await uiMessenger.delegate({
+          events: ['SnapController:snapInstalled'],
+          messenger: delegatee,
+        });
+        await uiMessenger.revoke({
+          events: ['SnapController:snapInstalled'],
+          messenger: delegatee,
+        });
+
+        await expect(
+          uiMessenger.delegate({
+            events: ['SnapController:snapInstalled'],
+            messenger: delegatee,
+          }),
+        ).resolves.not.toThrow();
+      });
+
+      it('silently ignores events that have not been delegated', async () => {
+        const delegatee = createDelegatee();
+
+        await expect(
+          uiMessenger.revoke({
+            events: ['SnapController:snapInstalled'],
+            messenger: delegatee,
+          }),
+        ).resolves.not.toThrow();
+      });
+    });
+  });
+});

--- a/ui/messengers/ui-messenger.test.ts
+++ b/ui/messengers/ui-messenger.test.ts
@@ -52,10 +52,9 @@ describe('UIMessenger', () => {
           messenger: delegatee,
         });
 
-        const result = await delegatee.call(
-          'SnapController:installSnaps',
-          { 'npm:my-snap': {} },
-        );
+        const result = await delegatee.call('SnapController:installSnaps', {
+          'npm:my-snap': {},
+        });
 
         expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
           'messengerCall',
@@ -72,9 +71,7 @@ describe('UIMessenger', () => {
           messenger: delegatee,
         });
 
-        expect(() =>
-          delegatee.call('KeyringController:addKeyring'),
-        ).toThrow(
+        expect(() => delegatee.call('KeyringController:addKeyring')).toThrow(
           'The action "KeyringController:addKeyring" has not been exposed to the UI.',
         );
       });

--- a/ui/messengers/ui-messenger.ts
+++ b/ui/messengers/ui-messenger.ts
@@ -83,11 +83,20 @@ export type UIMessengerEvents = WithJsonPayload<
 
 const UI_MESSENGER_NAMESPACE = 'UI';
 
+type HandlerFunction = () => void | Promise<void>;
+
+type UnsubscribeFunction = () => Promise<void>;
+
 export class UIMessenger extends Messenger<
   typeof UI_MESSENGER_NAMESPACE,
   UIMessengerActions,
   UIMessengerEvents
 > {
+  #unsubscribeFunctions: Map<
+    UIMessengerEvents['type'],
+    Map<HandlerFunction, UnsubscribeFunction>
+  > = new Map();
+
   constructor() {
     super({ namespace: UI_MESSENGER_NAMESPACE, captureException });
   }
@@ -127,6 +136,7 @@ export class UIMessenger extends Messenger<
    * @param handler - The event handler. The type of the parameters for this
    * event handler must match the type of the payload for this event type.
    * @returns A cleanup function that can be invoked to unsubscribe.
+   * @throws If the given handler is already subscribed to this event type.
    */
   // @ts-expect-error: Intentionally different type than `messenger.subscribe`.
   async subscribe<EventType extends UIMessengerEvents['type']>(
@@ -134,8 +144,18 @@ export class UIMessenger extends Messenger<
     handler: (
       ...payload: ExtractEventPayload<UIMessengerEvents, EventType>
     ) => void,
-  ): Promise<() => Promise<void>> {
-    return await subscribeToMessengerEvent(
+  ): Promise<void> {
+    if (!this.#unsubscribeFunctions.has(eventType)) {
+      this.#unsubscribeFunctions.set(eventType, new Map());
+    }
+
+    if (this.#unsubscribeFunctions.get(eventType)?.has(handler)) {
+      throw new Error(
+        `The handler is already subscribed to the event "${eventType}".`,
+      );
+    }
+
+    const unsubscribeFunction = await subscribeToMessengerEvent(
       eventType,
       // @ts-expect-error: TypeScript cannot verify that the payload is
       // JSON-serializable, because
@@ -145,6 +165,39 @@ export class UIMessenger extends Messenger<
       // know that the payload must be JSON-serializable.
       handler,
     );
+
+    this.#unsubscribeFunctions
+      .get(eventType)
+      ?.set(handler, unsubscribeFunction);
+  }
+
+  /**
+   * Unsubscribe from an event emitted by the background.
+   *
+   * Unregisters the given function as an event handler for the given event
+   * type and ignores the call if the given function is not currently subscribed
+   * to this event type.
+   *
+   * @param eventType - The event type. This is a unique identifier for this
+   * event.
+   * @param handler - The event handler to unsubscribe. Must be the same
+   * function that was used to subscribe to this event type.
+   */
+  // @ts-expect-error: Intentionally different type than `messenger.unsubscribe`.
+  async unsubscribe<EventType extends UIMessengerEvents['type']>(
+    eventType: EventType,
+    handler: (
+      ...payload: ExtractEventPayload<UIMessengerEvents, EventType>
+    ) => void,
+  ): Promise<void> {
+    const unsubscribeFunction = this.#unsubscribeFunctions
+      .get(eventType)
+      ?.get(handler);
+
+    if (unsubscribeFunction) {
+      await unsubscribeFunction();
+      this.#unsubscribeFunctions.get(eventType)?.delete(handler);
+    }
   }
 }
 

--- a/ui/messengers/ui-messenger.ts
+++ b/ui/messengers/ui-messenger.ts
@@ -1,8 +1,13 @@
 import {
   Messenger,
+  MessengerActions,
+  MessengerEvents,
   type ActionConstraint,
   type EventConstraint,
   type ExtractEventPayload,
+  type ExtractActionParameters,
+  ExtractActionResponse,
+  ExtractEventHandler,
 } from '@metamask/messenger';
 import type { Json } from '@metamask/utils';
 
@@ -17,7 +22,6 @@ import {
   submitRequestToBackground,
   subscribeToMessengerEvent,
 } from '../store/background-connection';
-import { captureException } from '../../shared/lib/sentry';
 import { MESSENGERS_WITH_EXCLUSIONS } from './configs';
 
 /**
@@ -82,91 +86,234 @@ export type UIMessengerEvents = WithJsonPayload<
   Exclude<RootMessengerEvents, { type: ExcludedEventTypes }>
 >;
 
-const UI_MESSENGER_NAMESPACE = 'UI';
+/**
+ * A messenger that actions and/or events can be delegated to.
+ *
+ * This is a minimal type interface to avoid complex incompatibilities resulting from generics over
+ * invariant types.
+ */
+type DelegatedMessenger = Pick<
+  // The type is broadened to all actions/events because some messenger methods
+  // are contravariant over this type (`registerDelegatedActionHandler` and
+  // `publishDelegated` for example). If this type is narrowed to just the
+  // delegated actions/events, the types for event payload and action parameters
+  // would not be wide enough.
+  Messenger<string, ActionConstraint, EventConstraint>,
+  | '_internalPublishDelegated'
+  | '_internalRegisterDelegatedActionHandler'
+  | '_internalUnregisterDelegatedActionHandler'
+  | 'captureException'
+>;
 
-type HandlerFunction = () => void | Promise<void>;
-
-type UnsubscribeFunction = () => Promise<void>;
-
-export class UIMessenger extends Messenger<
-  typeof UI_MESSENGER_NAMESPACE,
-  UIMessengerActions,
-  UIMessengerEvents
-> {
+// We intentionally don't extend the base `Messenger` class here because the UI
+// messenger doesn't need to implement the full messenger API. It's only used as
+// a bridge between the root messenger and the route messengers, and it
+// delegates all of its actions and events to the root messenger by default, so
+// it doesn't need to implement the full API itself.
+export class UIMessenger {
   /**
-   * Background subscriptions established for delegated events, keyed by event
-   * type. Each event type only needs one background subscription regardless of
-   * how many route messengers have been delegated that event.
+   * The set of messengers we've delegated actions to, by action type.
    */
-  #delegatedEventSubscriptions: Map<
+  readonly #actionDelegationTargets = new Map<
+    UIMessengerActions['type'],
+    Set<DelegatedMessenger>
+  >();
+
+  /**
+   * The set of messengers we've delegated events to and their event handlers, by event type.
+   */
+  readonly #subscriptionDelegationTargets = new Map<
     UIMessengerEvents['type'],
-    UnsubscribeFunction
-  > = new Map();
-
-  constructor() {
-    super({ namespace: UI_MESSENGER_NAMESPACE, captureException });
-  }
+    Map<DelegatedMessenger, () => Promise<void>>
+  >();
 
   /**
-   * Get the handler for a given action type.
+   * Delegate actions and events to a given messenger.
    *
-   * This is called when `call` is invoked on the messenger. We override it here
-   * to route all calls through the background connection, except for the
-   * excluded actions.
+   * Actions will be delegated by registering a handler on the delegatee
+   * messenger that submits a request to the background for the given action
+   * type and parameters. Events will be delegated by subscribing to the event
+   * on the root messenger and publishing it on the delegatee messenger when it
+   * occurs.
    *
-   * @param actionType - The action type. This is a unique identifier for this
-   * action.
-   * @returns The handler for this action type, or undefined if this action type
-   * is excluded or not found.
+   * @param options - The delegation options.
+   * @param options.actions - The action types to delegate.
+   * @param options.events - The event types to delegate.
+   * @param options.messenger - The messenger to delegate to.
+   * @throws If any action type has already been delegated to this messenger, or
+   * if any event type has already been delegated to this messenger.
    */
-  protected override getAction(
-    actionType: UIMessengerActions['type'],
-  ): ActionConstraint['handler'] | undefined {
-    if (EXCLUDED_ACTIONS.includes(actionType)) {
-      throw new Error(
-        `The action "${actionType}" has not been exposed to the UI.`,
-      );
-    }
-
-    return (...args: unknown[]) =>
-      submitRequestToBackground('messengerCall', [actionType, args]);
-  }
-
-  /**
-   * Delegate actions and/or events to another messenger.
-   *
-   * This overrides the base implementation to additionally subscribe to
-   * delegated events from the background connection, so that events emitted
-   * by the background are forwarded to route messengers via the standard
-   * delegation relay mechanism.
-   *
-   * @param args - Arguments for this function.
-   * @param args.actions - The action types to delegate.
-   * @param args.events - The event types to delegate.
-   * @param args.messenger - The messenger to delegate to.
-   */
-  override delegate({
+  async delegate<
+    Delegatee extends Messenger<string, ActionConstraint, EventConstraint>,
+    DelegatedActions extends (MessengerActions<Delegatee>['type'] &
+      UIMessengerActions['type'])[],
+    DelegatedEvents extends (MessengerEvents<Delegatee>['type'] &
+      UIMessengerEvents['type'])[],
+  >({
     actions,
     events,
     messenger,
   }: {
-    actions?: UIMessengerActions['type'][];
-    events?: UIMessengerEvents['type'][];
-    messenger: Messenger<string, ActionConstraint, EventConstraint>;
-  }): void {
-    super.delegate({ actions, events, messenger });
+    actions?: DelegatedActions;
+    events?: DelegatedEvents;
+    messenger: Delegatee;
+  }): Promise<void> {
+    for (const actionType of actions ?? []) {
+      const delegatedActionHandler = (
+        ...args: ExtractActionParameters<
+          MessengerActions<Delegatee> & UIMessengerActions,
+          typeof actionType
+        >
+      ): ExtractActionResponse<
+        MessengerActions<Delegatee> & UIMessengerActions,
+        typeof actionType
+      > => {
+        // This action handler needs to change to call the root messenger.
+        if (EXCLUDED_ACTIONS.includes(actionType)) {
+          throw new Error(
+            `The action "${actionType}" has not been exposed to the UI.`,
+          );
+        }
+
+        return submitRequestToBackground('messengerCall', [actionType, args]);
+      };
+
+      let delegationTargets = this.#actionDelegationTargets.get(actionType);
+      if (!delegationTargets) {
+        delegationTargets = new Set<DelegatedMessenger>();
+        this.#actionDelegationTargets.set(actionType, delegationTargets);
+      }
+
+      if (delegationTargets.has(messenger)) {
+        throw new Error(
+          `The action "${actionType}" has already been delegated to this messenger.`,
+        );
+      }
+
+      delegationTargets.add(messenger);
+
+      // Intentionally calling a "deprecated" method here, since this is the
+      // internal API for delegation.
+      messenger._internalRegisterDelegatedActionHandler(
+        actionType,
+        delegatedActionHandler,
+      );
+    }
+
+    const promises = (events ?? []).map(async (eventType) => {
+      const untypedSubscriber = (
+        ...payload: ExtractEventPayload<
+          MessengerEvents<Delegatee> & UIMessengerEvents,
+          typeof eventType
+        >
+      ): void => {
+        // Intentionally calling a "deprecated" method here, since this is the
+        // internal API for delegation.
+        messenger._internalPublishDelegated(eventType, ...payload);
+      };
+
+      // Cast to get more specific subscriber type for this specific event.
+      // The types get collapsed here to the type union of all delegated
+      // events, rather than the single subscriber type corresponding to this
+      // event.
+      const subscriber = untypedSubscriber as ExtractEventHandler<
+        MessengerEvents<Delegatee> & UIMessengerEvents,
+        typeof eventType
+      >;
+
+      let delegatedEventSubscriptions =
+        this.#subscriptionDelegationTargets.get(eventType);
+
+      if (!delegatedEventSubscriptions) {
+        delegatedEventSubscriptions = new Map();
+        this.#subscriptionDelegationTargets.set(
+          eventType,
+          delegatedEventSubscriptions,
+        );
+      }
+
+      if (delegatedEventSubscriptions.has(messenger)) {
+        throw new Error(
+          `The event '${eventType}' has already been delegated to this messenger`,
+        );
+      }
+
+      const unsubscribe = await subscribeToMessengerEvent(
+        eventType,
+        subscriber,
+      );
+
+      delegatedEventSubscriptions.set(messenger, unsubscribe);
+    });
+
+    await Promise.all(promises);
+  }
+
+  /**
+   * Revoke delegation of actions and events to a given messenger.
+   *
+   * This is essentially the inverse of `delegate`, and will remove the
+   * delegated action handlers and event subscriptions that were added in
+   * `delegate`.
+   *
+   * @param options - The revocation options.
+   * @param options.actions - The action types to revoke delegation for.
+   * @param options.events - The event types to revoke delegation for.
+   * @param options.messenger - The messenger to revoke delegation from.
+   * @returns A promise that resolves when the revocation is complete.
+   */
+  async revoke<
+    Delegatee extends Messenger<string, ActionConstraint, EventConstraint>,
+    DelegatedActions extends (MessengerActions<Delegatee>['type'] &
+      UIMessengerActions['type'])[],
+    DelegatedEvents extends (MessengerEvents<Delegatee>['type'] &
+      UIMessengerEvents['type'])[],
+  >({
+    actions,
+    events,
+    messenger,
+  }: {
+    actions?: DelegatedActions;
+    events?: DelegatedEvents;
+    messenger: Delegatee;
+  }): Promise<void> {
+    for (const actionType of actions ?? []) {
+      const delegationTargets = this.#actionDelegationTargets.get(actionType);
+      if (!delegationTargets?.has(messenger)) {
+        // Nothing to revoke.
+        continue;
+      }
+
+      // Intentionally calling a "deprecated" method here, since this is the
+      // internal API for delegation.
+      messenger._internalUnregisterDelegatedActionHandler(actionType);
+      delegationTargets.delete(messenger);
+
+      if (delegationTargets.size === 0) {
+        this.#actionDelegationTargets.delete(actionType);
+      }
+    }
 
     for (const eventType of events ?? []) {
-      if (!this.#delegatedEventSubscriptions.has(eventType)) {
-        subscribeToMessengerEvent(eventType, (...payload: unknown[]) => {
-          // @ts-expect-error: The payload type cannot be statically verified
-          // since it arrives as `unknown[]` from the background connection,
-          // but the background always sends the correct payload for each
-          // event type.
-          this._internalPublishDelegated(eventType, ...payload);
-        }).then((unsubscribe) => {
-          this.#delegatedEventSubscriptions.set(eventType, unsubscribe);
-        });
+      const delegationTargets =
+        this.#subscriptionDelegationTargets.get(eventType);
+
+      if (!delegationTargets) {
+        // Nothing to revoke.
+        continue;
+      }
+
+      const unsubscribe = delegationTargets.get(messenger);
+      if (!unsubscribe) {
+        // Nothing to revoke.
+        continue;
+      }
+
+      await unsubscribe();
+      delegationTargets.delete(messenger);
+
+      if (delegationTargets.size === 0) {
+        this.#subscriptionDelegationTargets.delete(eventType);
       }
     }
   }

--- a/ui/messengers/ui-messenger.ts
+++ b/ui/messengers/ui-messenger.ts
@@ -1,6 +1,7 @@
 import {
   Messenger,
   type ActionConstraint,
+  type EventConstraint,
   type ExtractEventPayload,
 } from '@metamask/messenger';
 import type { Json } from '@metamask/utils';
@@ -92,9 +93,14 @@ export class UIMessenger extends Messenger<
   UIMessengerActions,
   UIMessengerEvents
 > {
-  #unsubscribeFunctions: Map<
+  /**
+   * Background subscriptions established for delegated events, keyed by event
+   * type. Each event type only needs one background subscription regardless of
+   * how many route messengers have been delegated that event.
+   */
+  #delegatedEventSubscriptions: Map<
     UIMessengerEvents['type'],
-    Map<HandlerFunction, UnsubscribeFunction>
+    UnsubscribeFunction
   > = new Map();
 
   constructor() {
@@ -127,76 +133,41 @@ export class UIMessenger extends Messenger<
   }
 
   /**
-   * Subscribe to an event emitted by the background.
+   * Delegate actions and/or events to another messenger.
    *
-   * Registers the given function as an event handler for the given event type.
+   * This overrides the base implementation to additionally subscribe to
+   * delegated events from the background connection, so that events emitted
+   * by the background are forwarded to route messengers via the standard
+   * delegation relay mechanism.
    *
-   * @param eventType - The event type. This is a unique identifier for this
-   * event.
-   * @param handler - The event handler. The type of the parameters for this
-   * event handler must match the type of the payload for this event type.
-   * @returns A cleanup function that can be invoked to unsubscribe.
-   * @throws If the given handler is already subscribed to this event type.
+   * @param args - Arguments for this function.
+   * @param args.actions - The action types to delegate.
+   * @param args.events - The event types to delegate.
+   * @param args.messenger - The messenger to delegate to.
    */
-  // @ts-expect-error: Intentionally different type than `messenger.subscribe`.
-  async subscribe<EventType extends UIMessengerEvents['type']>(
-    eventType: EventType,
-    handler: (
-      ...payload: ExtractEventPayload<UIMessengerEvents, EventType>
-    ) => void,
-  ): Promise<void> {
-    if (!this.#unsubscribeFunctions.has(eventType)) {
-      this.#unsubscribeFunctions.set(eventType, new Map());
-    }
+  override delegate({
+    actions,
+    events,
+    messenger,
+  }: {
+    actions?: UIMessengerActions['type'][];
+    events?: UIMessengerEvents['type'][];
+    messenger: Messenger<string, ActionConstraint, EventConstraint>;
+  }): void {
+    super.delegate({ actions, events, messenger });
 
-    if (this.#unsubscribeFunctions.get(eventType)?.has(handler)) {
-      throw new Error(
-        `The handler is already subscribed to the event "${eventType}".`,
-      );
-    }
-
-    const unsubscribeFunction = await subscribeToMessengerEvent(
-      eventType,
-      // @ts-expect-error: TypeScript cannot verify that the payload is
-      // JSON-serializable, because
-      // `ExtractEventPayload<UIMessengerEvents, EventType>` is a deferred
-      // conditional type which cannot be resolved when `EventType` is generic.
-      // However, UIMessengerEvents is defined as WithJsonPayload<...>, so we
-      // know that the payload must be JSON-serializable.
-      handler,
-    );
-
-    this.#unsubscribeFunctions
-      .get(eventType)
-      ?.set(handler, unsubscribeFunction);
-  }
-
-  /**
-   * Unsubscribe from an event emitted by the background.
-   *
-   * Unregisters the given function as an event handler for the given event
-   * type and ignores the call if the given function is not currently subscribed
-   * to this event type.
-   *
-   * @param eventType - The event type. This is a unique identifier for this
-   * event.
-   * @param handler - The event handler to unsubscribe. Must be the same
-   * function that was used to subscribe to this event type.
-   */
-  // @ts-expect-error: Intentionally different type than `messenger.unsubscribe`.
-  async unsubscribe<EventType extends UIMessengerEvents['type']>(
-    eventType: EventType,
-    handler: (
-      ...payload: ExtractEventPayload<UIMessengerEvents, EventType>
-    ) => void,
-  ): Promise<void> {
-    const unsubscribeFunction = this.#unsubscribeFunctions
-      .get(eventType)
-      ?.get(handler);
-
-    if (unsubscribeFunction) {
-      await unsubscribeFunction();
-      this.#unsubscribeFunctions.get(eventType)?.delete(handler);
+    for (const eventType of events ?? []) {
+      if (!this.#delegatedEventSubscriptions.has(eventType)) {
+        subscribeToMessengerEvent(eventType, (...payload: unknown[]) => {
+          // @ts-expect-error: The payload type cannot be statically verified
+          // since it arrives as `unknown[]` from the background connection,
+          // but the background always sends the correct payload for each
+          // event type.
+          this._internalPublishDelegated(eventType, ...payload);
+        }).then((unsubscribe) => {
+          this.#delegatedEventSubscriptions.set(eventType, unsubscribe);
+        });
+      }
     }
   }
 }

--- a/ui/messengers/ui-messenger.ts
+++ b/ui/messengers/ui-messenger.ts
@@ -168,7 +168,6 @@ export class UIMessenger {
         MessengerActions<Delegatee> & UIMessengerActions,
         typeof actionType
       > => {
-        // This action handler needs to change to call the root messenger.
         if (EXCLUDED_ACTIONS.includes(actionType)) {
           throw new Error(
             `The action "${actionType}" has not been exposed to the UI.`,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The previous implementation assumed events were delegated to the UI messenger, but since the UI messenger runs in a separate context, we can't delegate events, and the usual method for subscribing to events doesn't work.

To fix it, I've updated the UI messenger to no longer extend the base messenger and instead handle delegation properly for both actions and events. This lets us remove a bunch of `ts-expect-error`s as well.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors core UI-to-background messaging and event subscription plumbing; mistakes could break action calls or event propagation across routes, though changes are covered by new unit tests.
> 
> **Overview**
> Fixes UI messenger delegation by **replacing inheritance from `Messenger` with an explicit `UIMessenger` delegator** that registers delegated action handlers and creates per-messenger background event subscriptions, plus a matching `revoke` to unregister handlers/unsubscribe.
> 
> Updates `createRouteMessenger` to construct route messengers with `captureException` (no longer using `parent`) and to treat delegation as async, capturing unexpected delegation failures to Sentry.
> 
> Adjusts the test `createMockUIMessenger` to register handlers directly on delegatee messengers (bypassing background), and adds comprehensive unit tests for `UIMessenger` action/event delegation, duplicate delegation errors, and revocation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11fd6dcf72b81b2b30c02db3c1164f24de2a5a85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->