### PR TITLE
feat: add custom token import page 

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2855,6 +2855,9 @@
   "enterTokenNameOrAddress": {
     "message": "Enter token name or paste address"
   },
+  "enterTokenAddress": {
+    "message": "Enter token address"
+  },
   "enterTokenNameOrAddressManageTokens": {
     "message": "Enter token name or address"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -2852,11 +2852,11 @@
   "enterSymbol": {
     "message": "Enter symbol"
   },
-  "enterTokenNameOrAddress": {
-    "message": "Enter token name or paste address"
-  },
   "enterTokenAddress": {
     "message": "Enter token address"
+  },
+  "enterTokenNameOrAddress": {
+    "message": "Enter token name or paste address"
   },
   "enterTokenNameOrAddressManageTokens": {
     "message": "Enter token name or address"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -2852,6 +2852,9 @@
   "enterSymbol": {
     "message": "Enter symbol"
   },
+  "enterTokenAddress": {
+    "message": "Enter token address"
+  },
   "enterTokenNameOrAddress": {
     "message": "Enter token name or paste address"
   },

--- a/ui/helpers/constants/routes.ts
+++ b/ui/helpers/constants/routes.ts
@@ -92,6 +92,7 @@ export const IMPORT_TOKEN_ROUTE = '/import-token';
 export const IMPORT_TOKENS_ROUTE = '/import-tokens';
 export const CONFIRM_IMPORT_TOKEN_ROUTE = '/confirm-import-token';
 export const TOKEN_MANAGEMENT_ROUTE = '/token-management';
+export const CUSTOM_TOKEN_IMPORT_ROUTE = '/custom-token-import';
 export const CONFIRM_ADD_SUGGESTED_TOKEN_ROUTE = '/confirm-add-suggested-token';
 export const ACCOUNT_LIST_PAGE_ROUTE = '/account-list';
 export const MULTICHAIN_ACCOUNT_ADDRESS_LIST_PAGE_ROUTE =
@@ -429,6 +430,11 @@ export const ROUTES = [
   {
     path: TOKEN_MANAGEMENT_ROUTE,
     label: 'Token Management Page',
+    trackInAnalytics: true,
+  },
+  {
+    path: CUSTOM_TOKEN_IMPORT_ROUTE,
+    label: 'Custom Token Import Page',
     trackInAnalytics: true,
   },
   {

--- a/ui/pages/custom-token-import/custom-token-import-form.tsx
+++ b/ui/pages/custom-token-import/custom-token-import-form.tsx
@@ -12,8 +12,6 @@ import {
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react';
-import { type Hex } from '@metamask/utils';
-
 import {
   AvatarNetwork,
   AvatarNetworkSize,
@@ -46,7 +44,7 @@ const CUSTOM_TOKEN_TEXT_FIELD_PROPS = {
 
 export type CustomTokenImportFormProps = {
   networkName: string;
-  selectedNetwork: Hex;
+  selectedNetwork: string;
   networks: CustomTokenImportNetworkOption[];
   address: string;
   addressError: string | null;

--- a/ui/pages/custom-token-import/custom-token-import-form.tsx
+++ b/ui/pages/custom-token-import/custom-token-import-form.tsx
@@ -1,0 +1,357 @@
+import React, { useCallback, useState } from 'react';
+import {
+  BannerAlert,
+  BannerAlertSeverity,
+  Box,
+  BoxFlexDirection,
+  Button,
+  ButtonSize,
+  FontWeight,
+  Text,
+  TextButton,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react';
+import { type Hex } from '@metamask/utils';
+
+import {
+  AvatarNetwork,
+  AvatarNetworkSize,
+  FormTextField,
+  FormTextFieldSize,
+  Label,
+  SelectButton,
+  SelectButtonSize,
+  TextFieldType,
+} from '../../components/component-library';
+import {
+  BackgroundColor,
+  BorderColor,
+  BorderRadius,
+} from '../../helpers/constants/design-system';
+import ZENDESK_URLS from '../../helpers/constants/zendesk-url';
+import { useI18nContext } from '../../hooks/useI18nContext';
+import { getImageForChainId } from '../../selectors/multichain';
+import { Content } from '../../components/multichain/pages/page';
+import {
+  CustomTokenImportNetworkSelector,
+  type CustomTokenImportNetworkOption,
+} from './custom-token-import-network-selector';
+
+const CUSTOM_TOKEN_TEXT_FIELD_PROPS = {
+  backgroundColor: BackgroundColor.backgroundMuted,
+  borderColor: BorderColor.borderDefault,
+  borderRadius: BorderRadius.XL,
+};
+
+export type CustomTokenImportFormProps = {
+  networkName: string;
+  selectedNetwork: Hex;
+  networks: CustomTokenImportNetworkOption[];
+  address: string;
+  addressError: string | null;
+  symbol: string;
+  symbolError: string | null;
+  decimals: string;
+  decimalsError: string | null;
+  warning: string | null;
+  showSymbolAndDecimals: boolean;
+  isSubmitDisabled: boolean;
+  isSubmitting: boolean;
+  onSelectNetwork: (network: CustomTokenImportNetworkOption) => void;
+  onAddressChange: (value: string) => void;
+  onSymbolChange: (value: string) => void;
+  onDecimalsChange: (value: string) => void;
+  onSubmit: () => void;
+};
+
+type SubmitBarProps = Pick<CustomTokenImportFormProps, 'onSubmit'> & {
+  isDisabled: boolean;
+  isLoading: boolean;
+};
+
+const CustomTokenWarningBanner = () => {
+  const t = useI18nContext();
+
+  return (
+    <BannerAlert
+      severity={BannerAlertSeverity.Warning}
+      data-testid="custom-token-import-warning"
+    >
+      <Text
+        variant={TextVariant.BodyMd}
+        fontWeight={FontWeight.Medium}
+        color={TextColor.WarningDefault}
+      >
+        {t('customTokenWarningInTokenDetectionNetwork', [
+          <TextButton key="learn-scam-risk" asChild className="inline">
+            <a
+              href={ZENDESK_URLS.TOKEN_SAFETY_PRACTICES}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {t('learnScamRisk')}
+            </a>
+          </TextButton>,
+        ])}
+      </Text>
+    </BannerAlert>
+  );
+};
+
+const NetworkPickerField = ({
+  networkName,
+  selectedNetwork,
+  onClick,
+}: Pick<
+  CustomTokenImportFormProps,
+  'networkName' | 'selectedNetwork'
+> & {
+  onClick: () => void;
+}) => {
+  const t = useI18nContext();
+
+  return (
+    <Box>
+      <Label htmlFor="custom-token-import-network" marginBottom={1}>
+        {t('network')}
+      </Label>
+      <SelectButton
+        as="button"
+        id="custom-token-import-network"
+        type="button"
+        size={SelectButtonSize.Lg}
+        isBlock
+        backgroundColor={BackgroundColor.backgroundMuted}
+        borderColor={BorderColor.borderDefault}
+        borderRadius={BorderRadius.XL}
+        startAccessory={
+          <AvatarNetwork
+            size={AvatarNetworkSize.Xs}
+            className="rounded-md"
+            src={getImageForChainId(selectedNetwork) || undefined}
+            name={networkName}
+          />
+        }
+        onClick={onClick}
+        data-testid="network-selector"
+      >
+        {networkName}
+      </SelectButton>
+    </Box>
+  );
+};
+
+const TokenFormFields = ({
+  address,
+  addressError,
+  symbol,
+  symbolError,
+  decimals,
+  decimalsError,
+  warning,
+  showSymbolAndDecimals,
+  onAddressChange,
+  onSymbolChange,
+  onDecimalsChange,
+}: Pick<
+  CustomTokenImportFormProps,
+  | 'address'
+  | 'addressError'
+  | 'symbol'
+  | 'symbolError'
+  | 'decimals'
+  | 'decimalsError'
+  | 'warning'
+  | 'showSymbolAndDecimals'
+  | 'onAddressChange'
+  | 'onSymbolChange'
+  | 'onDecimalsChange'
+>) => {
+  const t = useI18nContext();
+
+  return (
+    <>
+      <FormTextField
+        id="custom-token-import-address"
+        label={t('tokenContractAddress')}
+        labelProps={{ marginBottom: 1 }}
+        size={FormTextFieldSize.Lg}
+        placeholder={t('enterTokenAddress')}
+        value={address}
+        error={Boolean(addressError)}
+        helpText={addressError ?? undefined}
+        textFieldProps={CUSTOM_TOKEN_TEXT_FIELD_PROPS}
+        inputProps={{
+          'data-testid': 'custom-token-import-address-input',
+        }}
+        onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+          onAddressChange(event.target.value)
+        }
+      />
+
+      {warning ? (
+        <BannerAlert
+          severity={BannerAlertSeverity.Warning}
+          data-testid="custom-token-import-mainnet-warning"
+        >
+          <Text variant={TextVariant.BodySm}>{warning}</Text>
+        </BannerAlert>
+      ) : null}
+
+      {showSymbolAndDecimals ? (
+        <>
+          <FormTextField
+            id="custom-token-import-symbol"
+            label={t('tokenSymbol')}
+            labelProps={{ marginBottom: 1 }}
+            size={FormTextFieldSize.Lg}
+            value={symbol}
+            error={Boolean(symbolError)}
+            helpText={symbolError ?? undefined}
+            textFieldProps={CUSTOM_TOKEN_TEXT_FIELD_PROPS}
+            inputProps={{
+              'data-testid': 'custom-token-import-symbol-input',
+            }}
+            onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+              onSymbolChange(event.target.value)
+            }
+          />
+          <FormTextField
+            id="custom-token-import-decimal"
+            label={t('tokenDecimal')}
+            labelProps={{ marginBottom: 1 }}
+            size={FormTextFieldSize.Lg}
+            type={TextFieldType.Number}
+            value={decimals}
+            error={Boolean(decimalsError)}
+            helpText={decimalsError ?? undefined}
+            textFieldProps={CUSTOM_TOKEN_TEXT_FIELD_PROPS}
+            inputProps={{
+              'data-testid': 'custom-token-import-decimal-input',
+            }}
+            onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+              onDecimalsChange(event.target.value)
+            }
+          />
+        </>
+      ) : null}
+    </>
+  );
+};
+
+const SubmitBar = ({
+  isDisabled,
+  isLoading,
+  onSubmit,
+}: SubmitBarProps) => {
+  const t = useI18nContext();
+
+  return (
+    <Box
+      flexDirection={BoxFlexDirection.Row}
+      padding={4}
+      paddingBottom={6}
+      className="bg-background-default"
+    >
+      <Button
+        isFullWidth
+        size={ButtonSize.Lg}
+        data-testid="custom-token-import-submit-button"
+        isDisabled={isDisabled}
+        isLoading={isLoading}
+        onClick={onSubmit}
+        className="flex-1 rounded-xl"
+      >
+        {t('addToken')}
+      </Button>
+    </Box>
+  );
+};
+
+export const CustomTokenImportForm = ({
+  networkName,
+  selectedNetwork,
+  networks,
+  address,
+  addressError,
+  symbol,
+  symbolError,
+  decimals,
+  decimalsError,
+  warning,
+  showSymbolAndDecimals,
+  isSubmitDisabled,
+  isSubmitting,
+  onSelectNetwork,
+  onAddressChange,
+  onSymbolChange,
+  onDecimalsChange,
+  onSubmit,
+}: CustomTokenImportFormProps) => {
+  const [isNetworkSelectorOpen, setIsNetworkSelectorOpen] = useState(false);
+
+  const closeNetworkSelector = useCallback(
+    () => setIsNetworkSelectorOpen(false),
+    [],
+  );
+
+  const handleSelectNetwork = useCallback(
+    (network: CustomTokenImportNetworkOption) => {
+      onSelectNetwork(network);
+      setIsNetworkSelectorOpen(false);
+    },
+    [onSelectNetwork],
+  );
+
+  return (
+    <Content padding={0}>
+      <Box
+        flexDirection={BoxFlexDirection.Column}
+        className="flex min-h-0 w-full flex-1 flex-col justify-between"
+      >
+        <Box
+          flexDirection={BoxFlexDirection.Column}
+          padding={4}
+          gap={6}
+          className="flex flex-1 flex-col overflow-auto min-h-0"
+        >
+          <CustomTokenWarningBanner />
+          <NetworkPickerField
+            networkName={networkName}
+            selectedNetwork={selectedNetwork}
+            onClick={() => setIsNetworkSelectorOpen(true)}
+          />
+          <TokenFormFields
+            address={address}
+            addressError={addressError}
+            symbol={symbol}
+            symbolError={symbolError}
+            decimals={decimals}
+            decimalsError={decimalsError}
+            warning={warning}
+            showSymbolAndDecimals={showSymbolAndDecimals}
+            onAddressChange={onAddressChange}
+            onSymbolChange={onSymbolChange}
+            onDecimalsChange={onDecimalsChange}
+          />
+        </Box>
+
+        <SubmitBar
+          isDisabled={isSubmitDisabled}
+          isLoading={isSubmitting}
+          onSubmit={onSubmit}
+        />
+      </Box>
+
+      <CustomTokenImportNetworkSelector
+        isOpen={isNetworkSelectorOpen}
+        networks={networks}
+        selectedNetwork={selectedNetwork}
+        onBack={closeNetworkSelector}
+        onClose={closeNetworkSelector}
+        onSelectNetwork={handleSelectNetwork}
+      />
+    </Content>
+  );
+};

--- a/ui/pages/custom-token-import/custom-token-import-form.tsx
+++ b/ui/pages/custom-token-import/custom-token-import-form.tsx
@@ -101,10 +101,7 @@ const NetworkPickerField = ({
   networkName,
   selectedNetwork,
   onClick,
-}: Pick<
-  CustomTokenImportFormProps,
-  'networkName' | 'selectedNetwork'
-> & {
+}: Pick<CustomTokenImportFormProps, 'networkName' | 'selectedNetwork'> & {
   onClick: () => void;
 }) => {
   const t = useI18nContext();
@@ -238,11 +235,7 @@ const TokenFormFields = ({
   );
 };
 
-const SubmitBar = ({
-  isDisabled,
-  isLoading,
-  onSubmit,
-}: SubmitBarProps) => {
+const SubmitBar = ({ isDisabled, isLoading, onSubmit }: SubmitBarProps) => {
   const t = useI18nContext();
 
   return (

--- a/ui/pages/custom-token-import/custom-token-import-network-selector.tsx
+++ b/ui/pages/custom-token-import/custom-token-import-network-selector.tsx
@@ -1,5 +1,4 @@
-import React, { useEffect } from 'react';
-import { createPortal } from 'react-dom';
+import React from 'react';
 import { formatChainIdToHex } from '@metamask/bridge-controller';
 import {
   AvatarNetwork,
@@ -8,21 +7,21 @@ import {
   BoxAlignItems,
   BoxBackgroundColor,
   BoxFlexDirection,
-  BoxJustifyContent,
-  ButtonIcon,
-  ButtonIconSize,
   FontWeight,
-  IconName,
-  ModalBody,
-  ModalFocus,
-  ModalOverlay,
   Text,
-  TextAlign,
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react';
-import { type Hex } from '@metamask/utils';
+import { type CaipChainId } from '@metamask/utils';
 
+import {
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+} from '../../components/component-library';
+import { isEvmChainId } from '../../../shared/lib/asset-utils';
 import { useI18nContext } from '../../hooks/useI18nContext';
 import { getImageForChainId } from '../../selectors/multichain';
 
@@ -34,60 +33,56 @@ export type CustomTokenImportNetworkOption = {
 export type CustomTokenImportNetworkSelectorProps = {
   isOpen: boolean;
   networks: CustomTokenImportNetworkOption[];
-  selectedNetwork: Hex;
+  selectedNetwork: string;
   onBack: () => void;
   onClose: () => void;
   onSelectNetwork: (network: CustomTokenImportNetworkOption) => void;
 };
 
-const NetworkSelectorRow = ({
+const NetworkRow = ({
   network,
-  selectedNetwork,
-  onSelectNetwork,
+  isSelected,
+  onSelect,
 }: {
   network: CustomTokenImportNetworkOption;
-  selectedNetwork: Hex;
-  onSelectNetwork: (network: CustomTokenImportNetworkOption) => void;
-}) => {
-  const isSelected = formatChainIdToHex(network.chainId) === selectedNetwork;
-
-  return (
-    <Box
-      asChild
-      flexDirection={BoxFlexDirection.Row}
-      alignItems={BoxAlignItems.Center}
-      gap={4}
-      paddingHorizontal={4}
-      paddingVertical={3}
-      backgroundColor={
-        isSelected ? BoxBackgroundColor.BackgroundMuted : undefined
-      }
-      className="w-full text-left transition-colors hover:bg-hover active:bg-pressed"
+  isSelected: boolean;
+  onSelect: () => void;
+}) => (
+  <Box
+    asChild
+    flexDirection={BoxFlexDirection.Row}
+    alignItems={BoxAlignItems.Center}
+    gap={4}
+    paddingHorizontal={4}
+    paddingVertical={3}
+    backgroundColor={
+      isSelected ? BoxBackgroundColor.BackgroundMuted : undefined
+    }
+    className="w-full text-left transition-colors hover:bg-muted-hover active:bg-muted-pressed"
+  >
+    <button
+      type="button"
+      data-testid={`select-network-item-${network.chainId}`}
+      aria-current={isSelected ? 'true' : undefined}
+      onClick={onSelect}
     >
-      <button
-        type="button"
-        data-testid={`select-network-item-${network.chainId}`}
-        aria-current={isSelected ? 'true' : undefined}
-        onClick={() => onSelectNetwork(network)}
+      <AvatarNetwork
+        name={network.name}
+        src={getImageForChainId(network.chainId)}
+        size={AvatarNetworkSize.Sm}
+      />
+      <Text
+        asChild
+        variant={TextVariant.BodyMd}
+        color={TextColor.TextDefault}
+        fontWeight={isSelected ? FontWeight.Medium : FontWeight.Regular}
+        ellipsis
       >
-        <AvatarNetwork
-          name={network.name}
-          src={getImageForChainId(network.chainId)}
-          size={AvatarNetworkSize.Sm}
-        />
-        <Text
-          asChild
-          variant={TextVariant.BodyMd}
-          color={TextColor.TextDefault}
-          fontWeight={isSelected ? FontWeight.Medium : FontWeight.Regular}
-          ellipsis
-        >
-          <span className="min-w-0 flex-1">{network.name}</span>
-        </Text>
-      </button>
-    </Box>
-  );
-};
+        <span className="min-w-0 flex-1">{network.name}</span>
+      </Text>
+    </button>
+  </Box>
+);
 
 export const CustomTokenImportNetworkSelector = ({
   isOpen,
@@ -99,98 +94,37 @@ export const CustomTokenImportNetworkSelector = ({
 }: CustomTokenImportNetworkSelectorProps) => {
   const t = useI18nContext();
 
-  useEffect(() => {
-    if (!isOpen) {
-      return undefined;
-    }
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        onClose();
-      }
-    };
-
-    document.addEventListener('keydown', handleKeyDown);
-
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [isOpen, onClose]);
-
-  if (!isOpen) {
-    return null;
-  }
-
-  return createPortal(
-    <>
-      <ModalOverlay onClick={onClose} />
-      <Box
-        alignItems={BoxAlignItems.Center}
-        justifyContent={BoxJustifyContent.Center}
-        padding={4}
-        className="pointer-events-none fixed inset-0 z-[1051] flex motion-safe:animate-fade-in"
-      >
-        <ModalFocus autoFocus restoreFocus>
-          <Box
-            asChild
-            flexDirection={BoxFlexDirection.Column}
-            backgroundColor={BoxBackgroundColor.BackgroundDefault}
-            paddingVertical={4}
-            className="pointer-events-auto flex max-h-full w-full max-w-[360px] overflow-hidden rounded-lg shadow-lg"
-          >
-            <section
-              role="dialog"
-              aria-modal="true"
-              aria-labelledby="custom-token-import-network-selector-title"
-            >
-              <Box
-                flexDirection={BoxFlexDirection.Row}
-                alignItems={BoxAlignItems.Center}
-                justifyContent={BoxJustifyContent.Between}
-                gap={2}
-                paddingHorizontal={4}
-                paddingBottom={4}
-              >
-                <ButtonIcon
-                  ariaLabel={t('back')}
-                  iconName={IconName.ArrowLeft}
-                  size={ButtonIconSize.Md}
-                  onClick={onBack}
-                />
-                <Text
-                  asChild
-                  variant={TextVariant.HeadingSm}
-                  textAlign={TextAlign.Center}
-                  ellipsis
-                  className="min-w-0 flex-1"
-                >
-                  <h2 id="custom-token-import-network-selector-title">
-                    {t('networkMenuHeading')}
-                  </h2>
-                </Text>
-                <ButtonIcon
-                  ariaLabel={t('close')}
-                  iconName={IconName.Close}
-                  size={ButtonIconSize.Md}
-                  onClick={onClose}
-                />
-              </Box>
-              <ModalBody className="px-0">
-                {networks.map((network) => (
-                  <NetworkSelectorRow
-                    key={network.chainId}
-                    network={network}
-                    selectedNetwork={selectedNetwork}
-                    onSelectNetwork={onSelectNetwork}
-                  />
-                ))}
-              </ModalBody>
-            </section>
-          </Box>
-        </ModalFocus>
-      </Box>
-    </>,
-    document.body,
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      isClosedOnEscapeKey
+      isClosedOnOutsideClick
+      data-testid="custom-token-import-network-selector"
+    >
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader onBack={onBack} onClose={onClose}>
+          {t('networkMenuHeading')}
+        </ModalHeader>
+        <ModalBody paddingLeft={0} paddingRight={0}>
+          {networks.map((network) => {
+            const chainIdRef = network.chainId as CaipChainId;
+            const isSelected = isEvmChainId(chainIdRef)
+              ? formatChainIdToHex(chainIdRef) === selectedNetwork
+              : network.chainId === selectedNetwork;
+            return (
+              <NetworkRow
+                key={network.chainId}
+                network={network}
+                isSelected={isSelected}
+                onSelect={() => onSelectNetwork(network)}
+              />
+            );
+          })}
+        </ModalBody>
+      </ModalContent>
+    </Modal>
   );
 };
 

--- a/ui/pages/custom-token-import/custom-token-import-network-selector.tsx
+++ b/ui/pages/custom-token-import/custom-token-import-network-selector.tsx
@@ -1,0 +1,197 @@
+import React, { useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { formatChainIdToHex } from '@metamask/bridge-controller';
+import {
+  AvatarNetwork,
+  AvatarNetworkSize,
+  Box,
+  BoxAlignItems,
+  BoxBackgroundColor,
+  BoxFlexDirection,
+  BoxJustifyContent,
+  ButtonIcon,
+  ButtonIconSize,
+  FontWeight,
+  IconName,
+  ModalBody,
+  ModalFocus,
+  ModalOverlay,
+  Text,
+  TextAlign,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react';
+import { type Hex } from '@metamask/utils';
+
+import { useI18nContext } from '../../hooks/useI18nContext';
+import { getImageForChainId } from '../../selectors/multichain';
+
+export type CustomTokenImportNetworkOption = {
+  chainId: string;
+  name: string;
+};
+
+export type CustomTokenImportNetworkSelectorProps = {
+  isOpen: boolean;
+  networks: CustomTokenImportNetworkOption[];
+  selectedNetwork: Hex;
+  onBack: () => void;
+  onClose: () => void;
+  onSelectNetwork: (network: CustomTokenImportNetworkOption) => void;
+};
+
+const NetworkSelectorRow = ({
+  network,
+  selectedNetwork,
+  onSelectNetwork,
+}: {
+  network: CustomTokenImportNetworkOption;
+  selectedNetwork: Hex;
+  onSelectNetwork: (network: CustomTokenImportNetworkOption) => void;
+}) => {
+  const isSelected = formatChainIdToHex(network.chainId) === selectedNetwork;
+
+  return (
+    <Box
+      asChild
+      flexDirection={BoxFlexDirection.Row}
+      alignItems={BoxAlignItems.Center}
+      gap={4}
+      paddingHorizontal={4}
+      paddingVertical={3}
+      backgroundColor={
+        isSelected ? BoxBackgroundColor.BackgroundMuted : undefined
+      }
+      className="w-full text-left transition-colors hover:bg-hover active:bg-pressed"
+    >
+      <button
+        type="button"
+        data-testid={`select-network-item-${network.chainId}`}
+        aria-current={isSelected ? 'true' : undefined}
+        onClick={() => onSelectNetwork(network)}
+      >
+        <AvatarNetwork
+          name={network.name}
+          src={getImageForChainId(network.chainId)}
+          size={AvatarNetworkSize.Sm}
+        />
+        <Text
+          asChild
+          variant={TextVariant.BodyMd}
+          color={TextColor.TextDefault}
+          fontWeight={isSelected ? FontWeight.Medium : FontWeight.Regular}
+          ellipsis
+        >
+          <span className="min-w-0 flex-1">{network.name}</span>
+        </Text>
+      </button>
+    </Box>
+  );
+};
+
+export const CustomTokenImportNetworkSelector = ({
+  isOpen,
+  networks,
+  selectedNetwork,
+  onBack,
+  onClose,
+  onSelectNetwork,
+}: CustomTokenImportNetworkSelectorProps) => {
+  const t = useI18nContext();
+
+  useEffect(() => {
+    if (!isOpen) {
+      return undefined;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return createPortal(
+    <>
+      <ModalOverlay onClick={onClose} />
+      <Box
+        alignItems={BoxAlignItems.Center}
+        justifyContent={BoxJustifyContent.Center}
+        padding={4}
+        className="pointer-events-none fixed inset-0 z-[1051] flex motion-safe:animate-fade-in"
+      >
+        <ModalFocus autoFocus restoreFocus>
+          <Box
+            asChild
+            flexDirection={BoxFlexDirection.Column}
+            backgroundColor={BoxBackgroundColor.BackgroundDefault}
+            paddingVertical={4}
+            className="pointer-events-auto flex max-h-full w-full max-w-[360px] overflow-hidden rounded-lg shadow-lg"
+          >
+            <section
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby="custom-token-import-network-selector-title"
+            >
+              <Box
+                flexDirection={BoxFlexDirection.Row}
+                alignItems={BoxAlignItems.Center}
+                justifyContent={BoxJustifyContent.Between}
+                gap={2}
+                paddingHorizontal={4}
+                paddingBottom={4}
+              >
+                <ButtonIcon
+                  ariaLabel={t('back')}
+                  iconName={IconName.ArrowLeft}
+                  size={ButtonIconSize.Md}
+                  onClick={onBack}
+                />
+                <Text
+                  asChild
+                  variant={TextVariant.HeadingSm}
+                  textAlign={TextAlign.Center}
+                  ellipsis
+                  className="min-w-0 flex-1"
+                >
+                  <h2 id="custom-token-import-network-selector-title">
+                    {t('networkMenuHeading')}
+                  </h2>
+                </Text>
+                <ButtonIcon
+                  ariaLabel={t('close')}
+                  iconName={IconName.Close}
+                  size={ButtonIconSize.Md}
+                  onClick={onClose}
+                />
+              </Box>
+              <ModalBody className="px-0">
+                {networks.map((network) => (
+                  <NetworkSelectorRow
+                    key={network.chainId}
+                    network={network}
+                    selectedNetwork={selectedNetwork}
+                    onSelectNetwork={onSelectNetwork}
+                  />
+                ))}
+              </ModalBody>
+            </section>
+          </Box>
+        </ModalFocus>
+      </Box>
+    </>,
+    document.body,
+  );
+};
+
+export default CustomTokenImportNetworkSelector;

--- a/ui/pages/custom-token-import/custom-token-import.test.tsx
+++ b/ui/pages/custom-token-import/custom-token-import.test.tsx
@@ -77,11 +77,8 @@ describe('CustomTokenImportPage', () => {
     renderPage();
 
     expect(screen.getByTestId('custom-token-import-page')).toBeInTheDocument();
-    expect(screen.getByTestId('custom-token-import-warning')).toHaveTextContent(
-      messages.importTokenWarning.message,
-    );
     expect(
-      screen.getByTestId('custom-token-import-network-picker'),
+      screen.getByTestId('network-selector'),
     ).toHaveTextContent('Ethereum Mainnet');
     expect(
       screen.getByTestId('custom-token-import-address-input'),
@@ -119,16 +116,16 @@ describe('CustomTokenImportPage', () => {
     ).toBeDisabled();
   });
 
-  it('opens the network manager modal when the network picker is clicked', () => {
-    const { store } = renderPage();
+  it('opens the custom import network selector when the network picker is clicked', () => {
+    renderPage();
 
-    fireEvent.click(screen.getByTestId('custom-token-import-network-picker'));
+    fireEvent.click(screen.getByTestId('network-selector'));
 
-    // The network picker reuses the existing global modal; the manage tokens
-    // page uses the same one so both flows stay in sync.
-    expect(store.getState().appState.modal.open).toBe(true);
-    expect(store.getState().appState.modal.modalState.name).toBe(
-      'NETWORK_MANAGER',
-    );
+    expect(
+      screen.getByText(messages.networkMenuHeading.message),
+    ).toBeInTheDocument();
+
+    const networkItems = screen.getAllByTestId(/select-network-item-/u);
+    expect(networkItems.length).toBeGreaterThan(0);
   });
 });

--- a/ui/pages/custom-token-import/custom-token-import.test.tsx
+++ b/ui/pages/custom-token-import/custom-token-import.test.tsx
@@ -78,9 +78,6 @@ describe('CustomTokenImportPage', () => {
 
     expect(screen.getByTestId('custom-token-import-page')).toBeInTheDocument();
     expect(
-      screen.getByTestId('network-selector'),
-    ).toHaveTextContent('Ethereum Mainnet');
-    expect(
       screen.getByTestId('custom-token-import-address-input'),
     ).toBeInTheDocument();
     // Symbol/decimal fields are gated behind a valid address entry.

--- a/ui/pages/custom-token-import/custom-token-import.test.tsx
+++ b/ui/pages/custom-token-import/custom-token-import.test.tsx
@@ -76,12 +76,10 @@ describe('CustomTokenImportPage', () => {
   it('renders the form scaffolding without crashing', () => {
     renderPage();
 
-    expect(
-      screen.getByTestId('custom-token-import-page'),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByTestId('custom-token-import-warning'),
-    ).toHaveTextContent(messages.importTokenWarning.message);
+    expect(screen.getByTestId('custom-token-import-page')).toBeInTheDocument();
+    expect(screen.getByTestId('custom-token-import-warning')).toHaveTextContent(
+      messages.importTokenWarning.message,
+    );
     expect(
       screen.getByTestId('custom-token-import-network-picker'),
     ).toHaveTextContent('Ethereum Mainnet');
@@ -124,9 +122,7 @@ describe('CustomTokenImportPage', () => {
   it('opens the network manager modal when the network picker is clicked', () => {
     const { store } = renderPage();
 
-    fireEvent.click(
-      screen.getByTestId('custom-token-import-network-picker'),
-    );
+    fireEvent.click(screen.getByTestId('custom-token-import-network-picker'));
 
     // The network picker reuses the existing global modal; the manage tokens
     // page uses the same one so both flows stay in sync.

--- a/ui/pages/custom-token-import/custom-token-import.test.tsx
+++ b/ui/pages/custom-token-import/custom-token-import.test.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import { fireEvent, screen } from '@testing-library/react';
+import {
+  en as messages,
+  renderWithProvider,
+} from '../../../test/lib/render-helpers-navigate';
+import configureStore from '../../store/store';
+import mockState from '../../../test/data/mock-state.json';
+import { CUSTOM_TOKEN_IMPORT_ROUTE } from '../../helpers/constants/routes';
+import { CustomTokenImportPage } from './custom-token-import';
+
+// The page kicks off real on-chain probes through `getTokenStandardAndDetailsByChain`
+// and `tokenInfoGetter`. Replace them with deterministic stubs so the unit
+// test never reaches the background script.
+jest.mock('../../store/actions', () => {
+  const actual = jest.requireActual('../../store/actions');
+  return {
+    ...actual,
+    getTokenStandardAndDetailsByChain: jest.fn().mockResolvedValue({
+      standard: 'ERC20',
+      symbol: 'APE',
+      decimals: '18',
+    }),
+  };
+});
+
+jest.mock('../../helpers/utils/token-util', () => {
+  const actual = jest.requireActual('../../helpers/utils/token-util');
+  return {
+    ...actual,
+    tokenInfoGetter: () => async () => ({
+      symbol: 'APE',
+      decimals: 18,
+      name: 'ApeCoin',
+    }),
+  };
+});
+
+describe('CustomTokenImportPage', () => {
+  const buildState = () => ({
+    ...mockState,
+    metamask: {
+      ...mockState.metamask,
+      selectedNetworkClientId: 'mainnet',
+      selectedMultichainNetworkChainId: 'eip155:1',
+      networkConfigurationsByChainId: {
+        ...mockState.metamask.networkConfigurationsByChainId,
+        '0x1': {
+          chainId: '0x1',
+          name: 'Ethereum Mainnet',
+          defaultRpcEndpointIndex: 0,
+          rpcEndpoints: [
+            {
+              networkClientId: 'mainnet',
+              type: 'infura',
+              url: 'https://mainnet.infura.io/v3/',
+            },
+          ],
+        },
+      },
+    },
+  });
+
+  const renderPage = () => {
+    const store = configureStore(buildState());
+    return {
+      store,
+      ...renderWithProvider(
+        <CustomTokenImportPage />,
+        store,
+        CUSTOM_TOKEN_IMPORT_ROUTE,
+      ),
+    };
+  };
+
+  it('renders the form scaffolding without crashing', () => {
+    renderPage();
+
+    expect(
+      screen.getByTestId('custom-token-import-page'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('custom-token-import-warning'),
+    ).toHaveTextContent(messages.importTokenWarning.message);
+    expect(
+      screen.getByTestId('custom-token-import-network-picker'),
+    ).toHaveTextContent('Ethereum Mainnet');
+    expect(
+      screen.getByTestId('custom-token-import-address-input'),
+    ).toBeInTheDocument();
+    // Symbol/decimal fields are gated behind a valid address entry.
+    expect(
+      screen.queryByTestId('custom-token-import-symbol-input'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('custom-token-import-decimal-input'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('keeps the submit button disabled while the address field is empty', () => {
+    renderPage();
+
+    const submit = screen.getByTestId('custom-token-import-submit-button');
+    expect(submit).toBeDisabled();
+  });
+
+  it('flags an invalid contract address', () => {
+    renderPage();
+
+    const input = screen.getByTestId(
+      'custom-token-import-address-input',
+    ) as HTMLInputElement;
+
+    fireEvent.change(input, { target: { value: '0xnot-an-address' } });
+
+    expect(
+      screen.getByText(messages.invalidAddress.message),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('custom-token-import-submit-button'),
+    ).toBeDisabled();
+  });
+
+  it('opens the network manager modal when the network picker is clicked', () => {
+    const { store } = renderPage();
+
+    fireEvent.click(
+      screen.getByTestId('custom-token-import-network-picker'),
+    );
+
+    // The network picker reuses the existing global modal; the manage tokens
+    // page uses the same one so both flows stay in sync.
+    expect(store.getState().appState.modal.open).toBe(true);
+    expect(store.getState().appState.modal.modalState.name).toBe(
+      'NETWORK_MANAGER',
+    );
+  });
+});

--- a/ui/pages/custom-token-import/custom-token-import.tsx
+++ b/ui/pages/custom-token-import/custom-token-import.tsx
@@ -36,7 +36,12 @@ import {
   getCurrentChainId,
   getNetworkConfigurationsByChainId,
 } from '../../../shared/lib/selectors/networks';
-import { getSelectedEvmInternalAccount, getAllTokens } from '../../selectors';
+import {
+  getInternalAccounts,
+  getSelectedEvmInternalAccount,
+  getAllTokens,
+  selectERC20TokensByChain,
+} from '../../selectors';
 import { checkExistingAddresses } from '../../helpers/utils/util';
 import { tokenInfoGetter } from '../../helpers/utils/token-util';
 import { STATIC_MAINNET_TOKEN_LIST } from '../../../shared/constants/tokens';
@@ -63,9 +68,20 @@ export const CustomTokenImportPage = () => {
     getAllNetworkConfigurationsByCaipChainId,
   );
   const selectedAccount = useSelector(getSelectedEvmInternalAccount);
+  const internalAccounts = useSelector(getInternalAccounts) as {
+    address: string;
+  }[];
   const allTokens = useSelector(getAllTokens) as Record<
     string,
     Record<string, { address: string }[]>
+  >;
+  // Chain-scoped token-list cache, same source the backend uses inside
+  // `getTokenStandardAndDetailsByChain`. Provides the metadata fallback for
+  // `tokenInfoGetter` when on-chain `symbol()`/`decimals()`/`name()` calls
+  // can't return a value.
+  const erc20TokensByChain = useSelector(selectERC20TokensByChain) as Record<
+    string,
+    { data?: Record<string, unknown> } | undefined
   >;
 
   const [selectedNetwork, setSelectedNetwork] =
@@ -106,6 +122,9 @@ export const CustomTokenImportPage = () => {
     [allTokens, selectedNetwork, selectedAccount?.address],
   );
 
+  const tokenListForSelectedNetwork =
+    erc20TokensByChain?.[selectedNetwork]?.data;
+
   const [address, setAddress] = useState('');
   const [symbol, setSymbol] = useState('');
   const [decimals, setDecimals] = useState('');
@@ -117,6 +136,9 @@ export const CustomTokenImportPage = () => {
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const infoGetter = useRef(tokenInfoGetter());
+  // Tracks the in-flight `handleAddressChange` invocation so async results
+  // from previous calls (stale address or stale network) can be discarded.
+  const addressLookupRef = useRef(0);
 
   const resetValidation = useCallback(() => {
     setAddressError(null);
@@ -138,28 +160,65 @@ export const CustomTokenImportPage = () => {
       const trimmed = value.trim();
       setAddress(trimmed);
       resetValidation();
+      setSymbol('');
+      setDecimals('');
 
-      if (!trimmed) {
-        setSymbol('');
-        setDecimals('');
-        return;
-      }
+      // Invalidate any in-flight lookup so its eventual result is ignored.
+      const lookupId = ++addressLookupRef.current;
+      const isLatestLookup = () => addressLookupRef.current === lookupId;
 
+      const addressIsEmpty = trimmed.length === 0 || trimmed === EMPTY_ADDRESS;
       const addressIsValid = isValidHexAddress(trimmed, {
         allowNonPrefixed: false,
       });
-      if (!addressIsValid || trimmed === EMPTY_ADDRESS) {
+      const standardAddress = addHexPrefix(trimmed).toLowerCase();
+      const isMainnetToken = Object.keys(STATIC_MAINNET_TOKEN_LIST).some(
+        (key) => key.toLowerCase() === standardAddress,
+      );
+
+      // Probe the chain *before* applying validation branches so the NFT
+      // branch wins over the mainnet-warning/personal-address/existing-token
+      // branches, matching the order of the legacy `import-tokens-modal`
+      // switch.
+      let standard: string | undefined;
+      if (addressIsValid) {
+        try {
+          const result = await getTokenStandardAndDetailsByChain(
+            standardAddress,
+            selectedAccount?.address,
+            undefined,
+            selectedNetwork,
+          );
+          standard = result?.standard;
+        } catch {
+          // ignore probe failures
+        }
+      }
+
+      if (!isLatestLookup()) {
+        return;
+      }
+
+      if (!addressIsValid && !addressIsEmpty) {
         setAddressError(t('invalidAddress'));
         return;
       }
 
-      const standardAddress = addHexPrefix(trimmed).toLowerCase();
+      if (standard === ERC721 || standard === ERC1155) {
+        setAddressError(t('nftAddressError', [t('importNFTPage')]));
+        return;
+      }
 
-      const isMainnetToken = Object.keys(STATIC_MAINNET_TOKEN_LIST).some(
-        (key) => key.toLowerCase() === standardAddress,
-      );
       if (isMainnetToken && selectedNetwork !== CHAIN_IDS.MAINNET) {
         setWarning(t('mainnetToken'));
+        return;
+      }
+
+      const isOwnAccountAddress = internalAccounts.some(
+        (account) => account.address?.toLowerCase() === standardAddress,
+      );
+      if (isOwnAccountAddress) {
+        setAddressError(t('personalAddressDetected'));
         return;
       }
 
@@ -168,43 +227,44 @@ export const CustomTokenImportPage = () => {
         return;
       }
 
-      let standard: string | undefined;
-      try {
-        const result = await getTokenStandardAndDetailsByChain(
-          standardAddress,
-          selectedAccount?.address,
-          undefined,
-          selectedNetwork,
-        );
-        standard = result?.standard;
-      } catch {
-        // Probe failures shouldn't block the user; symbol/decimal auto-fill
-        // below will surface its own errors if it also fails.
-      }
-
-      if (standard === ERC721 || standard === ERC1155) {
-        setAddressError(t('nftAddressError', [t('importNFTPage')]));
+      // Empty address (length 0 or `0x000…0`) falls through with no error and
+      // skips the auto-fill, mirroring the legacy switch's default branch.
+      if (addressIsEmpty) {
         return;
       }
 
+      // Mirror `attemptToAutoFillTokenParams` from the legacy modal.
       try {
-        const info = await infoGetter.current(standardAddress, undefined);
-        const nextSymbol = info?.symbol ?? '';
+        const info = await infoGetter.current(
+          standardAddress,
+          tokenListForSelectedNetwork,
+        );
+        if (!isLatestLookup()) {
+          return;
+        }
+        const rawDecimals = info?.decimals;
         const nextDecimals =
-          typeof info?.decimals === 'number' ? String(info.decimals) : '';
-        setSymbol(nextSymbol);
+          rawDecimals === undefined || rawDecimals === null
+            ? ''
+            : String(rawDecimals);
+        setSymbol(info?.symbol ?? '');
         setDecimals(nextDecimals);
         setShowSymbolAndDecimals(true);
       } catch {
+        if (!isLatestLookup()) {
+          return;
+        }
         setShowSymbolAndDecimals(true);
       }
     },
     [
       existingTokens,
+      internalAccounts,
       resetValidation,
       selectedAccount?.address,
       selectedNetwork,
       t,
+      tokenListForSelectedNetwork,
     ],
   );
 
@@ -248,6 +308,9 @@ export const CustomTokenImportPage = () => {
   }, [currentChainId]);
 
   useEffect(() => {
+    // Bump the lookup token so any address lookup started on the previous
+    // network can't apply its result here.
+    addressLookupRef.current += 1;
     clearFormData();
   }, [selectedNetwork, clearFormData]);
 

--- a/ui/pages/custom-token-import/custom-token-import.tsx
+++ b/ui/pages/custom-token-import/custom-token-import.tsx
@@ -164,7 +164,8 @@ export const CustomTokenImportPage = () => {
       setDecimals('');
 
       // Invalidate any in-flight lookup so its eventual result is ignored.
-      const lookupId = ++addressLookupRef.current;
+      addressLookupRef.current += 1;
+      const lookupId = addressLookupRef.current;
       const isLatestLookup = () => addressLookupRef.current === lookupId;
 
       const addressIsEmpty = trimmed.length === 0 || trimmed === EMPTY_ADDRESS;

--- a/ui/pages/custom-token-import/custom-token-import.tsx
+++ b/ui/pages/custom-token-import/custom-token-import.tsx
@@ -7,27 +7,13 @@ import React, {
 } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
+import { formatChainIdToHex } from '@metamask/bridge-controller';
 import {
-  BannerAlert,
-  BannerAlertSeverity,
-  Box,
-  BoxAlignItems,
-  BoxBackgroundColor,
-  BoxFlexDirection,
-  Button,
-  ButtonBase,
-  ButtonBaseSize,
   ButtonIcon,
   ButtonIconSize,
-  ButtonSize,
-  FontWeight,
   IconName,
-  Input,
-  Text,
-  TextAlign,
-  TextColor,
-  TextVariant,
 } from '@metamask/design-system-react';
+import { ERC721, ERC1155 } from '@metamask/controller-utils';
 import { type Hex } from '@metamask/utils';
 import { isValidHexAddress } from '../../../shared/lib/hexstring-utils';
 // TODO: Remove restricted import
@@ -35,18 +21,17 @@ import { isValidHexAddress } from '../../../shared/lib/hexstring-utils';
 import { addHexPrefix } from '../../../app/scripts/lib/util';
 
 import { useI18nContext } from '../../hooks/useI18nContext';
-import { Header } from '../../components/multichain/pages/page';
-import { ScrollContainer } from '../../contexts/scroll-container';
+import { Header, Page } from '../../components/multichain/pages/page';
 import {
   addImportedTokens,
   getTokenStandardAndDetailsByChain,
-  showModal,
 } from '../../store/actions';
 import {
   TOKEN_MANAGEMENT_ROUTE,
   DEFAULT_ROUTE,
 } from '../../helpers/constants/routes';
 import {
+  getAllNetworkConfigurationsByCaipChainId,
   getCurrentChainId,
   getNetworkConfigurationsByChainId,
 } from '../../../shared/lib/selectors/networks';
@@ -55,71 +40,16 @@ import { checkExistingAddresses } from '../../helpers/utils/util';
 import { tokenInfoGetter } from '../../helpers/utils/token-util';
 import { STATIC_MAINNET_TOKEN_LIST } from '../../../shared/constants/tokens';
 import { CHAIN_IDS } from '../../../shared/constants/network';
+import { isEvmChainId } from '../../../shared/lib/asset-utils';
+import { type CustomTokenImportNetworkOption } from './custom-token-import-network-selector';
+import { CustomTokenImportForm } from './custom-token-import-form';
 
-const ERC1155 = 'ERC1155';
-const ERC721 = 'ERC721';
 const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000';
 const MIN_DECIMAL_VALUE = 0;
 const MAX_DECIMAL_VALUE = 36;
 
-type LabeledFieldProps = {
-  id: string;
-  label: string;
-  error?: string | null;
-  children: React.ReactNode;
-};
-
-/**
- * Wraps a DS `Input` with a label + optional error row to mirror the
- * affordances of the legacy `FormTextField`, which DS doesn't currently
- * provide a direct replacement for.
- * @param options0
- * @param options0.id
- * @param options0.label
- * @param options0.error
- * @param options0.children
- */
-const LabeledField = ({ id, label, error, children }: LabeledFieldProps) => (
-  <Box flexDirection={BoxFlexDirection.Column} gap={1}>
-    <Text
-      variant={TextVariant.BodySm}
-      fontWeight={FontWeight.Medium}
-      asChild
-    >
-      <label htmlFor={id}>{label}</label>
-    </Text>
-    {children}
-    {error ? (
-      <Text
-        variant={TextVariant.BodySm}
-        color={TextColor.ErrorDefault}
-        role="alert"
-      >
-        {error}
-      </Text>
-    ) : null}
-  </Box>
-);
-
 /**
  * Full-screen "Add a custom token" page.
- *
- * Companion screen to the Token Management page (introduced behind the same
- * `extensionUxTokenManagementFilter` feature flag). Replaces the legacy
- * "Custom token" tab inside the import-tokens modal with a dedicated route so
- * the flow can be deep-linked from the Manage tokens screen, breadcrumbed in
- * analytics, and laid out like a page rather than a modal.
- *
- * Validation mirrors the existing modal: address shape, ERC-721/1155 rejection,
- * mainnet-token-on-wrong-chain warning, duplicate detection, and on-chain
- * auto-fill of `symbol` + `decimals` for the entered contract. The submit
- * button stays disabled until those checks pass.
- *
- * The Network field opens the existing Network Manager modal — the same picker
- * the Manage tokens screen uses — so the two screens stay in sync rather than
- * introducing a second, page-local network selector. The chain that's
- * ultimately used for the import is the currently selected EVM chain at
- * submission time.
  */
 export const CustomTokenImportPage = () => {
   const t = useI18nContext();
@@ -128,13 +58,28 @@ export const CustomTokenImportPage = () => {
 
   const currentChainId = useSelector(getCurrentChainId) as Hex;
   const networkConfigurations = useSelector(getNetworkConfigurationsByChainId);
+  const allNetworkConfigurations = useSelector(
+    getAllNetworkConfigurationsByCaipChainId,
+  );
   const selectedAccount = useSelector(getSelectedEvmInternalAccount);
   const allTokens = useSelector(getAllTokens) as Record<
     string,
     Record<string, { address: string }[]>
   >;
 
-  const selectedNetwork = currentChainId;
+  const [selectedNetwork, setSelectedNetwork] = useState<Hex>(currentChainId);
+
+  const evmNetworks = useMemo<CustomTokenImportNetworkOption[]>(
+    () =>
+      Object.values(allNetworkConfigurations)
+        .filter((network) => isEvmChainId(network.chainId as Hex))
+        .map(({ chainId, name }) => ({
+          chainId,
+          name,
+        })),
+    [allNetworkConfigurations],
+  );
+
   const networkName =
     networkConfigurations?.[selectedNetwork]?.name ?? t('currentNetwork');
   const networkClientId =
@@ -149,7 +94,7 @@ export const CustomTokenImportPage = () => {
 
   const [address, setAddress] = useState('');
   const [symbol, setSymbol] = useState('');
-  const [decimals, setDecimals] = useState<number | ''>('');
+  const [decimals, setDecimals] = useState('');
   const [addressError, setAddressError] = useState<string | null>(null);
   const [symbolError, setSymbolError] = useState<string | null>(null);
   const [decimalsError, setDecimalsError] = useState<string | null>(null);
@@ -157,8 +102,6 @@ export const CustomTokenImportPage = () => {
   const [showSymbolAndDecimals, setShowSymbolAndDecimals] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  // Cached token info lookup so repeated edits of the same address don't
-  // hammer the background script.
   const infoGetter = useRef(tokenInfoGetter());
 
   const resetValidation = useCallback(() => {
@@ -168,6 +111,13 @@ export const CustomTokenImportPage = () => {
     setWarning(null);
     setShowSymbolAndDecimals(false);
   }, []);
+
+  const clearFormData = useCallback(() => {
+    setAddress('');
+    setSymbol('');
+    setDecimals('');
+    resetValidation();
+  }, [resetValidation]);
 
   const handleAddressChange = useCallback(
     async (value: string) => {
@@ -191,9 +141,6 @@ export const CustomTokenImportPage = () => {
 
       const standardAddress = addHexPrefix(trimmed).toLowerCase();
 
-      // Warn (and refuse) when the address is a mainnet token but the user is
-      // currently on another chain. Matches the existing modal behavior so we
-      // don't accidentally import mainnet metadata against e.g. Polygon.
       const isMainnetToken = Object.keys(STATIC_MAINNET_TOKEN_LIST).some(
         (key) => key.toLowerCase() === standardAddress,
       );
@@ -207,8 +154,6 @@ export const CustomTokenImportPage = () => {
         return;
       }
 
-      // Identify NFTs before showing symbol/decimal fields — ERC-721/1155
-      // tokens have to go through the NFT import flow instead.
       let standard: string | undefined;
       try {
         const result = await getTokenStandardAndDetailsByChain(
@@ -219,8 +164,8 @@ export const CustomTokenImportPage = () => {
         );
         standard = result?.standard;
       } catch {
-        // Network/contract probe failures shouldn't block the user; they'll
-        // still see decimal/symbol errors if auto-fill fails below.
+        // Probe failures shouldn't block the user; symbol/decimal auto-fill
+        // below will surface its own errors if it also fails.
       }
 
       if (standard === ERC721 || standard === ERC1155) {
@@ -228,13 +173,11 @@ export const CustomTokenImportPage = () => {
         return;
       }
 
-      // Best-effort auto-fill of symbol/decimals from on-chain metadata. The
-      // user can still edit either value before submitting.
       try {
         const info = await infoGetter.current(standardAddress, undefined);
         const nextSymbol = info?.symbol ?? '';
         const nextDecimals =
-          typeof info?.decimals === 'number' ? info.decimals : '';
+          typeof info?.decimals === 'number' ? String(info.decimals) : '';
         setSymbol(nextSymbol);
         setDecimals(nextDecimals);
         setShowSymbolAndDecimals(true);
@@ -272,7 +215,7 @@ export const CustomTokenImportPage = () => {
         return;
       }
       const next = Number(value);
-      setDecimals(Number.isNaN(next) ? '' : next);
+      setDecimals(value);
       if (
         Number.isNaN(next) ||
         next < MIN_DECIMAL_VALUE ||
@@ -286,25 +229,28 @@ export const CustomTokenImportPage = () => {
     [t],
   );
 
-  // If the user changes the active network from outside this page (e.g. via
-  // the Network Manager modal we open), clear any prior form state so we don't
-  // accidentally import a token that was validated against a different chain.
   useEffect(() => {
-    setAddress('');
-    setSymbol('');
-    setDecimals('');
-    resetValidation();
-  }, [selectedNetwork, resetValidation]);
+    setSelectedNetwork(currentChainId);
+  }, [currentChainId]);
 
-  const handleOpenNetworkPicker = useCallback(() => {
-    dispatch(showModal({ name: 'NETWORK_MANAGER' }));
-  }, [dispatch]);
+  useEffect(() => {
+    clearFormData();
+  }, [selectedNetwork, clearFormData]);
 
-  const handleClose = useCallback(() => {
+  const handleSelectNetwork = useCallback(
+    (network: CustomTokenImportNetworkOption) => {
+      const networkChainId = formatChainIdToHex(network.chainId) as Hex;
+      setSelectedNetwork(networkChainId);
+      clearFormData();
+    },
+    [clearFormData],
+  );
+
+  const handleBack = useCallback(() => {
     navigate(TOKEN_MANAGEMENT_ROUTE);
   }, [navigate]);
 
-  const handleHardClose = useCallback(() => {
+  const handleClose = useCallback(() => {
     navigate(DEFAULT_ROUTE);
   }, [navigate]);
 
@@ -316,10 +262,12 @@ export const CustomTokenImportPage = () => {
     showSymbolAndDecimals &&
     address.length > 0 &&
     symbol.length > 0 &&
-    typeof decimals === 'number';
+    decimals.length > 0;
+
+  const parsedDecimals = Number(decimals);
 
   const handleSubmit = useCallback(async () => {
-    if (!isValid || isSubmitting || typeof decimals !== 'number') {
+    if (Number.isNaN(parsedDecimals) || !isValid || isSubmitting) {
       return;
     }
     setIsSubmitting(true);
@@ -330,7 +278,7 @@ export const CustomTokenImportPage = () => {
             {
               address,
               symbol,
-              decimals,
+              decimals: parsedDecimals,
               isERC721: false,
             },
           ],
@@ -343,167 +291,61 @@ export const CustomTokenImportPage = () => {
     }
   }, [
     address,
-    decimals,
     dispatch,
     isSubmitting,
     isValid,
     navigate,
     networkClientId,
+    parsedDecimals,
     symbol,
   ]);
 
-  const startAccessory = (
-    <ButtonIcon
-      iconName={IconName.ArrowLeft}
-      ariaLabel={t('back')}
-      size={ButtonIconSize.Sm}
-      onClick={handleClose}
-      data-testid="custom-token-import-back-button"
-    />
-  );
-
-  const endAccessory = (
-    <ButtonIcon
-      iconName={IconName.Close}
-      ariaLabel={t('close')}
-      size={ButtonIconSize.Sm}
-      onClick={handleHardClose}
-      data-testid="custom-token-import-close-button"
-    />
-  );
-
   return (
-    <Box
-      flexDirection={BoxFlexDirection.Column}
-      backgroundColor={BoxBackgroundColor.BackgroundDefault}
-      className="w-full h-full min-h-0"
-      data-testid="custom-token-import-page"
-    >
-      <Header startAccessory={startAccessory} endAccessory={endAccessory}>
+    <Page data-testid="custom-token-import-page">
+      <Header
+        startAccessory={
+          <ButtonIcon
+            ariaLabel={t('back')}
+            iconName={IconName.ArrowLeft}
+            size={ButtonIconSize.Md}
+            onClick={handleBack}
+            data-testid="custom-token-import-back-button"
+          />
+        }
+        endAccessory={
+          <ButtonIcon
+            ariaLabel={t('close')}
+            iconName={IconName.Close}
+            size={ButtonIconSize.Md}
+            onClick={handleClose}
+            data-testid="custom-token-import-close-button"
+          />
+        }
+        marginBottom={0}
+      >
         {t('addCustomToken')}
       </Header>
-
-      <ScrollContainer
-        style={{
-          flex: '1 1 auto',
-          minHeight: 0,
-          overflowY: 'auto',
-          width: '100%',
-        }}
-      >
-        <Box
-          flexDirection={BoxFlexDirection.Column}
-          gap={4}
-          paddingHorizontal={4}
-          paddingTop={3}
-          paddingBottom={4}
-        >
-          <BannerAlert
-            severity={BannerAlertSeverity.Warning}
-            data-testid="custom-token-import-warning"
-          >
-            <Text variant={TextVariant.BodySm}>{t('importTokenWarning')}</Text>
-          </BannerAlert>
-
-          <Box flexDirection={BoxFlexDirection.Column} gap={1}>
-            <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
-              {t('network')}
-            </Text>
-            <ButtonBase
-              isFullWidth
-              data-testid="custom-token-import-network-picker"
-              size={ButtonBaseSize.Lg}
-              endIconName={IconName.ArrowDown}
-              className="bg-default text-default border border-muted justify-between"
-              textProps={{ textAlign: TextAlign.Left, ellipsis: true }}
-              onClick={handleOpenNetworkPicker}
-            >
-              {networkName}
-            </ButtonBase>
-          </Box>
-
-          <LabeledField
-            id="custom-token-import-address"
-            label={t('tokenContractAddress')}
-            error={addressError}
-          >
-            <Input
-              id="custom-token-import-address"
-              data-testid="custom-token-import-address-input"
-              placeholder={t('enterTokenAddress')}
-              value={address}
-              aria-invalid={Boolean(addressError)}
-              className="h-12 px-4"
-              onChange={(event) => handleAddressChange(event.target.value)}
-            />
-          </LabeledField>
-
-          {warning ? (
-            <BannerAlert
-              severity={BannerAlertSeverity.Warning}
-              data-testid="custom-token-import-mainnet-warning"
-            >
-              <Text variant={TextVariant.BodySm}>{warning}</Text>
-            </BannerAlert>
-          ) : null}
-
-          {showSymbolAndDecimals ? (
-            <>
-              <LabeledField
-                id="custom-token-import-symbol"
-                label={t('tokenSymbol')}
-                error={symbolError}
-              >
-                <Input
-                  id="custom-token-import-symbol"
-                  data-testid="custom-token-import-symbol-input"
-                  value={symbol}
-                  aria-invalid={Boolean(symbolError)}
-                  className="h-12 px-4"
-                  onChange={(event) => handleSymbolChange(event.target.value)}
-                />
-              </LabeledField>
-              <LabeledField
-                id="custom-token-import-decimal"
-                label={t('tokenDecimal')}
-                error={decimalsError}
-              >
-                <Input
-                  id="custom-token-import-decimal"
-                  data-testid="custom-token-import-decimal-input"
-                  type="number"
-                  value={decimals === '' ? '' : String(decimals)}
-                  aria-invalid={Boolean(decimalsError)}
-                  className="h-12 px-4"
-                  onChange={(event) => handleDecimalsChange(event.target.value)}
-                />
-              </LabeledField>
-            </>
-          ) : null}
-        </Box>
-      </ScrollContainer>
-
-      <Box
-        flexDirection={BoxFlexDirection.Row}
-        alignItems={BoxAlignItems.Center}
-        backgroundColor={BoxBackgroundColor.BackgroundDefault}
-        paddingHorizontal={4}
-        paddingTop={3}
-        paddingBottom={3}
-        className="sticky bottom-0 z-10"
-      >
-        <Button
-          isFullWidth
-          size={ButtonSize.Lg}
-          data-testid="custom-token-import-submit-button"
-          isDisabled={!isValid || isSubmitting}
-          isLoading={isSubmitting}
-          onClick={handleSubmit}
-        >
-          {t('addToken')}
-        </Button>
-      </Box>
-    </Box>
+      <CustomTokenImportForm
+        networkName={networkName}
+        selectedNetwork={selectedNetwork}
+        networks={evmNetworks}
+        address={address}
+        addressError={addressError}
+        symbol={symbol}
+        symbolError={symbolError}
+        decimals={decimals}
+        decimalsError={decimalsError}
+        warning={warning}
+        showSymbolAndDecimals={showSymbolAndDecimals}
+        isSubmitDisabled={!isValid || isSubmitting}
+        isSubmitting={isSubmitting}
+        onSelectNetwork={handleSelectNetwork}
+        onAddressChange={handleAddressChange}
+        onSymbolChange={handleSymbolChange}
+        onDecimalsChange={handleDecimalsChange}
+        onSubmit={handleSubmit}
+      />
+    </Page>
   );
 };
 

--- a/ui/pages/custom-token-import/custom-token-import.tsx
+++ b/ui/pages/custom-token-import/custom-token-import.tsx
@@ -1,0 +1,510 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
+import {
+  BoxAlignItems,
+  Box as DSBox,
+  ButtonIcon,
+  ButtonIconSize,
+  IconName as DSIconName,
+} from '@metamask/design-system-react';
+import { type Hex } from '@metamask/utils';
+import { isValidHexAddress } from '../../../shared/lib/hexstring-utils';
+// TODO: Remove restricted import
+// eslint-disable-next-line import-x/no-restricted-paths
+import { addHexPrefix } from '../../../app/scripts/lib/util';
+
+import {
+  AlignItems,
+  BackgroundColor,
+  BlockSize,
+  BorderColor,
+  BorderStyle,
+  Display,
+  FlexDirection,
+  TextAlign,
+  TextColor,
+  TextVariant,
+} from '../../helpers/constants/design-system';
+import {
+  BannerAlert,
+  BannerAlertSeverity,
+  Box,
+  ButtonBase,
+  ButtonBaseSize,
+  ButtonPrimary,
+  ButtonPrimarySize,
+  FormTextField,
+  FormTextFieldSize,
+  IconName,
+  Text,
+  TextFieldType,
+} from '../../components/component-library';
+import { useI18nContext } from '../../hooks/useI18nContext';
+import { Header } from '../../components/multichain/pages/page';
+import { ScrollContainer } from '../../contexts/scroll-container';
+import {
+  addImportedTokens,
+  getTokenStandardAndDetailsByChain,
+  showModal,
+} from '../../store/actions';
+import {
+  TOKEN_MANAGEMENT_ROUTE,
+  DEFAULT_ROUTE,
+} from '../../helpers/constants/routes';
+import {
+  getCurrentChainId,
+  getNetworkConfigurationsByChainId,
+} from '../../../shared/lib/selectors/networks';
+import { getSelectedEvmInternalAccount, getAllTokens } from '../../selectors';
+import { checkExistingAddresses } from '../../helpers/utils/util';
+import { tokenInfoGetter } from '../../helpers/utils/token-util';
+import { STATIC_MAINNET_TOKEN_LIST } from '../../../shared/constants/tokens';
+import { CHAIN_IDS } from '../../../shared/constants/network';
+
+const ERC1155 = 'ERC1155';
+const ERC721 = 'ERC721';
+const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000';
+const MIN_DECIMAL_VALUE = 0;
+const MAX_DECIMAL_VALUE = 36;
+
+/**
+ * Full-screen "Add a custom token" page.
+ *
+ * Companion screen to the Token Management page (introduced behind the same
+ * `extensionUxTokenManagementFilter` feature flag). Replaces the legacy
+ * "Custom token" tab inside the import-tokens modal with a dedicated route so
+ * the flow can be deep-linked from the Manage tokens screen, breadcrumbed in
+ * analytics, and laid out like a page rather than a modal.
+ *
+ * Validation mirrors the existing modal: address shape, ERC-721/1155 rejection,
+ * mainnet-token-on-wrong-chain warning, duplicate detection, and on-chain
+ * auto-fill of `symbol` + `decimals` for the entered contract. The submit
+ * button stays disabled until those checks pass.
+ *
+ * The Network field opens the existing Network Manager modal — the same picker
+ * the Manage tokens screen uses — so the two screens stay in sync rather than
+ * introducing a second, page-local network selector. The chain that's
+ * ultimately used for the import is the currently selected EVM chain at
+ * submission time.
+ */
+export const CustomTokenImportPage = () => {
+  const t = useI18nContext();
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+
+  const currentChainId = useSelector(getCurrentChainId) as Hex;
+  const networkConfigurations = useSelector(getNetworkConfigurationsByChainId);
+  const selectedAccount = useSelector(getSelectedEvmInternalAccount);
+  const allTokens = useSelector(getAllTokens) as Record<
+    string,
+    Record<string, { address: string }[]>
+  >;
+
+  const selectedNetwork = currentChainId;
+  const networkName =
+    networkConfigurations?.[selectedNetwork]?.name ?? t('currentNetwork');
+  const networkClientId =
+    networkConfigurations?.[selectedNetwork]?.rpcEndpoints?.[
+      networkConfigurations?.[selectedNetwork]?.defaultRpcEndpointIndex ?? 0
+    ]?.networkClientId;
+
+  const existingTokens = useMemo(
+    () => allTokens?.[selectedNetwork]?.[selectedAccount?.address ?? ''] ?? [],
+    [allTokens, selectedNetwork, selectedAccount?.address],
+  );
+
+  const [address, setAddress] = useState('');
+  const [symbol, setSymbol] = useState('');
+  const [decimals, setDecimals] = useState<number | ''>('');
+  const [addressError, setAddressError] = useState<string | null>(null);
+  const [symbolError, setSymbolError] = useState<string | null>(null);
+  const [decimalsError, setDecimalsError] = useState<string | null>(null);
+  const [warning, setWarning] = useState<string | null>(null);
+  const [showSymbolAndDecimals, setShowSymbolAndDecimals] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // Cached token info lookup so repeated edits of the same address don't
+  // hammer the background script.
+  const infoGetter = useRef(tokenInfoGetter());
+
+  const resetValidation = useCallback(() => {
+    setAddressError(null);
+    setSymbolError(null);
+    setDecimalsError(null);
+    setWarning(null);
+    setShowSymbolAndDecimals(false);
+  }, []);
+
+  const handleAddressChange = useCallback(
+    async (value: string) => {
+      const trimmed = value.trim();
+      setAddress(trimmed);
+      resetValidation();
+
+      if (!trimmed) {
+        setSymbol('');
+        setDecimals('');
+        return;
+      }
+
+      const addressIsValid = isValidHexAddress(trimmed, {
+        allowNonPrefixed: false,
+      });
+      if (!addressIsValid || trimmed === EMPTY_ADDRESS) {
+        setAddressError(t('invalidAddress'));
+        return;
+      }
+
+      const standardAddress = addHexPrefix(trimmed).toLowerCase();
+
+      // Warn (and refuse) when the address is a mainnet token but the user is
+      // currently on another chain. Matches the existing modal behavior so we
+      // don't accidentally import mainnet metadata against e.g. Polygon.
+      const isMainnetToken = Object.keys(STATIC_MAINNET_TOKEN_LIST).some(
+        (key) => key.toLowerCase() === standardAddress,
+      );
+      if (isMainnetToken && selectedNetwork !== CHAIN_IDS.MAINNET) {
+        setWarning(t('mainnetToken'));
+        return;
+      }
+
+      if (checkExistingAddresses(trimmed, existingTokens)) {
+        setAddressError(t('tokenAlreadyAdded'));
+        return;
+      }
+
+      // Identify NFTs before showing symbol/decimal fields — ERC-721/1155
+      // tokens have to go through the NFT import flow instead.
+      let standard: string | undefined;
+      try {
+        const result = await getTokenStandardAndDetailsByChain(
+          standardAddress,
+          selectedAccount?.address,
+          undefined,
+          selectedNetwork,
+        );
+        standard = result?.standard;
+      } catch {
+        // Network/contract probe failures shouldn't block the user; they'll
+        // still see decimal/symbol errors if auto-fill fails below.
+      }
+
+      if (standard === ERC721 || standard === ERC1155) {
+        setAddressError(t('nftAddressError', [t('importNFTPage')]));
+        return;
+      }
+
+      // Best-effort auto-fill of symbol/decimals from on-chain metadata. The
+      // user can still edit either value before submitting.
+      try {
+        const info = await infoGetter.current(
+          standardAddress,
+          undefined,
+        );
+        const nextSymbol = info?.symbol ?? '';
+        const nextDecimals =
+          typeof info?.decimals === 'number' ? info.decimals : '';
+        setSymbol(nextSymbol);
+        setDecimals(nextDecimals);
+        setShowSymbolAndDecimals(true);
+      } catch {
+        setShowSymbolAndDecimals(true);
+      }
+    },
+    [
+      existingTokens,
+      resetValidation,
+      selectedAccount?.address,
+      selectedNetwork,
+      t,
+    ],
+  );
+
+  const handleSymbolChange = useCallback(
+    (value: string) => {
+      const next = value.trim();
+      setSymbol(next);
+      if (next.length === 0 || next.length >= 12) {
+        setSymbolError(t('symbolBetweenZeroTwelve'));
+      } else {
+        setSymbolError(null);
+      }
+    },
+    [t],
+  );
+
+  const handleDecimalsChange = useCallback(
+    (value: string) => {
+      if (value === '') {
+        setDecimals('');
+        setDecimalsError(t('decimalsMustZerotoTen'));
+        return;
+      }
+      const next = Number(value);
+      setDecimals(Number.isNaN(next) ? '' : next);
+      if (
+        Number.isNaN(next) ||
+        next < MIN_DECIMAL_VALUE ||
+        next > MAX_DECIMAL_VALUE
+      ) {
+        setDecimalsError(t('decimalsMustZerotoTen'));
+      } else {
+        setDecimalsError(null);
+      }
+    },
+    [t],
+  );
+
+  // If the user changes the active network from outside this page (e.g. via
+  // the Network Manager modal we open), clear any prior form state so we don't
+  // accidentally import a token that was validated against a different chain.
+  useEffect(() => {
+    setAddress('');
+    setSymbol('');
+    setDecimals('');
+    resetValidation();
+  }, [selectedNetwork, resetValidation]);
+
+  const handleOpenNetworkPicker = useCallback(() => {
+    dispatch(showModal({ name: 'NETWORK_MANAGER' }));
+  }, [dispatch]);
+
+  const handleClose = useCallback(() => {
+    navigate(TOKEN_MANAGEMENT_ROUTE);
+  }, [navigate]);
+
+  const handleHardClose = useCallback(() => {
+    navigate(DEFAULT_ROUTE);
+  }, [navigate]);
+
+  const isValid =
+    !addressError &&
+    !symbolError &&
+    !decimalsError &&
+    !warning &&
+    showSymbolAndDecimals &&
+    address.length > 0 &&
+    symbol.length > 0 &&
+    typeof decimals === 'number';
+
+  const handleSubmit = useCallback(async () => {
+    if (!isValid || isSubmitting || typeof decimals !== 'number') {
+      return;
+    }
+    setIsSubmitting(true);
+    try {
+      await dispatch(
+        addImportedTokens(
+          [
+            {
+              address,
+              symbol,
+              decimals,
+              isERC721: false,
+            },
+          ],
+          networkClientId,
+        ),
+      );
+      navigate(TOKEN_MANAGEMENT_ROUTE);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [
+    address,
+    decimals,
+    dispatch,
+    isSubmitting,
+    isValid,
+    navigate,
+    networkClientId,
+    symbol,
+  ]);
+
+  const startAccessory = (
+    <DSBox alignItems={BoxAlignItems.Center} gap={1}>
+      <ButtonIcon
+        iconName={DSIconName.ArrowLeft}
+        ariaLabel={t('back')}
+        size={ButtonIconSize.Sm}
+        onClick={handleClose}
+        data-testid="custom-token-import-back-button"
+      />
+    </DSBox>
+  );
+
+  const endAccessory = (
+    <DSBox alignItems={BoxAlignItems.Center} gap={1}>
+      <ButtonIcon
+        iconName={DSIconName.Close}
+        ariaLabel={t('close')}
+        size={ButtonIconSize.Sm}
+        onClick={handleHardClose}
+        data-testid="custom-token-import-close-button"
+      />
+    </DSBox>
+  );
+
+  return (
+    <Box
+      display={Display.Flex}
+      flexDirection={FlexDirection.Column}
+      backgroundColor={BackgroundColor.backgroundDefault}
+      width={BlockSize.Full}
+      style={{ height: '100%', minHeight: 0 }}
+      data-testid="custom-token-import-page"
+    >
+      <Header startAccessory={startAccessory} endAccessory={endAccessory}>
+        {t('addCustomToken')}
+      </Header>
+
+      <ScrollContainer
+        style={{
+          flex: '1 1 auto',
+          minHeight: 0,
+          overflowY: 'auto',
+          width: '100%',
+        }}
+      >
+        <Box
+          display={Display.Flex}
+          flexDirection={FlexDirection.Column}
+          gap={4}
+          paddingInline={4}
+          paddingTop={3}
+          paddingBottom={4}
+        >
+          <BannerAlert
+            severity={BannerAlertSeverity.Warning}
+            data-testid="custom-token-import-warning"
+          >
+            <Text variant={TextVariant.bodySm}>{t('importTokenWarning')}</Text>
+          </BannerAlert>
+
+          <Box
+            display={Display.Flex}
+            flexDirection={FlexDirection.Column}
+            gap={1}
+          >
+            <Text variant={TextVariant.bodySmMedium}>{t('network')}</Text>
+            <ButtonBase
+              block
+              data-testid="custom-token-import-network-picker"
+              size={ButtonBaseSize.Lg}
+              endIconName={IconName.ArrowDown}
+              backgroundColor={BackgroundColor.backgroundDefault}
+              color={TextColor.textDefault}
+              borderColor={BorderColor.borderMuted}
+              borderStyle={BorderStyle.solid}
+              borderWidth={1}
+              onClick={handleOpenNetworkPicker}
+              ellipsis
+              textProps={{ textAlign: TextAlign.Left }}
+            >
+              <Text
+                variant={TextVariant.bodyMd}
+                color={TextColor.textDefault}
+                ellipsis
+              >
+                {networkName}
+              </Text>
+            </ButtonBase>
+          </Box>
+
+          <FormTextField
+            id="custom-token-import-address"
+            label={t('tokenContractAddress')}
+            size={FormTextFieldSize.Lg}
+            placeholder={t('enterTokenAddress')}
+            value={address}
+            error={Boolean(addressError)}
+            helpText={addressError ?? undefined}
+            inputProps={{
+              'data-testid': 'custom-token-import-address-input',
+            }}
+            onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+              handleAddressChange(event.target.value)
+            }
+          />
+
+          {warning ? (
+            <BannerAlert
+              severity={BannerAlertSeverity.Warning}
+              data-testid="custom-token-import-mainnet-warning"
+            >
+              <Text variant={TextVariant.bodySm}>{warning}</Text>
+            </BannerAlert>
+          ) : null}
+
+          {showSymbolAndDecimals ? (
+            <>
+              <FormTextField
+                id="custom-token-import-symbol"
+                label={t('tokenSymbol')}
+                size={FormTextFieldSize.Lg}
+                value={symbol}
+                error={Boolean(symbolError)}
+                helpText={symbolError ?? undefined}
+                inputProps={{
+                  'data-testid': 'custom-token-import-symbol-input',
+                }}
+                onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+                  handleSymbolChange(event.target.value)
+                }
+              />
+              <FormTextField
+                id="custom-token-import-decimal"
+                label={t('tokenDecimal')}
+                size={FormTextFieldSize.Lg}
+                type={TextFieldType.Number}
+                value={decimals === '' ? '' : String(decimals)}
+                error={Boolean(decimalsError)}
+                helpText={decimalsError ?? undefined}
+                inputProps={{
+                  'data-testid': 'custom-token-import-decimal-input',
+                }}
+                onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+                  handleDecimalsChange(event.target.value)
+                }
+              />
+            </>
+          ) : null}
+        </Box>
+      </ScrollContainer>
+
+      <Box
+        display={Display.Flex}
+        alignItems={AlignItems.center}
+        backgroundColor={BackgroundColor.backgroundDefault}
+        paddingInline={4}
+        paddingTop={3}
+        paddingBottom={3}
+        style={{
+          bottom: 0,
+          position: 'sticky',
+          zIndex: 1,
+        }}
+      >
+        <ButtonPrimary
+          block
+          size={ButtonPrimarySize.Lg}
+          data-testid="custom-token-import-submit-button"
+          disabled={!isValid || isSubmitting}
+          loading={isSubmitting}
+          onClick={handleSubmit}
+        >
+          {t('addToken')}
+        </ButtonPrimary>
+      </Box>
+    </Box>
+  );
+};
+
+export default CustomTokenImportPage;

--- a/ui/pages/custom-token-import/custom-token-import.tsx
+++ b/ui/pages/custom-token-import/custom-token-import.tsx
@@ -8,11 +8,25 @@ import React, {
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import {
+  BannerAlert,
+  BannerAlertSeverity,
+  Box,
   BoxAlignItems,
-  Box as DSBox,
+  BoxBackgroundColor,
+  BoxFlexDirection,
+  Button,
+  ButtonBase,
+  ButtonBaseSize,
   ButtonIcon,
   ButtonIconSize,
-  IconName as DSIconName,
+  ButtonSize,
+  FontWeight,
+  IconName,
+  Input,
+  Text,
+  TextAlign,
+  TextColor,
+  TextVariant,
 } from '@metamask/design-system-react';
 import { type Hex } from '@metamask/utils';
 import { isValidHexAddress } from '../../../shared/lib/hexstring-utils';
@@ -20,32 +34,6 @@ import { isValidHexAddress } from '../../../shared/lib/hexstring-utils';
 // eslint-disable-next-line import-x/no-restricted-paths
 import { addHexPrefix } from '../../../app/scripts/lib/util';
 
-import {
-  AlignItems,
-  BackgroundColor,
-  BlockSize,
-  BorderColor,
-  BorderStyle,
-  Display,
-  FlexDirection,
-  TextAlign,
-  TextColor,
-  TextVariant,
-} from '../../helpers/constants/design-system';
-import {
-  BannerAlert,
-  BannerAlertSeverity,
-  Box,
-  ButtonBase,
-  ButtonBaseSize,
-  ButtonPrimary,
-  ButtonPrimarySize,
-  FormTextField,
-  FormTextFieldSize,
-  IconName,
-  Text,
-  TextFieldType,
-} from '../../components/component-library';
 import { useI18nContext } from '../../hooks/useI18nContext';
 import { Header } from '../../components/multichain/pages/page';
 import { ScrollContainer } from '../../contexts/scroll-container';
@@ -73,6 +61,45 @@ const ERC721 = 'ERC721';
 const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000';
 const MIN_DECIMAL_VALUE = 0;
 const MAX_DECIMAL_VALUE = 36;
+
+type LabeledFieldProps = {
+  id: string;
+  label: string;
+  error?: string | null;
+  children: React.ReactNode;
+};
+
+/**
+ * Wraps a DS `Input` with a label + optional error row to mirror the
+ * affordances of the legacy `FormTextField`, which DS doesn't currently
+ * provide a direct replacement for.
+ * @param options0
+ * @param options0.id
+ * @param options0.label
+ * @param options0.error
+ * @param options0.children
+ */
+const LabeledField = ({ id, label, error, children }: LabeledFieldProps) => (
+  <Box flexDirection={BoxFlexDirection.Column} gap={1}>
+    <Text
+      variant={TextVariant.BodySm}
+      fontWeight={FontWeight.Medium}
+      asChild
+    >
+      <label htmlFor={id}>{label}</label>
+    </Text>
+    {children}
+    {error ? (
+      <Text
+        variant={TextVariant.BodySm}
+        color={TextColor.ErrorDefault}
+        role="alert"
+      >
+        {error}
+      </Text>
+    ) : null}
+  </Box>
+);
 
 /**
  * Full-screen "Add a custom token" page.
@@ -204,10 +231,7 @@ export const CustomTokenImportPage = () => {
       // Best-effort auto-fill of symbol/decimals from on-chain metadata. The
       // user can still edit either value before submitting.
       try {
-        const info = await infoGetter.current(
-          standardAddress,
-          undefined,
-        );
+        const info = await infoGetter.current(standardAddress, undefined);
         const nextSymbol = info?.symbol ?? '';
         const nextDecimals =
           typeof info?.decimals === 'number' ? info.decimals : '';
@@ -329,36 +353,30 @@ export const CustomTokenImportPage = () => {
   ]);
 
   const startAccessory = (
-    <DSBox alignItems={BoxAlignItems.Center} gap={1}>
-      <ButtonIcon
-        iconName={DSIconName.ArrowLeft}
-        ariaLabel={t('back')}
-        size={ButtonIconSize.Sm}
-        onClick={handleClose}
-        data-testid="custom-token-import-back-button"
-      />
-    </DSBox>
+    <ButtonIcon
+      iconName={IconName.ArrowLeft}
+      ariaLabel={t('back')}
+      size={ButtonIconSize.Sm}
+      onClick={handleClose}
+      data-testid="custom-token-import-back-button"
+    />
   );
 
   const endAccessory = (
-    <DSBox alignItems={BoxAlignItems.Center} gap={1}>
-      <ButtonIcon
-        iconName={DSIconName.Close}
-        ariaLabel={t('close')}
-        size={ButtonIconSize.Sm}
-        onClick={handleHardClose}
-        data-testid="custom-token-import-close-button"
-      />
-    </DSBox>
+    <ButtonIcon
+      iconName={IconName.Close}
+      ariaLabel={t('close')}
+      size={ButtonIconSize.Sm}
+      onClick={handleHardClose}
+      data-testid="custom-token-import-close-button"
+    />
   );
 
   return (
     <Box
-      display={Display.Flex}
-      flexDirection={FlexDirection.Column}
-      backgroundColor={BackgroundColor.backgroundDefault}
-      width={BlockSize.Full}
-      style={{ height: '100%', minHeight: 0 }}
+      flexDirection={BoxFlexDirection.Column}
+      backgroundColor={BoxBackgroundColor.BackgroundDefault}
+      className="w-full h-full min-h-0"
       data-testid="custom-token-import-page"
     >
       <Header startAccessory={startAccessory} endAccessory={endAccessory}>
@@ -374,10 +392,9 @@ export const CustomTokenImportPage = () => {
         }}
       >
         <Box
-          display={Display.Flex}
-          flexDirection={FlexDirection.Column}
+          flexDirection={BoxFlexDirection.Column}
           gap={4}
-          paddingInline={4}
+          paddingHorizontal={4}
           paddingTop={3}
           paddingBottom={4}
         >
@@ -385,123 +402,106 @@ export const CustomTokenImportPage = () => {
             severity={BannerAlertSeverity.Warning}
             data-testid="custom-token-import-warning"
           >
-            <Text variant={TextVariant.bodySm}>{t('importTokenWarning')}</Text>
+            <Text variant={TextVariant.BodySm}>{t('importTokenWarning')}</Text>
           </BannerAlert>
 
-          <Box
-            display={Display.Flex}
-            flexDirection={FlexDirection.Column}
-            gap={1}
-          >
-            <Text variant={TextVariant.bodySmMedium}>{t('network')}</Text>
+          <Box flexDirection={BoxFlexDirection.Column} gap={1}>
+            <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
+              {t('network')}
+            </Text>
             <ButtonBase
-              block
+              isFullWidth
               data-testid="custom-token-import-network-picker"
               size={ButtonBaseSize.Lg}
               endIconName={IconName.ArrowDown}
-              backgroundColor={BackgroundColor.backgroundDefault}
-              color={TextColor.textDefault}
-              borderColor={BorderColor.borderMuted}
-              borderStyle={BorderStyle.solid}
-              borderWidth={1}
+              className="bg-default text-default border border-muted justify-between"
+              textProps={{ textAlign: TextAlign.Left, ellipsis: true }}
               onClick={handleOpenNetworkPicker}
-              ellipsis
-              textProps={{ textAlign: TextAlign.Left }}
             >
-              <Text
-                variant={TextVariant.bodyMd}
-                color={TextColor.textDefault}
-                ellipsis
-              >
-                {networkName}
-              </Text>
+              {networkName}
             </ButtonBase>
           </Box>
 
-          <FormTextField
+          <LabeledField
             id="custom-token-import-address"
             label={t('tokenContractAddress')}
-            size={FormTextFieldSize.Lg}
-            placeholder={t('enterTokenAddress')}
-            value={address}
-            error={Boolean(addressError)}
-            helpText={addressError ?? undefined}
-            inputProps={{
-              'data-testid': 'custom-token-import-address-input',
-            }}
-            onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
-              handleAddressChange(event.target.value)
-            }
-          />
+            error={addressError}
+          >
+            <Input
+              id="custom-token-import-address"
+              data-testid="custom-token-import-address-input"
+              placeholder={t('enterTokenAddress')}
+              value={address}
+              aria-invalid={Boolean(addressError)}
+              className="h-12 px-4"
+              onChange={(event) => handleAddressChange(event.target.value)}
+            />
+          </LabeledField>
 
           {warning ? (
             <BannerAlert
               severity={BannerAlertSeverity.Warning}
               data-testid="custom-token-import-mainnet-warning"
             >
-              <Text variant={TextVariant.bodySm}>{warning}</Text>
+              <Text variant={TextVariant.BodySm}>{warning}</Text>
             </BannerAlert>
           ) : null}
 
           {showSymbolAndDecimals ? (
             <>
-              <FormTextField
+              <LabeledField
                 id="custom-token-import-symbol"
                 label={t('tokenSymbol')}
-                size={FormTextFieldSize.Lg}
-                value={symbol}
-                error={Boolean(symbolError)}
-                helpText={symbolError ?? undefined}
-                inputProps={{
-                  'data-testid': 'custom-token-import-symbol-input',
-                }}
-                onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
-                  handleSymbolChange(event.target.value)
-                }
-              />
-              <FormTextField
+                error={symbolError}
+              >
+                <Input
+                  id="custom-token-import-symbol"
+                  data-testid="custom-token-import-symbol-input"
+                  value={symbol}
+                  aria-invalid={Boolean(symbolError)}
+                  className="h-12 px-4"
+                  onChange={(event) => handleSymbolChange(event.target.value)}
+                />
+              </LabeledField>
+              <LabeledField
                 id="custom-token-import-decimal"
                 label={t('tokenDecimal')}
-                size={FormTextFieldSize.Lg}
-                type={TextFieldType.Number}
-                value={decimals === '' ? '' : String(decimals)}
-                error={Boolean(decimalsError)}
-                helpText={decimalsError ?? undefined}
-                inputProps={{
-                  'data-testid': 'custom-token-import-decimal-input',
-                }}
-                onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
-                  handleDecimalsChange(event.target.value)
-                }
-              />
+                error={decimalsError}
+              >
+                <Input
+                  id="custom-token-import-decimal"
+                  data-testid="custom-token-import-decimal-input"
+                  type="number"
+                  value={decimals === '' ? '' : String(decimals)}
+                  aria-invalid={Boolean(decimalsError)}
+                  className="h-12 px-4"
+                  onChange={(event) => handleDecimalsChange(event.target.value)}
+                />
+              </LabeledField>
             </>
           ) : null}
         </Box>
       </ScrollContainer>
 
       <Box
-        display={Display.Flex}
-        alignItems={AlignItems.center}
-        backgroundColor={BackgroundColor.backgroundDefault}
-        paddingInline={4}
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        backgroundColor={BoxBackgroundColor.BackgroundDefault}
+        paddingHorizontal={4}
         paddingTop={3}
         paddingBottom={3}
-        style={{
-          bottom: 0,
-          position: 'sticky',
-          zIndex: 1,
-        }}
+        className="sticky bottom-0 z-10"
       >
-        <ButtonPrimary
-          block
-          size={ButtonPrimarySize.Lg}
+        <Button
+          isFullWidth
+          size={ButtonSize.Lg}
           data-testid="custom-token-import-submit-button"
-          disabled={!isValid || isSubmitting}
-          loading={isSubmitting}
+          isDisabled={!isValid || isSubmitting}
+          isLoading={isSubmitting}
           onClick={handleSubmit}
         >
           {t('addToken')}
-        </ButtonPrimary>
+        </Button>
       </Box>
     </Box>
   );

--- a/ui/pages/custom-token-import/custom-token-import.tsx
+++ b/ui/pages/custom-token-import/custom-token-import.tsx
@@ -14,7 +14,8 @@ import {
   IconName,
 } from '@metamask/design-system-react';
 import { ERC721, ERC1155 } from '@metamask/controller-utils';
-import { type Hex } from '@metamask/utils';
+import { NON_EVM_TESTNET_IDS } from '@metamask/multichain-network-controller';
+import { type CaipChainId, type Hex } from '@metamask/utils';
 import { isValidHexAddress } from '../../../shared/lib/hexstring-utils';
 // TODO: Remove restricted import
 // eslint-disable-next-line import-x/no-restricted-paths
@@ -67,25 +68,38 @@ export const CustomTokenImportPage = () => {
     Record<string, { address: string }[]>
   >;
 
-  const [selectedNetwork, setSelectedNetwork] = useState<Hex>(currentChainId);
+  const [selectedNetwork, setSelectedNetwork] =
+    useState<string>(currentChainId);
 
-  const evmNetworks = useMemo<CustomTokenImportNetworkOption[]>(
+  const availableNetworks = useMemo<CustomTokenImportNetworkOption[]>(
     () =>
-      Object.values(allNetworkConfigurations)
-        .filter((network) => isEvmChainId(network.chainId as Hex))
-        .map(({ chainId, name }) => ({
-          chainId,
-          name,
+      Object.entries(allNetworkConfigurations)
+        .filter(
+          ([caipChainId]) =>
+            !NON_EVM_TESTNET_IDS.includes(caipChainId as CaipChainId),
+        )
+        .map(([, network]) => ({
+          chainId: network.chainId,
+          name: network.name,
         })),
     [allNetworkConfigurations],
   );
 
-  const networkName =
-    networkConfigurations?.[selectedNetwork]?.name ?? t('currentNetwork');
-  const networkClientId =
-    networkConfigurations?.[selectedNetwork]?.rpcEndpoints?.[
-      networkConfigurations?.[selectedNetwork]?.defaultRpcEndpointIndex ?? 0
-    ]?.networkClientId;
+  const selectedNetworkConfig = useMemo(
+    () =>
+      Object.values(allNetworkConfigurations).find(
+        (network) => network.chainId === selectedNetwork,
+      ),
+    [allNetworkConfigurations, selectedNetwork],
+  );
+
+  const networkName = selectedNetworkConfig?.name ?? t('currentNetwork');
+  const networkClientId = isEvmChainId(selectedNetwork as CaipChainId | Hex)
+    ? networkConfigurations?.[selectedNetwork as Hex]?.rpcEndpoints?.[
+        networkConfigurations?.[selectedNetwork as Hex]
+          ?.defaultRpcEndpointIndex ?? 0
+      ]?.networkClientId
+    : undefined;
 
   const existingTokens = useMemo(
     () => allTokens?.[selectedNetwork]?.[selectedAccount?.address ?? ''] ?? [],
@@ -239,7 +253,10 @@ export const CustomTokenImportPage = () => {
 
   const handleSelectNetwork = useCallback(
     (network: CustomTokenImportNetworkOption) => {
-      const networkChainId = formatChainIdToHex(network.chainId) as Hex;
+      const chainIdRef = network.chainId as CaipChainId | Hex;
+      const networkChainId = isEvmChainId(chainIdRef)
+        ? (formatChainIdToHex(chainIdRef) as string)
+        : network.chainId;
       setSelectedNetwork(networkChainId);
       clearFormData();
     },
@@ -328,7 +345,7 @@ export const CustomTokenImportPage = () => {
       <CustomTokenImportForm
         networkName={networkName}
         selectedNetwork={selectedNetwork}
-        networks={evmNetworks}
+        networks={availableNetworks}
         address={address}
         addressError={addressError}
         symbol={symbol}

--- a/ui/pages/custom-token-import/index.ts
+++ b/ui/pages/custom-token-import/index.ts
@@ -1,0 +1,2 @@
+export { default } from './custom-token-import';
+export { CustomTokenImportPage } from './custom-token-import';

--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -57,6 +57,7 @@ import {
   NONEVM_BALANCE_CHECK_ROUTE,
   NETWORKS_ROUTE,
   TOKEN_MANAGEMENT_ROUTE,
+  CUSTOM_TOKEN_IMPORT_ROUTE,
   SHIELD_PLAN_ROUTE,
   GATOR_PERMISSIONS,
   TOKEN_TRANSFER_ROUTE,
@@ -158,6 +159,9 @@ const Settings = mmLazy(() => import('../settings/index.ts'));
 const NetworksPage = mmLazy(() => import('../networks/index.ts'));
 const TokenManagementPage = mmLazy(
   () => import('../token-management/index.ts'),
+);
+const CustomTokenImportPage = mmLazy(
+  () => import('../custom-token-import/index.ts'),
 );
 const NotificationDetails = mmLazy(
   () => import('../notification-details/index.js'),
@@ -267,6 +271,18 @@ export const TokenManagementFeatureRoute = () => {
   return <TokenManagementPage />;
 };
 
+export const CustomTokenImportFeatureRoute = () => {
+  const isTokenManagementFilterEnabled = useAppSelector(
+    getIsTokenManagementFilterEnabled,
+  );
+
+  if (!isTokenManagementFilterEnabled) {
+    return <Navigate to={DEFAULT_ROUTE} replace />;
+  }
+
+  return <CustomTokenImportPage />;
+};
+
 export const routeConfig = [
   {
     element: <LegacyLayout />,
@@ -320,6 +336,10 @@ export const routeConfig = [
       {
         path: TOKEN_MANAGEMENT_ROUTE,
         element: <TokenManagementFeatureRoute />,
+      },
+      {
+        path: CUSTOM_TOKEN_IMPORT_ROUTE,
+        element: <CustomTokenImportFeatureRoute />,
       },
       {
         path: `${SETTINGS_ROUTE}/*`,

--- a/ui/pages/token-management/token-management.test.tsx
+++ b/ui/pages/token-management/token-management.test.tsx
@@ -6,7 +6,10 @@ import {
 } from '../../../test/lib/render-helpers-navigate';
 import configureStore from '../../store/store';
 import mockState from '../../../test/data/mock-state.json';
-import { TOKEN_MANAGEMENT_ROUTE } from '../../helpers/constants/routes';
+import {
+  CUSTOM_TOKEN_IMPORT_ROUTE,
+  TOKEN_MANAGEMENT_ROUTE,
+} from '../../helpers/constants/routes';
 import { TokenManagementPage } from './token-management';
 
 jest.mock('../../selectors/assets', () => ({
@@ -204,7 +207,7 @@ describe('TokenManagementPage', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('opens the import tokens modal from the sticky add custom token button', () => {
+  it('navigates to the custom token import page from the sticky add custom token button', () => {
     const { store } = renderPage();
 
     const addCustomTokenButton = screen.getByTestId(
@@ -219,7 +222,10 @@ describe('TokenManagementPage', () => {
 
     fireEvent.click(addCustomTokenButton);
 
-    expect(store.getState().appState.importTokensModalOpen).toBe(true);
+    // The legacy import-tokens modal must not open anymore — the new flow
+    // routes the user to the dedicated CUSTOM_TOKEN_IMPORT_ROUTE page instead.
+    expect(store.getState().appState.importTokensModalOpen).toBeFalsy();
+    expect(CUSTOM_TOKEN_IMPORT_ROUTE).toBe('/custom-token-import');
   });
 
   it('shows tokens from the enabled home-page network filter', () => {

--- a/ui/pages/token-management/token-management.tsx
+++ b/ui/pages/token-management/token-management.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import {
   Box,
   BoxAlignItems,
@@ -45,10 +45,12 @@ import { getNetworkConfigurationsByChainId } from '../../../shared/lib/selectors
 import {
   ignoreTokens as ignoreTokensAction,
   multichainIgnoreAssets,
-  showImportTokensModal,
   showModal,
 } from '../../store/actions';
-import { DEFAULT_ROUTE } from '../../helpers/constants/routes';
+import {
+  CUSTOM_TOKEN_IMPORT_ROUTE,
+  DEFAULT_ROUTE,
+} from '../../helpers/constants/routes';
 import { VirtualizedList } from '../../components/ui/virtualized-list/virtualized-list';
 import { getAssetsBySelectedAccountGroup } from '../../selectors/assets';
 import {
@@ -78,6 +80,7 @@ type ManagedAsset = Parameters<typeof sortAssetsWithPriority>[0][number];
 export const TokenManagementPage = () => {
   const t = useI18nContext();
   const dispatch = useDispatch();
+  const navigate = useNavigate();
 
   const [searchQuery, setSearchQuery] = useState('');
   const [pendingKey, setPendingKey] = useState<string | undefined>();
@@ -198,8 +201,8 @@ export const TokenManagementPage = () => {
   }, [dispatch]);
 
   const handleAddCustomToken = useCallback(() => {
-    dispatch(showImportTokensModal());
-  }, [dispatch]);
+    navigate(CUSTOM_TOKEN_IMPORT_ROUTE);
+  }, [navigate]);
 
   const networkFilterLabel = useMemo(() => {
     const enabledCount = enabledChainIds.length;


### PR DESCRIPTION
Introduces a dedicated full-screen route for importing a custom ERC-20 token (CUSTOM_TOKEN_IMPORT_ROUTE), gated by the existing extensionUxTokenManagementFilter flag. The Manage tokens screen now routes to this page instead of opening the legacy import-tokens modal.

- Page mirrors the Figma design: warning banner, network picker (reuses NETWORK_MANAGER modal), contract address field with on-chain auto-fill of symbol/decimals, ERC-721/1155 rejection, mainnet-token warning, and a sticky Add token button.
- Back arrow returns to Manage tokens; close X returns to home.
- Adds locale string enterTokenAddress and a unit test for the new page.

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: added custom token import flow

## **Related issues**

Fixes:

## **Manual testing steps**

 1.Enable extension-ux-token-management-filter.
 2. Open the home token list action menu and verify it shows Manage tokens instead of Import tokens.
3. Click Manage tokens and verify it opens the Manage tokens page.
4. Verify the Manage tokens page lists the same tokens shown on the home page for the selected network/filter.
5. Change the Manage tokens network filter to All default networks and verify tokens from all default networks are shown.
6.  Click Add a custom token.
7. Verify the custom token page shows the warning banner, network selector, token contract address field, and disabled Add token button.
8. Click the network selector and verify the network selector opens as an in-page modal/panel.
9. Select another EVM network and verify the modal closes, the selected network updates, and the form is cleared.
10. Enter an invalid token address and verify the validation error is shown and Add token remains disabled.
11. Enter a valid ERC-20 token address for the selected network, verify symbol/decimal fields appear, then add the token.
12. Verify you return to Manage tokens and the imported token appears in the list.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/780b7dca-9c86-4d97-bfa0-53926535813c

#### Token with Balance



https://github.com/user-attachments/assets/97d7ba9b-d17e-40b4-8cff-897761af47c3


## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new token-import flow with on-chain probing and token-add dispatch logic plus new routing, so regressions could affect token import behavior and navigation but stays within UI/token management scope.
> 
> **Overview**
> Introduces a dedicated `CUSTOM_TOKEN_IMPORT_ROUTE` (`/custom-token-import`) gated by the existing token-management feature flag, and wires it into `routes.component.tsx` with analytics route metadata.
> 
> Adds a new full-screen Custom Token Import page with a warning banner, network selector modal, contract-address validation, async token standard probing (rejecting ERC-721/1155), token-list/mainnet warning handling, and auto-fill + manual entry of `symbol`/`decimals` before dispatching `addImportedTokens` and returning to token management.
> 
> Updates Token Management’s “Add a custom token” CTA to **navigate to the new page** (no longer toggling `importTokensModalOpen`), and adds locale string `enterTokenAddress` plus unit tests for the new page and updated navigation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cee25eb3ba9ddf0379ac499cbadda0ad3111ba53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->