### PR TITLE
fix(perps): use Perps-owned toast path for token funded deposits

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5979,10 +5979,10 @@
     "message": "Adding funds to Perps"
   },
   "perpsDepositToastSuccessDescription": {
-    "message": "Your funds are ready to trade."
+    "message": "Funds are ready to trade"
   },
   "perpsDepositToastSuccessTitle": {
-    "message": "Funds added to Perps"
+    "message": "Your Perps account was funded"
   },
   "perpsDeposits": {
     "message": "Deposits"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -5979,10 +5979,10 @@
     "message": "Adding funds to Perps"
   },
   "perpsDepositToastSuccessDescription": {
-    "message": "Your funds are ready to trade."
+    "message": "Funds are ready to trade"
   },
   "perpsDepositToastSuccessTitle": {
-    "message": "Funds added to Perps"
+    "message": "Your Perps account was funded"
   },
   "perpsDeposits": {
     "message": "Deposits"

--- a/ui/components/app/perps/perps-deposit-toast.test.tsx
+++ b/ui/components/app/perps/perps-deposit-toast.test.tsx
@@ -293,6 +293,113 @@ describe('PerpsDepositToast', () => {
     );
   });
 
+  it('does not clear deposit result when completion toast rerenders before the duration elapses', () => {
+    jest.useFakeTimers();
+    const store = configureStore({
+      metamask: {
+        ...mockState.metamask,
+        transactions: [
+          buildPendingDepositTransaction({
+            id: 'result-tx-1',
+            status: TransactionStatus.confirmed,
+          }),
+        ],
+        lastDepositTransactionId: 'result-tx-1',
+        lastDepositResult: {
+          success: true,
+          error: '',
+          timestamp: 1_700_000_000_000,
+        },
+      },
+    });
+
+    renderWithProvider(<PerpsDepositToast />, store);
+
+    act(() => {
+      store.dispatch({
+        type: 'UPDATE_METAMASK_STATE',
+        value: {
+          lastDepositResult: {
+            success: true,
+            error: 'same result re-render',
+            timestamp: 1_700_000_000_000,
+          },
+        },
+      });
+    });
+
+    expect(submitRequestToBackgroundMock).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(4999);
+    });
+
+    expect(submitRequestToBackgroundMock).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+
+    expect(submitRequestToBackgroundMock).toHaveBeenCalledTimes(1);
+    expect(submitRequestToBackgroundMock).toHaveBeenCalledWith(
+      'perpsClearDepositResult',
+      [],
+    );
+  });
+
+  it('does not let a stale completion timer clear a newer deposit result', () => {
+    jest.useFakeTimers();
+    const store = configureStore({
+      metamask: {
+        ...mockState.metamask,
+        transactions: [
+          buildPendingDepositTransaction({
+            id: 'result-tx-1',
+            status: TransactionStatus.confirmed,
+          }),
+        ],
+        lastDepositTransactionId: 'result-tx-1',
+        lastDepositResult: {
+          success: true,
+          error: '',
+          timestamp: 1_700_000_000_000,
+        },
+      },
+    });
+
+    renderWithProvider(<PerpsDepositToast />, store);
+
+    act(() => {
+      jest.advanceTimersByTime(2500);
+      store.dispatch({
+        type: 'UPDATE_METAMASK_STATE',
+        value: {
+          lastDepositResult: {
+            success: true,
+            error: '',
+            timestamp: 1_700_000_005_000,
+          },
+        },
+      });
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(2500);
+    });
+
+    expect(submitRequestToBackgroundMock).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(2500);
+    });
+
+    expect(submitRequestToBackgroundMock).toHaveBeenCalledTimes(1);
+    expect(submitRequestToBackgroundMock).toHaveBeenCalledWith(
+      'perpsClearDepositResult',
+      [],
+    );
+  });
+
   it('clears deposit result when unmounted during completion toast', () => {
     jest.useFakeTimers();
     const store = configureStore({

--- a/ui/components/app/perps/perps-deposit-toast.test.tsx
+++ b/ui/components/app/perps/perps-deposit-toast.test.tsx
@@ -99,7 +99,7 @@ describe('PerpsDepositToast', () => {
     );
   });
 
-  it('does not render pending toast for token-funded deposits', () => {
+  it('renders pending toast for token-funded deposits', () => {
     const store = configureStore({
       metamask: {
         ...mockState.metamask,
@@ -119,7 +119,18 @@ describe('PerpsDepositToast', () => {
 
     renderWithProvider(<PerpsDepositToast />, store);
 
-    expect(mockToastLoading).not.toHaveBeenCalled();
+    expect(mockToastLoading).toHaveBeenCalledWith(
+      expect.objectContaining({
+        props: expect.objectContaining({
+          title: messages.perpsDepositToastPendingTitle.message,
+          description: messages.perpsDepositToastPendingDescription.message,
+        }),
+      }),
+      {
+        id: 'perps-deposit-toast',
+        duration: Infinity,
+      },
+    );
   });
 
   it('renders pending toast for native-token-funded deposits', () => {
@@ -458,7 +469,7 @@ describe('PerpsDepositToast', () => {
     );
   });
 
-  it('does not show completion toast for token-funded deposits', () => {
+  it('shows completion toast for token-funded deposits', () => {
     const store = configureStore({
       metamask: {
         ...mockState.metamask,
@@ -487,7 +498,18 @@ describe('PerpsDepositToast', () => {
 
     renderWithProvider(<PerpsDepositToast />, store);
 
-    expect(mockToastSuccess).not.toHaveBeenCalled();
+    expect(mockToastSuccess).toHaveBeenCalledWith(
+      expect.objectContaining({
+        props: expect.objectContaining({
+          title: messages.perpsDepositToastSuccessTitle.message,
+          description: messages.perpsDepositToastSuccessDescription.message,
+        }),
+      }),
+      {
+        id: 'perps-deposit-toast',
+        duration: 5000,
+      },
+    );
   });
 
   it('shows pending for the active deposit only when a stale perps tx remains submitted', () => {

--- a/ui/components/app/perps/perps-deposit-toast.test.tsx
+++ b/ui/components/app/perps/perps-deposit-toast.test.tsx
@@ -347,60 +347,7 @@ describe('PerpsDepositToast', () => {
     );
   });
 
-  it('does not let a stale completion timer clear a newer deposit result', () => {
-    jest.useFakeTimers();
-    const store = configureStore({
-      metamask: {
-        ...mockState.metamask,
-        transactions: [
-          buildPendingDepositTransaction({
-            id: 'result-tx-1',
-            status: TransactionStatus.confirmed,
-          }),
-        ],
-        lastDepositTransactionId: 'result-tx-1',
-        lastDepositResult: {
-          success: true,
-          error: '',
-          timestamp: 1_700_000_000_000,
-        },
-      },
-    });
-
-    renderWithProvider(<PerpsDepositToast />, store);
-
-    act(() => {
-      jest.advanceTimersByTime(2500);
-      store.dispatch({
-        type: 'UPDATE_METAMASK_STATE',
-        value: {
-          lastDepositResult: {
-            success: true,
-            error: '',
-            timestamp: 1_700_000_005_000,
-          },
-        },
-      });
-    });
-
-    act(() => {
-      jest.advanceTimersByTime(2500);
-    });
-
-    expect(submitRequestToBackgroundMock).not.toHaveBeenCalled();
-
-    act(() => {
-      jest.advanceTimersByTime(2500);
-    });
-
-    expect(submitRequestToBackgroundMock).toHaveBeenCalledTimes(1);
-    expect(submitRequestToBackgroundMock).toHaveBeenCalledWith(
-      'perpsClearDepositResult',
-      [],
-    );
-  });
-
-  it('clears deposit result when unmounted during completion toast', () => {
+  it('dismisses the completion toast without clearing deposit result when unmounted before duration elapses', () => {
     jest.useFakeTimers();
     const store = configureStore({
       metamask: {
@@ -427,17 +374,13 @@ describe('PerpsDepositToast', () => {
     unmount();
 
     expect(mockToastDismiss).toHaveBeenCalledWith('perps-deposit-toast');
-    expect(submitRequestToBackgroundMock).toHaveBeenCalledTimes(1);
-    expect(submitRequestToBackgroundMock).toHaveBeenCalledWith(
-      'perpsClearDepositResult',
-      [],
-    );
+    expect(submitRequestToBackgroundMock).not.toHaveBeenCalled();
 
     act(() => {
       jest.advanceTimersByTime(5000);
     });
 
-    expect(submitRequestToBackgroundMock).toHaveBeenCalledTimes(1);
+    expect(submitRequestToBackgroundMock).not.toHaveBeenCalled();
   });
 
   it('renders error toast when lastDepositResult is unsuccessful', () => {

--- a/ui/components/app/perps/perps-deposit-toast.test.tsx
+++ b/ui/components/app/perps/perps-deposit-toast.test.tsx
@@ -229,6 +229,36 @@ describe('PerpsDepositToast', () => {
     );
   });
 
+  it('renders success toast when the deposit transaction is no longer active', () => {
+    const store = configureStore({
+      metamask: {
+        ...mockState.metamask,
+        transactions: [],
+        lastDepositTransactionId: null,
+        lastDepositResult: {
+          success: true,
+          error: '',
+          timestamp: 1_700_000_000_000,
+        },
+      },
+    });
+
+    renderWithProvider(<PerpsDepositToast />, store);
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(
+      expect.objectContaining({
+        props: expect.objectContaining({
+          title: messages.perpsDepositToastSuccessTitle.message,
+          description: messages.perpsDepositToastSuccessDescription.message,
+        }),
+      }),
+      {
+        id: 'perps-deposit-toast',
+        duration: 5000,
+      },
+    );
+  });
+
   it('clears deposit result when completion toast duration elapses', () => {
     jest.useFakeTimers();
     const store = configureStore({

--- a/ui/components/app/perps/perps-deposit-toast.tsx
+++ b/ui/components/app/perps/perps-deposit-toast.tsx
@@ -6,7 +6,6 @@ import { submitRequestToBackground } from '../../../store/background-connection'
 import {
   selectPerpsDepositPending,
   selectPerpsLastDepositResult,
-  selectPerpsLastDepositTransactionId,
   selectPerpsShouldShowDepositToast,
 } from '../../../selectors/perps-controller';
 import { toast, ToastContent } from '../../ui/toast/toast';
@@ -23,9 +22,6 @@ export function PerpsDepositToast() {
   const t = useI18nContext();
   const depositInProgress = useSelector(selectPerpsDepositPending);
   const lastDepositResult = useSelector(selectPerpsLastDepositResult);
-  const lastDepositTransactionId = useSelector(
-    selectPerpsLastDepositTransactionId,
-  );
   const shouldShowDepositToast = useSelector(selectPerpsShouldShowDepositToast);
   const hasDepositResult = Boolean(lastDepositResult);
   const lastDepositResultError = lastDepositResult?.error;
@@ -33,47 +29,61 @@ export function PerpsDepositToast() {
   const lastDepositResultTimestamp = lastDepositResult?.timestamp;
 
   useEffect(() => {
-    if (!shouldShowDepositToast) {
-      toast.dismiss(id);
+    if (!hasDepositResult) {
       return;
     }
 
-    if (hasDepositResult) {
-      const isSuccess = lastDepositResultSuccess === true;
-      const title = isSuccess
-        ? t('perpsDepositToastSuccessTitle')
-        : t('perpsDepositToastErrorTitle');
-      const description = isSuccess
-        ? t('perpsDepositToastSuccessDescription')
-        : lastDepositResultError || t('perpsDepositToastErrorDescription');
-      const content = (
-        <ToastContent title={title} description={description} dataTestId={id} />
-      );
-      const options = { id, duration };
+    const isSuccess = lastDepositResultSuccess === true;
+    const title = isSuccess
+      ? t('perpsDepositToastSuccessTitle')
+      : t('perpsDepositToastErrorTitle');
+    const description = isSuccess
+      ? t('perpsDepositToastSuccessDescription')
+      : lastDepositResultError || t('perpsDepositToastErrorDescription');
+    const content = (
+      <ToastContent title={title} description={description} dataTestId={id} />
+    );
+    const options = { id, duration };
 
-      if (isSuccess) {
-        toast.success(content, options);
-      } else {
-        toast.error(content, options);
+    if (isSuccess) {
+      toast.success(content, options);
+    } else {
+      toast.error(content, options);
+    }
+
+    let clearDepositResultRequested = false;
+    const clearDepositResultOnce = () => {
+      if (clearDepositResultRequested) {
+        return;
       }
 
-      let clearDepositResultRequested = false;
-      const clearDepositResultOnce = () => {
-        if (clearDepositResultRequested) {
-          return;
-        }
+      clearDepositResultRequested = true;
+      clearDepositResult();
+    };
 
-        clearDepositResultRequested = true;
-        clearDepositResult();
-      };
+    const timeoutId = setTimeout(clearDepositResultOnce, duration);
 
-      const timeoutId = setTimeout(clearDepositResultOnce, duration);
+    return () => {
+      clearTimeout(timeoutId);
+      toast.dismiss(id);
+      clearDepositResultOnce();
+    };
+  }, [
+    hasDepositResult,
+    lastDepositResultError,
+    lastDepositResultSuccess,
+    lastDepositResultTimestamp,
+    t,
+  ]);
 
-      return () => {
-        clearTimeout(timeoutId);
-        toast.dismiss(id);
-        clearDepositResultOnce();
-      };
+  useEffect(() => {
+    if (hasDepositResult) {
+      return;
+    }
+
+    if (!shouldShowDepositToast) {
+      toast.dismiss(id);
+      return;
     }
 
     if (!depositInProgress) {
@@ -96,16 +106,7 @@ export function PerpsDepositToast() {
     return () => {
       toast.dismiss(id);
     };
-  }, [
-    depositInProgress,
-    hasDepositResult,
-    lastDepositResultError,
-    lastDepositResultSuccess,
-    lastDepositResultTimestamp,
-    lastDepositTransactionId,
-    shouldShowDepositToast,
-    t,
-  ]);
+  }, [depositInProgress, hasDepositResult, shouldShowDepositToast, t]);
 
   return null;
 }

--- a/ui/components/app/perps/perps-deposit-toast.tsx
+++ b/ui/components/app/perps/perps-deposit-toast.tsx
@@ -1,4 +1,4 @@
-import React, { type MutableRefObject, useEffect, useRef } from 'react';
+import React, { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { SECOND } from '../../../../shared/constants/time';
 import { useI18nContext } from '../../../hooks/useI18nContext';
@@ -18,36 +18,6 @@ const clearDepositResult = () =>
     () => undefined,
   );
 
-type DepositResult = NonNullable<
-  ReturnType<typeof selectPerpsLastDepositResult>
->;
-
-const getDepositResultKey = (depositResult: DepositResult) =>
-  depositResult.timestamp === undefined
-    ? [
-        depositResult.success,
-        depositResult.error,
-        depositResult.txHash,
-        depositResult.amount,
-        depositResult.asset,
-      ].join(':')
-    : `timestamp:${depositResult.timestamp}`;
-
-const clearDepositResultForKey = (
-  depositResultKey: string | null,
-  clearedDepositResultKeyRef: MutableRefObject<string | null>,
-) => {
-  if (
-    !depositResultKey ||
-    clearedDepositResultKeyRef.current === depositResultKey
-  ) {
-    return;
-  }
-
-  clearedDepositResultKeyRef.current = depositResultKey;
-  clearDepositResult();
-};
-
 export function PerpsDepositToast() {
   const t = useI18nContext();
   const depositInProgress = useSelector(selectPerpsDepositPending);
@@ -56,25 +26,7 @@ export function PerpsDepositToast() {
   const hasDepositResult = Boolean(lastDepositResult);
   const lastDepositResultError = lastDepositResult?.error;
   const lastDepositResultSuccess = lastDepositResult?.success;
-  const depositResultKey = lastDepositResult
-    ? getDepositResultKey(lastDepositResult)
-    : null;
-  const latestDepositResultKeyRef = useRef<string | null>(null);
-  const clearedDepositResultKeyRef = useRef<string | null>(null);
-
-  useEffect(() => {
-    latestDepositResultKeyRef.current = depositResultKey;
-  }, [depositResultKey]);
-
-  useEffect(
-    () => () => {
-      clearDepositResultForKey(
-        latestDepositResultKeyRef.current,
-        clearedDepositResultKeyRef,
-      );
-    },
-    [],
-  );
+  const lastDepositResultTimestamp = lastDepositResult?.timestamp;
 
   useEffect(() => {
     if (!hasDepositResult) {
@@ -99,30 +51,21 @@ export function PerpsDepositToast() {
       toast.error(content, options);
     }
 
-    return () => {
-      toast.dismiss(id);
-    };
-  }, [
-    depositResultKey,
-    hasDepositResult,
-    lastDepositResultError,
-    lastDepositResultSuccess,
-    t,
-  ]);
-
-  useEffect(() => {
-    if (!depositResultKey) {
-      return;
-    }
-
     const timeoutId = setTimeout(() => {
-      clearDepositResultForKey(depositResultKey, clearedDepositResultKeyRef);
+      clearDepositResult();
     }, duration);
 
     return () => {
       clearTimeout(timeoutId);
+      toast.dismiss(id);
     };
-  }, [depositResultKey]);
+  }, [
+    hasDepositResult,
+    lastDepositResultError,
+    lastDepositResultSuccess,
+    lastDepositResultTimestamp,
+    t,
+  ]);
 
   useEffect(() => {
     if (hasDepositResult) {

--- a/ui/components/app/perps/perps-deposit-toast.tsx
+++ b/ui/components/app/perps/perps-deposit-toast.tsx
@@ -115,14 +115,9 @@ export function PerpsDepositToast() {
       return;
     }
 
-    const timeoutId = setTimeout(
-      () =>
-        clearDepositResultForKey(
-          depositResultKey,
-          clearedDepositResultKeyRef,
-        ),
-      duration,
-    );
+    const timeoutId = setTimeout(() => {
+      clearDepositResultForKey(depositResultKey, clearedDepositResultKeyRef);
+    }, duration);
 
     return () => {
       clearTimeout(timeoutId);

--- a/ui/components/app/perps/perps-deposit-toast.tsx
+++ b/ui/components/app/perps/perps-deposit-toast.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { type MutableRefObject, useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { SECOND } from '../../../../shared/constants/time';
 import { useI18nContext } from '../../../hooks/useI18nContext';
@@ -18,6 +18,36 @@ const clearDepositResult = () =>
     () => undefined,
   );
 
+type DepositResult = NonNullable<
+  ReturnType<typeof selectPerpsLastDepositResult>
+>;
+
+const getDepositResultKey = (depositResult: DepositResult) =>
+  depositResult.timestamp === undefined
+    ? [
+        depositResult.success,
+        depositResult.error,
+        depositResult.txHash,
+        depositResult.amount,
+        depositResult.asset,
+      ].join(':')
+    : `timestamp:${depositResult.timestamp}`;
+
+const clearDepositResultForKey = (
+  depositResultKey: string | null,
+  clearedDepositResultKeyRef: MutableRefObject<string | null>,
+) => {
+  if (
+    !depositResultKey ||
+    clearedDepositResultKeyRef.current === depositResultKey
+  ) {
+    return;
+  }
+
+  clearedDepositResultKeyRef.current = depositResultKey;
+  clearDepositResult();
+};
+
 export function PerpsDepositToast() {
   const t = useI18nContext();
   const depositInProgress = useSelector(selectPerpsDepositPending);
@@ -26,7 +56,25 @@ export function PerpsDepositToast() {
   const hasDepositResult = Boolean(lastDepositResult);
   const lastDepositResultError = lastDepositResult?.error;
   const lastDepositResultSuccess = lastDepositResult?.success;
-  const lastDepositResultTimestamp = lastDepositResult?.timestamp;
+  const depositResultKey = lastDepositResult
+    ? getDepositResultKey(lastDepositResult)
+    : null;
+  const latestDepositResultKeyRef = useRef<string | null>(null);
+  const clearedDepositResultKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    latestDepositResultKeyRef.current = depositResultKey;
+  }, [depositResultKey]);
+
+  useEffect(
+    () => () => {
+      clearDepositResultForKey(
+        latestDepositResultKeyRef.current,
+        clearedDepositResultKeyRef,
+      );
+    },
+    [],
+  );
 
   useEffect(() => {
     if (!hasDepositResult) {
@@ -51,30 +99,35 @@ export function PerpsDepositToast() {
       toast.error(content, options);
     }
 
-    let clearDepositResultRequested = false;
-    const clearDepositResultOnce = () => {
-      if (clearDepositResultRequested) {
-        return;
-      }
-
-      clearDepositResultRequested = true;
-      clearDepositResult();
-    };
-
-    const timeoutId = setTimeout(clearDepositResultOnce, duration);
-
     return () => {
-      clearTimeout(timeoutId);
       toast.dismiss(id);
-      clearDepositResultOnce();
     };
   }, [
+    depositResultKey,
     hasDepositResult,
     lastDepositResultError,
     lastDepositResultSuccess,
-    lastDepositResultTimestamp,
     t,
   ]);
+
+  useEffect(() => {
+    if (!depositResultKey) {
+      return;
+    }
+
+    const timeoutId = setTimeout(
+      () =>
+        clearDepositResultForKey(
+          depositResultKey,
+          clearedDepositResultKeyRef,
+        ),
+      duration,
+    );
+
+    return () => {
+      clearTimeout(timeoutId);
+    };
+  }, [depositResultKey]);
 
   useEffect(() => {
     if (hasDepositResult) {

--- a/ui/selectors/perps-controller.test.ts
+++ b/ui/selectors/perps-controller.test.ts
@@ -286,7 +286,7 @@ describe('perps-controller selectors', () => {
       ).toBe(false);
     });
 
-    it('returns false for token-funded deposits with a non-native pay token', () => {
+    it('returns true for token-funded deposits with a non-native pay token', () => {
       expect(
         selectPerpsDepositPending(
           buildStateWithActiveDeposit({
@@ -301,7 +301,7 @@ describe('perps-controller selectors', () => {
             },
           }),
         ),
-      ).toBe(false);
+      ).toBe(true);
     });
 
     it('returns true for native-token-funded deposits', () => {
@@ -341,7 +341,7 @@ describe('perps-controller selectors', () => {
       ).toBe(true);
     });
 
-    it('returns false for a token-funded deposit transaction', () => {
+    it('returns true for a token-funded deposit transaction', () => {
       expect(
         selectPerpsShouldShowDepositToast(
           buildState({
@@ -363,7 +363,7 @@ describe('perps-controller selectors', () => {
             },
           }),
         ),
-      ).toBe(false);
+      ).toBe(true);
     });
   });
 

--- a/ui/selectors/perps-controller.ts
+++ b/ui/selectors/perps-controller.ts
@@ -5,8 +5,6 @@ import {
   type TransactionMeta,
 } from '@metamask/transaction-controller';
 import type { PerpsControllerState } from '@metamask/perps-controller';
-import { getNativeTokenAddress } from '@metamask/assets-controllers';
-import type { Hex } from '@metamask/utils';
 
 /**
  * The PerpsController state is flattened into state.metamask by
@@ -38,10 +36,6 @@ const PERPS_DEPOSIT_TRANSACTION_TYPES: ReadonlySet<TransactionType> = new Set([
 ]);
 
 const EMPTY_ARRAY: never[] = [];
-const EMPTY_TRANSACTION_DATA: Record<
-  string,
-  { paymentToken?: { address: Hex; chainId: Hex } }
-> = {};
 const EMPTY_TRADE_CONFIGURATIONS: PerpsControllerState['tradeConfigurations'] =
   { testnet: {}, mainnet: {} };
 
@@ -76,53 +70,15 @@ type PerpsDepositPendingState = {
   metamask: {
     transactions?: TransactionMeta[];
     lastDepositTransactionId?: string | null;
-    transactionData?: Record<
-      string,
-      {
-        paymentToken?: {
-          address: Hex;
-          chainId: Hex;
-        };
-      }
-    >;
   };
 };
 
-const isNativePayToken = (
-  paymentToken?:
-    | {
-        address: Hex;
-        chainId: Hex;
-      }
-    | undefined,
-) => {
-  if (!paymentToken) {
-    return true;
-  }
-
-  return (
-    paymentToken.address.toLowerCase() ===
-    getNativeTokenAddress(paymentToken.chainId).toLowerCase()
-  );
-};
-
-const isPerpsToastOwnedDepositTransaction = (
-  transaction?: TransactionMeta,
-  paymentToken?:
-    | {
-        address: Hex;
-        chainId: Hex;
-      }
-    | undefined,
-) => {
+const isPerpsToastOwnedDepositTransaction = (transaction?: TransactionMeta) => {
   if (!transaction?.type) {
     return false;
   }
 
-  return (
-    PERPS_DEPOSIT_TRANSACTION_TYPES.has(transaction.type) &&
-    isNativePayToken(paymentToken)
-  );
+  return PERPS_DEPOSIT_TRANSACTION_TYPES.has(transaction.type);
 };
 
 const selectPerpsActiveDepositTransaction = createSelector(
@@ -143,13 +99,8 @@ const selectPerpsActiveDepositTransaction = createSelector(
 
 export const selectPerpsShouldShowDepositToast = createSelector(
   selectPerpsActiveDepositTransaction,
-  (state: PerpsDepositPendingState) =>
-    state.metamask.transactionData ?? EMPTY_TRANSACTION_DATA,
-  (transaction, transactionData) =>
-    isPerpsToastOwnedDepositTransaction(
-      transaction ?? undefined,
-      transaction ? transactionData[transaction.id]?.paymentToken : undefined,
-    ),
+  (transaction) =>
+    isPerpsToastOwnedDepositTransaction(transaction ?? undefined),
 );
 
 /**
@@ -167,15 +118,8 @@ export const selectPerpsShouldShowDepositToast = createSelector(
  */
 export const selectPerpsDepositPending = createSelector(
   selectPerpsActiveDepositTransaction,
-  (state: PerpsDepositPendingState) =>
-    state.metamask.transactionData ?? EMPTY_TRANSACTION_DATA,
-  (tx, transactionData) => {
-    if (
-      !isPerpsToastOwnedDepositTransaction(
-        tx ?? undefined,
-        tx ? transactionData[tx.id]?.paymentToken : undefined,
-      )
-    ) {
+  (tx) => {
+    if (!isPerpsToastOwnedDepositTransaction(tx ?? undefined)) {
       return false;
     }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Updates Perps deposit toast ownership so token funded deposits use the same Perps owned toast flow as native deposits.

Previously, Perps deposit toasts were limited to native token funded deposit transactions. That left token funded deposits, such as USDC on Arbitrum, without Perps deposit completion feedback. The selector now treats active perpsDeposit and perpsDepositAndOrder transactions as Perps-owned regardless of payment token, and the tests cover pending and completion toasts for token-funded deposits.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug that prevented some Perps deposits from showing completion toasts.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3064

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/3d862c6f-d25e-4e02-b20b-61824d205b31



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Perps deposit toast gating and the timing of `perpsClearDepositResult`, which could impact when completion toasts appear/disappear and when deposit result state is cleared.
> 
> **Overview**
> Perps deposit toasts are now shown for **token-funded** `perpsDeposit` / `perpsDepositAndOrder` transactions by removing the native-token/payment-token gating from `selectPerpsDepositPending` and `selectPerpsShouldShowDepositToast`.
> 
> `PerpsDepositToast` splits pending vs completion behavior: completion toasts trigger whenever `lastDepositResult` exists (even if the deposit tx is no longer active), schedule `perpsClearDepositResult` only via the duration timeout (not on unmount/rerender), and always dismiss the toast on cleanup.
> 
> Updates/enhances tests to cover token-funded pending/completion toasts and the new timeout/unmount/rerender clearing semantics, and tweaks the success-toast copy in `en`/`en_GB` locales.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87bd3109d1f321823b1ee2e287f7962d3a98775b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->