### PR TITLE
ci: Fix TypeScript migration dashboard publish

### DIFF
--- a/.github/workflows/build-ts-migration-dashboard.yml
+++ b/.github/workflows/build-ts-migration-dashboard.yml
@@ -39,7 +39,7 @@ jobs:
         env:
           TS_MIGRATION_DASHBOARD_TOKEN: ${{ secrets.TS_MIGRATION_DASHBOARD_TOKEN }}
         run: |
-          git remote add ts-migration-dashboard "https://${TS_MIGRATION_DASHBOARD_TOKEN}@github.com/MetaMask/metamask-extension-ts-migration-dashboard.git"
+          git remote add ts-migration-dashboard "https://x-access-token:${TS_MIGRATION_DASHBOARD_TOKEN}@github.com/MetaMask/metamask-extension-ts-migration-dashboard.git"
           git config user.name "MetaMask Bot"
           git config user.email metamaskbot@users.noreply.github.com
           yarn ts-migration:dashboard:deploy


### PR DESCRIPTION
## **Description**

The recent change in the `TS_MIGRATION_DASHBOARD_TOKEN` value broke the deploy process. The new token is a GitHub app token rather than a personal access token, so it requires a different syntax when cloning a repo.

Docs: https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app-installation

## **Changelog**

CHANGELOG entry: null

## **Related issues**

This workflow was changed recently to support the new token here: https://github.com/MetaMask/metamask-extension/pull/42576
But the change was incomplete, as we saw.

This same error came up not long ago with the Storybook deployment as well, in PR #40073

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

Example failure: https://github.com/MetaMask/metamask-extension/actions/runs/25691565180/job/75429077840

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow tweak that only changes the git remote URL format used during CI deploy; failure mode is limited to the dashboard publish step.
> 
> **Overview**
> Fixes the `build-ts-migration-dashboard` workflow deploy step to authenticate to `metamask-extension-ts-migration-dashboard` using the GitHub App token URL form (`https://x-access-token:<token>@...`) instead of the previous token-in-username format.
> 
> This should restore `yarn ts-migration:dashboard:deploy` publishing on `main` when `TS_MIGRATION_DASHBOARD_TOKEN` is provided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e80ccb34f1a13e9b8a3c2a0d44d83966261e21f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->