### PR TITLE
fix: TRAM-3549: [Extension] Remove logic that disables Buy button for unsupported networks in token filter

### DIFF
--- a/ui/components/app/wallet-overview/coin-buttons.tsx
+++ b/ui/components/app/wallet-overview/coin-buttons.tsx
@@ -96,7 +96,6 @@ const CoinButtons = ({
   trackingLocation,
   isSwapsChain,
   isSigningEnabled,
-  isBuyableChain,
   classPrefix = 'coin',
   disableSendForNonEvm = false,
 }: CoinButtonsProps) => {
@@ -147,7 +146,6 @@ const CoinButtons = ({
   const isEvmAsset = isEvmChainId(normalizedChainId);
 
   const buttonTooltips = {
-    buyButton: [{ condition: !isBuyableChain, message: '' }],
     sendButton: [
       { condition: !isSigningEnabled, message: 'methodNotSupported' },
       {
@@ -356,14 +354,10 @@ const CoinButtons = ({
             size={IconSize.Md}
           />
         }
-        disabled={!isBuyableChain}
         data-testid={`${classPrefix}-overview-buy`}
         label={t('buy')}
         onClick={handleBuyAndSellOnClick}
         width={BlockSize.Full}
-        tooltipRender={(contents: React.ReactElement) =>
-          generateTooltip('buyButton', contents)
-        }
       />
       <IconButton
         className={`${classPrefix}-overview__button`}

--- a/ui/components/app/wallet-overview/eth-overview.test.js
+++ b/ui/components/app/wallet-overview/eth-overview.test.js
@@ -350,7 +350,7 @@ describe('EthOverview', () => {
       expect(buyButton).toBeInTheDocument();
     });
 
-    it('should have the Buy native token button disabled if chain id is not part of supported buyable chains', () => {
+    it('should keep the Buy native token button enabled even if chain id is not part of supported buyable chains', () => {
       const mockedStoreWithUnbuyableChainId = {
         ...mockStore,
         metamask: {
@@ -373,7 +373,7 @@ describe('EthOverview', () => {
       );
       const buyButton = queryByTestId(ETH_OVERVIEW_BUY);
       expect(buyButton).toBeInTheDocument();
-      expect(buyButton).toBeDisabled();
+      expect(buyButton).not.toBeDisabled();
     });
 
     it('should have the Buy native token enabled if chain id is part of supported buyable chains', () => {

--- a/ui/pages/asset/components/asset-page.test.tsx
+++ b/ui/pages/asset/components/asset-page.test.tsx
@@ -402,7 +402,7 @@ describe('AssetPage', () => {
     expect(buyButton).toBeEnabled();
   });
 
-  it('should disable the buy button on unsupported chains', () => {
+  it('should keep the buy button enabled on unsupported chains', () => {
     const { queryByTestId } = renderWithProvider(
       <AssetPage asset={token} optionsButton={null} />,
       configureMockStore([thunk])({
@@ -415,7 +415,7 @@ describe('AssetPage', () => {
     );
     const buyButton = queryByTestId('token-overview-buy');
     expect(buyButton).toBeInTheDocument();
-    expect(buyButton).toBeDisabled();
+    expect(buyButton).not.toBeDisabled();
   });
 
   it('should open the buy crypto URL for a buyable chain ID', async () => {

--- a/ui/pages/asset/components/token-buttons.tsx
+++ b/ui/pages/asset/components/token-buttons.tsx
@@ -27,7 +27,6 @@ import {
   IconName,
   IconSize,
 } from '../../../components/component-library';
-import { getIsNativeTokenBuyable } from '../../../ducks/ramps';
 
 import { Asset } from '../types/asset';
 import { navigateToSendRoute } from '../../confirmations/utils/send';
@@ -56,7 +55,6 @@ const TokenButtons = ({
 
   const currentChainId = token.chainId;
 
-  const isBuyableChain = useSelector(getIsNativeTokenBuyable);
   const { openBuyCryptoInPdapp } = useRamps();
   const { openBridgeExperience } = useBridging();
 
@@ -145,9 +143,7 @@ const TokenButtons = ({
         label={t('buy')}
         data-testid="token-overview-buy"
         onClick={handleBuyAndSellOnClick}
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        disabled={token.isERC721 || !isBuyableChain}
+        disabled={token.isERC721}
       />
 
       {shouldShowSendButton ? (


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The Buy button on the wallet overview and asset pages was disabled whenever the user was connected to a chain that is not in the supported buyable-chains list. This blocked users on unsupported networks from entering the buy/sell flow even though the downstream provider selection screen can already handle network changes on its own.

This PR removes the `isBuyableChain` gating from the Buy button in both `CoinButtons` (wallet overview) and `TokenButtons` (asset page), so the button is always rendered enabled regardless of the connected network. The associated tooltip entry and the `getIsNativeTokenBuyable` selector usage are removed alongside it. ERC-721 tokens remain disabled on the asset page Buy button as before.

Changes:
- `ui/components/app/wallet-overview/coin-buttons.tsx`: drop the `isBuyableChain` prop, the `buyButton` tooltip entry, and the `disabled` / `tooltipRender` props on the Buy `IconButton`.
- `ui/pages/asset/components/token-buttons.tsx`: drop the `getIsNativeTokenBuyable` selector and simplify the Buy button's `disabled` prop to `token.isERC721`.
- Updated unit tests in `eth-overview.test.js` and `asset-page.test.tsx` to assert the Buy button stays enabled on unsupported chains.

## **Changelog**

CHANGELOG entry: Fixed Buy button being disabled on the wallet overview and asset pages when the user is connected to a network outside the supported buyable-chains list.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TRAM-3549

## **Manual testing steps**

1. Check out this branch locally and build the extension.
2. Open MetaMask and switch to a network that is not in the supported buyable-chains list (e.g. Localhost / Anvil with chainId 1337).
3. On the wallet overview, confirm the Buy button is visible and enabled (not greyed out, no "unsupported" tooltip).
4. Open a native token asset page on the same network and confirm the Buy button is enabled.
5. Click the Buy button and confirm the buy/sell flow opens normally.
6. Open an ERC-721 asset page and confirm its Buy button remains disabled.
7. Run the targeted unit tests:
   - `yarn test:unit ui/components/app/wallet-overview/eth-overview.test.js`
   - `yarn test:unit ui/pages/asset/components/asset-page.test.tsx`

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- AEP_VISUAL_VALIDATION_START -->
## AEP Visual Validation

- Status: Passed
- Run ID: `68b9092c-5528-4b2f-8dc2-a89cb5fa2f01`
- LangSmith: https://smith.langchain.com/o/09df0f02-e7c8-47f9-b00a-9e4757168f81/projects/p/metamask-aep

### What was tested
- Visual validation passed: The execution evidence sufficiently proves the primary target behavior of PR #42599: the eth-overview-buy button (coin-buttons.tsx) renders as an enabled, non-disabled role=button on chainId 1337 (Localhost/Anvil), a chain not in MetaMask's buyable-chains list. The a11y tree observation explicitly confirms no disabled property is present, no tooltip wrapper is attached, and the button is visually equivalent to the other action buttons. The screenshot artifact exists at non-trivial size (34394 bytes). Confidence is medium rather than high because (1) screenshot pixels are not directly observable by this reviewer, requiring reliance on textual observations alone, and (2) the token-buttons.tsx change on the asset page is not covered by any visual assertion in this run.
- metamask-mm-visual-validation: passed. PR #42599 removes the isBuyableChain disabled guard from the Buy button. Visual validation confirms that on chainId 1337 (Localhost/Anvil, a non-buyable chain), the eth-overview-buy button renders as role=button name=Buy with no disabled attribute and no tooltip wrapper. The button is fully enabled and interactive. This matches the expected post-fix behavior: the Buy button is always enabled regardless of whether the current chain is in the buyable-chains list.

### Screenshots
<details><summary>buy-button-enabled-on-unsupported-chain-1779130205946.png</summary>

<img alt="buy-button-enabled-on-unsupported-chain-1779130205946.png" src="http://localhost:3000/v1/runs/68b9092c-5528-4b2f-8dc2-a89cb5fa2f01/artifacts/buy-button-enabled-on-unsupported-chain-1779130205946.png" width="420" />

[Open full-size image](http://localhost:3000/v1/runs/68b9092c-5528-4b2f-8dc2-a89cb5fa2f01/artifacts/buy-button-enabled-on-unsupported-chain-1779130205946.png)

</details>


> Screenshot URLs point at the local control plane. They are clickable from the demo machine, but GitHub may not render them inline unless CONTROL_PLANE_PUBLIC_URL is a public tunnel URL.
<!-- AEP_VISUAL_VALIDATION_END -->
