### PR TITLE
fix: tolerate sentinel network flag fetch failures

### DIFF
--- a/app/scripts/lib/transaction/sentinel-api.test.ts
+++ b/app/scripts/lib/transaction/sentinel-api.test.ts
@@ -175,10 +175,10 @@ describe('sentinel-api', () => {
       expect(result).toBeUndefined();
     });
 
-    it('throws if getNetworkData throws', async () => {
+    it('returns undefined if getNetworkData throws', async () => {
       fetchMock.mockRejectedValueOnce(new Error('API connection error'));
-      await expect(getSentinelNetworkFlags('0x1' as Hex)).rejects.toThrow(
-        'API connection error',
+      await expect(getSentinelNetworkFlags('0x1' as Hex)).resolves.toBe(
+        undefined,
       );
     });
   });
@@ -220,6 +220,17 @@ describe('sentinel-api', () => {
 
       const result = await getSendBundleSupportedChains(['0xFAFA']);
       expect(result).toEqual({ '0xFAFA': false });
+    });
+
+    it('returns false for all chains if getNetworkData throws', async () => {
+      fetchMock.mockRejectedValueOnce(new Error('API connection error'));
+
+      const result = await getSendBundleSupportedChains(chainIds);
+      expect(result).toEqual({
+        '0x1': false,
+        '0x89': false,
+        '0xFAFA': false,
+      });
     });
   });
 
@@ -294,11 +305,9 @@ describe('sentinel-api', () => {
       expect(result).toBe(false);
     });
 
-    it('throws if the fetch fails', async () => {
+    it('returns false if the fetch fails', async () => {
       fetchMock.mockRejectedValueOnce(new Error('API error!'));
-      await expect(isSendBundleSupported(mainnetHex)).rejects.toThrow(
-        'API error!',
-      );
+      await expect(isSendBundleSupported(mainnetHex)).resolves.toBe(false);
     });
   });
 });

--- a/app/scripts/lib/transaction/sentinel-api.test.ts
+++ b/app/scripts/lib/transaction/sentinel-api.test.ts
@@ -309,5 +309,16 @@ describe('sentinel-api', () => {
       fetchMock.mockRejectedValueOnce(new Error('API error!'));
       await expect(isSendBundleSupported(mainnetHex)).resolves.toBe(false);
     });
+
+    it('returns false if response json parsing fails', async () => {
+      fetchMock.mockResolvedValueOnce({
+        json: async () => {
+          throw new Error('Invalid JSON');
+        },
+        ok: true,
+      } as Response);
+
+      await expect(isSendBundleSupported(mainnetHex)).resolves.toBe(false);
+    });
   });
 });

--- a/app/scripts/lib/transaction/sentinel-api.test.ts
+++ b/app/scripts/lib/transaction/sentinel-api.test.ts
@@ -181,6 +181,17 @@ describe('sentinel-api', () => {
         undefined,
       );
     });
+
+    it('returns undefined if getNetworkData returns null', async () => {
+      fetchMock.mockResolvedValueOnce({
+        json: async () => null,
+        ok: true,
+      } as Response);
+
+      await expect(getSentinelNetworkFlags('0x1' as Hex)).resolves.toBe(
+        undefined,
+      );
+    });
   });
 
   describe('getSendBundleSupportedChains', () => {
@@ -224,6 +235,20 @@ describe('sentinel-api', () => {
 
     it('returns false for all chains if getNetworkData throws', async () => {
       fetchMock.mockRejectedValueOnce(new Error('API connection error'));
+
+      const result = await getSendBundleSupportedChains(chainIds);
+      expect(result).toEqual({
+        '0x1': false,
+        '0x89': false,
+        '0xFAFA': false,
+      });
+    });
+
+    it('returns false for all chains if getNetworkData returns null', async () => {
+      fetchMock.mockResolvedValueOnce({
+        json: async () => null,
+        ok: true,
+      } as Response);
 
       const result = await getSendBundleSupportedChains(chainIds);
       expect(result).toEqual({
@@ -315,6 +340,15 @@ describe('sentinel-api', () => {
         json: async () => {
           throw new Error('Invalid JSON');
         },
+        ok: true,
+      } as Response);
+
+      await expect(isSendBundleSupported(mainnetHex)).resolves.toBe(false);
+    });
+
+    it('returns false if response json is null', async () => {
+      fetchMock.mockResolvedValueOnce({
+        json: async () => null,
         ok: true,
       } as Response);
 

--- a/app/scripts/lib/transaction/sentinel-api.test.ts
+++ b/app/scripts/lib/transaction/sentinel-api.test.ts
@@ -341,7 +341,7 @@ describe('sentinel-api', () => {
           throw new Error('Invalid JSON');
         },
         ok: true,
-      } as Response);
+      } as unknown as Response);
 
       await expect(isSendBundleSupported(mainnetHex)).resolves.toBe(false);
     });

--- a/app/scripts/lib/transaction/sentinel-api.ts
+++ b/app/scripts/lib/transaction/sentinel-api.ts
@@ -99,7 +99,7 @@ async function getAllSentinelNetworkFlags(): Promise<SentinelNetworkMap> {
     const url = `${buildUrl('ethereum-mainnet')}${ENDPOINT_NETWORKS}`;
     const headers = await getSentinelApiHeadersAsync();
     const response = await getFetchWithTimeout()(url, { headers });
-    return response.json();
+    return await response.json();
   } catch {
     return {};
   }

--- a/app/scripts/lib/transaction/sentinel-api.ts
+++ b/app/scripts/lib/transaction/sentinel-api.ts
@@ -99,10 +99,15 @@ async function getAllSentinelNetworkFlags(): Promise<SentinelNetworkMap> {
     const url = `${buildUrl('ethereum-mainnet')}${ENDPOINT_NETWORKS}`;
     const headers = await getSentinelApiHeadersAsync();
     const response = await getFetchWithTimeout()(url, { headers });
-    return await response.json();
+    const networkFlags = (await response.json()) as unknown;
+    return isSentinelNetworkMap(networkFlags) ? networkFlags : {};
   } catch {
     return {};
   }
+}
+
+function isSentinelNetworkMap(value: unknown): value is SentinelNetworkMap {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
 /**

--- a/app/scripts/lib/transaction/sentinel-api.ts
+++ b/app/scripts/lib/transaction/sentinel-api.ts
@@ -95,10 +95,14 @@ export type SentinelNetworkMap = Record<string, SentinelNetwork>;
  * Returns all network data.
  */
 async function getAllSentinelNetworkFlags(): Promise<SentinelNetworkMap> {
-  const url = `${buildUrl('ethereum-mainnet')}${ENDPOINT_NETWORKS}`;
-  const headers = await getSentinelApiHeadersAsync();
-  const response = await getFetchWithTimeout()(url, { headers });
-  return response.json();
+  try {
+    const url = `${buildUrl('ethereum-mainnet')}${ENDPOINT_NETWORKS}`;
+    const headers = await getSentinelApiHeadersAsync();
+    const response = await getFetchWithTimeout()(url, { headers });
+    return response.json();
+  } catch {
+    return {};
+  }
 }
 
 /**


### PR DESCRIPTION
## **Description**

Sentinel network flag fetches now fail closed by returning an empty network flag map when the request fails. That makes downstream checks behave as if Sentinel-managed flags are disabled instead of rejecting and potentially blocking transaction publish paths.

The root cause was that `getAllSentinelNetworkFlags` let tx-sentinel fetch failures propagate to callers such as `isSendBundleSupported`.

## **Changelog**

CHANGELOG entry: Fixed transaction publishing when Sentinel network flag requests fail.

<!--
## **Related issues**

Fixes:
-->

<!--
## **Manual testing steps**

Not applicable; covered by unit tests.
-->

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## **Validation**

- `yarn test:unit app/scripts/lib/transaction/sentinel-api.test.ts --watchman=false`
- `yarn lint:changed:fix`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error-handling in Sentinel network flag retrieval to silently fall back to disabled flags, which can affect transaction feature gating (e.g., `sendBundle`) if the API response is malformed or unavailable.
> 
> **Overview**
> Sentinel network flag retrieval (`getAllSentinelNetworkFlags`) now **fails closed**: fetch/JSON errors or non-object payloads return an empty `SentinelNetworkMap` instead of propagating exceptions.
> 
> Unit tests were updated to expect `undefined`/`false` outcomes (rather than throws) and add coverage for null/invalid JSON responses impacting `getSentinelNetworkFlags`, `getSendBundleSupportedChains`, and `isSendBundleSupported`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71da1a6ba6beb8a18945ddd3cf594d10a344b332. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->