### PR TITLE
fix: convert exchange rate numbers to strings before passing to BigNumber

### DIFF
--- a/ui/components/app/currency-input/hooks/useTokenExchangeRate.tsx
+++ b/ui/components/app/currency-input/hooks/useTokenExchangeRate.tsx
@@ -61,7 +61,10 @@ export default function useTokenExchangeRate(
       return undefined;
     }
 
-    const nativeConversionRate = new Numeric(selectedNativeConversionRate, 10);
+    const nativeConversionRate = new Numeric(
+      String(selectedNativeConversionRate),
+      10,
+    );
 
     if (!tokenAddress) {
       return nativeConversionRate;
@@ -107,7 +110,9 @@ export default function useTokenExchangeRate(
       return undefined;
     }
 
-    return new Numeric(contractExchangeRate, 10).times(nativeConversionRate);
+    return new Numeric(String(contractExchangeRate), 10).times(
+      nativeConversionRate,
+    );
   }, [
     exchangeRates,
     chainId,

--- a/ui/pages/confirmations/hooks/transactions/dapp-swap-comparison/useDappSwapUSDValues.ts
+++ b/ui/pages/confirmations/hooks/transactions/dapp-swap-comparison/useDappSwapUSDValues.ts
@@ -83,7 +83,7 @@ export function useDappSwapUSDValues({
         ),
       );
       const conversionRate = new BigNumber(
-        getTokenValueFromRecord(fiatRates, tokenAddress) ?? 0,
+        String(getTokenValueFromRecord(fiatRates, tokenAddress) ?? 0),
       );
       const value = new BigNumber(tokenAmount ?? 0)
         .dividedBy(decimals)


### PR DESCRIPTION
## **Description**

Fixes a crash caused by `BigNumber` throwing when receiving a JavaScript `number` with more than 15 significant digits.

### Root Cause

`BigNumber` enforces a strict 15 significant digit limit on `number` inputs because IEEE 754 floats lose precision beyond that. Exchange rates returned from APIs are raw `number` values with no precision guarantee, and can exceed this limit.

### When does this happen?

The `BigNumber` constructor **only** validates significant digits for JS `number` inputs. Once a value is a `BigNumber` instance, all math operations (`.times()`, `.dividedBy()`, etc.) use arbitrary-precision arithmetic and never throw.

The crash happens at construction time — `new BigNumber(someNumber)` — not during math operations.

**Case 1: Large conversion rate (weak-currency locales like VND, IDR)**
```js
// ETH costs ~40 million VND
new BigNumber(40115252.21304121)     // ❌ 16 significant digits → THROWS
new BigNumber("40115252.21304121")   // ✅ string input → no limit
```

**Case 2: Very precise small price (micro-cap tokens)**
```js
// Token worth fractions of a cent
new BigNumber(0.00000123456789012345)  // ❌ 17 significant digits → THROWS
new BigNumber("0.00000123456789012345") // ✅ string input → no limit
```

**Case 3: Near-peg stablecoin with API floating point noise**
```js
// API returns USDC rate with floating point artifacts
new BigNumber(1.0000000000000002)    // ❌ 17 significant digits → THROWS
new BigNumber("1.0000000000000002")  // ✅ string input → no limit
```

**Case 4: Normal USD rate — no problem**
```js
// ETH at $2308
new BigNumber(2308.478)              // ✅ 7 significant digits → fine
```

**Case 5: Math after construction — no problem**
```js
// Once inside BigNumber, arithmetic is arbitrary precision
new BigNumber("1.000000000000001")
  .times("0.002")                    // ✅ BigNumber math → never throws
```

### What this PR fixes

Two call sites where raw API `number` values were passed directly to `BigNumber`/`Numeric` constructors:

1. **`useDappSwapUSDValues.ts`** — `fiatRates` from `fetchTokenExchangeRates` passed to `new BigNumber()`
2. **`useTokenExchangeRate.tsx`** — both `selectedNativeConversionRate` (from `CurrencyRateController` state) and `contractExchangeRate` (from `fetchTokenExchangeRates`) passed to `new Numeric()`

The fix wraps each value in `String()` before passing to the constructor. `BigNumber`'s string constructor has no significant digit limit.

### What this PR does NOT fix

There are ~210 usages of `new BigNumber()` across the codebase. This PR addresses the ones identified as high-risk (exchange rate / conversion rate values from external APIs). There may be other call sites that could hit the same issue with different data, but auditing every single `BigNumber` construction is impractical in a single PR. A longer-term solution could be to patch `fetchTokenExchangeRates` to return strings, or to add a lint rule catching `new BigNumber(<number-typed variable>)`.

A related but separate issue exists in `@metamask/assets-controllers` where `CurrencyRateController.boundedPrecisionNumber` uses `toFixed(9)` (which bounds **decimal** digits, not **significant** digits), allowing values with >15 significant digits to be stored in state for users with weak-currency locales.

## **Changelog**

CHANGELOG entry: Fixed a crash ("new BigNumber() number type has more than 15 significant digits") that could occur when viewing transaction confirmations, especially for users with non-USD currencies

## **Related issues**

Fixes: N/A (reported via user error reports / state logs)

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Manual testing steps**

1. Set MetaMask currency to weak currency
2. Initiate a dapp swap transaction (e.g. on Uniswap)
3. Verify the confirmation screen loads without a "BigNumber Error" crash
4. Verify fiat values display correctly on the confirmation

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, targeted type-conversion change to prevent `BigNumber`/`Numeric` constructor throws on high-precision API rates, with no behavioral change for normal inputs.
> 
> **Overview**
> Prevents crashes from `BigNumber`/`Numeric` rejecting JS `number` inputs with >15 significant digits by converting exchange-rate inputs to strings before construction.
> 
> This updates `useTokenExchangeRate` (native and token exchange rates) and `useDappSwapUSDValues` (fiat conversion rate) to wrap fetched/state rates in `String(...)` prior to arithmetic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 580884690bba977101de4e34e6e718c5318c7353. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->