### PR TITLE
fix: route 7702 downgrade through standard publish path on sponsored networks

### DIFF
--- a/app/scripts/lib/transaction/hooks/delegation-7702-publish.test.ts
+++ b/app/scripts/lib/transaction/hooks/delegation-7702-publish.test.ts
@@ -243,6 +243,31 @@ describe('Delegation 7702 Publish Hook', () => {
         transactionHash: undefined,
       });
     });
+
+    it('transaction type revokeDelegation must not be relayed', async () => {
+      isAtomicBatchSupportedMock.mockResolvedValueOnce([
+        {
+          chainId: TRANSACTION_META_MOCK.chainId,
+          delegationAddress: UPGRADE_CONTRACT_ADDRESS_MOCK,
+          isSupported: true,
+          upgradeContractAddress: UPGRADE_CONTRACT_ADDRESS_MOCK,
+        },
+      ]);
+
+      const result = await hookClass.getHook()(
+        {
+          ...TRANSACTION_META_MOCK,
+          type: TransactionType.revokeDelegation,
+          isGasFeeSponsored: true,
+          gasFeeTokens: [GAS_FEE_TOKEN_MOCK],
+          selectedGasFeeToken: GAS_FEE_TOKEN_MOCK.tokenAddress,
+        } as unknown as TransactionMeta,
+        SIGNED_TX_MOCK,
+      );
+
+      expect(result).toEqual({ transactionHash: undefined });
+      expect(submitRelayTransactionMock).not.toHaveBeenCalled();
+    });
   });
 
   it('submits request to transaction relay', async () => {

--- a/app/scripts/lib/transaction/hooks/delegation-7702-publish.ts
+++ b/app/scripts/lib/transaction/hooks/delegation-7702-publish.ts
@@ -5,6 +5,7 @@ import {
   PublishHook,
   PublishHookResult,
   TransactionMeta,
+  TransactionType,
 } from '@metamask/transaction-controller';
 import { Hex, createProjectLogger } from '@metamask/utils';
 import { ExecutionStruct } from '../../../../../shared/lib/delegation';
@@ -67,6 +68,11 @@ export class Delegation7702PublishHook {
     transactionMeta: TransactionMeta,
     _signedTx: string,
   ): Promise<PublishHookResult> {
+    if (transactionMeta.type === TransactionType.revokeDelegation) {
+      log('Skipping: revokeDelegation must publish as top-level setCode');
+      return EMPTY_RESULT;
+    }
+
     const { chainId, gasFeeTokens, selectedGasFeeToken, txParams } =
       transactionMeta;
 

--- a/app/scripts/lib/transaction/hooks/delegation-7702-publish.ts
+++ b/app/scripts/lib/transaction/hooks/delegation-7702-publish.ts
@@ -128,10 +128,6 @@ export class Delegation7702PublishHook {
     const includeTransfer =
       !isGaslessSwap && !transactionMeta.isGasFeeSponsored;
 
-    if (includeTransfer && (!gasFeeToken || gasFeeToken === undefined)) {
-      throw new Error('Gas fee token not found');
-    }
-
     const { nonce, ...txParamsWithoutNonce } = transactionMeta.txParams;
     const finalTransactionMeta: TransactionMeta = {
       ...transactionMeta,

--- a/app/scripts/messenger-client-init/confirmations/transaction-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/confirmations/transaction-controller-init.test.ts
@@ -696,6 +696,64 @@ describe('Transaction Controller Init', () => {
 
       expect(result).toStrictEqual({ transactionHash: '0xstxHash' });
     });
+
+    it('bypasses Delegation7702PublishHook for revokeDelegation on a sponsored chain', async () => {
+      jest
+        .mocked(sentinelApiModule.isSendBundleSupported)
+        .mockResolvedValue(true);
+
+      jest
+        .mocked(smartTransactionsModule.getSmartTransactionCommonParams)
+        .mockReturnValue({
+          isSmartTransaction: true,
+          featureFlags: {
+            extensionReturnTxHashAsap: false,
+            extensionReturnTxHashAsapBatch: false,
+            extensionSkipTransactionStatusPage: false,
+            mobileActive: false,
+            extensionActive: false,
+          },
+          isHardwareWalletAccount: false,
+        });
+
+      const delegation7702HookFn: jest.MockedFn<PublishHook> = jest.fn();
+      jest.mocked(Delegation7702PublishHook).mockImplementation(
+        () =>
+          ({
+            getHook: () => delegation7702HookFn,
+          }) as unknown as Delegation7702PublishHook,
+      );
+
+      type PHArgs = Parameters<typeof publishHook>[0];
+      const result = await publishHook({
+        flatState: {} as PHArgs['flatState'],
+        getTransactionMetricsRequest: () =>
+          ({
+            upsertTransactionUIMetricsFragment: jest.fn(),
+          }) as unknown as ReturnType<PHArgs['getTransactionMetricsRequest']>,
+        initMessenger: {
+          call: jest.fn(),
+        } as unknown as TransactionControllerInitMessenger,
+        keyringController: {
+          getKeyringForAccount: jest
+            .fn()
+            .mockResolvedValue({ type: 'HD Key Tree' }),
+        },
+        signedTx: '0xsigned',
+        smartTransactionsController:
+          {} as PHArgs['smartTransactionsController'],
+        transactionController: {
+          isAtomicBatchSupported: jest.fn(),
+        } as unknown as PHArgs['transactionController'],
+        transactionMeta: {
+          ...mockTransactionMeta,
+          type: TransactionType.revokeDelegation,
+        } as TransactionMeta,
+      });
+
+      expect(delegation7702HookFn).not.toHaveBeenCalled();
+      expect(result).toBeDefined();
+    });
   });
 
   describe('publishBatch hook', () => {

--- a/app/scripts/messenger-client-init/confirmations/transaction-controller-init.ts
+++ b/app/scripts/messenger-client-init/confirmations/transaction-controller-init.ts
@@ -445,10 +445,15 @@ export async function publishHook({
     transactionMeta.txParams?.from,
     keyringController,
   );
+
+  const isRevokeDelegation =
+    transactionMeta.type === TransactionType.revokeDelegation;
+
   let attemptedHook = false;
 
   if (
     keyringSupports7702 &&
+    !isRevokeDelegation &&
     (!isSmartTransaction || !sendBundleSupport || isExternalSign)
   ) {
     attemptedHook = true;

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -893,7 +893,7 @@
       "Reselect: Identity function warnings": 3
     },
     "ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.test.tsx": {
-      "MetaMask: Background connection not initialized": 114,
+      "MetaMask: Background connection not initialized": 132,
       "Reselect: Identity function warnings": 3
     },
     "ui/pages/confirmations/components/confirm/info/shared/gas-fee-token-icon/gas-fee-token-icon.test.tsx": {

--- a/ui/components/app/transaction-breakdown/transaction-breakdown-utils.test.ts
+++ b/ui/components/app/transaction-breakdown/transaction-breakdown-utils.test.ts
@@ -1,6 +1,7 @@
 import {
   TransactionMeta,
   TransactionStatus,
+  TransactionType,
 } from '@metamask/transaction-controller';
 import { getTransactionBreakdownData } from './transaction-breakdown-utils';
 
@@ -103,5 +104,22 @@ describe('getTransactionBreakdownData', () => {
     });
 
     expect(result.isGasFeeSponsored).toBeFalsy();
+  });
+
+  it('returns isGasFeeSponsored false for revokeDelegation even when sponsored flag is true', () => {
+    const result = getTransactionBreakdownData({
+      state: MOCK_STATE,
+      transaction: {
+        ...BASE_TX,
+        type: TransactionType.revokeDelegation,
+        status: TransactionStatus.confirmed,
+        isGasFeeSponsored: true,
+        txReceipt: { gasUsed: '0x5208' } as TransactionMeta['txReceipt'],
+      } as TransactionMeta,
+      isTokenApprove: false,
+      isHardwareWalletAccount: false,
+    });
+
+    expect(result.isGasFeeSponsored).toBe(false);
   });
 });

--- a/ui/components/app/transaction-breakdown/transaction-breakdown-utils.ts
+++ b/ui/components/app/transaction-breakdown/transaction-breakdown-utils.ts
@@ -112,6 +112,7 @@ export const getTransactionBreakdownData = ({
 
   const isGasActuallySponsored =
     isGasFeeSponsored &&
+    type !== TransactionType.revokeDelegation &&
     !isHardwareWalletAccount &&
     status !== TransactionStatus.rejected &&
     !(status === TransactionStatus.failed && !transaction.txReceipt?.gasUsed);

--- a/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.test.tsx
@@ -2,7 +2,11 @@ import React from 'react';
 import configureMockStore from 'redux-mock-store';
 import { QuoteResponse } from '@metamask/bridge-controller';
 
-import { CHAIN_IDS, GasFeeToken } from '@metamask/transaction-controller';
+import {
+  CHAIN_IDS,
+  GasFeeToken,
+  TransactionType,
+} from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
 import { getMockConfirmStateForTransaction } from '../../../../../../../../test/data/confirmations/helper';
 import { renderWithConfirmContextProvider } from '../../../../../../../../test/lib/confirmations/render-helpers';
@@ -41,6 +45,7 @@ function render({
   nativeFee = '0.001 ETH',
   estimationFailed = false,
   isGaslessSupported = false,
+  transactionType,
 }: {
   chainId?: Hex;
   gasFeeTokens?: GasFeeToken[];
@@ -49,6 +54,7 @@ function render({
   nativeFee?: string;
   estimationFailed?: boolean;
   isGaslessSupported?: boolean;
+  transactionType?: TransactionType;
 } = {}) {
   mockUseEstimationFailed.mockReturnValue(estimationFailed);
   mockUseIsGaslessSupported.mockReturnValue({
@@ -57,14 +63,18 @@ function render({
     pending: false,
   });
 
-  const state = getMockConfirmStateForTransaction(
-    genUnapprovedContractInteractionConfirmation({
-      chainId,
-      gasFeeTokens,
-      selectedGasFeeToken,
-      isGasFeeSponsored: isGaslessSupported,
-    }),
-  );
+  const confirmation = genUnapprovedContractInteractionConfirmation({
+    chainId,
+    gasFeeTokens,
+    selectedGasFeeToken,
+    isGasFeeSponsored: isGaslessSupported,
+  });
+
+  if (transactionType) {
+    confirmation.type = transactionType;
+  }
+
+  const state = getMockConfirmStateForTransaction(confirmation);
 
   const mockStore = configureMockStore()(state);
 
@@ -152,5 +162,14 @@ describe('<EditGasFeesRow />', () => {
       expect(queryByText(messages.unavailable.message)).toBeNull();
       expect(getByTestId('paid-by-meta-mask')).toBeInTheDocument();
     });
+  });
+
+  it('does not render "Paid by MetaMask" pill for revokeDelegation even on sponsored networks', () => {
+    const { queryByTestId } = render({
+      isGaslessSupported: true,
+      transactionType: TransactionType.revokeDelegation,
+    });
+
+    expect(queryByTestId('paid-by-meta-mask')).toBeNull();
   });
 });

--- a/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
@@ -76,6 +76,8 @@ export const EditGasFeesRow = ({
   const balanceChangesResult = useBalanceChanges({ chainId, simulationData });
   const isLoadingGasUsed = !simulationData || balanceChangesResult.pending;
 
+  // This prevents the gas fee row from showing as sponsored if stx is disabled
+  // by the user and 7702 is not supported in the chain.
   const { isSupported: isGaslessSupported } = useIsGaslessSupported();
   const isGasFeeSponsored =
     isGaslessSupported &&

--- a/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
@@ -1,4 +1,7 @@
-import { TransactionMeta } from '@metamask/transaction-controller';
+import {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
 import React from 'react';
 import { useSelector } from 'react-redux';
@@ -58,6 +61,7 @@ export const EditGasFeesRow = ({
     chainId,
     isGasFeeSponsored: doesSentinelAllowSponsorship,
     simulationData,
+    type: transactionType,
   } = transactionMeta;
 
   const estimationFailed = useEstimationFailed();
@@ -72,10 +76,11 @@ export const EditGasFeesRow = ({
   const balanceChangesResult = useBalanceChanges({ chainId, simulationData });
   const isLoadingGasUsed = !simulationData || balanceChangesResult.pending;
 
-  // This prevents the gas fee row from showing as sponsored if stx is disabled
-  // by the user and 7702 is not supported in the chain.
   const { isSupported: isGaslessSupported } = useIsGaslessSupported();
-  const isGasFeeSponsored = isGaslessSupported && doesSentinelAllowSponsorship;
+  const isGasFeeSponsored =
+    isGaslessSupported &&
+    doesSentinelAllowSponsorship &&
+    transactionType !== TransactionType.revokeDelegation;
 
   let tooltip = t('estimatedFeeTooltip');
   if (isGasFeeSponsored) {


### PR DESCRIPTION
## **Description**

This pull request updates how "revokeDelegation" transactions are handled, ensuring they are never treated as gas-sponsored transactions and do not trigger the Delegation7702 publish hook. It also updates the UI to avoid displaying the "Paid by MetaMask" pill for these transactions, even on sponsored networks. Several tests and utility functions are updated to reflect this new logic.

**Delegation7702 Publish Hook Logic:**
* The `Delegation7702PublishHook` now bypasses execution for transactions of type `revokeDelegation`, returning immediately and logging the skip.
* The `publishHook` logic in the transaction controller init flow is updated to skip the Delegation7702 hook for `revokeDelegation` transactions.
* Corresponding tests are added to ensure the hook is not called for `revokeDelegation` and that the transaction is not relayed.

**Gas Sponsorship Handling:**
* The utility function `getTransactionBreakdownData` is updated so that `isGasFeeSponsored` is always `false` for `revokeDelegation` transactions, regardless of other sponsorship flags.
* The `EditGasFeesRow` component and its utility logic are updated to ensure the "Paid by MetaMask" pill is not shown for `revokeDelegation` transactions, even if sponsorship is otherwise enabled.

**UI and Test Updates:**
* Unit tests for transaction breakdown and edit gas fees row are added/updated to verify the correct behavior for `revokeDelegation` transactions regarding gas sponsorship and UI rendering.

**Test Baseline Update:**
* The jest console baseline is updated to reflect the increased number of background connection initializations due to new or updated tests.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: route 7702 downgrade through standard publish path on sponsored networks

## **Related issues**

Fixes: user not able to disable Smart Account on gas fees sponsored networks

## **Manual testing steps**

1. Go to the Smart Account properties of an account which has his 7702 delegation enabled on a gas fees sponsored network
2. Toggle off the flag regarding the network to disable the delegation
3. The transaction "Account update" dialog pops up, confirm, the transaction is executed and the delegation is disabled
4. The flag for this network is disabled in the Smart Account properties of the account.

## **Screenshots/Recordings**

### **After**

<img width="250" height="500" alt="Disable Smart Account" src="https://github.com/user-attachments/assets/72f878bf-c710-49b1-9d44-9e826e850182" />

<img width="473" height="624" alt="Smart Account disabled" src="https://github.com/user-attachments/assets/1c96430f-587b-458e-88fb-27298b6c267f" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes transaction publishing logic to force `revokeDelegation` down the standard (non-relayed/non-sponsored) path, which could affect delegation disable flows on sponsored networks. Scope is limited and covered by new unit tests, but it touches core publish routing and UI sponsorship indicators.
> 
> **Overview**
> Ensures `TransactionType.revokeDelegation` is **never treated as gas-sponsored** and **never sent via the `Delegation7702PublishHook` relay path**, so delegation downgrades publish through the normal top-level transaction flow even on sponsored networks.
> 
> Updates UI sponsorship handling to avoid showing the *Paid by MetaMask* pill and to report `isGasFeeSponsored=false` for `revokeDelegation` in `getTransactionBreakdownData`, and adds/adjusts unit tests (plus jest console baseline) to lock in the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12c403302d64ca80679d638dbc78c4024624d70b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->