### PR TITLE
refactor: use `Box` component from DSR (assets team)

### DIFF
--- a/ui/components/app/assets/account-group-balance-change/account-group-balance-change.tsx
+++ b/ui/components/app/assets/account-group-balance-change/account-group-balance-change.tsx
@@ -35,7 +35,7 @@ const AccountGroupBalanceChangeComponent: React.FC<
         !anyEnabledNetworksAreAvailable && isZeroAmount(amountChange)
       }
     >
-      <Box flexDirection={BoxFlexDirection.Row} gap={1}>
+      <Box flexDirection={BoxFlexDirection.Row} gap={1} className="flex">
         <SensitiveText
           variant={TextVariant.bodyMdMedium}
           color={color}

--- a/ui/components/app/assets/account-group-balance-change/account-group-balance-change.tsx
+++ b/ui/components/app/assets/account-group-balance-change/account-group-balance-change.tsx
@@ -2,14 +2,13 @@ import { type BalanceChangePeriod } from '@metamask/assets-controllers';
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { Skeleton } from '@metamask/design-system-react';
-import {
-  Display,
-  TextVariant,
-} from '../../../../helpers/constants/design-system';
+
+import { TextVariant } from '../../../../helpers/constants/design-system';
 import { useFormatters } from '../../../../hooks/useFormatters';
 import { getCurrentCurrency } from '../../../../ducks/metamask/metamask';
 import { selectAnyEnabledNetworksAreAvailable } from '../../../../selectors';
-import { Box, SensitiveText } from '../../../component-library';
+import { Box, BoxFlexDirection } from '@metamask/design-system-react';
+import { SensitiveText } from '../../../component-library';
 import { isZeroAmount } from '../../../../helpers/utils/number-utils';
 import { useAccountGroupBalanceDisplay } from './useAccountGroupBalanceDisplay';
 
@@ -37,7 +36,7 @@ const AccountGroupBalanceChangeComponent: React.FC<
         !anyEnabledNetworksAreAvailable && isZeroAmount(amountChange)
       }
     >
-      <Box display={Display.Flex} gap={1}>
+      <Box flexDirection={BoxFlexDirection.Row} gap={1}>
         <SensitiveText
           variant={TextVariant.bodyMdMedium}
           color={color}

--- a/ui/components/app/assets/account-group-balance-change/account-group-balance-change.tsx
+++ b/ui/components/app/assets/account-group-balance-change/account-group-balance-change.tsx
@@ -1,13 +1,12 @@
 import { type BalanceChangePeriod } from '@metamask/assets-controllers';
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { Skeleton } from '@metamask/design-system-react';
+import { Box, BoxFlexDirection, Skeleton } from '@metamask/design-system-react';
 
 import { TextVariant } from '../../../../helpers/constants/design-system';
 import { useFormatters } from '../../../../hooks/useFormatters';
 import { getCurrentCurrency } from '../../../../ducks/metamask/metamask';
 import { selectAnyEnabledNetworksAreAvailable } from '../../../../selectors';
-import { Box, BoxFlexDirection } from '@metamask/design-system-react';
 import { SensitiveText } from '../../../component-library';
 import { isZeroAmount } from '../../../../helpers/utils/number-utils';
 import { useAccountGroupBalanceDisplay } from './useAccountGroupBalanceDisplay';

--- a/ui/components/app/assets/account-group-balance/account-group-balance.tsx
+++ b/ui/components/app/assets/account-group-balance/account-group-balance.tsx
@@ -161,7 +161,7 @@ export const AccountGroupBalance: React.FC<AccountGroupBalanceProps> = ({
       data-testid="account-group-balance-skeleton"
     >
       <Box
-        className={classnames(`${classPrefix}-overview__primary-balance`, {
+        className={classnames('flex', `${classPrefix}-overview__primary-balance`, {
           [`${classPrefix}-overview__cached-balance`]: balanceIsCached,
         })}
         data-testid={`${classPrefix}-overview__primary-currency`}

--- a/ui/components/app/assets/account-group-balance/account-group-balance.tsx
+++ b/ui/components/app/assets/account-group-balance/account-group-balance.tsx
@@ -9,13 +9,14 @@ import {
   selectBalanceBySelectedAccountGroup,
 } from '../../../../selectors/assets';
 
+import { TextVariant } from '../../../../helpers/constants/design-system';
 import {
-  AlignItems,
-  Display,
-  FlexWrap,
-  TextVariant,
-} from '../../../../helpers/constants/design-system';
-import { Box, SensitiveText } from '../../../component-library';
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxFlexWrap,
+} from '@metamask/design-system-react';
+import { SensitiveText } from '../../../component-library';
 import {
   getEnabledNetworksByNamespace,
   getMultichainNetwork,
@@ -164,9 +165,9 @@ export const AccountGroupBalance: React.FC<AccountGroupBalanceProps> = ({
           [`${classPrefix}-overview__cached-balance`]: balanceIsCached,
         })}
         data-testid={`${classPrefix}-overview__primary-currency`}
-        display={Display.Flex}
-        alignItems={AlignItems.center}
-        flexWrap={FlexWrap.Wrap}
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        flexWrap={BoxFlexWrap.Wrap}
       >
         <SensitiveText
           ellipsis

--- a/ui/components/app/assets/account-group-balance/account-group-balance.tsx
+++ b/ui/components/app/assets/account-group-balance/account-group-balance.tsx
@@ -161,9 +161,13 @@ export const AccountGroupBalance: React.FC<AccountGroupBalanceProps> = ({
       data-testid="account-group-balance-skeleton"
     >
       <Box
-        className={classnames('flex', `${classPrefix}-overview__primary-balance`, {
-          [`${classPrefix}-overview__cached-balance`]: balanceIsCached,
-        })}
+        className={classnames(
+          'flex',
+          `${classPrefix}-overview__primary-balance`,
+          {
+            [`${classPrefix}-overview__cached-balance`]: balanceIsCached,
+          },
+        )}
         data-testid={`${classPrefix}-overview__primary-currency`}
         flexDirection={BoxFlexDirection.Row}
         alignItems={BoxAlignItems.Center}

--- a/ui/components/app/assets/account-group-balance/account-group-balance.tsx
+++ b/ui/components/app/assets/account-group-balance/account-group-balance.tsx
@@ -5,17 +5,17 @@ import { formatChainIdToCaip } from '@metamask/bridge-controller';
 import { CaipChainId, Hex, isCaipChainId } from '@metamask/utils';
 import { Skeleton } from '@metamask/design-system-react';
 import {
-  getMultichainNativeTokenBalance,
-  selectBalanceBySelectedAccountGroup,
-} from '../../../../selectors/assets';
-
-import { TextVariant } from '../../../../helpers/constants/design-system';
-import {
   Box,
   BoxAlignItems,
   BoxFlexDirection,
   BoxFlexWrap,
 } from '@metamask/design-system-react';
+import {
+  getMultichainNativeTokenBalance,
+  selectBalanceBySelectedAccountGroup,
+} from '../../../../selectors/assets';
+
+import { TextVariant } from '../../../../helpers/constants/design-system';
 import { SensitiveText } from '../../../component-library';
 import {
   getEnabledNetworksByNamespace,

--- a/ui/components/app/assets/account-group-balance/account-group-balance.tsx
+++ b/ui/components/app/assets/account-group-balance/account-group-balance.tsx
@@ -3,12 +3,12 @@ import { useSelector } from 'react-redux';
 import classnames from 'clsx';
 import { formatChainIdToCaip } from '@metamask/bridge-controller';
 import { CaipChainId, Hex, isCaipChainId } from '@metamask/utils';
-import { Skeleton } from '@metamask/design-system-react';
 import {
   Box,
   BoxAlignItems,
   BoxFlexDirection,
   BoxFlexWrap,
+  Skeleton,
 } from '@metamask/design-system-react';
 import {
   getMultichainNativeTokenBalance,

--- a/ui/components/app/assets/asset-list/cells/generic-asset-cell-layout.tsx
+++ b/ui/components/app/assets/asset-list/cells/generic-asset-cell-layout.tsx
@@ -26,11 +26,7 @@ export default function GenericAssetCellLayout({
   footerRightDisplay,
 }: GenericAssetCellLayoutProps) {
   return (
-    <Box
-      flexDirection={BoxFlexDirection.Row}
-      gap={4}
-      className="h-full w-full"
-    >
+    <Box flexDirection={BoxFlexDirection.Row} gap={4} className="h-full w-full">
       <Box asChild>
         <a
           onClick={(e?: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {

--- a/ui/components/app/assets/asset-list/cells/generic-asset-cell-layout.tsx
+++ b/ui/components/app/assets/asset-list/cells/generic-asset-cell-layout.tsx
@@ -53,7 +53,7 @@ export default function GenericAssetCellLayout({
           >
             <Box
               flexDirection={BoxFlexDirection.Row}
-              justifyContent={BoxJustifyContent.SpaceBetween}
+              justifyContent={BoxJustifyContent.Between}
             >
               {headerLeftDisplay}
               {headerRightDisplay}
@@ -61,7 +61,7 @@ export default function GenericAssetCellLayout({
 
             <Box
               flexDirection={BoxFlexDirection.Row}
-              justifyContent={BoxJustifyContent.SpaceBetween}
+              justifyContent={BoxJustifyContent.Between}
             >
               {footerLeftDisplay}
               {footerRightDisplay}

--- a/ui/components/app/assets/asset-list/cells/generic-asset-cell-layout.tsx
+++ b/ui/components/app/assets/asset-list/cells/generic-asset-cell-layout.tsx
@@ -1,11 +1,9 @@
 import React, { ReactNode } from 'react';
-import { Box } from '../../../../component-library';
 import {
-  Display,
-  FlexDirection,
-  BlockSize,
-  JustifyContent,
-} from '../../../../../helpers/constants/design-system';
+  Box,
+  BoxFlexDirection,
+  BoxJustifyContent,
+} from '@metamask/design-system-react';
 import { ASSET_CELL_HEIGHT } from '../../constants';
 
 type GenericAssetCellLayoutProps = {
@@ -29,59 +27,47 @@ export default function GenericAssetCellLayout({
 }: GenericAssetCellLayoutProps) {
   return (
     <Box
-      display={Display.Flex}
-      flexDirection={FlexDirection.Row}
-      width={BlockSize.Full}
-      height={BlockSize.Full}
+      flexDirection={BoxFlexDirection.Row}
       gap={4}
+      className="h-full w-full"
     >
-      <Box
-        as="a"
-        onClick={(e?: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
-          e?.preventDefault();
-          if (onClick) {
-            onClick();
-          }
-        }}
-        display={Display.Flex}
-        flexDirection={FlexDirection.Row}
-        paddingTop={2}
-        paddingBottom={2}
-        paddingLeft={4}
-        paddingRight={4}
-        width={BlockSize.Full}
-        className={onClick ? 'hover:bg-hover cursor-pointer' : ''}
-        style={{
-          height: ASSET_CELL_HEIGHT,
-        }}
-        data-testid="multichain-token-list-button"
-      >
-        {badge}
-        <Box
-          display={Display.Flex}
-          flexDirection={FlexDirection.Column}
-          width={BlockSize.Full}
-          style={{ flexGrow: 1, overflow: 'hidden' }}
-          justifyContent={JustifyContent.center}
+      <Box asChild>
+        <a
+          onClick={(e?: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+            e?.preventDefault();
+            if (onClick) {
+              onClick();
+            }
+          }}
+          className={`flex w-full flex-row py-2 px-4 ${onClick ? 'hover:bg-hover cursor-pointer' : ''}`}
+          style={{
+            height: ASSET_CELL_HEIGHT,
+          }}
+          data-testid="multichain-token-list-button"
         >
+          {badge}
           <Box
-            display={Display.Flex}
-            flexDirection={FlexDirection.Row}
-            justifyContent={JustifyContent.spaceBetween}
+            flexDirection={BoxFlexDirection.Column}
+            justifyContent={BoxJustifyContent.Center}
+            className="w-full overflow-hidden grow"
           >
-            {headerLeftDisplay}
-            {headerRightDisplay}
-          </Box>
+            <Box
+              flexDirection={BoxFlexDirection.Row}
+              justifyContent={BoxJustifyContent.SpaceBetween}
+            >
+              {headerLeftDisplay}
+              {headerRightDisplay}
+            </Box>
 
-          <Box
-            display={Display.Flex}
-            flexDirection={FlexDirection.Row}
-            justifyContent={JustifyContent.spaceBetween}
-          >
-            {footerLeftDisplay}
-            {footerRightDisplay}
+            <Box
+              flexDirection={BoxFlexDirection.Row}
+              justifyContent={BoxJustifyContent.SpaceBetween}
+            >
+              {footerLeftDisplay}
+              {footerRightDisplay}
+            </Box>
           </Box>
-        </Box>
+        </a>
       </Box>
     </Box>
   );

--- a/ui/components/app/assets/asset-list/cells/generic-asset-cell-layout.tsx
+++ b/ui/components/app/assets/asset-list/cells/generic-asset-cell-layout.tsx
@@ -26,7 +26,11 @@ export default function GenericAssetCellLayout({
   footerRightDisplay,
 }: GenericAssetCellLayoutProps) {
   return (
-    <Box flexDirection={BoxFlexDirection.Row} gap={4} className="flex h-full w-full">
+    <Box
+      flexDirection={BoxFlexDirection.Row}
+      gap={4}
+      className="flex h-full w-full"
+    >
       <Box asChild>
         <a
           onClick={(e?: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {

--- a/ui/components/app/assets/asset-list/cells/generic-asset-cell-layout.tsx
+++ b/ui/components/app/assets/asset-list/cells/generic-asset-cell-layout.tsx
@@ -26,7 +26,7 @@ export default function GenericAssetCellLayout({
   footerRightDisplay,
 }: GenericAssetCellLayoutProps) {
   return (
-    <Box flexDirection={BoxFlexDirection.Row} gap={4} className="h-full w-full">
+    <Box flexDirection={BoxFlexDirection.Row} gap={4} className="flex h-full w-full">
       <Box asChild>
         <a
           onClick={(e?: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
@@ -45,11 +45,12 @@ export default function GenericAssetCellLayout({
           <Box
             flexDirection={BoxFlexDirection.Column}
             justifyContent={BoxJustifyContent.Center}
-            className="w-full overflow-hidden grow"
+            className="flex w-full overflow-hidden grow"
           >
             <Box
               flexDirection={BoxFlexDirection.Row}
               justifyContent={BoxJustifyContent.Between}
+              className="flex"
             >
               {headerLeftDisplay}
               {headerRightDisplay}
@@ -58,6 +59,7 @@ export default function GenericAssetCellLayout({
             <Box
               flexDirection={BoxFlexDirection.Row}
               justifyContent={BoxJustifyContent.Between}
+              className="flex"
             >
               {footerLeftDisplay}
               {footerRightDisplay}

--- a/ui/components/app/assets/asset-list/network-filter/network-filter.tsx
+++ b/ui/components/app/assets/asset-list/network-filter/network-filter.tsx
@@ -17,15 +17,13 @@ import {
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { SelectableListItem } from '../sort-control/sort-control';
 import { Text } from '../../../../component-library/text/text';
+import { TextColor, TextVariant } from '../../../../../helpers/constants/design-system';
 import {
-  AlignItems,
-  BlockSize,
-  Display,
-  JustifyContent,
-  TextColor,
-  TextVariant,
-} from '../../../../../helpers/constants/design-system';
-import { Box } from '../../../../component-library/box/box';
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxJustifyContent,
+} from '@metamask/design-system-react';
 import {
   AvatarNetwork,
   AvatarNetworkSize,
@@ -127,10 +125,10 @@ const NetworkFilter = ({
         testId="network-filter-all"
       >
         <Box
-          display={Display.Flex}
-          justifyContent={JustifyContent.spaceBetween}
-          width={BlockSize.Full}
+          flexDirection={BoxFlexDirection.Row}
+          justifyContent={BoxJustifyContent.SpaceBetween}
           gap={3}
+          className="w-full"
         >
           <Box>
             <Text
@@ -156,7 +154,10 @@ const NetworkFilter = ({
               </Text>
             )}
           </Box>
-          <Box display={Display.Flex} alignItems={AlignItems.center}>
+          <Box
+            flexDirection={BoxFlexDirection.Row}
+            alignItems={BoxAlignItems.Center}
+          >
             <InfoTooltip
               position="bottom"
               contentText={allAddedPopularNetworks.join(', ')}
@@ -191,11 +192,11 @@ const NetworkFilter = ({
         testId="network-filter-current"
       >
         <Box
-          display={Display.Flex}
-          justifyContent={JustifyContent.spaceBetween}
+          flexDirection={BoxFlexDirection.Row}
+          justifyContent={BoxJustifyContent.SpaceBetween}
           gap={3}
-          alignItems={AlignItems.center}
-          width={BlockSize.Full}
+          alignItems={BoxAlignItems.Center}
+          className="w-full"
         >
           <Box>
             <Text

--- a/ui/components/app/assets/asset-list/network-filter/network-filter.tsx
+++ b/ui/components/app/assets/asset-list/network-filter/network-filter.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxJustifyContent,
+} from '@metamask/design-system-react';
 import { setEnabledNetworks } from '../../../../../store/actions';
 import {
   getCurrentNetwork,
@@ -21,12 +27,6 @@ import {
   TextColor,
   TextVariant,
 } from '../../../../../helpers/constants/design-system';
-import {
-  Box,
-  BoxAlignItems,
-  BoxFlexDirection,
-  BoxJustifyContent,
-} from '@metamask/design-system-react';
 import {
   AvatarNetwork,
   AvatarNetworkSize,

--- a/ui/components/app/assets/asset-list/network-filter/network-filter.tsx
+++ b/ui/components/app/assets/asset-list/network-filter/network-filter.tsx
@@ -17,7 +17,10 @@ import {
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { SelectableListItem } from '../sort-control/sort-control';
 import { Text } from '../../../../component-library/text/text';
-import { TextColor, TextVariant } from '../../../../../helpers/constants/design-system';
+import {
+  TextColor,
+  TextVariant,
+} from '../../../../../helpers/constants/design-system';
 import {
   Box,
   BoxAlignItems,

--- a/ui/components/app/assets/asset-list/network-filter/network-filter.tsx
+++ b/ui/components/app/assets/asset-list/network-filter/network-filter.tsx
@@ -126,7 +126,7 @@ const NetworkFilter = ({
       >
         <Box
           flexDirection={BoxFlexDirection.Row}
-          justifyContent={BoxJustifyContent.SpaceBetween}
+          justifyContent={BoxJustifyContent.Between}
           gap={3}
           className="w-full"
         >
@@ -193,7 +193,7 @@ const NetworkFilter = ({
       >
         <Box
           flexDirection={BoxFlexDirection.Row}
-          justifyContent={BoxJustifyContent.SpaceBetween}
+          justifyContent={BoxJustifyContent.Between}
           gap={3}
           alignItems={BoxAlignItems.Center}
           className="w-full"

--- a/ui/components/app/assets/asset-list/network-filter/network-filter.tsx
+++ b/ui/components/app/assets/asset-list/network-filter/network-filter.tsx
@@ -131,7 +131,7 @@ const NetworkFilter = ({
           flexDirection={BoxFlexDirection.Row}
           justifyContent={BoxJustifyContent.Between}
           gap={3}
-          className="w-full"
+          className="flex w-full"
         >
           <Box>
             <Text
@@ -160,6 +160,7 @@ const NetworkFilter = ({
           <Box
             flexDirection={BoxFlexDirection.Row}
             alignItems={BoxAlignItems.Center}
+            className="flex"
           >
             <InfoTooltip
               position="bottom"
@@ -199,7 +200,7 @@ const NetworkFilter = ({
           justifyContent={BoxJustifyContent.Between}
           gap={3}
           alignItems={BoxAlignItems.Center}
-          className="w-full"
+          className="flex w-full"
         >
           <Box>
             <Text

--- a/ui/components/app/assets/asset-list/sort-control/sort-control.tsx
+++ b/ui/components/app/assets/asset-list/sort-control/sort-control.tsx
@@ -1,13 +1,13 @@
 import React, { ReactNode, useCallback, useContext } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import classnames from 'clsx';
-import { Box, Text } from '../../../../component-library';
+import { Box, BoxBackgroundColor } from '@metamask/design-system-react';
+import { Text } from '../../../../component-library';
 import { SortOrder, SortingCallbacksT } from '../../util/sort';
 import {
   AlignItems,
   BackgroundColor,
   BlockSize,
-  BorderRadius,
   Display,
   TextVariant,
 } from '../../../../../helpers/constants/design-system';
@@ -58,9 +58,8 @@ export const SelectableListItem = ({
       </Text>
       {isSelected && (
         <Box
-          className="selectable-list-item__selected-indicator"
-          borderRadius={BorderRadius.pill}
-          backgroundColor={BackgroundColor.primaryDefault}
+          className="selectable-list-item__selected-indicator rounded-full"
+          backgroundColor={BoxBackgroundColor.PrimaryDefault}
         />
       )}
     </Box>

--- a/ui/components/app/assets/defi-list/defi-list.tsx
+++ b/ui/components/app/assets/defi-list/defi-list.tsx
@@ -112,6 +112,7 @@ export default function DefiList({ onClick }: DefiListProps) {
         flexDirection={BoxFlexDirection.Column}
         alignItems={BoxAlignItems.Center}
         justifyContent={BoxJustifyContent.Center}
+        className="flex"
       >
         <PulseLoader />
       </Box>

--- a/ui/components/app/assets/defi-list/defi-list.tsx
+++ b/ui/components/app/assets/defi-list/defi-list.tsx
@@ -2,6 +2,12 @@ import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { Hex } from '@metamask/utils';
 import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxJustifyContent,
+} from '@metamask/design-system-react';
+import {
   getEnabledNetworksByNamespace,
   getSelectedAccount,
   getTokenSortConfig,
@@ -9,12 +15,6 @@ import {
 import { filterAssets } from '../util/filter';
 import { sortAssets } from '../util/sort';
 import PulseLoader from '../../../ui/pulse-loader';
-import {
-  Box,
-  BoxAlignItems,
-  BoxFlexDirection,
-  BoxJustifyContent,
-} from '@metamask/design-system-react';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 
 import { useFormatters } from '../../../../hooks/useFormatters';

--- a/ui/components/app/assets/defi-list/defi-list.tsx
+++ b/ui/components/app/assets/defi-list/defi-list.tsx
@@ -8,14 +8,13 @@ import {
 } from '../../../../selectors';
 import { filterAssets } from '../util/filter';
 import { sortAssets } from '../util/sort';
-import {
-  Display,
-  FlexDirection,
-  AlignItems,
-  JustifyContent,
-} from '../../../../helpers/constants/design-system';
 import PulseLoader from '../../../ui/pulse-loader';
-import { Box } from '../../../component-library';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxJustifyContent,
+} from '@metamask/design-system-react';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 
 import { useFormatters } from '../../../../hooks/useFormatters';
@@ -110,10 +109,9 @@ export default function DefiList({ onClick }: DefiListProps) {
   if (sortedFilteredDefi === undefined) {
     return (
       <Box
-        display={Display.Flex}
-        flexDirection={FlexDirection.Column}
-        alignItems={AlignItems.center}
-        justifyContent={JustifyContent.center}
+        flexDirection={BoxFlexDirection.Column}
+        alignItems={BoxAlignItems.Center}
+        justifyContent={BoxJustifyContent.Center}
       >
         <PulseLoader />
       </Box>

--- a/ui/components/app/assets/nfts/nft-default-image/__snapshots__/nft-default-image.test.js.snap
+++ b/ui/components/app/assets/nfts/nft-default-image/__snapshots__/nft-default-image.test.js.snap
@@ -3,7 +3,7 @@
 exports[`NFT Default Image should match snapshot with all provided props 1`] = `
 <div>
   <div
-    class="mm-box nft-default mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--rounded-lg"
+    class="flex flex-row items-center justify-center nft-default rounded-lg"
     data-testid="nft-default-image"
     tabindex="0"
   />
@@ -13,7 +13,7 @@ exports[`NFT Default Image should match snapshot with all provided props 1`] = `
 exports[`NFT Default Image should match snapshot with missing clickable prop 1`] = `
 <div>
   <div
-    class="mm-box nft-default mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--rounded-lg"
+    class="flex flex-row items-center justify-center nft-default rounded-lg"
     data-testid="nft-default-image"
     tabindex="0"
   />
@@ -23,7 +23,7 @@ exports[`NFT Default Image should match snapshot with missing clickable prop 1`]
 exports[`NFT Default Image should render with no props 1`] = `
 <div>
   <div
-    class="mm-box nft-default mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--rounded-lg"
+    class="flex flex-row items-center justify-center nft-default rounded-lg"
     data-testid="nft-default-image"
     tabindex="0"
   />

--- a/ui/components/app/assets/nfts/nft-default-image/__snapshots__/nft-default-image.test.js.snap
+++ b/ui/components/app/assets/nfts/nft-default-image/__snapshots__/nft-default-image.test.js.snap
@@ -3,7 +3,7 @@
 exports[`NFT Default Image should match snapshot with all provided props 1`] = `
 <div>
   <div
-    class="flex flex-row items-center justify-center nft-default rounded-lg"
+    class="flex-row items-center justify-center flex nft-default rounded-lg"
     data-testid="nft-default-image"
     tabindex="0"
   />
@@ -13,7 +13,7 @@ exports[`NFT Default Image should match snapshot with all provided props 1`] = `
 exports[`NFT Default Image should match snapshot with missing clickable prop 1`] = `
 <div>
   <div
-    class="flex flex-row items-center justify-center nft-default rounded-lg"
+    class="flex-row items-center justify-center flex nft-default rounded-lg"
     data-testid="nft-default-image"
     tabindex="0"
   />
@@ -23,7 +23,7 @@ exports[`NFT Default Image should match snapshot with missing clickable prop 1`]
 exports[`NFT Default Image should render with no props 1`] = `
 <div>
   <div
-    class="flex flex-row items-center justify-center nft-default rounded-lg"
+    class="flex-row items-center justify-center flex nft-default rounded-lg"
     data-testid="nft-default-image"
     tabindex="0"
   />

--- a/ui/components/app/assets/nfts/nft-default-image/nft-default-image.tsx
+++ b/ui/components/app/assets/nfts/nft-default-image/nft-default-image.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import classnames from 'clsx';
 import { useDispatch } from 'react-redux';
-import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import {
   Box,
   BoxAlignItems,
   BoxFlexDirection,
   BoxJustifyContent,
 } from '@metamask/design-system-react';
+import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { ButtonLink } from '../../../../component-library';
 import { showIpfsModal } from '../../../../../store/actions';
 

--- a/ui/components/app/assets/nfts/nft-default-image/nft-default-image.tsx
+++ b/ui/components/app/assets/nfts/nft-default-image/nft-default-image.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import classnames from 'clsx';
 import { useDispatch } from 'react-redux';
-import {
-  Display,
-  AlignItems,
-  JustifyContent,
-  BorderRadius,
-} from '../../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
-import { ButtonLink, Box } from '../../../../component-library';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxJustifyContent,
+} from '@metamask/design-system-react';
+import { ButtonLink } from '../../../../component-library';
 import { showIpfsModal } from '../../../../../store/actions';
 
 type NftDefaultImageProps = {
@@ -29,13 +29,12 @@ export default function NftDefaultImage({
     <Box
       tabIndex={0}
       data-testid="nft-default-image"
-      className={classnames(className, 'nft-default', {
+      className={classnames(className, 'nft-default', 'rounded-lg', {
         'nft-default--clickable': Boolean(clickable),
       })}
-      display={Display.Flex}
-      alignItems={AlignItems.center}
-      justifyContent={JustifyContent.center}
-      borderRadius={BorderRadius.LG}
+      flexDirection={BoxFlexDirection.Row}
+      alignItems={BoxAlignItems.Center}
+      justifyContent={BoxJustifyContent.Center}
     >
       {clickable && (
         <ButtonLink

--- a/ui/components/app/assets/nfts/nft-default-image/nft-default-image.tsx
+++ b/ui/components/app/assets/nfts/nft-default-image/nft-default-image.tsx
@@ -29,7 +29,7 @@ export default function NftDefaultImage({
     <Box
       tabIndex={0}
       data-testid="nft-default-image"
-      className={classnames(className, 'nft-default', 'rounded-lg', {
+      className={classnames('flex', className, 'nft-default', 'rounded-lg', {
         'nft-default--clickable': Boolean(clickable),
       })}
       flexDirection={BoxFlexDirection.Row}

--- a/ui/components/app/assets/nfts/nft-details/__snapshots__/nft-details.test.js.snap
+++ b/ui/components/app/assets/nfts/nft-details/__snapshots__/nft-details.test.js.snap
@@ -58,7 +58,7 @@ exports[`NFT Details should match minimal props and state snapshot 1`] = `
                   class="mm-box mm-badge-wrapper nft-item__badge-wrapper nft-item__badge-wrapper__clickable mm-box--display-block"
                 >
                   <div
-                    class="mm-box nft-item__default-image nft-default nft-default--clickable mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--rounded-lg"
+                    class="flex flex-row items-center justify-center nft-item__default-image nft-default rounded-lg nft-default--clickable"
                     data-testid="nft-default-image"
                     tabindex="0"
                   >

--- a/ui/components/app/assets/nfts/nft-details/__snapshots__/nft-details.test.js.snap
+++ b/ui/components/app/assets/nfts/nft-details/__snapshots__/nft-details.test.js.snap
@@ -58,7 +58,7 @@ exports[`NFT Details should match minimal props and state snapshot 1`] = `
                   class="mm-box mm-badge-wrapper nft-item__badge-wrapper nft-item__badge-wrapper__clickable mm-box--display-block"
                 >
                   <div
-                    class="flex flex-row items-center justify-center nft-item__default-image nft-default rounded-lg nft-default--clickable"
+                    class="flex-row items-center justify-center flex nft-item__default-image nft-default rounded-lg nft-default--clickable"
                     data-testid="nft-default-image"
                     tabindex="0"
                   >

--- a/ui/components/app/assets/nfts/nft-details/nft-detail-information-frame.tsx
+++ b/ui/components/app/assets/nfts/nft-details/nft-detail-information-frame.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 
-import { Box, Text } from '../../../../component-library';
 import {
-  AlignItems,
-  Display,
-  JustifyContent,
-} from '../../../../../helpers/constants/design-system';
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxJustifyContent,
+} from '@metamask/design-system-react';
+import { Text } from '../../../../component-library';
 
 type NftDetailInformationFrameProps = {
   title?: string;
@@ -38,9 +39,9 @@ const NftDetailInformationFrame = ({
 
       {icon ? (
         <Box
-          display={Display.Flex}
-          justifyContent={JustifyContent.center}
-          alignItems={AlignItems.center}
+          flexDirection={BoxFlexDirection.Row}
+          justifyContent={BoxJustifyContent.Center}
+          alignItems={BoxAlignItems.Center}
         >
           {' '}
           {buttonAddressValue ? (

--- a/ui/components/app/assets/nfts/nft-details/nft-detail-information-frame.tsx
+++ b/ui/components/app/assets/nfts/nft-details/nft-detail-information-frame.tsx
@@ -42,6 +42,7 @@ const NftDetailInformationFrame = ({
           flexDirection={BoxFlexDirection.Row}
           justifyContent={BoxJustifyContent.Center}
           alignItems={BoxAlignItems.Center}
+          className="flex"
         >
           {' '}
           {buttonAddressValue ? (

--- a/ui/components/app/assets/nfts/nft-grid/__snapshots__/nft-grid.test.tsx.snap
+++ b/ui/components/app/assets/nfts/nft-grid/__snapshots__/nft-grid.test.tsx.snap
@@ -3,12 +3,12 @@
 exports[`NftGrid matches the snapshot 1`] = `
 <DocumentFragment>
   <div
-    class="mm-box"
+    class=""
     style="margin: 16px;"
   >
     <div>
       <div
-        class="mm-box grid gap-4 pb-4 grid-cols-3"
+        class="grid gap-4 pb-4 grid-cols-3"
       />
     </div>
   </div>

--- a/ui/components/app/assets/nfts/nft-grid/nft-grid.tsx
+++ b/ui/components/app/assets/nfts/nft-grid/nft-grid.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { toHex } from '@metamask/controller-utils';
-import { Box } from '../../../../component-library';
+import { Box } from '@metamask/design-system-react';
 import { getNftImageAlt, getNftImage } from '../../../../../helpers/utils/nfts';
 import { NftItem } from '../../../../multichain/nft-item';
 import { NFT } from '../../../../multichain/asset-picker-amount/asset-picker-modal/types';

--- a/ui/components/app/assets/nfts/nfts-tab/nfts-tab.tsx
+++ b/ui/components/app/assets/nfts/nfts-tab/nfts-tab.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import { toHex } from '@metamask/controller-utils';
+import { Box } from '@metamask/design-system-react';
 import { useNftsCollections } from '../../../../../hooks/useNftsCollections';
 import {
   getIsMainnet,
@@ -9,7 +10,6 @@ import {
   getNftIsStillFetchingIndication,
 } from '../../../../../selectors';
 import { getPreferences } from '../../../../../../shared/lib/selectors/preferences';
-import { Box } from '@metamask/design-system-react';
 import NFTsDetectionNoticeNFTsTab from '../nfts-detection-notice-nfts-tab/nfts-detection-notice-nfts-tab';
 import { endTrace, TraceName } from '../../../../../../shared/lib/trace';
 import { useNfts } from '../../../../../hooks/useNfts';

--- a/ui/components/app/assets/nfts/nfts-tab/nfts-tab.tsx
+++ b/ui/components/app/assets/nfts/nfts-tab/nfts-tab.tsx
@@ -9,7 +9,7 @@ import {
   getNftIsStillFetchingIndication,
 } from '../../../../../selectors';
 import { getPreferences } from '../../../../../../shared/lib/selectors/preferences';
-import { Box } from '../../../../component-library';
+import { Box } from '@metamask/design-system-react';
 import NFTsDetectionNoticeNFTsTab from '../nfts-detection-notice-nfts-tab/nfts-detection-notice-nfts-tab';
 import { endTrace, TraceName } from '../../../../../../shared/lib/trace';
 import { useNfts } from '../../../../../hooks/useNfts';
@@ -66,7 +66,7 @@ export default function NftsTab() {
 
       <Box className="nfts-tab">
         {isMainnet && !useNftDetection ? (
-          <Box paddingTop={4} paddingInlineStart={4} paddingInlineEnd={4}>
+          <Box paddingTop={4} paddingHorizontal={4}>
             <NFTsDetectionNoticeNFTsTab />
           </Box>
         ) : null}

--- a/ui/components/app/assets/token-cell/__snapshots__/token-cell.test.tsx.snap
+++ b/ui/components/app/assets/token-cell/__snapshots__/token-cell.test.tsx.snap
@@ -3,10 +3,10 @@
 exports[`Token Cell should match snapshot 1`] = `
 <div>
   <div
-    class="mm-box mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-row mm-box--width-full mm-box--height-full"
+    class="flex flex-row gap-4 h-full w-full"
   >
     <a
-      class="mm-box hover:bg-hover cursor-pointer mm-box--padding-top-2 mm-box--padding-right-4 mm-box--padding-bottom-2 mm-box--padding-left-4 mm-box--display-flex mm-box--flex-direction-row mm-box--width-full"
+      class="flex w-full flex-row py-2 px-4 hover:bg-hover cursor-pointer"
       data-testid="multichain-token-list-button"
       style="height: 62px;"
     >
@@ -38,11 +38,10 @@ exports[`Token Cell should match snapshot 1`] = `
         </div>
       </div>
       <div
-        class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-center mm-box--width-full"
-        style="flex-grow: 1; overflow: hidden;"
+        class="flex flex-col justify-center w-full overflow-hidden grow"
       >
         <div
-          class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-space-between"
+          class="flex flex-row justify-between"
         >
           <div
             class="flex flex-row gap-2 min-w-0"
@@ -63,7 +62,7 @@ exports[`Token Cell should match snapshot 1`] = `
           </p>
         </div>
         <div
-          class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-space-between"
+          class="flex flex-row justify-between"
         >
           <div
             class="mm-box mm-box--display-flex mm-box--gap-1 mm-box--align-items-center"

--- a/ui/components/app/assets/token-cell/__snapshots__/token-cell.test.tsx.snap
+++ b/ui/components/app/assets/token-cell/__snapshots__/token-cell.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Token Cell should match snapshot 1`] = `
 <div>
   <div
-    class="flex flex-row gap-4 h-full w-full"
+    class="flex-row gap-4 flex h-full w-full"
   >
     <a
       class="flex w-full flex-row py-2 px-4 hover:bg-hover cursor-pointer"
@@ -38,10 +38,10 @@ exports[`Token Cell should match snapshot 1`] = `
         </div>
       </div>
       <div
-        class="flex flex-col justify-center w-full overflow-hidden grow"
+        class="flex-col justify-center flex w-full overflow-hidden grow"
       >
         <div
-          class="flex flex-row justify-between"
+          class="flex-row justify-between flex"
         >
           <div
             class="flex flex-row gap-2 min-w-0"
@@ -62,7 +62,7 @@ exports[`Token Cell should match snapshot 1`] = `
           </p>
         </div>
         <div
-          class="flex flex-row justify-between"
+          class="flex-row justify-between flex"
         >
           <div
             class="mm-box mm-box--display-flex mm-box--gap-1 mm-box--align-items-center"

--- a/ui/pages/asset/components/__snapshots__/asset-page.test.tsx.snap
+++ b/ui/pages/asset/components/__snapshots__/asset-page.test.tsx.snap
@@ -220,10 +220,10 @@ exports[`AssetPage should render a native asset 1`] = `
         Your balance
       </h4>
       <div
-        class="mm-box mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-row mm-box--width-full mm-box--height-full"
+        class="flex flex-row gap-4 h-full w-full"
       >
         <a
-          class="mm-box mm-box--padding-top-2 mm-box--padding-right-4 mm-box--padding-bottom-2 mm-box--padding-left-4 mm-box--display-flex mm-box--flex-direction-row mm-box--width-full"
+          class="flex w-full flex-row py-2 px-4 "
           data-testid="multichain-token-list-button"
           style="height: 62px;"
         >
@@ -255,11 +255,10 @@ exports[`AssetPage should render a native asset 1`] = `
             </div>
           </div>
           <div
-            class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-center mm-box--width-full"
-            style="flex-grow: 1; overflow: hidden;"
+            class="flex flex-col justify-center w-full overflow-hidden grow"
           >
             <div
-              class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-space-between"
+              class="flex flex-row justify-between"
             >
               <div
                 class="flex flex-row gap-2 min-w-0"
@@ -306,7 +305,7 @@ exports[`AssetPage should render a native asset 1`] = `
               </p>
             </div>
             <div
-              class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-space-between"
+              class="flex flex-row justify-between"
             >
               <div
                 class="mm-box mm-box--display-flex mm-box--gap-1 mm-box--align-items-center"
@@ -589,10 +588,10 @@ exports[`AssetPage should render an ERC20 asset without prices 1`] = `
         Your balance
       </h4>
       <div
-        class="mm-box mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-row mm-box--width-full mm-box--height-full"
+        class="flex flex-row gap-4 h-full w-full"
       >
         <a
-          class="mm-box mm-box--padding-top-2 mm-box--padding-right-4 mm-box--padding-bottom-2 mm-box--padding-left-4 mm-box--display-flex mm-box--flex-direction-row mm-box--width-full"
+          class="flex w-full flex-row py-2 px-4 "
           data-testid="multichain-token-list-button"
           style="height: 62px;"
         >
@@ -624,11 +623,10 @@ exports[`AssetPage should render an ERC20 asset without prices 1`] = `
             </div>
           </div>
           <div
-            class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-center mm-box--width-full"
-            style="flex-grow: 1; overflow: hidden;"
+            class="flex flex-col justify-center w-full overflow-hidden grow"
           >
             <div
-              class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-space-between"
+              class="flex flex-row justify-between"
             >
               <div
                 class="flex flex-row gap-2 min-w-0"
@@ -649,7 +647,7 @@ exports[`AssetPage should render an ERC20 asset without prices 1`] = `
               </p>
             </div>
             <div
-              class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-space-between"
+              class="flex flex-row justify-between"
             >
               <div
                 class="mm-box mm-box--display-flex mm-box--gap-1 mm-box--align-items-center"
@@ -1011,10 +1009,10 @@ exports[`AssetPage should render an ERC20 token with prices 1`] = `
         Your balance
       </h4>
       <div
-        class="mm-box mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-row mm-box--width-full mm-box--height-full"
+        class="flex flex-row gap-4 h-full w-full"
       >
         <a
-          class="mm-box mm-box--padding-top-2 mm-box--padding-right-4 mm-box--padding-bottom-2 mm-box--padding-left-4 mm-box--display-flex mm-box--flex-direction-row mm-box--width-full"
+          class="flex w-full flex-row py-2 px-4 "
           data-testid="multichain-token-list-button"
           style="height: 62px;"
         >
@@ -1046,11 +1044,10 @@ exports[`AssetPage should render an ERC20 token with prices 1`] = `
             </div>
           </div>
           <div
-            class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-center mm-box--width-full"
-            style="flex-grow: 1; overflow: hidden;"
+            class="flex flex-col justify-center w-full overflow-hidden grow"
           >
             <div
-              class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-space-between"
+              class="flex flex-row justify-between"
             >
               <div
                 class="flex flex-row gap-2 min-w-0"
@@ -1071,7 +1068,7 @@ exports[`AssetPage should render an ERC20 token with prices 1`] = `
               </p>
             </div>
             <div
-              class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-space-between"
+              class="flex flex-row justify-between"
             >
               <div
                 class="mm-box mm-box--display-flex mm-box--gap-1 mm-box--align-items-center"

--- a/ui/pages/asset/components/__snapshots__/asset-page.test.tsx.snap
+++ b/ui/pages/asset/components/__snapshots__/asset-page.test.tsx.snap
@@ -220,7 +220,7 @@ exports[`AssetPage should render a native asset 1`] = `
         Your balance
       </h4>
       <div
-        class="flex flex-row gap-4 h-full w-full"
+        class="flex-row gap-4 flex h-full w-full"
       >
         <a
           class="flex w-full flex-row py-2 px-4 "
@@ -255,10 +255,10 @@ exports[`AssetPage should render a native asset 1`] = `
             </div>
           </div>
           <div
-            class="flex flex-col justify-center w-full overflow-hidden grow"
+            class="flex-col justify-center flex w-full overflow-hidden grow"
           >
             <div
-              class="flex flex-row justify-between"
+              class="flex-row justify-between flex"
             >
               <div
                 class="flex flex-row gap-2 min-w-0"
@@ -305,7 +305,7 @@ exports[`AssetPage should render a native asset 1`] = `
               </p>
             </div>
             <div
-              class="flex flex-row justify-between"
+              class="flex-row justify-between flex"
             >
               <div
                 class="mm-box mm-box--display-flex mm-box--gap-1 mm-box--align-items-center"
@@ -588,7 +588,7 @@ exports[`AssetPage should render an ERC20 asset without prices 1`] = `
         Your balance
       </h4>
       <div
-        class="flex flex-row gap-4 h-full w-full"
+        class="flex-row gap-4 flex h-full w-full"
       >
         <a
           class="flex w-full flex-row py-2 px-4 "
@@ -623,10 +623,10 @@ exports[`AssetPage should render an ERC20 asset without prices 1`] = `
             </div>
           </div>
           <div
-            class="flex flex-col justify-center w-full overflow-hidden grow"
+            class="flex-col justify-center flex w-full overflow-hidden grow"
           >
             <div
-              class="flex flex-row justify-between"
+              class="flex-row justify-between flex"
             >
               <div
                 class="flex flex-row gap-2 min-w-0"
@@ -647,7 +647,7 @@ exports[`AssetPage should render an ERC20 asset without prices 1`] = `
               </p>
             </div>
             <div
-              class="flex flex-row justify-between"
+              class="flex-row justify-between flex"
             >
               <div
                 class="mm-box mm-box--display-flex mm-box--gap-1 mm-box--align-items-center"
@@ -1009,7 +1009,7 @@ exports[`AssetPage should render an ERC20 token with prices 1`] = `
         Your balance
       </h4>
       <div
-        class="flex flex-row gap-4 h-full w-full"
+        class="flex-row gap-4 flex h-full w-full"
       >
         <a
           class="flex w-full flex-row py-2 px-4 "
@@ -1044,10 +1044,10 @@ exports[`AssetPage should render an ERC20 token with prices 1`] = `
             </div>
           </div>
           <div
-            class="flex flex-col justify-center w-full overflow-hidden grow"
+            class="flex-col justify-center flex w-full overflow-hidden grow"
           >
             <div
-              class="flex flex-row justify-between"
+              class="flex-row justify-between flex"
             >
               <div
                 class="flex flex-row gap-2 min-w-0"
@@ -1068,7 +1068,7 @@ exports[`AssetPage should render an ERC20 token with prices 1`] = `
               </p>
             </div>
             <div
-              class="flex flex-row justify-between"
+              class="flex-row justify-between flex"
             >
               <div
                 class="mm-box mm-box--display-flex mm-box--gap-1 mm-box--align-items-center"

--- a/ui/pages/confirm-add-suggested-nft/__snapshots__/confirm-add-suggested-nft.test.js.snap
+++ b/ui/pages/confirm-add-suggested-nft/__snapshots__/confirm-add-suggested-nft.test.js.snap
@@ -170,7 +170,7 @@ exports[`ConfirmAddSuggestedNFT Component should match snapshot 1`] = `
                 class="m-0 p-0 rounded-md confirm-add-suggested-nft__nft-single"
               >
                 <div
-                  class="flex flex-row items-center justify-center confirm-add-suggested-nft__nft-single-image-default nft-default rounded-lg"
+                  class="flex-row items-center justify-center flex confirm-add-suggested-nft__nft-single-image-default nft-default rounded-lg"
                   data-testid="nft-default-image"
                   tabindex="0"
                 />
@@ -384,7 +384,7 @@ exports[`ConfirmAddSuggestedNFT Component should match snapshot 1`] = `
               class="m-0 p-0 rounded-md confirm-add-suggested-nft__nft-single"
             >
               <div
-                class="flex flex-row items-center justify-center confirm-add-suggested-nft__nft-single-image-default nft-default rounded-lg"
+                class="flex-row items-center justify-center flex confirm-add-suggested-nft__nft-single-image-default nft-default rounded-lg"
                 data-testid="nft-default-image"
                 tabindex="0"
               />

--- a/ui/pages/confirm-add-suggested-nft/__snapshots__/confirm-add-suggested-nft.test.js.snap
+++ b/ui/pages/confirm-add-suggested-nft/__snapshots__/confirm-add-suggested-nft.test.js.snap
@@ -170,7 +170,7 @@ exports[`ConfirmAddSuggestedNFT Component should match snapshot 1`] = `
                 class="m-0 p-0 rounded-md confirm-add-suggested-nft__nft-single"
               >
                 <div
-                  class="mm-box confirm-add-suggested-nft__nft-single-image-default nft-default mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--rounded-lg"
+                  class="flex flex-row items-center justify-center confirm-add-suggested-nft__nft-single-image-default nft-default rounded-lg"
                   data-testid="nft-default-image"
                   tabindex="0"
                 />
@@ -384,7 +384,7 @@ exports[`ConfirmAddSuggestedNFT Component should match snapshot 1`] = `
               class="m-0 p-0 rounded-md confirm-add-suggested-nft__nft-single"
             >
               <div
-                class="mm-box confirm-add-suggested-nft__nft-single-image-default nft-default mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--rounded-lg"
+                class="flex flex-row items-center justify-center confirm-add-suggested-nft__nft-single-image-default nft-default rounded-lg"
                 data-testid="nft-default-image"
                 tabindex="0"
               />

--- a/ui/pages/confirmations/components/confirm/info/nft-token-transfer/__snapshots__/nft-token-transfer.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/nft-token-transfer/__snapshots__/nft-token-transfer.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`NFTTokenTransferInfo renders correctly 1`] = `
               class="mm-box mm-badge-wrapper nft-item__badge-wrapper mm-box--display-block"
             >
               <div
-                class="mm-box nft-item__default-image nft-default mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--rounded-lg"
+                class="flex flex-row items-center justify-center nft-item__default-image nft-default rounded-lg"
                 data-testid="nft-default-image"
                 tabindex="0"
               />

--- a/ui/pages/confirmations/components/confirm/info/nft-token-transfer/__snapshots__/nft-token-transfer.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/nft-token-transfer/__snapshots__/nft-token-transfer.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`NFTTokenTransferInfo renders correctly 1`] = `
               class="mm-box mm-badge-wrapper nft-item__badge-wrapper mm-box--display-block"
             >
               <div
-                class="flex flex-row items-center justify-center nft-item__default-image nft-default rounded-lg"
+                class="flex-row items-center justify-center flex nft-item__default-image nft-default rounded-lg"
                 data-testid="nft-default-image"
                 tabindex="0"
               />

--- a/ui/pages/confirmations/components/confirm/info/shared/nft-send-heading/__snapshots__/nft-send-heading.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/shared/nft-send-heading/__snapshots__/nft-send-heading.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<NFTSendHeading /> renders component 1`] = `
 <div>
@@ -46,7 +46,7 @@ exports[`<NFTSendHeading /> renders component 1`] = `
               class="mm-box mm-badge-wrapper nft-item__badge-wrapper mm-box--display-block"
             >
               <div
-                class="mm-box nft-item__default-image nft-default mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--rounded-lg"
+                class="flex flex-row items-center justify-center nft-item__default-image nft-default rounded-lg"
                 data-testid="nft-default-image"
                 tabindex="0"
               />

--- a/ui/pages/confirmations/components/confirm/info/shared/nft-send-heading/__snapshots__/nft-send-heading.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/shared/nft-send-heading/__snapshots__/nft-send-heading.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`<NFTSendHeading /> renders component 1`] = `
               class="mm-box mm-badge-wrapper nft-item__badge-wrapper mm-box--display-block"
             >
               <div
-                class="flex flex-row items-center justify-center nft-item__default-image nft-default rounded-lg"
+                class="flex-row items-center justify-center flex nft-item__default-image nft-default rounded-lg"
                 data-testid="nft-default-image"
                 tabindex="0"
               />

--- a/ui/pages/defi/components/__snapshots__/defi-details-page.test.tsx.snap
+++ b/ui/pages/defi/components/__snapshots__/defi-details-page.test.tsx.snap
@@ -87,10 +87,10 @@ exports[`DeFiDetailsPage renders defi asset page 1`] = `
             Staked
           </p>
           <div
-            class="mm-box mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-row mm-box--width-full mm-box--height-full"
+            class="flex flex-row gap-4 h-full w-full"
           >
             <a
-              class="mm-box mm-box--padding-top-2 mm-box--padding-right-4 mm-box--padding-bottom-2 mm-box--padding-left-4 mm-box--display-flex mm-box--flex-direction-row mm-box--width-full"
+              class="flex w-full flex-row py-2 px-4 "
               data-testid="multichain-token-list-button"
               style="height: 62px;"
             >
@@ -122,11 +122,10 @@ exports[`DeFiDetailsPage renders defi asset page 1`] = `
                 </div>
               </div>
               <div
-                class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-center mm-box--width-full"
-                style="flex-grow: 1; overflow: hidden;"
+                class="flex flex-col justify-center w-full overflow-hidden grow"
               >
                 <div
-                  class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-space-between"
+                  class="flex flex-row justify-between"
                 >
                   <div
                     class="flex flex-row gap-2 min-w-0"
@@ -147,7 +146,7 @@ exports[`DeFiDetailsPage renders defi asset page 1`] = `
                   </p>
                 </div>
                 <div
-                  class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-space-between"
+                  class="flex flex-row justify-between"
                 >
                   <div
                     class="mm-box mm-box--display-flex mm-box--gap-1 mm-box--align-items-center"

--- a/ui/pages/defi/components/__snapshots__/defi-details-page.test.tsx.snap
+++ b/ui/pages/defi/components/__snapshots__/defi-details-page.test.tsx.snap
@@ -87,7 +87,7 @@ exports[`DeFiDetailsPage renders defi asset page 1`] = `
             Staked
           </p>
           <div
-            class="flex flex-row gap-4 h-full w-full"
+            class="flex-row gap-4 flex h-full w-full"
           >
             <a
               class="flex w-full flex-row py-2 px-4 "
@@ -122,10 +122,10 @@ exports[`DeFiDetailsPage renders defi asset page 1`] = `
                 </div>
               </div>
               <div
-                class="flex flex-col justify-center w-full overflow-hidden grow"
+                class="flex-col justify-center flex w-full overflow-hidden grow"
               >
                 <div
-                  class="flex flex-row justify-between"
+                  class="flex-row justify-between flex"
                 >
                   <div
                     class="flex flex-row gap-2 min-w-0"
@@ -146,7 +146,7 @@ exports[`DeFiDetailsPage renders defi asset page 1`] = `
                   </p>
                 </div>
                 <div
-                  class="flex flex-row justify-between"
+                  class="flex-row justify-between flex"
                 >
                   <div
                     class="mm-box mm-box--display-flex mm-box--gap-1 mm-box--align-items-center"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Use `Box` from DSR (assets team).

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-433

## **Manual testing steps**

1. Open extension app
2. Check that modified files don't cause UI regressions

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="371" height="1118" alt="image" src="https://github.com/user-attachments/assets/08010efc-af26-4659-8ae7-ca29334105bb" />

### **After**

<img width="379" height="1128" alt="image" src="https://github.com/user-attachments/assets/37ee0257-29f1-4d22-9f23-d17a2bb73635" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only refactor across balances, token/NFT/DeFi lists, and filters; no auth, transactions, or data logic changes—risk is mainly visual regression if DSR Box styling diverges from the old component-library Box.
> 
> **Overview**
> This PR **migrates layout `Box` usage** in the assets-team surfaces from the extension **component-library** to **`Box` (and related enums) from `@metamask/design-system-react`**, including **`Skeleton`** where touched.
> 
> **Layout API changes:** Old design-system props (`Display`, `FlexDirection`, `AlignItems`, `JustifyContent`, `BlockSize`, `BorderRadius`, etc.) are replaced with DSR types such as `BoxFlexDirection`, `BoxAlignItems`, `BoxJustifyContent`, and `BoxBackgroundColor`, often paired with **Tailwind-style `className` utilities** (`flex`, `w-full`, `py-2`, `rounded-lg`) instead of `mm-box--*` modifier classes.
> 
> **Notable structural tweak:** `generic-asset-cell-layout` switches the clickable row from **`Box as="a"`** to **`Box asChild`** wrapping a native **`<a>`** with equivalent flex/padding classes. **`nfts-tab`** uses DSR **`paddingHorizontal`** instead of separate inline padding props.
> 
> **Tests:** Jest snapshots are updated so expected DOM classes match the DSR/Tailwind output (e.g. token list rows, NFT default images, asset and DeFi detail pages).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee062f590c5754ac40296eb355923a0cf62de58c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->