### PR TITLE
fix: delegate transaction pay delegation action

### DIFF
--- a/app/scripts/messenger-client-init/messengers/transaction-controller-messenger.test.ts
+++ b/app/scripts/messenger-client-init/messengers/transaction-controller-messenger.test.ts
@@ -1,0 +1,41 @@
+import { Messenger } from '@metamask/messenger';
+import { getRootMessenger } from '../../lib/messenger';
+import {
+  getTransactionControllerInitMessenger,
+  getTransactionControllerMessenger,
+} from './transaction-controller-messenger';
+
+describe('getTransactionControllerMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = getRootMessenger<never, never>();
+    const transactionControllerMessenger =
+      getTransactionControllerMessenger(messenger);
+
+    expect(transactionControllerMessenger).toBeInstanceOf(Messenger);
+  });
+});
+
+describe('getTransactionControllerInitMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = getRootMessenger<never, never>();
+    const transactionControllerInitMessenger =
+      getTransactionControllerInitMessenger(messenger);
+
+    expect(transactionControllerInitMessenger).toBeInstanceOf(Messenger);
+  });
+
+  it('delegates TransactionPayController:getDelegationTransaction', () => {
+    const messenger = getRootMessenger<never, never>();
+    const delegateSpy = jest.spyOn(messenger, 'delegate');
+
+    getTransactionControllerInitMessenger(messenger);
+
+    expect(delegateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actions: expect.arrayContaining([
+          'TransactionPayController:getDelegationTransaction',
+        ]),
+      }),
+    );
+  });
+});

--- a/app/scripts/messenger-client-init/messengers/transaction-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/transaction-controller-messenger.ts
@@ -54,6 +54,7 @@ import {
   TransactionControllerUpdateTransactionAction,
 } from '@metamask/transaction-controller';
 import {
+  TransactionPayControllerGetDelegationTransactionAction,
   TransactionPayControllerGetStateAction,
   TransactionPayControllerGetStrategyAction,
 } from '@metamask/transaction-pay-controller';
@@ -138,6 +139,7 @@ type InitMessengerActions =
   | TransactionControllerGetStateAction
   | TransactionControllerIsAtomicBatchSupportedAction
   | TransactionControllerUpdateTransactionAction
+  | TransactionPayControllerGetDelegationTransactionAction
   | TransactionPayControllerGetStateAction
   | TransactionPayControllerGetStrategyAction;
 
@@ -218,6 +220,7 @@ export function getTransactionControllerInitMessenger(
       'TransactionController:getState',
       'TransactionController:isAtomicBatchSupported',
       'TransactionController:updateTransaction',
+      'TransactionPayController:getDelegationTransaction',
       'TransactionPayController:getState',
       'TransactionPayController:getStrategy',
     ],


### PR DESCRIPTION
## **Description**

Delegates `TransactionPayController:getDelegationTransaction` through `TransactionControllerInitMessenger` so MetaMask Pay publish flows can call the controller action during relay execution. This also adds messenger coverage to prevent the action from being dropped from the init allowlist again.

## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Run `yarn test:unit app/scripts/messenger-client-init/messengers/transaction-controller-messenger.test.ts --watchman=false`
2. Run `yarn lint:changed:fix`

<!--
## **Screenshots/Recordings**

### **Before**

[screenshots/recordings]

### **After**

[screenshots/recordings]
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.