### PR TITLE
feat(snaps): Display first party contract names in Snaps components

### DIFF
--- a/ui/hooks/snaps/useDisplayName.ts
+++ b/ui/hooks/snaps/useDisplayName.ts
@@ -2,6 +2,7 @@ import {
   CaipChainId,
   KnownCaipNamespace,
   CaipNamespace,
+  Hex,
 } from '@metamask/utils';
 import { useSelector } from 'react-redux';
 import {
@@ -14,6 +15,10 @@ import { toChecksumHexAddress } from '../../../shared/lib/hexstring-utils';
 import { decimalToHex } from '../../../shared/lib/conversion.utils';
 import { getAccountGroupsByAddress } from '../../selectors/multichain-accounts/account-tree';
 import { MultichainAccountsState } from '../../selectors/multichain-accounts/account-tree.types';
+import {
+  EXPERIENCES_TYPE,
+  FIRST_PARTY_CONTRACT_NAMES,
+} from '../../../shared/constants/first-party-contracts';
 
 export type UseDisplayNameParams = {
   chain: {
@@ -52,13 +57,23 @@ export const useDisplayName = (
     getAccountNameFromState(state, parsedAddress),
   );
 
+  const hexChainId = `0x${decimalToHex(isEip155 ? reference : `0`)}` as Hex;
+
   const addressBookEntry = useSelector((state: AddressBookMetaMaskState) =>
-    getAddressBookEntryByNetwork(
-      state,
-      parsedAddress,
-      `0x${decimalToHex(isEip155 ? reference : `0`)}`,
-    ),
+    getAddressBookEntryByNetwork(state, parsedAddress, hexChainId),
   );
+
+  const contractNames = Object.keys(
+    FIRST_PARTY_CONTRACT_NAMES,
+  ) as EXPERIENCES_TYPE[];
+
+  const firstPartyContractName =
+    isEip155 &&
+    contractNames.find((contractName) => {
+      return (
+        FIRST_PARTY_CONTRACT_NAMES[contractName][hexChainId] === parsedAddress
+      );
+    });
 
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
@@ -66,6 +81,7 @@ export const useDisplayName = (
     accountGroupName ||
     accountName ||
     (isEip155 && addressBookEntry?.name) ||
+    firstPartyContractName ||
     undefined
   );
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds support for displaying first party contract names in Snaps components that use `useDisplayName`.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Add support for displaying first party contract names in Snaps components


## **Screenshots/Recordings**
<img width="374" height="740" alt="Screenshot 2026-05-13 at 13 49 13" src="https://github.com/user-attachments/assets/31a75ac4-348a-404f-a86f-645b621015d4" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a small, read-only lookup to the `useDisplayName` hook with no state mutations or security-sensitive logic.
> 
> **Overview**
> `useDisplayName` now falls back to showing a **first-party contract name** when the resolved address matches a known MetaMask contract for the current EIP-155 `chainId`.
> 
> This refactors the chain ID passed to `getAddressBookEntryByNetwork` into a typed `hexChainId` (`Hex`) and uses `FIRST_PARTY_CONTRACT_NAMES`/`EXPERIENCES_TYPE` to map `(chainId, address)` to a display label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bec73793e09b81720c38c8b78d9c13964114a90c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->