### PR TITLE
chore: add locale entries for deposit and trade strings

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5904,6 +5904,9 @@
   "perpsDepositActivityTitle": {
     "message": "Funded Perps"
   },
+  "perpsDepositErrorBridgeFailed": {
+    "message": "Bridge failed"
+  },
   "perpsDepositFailed": {
     "message": "Deposit could not be completed. Try again."
   },
@@ -6400,6 +6403,9 @@
   },
   "perpsTrades": {
     "message": "Trades"
+  },
+  "perpsTransactionTitleOpenedLong": {
+    "message": "Opened long"
   },
   "perpsTriggerPrice": {
     "message": "Trigger price"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -5904,6 +5904,9 @@
   "perpsDepositActivityTitle": {
     "message": "Funded Perps"
   },
+  "perpsDepositErrorBridgeFailed": {
+    "message": "Bridge failed"
+  },
   "perpsDepositFailed": {
     "message": "Deposit could not be completed. Try again."
   },
@@ -6400,6 +6403,9 @@
   },
   "perpsTrades": {
     "message": "Trades"
+  },
+  "perpsTransactionTitleOpenedLong": {
+    "message": "Opened long"
   },
   "perpsTriggerPrice": {
     "message": "Trigger price"

--- a/shared/constants/perps.ts
+++ b/shared/constants/perps.ts
@@ -1,3 +1,12 @@
+/**
+ * i18n keys referenced from Perps tests via `enLocale`. Quoted literals are picked
+ * up by `yarn verify-locales` (development/verify-locale-strings.js).
+ */
+export const PERPS_TEST_EN_LOCALE_KEYS = {
+  depositErrorBridgeFailed: 'perpsDepositErrorBridgeFailed',
+  transactionTitleOpenedLong: 'perpsTransactionTitleOpenedLong',
+} as const;
+
 /** Max items shown in the Perps tab Recent Activity preview (matches Activity page slice). */
 export const PERPS_RECENT_ACTIVITY_MAX_TRANSACTIONS = 5;
 

--- a/ui/components/app/perps/perps-deposit-toast.test.tsx
+++ b/ui/components/app/perps/perps-deposit-toast.test.tsx
@@ -305,7 +305,7 @@ describe('PerpsDepositToast', () => {
         lastDepositTransactionId: 'result-tx-1',
         lastDepositResult: {
           success: false,
-          error: 'Bridge failed',
+          error: messages.perpsDepositErrorBridgeFailed.message,
         },
       },
     });
@@ -316,7 +316,7 @@ describe('PerpsDepositToast', () => {
       expect.objectContaining({
         props: expect.objectContaining({
           title: messages.perpsDepositToastErrorTitle.message,
-          description: 'Bridge failed',
+          description: messages.perpsDepositErrorBridgeFailed.message,
         }),
       }),
       {

--- a/ui/components/app/perps/transaction-card/transaction-card.test.tsx
+++ b/ui/components/app/perps/transaction-card/transaction-card.test.tsx
@@ -25,11 +25,11 @@ const createMockTransaction = (
   type: 'trade',
   category: 'position_open',
   symbol: 'ETH',
-  title: 'Opened long',
+  title: messages.perpsTransactionTitleOpenedLong.message,
   subtitle: '2.5 ETH @ $2,850.00',
   timestamp: Date.now() - 3600000,
   fill: {
-    shortTitle: 'Opened long',
+    shortTitle: messages.perpsTransactionTitleOpenedLong.message,
     amount: '+$7,125.00',
     amountNumber: 7125,
     isPositive: true,
@@ -58,14 +58,16 @@ describe('TransactionCard', () => {
 
   it('displays the transaction title', () => {
     const transaction = createMockTransaction({
-      title: 'Opened long',
+      title: messages.perpsTransactionTitleOpenedLong.message,
     });
     renderWithProvider(
       <TransactionCard transaction={transaction} />,
       mockStore,
     );
 
-    expect(screen.getByText('Opened long')).toBeInTheDocument();
+    expect(
+      screen.getByText(messages.perpsTransactionTitleOpenedLong.message),
+    ).toBeInTheDocument();
   });
 
   it('displays the token logo', () => {
@@ -171,7 +173,7 @@ describe('TransactionCard', () => {
         type: 'trade',
         symbol: 'ETH',
         fill: {
-          shortTitle: 'Opened long',
+          shortTitle: messages.perpsTransactionTitleOpenedLong.message,
           amount: '+$7,125.00',
           amountNumber: 7125,
           isPositive: true,
@@ -496,9 +498,9 @@ describe('TransactionCard', () => {
         type: 'trade',
         category: 'position_open',
         symbol: 'xyz:TSLA',
-        title: 'Opened long',
+        title: messages.perpsTransactionTitleOpenedLong.message,
         fill: {
-          shortTitle: 'Opened long',
+          shortTitle: messages.perpsTransactionTitleOpenedLong.message,
           amount: '+$2,400.00',
           amountNumber: 2400,
           isPositive: true,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Replace hard-coded strings to avoid later conflict with locale messages

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds new English locale strings and switches Perps UI tests from hard-coded text to i18n messages, with no production logic changes.
> 
> **Overview**
> Adds two new Perps locale entries (`perpsDepositErrorBridgeFailed`, `perpsTransactionTitleOpenedLong`) to `en` and `en_GB`.
> 
> Updates Perps UI tests to use the localized message values instead of hard-coded strings, and introduces `PERPS_TEST_EN_LOCALE_KEYS` in `shared/constants/perps.ts` to keep those test-referenced i18n keys discoverable by locale verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c568c326109a3a9c5647035df96d9250d28d8d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->