### PR TITLE
fix(perps): adjust market filter modal design to match Figma

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -6247,11 +6247,14 @@
   "perpsSortByPriceChange": {
     "message": "Price change"
   },
+  "perpsSortByRank": {
+    "message": "Rank"
+  },
   "perpsSortBySection": {
     "message": "Sort by"
   },
   "perpsSortByTitle": {
-    "message": "Sort"
+    "message": "Filter"
   },
   "perpsSortByVolume": {
     "message": "Volume"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -6247,11 +6247,14 @@
   "perpsSortByPriceChange": {
     "message": "Price change"
   },
+  "perpsSortByRank": {
+    "message": "Rank"
+  },
   "perpsSortBySection": {
     "message": "Sort by"
   },
   "perpsSortByTitle": {
-    "message": "Sort"
+    "message": "Filter"
   },
   "perpsSortByVolume": {
     "message": "Volume"

--- a/ui/pages/perps/market-list/components/dropdown/dropdown.tsx
+++ b/ui/pages/perps/market-list/components/dropdown/dropdown.tsx
@@ -186,39 +186,40 @@ export const Dropdown = <OptionId extends string>({
           }
           data-testid={`${testId}-menu`}
         >
-          {options.map((option, index) => (
-            <ButtonBase
-              key={option.id}
-              ref={(el) => {
-                optionRefs.current[index] = el;
-              }}
-              onClick={() => handleSelect(option)}
-              onKeyDown={(e) => handleOptionKeyDown(e, index)}
-              className="w-full justify-between text-left rounded-none px-3 py-2 bg-transparent min-w-0 h-auto hover:bg-hover active:bg-pressed"
-              role="option"
-              aria-selected={option.id === selectedId}
-              id={`${testId}-option-${option.id}`}
-              data-testid={`${testId}-option-${option.id}`}
-            >
-              <Text
-                variant={TextVariant.BodySm}
-                color={
-                  option.id === selectedId
-                    ? TextColor.TextDefault
-                    : TextColor.TextAlternative
-                }
+          {options.map((option, index) => {
+            const isSelected = option.id === selectedId;
+            return (
+              <ButtonBase
+                key={option.id}
+                ref={(el) => {
+                  optionRefs.current[index] = el;
+                }}
+                onClick={() => handleSelect(option)}
+                onKeyDown={(e) => handleOptionKeyDown(e, index)}
+                className={`w-full justify-between text-left rounded-none px-3 py-2 min-w-0 h-auto active:bg-pressed ${
+                  isSelected ? 'bg-hover' : 'bg-transparent hover:bg-hover'
+                }`}
+                role="option"
+                aria-selected={isSelected}
+                id={`${testId}-option-${option.id}`}
+                data-testid={`${testId}-option-${option.id}`}
               >
-                {option.label}
-              </Text>
-              {option.id === selectedId && (
-                <Icon
-                  name={IconName.Check}
-                  size={IconSize.Sm}
-                  color={IconColor.IconDefault}
-                />
-              )}
-            </ButtonBase>
-          ))}
+                <Text
+                  variant={TextVariant.BodySm}
+                  color={TextColor.TextDefault}
+                >
+                  {option.label}
+                </Text>
+                {isSelected && (
+                  <Icon
+                    name={IconName.Check}
+                    size={IconSize.Sm}
+                    color={IconColor.IconDefault}
+                  />
+                )}
+              </ButtonBase>
+            );
+          })}
         </Box>
       )}
     </Box>

--- a/ui/pages/perps/market-list/components/sort-dropdown/sort-dropdown.tsx
+++ b/ui/pages/perps/market-list/components/sort-dropdown/sort-dropdown.tsx
@@ -133,10 +133,7 @@ export const SortDropdown: React.FC<SortDropdownProps> = ({
             </Box>
 
             {/* Sort field options */}
-            <Box
-              flexDirection={BoxFlexDirection.Column}
-              className="w-full"
-            >
+            <Box flexDirection={BoxFlexDirection.Column} className="w-full">
               {SORT_FIELD_OPTIONS.map((option, index) => {
                 const isSelected = pendingField === option.id;
                 const isLast = index === SORT_FIELD_OPTIONS.length - 1;
@@ -180,10 +177,7 @@ export const SortDropdown: React.FC<SortDropdownProps> = ({
             </Box>
 
             {/* Sort direction options */}
-            <Box
-              flexDirection={BoxFlexDirection.Column}
-              className="w-full"
-            >
+            <Box flexDirection={BoxFlexDirection.Column} className="w-full">
               {(
                 [
                   { value: 'desc' as const, labelKey: 'perpsSortByHighToLow' },

--- a/ui/pages/perps/market-list/components/sort-dropdown/sort-dropdown.tsx
+++ b/ui/pages/perps/market-list/components/sort-dropdown/sort-dropdown.tsx
@@ -117,30 +117,42 @@ export const SortDropdown: React.FC<SortDropdownProps> = ({
         <ModalOverlay />
         <ModalContent size={ModalContentSize.Sm}>
           <ModalHeader onClose={handleClose}>
-            <Text variant={TextVariant.HeadingSm} fontWeight={FontWeight.Bold}>
-              {t('perpsSortByTitle')}
-            </Text>
+            {t('perpsSortByTitle')}
           </ModalHeader>
 
-          <ModalBody>
+          <ModalBody className="!p-0">
+            {/* "SORT BY" section header */}
+            <Box className="w-full px-4 pb-3">
+              <Text
+                variant={TextVariant.BodyXs}
+                color={TextColor.TextAlternative}
+                className="uppercase tracking-wide"
+              >
+                {t('perpsSortBySection')}
+              </Text>
+            </Box>
+
             {/* Sort field options */}
-            <Box flexDirection={BoxFlexDirection.Column}>
-              {SORT_FIELD_OPTIONS.map((option) => {
+            <Box
+              flexDirection={BoxFlexDirection.Column}
+              className="w-full"
+            >
+              {SORT_FIELD_OPTIONS.map((option, index) => {
                 const isSelected = pendingField === option.id;
+                const isLast = index === SORT_FIELD_OPTIONS.length - 1;
                 return (
                   <ButtonBase
                     key={option.id}
                     onClick={() => setPendingField(option.id)}
-                    className="w-full justify-between text-left rounded-none px-0 py-3 bg-transparent min-w-0 h-auto hover:bg-hover active:bg-pressed border-b border-border-muted last:border-b-0"
+                    className={`w-full justify-between text-left rounded-none px-4 min-w-0 h-[46px] active:bg-pressed ${
+                      isSelected ? 'bg-hover' : 'bg-transparent hover:bg-hover'
+                    } ${isLast ? 'border-b border-border-muted' : ''}`}
                     data-testid={`sort-field-option-${option.id}`}
                   >
                     <Text
                       variant={TextVariant.BodyMd}
-                      color={
-                        isSelected
-                          ? TextColor.TextDefault
-                          : TextColor.TextAlternative
-                      }
+                      color={TextColor.TextDefault}
+                      fontWeight={FontWeight.Medium}
                     >
                       {t(option.labelKey)}
                     </Text>
@@ -156,16 +168,22 @@ export const SortDropdown: React.FC<SortDropdownProps> = ({
               })}
             </Box>
 
-            {/* Sort direction section */}
-            <Box className="mt-4" flexDirection={BoxFlexDirection.Column}>
+            {/* "RANK" section header */}
+            <Box className="w-full px-4 pb-3 pt-5">
               <Text
-                variant={TextVariant.BodySm}
+                variant={TextVariant.BodyXs}
                 color={TextColor.TextAlternative}
-                className="mb-2 uppercase tracking-wide"
+                className="uppercase tracking-wide"
               >
-                {t('perpsSortBySection')}
+                {t('perpsSortByRank')}
               </Text>
+            </Box>
 
+            {/* Sort direction options */}
+            <Box
+              flexDirection={BoxFlexDirection.Column}
+              className="w-full"
+            >
               {(
                 [
                   { value: 'desc' as const, labelKey: 'perpsSortByHighToLow' },
@@ -177,16 +195,15 @@ export const SortDropdown: React.FC<SortDropdownProps> = ({
                   <ButtonBase
                     key={value}
                     onClick={() => setPendingDirection(value)}
-                    className="w-full justify-between text-left rounded-none px-0 py-3 bg-transparent min-w-0 h-auto hover:bg-hover active:bg-pressed border-b border-border-muted last:border-b-0"
+                    className={`w-full justify-between text-left rounded-none px-4 min-w-0 h-[46px] active:bg-pressed ${
+                      isSelected ? 'bg-hover' : 'bg-transparent hover:bg-hover'
+                    }`}
                     data-testid={`sort-direction-${value}`}
                   >
                     <Text
                       variant={TextVariant.BodyMd}
-                      color={
-                        isSelected
-                          ? TextColor.TextDefault
-                          : TextColor.TextAlternative
-                      }
+                      color={TextColor.TextDefault}
+                      fontWeight={FontWeight.Medium}
                     >
                       {t(labelKey)}
                     </Text>


### PR DESCRIPTION
## **Description**

The Perps market filter/sort modal and dropdown components did not match the Figma design. The sort hierarchy was hard to read (no section headers, items differentiated only by text color), and the selected state used a blue accent instead of a grey background.

This PR updates the components to match the [Figma spec](https://www.figma.com/design/Jp8owZibGXg26diIjDjVuq/Mobile-Perps?node-id=16461-7219):

- **SortDropdown modal**: Added "SORT BY" and "RANK" section headers (uppercase, grey, BodyXs) to clearly separate the two sections. Changed the modal title from "Sort" to "Filter" and passed it as a plain string so `ModalHeader` auto-centers it. Selected items now show a grey background (`bg-hover`) instead of text color changes. Items use consistent `TextDefault` color with `FontWeight.Medium`. Section divider border only between the two groups. Full-width clickable areas with 46px height.
- **Dropdown (FilterSelect)**: Selected options now use a grey background highlight (`bg-hover`) instead of text color differentiation. All option text uses `TextDefault` consistently.

## **Changelog**

CHANGELOG entry: Adjusted Perps market filter modal design to improve sort hierarchy readability and use correct grey selected state

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3020

## **Manual testing steps**

Feature: Perps Market Filter Modal

Scenario: Sort hierarchy is clearly readable
  Given the user is on the Perps Markets list page
  When the user taps the sort/filter button
  Then the modal title shows "Filter" centered
  And the modal displays a "SORT BY" section header above the sort field options
  And the modal displays a "RANK" section header above the direction options
  And a border separator divides the two sections

Scenario: Selected state uses grey background
  Given the user opens the filter modal
  When a sort field or direction option is selected
  Then the selected option has a grey background highlight
  And the selected option does not use blue text or accent
  And a checkmark icon appears on the selected option

Scenario: FilterSelect dropdown uses grey selected state
  Given the user is on the Perps Markets list page
  When the user opens the market type filter dropdown
  Then the currently selected filter option has a grey background
  And all option text uses the default color

## **Screenshots/Recordings**

### **Before**

### **After**
<img width="342" height="517" alt="Screenshot 2026-05-12 at 11 30 56" src="https://github.com/user-attachments/assets/312618c2-9154-4c3b-8524-33d91fc614c4" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit ce684dfa73d7525ac8806458601f67881b369441. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->