### PR TITLE
feat: add QR error content component

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -6881,6 +6881,46 @@
     "message": "Camera access needed",
     "description": "Title when the camera permission dialog was dismissed without a choice."
   },
+  "qrErrorNonUrPairingBody": {
+    "message": "Go back to your hardware wallet and find the option to share or export your accounts, choose MetaMask, then scan the QR code.",
+    "description": "Body text for the non-UR QR code error during pairing."
+  },
+  "qrErrorNonUrPairingTitle": {
+    "message": "Scan wallet sync QR code",
+    "description": "Title shown when scanned QR data is not a UR code during the pairing/import flow."
+  },
+  "qrErrorNonUrSigningBody": {
+    "message": "Go back to your hardware wallet and approve the transaction, then scan the QR code it shows.",
+    "description": "Body text for the non-UR QR code error during signing."
+  },
+  "qrErrorNonUrSigningTitle": {
+    "message": "Scan signature QR code",
+    "description": "Title shown when scanned QR data is not a UR code during the signing flow."
+  },
+  "qrErrorUrDecodeBody": {
+    "message": "Make sure the QR code is fully visible and well-lit, and try again. If the issue continues, you may need to update your hardware wallet's firmware.",
+    "description": "Body text for the UR decode error (universal for pairing and signing)."
+  },
+  "qrErrorUrDecodeTitle": {
+    "message": "Couldn't read QR code",
+    "description": "Title shown when the UR decoder encounters an error (universal for pairing and signing)."
+  },
+  "qrErrorWrongUrTypePairingBody": {
+    "message": "Go back to your hardware wallet, choose MetaMask as the wallet type, then generate and scan a new QR code.",
+    "description": "Body text for the wrong UR type error during pairing."
+  },
+  "qrErrorWrongUrTypePairingTitle": {
+    "message": "Wrong QR code",
+    "description": "Title shown when the UR type does not match what is expected during pairing."
+  },
+  "qrErrorWrongUrTypeSigningBody": {
+    "message": "Go back to your hardware wallet and approve the transaction, then scan the QR code it shows.",
+    "description": "Body text for the wrong UR type error during signing."
+  },
+  "qrErrorWrongUrTypeSigningTitle": {
+    "message": "Wrong QR code",
+    "description": "Title shown when the UR type does not match what is expected during signing."
+  },
   "queued": {
     "message": "Queued"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -6881,6 +6881,46 @@
     "message": "Camera access needed",
     "description": "Title when the camera permission dialog was dismissed without a choice."
   },
+  "qrErrorNonUrPairingBody": {
+    "message": "Go back to your hardware wallet and find the option to share or export your accounts, choose MetaMask, then scan the QR code.",
+    "description": "Body text for the non-UR QR code error during pairing."
+  },
+  "qrErrorNonUrPairingTitle": {
+    "message": "Scan wallet sync QR code",
+    "description": "Title shown when scanned QR data is not a UR code during the pairing/import flow."
+  },
+  "qrErrorNonUrSigningBody": {
+    "message": "Go back to your hardware wallet and approve the transaction, then scan the QR code it shows.",
+    "description": "Body text for the non-UR QR code error during signing."
+  },
+  "qrErrorNonUrSigningTitle": {
+    "message": "Scan signature QR code",
+    "description": "Title shown when scanned QR data is not a UR code during the signing flow."
+  },
+  "qrErrorUrDecodeBody": {
+    "message": "Make sure the QR code is fully visible and well-lit, and try again. If the issue continues, you may need to update your hardware wallet's firmware.",
+    "description": "Body text for the UR decode error (universal for pairing and signing)."
+  },
+  "qrErrorUrDecodeTitle": {
+    "message": "Couldn't read QR code",
+    "description": "Title shown when the UR decoder encounters an error (universal for pairing and signing)."
+  },
+  "qrErrorWrongUrTypePairingBody": {
+    "message": "Go back to your hardware wallet, choose MetaMask as the wallet type, then generate and scan a new QR code.",
+    "description": "Body text for the wrong UR type error during pairing."
+  },
+  "qrErrorWrongUrTypePairingTitle": {
+    "message": "Wrong QR code",
+    "description": "Title shown when the UR type does not match what is expected during pairing."
+  },
+  "qrErrorWrongUrTypeSigningBody": {
+    "message": "Go back to your hardware wallet and approve the transaction, then scan the QR code it shows.",
+    "description": "Body text for the wrong UR type error during signing."
+  },
+  "qrErrorWrongUrTypeSigningTitle": {
+    "message": "Wrong QR code",
+    "description": "Title shown when the UR type does not match what is expected during signing."
+  },
   "queued": {
     "message": "Queued"
   },

--- a/ui/components/app/qr-hardware-popover/qr-error-content/index.ts
+++ b/ui/components/app/qr-hardware-popover/qr-error-content/index.ts
@@ -2,7 +2,6 @@ export { QrErrorContent } from './qr-error-content';
 export {
   QrErrorType,
   QrErrorFlowContext,
-  QR_ERROR_LEARN_MORE_URL,
   type QrErrorContentProps,
 } from './qr-error-content.types';
 export { resolveErrorCopy, rootTestId } from './qr-error-content.utils';

--- a/ui/components/app/qr-hardware-popover/qr-error-content/index.ts
+++ b/ui/components/app/qr-hardware-popover/qr-error-content/index.ts
@@ -1,0 +1,8 @@
+export { QrErrorContent } from './qr-error-content';
+export {
+  QrErrorType,
+  QrErrorFlowContext,
+  QR_ERROR_LEARN_MORE_URL,
+  type QrErrorContentProps,
+} from './qr-error-content.types';
+export { resolveErrorCopy, rootTestId } from './qr-error-content.utils';

--- a/ui/components/app/qr-hardware-popover/qr-error-content/qr-error-content.stories.tsx
+++ b/ui/components/app/qr-hardware-popover/qr-error-content/qr-error-content.stories.tsx
@@ -1,0 +1,116 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import { Box, BoxBackgroundColor } from '@metamask/design-system-react';
+import { QrErrorContent } from './qr-error-content';
+import { QrErrorType, QrErrorFlowContext } from './qr-error-content.types';
+
+const meta = {
+  title: 'Components/App/QrErrorContent',
+  component: QrErrorContent,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: `
+Presentational component for QR scan error states during hardware wallet pairing and signing.
+
+**Error types**
+- **NonUrQrCode** (State 3) — scanned data is not a UR code. Copy differs between pairing and signing.
+- **WrongUrType** (State 4) — valid UR, but the type is wrong for this flow. Copy differs between pairing and signing.
+- **UrDecodeError** (State 5) — the UR decoder encountered an error. Copy is universal (same for pairing and signing).
+
+**Buttons**
+- **Learn more** (secondary) — opens the MetaMask support article.
+- **Continue** (primary) — calls \`onTryAgain\`.
+`.trim(),
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <Box
+        backgroundColor={BoxBackgroundColor.BackgroundDefault}
+        padding={4}
+        style={{ width: '100%', maxWidth: 400 }}
+      >
+        <Story />
+      </Box>
+    ),
+  ],
+  argTypes: {
+    errorType: {
+      control: 'select',
+      options: [
+        QrErrorType.NonUrQrCode,
+        QrErrorType.WrongUrType,
+        QrErrorType.UrDecodeError,
+      ],
+      description: 'Which QR scan error state to display.',
+    },
+    flowContext: {
+      control: 'select',
+      options: [QrErrorFlowContext.Pairing, QrErrorFlowContext.Signing],
+      description:
+        'Pairing vs signing flow context. Ignored for UrDecodeError.',
+    },
+    onTryAgain: {
+      action: 'onTryAgain',
+      description: 'Callback when the user clicks "Try again".',
+    },
+  },
+} satisfies Meta<typeof QrErrorContent>;
+
+export default meta;
+
+type Story = StoryObj<typeof QrErrorContent>;
+
+/** State 3 — Non-UR QR code scanned during pairing. */
+export const NonUrQrCodePairing: Story = {
+  name: 'State 3: Non-UR QR — Pairing',
+  args: {
+    errorType: QrErrorType.NonUrQrCode,
+    flowContext: QrErrorFlowContext.Pairing,
+    onTryAgain: () => undefined,
+  },
+};
+
+/** State 3 — Non-UR QR code scanned during signing. */
+export const NonUrQrCodeSigning: Story = {
+  name: 'State 3: Non-UR QR — Signing',
+  args: {
+    errorType: QrErrorType.NonUrQrCode,
+    flowContext: QrErrorFlowContext.Signing,
+    onTryAgain: () => undefined,
+  },
+};
+
+/** State 4 — Valid UR with wrong type during pairing. */
+export const WrongUrTypePairing: Story = {
+  name: 'State 4: Wrong UR Type — Pairing',
+  args: {
+    errorType: QrErrorType.WrongUrType,
+    flowContext: QrErrorFlowContext.Pairing,
+    onTryAgain: () => undefined,
+  },
+};
+
+/** State 4 — Valid UR with wrong type during signing. */
+export const WrongUrTypeSigning: Story = {
+  name: 'State 4: Wrong UR Type — Signing',
+  args: {
+    errorType: QrErrorType.WrongUrType,
+    flowContext: QrErrorFlowContext.Signing,
+    onTryAgain: () => undefined,
+  },
+};
+
+/** State 5 — UR decode error (universal, same for pairing and signing). */
+export const UrDecodeError: Story = {
+  name: 'State 5: UR Decode Error',
+  args: {
+    errorType: QrErrorType.UrDecodeError,
+    flowContext: QrErrorFlowContext.Pairing,
+    onTryAgain: () => undefined,
+  },
+};

--- a/ui/components/app/qr-hardware-popover/qr-error-content/qr-error-content.test.tsx
+++ b/ui/components/app/qr-hardware-popover/qr-error-content/qr-error-content.test.tsx
@@ -3,12 +3,9 @@ import { screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { renderWithLocalization } from '../../../../../test/lib/render-helpers';
 import { enLocale as messages } from '../../../../../test/lib/i18n-helpers';
+import ZENDESK_URLS from '../../../../helpers/constants/zendesk-url';
 import { QrErrorContent } from './qr-error-content';
-import {
-  QrErrorType,
-  QrErrorFlowContext,
-  QR_ERROR_LEARN_MORE_URL,
-} from './qr-error-content.types';
+import { QrErrorType, QrErrorFlowContext } from './qr-error-content.types';
 
 describe('QrErrorContent', () => {
   const openTabMock = jest.fn();
@@ -95,7 +92,7 @@ describe('QrErrorContent', () => {
 
     expect(openTabMock).toHaveBeenCalledTimes(1);
     expect(openTabMock).toHaveBeenCalledWith({
-      url: QR_ERROR_LEARN_MORE_URL,
+      url: ZENDESK_URLS.HARDWARE_QR_WALLETS,
     });
   });
 

--- a/ui/components/app/qr-hardware-popover/qr-error-content/qr-error-content.test.tsx
+++ b/ui/components/app/qr-hardware-popover/qr-error-content/qr-error-content.test.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { renderWithLocalization } from '../../../../../test/lib/render-helpers';
+import {
+  enLocale as messages,
+  tEn,
+} from '../../../../../test/lib/i18n-helpers';
+import { QrErrorContent } from './qr-error-content';
+import {
+  QrErrorType,
+  QrErrorFlowContext,
+  QR_ERROR_LEARN_MORE_URL,
+} from './qr-error-content.types';
+
+describe('QrErrorContent', () => {
+  const openTabMock = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // @ts-expect-error mocking platform
+    globalThis.platform = { openTab: openTabMock };
+  });
+
+  it('renders the correct root test-id, title, and body for a given variant', () => {
+    renderWithLocalization(
+      <QrErrorContent
+        errorType={QrErrorType.NonUrQrCode}
+        flowContext={QrErrorFlowContext.Pairing}
+        onTryAgain={jest.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByTestId('qr-error-nonUrQrCode-pairing'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(messages.qrErrorNonUrPairingTitle.message),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(messages.qrErrorNonUrPairingBody.message),
+    ).toBeInTheDocument();
+  });
+
+  it('renders "Learn more" and "Continue" buttons', () => {
+    renderWithLocalization(
+      <QrErrorContent
+        errorType={QrErrorType.WrongUrType}
+        flowContext={QrErrorFlowContext.Signing}
+        onTryAgain={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText(tEn('learnMoreUpperCase'))).toBeInTheDocument();
+    expect(screen.getByText(tEn('continue'))).toBeInTheDocument();
+  });
+
+  it('calls onTryAgain when "Try again" is clicked', async () => {
+    const user = userEvent.setup();
+    const onTryAgain = jest.fn();
+    renderWithLocalization(
+      <QrErrorContent
+        errorType={QrErrorType.NonUrQrCode}
+        flowContext={QrErrorFlowContext.Pairing}
+        onTryAgain={onTryAgain}
+      />,
+    );
+
+    await user.click(screen.getByTestId('qr-error-try-again'));
+    expect(onTryAgain).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens learn-more URL when "Learn more" is clicked', async () => {
+    const user = userEvent.setup();
+    renderWithLocalization(
+      <QrErrorContent
+        errorType={QrErrorType.UrDecodeError}
+        flowContext={QrErrorFlowContext.Signing}
+        onTryAgain={jest.fn()}
+      />,
+    );
+
+    await user.click(screen.getByTestId('qr-error-learn-more'));
+    expect(openTabMock).toHaveBeenCalledWith({
+      url: QR_ERROR_LEARN_MORE_URL,
+    });
+  });
+
+  it('renders the warning icon', () => {
+    renderWithLocalization(
+      <QrErrorContent
+        errorType={QrErrorType.UrDecodeError}
+        flowContext={QrErrorFlowContext.Pairing}
+        onTryAgain={jest.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByTestId('qr-error-urDecodeError-pairing'),
+    ).toBeInTheDocument();
+  });
+});

--- a/ui/components/app/qr-hardware-popover/qr-error-content/qr-error-content.test.tsx
+++ b/ui/components/app/qr-hardware-popover/qr-error-content/qr-error-content.test.tsx
@@ -2,10 +2,7 @@ import React from 'react';
 import { screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { renderWithLocalization } from '../../../../../test/lib/render-helpers';
-import {
-  enLocale as messages,
-  tEn,
-} from '../../../../../test/lib/i18n-helpers';
+import { enLocale as messages } from '../../../../../test/lib/i18n-helpers';
 import { QrErrorContent } from './qr-error-content';
 import {
   QrErrorType,
@@ -22,7 +19,7 @@ describe('QrErrorContent', () => {
     globalThis.platform = { openTab: openTabMock };
   });
 
-  it('renders the correct root test-id, title, and body for a given variant', () => {
+  it('renders the root element with the correct test-id', () => {
     renderWithLocalization(
       <QrErrorContent
         errorType={QrErrorType.NonUrQrCode}
@@ -34,6 +31,17 @@ describe('QrErrorContent', () => {
     expect(
       screen.getByTestId('qr-error-nonUrQrCode-pairing'),
     ).toBeInTheDocument();
+  });
+
+  it('renders the resolved title and body text', () => {
+    renderWithLocalization(
+      <QrErrorContent
+        errorType={QrErrorType.NonUrQrCode}
+        flowContext={QrErrorFlowContext.Pairing}
+        onTryAgain={jest.fn()}
+      />,
+    );
+
     expect(
       screen.getByText(messages.qrErrorNonUrPairingTitle.message),
     ).toBeInTheDocument();
@@ -42,7 +50,7 @@ describe('QrErrorContent', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders "Learn more" and "Continue" buttons', () => {
+  it('renders "Learn more" and "Continue" button labels', () => {
     renderWithLocalization(
       <QrErrorContent
         errorType={QrErrorType.WrongUrType}
@@ -51,11 +59,13 @@ describe('QrErrorContent', () => {
       />,
     );
 
-    expect(screen.getByText(tEn('learnMoreUpperCase'))).toBeInTheDocument();
-    expect(screen.getByText(tEn('continue'))).toBeInTheDocument();
+    expect(
+      screen.getByText(messages.learnMoreUpperCase.message),
+    ).toBeInTheDocument();
+    expect(screen.getByText(messages.continue.message)).toBeInTheDocument();
   });
 
-  it('calls onTryAgain when "Try again" is clicked', async () => {
+  it('calls onTryAgain exactly once when "Continue" is clicked', async () => {
     const user = userEvent.setup();
     const onTryAgain = jest.fn();
     renderWithLocalization(
@@ -67,10 +77,11 @@ describe('QrErrorContent', () => {
     );
 
     await user.click(screen.getByTestId('qr-error-try-again'));
+
     expect(onTryAgain).toHaveBeenCalledTimes(1);
   });
 
-  it('opens learn-more URL when "Learn more" is clicked', async () => {
+  it('opens the learn-more support URL when "Learn more" is clicked', async () => {
     const user = userEvent.setup();
     renderWithLocalization(
       <QrErrorContent
@@ -81,22 +92,26 @@ describe('QrErrorContent', () => {
     );
 
     await user.click(screen.getByTestId('qr-error-learn-more'));
+
+    expect(openTabMock).toHaveBeenCalledTimes(1);
     expect(openTabMock).toHaveBeenCalledWith({
       url: QR_ERROR_LEARN_MORE_URL,
     });
   });
 
-  it('renders the warning icon', () => {
+  it('does not call onTryAgain when "Learn more" is clicked', async () => {
+    const user = userEvent.setup();
+    const onTryAgain = jest.fn();
     renderWithLocalization(
       <QrErrorContent
         errorType={QrErrorType.UrDecodeError}
         flowContext={QrErrorFlowContext.Pairing}
-        onTryAgain={jest.fn()}
+        onTryAgain={onTryAgain}
       />,
     );
 
-    expect(
-      screen.getByTestId('qr-error-urDecodeError-pairing'),
-    ).toBeInTheDocument();
+    await user.click(screen.getByTestId('qr-error-learn-more'));
+
+    expect(onTryAgain).not.toHaveBeenCalled();
   });
 });

--- a/ui/components/app/qr-hardware-popover/qr-error-content/qr-error-content.tsx
+++ b/ui/components/app/qr-hardware-popover/qr-error-content/qr-error-content.tsx
@@ -29,6 +29,10 @@ import { resolveErrorCopy, rootTestId } from './qr-error-content.utils';
  * Renders one of five copy variations depending on `errorType` and
  * `flowContext`, plus "Learn more" (opens support article) and
  * "Try again" (calls `onTryAgain`).
+ * @param options0
+ * @param options0.errorType
+ * @param options0.flowContext
+ * @param options0.onTryAgain
  */
 export const QrErrorContent = ({
   errorType,

--- a/ui/components/app/qr-hardware-popover/qr-error-content/qr-error-content.tsx
+++ b/ui/components/app/qr-hardware-popover/qr-error-content/qr-error-content.tsx
@@ -17,10 +17,8 @@ import {
   TextVariant,
 } from '@metamask/design-system-react';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
-import {
-  QR_ERROR_LEARN_MORE_URL,
-  type QrErrorContentProps,
-} from './qr-error-content.types';
+import ZENDESK_URLS from '../../../../helpers/constants/zendesk-url';
+import type { QrErrorContentProps } from './qr-error-content.types';
 import { resolveErrorCopy, rootTestId } from './qr-error-content.utils';
 
 /**
@@ -43,7 +41,7 @@ export const QrErrorContent = ({
   const { title, body } = resolveErrorCopy(errorType, flowContext, t);
 
   const handleLearnMore = () => {
-    globalThis.platform.openTab({ url: QR_ERROR_LEARN_MORE_URL });
+    globalThis.platform.openTab({ url: ZENDESK_URLS.HARDWARE_QR_WALLETS });
   };
 
   return (

--- a/ui/components/app/qr-hardware-popover/qr-error-content/qr-error-content.tsx
+++ b/ui/components/app/qr-hardware-popover/qr-error-content/qr-error-content.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  Button,
+  ButtonSize,
+  ButtonVariant,
+  FontWeight,
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+  Text,
+  TextAlign,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react';
+import { useI18nContext } from '../../../../hooks/useI18nContext';
+import {
+  QR_ERROR_LEARN_MORE_URL,
+  type QrErrorContentProps,
+} from './qr-error-content.types';
+import { resolveErrorCopy, rootTestId } from './qr-error-content.utils';
+
+/**
+ * Presentational component for QR scan / decode error states.
+ *
+ * Renders one of five copy variations depending on `errorType` and
+ * `flowContext`, plus "Learn more" (opens support article) and
+ * "Try again" (calls `onTryAgain`).
+ */
+export const QrErrorContent = ({
+  errorType,
+  flowContext,
+  onTryAgain,
+}: QrErrorContentProps) => {
+  const t = useI18nContext();
+  const { title, body } = resolveErrorCopy(errorType, flowContext, t);
+
+  const handleLearnMore = () => {
+    globalThis.platform.openTab({ url: QR_ERROR_LEARN_MORE_URL });
+  };
+
+  return (
+    <Box
+      data-testid={rootTestId(errorType, flowContext)}
+      flexDirection={BoxFlexDirection.Column}
+      paddingHorizontal={4}
+      paddingBottom={4}
+      style={{ width: '100%' }}
+    >
+      <Box
+        flexDirection={BoxFlexDirection.Column}
+        alignItems={BoxAlignItems.Center}
+        paddingBottom={2}
+      >
+        <Icon
+          name={IconName.Danger}
+          color={IconColor.WarningDefault}
+          size={IconSize.Xl}
+        />
+      </Box>
+      <Box paddingTop={2} paddingBottom={2}>
+        <Text
+          variant={TextVariant.HeadingMd}
+          fontWeight={FontWeight.Medium}
+          textAlign={TextAlign.Center}
+          color={TextColor.TextDefault}
+        >
+          {title}
+        </Text>
+      </Box>
+      <Box padding={3}>
+        <Text
+          variant={TextVariant.BodyMd}
+          textAlign={TextAlign.Center}
+          color={TextColor.TextAlternative}
+        >
+          {body}
+        </Text>
+      </Box>
+      <Box flexDirection={BoxFlexDirection.Column} gap={3} marginTop={4}>
+        <Button
+          size={ButtonSize.Lg}
+          variant={ButtonVariant.Secondary}
+          onClick={handleLearnMore}
+          data-testid="qr-error-learn-more"
+          isFullWidth
+        >
+          {t('learnMoreUpperCase')}
+        </Button>
+        <Button
+          size={ButtonSize.Lg}
+          variant={ButtonVariant.Primary}
+          onClick={onTryAgain}
+          data-testid="qr-error-try-again"
+          isFullWidth
+        >
+          {t('continue')}
+        </Button>
+      </Box>
+    </Box>
+  );
+};

--- a/ui/components/app/qr-hardware-popover/qr-error-content/qr-error-content.types.ts
+++ b/ui/components/app/qr-hardware-popover/qr-error-content/qr-error-content.types.ts
@@ -25,10 +25,6 @@ export const QrErrorFlowContext = {
 export type QrErrorFlowContext =
   (typeof QrErrorFlowContext)[keyof typeof QrErrorFlowContext];
 
-/** Learn-more destination URL for QR / air-gapped hardware wallets. */
-export const QR_ERROR_LEARN_MORE_URL =
-  'https://support.metamask.io/more-web3/wallets/hardware-wallet-hub/#qr-codeair-gapped-wallets';
-
 export type QrErrorContentProps = {
   /** Which error state to display. */
   errorType: QrErrorType;

--- a/ui/components/app/qr-hardware-popover/qr-error-content/qr-error-content.types.ts
+++ b/ui/components/app/qr-hardware-popover/qr-error-content/qr-error-content.types.ts
@@ -1,0 +1,34 @@
+/**
+ * The QR scan error category determines which title + body copy to show.
+ *
+ * - `NonUrQrCode` — scanned data does not start with `ur:` (State 3).
+ * - `WrongUrType` — valid UR, but the UR type is not expected for this flow (State 4).
+ * - `UrDecodeError` — `urDecoder.isError()` returned `true` (State 5).
+ */
+export enum QrErrorType {
+  NonUrQrCode = 'nonUrQrCode',
+  WrongUrType = 'wrongUrType',
+  UrDecodeError = 'urDecodeError',
+}
+
+/**
+ * The flow context controls whether pairing- or signing-specific copy is used.
+ * State 5 (`UrDecodeError`) ignores this — its copy is universal.
+ */
+export enum QrErrorFlowContext {
+  Pairing = 'pairing',
+  Signing = 'signing',
+}
+
+/** Learn-more destination URL for QR / air-gapped hardware wallets. */
+export const QR_ERROR_LEARN_MORE_URL =
+  'https://support.metamask.io/more-web3/wallets/hardware-wallet-hub/#qr-codeair-gapped-wallets';
+
+export type QrErrorContentProps = {
+  /** Which error state to display. */
+  errorType: QrErrorType;
+  /** Whether the QR scan originated from a pairing or signing flow. */
+  flowContext: QrErrorFlowContext;
+  /** Invoked when the user taps "Try again". */
+  onTryAgain: () => void;
+};

--- a/ui/components/app/qr-hardware-popover/qr-error-content/qr-error-content.types.ts
+++ b/ui/components/app/qr-hardware-popover/qr-error-content/qr-error-content.types.ts
@@ -29,6 +29,6 @@ export type QrErrorContentProps = {
   errorType: QrErrorType;
   /** Whether the QR scan originated from a pairing or signing flow. */
   flowContext: QrErrorFlowContext;
-  /** Invoked when the user taps "Try again". */
+  /** Invoked when the user taps "Continue" to retry the scan. */
   onTryAgain: () => void;
 };

--- a/ui/components/app/qr-hardware-popover/qr-error-content/qr-error-content.types.ts
+++ b/ui/components/app/qr-hardware-popover/qr-error-content/qr-error-content.types.ts
@@ -5,20 +5,25 @@
  * - `WrongUrType` — valid UR, but the UR type is not expected for this flow (State 4).
  * - `UrDecodeError` — `urDecoder.isError()` returned `true` (State 5).
  */
-export enum QrErrorType {
-  NonUrQrCode = 'nonUrQrCode',
-  WrongUrType = 'wrongUrType',
-  UrDecodeError = 'urDecodeError',
-}
+export const QrErrorType = {
+  NonUrQrCode: 'nonUrQrCode',
+  WrongUrType: 'wrongUrType',
+  UrDecodeError: 'urDecodeError',
+} as const;
+
+export type QrErrorType = (typeof QrErrorType)[keyof typeof QrErrorType];
 
 /**
  * The flow context controls whether pairing- or signing-specific copy is used.
  * State 5 (`UrDecodeError`) ignores this — its copy is universal.
  */
-export enum QrErrorFlowContext {
-  Pairing = 'pairing',
-  Signing = 'signing',
-}
+export const QrErrorFlowContext = {
+  Pairing: 'pairing',
+  Signing: 'signing',
+} as const;
+
+export type QrErrorFlowContext =
+  (typeof QrErrorFlowContext)[keyof typeof QrErrorFlowContext];
 
 /** Learn-more destination URL for QR / air-gapped hardware wallets. */
 export const QR_ERROR_LEARN_MORE_URL =

--- a/ui/components/app/qr-hardware-popover/qr-error-content/qr-error-content.utils.test.ts
+++ b/ui/components/app/qr-hardware-popover/qr-error-content/qr-error-content.utils.test.ts
@@ -1,0 +1,115 @@
+import { tEn } from '../../../../../test/lib/i18n-helpers';
+import { QrErrorType, QrErrorFlowContext } from './qr-error-content.types';
+import { resolveErrorCopy, rootTestId } from './qr-error-content.utils';
+
+describe('qr-error-content utils', () => {
+  describe('resolveErrorCopy', () => {
+    describe('NonUrQrCode', () => {
+      it('returns pairing title and body when flow is Pairing', () => {
+        const result = resolveErrorCopy(
+          QrErrorType.NonUrQrCode,
+          QrErrorFlowContext.Pairing,
+          tEn,
+        );
+
+        expect(result.title).toBe(tEn('qrErrorNonUrPairingTitle'));
+        expect(result.body).toBe(tEn('qrErrorNonUrPairingBody'));
+      });
+
+      it('returns signing title and body when flow is Signing', () => {
+        const result = resolveErrorCopy(
+          QrErrorType.NonUrQrCode,
+          QrErrorFlowContext.Signing,
+          tEn,
+        );
+
+        expect(result.title).toBe(tEn('qrErrorNonUrSigningTitle'));
+        expect(result.body).toBe(tEn('qrErrorNonUrSigningBody'));
+      });
+    });
+
+    describe('WrongUrType', () => {
+      it('returns pairing title and body when flow is Pairing', () => {
+        const result = resolveErrorCopy(
+          QrErrorType.WrongUrType,
+          QrErrorFlowContext.Pairing,
+          tEn,
+        );
+
+        expect(result.title).toBe(tEn('qrErrorWrongUrTypePairingTitle'));
+        expect(result.body).toBe(tEn('qrErrorWrongUrTypePairingBody'));
+      });
+
+      it('returns signing title and body when flow is Signing', () => {
+        const result = resolveErrorCopy(
+          QrErrorType.WrongUrType,
+          QrErrorFlowContext.Signing,
+          tEn,
+        );
+
+        expect(result.title).toBe(tEn('qrErrorWrongUrTypeSigningTitle'));
+        expect(result.body).toBe(tEn('qrErrorWrongUrTypeSigningBody'));
+      });
+    });
+
+    describe('UrDecodeError', () => {
+      it('returns universal title and body regardless of flow context', () => {
+        const pairing = resolveErrorCopy(
+          QrErrorType.UrDecodeError,
+          QrErrorFlowContext.Pairing,
+          tEn,
+        );
+        const signing = resolveErrorCopy(
+          QrErrorType.UrDecodeError,
+          QrErrorFlowContext.Signing,
+          tEn,
+        );
+
+        expect(pairing.title).toBe(tEn('qrErrorUrDecodeTitle'));
+        expect(pairing.body).toBe(tEn('qrErrorUrDecodeBody'));
+        expect(signing).toStrictEqual(pairing);
+      });
+    });
+
+    describe('default fallback', () => {
+      it('falls back to UR decode copy for unrecognised error types', () => {
+        const result = resolveErrorCopy(
+          'unknownType' as QrErrorType,
+          QrErrorFlowContext.Pairing,
+          tEn,
+        );
+
+        expect(result.title).toBe(tEn('qrErrorUrDecodeTitle'));
+        expect(result.body).toBe(tEn('qrErrorUrDecodeBody'));
+      });
+    });
+  });
+
+  describe('rootTestId', () => {
+    it('produces the expected test-id for each error + flow combination', () => {
+      expect(
+        rootTestId(QrErrorType.NonUrQrCode, QrErrorFlowContext.Pairing),
+      ).toBe('qr-error-nonUrQrCode-pairing');
+
+      expect(
+        rootTestId(QrErrorType.NonUrQrCode, QrErrorFlowContext.Signing),
+      ).toBe('qr-error-nonUrQrCode-signing');
+
+      expect(
+        rootTestId(QrErrorType.WrongUrType, QrErrorFlowContext.Pairing),
+      ).toBe('qr-error-wrongUrType-pairing');
+
+      expect(
+        rootTestId(QrErrorType.WrongUrType, QrErrorFlowContext.Signing),
+      ).toBe('qr-error-wrongUrType-signing');
+
+      expect(
+        rootTestId(QrErrorType.UrDecodeError, QrErrorFlowContext.Pairing),
+      ).toBe('qr-error-urDecodeError-pairing');
+
+      expect(
+        rootTestId(QrErrorType.UrDecodeError, QrErrorFlowContext.Signing),
+      ).toBe('qr-error-urDecodeError-signing');
+    });
+  });
+});

--- a/ui/components/app/qr-hardware-popover/qr-error-content/qr-error-content.utils.test.ts
+++ b/ui/components/app/qr-hardware-popover/qr-error-content/qr-error-content.utils.test.ts
@@ -1,112 +1,151 @@
-import { tEn } from '../../../../../test/lib/i18n-helpers';
+import { enLocale as messages } from '../../../../../test/lib/i18n-helpers';
 import { QrErrorType, QrErrorFlowContext } from './qr-error-content.types';
 import { resolveErrorCopy, rootTestId } from './qr-error-content.utils';
 
+const mockT = jest.fn((key: string) => `[${key}]`);
+
 describe('qr-error-content utils', () => {
   describe('resolveErrorCopy', () => {
-    describe('NonUrQrCode', () => {
-      it('returns pairing title and body when flow is Pairing', () => {
-        const result = resolveErrorCopy(
-          QrErrorType.NonUrQrCode,
-          QrErrorFlowContext.Pairing,
-          tEn,
-        );
-
-        expect(result.title).toBe(tEn('qrErrorNonUrPairingTitle'));
-        expect(result.body).toBe(tEn('qrErrorNonUrPairingBody'));
-      });
-
-      it('returns signing title and body when flow is Signing', () => {
-        const result = resolveErrorCopy(
-          QrErrorType.NonUrQrCode,
-          QrErrorFlowContext.Signing,
-          tEn,
-        );
-
-        expect(result.title).toBe(tEn('qrErrorNonUrSigningTitle'));
-        expect(result.body).toBe(tEn('qrErrorNonUrSigningBody'));
-      });
+    beforeEach(() => {
+      mockT.mockClear();
     });
 
-    describe('WrongUrType', () => {
-      it('returns pairing title and body when flow is Pairing', () => {
-        const result = resolveErrorCopy(
-          QrErrorType.WrongUrType,
-          QrErrorFlowContext.Pairing,
-          tEn,
-        );
+    it('returns pairing title and body for NonUrQrCode + Pairing', () => {
+      resolveErrorCopy(
+        QrErrorType.NonUrQrCode,
+        QrErrorFlowContext.Pairing,
+        mockT,
+      );
 
-        expect(result.title).toBe(tEn('qrErrorWrongUrTypePairingTitle'));
-        expect(result.body).toBe(tEn('qrErrorWrongUrTypePairingBody'));
-      });
-
-      it('returns signing title and body when flow is Signing', () => {
-        const result = resolveErrorCopy(
-          QrErrorType.WrongUrType,
-          QrErrorFlowContext.Signing,
-          tEn,
-        );
-
-        expect(result.title).toBe(tEn('qrErrorWrongUrTypeSigningTitle'));
-        expect(result.body).toBe(tEn('qrErrorWrongUrTypeSigningBody'));
-      });
+      expect(mockT).toHaveBeenCalledWith('qrErrorNonUrPairingTitle');
+      expect(mockT).toHaveBeenCalledWith('qrErrorNonUrPairingBody');
     });
 
-    describe('UrDecodeError', () => {
-      it('returns universal title and body regardless of flow context', () => {
-        const pairing = resolveErrorCopy(
-          QrErrorType.UrDecodeError,
-          QrErrorFlowContext.Pairing,
-          tEn,
-        );
-        const signing = resolveErrorCopy(
-          QrErrorType.UrDecodeError,
-          QrErrorFlowContext.Signing,
-          tEn,
-        );
+    it('returns signing title and body for NonUrQrCode + Signing', () => {
+      resolveErrorCopy(
+        QrErrorType.NonUrQrCode,
+        QrErrorFlowContext.Signing,
+        mockT,
+      );
 
-        expect(pairing.title).toBe(tEn('qrErrorUrDecodeTitle'));
-        expect(pairing.body).toBe(tEn('qrErrorUrDecodeBody'));
-        expect(signing).toStrictEqual(pairing);
-      });
+      expect(mockT).toHaveBeenCalledWith('qrErrorNonUrSigningTitle');
+      expect(mockT).toHaveBeenCalledWith('qrErrorNonUrSigningBody');
     });
 
-    describe('default fallback', () => {
-      it('falls back to UR decode copy for unrecognised error types', () => {
-        const result = resolveErrorCopy(
-          'unknownType' as QrErrorType,
-          QrErrorFlowContext.Pairing,
-          tEn,
-        );
+    it('returns pairing title and body for WrongUrType + Pairing', () => {
+      resolveErrorCopy(
+        QrErrorType.WrongUrType,
+        QrErrorFlowContext.Pairing,
+        mockT,
+      );
 
-        expect(result.title).toBe(tEn('qrErrorUrDecodeTitle'));
-        expect(result.body).toBe(tEn('qrErrorUrDecodeBody'));
+      expect(mockT).toHaveBeenCalledWith('qrErrorWrongUrTypePairingTitle');
+      expect(mockT).toHaveBeenCalledWith('qrErrorWrongUrTypePairingBody');
+    });
+
+    it('returns signing title and body for WrongUrType + Signing', () => {
+      resolveErrorCopy(
+        QrErrorType.WrongUrType,
+        QrErrorFlowContext.Signing,
+        mockT,
+      );
+
+      expect(mockT).toHaveBeenCalledWith('qrErrorWrongUrTypeSigningTitle');
+      expect(mockT).toHaveBeenCalledWith('qrErrorWrongUrTypeSigningBody');
+    });
+
+    it('returns universal title and body for UrDecodeError + Pairing', () => {
+      resolveErrorCopy(
+        QrErrorType.UrDecodeError,
+        QrErrorFlowContext.Pairing,
+        mockT,
+      );
+
+      expect(mockT).toHaveBeenCalledWith('qrErrorUrDecodeTitle');
+      expect(mockT).toHaveBeenCalledWith('qrErrorUrDecodeBody');
+    });
+
+    it('returns the same universal copy for UrDecodeError + Signing', () => {
+      resolveErrorCopy(
+        QrErrorType.UrDecodeError,
+        QrErrorFlowContext.Signing,
+        mockT,
+      );
+
+      expect(mockT).toHaveBeenCalledWith('qrErrorUrDecodeTitle');
+      expect(mockT).toHaveBeenCalledWith('qrErrorUrDecodeBody');
+    });
+
+    it('falls back to UR decode copy for unrecognised error types', () => {
+      resolveErrorCopy(
+        'unknownType' as QrErrorType,
+        QrErrorFlowContext.Pairing,
+        mockT,
+      );
+
+      expect(mockT).toHaveBeenCalledWith('qrErrorUrDecodeTitle');
+      expect(mockT).toHaveBeenCalledWith('qrErrorUrDecodeBody');
+    });
+
+    it('returns an object with title and body string properties', () => {
+      const result = resolveErrorCopy(
+        QrErrorType.NonUrQrCode,
+        QrErrorFlowContext.Pairing,
+        mockT,
+      );
+
+      expect(result).toHaveProperty('title');
+      expect(result).toHaveProperty('body');
+      expect(typeof result.title).toBe('string');
+      expect(typeof result.body).toBe('string');
+    });
+
+    it('passes the correct locale keys that exist in the messages bundle', () => {
+      const keysUsed: string[] = [];
+      const capturingT = jest.fn((key: string) => {
+        keysUsed.push(key);
+        return `[${key}]`;
       });
+
+      const allTypes = [
+        QrErrorType.NonUrQrCode,
+        QrErrorType.WrongUrType,
+        QrErrorType.UrDecodeError,
+      ];
+      const allFlows = [QrErrorFlowContext.Pairing, QrErrorFlowContext.Signing];
+
+      for (const errorType of allTypes) {
+        for (const flow of allFlows) {
+          resolveErrorCopy(errorType, flow, capturingT);
+        }
+      }
+
+      for (const key of keysUsed) {
+        expect(messages).toHaveProperty(key);
+      }
     });
   });
 
   describe('rootTestId', () => {
-    it('produces the expected test-id for each error + flow combination', () => {
+    it('concatenates error type and flow context with the qr-error prefix', () => {
       expect(
         rootTestId(QrErrorType.NonUrQrCode, QrErrorFlowContext.Pairing),
       ).toBe('qr-error-nonUrQrCode-pairing');
+    });
 
+    it('reflects the signing flow context', () => {
       expect(
         rootTestId(QrErrorType.NonUrQrCode, QrErrorFlowContext.Signing),
       ).toBe('qr-error-nonUrQrCode-signing');
+    });
 
+    it('reflects the WrongUrType error type', () => {
       expect(
         rootTestId(QrErrorType.WrongUrType, QrErrorFlowContext.Pairing),
       ).toBe('qr-error-wrongUrType-pairing');
+    });
 
-      expect(
-        rootTestId(QrErrorType.WrongUrType, QrErrorFlowContext.Signing),
-      ).toBe('qr-error-wrongUrType-signing');
-
-      expect(
-        rootTestId(QrErrorType.UrDecodeError, QrErrorFlowContext.Pairing),
-      ).toBe('qr-error-urDecodeError-pairing');
-
+    it('reflects the UrDecodeError error type', () => {
       expect(
         rootTestId(QrErrorType.UrDecodeError, QrErrorFlowContext.Signing),
       ).toBe('qr-error-urDecodeError-signing');

--- a/ui/components/app/qr-hardware-popover/qr-error-content/qr-error-content.utils.ts
+++ b/ui/components/app/qr-hardware-popover/qr-error-content/qr-error-content.utils.ts
@@ -1,0 +1,66 @@
+import { useI18nContext } from '../../../../hooks/useI18nContext';
+import { QrErrorType, QrErrorFlowContext } from './qr-error-content.types';
+
+/**
+ * Translate function returned by `useI18nContext`.
+ */
+type TranslateFn = ReturnType<typeof useI18nContext>;
+
+/**
+ * Resolves the localized title and body for the given error + flow combination.
+ *
+ * State 5 (`UrDecodeError`) ignores `flowContext` — its copy is universal.
+ *
+ * @param errorType - Which scan error occurred.
+ * @param flowContext - Pairing vs signing flow.
+ * @param t - i18n translate function.
+ * @returns Localized `title` and `body`.
+ */
+export function resolveErrorCopy(
+  errorType: QrErrorType,
+  flowContext: QrErrorFlowContext,
+  t: TranslateFn,
+): { title: string; body: string } {
+  const isPairing = flowContext === QrErrorFlowContext.Pairing;
+
+  switch (errorType) {
+    case QrErrorType.NonUrQrCode:
+      return {
+        title: isPairing
+          ? t('qrErrorNonUrPairingTitle')
+          : t('qrErrorNonUrSigningTitle'),
+        body: isPairing
+          ? t('qrErrorNonUrPairingBody')
+          : t('qrErrorNonUrSigningBody'),
+      };
+    case QrErrorType.WrongUrType:
+      return {
+        title: isPairing
+          ? t('qrErrorWrongUrTypePairingTitle')
+          : t('qrErrorWrongUrTypeSigningTitle'),
+        body: isPairing
+          ? t('qrErrorWrongUrTypePairingBody')
+          : t('qrErrorWrongUrTypeSigningBody'),
+      };
+    case QrErrorType.UrDecodeError:
+    default:
+      return {
+        title: t('qrErrorUrDecodeTitle'),
+        body: t('qrErrorUrDecodeBody'),
+      };
+  }
+}
+
+/**
+ * Returns the `data-testid` for the root wrapper.
+ *
+ * @param errorType - Which scan error occurred.
+ * @param flowContext - Pairing vs signing flow.
+ * @returns A stable test-id string.
+ */
+export function rootTestId(
+  errorType: QrErrorType,
+  flowContext: QrErrorFlowContext,
+): string {
+  return `qr-error-${errorType}-${flowContext}`;
+}

--- a/ui/helpers/constants/zendesk-url.ts
+++ b/ui/helpers/constants/zendesk-url.ts
@@ -11,6 +11,8 @@ const ZENDESK_URLS = {
     'https://support.metamask.io/transactions-and-gas/gas-fees/?utm_source=extension',
   HARDWARE_CONNECTION:
     'https://support.metamask.io/privacy-and-security/hardware-wallet-hub/?utm_source=extension',
+  HARDWARE_QR_WALLETS:
+    'https://support.metamask.io/more-web3/wallets/hardware-wallet-hub/?utm_source=extension#qr-codeair-gapped-wallets',
   HARDWARE_CONNECTION_TREZOR_LEDGER:
     'https://support.metamask.io/more-web3/wallets/how-to-connect-a-trezor-or-ledger-hardware-wallet/?utm_source=extension',
   IMPORT_ACCOUNT_MOBILE:


### PR DESCRIPTION
## **Description**
This PR adds QR error content component which displays specific error determined after processing input logic.

This component is not integrated anywhere in the system yet. This PR is only adding independent UI component which only can be visually tested in storybook. 

The plan is to later integrate this component into the component stack related to the QR hardware wallet functionality.

Figma design specification: https://www.figma.com/design/1F3yNWYLOVPFpTPeJugH20/SWAP?node-id=13983-13394&m=dev

Additional notes:
- This component is only displaying **content** which we will embed into the existing popover component and later on into the modal when we do some final refactoring of the QR hardware wallet popover component and other nested components. We're using content only for these because of the existing UI architecture.

## **Changelog**
<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->
CHANGELOG entry: null

## **Related issues**
Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1768

## **Manual testing steps**
1. Run storybook (`yarn storybook`).
2. Find component: `QrErrorContent`
3. Verify that the component is visually matching design specification from [Figma](https://www.figma.com/design/1F3yNWYLOVPFpTPeJugH20/SWAP?node-id=13983-13394&m=dev).
4. Verify that the component is capable of displaying all the QR related errors we need.

## **Screenshots/Recordings**

### **Before**
This component was not available before. Nothing to show here.

### **After**
<img width="1023" height="615" alt="Screenshot 2026-05-13 at 18 58 07" src="https://github.com/user-attachments/assets/394fb04c-747d-42e8-aede-e7ea6e77fb06" />
<img width="1023" height="587" alt="Screenshot 2026-05-13 at 18 58 25" src="https://github.com/user-attachments/assets/3b019308-fe05-4da3-8dd0-aaae0d5d1445" />
<img width="1023" height="587" alt="Screenshot 2026-05-13 at 18 58 38" src="https://github.com/user-attachments/assets/5ed50515-2402-46c1-9711-5a427b7dfcba" />
<img width="1023" height="587" alt="Screenshot 2026-05-13 at 18 58 53" src="https://github.com/user-attachments/assets/7f08a5d2-d0c6-4a9b-9a87-8dcc52b5466a" />
<img width="1028" height="605" alt="Screenshot 2026-05-13 at 18 59 08" src="https://github.com/user-attachments/assets/f727f777-ca7d-4292-9915-db588a7968fd" />

## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new, not-yet-integrated presentational component plus i18n strings and a support URL constant, with unit/storybook coverage and no changes to existing flows.
> 
> **Overview**
> Adds a new `QrErrorContent` component to display QR hardware-wallet scan/decode error states (non-UR, wrong UR type, UR decode error) with pairing vs signing copy resolution, a “Learn more” support link, and a “Continue” retry action.
> 
> Introduces the required i18n strings in `en`/`en_GB`, adds a `ZENDESK_URLS.HARDWARE_QR_WALLETS` constant, and includes Storybook stories plus unit tests for copy resolution, test IDs, and button behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e4bd9f870d271e4d339ee9c534bee4ef3191e70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->