### PR TITLE
fix: TRAM-3549: [Extension] Remove logic that disables Buy button for unsupported networks in token filter

### DIFF
--- a/ui/components/app/wallet-overview/coin-buttons.tsx
+++ b/ui/components/app/wallet-overview/coin-buttons.tsx
@@ -84,7 +84,6 @@ type CoinButtonsProps = {
   trackingLocation: string;
   isSwapsChain: boolean;
   isSigningEnabled: boolean;
-  isBuyableChain: boolean;
   classPrefix?: string;
   /** When true, disables the send button for non-EVM chains (used on asset page) */
   disableSendForNonEvm?: boolean;
@@ -96,7 +95,6 @@ const CoinButtons = ({
   trackingLocation,
   isSwapsChain,
   isSigningEnabled,
-  isBuyableChain,
   classPrefix = 'coin',
   disableSendForNonEvm = false,
 }: CoinButtonsProps) => {
@@ -147,7 +145,6 @@ const CoinButtons = ({
   const isEvmAsset = isEvmChainId(normalizedChainId);
 
   const buttonTooltips = {
-    buyButton: [{ condition: !isBuyableChain, message: '' }],
     sendButton: [
       { condition: !isSigningEnabled, message: 'methodNotSupported' },
       {
@@ -356,14 +353,10 @@ const CoinButtons = ({
             size={IconSize.Md}
           />
         }
-        disabled={!isBuyableChain}
         data-testid={`${classPrefix}-overview-buy`}
         label={t('buy')}
         onClick={handleBuyAndSellOnClick}
         width={BlockSize.Full}
-        tooltipRender={(contents: React.ReactElement) =>
-          generateTooltip('buyButton', contents)
-        }
       />
       <IconButton
         className={`${classPrefix}-overview__button`}

--- a/ui/components/app/wallet-overview/coin-overview.tsx
+++ b/ui/components/app/wallet-overview/coin-overview.tsx
@@ -69,7 +69,6 @@ export type CoinOverviewProps = {
   classPrefix?: string;
   chainId: CaipChainId | Hex;
   isBridgeChain: boolean;
-  isBuyableChain: boolean;
   isSwapsChain: boolean;
   isSigningEnabled: boolean;
 };
@@ -183,7 +182,6 @@ export const CoinOverview = ({
   classPrefix = 'coin',
   chainId,
   isBridgeChain,
-  isBuyableChain,
   isSwapsChain,
   isSigningEnabled,
 }: CoinOverviewProps) => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Step execute failed: Claude Code returned an error result: Credit balance is too low

## **Changelog**

CHANGELOG entry: Fixed step execute failed: Claude Code returned an error result: Credit balance is too low

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TRAM-3549

## **Manual testing steps**

1. Check out this branch locally.
2. Open the affected flow and verify the changed behavior.
3. Confirm the targeted unit test still passes and wait for CI to complete.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- AEP_VISUAL_VALIDATION_START -->
## AEP Visual Validation

- Status: Failed
- Run ID: `dfdac303-1bd1-4019-936a-05af107f46a6`
- LangSmith: https://smith.langchain.com/o/09df0f02-e7c8-47f9-b00a-9e4757168f81/projects/p/metamask-aep

### What was tested
- Visual validation failed: MetaMask extension build failed before mm launch preflight. Last output:  ENOENT: no such file or directory, open '/opt/workspaces/metamask-extension/development/.webpack/launch.js'
  at Object.readFileSync (node:fs:439:20)
  at loadModuleData (/opt/workspaces/metamask-extension/node_modules/lavamoat/src/kernel.js:151:32)
  at Object.internalRequire (LavaMoat/core/kernel:1359:28)
  at runLava (/opt/workspaces/metamask-extension/node_modules/lavamoat/src/index.js:97:12)
- metamask-mm-visual-validation: failed. MetaMask extension build failed before mm launch preflight. Last output:  ENOENT: no such file or directory, open '/opt/workspaces/metamask-extension/development/.webpack/launch.js'
  at Object.readFileSync (node:fs:439:20)
  at loadModuleData (/opt/workspaces/metamask-extension/node_modules/lavamoat/src/kernel.js:151:32)
  at Object.internalRequire (LavaMoat/core/kernel:1359:28)
  at runLava (/opt/workspaces/metamask-extension/node_modules/lavamoat/src/index.js:97:12)

> Screenshot URLs point at the local control plane. They are clickable from the demo machine, but GitHub may not render them inline unless CONTROL_PLANE_PUBLIC_URL is a public tunnel URL.
<!-- AEP_VISUAL_VALIDATION_END -->
