### PR TITLE
fix: musd duplicate toast cp-13.31.0

### DIFF
--- a/ui/helpers/constants/transactions.js
+++ b/ui/helpers/constants/transactions.js
@@ -37,6 +37,7 @@ export const TOAST_EXCLUDED_TRANSACTION_TYPES = new Set([
   TransactionType.shieldSubscriptionApprove,
   TransactionType.musdConversion,
   TransactionType.musdClaim,
+  TransactionType.musdRelayDeposit,
   TransactionType.perpsDeposit,
   TransactionType.perpsDepositAndOrder,
   TransactionType.perpsWithdraw,

--- a/ui/selectors/toast.test.ts
+++ b/ui/selectors/toast.test.ts
@@ -89,9 +89,10 @@ describe('toast selectors', () => {
               time: 7,
               type: TransactionType.shieldSubscriptionApprove,
             },
-            { id: '7', time: 8, type: TransactionType.perpsDeposit },
-            { id: '8', time: 9, type: TransactionType.perpsDepositAndOrder },
-            { id: '9', time: 10, type: TransactionType.perpsRelayDeposit },
+            { id: '7', time: 8, type: TransactionType.musdRelayDeposit },
+            { id: '8', time: 9, type: TransactionType.perpsDeposit },
+            { id: '9', time: 10, type: TransactionType.perpsDepositAndOrder },
+            { id: '10', time: 11, type: TransactionType.perpsRelayDeposit },
           ],
         },
       } as unknown as SelectorState;
@@ -451,6 +452,32 @@ describe('toast selectors', () => {
                 { type: TransactionType.tokenMethodApprove },
                 { type: TransactionType.musdRelayDeposit },
               ],
+            },
+          ],
+        },
+      } as unknown as SelectorState;
+
+      expect(selectSmartTransactions(state)).toStrictEqual([]);
+    });
+
+    it('excludes smart transaction toasts for top-level mUSD relay deposits', () => {
+      const state = {
+        metamask: {
+          pendingApprovals: {
+            'approval-1': {
+              id: 'approval-1',
+              type: 'smartTransaction:showSmartTransactionStatusPage',
+              requestState: {
+                txId: 'tx-1',
+                smartTransaction: { status: 'pending' },
+              },
+            },
+          },
+          transactions: [
+            {
+              id: 'tx-1',
+              status: 'submitted',
+              type: TransactionType.musdRelayDeposit,
             },
           ],
         },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes duplicate mUSD conversion toasts by excluding top-level musdRelayDeposit transactions from the generic ToastListener flow

Longer term solution is to expand transaction toasts and not have mUSD have its custom implementation.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/42570

## **Manual testing steps**

1. Have stable coins on Ethereum Mainnet
2. Convert to mUSD from the Tokens list

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates toast-eligibility filtering for a single transaction type and adds/adjusts unit tests; main impact is potential UX change in which toasts are suppressed.
> 
> **Overview**
> Prevents duplicate mUSD-related toasts by adding `TransactionType.musdRelayDeposit` to `TOAST_EXCLUDED_TRANSACTION_TYPES`, so top-level mUSD relay deposit transactions are filtered out of the generic toast flow.
> 
> Updates `toast` selector tests to cover this exclusion, including a new case ensuring `selectSmartTransactions` does not emit smart-transaction toasts for top-level `musdRelayDeposit` transactions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 880d2b0ab013c63db7fdac0efdfedbc883147152. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->