### PR TITLE
feat: route Perps withdraw through confirmation flow

### DIFF
--- a/ui/components/app/perps/hooks/createPerpsWithdrawTransaction.test.ts
+++ b/ui/components/app/perps/hooks/createPerpsWithdrawTransaction.test.ts
@@ -1,0 +1,66 @@
+import { TransactionType } from '@metamask/transaction-controller';
+
+import { CHAIN_IDS } from '../../../../../shared/constants/network';
+import {
+  addTransaction,
+  findNetworkClientIdByChainId,
+} from '../../../../store/actions';
+import { ARBITRUM_USDC } from '../../../../pages/confirmations/constants/perps';
+import { createPerpsWithdrawTransaction } from './createPerpsWithdrawTransaction';
+
+jest.mock('../../../../store/actions', () => ({
+  addTransaction: jest.fn(),
+  findNetworkClientIdByChainId: jest.fn(),
+}));
+
+const addTransactionMock = jest.mocked(addTransaction);
+const findNetworkClientIdByChainIdMock = jest.mocked(
+  findNetworkClientIdByChainId,
+);
+
+const MOCK_ACCOUNT_ADDRESS = '0x1234567890123456789012345678901234567890';
+const MOCK_NETWORK_CLIENT_ID = 'arbitrum-mainnet';
+
+describe('createPerpsWithdrawTransaction', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    findNetworkClientIdByChainIdMock.mockResolvedValue(
+      MOCK_NETWORK_CLIENT_ID as never,
+    );
+    addTransactionMock.mockResolvedValue({ id: 'tx-123' } as never);
+  });
+
+  it('creates a perpsWithdraw transaction on Arbitrum and returns the id', async () => {
+    const result = await createPerpsWithdrawTransaction({
+      accountAddress: MOCK_ACCOUNT_ADDRESS,
+    });
+
+    expect(findNetworkClientIdByChainIdMock).toHaveBeenCalledWith(
+      CHAIN_IDS.ARBITRUM,
+    );
+    expect(addTransactionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: MOCK_ACCOUNT_ADDRESS,
+        to: ARBITRUM_USDC.address,
+        value: '0x0',
+        data: expect.stringMatching(/^0xa9059cbb/u),
+      }),
+      {
+        networkClientId: MOCK_NETWORK_CLIENT_ID,
+        type: TransactionType.perpsWithdraw,
+      },
+    );
+    expect(result).toStrictEqual({ transactionId: 'tx-123' });
+  });
+
+  it('throws when the transaction is not created', async () => {
+    addTransactionMock.mockResolvedValueOnce({} as never);
+
+    await expect(
+      createPerpsWithdrawTransaction({
+        accountAddress: MOCK_ACCOUNT_ADDRESS,
+      }),
+    ).rejects.toThrow('Perps withdraw transaction was not created');
+  });
+});

--- a/ui/components/app/perps/hooks/createPerpsWithdrawTransaction.ts
+++ b/ui/components/app/perps/hooks/createPerpsWithdrawTransaction.ts
@@ -31,7 +31,9 @@ export type CreatedPerpsWithdrawTransaction = {
 export async function createPerpsWithdrawTransaction({
   accountAddress,
 }: CreatePerpsWithdrawTransactionParams): Promise<CreatedPerpsWithdrawTransaction> {
-  const networkClientId = await findNetworkClientIdByChainId(CHAIN_IDS.ARBITRUM);
+  const networkClientId = await findNetworkClientIdByChainId(
+    CHAIN_IDS.ARBITRUM,
+  );
   const transferData = generateERC20TransferData({
     toAddress: accountAddress,
     amount: '0x0',

--- a/ui/components/app/perps/hooks/createPerpsWithdrawTransaction.ts
+++ b/ui/components/app/perps/hooks/createPerpsWithdrawTransaction.ts
@@ -1,0 +1,59 @@
+import { TransactionType } from '@metamask/transaction-controller';
+import type { Hex } from '@metamask/utils';
+
+import { CHAIN_IDS } from '../../../../../shared/constants/network';
+import {
+  addTransaction,
+  findNetworkClientIdByChainId,
+} from '../../../../store/actions';
+import { ARBITRUM_USDC } from '../../../../pages/confirmations/constants/perps';
+import { generateERC20TransferData } from '../../../../pages/confirmations/send-utils/send.utils';
+
+export type CreatePerpsWithdrawTransactionParams = {
+  accountAddress: Hex;
+};
+
+export type CreatedPerpsWithdrawTransaction = {
+  transactionId: string;
+};
+
+/**
+ * Creates the placeholder transaction used to launch the Perps withdraw
+ * custom amount confirmation.
+ *
+ * The final withdraw is a Hyperliquid signed action, but confirmations need a
+ * staged transaction shell so the user can choose the withdraw amount/token.
+ *
+ * @param params - Parameters for the withdraw transaction.
+ * @param params.accountAddress - Selected account and eventual recipient.
+ * @returns The created transaction ID.
+ */
+export async function createPerpsWithdrawTransaction({
+  accountAddress,
+}: CreatePerpsWithdrawTransactionParams): Promise<CreatedPerpsWithdrawTransaction> {
+  const networkClientId = await findNetworkClientIdByChainId(CHAIN_IDS.ARBITRUM);
+  const transferData = generateERC20TransferData({
+    toAddress: accountAddress,
+    amount: '0x0',
+    sendToken: ARBITRUM_USDC,
+  });
+
+  const txMeta = await addTransaction(
+    {
+      from: accountAddress,
+      to: ARBITRUM_USDC.address,
+      data: transferData,
+      value: '0x0',
+    },
+    {
+      networkClientId,
+      type: TransactionType.perpsWithdraw,
+    },
+  );
+
+  if (!txMeta?.id) {
+    throw new Error('Perps withdraw transaction was not created');
+  }
+
+  return { transactionId: txMeta.id };
+}

--- a/ui/components/app/perps/hooks/usePerpsWithdrawNavigation.test.ts
+++ b/ui/components/app/perps/hooks/usePerpsWithdrawNavigation.test.ts
@@ -1,7 +1,15 @@
-import { act } from '@testing-library/react-hooks';
+import React from 'react';
+import { Provider } from 'react-redux';
+import { act, renderHook } from '@testing-library/react-hooks';
+import { MemoryRouter } from 'react-router-dom';
 import mockState from '../../../../../test/data/mock-state.json';
-import { renderHookWithProvider } from '../../../../../test/lib/render-helpers-navigate';
-import { PERPS_WITHDRAW_ROUTE } from '../../../../helpers/constants/routes';
+import {
+  CONFIRM_TRANSACTION_ROUTE,
+  PERPS_WITHDRAW_ROUTE,
+} from '../../../../helpers/constants/routes';
+import { ConfirmationLoader } from '../../../../pages/confirmations/hooks/useConfirmationNavigation';
+import { getSelectedInternalAccount } from '../../../../../shared/lib/selectors/accounts';
+import { createPerpsWithdrawTransaction } from './createPerpsWithdrawTransaction';
 import { usePerpsWithdrawNavigation } from './usePerpsWithdrawNavigation';
 
 const mockNavigate = jest.fn();
@@ -11,13 +19,97 @@ jest.mock('react-router-dom', () => ({
   useNavigate: () => mockNavigate,
 }));
 
+jest.mock('../../../../../shared/lib/selectors/accounts', () => ({
+  getSelectedInternalAccount: jest.fn(),
+}));
+
+jest.mock(
+  '../../../../pages/confirmations/hooks/useConfirmationNavigation',
+  () => ({
+    ConfirmationLoader: {
+      CustomAmount: 'customAmount',
+    },
+  }),
+);
+
+jest.mock('./createPerpsWithdrawTransaction', () => ({
+  createPerpsWithdrawTransaction: jest.fn(),
+}));
+
+const getSelectedInternalAccountMock = jest.mocked(getSelectedInternalAccount);
+const mockCreatePerpsWithdrawTransaction = jest.mocked(
+  createPerpsWithdrawTransaction,
+);
+
+const MOCK_ACCOUNT_ADDRESS = '0x1234567890123456789012345678901234567890';
+const MOCK_TX_ID = 'withdraw-tx-id';
+
+function createMockStore(state = mockState) {
+  return {
+    getState: () => state,
+    subscribe: jest.fn(() => jest.fn()),
+    dispatch: jest.fn(),
+  };
+}
+
+function buildStateWithPerpsWithdrawFlag(enabled: boolean) {
+  return {
+    ...mockState,
+    metamask: {
+      ...mockState.metamask,
+      remoteFeatureFlags: {
+        ...mockState.metamask.remoteFeatureFlags,
+        /* eslint-disable @typescript-eslint/naming-convention */
+        confirmations_pay_post_quote: {
+          perpsWithdraw: { enabled },
+        },
+        /* eslint-enable @typescript-eslint/naming-convention */
+      },
+    },
+  };
+}
+
+function renderUsePerpsWithdrawNavigation(
+  hook: () => ReturnType<typeof usePerpsWithdrawNavigation>,
+  state = mockState,
+  pathname = '/',
+) {
+  const store = createMockStore(state);
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(
+      Provider,
+      { store: store as never },
+      React.createElement(
+        MemoryRouter,
+        {
+          initialEntries: [pathname],
+          future: {
+            /* eslint-disable @typescript-eslint/naming-convention */
+            v7_relativeSplatPath: true,
+            v7_startTransition: true,
+            /* eslint-enable @typescript-eslint/naming-convention */
+          },
+        },
+        children,
+      ),
+    );
+
+  return renderHook(hook, { wrapper });
+}
+
 describe('usePerpsWithdrawNavigation', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    getSelectedInternalAccountMock.mockReturnValue({
+      address: MOCK_ACCOUNT_ADDRESS,
+    } as never);
+    mockCreatePerpsWithdrawTransaction.mockResolvedValue({
+      transactionId: MOCK_TX_ID,
+    });
   });
 
-  it('navigates to perps withdraw route by default', async () => {
-    const { result } = renderHookWithProvider(
+  it('navigates to legacy perps withdraw route by default', async () => {
+    const { result } = renderUsePerpsWithdrawNavigation(
       () => usePerpsWithdrawNavigation(),
       mockState,
     );
@@ -29,11 +121,12 @@ describe('usePerpsWithdrawNavigation', () => {
     });
 
     expect(mockNavigate).toHaveBeenCalledWith(PERPS_WITHDRAW_ROUTE);
+    expect(mockCreatePerpsWithdrawTransaction).not.toHaveBeenCalled();
     expect(triggerResult).toStrictEqual({ route: PERPS_WITHDRAW_ROUTE });
   });
 
-  it('does not navigate when navigateOnTrigger is false', async () => {
-    const { result } = renderHookWithProvider(
+  it('does not navigate to legacy route when navigateOnTrigger is false', async () => {
+    const { result } = renderUsePerpsWithdrawNavigation(
       () => usePerpsWithdrawNavigation({ navigateOnTrigger: false }),
       mockState,
     );
@@ -45,13 +138,14 @@ describe('usePerpsWithdrawNavigation', () => {
     });
 
     expect(mockNavigate).not.toHaveBeenCalled();
+    expect(mockCreatePerpsWithdrawTransaction).not.toHaveBeenCalled();
     expect(triggerResult).toStrictEqual({ route: PERPS_WITHDRAW_ROUTE });
   });
 
   it('invokes onNavigated with route', async () => {
     const onNavigated = jest.fn();
 
-    const { result } = renderHookWithProvider(
+    const { result } = renderUsePerpsWithdrawNavigation(
       () => usePerpsWithdrawNavigation({ onNavigated }),
       mockState,
     );
@@ -63,21 +157,102 @@ describe('usePerpsWithdrawNavigation', () => {
     expect(onNavigated).toHaveBeenCalledWith(PERPS_WITHDRAW_ROUTE);
   });
 
-  it('returns null when there is no selected account', async () => {
-    const stateWithoutSelectedAccount = {
-      ...mockState,
-      metamask: {
-        ...mockState.metamask,
-        internalAccounts: {
-          ...mockState.metamask.internalAccounts,
-          selectedAccount: '',
-        },
-      },
-    };
-
-    const { result } = renderHookWithProvider(
+  it('creates a perpsWithdraw transaction and navigates to confirmation when the flag is enabled', async () => {
+    const { result } = renderUsePerpsWithdrawNavigation(
       () => usePerpsWithdrawNavigation(),
-      stateWithoutSelectedAccount,
+      buildStateWithPerpsWithdrawFlag(true),
+    );
+
+    let triggerResult: Awaited<ReturnType<typeof result.current.trigger>> =
+      null;
+    await act(async () => {
+      triggerResult = await result.current.trigger();
+    });
+
+    expect(mockCreatePerpsWithdrawTransaction).toHaveBeenCalledWith({
+      accountAddress: MOCK_ACCOUNT_ADDRESS,
+    });
+    expect(mockNavigate).toHaveBeenCalledWith({
+      pathname: `${CONFIRM_TRANSACTION_ROUTE}/${MOCK_TX_ID}`,
+      search: `loader=${ConfirmationLoader.CustomAmount}`,
+    });
+    expect(triggerResult).toStrictEqual({
+      route: `${CONFIRM_TRANSACTION_ROUTE}/${MOCK_TX_ID}`,
+      transactionId: MOCK_TX_ID,
+    });
+  });
+
+  it('adds goBackTo when confirmation flow starts from a non-root route', async () => {
+    const { result } = renderUsePerpsWithdrawNavigation(
+      () => usePerpsWithdrawNavigation(),
+      buildStateWithPerpsWithdrawFlag(true),
+      '/perps/trade/BTC',
+    );
+
+    await act(async () => {
+      await result.current.trigger();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith({
+      pathname: `${CONFIRM_TRANSACTION_ROUTE}/${MOCK_TX_ID}`,
+      search: `loader=${ConfirmationLoader.CustomAmount}&goBackTo=%2Fperps%2Ftrade%2FBTC`,
+    });
+  });
+
+  it('creates confirmation transaction without navigating when navigateOnTrigger is false', async () => {
+    const { result } = renderUsePerpsWithdrawNavigation(
+      () =>
+        usePerpsWithdrawNavigation({
+          navigateOnTrigger: false,
+        }),
+      buildStateWithPerpsWithdrawFlag(true),
+    );
+
+    let triggerResult: Awaited<ReturnType<typeof result.current.trigger>> =
+      null;
+    await act(async () => {
+      triggerResult = await result.current.trigger();
+    });
+
+    expect(mockCreatePerpsWithdrawTransaction).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(triggerResult).toStrictEqual({
+      route: `${CONFIRM_TRANSACTION_ROUTE}/${MOCK_TX_ID}`,
+      transactionId: MOCK_TX_ID,
+    });
+  });
+
+  it('returns null when confirmation transaction creation fails', async () => {
+    mockCreatePerpsWithdrawTransaction.mockRejectedValueOnce(
+      new Error('create failed'),
+    );
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    const { result } = renderUsePerpsWithdrawNavigation(
+      () => usePerpsWithdrawNavigation(),
+      buildStateWithPerpsWithdrawFlag(true),
+    );
+
+    let triggerResult: Awaited<ReturnType<typeof result.current.trigger>> =
+      null;
+    await act(async () => {
+      triggerResult = await result.current.trigger();
+    });
+
+    expect(triggerResult).toBeNull();
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('returns null when there is no selected account', async () => {
+    getSelectedInternalAccountMock.mockReturnValue(undefined as never);
+
+    const { result } = renderUsePerpsWithdrawNavigation(
+      () => usePerpsWithdrawNavigation(),
+      mockState,
     );
 
     const consoleErrorSpy = jest
@@ -90,12 +265,13 @@ describe('usePerpsWithdrawNavigation', () => {
     });
 
     expect(mockNavigate).not.toHaveBeenCalled();
+    expect(mockCreatePerpsWithdrawTransaction).not.toHaveBeenCalled();
     expect(triggerResult).toBeNull();
     consoleErrorSpy.mockRestore();
   });
 
   it('allows sequential triggers after each completes', async () => {
-    const { result } = renderHookWithProvider(
+    const { result } = renderUsePerpsWithdrawNavigation(
       () => usePerpsWithdrawNavigation(),
       mockState,
     );
@@ -118,7 +294,7 @@ describe('usePerpsWithdrawNavigation', () => {
       .spyOn(console, 'error')
       .mockImplementation(() => undefined);
 
-    const { result } = renderHookWithProvider(
+    const { result } = renderUsePerpsWithdrawNavigation(
       () => usePerpsWithdrawNavigation(),
       mockState,
     );

--- a/ui/components/app/perps/hooks/usePerpsWithdrawNavigation.ts
+++ b/ui/components/app/perps/hooks/usePerpsWithdrawNavigation.ts
@@ -5,7 +5,7 @@ import { TransactionType } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 
 import { getSelectedInternalAccount } from '../../../../../shared/lib/selectors/accounts';
-import type { RemoteFeatureFlagsState } from '../../../../selectors/remote-feature-flags';
+import type { RemoteFeatureFlagsState } from '../../../../../shared/lib/selectors/remote-feature-flags';
 import {
   CONFIRM_TRANSACTION_ROUTE,
   PERPS_WITHDRAW_ROUTE,

--- a/ui/components/app/perps/hooks/usePerpsWithdrawNavigation.ts
+++ b/ui/components/app/perps/hooks/usePerpsWithdrawNavigation.ts
@@ -1,13 +1,24 @@
 import { useCallback, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { TransactionType } from '@metamask/transaction-controller';
+import type { Hex } from '@metamask/utils';
 
 import { getSelectedInternalAccount } from '../../../../../shared/lib/selectors/accounts';
-import { PERPS_WITHDRAW_ROUTE } from '../../../../helpers/constants/routes';
+import type { RemoteFeatureFlagsState } from '../../../../selectors/remote-feature-flags';
+import {
+  CONFIRM_TRANSACTION_ROUTE,
+  PERPS_WITHDRAW_ROUTE,
+} from '../../../../helpers/constants/routes';
+import { ConfirmationLoader } from '../../../../pages/confirmations/hooks/useConfirmationNavigation';
+import { selectPayQuoteConfig } from '../../../../pages/confirmations/selectors/feature-flags';
+import { createPerpsWithdrawTransaction } from './createPerpsWithdrawTransaction';
 
 export type PerpsWithdrawNavigationResponse = {
-  /** Route opened (or that would be opened) for the withdraw flow */
+  /** Route opened (or that would be opened) for the withdraw flow. */
   route: string;
+  /** Created transaction ID when routed through the confirmation flow. */
+  transactionId?: string;
 };
 
 export type PerpsWithdrawNavigationOptions = {
@@ -22,14 +33,11 @@ export type PerpsWithdrawNavigationResult = {
 };
 
 /**
- * Perps-owned entrypoint for opening the withdraw flow (dedicated route).
+ * Perps-owned entrypoint for opening the withdraw flow.
  *
- * Sibling to {@link usePerpsDepositConfirmation}: same `trigger` / `isLoading` shape.
- * Deposit confirmation is backed by `depositWithConfirmation`, which builds an EVM
- * transaction and submits it through `TransactionController` (`perpsDeposit`).
- * Withdraw is API-only (`perpsWithdraw`) with no staged `TransactionMeta`, so it
- * cannot reuse that confirmations path without new controller support. Completion
- * feedback on the wallet home uses `PerpsWithdrawToast` and `lastWithdrawResult`.
+ * When `confirmations_pay_post_quote.perpsWithdraw.enabled` is true, this
+ * starts the custom amount confirmation flow. Otherwise it falls back to the
+ * legacy standalone Perps withdraw route while the confirmation flow rolls out.
  *
  * @param options
  */
@@ -38,7 +46,13 @@ export function usePerpsWithdrawNavigation(
 ): PerpsWithdrawNavigationResult {
   const { navigateOnTrigger = true, onNavigated } = options;
   const navigate = useNavigate();
+  const location = useLocation();
   const selectedAccount = useSelector(getSelectedInternalAccount);
+  const isConfirmationFlowEnabled = useSelector(
+    (state: RemoteFeatureFlagsState) =>
+      selectPayQuoteConfig(state, TransactionType.perpsWithdraw).enabled ===
+      true,
+  );
   const [isLoading, setIsLoading] = useState(false);
 
   const isInFlightRef = useRef(false);
@@ -57,6 +71,33 @@ export function usePerpsWithdrawNavigation(
     setIsLoading(true);
 
     try {
+      if (isConfirmationFlowEnabled) {
+        const { transactionId } = await createPerpsWithdrawTransaction({
+          accountAddress: selectedAccount.address as Hex,
+        });
+        const route = `${CONFIRM_TRANSACTION_ROUTE}/${transactionId}`;
+
+        if (navigateOnTrigger) {
+          const params = new URLSearchParams({
+            loader: ConfirmationLoader.CustomAmount,
+          });
+
+          const goBackTo = location.pathname + location.search;
+          if (goBackTo && goBackTo !== '/') {
+            params.set('goBackTo', goBackTo);
+          }
+
+          navigate({
+            pathname: route,
+            search: params.toString(),
+          });
+        }
+
+        onNavigated?.(route);
+
+        return { route, transactionId };
+      }
+
       if (navigateOnTrigger) {
         navigate(PERPS_WITHDRAW_ROUTE);
       }
@@ -72,7 +113,10 @@ export function usePerpsWithdrawNavigation(
       setIsLoading(false);
     }
   }, [
+    isConfirmationFlowEnabled,
     isLoading,
+    location.pathname,
+    location.search,
     navigate,
     navigateOnTrigger,
     onNavigated,

--- a/ui/pages/confirmations/components/developer/perps-withdraw-button/perps-withdraw-button.test.tsx
+++ b/ui/pages/confirmations/components/developer/perps-withdraw-button/perps-withdraw-button.test.tsx
@@ -1,52 +1,56 @@
 import React from 'react';
-import { fireEvent, screen, waitFor } from '@testing-library/react';
-import { TransactionType } from '@metamask/transaction-controller';
-import configureStore from '../../../../../store/store';
+import { Provider } from 'react-redux';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import mockState from '../../../../../../test/data/mock-state.json';
-import { renderWithProvider } from '../../../../../../test/lib/render-helpers-navigate';
-import {
-  addTransaction,
-  findNetworkClientIdByChainId,
-} from '../../../../../store/actions';
+import { createPerpsWithdrawTransaction } from '../../../../../components/app/perps/hooks/createPerpsWithdrawTransaction';
 import { getSelectedInternalAccount } from '../../../../../../shared/lib/selectors/accounts';
 import {
   ConfirmationLoader,
   useConfirmationNavigation,
 } from '../../../hooks/useConfirmationNavigation';
-import { ARBITRUM_USDC } from '../../../constants/perps';
-import { CHAIN_IDS } from '../../../../../../shared/constants/network';
 import { PerpsWithdrawButton } from './perps-withdraw-button';
 
-jest.mock('../../../../../store/actions', () => ({
-  addTransaction: jest.fn(),
-  findNetworkClientIdByChainId: jest.fn(),
-}));
+jest.mock(
+  '../../../../../components/app/perps/hooks/createPerpsWithdrawTransaction',
+  () => ({
+    createPerpsWithdrawTransaction: jest.fn(),
+  }),
+);
 
 jest.mock('../../../../../../shared/lib/selectors/accounts', () => ({
   getSelectedInternalAccount: jest.fn(),
 }));
 
-jest.mock('../../../hooks/useConfirmationNavigation', () => {
-  const actual = jest.requireActual('../../../hooks/useConfirmationNavigation');
-  return {
-    ...actual,
-    useConfirmationNavigation: jest.fn(),
-  };
-});
+jest.mock('../../../hooks/useConfirmationNavigation', () => ({
+  ConfirmationLoader: {
+    CustomAmount: 'customAmount',
+  },
+  useConfirmationNavigation: jest.fn(),
+}));
 
-const addTransactionMock = jest.mocked(addTransaction);
-const findNetworkClientIdByChainIdMock = jest.mocked(
-  findNetworkClientIdByChainId,
+const createPerpsWithdrawTransactionMock = jest.mocked(
+  createPerpsWithdrawTransaction,
 );
 const getSelectedInternalAccountMock = jest.mocked(getSelectedInternalAccount);
 const useConfirmationNavigationMock = jest.mocked(useConfirmationNavigation);
 
 const MOCK_ACCOUNT_ADDRESS = '0x1234567890123456789012345678901234567890';
-const MOCK_NETWORK_CLIENT_ID = 'arbitrum-mainnet';
 const MOCK_TX_ID = 'withdraw-tx-id';
 
+function createMockStore() {
+  return {
+    getState: () => mockState,
+    subscribe: jest.fn(() => jest.fn()),
+    dispatch: jest.fn(),
+  };
+}
+
 function renderButton() {
-  return renderWithProvider(<PerpsWithdrawButton />, configureStore(mockState));
+  return render(
+    <Provider store={createMockStore() as never}>
+      <PerpsWithdrawButton />
+    </Provider>,
+  );
 }
 
 describe('PerpsWithdrawButton', () => {
@@ -59,10 +63,9 @@ describe('PerpsWithdrawButton', () => {
     getSelectedInternalAccountMock.mockReturnValue({
       address: MOCK_ACCOUNT_ADDRESS,
     } as never);
-    findNetworkClientIdByChainIdMock.mockResolvedValue(
-      MOCK_NETWORK_CLIENT_ID as never,
-    );
-    addTransactionMock.mockResolvedValue({ id: MOCK_TX_ID } as never);
+    createPerpsWithdrawTransactionMock.mockResolvedValue({
+      transactionId: MOCK_TX_ID,
+    });
     useConfirmationNavigationMock.mockReturnValue({
       navigateToTransaction: navigateToTransactionMock,
       navigateToTransactions: navigateToTransactionsMock,
@@ -85,31 +88,19 @@ describe('PerpsWithdrawButton', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Trigger' }));
 
     await waitFor(() => {
-      expect(addTransactionMock).toHaveBeenCalledTimes(1);
+      expect(createPerpsWithdrawTransactionMock).toHaveBeenCalledTimes(1);
     });
 
-    expect(findNetworkClientIdByChainIdMock).toHaveBeenCalledWith(
-      CHAIN_IDS.ARBITRUM,
-    );
-
-    expect(addTransactionMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        from: MOCK_ACCOUNT_ADDRESS,
-        to: ARBITRUM_USDC.address,
-        value: '0x0',
-      }),
-      {
-        networkClientId: MOCK_NETWORK_CLIENT_ID,
-        type: TransactionType.perpsWithdraw,
-      },
-    );
+    expect(createPerpsWithdrawTransactionMock).toHaveBeenCalledWith({
+      accountAddress: MOCK_ACCOUNT_ADDRESS,
+    });
 
     expect(navigateToTransactionMock).toHaveBeenCalledWith(MOCK_TX_ID, {
       loader: ConfirmationLoader.CustomAmount,
     });
   });
 
-  it('does not call addTransaction when there is no selected account', () => {
+  it('does not create a transaction when there is no selected account', () => {
     getSelectedInternalAccountMock.mockReturnValue(undefined as never);
     const consoleErrorSpy = jest
       .spyOn(console, 'error')
@@ -119,7 +110,7 @@ describe('PerpsWithdrawButton', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Trigger' }));
 
-    expect(addTransactionMock).not.toHaveBeenCalled();
+    expect(createPerpsWithdrawTransactionMock).not.toHaveBeenCalled();
     expect(navigateToTransactionMock).not.toHaveBeenCalled();
 
     consoleErrorSpy.mockRestore();

--- a/ui/pages/confirmations/components/developer/perps-withdraw-button/perps-withdraw-button.tsx
+++ b/ui/pages/confirmations/components/developer/perps-withdraw-button/perps-withdraw-button.tsx
@@ -1,21 +1,14 @@
 import React, { useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
 import type { Hex } from '@metamask/utils';
-import { TransactionType } from '@metamask/transaction-controller';
 
-import {
-  addTransaction,
-  findNetworkClientIdByChainId,
-} from '../../../../../store/actions';
 import { getSelectedInternalAccount } from '../../../../../../shared/lib/selectors/accounts';
-import { CHAIN_IDS } from '../../../../../../shared/constants/network';
+import { createPerpsWithdrawTransaction } from '../../../../../components/app/perps/hooks/createPerpsWithdrawTransaction';
 import { DeveloperButton } from '../developer-button';
-import { ARBITRUM_USDC } from '../../../constants/perps';
 import {
   ConfirmationLoader,
   useConfirmationNavigation,
 } from '../../../hooks/useConfirmationNavigation';
-import { generateERC20TransferData } from '../utils';
 
 export const PerpsWithdrawButton = () => {
   const { navigateToTransaction } = useConfirmationNavigation();
@@ -32,35 +25,13 @@ export const PerpsWithdrawButton = () => {
     setIsLoading(true);
 
     try {
-      const networkClientId = await findNetworkClientIdByChainId(
-        CHAIN_IDS.ARBITRUM,
-      );
-
-      // Placeholder 0-USDC transfer: the real withdraw flow uses a Hyperliquid
-      // signed withdraw action, not an on-chain ERC-20 transfer. Recipient is
-      // the user's own address since withdrawn USDC ultimately returns to them.
-      const transferData = generateERC20TransferData(
-        selectedAccount.address as Hex,
-        '0',
-        ARBITRUM_USDC.decimals,
-      );
-
-      const txMeta = await addTransaction(
-        {
-          from: selectedAccount.address as Hex,
-          to: ARBITRUM_USDC.address,
-          data: transferData,
-          value: '0x0',
-        },
-        {
-          networkClientId,
-          type: TransactionType.perpsWithdraw,
-        },
-      );
+      const { transactionId } = await createPerpsWithdrawTransaction({
+        accountAddress: selectedAccount.address as Hex,
+      });
 
       setHasTriggered(true);
 
-      navigateToTransaction(txMeta.id, {
+      navigateToTransaction(transactionId, {
         loader: ConfirmationLoader.CustomAmount,
       });
     } catch (error) {


### PR DESCRIPTION
## **Description**

Wires the Perps `Total balance -> Withdraw` entry point to the new Perps Withdraw confirmation flow when `confirmations_pay_post_quote.perpsWithdraw.enabled` is enabled.

This PR:
- Adds a shared `createPerpsWithdrawTransaction` helper for creating the placeholder `perpsWithdraw` transaction used by the custom amount confirmation flow
- Updates `usePerpsWithdrawNavigation` to route to the new confirmation flow when the remote flag is enabled
- Keeps the legacy `/perps/withdraw` route as the fallback while rollout is in progress
- Refactors the Settings -> Debug -> Perps Withdraw trigger to use the same transaction helper
- Adds focused unit coverage for the new helper, feature-flagged routing, fallback routing, and debug trigger behavior

## **Changelog**

CHANGELOG entry: Added a feature-flagged confirmation flow for Perps withdrawals

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1216

## **Manual testing steps**

1. Enable `confirmations_pay_post_quote.perpsWithdraw.enabled`.
2. Go to the Perps tab.
3. Open the `Total balance` dropdown.
4. Click `Withdraw`.
5. Confirm the new Perps Withdraw confirmation UI opens.
6. Disable `confirmations_pay_post_quote.perpsWithdraw.enabled`.
7. Repeat steps 2-4 and confirm the legacy `/perps/withdraw` route opens.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Perps withdraw entrypoint to conditionally create a staged `perpsWithdraw` `TransactionMeta` and deep-link into the confirmations flow based on a remote feature flag; navigation/query-param behavior changes could affect withdraw UX during rollout.
> 
> **Overview**
> Routes Perps withdraw through the confirmations *custom amount* flow when `confirmations_pay_post_quote.perpsWithdraw.enabled` is enabled, otherwise continuing to use the legacy `/perps/withdraw` route.
> 
> Adds a shared `createPerpsWithdrawTransaction` helper that creates a placeholder `perpsWithdraw` transaction (0-value ERC-20 transfer shell on Arbitrum USDC) and updates both `usePerpsWithdrawNavigation` and the dev `PerpsWithdrawButton` to use it, including support for a `goBackTo` query param when launched from non-root pages. Unit tests are expanded/added to cover flagged routing, helper behavior, and error/fallback paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d383aa8baadade717fce268c09e955b8b1da3f62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->