### PR TITLE
chore: prefer webpack build links

### DIFF
--- a/.github/scripts/post-nightly-builds.mts
+++ b/.github/scripts/post-nightly-builds.mts
@@ -298,98 +298,6 @@ async function postSuccessNotification(env: any, version: string) {
             },
             {
               type: 'link' as const,
-              url: buildLinks.browserify.main.chrome,
-              text: 'Main Chrome Extension',
-            },
-            {
-              type: 'text' as const,
-              text: '\n',
-            },
-            {
-              type: 'emoji' as const,
-              name: 'firefox',
-            },
-            {
-              type: 'text' as const,
-              text: ' ',
-            },
-            {
-              type: 'link' as const,
-              url: buildLinks.browserify.main.firefox,
-              text: 'Main Firefox Extension',
-            },
-            {
-              type: 'text' as const,
-              text: '\n',
-            },
-            {
-              type: 'emoji' as const,
-              name: 'test_tube',
-            },
-            {
-              type: 'text' as const,
-              text: ' ',
-            },
-            {
-              type: 'link' as const,
-              url: buildLinks.browserify.experimental.chrome,
-              text: 'Experimental Chrome Extension',
-            },
-            {
-              type: 'text' as const,
-              text: '\n',
-            },
-            {
-              type: 'emoji' as const,
-              name: 'test_tube',
-            },
-            {
-              type: 'text' as const,
-              text: ' ',
-            },
-            {
-              type: 'link' as const,
-              url: buildLinks.browserify.experimental.firefox,
-              text: 'Experimental Firefox Extension',
-            },
-            {
-              type: 'text' as const,
-              text: '\n',
-            },
-          ],
-        },
-      ],
-    },
-    {
-      type: 'divider',
-    },
-    {
-      type: 'rich_text',
-      elements: [
-        {
-          type: 'rich_text_section',
-          elements: [
-            {
-              type: 'emoji' as const,
-              name: 'package',
-            },
-            {
-              type: 'text' as const,
-              text: ' Webpack Download Links:\n',
-              style: {
-                bold: true,
-              },
-            },
-            {
-              type: 'emoji' as const,
-              name: 'chrome',
-            },
-            {
-              type: 'text' as const,
-              text: ' ',
-            },
-            {
-              type: 'link' as const,
               url: buildLinks.webpack.main.chrome,
               text: 'Main Chrome Extension',
             },
@@ -442,6 +350,98 @@ async function postSuccessNotification(env: any, version: string) {
             {
               type: 'link' as const,
               url: buildLinks.webpack.experimental.firefox,
+              text: 'Experimental Firefox Extension',
+            },
+            {
+              type: 'text' as const,
+              text: '\n',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      type: 'divider',
+    },
+    {
+      type: 'rich_text',
+      elements: [
+        {
+          type: 'rich_text_section',
+          elements: [
+            {
+              type: 'emoji' as const,
+              name: 'package',
+            },
+            {
+              type: 'text' as const,
+              text: ' Deprecated Browserify Fallback Download Links:\n',
+              style: {
+                bold: true,
+              },
+            },
+            {
+              type: 'emoji' as const,
+              name: 'chrome',
+            },
+            {
+              type: 'text' as const,
+              text: ' ',
+            },
+            {
+              type: 'link' as const,
+              url: buildLinks.browserify.main.chrome,
+              text: 'Main Chrome Extension',
+            },
+            {
+              type: 'text' as const,
+              text: '\n',
+            },
+            {
+              type: 'emoji' as const,
+              name: 'firefox',
+            },
+            {
+              type: 'text' as const,
+              text: ' ',
+            },
+            {
+              type: 'link' as const,
+              url: buildLinks.browserify.main.firefox,
+              text: 'Main Firefox Extension',
+            },
+            {
+              type: 'text' as const,
+              text: '\n',
+            },
+            {
+              type: 'emoji' as const,
+              name: 'test_tube',
+            },
+            {
+              type: 'text' as const,
+              text: ' ',
+            },
+            {
+              type: 'link' as const,
+              url: buildLinks.browserify.experimental.chrome,
+              text: 'Experimental Chrome Extension',
+            },
+            {
+              type: 'text' as const,
+              text: '\n',
+            },
+            {
+              type: 'emoji' as const,
+              name: 'test_tube',
+            },
+            {
+              type: 'text' as const,
+              text: ' ',
+            },
+            {
+              type: 'link' as const,
+              url: buildLinks.browserify.experimental.firefox,
               text: 'Experimental Firefox Extension',
             },
             {

--- a/.github/scripts/release-create-gh-release.sh
+++ b/.github/scripts/release-create-gh-release.sh
@@ -147,24 +147,8 @@ fi
 
 printf '%s\n' "Creating GitHub Release for ${tag}..."
 
-# Collect and validate browserify artifacts
-browserify_artifacts=()
-for artifact in build-dist-browserify/builds/metamask-chrome-*.zip \
-                build-dist-mv2-browserify/builds/metamask-firefox-*.zip \
-                build-flask-browserify/builds/metamask-flask-chrome-*.zip \
-                build-flask-mv2-browserify/builds/metamask-flask-firefox-*.zip; do
-    if ! compgen -G "${artifact}" > /dev/null; then
-        echo "::error::Required browserify artifact not found: ${artifact}"
-        exit 1
-    fi
-    while IFS= read -r file; do
-        browserify_artifacts+=("${file}")
-    done < <(compgen -G "${artifact}")
-done
-
 # Collect and validate webpack artifacts
-# Also rename them to include "-webpack" suffix before the .zip extension
-# so they don't collide with browserify artifacts on the release.
+# These use the canonical asset names because webpack is the preferred build.
 webpack_artifacts=()
 for artifact in build-dist-webpack/builds/metamask-chrome-*.zip \
                 build-dist-mv2-webpack/builds/metamask-firefox-*.zip \
@@ -175,16 +159,33 @@ for artifact in build-dist-webpack/builds/metamask-chrome-*.zip \
         exit 1
     fi
     while IFS= read -r file; do
-        renamed="${file%.zip}-webpack.zip"
+        webpack_artifacts+=("${file}")
+    done < <(compgen -G "${artifact}")
+done
+
+# Collect and validate deprecated browserify fallback artifacts.
+# Rename them so release consumers can clearly distinguish them from
+# the preferred webpack assets while still having them available.
+browserify_artifacts=()
+for artifact in build-dist-browserify/builds/metamask-chrome-*.zip \
+                build-dist-mv2-browserify/builds/metamask-firefox-*.zip \
+                build-flask-browserify/builds/metamask-flask-chrome-*.zip \
+                build-flask-mv2-browserify/builds/metamask-flask-firefox-*.zip; do
+    if ! compgen -G "${artifact}" > /dev/null; then
+        echo "::error::Required browserify artifact not found: ${artifact}"
+        exit 1
+    fi
+    while IFS= read -r file; do
+        renamed="${file%.zip}-browserify-deprecated.zip"
         mv "${file}" "${renamed}"
-        webpack_artifacts+=("${renamed}")
+        browserify_artifacts+=("${renamed}")
     done < <(compgen -G "${artifact}")
 done
 
 release_body="$(awk -v version="[${VERSION}]" -f .github/scripts/show-changelog.awk CHANGELOG.md)"
 gh release create "${tag}" \
-    "${browserify_artifacts[@]}" \
     "${webpack_artifacts[@]}" \
+    "${browserify_artifacts[@]}" \
     --title "Version ${VERSION}" \
     --notes "${release_body}" \
     --target "${RELEASE_SHA}"

--- a/.github/scripts/release-create-gh-release.sh
+++ b/.github/scripts/release-create-gh-release.sh
@@ -164,7 +164,7 @@ done
 
 # Collect and validate deprecated browserify fallback artifacts.
 # Rename them so release consumers can clearly distinguish them from
-# the preferred webpack assets while still having them available.
+# the webpack assets while still having them available.
 browserify_artifacts=()
 for artifact in build-dist-browserify/builds/metamask-chrome-*.zip \
                 build-dist-mv2-browserify/builds/metamask-firefox-*.zip \

--- a/.github/scripts/release-create-gh-release.sh
+++ b/.github/scripts/release-create-gh-release.sh
@@ -148,7 +148,6 @@ fi
 printf '%s\n' "Creating GitHub Release for ${tag}..."
 
 # Collect and validate webpack artifacts
-# These use the canonical asset names because webpack is the preferred build.
 webpack_artifacts=()
 for artifact in build-dist-webpack/builds/metamask-chrome-*.zip \
                 build-dist-mv2-webpack/builds/metamask-firefox-*.zip \

--- a/.github/scripts/slack-rc-notification.mts
+++ b/.github/scripts/slack-rc-notification.mts
@@ -5,7 +5,7 @@
  * metamask-mobile/scripts/slack-rc-notification.mjs (bot token + chat.postMessage).
  *
  * Build URLs use `getBuildLinks` from development/metamaskbot-build-announce/artifacts.ts
- * (main Chrome/Firefox for preferred Webpack + deprecated Browserify fallback).
+ * (main Chrome/Firefox for Webpack + deprecated Browserify fallback).
  *
  * Local / manual testing
  * ----------------------

--- a/.github/scripts/slack-rc-notification.mts
+++ b/.github/scripts/slack-rc-notification.mts
@@ -5,7 +5,7 @@
  * metamask-mobile/scripts/slack-rc-notification.mjs (bot token + chat.postMessage).
  *
  * Build URLs use `getBuildLinks` from development/metamaskbot-build-announce/artifacts.ts
- * (main Chrome/Firefox for Browserify + Webpack).
+ * (main Chrome/Firefox for preferred Webpack + deprecated Browserify fallback).
  *
  * Local / manual testing
  * ----------------------
@@ -269,30 +269,6 @@ function buildSlackMessage(options: {
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: '*📦 Main build zips (Browserify)*',
-      },
-    },
-    {
-      type: 'section',
-      fields: [
-        {
-          type: 'mrkdwn',
-          text: isValidUrl(b.chrome)
-            ? `*Chrome (MV3):*\n<${b.chrome}|Download zip>`
-            : '*Chrome (MV3):*\n_Not available_',
-        },
-        {
-          type: 'mrkdwn',
-          text: isValidUrl(b.firefox)
-            ? `*Firefox (MV2):*\n<${b.firefox}|Download zip>`
-            : '*Firefox (MV2):*\n_Not available_',
-        },
-      ],
-    },
-    {
-      type: 'section',
-      text: {
-        type: 'mrkdwn',
         text: '*📦 Main build zips (Webpack)*',
       },
     },
@@ -309,6 +285,30 @@ function buildSlackMessage(options: {
           type: 'mrkdwn',
           text: isValidUrl(w.firefox)
             ? `*Firefox (MV2):*\n<${w.firefox}|Download zip>`
+            : '*Firefox (MV2):*\n_Not available_',
+        },
+      ],
+    },
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: '*📦 Deprecated main build zips (Browserify)*',
+      },
+    },
+    {
+      type: 'section',
+      fields: [
+        {
+          type: 'mrkdwn',
+          text: isValidUrl(b.chrome)
+            ? `*Chrome (MV3):*\n<${b.chrome}|Download zip>`
+            : '*Chrome (MV3):*\n_Not available_',
+        },
+        {
+          type: 'mrkdwn',
+          text: isValidUrl(b.firefox)
+            ? `*Firefox (MV2):*\n<${b.firefox}|Download zip>`
             : '*Firefox (MV2):*\n_Not available_',
         },
       ],

--- a/development/metamaskbot-build-announce/artifacts.test.ts
+++ b/development/metamaskbot-build-announce/artifacts.test.ts
@@ -46,75 +46,22 @@ describe('buildArtifactsBody', () => {
       buildsFromSha: 'abc1234',
     });
 
-    expect(result.indexOf('Webpack builds')).toBeGreaterThan(-1);
-    expect(result).toContain(
+    const webpackBuildsIndex = result.indexOf('Webpack builds');
+    const allArtifactsIndex = result.indexOf('all artifacts');
+    const deprecatedBuildsIndex = result.indexOf(
       '<details><summary>Deprecated Browserify fallback builds</summary><ul>',
     );
-    expect(
-      result.indexOf('Deprecated Browserify fallback builds'),
-    ).toBeGreaterThan(result.indexOf('all artifacts'));
-    expect(result.indexOf('Browserify builds')).toBeGreaterThan(
-      result.indexOf('Deprecated Browserify fallback builds'),
-    );
+    const browserifyBuildsIndex = result.indexOf('Browserify builds');
+
+    expect(webpackBuildsIndex).toBeGreaterThan(-1);
+    expect(allArtifactsIndex).toBeGreaterThan(webpackBuildsIndex);
+    expect(deprecatedBuildsIndex).toBeGreaterThan(allArtifactsIndex);
+    expect(browserifyBuildsIndex).toBeGreaterThan(deprecatedBuildsIndex);
     expect(result).toContain(
       `${HOST}/build-dist-webpack/builds/metamask-chrome-${VERSION}.zip`,
     );
     expect(result).toContain(
-      `${HOST}/build-dist-mv2-webpack/builds/metamask-firefox-${VERSION}.zip`,
-    );
-    expect(result).toContain(
-      `${HOST}/build-beta-webpack/builds/metamask-chrome-${VERSION}-beta.0.zip`,
-    );
-    expect(result).toContain(
-      `${HOST}/build-beta-mv2-webpack/builds/metamask-firefox-${VERSION}-beta.0.zip`,
-    );
-    expect(result).toContain(
-      `${HOST}/build-flask-webpack/builds/metamask-chrome-${VERSION}-flask.0.zip`,
-    );
-    expect(result).toContain(
-      `${HOST}/build-flask-mv2-webpack/builds/metamask-firefox-${VERSION}-flask.0.zip`,
-    );
-    expect(result).toContain(
-      `${HOST}/build-test-webpack/builds/metamask-chrome-${VERSION}.zip`,
-    );
-    expect(result).toContain(
-      `${HOST}/build-test-mv2-webpack/builds/metamask-firefox-${VERSION}.zip`,
-    );
-    expect(result).toContain(
-      `${HOST}/build-test-flask-webpack/builds/metamask-chrome-${VERSION}-flask.0.zip`,
-    );
-    expect(result).toContain(
-      `${HOST}/build-test-flask-mv2-webpack/builds/metamask-firefox-${VERSION}-flask.0.zip`,
-    );
-    expect(result).toContain(
       `${HOST}/build-dist-browserify/builds/metamask-chrome-${VERSION}.zip`,
-    );
-    expect(result).toContain(
-      `${HOST}/build-dist-mv2-browserify/builds/metamask-firefox-${VERSION}.zip`,
-    );
-    expect(result).toContain(
-      `${HOST}/build-beta-browserify/builds/metamask-beta-chrome-${VERSION}-beta.0.zip`,
-    );
-    expect(result).toContain(
-      `${HOST}/build-beta-mv2-browserify/builds/metamask-beta-firefox-${VERSION}-beta.0.zip`,
-    );
-    expect(result).toContain(
-      `${HOST}/build-flask-browserify/builds/metamask-flask-chrome-${VERSION}-flask.0.zip`,
-    );
-    expect(result).toContain(
-      `${HOST}/build-flask-mv2-browserify/builds/metamask-flask-firefox-${VERSION}-flask.0.zip`,
-    );
-    expect(result).toContain(
-      `${HOST}/build-test-browserify/builds/metamask-chrome-${VERSION}.zip`,
-    );
-    expect(result).toContain(
-      `${HOST}/build-test-mv2-browserify/builds/metamask-firefox-${VERSION}.zip`,
-    );
-    expect(result).toContain(
-      `${HOST}/build-test-flask-browserify/builds/metamask-flask-chrome-${VERSION}-flask.0.zip`,
-    );
-    expect(result).toContain(
-      `${HOST}/build-test-flask-mv2-browserify/builds/metamask-flask-firefox-${VERSION}-flask.0.zip`,
     );
     expect(result).not.toContain('build-experimental-webpack');
     expect(result).not.toContain('build-experimental-browserify');

--- a/development/metamaskbot-build-announce/artifacts.test.ts
+++ b/development/metamaskbot-build-announce/artifacts.test.ts
@@ -47,9 +47,15 @@ describe('buildArtifactsBody', () => {
     });
 
     expect(result.indexOf('Webpack builds')).toBeGreaterThan(-1);
+    expect(result).toContain(
+      '<details><summary>Deprecated Browserify fallback builds</summary><ul>',
+    );
     expect(
       result.indexOf('Deprecated Browserify fallback builds'),
-    ).toBeGreaterThan(result.indexOf('Webpack builds'));
+    ).toBeGreaterThan(result.indexOf('all artifacts'));
+    expect(result.indexOf('Browserify builds')).toBeGreaterThan(
+      result.indexOf('Deprecated Browserify fallback builds'),
+    );
     expect(result).toContain(
       `${HOST}/build-dist-webpack/builds/metamask-chrome-${VERSION}.zip`,
     );

--- a/development/metamaskbot-build-announce/artifacts.test.ts
+++ b/development/metamaskbot-build-announce/artifacts.test.ts
@@ -46,9 +46,72 @@ describe('buildArtifactsBody', () => {
       buildsFromSha: 'abc1234',
     });
 
+    expect(result.indexOf('Webpack builds')).toBeGreaterThan(-1);
+    expect(
+      result.indexOf('Deprecated Browserify fallback builds'),
+    ).toBeGreaterThan(result.indexOf('Webpack builds'));
     expect(result).toContain(
       `${HOST}/build-dist-webpack/builds/metamask-chrome-${VERSION}.zip`,
     );
+    expect(result).toContain(
+      `${HOST}/build-dist-mv2-webpack/builds/metamask-firefox-${VERSION}.zip`,
+    );
+    expect(result).toContain(
+      `${HOST}/build-beta-webpack/builds/metamask-chrome-${VERSION}-beta.0.zip`,
+    );
+    expect(result).toContain(
+      `${HOST}/build-beta-mv2-webpack/builds/metamask-firefox-${VERSION}-beta.0.zip`,
+    );
+    expect(result).toContain(
+      `${HOST}/build-flask-webpack/builds/metamask-chrome-${VERSION}-flask.0.zip`,
+    );
+    expect(result).toContain(
+      `${HOST}/build-flask-mv2-webpack/builds/metamask-firefox-${VERSION}-flask.0.zip`,
+    );
+    expect(result).toContain(
+      `${HOST}/build-test-webpack/builds/metamask-chrome-${VERSION}.zip`,
+    );
+    expect(result).toContain(
+      `${HOST}/build-test-mv2-webpack/builds/metamask-firefox-${VERSION}.zip`,
+    );
+    expect(result).toContain(
+      `${HOST}/build-test-flask-webpack/builds/metamask-chrome-${VERSION}-flask.0.zip`,
+    );
+    expect(result).toContain(
+      `${HOST}/build-test-flask-mv2-webpack/builds/metamask-firefox-${VERSION}-flask.0.zip`,
+    );
+    expect(result).toContain(
+      `${HOST}/build-dist-browserify/builds/metamask-chrome-${VERSION}.zip`,
+    );
+    expect(result).toContain(
+      `${HOST}/build-dist-mv2-browserify/builds/metamask-firefox-${VERSION}.zip`,
+    );
+    expect(result).toContain(
+      `${HOST}/build-beta-browserify/builds/metamask-beta-chrome-${VERSION}-beta.0.zip`,
+    );
+    expect(result).toContain(
+      `${HOST}/build-beta-mv2-browserify/builds/metamask-beta-firefox-${VERSION}-beta.0.zip`,
+    );
+    expect(result).toContain(
+      `${HOST}/build-flask-browserify/builds/metamask-flask-chrome-${VERSION}-flask.0.zip`,
+    );
+    expect(result).toContain(
+      `${HOST}/build-flask-mv2-browserify/builds/metamask-flask-firefox-${VERSION}-flask.0.zip`,
+    );
+    expect(result).toContain(
+      `${HOST}/build-test-browserify/builds/metamask-chrome-${VERSION}.zip`,
+    );
+    expect(result).toContain(
+      `${HOST}/build-test-mv2-browserify/builds/metamask-firefox-${VERSION}.zip`,
+    );
+    expect(result).toContain(
+      `${HOST}/build-test-flask-browserify/builds/metamask-flask-chrome-${VERSION}-flask.0.zip`,
+    );
+    expect(result).toContain(
+      `${HOST}/build-test-flask-mv2-browserify/builds/metamask-flask-firefox-${VERSION}-flask.0.zip`,
+    );
+    expect(result).not.toContain('build-experimental-webpack');
+    expect(result).not.toContain('build-experimental-browserify');
     expect(result).toContain('Builds ready [abc1234]');
     expect(result).not.toContain('reused from');
     expect(result).toContain(

--- a/development/metamaskbot-build-announce/artifacts.ts
+++ b/development/metamaskbot-build-announce/artifacts.ts
@@ -171,14 +171,18 @@ export function getBuildLinks({
  * Renders build links as HTML content rows (e.g. "builds: chrome, firefox").
  *
  * @param buildLinks - BuildLinks from getBuildLinks.
+ * @param bundlers - The bundlers to include, in display order.
+ * @param browserifyPrefix - The browserify row label.
  * @returns Array of HTML strings, one per bundler/build type combination.
  */
-function formatBuildLinks(buildLinks: BuildLinks): string[] {
-  return Object.entries(buildLinks).flatMap(([bundler, types]) => {
-    const prefix =
-      bundler === 'webpack'
-        ? 'Webpack builds'
-        : 'Deprecated Browserify fallback builds';
+function formatBuildLinks(
+  buildLinks: BuildLinks,
+  bundlers: (keyof BuildLinks)[] = ['webpack', 'browserify'],
+  browserifyPrefix = 'Deprecated Browserify fallback builds',
+): string[] {
+  return bundlers.flatMap((bundler) => {
+    const types = buildLinks[bundler];
+    const prefix = bundler === 'webpack' ? 'Webpack builds' : browserifyPrefix;
     return (
       Object.entries(types)
         // Experimental builds are only created nightly, not on PRs
@@ -221,7 +225,8 @@ export function buildArtifactsBody({
 }) {
   const contentRows: string[] = [];
 
-  contentRows.push(...formatBuildLinks(getBuildLinks({ hostUrl, version })));
+  const buildLinks = getBuildLinks({ hostUrl, version });
+  contentRows.push(...formatBuildLinks(buildLinks, ['webpack']));
 
   contentRows.push(
     `bundle size: ${artifacts.link('bundleSizeStats')}`,
@@ -231,6 +236,17 @@ export function buildArtifactsBody({
     `typescript migration: ${artifacts.link('tsMigrationDashboard')}`,
     artifacts.link('allArtifacts'),
   );
+
+  const deprecatedBuildRows = formatBuildLinks(
+    buildLinks,
+    ['browserify'],
+    'Browserify builds',
+  );
+  const deprecatedBuildsContent = [
+    '<details><summary>Deprecated Browserify fallback builds</summary><ul>',
+    deprecatedBuildRows.map((row) => `<li>${row}</li>`).join('\n'),
+    '</ul></details>',
+  ].join('');
 
   const isReused = buildsFromSha !== shortSha;
   const reusedTag = isReused ? ` [reused from ${buildsFromSha}]` : '';
@@ -242,7 +258,7 @@ export function buildArtifactsBody({
 
   const hiddenContent = `<ul>${warningItem}\n${contentRows
     .map((row) => `<li>${row}</li>`)
-    .join('\n')}</ul>`;
+    .join('\n')}</ul>\n${deprecatedBuildsContent}`;
 
   return `<details><summary>Builds ready [${shortSha}]${reusedTag}</summary>${hiddenContent}</details>\n\n`;
 }

--- a/development/metamaskbot-build-announce/artifacts.ts
+++ b/development/metamaskbot-build-announce/artifacts.ts
@@ -112,32 +112,6 @@ export function getBuildLinks({
   releaseVersion?: string;
 }): BuildLinks {
   return {
-    browserify: {
-      main: {
-        chrome: `${hostUrl}/build-dist-browserify/builds/metamask-chrome-${version}.zip`,
-        firefox: `${hostUrl}/build-dist-mv2-browserify/builds/metamask-firefox-${version}.zip`,
-      },
-      beta: {
-        chrome: `${hostUrl}/build-beta-browserify/builds/metamask-beta-chrome-${version}-beta.${releaseVersion}.zip`,
-        firefox: `${hostUrl}/build-beta-mv2-browserify/builds/metamask-beta-firefox-${version}-beta.${releaseVersion}.zip`,
-      },
-      experimental: {
-        chrome: `${hostUrl}/build-experimental-browserify/builds/metamask-experimental-chrome-${version}-experimental.${releaseVersion}.zip`,
-        firefox: `${hostUrl}/build-experimental-mv2-browserify/builds/metamask-experimental-firefox-${version}-experimental.${releaseVersion}.zip`,
-      },
-      flask: {
-        chrome: `${hostUrl}/build-flask-browserify/builds/metamask-flask-chrome-${version}-flask.${releaseVersion}.zip`,
-        firefox: `${hostUrl}/build-flask-mv2-browserify/builds/metamask-flask-firefox-${version}-flask.${releaseVersion}.zip`,
-      },
-      test: {
-        chrome: `${hostUrl}/build-test-browserify/builds/metamask-chrome-${version}.zip`,
-        firefox: `${hostUrl}/build-test-mv2-browserify/builds/metamask-firefox-${version}.zip`,
-      },
-      'test-flask': {
-        chrome: `${hostUrl}/build-test-flask-browserify/builds/metamask-flask-chrome-${version}-flask.${releaseVersion}.zip`,
-        firefox: `${hostUrl}/build-test-flask-mv2-browserify/builds/metamask-flask-firefox-${version}-flask.${releaseVersion}.zip`,
-      },
-    },
     webpack: {
       main: {
         chrome: `${hostUrl}/build-dist-webpack/builds/metamask-chrome-${version}.zip`,
@@ -164,6 +138,32 @@ export function getBuildLinks({
         firefox: `${hostUrl}/build-test-flask-mv2-webpack/builds/metamask-firefox-${version}-flask.${releaseVersion}.zip`,
       },
     },
+    browserify: {
+      main: {
+        chrome: `${hostUrl}/build-dist-browserify/builds/metamask-chrome-${version}.zip`,
+        firefox: `${hostUrl}/build-dist-mv2-browserify/builds/metamask-firefox-${version}.zip`,
+      },
+      beta: {
+        chrome: `${hostUrl}/build-beta-browserify/builds/metamask-beta-chrome-${version}-beta.${releaseVersion}.zip`,
+        firefox: `${hostUrl}/build-beta-mv2-browserify/builds/metamask-beta-firefox-${version}-beta.${releaseVersion}.zip`,
+      },
+      experimental: {
+        chrome: `${hostUrl}/build-experimental-browserify/builds/metamask-experimental-chrome-${version}-experimental.${releaseVersion}.zip`,
+        firefox: `${hostUrl}/build-experimental-mv2-browserify/builds/metamask-experimental-firefox-${version}-experimental.${releaseVersion}.zip`,
+      },
+      flask: {
+        chrome: `${hostUrl}/build-flask-browserify/builds/metamask-flask-chrome-${version}-flask.${releaseVersion}.zip`,
+        firefox: `${hostUrl}/build-flask-mv2-browserify/builds/metamask-flask-firefox-${version}-flask.${releaseVersion}.zip`,
+      },
+      test: {
+        chrome: `${hostUrl}/build-test-browserify/builds/metamask-chrome-${version}.zip`,
+        firefox: `${hostUrl}/build-test-mv2-browserify/builds/metamask-firefox-${version}.zip`,
+      },
+      'test-flask': {
+        chrome: `${hostUrl}/build-test-flask-browserify/builds/metamask-flask-chrome-${version}-flask.${releaseVersion}.zip`,
+        firefox: `${hostUrl}/build-test-flask-mv2-browserify/builds/metamask-flask-firefox-${version}-flask.${releaseVersion}.zip`,
+      },
+    },
   };
 }
 
@@ -175,7 +175,10 @@ export function getBuildLinks({
  */
 function formatBuildLinks(buildLinks: BuildLinks): string[] {
   return Object.entries(buildLinks).flatMap(([bundler, types]) => {
-    const prefix = bundler === 'browserify' ? 'builds' : 'webpack builds';
+    const prefix =
+      bundler === 'webpack'
+        ? 'Webpack builds'
+        : 'Deprecated Browserify fallback builds';
     return (
       Object.entries(types)
         // Experimental builds are only created nightly, not on PRs


### PR DESCRIPTION
## **Description**

Prefer Webpack build assets in automated release/prerelease notifications while keeping Browserify assets available as deprecated fallback builds.

This updates the PR build-links comment, nightly Slack notification, RC Slack notification, and GitHub Release asset upload ordering/naming so Webpack is shown first and Browserify remains clearly labeled for fallback use.

## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. `yarn test:unit development/metamaskbot-build-announce/artifacts.test.ts development/metamaskbot-build-announce/index.test.ts`
2. `bash -n .github/scripts/release-create-gh-release.sh`
3. `DRY_RUN=1 SEMVER=13.32.0 GITHUB_RUN_ID=123 HOST_URL=https://example.com/metamask-extension/123 yarn slack:rc-notify`
4. `yarn lint:changed:fix`
5. `git diff --check`
6. Nightly Slack notification tested successfully in `#tmp-flaky-test-report-test`: https://consensys.slack.com/archives/C08P4QQCWG1/p1778624799478219
7. Actual RC Slack notification posting was not tested because the current RC Slack notify workflow is broken/skips before posting. Example run: https://github.com/MetaMask/metamask-extension/actions/runs/25761793499

<!--
## **Screenshots/Recordings**

If applicable, add screenshots and/or recordings to visualize the before and after of your change.

### **Before**

[screenshots/recordings]

### **After**

[screenshots/recordings]
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes release asset naming/ordering and notification links; mistakes could break automated download links or downstream release consumers, though no runtime product code is affected.
> 
> **Overview**
> Automated build announcements now **prefer Webpack**: nightly Slack posts and RC Slack notifications show Webpack download links first and label Browserify links as *deprecated fallback*.
> 
> GitHub Release creation uploads Webpack zips without renaming, and uploads Browserify artifacts as `*-browserify-deprecated.zip` to avoid collisions and make their status explicit.
> 
> PR build comment generation (`buildArtifactsBody`) is updated to list Webpack builds in the main section and tuck Browserify links into a collapsed *Deprecated Browserify fallback builds* block; unit tests are updated to assert ordering and presence of both link sets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95a31d2b757da5811f75cf0e5b9a19ea50f6fcad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

