### PR TITLE
fix: Monad swap activity in asset details

### DIFF
--- a/shared/lib/multichain/transformations.test.ts
+++ b/shared/lib/multichain/transformations.test.ts
@@ -231,6 +231,68 @@ describe('selectTransactions', () => {
     expect(result.pages[0].data).toHaveLength(1);
   });
 
+  it('shows swaps where only valueTransfers identify the account', () => {
+    const router = '0x2222222222222222222222222222222222222222';
+    const pool = '0x3333333333333333333333333333333333333333';
+    const usdcAddress = '0x754704Bc059F8C67012fEd69BC8A327a5aafb603';
+
+    const result = selectTransactions({ address: account })(
+      createData([
+        {
+          ...baseRawTx,
+          chainId: 143,
+          from: router,
+          to: pool,
+          value: '0',
+          valueTransfers: [
+            {
+              from: account,
+              to: router,
+              amount: '30000000000000000000',
+              decimal: 18,
+              symbol: 'MON',
+              transferType: 'internal',
+            },
+            {
+              from: pool,
+              to: account,
+              amount: '866885',
+              decimal: 6,
+              symbol: 'USDC',
+              name: 'USD Coin',
+              contractAddress: usdcAddress,
+              transferType: 'erc20',
+            },
+          ],
+        },
+      ]),
+    );
+
+    const transaction = result.pages[0]?.data[0];
+    expect(transaction).toBeDefined();
+    if (!transaction) {
+      throw new Error('Expected Monad swap transaction to be included');
+    }
+    expect(transaction.amounts?.from).toStrictEqual({
+      token: {
+        address: NATIVE_TOKEN_ADDRESS,
+        symbol: 'MON',
+        decimals: 18,
+        chainId: '0x8f',
+      },
+      amount: -30000000000000000000n,
+    });
+    expect(transaction.amounts?.to).toStrictEqual({
+      token: {
+        address: usdcAddress.toLowerCase(),
+        symbol: 'USDC',
+        decimals: 6,
+        chainId: '0x8f',
+      },
+      amount: 866885n,
+    });
+  });
+
   it('blocks incoming native transfers where the account is the recipient', () => {
     const result = selectTransactions({ address: account })(
       createData([

--- a/shared/lib/multichain/transformations.ts
+++ b/shared/lib/multichain/transformations.ts
@@ -114,9 +114,15 @@ export function normalizeTransaction(
       vt.contractAddress,
   );
 
+  const hasOutgoingValueTransfer =
+    transaction.valueTransfers?.some(
+      (vt) => vt.from?.toLowerCase() === address.toLowerCase(),
+    ) ?? false;
+
   const isIncomingTokenTransfer =
     valueTransfer?.to?.toLowerCase() === address.toLowerCase() &&
-    from.toLowerCase() !== address.toLowerCase();
+    from.toLowerCase() !== address.toLowerCase() &&
+    !hasOutgoingValueTransfer;
 
   const amount = valueTransfer?.amount;
   const contractAddress = valueTransfer?.contractAddress as string;
@@ -198,9 +204,6 @@ export function selectTransactions({
         // Filter out transactions not involving the current address
         const rawFrom = raw.from?.toLowerCase();
         const rawTo = raw.to?.toLowerCase();
-        if (rawFrom !== addr && rawTo !== addr) {
-          return result;
-        }
 
         // Filter out excluded transaction hashes (e.g. internal prerequisite transactions)
         if (raw.hash && excludedTxHashes?.has(raw.hash.toLowerCase())) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fix the Monad token details by relaxing the filtering. API-sourced EVM transactions are already filtered by account address parameter

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: Monad swap activity in asset details

## **Related issues**

Fixes: #42044 

## **Manual testing steps**

1. Do a Monad swap
2. Check the token details page

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="381" height="256" alt="image" src="https://github.com/user-attachments/assets/029a8719-99e4-4f52-a5f1-9da3af52007b" />

### **After**

<img width="348" height="234" alt="image" src="https://github.com/user-attachments/assets/4844ffcf-31e2-437f-a0f7-51a149205929" />

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes transaction inclusion and incoming-transfer detection logic, which can affect what activity is shown/hidden and could reintroduce spam/poisoning edge cases if the API returns unrelated transfers.
> 
> **Overview**
> Fixes asset-activity filtering so swaps are included even when the top-level `from`/`to` fields don’t match the account (e.g., Monad swaps where only `valueTransfers` reference the user).
> 
> Updates `normalizeTransaction` to avoid classifying a token transfer as purely incoming when the account also has an outgoing `valueTransfers` entry in the same transaction, and adds a regression test covering the Monad swap scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dee15d504b84ab07db8012157a6832feefc5ccf4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->