### PR TITLE
feat: add post-quote perps withdraw toasts

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -6553,12 +6553,6 @@
   "perpsWithdrawNoAccount": {
     "message": "No account selected. Select an account and try again."
   },
-  "perpsWithdrawReceive": {
-    "message": "Receive"
-  },
-  "perpsWithdrawRoutesError": {
-    "message": "Could not load withdrawal limits. Try again later."
-  },
   "perpsWithdrawPostQuoteToastErrorDescription": {
     "message": "Failed to proceed with withdrawal"
   },
@@ -6580,6 +6574,12 @@
   },
   "perpsWithdrawPostQuoteToastSuccessTitle": {
     "message": "Withdrawal complete"
+  },
+  "perpsWithdrawReceive": {
+    "message": "Receive"
+  },
+  "perpsWithdrawRoutesError": {
+    "message": "Could not load withdrawal limits. Try again later."
   },
   "perpsWithdrawToastErrorTitle": {
     "message": "Withdrawal failed"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -6559,6 +6559,28 @@
   "perpsWithdrawRoutesError": {
     "message": "Could not load withdrawal limits. Try again later."
   },
+  "perpsWithdrawPostQuoteToastErrorDescription": {
+    "message": "Failed to proceed with withdrawal"
+  },
+  "perpsWithdrawPostQuoteToastErrorTitle": {
+    "message": "Something went wrong"
+  },
+  "perpsWithdrawPostQuoteToastPendingDescription": {
+    "message": "Available in about 1 minute"
+  },
+  "perpsWithdrawPostQuoteToastPendingTitle": {
+    "message": "Withdrawal in progress"
+  },
+  "perpsWithdrawPostQuoteToastSuccessDescription": {
+    "message": "$1 $2 moved to your wallet",
+    "description": "$1 is the formatted USD amount, e.g. '$20.73'. $2 is the destination token symbol, e.g. 'BNB'."
+  },
+  "perpsWithdrawPostQuoteToastSuccessGenericDescription": {
+    "message": "Funds moved to your wallet"
+  },
+  "perpsWithdrawPostQuoteToastSuccessTitle": {
+    "message": "Withdrawal complete"
+  },
   "perpsWithdrawToastErrorTitle": {
     "message": "Withdrawal failed"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -6553,6 +6553,28 @@
   "perpsWithdrawNoAccount": {
     "message": "No account selected. Select an account and try again."
   },
+  "perpsWithdrawPostQuoteToastErrorDescription": {
+    "message": "Failed to proceed with withdrawal"
+  },
+  "perpsWithdrawPostQuoteToastErrorTitle": {
+    "message": "Something went wrong"
+  },
+  "perpsWithdrawPostQuoteToastPendingDescription": {
+    "message": "Available in about 1 minute"
+  },
+  "perpsWithdrawPostQuoteToastPendingTitle": {
+    "message": "Withdrawal in progress"
+  },
+  "perpsWithdrawPostQuoteToastSuccessDescription": {
+    "message": "$1 $2 moved to your wallet",
+    "description": "$1 is the formatted USD amount, e.g. '$20.73'. $2 is the destination token symbol, e.g. 'BNB'."
+  },
+  "perpsWithdrawPostQuoteToastSuccessGenericDescription": {
+    "message": "Funds moved to your wallet"
+  },
+  "perpsWithdrawPostQuoteToastSuccessTitle": {
+    "message": "Withdrawal complete"
+  },
   "perpsWithdrawReceive": {
     "message": "Receive"
   },

--- a/ui/components/app/toast-listener/shared.test.tsx
+++ b/ui/components/app/toast-listener/shared.test.tsx
@@ -1,7 +1,13 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
-import { ToastContent, showToast, type ToastStatus } from './shared';
+import {
+  CustomToastContent,
+  ToastContent,
+  showCustomSuccessToast,
+  showToast,
+  type ToastStatus,
+} from './shared';
 
 const mockToastLoading = jest.fn();
 const mockToastSuccess = jest.fn();
@@ -21,7 +27,18 @@ jest.mock('../../../helpers/utils/transaction-display', () => ({
 }));
 
 jest.mock('../../ui/toast/toast', () => ({
-  ToastContent: ({ title }: { title: string }) => <div>{title}</div>,
+  ToastContent: ({
+    title,
+    description,
+  }: {
+    title: string;
+    description?: string;
+  }) => (
+    <div>
+      <p>{title}</p>
+      {description ? <p>{description}</p> : null}
+    </div>
+  ),
 }));
 
 describe('toast-listener/shared', () => {
@@ -38,6 +55,20 @@ describe('toast-listener/shared', () => {
     expect(mockUseTransactionDisplay).toHaveBeenCalledWith('pending');
     expect(
       screen.getByText(messages.transactionSubmitted.message),
+    ).toBeInTheDocument();
+  });
+
+  it('renders custom toast content', () => {
+    render(
+      <CustomToastContent
+        title="Withdrawal complete"
+        description="$20.73 BNB moved to your wallet"
+      />,
+    );
+
+    expect(screen.getByText('Withdrawal complete')).toBeInTheDocument();
+    expect(
+      screen.getByText('$20.73 BNB moved to your wallet'),
     ).toBeInTheDocument();
   });
 
@@ -61,6 +92,17 @@ describe('toast-listener/shared', () => {
     showToast('toast-id', 'failed' as ToastStatus);
 
     expect(mockToastError).toHaveBeenCalledWith(expect.any(Object), {
+      id: 'toast-id',
+    });
+  });
+
+  it('shows a custom success toast', () => {
+    showCustomSuccessToast('toast-id', {
+      title: 'Withdrawal complete',
+      description: '$20.73 BNB moved to your wallet',
+    });
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(expect.any(Object), {
       id: 'toast-id',
     });
   });

--- a/ui/components/app/toast-listener/shared.test.tsx
+++ b/ui/components/app/toast-listener/shared.test.tsx
@@ -2,9 +2,8 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
 import {
-  CustomToastContent,
   ToastContent,
-  showCustomSuccessToast,
+  showSuccessToast,
   showToast,
   type ToastStatus,
 } from './shared';
@@ -60,7 +59,8 @@ describe('toast-listener/shared', () => {
 
   it('renders custom toast content', () => {
     render(
-      <CustomToastContent
+      <ToastContent
+        status="success"
         title={messages.perpsWithdrawPostQuoteToastSuccessTitle.message}
         description="$20.73 BNB moved to your wallet"
       />,
@@ -99,7 +99,7 @@ describe('toast-listener/shared', () => {
   });
 
   it('shows a custom success toast', () => {
-    showCustomSuccessToast('toast-id', {
+    showSuccessToast('toast-id', {
       title: messages.perpsWithdrawPostQuoteToastSuccessTitle.message,
       description: '$20.73 BNB moved to your wallet',
     });

--- a/ui/components/app/toast-listener/shared.test.tsx
+++ b/ui/components/app/toast-listener/shared.test.tsx
@@ -61,12 +61,14 @@ describe('toast-listener/shared', () => {
   it('renders custom toast content', () => {
     render(
       <CustomToastContent
-        title="Withdrawal complete"
+        title={messages.perpsWithdrawPostQuoteToastSuccessTitle.message}
         description="$20.73 BNB moved to your wallet"
       />,
     );
 
-    expect(screen.getByText('Withdrawal complete')).toBeInTheDocument();
+    expect(
+      screen.getByText(messages.perpsWithdrawPostQuoteToastSuccessTitle.message),
+    ).toBeInTheDocument();
     expect(
       screen.getByText('$20.73 BNB moved to your wallet'),
     ).toBeInTheDocument();
@@ -98,7 +100,7 @@ describe('toast-listener/shared', () => {
 
   it('shows a custom success toast', () => {
     showCustomSuccessToast('toast-id', {
-      title: 'Withdrawal complete',
+      title: messages.perpsWithdrawPostQuoteToastSuccessTitle.message,
       description: '$20.73 BNB moved to your wallet',
     });
 

--- a/ui/components/app/toast-listener/shared.test.tsx
+++ b/ui/components/app/toast-listener/shared.test.tsx
@@ -67,7 +67,9 @@ describe('toast-listener/shared', () => {
     );
 
     expect(
-      screen.getByText(messages.perpsWithdrawPostQuoteToastSuccessTitle.message),
+      screen.getByText(
+        messages.perpsWithdrawPostQuoteToastSuccessTitle.message,
+      ),
     ).toBeInTheDocument();
     expect(
       screen.getByText('$20.73 BNB moved to your wallet'),

--- a/ui/components/app/toast-listener/shared.tsx
+++ b/ui/components/app/toast-listener/shared.tsx
@@ -13,6 +13,24 @@ export const ToastContent = ({ status }: { status: TransactionStatus }) => {
   return <ToastContentBase title={title} />;
 };
 
+export const CustomToastContent = ({
+  title,
+  description,
+  dataTestId,
+}: {
+  title: string;
+  description?: string;
+  dataTestId?: string;
+}) => {
+  return (
+    <ToastContentBase
+      title={title}
+      description={description}
+      dataTestId={dataTestId}
+    />
+  );
+};
+
 export function showPendingToast(id: string) {
   toast.loading(<ToastContent status="pending" />, { id });
 }
@@ -27,6 +45,27 @@ export function showFailedToast(id: string) {
 
 export function dismissToast(id: string) {
   toast.dismiss(id);
+}
+
+export function showCustomPendingToast(
+  id: string,
+  props: React.ComponentProps<typeof CustomToastContent>,
+) {
+  toast.loading(<CustomToastContent {...props} />, { id });
+}
+
+export function showCustomSuccessToast(
+  id: string,
+  props: React.ComponentProps<typeof CustomToastContent>,
+) {
+  toast.success(<CustomToastContent {...props} />, { id });
+}
+
+export function showCustomFailedToast(
+  id: string,
+  props: React.ComponentProps<typeof CustomToastContent>,
+) {
+  toast.error(<CustomToastContent {...props} />, { id });
 }
 
 export function showToast(id: string, status: ToastStatus) {

--- a/ui/components/app/toast-listener/shared.tsx
+++ b/ui/components/app/toast-listener/shared.tsx
@@ -8,64 +8,43 @@ import { ToastContent as ToastContentBase } from '../../ui/toast/toast';
 
 export type ToastStatus = 'pending' | 'success' | 'failed';
 
-export const ToastContent = ({ status }: { status: TransactionStatus }) => {
-  const { title } = useTransactionDisplay(status);
-  return <ToastContentBase title={title} />;
+type ToastContentOptions = {
+  title?: string;
+  description?: string;
+  dataTestId?: string;
 };
 
-export const CustomToastContent = ({
+export const ToastContent = ({
+  status,
   title,
   description,
   dataTestId,
-}: {
-  title: string;
-  description?: string;
-  dataTestId?: string;
-}) => {
+}: { status: TransactionStatus } & ToastContentOptions) => {
+  const { title: statusTitle } = useTransactionDisplay(status);
+
   return (
     <ToastContentBase
-      title={title}
+      title={title ?? statusTitle}
       description={description}
       dataTestId={dataTestId}
     />
   );
 };
 
-export function showPendingToast(id: string) {
-  toast.loading(<ToastContent status="pending" />, { id });
+export function showPendingToast(id: string, options?: ToastContentOptions) {
+  toast.loading(<ToastContent status="pending" {...options} />, { id });
 }
 
-export function showSuccessToast(id: string) {
-  toast.success(<ToastContent status="success" />, { id });
+export function showSuccessToast(id: string, options?: ToastContentOptions) {
+  toast.success(<ToastContent status="success" {...options} />, { id });
 }
 
-export function showFailedToast(id: string) {
-  toast.error(<ToastContent status="failed" />, { id });
+export function showFailedToast(id: string, options?: ToastContentOptions) {
+  toast.error(<ToastContent status="failed" {...options} />, { id });
 }
 
 export function dismissToast(id: string) {
   toast.dismiss(id);
-}
-
-export function showCustomPendingToast(
-  id: string,
-  props: React.ComponentProps<typeof CustomToastContent>,
-) {
-  toast.loading(<CustomToastContent {...props} />, { id });
-}
-
-export function showCustomSuccessToast(
-  id: string,
-  props: React.ComponentProps<typeof CustomToastContent>,
-) {
-  toast.success(<CustomToastContent {...props} />, { id });
-}
-
-export function showCustomFailedToast(
-  id: string,
-  props: React.ComponentProps<typeof CustomToastContent>,
-) {
-  toast.error(<CustomToastContent {...props} />, { id });
 }
 
 export function showToast(id: string, status: ToastStatus) {

--- a/ui/components/app/toast-listener/toast-listener.test.tsx
+++ b/ui/components/app/toast-listener/toast-listener.test.tsx
@@ -4,6 +4,7 @@ import { ToastListener } from './toast-listener';
 
 const mockUseSelector = jest.fn();
 const mockUseSmartTransactionToasts = jest.fn();
+const mockUsePerpsWithdrawTransactionToasts = jest.fn();
 const mockIsInteractiveUI = jest.fn();
 
 jest.mock('react-redux', () => ({
@@ -20,6 +21,11 @@ jest.mock('../../../../shared/lib/environment-type', () => ({
 
 jest.mock('./useSmartTransactionToasts', () => ({
   useSmartTransactionToasts: () => mockUseSmartTransactionToasts(),
+}));
+
+jest.mock('./usePerpsWithdrawTransactionToasts', () => ({
+  usePerpsWithdrawTransactionToasts: () =>
+    mockUsePerpsWithdrawTransactionToasts(),
 }));
 
 describe('ToastListener', () => {
@@ -39,30 +45,33 @@ describe('ToastListener', () => {
     render(<ToastListener />);
   }
 
-  it('mounts the smart transaction toast hook when enabled in interactive UI', () => {
+  it('mounts toast hooks when smart transaction toasts are enabled in interactive UI', () => {
     renderToastListener({
       transactionToastEnabled: true,
       isInteractive: true,
     });
 
     expect(mockUseSmartTransactionToasts).toHaveBeenCalledTimes(1);
+    expect(mockUsePerpsWithdrawTransactionToasts).toHaveBeenCalledTimes(1);
   });
 
-  it('does not mount the smart transaction toast hook when the flag is disabled', () => {
+  it('mounts only the perps withdraw toast hook when the smart transaction toast flag is disabled', () => {
     renderToastListener({
       transactionToastEnabled: false,
       isInteractive: true,
     });
 
     expect(mockUseSmartTransactionToasts).not.toHaveBeenCalled();
+    expect(mockUsePerpsWithdrawTransactionToasts).toHaveBeenCalledTimes(1);
   });
 
-  it('does not mount the smart transaction toast hook in non-interactive UI', () => {
+  it('does not mount toast hooks in non-interactive UI', () => {
     renderToastListener({
       transactionToastEnabled: true,
       isInteractive: false,
     });
 
     expect(mockUseSmartTransactionToasts).not.toHaveBeenCalled();
+    expect(mockUsePerpsWithdrawTransactionToasts).not.toHaveBeenCalled();
   });
 });

--- a/ui/components/app/toast-listener/toast-listener.tsx
+++ b/ui/components/app/toast-listener/toast-listener.tsx
@@ -3,9 +3,16 @@ import { useSelector } from 'react-redux';
 import { getExtensionSkipTransactionStatusPage } from '../../../../shared/lib/selectors/smart-transactions';
 import { isInteractiveUI } from '../../../../shared/lib/environment-type';
 import { useSmartTransactionToasts } from './useSmartTransactionToasts';
+import { usePerpsWithdrawTransactionToasts } from './usePerpsWithdrawTransactionToasts';
 
-const ToastListenerInner = () => {
+const SmartTransactionToastListener = () => {
   useSmartTransactionToasts();
+
+  return null;
+};
+
+const PerpsWithdrawTransactionToastListener = () => {
+  usePerpsWithdrawTransactionToasts();
 
   return null;
 };
@@ -16,9 +23,14 @@ export function ToastListener() {
   );
   const isInteractive = isInteractiveUI();
 
-  if (!transactionToastEnabled || !isInteractive) {
+  if (!isInteractive) {
     return null;
   }
 
-  return <ToastListenerInner />;
+  return (
+    <>
+      <PerpsWithdrawTransactionToastListener />
+      {transactionToastEnabled ? <SmartTransactionToastListener /> : null}
+    </>
+  );
 }

--- a/ui/components/app/toast-listener/usePerpsWithdrawTransactionToasts.test.ts
+++ b/ui/components/app/toast-listener/usePerpsWithdrawTransactionToasts.test.ts
@@ -1,0 +1,249 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { TransactionStatus } from '@metamask/transaction-controller';
+import type { PerpsWithdrawToastTransaction } from '../../../selectors/toast';
+import { usePerpsWithdrawTransactionToasts } from './usePerpsWithdrawTransactionToasts';
+
+const mockUseSelector = jest.fn();
+const mockShowCustomPendingToast = jest.fn();
+const mockShowCustomSuccessToast = jest.fn();
+const mockShowCustomFailedToast = jest.fn();
+
+jest.mock('react-redux', () => ({
+  useSelector: (selector: unknown) => mockUseSelector(selector),
+}));
+
+jest.mock('../../../hooks/useI18nContext', () => ({
+  useI18nContext: () => (key: string, args?: string[]) =>
+    args?.length ? `${key}:${args.join('|')}` : key,
+}));
+
+jest.mock('./shared', () => ({
+  showCustomPendingToast: (
+    ...args: Parameters<typeof mockShowCustomPendingToast>
+  ) => mockShowCustomPendingToast(...args),
+  showCustomSuccessToast: (
+    ...args: Parameters<typeof mockShowCustomSuccessToast>
+  ) => mockShowCustomSuccessToast(...args),
+  showCustomFailedToast: (
+    ...args: Parameters<typeof mockShowCustomFailedToast>
+  ) => mockShowCustomFailedToast(...args),
+}));
+
+describe('usePerpsWithdrawTransactionToasts', () => {
+  let mockTransactions: PerpsWithdrawToastTransaction[];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockTransactions = [];
+    mockUseSelector.mockImplementation(() => mockTransactions);
+  });
+
+  it('does not toast existing transactions on initial mount', () => {
+    mockTransactions = [
+      {
+        id: 'tx-1',
+        isPostQuote: true,
+        status: TransactionStatus.confirmed,
+        targetFiat: 20.73,
+        tokenSymbol: 'BNB',
+      },
+    ];
+
+    renderHook(() => usePerpsWithdrawTransactionToasts());
+
+    expect(mockShowCustomSuccessToast).not.toHaveBeenCalled();
+  });
+
+  it('shows a pending toast when a withdraw is approved', () => {
+    mockTransactions = [
+      {
+        id: 'tx-1',
+        isPostQuote: true,
+        status: TransactionStatus.unapproved,
+        targetFiat: 20.73,
+        tokenSymbol: 'BNB',
+      },
+    ];
+
+    const { rerender } = renderHook(() => usePerpsWithdrawTransactionToasts());
+
+    mockTransactions = [
+      {
+        id: 'tx-1',
+        isPostQuote: true,
+        status: TransactionStatus.approved,
+        targetFiat: 20.73,
+        tokenSymbol: 'BNB',
+      },
+    ];
+    rerender();
+
+    expect(mockShowCustomPendingToast).toHaveBeenCalledWith(
+      'perps-withdraw-tx-1',
+      {
+        title: 'perpsWithdrawPostQuoteToastPendingTitle',
+        description: 'perpsWithdrawPostQuoteToastPendingDescription',
+        dataTestId: 'perps-withdraw-pending-toast',
+      },
+    );
+  });
+
+  it('shows a pending toast when a new withdraw first appears as submitted', () => {
+    const { rerender } = renderHook(() => usePerpsWithdrawTransactionToasts());
+
+    mockTransactions = [
+      {
+        id: 'tx-1',
+        isPostQuote: true,
+        status: TransactionStatus.submitted,
+        targetFiat: 20.73,
+        tokenSymbol: 'BNB',
+      },
+    ];
+    rerender();
+
+    expect(mockShowCustomPendingToast).toHaveBeenCalledWith(
+      'perps-withdraw-tx-1',
+      expect.objectContaining({
+        title: 'perpsWithdrawPostQuoteToastPendingTitle',
+      }),
+    );
+  });
+
+  it('does not duplicate the pending toast as the transaction continues submitting', () => {
+    mockTransactions = [
+      {
+        id: 'tx-1',
+        isPostQuote: true,
+        status: TransactionStatus.unapproved,
+        targetFiat: 20.73,
+        tokenSymbol: 'BNB',
+      },
+    ];
+
+    const { rerender } = renderHook(() => usePerpsWithdrawTransactionToasts());
+
+    mockTransactions = [
+      {
+        id: 'tx-1',
+        isPostQuote: true,
+        status: TransactionStatus.approved,
+        targetFiat: 20.73,
+        tokenSymbol: 'BNB',
+      },
+    ];
+    rerender();
+
+    mockTransactions = [
+      {
+        id: 'tx-1',
+        isPostQuote: true,
+        status: TransactionStatus.submitted,
+        targetFiat: 20.73,
+        tokenSymbol: 'BNB',
+      },
+    ];
+    rerender();
+
+    expect(mockShowCustomPendingToast).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a success toast with the post-quote amount and token symbol', () => {
+    mockTransactions = [
+      {
+        id: 'tx-1',
+        isPostQuote: true,
+        status: TransactionStatus.approved,
+        targetFiat: 20.73,
+        tokenSymbol: 'BNB',
+      },
+    ];
+
+    const { rerender } = renderHook(() => usePerpsWithdrawTransactionToasts());
+
+    mockTransactions = [
+      {
+        id: 'tx-1',
+        isPostQuote: true,
+        status: TransactionStatus.confirmed,
+        targetFiat: 20.73,
+        tokenSymbol: 'BNB',
+      },
+    ];
+    rerender();
+
+    expect(mockShowCustomSuccessToast).toHaveBeenCalledWith(
+      'perps-withdraw-tx-1',
+      {
+        title: 'perpsWithdrawPostQuoteToastSuccessTitle',
+        description:
+          'perpsWithdrawPostQuoteToastSuccessDescription:$20.73|BNB',
+        dataTestId: 'perps-withdraw-success-toast',
+      },
+    );
+  });
+
+  it('shows the generic success description when post-quote details are missing', () => {
+    mockTransactions = [
+      {
+        id: 'tx-1',
+        isPostQuote: false,
+        status: TransactionStatus.approved,
+        tokenSymbol: 'USDC',
+      },
+    ];
+
+    const { rerender } = renderHook(() => usePerpsWithdrawTransactionToasts());
+
+    mockTransactions = [
+      {
+        id: 'tx-1',
+        isPostQuote: false,
+        status: TransactionStatus.confirmed,
+        tokenSymbol: 'USDC',
+      },
+    ];
+    rerender();
+
+    expect(mockShowCustomSuccessToast).toHaveBeenCalledWith(
+      'perps-withdraw-tx-1',
+      expect.objectContaining({
+        description: 'perpsWithdrawPostQuoteToastSuccessGenericDescription',
+      }),
+    );
+  });
+
+  it('shows a failed toast when a withdraw fails', () => {
+    mockTransactions = [
+      {
+        id: 'tx-1',
+        isPostQuote: true,
+        status: TransactionStatus.approved,
+        targetFiat: 20.73,
+        tokenSymbol: 'BNB',
+      },
+    ];
+
+    const { rerender } = renderHook(() => usePerpsWithdrawTransactionToasts());
+
+    mockTransactions = [
+      {
+        id: 'tx-1',
+        isPostQuote: true,
+        status: TransactionStatus.failed,
+        targetFiat: 20.73,
+        tokenSymbol: 'BNB',
+      },
+    ];
+    rerender();
+
+    expect(mockShowCustomFailedToast).toHaveBeenCalledWith(
+      'perps-withdraw-tx-1',
+      {
+        title: 'perpsWithdrawPostQuoteToastErrorTitle',
+        description: 'perpsWithdrawPostQuoteToastErrorDescription',
+        dataTestId: 'perps-withdraw-failed-toast',
+      },
+    );
+  });
+});

--- a/ui/components/app/toast-listener/usePerpsWithdrawTransactionToasts.test.ts
+++ b/ui/components/app/toast-listener/usePerpsWithdrawTransactionToasts.test.ts
@@ -78,14 +78,11 @@ describe('usePerpsWithdrawTransactionToasts', () => {
     ];
     rerender();
 
-    expect(mockShowPendingToast).toHaveBeenCalledWith(
-      'perps-withdraw-tx-1',
-      {
-        title: 'perpsWithdrawPostQuoteToastPendingTitle',
-        description: 'perpsWithdrawPostQuoteToastPendingDescription',
-        dataTestId: 'perps-withdraw-pending-toast',
-      },
-    );
+    expect(mockShowPendingToast).toHaveBeenCalledWith('perps-withdraw-tx-1', {
+      title: 'perpsWithdrawPostQuoteToastPendingTitle',
+      description: 'perpsWithdrawPostQuoteToastPendingDescription',
+      dataTestId: 'perps-withdraw-pending-toast',
+    });
   });
 
   it('shows a pending toast when a new withdraw first appears as submitted', () => {
@@ -192,15 +189,11 @@ describe('usePerpsWithdrawTransactionToasts', () => {
     ];
     rerender();
 
-    expect(mockShowSuccessToast).toHaveBeenCalledWith(
-      'perps-withdraw-tx-1',
-      {
-        title: 'perpsWithdrawPostQuoteToastSuccessTitle',
-        description:
-          'perpsWithdrawPostQuoteToastSuccessDescription:$20.73|BNB',
-        dataTestId: 'perps-withdraw-success-toast',
-      },
-    );
+    expect(mockShowSuccessToast).toHaveBeenCalledWith('perps-withdraw-tx-1', {
+      title: 'perpsWithdrawPostQuoteToastSuccessTitle',
+      description: 'perpsWithdrawPostQuoteToastSuccessDescription:$20.73|BNB',
+      dataTestId: 'perps-withdraw-success-toast',
+    });
   });
 
   it('shows the generic success description when post-quote details are missing', () => {
@@ -257,13 +250,10 @@ describe('usePerpsWithdrawTransactionToasts', () => {
     ];
     rerender();
 
-    expect(mockShowFailedToast).toHaveBeenCalledWith(
-      'perps-withdraw-tx-1',
-      {
-        title: 'perpsWithdrawPostQuoteToastErrorTitle',
-        description: 'perpsWithdrawPostQuoteToastErrorDescription',
-        dataTestId: 'perps-withdraw-failed-toast',
-      },
-    );
+    expect(mockShowFailedToast).toHaveBeenCalledWith('perps-withdraw-tx-1', {
+      title: 'perpsWithdrawPostQuoteToastErrorTitle',
+      description: 'perpsWithdrawPostQuoteToastErrorDescription',
+      dataTestId: 'perps-withdraw-failed-toast',
+    });
   });
 });

--- a/ui/components/app/toast-listener/usePerpsWithdrawTransactionToasts.test.ts
+++ b/ui/components/app/toast-listener/usePerpsWithdrawTransactionToasts.test.ts
@@ -7,6 +7,7 @@ const mockUseSelector = jest.fn();
 const mockShowCustomPendingToast = jest.fn();
 const mockShowCustomSuccessToast = jest.fn();
 const mockShowCustomFailedToast = jest.fn();
+const mockDismissToast = jest.fn();
 
 jest.mock('react-redux', () => ({
   useSelector: (selector: unknown) => mockUseSelector(selector),
@@ -18,6 +19,8 @@ jest.mock('../../../hooks/useI18nContext', () => ({
 }));
 
 jest.mock('./shared', () => ({
+  dismissToast: (...args: Parameters<typeof mockDismissToast>) =>
+    mockDismissToast(...args),
   showCustomPendingToast: (
     ...args: Parameters<typeof mockShowCustomPendingToast>
   ) => mockShowCustomPendingToast(...args),
@@ -146,6 +149,26 @@ describe('usePerpsWithdrawTransactionToasts', () => {
     rerender();
 
     expect(mockShowCustomPendingToast).toHaveBeenCalledTimes(1);
+  });
+
+  it('dismisses the pending toast when a withdraw disappears before resolving', () => {
+    const { rerender } = renderHook(() => usePerpsWithdrawTransactionToasts());
+
+    mockTransactions = [
+      {
+        id: 'tx-1',
+        isPostQuote: true,
+        status: TransactionStatus.submitted,
+        targetFiat: 20.73,
+        tokenSymbol: 'BNB',
+      },
+    ];
+    rerender();
+
+    mockTransactions = [];
+    rerender();
+
+    expect(mockDismissToast).toHaveBeenCalledWith('perps-withdraw-tx-1');
   });
 
   it('shows a success toast with the post-quote amount and token symbol', () => {

--- a/ui/components/app/toast-listener/usePerpsWithdrawTransactionToasts.test.ts
+++ b/ui/components/app/toast-listener/usePerpsWithdrawTransactionToasts.test.ts
@@ -4,9 +4,9 @@ import type { PerpsWithdrawToastTransaction } from '../../../selectors/toast';
 import { usePerpsWithdrawTransactionToasts } from './usePerpsWithdrawTransactionToasts';
 
 const mockUseSelector = jest.fn();
-const mockShowCustomPendingToast = jest.fn();
-const mockShowCustomSuccessToast = jest.fn();
-const mockShowCustomFailedToast = jest.fn();
+const mockShowPendingToast = jest.fn();
+const mockShowSuccessToast = jest.fn();
+const mockShowFailedToast = jest.fn();
 const mockDismissToast = jest.fn();
 
 jest.mock('react-redux', () => ({
@@ -21,15 +21,12 @@ jest.mock('../../../hooks/useI18nContext', () => ({
 jest.mock('./shared', () => ({
   dismissToast: (...args: Parameters<typeof mockDismissToast>) =>
     mockDismissToast(...args),
-  showCustomPendingToast: (
-    ...args: Parameters<typeof mockShowCustomPendingToast>
-  ) => mockShowCustomPendingToast(...args),
-  showCustomSuccessToast: (
-    ...args: Parameters<typeof mockShowCustomSuccessToast>
-  ) => mockShowCustomSuccessToast(...args),
-  showCustomFailedToast: (
-    ...args: Parameters<typeof mockShowCustomFailedToast>
-  ) => mockShowCustomFailedToast(...args),
+  showPendingToast: (...args: Parameters<typeof mockShowPendingToast>) =>
+    mockShowPendingToast(...args),
+  showSuccessToast: (...args: Parameters<typeof mockShowSuccessToast>) =>
+    mockShowSuccessToast(...args),
+  showFailedToast: (...args: Parameters<typeof mockShowFailedToast>) =>
+    mockShowFailedToast(...args),
 }));
 
 describe('usePerpsWithdrawTransactionToasts', () => {
@@ -54,7 +51,7 @@ describe('usePerpsWithdrawTransactionToasts', () => {
 
     renderHook(() => usePerpsWithdrawTransactionToasts());
 
-    expect(mockShowCustomSuccessToast).not.toHaveBeenCalled();
+    expect(mockShowSuccessToast).not.toHaveBeenCalled();
   });
 
   it('shows a pending toast when a withdraw is approved', () => {
@@ -81,7 +78,7 @@ describe('usePerpsWithdrawTransactionToasts', () => {
     ];
     rerender();
 
-    expect(mockShowCustomPendingToast).toHaveBeenCalledWith(
+    expect(mockShowPendingToast).toHaveBeenCalledWith(
       'perps-withdraw-tx-1',
       {
         title: 'perpsWithdrawPostQuoteToastPendingTitle',
@@ -105,7 +102,7 @@ describe('usePerpsWithdrawTransactionToasts', () => {
     ];
     rerender();
 
-    expect(mockShowCustomPendingToast).toHaveBeenCalledWith(
+    expect(mockShowPendingToast).toHaveBeenCalledWith(
       'perps-withdraw-tx-1',
       expect.objectContaining({
         title: 'perpsWithdrawPostQuoteToastPendingTitle',
@@ -148,7 +145,7 @@ describe('usePerpsWithdrawTransactionToasts', () => {
     ];
     rerender();
 
-    expect(mockShowCustomPendingToast).toHaveBeenCalledTimes(1);
+    expect(mockShowPendingToast).toHaveBeenCalledTimes(1);
   });
 
   it('dismisses the pending toast when a withdraw disappears before resolving', () => {
@@ -195,7 +192,7 @@ describe('usePerpsWithdrawTransactionToasts', () => {
     ];
     rerender();
 
-    expect(mockShowCustomSuccessToast).toHaveBeenCalledWith(
+    expect(mockShowSuccessToast).toHaveBeenCalledWith(
       'perps-withdraw-tx-1',
       {
         title: 'perpsWithdrawPostQuoteToastSuccessTitle',
@@ -228,7 +225,7 @@ describe('usePerpsWithdrawTransactionToasts', () => {
     ];
     rerender();
 
-    expect(mockShowCustomSuccessToast).toHaveBeenCalledWith(
+    expect(mockShowSuccessToast).toHaveBeenCalledWith(
       'perps-withdraw-tx-1',
       expect.objectContaining({
         description: 'perpsWithdrawPostQuoteToastSuccessGenericDescription',
@@ -260,7 +257,7 @@ describe('usePerpsWithdrawTransactionToasts', () => {
     ];
     rerender();
 
-    expect(mockShowCustomFailedToast).toHaveBeenCalledWith(
+    expect(mockShowFailedToast).toHaveBeenCalledWith(
       'perps-withdraw-tx-1',
       {
         title: 'perpsWithdrawPostQuoteToastErrorTitle',

--- a/ui/components/app/toast-listener/usePerpsWithdrawTransactionToasts.ts
+++ b/ui/components/app/toast-listener/usePerpsWithdrawTransactionToasts.ts
@@ -1,0 +1,109 @@
+import { useEffect, useRef } from 'react';
+import { useSelector } from 'react-redux';
+import { TransactionStatus } from '@metamask/transaction-controller';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import {
+  selectPerpsWithdrawTransactionsForToast,
+  type PerpsWithdrawToastTransaction,
+} from '../../../selectors/toast';
+import {
+  showCustomFailedToast,
+  showCustomPendingToast,
+  showCustomSuccessToast,
+} from './shared';
+
+const PENDING_STATUSES = new Set<TransactionStatus>([
+  TransactionStatus.approved,
+  TransactionStatus.signed,
+  TransactionStatus.submitted,
+]);
+
+const FAILED_STATUSES = new Set<TransactionStatus>([
+  TransactionStatus.failed,
+  TransactionStatus.dropped,
+]);
+
+function generateToastId(transactionId: string): string {
+  return `perps-withdraw-${transactionId}`;
+}
+
+function getSuccessDescription(
+  transaction: PerpsWithdrawToastTransaction,
+  t: ReturnType<typeof useI18nContext>,
+): string {
+  if (!transaction.isPostQuote || transaction.targetFiat === undefined) {
+    return t('perpsWithdrawPostQuoteToastSuccessGenericDescription');
+  }
+
+  return t('perpsWithdrawPostQuoteToastSuccessDescription', [
+    `$${transaction.targetFiat.toFixed(2)}`,
+    transaction.tokenSymbol,
+  ]);
+}
+
+export function usePerpsWithdrawTransactionToasts() {
+  const t = useI18nContext();
+  const transactions = useSelector(selectPerpsWithdrawTransactionsForToast);
+  const hasInitializedRef = useRef(false);
+  const previousStatusesRef = useRef<Record<string, TransactionStatus | null>>(
+    {},
+  );
+  const pendingToastShownIdsRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    const nextStatuses: Record<string, TransactionStatus | null> = {};
+
+    for (const transaction of transactions) {
+      nextStatuses[transaction.id] = transaction.status ?? null;
+    }
+
+    if (!hasInitializedRef.current) {
+      previousStatusesRef.current = nextStatuses;
+      hasInitializedRef.current = true;
+      return;
+    }
+
+    for (const transaction of transactions) {
+      const { id, status } = transaction;
+      const previousStatus = previousStatusesRef.current[id];
+
+      if (!status || previousStatus === status) {
+        continue;
+      }
+
+      const toastId = generateToastId(id);
+
+      if (
+        PENDING_STATUSES.has(status) &&
+        !pendingToastShownIdsRef.current.has(id)
+      ) {
+        pendingToastShownIdsRef.current.add(id);
+        showCustomPendingToast(toastId, {
+          title: t('perpsWithdrawPostQuoteToastPendingTitle'),
+          description: t('perpsWithdrawPostQuoteToastPendingDescription'),
+          dataTestId: 'perps-withdraw-pending-toast',
+        });
+        continue;
+      }
+
+      if (status === TransactionStatus.confirmed) {
+        showCustomSuccessToast(toastId, {
+          title: t('perpsWithdrawPostQuoteToastSuccessTitle'),
+          description: getSuccessDescription(transaction, t),
+          dataTestId: 'perps-withdraw-success-toast',
+        });
+        continue;
+      }
+
+      if (FAILED_STATUSES.has(status)) {
+        showCustomFailedToast(toastId, {
+          title: t('perpsWithdrawPostQuoteToastErrorTitle'),
+          description: t('perpsWithdrawPostQuoteToastErrorDescription'),
+          dataTestId: 'perps-withdraw-failed-toast',
+        });
+      }
+    }
+
+    previousStatusesRef.current = nextStatuses;
+  }, [t, transactions]);
+}

--- a/ui/components/app/toast-listener/usePerpsWithdrawTransactionToasts.ts
+++ b/ui/components/app/toast-listener/usePerpsWithdrawTransactionToasts.ts
@@ -7,6 +7,7 @@ import {
   type PerpsWithdrawToastTransaction,
 } from '../../../selectors/toast';
 import {
+  dismissToast,
   showCustomFailedToast,
   showCustomPendingToast,
   showCustomSuccessToast,
@@ -101,6 +102,19 @@ export function usePerpsWithdrawTransactionToasts() {
           description: t('perpsWithdrawPostQuoteToastErrorDescription'),
           dataTestId: 'perps-withdraw-failed-toast',
         });
+      }
+    }
+
+    for (const [id, previousStatus] of Object.entries(
+      previousStatusesRef.current,
+    )) {
+      if (previousStatus && PENDING_STATUSES.has(previousStatus)) {
+        const toastId = generateToastId(id);
+
+        if (!(id in nextStatuses)) {
+          dismissToast(toastId);
+          pendingToastShownIdsRef.current.delete(id);
+        }
       }
     }
 

--- a/ui/components/app/toast-listener/usePerpsWithdrawTransactionToasts.ts
+++ b/ui/components/app/toast-listener/usePerpsWithdrawTransactionToasts.ts
@@ -24,13 +24,28 @@ const FAILED_STATUSES = new Set<TransactionStatus>([
   TransactionStatus.dropped,
 ]);
 
+type TransactionStatusesById = Record<string, TransactionStatus | null>;
+type I18nTranslator = ReturnType<typeof useI18nContext>;
+
 function generateToastId(transactionId: string): string {
   return `perps-withdraw-${transactionId}`;
 }
 
+function getTransactionStatusesById(
+  transactions: PerpsWithdrawToastTransaction[],
+): TransactionStatusesById {
+  const statuses: TransactionStatusesById = {};
+
+  for (const transaction of transactions) {
+    statuses[transaction.id] = transaction.status ?? null;
+  }
+
+  return statuses;
+}
+
 function getSuccessDescription(
   transaction: PerpsWithdrawToastTransaction,
-  t: ReturnType<typeof useI18nContext>,
+  t: I18nTranslator,
 ): string {
   if (!transaction.isPostQuote || transaction.targetFiat === undefined) {
     return t('perpsWithdrawPostQuoteToastSuccessGenericDescription');
@@ -40,6 +55,92 @@ function getSuccessDescription(
     `$${transaction.targetFiat.toFixed(2)}`,
     transaction.tokenSymbol,
   ]);
+}
+
+function showPendingWithdrawToast(toastId: string, t: I18nTranslator): void {
+  showPendingToast(toastId, {
+    title: t('perpsWithdrawPostQuoteToastPendingTitle'),
+    description: t('perpsWithdrawPostQuoteToastPendingDescription'),
+    dataTestId: 'perps-withdraw-pending-toast',
+  });
+}
+
+function showSuccessWithdrawToast(
+  toastId: string,
+  transaction: PerpsWithdrawToastTransaction,
+  t: I18nTranslator,
+): void {
+  showSuccessToast(toastId, {
+    title: t('perpsWithdrawPostQuoteToastSuccessTitle'),
+    description: getSuccessDescription(transaction, t),
+    dataTestId: 'perps-withdraw-success-toast',
+  });
+}
+
+function showFailedWithdrawToast(toastId: string, t: I18nTranslator): void {
+  showFailedToast(toastId, {
+    title: t('perpsWithdrawPostQuoteToastErrorTitle'),
+    description: t('perpsWithdrawPostQuoteToastErrorDescription'),
+    dataTestId: 'perps-withdraw-failed-toast',
+  });
+}
+
+function handleChangedWithdrawTransaction({
+  transaction,
+  previousStatus,
+  pendingToastShownIds,
+  t,
+}: {
+  transaction: PerpsWithdrawToastTransaction;
+  previousStatus: TransactionStatus | null | undefined;
+  pendingToastShownIds: Set<string>;
+  t: I18nTranslator;
+}): void {
+  const { id, status } = transaction;
+
+  if (!status || previousStatus === status) {
+    return;
+  }
+
+  const toastId = generateToastId(id);
+
+  if (PENDING_STATUSES.has(status) && !pendingToastShownIds.has(id)) {
+    pendingToastShownIds.add(id);
+    showPendingWithdrawToast(toastId, t);
+    return;
+  }
+
+  if (status === TransactionStatus.confirmed) {
+    showSuccessWithdrawToast(toastId, transaction, t);
+    return;
+  }
+
+  if (FAILED_STATUSES.has(status)) {
+    showFailedWithdrawToast(toastId, t);
+  }
+}
+
+function dismissRemovedPendingToasts({
+  previousStatuses,
+  nextStatuses,
+  pendingToastShownIds,
+}: {
+  previousStatuses: TransactionStatusesById;
+  nextStatuses: TransactionStatusesById;
+  pendingToastShownIds: Set<string>;
+}): void {
+  for (const [id, previousStatus] of Object.entries(previousStatuses)) {
+    if (!previousStatus || !PENDING_STATUSES.has(previousStatus)) {
+      continue;
+    }
+
+    if (id in nextStatuses) {
+      continue;
+    }
+
+    dismissToast(generateToastId(id));
+    pendingToastShownIds.delete(id);
+  }
 }
 
 export function usePerpsWithdrawTransactionToasts() {
@@ -52,11 +153,7 @@ export function usePerpsWithdrawTransactionToasts() {
   const pendingToastShownIdsRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
-    const nextStatuses: Record<string, TransactionStatus | null> = {};
-
-    for (const transaction of transactions) {
-      nextStatuses[transaction.id] = transaction.status ?? null;
-    }
+    const nextStatuses = getTransactionStatusesById(transactions);
 
     if (!hasInitializedRef.current) {
       previousStatusesRef.current = nextStatuses;
@@ -65,58 +162,19 @@ export function usePerpsWithdrawTransactionToasts() {
     }
 
     for (const transaction of transactions) {
-      const { id, status } = transaction;
-      const previousStatus = previousStatusesRef.current[id];
-
-      if (!status || previousStatus === status) {
-        continue;
-      }
-
-      const toastId = generateToastId(id);
-
-      if (
-        PENDING_STATUSES.has(status) &&
-        !pendingToastShownIdsRef.current.has(id)
-      ) {
-        pendingToastShownIdsRef.current.add(id);
-        showPendingToast(toastId, {
-          title: t('perpsWithdrawPostQuoteToastPendingTitle'),
-          description: t('perpsWithdrawPostQuoteToastPendingDescription'),
-          dataTestId: 'perps-withdraw-pending-toast',
-        });
-        continue;
-      }
-
-      if (status === TransactionStatus.confirmed) {
-        showSuccessToast(toastId, {
-          title: t('perpsWithdrawPostQuoteToastSuccessTitle'),
-          description: getSuccessDescription(transaction, t),
-          dataTestId: 'perps-withdraw-success-toast',
-        });
-        continue;
-      }
-
-      if (FAILED_STATUSES.has(status)) {
-        showFailedToast(toastId, {
-          title: t('perpsWithdrawPostQuoteToastErrorTitle'),
-          description: t('perpsWithdrawPostQuoteToastErrorDescription'),
-          dataTestId: 'perps-withdraw-failed-toast',
-        });
-      }
+      handleChangedWithdrawTransaction({
+        transaction,
+        previousStatus: previousStatusesRef.current[transaction.id],
+        pendingToastShownIds: pendingToastShownIdsRef.current,
+        t,
+      });
     }
 
-    for (const [id, previousStatus] of Object.entries(
-      previousStatusesRef.current,
-    )) {
-      if (previousStatus && PENDING_STATUSES.has(previousStatus)) {
-        const toastId = generateToastId(id);
-
-        if (!(id in nextStatuses)) {
-          dismissToast(toastId);
-          pendingToastShownIdsRef.current.delete(id);
-        }
-      }
-    }
+    dismissRemovedPendingToasts({
+      previousStatuses: previousStatusesRef.current,
+      nextStatuses,
+      pendingToastShownIds: pendingToastShownIdsRef.current,
+    });
 
     previousStatusesRef.current = nextStatuses;
   }, [t, transactions]);

--- a/ui/components/app/toast-listener/usePerpsWithdrawTransactionToasts.ts
+++ b/ui/components/app/toast-listener/usePerpsWithdrawTransactionToasts.ts
@@ -8,9 +8,9 @@ import {
 } from '../../../selectors/toast';
 import {
   dismissToast,
-  showCustomFailedToast,
-  showCustomPendingToast,
-  showCustomSuccessToast,
+  showFailedToast,
+  showPendingToast,
+  showSuccessToast,
 } from './shared';
 
 const PENDING_STATUSES = new Set<TransactionStatus>([
@@ -79,7 +79,7 @@ export function usePerpsWithdrawTransactionToasts() {
         !pendingToastShownIdsRef.current.has(id)
       ) {
         pendingToastShownIdsRef.current.add(id);
-        showCustomPendingToast(toastId, {
+        showPendingToast(toastId, {
           title: t('perpsWithdrawPostQuoteToastPendingTitle'),
           description: t('perpsWithdrawPostQuoteToastPendingDescription'),
           dataTestId: 'perps-withdraw-pending-toast',
@@ -88,7 +88,7 @@ export function usePerpsWithdrawTransactionToasts() {
       }
 
       if (status === TransactionStatus.confirmed) {
-        showCustomSuccessToast(toastId, {
+        showSuccessToast(toastId, {
           title: t('perpsWithdrawPostQuoteToastSuccessTitle'),
           description: getSuccessDescription(transaction, t),
           dataTestId: 'perps-withdraw-success-toast',
@@ -97,7 +97,7 @@ export function usePerpsWithdrawTransactionToasts() {
       }
 
       if (FAILED_STATUSES.has(status)) {
-        showCustomFailedToast(toastId, {
+        showFailedToast(toastId, {
           title: t('perpsWithdrawPostQuoteToastErrorTitle'),
           description: t('perpsWithdrawPostQuoteToastErrorDescription'),
           dataTestId: 'perps-withdraw-failed-toast',

--- a/ui/components/ui/toast/toast.test.tsx
+++ b/ui/components/ui/toast/toast.test.tsx
@@ -20,9 +20,9 @@ describe('ToastContent', () => {
       />,
     );
 
-    expect(
-      screen.getByText('$20.73 BNB moved to your wallet'),
-    ).toHaveClass('mt-1');
+    expect(screen.getByText('$20.73 BNB moved to your wallet')).toHaveClass(
+      'mt-1',
+    );
   });
 
   it('renders an action button when onActionClick is provided', () => {

--- a/ui/components/ui/toast/toast.test.tsx
+++ b/ui/components/ui/toast/toast.test.tsx
@@ -9,7 +9,20 @@ jest.mock('../icon/status-icon', () => ({
 describe('ToastContent', () => {
   it('renders the title', () => {
     render(<ToastContent title="Transaction pending" />);
-    expect(screen.getByText('Transaction pending')).toBeInTheDocument();
+    expect(screen.getByText('Transaction pending')).toHaveClass('font-bold');
+  });
+
+  it('renders the description when provided', () => {
+    render(
+      <ToastContent
+        title="Withdrawal complete"
+        description="$20.73 BNB moved to your wallet"
+      />,
+    );
+
+    expect(
+      screen.getByText('$20.73 BNB moved to your wallet'),
+    ).toHaveClass('mt-1');
   });
 
   it('renders an action button when onActionClick is provided', () => {

--- a/ui/components/ui/toast/toast.tsx
+++ b/ui/components/ui/toast/toast.tsx
@@ -90,10 +90,12 @@ export const ToastContent = ({
   return (
     <div data-testid={dataTestId}>
       <div className="flex min-w-0 flex-col">
-        <p className="text-m-body-md">{title}</p>
+        <p className="text-m-body-md font-bold">{title}</p>
 
         {description && (
-          <p className="text-s-body-sm text-text-alternative">{description}</p>
+          <p className="mt-1 text-s-body-sm text-text-alternative">
+            {description}
+          </p>
         )}
       </div>
 

--- a/ui/selectors/toast.test.ts
+++ b/ui/selectors/toast.test.ts
@@ -1,10 +1,14 @@
-import { TransactionType } from '@metamask/transaction-controller';
+import {
+  TransactionStatus,
+  TransactionType,
+} from '@metamask/transaction-controller';
 import {
   selectTransactionIds,
   selectBridgeApprovalTxIds,
   selectCrossChainBridgeSourceTxIds,
   selectEvmTransactionsForToast,
   selectNonEvmTransactionsForToast,
+  selectPerpsWithdrawTransactionsForToast,
   selectSmartTransactions,
 } from './toast';
 
@@ -93,6 +97,7 @@ describe('toast selectors', () => {
             { id: '8', time: 9, type: TransactionType.perpsDeposit },
             { id: '9', time: 10, type: TransactionType.perpsDepositAndOrder },
             { id: '10', time: 11, type: TransactionType.perpsRelayDeposit },
+            { id: '11', time: 12, type: TransactionType.perpsWithdraw },
           ],
         },
       } as unknown as SelectorState;
@@ -277,6 +282,140 @@ describe('toast selectors', () => {
       const results = selectEvmTransactionsForToast(state);
 
       expect(results).toStrictEqual([]);
+    });
+  });
+
+  describe('selectPerpsWithdrawTransactionsForToast', () => {
+    it('returns perps withdraw transactions with post-quote toast data', () => {
+      const state = {
+        metamask: {
+          transactions: [
+            { id: '0', time: 1, type: TransactionType.simpleSend },
+            {
+              id: '1',
+              time: 2,
+              type: TransactionType.perpsWithdraw,
+              status: TransactionStatus.confirmed,
+              metamaskPay: {
+                isPostQuote: true,
+                targetFiat: '20.73',
+                chainId: '0x38',
+                tokenAddress: '0xtoken',
+              },
+            },
+          ],
+          allTokens: {
+            '0x38': {
+              '0xabc': [{ address: '0xtoken', symbol: 'BNB' }],
+            },
+          },
+          networkConfigurationsByChainId: {
+            '0x38': { nativeCurrency: 'BNB' },
+          },
+        },
+      } as unknown as SelectorState;
+
+      const results = selectPerpsWithdrawTransactionsForToast(state);
+
+      expect(results).toStrictEqual([
+        {
+          id: '1',
+          isPostQuote: true,
+          status: TransactionStatus.confirmed,
+          targetFiat: 20.73,
+          tokenSymbol: 'BNB',
+        },
+      ]);
+    });
+
+    it('falls back to the network ticker when the token is not imported', () => {
+      const state = {
+        metamask: {
+          transactions: [
+            {
+              id: '1',
+              time: 2,
+              type: TransactionType.perpsWithdraw,
+              status: TransactionStatus.confirmed,
+              metamaskPay: {
+                isPostQuote: true,
+                targetFiat: '1.50',
+                chainId: '0x1',
+                tokenAddress: '0xunknown',
+              },
+            },
+          ],
+          allTokens: {},
+          networkConfigurationsByChainId: {
+            '0x1': { nativeCurrency: 'ETH' },
+          },
+        },
+      } as unknown as SelectorState;
+
+      const results = selectPerpsWithdrawTransactionsForToast(state);
+
+      expect(results).toStrictEqual([
+        {
+          id: '1',
+          isPostQuote: true,
+          status: TransactionStatus.confirmed,
+          targetFiat: 1.5,
+          tokenSymbol: 'ETH',
+        },
+      ]);
+    });
+
+    it('returns generic USDC data when post-quote metadata is missing', () => {
+      const state = {
+        metamask: {
+          transactions: [
+            {
+              id: '1',
+              time: 2,
+              type: TransactionType.perpsWithdraw,
+              status: TransactionStatus.failed,
+            },
+          ],
+        },
+      } as unknown as SelectorState;
+
+      const results = selectPerpsWithdrawTransactionsForToast(state);
+
+      expect(results).toStrictEqual([
+        {
+          id: '1',
+          isPostQuote: false,
+          status: TransactionStatus.failed,
+          tokenSymbol: 'USDC',
+        },
+      ]);
+    });
+
+    it('includes transactions with nested perps withdraw metadata', () => {
+      const state = {
+        metamask: {
+          transactions: [
+            {
+              id: '1',
+              time: 2,
+              type: TransactionType.simpleSend,
+              nestedTransactions: [{ type: TransactionType.perpsWithdraw }],
+              status: TransactionStatus.approved,
+            },
+          ],
+        },
+      } as unknown as SelectorState;
+
+      const results = selectPerpsWithdrawTransactionsForToast(state);
+
+      expect(results).toStrictEqual([
+        {
+          id: '1',
+          isPostQuote: false,
+          status: TransactionStatus.approved,
+          tokenSymbol: 'USDC',
+        },
+      ]);
     });
   });
 

--- a/ui/selectors/toast.ts
+++ b/ui/selectors/toast.ts
@@ -12,6 +12,7 @@ import {
   TOAST_EXCLUDED_TRANSACTION_TYPES,
   TOAST_EXCLUDED_NON_EVM_TRANSACTION_TYPES,
 } from '../helpers/constants/transactions';
+import { isPerpsWithdrawTransaction } from '../../shared/lib/transactions.utils';
 import { getPendingApprovals } from './approvals';
 import { EMPTY_ARRAY, EMPTY_OBJECT } from './shared';
 import {
@@ -27,6 +28,99 @@ const selectNonEvmTransactions = (state: MetaMaskReduxState) =>
 
 const selectTxHistory = (state: MetaMaskReduxState) =>
   state.metamask?.txHistory ?? EMPTY_OBJECT;
+
+type TokenLike = {
+  address?: string;
+  symbol?: string;
+};
+
+export type PerpsWithdrawToastTransaction = {
+  id: string;
+  isPostQuote: boolean;
+  status?: TransactionStatus;
+  targetFiat?: number;
+  tokenSymbol: string;
+};
+
+const selectAllTokens = (state: MetaMaskReduxState) =>
+  state.metamask?.allTokens ?? EMPTY_OBJECT;
+
+const selectNetworkConfigurationsByChainId = (state: MetaMaskReduxState) =>
+  state.metamask?.networkConfigurationsByChainId ?? EMPTY_OBJECT;
+
+function getTokenSymbol(
+  allTokens: unknown,
+  chainId?: string,
+  tokenAddress?: string,
+): string | undefined {
+  if (!chainId || !tokenAddress) {
+    return undefined;
+  }
+
+  const chainTokensByAccount =
+    (allTokens as Record<string, Record<string, TokenLike[]>>)[chainId] ??
+    EMPTY_OBJECT;
+  const tokens = Object.values(chainTokensByAccount).flat();
+
+  return tokens.find(
+    (token) =>
+      token.address?.toLowerCase() === tokenAddress.toLowerCase() &&
+      token.symbol,
+  )?.symbol;
+}
+
+function getNetworkTicker(
+  networkConfigurationsByChainId: unknown,
+  chainId?: string,
+): string | undefined {
+  if (!chainId) {
+    return undefined;
+  }
+
+  return (
+    networkConfigurationsByChainId as Record<
+      string,
+      { nativeCurrency?: string }
+    >
+  )[chainId]?.nativeCurrency;
+}
+
+function getPerpsWithdrawToastTransaction(
+  transaction: TransactionMeta,
+  allTokens: unknown,
+  networkConfigurationsByChainId: unknown,
+): PerpsWithdrawToastTransaction {
+  const { metamaskPay } = transaction;
+
+  if (metamaskPay?.isPostQuote !== true) {
+    return {
+      id: transaction.id,
+      isPostQuote: false,
+      status: transaction.status,
+      tokenSymbol: 'USDC',
+    };
+  }
+
+  const rawTargetFiat = Number(metamaskPay.targetFiat);
+  const targetFiat =
+    Number.isFinite(rawTargetFiat) && rawTargetFiat > 0
+      ? rawTargetFiat
+      : undefined;
+  const { chainId } = metamaskPay;
+  const { tokenAddress } = metamaskPay;
+  const tokenSymbol =
+    getTokenSymbol(allTokens, chainId, tokenAddress) ??
+    getNetworkTicker(networkConfigurationsByChainId, chainId) ??
+    'USDC';
+
+  return {
+    id: transaction.id,
+    isPostQuote: true,
+    status: transaction.status,
+    targetFiat,
+    tokenSymbol,
+  };
+}
 
 export const selectTransactionIds = createSelector(
   selectTransactions,
@@ -227,4 +321,20 @@ export const selectSmartTransactions = createDeepEqualSelector(
 
     return result;
   },
+);
+
+export const selectPerpsWithdrawTransactionsForToast = createDeepEqualSelector(
+  selectTransactions,
+  selectAllTokens,
+  selectNetworkConfigurationsByChainId,
+  (transactions, allTokens, networkConfigurationsByChainId) =>
+    transactions
+      .filter(isPerpsWithdrawTransaction)
+      .map((transaction) =>
+        getPerpsWithdrawToastTransaction(
+          transaction,
+          allTokens,
+          networkConfigurationsByChainId,
+        ),
+      ),
 );


### PR DESCRIPTION
## **Description**

Adds dedicated in-app toast notifications for post-quote `TransactionType.perpsWithdraw` transactions.

This mirrors the mobile withdrawal notification content for pending, success, and failure states. Success toasts resolve the post-quote fiat amount and token symbol from transaction metadata when available, with a generic fallback when details are missing.

Also updates the shared toast layout so toast titles are bold and descriptions have more spacing, better matching the mobile design.

## **Changelog**

CHANGELOG entry: Added in-app notifications for Perps withdrawals

## **Related issues**

Fixes: CONF-1217

## **Manual testing steps**

1. Submit a post-quote Perps withdrawal.
2. Confirm that the pending toast appears with “Withdrawal in progress” and “Available in about 1 minute”.
3. Wait for the withdrawal transaction to confirm.
4. Confirm that the success toast appears with “Withdrawal complete” and the resolved fiat amount/token symbol.
5. Trigger or simulate a failed/dropped withdrawal transaction.
6. Confirm that the failure toast appears with “Something went wrong” and “Failed to proceed with withdrawal”.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/notification change that adds new selectors and a toast hook; main risk is incorrect toast triggering or messaging due to transaction status/metadata edge cases.
> 
> **Overview**
> Adds a new `usePerpsWithdrawTransactionToasts` hook and selector (`selectPerpsWithdrawTransactionsForToast`) to surface dedicated pending/success/failed in-app toasts for `TransactionType.perpsWithdraw`, including post-quote amount + token symbol resolution with sensible fallbacks.
> 
> Extends the shared toast helpers to support custom `title`/`description`/`dataTestId`, mounts the Perps withdraw listener whenever the UI is interactive, and tweaks toast UI styling (bold titles, spaced descriptions). New i18n strings and tests cover the new toast flows and selector behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53fbfae43348415d328cd307073a71d2b2cb87ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->