### PR TITLE
ci: create stable→release sync PRs after hotfix releases (MCRM-66)

### DIFF
--- a/.github/scripts/release-branch-sync.sh
+++ b/.github/scripts/release-branch-sync.sh
@@ -1,0 +1,347 @@
+#!/bin/bash
+# =============================================================================
+# Release Branch Sync Script
+# =============================================================================
+# Purpose: After a release branch is merged into stable, create PRs to sync
+#          stable into all active release branches. This ensures hotfixes and
+#          release commits from the previous version are present in the next
+#          (and any other still-open) release branches.
+#
+# Flow:
+#   1. Find release branches with active release PRs (open PRs titled
+#      "release: X.Y.Z"). Uses a high `gh pr list --limit` so the next
+#      release PR isn't missed when there are many other open PRs in the
+#      repo (this previously caused hotfix syncs to be silently skipped —
+#      see https://consensyssoftware.atlassian.net/browse/MCRM-66).
+#   2. For each one (newer than the just-merged version), create a branch
+#      from stable (stable-sync-release-X.Y.Z).
+#   3. Create a PR from that branch into the release branch.
+#   4. Conflicts are left for manual resolution by developers.
+#
+# Note: Only release branches with an active release PR are synced. This
+#       ensures we don't create unnecessary sync PRs for abandoned or
+#       completed releases.
+#
+# This script is a self-contained port of
+# `metamask/github-tools/.github/scripts/release-branch-sync.sh` with the
+# pagination fix above. Keeping it in-repo avoids waiting on an upstream
+# release of github-tools whenever this workflow needs a fix.
+#
+# Environment variables:
+#   MERGED_RELEASE_BRANCH - The release branch that was just merged (e.g., release/13.20.1)
+#   GITHUB_TOKEN          - GitHub token for authentication and PR creation
+# =============================================================================
+
+set -euo pipefail
+
+# Regex pattern for valid release branch names (release/X.Y.Z)
+RELEASE_BRANCH_PATTERN='^release/[0-9]+\.[0-9]+\.[0-9]+$'
+
+# How many open PRs to scan when looking for active release PRs.
+# Must be high enough that the next release PR is always included even when
+# the repo has many other open PRs (the default `gh pr list` limit of 30
+# is what caused MCRM-66).
+PR_LIST_LIMIT=500
+
+# -----------------------------------------------------------------------------
+# Helper Functions
+# -----------------------------------------------------------------------------
+
+log_info() {
+  echo "INFO: $1"
+}
+
+log_success() {
+  echo "SUCCESS: $1"
+}
+
+log_warning() {
+  echo "WARNING: $1"
+}
+
+log_error() {
+  echo "ERROR: $1" >&2
+}
+
+log_section() {
+  echo ""
+  echo "============================================================"
+  echo "$1"
+  echo "============================================================"
+}
+
+# Validate that a branch name matches the release/X.Y.Z format
+is_valid_release_branch() {
+  local branch=$1
+  [[ "$branch" =~ $RELEASE_BRANCH_PATTERN ]]
+}
+
+# Check if a sync PR already exists for a release branch
+pr_exists() {
+  local release_branch=$1
+  local sync_branch=$2
+
+  local existing_pr
+  # Use fallback to "0" if gh command fails (network/auth issues).
+  # This is safe because gh pr create will also fail if there's a real issue,
+  # and GitHub rejects duplicate PRs anyway.
+  existing_pr=$(gh pr list --base "$release_branch" --head "$sync_branch" --state open --json number --jq 'length' 2>/dev/null || echo "0")
+
+  [[ "$existing_pr" -gt 0 ]]
+}
+
+# Parse version from release branch name (release/X.Y.Z -> X.Y.Z)
+parse_version() {
+  local branch=$1
+  echo "$branch" | sed 's|release/||'
+}
+
+# Compare two semantic versions.
+# Returns: 0 if v1 < v2, 1 if v1 >= v2
+is_version_older() {
+  local v1=$1
+  local v2=$2
+
+  local oldest
+  oldest=$(printf '%s\n%s\n' "$v1" "$v2" | sort -V | head -n1)
+
+  [[ "$v1" == "$oldest" && "$v1" != "$v2" ]]
+}
+
+# Check if stable has commits that the release branch doesn't have
+stable_has_new_commits() {
+  local release_branch=$1
+
+  local ahead_count
+  ahead_count=$(git rev-list --count "origin/${release_branch}..origin/stable" 2>/dev/null || echo "0")
+
+  [[ "$ahead_count" -gt 0 ]]
+}
+
+# Find release branches that have active release PRs (open).
+# Active release PRs have titles matching "release: X.Y.Z" pattern.
+# Echoes a newline-separated list of release branch names sorted by version.
+get_active_release_branches() {
+  local pr_titles
+  pr_titles=$(gh pr list \
+    --state open \
+    --limit "${PR_LIST_LIMIT}" \
+    --json title \
+    --jq '.[] | select(.title | test("^release:\\s*[0-9]+\\.[0-9]+\\.[0-9]+"; "i")) | .title' \
+    2>/dev/null || echo "")
+
+  if [[ -z "$pr_titles" ]]; then
+    return
+  fi
+
+  local branches=""
+  while IFS= read -r title; do
+    if [[ -z "$title" ]]; then
+      continue
+    fi
+    local version
+    version=$(echo "$title" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+    if [[ -z "$version" ]]; then
+      continue
+    fi
+    local branch="release/${version}"
+    # Skip duplicates (use grep -Fx for exact string matching, avoiding regex
+    # issues with the '.' characters in version numbers).
+    if [[ -n "$branches" ]] && echo "$branches" | grep -Fxq "$branch"; then
+      continue
+    fi
+    if [[ -n "$branches" ]]; then
+      branches="${branches}"$'\n'"${branch}"
+    else
+      branches="$branch"
+    fi
+  done <<< "$pr_titles"
+
+  echo "$branches" | sort -t'/' -k2 -V
+}
+
+# Create a sync PR for a release branch
+create_sync_pr() {
+  local release_branch=$1
+  local sync_branch=$2
+
+  local body="## Summary
+
+This PR syncs the latest changes from \`stable\` into \`${release_branch}\`.
+
+## Why is this needed?
+
+A release branch (\`${MERGED_RELEASE_BRANCH}\`) was merged into \`stable\`. This PR brings those changes (hotfixes, etc.) into \`${release_branch}\`.
+
+## Action Required
+
+**Please review and resolve any merge conflicts manually.**
+
+If there are conflicts, they will appear in this PR. Resolve them to ensure the release branch has all the latest fixes from stable."
+
+  gh pr create \
+    --base "$release_branch" \
+    --head "$sync_branch" \
+    --title "chore: sync stable into ${release_branch}" \
+    --body "$body"
+}
+
+# Process a single release branch.
+# Returns: 0 = PR created, 1 = failed, 2 = skipped
+process_release_branch() {
+  local release_branch=$1
+  local merged_version=$2
+  local release_version
+  release_version=$(parse_version "$release_branch")
+
+  log_section "Processing ${release_branch}"
+
+  # Skip branches that don't match the release/X.Y.Z format
+  if ! is_valid_release_branch "$release_branch"; then
+    log_info "Skipping ${release_branch} (does not match release/X.Y.Z format)"
+    return 2
+  fi
+
+  # Skip the branch that was just merged
+  if [[ "$release_branch" == "$MERGED_RELEASE_BRANCH" ]]; then
+    log_info "Skipping ${release_branch} (just merged into stable)"
+    return 2
+  fi
+
+  # Skip branches older than the merged release
+  if is_version_older "$release_version" "$merged_version"; then
+    log_info "Skipping ${release_branch} (older than merged release ${MERGED_RELEASE_BRANCH})"
+    return 2
+  fi
+
+  # Verify the branch exists on the remote
+  if ! git ls-remote --heads origin "$release_branch" | grep -q "$release_branch"; then
+    log_warning "Skipping ${release_branch} (branch does not exist on remote)"
+    return 2
+  fi
+
+  # Create sync branch name (replace / with -)
+  local sync_branch="stable-sync-${release_branch//\//-}"
+
+  # Check if a sync PR already exists
+  if pr_exists "$release_branch" "$sync_branch"; then
+    log_warning "Sync PR already exists for ${release_branch}, skipping"
+    return 2
+  fi
+
+  # Check if stable has any new commits compared to the release branch
+  if ! stable_has_new_commits "$release_branch"; then
+    log_success "${release_branch} is already up-to-date with stable, no sync needed"
+    return 2
+  fi
+
+  log_info "Creating sync branch: ${sync_branch} (from stable)"
+
+  # Ensure we're on a clean state
+  git checkout -f origin/stable 2>/dev/null || true
+  git clean -fd
+
+  # Delete local sync branch if it exists
+  git branch -D "$sync_branch" 2>/dev/null || true
+
+  # Create sync branch from stable
+  git checkout -b "$sync_branch" origin/stable
+
+  # Push the sync branch (force in case it exists remotely)
+  log_info "Pushing ${sync_branch}..."
+  if git push -u origin "$sync_branch" --force; then
+    log_success "Pushed ${sync_branch}"
+  else
+    log_error "Failed to push ${sync_branch}"
+    return 1
+  fi
+
+  # Create the PR (stable-sync branch → release branch)
+  log_info "Creating PR: ${sync_branch} → ${release_branch}"
+  if create_sync_pr "$release_branch" "$sync_branch"; then
+    log_success "Created PR for ${release_branch}"
+  else
+    log_error "Failed to create PR for ${release_branch}"
+    return 1
+  fi
+
+  return 0
+}
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+
+main() {
+  log_section "Release Branch Sync"
+
+  if [[ -z "${MERGED_RELEASE_BRANCH:-}" ]]; then
+    log_error "MERGED_RELEASE_BRANCH environment variable is required"
+    exit 1
+  fi
+
+  # Defense in depth — the workflow also validates this format.
+  if ! is_valid_release_branch "$MERGED_RELEASE_BRANCH"; then
+    log_error "MERGED_RELEASE_BRANCH '${MERGED_RELEASE_BRANCH}' does not match release/X.Y.Z format"
+    exit 1
+  fi
+
+  if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+    log_error "GITHUB_TOKEN environment variable is required"
+    exit 1
+  fi
+
+  log_info "Merged release branch: ${MERGED_RELEASE_BRANCH}"
+
+  local merged_version
+  merged_version=$(parse_version "$MERGED_RELEASE_BRANCH")
+  log_info "Merged version: ${merged_version}"
+
+  log_info "Fetching all branches..."
+  git fetch --all --prune
+
+  log_info "Finding release branches with active release PRs (scanning up to ${PR_LIST_LIMIT} open PRs)..."
+  local release_branches
+  release_branches=$(get_active_release_branches)
+
+  if [[ -z "$release_branches" ]]; then
+    log_warning "No active release branches found (no open PRs with 'release: X.Y.Z' title)"
+    exit 0
+  fi
+
+  log_info "Found active release branches:"
+  while IFS= read -r branch; do
+    echo "  - $branch"
+  done <<< "$release_branches"
+
+  local processed=0
+  local skipped=0
+  local failed=0
+
+  while IFS= read -r branch; do
+    if [[ -z "$branch" ]]; then
+      continue
+    fi
+
+    local result
+    process_release_branch "$branch" "$merged_version" && result=$? || result=$?
+
+    case $result in
+      0) ((processed++)) || true ;;  # PR created
+      1) ((failed++)) || true ;;     # Failed
+      2) ((skipped++)) || true ;;    # Skipped
+    esac
+  done <<< "$release_branches"
+
+  log_section "Summary"
+  log_info "PRs created: ${processed}"
+  log_info "Skipped: ${skipped}"
+  if [[ "$failed" -gt 0 ]]; then
+    log_error "Failed: ${failed}"
+    exit 1
+  fi
+
+  log_success "Release branch sync completed!"
+}
+
+main "$@"

--- a/.github/workflows/release-branch-sync.yml
+++ b/.github/workflows/release-branch-sync.yml
@@ -37,8 +37,25 @@ jobs:
     if: needs.validate-branch.outputs.is-valid == 'true'
     runs-on: ubuntu-latest
     steps:
-      - name: Sync release branches with stable
-        uses: metamask/github-tools/.github/actions/release-branch-sync@v1
+      # We use an in-repo script (rather than
+      # metamask/github-tools/.github/actions/release-branch-sync) because
+      # that action's `gh pr list` call did not pass `--limit`, defaulting
+      # to 30 results. When the next release PR fell outside the first 30
+      # open PRs (which happened after hotfix releases like 13.20.1), no
+      # sync PR was created. See MCRM-66.
+      - name: Checkout repository
+        uses: actions/checkout@v6
         with:
-          merged-release-branch: ${{ github.event.pull_request.head.ref }}
-          github-token: ${{ secrets.STABLE_SYNC_TOKEN }}
+          fetch-depth: 0
+          token: ${{ secrets.STABLE_SYNC_TOKEN }}
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "metamaskbot"
+          git config --global user.email "metamaskbot@users.noreply.github.com"
+
+      - name: Sync stable into open release branches
+        env:
+          MERGED_RELEASE_BRANCH: ${{ github.event.pull_request.head.ref }}
+          GITHUB_TOKEN: ${{ secrets.STABLE_SYNC_TOKEN }}
+        run: bash .github/scripts/release-branch-sync.sh


### PR DESCRIPTION
## **Description**

Fixes [MCRM-66](https://consensyssoftware.atlassian.net/browse/MCRM-66): after a hotfix release (e.g. `release/13.20.1`) is merged into `stable`, the `Release Branch Sync` workflow does not auto-create a sync PR for the next open release branch (e.g. `release/13.21.0`), so the next release ships without the hotfix commits unless someone notices and creates the sync PR manually (this happened for [#40585](https://github.com/MetaMask/metamask-extension/pull/40585)).

### Root cause

`.github/workflows/release-branch-sync.yml` delegates to `metamask/github-tools/.github/actions/release-branch-sync@v1`. That action's `release-branch-sync.sh` finds active release branches with:

```bash
gh pr list \
  --state open \
  --json title,isDraft \
  --jq '.[] | select(.title | test("^release:\\s*[0-9]+\\.[0-9]+\\.[0-9]+"; "i")) | .title'
```

No `--limit` is passed, so `gh` defaults to **30 results**. The metamask-extension repo routinely has hundreds of open PRs, and the next release PR is often older than the 30 most-recently-created open PRs, so it falls outside that window. The script then logs `No active release branches found` and exits cleanly.

This isn't strictly a hotfix-only bug — any release merge can hit it when the next release PR isn't in the top 30 open PRs. The 13.20.1 hotfix just happened to be when it bit.

Confirmed by inspecting the actual failed run for 13.20.1 ([run 22641691389](https://github.com/MetaMask/metamask-extension/actions/runs/22641691389)):

```
INFO: Finding release branches with active release PRs (open/draft PRs titled 'release: X.Y.Z')...
WARNING: No active release branches found (no open/draft PRs with 'release: X.Y.Z' title)
```

And reproduced today against this repo's live state:
- ``gh pr list --state open`` (default limit 30) → matches **0** `release: X.Y.Z` PRs
- ``gh pr list --state open --limit 500`` → matches `release: 13.31.0`

### Fix

Replace the call to `metamask/github-tools/.github/actions/release-branch-sync@v1` with an in-repo bash script (`.github/scripts/release-branch-sync.sh`) that is otherwise behavior-compatible with the upstream script but:

- Calls `gh pr list --state open --limit 500` so the next release PR is always included.
- Lives in this repo, so future fixes to this CI logic don't require waiting on a `metamask/github-tools` release.

Apart from the `--limit` fix, everything else (branch validation, version comparison so older release branches aren't synced into, sync-branch naming, duplicate-PR detection, ahead-count check, force-pushed sync branch, PR body) matches the upstream action 1:1.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [MCRM-66](https://consensyssoftware.atlassian.net/browse/MCRM-66)

## **Manual testing steps**

This workflow only runs on `pull_request: closed` against `stable`, so it can't be exercised from a feature branch PR. Verification done locally:

1. Reproduced the bug live against the repo today:
   ```bash
   gh pr list --state open --json title \
     --jq '.[] | select(.title | test("^release:\\s*[0-9]+\\.[0-9]+\\.[0-9]+"; "i")) | .title'
   # (empty — default limit 30)

   gh pr list --state open --limit 500 --json title \
     --jq '.[] | select(.title | test("^release:\\s*[0-9]+\\.[0-9]+\\.[0-9]+"; "i")) | .title'
   # release: 13.31.0
   ```
2. Validated the script with `bash -n` and `js-yaml`.
3. Unit-tested the version-comparison helper for the hotfix scenario:
   - `13.21.0` is not older than `13.20.1` (so it would be processed)
   - `13.20.0` is older than `13.20.1` (so it would be skipped)
   - Equal versions are not "older" (the just-merged branch is skipped via the dedicated `MERGED_RELEASE_BRANCH` check anyway)

Once merged, the next time a release PR (normal or hotfix) is merged into `stable`, this workflow will scan up to 500 open PRs and create sync PRs into every newer open release branch.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've applied the right labels on the PR

Made with [Cursor](https://cursor.com)

[MCRM-66]: https://consensyssoftware.atlassian.net/browse/MCRM-66?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MCRM-66]: https://consensyssoftware.atlassian.net/browse/MCRM-66?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes CI automation that force-pushes branches and opens PRs; mistakes could spam PRs or target the wrong branches, but scope is limited to the release-sync workflow.
> 
> **Overview**
> Fixes missed stable→release sync PRs by replacing the `metamask/github-tools` release-sync action with an in-repo `.github/scripts/release-branch-sync.sh` and wiring the workflow to run it.
> 
> The new script increases `gh pr list` coverage (uses `--limit 500`) when discovering active release PRs, then creates/force-pushes `stable-sync-*` branches and opens PRs into newer active `release/X.Y.Z` branches (skipping already-synced, missing, or up-to-date branches).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96bcf050f5ed3544c3e7a2bf1bbf6cb4a99d4cbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->