### PR TITLE
fix: read correct state based on feature flag

### DIFF
--- a/app/scripts/controllers/permissions/snaps/specifications.test.ts
+++ b/app/scripts/controllers/permissions/snaps/specifications.test.ts
@@ -1,0 +1,119 @@
+import { ASSETS_UNIFY_STATE_FLAG } from '../../../../../shared/lib/assets-unify-state/remote-feature-flag';
+import { getIsAssetsUnifiedStateIncludedInBuild } from '../../../../../shared/lib/environment';
+import { getSnapPermissionSpecifications } from './specifications';
+
+// Use the real implementation instead of the global mock in test/jest/setup.js
+jest.mock(
+  '../../../../../shared/lib/assets-unify-state/remote-feature-flag',
+  () =>
+    jest.requireActual(
+      '../../../../../shared/lib/assets-unify-state/remote-feature-flag',
+    ),
+);
+
+jest.mock('../../../../../shared/lib/environment', () => ({
+  ...jest.requireActual('../../../../../shared/lib/environment'),
+  getIsAssetsUnifiedStateIncludedInBuild: jest.fn(),
+}));
+
+// Capture the hooks passed to buildSnapRestrictedMethodSpecifications so we
+// can call getPreferences() directly without spinning up a full messenger.
+let capturedHooks: Record<string, () => unknown> = {};
+jest.mock('@metamask/snaps-rpc-methods', () => ({
+  buildSnapEndowmentSpecifications: jest.fn(() => ({})),
+  buildSnapRestrictedMethodSpecifications: jest.fn((_excluded, hooks) => {
+    capturedHooks = hooks;
+    return {};
+  }),
+}));
+
+const BASE_PREFERENCES_STATE = {
+  currentLocale: 'en',
+  openSeaEnabled: false,
+  preferences: { privacyMode: false, showTestNetworks: false },
+  securityAlertsEnabled: false,
+  useCurrencyRateCheck: false,
+  usePhishDetect: false,
+  useTransactionSimulations: false,
+  useTokenDetection: false,
+  useMultiAccountBalanceChecker: false,
+  useNftDetection: false,
+};
+
+function buildMessenger(
+  overrides: Partial<Record<string, () => unknown>> = {},
+) {
+  const defaults: Record<string, () => unknown> = {
+    'RemoteFeatureFlagController:getState': () => ({
+      remoteFeatureFlags: {},
+    }),
+    'AssetsController:getState': () => ({ selectedCurrency: 'eur' }),
+    'CurrencyRateController:getState': () => ({ currentCurrency: 'usd' }),
+    'PreferencesController:getState': () => BASE_PREFERENCES_STATE,
+    ...overrides,
+  };
+
+  return {
+    call: jest.fn((action: string) => defaults[action]?.()),
+  };
+}
+
+describe('getSnapPermissionSpecifications', () => {
+  describe('getPreferences – currency source', () => {
+    it('uses AssetsController selectedCurrency when assetsUnifyState is enabled', () => {
+      jest.mocked(getIsAssetsUnifiedStateIncludedInBuild).mockReturnValue(true);
+
+      const messenger = buildMessenger({
+        'RemoteFeatureFlagController:getState': () => ({
+          remoteFeatureFlags: {
+            [ASSETS_UNIFY_STATE_FLAG]: { enabled: true, featureVersion: '1' },
+          },
+        }),
+        'AssetsController:getState': () => ({ selectedCurrency: 'eur' }),
+      });
+
+      getSnapPermissionSpecifications(messenger as never);
+      const result = capturedHooks.getPreferences();
+
+      expect(result).toMatchObject({ currency: 'eur' });
+    });
+
+    it('uses CurrencyRateController currentCurrency when assetsUnifyState is disabled', () => {
+      jest.mocked(getIsAssetsUnifiedStateIncludedInBuild).mockReturnValue(true);
+
+      const messenger = buildMessenger({
+        'RemoteFeatureFlagController:getState': () => ({
+          remoteFeatureFlags: {
+            [ASSETS_UNIFY_STATE_FLAG]: { enabled: false, featureVersion: null },
+          },
+        }),
+        'CurrencyRateController:getState': () => ({ currentCurrency: 'gbp' }),
+      });
+
+      getSnapPermissionSpecifications(messenger as never);
+      const result = capturedHooks.getPreferences();
+
+      expect(result).toMatchObject({ currency: 'gbp' });
+    });
+
+    it('uses CurrencyRateController currentCurrency when assetsUnifyState build flag is off', () => {
+      jest
+        .mocked(getIsAssetsUnifiedStateIncludedInBuild)
+        .mockReturnValue(false);
+
+      const messenger = buildMessenger({
+        'RemoteFeatureFlagController:getState': () => ({
+          remoteFeatureFlags: {
+            [ASSETS_UNIFY_STATE_FLAG]: { enabled: true, featureVersion: '1' },
+          },
+        }),
+        'CurrencyRateController:getState': () => ({ currentCurrency: 'usd' }),
+      });
+
+      getSnapPermissionSpecifications(messenger as never);
+      const result = capturedHooks.getPreferences();
+
+      expect(result).toMatchObject({ currency: 'usd' });
+    });
+  });
+});

--- a/app/scripts/controllers/permissions/snaps/specifications.ts
+++ b/app/scripts/controllers/permissions/snaps/specifications.ts
@@ -42,7 +42,6 @@ import {
   type AssetsUnifyStateFeatureFlag,
 } from '../../../../../shared/lib/assets-unify-state/remote-feature-flag';
 import { getIsAssetsUnifiedStateIncludedInBuild } from '../../../../../shared/lib/environment';
-import { getMnemonic, getMnemonicSeed } from './utils';
 
 export type SnapPermissionSpecificationsActions =
   | AppStateControllerGetUnlockPromiseAction

--- a/app/scripts/controllers/permissions/snaps/specifications.ts
+++ b/app/scripts/controllers/permissions/snaps/specifications.ts
@@ -5,6 +5,8 @@ import {
 } from '@metamask/snaps-rpc-methods';
 import { ControllerGetStateAction } from '@metamask/base-controller';
 import { CurrencyRateController } from '@metamask/assets-controllers';
+import type { AssetsControllerGetStateAction } from '@metamask/assets-controller';
+import type { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
 import {
   SnapControllerClearSnapStateAction,
   SnapControllerGetSnapAction,
@@ -34,6 +36,13 @@ import { PreferencesControllerGetStateAction } from '../../preferences-controlle
 import { KeyringType } from '../../../../../shared/constants/keyring';
 import { AppStateControllerGetUnlockPromiseAction } from '../../app-state-controller-method-action-types';
 import { RootMessenger } from '../../../lib/messenger';
+import {
+  isAssetsUnifyStateFeatureEnabled,
+  ASSETS_UNIFY_STATE_VERSION_1,
+  type AssetsUnifyStateFeatureFlag,
+} from '../../../../../shared/lib/assets-unify-state/remote-feature-flag';
+import { getIsAssetsUnifiedStateIncludedInBuild } from '../../../../../shared/lib/environment';
+import { getMnemonic, getMnemonicSeed } from './utils';
 
 export type SnapPermissionSpecificationsActions =
   | AppStateControllerGetUnlockPromiseAction
@@ -42,6 +51,8 @@ export type SnapPermissionSpecificationsActions =
       'CurrencyRateController',
       CurrencyRateController['state']
     >
+  | AssetsControllerGetStateAction
+  | RemoteFeatureFlagControllerGetStateAction
   | SnapInterfaceControllerCreateInterfaceAction
   | SnapInterfaceControllerGetInterfaceAction
   | SnapControllerGetSnapAction
@@ -79,9 +90,20 @@ export function getSnapPermissionSpecifications(
          * is a subset of the full preferences state.
          */
         getPreferences: () => {
-          const currency = messenger.call(
-            'CurrencyRateController:getState',
-          ).currentCurrency;
+          const isAssetsUnifyStateEnabled =
+            getIsAssetsUnifiedStateIncludedInBuild() &&
+            isAssetsUnifyStateFeatureEnabled(
+              messenger.call('RemoteFeatureFlagController:getState')
+                ?.remoteFeatureFlags?.assetsUnifyState as
+                | AssetsUnifyStateFeatureFlag
+                | null
+                | undefined,
+              ASSETS_UNIFY_STATE_VERSION_1,
+            );
+
+          const currency = isAssetsUnifyStateEnabled
+            ? messenger.call('AssetsController:getState').selectedCurrency
+            : messenger.call('CurrencyRateController:getState').currentCurrency;
 
           const {
             currentLocale: locale,

--- a/app/scripts/messenger-client-init/messengers/permission-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/permission-controller-messenger.ts
@@ -100,6 +100,7 @@ export function getPermissionControllerInitMessenger(
     actions: [
       'AppStateController:getUnlockPromise',
       'AccountsController:listAccounts',
+      'AssetsController:getState',
       'CurrencyRateController:getState',
       'KeyringController:getKeyringsByType',
       'KeyringController:withKeyring',
@@ -111,6 +112,7 @@ export function getPermissionControllerInitMessenger(
       'PhishingController:testOrigin',
       'PreferencesController:getState',
       'RateLimitController:call',
+      'RemoteFeatureFlagController:getState',
       'SnapController:clearSnapState',
       'SnapController:getSnap',
       'SnapController:getSnapState',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Correctly selects the selected currency for the app based on a feature flag.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is limited to how `getPreferences` derives `currency` for Snaps, guarded by build-time and remote feature flags and covered by new unit tests.
> 
> **Overview**
> Updates Snap permission `getPreferences` to derive `currency` from `AssetsController.selectedCurrency` when the *assets unified state* build flag and remote rollout flag are enabled; otherwise it falls back to `CurrencyRateController.currentCurrency`.
> 
> Wires `AssetsController:getState` and `RemoteFeatureFlagController:getState` into the permission-controller init messenger, and adds unit tests covering the three flag combinations to prevent regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 562a717e512a8ffef445262900adb45249d7f2b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->