### PR TITLE
test: add e2e test coverage for network picker visibility across connection entrypoints and provider mixing

### DIFF
--- a/test/e2e/page-objects/pages/header-navbar.ts
+++ b/test/e2e/page-objects/pages/header-navbar.ts
@@ -28,6 +28,9 @@ class HeaderNavbar {
 
   private readonly globalNetworksMenu = '[data-testid="global-menu-networks"]';
 
+  private readonly dappConnectionControlBar =
+    '[data-testid="dapp-connection-control-bar"]';
+
   private readonly dappNetworkButton =
     '[data-testid="dapp-connection-control-bar__network-button"]';
 
@@ -267,6 +270,34 @@ class HeaderNavbar {
     await this.driver.waitForSelector(
       this.selectedNetworkItem(expectedNetwork),
     );
+  }
+
+  /**
+   * Assert that the dapp connection control bar is rendered and that the
+   * network picker button is NOT present for the currently active tab. Used
+   * to validate the gating on `sessionProperties['eip1193-compatible']` in
+   * the CAIP-25 caveat: pure Multichain API and non-EVM connections must not
+   * show a network picker even when the bar itself is visible.
+   */
+  async checkDappNetworkButtonNotVisible(): Promise<void> {
+    console.log(
+      'Verify the dapp connection control bar network picker is NOT visible',
+    );
+    await this.driver.waitForSelector(this.dappConnectionControlBar);
+    await this.driver.assertElementNotPresent(this.dappNetworkButton);
+  }
+
+  /**
+   * Assert that the dapp connection control bar network picker button is
+   * rendered for the currently active tab. Used to validate that EIP-1193
+   * compatible connections (legacy `window.ethereum` and
+   * `@metamask/connect-evm`) expose the network picker.
+   */
+  async checkDappNetworkButtonVisible(): Promise<void> {
+    console.log(
+      'Verify the dapp connection control bar network picker is visible',
+    );
+    await this.driver.waitForSelector(this.dappNetworkButton);
   }
 
   /**

--- a/test/e2e/page-objects/pages/header-navbar.ts
+++ b/test/e2e/page-objects/pages/header-navbar.ts
@@ -284,7 +284,9 @@ class HeaderNavbar {
       'Verify the dapp connection control bar network picker is NOT visible',
     );
     await this.driver.waitForSelector(this.dappConnectionControlBar);
-    await this.driver.assertElementNotPresent(this.dappNetworkButton);
+    await this.driver.assertElementNotPresent(this.dappNetworkButton, {
+      waitAtLeastGuard: 500,
+    });
   }
 
   /**

--- a/test/e2e/page-objects/pages/test-dapp-mm-connect.ts
+++ b/test/e2e/page-objects/pages/test-dapp-mm-connect.ts
@@ -35,6 +35,18 @@ export class TestDappMmConnect {
   /** "Connect (Wagmi)" button. */
   private readonly connectWagmiButton = { testId: 'app-btn-connect-wagmi' };
 
+  /**
+   * "Connect (window.ethereum)" button.
+   *
+   * Unlike `connectLegacyButton`, this button is still rendered while another
+   * provider (e.g. the multichain session) is already connected to the dapp,
+   * so it is the reliable entrypoint for re-connecting via EIP-1193 on top of
+   * an existing connection.
+   */
+  private readonly connectWindowEthereumButton = {
+    testId: 'app-btn-connect-window-ethereum',
+  };
+
   /** "Disconnect All" button — calls sdkDisconnect() on the mm-connect dapp. */
   private readonly disconnectButton = { testId: 'app-btn-disconnect' };
 
@@ -495,6 +507,16 @@ export class TestDappMmConnect {
 
   async connectLegacy(): Promise<void> {
     await this.driver.clickElement(this.connectLegacyButton);
+  }
+
+  /**
+   * Click the "Connect (window.ethereum)" button. Use this in scenarios where
+   * the dapp already has an active connection (e.g. an existing multichain
+   * session) — the `connectLegacyButton` is hidden in that state, but the
+   * window.ethereum entrypoint stays available.
+   */
+  async connectWindowEthereum(): Promise<void> {
+    await this.driver.clickElement(this.connectWindowEthereumButton);
   }
 
   async checkLegacyCardVisible(): Promise<void> {

--- a/test/e2e/tests/mm-connect/dapp-connection-control-bar-network-picker.spec.ts
+++ b/test/e2e/tests/mm-connect/dapp-connection-control-bar-network-picker.spec.ts
@@ -26,10 +26,6 @@ const MM_CONNECT_DAPP_OPTIONS = {
   customDappPaths: [DAPP_PATH.TEST_DAPP_MM_CONNECT],
 };
 
-const SOLANA_DAPP_OPTIONS = {
-  customDappPaths: [DAPP_PATH.TEST_DAPP_SOLANA],
-};
-
 const EVM_AND_SOLANA_FIXTURE_SCOPES_WITH_EIP1193_COMPATIBLE = {
   isMultichainOrigin: true,
   requiredScopes: {},
@@ -67,11 +63,6 @@ async function approveConnectFromDialog(driver: Driver): Promise<void> {
   await confirmation.confirmConnect();
 }
 
-/** Build the full popup URL for the test dapp origin. */
-function popupUrl(driver: Driver): string {
-  return `${driver.extensionUrl}/${PAGES.POPUP}.html?activeTabOrigin=${DAPP_URL}`;
-}
-
 /**
  * Open the MetaMask popup with the test dapp as `activeTabOrigin`. The
  * `DappConnectionControlBar` is only rendered when the wallet popup has a
@@ -82,7 +73,9 @@ function popupUrl(driver: Driver): string {
  * @returns A `HeaderNavbar` page object scoped to the popup window.
  */
 async function openPopupForDapp(driver: Driver): Promise<HeaderNavbar> {
-  await driver.openNewPage(popupUrl(driver));
+  await driver.openNewPage(
+    `${driver.extensionUrl}/${PAGES.POPUP}.html?activeTabOrigin=${DAPP_URL}`,
+  );
   return new HeaderNavbar(driver);
 }
 
@@ -178,7 +171,9 @@ describe('DappConnectionControlBar - network picker visibility', function (this:
         {
           fixtures: new FixtureBuilderV2().build(),
           title: this.test?.fullTitle(),
-          dappOptions: SOLANA_DAPP_OPTIONS,
+          dappOptions: {
+            customDappPaths: [DAPP_PATH.TEST_DAPP_SOLANA],
+          },
         },
         async ({ driver }: { driver: Driver }) => {
           await login(driver);

--- a/test/e2e/tests/mm-connect/dapp-connection-control-bar-network-picker.spec.ts
+++ b/test/e2e/tests/mm-connect/dapp-connection-control-bar-network-picker.spec.ts
@@ -22,10 +22,6 @@ import { TestDappSolana } from '../../page-objects/pages/test-dapp-solana';
 
 // ── Shared fixture options ─────────────────────────────────────────────────
 
-const MM_CONNECT_DAPP_OPTIONS = {
-  customDappPaths: [DAPP_PATH.TEST_DAPP_MM_CONNECT],
-};
-
 const EVM_AND_SOLANA_FIXTURE_SCOPES_WITH_EIP1193_COMPATIBLE = {
   isMultichainOrigin: true,
   requiredScopes: {},
@@ -86,7 +82,9 @@ describe('DappConnectionControlBar - network picker visibility', function (this:
         {
           fixtures: new FixtureBuilderV2().build(),
           title: this.test?.fullTitle(),
-          dappOptions: MM_CONNECT_DAPP_OPTIONS,
+          dappOptions: {
+            customDappPaths: [DAPP_PATH.TEST_DAPP_MM_CONNECT],
+          },
         },
         async ({ driver }: { driver: Driver }) => {
           await login(driver);
@@ -113,7 +111,9 @@ describe('DappConnectionControlBar - network picker visibility', function (this:
         {
           fixtures: new FixtureBuilderV2().build(),
           title: this.test?.fullTitle(),
-          dappOptions: MM_CONNECT_DAPP_OPTIONS,
+          dappOptions: {
+            customDappPaths: [DAPP_PATH.TEST_DAPP_MM_CONNECT],
+          },
         },
         async ({ driver }: { driver: Driver }) => {
           await login(driver);
@@ -140,7 +140,9 @@ describe('DappConnectionControlBar - network picker visibility', function (this:
         {
           fixtures: new FixtureBuilderV2().build(),
           title: this.test?.fullTitle(),
-          dappOptions: MM_CONNECT_DAPP_OPTIONS,
+          dappOptions: {
+            customDappPaths: [DAPP_PATH.TEST_DAPP_MM_CONNECT],
+          },
         },
         async ({ driver }: { driver: Driver }) => {
           await login(driver);
@@ -197,7 +199,9 @@ describe('DappConnectionControlBar - network picker visibility', function (this:
         {
           fixtures: new FixtureBuilderV2().build(),
           title: this.test?.fullTitle(),
-          dappOptions: MM_CONNECT_DAPP_OPTIONS,
+          dappOptions: {
+            customDappPaths: [DAPP_PATH.TEST_DAPP_MM_CONNECT],
+          },
         },
         async ({ driver }: { driver: Driver }) => {
           await login(driver);

--- a/test/e2e/tests/mm-connect/dapp-connection-control-bar-network-picker.spec.ts
+++ b/test/e2e/tests/mm-connect/dapp-connection-control-bar-network-picker.spec.ts
@@ -1,0 +1,295 @@
+import { Suite } from 'mocha';
+import { SolScope } from '@metamask/keyring-api';
+
+import {
+  DAPP_PATH,
+  DAPP_URL,
+  DEFAULT_FIXTURE_ACCOUNT_LOWERCASE,
+  DEFAULT_FIXTURE_SOLANA_ACCOUNT,
+  LOCALHOST_NETWORK_CLIENT_ID,
+  MM_CONNECT_EVM_CHAINS,
+  WINDOW_TITLES,
+} from '../../constants';
+import { withFixtures } from '../../helpers';
+import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
+import { login } from '../../page-objects/flows/login.flow';
+import { connectSolanaTestDapp } from '../../flask/solana-wallet-standard/testHelpers';
+import { Driver, PAGES } from '../../webdriver/driver';
+import ConnectAccountConfirmation from '../../page-objects/pages/confirmations/connect-account-confirmation';
+import HeaderNavbar from '../../page-objects/pages/header-navbar';
+import { TestDappMmConnect as TestDapp } from '../../page-objects/pages/test-dapp-mm-connect';
+import { TestDappSolana } from '../../page-objects/pages/test-dapp-solana';
+
+// ── Shared fixture options ─────────────────────────────────────────────────
+
+const MM_CONNECT_DAPP_OPTIONS = {
+  customDappPaths: [DAPP_PATH.TEST_DAPP_MM_CONNECT],
+};
+
+const SOLANA_DAPP_OPTIONS = {
+  customDappPaths: [DAPP_PATH.TEST_DAPP_SOLANA],
+};
+
+const EVM_AND_SOLANA_FIXTURE_SCOPES_WITH_EIP1193_COMPATIBLE = {
+  isMultichainOrigin: true,
+  requiredScopes: {},
+  optionalScopes: {
+    'eip155:1337': {
+      accounts: [`eip155:1337:${DEFAULT_FIXTURE_ACCOUNT_LOWERCASE}`],
+    },
+    'wallet:eip155': {
+      accounts: [`wallet:eip155:${DEFAULT_FIXTURE_ACCOUNT_LOWERCASE}`],
+    },
+    [SolScope.Mainnet]: {
+      accounts: [`${SolScope.Mainnet}:${DEFAULT_FIXTURE_SOLANA_ACCOUNT}`],
+    },
+  },
+  sessionProperties: { 'eip1193-compatible': true },
+};
+
+const EVM_AND_SOLANA_FIXTURE_SCOPES_WITHOUT_EIP1193_COMPATIBLE = {
+  ...EVM_AND_SOLANA_FIXTURE_SCOPES_WITH_EIP1193_COMPATIBLE,
+  sessionProperties: {},
+};
+
+// ── Shared helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Approve the MetaMask connect dialog opened by the dapp. Caller is
+ * responsible for triggering the connect action on the dapp first.
+ *
+ * @param driver - Selenium driver
+ */
+async function approveConnectFromDialog(driver: Driver): Promise<void> {
+  await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+  const confirmation = new ConnectAccountConfirmation(driver);
+  await confirmation.checkPageIsLoaded();
+  await confirmation.confirmConnect();
+}
+
+/** Build the full popup URL for the test dapp origin. */
+function popupUrl(driver: Driver): string {
+  return `${driver.extensionUrl}/${PAGES.POPUP}.html?activeTabOrigin=${DAPP_URL}`;
+}
+
+/**
+ * Open the MetaMask popup with the test dapp as `activeTabOrigin`. The
+ * `DappConnectionControlBar` is only rendered when the wallet popup has a
+ * non-empty active tab origin, so this is the only way to drive its
+ * conditional render in E2E tests.
+ *
+ * @param driver - Selenium driver
+ * @returns A `HeaderNavbar` page object scoped to the popup window.
+ */
+async function openPopupForDapp(driver: Driver): Promise<HeaderNavbar> {
+  await driver.openNewPage(popupUrl(driver));
+  return new HeaderNavbar(driver);
+}
+
+describe('DappConnectionControlBar - network picker visibility', function (this: Suite) {
+  describe('single-provider connections', function (this: Suite) {
+    it('renders the network picker after connect-evm Legacy EVM connection', async function () {
+      await withFixtures(
+        {
+          fixtures: new FixtureBuilderV2().build(),
+          title: this.test?.fullTitle(),
+          dappOptions: MM_CONNECT_DAPP_OPTIONS,
+        },
+        async ({ driver }: { driver: Driver }) => {
+          await login(driver);
+
+          const testDapp = new TestDapp(driver);
+          await testDapp.openPage();
+
+          // Legacy EVM uses wallet_requestPermissions, which the extension's
+          // chain-agnostic-permission middleware converts into a CAIP-25
+          // caveat with `eip1193-compatible: true`.
+          await testDapp.connectLegacy();
+          await approveConnectFromDialog(driver);
+          await testDapp.switchTo();
+          await testDapp.checkLegacyCardVisible();
+
+          const headerNavbar = await openPopupForDapp(driver);
+          await headerNavbar.checkDappNetworkButtonVisible();
+        },
+      );
+    });
+
+    it('renders the network picker after connect-evm Wagmi connection', async function () {
+      await withFixtures(
+        {
+          fixtures: new FixtureBuilderV2().build(),
+          title: this.test?.fullTitle(),
+          dappOptions: MM_CONNECT_DAPP_OPTIONS,
+        },
+        async ({ driver }: { driver: Driver }) => {
+          await login(driver);
+
+          const testDapp = new TestDapp(driver);
+          await testDapp.openPage();
+
+          // Wagmi goes through @metamask/connect-evm which explicitly sends
+          // sessionProperties['eip1193-compatible'] = true in its
+          // wallet_createSession call.
+          await testDapp.connectWagmi();
+          await approveConnectFromDialog(driver);
+          await testDapp.switchTo();
+          await testDapp.checkWagmiCardVisible();
+
+          const headerNavbar = await openPopupForDapp(driver);
+          await headerNavbar.checkDappNetworkButtonVisible();
+        },
+      );
+    });
+
+    it('does not render the network picker after a pure Multichain API connection with EVM scopes only', async function () {
+      await withFixtures(
+        {
+          fixtures: new FixtureBuilderV2().build(),
+          title: this.test?.fullTitle(),
+          dappOptions: MM_CONNECT_DAPP_OPTIONS,
+        },
+        async ({ driver }: { driver: Driver }) => {
+          await login(driver);
+
+          const testDapp = new TestDapp(driver);
+          await testDapp.openPage();
+
+          // Pure multichain wallet_createSession does NOT send
+          // eip1193-compatible. Even though only EVM scopes are requested,
+          // the picker must stay hidden.
+          await testDapp.selectNetworks([
+            MM_CONNECT_EVM_CHAINS.LOCALHOST,
+            MM_CONNECT_EVM_CHAINS.POLYGON,
+          ]);
+          await testDapp.clickConnect();
+          await approveConnectFromDialog(driver);
+          await testDapp.switchTo();
+          await testDapp.checkConnectionStatus('connected');
+
+          const headerNavbar = await openPopupForDapp(driver);
+          await headerNavbar.checkDappNetworkButtonNotVisible();
+        },
+      );
+    });
+
+    it('does not render the network picker after a Solana-only Wallet Standard connection', async function () {
+      await withFixtures(
+        {
+          fixtures: new FixtureBuilderV2().build(),
+          title: this.test?.fullTitle(),
+          dappOptions: SOLANA_DAPP_OPTIONS,
+        },
+        async ({ driver }: { driver: Driver }) => {
+          await login(driver);
+
+          const testDapp = new TestDappSolana(driver);
+          await testDapp.openTestDappPage();
+          await testDapp.checkPageIsLoaded();
+
+          await connectSolanaTestDapp(driver, testDapp);
+
+          const headerNavbar = await openPopupForDapp(driver);
+          await headerNavbar.checkDappNetworkButtonNotVisible();
+        },
+      );
+    });
+  });
+
+  describe('reconnection / session property preservation', function (this: Suite) {
+    it('shows the network picker after upgrading a pure Multichain connection with connect-evm', async function () {
+      await withFixtures(
+        {
+          fixtures: new FixtureBuilderV2().build(),
+          title: this.test?.fullTitle(),
+          dappOptions: MM_CONNECT_DAPP_OPTIONS,
+        },
+        async ({ driver }: { driver: Driver }) => {
+          await login(driver);
+
+          const testDapp = new TestDapp(driver);
+          await testDapp.openPage();
+
+          // 1. Pure Multichain connection — eip1193-compatible NOT set.
+          await testDapp.selectNetworks([MM_CONNECT_EVM_CHAINS.LOCALHOST]);
+          await testDapp.clickConnect();
+          await approveConnectFromDialog(driver);
+          await testDapp.switchTo();
+          await testDapp.checkConnectionStatus('connected');
+
+          const headerNavbarBefore = await openPopupForDapp(driver);
+          await headerNavbarBefore.checkDappNetworkButtonNotVisible();
+          await driver.closeWindow();
+
+          // 2. Same origin reconnects via the window.ethereum EIP-1193
+          // entrypoint. The Legacy EVM button is hidden by the playground
+          // dapp while a multichain session is active, so we use the
+          // window.ethereum button instead. The EIP-1193 path injects
+          // `eip1193-compatible: true` into the existing CAIP-25 caveat, so
+          // the picker must become visible.
+          await testDapp.switchTo();
+          await testDapp.connectWindowEthereum();
+          await approveConnectFromDialog(driver);
+          await testDapp.switchTo();
+          await testDapp.checkLegacyCardVisible();
+
+          const headerNavbarAfter = await openPopupForDapp(driver);
+          await headerNavbarAfter.checkDappNetworkButtonVisible();
+        },
+      );
+    });
+  });
+
+  describe('mixed-provider origins', function (this: Suite) {
+    // These tests pre-seed combined EVM + Solana CAIP-25 caveats via the
+    // fixture builder so they isolate the picker's gating logic from the
+    // exact sequence used to reach that state in the wild (e.g. connect-evm
+    // followed by Solana Wallet Standard). The per-domain selected network
+    // (set by the wallet during a real connect) is also seeded so the only
+    // variable across these two tests is `sessionProperties['eip1193-compatible']`.
+
+    it('renders the network picker when EVM and Solana scopes coexist with eip1193-compatible set', async function () {
+      await withFixtures(
+        {
+          fixtures: new FixtureBuilderV2()
+            .withPermissionControllerConnectedToTestDapp({
+              scopes: EVM_AND_SOLANA_FIXTURE_SCOPES_WITH_EIP1193_COMPATIBLE,
+            })
+            .withSelectedNetworkController({
+              domains: { [DAPP_URL]: LOCALHOST_NETWORK_CLIENT_ID },
+            })
+            .build(),
+          title: this.test?.fullTitle(),
+        },
+        async ({ driver }: { driver: Driver }) => {
+          await login(driver);
+
+          const headerNavbar = await openPopupForDapp(driver);
+          await headerNavbar.checkDappNetworkButtonVisible();
+        },
+      );
+    });
+
+    it('does not render the network picker when EVM and Solana scopes coexist without eip1193-compatible', async function () {
+      await withFixtures(
+        {
+          fixtures: new FixtureBuilderV2()
+            .withPermissionControllerConnectedToTestDapp({
+              scopes: EVM_AND_SOLANA_FIXTURE_SCOPES_WITHOUT_EIP1193_COMPATIBLE,
+            })
+            .withSelectedNetworkController({
+              domains: { [DAPP_URL]: LOCALHOST_NETWORK_CLIENT_ID },
+            })
+            .build(),
+          title: this.test?.fullTitle(),
+        },
+        async ({ driver }: { driver: Driver }) => {
+          await login(driver);
+
+          const headerNavbar = await openPopupForDapp(driver);
+          await headerNavbar.checkDappNetworkButtonNotVisible();
+        },
+      );
+    });
+  });
+});


### PR DESCRIPTION
## **Description**

Adds E2E test coverage for the conditional network picker rendering in the `DappConnectionControlBar`, introduced in #42498.

PR #42498 gates the EVM network picker on `sessionProperties['eip1193-compatible']` in the CAIP-25 caveat. While unit tests cover the selector and component rendering paths, E2E tests are needed to validate the full data flow — from dapp connection through middleware persistence to UI rendering — particularly around edge cases where multiple providers or reconnection flows could unintentionally overwrite session properties.

### Test matrix

| Scenario | `eip1193-compatible` | Picker visible? |
| --- | --- | --- |
| connect-evm Legacy EVM | Yes | Yes |
| connect-evm Wagmi | Yes | Yes |
| Pure Multichain API (EVM-only scopes) | No | No |
| Solana Wallet Standard | No | No |
| Pure Multichain → reconnect via connect-evm | Yes (added on reconnect) | Yes |
| Pre-seeded EVM + Solana with `eip1193-compatible` | Yes | Yes |
| Pre-seeded EVM + Solana without `eip1193-compatible` | No | No |

### Changes

| File | Change |
| --- | --- |
| `test/e2e/tests/mm-connect/dapp-connection-control-bar-network-picker.spec.ts` | New spec covering all seven scenarios above across three `describe` groups: single-provider connections, reconnection/session property preservation, and mixed-provider origins |
| `test/e2e/page-objects/pages/header-navbar.ts` | Added `checkDappNetworkButtonVisible()` and `checkDappNetworkButtonNotVisible()` helpers that assert network picker presence/absence in the control bar |
| `test/e2e/page-objects/pages/test-dapp-mm-connect.ts` | Added `connectWindowEthereum()` method and corresponding selector for the "Connect (window.ethereum)" button, used to trigger an EIP-1193 connection on top of an existing multichain session |

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/WAPI-1491
Related: #42498

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Manual testing steps**

1. Build a test build: `yarn build:test`
2. Run the new spec:
   ```
   yarn test:e2e:single test/e2e/tests/mm-connect/dapp-connection-control-bar-network-picker.spec.ts --browser=chrome
   ```
3. Verify all seven tests pass.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are isolated to E2E tests and page-object helpers, with no production code or security-sensitive logic modified.
> 
> **Overview**
> Adds a new E2E spec (`dapp-connection-control-bar-network-picker.spec.ts`) that validates when the `DappConnectionControlBar` network picker should appear based on `sessionProperties['eip1193-compatible']`, across legacy/wagmi connect-evm, pure multichain sessions, Solana-only connections, reconnection flows, and mixed EVM+Solana origins.
> 
> Extends E2E page objects to support these assertions by adding `HeaderNavbar.checkDappNetworkButtonVisible/NotVisible()` and a mm-connect dapp helper `connectWindowEthereum()` for reconnection scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62941285d2abd115f3fae0ee189ccce516b453aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->