### PR TITLE
fix: handle unsupported network from API

### DIFF
--- a/shared/lib/error.test.ts
+++ b/shared/lib/error.test.ts
@@ -3,6 +3,7 @@ import {
   isErrorWithMessage,
   logErrorWithMessage,
   createErrorFromNetworkRequest,
+  getErrorBodyMessage,
 } from './error';
 
 jest.mock('loglevel');
@@ -31,6 +32,20 @@ describe('error module', () => {
     it('calls loglevel.error with string representation of parameter passed in when parameter is not an instance of Error', () => {
       logErrorWithMessage({ test: 'test' });
       expect(log.error).toHaveBeenCalledWith({ test: 'test' });
+    });
+  });
+
+  describe('getErrorBodyMessage', () => {
+    it('returns the message from an error body', () => {
+      expect(getErrorBodyMessage({ message: 'Bad request' })).toBe(
+        'Bad request',
+      );
+    });
+
+    it('returns undefined when the body has no message string', () => {
+      expect(getErrorBodyMessage({ message: 400 })).toBeUndefined();
+      expect(getErrorBodyMessage({ error: 'Bad request' })).toBeUndefined();
+      expect(getErrorBodyMessage(undefined)).toBeUndefined();
     });
   });
 

--- a/shared/lib/error.ts
+++ b/shared/lib/error.ts
@@ -32,12 +32,6 @@ export function logErrorWithMessage(error: unknown) {
   log.error(isErrorWithMessage(error) ? getErrorMessage(error) : error);
 }
 
-/**
- * Gets the message string from an http error response body.
- *
- * @param body - The parsed error response body.
- * @returns The message string if present.
- */
 export function getErrorBodyMessage(body: unknown) {
   if (!body || typeof body !== 'object' || !('message' in body)) {
     return undefined;

--- a/shared/lib/error.ts
+++ b/shared/lib/error.ts
@@ -32,6 +32,21 @@ export function logErrorWithMessage(error: unknown) {
   log.error(isErrorWithMessage(error) ? getErrorMessage(error) : error);
 }
 
+/**
+ * Gets the message string from an http error response body.
+ *
+ * @param body - The parsed error response body.
+ * @returns The message string if present.
+ */
+export function getErrorBodyMessage(body: unknown) {
+  if (!body || typeof body !== 'object' || !('message' in body)) {
+    return undefined;
+  }
+
+  const { message } = body as { message?: unknown };
+  return typeof message === 'string' ? message : undefined;
+}
+
 export enum OAuthErrorMessages {
   // Error message for Authentication Server when failed to get the auth token
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860

--- a/ui/components/multichain/activity-v2/useTransactionsQuery.test.ts
+++ b/ui/components/multichain/activity-v2/useTransactionsQuery.test.ts
@@ -34,7 +34,6 @@ const expectedEvmAddress = selectedAddress;
 const expectedNetworks = ['eip155:1'];
 const emptyResponse = {
   data: [],
-  unprocessedNetworks: [],
   pageInfo: {
     count: 0,
     hasNextPage: false,

--- a/ui/components/multichain/activity-v2/useTransactionsQuery.test.ts
+++ b/ui/components/multichain/activity-v2/useTransactionsQuery.test.ts
@@ -32,7 +32,7 @@ jest.mock('../../../helpers/api-client', () => ({
 const selectedAddress = '0x4f5243ceea96cee1da0fdb89c756d0e999439424';
 const expectedEvmAddress = selectedAddress;
 const expectedNetworks = ['eip155:1'];
-const emptyTransactionsResponse = {
+const emptyResponse = {
   data: [],
   unprocessedNetworks: [],
   pageInfo: {
@@ -114,7 +114,7 @@ describe('useTransactionsQuery', () => {
 
     const queryOptions = mockUseInfiniteQuery.mock.calls[0][0];
     await expect(queryOptions.queryFn({})).resolves.toStrictEqual(
-      emptyTransactionsResponse,
+      emptyResponse,
     );
   });
 
@@ -275,6 +275,6 @@ describe('usePrefetchTransactions', () => {
 
     await expect(
       mockQueryClient.prefetchInfiniteQuery.mock.results[0].value,
-    ).resolves.toStrictEqual(emptyTransactionsResponse);
+    ).resolves.toStrictEqual(emptyResponse);
   });
 });

--- a/ui/components/multichain/activity-v2/useTransactionsQuery.test.ts
+++ b/ui/components/multichain/activity-v2/useTransactionsQuery.test.ts
@@ -5,6 +5,7 @@ import {
   act,
   renderHook as renderHookBase,
 } from '@testing-library/react-hooks';
+import { HttpError } from '@metamask/core-backend';
 import {
   usePrefetchTransactions,
   useTransactionsQuery,
@@ -31,6 +32,14 @@ jest.mock('../../../helpers/api-client', () => ({
 const selectedAddress = '0x4f5243ceea96cee1da0fdb89c756d0e999439424';
 const expectedEvmAddress = selectedAddress;
 const expectedNetworks = ['eip155:1'];
+const emptyTransactionsResponse = {
+  data: [],
+  unprocessedNetworks: [],
+  pageInfo: {
+    count: 0,
+    hasNextPage: false,
+  },
+};
 const mockStore = configureMockStore()({
   localeMessages: {
     currentLocale: 'en_GB',
@@ -82,6 +91,54 @@ afterEach(() => {
 });
 
 describe('useTransactionsQuery', () => {
+  it('normalizes unsupported network api errors to an empty response', async () => {
+    const unsupportedNetworksError = new HttpError(
+      'http 400: Bad Request',
+      400,
+      'Bad Request',
+      'https://accounts.api.cx.metamask.io/v4/multiaccount/transactions',
+      {
+        statusCode: 400,
+        message:
+          'networks param contains no supported chains: eip155:43114, eip155:324',
+      },
+    );
+    mockGetV4MultiAccountTransactionsInfiniteQueryOptions.mockReturnValue({
+      queryKey: ['transactions'],
+      queryFn: jest.fn().mockRejectedValue(unsupportedNetworksError),
+      getNextPageParam: jest.fn(),
+      enabled: true,
+    });
+
+    renderQueryHook(() => useTransactionsQuery());
+
+    const queryOptions = mockUseInfiniteQuery.mock.calls[0][0];
+    await expect(queryOptions.queryFn({})).resolves.toStrictEqual(
+      emptyTransactionsResponse,
+    );
+  });
+
+  it('keeps unexpected api errors as query errors', async () => {
+    const unexpectedError = new HttpError(
+      'http 500: Internal Server Error',
+      500,
+      'Internal Server Error',
+      'https://accounts.api.cx.metamask.io/v4/multiaccount/transactions',
+      { statusCode: 500, message: 'Unexpected error' },
+    );
+    mockGetV4MultiAccountTransactionsInfiniteQueryOptions.mockReturnValue({
+      queryKey: ['transactions'],
+      queryFn: jest.fn().mockRejectedValue(unexpectedError),
+      getNextPageParam: jest.fn(),
+      enabled: true,
+    });
+
+    renderQueryHook(() => useTransactionsQuery());
+
+    const queryOptions = mockUseInfiniteQuery.mock.calls[0][0];
+    await expect(queryOptions.queryFn({})).rejects.toBe(unexpectedError);
+  });
+
   it('composes query options and delegates to useInfiniteQuery', () => {
     renderQueryHook(() => useTransactionsQuery());
 
@@ -171,7 +228,53 @@ describe('usePrefetchTransactions', () => {
     });
 
     expect(mockQueryClient.prefetchInfiniteQuery).toHaveBeenCalledWith(
-      expect.objectContaining({ ...queryOptions, staleTime: 300000 }),
+      expect.objectContaining({
+        queryKey: queryOptions.queryKey,
+        queryFn: expect.any(Function),
+        getNextPageParam: queryOptions.getNextPageParam,
+        enabled: true,
+        retry: false,
+        staleTime: 300000,
+      }),
     );
+  });
+
+  it('prefetches unsupported networks as an empty response', async () => {
+    const unsupportedNetworksError = new HttpError(
+      'http 400: Bad Request',
+      400,
+      'Bad Request',
+      'https://accounts.api.cx.metamask.io/v4/multiaccount/transactions',
+      {
+        statusCode: 400,
+        message: 'networks param contains no supported chains: eip155:43114',
+      },
+    );
+    const mockQueryClient = {
+      getQueryData: jest.fn().mockReturnValue(undefined),
+      isFetching: jest.fn().mockReturnValue(0),
+      prefetchInfiniteQuery: jest.fn(({ queryFn }) => queryFn({})),
+    };
+    const queryOptions = {
+      queryKey: ['transactions'],
+      queryFn: jest.fn().mockRejectedValue(unsupportedNetworksError),
+      getNextPageParam: jest.fn(),
+      enabled: true,
+    };
+
+    mockUseQueryClient.mockReturnValue(mockQueryClient);
+    mockGetV4MultiAccountTransactionsInfiniteQueryOptions.mockReturnValue(
+      queryOptions,
+    );
+
+    const { result } = renderQueryHook(() => usePrefetchTransactions());
+
+    act(() => {
+      result.current();
+    });
+
+    await expect(
+      mockQueryClient.prefetchInfiniteQuery.mock.results[0].value,
+    ).resolves.toStrictEqual(emptyTransactionsResponse);
   });
 });

--- a/ui/components/multichain/activity-v2/useTransactionsQuery.ts
+++ b/ui/components/multichain/activity-v2/useTransactionsQuery.ts
@@ -19,8 +19,9 @@ const knownApiMessages = ['networks param contains no supported chains'];
 type TransactionsQueryOptions = ReturnType<
   typeof apiClient.accounts.getV4MultiAccountTransactionsInfiniteQueryOptions
 >;
-type TransactionsQueryFunction = NonNullable<
-  TransactionsQueryOptions['queryFn']
+type TransactionsQueryFunction = Extract<
+  NonNullable<TransactionsQueryOptions['queryFn']>,
+  (...args: never[]) => unknown
 >;
 
 function isKnownApiResponseError(error: unknown) {
@@ -36,12 +37,12 @@ function isKnownApiResponseError(error: unknown) {
   );
 }
 
-function withKnownApiResponse(queryFn: TransactionsQueryFunction | undefined) {
-  if (!queryFn) {
-    return undefined;
+function withKnownApiResponse(queryFn: TransactionsQueryOptions['queryFn']) {
+  if (typeof queryFn !== 'function') {
+    return queryFn;
   }
 
-  return async (context) => {
+  return async (context: Parameters<TransactionsQueryFunction>[0]) => {
     try {
       return await queryFn(context);
     } catch (error) {
@@ -115,9 +116,9 @@ export function useTransactionsQuery(filter?: ActivityListFilter) {
       lang,
     });
 
-  // @ts-expect-error apiClient returns v5 types, repo still in v4
   return useInfiniteQuery({
     ...queryOptions,
+    // @ts-expect-error apiClient returns v5 types, repo still in v4
     queryFn: withKnownApiResponse(queryOptions.queryFn),
     select: selectFn,
     enabled:
@@ -164,9 +165,9 @@ export function usePrefetchTransactions() {
     }
 
     queryClient
-      // @ts-expect-error apiClient returns v5 types, repo still in v4
       .prefetchInfiniteQuery({
         ...queryOptions,
+        // @ts-expect-error apiClient returns v5 types, repo still in v4
         queryFn: withKnownApiResponse(queryOptions.queryFn),
         retry: false,
         staleTime: 5 * MINUTE,

--- a/ui/components/multichain/activity-v2/useTransactionsQuery.ts
+++ b/ui/components/multichain/activity-v2/useTransactionsQuery.ts
@@ -1,7 +1,10 @@
 import { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query';
+import type { V4MultiAccountTransactionsResponse } from '@metamask/core-backend';
+import { HttpError } from '@metamask/core-backend';
 import type { CaipChainId } from '@metamask/utils';
+import { getErrorBodyMessage } from '../../../../shared/lib/error';
 import { selectTransactions } from '../../../../shared/lib/multichain/transformations';
 import { MINUTE } from '../../../../shared/constants/time';
 import { getUseExternalServices } from '../../../selectors';
@@ -11,6 +14,57 @@ import { apiClient } from '../../../helpers/api-client';
 import { selectEnabledNetworksAsCaipChainIds } from '../../../selectors/multichain/networks';
 import { selectRequiredTransactionHashes } from '../../../selectors/transactionController';
 import type { ActivityListFilter } from './helpers';
+
+const knownEmptyActivityApiMessages = [
+  'networks param contains no supported chains',
+];
+
+type TransactionsQueryOptions = ReturnType<
+  typeof apiClient.accounts.getV4MultiAccountTransactionsInfiniteQueryOptions
+>;
+type TransactionsQueryFunction = NonNullable<
+  TransactionsQueryOptions['queryFn']
+>;
+
+function isKnownEmptyActivityResponseError(error: unknown) {
+  if (!(error instanceof HttpError) || error.status !== 400) {
+    return false;
+  }
+
+  const errorBodyMessage = getErrorBodyMessage(error.body);
+  return Boolean(
+    errorBodyMessage &&
+      knownEmptyActivityApiMessages.some((knownMessage) =>
+        errorBodyMessage.includes(knownMessage),
+      ),
+  );
+}
+
+function withKnownApiResponse(
+  queryFn: TransactionsQueryFunction | undefined,
+) {
+  if (!queryFn) {
+    return undefined;
+  }
+
+  return async (context) => {
+    try {
+      return await queryFn(context);
+    } catch (error) {
+      if (isKnownEmptyActivityResponseError(error)) {
+        return {
+          data: [],
+          unprocessedNetworks: [],
+          pageInfo: {
+            count: 0,
+            hasNextPage: false,
+          },
+        } satisfies V4MultiAccountTransactionsResponse;
+      }
+      throw error;
+    }
+  };
+}
 
 function getTransactionApiLanguage(locale: string) {
   return locale.split('-')[0];
@@ -71,6 +125,7 @@ export function useTransactionsQuery(filter?: ActivityListFilter) {
   // @ts-expect-error apiClient returns v5 types, repo still in v4
   return useInfiniteQuery({
     ...queryOptions,
+    queryFn: withKnownApiResponse(queryOptions.queryFn),
     select: selectFn,
     enabled:
       Boolean(useExternalServices) &&
@@ -119,6 +174,7 @@ export function usePrefetchTransactions() {
       // @ts-expect-error apiClient returns v5 types, repo still in v4
       .prefetchInfiniteQuery({
         ...queryOptions,
+        queryFn: withKnownApiResponse(queryOptions.queryFn),
         retry: false,
         staleTime: 5 * MINUTE,
       })

--- a/ui/components/multichain/activity-v2/useTransactionsQuery.ts
+++ b/ui/components/multichain/activity-v2/useTransactionsQuery.ts
@@ -15,9 +15,7 @@ import { selectEnabledNetworksAsCaipChainIds } from '../../../selectors/multicha
 import { selectRequiredTransactionHashes } from '../../../selectors/transactionController';
 import type { ActivityListFilter } from './helpers';
 
-const knownEmptyActivityApiMessages = [
-  'networks param contains no supported chains',
-];
+const knownApiMessages = ['networks param contains no supported chains'];
 
 type TransactionsQueryOptions = ReturnType<
   typeof apiClient.accounts.getV4MultiAccountTransactionsInfiniteQueryOptions
@@ -26,23 +24,22 @@ type TransactionsQueryFunction = NonNullable<
   TransactionsQueryOptions['queryFn']
 >;
 
-function isKnownEmptyActivityResponseError(error: unknown) {
+function isKnownApiResponseError(error: unknown) {
   if (!(error instanceof HttpError) || error.status !== 400) {
     return false;
   }
 
   const errorBodyMessage = getErrorBodyMessage(error.body);
+
   return Boolean(
     errorBodyMessage &&
-      knownEmptyActivityApiMessages.some((knownMessage) =>
-        errorBodyMessage.includes(knownMessage),
-      ),
+    knownApiMessages.some((knownMessage) =>
+      errorBodyMessage.includes(knownMessage),
+    ),
   );
 }
 
-function withKnownApiResponse(
-  queryFn: TransactionsQueryFunction | undefined,
-) {
+function withKnownApiResponse(queryFn: TransactionsQueryFunction | undefined) {
   if (!queryFn) {
     return undefined;
   }
@@ -51,7 +48,7 @@ function withKnownApiResponse(
     try {
       return await queryFn(context);
     } catch (error) {
-      if (isKnownEmptyActivityResponseError(error)) {
+      if (isKnownApiResponseError(error)) {
         return {
           data: [],
           unprocessedNetworks: [],

--- a/ui/components/multichain/activity-v2/useTransactionsQuery.ts
+++ b/ui/components/multichain/activity-v2/useTransactionsQuery.ts
@@ -1,7 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query';
-import type { V4MultiAccountTransactionsResponse } from '@metamask/core-backend';
 import { HttpError } from '@metamask/core-backend';
 import type { CaipChainId } from '@metamask/utils';
 import { getErrorBodyMessage } from '../../../../shared/lib/error';
@@ -33,9 +32,7 @@ function isKnownApiResponseError(error: unknown) {
 
   return Boolean(
     errorBodyMessage &&
-    knownApiMessages.some((knownMessage) =>
-      errorBodyMessage.includes(knownMessage),
-    ),
+    knownApiMessages.some((message) => errorBodyMessage.includes(message)),
   );
 }
 
@@ -51,12 +48,11 @@ function withKnownApiResponse(queryFn: TransactionsQueryFunction | undefined) {
       if (isKnownApiResponseError(error)) {
         return {
           data: [],
-          unprocessedNetworks: [],
           pageInfo: {
             count: 0,
             hasNextPage: false,
           },
-        } satisfies V4MultiAccountTransactionsResponse;
+        };
       }
       throw error;
     }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

API treats unsupported networks as a 400 error

This PR normalizes that response as an empty result instead

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: handle unsupported network from API

## **Related issues**

Fixes: #42402 

## **Manual testing steps**

0. On an empty account
1. Go to Activity tab
2. Switch to a known API-unsupported network ie. Avalanche

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="365" height="208" alt="image" src="https://github.com/user-attachments/assets/e7739966-a96e-4355-a8a8-4384ebc2d15d" />

### **After**

<img width="343" height="328" alt="image" src="https://github.com/user-attachments/assets/dc06f970-55c0-438e-a546-c90ba9464629" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes runtime query behavior for transactions fetching/prefetching by intercepting specific `HttpError` 400 responses and returning an empty dataset, which could mask real API issues if the message match is too broad.
> 
> **Overview**
> Prevents the Activity transactions query from failing when the Accounts API returns a known *unsupported networks* 400 error by wrapping the React Query `queryFn` to return an **empty transactions response** instead of throwing.
> 
> Adds a shared `getErrorBodyMessage` helper to safely read `body.message` for error matching, and expands tests to cover the new normalization behavior for both `useTransactionsQuery` and `usePrefetchTransactions` (while ensuring unexpected errors still reject).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 336478ee7a5acae8bba77490d031bf2df44555c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->