### PR TITLE
refactor: base reader component used for QR hardware wallets

### DIFF
--- a/ui/components/app/modals/qr-scanner/index.scss
+++ b/ui/components/app/modals/qr-scanner/index.scss
@@ -7,6 +7,8 @@
   border-radius: 8px;
 
   &__content {
+    width: 100%;
+
     &__video-wrapper {
       overflow: hidden;
       width: 100%;

--- a/ui/components/app/modals/qr-scanner/index.scss
+++ b/ui/components/app/modals/qr-scanner/index.scss
@@ -4,22 +4,9 @@
   width: 100%;
   height: 100%;
   background-color: var(--color-background-default);
-  display: flex;
-  flex-flow: column;
   border-radius: 8px;
 
-  &__title {
-    @include design-system.H3;
-
-    font-weight: 500;
-    padding: 16px 0;
-    text-align: center;
-  }
-
   &__content {
-    padding-left: 20px;
-    padding-right: 20px;
-
     &__video-wrapper {
       overflow: hidden;
       width: 100%;
@@ -53,28 +40,6 @@
     }
   }
 
-  &__status {
-    @include design-system.H6;
-
-    text-align: center;
-    padding: 15px;
-  }
-
-  &__image {
-    @include design-system.H3;
-
-    font-weight: 500;
-    padding: 16px 0 0;
-    text-align: center;
-  }
-
-  &__error {
-    @include design-system.Paragraph;
-
-    text-align: center;
-    padding: 15px;
-  }
-
   &__footer {
     padding: 20px;
     flex-direction: row;
@@ -103,4 +68,3 @@
     font-weight: 300;
   }
 }
-

--- a/ui/components/app/qr-hardware-popover/base-reader-reducer.ts
+++ b/ui/components/app/qr-hardware-popover/base-reader-reducer.ts
@@ -3,10 +3,6 @@ import {
   type CameraReadyStateValue,
 } from './base-reader.types';
 
-// ---------------------------------------------------------------------------
-// Actions
-// ---------------------------------------------------------------------------
-
 export const ActionType = {
   SetReady: 'SET_READY',
   SetBlocked: 'SET_BLOCKED',
@@ -30,10 +26,6 @@ type Action =
   | { type: typeof ActionType.SetPermissionActionLoading; payload: boolean }
   | { type: typeof ActionType.Reset };
 
-// ---------------------------------------------------------------------------
-// State
-// ---------------------------------------------------------------------------
-
 export type BaseReaderState = {
   readyState: CameraReadyStateValue;
   error: (Error & { type?: string }) | null;
@@ -55,10 +47,6 @@ export function getInitialState(): BaseReaderState {
     permissionActionLoading: false,
   };
 }
-
-// ---------------------------------------------------------------------------
-// Reducer
-// ---------------------------------------------------------------------------
 
 /**
  * Pure reducer for the BaseReader component state machine.

--- a/ui/components/app/qr-hardware-popover/base-reader-reducer.ts
+++ b/ui/components/app/qr-hardware-popover/base-reader-reducer.ts
@@ -1,0 +1,111 @@
+import {
+  CameraReadyState,
+  type CameraReadyStateValue,
+} from './base-reader.types';
+
+// ---------------------------------------------------------------------------
+// Actions
+// ---------------------------------------------------------------------------
+
+export const ActionType = {
+  SetReady: 'SET_READY',
+  SetBlocked: 'SET_BLOCKED',
+  SetNeeded: 'SET_NEEDED',
+  SetAccessingCamera: 'SET_ACCESSING_CAMERA',
+  SetError: 'SET_ERROR',
+  ClearError: 'CLEAR_ERROR',
+  SetScanProgress: 'SET_SCAN_PROGRESS',
+  SetPermissionActionLoading: 'SET_PERMISSION_ACTION_LOADING',
+  Reset: 'RESET',
+} as const;
+
+type Action =
+  | { type: typeof ActionType.SetReady }
+  | { type: typeof ActionType.SetBlocked }
+  | { type: typeof ActionType.SetNeeded }
+  | { type: typeof ActionType.SetAccessingCamera }
+  | { type: typeof ActionType.SetError; payload: Error & { type?: string } }
+  | { type: typeof ActionType.ClearError }
+  | { type: typeof ActionType.SetScanProgress; payload: number }
+  | { type: typeof ActionType.SetPermissionActionLoading; payload: boolean }
+  | { type: typeof ActionType.Reset };
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+export type BaseReaderState = {
+  readyState: CameraReadyStateValue;
+  error: (Error & { type?: string }) | null;
+  scanProgress: number;
+  permissionActionLoading: boolean;
+};
+
+/**
+ * Creates the initial state for the BaseReader reducer.
+ *
+ * @returns A fresh {@link BaseReaderState} with camera in accessing mode,
+ * no error, zero progress, and no loading indicator.
+ */
+export function getInitialState(): BaseReaderState {
+  return {
+    readyState: CameraReadyState.AccessingCamera,
+    error: null,
+    scanProgress: 0,
+    permissionActionLoading: false,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Reducer
+// ---------------------------------------------------------------------------
+
+/**
+ * Pure reducer for the BaseReader component state machine.
+ *
+ * Handles transitions between camera readiness phases, error state,
+ * scan progress updates, and permission action loading indicators.
+ *
+ * @param state - The current reducer state.
+ * @param action - The dispatched action describing the state transition.
+ * @returns The next state after applying the action.
+ */
+export function baseReaderReducer(
+  state: BaseReaderState,
+  action: Action,
+): BaseReaderState {
+  switch (action.type) {
+    case ActionType.SetReady:
+      return {
+        ...state,
+        readyState: CameraReadyState.Ready,
+        permissionActionLoading: false,
+      };
+    case ActionType.SetBlocked:
+      return {
+        ...state,
+        readyState: CameraReadyState.CameraAccessBlocked,
+        permissionActionLoading: false,
+      };
+    case ActionType.SetNeeded:
+      return {
+        ...state,
+        readyState: CameraReadyState.CameraAccessNeeded,
+        permissionActionLoading: false,
+      };
+    case ActionType.SetAccessingCamera:
+      return { ...state, readyState: CameraReadyState.AccessingCamera };
+    case ActionType.SetError:
+      return { ...state, error: action.payload };
+    case ActionType.ClearError:
+      return { ...state, error: null };
+    case ActionType.SetScanProgress:
+      return { ...state, scanProgress: action.payload };
+    case ActionType.SetPermissionActionLoading:
+      return { ...state, permissionActionLoading: action.payload };
+    case ActionType.Reset:
+      return getInitialState();
+    default:
+      return state;
+  }
+}

--- a/ui/components/app/qr-hardware-popover/base-reader-reducer.ts
+++ b/ui/components/app/qr-hardware-popover/base-reader-reducer.ts
@@ -1,6 +1,7 @@
 import {
   CameraReadyState,
   type CameraReadyStateValue,
+  type WebcamError,
 } from './base-reader.types';
 
 export const ActionType = {
@@ -20,7 +21,7 @@ type Action =
   | { type: typeof ActionType.SetBlocked }
   | { type: typeof ActionType.SetNeeded }
   | { type: typeof ActionType.SetAccessingCamera }
-  | { type: typeof ActionType.SetError; payload: Error & { type?: string } }
+  | { type: typeof ActionType.SetError; payload: WebcamError }
   | { type: typeof ActionType.ClearError }
   | { type: typeof ActionType.SetScanProgress; payload: number }
   | { type: typeof ActionType.SetPermissionActionLoading; payload: boolean }
@@ -28,7 +29,7 @@ type Action =
 
 export type BaseReaderState = {
   readyState: CameraReadyStateValue;
-  error: (Error & { type?: string }) | null;
+  error: WebcamError | null;
   scanProgress: number;
   permissionActionLoading: boolean;
 };

--- a/ui/components/app/qr-hardware-popover/base-reader.test.tsx
+++ b/ui/components/app/qr-hardware-popover/base-reader.test.tsx
@@ -15,7 +15,12 @@ import {
 } from '../../../../shared/constants/app';
 import { MetaMetricsEventName } from '../../../../shared/constants/metametrics';
 import { getEnvironmentType } from '../../../../shared/lib/environment-type';
-import type { BaseReaderProps } from './base-reader.types';
+import { CameraPermissionState } from '../../../contexts/hardware-wallets/constants';
+import {
+  DOMExceptionName,
+  WebcamErrorType,
+  type BaseReaderProps,
+} from './base-reader.types';
 import BaseReader from './base-reader';
 import EnhancedReader from './enhanced-reader';
 
@@ -69,7 +74,7 @@ function setupWebcamUtilsSuccess() {
     environmentReady: true,
   });
   mockQueryCameraPermission.mockResolvedValue({
-    state: 'prompt',
+    state: CameraPermissionState.Prompt,
     permissionStatus: null,
   });
   mockRequestVideoStream.mockResolvedValue(
@@ -158,7 +163,7 @@ describe('BaseReader', () => {
       environmentReady: true,
     });
     mockQueryCameraPermission.mockResolvedValue({
-      state: 'granted',
+      state: CameraPermissionState.Granted,
       permissionStatus: null,
     });
 
@@ -183,9 +188,9 @@ describe('BaseReader', () => {
       environmentReady: true,
     });
     mockQueryCameraPermission.mockResolvedValue({
-      state: 'denied',
+      state: CameraPermissionState.Denied,
       permissionStatus: {
-        state: 'denied',
+        state: CameraPermissionState.Denied,
         addEventListener: jest.fn(),
       } as unknown as PermissionStatus,
     });
@@ -207,9 +212,9 @@ describe('BaseReader', () => {
       environmentReady: true,
     });
     mockQueryCameraPermission.mockResolvedValue({
-      state: 'denied',
+      state: CameraPermissionState.Denied,
       permissionStatus: {
-        state: 'denied',
+        state: CameraPermissionState.Denied,
         addEventListener: jest.fn(),
       } as unknown as PermissionStatus,
     });
@@ -234,14 +239,14 @@ describe('BaseReader', () => {
 
     let capturedChangeHandler: (() => void) | null = null;
     const mockPermissionStatus = {
-      state: 'denied' as PermissionState,
+      state: CameraPermissionState.Denied as PermissionState,
       addEventListener: jest.fn((_event: string, handler: () => void) => {
         capturedChangeHandler = handler;
       }),
     } as unknown as PermissionStatus;
 
     mockQueryCameraPermission.mockResolvedValue({
-      state: 'denied',
+      state: CameraPermissionState.Denied,
       permissionStatus: mockPermissionStatus,
     });
 
@@ -274,14 +279,14 @@ describe('BaseReader', () => {
 
     let capturedChangeHandler: (() => void) | null = null;
     const mockPermissionStatus = {
-      state: 'denied' as PermissionState,
+      state: CameraPermissionState.Denied as PermissionState,
       addEventListener: jest.fn((_event: string, handler: () => void) => {
         capturedChangeHandler = handler;
       }),
     } as unknown as PermissionStatus;
 
     mockQueryCameraPermission.mockResolvedValue({
-      state: 'denied',
+      state: CameraPermissionState.Denied,
       permissionStatus: mockPermissionStatus,
     });
 
@@ -317,9 +322,9 @@ describe('BaseReader', () => {
       environmentReady: true,
     });
     mockQueryCameraPermission.mockResolvedValue({
-      state: 'denied',
+      state: CameraPermissionState.Denied,
       permissionStatus: {
-        state: 'denied',
+        state: CameraPermissionState.Denied,
         addEventListener: jest.fn(),
       } as unknown as PermissionStatus,
     });
@@ -346,9 +351,9 @@ describe('BaseReader', () => {
     });
     mockIsFirefoxBrowser.mockReturnValue(true);
     mockQueryCameraPermission.mockResolvedValue({
-      state: 'denied',
+      state: CameraPermissionState.Denied,
       permissionStatus: {
-        state: 'denied',
+        state: CameraPermissionState.Denied,
         addEventListener: jest.fn(),
       } as unknown as PermissionStatus,
     });
@@ -373,7 +378,7 @@ describe('BaseReader', () => {
         environmentReady: true,
       });
       mockQueryCameraPermission.mockResolvedValue({
-        state: 'prompt',
+        state: CameraPermissionState.Prompt,
         permissionStatus: null,
       });
       mockRequestVideoStream.mockResolvedValue(
@@ -400,14 +405,14 @@ describe('BaseReader', () => {
         environmentReady: true,
       });
       mockQueryCameraPermission.mockResolvedValue({
-        state: 'prompt',
+        state: CameraPermissionState.Prompt,
         permissionStatus: {
-          state: 'prompt',
+          state: CameraPermissionState.Prompt,
           addEventListener: jest.fn(),
         } as unknown as PermissionStatus,
       });
       const notAllowed = new Error('denied');
-      notAllowed.name = 'NotAllowedError';
+      notAllowed.name = DOMExceptionName.NotAllowed;
       mockRequestVideoStream.mockRejectedValueOnce(notAllowed);
 
       renderWithProvider(<BaseReader {...defaultProps} />);
@@ -427,7 +432,7 @@ describe('BaseReader', () => {
         environmentReady: true,
       });
       mockQueryCameraPermission.mockResolvedValue({
-        state: 'prompt',
+        state: CameraPermissionState.Prompt,
         permissionStatus: null,
       });
       const notReadable = new Error('Could not start video source');
@@ -456,14 +461,14 @@ describe('BaseReader', () => {
         environmentReady: true,
       });
       mockQueryCameraPermission.mockResolvedValue({
-        state: 'prompt',
+        state: CameraPermissionState.Prompt,
         permissionStatus: {
-          state: 'prompt',
+          state: CameraPermissionState.Prompt,
           addEventListener: jest.fn(),
         } as unknown as PermissionStatus,
       });
       const notAllowed = new Error('denied');
-      notAllowed.name = 'NotAllowedError';
+      notAllowed.name = DOMExceptionName.NotAllowed;
       mockRequestVideoStream.mockRejectedValueOnce(notAllowed);
 
       renderWithProvider(<BaseReader {...defaultProps} />);
@@ -488,18 +493,18 @@ describe('BaseReader', () => {
       // second call (from reconcileNotAllowedPermission) returns denied
       mockQueryCameraPermission
         .mockResolvedValueOnce({
-          state: 'prompt',
+          state: CameraPermissionState.Prompt,
           permissionStatus: null,
         })
         .mockResolvedValueOnce({
-          state: 'denied',
+          state: CameraPermissionState.Denied,
           permissionStatus: {
-            state: 'denied',
+            state: CameraPermissionState.Denied,
             addEventListener: jest.fn(),
           } as unknown as PermissionStatus,
         });
       const notAllowed = new Error('denied');
-      notAllowed.name = 'NotAllowedError';
+      notAllowed.name = DOMExceptionName.NotAllowed;
       mockRequestVideoStream.mockRejectedValueOnce(notAllowed);
 
       renderWithProvider(<BaseReader {...defaultProps} />);
@@ -519,14 +524,14 @@ describe('BaseReader', () => {
         environmentReady: true,
       });
       mockQueryCameraPermission.mockResolvedValue({
-        state: 'prompt',
+        state: CameraPermissionState.Prompt,
         permissionStatus: {
-          state: 'prompt',
+          state: CameraPermissionState.Prompt,
           addEventListener: jest.fn(),
         } as unknown as PermissionStatus,
       });
       const notAllowed = new Error('denied');
-      notAllowed.name = 'NotAllowedError';
+      notAllowed.name = DOMExceptionName.NotAllowed;
       mockRequestVideoStream.mockRejectedValueOnce(notAllowed);
 
       renderWithProvider(<BaseReader {...defaultProps} />);
@@ -551,14 +556,14 @@ describe('BaseReader', () => {
       environmentReady: true,
     });
     mockQueryCameraPermission.mockResolvedValue({
-      state: 'prompt',
+      state: CameraPermissionState.Prompt,
       permissionStatus: {
-        state: 'prompt',
+        state: CameraPermissionState.Prompt,
         addEventListener: jest.fn(),
       } as unknown as PermissionStatus,
     });
     const notAllowed = new Error('denied');
-    notAllowed.name = 'NotAllowedError';
+    notAllowed.name = DOMExceptionName.NotAllowed;
     mockRequestVideoStream.mockRejectedValueOnce(notAllowed);
 
     renderWithProvider(<BaseReader {...defaultProps} />);
@@ -587,14 +592,14 @@ describe('BaseReader', () => {
       environmentReady: true,
     });
     mockQueryCameraPermission.mockResolvedValue({
-      state: 'prompt',
+      state: CameraPermissionState.Prompt,
       permissionStatus: {
-        state: 'prompt',
+        state: CameraPermissionState.Prompt,
         addEventListener: jest.fn(),
       } as unknown as PermissionStatus,
     });
     const notAllowed = new Error('denied');
-    notAllowed.name = 'NotAllowedError';
+    notAllowed.name = DOMExceptionName.NotAllowed;
     mockRequestVideoStream.mockRejectedValueOnce(notAllowed);
 
     renderWithProvider(<BaseReader {...defaultProps} />);
@@ -602,9 +607,9 @@ describe('BaseReader', () => {
 
     mockRequestVideoStream.mockRejectedValueOnce(notAllowed);
     mockQueryCameraPermission.mockResolvedValueOnce({
-      state: 'denied',
+      state: CameraPermissionState.Denied,
       permissionStatus: {
-        state: 'denied',
+        state: CameraPermissionState.Denied,
         addEventListener: jest.fn(),
       } as unknown as PermissionStatus,
     });
@@ -628,9 +633,9 @@ describe('BaseReader', () => {
       environmentReady: true,
     });
     mockQueryCameraPermission.mockResolvedValue({
-      state: 'denied',
+      state: CameraPermissionState.Denied,
       permissionStatus: {
-        state: 'denied',
+        state: CameraPermissionState.Denied,
         addEventListener: jest.fn(),
       } as unknown as PermissionStatus,
     });
@@ -639,7 +644,7 @@ describe('BaseReader', () => {
     await screen.findByTestId('qr-camera-access-blocked');
 
     mockQueryCameraPermission.mockResolvedValueOnce({
-      state: 'granted',
+      state: CameraPermissionState.Granted,
       permissionStatus: null,
     });
     mockRequestVideoStream.mockResolvedValueOnce(
@@ -663,9 +668,9 @@ describe('BaseReader', () => {
       environmentReady: true,
     });
     mockQueryCameraPermission.mockResolvedValue({
-      state: 'denied',
+      state: CameraPermissionState.Denied,
       permissionStatus: {
-        state: 'denied',
+        state: CameraPermissionState.Denied,
         addEventListener: jest.fn(),
       } as unknown as PermissionStatus,
     });
@@ -690,7 +695,7 @@ describe('BaseReader', () => {
     const webcamError = new Error('No webcam found') as Error & {
       type?: string;
     };
-    webcamError.type = 'NO_WEBCAM_FOUND';
+    webcamError.type = WebcamErrorType.NoWebcamFound;
     mockCheckStatus.mockRejectedValue(webcamError);
 
     renderWithProvider(<BaseReader {...defaultProps} />);
@@ -759,7 +764,7 @@ describe('BaseReader', () => {
     const webcamError = new Error('No webcam found') as Error & {
       type?: string;
     };
-    webcamError.type = 'NO_WEBCAM_FOUND';
+    webcamError.type = WebcamErrorType.NoWebcamFound;
     mockCheckStatus.mockRejectedValue(webcamError);
 
     renderWithProvider(<BaseReader {...defaultProps} />);
@@ -778,7 +783,7 @@ describe('BaseReader', () => {
     const webcamError = new Error('No webcam found') as Error & {
       type?: string;
     };
-    webcamError.type = 'NO_WEBCAM_FOUND';
+    webcamError.type = WebcamErrorType.NoWebcamFound;
     mockCheckStatus.mockRejectedValueOnce(webcamError);
 
     renderWithProvider(<BaseReader {...defaultProps} />);
@@ -826,9 +831,9 @@ describe('BaseReader', () => {
         environmentReady: true,
       });
       mockQueryCameraPermission.mockResolvedValue({
-        state: 'denied',
+        state: CameraPermissionState.Denied,
         permissionStatus: {
-          state: 'denied',
+          state: CameraPermissionState.Denied,
           addEventListener: jest.fn(),
         } as unknown as PermissionStatus,
       });
@@ -855,14 +860,14 @@ describe('BaseReader', () => {
         environmentReady: true,
       });
       mockQueryCameraPermission.mockResolvedValue({
-        state: 'prompt',
+        state: CameraPermissionState.Prompt,
         permissionStatus: {
-          state: 'prompt',
+          state: CameraPermissionState.Prompt,
           addEventListener: jest.fn(),
         } as unknown as PermissionStatus,
       });
       const notAllowed = new Error('denied');
-      notAllowed.name = 'NotAllowedError';
+      notAllowed.name = DOMExceptionName.NotAllowed;
       mockRequestVideoStream.mockRejectedValueOnce(notAllowed);
 
       await act(async () => {
@@ -887,9 +892,9 @@ describe('BaseReader', () => {
         environmentReady: true,
       });
       mockQueryCameraPermission.mockResolvedValue({
-        state: 'denied',
+        state: CameraPermissionState.Denied,
         permissionStatus: {
-          state: 'denied',
+          state: CameraPermissionState.Denied,
           addEventListener: jest.fn(),
         } as unknown as PermissionStatus,
       });
@@ -919,14 +924,14 @@ describe('BaseReader', () => {
         environmentReady: true,
       });
       mockQueryCameraPermission.mockResolvedValue({
-        state: 'prompt',
+        state: CameraPermissionState.Prompt,
         permissionStatus: {
-          state: 'prompt',
+          state: CameraPermissionState.Prompt,
           addEventListener: jest.fn(),
         } as unknown as PermissionStatus,
       });
       const notAllowed = new Error('denied');
-      notAllowed.name = 'NotAllowedError';
+      notAllowed.name = DOMExceptionName.NotAllowed;
       mockRequestVideoStream.mockRejectedValueOnce(notAllowed);
 
       await act(async () => {
@@ -957,9 +962,9 @@ describe('BaseReader', () => {
         environmentReady: true,
       });
       mockQueryCameraPermission.mockResolvedValue({
-        state: 'denied',
+        state: CameraPermissionState.Denied,
         permissionStatus: {
-          state: 'denied',
+          state: CameraPermissionState.Denied,
           addEventListener: jest.fn(),
         } as unknown as PermissionStatus,
       });
@@ -969,7 +974,7 @@ describe('BaseReader', () => {
       });
 
       mockQueryCameraPermission.mockResolvedValueOnce({
-        state: 'granted',
+        state: CameraPermissionState.Granted,
         permissionStatus: null,
       });
       mockRequestVideoStream.mockResolvedValueOnce(
@@ -1002,14 +1007,14 @@ describe('BaseReader', () => {
         environmentReady: true,
       });
       mockQueryCameraPermission.mockResolvedValue({
-        state: 'prompt',
+        state: CameraPermissionState.Prompt,
         permissionStatus: {
-          state: 'prompt',
+          state: CameraPermissionState.Prompt,
           addEventListener: jest.fn(),
         } as unknown as PermissionStatus,
       });
       const notAllowed = new Error('denied');
-      notAllowed.name = 'NotAllowedError';
+      notAllowed.name = DOMExceptionName.NotAllowed;
       mockRequestVideoStream.mockRejectedValueOnce(notAllowed);
 
       await act(async () => {
@@ -1018,9 +1023,9 @@ describe('BaseReader', () => {
 
       mockRequestVideoStream.mockRejectedValueOnce(notAllowed);
       mockQueryCameraPermission.mockResolvedValueOnce({
-        state: 'denied',
+        state: CameraPermissionState.Denied,
         permissionStatus: {
-          state: 'denied',
+          state: CameraPermissionState.Denied,
           addEventListener: jest.fn(),
         } as unknown as PermissionStatus,
       });
@@ -1051,7 +1056,7 @@ describe('BaseReader', () => {
         environmentReady: true,
       });
       mockQueryCameraPermission.mockResolvedValue({
-        state: 'granted',
+        state: CameraPermissionState.Granted,
         permissionStatus: null,
       });
 

--- a/ui/components/app/qr-hardware-popover/base-reader.tsx
+++ b/ui/components/app/qr-hardware-popover/base-reader.tsx
@@ -47,7 +47,7 @@ import EnhancedReader from './enhanced-reader';
  * (popup / side panel) cannot prompt for camera access.
  * 2. **Permission flow** — queries the Permissions API, calls `getUserMedia`,
  * and classifies the result into one of four {@link CameraReadyState} values.
- * 3. **QR decoding** — once the camera is ready, renders `EnhancedReader,`
+ * 3. **QR decoding** — once the camera is ready, renders `EnhancedReader`,
  * which continuously feeds scanned payloads into a `URDecoder` until a full
  * UR is assembled and forwarded to `handleSuccess`.
  * 4. **Error UI** — displays recoverable camera / scan errors with retry.

--- a/ui/components/app/qr-hardware-popover/base-reader.tsx
+++ b/ui/components/app/qr-hardware-popover/base-reader.tsx
@@ -228,7 +228,7 @@ const BaseReader = ({
         {title ? (
           <Box paddingTop={4} paddingBottom={4}>
             <Text
-              variant={TextVariant.HeadingMd}
+              variant={TextVariant.HeadingLg}
               fontWeight={FontWeight.Medium}
               textAlign={TextAlign.Center}
             >

--- a/ui/components/app/qr-hardware-popover/base-reader.tsx
+++ b/ui/components/app/qr-hardware-popover/base-reader.tsx
@@ -1,3 +1,42 @@
+import React, { useContext, useCallback, useEffect, useRef } from 'react';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  FontWeight,
+  Text,
+  TextAlign,
+  TextVariant,
+} from '@metamask/design-system-react';
+import { MetaMetricsEventName } from '../../../../shared/constants/metametrics';
+import {
+  getChromiumExtensionCameraSiteSettingsUrl,
+  getMozExtensionOriginForDisplay,
+  isFirefoxBrowser,
+} from '../../../../shared/lib/browser-runtime.utils';
+import { MetaMetricsContext } from '../../../contexts/metametrics';
+import PageContainerFooter from '../../ui/page-container/page-container-footer/page-container-footer.component';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import {
+  CameraAccessErrorContent,
+  CameraAccessErrorContentVariant,
+} from '../camera-access-error-content';
+import {
+  CameraReadyState,
+  WebcamErrorType,
+  type BaseReaderProps,
+} from './base-reader.types';
+import {
+  cameraReadyStateToErrorCode,
+  buildQrCameraRecoveryTrackEventArgs,
+} from './base-reader-utils';
+import {
+  useBaseReaderReducer,
+  useDecoderLifecycle,
+  useCameraPermission,
+} from './qr-hooks';
+import EnhancedReader from './enhanced-reader';
+
 /**
  * `BaseReader` — low-level QR camera scanner component.
  *
@@ -17,99 +56,16 @@
  * the `PermissionStatus.change` event so the scanner transitions to READY
  * automatically when the user grants camera access in browser settings.
  *
+ * @param options0 - Component props.
+ * @param options0.isReadingWallet - True when scanning a wallet sync QR code;
+ * false for transaction signing.
+ * @param options0.handleCancel - Called when the user cancels the QR scan flow.
+ * @param options0.handleSuccess - Called when a complete UR payload has been
+ * decoded from the QR code stream.
+ * @param options0.setErrorTitle - Sets the popover title to an error-specific
+ * heading.
  * @see CameraReadyState for the state machine definition.
  */
-import React, {
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-  useCallback,
-} from 'react';
-import log from 'loglevel';
-import { URDecoder } from '@ngraveio/bc-ur';
-import { ENVIRONMENT_TYPE_FULLSCREEN } from '../../../../shared/constants/app';
-import { getEnvironmentType } from '../../../../shared/lib/environment-type';
-import {
-  getChromiumExtensionCameraSiteSettingsUrl,
-  getMozExtensionOriginForDisplay,
-  isFirefoxBrowser,
-} from '../../../../shared/lib/browser-runtime.utils';
-import { MetaMetricsEventName } from '../../../../shared/constants/metametrics';
-import { MetaMetricsContext } from '../../../contexts/metametrics';
-import WebcamUtils from '../../../helpers/utils/webcam-utils';
-import PageContainerFooter from '../../ui/page-container/page-container-footer/page-container-footer.component';
-import { useI18nContext } from '../../../hooks/useI18nContext';
-import {
-  CameraAccessErrorContent,
-  CameraAccessErrorContentVariant,
-} from '../camera-access-error-content';
-import { CameraPermissionState } from '../../../contexts/hardware-wallets/constants';
-import {
-  CameraReadyState,
-  type BaseReaderProps,
-  type CameraReadyStateValue,
-  type WebcamError,
-} from './base-reader.types';
-import {
-  cameraReadyStateToErrorCode,
-  buildQrCameraRecoveryTrackEventArgs,
-} from './base-reader-utils';
-import EnhancedReader from './enhanced-reader';
-
-// ---------------------------------------------------------------------------
-// Hooks – camera permission lifecycle
-// ---------------------------------------------------------------------------
-
-/**
- * Manages the `PermissionStatus.change` subscription so the scanner can
- * transition to READY when the user grants camera access externally.
- *
- * @returns Ref-backed helpers to attach, clean up, and access the listener.
- */
-function usePermissionChangeListener() {
-  const permissionStatusRef = useRef<PermissionStatus | null>(null);
-  const handlerRef = useRef<(() => void) | null>(null);
-
-  const cleanup = useCallback(() => {
-    const status = permissionStatusRef.current;
-    const handler = handlerRef.current;
-    if (status && handler) {
-      if (typeof status.removeEventListener === 'function') {
-        status.removeEventListener('change', handler);
-      } else {
-        status.onchange = null;
-      }
-    }
-    permissionStatusRef.current = null;
-    handlerRef.current = null;
-  }, []);
-
-  const attach = useCallback(
-    (permissionStatus: PermissionStatus | null, onGranted: () => void) => {
-      cleanup();
-      if (!permissionStatus) {
-        return;
-      }
-      permissionStatusRef.current = permissionStatus;
-      const handler = () => {
-        if (permissionStatus.state === CameraPermissionState.Granted) {
-          onGranted();
-        }
-      };
-      handlerRef.current = handler;
-      if (typeof permissionStatus.addEventListener === 'function') {
-        permissionStatus.addEventListener('change', handler);
-      } else {
-        permissionStatus.onchange = handler;
-      }
-    },
-    [cleanup],
-  );
-
-  return { attach, cleanup } as const;
-}
-
 const BaseReader = ({
   isReadingWallet,
   handleCancel,
@@ -119,29 +75,22 @@ const BaseReader = ({
   const t = useI18nContext();
   const { trackEvent } = useContext(MetaMetricsContext);
 
-  const [readyState, setReadyState] = useState<CameraReadyStateValue>(
-    CameraReadyState.AccessingCamera,
-  );
-  const [error, setError] = useState<WebcamError | null>(null);
-  const [urDecoder, setUrDecoder] = useState(() => new URDecoder());
-  const [scanProgress, setScanProgress] = useState(0);
-  const [permissionActionLoading, setPermissionActionLoading] = useState(false);
-
-  const mountedRef = useRef(false);
-  const errorTypeViewCountRef = useRef(0);
-  const lastTrackedReadyStateRef = useRef<CameraReadyStateValue | null>(null);
-  const prevErrorReadyStateRef = useRef<CameraReadyStateValue | null>(null);
   const {
-    attach: attachPermissionListener,
-    cleanup: cleanupPermissionListener,
-  } = usePermissionChangeListener();
+    state: { readyState, error, scanProgress, permissionActionLoading },
+    setReady,
+    setBlocked,
+    setNeeded,
+    setError,
+    setScanProgress,
+    setPermissionActionLoading,
+    reset,
+  } = useBaseReaderReducer();
 
   // ---- MetaMetrics tracking -----------------------------------------------
-  // `readyState` is set asynchronously from multiple code paths (initial
-  // permission query, getUserMedia rejection, Continue-button retry, and the
-  // PermissionStatus change listener). A reactive `useEffect` is the only
-  // way to reliably track every transition without duplicating fire-once
-  // guards inside each handler.
+
+  const errorTypeViewCountRef = useRef(0);
+  const lastTrackedReadyStateRef = useRef<typeof readyState | null>(null);
+  const prevErrorReadyStateRef = useRef<typeof readyState | null>(null);
 
   useEffect(() => {
     const errorCode = cameraReadyStateToErrorCode(readyState);
@@ -187,158 +136,7 @@ const BaseReader = ({
     );
   }, [readyState, trackEvent]);
 
-  // ---- camera helpers -----------------------------------------------------
-
-  /**
-   * Auto-recovery callback for the `PermissionStatus.change` event.
-   * Proves the camera works by briefly acquiring and releasing a stream,
-   * then transitions to READY. Errors are logged silently — the user
-   * remains on the instructional UI and can retry manually via Continue button.
-   */
-  const acquireCameraAndTransitionToReady = useCallback(async () => {
-    try {
-      const stream = await WebcamUtils.requestVideoStream();
-      WebcamUtils.stopVideoStream(stream);
-      if (mountedRef.current) {
-        cleanupPermissionListener();
-        setReadyState(CameraReadyState.Ready);
-      }
-    } catch (cameraError) {
-      log.info(
-        'QR camera: could not acquire stream after permission grant',
-        cameraError,
-      );
-    }
-  }, [cleanupPermissionListener]);
-
-  /**
-   * After `getUserMedia` throws `NotAllowedError`, re-queries the permission
-   * and attaches a change listener so the component recovers automatically.
-   *
-   * @returns The current permission state after re-querying.
-   */
-  const reconcileNotAllowedPermission =
-    useCallback(async (): Promise<PermissionState> => {
-      const { state, permissionStatus } =
-        await WebcamUtils.queryCameraPermission();
-      attachPermissionListener(
-        permissionStatus,
-        acquireCameraAndTransitionToReady,
-      );
-      return state;
-    }, [attachPermissionListener, acquireCameraAndTransitionToReady]);
-
-  // ---- permission flow entry points ---------------------------------------
-
-  /**
-   * Classifies a `NotAllowedError` after re-querying the permission state
-   * and updates the UI to the appropriate error screen.
-   */
-  const handleNotAllowedError = useCallback(async () => {
-    const nextState = await reconcileNotAllowedPermission();
-    if (!mountedRef.current) {
-      return;
-    }
-    const useBlockedUi =
-      nextState === CameraPermissionState.Denied ||
-      (nextState === CameraPermissionState.Prompt && isFirefoxBrowser());
-    setReadyState(
-      useBlockedUi
-        ? CameraReadyState.CameraAccessBlocked
-        : CameraReadyState.CameraAccessNeeded,
-    );
-  }, [reconcileNotAllowedPermission]);
-
-  /**
-   * Prompts the user for camera access via `getUserMedia` (used when the
-   * Permissions API returns `'prompt'`). On success transitions to READY;
-   * on `NotAllowedError` classifies the denial; other errors bubble up.
-   */
-  const promptForCameraAccess = useCallback(async () => {
-    try {
-      const stream = await WebcamUtils.requestVideoStream();
-      WebcamUtils.stopVideoStream(stream);
-      if (mountedRef.current) {
-        cleanupPermissionListener();
-        setReadyState(CameraReadyState.Ready);
-      }
-    } catch (cameraError) {
-      if ((cameraError as { name?: string }).name === 'NotAllowedError') {
-        await handleNotAllowedError();
-      } else if (mountedRef.current) {
-        setError(cameraError as WebcamError);
-      }
-    }
-  }, [cleanupPermissionListener, handleNotAllowedError]);
-
-  /**
-   * Initial permission flow executed once the environment check passes.
-   * Queries the permission API, then dispatches to the appropriate handler
-   * based on the current permission state.
-   */
-  const startCameraPermissionFlow = useCallback(async () => {
-    const { state, permissionStatus } =
-      await WebcamUtils.queryCameraPermission();
-
-    if (state === CameraPermissionState.Denied) {
-      attachPermissionListener(
-        permissionStatus,
-        acquireCameraAndTransitionToReady,
-      );
-      if (mountedRef.current) {
-        setReadyState(CameraReadyState.CameraAccessBlocked);
-      }
-      return;
-    }
-
-    // Skip getUserMedia when already granted — EnhancedReader will open the
-    // camera once, avoiding a redundant open/close cycle that slows scanning.
-    if (state === CameraPermissionState.Granted) {
-      if (mountedRef.current) {
-        cleanupPermissionListener();
-        setReadyState(CameraReadyState.Ready);
-      }
-      return;
-    }
-
-    await promptForCameraAccess();
-  }, [
-    attachPermissionListener,
-    acquireCameraAndTransitionToReady,
-    cleanupPermissionListener,
-    promptForCameraAccess,
-  ]);
-
-  // ---- environment check --------------------------------------------------
-
-  /**
-   * Ensures the extension runs in a context capable of prompting for camera
-   * access. Popup / side panel environments redirect to a fullscreen tab.
-   */
-  const checkEnvironment = useCallback(async () => {
-    try {
-      const { environmentReady } = await WebcamUtils.checkStatus();
-      if (
-        !environmentReady &&
-        getEnvironmentType() !== ENVIRONMENT_TYPE_FULLSCREEN
-      ) {
-        const currentUrl = new URL(globalThis.location.href);
-        const currentHash = currentUrl.hash;
-        const currentRoute = currentHash ? currentHash.substring(1) : null;
-        globalThis.platform.openExtensionInBrowser(currentRoute);
-        return;
-      }
-    } catch (environmentError) {
-      if (mountedRef.current) {
-        setError(environmentError as WebcamError);
-      }
-      return;
-    }
-    await startCameraPermissionFlow();
-  }, [startCameraPermissionFlow]);
-
-  // ---- "Continue" handlers for camera-access error states -----------------
-
+  /** Fires a MetaMetrics event when the user clicks a recovery CTA button. */
   const trackCameraRecoveryCtaClicked = useCallback(() => {
     const errorCode = cameraReadyStateToErrorCode(readyState);
     if (errorCode === null) {
@@ -353,166 +151,65 @@ const BaseReader = ({
     );
   }, [readyState, trackEvent]);
 
-  /**
-   * Handler for the "needed" (prompt-dismissed) Continue button.
-   * Re-requests camera access via `getUserMedia`.
-   */
-  const handleCameraAccessNeededContinue = useCallback(async () => {
-    trackCameraRecoveryCtaClicked();
-    setPermissionActionLoading(true);
-    try {
-      const stream = await WebcamUtils.requestVideoStream();
-      WebcamUtils.stopVideoStream(stream);
-      if (mountedRef.current) {
-        cleanupPermissionListener();
-        setReadyState(CameraReadyState.Ready);
-      }
-    } catch (cameraError) {
-      const domError = cameraError as { name?: string };
-      if (domError.name === 'NotAllowedError') {
-        const nextState = await reconcileNotAllowedPermission();
-        if (
-          mountedRef.current &&
-          (nextState === CameraPermissionState.Denied ||
-            (nextState === CameraPermissionState.Prompt && isFirefoxBrowser()))
-        ) {
-          setReadyState(CameraReadyState.CameraAccessBlocked);
-        }
-      } else if (mountedRef.current) {
-        setError(cameraError as WebcamError);
-      }
-    } finally {
-      if (mountedRef.current) {
-        setPermissionActionLoading(false);
-      }
-    }
-  }, [
-    cleanupPermissionListener,
-    reconcileNotAllowedPermission,
-    trackCameraRecoveryCtaClicked,
-  ]);
+  // ---- Decoder lifecycle --------------------------------------------------
 
-  /**
-   * Handler for the "blocked" Continue button.
-   * Re-checks the permission state; if no longer denied, acquires the camera.
-   */
-  const handleCameraAccessBlockedContinue = useCallback(async () => {
-    trackCameraRecoveryCtaClicked();
-    setPermissionActionLoading(true);
-    try {
-      const { state } = await WebcamUtils.queryCameraPermission();
-      if (state === CameraPermissionState.Denied) {
-        return;
-      }
-      const stream = await WebcamUtils.requestVideoStream();
-      WebcamUtils.stopVideoStream(stream);
-      if (mountedRef.current) {
-        cleanupPermissionListener();
-        setReadyState(CameraReadyState.Ready);
-      }
-    } catch (cameraError) {
-      const domError = cameraError as { name?: string };
-      if (domError.name === 'NotAllowedError') {
-        await reconcileNotAllowedPermission();
-      } else if (mountedRef.current) {
-        setError(cameraError as WebcamError);
-      }
-    } finally {
-      if (mountedRef.current) {
-        setPermissionActionLoading(false);
-      }
-    }
-  }, [
-    cleanupPermissionListener,
-    reconcileNotAllowedPermission,
-    trackCameraRecoveryCtaClicked,
-  ]);
+  const { handleScan, resetDecoder } = useDecoderLifecycle(
+    { handleSuccess, isReadingWallet, setErrorTitle },
+    { setScanProgress, setError },
+    t as (...args: string[]) => string,
+  );
 
-  /**
-   * Opens the Chromium camera site-settings page in a new tab.
-   */
+  // ---- Camera permission lifecycle ----------------------------------------
+
+  const {
+    handleCameraAccessNeededContinue,
+    handleCameraAccessBlockedContinue,
+    cleanupPermissionListener,
+    checkEnvironment,
+  } = useCameraPermission(
+    {
+      setReady,
+      setBlocked,
+      setNeeded,
+      setError,
+      setPermissionActionLoading,
+    },
+    { trackCameraRecoveryCtaClicked },
+  );
+
+  // ---- tryAgain -----------------------------------------------------------
+
+  /** Resets all scanner state and re-enters the environment check. */
+  const tryAgain = useCallback(() => {
+    cleanupPermissionListener();
+    reset();
+    resetDecoder();
+    checkEnvironment();
+  }, [cleanupPermissionListener, reset, resetDecoder, checkEnvironment]);
+
+  // ---- Chromium settings --------------------------------------------------
+
+  /** Opens the Chromium camera site-settings page in a new tab. */
   const handleOpenChromiumCameraSettings = useCallback(() => {
     globalThis.platform.openTab({
       url: getChromiumExtensionCameraSiteSettingsUrl(),
     });
   }, []);
 
-  // ---- QR scan callback ---------------------------------------------------
+  // ---- Render: error UI ---------------------------------------------------
 
-  /**
-   * Feeds a scanned QR payload into the `URDecoder`. When the UR is fully
-   * assembled, invokes `handleSuccess` with the decoded result.
-   *
-   * @param data - Raw text content of a single scanned QR frame.
-   */
-  const handleScan = useCallback(
-    (data: string | null) => {
-      try {
-        if (!data || urDecoder.isComplete()) {
-          return;
-        }
-        urDecoder.receivePart(data);
-        setScanProgress(urDecoder.estimatedPercentComplete());
-        if (urDecoder.isComplete()) {
-          const result = urDecoder.resultUR();
-          handleSuccess(result).catch((successError: WebcamError) =>
-            setError(successError),
-          );
-        }
-      } catch {
-        if (isReadingWallet) {
-          setErrorTitle(t('QRHardwareUnknownQRCodeTitle'));
-        } else {
-          setErrorTitle(t('QRHardwareInvalidTransactionTitle'));
-        }
-        setError(new Error(t('unknownQrCode')) as WebcamError);
-      }
-    },
-    [handleSuccess, isReadingWallet, setErrorTitle, t, urDecoder],
-  );
-
-  // ---- lifecycle ----------------------------------------------------------
-
-  useEffect(() => {
-    mountedRef.current = true;
-    checkEnvironment();
-    return () => {
-      mountedRef.current = false;
-      cleanupPermissionListener();
-    };
-  }, [checkEnvironment, cleanupPermissionListener]);
-
-  /**
-   * Resets all scanner state and re-enters the environment check.
-   */
-  const tryAgain = () => {
-    cleanupPermissionListener();
-    setReadyState(CameraReadyState.AccessingCamera);
-    setError(null);
-    setUrDecoder(new URDecoder());
-    setScanProgress(0);
-    setPermissionActionLoading(false);
-    checkEnvironment();
-  };
-
-  // ---- render helpers -----------------------------------------------------
-
-  /**
-   * Renders the error overlay (no-webcam, unknown QR, mismatched sign-id, or
-   * generic camera error) with Cancel / Try Again footer buttons.
-   */
-  const renderError = () => {
+  if (error) {
     let title: string | undefined;
     let message: string;
 
-    if (error?.type === 'NO_WEBCAM_FOUND') {
+    if (error.type === WebcamErrorType.NoWebcamFound) {
       title = t('noWebcamFoundTitle');
       message = t('noWebcamFound');
-    } else if (error?.message === t('unknownQrCode')) {
+    } else if (error.message === t('unknownQrCode')) {
       message = isReadingWallet
         ? t('QRHardwareUnknownWalletQRCode')
         : t('unknownQrCode');
-    } else if (error?.message === t('QRHardwareMismatchedSignId')) {
+    } else if (error.message === t('QRHardwareMismatchedSignId')) {
       message = t('QRHardwareMismatchedSignId');
     } else {
       title = t('generalCameraErrorTitle');
@@ -520,14 +217,34 @@ const BaseReader = ({
     }
 
     return (
-      <>
-        <div className="qr-scanner__image">
+      <Box
+        flexDirection={BoxFlexDirection.Column}
+        alignItems={BoxAlignItems.Center}
+        className="qr-scanner"
+      >
+        <Box paddingTop={4} className="text-center">
           <img src="images/webcam.svg" width="70" height="70" alt="" />
-        </div>
-        {title ? <div className="qr-scanner__title">{title}</div> : null}
-        <div className="qr-scanner__error" data-testid="qr-scanner__error">
-          {message}
-        </div>
+        </Box>
+        {title ? (
+          <Box paddingTop={4} paddingBottom={4}>
+            <Text
+              variant={TextVariant.HeadingMd}
+              fontWeight={FontWeight.Medium}
+              textAlign={TextAlign.Center}
+            >
+              {title}
+            </Text>
+          </Box>
+        ) : null}
+        <Box padding={4}>
+          <Text
+            variant={TextVariant.BodyMd}
+            textAlign={TextAlign.Center}
+            data-testid="qr-scanner__error"
+          >
+            {message}
+          </Text>
+        </Box>
         <PageContainerFooter
           onCancel={() => {
             setErrorTitle('');
@@ -541,26 +258,35 @@ const BaseReader = ({
           submitText={t('tryAgain')}
           submitButtonType="confirm"
         />
-      </>
+      </Box>
     );
-  };
+  }
 
-  /**
-   * Renders the main scanner area: one of the camera-access error states,
-   * the "accessing camera" loading message, or the live QR scanner.
-   */
-  const renderVideo = () => {
-    if (readyState === CameraReadyState.CameraAccessNeeded) {
-      return (
+  // ---- Render: camera-access error states ---------------------------------
+
+  if (readyState === CameraReadyState.CameraAccessNeeded) {
+    return (
+      <Box
+        flexDirection={BoxFlexDirection.Column}
+        alignItems={BoxAlignItems.Center}
+        className="qr-scanner"
+      >
         <CameraAccessErrorContent
           variant={CameraAccessErrorContentVariant.Needed}
           onContinue={handleCameraAccessNeededContinue}
           continueLoading={permissionActionLoading}
         />
-      );
-    }
-    if (readyState === CameraReadyState.CameraAccessBlocked) {
-      return (
+      </Box>
+    );
+  }
+
+  if (readyState === CameraReadyState.CameraAccessBlocked) {
+    return (
+      <Box
+        flexDirection={BoxFlexDirection.Column}
+        alignItems={BoxAlignItems.Center}
+        className="qr-scanner"
+      >
         <CameraAccessErrorContent
           variant={CameraAccessErrorContentVariant.Blocked}
           isFirefox={isFirefoxBrowser()}
@@ -569,43 +295,49 @@ const BaseReader = ({
           onContinue={handleCameraAccessBlockedContinue}
           continueLoading={permissionActionLoading}
         />
-      );
-    }
-
-    let statusMessage: string | undefined;
-    if (readyState === CameraReadyState.AccessingCamera) {
-      statusMessage = t('accessingYourCamera');
-    } else if (readyState === CameraReadyState.Ready) {
-      statusMessage = t('QRHardwareScanInstructions');
-    }
-
-    return (
-      <>
-        <div className="qr-scanner__content">
-          {readyState === CameraReadyState.Ready ? (
-            <EnhancedReader onFrame={handleScan} />
-          ) : null}
-        </div>
-        {scanProgress > 0 && (
-          <div
-            className="qr-scanner__progress"
-            data-testid="qr-reader-progress-bar"
-            style={
-              {
-                '--progress': `${Math.floor(scanProgress * 100)}%`,
-              } as React.CSSProperties
-            }
-          />
-        )}
-        {statusMessage && (
-          <div className="qr-scanner__status">{statusMessage}</div>
-        )}
-      </>
+      </Box>
     );
-  };
+  }
+
+  // ---- Render: scanner / loading ------------------------------------------
+
+  let statusMessage: string | undefined;
+  if (readyState === CameraReadyState.AccessingCamera) {
+    statusMessage = t('accessingYourCamera');
+  } else if (readyState === CameraReadyState.Ready) {
+    statusMessage = t('QRHardwareScanInstructions');
+  }
 
   return (
-    <div className="qr-scanner">{error ? renderError() : renderVideo()}</div>
+    <Box
+      flexDirection={BoxFlexDirection.Column}
+      alignItems={BoxAlignItems.Center}
+      className="qr-scanner"
+    >
+      <Box paddingLeft={5} paddingRight={5} className="qr-scanner__content">
+        {readyState === CameraReadyState.Ready ? (
+          <EnhancedReader onFrame={handleScan} />
+        ) : null}
+      </Box>
+      {scanProgress > 0 && (
+        <div
+          className="qr-scanner__progress"
+          data-testid="qr-reader-progress-bar"
+          style={
+            {
+              '--progress': `${Math.floor(scanProgress * 100)}%`,
+            } as React.CSSProperties
+          }
+        />
+      )}
+      {statusMessage && (
+        <Box padding={4}>
+          <Text variant={TextVariant.BodySm} textAlign={TextAlign.Center}>
+            {statusMessage}
+          </Text>
+        </Box>
+      )}
+    </Box>
   );
 };
 

--- a/ui/components/app/qr-hardware-popover/base-reader.tsx
+++ b/ui/components/app/qr-hardware-popover/base-reader.tsx
@@ -156,7 +156,7 @@ const BaseReader = ({
   const { handleScan, resetDecoder } = useDecoderLifecycle(
     { handleSuccess, isReadingWallet, setErrorTitle },
     { setScanProgress, setError },
-    t as (...args: string[]) => string,
+    t,
   );
 
   // ---- Camera permission lifecycle ----------------------------------------

--- a/ui/components/app/qr-hardware-popover/base-reader.types.ts
+++ b/ui/components/app/qr-hardware-popover/base-reader.types.ts
@@ -36,6 +36,20 @@ export type BaseReaderProps = {
 };
 
 /**
+ * Known webcam error type discriminants produced by `WebcamUtils`.
+ */
+export const WebcamErrorType = {
+  NoWebcamFound: 'NO_WEBCAM_FOUND',
+} as const;
+
+/**
+ * DOMException names thrown by `getUserMedia` that require special handling.
+ */
+export const DOMExceptionName = {
+  NotAllowed: 'NotAllowedError',
+} as const;
+
+/**
  * Typed webcam error with an optional `type` discriminant used by
  * `WebcamUtils.checkStatus` for the `NO_WEBCAM_FOUND` case.
  */

--- a/ui/components/app/qr-hardware-popover/qr-hooks/index.ts
+++ b/ui/components/app/qr-hardware-popover/qr-hooks/index.ts
@@ -1,0 +1,3 @@
+export { useBaseReaderReducer } from './useBaseReaderReducer';
+export { useDecoderLifecycle } from './useDecoderLifecycle';
+export { useCameraPermission } from './useCameraPermission';

--- a/ui/components/app/qr-hardware-popover/qr-hooks/qr-hooks-utils.test.ts
+++ b/ui/components/app/qr-hardware-popover/qr-hooks/qr-hooks-utils.test.ts
@@ -1,0 +1,119 @@
+import { isFirefoxBrowser } from '../../../../../shared/lib/browser-runtime.utils';
+import { CameraPermissionState } from '../../../../contexts/hardware-wallets/constants';
+import { DOMExceptionName } from '../base-reader.types';
+import {
+  shouldShowBlockedUi,
+  isNotAllowedError,
+  extractCurrentRoute,
+} from './qr-hooks-utils';
+
+jest.mock('../../../../../shared/lib/browser-runtime.utils', () => ({
+  ...jest.requireActual('../../../../../shared/lib/browser-runtime.utils'),
+  isFirefoxBrowser: jest.fn(() => false),
+}));
+
+const mockIsFirefoxBrowser = jest.mocked(isFirefoxBrowser);
+
+describe('qr-hooks-utils', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsFirefoxBrowser.mockReturnValue(false);
+  });
+
+  describe('shouldShowBlockedUi', () => {
+    it('returns true when permission state is denied on Chromium', () => {
+      mockIsFirefoxBrowser.mockReturnValue(false);
+      expect(shouldShowBlockedUi(CameraPermissionState.Denied)).toBe(true);
+    });
+
+    it('returns true when permission state is denied on Firefox', () => {
+      mockIsFirefoxBrowser.mockReturnValue(true);
+      expect(shouldShowBlockedUi(CameraPermissionState.Denied)).toBe(true);
+    });
+
+    it('returns false when permission state is prompt on Chromium', () => {
+      mockIsFirefoxBrowser.mockReturnValue(false);
+      expect(shouldShowBlockedUi(CameraPermissionState.Prompt)).toBe(false);
+    });
+
+    it('returns true when permission state is prompt on Firefox', () => {
+      mockIsFirefoxBrowser.mockReturnValue(true);
+      expect(shouldShowBlockedUi(CameraPermissionState.Prompt)).toBe(true);
+    });
+
+    it('returns false when permission state is granted on Chromium', () => {
+      mockIsFirefoxBrowser.mockReturnValue(false);
+      expect(shouldShowBlockedUi(CameraPermissionState.Granted)).toBe(false);
+    });
+
+    it('returns false when permission state is granted on Firefox', () => {
+      mockIsFirefoxBrowser.mockReturnValue(true);
+      expect(shouldShowBlockedUi(CameraPermissionState.Granted)).toBe(false);
+    });
+  });
+
+  describe('isNotAllowedError', () => {
+    it('returns true for an error with name NotAllowedError', () => {
+      const error = new Error('denied');
+      error.name = DOMExceptionName.NotAllowed;
+      expect(isNotAllowedError(error)).toBe(true);
+    });
+
+    it('returns false for an error with a different name', () => {
+      const error = new Error('not readable');
+      error.name = 'NotReadableError';
+      expect(isNotAllowedError(error)).toBe(false);
+    });
+
+    it('returns false for a plain Error without a custom name', () => {
+      expect(isNotAllowedError(new Error('generic'))).toBe(false);
+    });
+
+    it('returns false for null', () => {
+      expect(isNotAllowedError(null)).toBe(false);
+    });
+
+    it('returns false for undefined', () => {
+      expect(isNotAllowedError(undefined)).toBe(false);
+    });
+
+    it('returns false for a non-object value', () => {
+      expect(isNotAllowedError(DOMExceptionName.NotAllowed)).toBe(false);
+    });
+  });
+
+  describe('extractCurrentRoute', () => {
+    const originalLocation = globalThis.location;
+
+    afterEach(() => {
+      Object.defineProperty(globalThis, 'location', {
+        value: originalLocation,
+        writable: true,
+      });
+    });
+
+    it('returns the hash without the leading # character', () => {
+      Object.defineProperty(globalThis, 'location', {
+        value: new URL('chrome-extension://abc/home.html#/settings/general'),
+        writable: true,
+      });
+      expect(extractCurrentRoute()).toBe('/settings/general');
+    });
+
+    it('returns null when there is no hash', () => {
+      Object.defineProperty(globalThis, 'location', {
+        value: new URL('chrome-extension://abc/home.html'),
+        writable: true,
+      });
+      expect(extractCurrentRoute()).toBeNull();
+    });
+
+    it('returns null for an empty hash', () => {
+      Object.defineProperty(globalThis, 'location', {
+        value: new URL('chrome-extension://abc/home.html#'),
+        writable: true,
+      });
+      expect(extractCurrentRoute()).toBeNull();
+    });
+  });
+});

--- a/ui/components/app/qr-hardware-popover/qr-hooks/qr-hooks-utils.ts
+++ b/ui/components/app/qr-hardware-popover/qr-hooks/qr-hooks-utils.ts
@@ -1,0 +1,46 @@
+import { isFirefoxBrowser } from '../../../../../shared/lib/browser-runtime.utils';
+import { CameraPermissionState } from '../../../../contexts/hardware-wallets/constants';
+import { DOMExceptionName } from '../base-reader.types';
+
+/**
+ * Determines whether the camera-access-blocked UI should be shown
+ * based on the current permission state and browser type.
+ *
+ * Blocked UI is shown when permission is explicitly denied, or when
+ * the permission is still "prompt" on Firefox (which treats dismissed
+ * prompts as persistent blocks).
+ *
+ * @param permissionState - The current camera permission state.
+ * @returns True if the blocked error UI should be displayed.
+ */
+export function shouldShowBlockedUi(permissionState: PermissionState): boolean {
+  return (
+    permissionState === CameraPermissionState.Denied ||
+    (permissionState === CameraPermissionState.Prompt && isFirefoxBrowser())
+  );
+}
+
+/**
+ * Type guard that checks whether an error is a DOMException with
+ * the `NotAllowedError` name, indicating the user denied camera access.
+ *
+ * @param error - The caught error to check.
+ * @returns True if the error is a NotAllowedError.
+ */
+export function isNotAllowedError(error: unknown): boolean {
+  return (error as { name?: string })?.name === DOMExceptionName.NotAllowed;
+}
+
+/**
+ * Extracts the current route path from the URL hash.
+ *
+ * Used to preserve navigation state when redirecting from popup/side-panel
+ * to a fullscreen tab for camera access.
+ *
+ * @returns The route string (hash without the leading `#`), or null if empty.
+ */
+export function extractCurrentRoute(): string | null {
+  const currentUrl = new URL(globalThis.location.href);
+  const currentHash = currentUrl.hash;
+  return currentHash ? currentHash.substring(1) : null;
+}

--- a/ui/components/app/qr-hardware-popover/qr-hooks/qr-hooks.types.ts
+++ b/ui/components/app/qr-hardware-popover/qr-hooks/qr-hooks.types.ts
@@ -1,0 +1,27 @@
+import type { WebcamError } from '../base-reader.types';
+
+/**
+ * State dispatch functions consumed by the camera permission hook.
+ */
+export type StateDispatchers = {
+  setReady: () => void;
+  setBlocked: () => void;
+  setNeeded: () => void;
+  setError: (error: WebcamError) => void;
+  setPermissionActionLoading: (loading: boolean) => void;
+};
+
+/**
+ * MetaMetrics tracking callbacks for camera recovery CTA events.
+ */
+export type TrackingCallbacks = {
+  trackCameraRecoveryCtaClicked: () => void;
+};
+
+/**
+ * State update callbacks consumed by the decoder lifecycle hook.
+ */
+export type DecoderCallbacks = {
+  setScanProgress: (progress: number) => void;
+  setError: (error: WebcamError) => void;
+};

--- a/ui/components/app/qr-hardware-popover/qr-hooks/useBaseReaderReducer.test.ts
+++ b/ui/components/app/qr-hardware-popover/qr-hooks/useBaseReaderReducer.test.ts
@@ -1,0 +1,177 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { CameraReadyState, WebcamErrorType } from '../base-reader.types';
+import {
+  baseReaderReducer,
+  getInitialState,
+  ActionType,
+} from '../base-reader-reducer';
+import { useBaseReaderReducer } from './useBaseReaderReducer';
+
+describe('baseReaderReducer', () => {
+  describe('getInitialState', () => {
+    it('returns AccessingCamera with no error and zero progress', () => {
+      const state = getInitialState();
+      expect(state).toStrictEqual({
+        readyState: CameraReadyState.AccessingCamera,
+        error: null,
+        scanProgress: 0,
+        permissionActionLoading: false,
+      });
+    });
+  });
+
+  describe('SetReady', () => {
+    it('transitions readyState to Ready and clears permissionActionLoading', () => {
+      const prev = {
+        ...getInitialState(),
+        permissionActionLoading: true,
+      };
+      const next = baseReaderReducer(prev, { type: ActionType.SetReady });
+      expect(next.readyState).toBe(CameraReadyState.Ready);
+      expect(next.permissionActionLoading).toBe(false);
+    });
+  });
+
+  describe('SetBlocked', () => {
+    it('transitions readyState to CameraAccessBlocked', () => {
+      const next = baseReaderReducer(getInitialState(), {
+        type: ActionType.SetBlocked,
+      });
+      expect(next.readyState).toBe(CameraReadyState.CameraAccessBlocked);
+      expect(next.permissionActionLoading).toBe(false);
+    });
+  });
+
+  describe('SetNeeded', () => {
+    it('transitions readyState to CameraAccessNeeded', () => {
+      const next = baseReaderReducer(getInitialState(), {
+        type: ActionType.SetNeeded,
+      });
+      expect(next.readyState).toBe(CameraReadyState.CameraAccessNeeded);
+      expect(next.permissionActionLoading).toBe(false);
+    });
+  });
+
+  describe('SetAccessingCamera', () => {
+    it('transitions readyState to AccessingCamera', () => {
+      const prev = {
+        ...getInitialState(),
+        readyState: CameraReadyState.Ready,
+      };
+      const next = baseReaderReducer(prev, {
+        type: ActionType.SetAccessingCamera,
+      });
+      expect(next.readyState).toBe(CameraReadyState.AccessingCamera);
+    });
+  });
+
+  describe('SetError', () => {
+    it('stores the error object', () => {
+      const error = new Error('webcam broken') as Error & { type?: string };
+      error.type = WebcamErrorType.NoWebcamFound;
+      const next = baseReaderReducer(getInitialState(), {
+        type: ActionType.SetError,
+        payload: error,
+      });
+      expect(next.error).toBe(error);
+    });
+  });
+
+  describe('ClearError', () => {
+    it('sets error to null', () => {
+      const prev = {
+        ...getInitialState(),
+        error: new Error('something'),
+      };
+      const next = baseReaderReducer(prev, { type: ActionType.ClearError });
+      expect(next.error).toBeNull();
+    });
+  });
+
+  describe('SetScanProgress', () => {
+    it('updates scanProgress', () => {
+      const next = baseReaderReducer(getInitialState(), {
+        type: ActionType.SetScanProgress,
+        payload: 0.75,
+      });
+      expect(next.scanProgress).toBe(0.75);
+    });
+  });
+
+  describe('SetPermissionActionLoading', () => {
+    it('toggles the loading flag', () => {
+      const next = baseReaderReducer(getInitialState(), {
+        type: ActionType.SetPermissionActionLoading,
+        payload: true,
+      });
+      expect(next.permissionActionLoading).toBe(true);
+    });
+  });
+
+  describe('Reset', () => {
+    it('returns the initial state regardless of current state', () => {
+      const dirty = {
+        readyState: CameraReadyState.Ready,
+        error: new Error('whoops'),
+        scanProgress: 0.5,
+        permissionActionLoading: true,
+      };
+      const next = baseReaderReducer(dirty, { type: ActionType.Reset });
+      expect(next).toStrictEqual(getInitialState());
+    });
+  });
+
+  describe('unknown action', () => {
+    it('returns current state unchanged', () => {
+      const state = getInitialState();
+      const next = baseReaderReducer(state, {
+        type: 'UNKNOWN_ACTION',
+      } as never);
+      expect(next).toBe(state);
+    });
+  });
+});
+
+describe('useBaseReaderReducer', () => {
+  it('exposes dispatch helpers that update state correctly', () => {
+    const { result } = renderHook(() => useBaseReaderReducer());
+
+    expect(result.current.state.readyState).toBe(
+      CameraReadyState.AccessingCamera,
+    );
+
+    act(() => result.current.setReady());
+    expect(result.current.state.readyState).toBe(CameraReadyState.Ready);
+
+    act(() => result.current.setBlocked());
+    expect(result.current.state.readyState).toBe(
+      CameraReadyState.CameraAccessBlocked,
+    );
+
+    act(() => result.current.setNeeded());
+    expect(result.current.state.readyState).toBe(
+      CameraReadyState.CameraAccessNeeded,
+    );
+
+    act(() => result.current.setAccessingCamera());
+    expect(result.current.state.readyState).toBe(
+      CameraReadyState.AccessingCamera,
+    );
+
+    const err = new Error('test error');
+    act(() => result.current.setError(err));
+    expect(result.current.state.error).toBe(err);
+
+    act(() => result.current.clearError());
+    expect(result.current.state.error).toBeNull();
+
+    act(() => result.current.setScanProgress(0.42));
+    expect(result.current.state.scanProgress).toBe(0.42);
+
+    act(() => result.current.setPermissionActionLoading(true));
+    expect(result.current.state.permissionActionLoading).toBe(true);
+
+    act(() => result.current.reset());
+    expect(result.current.state).toStrictEqual(getInitialState());
+  });
+});

--- a/ui/components/app/qr-hardware-popover/qr-hooks/useBaseReaderReducer.ts
+++ b/ui/components/app/qr-hardware-popover/qr-hooks/useBaseReaderReducer.ts
@@ -1,0 +1,76 @@
+import { useReducer, useCallback } from 'react';
+import {
+  baseReaderReducer,
+  getInitialState,
+  ActionType,
+} from '../base-reader-reducer';
+
+/**
+ * Wraps the BaseReader reducer and provides typed dispatch helpers so callers
+ * don't need to construct action objects directly.
+ *
+ * @returns An object containing the current state and memoized dispatch
+ * functions: `setReady`, `setBlocked`, `setNeeded`, `setAccessingCamera`,
+ * `setError`, `clearError`, `setScanProgress`, `setPermissionActionLoading`,
+ * and `reset`.
+ */
+export function useBaseReaderReducer() {
+  const [state, dispatch] = useReducer(
+    baseReaderReducer,
+    undefined,
+    getInitialState,
+  );
+
+  const setReady = useCallback(
+    () => dispatch({ type: ActionType.SetReady }),
+    [],
+  );
+  const setBlocked = useCallback(
+    () => dispatch({ type: ActionType.SetBlocked }),
+    [],
+  );
+  const setNeeded = useCallback(
+    () => dispatch({ type: ActionType.SetNeeded }),
+    [],
+  );
+  const setAccessingCamera = useCallback(
+    () => dispatch({ type: ActionType.SetAccessingCamera }),
+    [],
+  );
+  const setError = useCallback(
+    (error: Error & { type?: string }) =>
+      dispatch({ type: ActionType.SetError, payload: error }),
+    [],
+  );
+  const clearError = useCallback(
+    () => dispatch({ type: ActionType.ClearError }),
+    [],
+  );
+  const setScanProgress = useCallback(
+    (progress: number) =>
+      dispatch({ type: ActionType.SetScanProgress, payload: progress }),
+    [],
+  );
+  const setPermissionActionLoading = useCallback(
+    (loading: boolean) =>
+      dispatch({
+        type: ActionType.SetPermissionActionLoading,
+        payload: loading,
+      }),
+    [],
+  );
+  const reset = useCallback(() => dispatch({ type: ActionType.Reset }), []);
+
+  return {
+    state,
+    setReady,
+    setBlocked,
+    setNeeded,
+    setAccessingCamera,
+    setError,
+    clearError,
+    setScanProgress,
+    setPermissionActionLoading,
+    reset,
+  } as const;
+}

--- a/ui/components/app/qr-hardware-popover/qr-hooks/useCameraPermission.test.ts
+++ b/ui/components/app/qr-hardware-popover/qr-hooks/useCameraPermission.test.ts
@@ -1,0 +1,515 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { waitFor } from '@testing-library/react';
+import WebcamUtils from '../../../../helpers/utils/webcam-utils';
+import { getEnvironmentType } from '../../../../../shared/lib/environment-type';
+import { isFirefoxBrowser } from '../../../../../shared/lib/browser-runtime.utils';
+import {
+  ENVIRONMENT_TYPE_FULLSCREEN,
+  ENVIRONMENT_TYPE_POPUP,
+} from '../../../../../shared/constants/app';
+import { CameraPermissionState } from '../../../../contexts/hardware-wallets/constants';
+import { DOMExceptionName } from '../base-reader.types';
+import { useCameraPermission } from './useCameraPermission';
+
+jest.mock('../../../../../shared/lib/environment-type', () => ({
+  getEnvironmentType: jest.fn(),
+}));
+
+jest.mock('../../../../../shared/lib/browser-runtime.utils', () => ({
+  ...jest.requireActual('../../../../../shared/lib/browser-runtime.utils'),
+  isFirefoxBrowser: jest.fn(() => false),
+}));
+
+jest.mock('../../../../helpers/utils/webcam-utils');
+
+const mockGetEnvironmentType = jest.mocked(getEnvironmentType);
+const mockIsFirefoxBrowser = jest.mocked(isFirefoxBrowser);
+const mockCheckStatus = jest.mocked(WebcamUtils.checkStatus);
+const mockQueryCameraPermission = jest.mocked(
+  WebcamUtils.queryCameraPermission,
+);
+const mockRequestVideoStream = jest.mocked(WebcamUtils.requestVideoStream);
+const mockStopVideoStream = jest.mocked(WebcamUtils.stopVideoStream);
+
+const mockStream = {
+  getTracks: () => [{ stop: jest.fn() }],
+} as unknown as MediaStream;
+
+describe('useCameraPermission', () => {
+  const mockSetReady = jest.fn();
+  const mockSetBlocked = jest.fn();
+  const mockSetNeeded = jest.fn();
+  const mockSetError = jest.fn();
+  const mockSetPermissionActionLoading = jest.fn();
+  const mockTrackCameraRecoveryCtaClicked = jest.fn();
+
+  const defaultDispatchers = {
+    setReady: mockSetReady,
+    setBlocked: mockSetBlocked,
+    setNeeded: mockSetNeeded,
+    setError: mockSetError,
+    setPermissionActionLoading: mockSetPermissionActionLoading,
+  };
+
+  const defaultTracking = {
+    trackCameraRecoveryCtaClicked: mockTrackCameraRecoveryCtaClicked,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetEnvironmentType.mockReturnValue(ENVIRONMENT_TYPE_FULLSCREEN);
+    mockIsFirefoxBrowser.mockReturnValue(false);
+    mockStopVideoStream.mockImplementation(() => undefined);
+    // @ts-expect-error mocking platform
+    global.platform = {
+      openTab: jest.fn(),
+      openExtensionInBrowser: jest.fn(),
+    };
+  });
+
+  function renderCameraHook(
+    dispatchers = defaultDispatchers,
+    tracking = defaultTracking,
+  ) {
+    return renderHook(() => useCameraPermission(dispatchers, tracking));
+  }
+
+  describe('environment check', () => {
+    it('redirects to fullscreen when environment is not ready in popup', async () => {
+      mockGetEnvironmentType.mockReturnValue(ENVIRONMENT_TYPE_POPUP);
+      mockCheckStatus.mockResolvedValue({
+        permissions: false,
+        environmentReady: false,
+      });
+
+      renderCameraHook();
+
+      await waitFor(() => {
+        expect(global.platform.openExtensionInBrowser).toHaveBeenCalled();
+      });
+      expect(mockQueryCameraPermission).not.toHaveBeenCalled();
+    });
+
+    it('does not redirect when already in fullscreen even if environment is not ready', async () => {
+      mockGetEnvironmentType.mockReturnValue(ENVIRONMENT_TYPE_FULLSCREEN);
+      mockCheckStatus.mockResolvedValue({
+        permissions: false,
+        environmentReady: false,
+      });
+      mockQueryCameraPermission.mockResolvedValue({
+        state: CameraPermissionState.Granted,
+        permissionStatus: null,
+      });
+
+      renderCameraHook();
+
+      await waitFor(() => {
+        expect(mockSetReady).toHaveBeenCalled();
+      });
+      expect(global.platform.openExtensionInBrowser).not.toHaveBeenCalled();
+    });
+
+    it('calls setError when checkStatus throws', async () => {
+      const envError = new Error('checkStatus failed');
+      mockCheckStatus.mockRejectedValue(envError);
+
+      renderCameraHook();
+
+      await waitFor(() => {
+        expect(mockSetError).toHaveBeenCalledWith(envError);
+      });
+    });
+
+    it('queries camera permission after environment passes', async () => {
+      mockCheckStatus.mockResolvedValue({
+        permissions: true,
+        environmentReady: true,
+      });
+      mockQueryCameraPermission.mockResolvedValue({
+        state: CameraPermissionState.Granted,
+        permissionStatus: null,
+      });
+
+      renderCameraHook();
+
+      await waitFor(() => {
+        expect(mockQueryCameraPermission).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('permission flow', () => {
+    it('calls setReady when permission is already granted', async () => {
+      mockCheckStatus.mockResolvedValue({
+        permissions: true,
+        environmentReady: true,
+      });
+      mockQueryCameraPermission.mockResolvedValue({
+        state: CameraPermissionState.Granted,
+        permissionStatus: null,
+      });
+
+      renderCameraHook();
+
+      await waitFor(() => {
+        expect(mockSetReady).toHaveBeenCalled();
+      });
+      expect(mockRequestVideoStream).not.toHaveBeenCalled();
+    });
+
+    it('calls setBlocked when permission is denied', async () => {
+      mockCheckStatus.mockResolvedValue({
+        permissions: false,
+        environmentReady: true,
+      });
+      mockQueryCameraPermission.mockResolvedValue({
+        state: CameraPermissionState.Denied,
+        permissionStatus: {
+          state: CameraPermissionState.Denied,
+          addEventListener: jest.fn(),
+        } as unknown as PermissionStatus,
+      });
+
+      renderCameraHook();
+
+      await waitFor(() => {
+        expect(mockSetBlocked).toHaveBeenCalled();
+      });
+    });
+
+    it('calls setReady on successful getUserMedia from prompt state', async () => {
+      mockCheckStatus.mockResolvedValue({
+        permissions: true,
+        environmentReady: true,
+      });
+      mockQueryCameraPermission.mockResolvedValue({
+        state: CameraPermissionState.Prompt,
+        permissionStatus: null,
+      });
+      mockRequestVideoStream.mockResolvedValue(mockStream);
+
+      renderCameraHook();
+
+      await waitFor(() => {
+        expect(mockSetReady).toHaveBeenCalled();
+      });
+      expect(mockStopVideoStream).toHaveBeenCalledWith(mockStream);
+    });
+
+    it('calls setNeeded on NotAllowedError when re-queried permission is prompt on Chromium', async () => {
+      mockCheckStatus.mockResolvedValue({
+        permissions: true,
+        environmentReady: true,
+      });
+      mockQueryCameraPermission.mockResolvedValue({
+        state: CameraPermissionState.Prompt,
+        permissionStatus: {
+          state: CameraPermissionState.Prompt,
+          addEventListener: jest.fn(),
+        } as unknown as PermissionStatus,
+      });
+      const notAllowed = new Error('denied');
+      notAllowed.name = DOMExceptionName.NotAllowed;
+      mockRequestVideoStream.mockRejectedValue(notAllowed);
+      mockIsFirefoxBrowser.mockReturnValue(false);
+
+      renderCameraHook();
+
+      await waitFor(() => {
+        expect(mockSetNeeded).toHaveBeenCalled();
+      });
+    });
+
+    it('calls setBlocked on NotAllowedError when re-queried is prompt on Firefox', async () => {
+      mockCheckStatus.mockResolvedValue({
+        permissions: true,
+        environmentReady: true,
+      });
+      mockQueryCameraPermission.mockResolvedValue({
+        state: CameraPermissionState.Prompt,
+        permissionStatus: {
+          state: CameraPermissionState.Prompt,
+          addEventListener: jest.fn(),
+        } as unknown as PermissionStatus,
+      });
+      const notAllowed = new Error('denied');
+      notAllowed.name = DOMExceptionName.NotAllowed;
+      mockRequestVideoStream.mockRejectedValue(notAllowed);
+      mockIsFirefoxBrowser.mockReturnValue(true);
+
+      renderCameraHook();
+
+      await waitFor(() => {
+        expect(mockSetBlocked).toHaveBeenCalled();
+      });
+    });
+
+    it('calls setError on non-NotAllowedError camera failures', async () => {
+      mockCheckStatus.mockResolvedValue({
+        permissions: true,
+        environmentReady: true,
+      });
+      mockQueryCameraPermission.mockResolvedValue({
+        state: CameraPermissionState.Prompt,
+        permissionStatus: null,
+      });
+      const notReadable = new Error('Could not start video source');
+      notReadable.name = 'NotReadableError';
+      mockRequestVideoStream.mockRejectedValue(notReadable);
+
+      renderCameraHook();
+
+      await waitFor(() => {
+        expect(mockSetError).toHaveBeenCalledWith(notReadable);
+      });
+    });
+  });
+
+  describe('handleCameraAccessNeededContinue', () => {
+    it('tracks CTA click and calls setReady on successful getUserMedia', async () => {
+      mockCheckStatus.mockResolvedValue({
+        permissions: true,
+        environmentReady: true,
+      });
+      mockQueryCameraPermission.mockResolvedValue({
+        state: CameraPermissionState.Prompt,
+        permissionStatus: {
+          state: CameraPermissionState.Prompt,
+          addEventListener: jest.fn(),
+        } as unknown as PermissionStatus,
+      });
+      const notAllowed = new Error('denied');
+      notAllowed.name = DOMExceptionName.NotAllowed;
+      mockRequestVideoStream.mockRejectedValueOnce(notAllowed);
+
+      const { result } = renderCameraHook();
+
+      await waitFor(() => {
+        expect(mockSetNeeded).toHaveBeenCalled();
+      });
+
+      mockRequestVideoStream.mockResolvedValueOnce(mockStream);
+
+      await act(async () => {
+        await result.current.handleCameraAccessNeededContinue();
+      });
+
+      expect(mockTrackCameraRecoveryCtaClicked).toHaveBeenCalled();
+      expect(mockSetPermissionActionLoading).toHaveBeenCalledWith(true);
+      expect(mockSetReady).toHaveBeenCalled();
+      expect(mockSetPermissionActionLoading).toHaveBeenCalledWith(false);
+    });
+
+    it('transitions to blocked when retry still results in NotAllowedError with denied state', async () => {
+      mockCheckStatus.mockResolvedValue({
+        permissions: true,
+        environmentReady: true,
+      });
+      mockQueryCameraPermission.mockResolvedValue({
+        state: CameraPermissionState.Prompt,
+        permissionStatus: {
+          state: CameraPermissionState.Prompt,
+          addEventListener: jest.fn(),
+        } as unknown as PermissionStatus,
+      });
+      const notAllowed = new Error('denied');
+      notAllowed.name = DOMExceptionName.NotAllowed;
+      mockRequestVideoStream.mockRejectedValue(notAllowed);
+      mockIsFirefoxBrowser.mockReturnValue(false);
+
+      const { result } = renderCameraHook();
+
+      await waitFor(() => {
+        expect(mockSetNeeded).toHaveBeenCalled();
+      });
+
+      mockQueryCameraPermission.mockResolvedValueOnce({
+        state: CameraPermissionState.Denied,
+        permissionStatus: {
+          state: CameraPermissionState.Denied,
+          addEventListener: jest.fn(),
+        } as unknown as PermissionStatus,
+      });
+
+      await act(async () => {
+        await result.current.handleCameraAccessNeededContinue();
+      });
+
+      expect(mockSetBlocked).toHaveBeenCalled();
+      expect(mockSetPermissionActionLoading).toHaveBeenCalledWith(false);
+    });
+
+    it('calls setError on non-NotAllowed camera failure', async () => {
+      mockCheckStatus.mockResolvedValue({
+        permissions: true,
+        environmentReady: true,
+      });
+      mockQueryCameraPermission.mockResolvedValue({
+        state: CameraPermissionState.Prompt,
+        permissionStatus: {
+          state: CameraPermissionState.Prompt,
+          addEventListener: jest.fn(),
+        } as unknown as PermissionStatus,
+      });
+      const notAllowed = new Error('denied');
+      notAllowed.name = DOMExceptionName.NotAllowed;
+      mockRequestVideoStream.mockRejectedValueOnce(notAllowed);
+
+      const { result } = renderCameraHook();
+
+      await waitFor(() => {
+        expect(mockSetNeeded).toHaveBeenCalled();
+      });
+
+      const hardwareError = new Error('Camera hardware failure');
+      hardwareError.name = 'NotReadableError';
+      mockRequestVideoStream.mockRejectedValueOnce(hardwareError);
+
+      await act(async () => {
+        await result.current.handleCameraAccessNeededContinue();
+      });
+
+      expect(mockSetError).toHaveBeenCalledWith(hardwareError);
+      expect(mockSetPermissionActionLoading).toHaveBeenCalledWith(false);
+    });
+  });
+
+  describe('handleCameraAccessBlockedContinue', () => {
+    it('tracks CTA click and calls setReady when permission is no longer denied', async () => {
+      mockCheckStatus.mockResolvedValue({
+        permissions: false,
+        environmentReady: true,
+      });
+      mockQueryCameraPermission.mockResolvedValue({
+        state: CameraPermissionState.Denied,
+        permissionStatus: {
+          state: CameraPermissionState.Denied,
+          addEventListener: jest.fn(),
+        } as unknown as PermissionStatus,
+      });
+
+      const { result } = renderCameraHook();
+
+      await waitFor(() => {
+        expect(mockSetBlocked).toHaveBeenCalled();
+      });
+
+      mockQueryCameraPermission.mockResolvedValueOnce({
+        state: CameraPermissionState.Granted,
+        permissionStatus: null,
+      });
+      mockRequestVideoStream.mockResolvedValueOnce(mockStream);
+
+      await act(async () => {
+        await result.current.handleCameraAccessBlockedContinue();
+      });
+
+      expect(mockTrackCameraRecoveryCtaClicked).toHaveBeenCalled();
+      expect(mockSetReady).toHaveBeenCalled();
+      expect(mockSetPermissionActionLoading).toHaveBeenCalledWith(false);
+    });
+
+    it('does not transition when permission is still denied', async () => {
+      mockCheckStatus.mockResolvedValue({
+        permissions: false,
+        environmentReady: true,
+      });
+      mockQueryCameraPermission.mockResolvedValue({
+        state: CameraPermissionState.Denied,
+        permissionStatus: {
+          state: CameraPermissionState.Denied,
+          addEventListener: jest.fn(),
+        } as unknown as PermissionStatus,
+      });
+
+      const { result } = renderCameraHook();
+
+      await waitFor(() => {
+        expect(mockSetBlocked).toHaveBeenCalled();
+      });
+
+      mockSetReady.mockClear();
+
+      await act(async () => {
+        await result.current.handleCameraAccessBlockedContinue();
+      });
+
+      expect(mockSetReady).not.toHaveBeenCalled();
+      expect(mockSetPermissionActionLoading).toHaveBeenCalledWith(false);
+    });
+
+    it('calls setError on non-NotAllowed camera failure after permission changes', async () => {
+      mockCheckStatus.mockResolvedValue({
+        permissions: false,
+        environmentReady: true,
+      });
+      mockQueryCameraPermission.mockResolvedValue({
+        state: CameraPermissionState.Denied,
+        permissionStatus: {
+          state: CameraPermissionState.Denied,
+          addEventListener: jest.fn(),
+        } as unknown as PermissionStatus,
+      });
+
+      const { result } = renderCameraHook();
+
+      await waitFor(() => {
+        expect(mockSetBlocked).toHaveBeenCalled();
+      });
+
+      mockQueryCameraPermission.mockResolvedValueOnce({
+        state: CameraPermissionState.Granted,
+        permissionStatus: null,
+      });
+      const hardwareError = new Error('Camera hardware failure');
+      hardwareError.name = 'NotReadableError';
+      mockRequestVideoStream.mockRejectedValueOnce(hardwareError);
+
+      await act(async () => {
+        await result.current.handleCameraAccessBlockedContinue();
+      });
+
+      expect(mockSetError).toHaveBeenCalledWith(hardwareError);
+      expect(mockSetPermissionActionLoading).toHaveBeenCalledWith(false);
+    });
+  });
+
+  describe('permission change listener', () => {
+    it('auto-recovers when PermissionStatus fires change with granted', async () => {
+      mockCheckStatus.mockResolvedValue({
+        permissions: false,
+        environmentReady: true,
+      });
+
+      let capturedHandler: (() => void) | null = null;
+      const mockPermissionStatus = {
+        state: CameraPermissionState.Denied as PermissionState,
+        addEventListener: jest.fn((_event: string, handler: () => void) => {
+          capturedHandler = handler;
+        }),
+      } as unknown as PermissionStatus;
+
+      mockQueryCameraPermission.mockResolvedValue({
+        state: CameraPermissionState.Denied,
+        permissionStatus: mockPermissionStatus,
+      });
+
+      renderCameraHook();
+
+      await waitFor(() => {
+        expect(mockSetBlocked).toHaveBeenCalled();
+      });
+
+      (mockPermissionStatus as { state: PermissionState }).state =
+        CameraPermissionState.Granted;
+      mockRequestVideoStream.mockResolvedValueOnce(mockStream);
+
+      expect(capturedHandler).not.toBeNull();
+      await act(async () => {
+        (capturedHandler as () => void)();
+      });
+
+      expect(mockSetReady).toHaveBeenCalled();
+    });
+  });
+});

--- a/ui/components/app/qr-hardware-popover/qr-hooks/useCameraPermission.ts
+++ b/ui/components/app/qr-hardware-popover/qr-hooks/useCameraPermission.ts
@@ -97,8 +97,22 @@ export function useCameraPermission(
   } = usePermissionChangeListener();
 
   /**
-   * Proves the camera works by briefly acquiring and releasing a stream,
-   * then transitions to READY. Errors are logged silently.
+   * Probes the camera after an external permission grant, then transitions
+   * to READY on success.
+   *
+   * Wired as the `PermissionStatus.onchange` callback, so the scanner can
+   * auto-recover when the user grants camera access outside our UI
+   * (e.g. browser settings, address-bar permission icon). Without this,
+   * the user would be stuck on the blocked/needed screen even after
+   * granting permission and would have to close and reopen the QR flow.
+   *
+   * A `granted` state alone does not guarantee the hardware is available
+   * (exclusive lock, a device disconnected), so we do a short
+   * `getUserMedia` / `stop` round-trip to confirm the camera can actually
+   * be opened. The stream is released immediately because `EnhancedReader`
+   * opens its own once READY renders.
+   *
+   * On failure the UI stays on the recovery screen and the user can retry.
    */
   const acquireCameraAndTransitionToReady = useCallback(async () => {
     try {

--- a/ui/components/app/qr-hardware-popover/qr-hooks/useCameraPermission.ts
+++ b/ui/components/app/qr-hardware-popover/qr-hooks/useCameraPermission.ts
@@ -1,0 +1,324 @@
+import { useCallback, useEffect, useRef } from 'react';
+import log from 'loglevel';
+import { ENVIRONMENT_TYPE_FULLSCREEN } from '../../../../../shared/constants/app';
+import { getEnvironmentType } from '../../../../../shared/lib/environment-type';
+import { CameraPermissionState } from '../../../../contexts/hardware-wallets/constants';
+import WebcamUtils from '../../../../helpers/utils/webcam-utils';
+import type { WebcamError } from '../base-reader.types';
+import type { StateDispatchers, TrackingCallbacks } from './qr-hooks.types';
+import {
+  shouldShowBlockedUi,
+  isNotAllowedError,
+  extractCurrentRoute,
+} from './qr-hooks-utils';
+
+/**
+ * Manages the `PermissionStatus.change` subscription so the scanner can
+ * transition to READY when the user grants camera access externally.
+ *
+ * @returns An object with `attach` (subscribe to permission changes) and
+ * `cleanup` (unsubscribe and release references).
+ */
+function usePermissionChangeListener() {
+  const permissionStatusRef = useRef<PermissionStatus | null>(null);
+  const handlerRef = useRef<(() => void) | null>(null);
+
+  const cleanup = useCallback(() => {
+    const status = permissionStatusRef.current;
+    const handler = handlerRef.current;
+    if (status && handler) {
+      if (typeof status.removeEventListener === 'function') {
+        status.removeEventListener('change', handler);
+      } else {
+        status.onchange = null;
+      }
+    }
+    permissionStatusRef.current = null;
+    handlerRef.current = null;
+  }, []);
+
+  const attach = useCallback(
+    (permissionStatus: PermissionStatus | null, onGranted: () => void) => {
+      cleanup();
+      if (!permissionStatus) {
+        return;
+      }
+      permissionStatusRef.current = permissionStatus;
+      const handler = () => {
+        if (permissionStatus.state === CameraPermissionState.Granted) {
+          onGranted();
+        }
+      };
+      handlerRef.current = handler;
+      if (typeof permissionStatus.addEventListener === 'function') {
+        permissionStatus.addEventListener('change', handler);
+      } else {
+        permissionStatus.onchange = handler;
+      }
+    },
+    [cleanup],
+  );
+
+  return { attach, cleanup } as const;
+}
+
+/**
+ * Encapsulates the full camera permission lifecycle:
+ * - Environment check (redirect to fullscreen if needed)
+ * - Permission query and classification
+ * - getUserMedia acquisition
+ * - PermissionStatus change listener for auto-recovery
+ * - Continue button handlers for blocked/needed states
+ *
+ * @param dispatchers - State transition dispatchers and current readyState.
+ * @param tracking - MetaMetrics tracking callbacks for CTA click events.
+ * @returns An object with `handleCameraAccessNeededContinue`,
+ * `handleCameraAccessBlockedContinue`, `cleanupPermissionListener`,
+ * and `checkEnvironment`.
+ */
+export function useCameraPermission(
+  dispatchers: StateDispatchers,
+  tracking: TrackingCallbacks,
+) {
+  const {
+    setReady,
+    setBlocked,
+    setNeeded,
+    setError,
+    setPermissionActionLoading,
+  } = dispatchers;
+
+  const { trackCameraRecoveryCtaClicked } = tracking;
+
+  const mountedRef = useRef(false);
+  const {
+    attach: attachPermissionListener,
+    cleanup: cleanupPermissionListener,
+  } = usePermissionChangeListener();
+
+  /**
+   * Proves the camera works by briefly acquiring and releasing a stream,
+   * then transitions to READY. Errors are logged silently.
+   */
+  const acquireCameraAndTransitionToReady = useCallback(async () => {
+    try {
+      const stream = await WebcamUtils.requestVideoStream();
+      WebcamUtils.stopVideoStream(stream);
+      if (mountedRef.current) {
+        cleanupPermissionListener();
+        setReady();
+      }
+    } catch (cameraError) {
+      log.info(
+        'QR camera: could not acquire stream after permission grant',
+        cameraError,
+      );
+    }
+  }, [cleanupPermissionListener, setReady]);
+
+  /**
+   * Re-queries the permission state after a `NotAllowedError` and attaches
+   * a change listener for auto-recovery.
+   *
+   * @returns The current permission state after re-querying.
+   */
+  const reconcileNotAllowedPermission =
+    useCallback(async (): Promise<PermissionState> => {
+      const { state, permissionStatus } =
+        await WebcamUtils.queryCameraPermission();
+      attachPermissionListener(
+        permissionStatus,
+        acquireCameraAndTransitionToReady,
+      );
+      return state;
+    }, [attachPermissionListener, acquireCameraAndTransitionToReady]);
+
+  /**
+   * Classifies a `NotAllowedError` after re-querying the permission state
+   * and dispatches to the appropriate UI (blocked or needed).
+   */
+  const handleNotAllowedError = useCallback(async () => {
+    const nextState = await reconcileNotAllowedPermission();
+    if (!mountedRef.current) {
+      return;
+    }
+    if (shouldShowBlockedUi(nextState)) {
+      setBlocked();
+    } else {
+      setNeeded();
+    }
+  }, [reconcileNotAllowedPermission, setBlocked, setNeeded]);
+
+  /**
+   * Prompts the user for camera access via `getUserMedia`. On success
+   * transitions to READY; on `NotAllowedError` classifies the denial.
+   */
+  const promptForCameraAccess = useCallback(async () => {
+    try {
+      const stream = await WebcamUtils.requestVideoStream();
+      WebcamUtils.stopVideoStream(stream);
+      if (mountedRef.current) {
+        cleanupPermissionListener();
+        setReady();
+      }
+    } catch (cameraError) {
+      if (isNotAllowedError(cameraError)) {
+        await handleNotAllowedError();
+      } else if (mountedRef.current) {
+        setError(cameraError as WebcamError);
+      }
+    }
+  }, [cleanupPermissionListener, setReady, handleNotAllowedError, setError]);
+
+  /**
+   * Initial permission flow. Queries the Permissions API, then dispatches
+   * to the appropriate handler based on the current permission state.
+   */
+  const startCameraPermissionFlow = useCallback(async () => {
+    const { state, permissionStatus } =
+      await WebcamUtils.queryCameraPermission();
+
+    if (state === CameraPermissionState.Denied) {
+      attachPermissionListener(
+        permissionStatus,
+        acquireCameraAndTransitionToReady,
+      );
+      if (mountedRef.current) {
+        setBlocked();
+      }
+      return;
+    }
+
+    if (state === CameraPermissionState.Granted) {
+      if (mountedRef.current) {
+        cleanupPermissionListener();
+        setReady();
+      }
+      return;
+    }
+
+    await promptForCameraAccess();
+  }, [
+    attachPermissionListener,
+    acquireCameraAndTransitionToReady,
+    cleanupPermissionListener,
+    setReady,
+    setBlocked,
+    promptForCameraAccess,
+  ]);
+
+  /**
+   * Ensures the extension runs in a context capable of prompting for camera
+   * access. Popup/side-panel environments redirect to a fullscreen tab.
+   */
+  const checkEnvironment = useCallback(async () => {
+    try {
+      const { environmentReady } = await WebcamUtils.checkStatus();
+      if (
+        !environmentReady &&
+        getEnvironmentType() !== ENVIRONMENT_TYPE_FULLSCREEN
+      ) {
+        globalThis.platform.openExtensionInBrowser(extractCurrentRoute());
+        return;
+      }
+    } catch (environmentError) {
+      if (mountedRef.current) {
+        setError(environmentError as WebcamError);
+      }
+      return;
+    }
+    await startCameraPermissionFlow();
+  }, [startCameraPermissionFlow, setError]);
+
+  /**
+   * Handler for the "needed" (prompt-dismissed) Continue button.
+   * Re-requests camera access via `getUserMedia`.
+   */
+  const handleCameraAccessNeededContinue = useCallback(async () => {
+    trackCameraRecoveryCtaClicked();
+    setPermissionActionLoading(true);
+    try {
+      const stream = await WebcamUtils.requestVideoStream();
+      WebcamUtils.stopVideoStream(stream);
+      if (mountedRef.current) {
+        cleanupPermissionListener();
+        setReady();
+      }
+    } catch (cameraError) {
+      if (isNotAllowedError(cameraError)) {
+        const nextState = await reconcileNotAllowedPermission();
+        if (mountedRef.current && shouldShowBlockedUi(nextState)) {
+          setBlocked();
+        }
+      } else if (mountedRef.current) {
+        setError(cameraError as WebcamError);
+      }
+    } finally {
+      if (mountedRef.current) {
+        setPermissionActionLoading(false);
+      }
+    }
+  }, [
+    trackCameraRecoveryCtaClicked,
+    setPermissionActionLoading,
+    cleanupPermissionListener,
+    setReady,
+    reconcileNotAllowedPermission,
+    setBlocked,
+    setError,
+  ]);
+
+  /**
+   * Handler for the "blocked" Continue button. Re-checks the permission
+   * state; if no longer denied, acquires the camera.
+   */
+  const handleCameraAccessBlockedContinue = useCallback(async () => {
+    trackCameraRecoveryCtaClicked();
+    setPermissionActionLoading(true);
+    try {
+      const { state } = await WebcamUtils.queryCameraPermission();
+      if (state === CameraPermissionState.Denied) {
+        return;
+      }
+      const stream = await WebcamUtils.requestVideoStream();
+      WebcamUtils.stopVideoStream(stream);
+      if (mountedRef.current) {
+        cleanupPermissionListener();
+        setReady();
+      }
+    } catch (cameraError) {
+      if (isNotAllowedError(cameraError)) {
+        await reconcileNotAllowedPermission();
+      } else if (mountedRef.current) {
+        setError(cameraError as WebcamError);
+      }
+    } finally {
+      if (mountedRef.current) {
+        setPermissionActionLoading(false);
+      }
+    }
+  }, [
+    trackCameraRecoveryCtaClicked,
+    setPermissionActionLoading,
+    cleanupPermissionListener,
+    setReady,
+    reconcileNotAllowedPermission,
+    setError,
+  ]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    checkEnvironment();
+    return () => {
+      mountedRef.current = false;
+      cleanupPermissionListener();
+    };
+  }, [checkEnvironment, cleanupPermissionListener]);
+
+  return {
+    handleCameraAccessNeededContinue,
+    handleCameraAccessBlockedContinue,
+    cleanupPermissionListener,
+    checkEnvironment,
+  } as const;
+}

--- a/ui/components/app/qr-hardware-popover/qr-hooks/useDecoderLifecycle.test.ts
+++ b/ui/components/app/qr-hardware-popover/qr-hooks/useDecoderLifecycle.test.ts
@@ -1,0 +1,341 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { URDecoder } from '@ngraveio/bc-ur';
+import { useDecoderLifecycle } from './useDecoderLifecycle';
+
+jest.mock('@ngraveio/bc-ur', () => {
+  const actual = jest.requireActual('@ngraveio/bc-ur');
+  return {
+    ...actual,
+    URDecoder: jest.fn().mockImplementation(() => ({
+      isComplete: jest.fn().mockReturnValue(false),
+      receivePart: jest.fn(),
+      estimatedPercentComplete: jest.fn().mockReturnValue(0),
+      resultUR: jest.fn(),
+    })),
+  };
+});
+
+const mockURDecoder = jest.mocked(URDecoder);
+
+describe('useDecoderLifecycle', () => {
+  const mockHandleSuccess = jest.fn().mockResolvedValue(undefined);
+  const mockSetErrorTitle = jest.fn();
+  const mockSetScanProgress = jest.fn();
+  const mockSetError = jest.fn();
+  const mockT = jest.fn((key: string) => key);
+
+  const defaultProps = {
+    handleSuccess: mockHandleSuccess,
+    isReadingWallet: true,
+    setErrorTitle: mockSetErrorTitle,
+  };
+
+  const defaultCallbacks = {
+    setScanProgress: mockSetScanProgress,
+    setError: mockSetError,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function renderDecoderHook(
+    props = defaultProps,
+    callbacks = defaultCallbacks,
+  ) {
+    return renderHook(() => useDecoderLifecycle(props, callbacks, mockT));
+  }
+
+  describe('handleScan', () => {
+    it('ignores null data', () => {
+      const { result } = renderDecoderHook();
+
+      act(() => {
+        result.current.handleScan(null);
+      });
+
+      expect(mockSetScanProgress).not.toHaveBeenCalled();
+    });
+
+    it('ignores empty string data', () => {
+      const { result } = renderDecoderHook();
+
+      act(() => {
+        result.current.handleScan('');
+      });
+
+      expect(mockSetScanProgress).not.toHaveBeenCalled();
+    });
+
+    it('feeds data into the decoder and updates progress', () => {
+      const mockInstance = {
+        isComplete: jest.fn().mockReturnValue(false),
+        receivePart: jest.fn(),
+        estimatedPercentComplete: jest.fn().mockReturnValue(0.5),
+        resultUR: jest.fn(),
+      };
+      mockURDecoder.mockImplementation(
+        () => mockInstance as unknown as URDecoder,
+      );
+
+      const { result } = renderDecoderHook();
+
+      act(() => {
+        result.current.handleScan('UR:CRYPTO-HDKEY/1-2/some-data');
+      });
+
+      expect(mockInstance.receivePart).toHaveBeenCalledWith(
+        'UR:CRYPTO-HDKEY/1-2/some-data',
+      );
+      expect(mockSetScanProgress).toHaveBeenCalledWith(0.5);
+    });
+
+    it('calls handleSuccess when decoder completes', () => {
+      const mockResult = { type: 'crypto-hdkey' };
+      const mockInstance = {
+        isComplete: jest
+          .fn()
+          .mockReturnValueOnce(false)
+          .mockReturnValueOnce(true),
+        receivePart: jest.fn(),
+        estimatedPercentComplete: jest.fn().mockReturnValue(1),
+        resultUR: jest.fn().mockReturnValue(mockResult),
+      };
+      mockURDecoder.mockImplementation(
+        () => mockInstance as unknown as URDecoder,
+      );
+
+      const { result } = renderDecoderHook();
+
+      act(() => {
+        result.current.handleScan('final-frame');
+      });
+
+      expect(mockHandleSuccess).toHaveBeenCalledWith(mockResult);
+    });
+
+    it('does not process data when decoder is already complete', () => {
+      const mockInstance = {
+        isComplete: jest.fn().mockReturnValue(true),
+        receivePart: jest.fn(),
+        estimatedPercentComplete: jest.fn(),
+        resultUR: jest.fn(),
+      };
+      mockURDecoder.mockImplementation(
+        () => mockInstance as unknown as URDecoder,
+      );
+
+      const { result } = renderDecoderHook();
+
+      act(() => {
+        result.current.handleScan('extra-frame');
+      });
+
+      expect(mockInstance.receivePart).not.toHaveBeenCalled();
+    });
+
+    it('sets wallet error title when scan throws and isReadingWallet is true', () => {
+      const mockInstance = {
+        isComplete: jest.fn().mockReturnValue(false),
+        receivePart: jest.fn().mockImplementation(() => {
+          throw new Error('invalid payload');
+        }),
+        estimatedPercentComplete: jest.fn(),
+        resultUR: jest.fn(),
+      };
+      mockURDecoder.mockImplementation(
+        () => mockInstance as unknown as URDecoder,
+      );
+
+      const { result } = renderDecoderHook({
+        ...defaultProps,
+        isReadingWallet: true,
+      });
+
+      act(() => {
+        result.current.handleScan('bad-data');
+      });
+
+      expect(mockSetErrorTitle).toHaveBeenCalledWith(
+        'QRHardwareUnknownQRCodeTitle',
+      );
+      expect(mockSetError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'unknownQrCode' }),
+      );
+    });
+
+    it('sets transaction error title when scan throws and isReadingWallet is false', () => {
+      const mockInstance = {
+        isComplete: jest.fn().mockReturnValue(false),
+        receivePart: jest.fn().mockImplementation(() => {
+          throw new Error('invalid payload');
+        }),
+        estimatedPercentComplete: jest.fn(),
+        resultUR: jest.fn(),
+      };
+      mockURDecoder.mockImplementation(
+        () => mockInstance as unknown as URDecoder,
+      );
+
+      const { result } = renderDecoderHook({
+        ...defaultProps,
+        isReadingWallet: false,
+      });
+
+      act(() => {
+        result.current.handleScan('bad-data');
+      });
+
+      expect(mockSetErrorTitle).toHaveBeenCalledWith(
+        'QRHardwareInvalidTransactionTitle',
+      );
+    });
+
+    it('calls setError when handleSuccess rejects', async () => {
+      const rejectError = new Error('processing failed');
+      const mockInstance = {
+        isComplete: jest
+          .fn()
+          .mockReturnValueOnce(false)
+          .mockReturnValueOnce(true),
+        receivePart: jest.fn(),
+        estimatedPercentComplete: jest.fn().mockReturnValue(1),
+        resultUR: jest.fn().mockReturnValue({ type: 'crypto-hdkey' }),
+      };
+      mockURDecoder.mockImplementation(
+        () => mockInstance as unknown as URDecoder,
+      );
+
+      const failingHandleSuccess = jest.fn().mockRejectedValue(rejectError);
+      const { result } = renderDecoderHook({
+        ...defaultProps,
+        handleSuccess: failingHandleSuccess,
+      });
+
+      act(() => {
+        result.current.handleScan('final-frame');
+      });
+
+      await new Promise(process.nextTick);
+      expect(mockSetError).toHaveBeenCalledWith(rejectError);
+    });
+  });
+
+  describe('lazy decoder initialization', () => {
+    it('constructs URDecoder only once across multiple handleScan calls', () => {
+      const mockInstance = {
+        isComplete: jest.fn().mockReturnValue(false),
+        receivePart: jest.fn(),
+        estimatedPercentComplete: jest.fn().mockReturnValue(0),
+        resultUR: jest.fn(),
+      };
+      mockURDecoder.mockImplementation(
+        () => mockInstance as unknown as URDecoder,
+      );
+
+      const { result } = renderDecoderHook();
+
+      act(() => {
+        result.current.handleScan('frame-1');
+        result.current.handleScan('frame-2');
+        result.current.handleScan('frame-3');
+      });
+
+      expect(mockURDecoder).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not construct URDecoder until first handleScan call', () => {
+      mockURDecoder.mockImplementation(
+        () =>
+          ({
+            isComplete: jest.fn().mockReturnValue(false),
+            receivePart: jest.fn(),
+            estimatedPercentComplete: jest.fn().mockReturnValue(0),
+            resultUR: jest.fn(),
+          }) as unknown as URDecoder,
+      );
+
+      renderDecoderHook();
+
+      expect(mockURDecoder).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('resetDecoder', () => {
+    it('resets progress to zero', () => {
+      const { result } = renderDecoderHook();
+
+      act(() => {
+        result.current.resetDecoder();
+      });
+
+      expect(mockSetScanProgress).toHaveBeenCalledWith(0);
+    });
+
+    it('creates a fresh decoder so subsequent scans start from scratch', () => {
+      const completedInstance = {
+        isComplete: jest.fn().mockReturnValue(true),
+        receivePart: jest.fn(),
+        estimatedPercentComplete: jest.fn().mockReturnValue(1),
+        resultUR: jest.fn(),
+      };
+      const freshInstance = {
+        isComplete: jest.fn().mockReturnValue(false),
+        receivePart: jest.fn(),
+        estimatedPercentComplete: jest.fn().mockReturnValue(0),
+        resultUR: jest.fn(),
+      };
+
+      mockURDecoder
+        .mockImplementationOnce(() => completedInstance as unknown as URDecoder)
+        .mockImplementationOnce(() => freshInstance as unknown as URDecoder);
+
+      const { result } = renderDecoderHook();
+
+      act(() => {
+        result.current.handleScan('data-after-complete');
+      });
+      expect(completedInstance.receivePart).not.toHaveBeenCalled();
+
+      act(() => {
+        result.current.resetDecoder();
+      });
+
+      act(() => {
+        result.current.handleScan('new-scan-data');
+      });
+      expect(freshInstance.receivePart).toHaveBeenCalledWith('new-scan-data');
+    });
+  });
+
+  describe('multi-frame scanning', () => {
+    it('accumulates progress across multiple scan calls', () => {
+      const mockInstance = {
+        isComplete: jest.fn().mockReturnValue(false),
+        receivePart: jest.fn(),
+        estimatedPercentComplete: jest
+          .fn()
+          .mockReturnValueOnce(0.25)
+          .mockReturnValueOnce(0.5)
+          .mockReturnValueOnce(0.75),
+        resultUR: jest.fn(),
+      };
+      mockURDecoder.mockImplementation(
+        () => mockInstance as unknown as URDecoder,
+      );
+
+      const { result } = renderDecoderHook();
+
+      act(() => {
+        result.current.handleScan('frame-1');
+        result.current.handleScan('frame-2');
+        result.current.handleScan('frame-3');
+      });
+
+      expect(mockInstance.receivePart).toHaveBeenCalledTimes(3);
+      expect(mockSetScanProgress).toHaveBeenCalledWith(0.25);
+      expect(mockSetScanProgress).toHaveBeenCalledWith(0.5);
+      expect(mockSetScanProgress).toHaveBeenCalledWith(0.75);
+    });
+  });
+});

--- a/ui/components/app/qr-hardware-popover/qr-hooks/useDecoderLifecycle.ts
+++ b/ui/components/app/qr-hardware-popover/qr-hooks/useDecoderLifecycle.ts
@@ -1,5 +1,6 @@
 import { useCallback, useRef } from 'react';
 import { URDecoder } from '@ngraveio/bc-ur';
+import type { useI18nContext } from '../../../../hooks/useI18nContext';
 import type { BaseReaderProps, WebcamError } from '../base-reader.types';
 import type { DecoderCallbacks } from './qr-hooks.types';
 
@@ -24,7 +25,7 @@ export function useDecoderLifecycle(
     'handleSuccess' | 'isReadingWallet' | 'setErrorTitle'
   >,
   callbacks: DecoderCallbacks,
-  t: (...args: string[]) => string,
+  t: ReturnType<typeof useI18nContext>,
 ) {
   const { handleSuccess, isReadingWallet, setErrorTitle } = props;
   const { setScanProgress, setError } = callbacks;

--- a/ui/components/app/qr-hardware-popover/qr-hooks/useDecoderLifecycle.ts
+++ b/ui/components/app/qr-hardware-popover/qr-hooks/useDecoderLifecycle.ts
@@ -1,0 +1,99 @@
+import { useCallback, useRef } from 'react';
+import { URDecoder } from '@ngraveio/bc-ur';
+import type { BaseReaderProps, WebcamError } from '../base-reader.types';
+import type { DecoderCallbacks } from './qr-hooks.types';
+
+/**
+ * Manages the URDecoder lifecycle: creating, receiving parts, tracking
+ * progress, and forwarding complete URs to the parent handler.
+ *
+ * The decoder is stored in a ref rather than state because its internal
+ * mutation (receivePart) shouldn't trigger re-renders — only the derived
+ * `scanProgress` needs to update the UI.
+ *
+ * @param props - Subset of BaseReader props needed for decoding:
+ * `handleSuccess`, `isReadingWallet`, and `setErrorTitle`.
+ * @param callbacks - State dispatchers: `setScanProgress` and `setError`.
+ * @param t - i18n translation function used for error messages.
+ * @returns An object with `handleScan` (feed QR frames) and `resetDecoder`
+ * (reinitialize the decoder for retry flows).
+ */
+export function useDecoderLifecycle(
+  props: Pick<
+    BaseReaderProps,
+    'handleSuccess' | 'isReadingWallet' | 'setErrorTitle'
+  >,
+  callbacks: DecoderCallbacks,
+  t: (...args: string[]) => string,
+) {
+  const { handleSuccess, isReadingWallet, setErrorTitle } = props;
+  const { setScanProgress, setError } = callbacks;
+  const decoderRef = useRef<URDecoder | null>(null);
+
+  /**
+   * Lazy-init accessor for the URDecoder ref.
+   *
+   * Constructs the decoder on first access and returns the same instance on
+   * subsequent calls, avoiding wasteful instantiation on every render while
+   * providing a guaranteed non-null return type to callers.
+   *
+   * @returns The current URDecoder instance (created if not yet initialized).
+   */
+  function getDecoder(): URDecoder {
+    if (decoderRef.current === null) {
+      decoderRef.current = new URDecoder();
+    }
+    return decoderRef.current;
+  }
+
+  /**
+   * Resets the decoder to a fresh instance and clears scan progress.
+   * Used when retrying after an error.
+   */
+  const resetDecoder = useCallback(() => {
+    decoderRef.current = new URDecoder();
+    setScanProgress(0);
+  }, [setScanProgress]);
+
+  /**
+   * Feeds a scanned QR payload into the URDecoder. When the UR is fully
+   * assembled, invokes `handleSuccess` with the decoded result.
+   *
+   * @param data - Raw text content of a single scanned QR frame, or null.
+   */
+  const handleScan = useCallback(
+    (data: string | null) => {
+      try {
+        const decoder = getDecoder();
+        if (!data || decoder.isComplete()) {
+          return;
+        }
+        decoder.receivePart(data);
+        setScanProgress(decoder.estimatedPercentComplete());
+        if (decoder.isComplete()) {
+          const result = decoder.resultUR();
+          handleSuccess(result).catch((successError: WebcamError) =>
+            setError(successError),
+          );
+        }
+      } catch {
+        if (isReadingWallet) {
+          setErrorTitle(t('QRHardwareUnknownQRCodeTitle'));
+        } else {
+          setErrorTitle(t('QRHardwareInvalidTransactionTitle'));
+        }
+        setError(new Error(t('unknownQrCode')));
+      }
+    },
+    [
+      handleSuccess,
+      isReadingWallet,
+      setErrorTitle,
+      t,
+      setScanProgress,
+      setError,
+    ],
+  );
+
+  return { handleScan, resetDecoder } as const;
+}


### PR DESCRIPTION
## **Description**
This PR is introducing refactoring of the base reader component which is used for QR code scanning in QR hardware wallet flows.

## **Summary of the refactoring changes**
What | Why
-- | --
Extracted useBaseReaderReducer hook with a pure reducer | Separates state machine logic from the component, making it independently testable without rendering.
Extracted useDecoderLifecycle hook | Encapsulates URDecoder lifecycle (creation, frame ingestion, progress, completion) with lazy initialization to avoid wasteful per-render instantiation.
Extracted useCameraPermission hook | Owns the full camera permission flow: environment check, permission query, getUserMedia, PermissionStatus change listener, and Continue handlers.
Extracted pure utility functions into qr-hooks-utils.ts | Reduces hook complexity by pulling out reusable logic that was duplicated inline in multiple places.
Refactored BaseReader to render-only TSX | All state management, decoder logic, and camera permission flows are delegated to hooks. The component itself only wires hooks together, handles MetaMetrics tracking, and renders.
Migrated JSX to Box/Text from @metamask/design-system-react | Aligns with project convention. Trimmed corresponding SCSS rules that are now handled by design system component props.
Added dedicated type files for hooks and component | Centralizes shared types and constants, improving discoverability and reducing inline duplication.
Organized hooks into qr-hooks/ subfolder with barrel export | Groups all QR-related hooks, types, and utilities with a single import point.
Added 114 unit tests across 8 suites | Every extracted module has its own atomic test file covering core behavior and edge cases.

## **Changelog**
<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->
CHANGELOG entry: null

## **Related issues**
Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1765

## **Manual testing steps**
1. Test QR hardware wallet flows and make sure it works in Firefox and Chrome (onboard hardware wallet, send, swap, etc).

## **Screenshots/Recordings**

### **Before**
<img width="833" height="1011" alt="image" src="https://github.com/user-attachments/assets/8c2ef5f5-6e65-4d69-8617-25375e16d99f" />

### **After**
No UI changes, just confirming that reader is the same as before.
<img width="833" height="1011" alt="Screenshot 2026-05-12 at 19 17 15" src="https://github.com/user-attachments/assets/b7e62f29-55bd-4d13-811d-ba8a701c1cfb" />

## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors the QR hardware wallet scanner’s camera permission and decoding flow into new hooks/reducer, which could affect environment redirects and permission-state transitions despite added test coverage.
> 
> **Overview**
> Refactors `BaseReader` for QR hardware wallet scanning by extracting its state machine into a pure reducer (`base-reader-reducer`) and splitting camera permission handling and UR decoding into dedicated hooks under `qr-hooks/`.
> 
> Updates the component to be mostly render/wiring logic, standardizes error/DOM exception discriminants (`WebcamErrorType`, `DOMExceptionName`), and migrates UI structure to `@metamask/design-system-react`, trimming now-unused QR scanner SCSS.
> 
> Adds extensive unit tests for the new reducer/hooks/utilities and updates existing `BaseReader` tests to use shared permission/error constants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fb5851e9b2d4a80ee54a0105df98db05c562e2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->