### PR TITLE
ci: Fix TypeScript migration dashboard deployment

### DIFF
--- a/.github/workflows/build-ts-migration-dashboard.yml
+++ b/.github/workflows/build-ts-migration-dashboard.yml
@@ -10,6 +10,7 @@ jobs:
   build-ts-migration-dashboard:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    environment: ${{ github.ref_name == 'main' && 'default-branch' || null }}
     env:
       # For a `pull_request` event, the branch is `github.head_ref``.
       # For a `push` event, the branch is `github.ref_name`.


### PR DESCRIPTION
## **Description**

The TypeScript migration dashboard deployment recently began failing due to an expired token. This token will be replaced with a new token scoped to the `default-branch` environment, which requires this 1-line change to the workflow to access.

## **Changelog**

N/A

## **Related issues**

The new token is configured here: https://github.com/MetaMask/patroll/pull/84

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
