### PR TITLE
chore: bump `@metamask/tron-wallet-snap` to `1.25.4-preview-7aab63e`

### DIFF
--- a/package.json
+++ b/package.json
@@ -435,7 +435,7 @@
     "@metamask/subscription-controller": "^6.1.2",
     "@metamask/transaction-controller": "^65.1.0",
     "@metamask/transaction-pay-controller": "^22.0.0",
-    "@metamask/tron-wallet-snap": "^1.25.3",
+    "@metamask/tron-wallet-snap": "npm:@metamask-previews/tron-wallet-snap@1.25.4-preview-7aab63e",
     "@metamask/user-operation-controller": "^41.2.0",
     "@metamask/utils": "^11.11.0",
     "@mui/material": "^5.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8553,10 +8553,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/tron-wallet-snap@npm:^1.25.3":
-  version: 1.25.3
-  resolution: "@metamask/tron-wallet-snap@npm:1.25.3"
-  checksum: 10/689d97290b8b1a317f5e8e71884080240cef460d171721ebe28ab8f9eb00b9693910fd583177826618d5e1bb73661f5f5a547c997880c97bc0870cd72066e290
+"@metamask/tron-wallet-snap@npm:@metamask-previews/tron-wallet-snap@1.25.4-preview-7aab63e":
+  version: 1.25.4-preview-7aab63e
+  resolution: "@metamask-previews/tron-wallet-snap@npm:1.25.4-preview-7aab63e"
+  checksum: 10/fe046f85e57af9ee5bf0099cd693ff32afb60096b2b0ea19feec5f7462abf90814761e693d04ba4bfe3d5ccc9b29d9aa4726046848f8384d28bfcc6529391c2b
   languageName: node
   linkType: hard
 
@@ -33677,7 +33677,7 @@ __metadata:
     "@metamask/test-snaps": "npm:^3.4.2"
     "@metamask/transaction-controller": "npm:^65.1.0"
     "@metamask/transaction-pay-controller": "npm:^22.0.0"
-    "@metamask/tron-wallet-snap": "npm:^1.25.3"
+    "@metamask/tron-wallet-snap": "npm:@metamask-previews/tron-wallet-snap@1.25.4-preview-7aab63e"
     "@metamask/user-operation-controller": "npm:^41.2.0"
     "@metamask/utils": "npm:^11.11.0"
     "@mui/material": "npm:^5.18.0"


### PR DESCRIPTION
## Description

Bumps `@metamask/tron-wallet-snap` to the published preview build from MetaMask/snap-tron-wallet#301.

Preview package: `@metamask-previews/tron-wallet-snap@1.25.4-preview-7aab63e`
Preview comment: https://github.com/MetaMask/snap-tron-wallet/pull/301#issuecomment-4442507877

## Changelog

CHANGELOG entry: null

## Related issues

n/a

## Manual testing steps

n/a

## Screenshots/Recordings

### Before

n/a

### After

n/a