### PR TITLE
fix: Fix slow unlock when network is slow

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -879,8 +879,6 @@ export default class MetamaskController extends EventEmitter {
 
     this.provider =
       this.networkController.getProviderAndBlockTracker().provider;
-    this.blockTracker =
-      this.networkController.getProviderAndBlockTracker().blockTracker;
 
     this.on('update', (update) => {
       this.metaMetricsController.handleMetaMaskStateUpdate(update);
@@ -5502,12 +5500,6 @@ export default class MetamaskController extends EventEmitter {
         // unlock the seedless onboarding vault
         await this.seedlessOnboardingController.submitPassword(password);
       }
-    }
-
-    try {
-      await this.blockTracker.checkForLatestBlock();
-    } catch (error) {
-      log.error('Error while unlocking extension.', error);
     }
 
     await this.accountsController.updateAccounts();


### PR DESCRIPTION
## **Description**

If you are on a network where requests to the legacy "globally selected network" are slow, then the login process will be noticeably slower. This is because we _block login_ until a request for the latest block resolves.

This serves no purpose. We had originally added this check for the latest block to ensure that the state of pending transactions was promptly updated (in #8445), but this is no longer necessary (and no longer even has this effect, since this block tracker isn't used for pending transactions anymore). It also never should have been blocking.

## **Changelog**

CHANGELOG entry: Improve login speed on slow networks

## **Related issues**

N/A

## **Manual testing steps**

1. Lock the wallet
2. Open the "Request conditions" tab of Chrome Dev Tools, and create a request condition for `*//*.infura.io` with a custom profile that has a very slow upload/download speed and/or high latency (e.g. 1 kb/s + 500ms latency)
3. Unlock the wallet

Before this change, the loader will stay on the screen for a long time after submitting your password. After this PR, it will go away quickly.

## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/43036868-f7f4-49b7-a6a9-059a8b9e4ad0

### **After**

https://github.com/user-attachments/assets/f69a4105-4272-4a22-85db-e0c4417edf05

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk change that removes an unused network-dependent block check from the unlock path, reducing perceived login latency; primary risk is any unexpected reliance on this check for post-unlock state refresh timing.
> 
> **Overview**
> Unlock no longer waits on a `blockTracker.checkForLatestBlock()` call, removing a network-dependent delay that could keep the loader up on slow connections.
> 
> The controller also stops storing the `blockTracker` instance from `NetworkController`, reflecting that it’s no longer needed for the unlock flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 330f1fdb8f712564708d4dce5c87e23e6606c004. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->