### PR TITLE
feat(rewards): expose VIP perps fee discount via getPerpsDiscountForAccount

### DIFF
--- a/app/scripts/constants/sentry-state.ts
+++ b/app/scripts/constants/sentry-state.ts
@@ -293,6 +293,7 @@ export const SENTRY_BACKGROUND_STATE: SentryBackgroundControllerMasks = {
     rewardsSeasonStatuses: false,
     rewardsSubscriptionTokens: false,
     rewardsPointsEstimateHistory: false,
+    rewardsVipPerpsFees: false,
   },
   NotificationServicesPushController: {
     fcmToken: false,

--- a/app/scripts/controllers/perps/infrastructure.test.ts
+++ b/app/scripts/controllers/perps/infrastructure.test.ts
@@ -46,6 +46,7 @@ describe('createPerpsInfrastructure', () => {
   const mockGetStorageItem = jest.fn();
   const mockSetStorageItem = jest.fn();
   const mockRemoveStorageItem = jest.fn();
+  const mockGetPerpsDiscountForAccount = jest.fn();
 
   function getDeps(
     overrides?: Partial<InfrastructureDeps>,
@@ -55,6 +56,7 @@ describe('createPerpsInfrastructure', () => {
       getStorageItem: mockGetStorageItem,
       setStorageItem: mockSetStorageItem,
       removeStorageItem: mockRemoveStorageItem,
+      getPerpsDiscountForAccount: mockGetPerpsDiscountForAccount,
       ...overrides,
     };
   }
@@ -64,6 +66,7 @@ describe('createPerpsInfrastructure', () => {
     mockGetStorageItem.mockReset().mockResolvedValue({});
     mockSetStorageItem.mockReset().mockResolvedValue(undefined);
     mockRemoveStorageItem.mockReset().mockResolvedValue(undefined);
+    mockGetPerpsDiscountForAccount.mockReset().mockResolvedValue(0);
   });
 
   afterEach(() => {
@@ -728,7 +731,35 @@ describe('createPerpsInfrastructure', () => {
   });
 
   describe('rewards', () => {
-    it('returns 0 discount as default stub', async () => {
+    it('delegates to the injected getPerpsDiscountForAccount with the perps base fee', async () => {
+      mockGetPerpsDiscountForAccount.mockResolvedValueOnce(5000);
+      const infrastructure = createPerpsInfrastructure(getDeps());
+      const discount = await infrastructure.rewards.getPerpsDiscountForAccount(
+        'eip155:42161:0x1234',
+        10,
+      );
+
+      expect(discount).toBe(5000);
+      // Base fee bips comes from the perps package constants
+      // (BUILDER_FEE_CONFIG.MaxFeeDecimal * BASIS_POINTS_DIVISOR = 0.001 * 10000 = 10).
+      expect(mockGetPerpsDiscountForAccount).toHaveBeenCalledWith(
+        'eip155:42161:0x1234',
+        10,
+      );
+    });
+
+    it('returns 0 when the injected getPerpsDiscountForAccount throws', async () => {
+      mockGetPerpsDiscountForAccount.mockRejectedValueOnce(new Error('boom'));
+      const infrastructure = createPerpsInfrastructure(getDeps());
+      const discount = await infrastructure.rewards.getPerpsDiscountForAccount(
+        'eip155:42161:0x1234',
+        10,
+      );
+      expect(discount).toBe(0);
+    });
+
+    it('collapses a null discount to 0 so the core perps-controller never sees null', async () => {
+      mockGetPerpsDiscountForAccount.mockResolvedValueOnce(null);
       const infrastructure = createPerpsInfrastructure(getDeps());
       const discount = await infrastructure.rewards.getPerpsDiscountForAccount(
         'eip155:42161:0x1234',

--- a/app/scripts/controllers/perps/infrastructure.ts
+++ b/app/scripts/controllers/perps/infrastructure.ts
@@ -5,7 +5,7 @@
  * Several dependencies are stubbed pending integration with extension services.
  */
 
-import { createProjectLogger } from '@metamask/utils';
+import { CaipAccountId, createProjectLogger } from '@metamask/utils';
 import type * as Sentry from '@sentry/browser';
 import type {
   PerpsPlatformDependencies,
@@ -57,6 +57,18 @@ export type InfrastructureDeps = {
    * failures.
    */
   isDisconnecting?: () => boolean;
+  /**
+   * Bridge to {@link RewardsController.getPerpsDiscountForAccount}. The
+   * rewards controller owns the fee-discount logic; perps just supplies the
+   * account and its own base fee in bips. The controller returns null when
+   * the discount is currently unknowable (unhydrated cache, fetch error, no
+   * subscription); this adapter collapses null to 0 before returning to the
+   * core perps-controller, which expects a numeric discount.
+   */
+  getPerpsDiscountForAccount: (
+    caipAccountId: `${string}:${string}:${string}`,
+    baseFeeBips: number,
+  ) => Promise<number | null>;
 };
 
 const debugLog = createProjectLogger('perps');
@@ -354,12 +366,29 @@ export function createPerpsInfrastructure(
     cacheInvalidator: createCacheInvalidator(),
     diskCache: createDiskCache(deps),
     rewards: {
+      // The perps package only passes `caipAccountId`; the rewards controller
+      // additionally needs the perps MetaMask builder base fee in bips so it
+      // can convert the absolute reward fee into a discount fraction. We
+      // source the base fee from the perps package's own constants here so
+      // the rewards controller stays a pure transformer.
       getPerpsDiscountForAccount: async (
-        _caipAccountId: `${string}:${string}:${string}`,
-        _baseFeeBips: number,
+        caipAccountId: `${string}:${string}:${string}`,
+        baseFeeBips: number,
       ) => {
-        // TODO: Wire to RewardsController when available
-        return 0;
+        try {
+          const result = await deps.getPerpsDiscountForAccount(
+            caipAccountId,
+            baseFeeBips,
+          );
+          // The rewards controller returns null when the discount is
+          // currently unknowable; treat it the same as a thrown error so
+          // the core perps-controller (which expects a number) sees a
+          // safe "no discount" fallback.
+          return result ?? 0;
+        } catch {
+          // Never let a discount lookup failure block a trade — return 0.
+          return 0;
+        }
       },
     },
   };

--- a/app/scripts/controllers/rewards/rewards-controller-method-action-types.ts
+++ b/app/scripts/controllers/rewards/rewards-controller-method-action-types.ts
@@ -25,6 +25,35 @@ export type RewardsControllerGetActualSubscriptionIdAction = {
 };
 
 /**
+ * Get perps fee discount for an account.
+ *
+ * Calls the authenticated `/vip/fees` endpoint (bypassing the local
+ * `subscription.features.vip.enabled` flag — the backend is the source of
+ * truth) and converts the absolute VIP builder fee into a discount fraction
+ * relative to `baseFeeBips`. Responses are cached per-subscription for
+ * `VIP_PERPS_FEES_CACHE_THRESHOLD_MS` to keep traffic low. When the backend
+ * returns a valid fee response, the controller also flips the
+ * subscription's `features.vip.enabled` flag to `true` so the rest of the
+ * app reflects the user's VIP status.
+ *
+ * @param account - The account address in CAIP-10 format
+ * @param baseFeeBips - The perps MetaMask builder base fee in basis points
+ * that the caller would apply absent any discount. Used to convert the VIP
+ * absolute fee into a discount fraction (caller owns the source of truth
+ * for the base fee; the controller is a pure transformer).
+ * @returns Promise<number | null> - Discount in basis points (0-10000), or
+ * null when the discount is currently unknowable (rewards disabled, no
+ * subscription, unhydrated cache, fetch error). Callers should treat null
+ * as "no discount available yet" — skip caching and retry next call. A
+ * literal 0 means "no discount applies — safe to cache" (tier 0 / non-VIP
+ * response, out-of-range bips).
+ */
+export type RewardsControllerGetPerpsDiscountForAccountAction = {
+  type: `RewardsController:getPerpsDiscountForAccount`;
+  handler: RewardsController['getPerpsDiscountForAccount'];
+};
+
+/**
  * Check if an internal account supports opt-in for rewards.
  *
  * @param account - The internal account to check
@@ -174,6 +203,7 @@ export type RewardsControllerLinkAccountsToSubscriptionCandidateAction = {
 export type RewardsControllerMethodActions =
   | RewardsControllerResetStateAction
   | RewardsControllerGetActualSubscriptionIdAction
+  | RewardsControllerGetPerpsDiscountForAccountAction
   | RewardsControllerIsOptInSupportedAction
   | RewardsControllerGetHasAccountOptedInAction
   | RewardsControllerGetOptInStatusAction

--- a/app/scripts/controllers/rewards/rewards-controller.test.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.test.ts
@@ -1,6 +1,7 @@
 /**
  * @jest-environment node
  */
+import log from 'loglevel';
 import {
   Messenger,
   MessengerActions,
@@ -46,6 +47,7 @@ import {
 } from './rewards-controller';
 import type {
   RewardsControllerState,
+  RewardsAccountState,
   SeasonTierDto,
   LoginResponseDto,
   DiscoverSeasonsDto,
@@ -53,6 +55,7 @@ import type {
   SeasonStateDto,
   SubscriptionDto,
   ChallengeDto,
+  VipFeesResponseDto,
 } from './rewards-controller.types';
 import {
   InvalidTimestampError,
@@ -67,6 +70,7 @@ import {
   RewardsDataServiceGetOptInStatusAction,
   RewardsDataServiceGetSeasonMetadataAction,
   RewardsDataServiceGetSeasonStatusAction,
+  RewardsDataServiceGetVipFeesAction,
   RewardsDataServiceLoginAction,
   RewardsDataServiceMobileJoinAction,
   RewardsDataServiceMobileOptinAction,
@@ -228,6 +232,7 @@ async function withController<ReturnValue>(
     | RewardsDataServiceGetSeasonMetadataAction
     | RewardsDataServiceGetDiscoverSeasonsAction
     | RewardsDataServiceGenerateChallengeAction
+    | RewardsDataServiceGetVipFeesAction
     | RewardsDataServiceSiweLoginAction
     | RewardsDataServiceSiweJoinAction
     | AccountTreeControllerGetAccountsFromSelectedAccountGroupAction
@@ -267,6 +272,7 @@ async function withController<ReturnValue>(
       'RewardsDataService:validateReferralCode',
       'RewardsDataService:getDiscoverSeasons',
       'RewardsDataService:getSeasonMetadata',
+      'RewardsDataService:getVipFees',
       'AccountTreeController:getAccountsFromSelectedAccountGroup',
       'AccountsController:listMultichainAccounts',
       'AccountsController:getSelectedMultichainAccount',
@@ -364,6 +370,7 @@ describe('RewardsController', () => {
         rewardsSeasonStatuses: {},
         rewardsSubscriptionTokens: {},
         rewardsPointsEstimateHistory: [],
+        rewardsVipPerpsFees: {},
       });
     });
   });
@@ -701,6 +708,460 @@ describe('RewardsController', () => {
 
         expect(result).toBeNull();
       });
+    });
+  });
+
+  describe('getPerpsDiscountForAccount', () => {
+    const BASE_FEE_BIPS = 10;
+    const VIP_SUB_ID = 'sub-vip-1';
+    const VIP_SUB_TOKEN = 'token-for-sub-vip-1';
+    const VIP_ACCOUNT = MOCK_CAIP_ACCOUNT;
+    const NON_VIP_SUB_ID = 'sub-non-vip-1';
+
+    const vipSubscription: SubscriptionDto = {
+      id: VIP_SUB_ID,
+      referralCode: 'REF',
+      accounts: [{ address: MOCK_ACCOUNT_ADDRESS, chainId: 1 }],
+      createdAt: new Date().toISOString(),
+      features: { vip: { enabled: true } },
+    };
+
+    const nonVipSubscription: SubscriptionDto = {
+      id: NON_VIP_SUB_ID,
+      referralCode: 'REF2',
+      accounts: [{ address: MOCK_ACCOUNT_ADDRESS, chainId: 1 }],
+      createdAt: new Date().toISOString(),
+      features: { vip: { enabled: false } },
+    };
+
+    const buildVipFeesResponse = (
+      builderFeeBips: string,
+    ): VipFeesResponseDto => ({
+      vipTier: 1,
+      fees: {
+        hyperliquid: { builderCode: '0xbuilder', builderFeeBips },
+        swaps: { feeBips: '50' },
+      },
+      updatedAt: '2026-05-01T00:00:00.000Z',
+    });
+
+    const vipAccountState = (overrides: Partial<RewardsAccountState> = {}) =>
+      ({
+        account: VIP_ACCOUNT,
+        hasOptedIn: true,
+        subscriptionId: VIP_SUB_ID,
+        perpsFeeDiscount: null,
+        lastPerpsDiscountRateFetched: null,
+        ...overrides,
+      }) as RewardsAccountState;
+
+    const stateWithVipAccount = (
+      overrides: Partial<RewardsControllerState> = {},
+    ): Partial<RewardsControllerState> => ({
+      rewardsAccounts: { [VIP_ACCOUNT]: vipAccountState() },
+      rewardsSubscriptions: { [VIP_SUB_ID]: vipSubscription },
+      rewardsSubscriptionTokens: { [VIP_SUB_ID]: VIP_SUB_TOKEN },
+      ...overrides,
+    });
+
+    it('returns null when rewards is disabled', async () => {
+      await withController(
+        { state: stateWithVipAccount(), isDisabled: true },
+        async ({ controller, mockMessengerCall }) => {
+          const result = await controller.getPerpsDiscountForAccount(
+            VIP_ACCOUNT,
+            BASE_FEE_BIPS,
+          );
+
+          expect(result).toBeNull();
+          expect(mockMessengerCall).not.toHaveBeenCalled();
+        },
+      );
+    });
+
+    it('returns null for accounts the controller has never seen', async () => {
+      await withController(
+        { isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          const result = await controller.getPerpsDiscountForAccount(
+            VIP_ACCOUNT,
+            BASE_FEE_BIPS,
+          );
+
+          expect(result).toBeNull();
+          expect(mockMessengerCall).not.toHaveBeenCalled();
+        },
+      );
+    });
+
+    it('returns null when the account has no linked subscription', async () => {
+      await withController(
+        {
+          state: {
+            rewardsAccounts: {
+              [VIP_ACCOUNT]: vipAccountState({ subscriptionId: null }),
+            },
+          },
+          isDisabled: false,
+        },
+        async ({ controller, mockMessengerCall }) => {
+          const result = await controller.getPerpsDiscountForAccount(
+            VIP_ACCOUNT,
+            BASE_FEE_BIPS,
+          );
+
+          expect(result).toBeNull();
+          expect(mockMessengerCall).not.toHaveBeenCalled();
+        },
+      );
+    });
+
+    it('returns null when baseFeeBips is non-positive (defensive)', async () => {
+      await withController(
+        { state: stateWithVipAccount(), isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          const result = await controller.getPerpsDiscountForAccount(
+            VIP_ACCOUNT,
+            0,
+          );
+
+          expect(result).toBeNull();
+          expect(mockMessengerCall).not.toHaveBeenCalled();
+        },
+      );
+    });
+
+    it('returns null when the subscription record is missing from state (unhydrated)', async () => {
+      await withController(
+        {
+          state: {
+            rewardsAccounts: {
+              [VIP_ACCOUNT]: vipAccountState({
+                subscriptionId: NON_VIP_SUB_ID,
+              }),
+            },
+            // Note: rewardsSubscriptions intentionally omits NON_VIP_SUB_ID
+            // to simulate an unhydrated subscription record.
+          },
+          isDisabled: false,
+        },
+        async ({ controller, mockMessengerCall }) => {
+          const result = await controller.getPerpsDiscountForAccount(
+            VIP_ACCOUNT,
+            BASE_FEE_BIPS,
+          );
+
+          expect(result).toBeNull();
+          expect(mockMessengerCall).not.toHaveBeenCalled();
+        },
+      );
+    });
+
+    it('calls /vip/fees even when the subscription is flagged as not VIP, and promotes the subscription on a valid response', async () => {
+      await withController(
+        {
+          state: {
+            rewardsAccounts: {
+              [VIP_ACCOUNT]: vipAccountState({
+                subscriptionId: NON_VIP_SUB_ID,
+              }),
+            },
+            rewardsSubscriptions: { [NON_VIP_SUB_ID]: nonVipSubscription },
+            rewardsSubscriptionTokens: { [NON_VIP_SUB_ID]: VIP_SUB_TOKEN },
+          },
+          isDisabled: false,
+        },
+        async ({ controller, mockMessengerCall }) => {
+          mockMessengerCall.mockImplementation(
+            (method: string, ..._args: unknown[]): unknown => {
+              if (method === 'RewardsDataService:getVipFees') {
+                return Promise.resolve(buildVipFeesResponse('5'));
+              }
+              return Promise.resolve(undefined);
+            },
+          );
+
+          const result = await controller.getPerpsDiscountForAccount(
+            VIP_ACCOUNT,
+            BASE_FEE_BIPS,
+          );
+
+          expect(result).toBe(5000);
+          expect(mockMessengerCall).toHaveBeenCalledWith(
+            'RewardsDataService:getVipFees',
+            VIP_SUB_TOKEN,
+          );
+          expect(
+            controller.state.rewardsSubscriptions[NON_VIP_SUB_ID]?.features?.vip
+              ?.enabled,
+          ).toBe(true);
+        },
+      );
+    });
+
+    it('converts the absolute VIP builder fee into a discount fraction', async () => {
+      await withController(
+        { state: stateWithVipAccount(), isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          mockMessengerCall.mockImplementation(
+            (method: string, ..._args: unknown[]): unknown => {
+              if (method === 'RewardsDataService:getVipFees') {
+                return Promise.resolve(buildVipFeesResponse('5'));
+              }
+              return Promise.resolve(undefined);
+            },
+          );
+
+          const result = await controller.getPerpsDiscountForAccount(
+            VIP_ACCOUNT,
+            BASE_FEE_BIPS,
+          );
+
+          expect(result).toBe(5000);
+          expect(mockMessengerCall).toHaveBeenCalledWith(
+            'RewardsDataService:getVipFees',
+            VIP_SUB_TOKEN,
+          );
+        },
+      );
+    });
+
+    it('persists the raw VIP builder fee in the per-subscription cache', async () => {
+      await withController(
+        { state: stateWithVipAccount(), isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          mockMessengerCall.mockImplementation(
+            (method: string, ..._args: unknown[]): unknown => {
+              if (method === 'RewardsDataService:getVipFees') {
+                return Promise.resolve(buildVipFeesResponse('5'));
+              }
+              return Promise.resolve(undefined);
+            },
+          );
+
+          await controller.getPerpsDiscountForAccount(
+            VIP_ACCOUNT,
+            BASE_FEE_BIPS,
+          );
+
+          expect(controller.state.rewardsVipPerpsFees[VIP_SUB_ID]).toEqual({
+            hyperliquidBuilderFeeBips: '5',
+            lastFetched: expect.any(Number),
+          });
+          // VIP path must not pollute the per-account legacy cache slot.
+          expect(
+            controller.state.rewardsAccounts[VIP_ACCOUNT].perpsFeeDiscount,
+          ).toBeNull();
+          expect(
+            controller.state.rewardsAccounts[VIP_ACCOUNT]
+              .lastPerpsDiscountRateFetched,
+          ).toBeNull();
+        },
+      );
+    });
+
+    it('reuses the per-subscription cache within the TTL without re-fetching', async () => {
+      await withController(
+        {
+          state: stateWithVipAccount({
+            rewardsVipPerpsFees: {
+              [VIP_SUB_ID]: {
+                hyperliquidBuilderFeeBips: '5',
+                lastFetched: Date.now(),
+              },
+            },
+          }),
+          isDisabled: false,
+        },
+        async ({ controller, mockMessengerCall }) => {
+          const result = await controller.getPerpsDiscountForAccount(
+            VIP_ACCOUNT,
+            BASE_FEE_BIPS,
+          );
+
+          expect(result).toBe(5000);
+          expect(mockMessengerCall).not.toHaveBeenCalledWith(
+            'RewardsDataService:getVipFees',
+            expect.anything(),
+          );
+        },
+      );
+    });
+
+    it('re-derives the discount from cache when baseFeeBips changes', async () => {
+      await withController(
+        {
+          state: stateWithVipAccount({
+            rewardsVipPerpsFees: {
+              [VIP_SUB_ID]: {
+                hyperliquidBuilderFeeBips: '5',
+                lastFetched: Date.now(),
+              },
+            },
+          }),
+          isDisabled: false,
+        },
+        async ({ controller }) => {
+          const a = await controller.getPerpsDiscountForAccount(
+            VIP_ACCOUNT,
+            10,
+          );
+          const b = await controller.getPerpsDiscountForAccount(
+            VIP_ACCOUNT,
+            20,
+          );
+
+          expect(a).toBe(5000);
+          expect(b).toBe(7500);
+        },
+      );
+    });
+
+    it('returns 0 and logs when the VIP builder fee exceeds the base (negative discount)', async () => {
+      await withController(
+        { state: stateWithVipAccount(), isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          mockMessengerCall.mockImplementation(
+            (method: string, ..._args: unknown[]): unknown => {
+              if (method === 'RewardsDataService:getVipFees') {
+                return Promise.resolve(buildVipFeesResponse('15'));
+              }
+              return Promise.resolve(undefined);
+            },
+          );
+
+          const result = await controller.getPerpsDiscountForAccount(
+            VIP_ACCOUNT,
+            BASE_FEE_BIPS,
+          );
+
+          expect(result).toBe(0);
+        },
+      );
+    });
+
+    it('returns null and logs when the VIP builder fee is negative', async () => {
+      await withController(
+        { state: stateWithVipAccount(), isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          mockMessengerCall.mockImplementation(
+            (method: string, ..._args: unknown[]): unknown => {
+              if (method === 'RewardsDataService:getVipFees') {
+                return Promise.resolve(buildVipFeesResponse('-5'));
+              }
+              return Promise.resolve(undefined);
+            },
+          );
+
+          const result = await controller.getPerpsDiscountForAccount(
+            VIP_ACCOUNT,
+            BASE_FEE_BIPS,
+          );
+
+          expect(result).toBeNull();
+          expect(log.warn).toHaveBeenCalledWith(
+            'RewardsController: VIP fees returned a non-numeric builderFeeBips:',
+            '-5',
+          );
+        },
+      );
+    });
+
+    it('returns 10000 when the VIP builder fee is 0 (full discount, boundary)', async () => {
+      await withController(
+        { state: stateWithVipAccount(), isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          mockMessengerCall.mockImplementation(
+            (method: string, ..._args: unknown[]): unknown => {
+              if (method === 'RewardsDataService:getVipFees') {
+                return Promise.resolve(buildVipFeesResponse('0'));
+              }
+              return Promise.resolve(undefined);
+            },
+          );
+
+          const result = await controller.getPerpsDiscountForAccount(
+            VIP_ACCOUNT,
+            BASE_FEE_BIPS,
+          );
+
+          expect(result).toBe(10000);
+        },
+      );
+    });
+
+    it('returns 0 with no warning when the VIP builder fee equals the base (boundary)', async () => {
+      jest.mocked(log.warn).mockClear();
+      await withController(
+        { state: stateWithVipAccount(), isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          mockMessengerCall.mockImplementation(
+            (method: string, ..._args: unknown[]): unknown => {
+              if (method === 'RewardsDataService:getVipFees') {
+                return Promise.resolve(buildVipFeesResponse('10'));
+              }
+              return Promise.resolve(undefined);
+            },
+          );
+
+          const result = await controller.getPerpsDiscountForAccount(
+            VIP_ACCOUNT,
+            BASE_FEE_BIPS,
+          );
+
+          expect(result).toBe(0);
+        },
+      );
+    });
+
+    it('returns null when /vip/fees errors (no legacy fallback)', async () => {
+      await withController(
+        { state: stateWithVipAccount(), isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          mockMessengerCall.mockImplementation(
+            (method: string, ..._args: unknown[]): unknown => {
+              if (method === 'RewardsDataService:getVipFees') {
+                return Promise.reject(new Error('boom'));
+              }
+              return Promise.resolve(undefined);
+            },
+          );
+
+          const result = await controller.getPerpsDiscountForAccount(
+            VIP_ACCOUNT,
+            BASE_FEE_BIPS,
+          );
+
+          expect(result).toBeNull();
+        },
+      );
+    });
+
+    it('returns 0 when /vip/fees returns tier 0 (fees=null)', async () => {
+      await withController(
+        { state: stateWithVipAccount(), isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          mockMessengerCall.mockImplementation(
+            (method: string, ..._args: unknown[]): unknown => {
+              if (method === 'RewardsDataService:getVipFees') {
+                return Promise.resolve({
+                  vipTier: 0,
+                  fees: null,
+                  updatedAt: null,
+                } as VipFeesResponseDto);
+              }
+              return Promise.resolve(undefined);
+            },
+          );
+
+          const result = await controller.getPerpsDiscountForAccount(
+            VIP_ACCOUNT,
+            BASE_FEE_BIPS,
+          );
+
+          expect(result).toBe(0);
+        },
+      );
     });
   });
 

--- a/app/scripts/controllers/rewards/rewards-controller.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.ts
@@ -35,6 +35,8 @@ import {
   type SeasonStatusDto,
   type SubscriptionDto,
   type PointsEstimateHistoryEntry,
+  type VipFeesResponseDto,
+  type VipPerpsFeesState,
   SeasonStateDto,
   SeasonMetadataDto,
   DiscoverSeasonsDto,
@@ -65,6 +67,10 @@ const SEASON_METADATA_CACHE_THRESHOLD_MS = 1000 * 60 * 1; // 1 minute
 
 // Opt-in status stale threshold for not opted-in accounts to force a fresh check (less strict than in mobile for now)
 const NOT_OPTED_IN_OIS_STALE_CACHE_THRESHOLD_MS = 1000 * 60 * 60; // 1 hour
+
+// VIP perps fees cache threshold — read on every perps trade UI render, so
+// cache for 1 hour to keep traffic to /vip/fees low.
+const VIP_PERPS_FEES_CACHE_THRESHOLD_MS = 1000 * 60 * 60;
 
 // Maximum number of points estimate history entries to keep for Customer Support diagnostics
 const MAX_POINTS_ESTIMATE_HISTORY_ENTRIES = 50;
@@ -121,6 +127,12 @@ const metadata = {
     includeInDebugSnapshot: false,
     usedInUi: false,
   },
+  rewardsVipPerpsFees: {
+    includeInStateLogs: true,
+    persist: true,
+    includeInDebugSnapshot: false,
+    usedInUi: false,
+  },
 };
 
 /**
@@ -134,6 +146,7 @@ export const getRewardsControllerDefaultState = (): RewardsControllerState => ({
   rewardsSeasonStatuses: {},
   rewardsSubscriptionTokens: {},
   rewardsPointsEstimateHistory: [],
+  rewardsVipPerpsFees: {},
 });
 
 export const defaultRewardsControllerState = getRewardsControllerDefaultState();
@@ -242,6 +255,7 @@ const MESSENGER_EXPOSED_METHODS = [
   'getOptInStatus',
   'isOptInSupported',
   'getActualSubscriptionId',
+  'getPerpsDiscountForAccount',
   'resetState',
 ] as const;
 
@@ -263,6 +277,11 @@ export class RewardsController extends BaseController<
   #isTronDisabled: () => boolean;
 
   #reauthPromises: Map<string, Promise<void>> = new Map();
+
+  // Deduplicates concurrent /vip/fees fetches for the same subscriptionId.
+  // Cleared when the promise settles (success or failure).
+  #vipFeesFetchInFlight: Map<string, Promise<VipFeesResponseDto | 0>> =
+    new Map();
 
   /**
    * Perform silent re-authentication for a given subscription ID.
@@ -585,6 +604,166 @@ export class RewardsController extends BaseController<
   getActualSubscriptionId(account: CaipAccountId): string | null {
     const accountState = this.#getAccountState(account);
     return accountState?.subscriptionId || null;
+  }
+
+  /**
+   * Get perps fee discount for an account.
+   *
+   * Calls the authenticated `/vip/fees` endpoint (bypassing the local
+   * `subscription.features.vip.enabled` flag — the backend is the source of
+   * truth) and converts the absolute VIP builder fee into a discount fraction
+   * relative to `baseFeeBips`. Responses are cached per-subscription for
+   * `VIP_PERPS_FEES_CACHE_THRESHOLD_MS` to keep traffic low. When the backend
+   * returns a valid fee response, the controller also flips the
+   * subscription's `features.vip.enabled` flag to `true` so the rest of the
+   * app reflects the user's VIP status.
+   *
+   * @param account - The account address in CAIP-10 format
+   * @param baseFeeBips - The perps MetaMask builder base fee in basis points
+   * that the caller would apply absent any discount. Used to convert the VIP
+   * absolute fee into a discount fraction (caller owns the source of truth
+   * for the base fee; the controller is a pure transformer).
+   * @returns Promise<number | null> - Discount in basis points (0-10000), or
+   * null when the discount is currently unknowable (rewards disabled, no
+   * subscription, unhydrated cache, fetch error). Callers should treat null
+   * as "no discount available yet" — skip caching and retry next call. A
+   * literal 0 means "no discount applies — safe to cache" (tier 0 / non-VIP
+   * response, out-of-range bips).
+   */
+  async getPerpsDiscountForAccount(
+    account: CaipAccountId,
+    baseFeeBips: number,
+  ): Promise<number | null> {
+    if (!this.isRewardsFeatureEnabled()) {
+      return null;
+    }
+
+    const vipDiscountBips = await this.#getVipPerpsDiscountBips(
+      account,
+      baseFeeBips,
+    );
+    return vipDiscountBips;
+  }
+
+  /**
+   * Resolve a VIP-driven perps discount for the given account. Returns null
+   * when the discount is currently unknowable (invalid input, no subscription,
+   * fetch error). Returns 0 when no discount applies (tier-0 response,
+   * out-of-range bips).
+   */
+  async #getVipPerpsDiscountBips(
+    account: CaipAccountId,
+    baseFeeBips: number,
+  ): Promise<number | null> {
+    if (!Number.isFinite(baseFeeBips) || baseFeeBips <= 0) {
+      return null;
+    }
+
+    const accountState = this.#getAccountState(account);
+    const subscriptionId = accountState?.subscriptionId;
+    if (!subscriptionId) {
+      return null;
+    }
+
+    const subscription = this.state.rewardsSubscriptions[subscriptionId];
+    if (!subscription) {
+      // Subscription record missing from state — treat as unhydrated so the
+      // caller can retry once the subscription is loaded.
+      return null;
+    }
+
+    let builderFeeBipsRaw: string;
+    const cached = this.state.rewardsVipPerpsFees[subscriptionId];
+    const cacheAgeMs = cached ? Date.now() - cached.lastFetched : null;
+    if (
+      cached &&
+      cacheAgeMs !== null &&
+      cacheAgeMs < VIP_PERPS_FEES_CACHE_THRESHOLD_MS
+    ) {
+      builderFeeBipsRaw = cached.hyperliquidBuilderFeeBips;
+    } else {
+      // Deduplicate concurrent fetches: if there's already an in-flight
+      // request for this subscriptionId, await it instead of firing another.
+      let inFlight = this.#vipFeesFetchInFlight.get(subscriptionId);
+      if (!inFlight) {
+        inFlight = this.#withAuthRetry(() => {
+          const subscriptionToken = this.#getSubscriptionToken(subscriptionId);
+          if (!subscriptionToken) {
+            throw new AuthorizationFailedError(
+              `No subscription token found for subscription ID: ${subscriptionId}`,
+            );
+          }
+          return this.messenger.call(
+            'RewardsDataService:getVipFees',
+            subscriptionToken,
+          );
+        }, subscriptionId).then((vipFeeResponse): VipFeesResponseDto | 0 => {
+          // Backend contract: tier-0 responses have fees=null and vipTier=0.
+          if (
+            !vipFeeResponse?.fees ||
+            vipFeeResponse.vipTier <= 0 ||
+            !vipFeeResponse.fees.hyperliquid?.builderFeeBips
+          ) {
+            return 0;
+          }
+          const rawBips = vipFeeResponse.fees.hyperliquid.builderFeeBips;
+          const next: VipPerpsFeesState = {
+            hyperliquidBuilderFeeBips: rawBips,
+            lastFetched: Date.now(),
+          };
+          this.update((state) => {
+            state.rewardsVipPerpsFees[subscriptionId] = next;
+            const subState = state.rewardsSubscriptions[subscriptionId];
+            if (subState) {
+              subState.features = {
+                ...subState.features,
+                vip: { enabled: true },
+              };
+            }
+          });
+          return vipFeeResponse;
+        });
+        this.#vipFeesFetchInFlight.set(subscriptionId, inFlight);
+        const cleanup = () => this.#vipFeesFetchInFlight.delete(subscriptionId);
+        inFlight.then(cleanup, cleanup);
+      }
+
+      try {
+        const result = await inFlight;
+        if (result === 0) {
+          return 0;
+        }
+        const feeResponse = result as VipFeesResponseDto;
+        builderFeeBipsRaw = feeResponse.fees?.hyperliquid?.builderFeeBips ?? '';
+      } catch (error) {
+        log.warn(
+          'RewardsController: VIP fees fetch failed; returning no discount:',
+          error instanceof Error ? error.message : String(error),
+        );
+        return null;
+      }
+    }
+
+    const builderFeeBips = parseFloat(builderFeeBipsRaw);
+    if (!Number.isFinite(builderFeeBips) || builderFeeBips < 0) {
+      log.warn(
+        'RewardsController: VIP fees returned a non-numeric builderFeeBips:',
+        builderFeeBipsRaw,
+      );
+      return null;
+    }
+
+    // Valid range is [0, 10000]: 0 means VIP fee equals base (no discount),
+    // 10000 means VIP fee is 0 (100% discount). Anything outside that range
+    // would require a negative builder fee or one larger than the base —
+    // both indicate backend misconfig, so log and return 0.
+    const rawDiscountBips = Math.round(
+      10000 * (1 - builderFeeBips / baseFeeBips),
+    );
+    if (rawDiscountBips < 0 || rawDiscountBips > 10000) {
+      return 0;
+    }
+    return rawDiscountBips;
   }
 
   /**
@@ -1674,6 +1853,7 @@ export class RewardsController extends BaseController<
       }
 
       delete state.rewardsSubscriptionTokens[subscriptionId];
+      delete state.rewardsVipPerpsFees[subscriptionId];
     });
 
     log.debug(

--- a/app/scripts/controllers/rewards/rewards-controller.types.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.types.ts
@@ -36,12 +36,23 @@ import {
   RewardsDataServiceGetSeasonMetadataAction,
   RewardsDataServiceGetDiscoverSeasonsAction,
   RewardsDataServiceGenerateChallengeAction,
+  RewardsDataServiceGetVipFeesAction,
 } from './rewards-data-service-method-action-types';
 import { RewardsControllerMethodActions } from './rewards-controller-method-action-types';
 
 export type LoginResponseDto = {
   sessionId: string;
   subscription: SubscriptionDto;
+};
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type VipFeatureDto = {
+  enabled: boolean;
+};
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type SubscriptionFeaturesDto = {
+  vip: VipFeatureDto;
 };
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
@@ -54,6 +65,48 @@ export type SubscriptionDto = {
   }[];
   createdAt: string;
   candidateAt?: string;
+  /**
+   * Per-subscription feature flags (VIP, etc.). Optional for backward
+   * compatibility with subscriptions persisted before this field was added —
+   * callers must treat `features?.vip?.enabled !== true` as non-VIP.
+   */
+  features?: SubscriptionFeaturesDto;
+};
+
+// Backend wire format for GET /vip/fees — mirrors va-mmcx-rewards
+// src/main/vip/dto/vip-fees.dto.ts (PR #546). Fee bips are returned as
+// strings; the controller parses them as needed.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type HyperliquidVipFeesDto = {
+  builderCode: string;
+  builderFeeBips: string;
+};
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type SwapsVipFeesDto = {
+  feeBips: string;
+};
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type VipFeesGroupDto = {
+  hyperliquid: HyperliquidVipFeesDto;
+  swaps: SwapsVipFeesDto;
+};
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type VipFeesResponseDto = {
+  vipTier: number;
+  fees: VipFeesGroupDto | null;
+  updatedAt: string | null;
+};
+
+// Per-subscription cache for VIP perps builder fee.
+// We store the raw bips string from the backend rather than a derived
+// discount so the cache stays valid if the perps base fee constant changes.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type VipPerpsFeesState = {
+  hyperliquidBuilderFeeBips: string;
+  lastFetched: number;
 };
 
 export type MobileLoginDto = {
@@ -762,6 +815,12 @@ export type RewardsControllerState = {
   rewardsSeasonStatuses: { [compositeId: string]: SeasonStatusState };
   rewardsSubscriptionTokens: { [subscriptionId: string]: string };
   /**
+   * Per-subscription cache of the latest VIP fees response (raw bips string)
+   * with a `lastFetched` timestamp. The discount is re-derived at read time
+   * so callers can pass a different base fee without invalidating the cache.
+   */
+  rewardsVipPerpsFees: { [subscriptionId: string]: VipPerpsFeesState };
+  /**
    * History of points estimates for Customer Support diagnostics.
    * Stores the last N successful estimates to verify user-reported discrepancies.
    */
@@ -861,6 +920,7 @@ type AllowedActions =
   | RewardsDataServiceGetSeasonMetadataAction
   | RewardsDataServiceGetDiscoverSeasonsAction
   | RewardsDataServiceGenerateChallengeAction
+  | RewardsDataServiceGetVipFeesAction
   | AccountTreeControllerGetAccountsFromSelectedAccountGroupAction
   | SnapControllerHandleRequestAction;
 

--- a/app/scripts/controllers/rewards/rewards-data-service-method-action-types.ts
+++ b/app/scripts/controllers/rewards/rewards-data-service-method-action-types.ts
@@ -146,6 +146,17 @@ export type RewardsDataServiceGetSeasonMetadataAction = {
 };
 
 /**
+ * Get the VIP fee table for the current subscription.
+ *
+ * @param subscriptionToken - The subscription token used for authentication.
+ * @returns The VIP fee response (tier 0 will have `fees=null`).
+ */
+export type RewardsDataServiceGetVipFeesAction = {
+  type: `RewardsDataService:getVipFees`;
+  handler: RewardsDataService['getVipFees'];
+};
+
+/**
  * Generate a challenge for SIWE (Sign-In with Ethereum) authentication.
  *
  * @param body - The challenge generation request body containing address.
@@ -173,4 +184,5 @@ export type RewardsDataServiceMethodActions =
   | RewardsDataServiceGetOptInStatusAction
   | RewardsDataServiceGetDiscoverSeasonsAction
   | RewardsDataServiceGetSeasonMetadataAction
+  | RewardsDataServiceGetVipFeesAction
   | RewardsDataServiceGenerateChallengeAction;

--- a/app/scripts/controllers/rewards/rewards-data-service.test.ts
+++ b/app/scripts/controllers/rewards/rewards-data-service.test.ts
@@ -2225,4 +2225,65 @@ describe('RewardsDataService', () => {
       expect(result).toBe('UNKNOWN');
     });
   });
+
+  describe('getVipFees', () => {
+    const mockSubscriptionToken = 'token-vip-fees';
+    const mockVipFees = {
+      vipTier: 1,
+      fees: {
+        hyperliquid: { builderCode: '0xbuilder', builderFeeBips: '5' },
+        swaps: { feeBips: '50' },
+      },
+      updatedAt: '2026-05-01T00:00:00.000Z',
+    };
+
+    beforeEach(() => {
+      service = createService();
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: jest.fn().mockResolvedValue(mockVipFees),
+      } as unknown as Response);
+    });
+
+    it('fetches VIP fees using the expected endpoint and auth headers', async () => {
+      const result = await service.getVipFees(mockSubscriptionToken);
+
+      expect(result).toEqual(mockVipFees);
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${REWARDS_API_URL.UAT}/vip/fees`,
+        expect.objectContaining({
+          method: 'GET',
+          credentials: 'omit',
+          headers: expect.objectContaining({
+            'Content-Type': 'application/json',
+            'rewards-access-token': mockSubscriptionToken,
+          }),
+        }),
+      );
+    });
+
+    it('throws when the VIP fees response is not ok', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+      } as Response);
+
+      await expect(service.getVipFees(mockSubscriptionToken)).rejects.toThrow(
+        'Get VIP fees failed: 500',
+      );
+    });
+
+    it('throws AuthorizationFailedError when response status is 403', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 403,
+        json: jest.fn().mockResolvedValue({}),
+      } as unknown as Response);
+
+      await expect(service.getVipFees(mockSubscriptionToken)).rejects.toThrow(
+        AuthorizationFailedError,
+      );
+    });
+  });
 });

--- a/app/scripts/controllers/rewards/rewards-data-service.ts
+++ b/app/scripts/controllers/rewards/rewards-data-service.ts
@@ -26,6 +26,7 @@ import type {
   ChallengeDto,
   SiweLoginDto,
   SiweJoinDto,
+  VipFeesResponseDto,
 } from './rewards-controller.types';
 import { RewardsDataServiceMethodActions } from './rewards-data-service-method-action-types';
 import { RewardsDataServiceMessenger } from './rewards-data-service-types';
@@ -81,6 +82,7 @@ const MESSENGER_EXPOSED_METHODS = [
   'getSeasonMetadata',
   'getDiscoverSeasons',
   'generateChallenge',
+  'getVipFees',
 ] as const;
 
 export type RewardsDataServiceActions = RewardsDataServiceMethodActions;
@@ -667,6 +669,28 @@ export class RewardsDataService {
     }
 
     return data as SeasonMetadataDto;
+  }
+
+  /**
+   * Get the VIP fee table for the current subscription.
+   *
+   * @param subscriptionToken - The subscription token used for authentication.
+   * @returns The VIP fee response (tier 0 will have `fees=null`).
+   */
+  async getVipFees(subscriptionToken: string): Promise<VipFeesResponseDto> {
+    const response = await this.makeRequest(
+      '/vip/fees',
+      {
+        method: 'GET',
+      },
+      subscriptionToken,
+    );
+
+    if (!response.ok) {
+      throw new Error(`Get VIP fees failed: ${response.status}`);
+    }
+
+    return (await response.json()) as VipFeesResponseDto;
   }
 
   /**

--- a/app/scripts/messenger-client-init/messengers/perps-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/perps-controller-messenger.ts
@@ -25,6 +25,7 @@ import {
 } from '@metamask/storage-service';
 import { TransactionControllerAddTransactionAction } from '@metamask/transaction-controller';
 import { MetaMetricsControllerTrackEventAction } from '../../controllers/metametrics-controller-method-action-types';
+import { RewardsControllerGetPerpsDiscountForAccountAction } from '../../controllers/rewards/rewards-controller-method-action-types';
 import { RootMessenger } from '../../lib/messenger';
 
 type AllowedActions =
@@ -41,7 +42,8 @@ type AllowedActions =
   | MetaMetricsControllerTrackEventAction
   | StorageServiceGetItemAction
   | StorageServiceSetItemAction
-  | StorageServiceRemoveItemAction;
+  | StorageServiceRemoveItemAction
+  | RewardsControllerGetPerpsDiscountForAccountAction;
 
 type AllowedEvents =
   | RemoteFeatureFlagControllerStateChangeEvent
@@ -89,6 +91,7 @@ export function getPerpsControllerMessenger(
       'StorageService:getItem',
       'StorageService:setItem',
       'StorageService:removeItem',
+      'RewardsController:getPerpsDiscountForAccount',
     ],
     events: [
       'RemoteFeatureFlagController:stateChange',

--- a/app/scripts/messenger-client-init/messengers/rewards-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/rewards-controller-messenger.ts
@@ -41,6 +41,7 @@ export function getRewardsControllerMessenger(
       'RewardsDataService:getSeasonMetadata',
       'RewardsDataService:getDiscoverSeasons',
       'RewardsDataService:generateChallenge',
+      'RewardsDataService:getVipFees',
       'SnapController:handleRequest',
     ],
     events: [

--- a/app/scripts/messenger-client-init/perps-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/perps-controller-init.test.ts
@@ -296,7 +296,40 @@ describe('PerpsControllerInit', () => {
         setStorageItem: expect.any(Function),
         removeStorageItem: expect.any(Function),
         isDisconnecting: expect.any(Function),
+        getPerpsDiscountForAccount: expect.any(Function),
       });
+    });
+
+    it('getPerpsDiscountForAccount from createPerpsInfrastructure delegates to RewardsController:getPerpsDiscountForAccount', async () => {
+      const call = jest.fn().mockResolvedValue(5000);
+      const request = getInitRequestMock();
+      request.controllerMessenger = {
+        call,
+      } as unknown as PerpsControllerMessenger;
+      let capturedDeps: InfrastructureDeps | undefined;
+
+      jest
+        .mocked(createPerpsInfrastructure)
+        .mockImplementationOnce((deps: InfrastructureDeps) => {
+          capturedDeps = deps;
+          return {} as PerpsPlatformDependencies;
+        });
+
+      PerpsControllerInit(request);
+      expect(capturedDeps).toBeDefined();
+      const deps = capturedDeps as InfrastructureDeps;
+
+      const result = await deps.getPerpsDiscountForAccount(
+        'eip155:42161:0xabc',
+        10,
+      );
+
+      expect(result).toBe(5000);
+      expect(call).toHaveBeenCalledWith(
+        'RewardsController:getPerpsDiscountForAccount',
+        'eip155:42161:0xabc',
+        10,
+      );
     });
 
     it('trackEvent from createPerpsInfrastructure delegates to MetaMetricsController:trackEvent', () => {

--- a/app/scripts/messenger-client-init/perps-controller-init.ts
+++ b/app/scripts/messenger-client-init/perps-controller-init.ts
@@ -77,6 +77,12 @@ export const PerpsControllerInit: MessengerClientInitFunction<
         key,
       ),
     isDisconnecting: () => isDisconnecting,
+    getPerpsDiscountForAccount: (caipAccountId, baseFeeBips) =>
+      controllerMessenger.call(
+        'RewardsController:getPerpsDiscountForAccount',
+        caipAccountId,
+        baseFeeBips,
+      ),
   });
   const fallbackBlockedRegions = getFallbackBlockedRegions();
   const hyperLiquidBuilderAddresses = getHyperLiquidBuilderAddresses();

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2997,6 +2997,10 @@ export default class MetamaskController extends EventEmitter {
         this.rewardsController.linkAccountsToSubscriptionCandidate.bind(
           this.rewardsController,
         ),
+      rewardsGetPerpsDiscountForAccount:
+        this.rewardsController.getPerpsDiscountForAccount.bind(
+          this.rewardsController,
+        ),
 
       // claims
       getSubmitClaimConfig: this.claimsController.getSubmitClaimConfig.bind(

--- a/shared/constants/rewards.ts
+++ b/shared/constants/rewards.ts
@@ -1,4 +1,5 @@
 export const REWARDS_API_URL = {
+  DEV: 'https://rewards.dev-api.cx.metamask.io',
   UAT: 'https://rewards.uat-api.cx.metamask.io',
   PRD: 'https://rewards.api.cx.metamask.io',
 };

--- a/shared/types/background.ts
+++ b/shared/types/background.ts
@@ -323,6 +323,7 @@ export type ControllerStatePropertiesEnumerated = {
   rewardsSeasonStatuses: RewardsControllerState['rewardsSeasonStatuses'];
   rewardsSubscriptionTokens: RewardsControllerState['rewardsSubscriptionTokens'];
   rewardsPointsEstimateHistory: RewardsControllerState['rewardsPointsEstimateHistory'];
+  rewardsVipPerpsFees: RewardsControllerState['rewardsVipPerpsFees'];
   claims: ClaimsControllerState['claims'];
   claimsConfigurations: ClaimsControllerState['claimsConfigurations'];
   drafts: ClaimsControllerState['drafts'];

--- a/test/e2e/fixtures/default-fixture.json
+++ b/test/e2e/fixtures/default-fixture.json
@@ -1013,7 +1013,8 @@
       "rewardsSeasonStatuses": {},
       "rewardsSeasons": {},
       "rewardsSubscriptionTokens": {},
-      "rewardsSubscriptions": {}
+      "rewardsSubscriptions": {},
+      "rewardsVipPerpsFees": {}
     },
     "SeedlessOnboardingController": {
       "isSeedlessOnboardingUserAuthenticated": false,

--- a/test/e2e/fixtures/onboarding-fixture.json
+++ b/test/e2e/fixtures/onboarding-fixture.json
@@ -2088,7 +2088,8 @@
       "rewardsSeasonStatuses": {},
       "rewardsSeasons": {},
       "rewardsSubscriptionTokens": {},
-      "rewardsSubscriptions": {}
+      "rewardsSubscriptions": {},
+      "rewardsVipPerpsFees": {}
     },
     "SeedlessOnboardingController": {
       "isSeedlessOnboardingUserAuthenticated": false,

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
@@ -337,7 +337,8 @@
     "rewardsSeasonStatuses": "object",
     "rewardsSeasons": "object",
     "rewardsSubscriptionTokens": "object",
-    "rewardsSubscriptions": "object"
+    "rewardsSubscriptions": "object",
+    "rewardsVipPerpsFees": "object"
   },
   "RewardsDataService": "undefined",
   "SeedlessOnboardingController": "object",

--- a/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-background-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-background-state.json
@@ -260,7 +260,8 @@
       "rewardsSeasonStatuses": "object",
       "rewardsSeasons": "object",
       "rewardsSubscriptionTokens": "object",
-      "rewardsSubscriptions": "object"
+      "rewardsSubscriptions": "object",
+      "rewardsVipPerpsFees": "object"
     },
     "SeedlessOnboardingController": "object",
     "SelectedNetworkController": { "domains": "object" },

--- a/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
@@ -265,7 +265,8 @@
       "rewardsSeasonStatuses": "object",
       "rewardsSeasons": "object",
       "rewardsSubscriptionTokens": "object",
-      "rewardsSubscriptions": "object"
+      "rewardsSubscriptions": "object",
+      "rewardsVipPerpsFees": "object"
     },
     "SeedlessOnboardingController": "object",
     "SelectedNetworkController": { "domains": "object" },

--- a/test/e2e/tests/settings/state-logs.json
+++ b/test/e2e/tests/settings/state-logs.json
@@ -1261,6 +1261,7 @@
     "rewardsSeasons": {},
     "rewardsSeasonStatuses": {},
     "rewardsSubscriptions": {},
+    "rewardsVipPerpsFees": {},
     "securityAlertsEnabled": "boolean",
     "seedPhraseBackedUp": "null",
     "passkeyRecord": "null",

--- a/ui/components/app/perps/close-position/close-position-modal.test.tsx
+++ b/ui/components/app/perps/close-position/close-position-modal.test.tsx
@@ -114,8 +114,20 @@ jest.mock('../../../../hooks/perps/usePerpsEligibility', () => ({
   usePerpsEligibility: () => mockUsePerpsEligibility(),
 }));
 
+type MockedUsePerpsOrderFeesReturn = {
+  feeRate: number | undefined;
+  isLoading: boolean;
+  metamaskFeeRateDiscountPercentage: number | undefined;
+};
+const mockUsePerpsOrderFees = jest.fn<MockedUsePerpsOrderFeesReturn, []>(
+  () => ({
+    feeRate: 0.00145,
+    isLoading: false,
+    metamaskFeeRateDiscountPercentage: undefined,
+  }),
+);
 jest.mock('../../../../hooks/perps/usePerpsOrderFees', () => ({
-  usePerpsOrderFees: () => ({ feeRate: 0.00145, isLoading: false }),
+  usePerpsOrderFees: () => mockUsePerpsOrderFees(),
 }));
 
 jest.mock('../perps-toast', () => ({
@@ -144,6 +156,11 @@ describe('ClosePositionModal', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUsePerpsEligibility.mockReturnValue({ isEligible: true });
+    mockUsePerpsOrderFees.mockReturnValue({
+      feeRate: 0.00145,
+      isLoading: false,
+      metamaskFeeRateDiscountPercentage: undefined,
+    });
     mockSubmitRequestToBackground.mockResolvedValue({ success: true });
   });
 
@@ -703,6 +720,79 @@ describe('ClosePositionModal', () => {
       // sanity: margin must be positive and must NOT include an extra pnl on top
       // (basePosition: marginUsed=2375, unrealizedPnl=375 — receive should be ~2375-fees, not ~2750-fees)
       expect(marginValue).toBe(2375);
+    });
+  });
+
+  describe('MetaMask fee discount badge', () => {
+    it('does not render the discount badge when no discount is active', () => {
+      mockUsePerpsOrderFees.mockReturnValue({
+        feeRate: 0.00145,
+        isLoading: false,
+        metamaskFeeRateDiscountPercentage: undefined,
+      });
+
+      renderWithProvider(
+        <ClosePositionModal
+          isOpen
+          onClose={jest.fn()}
+          position={basePosition}
+          currentPrice={2900}
+        />,
+        mockStore,
+      );
+
+      expect(
+        screen.queryByTestId('perps-fees-display-discount'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders the inline discount badge next to the fees value when a discount is active', () => {
+      mockUsePerpsOrderFees.mockReturnValue({
+        feeRate: 0.00045 + 0.0005, // protocol + half-off builder
+        isLoading: false,
+        metamaskFeeRateDiscountPercentage: 50,
+      });
+
+      renderWithProvider(
+        <ClosePositionModal
+          isOpen
+          onClose={jest.fn()}
+          position={basePosition}
+          currentPrice={2900}
+        />,
+        mockStore,
+      );
+
+      expect(
+        screen.getByTestId('perps-fees-display-discount'),
+      ).toBeInTheDocument();
+      expect(screen.getByText('-50%')).toBeInTheDocument();
+      // Fee value text still present
+      expect(
+        screen.getByTestId('perps-close-summary-fees-value'),
+      ).toBeInTheDocument();
+    });
+
+    it('does not render the discount badge while feeRate is unavailable', () => {
+      mockUsePerpsOrderFees.mockReturnValue({
+        feeRate: undefined,
+        isLoading: true,
+        metamaskFeeRateDiscountPercentage: 50,
+      });
+
+      renderWithProvider(
+        <ClosePositionModal
+          isOpen
+          onClose={jest.fn()}
+          position={basePosition}
+          currentPrice={2900}
+        />,
+        mockStore,
+      );
+
+      expect(
+        screen.queryByTestId('perps-fees-display-discount'),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/ui/components/app/perps/close-position/close-position-modal.tsx
+++ b/ui/components/app/perps/close-position/close-position-modal.tsx
@@ -49,6 +49,7 @@ import {
 import { handlePerpsError } from '../utils/translate-perps-error';
 import { PERPS_MIN_MARKET_ORDER_USD } from '../constants';
 import { usePerpsOrderFees } from '../../../../hooks/perps/usePerpsOrderFees';
+import { PerpsFeesDisplay } from '../perps-fees-display';
 import { CloseAmountSection } from '../order-entry';
 import {
   PERPS_TOAST_KEYS,
@@ -307,7 +308,7 @@ export const ClosePositionModal: React.FC<ClosePositionModalProps> = ({
     [closeSize, currentPrice],
   );
 
-  const { feeRate } = usePerpsOrderFees({
+  const { feeRate, metamaskFeeRateDiscountPercentage } = usePerpsOrderFees({
     symbol: position.symbol,
     orderType: 'market',
   });
@@ -616,13 +617,16 @@ export const ClosePositionModal: React.FC<ClosePositionModalProps> = ({
                   >
                     {t('perpsFees')}
                   </Text>
-                  <Text
-                    variant={TextVariant.BodySm}
-                    fontWeight={FontWeight.Medium}
-                    data-testid="perps-close-summary-fees-value"
-                  >
-                    -{formatFiat(roundedFees)}
-                  </Text>
+                  <PerpsFeesDisplay
+                    metamaskFeeRateDiscountPercentage={
+                      feeRate === undefined
+                        ? undefined
+                        : metamaskFeeRateDiscountPercentage
+                    }
+                    formatFeeText={`-${formatFiat(roundedFees)}`}
+                    feeTextFontWeight={FontWeight.Medium}
+                    feeTextTestId="perps-close-summary-fees-value"
+                  />
                 </Box>
 
                 {/* You'll receive */}

--- a/ui/components/app/perps/order-entry/components/order-summary/order-summary.test.tsx
+++ b/ui/components/app/perps/order-entry/components/order-summary/order-summary.test.tsx
@@ -101,4 +101,75 @@ describe('OrderSummary', () => {
       expect(screen.getByText('$42,500.00')).toBeInTheDocument();
     });
   });
+
+  describe('MetaMask fee discount badge', () => {
+    it('does not render the discount badge when metamaskFeeRateDiscountPercentage is undefined', () => {
+      renderWithProvider(
+        <OrderSummary
+          marginRequired="$1,000.00"
+          estimatedFees="$0.50"
+          liquidationPrice="$42,500.00"
+        />,
+        mockStore,
+      );
+
+      expect(
+        screen.queryByTestId('perps-fees-display-discount'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders the discount badge in the fees row when metamaskFeeRateDiscountPercentage > 0', () => {
+      renderWithProvider(
+        <OrderSummary
+          marginRequired="$1,000.00"
+          estimatedFees="$0.50"
+          liquidationPrice="$42,500.00"
+          metamaskFeeRateDiscountPercentage={50}
+        />,
+        mockStore,
+      );
+
+      expect(
+        screen.getByTestId('perps-fees-display-discount'),
+      ).toBeInTheDocument();
+      expect(screen.getByText('-50%')).toBeInTheDocument();
+      // Fee text still renders alongside the badge
+      expect(screen.getByText('$0.50')).toBeInTheDocument();
+    });
+
+    it('does not render the discount badge when metamaskFeeRateDiscountPercentage is 0', () => {
+      renderWithProvider(
+        <OrderSummary
+          marginRequired="$1,000.00"
+          estimatedFees="$0.50"
+          liquidationPrice="$42,500.00"
+          metamaskFeeRateDiscountPercentage={0}
+        />,
+        mockStore,
+      );
+
+      expect(
+        screen.queryByTestId('perps-fees-display-discount'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('does not render the discount badge when estimatedFees is null even if a discount is active', () => {
+      renderWithProvider(
+        <OrderSummary
+          marginRequired="$1,000.00"
+          estimatedFees={null}
+          liquidationPrice="$42,500.00"
+          metamaskFeeRateDiscountPercentage={50}
+        />,
+        mockStore,
+      );
+
+      expect(
+        screen.queryByTestId('perps-fees-display-discount'),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByTestId('perps-order-summary-estimated-fees'),
+      ).toHaveTextContent('-');
+    });
+  });
 });

--- a/ui/components/app/perps/order-entry/components/order-summary/order-summary.tsx
+++ b/ui/components/app/perps/order-entry/components/order-summary/order-summary.tsx
@@ -9,6 +9,7 @@ import {
   BoxAlignItems,
 } from '@metamask/design-system-react';
 import { useI18nContext } from '../../../../../../hooks/useI18nContext';
+import { PerpsFeesDisplay } from '../../../perps-fees-display';
 import type { OrderSummaryProps } from '../../order-entry.types';
 
 /**
@@ -18,11 +19,13 @@ import type { OrderSummaryProps } from '../../order-entry.types';
  * @param props.marginRequired - Margin required for the position
  * @param props.estimatedFees - Estimated trading fees
  * @param props.liquidationPrice - Estimated liquidation price
+ * @param props.metamaskFeeRateDiscountPercentage - MetaMask fee discount percentage (whole numbers)
  */
 export const OrderSummary: React.FC<OrderSummaryProps> = ({
   marginRequired,
   estimatedFees,
   liquidationPrice,
+  metamaskFeeRateDiscountPercentage,
 }) => {
   const t = useI18nContext();
 
@@ -73,13 +76,13 @@ export const OrderSummary: React.FC<OrderSummaryProps> = ({
         <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
           {t('perpsFees')}
         </Text>
-        <Text
-          variant={TextVariant.BodySm}
-          color={TextColor.TextDefault}
-          data-testid="perps-order-summary-estimated-fees"
-        >
-          {estimatedFees ?? '-'}
-        </Text>
+        <PerpsFeesDisplay
+          metamaskFeeRateDiscountPercentage={
+            estimatedFees ? metamaskFeeRateDiscountPercentage : undefined
+          }
+          formatFeeText={estimatedFees ?? '-'}
+          feeTextTestId="perps-order-summary-estimated-fees"
+        />
       </Box>
     </Box>
   );

--- a/ui/components/app/perps/order-entry/order-entry.tsx
+++ b/ui/components/app/perps/order-entry/order-entry.tsx
@@ -95,7 +95,7 @@ export const OrderEntry: React.FC<OrderEntryProps> = ({
   const marketInfo = usePerpsMarketInfo(asset);
 
   // Fetch dynamic fee rates from the controller (user-specific, with discounts)
-  const { feeRate } = usePerpsOrderFees({
+  const { feeRate, metamaskFeeRateDiscountPercentage } = usePerpsOrderFees({
     symbol: asset,
     orderType: orderType ?? 'market',
   });
@@ -397,6 +397,9 @@ export const OrderEntry: React.FC<OrderEntryProps> = ({
             marginRequired={calculations.marginRequired}
             estimatedFees={calculations.estimatedFees}
             liquidationPrice={calculations.liquidationPrice}
+            metamaskFeeRateDiscountPercentage={
+              metamaskFeeRateDiscountPercentage
+            }
           />
         )}
       </Box>

--- a/ui/components/app/perps/order-entry/order-entry.types.ts
+++ b/ui/components/app/perps/order-entry/order-entry.types.ts
@@ -216,6 +216,12 @@ export type OrderSummaryProps = {
   estimatedFees: string | null;
   /** Estimated liquidation price */
   liquidationPrice: string | null;
+  /**
+   * MetaMask fee discount percentage (whole numbers). When provided and
+   * positive, the fees row renders an inline `-X%` badge alongside the fee
+   * value.
+   */
+  metamaskFeeRateDiscountPercentage?: number;
 };
 
 /**

--- a/ui/components/app/perps/perps-fees-display/index.ts
+++ b/ui/components/app/perps/perps-fees-display/index.ts
@@ -1,0 +1,2 @@
+export { PerpsFeesDisplay } from './perps-fees-display';
+export type { PerpsFeesDisplayProps } from './perps-fees-display';

--- a/ui/components/app/perps/perps-fees-display/perps-fees-display.test.tsx
+++ b/ui/components/app/perps/perps-fees-display/perps-fees-display.test.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { PerpsFeesDisplay } from './perps-fees-display';
+
+describe('PerpsFeesDisplay', () => {
+  describe('discount badge visibility', () => {
+    it('hides the discount badge when metamaskFeeRateDiscountPercentage is undefined', () => {
+      render(<PerpsFeesDisplay formatFeeText="$10.00" />);
+
+      expect(
+        screen.queryByTestId('perps-fees-display-discount'),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByText(/-\d+%/u)).not.toBeInTheDocument();
+    });
+
+    it('hides the discount badge when metamaskFeeRateDiscountPercentage is zero', () => {
+      render(
+        <PerpsFeesDisplay
+          formatFeeText="$10.00"
+          metamaskFeeRateDiscountPercentage={0}
+        />,
+      );
+
+      expect(
+        screen.queryByTestId('perps-fees-display-discount'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('hides the discount badge when metamaskFeeRateDiscountPercentage is negative', () => {
+      render(
+        <PerpsFeesDisplay
+          formatFeeText="$10.00"
+          metamaskFeeRateDiscountPercentage={-5}
+        />,
+      );
+
+      expect(
+        screen.queryByTestId('perps-fees-display-discount'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders the discount badge when metamaskFeeRateDiscountPercentage is positive', () => {
+      render(
+        <PerpsFeesDisplay
+          formatFeeText="$10.00"
+          metamaskFeeRateDiscountPercentage={15}
+        />,
+      );
+
+      expect(
+        screen.getByTestId('perps-fees-display-discount'),
+      ).toBeInTheDocument();
+      expect(screen.getByText('-15%')).toBeInTheDocument();
+    });
+
+    [1, 5, 10, 25, 50, 100].forEach((percentage) => {
+      it(`renders the discount label correctly for ${percentage} percent`, () => {
+        render(
+          <PerpsFeesDisplay
+            formatFeeText="$10.00"
+            metamaskFeeRateDiscountPercentage={percentage}
+          />,
+        );
+
+        expect(screen.getByText(`-${percentage}%`)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('fee text rendering', () => {
+    it('always renders the formatted fee text', () => {
+      render(<PerpsFeesDisplay formatFeeText="$25.50" />);
+
+      expect(screen.getByText('$25.50')).toBeInTheDocument();
+    });
+
+    it('renders both fee text and discount when both are present', () => {
+      render(
+        <PerpsFeesDisplay
+          formatFeeText="$100.00"
+          metamaskFeeRateDiscountPercentage={20}
+        />,
+      );
+
+      expect(screen.getByText('$100.00')).toBeInTheDocument();
+      expect(screen.getByText('-20%')).toBeInTheDocument();
+    });
+
+    it('forwards the optional feeTextTestId to the fee text node', () => {
+      render(
+        <PerpsFeesDisplay formatFeeText="$0.50" feeTextTestId="my-fee-text" />,
+      );
+
+      expect(screen.getByTestId('my-fee-text')).toHaveTextContent('$0.50');
+    });
+  });
+});

--- a/ui/components/app/perps/perps-fees-display/perps-fees-display.tsx
+++ b/ui/components/app/perps/perps-fees-display/perps-fees-display.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import {
+  Box,
+  BoxAlignItems,
+  BoxBackgroundColor,
+  BoxFlexDirection,
+  FontWeight,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react';
+
+export type PerpsFeesDisplayProps = {
+  /**
+   * MetaMask fee discount in whole percentage points. When `undefined`, `0`,
+   * or negative, the discount badge is not rendered (matching mobile's
+   * `PerpsFeesDisplay`).
+   */
+  metamaskFeeRateDiscountPercentage?: number;
+  /** Pre-formatted fee text (e.g. `"$0.50"`). Always rendered. */
+  formatFeeText: string;
+  /** Optional override for the fee text variant (defaults to BodySm). */
+  variant?: TextVariant;
+  /** Optional override for the fee text color (defaults to TextDefault). */
+  feeTextColor?: TextColor;
+  /** Optional override for the fee text font weight. */
+  feeTextFontWeight?: FontWeight;
+  /** Optional override for the testid on the fee text element. */
+  feeTextTestId?: string;
+};
+
+/**
+ * Renders the estimated fee text with an inline `-X%` warning-colored badge
+ * when a MetaMask fee discount is active. Mirrors mobile's
+ * `app/components/UI/Perps/components/PerpsFeesDisplay/PerpsFeesDisplay.tsx`.
+ *
+ * The badge is hidden entirely when `metamaskFeeRateDiscountPercentage` is `undefined`, `0`,
+ * or negative — the surrounding row stays clean when no discount applies.
+ *
+ * Extension does not have the mobile `TagColored` component, so the badge is
+ * built from a `Box` with the warning-muted background plus the design
+ * system's `MetamaskFoxOutline` icon, matching the existing warning-tone
+ * patterns already used inside the perps UI (e.g. the partial-close min
+ * notional banner in `ClosePositionModal`).
+ *
+ * @param props - Component props.
+ * @param props.metamaskFeeRateDiscountPercentage - MetaMask fee discount in whole percentage points. The badge is hidden when this is `undefined`, `0`, or negative.
+ * @param props.formatFeeText - Pre-formatted fee text (e.g. `"$0.50"`), always rendered.
+ * @param props.variant - Text variant for the fee value (defaults to BodySm).
+ * @param props.feeTextColor - Text color for the fee value (defaults to TextDefault).
+ * @param props.feeTextFontWeight - Optional font weight for the fee value.
+ * @param props.feeTextTestId - Optional testid forwarded to the fee value text node.
+ */
+export const PerpsFeesDisplay: React.FC<PerpsFeesDisplayProps> = ({
+  metamaskFeeRateDiscountPercentage,
+  formatFeeText,
+  variant = TextVariant.BodySm,
+  feeTextColor = TextColor.TextDefault,
+  feeTextFontWeight,
+  feeTextTestId,
+}) => (
+  <Box
+    flexDirection={BoxFlexDirection.Row}
+    alignItems={BoxAlignItems.Center}
+    gap={1}
+  >
+    {metamaskFeeRateDiscountPercentage !== undefined &&
+    metamaskFeeRateDiscountPercentage > 0 ? (
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        gap={1}
+        backgroundColor={BoxBackgroundColor.WarningMuted}
+        paddingLeft={1}
+        paddingRight={1}
+        className="rounded"
+        data-testid="perps-fees-display-discount"
+      >
+        <Icon
+          name={IconName.MetamaskFoxOutline}
+          size={IconSize.Sm}
+          color={IconColor.WarningDefault}
+        />
+        <Text variant={TextVariant.BodyXs} color={TextColor.WarningDefault}>
+          {`-${metamaskFeeRateDiscountPercentage}%`}
+        </Text>
+      </Box>
+    ) : null}
+    <Text
+      variant={variant}
+      color={feeTextColor}
+      fontWeight={feeTextFontWeight}
+      data-testid={feeTextTestId}
+    >
+      {formatFeeText}
+    </Text>
+  </Box>
+);
+
+export default PerpsFeesDisplay;

--- a/ui/components/app/perps/reverse-position/reverse-position-modal.test.tsx
+++ b/ui/components/app/perps/reverse-position/reverse-position-modal.test.tsx
@@ -237,6 +237,36 @@ describe('ReversePositionModal', () => {
         '--',
       );
     });
+
+    it('does not render the discount badge while the fee placeholder is shown', () => {
+      mockUsePerpsOrderFees.mockReturnValue({
+        feeRate: undefined,
+        isLoading: true,
+        hasError: false,
+        metamaskFeeRateDiscountPercentage: 50,
+      });
+
+      renderWithProvider(<ReversePositionModal {...defaultProps} />, mockStore);
+
+      expect(
+        screen.queryByTestId('perps-fees-display-discount'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders the discount badge alongside the fee value when fees are available', () => {
+      mockUsePerpsOrderFees.mockReturnValue({
+        feeRate: 0.0001,
+        isLoading: false,
+        hasError: false,
+        metamaskFeeRateDiscountPercentage: 50,
+      });
+
+      renderWithProvider(<ReversePositionModal {...defaultProps} />, mockStore);
+
+      expect(
+        screen.getByTestId('perps-fees-display-discount'),
+      ).toBeInTheDocument();
+    });
   });
 
   describe('long position', () => {

--- a/ui/components/app/perps/reverse-position/reverse-position-modal.tsx
+++ b/ui/components/app/perps/reverse-position/reverse-position-modal.tsx
@@ -44,6 +44,7 @@ import { getPositionDirection } from '../utils';
 import { handlePerpsError } from '../utils/translate-perps-error';
 import { PERPS_TOAST_KEYS, usePerpsToast } from '../perps-toast';
 import { PerpsGeoBlockModal } from '../perps-geo-block-modal';
+import { PerpsFeesDisplay } from '../perps-fees-display';
 import { usePerpsOrderFees } from '../../../../hooks/perps/usePerpsOrderFees';
 import type { Position } from '../types';
 
@@ -110,6 +111,7 @@ export const ReversePositionModal: React.FC<ReversePositionModalProps> = ({
     feeRate,
     isLoading: isFeeLoading,
     hasError: hasFeeError,
+    metamaskFeeRateDiscountPercentage,
   } = usePerpsOrderFees({
     symbol: position.symbol,
     orderType: 'market',
@@ -259,17 +261,22 @@ export const ReversePositionModal: React.FC<ReversePositionModalProps> = ({
                 >
                   {t('perpsFees')}
                 </Text>
-                <Text
-                  variant={TextVariant.BodySm}
-                  fontWeight={FontWeight.Medium}
-                  data-testid="perps-reverse-fee-value"
-                >
-                  {shouldShowFeePlaceholder
-                    ? '--'
-                    : formatPerpsFiat(estimatedFees, {
-                        ranges: PRICE_RANGES_MINIMAL_VIEW,
-                      })}
-                </Text>
+                <PerpsFeesDisplay
+                  metamaskFeeRateDiscountPercentage={
+                    shouldShowFeePlaceholder
+                      ? undefined
+                      : metamaskFeeRateDiscountPercentage
+                  }
+                  formatFeeText={
+                    shouldShowFeePlaceholder
+                      ? '--'
+                      : formatPerpsFiat(estimatedFees, {
+                          ranges: PRICE_RANGES_MINIMAL_VIEW,
+                        })
+                  }
+                  feeTextFontWeight={FontWeight.Medium}
+                  feeTextTestId="perps-reverse-fee-value"
+                />
               </Box>
               {error && (
                 <Box

--- a/ui/hooks/perps/index.ts
+++ b/ui/hooks/perps/index.ts
@@ -4,6 +4,7 @@ export { usePerpsMeasurement } from './usePerpsMeasurement';
 export { usePerpsLifecycleBreadcrumbs } from './usePerpsLifecycleBreadcrumbs';
 export { usePerpsMarketInfo } from './usePerpsMarketInfo';
 export { usePerpsOrderFees } from './usePerpsOrderFees';
+export { usePerpsMetamaskFeeDiscountBips } from './usePerpsMetamaskFeeDiscountBips';
 export type {
   UsePerpsOrderFormOptions,
   UsePerpsOrderFormReturn,

--- a/ui/hooks/perps/usePerpsMetamaskFeeDiscountBips.test.ts
+++ b/ui/hooks/perps/usePerpsMetamaskFeeDiscountBips.test.ts
@@ -1,0 +1,333 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { toChecksumHexAddress } from '@metamask/controller-utils';
+import { getSelectedInternalAccount } from '../../../shared/lib/selectors/accounts';
+import { getCurrentChainId } from '../../../shared/lib/selectors/networks';
+import {
+  clearPerpsFeeDiscountCacheForTests,
+  usePerpsMetamaskFeeDiscountBips,
+} from './usePerpsMetamaskFeeDiscountBips';
+
+const mockSubmitRequestToBackground = jest.fn();
+jest.mock('../../store/background-connection', () => ({
+  submitRequestToBackground: (...args: unknown[]) =>
+    mockSubmitRequestToBackground(...args),
+}));
+
+const mockUseSelector = jest.fn();
+jest.mock('react-redux', () => ({
+  useSelector: (selector: unknown) => mockUseSelector(selector),
+}));
+
+const TEST_ADDRESS = '0xabc0000000000000000000000000000000000def';
+const TEST_CHAIN_ID = '0xa4b1'; // Arbitrum One (42161)
+const TEST_CAIP_ACCOUNT_ID = `eip155:42161:${toChecksumHexAddress(
+  TEST_ADDRESS,
+)}`;
+const ORIGINAL_METAMASK_FEE_BIPS = 10;
+
+function setSelectors(
+  overrides: { address?: string | null; chainId?: string } = {},
+) {
+  const address = 'address' in overrides ? overrides.address : TEST_ADDRESS;
+  const chainId = overrides.chainId ?? TEST_CHAIN_ID;
+  mockUseSelector.mockImplementation((selector) => {
+    if (selector === getSelectedInternalAccount) {
+      return address ? { address } : undefined;
+    }
+    if (selector === getCurrentChainId) {
+      return chainId;
+    }
+    return undefined;
+  });
+}
+
+function setDiscountResponse(discountBips: number | null | Error) {
+  mockSubmitRequestToBackground.mockImplementation((method: string) => {
+    if (method === 'rewardsGetPerpsDiscountForAccount') {
+      if (discountBips instanceof Error) {
+        return Promise.reject(discountBips);
+      }
+      return Promise.resolve(discountBips);
+    }
+    return Promise.resolve(undefined);
+  });
+}
+
+describe('usePerpsMetamaskFeeDiscountBips', () => {
+  beforeEach(() => {
+    mockSubmitRequestToBackground.mockReset();
+    mockUseSelector.mockReset();
+    clearPerpsFeeDiscountCacheForTests();
+    setSelectors();
+  });
+
+  it('returns undefined while the discount lookup is in flight', () => {
+    mockSubmitRequestToBackground.mockReturnValue(new Promise(() => undefined));
+    const { result } = renderHook(() =>
+      usePerpsMetamaskFeeDiscountBips(ORIGINAL_METAMASK_FEE_BIPS),
+    );
+    expect(result.current).toBeUndefined();
+  });
+
+  it('returns the discount in basis points when > 0', async () => {
+    setDiscountResponse(5000);
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      usePerpsMetamaskFeeDiscountBips(ORIGINAL_METAMASK_FEE_BIPS),
+    );
+    await waitForNextUpdate();
+
+    expect(result.current).toBe(5000);
+  });
+
+  it('caps the discount at 10000 bips (100%)', async () => {
+    setDiscountResponse(12000);
+
+    const { result, waitForNextUpdate } = renderHook(() =>
+      usePerpsMetamaskFeeDiscountBips(ORIGINAL_METAMASK_FEE_BIPS),
+    );
+    await waitForNextUpdate();
+
+    expect(result.current).toBe(10000);
+  });
+
+  it('returns undefined when bips is exactly 0', async () => {
+    setDiscountResponse(0);
+
+    const { result } = renderHook(() =>
+      usePerpsMetamaskFeeDiscountBips(ORIGINAL_METAMASK_FEE_BIPS),
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('returns undefined when the controller returns null (unhydrated / non-eligible)', async () => {
+    setDiscountResponse(null);
+
+    const { result } = renderHook(() =>
+      usePerpsMetamaskFeeDiscountBips(ORIGINAL_METAMASK_FEE_BIPS),
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('swallows a thrown discount lookup (returns undefined, no error surfaced)', async () => {
+    setDiscountResponse(new Error('network down'));
+
+    const { result } = renderHook(() =>
+      usePerpsMetamaskFeeDiscountBips(ORIGINAL_METAMASK_FEE_BIPS),
+    );
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('returns undefined and skips the lookup entirely when no account is selected', async () => {
+    setSelectors({ address: null });
+    setDiscountResponse(5000);
+
+    const { result } = renderHook(() =>
+      usePerpsMetamaskFeeDiscountBips(ORIGINAL_METAMASK_FEE_BIPS),
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current).toBeUndefined();
+    expect(mockSubmitRequestToBackground).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined when the chain id cannot be parsed to CAIP-10', async () => {
+    setSelectors({ chainId: 'not-a-chain-id' });
+    setDiscountResponse(5000);
+
+    const { result } = renderHook(() =>
+      usePerpsMetamaskFeeDiscountBips(ORIGINAL_METAMASK_FEE_BIPS),
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current).toBeUndefined();
+    expect(mockSubmitRequestToBackground).not.toHaveBeenCalled();
+  });
+
+  it('calls rewardsGetPerpsDiscountForAccount with the CAIP-10 id and the original MM fee bips', async () => {
+    setDiscountResponse(2500);
+
+    const { waitForNextUpdate } = renderHook(() =>
+      usePerpsMetamaskFeeDiscountBips(ORIGINAL_METAMASK_FEE_BIPS),
+    );
+    await waitForNextUpdate();
+
+    expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+      'rewardsGetPerpsDiscountForAccount',
+      [TEST_CAIP_ACCOUNT_ID, ORIGINAL_METAMASK_FEE_BIPS],
+    );
+  });
+
+  it('caches a non-null discount across rerenders for the same address', async () => {
+    setDiscountResponse(2000);
+
+    const { waitForNextUpdate, rerender, result } = renderHook(() =>
+      usePerpsMetamaskFeeDiscountBips(ORIGINAL_METAMASK_FEE_BIPS),
+    );
+    await waitForNextUpdate();
+    expect(result.current).toBe(2000);
+
+    // Force a re-render — the effect deps (selectedAddress, currentChainId)
+    // haven't changed, so the effect shouldn't re-fire. Even if it did, the
+    // cache should keep the call count at 1.
+    rerender();
+
+    const discountCalls = mockSubmitRequestToBackground.mock.calls.filter(
+      (call) => call[0] === 'rewardsGetPerpsDiscountForAccount',
+    );
+    expect(discountCalls).toHaveLength(1);
+    expect(result.current).toBe(2000);
+  });
+
+  it('serves the cached discount synchronously on a fresh mount (no extra background call)', async () => {
+    setDiscountResponse(3000);
+
+    // First mount: populates the cache.
+    const first = renderHook(() =>
+      usePerpsMetamaskFeeDiscountBips(ORIGINAL_METAMASK_FEE_BIPS),
+    );
+    await first.waitForNextUpdate();
+    expect(first.result.current).toBe(3000);
+    first.unmount();
+
+    // Second mount with the same address: should hit the cache and not call
+    // the background again.
+    const second = renderHook(() =>
+      usePerpsMetamaskFeeDiscountBips(ORIGINAL_METAMASK_FEE_BIPS),
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(second.result.current).toBe(3000);
+    const discountCalls = mockSubmitRequestToBackground.mock.calls.filter(
+      (call) => call[0] === 'rewardsGetPerpsDiscountForAccount',
+    );
+    expect(discountCalls).toHaveLength(1);
+  });
+
+  it('refetches when the chain changes for the same address (cache is keyed by CAIP account id)', async () => {
+    setDiscountResponse(2000);
+
+    const { rerender, result, waitForNextUpdate } = renderHook(
+      ({ chainId }: { chainId: string }) => {
+        setSelectors({ chainId });
+        return usePerpsMetamaskFeeDiscountBips(ORIGINAL_METAMASK_FEE_BIPS);
+      },
+      { initialProps: { chainId: TEST_CHAIN_ID } },
+    );
+    await waitForNextUpdate();
+    expect(result.current).toBe(2000);
+
+    // Switch to a different chain for the same address. The CAIP account id
+    // changes, so the cache must miss and the background must be called again.
+    setDiscountResponse(4000);
+    rerender({ chainId: '0x1' });
+    await waitForNextUpdate();
+    expect(result.current).toBe(4000);
+
+    const discountCalls = mockSubmitRequestToBackground.mock.calls.filter(
+      (call) => call[0] === 'rewardsGetPerpsDiscountForAccount',
+    );
+    expect(discountCalls).toHaveLength(2);
+    expect(discountCalls[0][1][0]).toBe(TEST_CAIP_ACCOUNT_ID);
+    expect(discountCalls[1][1][0]).toBe(
+      `eip155:1:${toChecksumHexAddress(TEST_ADDRESS)}`,
+    );
+  });
+
+  it('does not cache a null discount (refetches on next effect run)', async () => {
+    setDiscountResponse(null);
+
+    const { rerender } = renderHook(
+      ({ chainId }: { chainId: string }) => {
+        setSelectors({ chainId });
+        return usePerpsMetamaskFeeDiscountBips(ORIGINAL_METAMASK_FEE_BIPS);
+      },
+      { initialProps: { chainId: TEST_CHAIN_ID } },
+    );
+    // Flush the initial null lookup. `waitForNextUpdate` would hang here
+    // because the hook stays at its initial `undefined` value — there's no
+    // state change to await.
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Changing chainId re-runs the effect.
+    rerender({ chainId: '0x1' });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const discountCalls = mockSubmitRequestToBackground.mock.calls.filter(
+      (call) => call[0] === 'rewardsGetPerpsDiscountForAccount',
+    );
+    expect(discountCalls).toHaveLength(2);
+  });
+
+  it('resets to undefined immediately when the account switches before the new fetch resolves', async () => {
+    // First account resolves to 5000.
+    setDiscountResponse(5000);
+    const { rerender, result, waitForNextUpdate } = renderHook(
+      ({ address }: { address: string }) => {
+        setSelectors({ address });
+        return usePerpsMetamaskFeeDiscountBips(ORIGINAL_METAMASK_FEE_BIPS);
+      },
+      { initialProps: { address: TEST_ADDRESS } },
+    );
+    await waitForNextUpdate();
+    expect(result.current).toBe(5000);
+
+    // Switch to a new address. New fetch is deliberately never resolved.
+    mockSubmitRequestToBackground.mockReturnValue(new Promise(() => undefined));
+    rerender({ address: '0x1111111111111111111111111111111111111111' });
+
+    // The previous discount must be cleared synchronously — before the new
+    // fetch settles — so downstream memos don't apply account-A's discount
+    // to account-B's trades.
+    expect(result.current).toBeUndefined();
+  });
+
+  it('does not update state after unmount', async () => {
+    let resolveDiscount!: (v: number | null) => void;
+    mockSubmitRequestToBackground.mockImplementation((method: string) => {
+      if (method === 'rewardsGetPerpsDiscountForAccount') {
+        return new Promise<number | null>((res) => {
+          resolveDiscount = res;
+        });
+      }
+      return Promise.resolve(undefined);
+    });
+
+    const { result, unmount } = renderHook(() =>
+      usePerpsMetamaskFeeDiscountBips(ORIGINAL_METAMASK_FEE_BIPS),
+    );
+
+    unmount();
+
+    await act(async () => {
+      resolveDiscount(5000);
+      await Promise.resolve();
+    });
+
+    // result.current sticks to the last value rendered before unmount.
+    expect(result.current).toBeUndefined();
+  });
+});

--- a/ui/hooks/perps/usePerpsMetamaskFeeDiscountBips.ts
+++ b/ui/hooks/perps/usePerpsMetamaskFeeDiscountBips.ts
@@ -1,0 +1,163 @@
+import { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
+import type { CaipAccountId } from '@metamask/utils';
+import { parseCaipChainId, toCaipAccountId } from '@metamask/utils';
+import { toChecksumHexAddress } from '@metamask/controller-utils';
+
+import { submitRequestToBackground } from '../../store/background-connection';
+import { getSelectedInternalAccount } from '../../../shared/lib/selectors/accounts';
+import { getCurrentChainId } from '../../../shared/lib/selectors/networks';
+
+/**
+ * Cache TTL for the per-address fee discount lookup. Mirrors mobile's
+ * `PERFORMANCE_CONFIG.FeeDiscountCacheDurationMs` (5 minutes).
+ */
+const FEE_DISCOUNT_CACHE_TTL_MS = 1000 * 60 * 5;
+
+type FeeDiscountCacheEntry = {
+  caipAccountId: CaipAccountId;
+  discountBips: number;
+  timestamp: number;
+};
+
+let feeDiscountCache: FeeDiscountCacheEntry | null = null;
+
+/** Test-only: wipe the module-level fee discount cache so tests start clean. */
+export function clearPerpsFeeDiscountCacheForTests(): void {
+  feeDiscountCache = null;
+}
+
+function formatAccountToCaipAccountId(
+  address: string,
+  chainId: string,
+): CaipAccountId | null {
+  try {
+    const decimal = chainId.startsWith('0x')
+      ? Number.parseInt(chainId, 16)
+      : Number.parseInt(chainId, 10);
+    if (!Number.isFinite(decimal)) {
+      return null;
+    }
+    const caipChainId = `eip155:${decimal}` as `${string}:${string}`;
+    const { namespace, reference } = parseCaipChainId(caipChainId);
+    const normalizedAddress =
+      namespace === 'eip155' ? toChecksumHexAddress(address) : address;
+    return toCaipAccountId(namespace, reference, normalizedAddress);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Maximum discount expressible in basis points (10000 bips = 100%). The
+ * rewards controller can in theory return a larger number for misconfigured
+ * subscriptions; we clamp here so downstream math never produces a negative
+ * post-discount fee rate.
+ */
+const MAX_DISCOUNT_BIPS = 10000;
+
+/**
+ * Reads the current MetaMask perps fee discount for the selected account from
+ * `RewardsController.getPerpsDiscountForAccount` and exposes it in **basis
+ * points** (e.g. `5000` for 50% off). The lookup is cached per address for
+ * {@link FEE_DISCOUNT_CACHE_TTL_MS} so re-renders don't hammer the data service.
+ *
+ * Bips is the native unit used by the rewards controller and by the
+ * HyperLiquid provider (`setUserFeeDiscount(bips)`), so callers can apply the
+ * discount directly via `rate * (1 - bips / 10000)` without an intermediate
+ * percentage round-trip. Convert to percentage at the display boundary only.
+ *
+ * Returns `undefined` whenever a discount is not in effect:
+ * - no selected EVM account
+ * - chain id can't be formatted to a CAIP-10 account id
+ * - the controller returns `null` (rewards disabled, subscription not
+ * hydrated, upstream fetch error)
+ * - the controller throws
+ * - the controller returns `0` bips
+ *
+ * Callers can rely on `undefined` to mean "don't apply or display a
+ * discount" without needing additional gating.
+ *
+ * @param baseFeeBips - Un-discounted MetaMask builder fee in basis points
+ * that the caller would apply absent any discount. The controller uses this
+ * as the denominator when turning the VIP absolute fee into a discount
+ * fraction.
+ * @returns Discount in basis points (capped at {@link MAX_DISCOUNT_BIPS}) or
+ * `undefined`.
+ */
+export function usePerpsMetamaskFeeDiscountBips(
+  baseFeeBips: number,
+): number | undefined {
+  const selectedAccount = useSelector(getSelectedInternalAccount);
+  const selectedAddress = selectedAccount?.address;
+  const currentChainId = useSelector(getCurrentChainId);
+
+  const [discountBips, setDiscountBips] = useState<number | undefined>(
+    undefined,
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!selectedAddress) {
+      setDiscountBips(undefined);
+      return undefined;
+    }
+
+    const caipAccountId = formatAccountToCaipAccountId(
+      selectedAddress,
+      currentChainId,
+    );
+    if (!caipAccountId) {
+      setDiscountBips(undefined);
+      return undefined;
+    }
+
+    const now = Date.now();
+    if (
+      feeDiscountCache?.caipAccountId === caipAccountId &&
+      now - feeDiscountCache.timestamp < FEE_DISCOUNT_CACHE_TTL_MS
+    ) {
+      setDiscountBips(feeDiscountCache.discountBips);
+      return undefined;
+    }
+
+    // Clear the previous account's discount immediately so downstream memos
+    // don't apply a stale discount while the new fetch is in flight.
+    setDiscountBips(undefined);
+
+    submitRequestToBackground<number | null>(
+      'rewardsGetPerpsDiscountForAccount',
+      [caipAccountId, baseFeeBips],
+    )
+      .then((bips) => {
+        if (cancelled) {
+          return;
+        }
+        // `null` means the discount is currently unknowable (rewards disabled,
+        // subscription not yet hydrated, fetch error). Don't cache.
+        if (bips === null) {
+          setDiscountBips(undefined);
+          return;
+        }
+        feeDiscountCache = {
+          caipAccountId,
+          discountBips: bips,
+          timestamp: Date.now(),
+        };
+        setDiscountBips(bips);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setDiscountBips(undefined);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedAddress, currentChainId, baseFeeBips]);
+
+  return discountBips !== undefined && discountBips > 0
+    ? Math.min(discountBips, MAX_DISCOUNT_BIPS)
+    : undefined;
+}

--- a/ui/hooks/perps/usePerpsOrderFees.test.ts
+++ b/ui/hooks/perps/usePerpsOrderFees.test.ts
@@ -1,5 +1,9 @@
 import { renderHook, act } from '@testing-library/react-hooks';
 import type { FeeCalculationResult } from '@metamask/perps-controller';
+import { toChecksumHexAddress } from '@metamask/controller-utils';
+import { getSelectedInternalAccount } from '../../../shared/lib/selectors/accounts';
+import { getCurrentChainId } from '../../../shared/lib/selectors/networks';
+import { clearPerpsFeeDiscountCacheForTests } from './usePerpsMetamaskFeeDiscountBips';
 import { usePerpsOrderFees } from './usePerpsOrderFees';
 
 const mockSubmitRequestToBackground = jest.fn();
@@ -7,6 +11,33 @@ jest.mock('../../store/background-connection', () => ({
   submitRequestToBackground: (...args: unknown[]) =>
     mockSubmitRequestToBackground(...args),
 }));
+
+const mockUseSelector = jest.fn();
+jest.mock('react-redux', () => ({
+  useSelector: (selector: unknown) => mockUseSelector(selector),
+}));
+
+const TEST_ADDRESS = '0xabc0000000000000000000000000000000000def';
+const TEST_CHAIN_ID = '0xa4b1'; // Arbitrum One (42161)
+const TEST_CAIP_ACCOUNT_ID = `eip155:42161:${toChecksumHexAddress(
+  TEST_ADDRESS,
+)}`;
+
+function setSelectors(
+  overrides: { address?: string | null; chainId?: string } = {},
+) {
+  const address = 'address' in overrides ? overrides.address : TEST_ADDRESS;
+  const chainId = overrides.chainId ?? TEST_CHAIN_ID;
+  mockUseSelector.mockImplementation((selector) => {
+    if (selector === getSelectedInternalAccount) {
+      return address ? { address } : undefined;
+    }
+    if (selector === getCurrentChainId) {
+      return chainId;
+    }
+    return undefined;
+  });
+}
 
 function makeFeeResult(
   overrides: Partial<FeeCalculationResult> = {},
@@ -22,9 +53,46 @@ function makeFeeResult(
   };
 }
 
+/**
+ * Default background wiring: route `perpsCalculateFees` to a configurable fee
+ * result and `rewardsGetPerpsDiscountForAccount` to a configurable discount.
+ * Tests that need finer control (per-call sequencing, rejection) can override
+ * via `mockSubmitRequestToBackground.mockImplementation` directly.
+ *
+ * @param options0 - Configurable test wiring.
+ * @param options0.feeResponse - Fee result returned from `perpsCalculateFees`.
+ * @param options0.feeError - Error used to reject `perpsCalculateFees` instead of resolving.
+ * @param options0.discountBips - Discount in bips returned from `rewardsGetPerpsDiscountForAccount`.
+ */
+function setBackgroundResponses({
+  feeResponse,
+  feeError,
+  discountBips,
+}: {
+  feeResponse?: FeeCalculationResult;
+  feeError?: Error;
+  discountBips?: number | null;
+} = {}) {
+  mockSubmitRequestToBackground.mockImplementation((method: string) => {
+    if (method === 'perpsCalculateFees') {
+      if (feeError) {
+        return Promise.reject(feeError);
+      }
+      return Promise.resolve(feeResponse ?? makeFeeResult());
+    }
+    if (method === 'rewardsGetPerpsDiscountForAccount') {
+      return Promise.resolve(discountBips ?? null);
+    }
+    return Promise.resolve(undefined);
+  });
+}
+
 describe('usePerpsOrderFees', () => {
   beforeEach(() => {
     mockSubmitRequestToBackground.mockReset();
+    mockUseSelector.mockReset();
+    clearPerpsFeeDiscountCacheForTests();
+    setSelectors();
   });
 
   it('returns undefined feeRate while loading', () => {
@@ -40,7 +108,7 @@ describe('usePerpsOrderFees', () => {
 
   it('returns the dynamic fee rate after the fetch resolves', async () => {
     const feeResult = makeFeeResult({ feeRate: 0.001 });
-    mockSubmitRequestToBackground.mockResolvedValue(feeResult);
+    setBackgroundResponses({ feeResponse: feeResult, discountBips: null });
 
     const { result, waitForNextUpdate } = renderHook(() =>
       usePerpsOrderFees({ symbol: 'BTC', orderType: 'market' }),
@@ -57,7 +125,7 @@ describe('usePerpsOrderFees', () => {
   });
 
   it('calls perpsCalculateFees with the correct params', async () => {
-    mockSubmitRequestToBackground.mockResolvedValue(makeFeeResult());
+    setBackgroundResponses({ feeResponse: makeFeeResult() });
 
     const { waitForNextUpdate } = renderHook(() =>
       usePerpsOrderFees({
@@ -77,7 +145,7 @@ describe('usePerpsOrderFees', () => {
   });
 
   it('falls back to base rates when the RPC call fails', async () => {
-    mockSubmitRequestToBackground.mockRejectedValue(new Error('network error'));
+    setBackgroundResponses({ feeError: new Error('network error') });
 
     const { result } = renderHook(() =>
       usePerpsOrderFees({
@@ -107,7 +175,7 @@ describe('usePerpsOrderFees', () => {
   });
 
   it('uses zero fee amounts in fallback mode when amount is missing', async () => {
-    mockSubmitRequestToBackground.mockRejectedValue(new Error('network error'));
+    setBackgroundResponses({ feeError: new Error('network error') });
 
     const { result } = renderHook(() =>
       usePerpsOrderFees({ symbol: 'BTC', orderType: 'market' }),
@@ -129,11 +197,14 @@ describe('usePerpsOrderFees', () => {
 
   it('does not update state after unmount', async () => {
     let resolvePromise!: (v: FeeCalculationResult) => void;
-    mockSubmitRequestToBackground.mockReturnValue(
-      new Promise<FeeCalculationResult>((res) => {
-        resolvePromise = res;
-      }),
-    );
+    mockSubmitRequestToBackground.mockImplementation((method: string) => {
+      if (method === 'perpsCalculateFees') {
+        return new Promise<FeeCalculationResult>((res) => {
+          resolvePromise = res;
+        });
+      }
+      return Promise.resolve(null);
+    });
 
     const { result, unmount } = renderHook(() =>
       usePerpsOrderFees({ symbol: 'BTC', orderType: 'market' }),
@@ -153,9 +224,14 @@ describe('usePerpsOrderFees', () => {
   it('refetches when symbol changes', async () => {
     const btcResult = makeFeeResult({ feeRate: 0.001 });
     const ethResult = makeFeeResult({ feeRate: 0.0008 });
-    mockSubmitRequestToBackground
-      .mockResolvedValueOnce(btcResult)
-      .mockResolvedValueOnce(ethResult);
+    let feeCall = 0;
+    mockSubmitRequestToBackground.mockImplementation((method: string) => {
+      if (method === 'perpsCalculateFees') {
+        feeCall += 1;
+        return Promise.resolve(feeCall === 1 ? btcResult : ethResult);
+      }
+      return Promise.resolve(null);
+    });
 
     const { result, waitForNextUpdate, rerender } = renderHook(
       ({ symbol }: { symbol: string }) =>
@@ -176,9 +252,17 @@ describe('usePerpsOrderFees', () => {
   });
 
   it('clears error state on successful refetch', async () => {
-    mockSubmitRequestToBackground.mockRejectedValueOnce(
-      new Error('network error'),
-    );
+    let feeCall = 0;
+    mockSubmitRequestToBackground.mockImplementation((method: string) => {
+      if (method === 'perpsCalculateFees') {
+        feeCall += 1;
+        if (feeCall === 1) {
+          return Promise.reject(new Error('network error'));
+        }
+        return Promise.resolve(makeFeeResult({ feeRate: 0.001 }));
+      }
+      return Promise.resolve(null);
+    });
 
     const { result, waitForNextUpdate, rerender } = renderHook(
       ({ symbol }: { symbol: string }) =>
@@ -193,13 +277,203 @@ describe('usePerpsOrderFees', () => {
     expect(result.current.hasError).toBe(true);
     expect(result.current.feeRate).toBe(0.00145);
 
-    mockSubmitRequestToBackground.mockResolvedValueOnce(
-      makeFeeResult({ feeRate: 0.001 }),
-    );
     rerender({ symbol: 'ETH' });
     await waitForNextUpdate();
 
     expect(result.current.hasError).toBe(false);
     expect(result.current.feeRate).toBe(0.001);
+  });
+
+  describe('discount surface', () => {
+    it('exposes metamaskFeeRateDiscountPercentage when bips > 0', async () => {
+      setBackgroundResponses({
+        feeResponse: makeFeeResult(),
+        discountBips: 5000,
+      });
+
+      const { result, waitForNextUpdate } = renderHook(() =>
+        usePerpsOrderFees({ symbol: 'BTC', orderType: 'market' }),
+      );
+      await waitForNextUpdate();
+
+      expect(result.current.metamaskFeeRateDiscountPercentage).toBe(50);
+    });
+
+    it('caps the discount at 100% (10000 bips)', async () => {
+      setBackgroundResponses({
+        feeResponse: makeFeeResult(),
+        discountBips: 12000,
+      });
+
+      const { result, waitForNextUpdate } = renderHook(() =>
+        usePerpsOrderFees({ symbol: 'BTC', orderType: 'market' }),
+      );
+      await waitForNextUpdate();
+
+      expect(result.current.metamaskFeeRateDiscountPercentage).toBe(100);
+    });
+
+    it('is undefined when discountBips is 0', async () => {
+      setBackgroundResponses({
+        feeResponse: makeFeeResult(),
+        discountBips: 0,
+      });
+
+      const { result, waitForNextUpdate } = renderHook(() =>
+        usePerpsOrderFees({ symbol: 'BTC', orderType: 'market' }),
+      );
+      await waitForNextUpdate();
+
+      expect(result.current.metamaskFeeRateDiscountPercentage).toBeUndefined();
+    });
+
+    it('is undefined when the rewards controller returns null', async () => {
+      setBackgroundResponses({
+        feeResponse: makeFeeResult(),
+        discountBips: null,
+      });
+
+      const { result, waitForNextUpdate } = renderHook(() =>
+        usePerpsOrderFees({ symbol: 'BTC', orderType: 'market' }),
+      );
+      await waitForNextUpdate();
+
+      expect(result.current.metamaskFeeRateDiscountPercentage).toBeUndefined();
+    });
+
+    it('is undefined and skips the lookup when no account is selected', async () => {
+      setSelectors({ address: null });
+      setBackgroundResponses({
+        feeResponse: makeFeeResult(),
+        discountBips: 5000,
+      });
+
+      const { result, waitForNextUpdate } = renderHook(() =>
+        usePerpsOrderFees({ symbol: 'BTC', orderType: 'market' }),
+      );
+      await waitForNextUpdate();
+
+      expect(result.current.metamaskFeeRateDiscountPercentage).toBeUndefined();
+      const calledMethods = mockSubmitRequestToBackground.mock.calls.map(
+        (call) => call[0],
+      );
+      expect(calledMethods).not.toContain('rewardsGetPerpsDiscountForAccount');
+    });
+
+    it('calls rewardsGetPerpsDiscountForAccount with the CAIP-10 id and original MM bips', async () => {
+      setBackgroundResponses({
+        feeResponse: makeFeeResult(),
+        discountBips: 0,
+      });
+
+      const { waitForNextUpdate } = renderHook(() =>
+        usePerpsOrderFees({ symbol: 'BTC', orderType: 'market' }),
+      );
+      await waitForNextUpdate();
+
+      expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+        'rewardsGetPerpsDiscountForAccount',
+        [TEST_CAIP_ACCOUNT_ID, 10],
+      );
+    });
+
+    it('caches a non-null discount across rerenders for the same address', async () => {
+      setBackgroundResponses({
+        feeResponse: makeFeeResult(),
+        discountBips: 2000,
+      });
+
+      const { waitForNextUpdate, rerender } = renderHook(
+        ({ symbol }: { symbol: string }) =>
+          usePerpsOrderFees({ symbol, orderType: 'market' }),
+        { initialProps: { symbol: 'BTC' } },
+      );
+
+      await waitForNextUpdate();
+
+      rerender({ symbol: 'ETH' });
+      await waitForNextUpdate();
+
+      const discountCalls = mockSubmitRequestToBackground.mock.calls.filter(
+        (call) => call[0] === 'rewardsGetPerpsDiscountForAccount',
+      );
+      expect(discountCalls).toHaveLength(1);
+    });
+
+    it('applies the discount to metamaskFeeRate / feeRate / amounts when active', async () => {
+      setBackgroundResponses({
+        feeResponse: makeFeeResult({
+          feeRate: 0.00145,
+          protocolFeeRate: 0.00045,
+          metamaskFeeRate: 0.001,
+          feeAmount: 0.145,
+          protocolFeeAmount: 0.045,
+          metamaskFeeAmount: 0.1,
+        }),
+        discountBips: 5000,
+      });
+
+      const { result, waitForNextUpdate } = renderHook(() =>
+        usePerpsOrderFees({
+          symbol: 'BTC',
+          orderType: 'market',
+          amount: '100',
+        }),
+      );
+      await waitForNextUpdate();
+
+      expect(result.current.metamaskFeeRateDiscountPercentage).toBe(50);
+      expect(result.current.metamaskFeeRate).toBeCloseTo(0.0005, 10);
+      expect(result.current.feeRate).toBeCloseTo(0.00095, 10);
+      expect(result.current.protocolFeeRate).toBe(0.00045);
+      expect(result.current.feeResult).toEqual({
+        feeRate: 0.00095,
+        protocolFeeRate: 0.00045,
+        metamaskFeeRate: 0.0005,
+        feeAmount: 0.095,
+        protocolFeeAmount: 0.045,
+        metamaskFeeAmount: 0.05,
+      });
+    });
+
+    it('does not modify rates when no discount is active', async () => {
+      setBackgroundResponses({
+        feeResponse: makeFeeResult({
+          feeRate: 0.00145,
+          protocolFeeRate: 0.00045,
+          metamaskFeeRate: 0.001,
+        }),
+        discountBips: 0,
+      });
+
+      const { result, waitForNextUpdate } = renderHook(() =>
+        usePerpsOrderFees({ symbol: 'BTC', orderType: 'market' }),
+      );
+      await waitForNextUpdate();
+
+      expect(result.current.metamaskFeeRateDiscountPercentage).toBeUndefined();
+      expect(result.current.metamaskFeeRate).toBe(0.001);
+      expect(result.current.feeRate).toBe(0.00145);
+    });
+
+    it('swallows a thrown discount lookup (no error state surfaced)', async () => {
+      mockSubmitRequestToBackground.mockImplementation((method: string) => {
+        if (method === 'perpsCalculateFees') {
+          return Promise.resolve(makeFeeResult());
+        }
+        if (method === 'rewardsGetPerpsDiscountForAccount') {
+          return Promise.reject(new Error('network down'));
+        }
+        return Promise.resolve(null);
+      });
+
+      const { result, waitForNextUpdate } = renderHook(() =>
+        usePerpsOrderFees({ symbol: 'BTC', orderType: 'market' }),
+      );
+      await waitForNextUpdate();
+
+      expect(result.current.metamaskFeeRateDiscountPercentage).toBeUndefined();
+      expect(result.current.hasError).toBe(false);
+    });
   });
 });

--- a/ui/hooks/perps/usePerpsOrderFees.ts
+++ b/ui/hooks/perps/usePerpsOrderFees.ts
@@ -1,10 +1,14 @@
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useMemo, useState, useRef } from 'react';
 import type {
   FeeCalculationResult,
   OrderType,
 } from '@metamask/perps-controller';
 
 import { submitRequestToBackground } from '../../store/background-connection';
+import { usePerpsMetamaskFeeDiscountBips } from './usePerpsMetamaskFeeDiscountBips';
+
+/** Basis-point denominator: 10000 bips = 100%. */
+const BASIS_POINTS_DIVISOR = 10000;
 
 type UsePerpsOrderFeesOptions = {
   /** Asset symbol (e.g. 'BTC', 'ETH', 'xyz:TSLA') */
@@ -29,6 +33,12 @@ type UsePerpsOrderFeesReturn = {
   protocolFeeRate?: number;
   /** MetaMask builder fee rate, if available */
   metamaskFeeRate?: number;
+  /**
+   * Fee discount in whole percentage points .
+   * `undefined` when no discount is in effect or when the lookup hasn't completed yet,
+   * so callers can skip rendering the badge entirely.
+   */
+  metamaskFeeRateDiscountPercentage: number | undefined;
   /** Full result from the controller, if available */
   feeResult?: FeeCalculationResult;
   /** Whether the async fee fetch is in progress */
@@ -42,6 +52,12 @@ const FALLBACK_FEE_RATES = {
   protocolFeeRate: 0.00045,
   metamaskFeeRate: 0.001,
 } as const;
+
+/**
+ * Un-discounted MetaMask builder fee expressed in basis points. Derived from
+ * the decimal fallback rate so the two stay in sync (0.001 decimal = 10 bps).
+ */
+const ORIGINAL_METAMASK_FEE_BIPS = FALLBACK_FEE_RATES.metamaskFeeRate * 10000;
 
 function createFallbackFeeResult(amount?: string): FeeCalculationResult {
   const parsedAmount = Number.parseFloat(amount ?? '');
@@ -132,11 +148,63 @@ export function usePerpsOrderFees({
     };
   }, [symbol, orderType, amount, isMaker]);
 
+  const metamaskFeeDiscountBips = usePerpsMetamaskFeeDiscountBips(
+    ORIGINAL_METAMASK_FEE_BIPS,
+  );
+
+  // The core perps-controller only applies the MetaMask fee discount inside
+  // trading operations (placeOrder, closePosition, ...); its `calculateFees`
+  // returns un-discounted rates. Apply the discount here so consumers see a
+  // consistent fee — matching the `-X%` badge surfaced via
+  // `metamaskFeeRateDiscountPercentage`.
+  const discountedFeeResult = useMemo<FeeCalculationResult | undefined>(() => {
+    if (!feeResult) {
+      return feeResult;
+    }
+    if (
+      metamaskFeeDiscountBips === undefined ||
+      metamaskFeeDiscountBips <= 0 ||
+      feeResult.metamaskFeeRate === undefined
+    ) {
+      return feeResult;
+    }
+    const factor = 1 - metamaskFeeDiscountBips / BASIS_POINTS_DIVISOR;
+    const discountedMetamaskFeeRate = feeResult.metamaskFeeRate * factor;
+    const discountedMetamaskFeeAmount =
+      feeResult.metamaskFeeAmount === undefined
+        ? undefined
+        : feeResult.metamaskFeeAmount * factor;
+    const discountedFeeRate =
+      feeResult.protocolFeeRate === undefined
+        ? discountedMetamaskFeeRate
+        : feeResult.protocolFeeRate + discountedMetamaskFeeRate;
+    const discountedFeeAmount =
+      feeResult.protocolFeeAmount !== undefined &&
+      discountedMetamaskFeeAmount !== undefined
+        ? feeResult.protocolFeeAmount + discountedMetamaskFeeAmount
+        : discountedMetamaskFeeAmount;
+    return {
+      ...feeResult,
+      feeRate: discountedFeeRate,
+      feeAmount: discountedFeeAmount,
+      metamaskFeeRate: discountedMetamaskFeeRate,
+      metamaskFeeAmount: discountedMetamaskFeeAmount,
+    };
+  }, [feeResult, metamaskFeeDiscountBips]);
+
+  // Convert bips to a whole-percentage value at the display boundary only —
+  // PerpsFeesDisplay and analogous consumers render `-X%` in the discount badge.
+  const metamaskFeeRateDiscountPercentage =
+    metamaskFeeDiscountBips === undefined
+      ? undefined
+      : metamaskFeeDiscountBips / 100;
+
   return {
-    feeRate: feeResult?.feeRate,
-    protocolFeeRate: feeResult?.protocolFeeRate,
-    metamaskFeeRate: feeResult?.metamaskFeeRate,
-    feeResult,
+    feeRate: discountedFeeResult?.feeRate,
+    protocolFeeRate: discountedFeeResult?.protocolFeeRate,
+    metamaskFeeRate: discountedFeeResult?.metamaskFeeRate,
+    metamaskFeeRateDiscountPercentage,
+    feeResult: discountedFeeResult,
     isLoading,
     hasError,
   };

--- a/ui/pages/perps/perps-order-entry-page.tsx
+++ b/ui/pages/perps/perps-order-entry-page.tsx
@@ -312,11 +312,14 @@ const PerpsOrderEntryPage: React.FC = () => {
 
   const isOrderPending = isSubmitting;
 
-  // Dynamic fee rate for close-mode order submission tracking
-  const { feeRate: closeFeeRate } = usePerpsOrderFees({
-    symbol: decodedSymbol ?? '',
-    orderType: 'market',
-  });
+  // Dynamic fee rate for close-mode order submission tracking. Also surfaces
+  // the MetaMask fee discount percentage (when applicable) so the
+  // OrderSummary can render the inline `-X%` badge next to the estimated fees.
+  const { feeRate: closeFeeRate, metamaskFeeRateDiscountPercentage } =
+    usePerpsOrderFees({
+      symbol: decodedSymbol ?? '',
+      orderType: 'market',
+    });
 
   const isLimitPriceInvalid = useMemo(() => {
     if (orderType !== 'limit' || !orderFormState) {
@@ -1443,6 +1446,9 @@ const PerpsOrderEntryPage: React.FC = () => {
             marginRequired={orderCalculations.marginRequired}
             estimatedFees={orderCalculations.estimatedFees}
             liquidationPrice={orderCalculations.liquidationPrice}
+            metamaskFeeRateDiscountPercentage={
+              metamaskFeeRateDiscountPercentage
+            }
           />
         )}
         {submitError && (


### PR DESCRIPTION
## **Description**

Mirrors the mobile change ([MetaMask/metamask-mobile#30024](https://github.com/MetaMask/metamask-mobile/pull/30024)) for the extension. Surfaces the VIP perps fee discount through the rewards controller: when a subscription has VIP enabled, the discount is derived from the new authenticated `GET /vip/fees` endpoint; otherwise 0 is returned. 

### **Application points where the reduction is now surfaced**

All UI surfaces below read the discount through the new `usePerpsMetamaskFeeDiscount` hook (`ui/hooks/perps/usePerpsMetamaskFeeDiscount.ts`), which calls `RewardsController:getPerpsDiscountForAccount` for the active account and caches the result:

- **Order entry page** — `ui/pages/perps/perps-order-entry-page.tsx`
- **Order summary (inside order entry)** — `ui/components/app/perps/order-entry/components/order-summary/order-summary.tsx`
- **Close position modal** — `ui/components/app/perps/close-position/close-position-modal.tsx`
- **Reverse position modal** — `ui/components/app/perps/reverse-position/reverse-position-modal.tsx`
- **Shared fees display component** — `ui/components/app/perps/perps-fees-display/perps-fees-display.tsx`

### Actual trades (distinct path)

Trade execution does **not** go through the UI hook. The discount applied to an actual on-chain perps trade is resolved by the perps controller in the **core repo** (`@metamask/perps-controller`), which calls `getPerpsDiscountForAccount` via the infrastructure bridge in `app/scripts/controllers/perps/infrastructure.ts`. That bridge also delegates to `RewardsController:getPerpsDiscountForAccount`, so the UI display and the trade itself share the same source of truth — but the trade path is the controller-side call, not the React hook.

## **Screenshots/Recordings**

<img width="798" height="873" alt="image" src="https://github.com/user-attachments/assets/4c5996b0-093e-4ce8-a98c-53734ce7bed1" />
<img width="1179" height="750" alt="Screenshot 2026-05-15 at 9 33 20 PM" src="https://github.com/user-attachments/assets/bd4ff03f-1a95-40ba-affd-fe92bfcda95d" />

## **Changelog**

CHANGELOG entry: null

## **Manual testing steps**

1. With a VIP-enabled rewards subscription, open the perps order entry screen.
2. Confirm the displayed MetaMask builder fee drops from 10 bps to the discounted rate returned by `/vip/fees`.
3. With a non-VIP subscription, confirm the fee remains at 10 bps and `/vip/fees` is never called (check network panel).
4. Simulate `/vip/fees` returning a builder fee greater than 10 (e.g. 15) and confirm the UI shows the un-discounted 10 bps rate (no crash; warning logged).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new authenticated `/vip/fees` call and caching to derive perps fee discounts and applies them to perps fee calculations/UX, which could impact displayed and applied trading fees if the conversion or caching is wrong.
> 
> **Overview**
> Derives a **VIP perps fee discount** via a new `RewardsController.getPerpsDiscountForAccount` method backed by an authenticated `GET /vip/fees` call, with per-subscription caching/in-flight de-duping and a new persisted `rewardsVipPerpsFees` state slice (plus masking/fixtures/types updates).
> 
> Plumbs this discount into **perps trade execution** via the perps infrastructure/messenger bridge (null/throw -> `0` fallback), and into the **perps UI** via a new `usePerpsMetamaskFeeDiscountBips` + updates to `usePerpsOrderFees` to apply the discount to returned fee rates/amounts.
> 
> Adds a shared `PerpsFeesDisplay` component and updates perps order entry/summary, close-position, and reverse-position views/tests to show an inline `-X%` discount badge only when fees are available and a positive discount is active.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0d3ec956b2816f0f70cbe155f6d567303c8928d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->