### PR TITLE
fix: positionTPSL shouldn't appear in order section

### DIFF
--- a/ui/components/app/perps/utils/index.ts
+++ b/ui/components/app/perps/utils/index.ts
@@ -21,6 +21,8 @@ export {
   shouldDisplayOrderInMarketDetailsOrders,
   buildDisplayOrdersWithSyntheticTpsl,
   isOrderAssociatedWithFullPosition,
+  derivePositionTpslPricesFromOrders,
+  willFlipPosition,
   formatOrderLabel,
 } from './orderUtils';
 

--- a/ui/components/app/perps/utils/orderUtils.test.ts
+++ b/ui/components/app/perps/utils/orderUtils.test.ts
@@ -1,9 +1,11 @@
-import type { Order, Position } from '@metamask/perps-controller';
+import type { Order, OrderParams, Position } from '@metamask/perps-controller';
 import {
   isOrderAssociatedWithFullPosition,
   shouldDisplayOrderInMarketDetailsOrders,
   buildDisplayOrdersWithSyntheticTpsl,
   normalizeMarketDetailsOrders,
+  derivePositionTpslPricesFromOrders,
+  willFlipPosition,
   formatOrderLabel,
 } from './orderUtils';
 
@@ -66,7 +68,7 @@ describe('orderUtils', () => {
       expect(isOrderAssociatedWithFullPosition(order, position)).toBe(false);
     });
 
-    it('returns false when isPositionTpsl is explicitly false', () => {
+    it('returns false when isPositionTpsl is explicitly false on a non-trigger order', () => {
       const order = makeOrder({
         reduceOnly: true,
         isPositionTpsl: false,
@@ -76,6 +78,24 @@ describe('orderUtils', () => {
       });
       const position = makePosition({ symbol: 'ETH', size: '1.0' });
       expect(isOrderAssociatedWithFullPosition(order, position)).toBe(false);
+    });
+
+    it('returns true for a TP/SL trigger with isPositionTpsl=false when size matches the position (HL market-order child)', () => {
+      // Hyperliquid tags TP/SL children of a market order with isPositionTpsl=false
+      // even though they cover the full resulting position. Size match wins.
+      const order = makeOrder({
+        reduceOnly: true,
+        isPositionTpsl: false,
+        isTrigger: true,
+        symbol: 'ETH',
+        side: 'sell',
+        size: '1.0',
+        originalSize: '1.0',
+        triggerPrice: '3300',
+        detailedOrderType: 'Take Profit Limit',
+      });
+      const position = makePosition({ symbol: 'ETH', size: '1.0' });
+      expect(isOrderAssociatedWithFullPosition(order, position)).toBe(true);
     });
 
     it('returns true when reduce-only order matches full position size (sell closing long)', () => {
@@ -164,6 +184,167 @@ describe('orderUtils', () => {
         isPositionTpsl: true,
       });
       expect(shouldDisplayOrderInMarketDetailsOrders(positionTpsl)).toBe(false);
+    });
+
+    it('excludes zero-size reduce-only trigger orders matching the position even without isPositionTpsl flag', () => {
+      // Hyperliquid positionTPSL trigger orders carry size '0' (whole-position
+      // trigger). WebSocket order updates omit isPositionTpsl, so the UI must
+      // still recognise the order as full-position when size is zero and the
+      // trigger matches the active position.
+      const positionTpslNoFlag = makeOrder({
+        reduceOnly: true,
+        isTrigger: true,
+        symbol: 'ETH',
+        side: 'sell',
+        size: '0',
+        originalSize: '0',
+        triggerPrice: '3200.00',
+        detailedOrderType: 'Take Profit Market',
+      });
+      const position = makePosition({ symbol: 'ETH', size: '1.0' });
+      expect(
+        shouldDisplayOrderInMarketDetailsOrders(positionTpslNoFlag, position),
+      ).toBe(false);
+    });
+
+    it('keeps a flag-less zero-size reduce-only trigger visible when no matching position exists', () => {
+      const orphanTpsl = makeOrder({
+        reduceOnly: true,
+        isTrigger: true,
+        symbol: 'ETH',
+        side: 'sell',
+        size: '0',
+        originalSize: '0',
+        triggerPrice: '3200.00',
+      });
+      expect(shouldDisplayOrderInMarketDetailsOrders(orphanTpsl)).toBe(true);
+    });
+
+    it('keeps a flag-less zero-size reduce-only order without isTrigger visible (cannot infer position binding)', () => {
+      const zeroSizeNonTrigger = makeOrder({
+        reduceOnly: true,
+        symbol: 'ETH',
+        side: 'sell',
+        size: '0',
+        originalSize: '0',
+      });
+      const position = makePosition({ symbol: 'ETH', size: '1.0' });
+      expect(
+        shouldDisplayOrderInMarketDetailsOrders(zeroSizeNonTrigger, position),
+      ).toBe(true);
+    });
+  });
+
+  describe('willFlipPosition', () => {
+    const makeParams = (overrides: Partial<OrderParams> = {}): OrderParams =>
+      ({
+        symbol: 'ETH',
+        isBuy: false,
+        size: '2.0',
+        orderType: 'market',
+        ...overrides,
+      }) as OrderParams;
+
+    it('returns false for reduce-only orders', () => {
+      expect(
+        willFlipPosition(
+          makePosition({ size: '1.0' }),
+          makeParams({ reduceOnly: true }),
+        ),
+      ).toBe(false);
+    });
+
+    it('returns false for limit orders', () => {
+      expect(
+        willFlipPosition(
+          makePosition({ size: '1.0' }),
+          makeParams({ orderType: 'limit' }),
+        ),
+      ).toBe(false);
+    });
+
+    it('returns false when order direction matches position direction', () => {
+      expect(
+        willFlipPosition(
+          makePosition({ size: '1.0' }),
+          makeParams({ isBuy: true, size: '5.0' }),
+        ),
+      ).toBe(false);
+    });
+
+    it('returns true when opposing market order exceeds the position size', () => {
+      expect(
+        willFlipPosition(
+          makePosition({ size: '1.0' }),
+          makeParams({ isBuy: false, size: '2.0' }),
+        ),
+      ).toBe(true);
+    });
+
+    it('returns false when opposing market order matches the position size (full close, no flip)', () => {
+      expect(
+        willFlipPosition(
+          makePosition({ size: '1.0' }),
+          makeParams({ isBuy: false, size: '1.0' }),
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe('derivePositionTpslPricesFromOrders', () => {
+    it('returns empty when no position is provided', () => {
+      const order = makeOrder({
+        reduceOnly: true,
+        isTrigger: true,
+        isPositionTpsl: true,
+        triggerPrice: '3200',
+        detailedOrderType: 'Take Profit Market',
+      });
+      expect(derivePositionTpslPricesFromOrders([order])).toEqual({});
+    });
+
+    it('returns TP and SL prices from positionTPSL trigger orders matching the position', () => {
+      const position = makePosition({ symbol: 'ETH', size: '1.0' });
+      const tp = makeOrder({
+        orderId: 'tp',
+        reduceOnly: true,
+        isTrigger: true,
+        isPositionTpsl: true,
+        symbol: 'ETH',
+        side: 'sell',
+        triggerPrice: '3200',
+        detailedOrderType: 'Take Profit Market',
+      });
+      const sl = makeOrder({
+        orderId: 'sl',
+        reduceOnly: true,
+        isTrigger: true,
+        symbol: 'ETH',
+        side: 'sell',
+        size: '0',
+        originalSize: '0',
+        triggerPrice: '2800',
+        detailedOrderType: 'Stop Market',
+      });
+      expect(derivePositionTpslPricesFromOrders([tp, sl], position)).toEqual({
+        takeProfitPrice: '3200',
+        stopLossPrice: '2800',
+      });
+    });
+
+    it('ignores non-positionTPSL trigger orders', () => {
+      const position = makePosition({ symbol: 'ETH', size: '1.0' });
+      const limitTrigger = makeOrder({
+        reduceOnly: false,
+        isTrigger: true,
+        symbol: 'ETH',
+        side: 'sell',
+        triggerPrice: '3300',
+        detailedOrderType: 'Stop Limit',
+      });
+      expect(
+        derivePositionTpslPricesFromOrders([limitTrigger], position),
+      ).toEqual({});
     });
   });
 

--- a/ui/components/app/perps/utils/orderUtils.ts
+++ b/ui/components/app/perps/utils/orderUtils.ts
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js';
 import { capitalize } from 'lodash';
-import type { Order, Position } from '@metamask/perps-controller';
+import type { Order, OrderParams, Position } from '@metamask/perps-controller';
 
 const FULL_POSITION_SIZE_TOLERANCE = new BigNumber('0.00000001');
 const ORDER_PRICE_MATCH_TOLERANCE = new BigNumber('0.00000001');
@@ -153,17 +153,103 @@ export const isOrderAssociatedWithFullPosition = (
     return false;
   }
 
-  if (order.isPositionTpsl === false) {
+  // Hyperliquid tags TP/SL children of a market order with
+  // `isPositionTpsl: false` (normalTpsl grouping) even after the parent
+  // fills — the resulting trigger orders cover the entire open position.
+  // Trust `isPositionTpsl: false` only when the order is NOT a TP/SL
+  // trigger; otherwise fall through to size matching, which is the
+  // authoritative signal that this is a full-position close.
+  if (order.isPositionTpsl === false && order.isTrigger !== true) {
     return false;
   }
 
   const orderSize = getAbsoluteOrderSize(order);
   const positionSize = getAbsolutePositionSize(position);
-  if (!orderSize || !positionSize) {
+
+  // Hyperliquid positionTPSL trigger orders may also be placed with size 0
+  // (the trigger acts on whatever the current position size is). When the
+  // adapter cannot back-fill the size, treat a reduce-only trigger on a
+  // matching position+closing-side as position-bound.
+  if (!orderSize) {
+    return order.isTrigger === true;
+  }
+
+  if (!positionSize) {
     return false;
   }
 
   return orderSize.minus(positionSize).abs().lte(FULL_POSITION_SIZE_TOLERANCE);
+};
+
+/**
+ * Returns true when a non-reduce-only market order is large enough to flip the
+ * current position (close the existing side and open the opposite side).
+ * Mirrors `app/components/UI/Perps/utils/orderUtils.ts:willFlipPosition` on
+ * mobile so the order-entry page can replicate the two-step market+TPSL
+ * flow that yields `grouping: 'positionTpsl'` on Hyperliquid.
+ *
+ * @param currentPosition - The existing position
+ * @param orderParams - The order about to be submitted
+ * @returns Whether the order will flip the position
+ */
+export const willFlipPosition = (
+  currentPosition: Position,
+  orderParams: OrderParams,
+): boolean => {
+  if (orderParams.reduceOnly === true) {
+    return false;
+  }
+  if (orderParams.orderType !== 'market') {
+    return false;
+  }
+  const currentPositionSize = parseFloat(currentPosition.size);
+  const positionDirection = currentPositionSize > 0 ? 'long' : 'short';
+  const orderDirection = orderParams.isBuy ? 'long' : 'short';
+  if (positionDirection === orderDirection) {
+    return false;
+  }
+  const orderSize = parseFloat(orderParams.size);
+  return orderSize > Math.abs(currentPositionSize);
+};
+
+/**
+ * Derives the take-profit and stop-loss prices for the active position by
+ * inspecting full-position reduce-only trigger orders. Used as a UI fallback
+ * when the controller fails to populate `position.takeProfitPrice` /
+ * `position.stopLossPrice` (e.g. Hyperliquid WebSocket order updates that
+ * omit `isPositionTpsl`).
+ *
+ * @param orders - The orders to inspect
+ * @param position - The current position
+ * @returns Object with takeProfitPrice / stopLossPrice when discoverable
+ */
+export const derivePositionTpslPricesFromOrders = (
+  orders: Order[],
+  position?: Position,
+): { takeProfitPrice?: string; stopLossPrice?: string } => {
+  if (!position) {
+    return {};
+  }
+
+  const result: { takeProfitPrice?: string; stopLossPrice?: string } = {};
+  for (const order of orders) {
+    if (!order.isTrigger || !isOrderAssociatedWithFullPosition(order, position)) {
+      continue;
+    }
+
+    const triggerPrice = getOrderTriggerPrice(order)?.toFixed();
+    if (!triggerPrice) {
+      continue;
+    }
+
+    const detailedType = (order.detailedOrderType ?? '').toLowerCase();
+    if (!result.takeProfitPrice && detailedType.includes('take profit')) {
+      result.takeProfitPrice = triggerPrice;
+    } else if (!result.stopLossPrice && detailedType.includes('stop')) {
+      result.stopLossPrice = triggerPrice;
+    }
+  }
+  return result;
 };
 
 /**

--- a/ui/pages/perps/perps-market-detail-page.tsx
+++ b/ui/pages/perps/perps-market-detail-page.tsx
@@ -95,7 +95,10 @@ import {
   formatPerpsFiatMinimal,
   formatPerpsFiatUniversal,
 } from '../../components/app/perps/utils/formatPerpsDisplayPrice';
-import { normalizeMarketDetailsOrders } from '../../components/app/perps/utils/orderUtils';
+import {
+  derivePositionTpslPricesFromOrders,
+  normalizeMarketDetailsOrders,
+} from '../../components/app/perps/utils/orderUtils';
 import { PerpsDetailPageSkeleton } from '../../components/app/perps/perps-skeletons';
 import { Skeleton } from '../../components/component-library/skeleton';
 import { Popover, PopoverPosition } from '../../components/component-library';
@@ -471,23 +474,41 @@ const PerpsMarketDetailPage: React.FC = () => {
   // real trigger exists. Full-position TP/SL is excluded from this list — it
   // appears in the auto-close section above (driven by position.takeProfitPrice
   // / stopLossPrice).
-  const orders = useMemo(() => {
+  const marketOrders = useMemo(() => {
     if (!decodedSymbol) {
       return [];
     }
-    const marketOrders = allOrders
+    return allOrders
       .filter(
         (order) =>
           order.symbol.toLowerCase() === decodedSymbol.toLowerCase() &&
           order.status === 'open',
       )
       .sort((a, b) => (b.timestamp || 0) - (a.timestamp || 0));
+  }, [decodedSymbol, allOrders]);
 
-    return normalizeMarketDetailsOrders({
-      orders: marketOrders,
-      existingPosition: position,
-    });
-  }, [decodedSymbol, allOrders, position]);
+  const orders = useMemo(
+    () =>
+      normalizeMarketDetailsOrders({
+        orders: marketOrders,
+        existingPosition: position,
+      }),
+    [marketOrders, position],
+  );
+
+  // Hyperliquid sometimes omits `isPositionTpsl` on WebSocket order updates,
+  // so the controller may not surface `position.takeProfitPrice` /
+  // `stopLossPrice` even when full-position TP/SL trigger orders are open.
+  // Derive the missing prices from those orders so the auto-close row matches
+  // what the user just configured.
+  const derivedPositionTpsl = useMemo(
+    () => derivePositionTpslPricesFromOrders(marketOrders, position),
+    [marketOrders, position],
+  );
+  const effectiveTakeProfitPrice =
+    position?.takeProfitPrice ?? derivedPositionTpsl.takeProfitPrice;
+  const effectiveStopLossPrice =
+    position?.stopLossPrice ?? derivedPositionTpsl.stopLossPrice;
 
   // Candle period: persisted in PreferencesController across sessions/markets.
   // Local override gives instant UI feedback; background save persists for next visit.
@@ -606,8 +627,8 @@ const PerpsMarketDetailPage: React.FC = () => {
     // Position-specific lines (only when user has an open position)
     if (position) {
       // Take Profit line — matches mobile `success.default`
-      if (position.takeProfitPrice) {
-        const tpPrice = parsePerpsDisplayPrice(position.takeProfitPrice);
+      if (effectiveTakeProfitPrice) {
+        const tpPrice = parsePerpsDisplayPrice(effectiveTakeProfitPrice);
         if (!isNaN(tpPrice) && tpPrice > 0) {
           lines.push({
             price: tpPrice,
@@ -633,8 +654,8 @@ const PerpsMarketDetailPage: React.FC = () => {
 
       // Stop Loss line — matches mobile `background.alternative`
       // Intentionally subtle: SL is a reference marker, not a danger indicator like Liq.
-      if (position.stopLossPrice) {
-        const slPrice = parsePerpsDisplayPrice(position.stopLossPrice);
+      if (effectiveStopLossPrice) {
+        const slPrice = parsePerpsDisplayPrice(effectiveStopLossPrice);
         if (!isNaN(slPrice) && slPrice > 0) {
           lines.push({
             price: slPrice,
@@ -661,7 +682,13 @@ const PerpsMarketDetailPage: React.FC = () => {
     }
 
     return lines;
-  }, [position, chartCurrentPrice, isDark]);
+  }, [
+    position,
+    chartCurrentPrice,
+    isDark,
+    effectiveTakeProfitPrice,
+    effectiveStopLossPrice,
+  ]);
 
   // Handle candle period change
   //
@@ -1373,8 +1400,8 @@ const PerpsMarketDetailPage: React.FC = () => {
                       variant={TextVariant.BodyMd}
                       fontWeight={FontWeight.Medium}
                     >
-                      {position.takeProfitPrice
-                        ? formatPerpsFiatUniversal(position.takeProfitPrice)
+                      {effectiveTakeProfitPrice
+                        ? formatPerpsFiatUniversal(effectiveTakeProfitPrice)
                         : '-'}
                     </Text>
                     <Text
@@ -1387,8 +1414,8 @@ const PerpsMarketDetailPage: React.FC = () => {
                       variant={TextVariant.BodyMd}
                       fontWeight={FontWeight.Medium}
                     >
-                      {position.stopLossPrice
-                        ? formatPerpsFiatUniversal(position.stopLossPrice)
+                      {effectiveStopLossPrice
+                        ? formatPerpsFiatUniversal(effectiveStopLossPrice)
                         : '-'}
                     </Text>
                   </Box>
@@ -1942,7 +1969,11 @@ const PerpsMarketDetailPage: React.FC = () => {
           key={position.symbol}
           isOpen={isTPSLModalOpen}
           onClose={handleCloseTPSLModal}
-          position={position}
+          position={{
+            ...position,
+            takeProfitPrice: effectiveTakeProfitPrice,
+            stopLossPrice: effectiveStopLossPrice,
+          }}
           currentPrice={currentPrice}
         />
       )}

--- a/ui/pages/perps/perps-order-entry-page.tsx
+++ b/ui/pages/perps/perps-order-entry-page.tsx
@@ -87,6 +87,7 @@ import {
   normalizeTpslPrices,
   safeDecodeURIComponent,
   formatSignedChangePercent,
+  willFlipPosition,
 } from '../../components/app/perps/utils';
 import {
   parsePerpsDisplayPrice,
@@ -1097,9 +1098,30 @@ const PerpsOrderEntryPage: React.FC = () => {
       // emitted above by replacePerpsToastByKey. Re-emitting from the
       // market-detail useEffect races with the ORDER_SUBMITTED replace below
       // and can leave the toast stuck at "Submitting your trade".
+      //
+      // Market orders with TP/SL on a new (or flipping) position route through
+      // the two-step flow used by mobile: place the market order without
+      // TP/SL, then call `perpsUpdatePositionTPSL` so the controller submits
+      // the trigger orders under `grouping: 'positionTpsl'`. Sending TP/SL in
+      // the same `placeOrder` call falls back to the controller's
+      // `normalTpsl` default, which leaves the resulting trigger orders
+      // tagged `isPositionTpsl: false` and breaks the auto-close/orders
+      // partition on the market-detail page.
+      const shouldHandleTpslSeparately =
+        (orderParams.takeProfitPrice || orderParams.stopLossPrice) &&
+        orderFormState.type === 'market' &&
+        (!position || willFlipPosition(position, orderParams));
+      const placeOrderParams = shouldHandleTpslSeparately
+        ? (() => {
+            const stripped = { ...orderParams };
+            delete stripped.takeProfitPrice;
+            delete stripped.stopLossPrice;
+            return stripped;
+          })()
+        : orderParams;
       const result = await submitRequestToBackground<PerpsBackgroundResult>(
         'perpsPlaceOrder',
-        [orderParams],
+        [placeOrderParams],
       );
       if (!result.success) {
         const message = result.error || 'Failed to place order';
@@ -1108,6 +1130,36 @@ const PerpsOrderEntryPage: React.FC = () => {
           message,
         );
         throw new Error(result.error ?? 'Failed to place order');
+      }
+      if (shouldHandleTpslSeparately) {
+        const { takeProfitPrice: cleanTp, stopLossPrice: cleanSl } =
+          normalizeTpslPrices({
+            takeProfitPrice: orderParams.takeProfitPrice,
+            stopLossPrice: orderParams.stopLossPrice,
+          });
+        const tpslResult =
+          await submitRequestToBackground<PerpsBackgroundResult>(
+            'perpsUpdatePositionTPSL',
+            [
+              {
+                symbol: orderFormState.asset,
+                takeProfitPrice: cleanTp,
+                stopLossPrice: cleanSl,
+              },
+            ],
+          );
+        if (!tpslResult.success) {
+          // The market order already filled; surface the TP/SL failure
+          // separately so the user knows the position opened but the
+          // trigger orders were not attached.
+          const tpslMessage =
+            tpslResult.error || 'Failed to attach TP/SL to position';
+          reportTransactionFailure(
+            MetaMetricsEventName.PerpsRiskManagement,
+            tpslMessage,
+          );
+          throw new Error(tpslMessage);
+        }
       }
       // Navigate only on success. On failure, stay on the form so the catch
       // block's failure toast renders on the current page. Navigating before


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Placing a market order with TP/SL via the perps order-entry UI sent both the market order and the TP/SL inputs in a single `perpsPlaceOrder` call. The `@metamask/perps-controller` default for that path is `grouping: 'normalTpsl'` (`orderCalculations.cjs:282`), so Hyperliquid returned the resulting trigger orders with `isPositionTpsl: false`. That left `position.takeProfitPrice/stopLossPrice` unpopulated (the controller's `extractTPSLFromOrders` skips orders without the flag) and the predicate behind the market-detail Orders section let the trigger orders through — TP/SL ended up in the Orders list instead of the Auto-close row.

Mobile already routes the same scenario through a separate `updatePositionTPSL` call (`PerpsOrderView.tsx:1126`) which the controller submits under `grouping: 'positionTpsl'` (`HyperLiquidProvider.cjs:1098`). The fix mirrors that split on the extension: when a market order with TP/SL targets a new (or flipping) position, we strip the TP/SL from `perpsPlaceOrder` and follow up with `perpsUpdatePositionTPSL`. The resulting trigger orders come back tagged `isPositionTpsl: true`, so the existing partition logic works as designed.

Defense in depth: `isOrderAssociatedWithFullPosition` now tolerates the rare `isPositionTpsl: false` flag on TP/SL trigger orders (size match wins), and the market-detail page derives Auto-close prices from the matching positionTPSL orders when the controller has not surfaced them. These guard against legacy on-chain orders and any future WS update path that drops the flag.

## **Changelog**

CHANGELOG entry: Fixed a perps bug where market orders submitted with TP/SL left the Auto-close section empty and surfaced the TP/SL orders in the Orders section of the market detail page.

## **Related issues**

Fixes: [TAT-3065](https://consensyssoftware.atlassian.net/browse/TAT-3065)

## **Manual testing steps**

1. Unlock the wallet and open the Perps tab.
2. Pick a market where you do not currently hold a position (e.g. AVAX).
3. From the market detail page, tap **Long** to open the order entry screen.
4. Enter a notional (e.g. `10`), enable Auto-close, set a TP price above the entry, a SL price below the entry but above liquidation, and submit.
5. After the toast confirms the order filled, navigate back to the same market detail page.
6. **Expected**: the Auto-close row shows the TP/SL values you just entered, and the Orders section does not list any TP/SL trigger orders.
7. (Optional) Repeat with a limit order plus TP/SL. The TP/SL orders should appear in the Orders section while the limit is open and migrate to Auto-close once the limit fills.

## **Screenshots/Recordings**

Real $10 AVAX market+TPSL placed through the order-entry UI on the same wallet, captured against buggy main vs the fix branch. Before: Auto-close shows '-' placeholders and the positionTPSL trigger leaks into the Orders section. After: Auto-close displays TP $11 / SL $9 and the Orders section is clean.

<table>
<tr><td colspan="2"><strong>AVAX market detail — Auto-close + Orders partition after a $10 market+TPSL via UI — Same UI flow on both sides. Before run is on vanilla main (commit 5b4e0445c8); after run is on the fix branch. Real on-chain Hyperliquid orders, no injected state.</strong></td></tr>
<tr>
<td align="center" width="50%"><em>Before</em><br/><img src="artifacts/before-evidence-ac1-real-avax-market-tpsl.png" alt="before" width="400" /></td>
<td align="center" width="50%"><em>After</em><br/><img src="artifacts/after-evidence-ac1-real-avax-market-tpsl.png" alt="after" width="400" /></td>
</tr>
</table>

## **Validation Recipe**

`temp/tasks/fix/tat-3065-0513-153038/artifacts/recipe.json` (verify) and `recipe-baseline.json` (buggy main capture). Both drive the same UI flow against a live Hyperliquid mainnet account — no injected channel state. The verify recipe passes 22/22 on the fix branch; the baseline recipe passes 22/22 against vanilla main and asserts the buggy values (`isPositionTpsl: false`, `TP -, SL -`, `leakCount > 0`).

<details>
<summary>recipe.json (verify)</summary>

```json
{
  "title": "TAT-3065 real $10 AVAX market+TPSL via UI",
  "schema_version": 1,
  "validate": {
    "workflow": {
      "pre_conditions": ["wallet.unlocked", "perps.feature_enabled"],
      "entry": "gate-nav-perps",
      "teardown": [
        {
          "id": "teardown-close-avax",
          "action": "eval_async",
          "expression": "perpsClosePosition({symbol:'AVAX',orderType:'market'})"
        }
      ],
      "nodes": {
        "gate-nav-perps": { "action": "call", "ref": "perps/navigate-perps-tab" },
        "gate-cleanup-pre-existing-avax": { "action": "eval_async", "expression": "perpsClosePosition AVAX if present" },
        "setup-nav-market": { "action": "call", "ref": "perps/navigate-to-market-detail", "params": { "symbol": "AVAX" } },
        "setup-press-long": { "action": "press", "test_id": "perps-long-cta-button" },
        "setup-set-amount": { "action": "set_input", "test_id": "amount-input-field", "value": "10" },
        "setup-toggle-autoclose": { "action": "eval_sync", "expression": "click .toggle-button label" },
        "setup-set-tp": { "action": "set_input", "test_id": "tp-price-input", "value": "11" },
        "setup-set-sl": { "action": "set_input", "test_id": "sl-price-input", "value": "9" },
        "setup-submit": { "action": "press", "test_id": "submit-order-button" },
        "setup-wait-fill": { "action": "eval_async", "expression": "poll perpsGetPositions until AVAX appears" },
        "setup-wait-tpsl-orders": {
          "action": "eval_async",
          "assert": { "all": [{ "operator": "eq", "field": "allPositionTpsl", "value": true }] }
        },
        "ac1-assert-autoclose-shows-positiontpsl": {
          "action": "eval_sync",
          "assert": { "all": [
            { "operator": "eq", "field": "hasTpPrice", "value": true },
            { "operator": "eq", "field": "hasSlPrice", "value": true },
            { "operator": "eq", "field": "hasPlaceholderTp", "value": false },
            { "operator": "eq", "field": "hasPlaceholderSl", "value": false }
          ]}
        },
        "ac2-assert-positiontpsl-not-in-orders": {
          "action": "eval_async",
          "assert": { "all": [{ "operator": "eq", "field": "leakCount", "value": 0 }] }
        },
        "ac-screenshot-final": { "action": "screenshot", "filename": "evidence-ac1-real-avax-market-tpsl.png" }
      }
    }
  }
}
```

Full recipe + baseline are checked in alongside this PR under `temp/tasks/fix/tat-3065-0513-153038/artifacts/`.
</details>

## **Recipe Workflow**

<details>
<summary>workflow.mmd</summary>

```mermaid
flowchart TD
  ENTRY([ENTRY]) --> gate_nav_perps
  gate_nav_perps[[gate-nav-perps perps/navigate-perps-tab]] --> gate_cleanup_pre_existing_avax
  gate_cleanup_pre_existing_avax[gate-cleanup-pre-existing-avax eval_async] --> setup_nav_market
  setup_nav_market[[setup-nav-market perps/navigate-to-market-detail]] --> setup_press_long
  setup_press_long[setup-press-long press] --> setup_set_amount
  setup_set_amount[setup-set-amount set_input 10] --> setup_toggle_autoclose
  setup_toggle_autoclose[setup-toggle-autoclose eval_sync] --> setup_set_tp
  setup_set_tp[setup-set-tp set_input 11] --> setup_set_sl
  setup_set_sl[setup-set-sl set_input 9] --> setup_submit
  setup_submit[setup-submit press submit-order-button] --> setup_wait_fill
  setup_wait_fill[setup-wait-fill eval_async poll position] --> setup_wait_tpsl_orders
  setup_wait_tpsl_orders[setup-wait-tpsl-orders allPositionTpsl=true] --> setup_nav_avax_detail
  setup_nav_avax_detail[[setup-nav-avax-detail perps/navigate-to-market-detail]] --> ac1
  ac1[ac1-assert-autoclose-shows-positiontpsl] --> ac2
  ac2[ac2-assert-positiontpsl-not-in-orders leakCount=0] --> screenshot
  screenshot[ac-screenshot-final] --> done([end])
```

</details>

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



[TAT-3065]: https://consensyssoftware.atlassian.net/browse/TAT-3065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes perps order-submission flow to split market + TP/SL into two background calls and adds new TP/SL inference logic; mistakes could cause missing/incorrect trigger attachment or UI misclassification of orders.
> 
> **Overview**
> Fixes a perps UI bug where **full-position TP/SL trigger orders** could appear in the Market Details **Orders** section and leave the **Auto-close** row empty.
> 
> Market order submission now conditionally strips TP/SL from `perpsPlaceOrder` and follows up with `perpsUpdatePositionTPSL` when opening a new position or flipping an existing one (using new `willFlipPosition`). The market detail page also derives missing TP/SL prices from matching reduce-only trigger orders (`derivePositionTpslPricesFromOrders`) and uses these effective prices for chart lines, Auto-close display, and the TP/SL modal.
> 
> Order classification was hardened to better recognize Hyperliquid edge cases (e.g., TP/SL triggers with `isPositionTpsl=false` and zero-size full-position triggers), with expanded unit tests and new exports from perps utils.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0d1badfc8387ffd1eaf96d122ae13101d93477a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->